### PR TITLE
Fixes for test infrastructure to support scalars

### DIFF
--- a/tests/TTIR/test_basic_ops.py
+++ b/tests/TTIR/test_basic_ops.py
@@ -7,6 +7,8 @@ import pytest
 import jax
 import jax.numpy as jnp
 import numpy
+from jax import export
+
 
 from infrastructure import verify_module
 
@@ -222,6 +224,12 @@ def test_transpose_op_2d():
         return jnp.transpose(a)
 
     verify_module(module_transpose, [(3, 3)])
+
+def test_shape_scalar():
+    def module_shape_scalar(a):
+        return a.shape[0]
+
+    verify_module(module_shape_scalar, [(3, 3)])
 
 
 # Transpose op failing for higher ranks/dimensions.

--- a/tests/TTIR/test_basic_ops.py
+++ b/tests/TTIR/test_basic_ops.py
@@ -225,13 +225,13 @@ def test_transpose_op_2d():
 
 
 @pytest.mark.skip(
-    "Scalar ops currently not working due to issue https://github.com/tenstorrent/tt-xla/issues/73"
+    "Scalars currently not working due to issue https://github.com/tenstorrent/tt-xla/issues/73"
 )
-def test_shape_scalar():
-    def module_shape_scalar(a):
+def test_scalar_type():
+    def module_scalar_type(a):
         return a.shape[0]
 
-    verify_module(module_shape_scalar, [(3, 3)])
+    verify_module(module_scalar_type, [(3, 3)])
 
 
 # Transpose op failing for higher ranks/dimensions.

--- a/tests/TTIR/test_basic_ops.py
+++ b/tests/TTIR/test_basic_ops.py
@@ -7,8 +7,6 @@ import pytest
 import jax
 import jax.numpy as jnp
 import numpy
-from jax import export
-
 
 from infrastructure import verify_module
 

--- a/tests/TTIR/test_basic_ops.py
+++ b/tests/TTIR/test_basic_ops.py
@@ -225,6 +225,10 @@ def test_transpose_op_2d():
 
     verify_module(module_transpose, [(3, 3)])
 
+
+@pytest.mark.skip(
+    "Scalar ops currently not working due to issue https://github.com/tenstorrent/tt-xla/issues/73"
+)
 def test_shape_scalar():
     def module_shape_scalar(a):
         return a.shape[0]

--- a/tests/infrastructure.py
+++ b/tests/infrastructure.py
@@ -42,7 +42,11 @@ def compare_tensor_to_golden(
         if assert_on_error:
             assert ret, f"PCC is {pcc} which is less than {required_pcc}"
 
-    atol = jnp.abs(tensor - golden) if len(tensor.shape) == 0 else jnp.max(jnp.abs(tensor - golden))
+    atol = (
+        jnp.abs(tensor - golden)
+        if len(tensor.shape) == 0
+        else jnp.max(jnp.abs(tensor - golden))
+    )
     ret = ret and atol <= required_atol
     if assert_on_error:
         assert ret, f"ATOL is {atol} which is greater than {required_atol}"

--- a/tests/infrastructure.py
+++ b/tests/infrastructure.py
@@ -42,7 +42,7 @@ def compare_tensor_to_golden(
         if assert_on_error:
             assert ret, f"PCC is {pcc} which is less than {required_pcc}"
 
-    atol = jnp.max(jnp.abs(tensor - golden))
+    atol = jnp.abs(tensor - golden) if len(tensor.shape) == 0 else jnp.max(jnp.abs(tensor - golden))
     ret = ret and atol <= required_atol
     if assert_on_error:
         assert ret, f"ATOL is {atol} which is greater than {required_atol}"

--- a/tests/infrastructure.py
+++ b/tests/infrastructure.py
@@ -17,6 +17,7 @@ def run_on_cpu():
         yield
 
 
+# TODO(issue #80): Make this creation more explicit regarding the originating devices.
 def random_input_tensor(shape, key=42, on_device=False, dtype=jnp.float32):
     device_cpu = jax.devices("cpu")[0]
     with jax.default_device(device_cpu):
@@ -39,6 +40,7 @@ def compare_tensor_to_golden(
 ):
     ret = True
 
+    # TODO (issue #81): Remove these reshapes once the PJRT can handle scalars.
     if tensor.ndim == 0:
         tensor = tensor.reshape((1,))
     if golden.ndim == 0:

--- a/tests/infrastructure.py
+++ b/tests/infrastructure.py
@@ -48,6 +48,7 @@ def compare_tensor_to_golden(
         )
         if assert_on_error:
             assert ret, f"PCC is {pcc} which is less than {required_pcc}"
+
     atol = jnp.max(jnp.abs(tensor - golden))
     ret = ret and atol <= required_atol
     if assert_on_error:


### PR DESCRIPTION
Our test infrastructure on the tt-xla side calls some jax ops (specifically `max` op), on the results of the pytests. If the test result is scalar, the op fails because it does not support that shape. This MR gives a fix for that.

However, the scalars are not fully enabled on the tt-mlir (see issue https://github.com/tenstorrent/tt-mlir/issues/1306), and test is currently marked as skipped until we merge and ingest the fix on the tt-mlir side.