### PR TITLE
Refactor module builder and fix issue 41

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -49,6 +49,7 @@ StablehloReferenceProcess
 StablehloReferenceOps
 StablehloPasses
 ChloOps
+Version
 VhloOps
 VhloTypes
 StablehloOps

--- a/src/common/api_impl.h
+++ b/src/common/api_impl.h
@@ -8,8 +8,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // https://llvm.org/LICENSE.txt
 
-#ifndef IREE_PJRT_PLUGIN_PJRT_COMMON_API_IMPL_H_
-#define IREE_PJRT_PLUGIN_PJRT_COMMON_API_IMPL_H_
+#ifndef TT_XLA_SRC_COMMON_API_IMPL_H_
+#define TT_XLA_SRC_COMMON_API_IMPL_H_
 
 #include <atomic>
 #include <iostream>
@@ -378,7 +378,6 @@ private:
   std::vector<DeviceInstance *> addressable_devices_;
 
   std::unique_ptr<ModuleBuilder> module_builder_;
-  std::optional<mlir::MLIRContext> context_;
 
   // Synchronization.
   // We keep one global execution timeline across all devices. The management
@@ -432,4 +431,4 @@ static void BindApi(PJRT_Api *api) {
 
 } // namespace tt::pjrt
 
-#endif // IREE_PJRT_PLUGIN_PJRT_COMMON_API_IMPL_H_
+#endif // TT_XLA_SRC_COMMON_API_IMPL_H_

--- a/tests/TTIR/test_basic_ops.py
+++ b/tests/TTIR/test_basic_ops.py
@@ -108,7 +108,6 @@ def test_div_op():
     verify_module(module_div, [(3, 3, 3), (3, 3, 3)], required_atol=35e-2)
 
 
-@pytest.mark.skip("VHLO Legalization failed.")
 def test_dot_general_op():
     def module_dot_general(a, b):
         return jnp.dot(a, b)

--- a/tests/TTIR/test_mnist.py
+++ b/tests/TTIR/test_mnist.py
@@ -9,7 +9,6 @@ import jax.numpy as jnp
 from infrastructure import verify_module
 
 
-@pytest.mark.skip("VHLO Legalization failed.")
 def test_matmul():
     def module_matmul(a, b):
         return jnp.matmul(a, b)
@@ -17,7 +16,6 @@ def test_matmul():
     verify_module(module_matmul, [(32, 32), (32, 32)], required_atol=3e-2)
 
 
-@pytest.mark.skip("VHLO Legalization failed.")
 def test_matmul_with_bias():
     def module_matmul(a, b, bias):
         return jnp.matmul(a, b) + bias


### PR DESCRIPTION
Fixes #41 by adding `-vhlo-to-version` pass before `-vhlo-legalize-to-stablehlo` in order to update VHLO to latest version. That converts v1 ops to v2 ops, and then `-vhlo-legalize-to-stablehlo` successfully converts `vhlo.dot_general_v2`.

Refactored module builder in the process:
- Reorganized code into multiple functions
- Moved dialects and passes registration into constructor so it is done only once and not during every compile
- Changed module builder to return PJRT status instead of throwing errors, previous error messages are now logged and status is reported from `api_impl.cc::ClientInstance::Compile` function
- Removed unnecessary includes and sorted them