### PR TITLE
Added support for scalars in tt-xla

### DIFF
--- a/src/common/api_impl.cc
+++ b/src/common/api_impl.cc
@@ -1035,7 +1035,7 @@ LoadedExecutableInstance::Execute(PJRT_LoadedExecutable_Execute_Args *args) {
   assert(rt_outputs.size() == output_specs.size());
 
   for (size_t i = 0; i < output_specs.size(); ++i) {
-    bool is_scalar = client_.get_module_builder()->is_output_scalar(i);
+    bool is_scalar = client_.isOutputScalar(i);
     // PJRT expects an empty shape for scalars.
     std::vector<std::uint32_t> output_shape =
         is_scalar ? std::vector<std::uint32_t>() : output_specs[i].shape;

--- a/src/common/api_impl.cc
+++ b/src/common/api_impl.cc
@@ -1035,9 +1035,13 @@ LoadedExecutableInstance::Execute(PJRT_LoadedExecutable_Execute_Args *args) {
   assert(rt_outputs.size() == output_specs.size());
 
   for (size_t i = 0; i < output_specs.size(); ++i) {
+    bool is_scalar = client_.get_module_builder()->is_output_scalar(i);
+    // PJRT expects an empty shape for scalars.
+    std::vector<std::uint32_t> output_shape =
+        is_scalar ? std::vector<std::uint32_t>() : output_specs[i].shape;
     auto result_buffer = std::make_unique<BufferInstance>(
-        *this->addressable_devices_[dev_index], rt_outputs[i],
-        output_specs[i].shape, output_specs[i].stride);
+        *this->addressable_devices_[dev_index], rt_outputs[i], output_shape,
+        output_specs[i].stride);
     result_buffer->setType(
         convertElementTypeToBufferType(output_specs[i].dataType));
     DLOG_F(INFO, "Runtime output id: %d", result_buffer->unique_id());

--- a/src/common/api_impl.h
+++ b/src/common/api_impl.h
@@ -370,9 +370,9 @@ public:
   // Advances the timeline, returning (current, next) time point values.
   std::tuple<uint64_t, uint64_t> AdvanceTimeline();
 
-  // Returns the module builder used for this ClientInstance.
-  const ModuleBuilder *get_module_builder() const {
-    return module_builder_.get();
+  // Checks if the output on the i-th index is a scalar.
+  bool isOutputScalar(const int index) const {
+    return module_builder_->isOutputScalar(index);
   }
 
 protected:

--- a/src/common/api_impl.h
+++ b/src/common/api_impl.h
@@ -370,6 +370,11 @@ public:
   // Advances the timeline, returning (current, next) time point values.
   std::tuple<uint64_t, uint64_t> AdvanceTimeline();
 
+  // Returns the module builder used for this ClientInstance.
+  const ModuleBuilder *get_module_builder() const {
+    return module_builder_.get();
+  }
+
 protected:
   std::string cached_platform_name_;
   std::string cached_platform_version_;

--- a/src/common/api_impl.h
+++ b/src/common/api_impl.h
@@ -371,7 +371,7 @@ public:
   std::tuple<uint64_t, uint64_t> AdvanceTimeline();
 
   // Checks if the output on the i-th index is a scalar.
-  bool isOutputScalar(const int index) const {
+  bool isOutputScalar(const size_t index) const {
     return module_builder_->isOutputScalar(index);
   }
 

--- a/src/common/module_builder.h
+++ b/src/common/module_builder.h
@@ -33,7 +33,7 @@ public:
 
   size_t getNumOutputs() const { return m_num_outputs; };
 
-  bool is_output_scalar(int index) const { return m_is_output_scalar[index]; }
+  bool isOutputScalar(int index) const { return m_is_output_scalar[index]; }
 
 private:
   // Creates VHLO module from the input program code.
@@ -58,7 +58,7 @@ private:
   void collectOutputTypes(mlir::ModuleOp &&module);
 
   // Prints module to console for debug purposes.
-  static void print_module(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module);
+  static void printModule(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module);
 
   // MLIR context handle.
   std::unique_ptr<mlir::MLIRContext> m_context;

--- a/src/common/module_builder.h
+++ b/src/common/module_builder.h
@@ -33,7 +33,7 @@ public:
 
   size_t getNumOutputs() const { return m_num_outputs; };
 
-  bool isOutputScalar(int index) const;
+  bool isOutputScalar(size_t index) const;
 
 private:
   // Creates VHLO module from the input program code.

--- a/src/common/module_builder.h
+++ b/src/common/module_builder.h
@@ -33,7 +33,7 @@ public:
 
   size_t getNumOutputs() const { return m_num_outputs; };
 
-  bool isOutputScalar(int index) const { return m_is_output_scalar[index]; }
+  bool isOutputScalar(int index) const;
 
 private:
   // Creates VHLO module from the input program code.
@@ -42,6 +42,10 @@ private:
 
   // Converts VHLO module to StableHLO module.
   void convertFromVHLOToSHLO(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module);
+
+  // Fills up the m_is_output_scalar array with information is the output type
+  // scalar or not.
+  void collectOutputTypes(const mlir::OwningOpRef<mlir::ModuleOp> &module);
 
   // Converts StableHLO module to TTIR module.
   void convertFromSHLOToTTIR(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module);
@@ -53,12 +57,11 @@ private:
   void
   createFlatbufferBinary(const mlir::OwningOpRef<mlir::ModuleOp> &mlir_module);
 
-  // Fills up the m_is_output_scalar array with information is the output type
-  // scalar or not.
-  void collectOutputTypes(mlir::ModuleOp &&module);
-
   // Prints module to console for debug purposes.
   static void printModule(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module);
+
+  // Checks if a particular type is scalar.
+  bool isScalarType(mlir::Type type);
 
   // MLIR context handle.
   std::unique_ptr<mlir::MLIRContext> m_context;

--- a/src/common/module_builder.h
+++ b/src/common/module_builder.h
@@ -33,6 +33,8 @@ public:
 
   size_t getNumOutputs() const { return m_num_outputs; };
 
+  bool is_output_scalar(int index) const { return m_is_output_scalar[index]; }
+
 private:
   // Creates VHLO module from the input program code.
   mlir::OwningOpRef<mlir::ModuleOp>
@@ -51,6 +53,10 @@ private:
   void
   createFlatbufferBinary(const mlir::OwningOpRef<mlir::ModuleOp> &mlir_module);
 
+  // Fills up the m_is_output_scalar array with information is the output type
+  // scalar or not.
+  void collectOutputTypes(mlir::ModuleOp &&module);
+
   // Prints module to console for debug purposes.
   static void print_module(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module);
 
@@ -68,6 +74,9 @@ private:
 
   // Holds status of the last builder action.
   tt_pjrt_status m_status;
+
+  // For every output, holds if the type is a scalar or not.
+  std::vector<bool> m_is_output_scalar;
 };
 
 } // namespace tt::pjrt

--- a/tests/infrastructure.py
+++ b/tests/infrastructure.py
@@ -40,13 +40,6 @@ def compare_tensor_to_golden(
 ):
     ret = True
 
-    # TODO (issue #81): Remove these reshapes once the PJRT can handle scalars.
-    if tensor.ndim == 0:
-        tensor = tensor.reshape((1,))
-    if golden.ndim == 0:
-        with run_on_cpu():
-            golden = golden.reshape((1,))
-
     if tensor.device != golden.device:
         tensor = jax.device_put(tensor, golden.device)
 


### PR DESCRIPTION
Due to the fact that scalars are not supported in our TTIR dialect and instead promoted to tensors during StableHLO->TTIR conversion, the PJRT runtime did not now that return values of jax functions were scalars and not 1x1 tensors. This led to the behaviour of the python calls differing between CPU and Silicon calls, with CPU calls returning scalars as expected, and Silicon jax calls returning 1x1 tensors. 

This necessitated a workaround reshaping in the test infra, and additionally did not match with that the end user of the jax framework expected. This PR fixes that, by adding tracking of scalars on the PJRT runtime side. 

Fixes issue https://github.com/tenstorrent/tt-xla/issues/81