### PR TITLE
Enabling non-hardcoded run of our test infrastructure

### DIFF
--- a/inc/common/pjrt_implementation/device_description.h
+++ b/inc/common/pjrt_implementation/device_description.h
@@ -20,7 +20,7 @@ namespace tt::pjrt {
 class DeviceDescription {
 
 public:
-  DeviceDescription(int32_t client_id) : client_id_(client_id) {};
+  DeviceDescription(int32_t device_id) : m_device_id(device_id) {};
   ~DeviceDescription();
   operator PJRT_DeviceDescription *() {
     return reinterpret_cast<PJRT_DeviceDescription *>(this);
@@ -35,21 +35,18 @@ public:
   std::string_view debug_string() { return to_string(); }
   std::string_view to_string() {
     std::stringstream ss;
-    ss << kind_string_ << "(id=" << device_id() << ", arch=" << arch_string_
+    ss << kind_string_ << "(id=" << getDeviceId() << ", arch=" << arch_string_
        << ")";
     user_string_ = ss.str();
     return user_string_;
   }
 
-  // TODO
-  int64_t device_id() { return 0; }
-
-  int client_id() { return client_id_; }
+  int getDeviceId() { return m_device_id; }
 
   int process_index() { return 0; }
 
 private:
-  int client_id_;
+  int m_device_id;
 
   // TODO We should understand better how these are used.
   // See https://github.com/tenstorrent/tt-xla/issues/125

--- a/inc/common/pjrt_implementation/device_instance.h
+++ b/inc/common/pjrt_implementation/device_instance.h
@@ -25,8 +25,8 @@ class BufferInstance;
 class DeviceInstance {
 
 public:
-  DeviceInstance(int client_id, ClientInstance &client)
-      : client_(client), description_(client_id) {}
+  DeviceInstance(int device_id, ClientInstance &client)
+      : client_(client), description_(device_id) {}
   ~DeviceInstance();
   operator PJRT_Device *() { return reinterpret_cast<PJRT_Device *>(this); }
   static void BindApi(PJRT_Api *api);

--- a/inc/common/pjrt_implementation/executable_image.h
+++ b/inc/common/pjrt_implementation/executable_image.h
@@ -26,7 +26,9 @@ class ExecutableImage {
 
 public:
   ExecutableImage(const tt::runtime::Binary &binary, std::string code,
-                  const std::vector<bool> &is_output_scalar);
+                  const std::vector<bool> &is_output_scalar,
+                  size_t num_addressable_devices);
+
   operator PJRT_Executable *() {
     return reinterpret_cast<PJRT_Executable *>(this);
   }
@@ -53,6 +55,10 @@ public:
   // Checks if the output on the i-th index is a scalar.
   bool isOutputScalar(size_t index) const;
 
+  const size_t get_num_addressable_devices() const {
+    return num_addressable_devices;
+  }
+
 private:
   // The reference count. Must be disposed when reaching zero.
   std::atomic<int> m_ref_count;
@@ -65,6 +71,7 @@ private:
 
   size_t m_arg_count;
   size_t m_result_count;
+  size_t num_addressable_devices;
 
   // For every output, holds if the type is a scalar or not.
   std::vector<bool> m_is_output_scalar;

--- a/src/common/module_builder.h
+++ b/src/common/module_builder.h
@@ -36,6 +36,10 @@ public:
     return m_is_output_scalar;
   };
 
+  // This needs to return the number of addressable devices from the StableHLO
+  // code. Currently hardcoded to one, as we only support one-chip execution.
+  size_t getNumAddressableDevices() const { return 1; }
+
 private:
   // Creates VHLO module from the input program code.
   mlir::OwningOpRef<mlir::ModuleOp>

--- a/src/common/pjrt_implementation/client_instance.cc
+++ b/src/common/pjrt_implementation/client_instance.cc
@@ -164,12 +164,10 @@ void ClientInstance::BindApi(PJRT_Api *api) {
 tt_pjrt_status ClientInstance::PopulateDevices() {
   DLOG_F(LOG_DEBUG, "ClientInstance::PopulateDevices");
   auto [system_desc, chip_ids] = tt::runtime::getCurrentSystemDesc();
-  int device_info_count_ =
-      1; // TODO: revert to chip_ids.size(); once
-         // https://github.com/tenstorrent/tt-xla/issues/9 is fixed
+  int devices_count = chip_ids.size();
 
-  devices_.resize(device_info_count_);
-  for (size_t i = 0; i < device_info_count_; ++i) {
+  devices_.resize(devices_count);
+  for (size_t i = 0; i < devices_count; ++i) {
     devices_[i] = new DeviceInstance(i, *this);
   }
 
@@ -197,7 +195,8 @@ PJRT_Error *ClientInstance::Compile(const PJRT_Program *program,
       *this,
       new ExecutableImage(module_builder_->getBinary(),
                           std::string(program->code, program->code_size),
-                          module_builder_->getIsOutputScalar()),
+                          module_builder_->getIsOutputScalar(),
+                          module_builder_->getNumAddressableDevices()),
       addressable_devices_);
   *out_executable = executable.release();
 

--- a/src/common/pjrt_implementation/device_description.cc
+++ b/src/common/pjrt_implementation/device_description.cc
@@ -20,7 +20,8 @@ void DeviceDescription::BindApi(PJRT_Api *api) {
   DLOG_F(LOG_DEBUG, "DeviceDescription::BindApi");
   api->PJRT_DeviceDescription_Id =
       +[](PJRT_DeviceDescription_Id_Args *args) -> PJRT_Error * {
-    args->id = DeviceDescription::Unwrap(args->device_description)->client_id();
+    args->id =
+        DeviceDescription::Unwrap(args->device_description)->getDeviceId();
     return nullptr;
   };
   api->PJRT_DeviceDescription_ProcessIndex =

--- a/src/common/pjrt_implementation/executable_image.cc
+++ b/src/common/pjrt_implementation/executable_image.cc
@@ -21,11 +21,13 @@ const std::string_view kMlirFormat = "mlir";
 
 ExecutableImage::ExecutableImage(const tt::runtime::Binary &binary,
                                  std::string code,
-                                 const std::vector<bool> &is_output_scalar)
+                                 const std::vector<bool> &is_output_scalar,
+                                 size_t num_addressable_devices)
     : m_ref_count(1), m_binary(binary), m_code(code),
       m_arg_count(binary.getProgramInputs(0).size()),
       m_result_count(binary.getProgramOutputs(0).size()),
-      m_is_output_scalar(is_output_scalar) {
+      m_is_output_scalar(is_output_scalar),
+      num_addressable_devices(num_addressable_devices) {
   if (m_result_count != m_is_output_scalar.size()) {
     // TODO: We should throw error instead, otherwise execution will continue
     // and crash later.
@@ -138,7 +140,7 @@ void ExecutableImage::BindApi(PJRT_Api *api) {
 }
 
 bool ExecutableImage::isOutputScalar(const size_t index) const {
-  assert(index < is_output_scalar.size() && "Output index out of range");
+  assert(index < m_is_output_scalar.size() && "Output index out of range");
   return m_is_output_scalar[index];
 }
 

--- a/src/common/pjrt_implementation/loaded_executable_instance.cc
+++ b/src/common/pjrt_implementation/loaded_executable_instance.cc
@@ -10,6 +10,8 @@
 
 #include "common/pjrt_implementation/loaded_executable_instance.h"
 
+#include <unordered_set>
+
 #include "common/pjrt_implementation/buffer_instance.h"
 #include "common/pjrt_implementation/client_instance.h"
 #include "common/pjrt_implementation/error_instance.h"
@@ -32,12 +34,15 @@ void LoadedExecutableInstance::BindApi(PJRT_Api *api) {
     DLOG_F(
         LOG_DEBUG,
         "LoadedExecutableInstance::PJRT_LoadedExecutable_AddressableDevices");
-    const std::vector<DeviceInstance *> &devices =
-        LoadedExecutableInstance::Unwrap(args->executable)
-            ->addressable_devices();
+    LoadedExecutableInstance *loaded_executable =
+        LoadedExecutableInstance::Unwrap(args->executable);
+    const std::vector<DeviceInstance *> &addressable_devices =
+        loaded_executable->addressable_devices();
+    int num_addressable_devices =
+        loaded_executable->image_->get_num_addressable_devices();
     args->addressable_devices = const_cast<PJRT_Device **>(
-        reinterpret_cast<PJRT_Device *const *>(devices.data()));
-    args->num_addressable_devices = devices.size();
+        reinterpret_cast<PJRT_Device *const *>(addressable_devices.data()));
+    args->num_addressable_devices = num_addressable_devices;
     return nullptr;
   };
   api->PJRT_LoadedExecutable_Delete =
@@ -77,22 +82,40 @@ LoadedExecutableInstance::Execute(PJRT_LoadedExecutable_Execute_Args *args) {
   DLOG_F(LOG_DEBUG, "LoadedExecutableInstance::Execute");
 
   auto [system_desc, chip_ids] = tt::runtime::getCurrentSystemDesc();
-  int dev_0 = chip_ids[0];
-  tt::runtime::Device device = tt::runtime::openDevice({dev_0});
 
+  // Sanity check, as we only support execution on one chip currently.
   assert(args->num_devices == 1);
+
   int dev_index = 0;
   const tt::runtime::Binary &binary = image_->get_binary();
 
   std::vector<tt::runtime::Tensor> rt_inputs;
   rt_inputs.reserve(args->num_args);
 
+  std::unordered_set<int> device_ids;
+
   for (size_t i = 0; i < args->num_args; ++i) {
     BufferInstance *buffer =
         BufferInstance::Unwrap(args->argument_lists[dev_index][i]);
     rt_inputs.emplace_back(buffer->tensor());
+    int64_t buffer_device_id =
+        buffer->device().device_description()->getDeviceId();
+    device_ids.insert(chip_ids[buffer_device_id]);
     DLOG_F(INFO, "Runtime input id: %d", buffer->unique_id());
   }
+
+  std::vector<int> device_ids_vector(device_ids.begin(), device_ids.end());
+
+  // If there are no input buffers, we still want to run on a device.
+  // TODO: Now we will run only on the first one, but this should be somehow
+  // explicit.
+  if (device_ids.size() == 0) {
+    device_ids_vector.push_back(chip_ids[0]);
+  }
+
+  assert(device_ids_vector.size() == 1);
+
+  tt::runtime::Device device = tt::runtime::openDevice(device_ids_vector);
 
   std::vector<tt::runtime::Tensor> rt_outputs =
       tt::runtime::submit(device, binary, 0, rt_inputs);

--- a/tests/infra/device_connector.py
+++ b/tests/infra/device_connector.py
@@ -69,9 +69,9 @@ class DeviceConnector:
 
         return False
 
-    def connect_tt_device(self) -> jax.Device:
+    def connect_tt_device(self, device_num: int = 0) -> jax.Device:
         """Returns TTDevice handle."""
-        return self.connect_device(DeviceType.TT)
+        return self.connect_device(DeviceType.TT, device_num)
 
     def connect_cpu(self) -> jax.Device:
         """Returns CPUDevice handle."""
@@ -81,9 +81,23 @@ class DeviceConnector:
         """Returns GPUDevice handle."""
         return self.connect_device(DeviceType.GPU)
 
-    def connect_device(self, device_type: DeviceType) -> jax.Device:
-        """Returns handle for device identified by `device_type`."""
-        return jax.devices(device_type.value)[0]
+    def connect_device(
+        self, device_type: DeviceType, device_num: int = 0
+    ) -> jax.Device:
+        """
+        Returns handle for device identified by `device_type`.
+
+        If there are multiple available devices of `device_type`, `device_num` makes it
+        possible to choose between them. By default, returns first available device.
+        """
+        assert device_num < self._number_of_devices(device_type)
+        assert device_num >= 0
+
+        return jax.devices(device_type.value)[device_num]
+
+    def _number_of_devices(self, device_type: DeviceType) -> int:
+        """Returns the number of available devices of specified type."""
+        return len(jax.devices(device_type.value))
 
     def _supported_devices(self) -> Sequence[DeviceType]:
         """Returns list of supported device types."""

--- a/tests/infra/device_runner.py
+++ b/tests/infra/device_runner.py
@@ -19,14 +19,14 @@ class DeviceRunner:
     """
 
     @staticmethod
-    def run_on_tt_device(workload: Workload) -> Tensor:
+    def run_on_tt_device(workload: Workload, device_num: int = 0) -> Tensor:
         """Runs `workload` on TT device."""
-        return DeviceRunner._run_on_device(DeviceType.TT, workload)
+        return DeviceRunner._run_on_device(workload, DeviceType.TT, device_num)
 
     @staticmethod
     def run_on_cpu(workload: Workload) -> Tensor:
         """Runs `workload` on CPU."""
-        return DeviceRunner._run_on_device(DeviceType.CPU, workload)
+        return DeviceRunner._run_on_device(workload, DeviceType.CPU)
 
     @staticmethod
     def run_on_gpu(workload: Workload) -> Tensor:
@@ -34,14 +34,14 @@ class DeviceRunner:
         raise NotImplementedError("Support for GPUs not implemented")
 
     @staticmethod
-    def put_on_tt_device(workload: Workload) -> Workload:
+    def put_on_tt_device(workload: Workload, device_num: int = 0) -> Workload:
         """Puts `workload` on TT device."""
-        return DeviceRunner._put_on_device(DeviceType.TT, workload)
+        return DeviceRunner._put_on_device(workload, DeviceType.TT, device_num)
 
     @staticmethod
     def put_on_cpu(workload: Workload) -> Workload:
         """Puts `workload` on CPU."""
-        return DeviceRunner._put_on_device(DeviceType.CPU, workload)
+        return DeviceRunner._put_on_device(workload, DeviceType.CPU)
 
     @staticmethod
     def put_on_gpu(workload: Workload) -> Workload:
@@ -64,18 +64,22 @@ class DeviceRunner:
         raise NotImplementedError("Support for GPUs not implemented")
 
     @staticmethod
-    def _run_on_device(device_type: DeviceType, workload: Workload) -> Tensor:
+    def _run_on_device(
+        workload: Workload, device_type: DeviceType, device_num: int = 0
+    ) -> Tensor:
         """Runs `workload` on device identified by `device_type`."""
-        device_workload = DeviceRunner._put_on_device(device_type, workload)
-        device = device_connector.connect_device(device_type)
+        device_workload = DeviceRunner._put_on_device(workload, device_type, device_num)
+        device = device_connector.connect_device(device_type, device_num)
 
         with jax.default_device(device):
             return device_workload.execute()
 
     @staticmethod
-    def _put_on_device(device_type: DeviceType, workload: Workload) -> Workload:
+    def _put_on_device(
+        workload: Workload, device_type: DeviceType, device_num: int = 0
+    ) -> Workload:
         """Puts `workload` on device and returns it."""
-        device = device_connector.connect_device(device_type)
+        device = device_connector.connect_device(device_type, device_num)
         return DeviceRunner._safely_put_workload_on_device(workload, device)
 
     @staticmethod


### PR DESCRIPTION
As per issue https://github.com/tenstorrent/tt-xla/issues/9, our test infra had a problem when detecting two TT devices, as is the case on the two-chip N300, which was workarounded by hardcoding which devices to use. This PR fixes that, instead just setting that the number of devices that the backend uses is capped to 1. Additionally, there was a bug in our old infra which ran the tests on cpu instead of a TT device, so this PR also fixes that.

Fixes https://github.com/tenstorrent/tt-xla/issues/9.