### PR TITLE
Update build-image.yml to use n300 for builds

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -8,7 +8,7 @@ jobs:
   build:
 
     runs-on:
-      - ubuntu-latest
+      - n300
 
     env:
       BASE_IMAGE_NAME:      ghcr.io/${{ github.repository }}/tt-xla-base-ubuntu-22-04


### PR DESCRIPTION
This is to avoid out of disk space error as Github runners have limited space.