### PR TITLE
Enabling tests for scalars in tt-xla

### DIFF
--- a/tests/TTIR/test_basic_ops.py
+++ b/tests/TTIR/test_basic_ops.py
@@ -233,11 +233,12 @@ def test_transpose_op(input_shapes):
     verify_module(module_transpose, input_shapes)
 
 
-def test_scalar_type():
+@pytest.mark.parametrize("input_shapes", [[(3, 3)]])
+def test_scalar_type(input_shapes):
     def module_scalar_type(a):
         return a.shape[0]
 
-    verify_module(module_scalar_type, [(3, 3)])
+    verify_module(module_scalar_type, input_shapes)
 
 
 dim0_cases = []


### PR DESCRIPTION
Since tt-xla uplifted the `tt-mlir` which has `tt-metal` with the fix given in https://github.com/tenstorrent/tt-metal/pull/15201, we can now enable the scalar test `test_scalar_type` in `tests/TTIR/test_basic_ops.py`