### PR TITLE
Uplift MLIR, add slice tests.

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -94,6 +94,9 @@ target_link_libraries(TTPJRTCommon PUBLIC
     MLIR
     TTMLIR
     TTPJRTCommonDylibPlatform
+    TTMLIRStatic
+    TTMLIRTosaToTTIR
+    MLIRTTIRPipelines
     TTMLIRStableHLOToTTIR
     ${STABLEHLO_LIBS}
 )

--- a/tests/TTIR/test_basic_ops.py
+++ b/tests/TTIR/test_basic_ops.py
@@ -6,6 +6,7 @@
 import pytest
 import jax
 import jax.numpy as jnp
+import numpy
 
 from infrastructure import verify_module
 
@@ -176,4 +177,49 @@ def test_transpose_op_3d():
     return jnp.transpose(a)
 
   verify_module(module_transpose, [(3, 3, 3)])
+
+dim0_cases = []
+for begin in numpy.arange(10).tolist():
+  for end in numpy.arange(90, 100).tolist():
+    dim0_cases.append((begin, end, 0))
+
+dim1_cases = []
+for begin in numpy.arange(10).tolist():
+  for end in numpy.arange(90, 100).tolist():
+    dim1_cases.append((begin, end, 1))
+
+dim2_cases = []
+for begin in numpy.arange(0, 64, 32).tolist():
+  for end in numpy.arange(64, 128, 32).tolist():
+    dim2_cases.append((begin, end, 2))
+
+dim3_cases = []
+for begin in numpy.arange(0, 64, 32).tolist():
+  for end in numpy.arange(64, 128, 32).tolist():
+    dim3_cases.append((begin, end, 3))
+
+@pytest.mark.parametrize(
+  "begin, end, dim",
+  [
+    *dim2_cases,
+    *dim3_cases,
+    *dim0_cases,
+    *dim1_cases
+  ]
+)
+def test_slice(begin, end, dim):
+
+  def module_slice(a):
+    if dim == 0:
+      return a[begin:end, :, :, :]
+    elif dim == 1:
+      return a[:, begin:end, :, :]
+    elif dim == 2:
+      return a[:, :, begin:end, :]
+    else:
+      return a[:, :, :, begin:end]
+
+  shape = [10, 10, 10, 10]
+  shape[dim] = 128
+  verify_module(module_slice, [shape])
 


### PR DESCRIPTION
Added tests for `slice` and uplifted MLIR

The MLIR uplift required a few more register calls and using implicit nesting in the pass manager rather than the default explicit. I chose to do this because the pass manager used by `ttmlir-opt` has implicit nesting and is able to run the tests we otherwise wouldn't be able to here.