### PR TITLE
Support for superset integration

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from datetime import datetime
+from enum import Enum
+from typing import Callable
+
+import pytest
+
+
+class RecordProperties(Enum):
+    """Properties we can record."""
+
+    # Timestamp of test start.
+    START_TIMESTAMP = "start_timestamp"
+    # Timestamp of test end.
+    END_TIMESTAMP = "end_timestamp"
+    # Frontend or framework used to run the test.
+    FRONTEND = "frontend"
+    # Kind of operation. e.g. eltwise.
+    OP_KIND = "op_kind"
+    # Name of the operation in the framework. e.g. torch.conv2d.
+    FRAMEWORK_OP_NAME = "framework_op_name"
+    # Name of the operation. e.g. ttir.conv2d.
+    OP_NAME = "op_name"
+    # Name of the model in which this op appears.
+    MODEL_NAME = "model_name"
+
+
+@pytest.fixture(scope="function", autouse=True)
+def record_test_timestamp(record_property: Callable):
+    """
+    Autouse fixture used to capture execution time of a test.
+
+    Parameters:
+    ----------
+    record_property: Callable
+        A pytest built-in function used to record test metadata, such as custom
+        properties or additional information about the test execution.
+
+    Yields:
+    -------
+    Callable
+        The `record_property` callable, allowing tests to add additional properties if
+        needed.
+
+
+    Example:
+    --------
+    ```
+    def test_model(fixture1, fixture2, ..., record_tt_xla_property):
+        record_tt_xla_property("key", value)
+
+        # Test logic...
+    ```
+    """
+    start_timestamp = datetime.strftime(datetime.now(), "%Y-%m-%dT%H:%M:%S%z")
+    record_property(RecordProperties.START_TIMESTAMP.value, start_timestamp)
+
+    # Run the test.
+    yield
+
+    end_timestamp = datetime.strftime(datetime.now(), "%Y-%m-%dT%H:%M:%S%z")
+    record_property(RecordProperties.END_TIMESTAMP.value, end_timestamp)
+
+
+@pytest.fixture(scope="function", autouse=True)
+def record_tt_xla_property(record_property: Callable):
+    """
+    Autouse fixture that automatically records some test properties for each test
+    function.
+
+    It also yields back callable which can be explicitly used in tests to record
+    additional properties.
+
+    Example:
+
+    ```
+    def test_model(fixture1, fixture2, ..., record_tt_xla_property):
+        record_tt_xla_property("key", value)
+
+        # Test logic...
+    ```
+
+    Parameters:
+    ----------
+    record_property: Callable
+        A pytest built-in function used to record test metadata, such as custom
+        properties or additional information about the test execution.
+
+    Yields:
+    -------
+    Callable
+        The `record_property` callable, allowing tests to add additional properties if
+        needed.
+    """
+    # Record default properties for tt-xla.
+    record_property(RecordProperties.FRONTEND.value, "tt-xla")
+
+    # Run the test.
+    yield record_property

--- a/tests/jax/graphs/test_simple_regression.py
+++ b/tests/jax/graphs/test_simple_regression.py
@@ -10,9 +10,6 @@ from infra import run_graph_test_with_random_inputs
 @pytest.mark.parametrize(
     ["weights", "bias", "X", "y"], [[(1, 2), (1, 1), (2, 1), (1, 1)]]
 )
-@pytest.mark.xfail(
-    reason="Atol comparison failed. Calculated: atol=0.850662112236023. Required: atol=0.16"
-)
 def test_simple_regression(weights, bias, X, y):
     def simple_regression(weights, bias, X, y):
         def loss(weights, bias, X, y):

--- a/tests/jax/models/albert/v2/base/test_albert_base.py
+++ b/tests/jax/models/albert/v2/base/test_albert_base.py
@@ -11,7 +11,7 @@ from utils import record_model_test_properties, runtime_fail
 from ..tester import AlbertV2Tester
 
 MODEL_PATH = "albert/albert-base-v2"
-MODEL_NAME = MODEL_PATH.split("/")[1]
+MODEL_NAME = "albert-v2-base"
 
 
 # ----- Fixtures -----

--- a/tests/jax/models/albert/v2/base/test_albert_base.py
+++ b/tests/jax/models/albert/v2/base/test_albert_base.py
@@ -2,12 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import pytest
 from infra import RunMode
+from utils import record_model_test_properties, runtime_fail
 
 from ..tester import AlbertV2Tester
 
 MODEL_PATH = "albert/albert-base-v2"
+MODEL_NAME = MODEL_PATH.split("/")[1]
 
 
 # ----- Fixtures -----
@@ -27,16 +31,27 @@ def training_tester() -> AlbertV2Tester:
 
 
 @pytest.mark.xfail(
-    reason="Cannot get the device from a tensor with host storage (https://github.com/tenstorrent/tt-xla/issues/171)"
+    reason=(
+        runtime_fail(
+            "Cannot get the device from a tensor with host storage "
+            "(https://github.com/tenstorrent/tt-xla/issues/171)"
+        )
+    )
 )
 def test_flax_albert_v2_base_inference(
     inference_tester: AlbertV2Tester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MODEL_NAME)
+
     inference_tester.test()
 
 
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_flax_albert_v2_base_training(
     training_tester: AlbertV2Tester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MODEL_NAME)
+
     training_tester.test()

--- a/tests/jax/models/albert/v2/large/test_albert_large.py
+++ b/tests/jax/models/albert/v2/large/test_albert_large.py
@@ -2,12 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import pytest
 from infra import RunMode
+from utils import record_model_test_properties, runtime_fail
 
 from ..tester import AlbertV2Tester
 
 MODEL_PATH = "albert/albert-large-v2"
+MODEL_NAME = MODEL_PATH.split("/")[1]
 
 
 # ----- Fixtures -----
@@ -27,16 +31,27 @@ def training_tester() -> AlbertV2Tester:
 
 
 @pytest.mark.xfail(
-    reason="Cannot get the device from a tensor with host storage (https://github.com/tenstorrent/tt-xla/issues/171)"
+    reason=(
+        runtime_fail(
+            "Cannot get the device from a tensor with host storage "
+            "(https://github.com/tenstorrent/tt-xla/issues/171)"
+        )
+    )
 )
 def test_flax_albert_v2_large_inference(
     inference_tester: AlbertV2Tester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MODEL_NAME)
+
     inference_tester.test()
 
 
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_flax_albert_v2_large_training(
     training_tester: AlbertV2Tester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MODEL_NAME)
+
     training_tester.test()

--- a/tests/jax/models/albert/v2/large/test_albert_large.py
+++ b/tests/jax/models/albert/v2/large/test_albert_large.py
@@ -11,7 +11,7 @@ from utils import record_model_test_properties, runtime_fail
 from ..tester import AlbertV2Tester
 
 MODEL_PATH = "albert/albert-large-v2"
-MODEL_NAME = MODEL_PATH.split("/")[1]
+MODEL_NAME = "albert-v2-large"
 
 
 # ----- Fixtures -----

--- a/tests/jax/models/albert/v2/xlarge/test_albert_xlarge.py
+++ b/tests/jax/models/albert/v2/xlarge/test_albert_xlarge.py
@@ -11,7 +11,7 @@ from utils import record_model_test_properties, runtime_fail
 from ..tester import AlbertV2Tester
 
 MODEL_PATH = "albert/albert-xlarge-v2"
-MODEL_NAME = MODEL_PATH.split("/")[1]
+MODEL_NAME = "albert-v2-xlarge"
 
 
 # ----- Fixtures -----

--- a/tests/jax/models/albert/v2/xlarge/test_albert_xlarge.py
+++ b/tests/jax/models/albert/v2/xlarge/test_albert_xlarge.py
@@ -2,12 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import pytest
 from infra import RunMode
+from utils import record_model_test_properties, runtime_fail
 
 from ..tester import AlbertV2Tester
 
 MODEL_PATH = "albert/albert-xlarge-v2"
+MODEL_NAME = MODEL_PATH.split("/")[1]
 
 
 # ----- Fixtures -----
@@ -27,16 +31,27 @@ def training_tester() -> AlbertV2Tester:
 
 
 @pytest.mark.xfail(
-    reason="Cannot get the device from a tensor with host storage (https://github.com/tenstorrent/tt-xla/issues/171)"
+    reason=(
+        runtime_fail(
+            "Cannot get the device from a tensor with host storage "
+            "(https://github.com/tenstorrent/tt-xla/issues/171)"
+        )
+    )
 )
 def test_flax_albert_v2_xlarge_inference(
     inference_tester: AlbertV2Tester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MODEL_NAME)
+
     inference_tester.test()
 
 
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_flax_albert_v2_xlarge_training(
     training_tester: AlbertV2Tester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MODEL_NAME)
+
     training_tester.test()

--- a/tests/jax/models/albert/v2/xxlarge/test_albert_xxlarge.py
+++ b/tests/jax/models/albert/v2/xxlarge/test_albert_xxlarge.py
@@ -11,7 +11,7 @@ from utils import record_model_test_properties, runtime_fail
 from ..tester import AlbertV2Tester
 
 MODEL_PATH = "albert/albert-xxlarge-v2"
-MODEL_NAME = MODEL_PATH.split("/")[1]
+MODEL_NAME = "albert-v2-xxlarge"
 
 
 # ----- Fixtures -----

--- a/tests/jax/models/albert/v2/xxlarge/test_albert_xxlarge.py
+++ b/tests/jax/models/albert/v2/xxlarge/test_albert_xxlarge.py
@@ -2,12 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import pytest
 from infra import RunMode
+from utils import record_model_test_properties, runtime_fail
 
 from ..tester import AlbertV2Tester
 
 MODEL_PATH = "albert/albert-xxlarge-v2"
+MODEL_NAME = MODEL_PATH.split("/")[1]
 
 
 # ----- Fixtures -----
@@ -27,16 +31,27 @@ def training_tester() -> AlbertV2Tester:
 
 
 @pytest.mark.xfail(
-    reason="Cannot get the device from a tensor with host storage (https://github.com/tenstorrent/tt-xla/issues/171)"
+    reason=(
+        runtime_fail(
+            "Cannot get the device from a tensor with host storage "
+            "(https://github.com/tenstorrent/tt-xla/issues/171)"
+        )
+    )
 )
 def test_flax_albert_v2_xxlarge_inference(
     inference_tester: AlbertV2Tester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MODEL_NAME)
+
     inference_tester.test()
 
 
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_flax_albert_v2_xxlarge_training(
     training_tester: AlbertV2Tester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MODEL_NAME)
+
     training_tester.test()

--- a/tests/jax/models/bart/base/test_bart_base.py
+++ b/tests/jax/models/bart/base/test_bart_base.py
@@ -11,7 +11,7 @@ from utils import record_model_test_properties, runtime_fail
 from ..tester import FlaxBartForCausalLMTester
 
 MODEL_PATH = "facebook/bart-base"
-MODEL_NAME = MODEL_PATH.split("/")[1]
+MODEL_NAME = "bart-base"
 
 
 # ----- Fixtures -----

--- a/tests/jax/models/bart/base/test_bart_base.py
+++ b/tests/jax/models/bart/base/test_bart_base.py
@@ -2,12 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import pytest
 from infra import RunMode
+from utils import record_model_test_properties, runtime_fail
 
 from ..tester import FlaxBartForCausalLMTester
 
 MODEL_PATH = "facebook/bart-base"
+MODEL_NAME = MODEL_PATH.split("/")[1]
 
 
 # ----- Fixtures -----
@@ -27,16 +31,27 @@ def training_tester() -> FlaxBartForCausalLMTester:
 
 
 @pytest.mark.xfail(
-    reason="Cannot get the device from a tensor with host storage (https://github.com/tenstorrent/tt-xla/issues/171)"
+    reason=(
+        runtime_fail(
+            "Cannot get the device from a tensor with host storage "
+            "(https://github.com/tenstorrent/tt-xla/issues/171)"
+        )
+    )
 )
 def test_flax_bart_base_inference(
     inference_tester: FlaxBartForCausalLMTester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MODEL_NAME)
+
     inference_tester.test()
 
 
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_flax_bart_base_training(
     training_tester: FlaxBartForCausalLMTester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MODEL_NAME)
+
     training_tester.test()

--- a/tests/jax/models/bart/large/test_bart_large.py
+++ b/tests/jax/models/bart/large/test_bart_large.py
@@ -11,7 +11,7 @@ from utils import compile_fail, record_model_test_properties
 from ..tester import FlaxBartForCausalLMTester
 
 MODEL_PATH = "facebook/bart-large"
-MODEL_NAME = MODEL_PATH.split("/")[1]
+MODEL_NAME = "bart-large"
 
 
 # ----- Fixtures -----

--- a/tests/jax/models/bart/large/test_bart_large.py
+++ b/tests/jax/models/bart/large/test_bart_large.py
@@ -2,12 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import pytest
 from infra import RunMode
+from utils import compile_fail, record_model_test_properties
 
 from ..tester import FlaxBartForCausalLMTester
 
 MODEL_PATH = "facebook/bart-large"
+MODEL_NAME = MODEL_PATH.split("/")[1]
 
 
 # ----- Fixtures -----
@@ -27,16 +31,24 @@ def training_tester() -> FlaxBartForCausalLMTester:
 
 
 @pytest.mark.xfail(
-    reason="Unsupported data type (https://github.com/tenstorrent/tt-xla/issues/214)"
+    reason=compile_fail(
+        "Unsupported data type (https://github.com/tenstorrent/tt-xla/issues/214)"
+    )
 )
 def test_flax_bart_large_inference(
     inference_tester: FlaxBartForCausalLMTester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MODEL_NAME)
+
     inference_tester.test()
 
 
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_flax_bart_large_training(
     training_tester: FlaxBartForCausalLMTester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MODEL_NAME)
+
     training_tester.test()

--- a/tests/jax/models/bert/base/test_bert_base.py
+++ b/tests/jax/models/bert/base/test_bert_base.py
@@ -11,7 +11,7 @@ from utils import record_model_test_properties, runtime_fail
 from ..tester import FlaxBertForMaskedLMTester
 
 MODEL_PATH = "google-bert/bert-base-uncased"
-MODEL_NAME = MODEL_PATH.split("/")[1]
+MODEL_NAME = "bert-base"
 
 # ----- Fixtures -----
 

--- a/tests/jax/models/bert/base/test_bert_base.py
+++ b/tests/jax/models/bert/base/test_bert_base.py
@@ -2,13 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import pytest
 from infra import RunMode
+from utils import record_model_test_properties, runtime_fail
 
 from ..tester import FlaxBertForMaskedLMTester
 
 MODEL_PATH = "google-bert/bert-base-uncased"
-
+MODEL_NAME = MODEL_PATH.split("/")[1]
 
 # ----- Fixtures -----
 
@@ -27,16 +30,27 @@ def training_tester() -> FlaxBertForMaskedLMTester:
 
 
 @pytest.mark.xfail(
-    reason="Cannot get the device from a tensor with host storage (https://github.com/tenstorrent/tt-xla/issues/171)"
+    reason=(
+        runtime_fail(
+            "Cannot get the device from a tensor with host storage "
+            "(https://github.com/tenstorrent/tt-xla/issues/171)"
+        )
+    )
 )
 def test_flax_bert_base_inference(
     inference_tester: FlaxBertForMaskedLMTester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MODEL_NAME)
+
     inference_tester.test()
 
 
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_flax_bert_base_training(
     training_tester: FlaxBertForMaskedLMTester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MODEL_NAME)
+
     training_tester.test()

--- a/tests/jax/models/bert/large/test_bert_large.py
+++ b/tests/jax/models/bert/large/test_bert_large.py
@@ -11,7 +11,7 @@ from utils import record_model_test_properties, runtime_fail
 from ..tester import FlaxBertForMaskedLMTester
 
 MODEL_PATH = "google-bert/bert-large-uncased"
-MODEL_NAME = MODEL_PATH.split("/")[1]
+MODEL_NAME = "bert-large"
 
 # ----- Fixtures -----
 

--- a/tests/jax/models/bert/large/test_bert_large.py
+++ b/tests/jax/models/bert/large/test_bert_large.py
@@ -2,13 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import pytest
 from infra import RunMode
+from utils import record_model_test_properties, runtime_fail
 
 from ..tester import FlaxBertForMaskedLMTester
 
 MODEL_PATH = "google-bert/bert-large-uncased"
-
+MODEL_NAME = MODEL_PATH.split("/")[1]
 
 # ----- Fixtures -----
 
@@ -27,16 +30,25 @@ def training_tester() -> FlaxBertForMaskedLMTester:
 
 
 @pytest.mark.xfail(
-    reason="Cannot get the device from a tensor with host storage (https://github.com/tenstorrent/tt-xla/issues/171)"
+    reason=runtime_fail(
+        "Cannot get the device from a tensor with host storage "
+        "(https://github.com/tenstorrent/tt-xla/issues/171)"
+    )
 )
 def test_flax_bert_large_inference(
     inference_tester: FlaxBertForMaskedLMTester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MODEL_NAME)
+
     inference_tester.test()
 
 
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_flax_bert_large_training(
     training_tester: FlaxBertForMaskedLMTester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MODEL_NAME)
+
     training_tester.test()

--- a/tests/jax/models/distilbert/test_distilbert.py
+++ b/tests/jax/models/distilbert/test_distilbert.py
@@ -2,15 +2,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict, Sequence
+from typing import Callable, Dict, Sequence
 
 import jax
 import pytest
 from flax import linen as nn
 from infra import ModelTester, RunMode
 from transformers import AutoTokenizer, FlaxDistilBertForMaskedLM
+from utils import record_model_test_properties, runtime_fail
 
 MODEL_PATH = "distilbert/distilbert-base-uncased"
+MODEL_NAME = MODEL_PATH.split("/")[1]
 
 # ----- Tester -----
 
@@ -54,16 +56,25 @@ def training_tester() -> FlaxDistilBertForMaskedLMTester:
 
 
 @pytest.mark.xfail(
-    reason="Cannot get the device from a tensor with host storage (https://github.com/tenstorrent/tt-xla/issues/171)"
+    reason=runtime_fail(
+        "Cannot get the device from a tensor with host storage "
+        "(https://github.com/tenstorrent/tt-xla/issues/171)"
+    )
 )
 def test_flax_distilbert_inference(
     inference_tester: FlaxDistilBertForMaskedLMTester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MODEL_NAME)
+
     inference_tester.test()
 
 
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_flax_distilbert_training(
     training_tester: FlaxDistilBertForMaskedLMTester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MODEL_NAME)
+
     training_tester.test()

--- a/tests/jax/models/distilbert/test_distilbert.py
+++ b/tests/jax/models/distilbert/test_distilbert.py
@@ -12,7 +12,7 @@ from transformers import AutoTokenizer, FlaxDistilBertForMaskedLM
 from utils import record_model_test_properties, runtime_fail
 
 MODEL_PATH = "distilbert/distilbert-base-uncased"
-MODEL_NAME = MODEL_PATH.split("/")[1]
+MODEL_NAME = "distilbert"
 
 # ----- Tester -----
 

--- a/tests/jax/models/gpt2/base/test_gpt2_base.py
+++ b/tests/jax/models/gpt2/base/test_gpt2_base.py
@@ -2,14 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
 
 import pytest
 from infra import ModelTester, RunMode
+from utils import record_model_test_properties, runtime_fail
 
 from ..tester import GPT2Tester
 
 MODEL_PATH = "openai-community/gpt2"
-
+MODEL_NAME = MODEL_PATH.split("/")[1]
 
 # ----- Fixtures -----
 
@@ -28,16 +30,25 @@ def training_tester() -> GPT2Tester:
 
 
 @pytest.mark.xfail(
-    reason="Cannot get the device from a tensor with host storage (https://github.com/tenstorrent/tt-xla/issues/171)"
+    reason=runtime_fail(
+        "Cannot get the device from a tensor with host storage "
+        "(https://github.com/tenstorrent/tt-xla/issues/171)"
+    )
 )
 def test_gpt2_base_inference(
     inference_tester: GPT2Tester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MODEL_NAME)
+
     inference_tester.test()
 
 
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_gpt2_base_training(
     training_tester: GPT2Tester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MODEL_NAME)
+
     training_tester.test()

--- a/tests/jax/models/gpt2/base/test_gpt2_base.py
+++ b/tests/jax/models/gpt2/base/test_gpt2_base.py
@@ -11,7 +11,7 @@ from utils import record_model_test_properties, runtime_fail
 from ..tester import GPT2Tester
 
 MODEL_PATH = "openai-community/gpt2"
-MODEL_NAME = MODEL_PATH.split("/")[1]
+MODEL_NAME = "gpt2-base"
 
 # ----- Fixtures -----
 

--- a/tests/jax/models/gpt2/large/test_gpt2_large.py
+++ b/tests/jax/models/gpt2/large/test_gpt2_large.py
@@ -11,7 +11,7 @@ from utils import record_model_test_properties, runtime_fail
 from ..tester import GPT2Tester
 
 MODEL_PATH = "openai-community/gpt2-large"
-MODEL_NAME = MODEL_PATH.split("/")[1]
+MODEL_NAME = "gpt2-large"
 
 
 # ----- Fixtures -----

--- a/tests/jax/models/gpt2/large/test_gpt2_large.py
+++ b/tests/jax/models/gpt2/large/test_gpt2_large.py
@@ -2,13 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
 
 import pytest
 from infra import ModelTester, RunMode
+from utils import record_model_test_properties, runtime_fail
 
 from ..tester import GPT2Tester
 
 MODEL_PATH = "openai-community/gpt2-large"
+MODEL_NAME = MODEL_PATH.split("/")[1]
 
 
 # ----- Fixtures -----
@@ -28,16 +31,25 @@ def training_tester() -> GPT2Tester:
 
 
 @pytest.mark.xfail(
-    reason="Cannot get the device from a tensor with host storage (https://github.com/tenstorrent/tt-xla/issues/171)"
+    reason=runtime_fail(
+        "Cannot get the device from a tensor with host storage "
+        "(https://github.com/tenstorrent/tt-xla/issues/171)"
+    )
 )
 def test_gpt2_large_inference(
     inference_tester: GPT2Tester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MODEL_NAME)
+
     inference_tester.test()
 
 
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_gpt2_large_training(
     training_tester: GPT2Tester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MODEL_NAME)
+
     training_tester.test()

--- a/tests/jax/models/gpt2/medium/test_gpt2_medium.py
+++ b/tests/jax/models/gpt2/medium/test_gpt2_medium.py
@@ -2,13 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
 
 import pytest
 from infra import ModelTester, RunMode
+from utils import record_model_test_properties, runtime_fail
 
 from ..tester import GPT2Tester
 
 MODEL_PATH = "openai-community/gpt2-medium"
+MODEL_NAME = MODEL_PATH.split("/")[1]
 
 
 # ----- Fixtures -----
@@ -28,16 +31,25 @@ def training_tester() -> GPT2Tester:
 
 
 @pytest.mark.xfail(
-    reason="Cannot get the device from a tensor with host storage (https://github.com/tenstorrent/tt-xla/issues/171)"
+    reason=runtime_fail(
+        "Cannot get the device from a tensor with host storage "
+        "(https://github.com/tenstorrent/tt-xla/issues/171)"
+    )
 )
 def test_gpt2_medium_inference(
     inference_tester: GPT2Tester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MODEL_NAME)
+
     inference_tester.test()
 
 
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_gpt2_medium_training(
     training_tester: GPT2Tester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MODEL_NAME)
+
     training_tester.test()

--- a/tests/jax/models/gpt2/medium/test_gpt2_medium.py
+++ b/tests/jax/models/gpt2/medium/test_gpt2_medium.py
@@ -11,7 +11,7 @@ from utils import record_model_test_properties, runtime_fail
 from ..tester import GPT2Tester
 
 MODEL_PATH = "openai-community/gpt2-medium"
-MODEL_NAME = MODEL_PATH.split("/")[1]
+MODEL_NAME = "gpt2-medium"
 
 
 # ----- Fixtures -----

--- a/tests/jax/models/gpt2/xl/test_gpt2_xl.py
+++ b/tests/jax/models/gpt2/xl/test_gpt2_xl.py
@@ -11,7 +11,7 @@ from utils import record_model_test_properties
 from ..tester import GPT2Tester
 
 MODEL_PATH = "openai-community/gpt2-xl"
-MODEL_NAME = MODEL_PATH.split("/")[1]
+MODEL_NAME = "gpt2-xl"
 
 
 # ----- Fixtures -----

--- a/tests/jax/models/gpt2/xl/test_gpt2_xl.py
+++ b/tests/jax/models/gpt2/xl/test_gpt2_xl.py
@@ -2,13 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
 
 import pytest
 from infra import ModelTester, RunMode
+from utils import record_model_test_properties
 
 from ..tester import GPT2Tester
 
 MODEL_PATH = "openai-community/gpt2-xl"
+MODEL_NAME = MODEL_PATH.split("/")[1]
 
 
 # ----- Fixtures -----
@@ -27,18 +30,23 @@ def training_tester() -> GPT2Tester:
 # ----- Tests -----
 
 
-# @pytest.mark.xfail(
-#    reason="Cannot get the device from a tensor with host storage (https://github.com/tenstorrent/tt-xla/issues/171)"
-# )
-@pytest.mark.skip(reason="OOMs in CI")
+@pytest.mark.skip(
+    reason="OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186)"
+)
 def test_gpt2_xl_inference(
     inference_tester: GPT2Tester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MODEL_NAME)
+
     inference_tester.test()
 
 
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_gpt2_xl_training(
     training_tester: GPT2Tester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MODEL_NAME)
+
     training_tester.test()

--- a/tests/jax/models/llama/openllama_3b_v2/test_openllama_3b_v2.py
+++ b/tests/jax/models/llama/openllama_3b_v2/test_openllama_3b_v2.py
@@ -11,7 +11,7 @@ from utils import record_model_test_properties
 from ..tester import LLamaTester
 
 MODEL_PATH = "openlm-research/open_llama_3b_v2"
-MODEL_NAME = MODEL_PATH.split("/")[1]
+MODEL_NAME = "open-llama-3b-v2"
 
 
 # ----- Fixtures -----

--- a/tests/jax/models/llama/openllama_3b_v2/test_openllama_3b_v2.py
+++ b/tests/jax/models/llama/openllama_3b_v2/test_openllama_3b_v2.py
@@ -2,12 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import pytest
 from infra import RunMode
+from utils import record_model_test_properties
 
 from ..tester import LLamaTester
 
 MODEL_PATH = "openlm-research/open_llama_3b_v2"
+MODEL_NAME = MODEL_PATH.split("/")[1]
 
 
 # ----- Fixtures -----
@@ -26,18 +30,23 @@ def training_tester() -> LLamaTester:
 # ----- Tests -----
 
 
-# @pytest.mark.xfail(reason="failed to legalize operation 'ttir.gather'")
 @pytest.mark.skip(
     reason="OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186)"
 )
 def test_openllama3b_inference(
     inference_tester: LLamaTester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MODEL_NAME)
+
     inference_tester.test()
 
 
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_openllama3b_training(
     training_tester: LLamaTester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MODEL_NAME)
+
     training_tester.test()

--- a/tests/jax/models/mlpmixer/test_mlpmixer.py
+++ b/tests/jax/models/mlpmixer/test_mlpmixer.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Dict, Sequence
+from typing import Any, Callable, Dict, Sequence
 
 import flax.traverse_util
 import fsspec
@@ -12,6 +12,7 @@ import numpy
 import pytest
 from flax import linen as nn
 from infra import ModelTester, RunMode
+from utils import record_model_test_properties, runtime_fail
 
 from .model_implementation import MlpMixer
 
@@ -88,17 +89,27 @@ def training_tester() -> MlpMixerTester:
 
 
 @pytest.mark.skip(
-    reason=(
+    reason=runtime_fail(
         "Statically allocated circular buffers in program 16 clash with L1 buffers "
         "on core range [(x=0,y=0) - (x=6,y=0)]. L1 buffer allocated at 475136 and "
         "static circular buffer region ends at 951136 "
         "(https://github.com/tenstorrent/tt-xla/issues/187)"
     )
 )  # segfault
-def test_mlpmixer_inference(inference_tester: MlpMixerTester):
+def test_mlpmixer_inference(
+    inference_tester: MlpMixerTester,
+    record_tt_xla_property: Callable,
+):
+    record_model_test_properties(record_tt_xla_property, MlpMixer.__qualname__)
+
     inference_tester.test()
 
 
 @pytest.mark.skip(reason="Support for training not implemented")
-def test_mlpmixer_training(training_tester: MlpMixerTester):
+def test_mlpmixer_training(
+    training_tester: MlpMixerTester,
+    record_tt_xla_property: Callable,
+):
+    record_model_test_properties(record_tt_xla_property, MlpMixer.__qualname__)
+
     training_tester.test()

--- a/tests/jax/models/mlpmixer/test_mlpmixer.py
+++ b/tests/jax/models/mlpmixer/test_mlpmixer.py
@@ -100,7 +100,7 @@ def test_mlpmixer_inference(
     inference_tester: MlpMixerTester,
     record_tt_xla_property: Callable,
 ):
-    record_model_test_properties(record_tt_xla_property, MlpMixer.__qualname__)
+    record_model_test_properties(record_tt_xla_property, "mlpmixer")
 
     inference_tester.test()
 
@@ -110,6 +110,6 @@ def test_mlpmixer_training(
     training_tester: MlpMixerTester,
     record_tt_xla_property: Callable,
 ):
-    record_model_test_properties(record_tt_xla_property, MlpMixer.__qualname__)
+    record_model_test_properties(record_tt_xla_property, "mlpmixer")
 
     training_tester.test()

--- a/tests/jax/models/mnist/cnn/dropout/test_mnist_cnn_dropout.py
+++ b/tests/jax/models/mnist/cnn/dropout/test_mnist_cnn_dropout.py
@@ -2,9 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
 
 import pytest
 from infra import RunMode
+from utils import record_model_test_properties
 
 from ..tester import MNISTCNNTester
 from .model_implementation import MNISTCNNDropoutModel
@@ -27,12 +29,22 @@ def training_tester() -> MNISTCNNTester:
 
 def test_mnist_cnn_dropout_inference(
     inference_tester: MNISTCNNTester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(
+        record_tt_xla_property, MNISTCNNDropoutModel.__qualname__
+    )
+
     inference_tester.test()
 
 
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_mnist_cnn_nodropout_training(
     training_tester: MNISTCNNTester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(
+        record_tt_xla_property, MNISTCNNDropoutModel.__qualname__
+    )
+
     training_tester.test()

--- a/tests/jax/models/mnist/cnn/dropout/test_mnist_cnn_dropout.py
+++ b/tests/jax/models/mnist/cnn/dropout/test_mnist_cnn_dropout.py
@@ -31,9 +31,7 @@ def test_mnist_cnn_dropout_inference(
     inference_tester: MNISTCNNTester,
     record_tt_xla_property: Callable,
 ):
-    record_model_test_properties(
-        record_tt_xla_property, MNISTCNNDropoutModel.__qualname__
-    )
+    record_model_test_properties(record_tt_xla_property, "mnist-cnn-dropout")
 
     inference_tester.test()
 
@@ -43,8 +41,6 @@ def test_mnist_cnn_nodropout_training(
     training_tester: MNISTCNNTester,
     record_tt_xla_property: Callable,
 ):
-    record_model_test_properties(
-        record_tt_xla_property, MNISTCNNDropoutModel.__qualname__
-    )
+    record_model_test_properties(record_tt_xla_property, "mnist-cnn-dropout")
 
     training_tester.test()

--- a/tests/jax/models/mnist/cnn/nodropout/test_mnist_cnn_nodropout.py
+++ b/tests/jax/models/mnist/cnn/nodropout/test_mnist_cnn_nodropout.py
@@ -31,9 +31,7 @@ def test_mnist_cnn_nodropout_inference(
     inference_tester: MNISTCNNTester,
     record_tt_xla_property: Callable,
 ):
-    record_model_test_properties(
-        record_tt_xla_property, MNISTCNNNoDropoutModel.__qualname__
-    )
+    record_model_test_properties(record_tt_xla_property, "mnist-cnn-nodropout")
 
     inference_tester.test()
 
@@ -43,8 +41,6 @@ def test_mnist_cnn_nodropout_training(
     training_tester: MNISTCNNTester,
     record_tt_xla_property: Callable,
 ):
-    record_model_test_properties(
-        record_tt_xla_property, MNISTCNNNoDropoutModel.__qualname__
-    )
+    record_model_test_properties(record_tt_xla_property, "mnist-cnn-nodropout")
 
     training_tester.test()

--- a/tests/jax/models/mnist/cnn/nodropout/test_mnist_cnn_nodropout.py
+++ b/tests/jax/models/mnist/cnn/nodropout/test_mnist_cnn_nodropout.py
@@ -2,9 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
 
 import pytest
 from infra import RunMode
+from utils import record_model_test_properties
 
 from ..tester import MNISTCNNTester
 from .model_implementation import MNISTCNNNoDropoutModel
@@ -27,12 +29,22 @@ def training_tester() -> MNISTCNNTester:
 
 def test_mnist_cnn_nodropout_inference(
     inference_tester: MNISTCNNTester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(
+        record_tt_xla_property, MNISTCNNNoDropoutModel.__qualname__
+    )
+
     inference_tester.test()
 
 
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_mnist_cnn_nodropout_training(
     training_tester: MNISTCNNTester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(
+        record_tt_xla_property, MNISTCNNNoDropoutModel.__qualname__
+    )
+
     training_tester.test()

--- a/tests/jax/models/mnist/mlp/test_mnist_mlp.py
+++ b/tests/jax/models/mnist/mlp/test_mnist_mlp.py
@@ -76,18 +76,19 @@ def training_tester(request) -> MNISTMLPTester:
         (256, 128, 64),
     ],
     indirect=True,
+    ids=lambda val: f"{val}",
 )
-def test_mnist_inference(
+def test_mnist_mlp_inference(
     inference_tester: MNISTMLPTester,
     record_tt_xla_property: Callable,
 ):
-    record_model_test_properties(record_tt_xla_property, MNISTMLPModel.__qualname__)
+    record_model_test_properties(record_tt_xla_property, "mnist-mlp")
 
     inference_tester.test()
 
 
 @pytest.mark.skip(reason="Support for training not implemented")
-def test_mnist_training(
+def test_mnist_mlp_training(
     training_tester: MNISTMLPTester,
     record_tt_xla_property: Callable,
 ):

--- a/tests/jax/models/mnist/mlp/test_mnist_mlp.py
+++ b/tests/jax/models/mnist/mlp/test_mnist_mlp.py
@@ -2,12 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Sequence
+from typing import Callable, Sequence
 
 import jax
 import pytest
 from flax import linen as nn
 from infra import ComparisonConfig, ModelTester, RunMode
+from utils import record_model_test_properties
 
 from .model_implementation import MNISTMLPModel
 
@@ -78,12 +79,18 @@ def training_tester(request) -> MNISTMLPTester:
 )
 def test_mnist_inference(
     inference_tester: MNISTMLPTester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MNISTMLPModel.__qualname__)
+
     inference_tester.test()
 
 
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_mnist_training(
     training_tester: MNISTMLPTester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MNISTMLPModel.__qualname__)
+
     training_tester.test()

--- a/tests/jax/models/roberta/base/test_roberta_base.py
+++ b/tests/jax/models/roberta/base/test_roberta_base.py
@@ -2,12 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import pytest
 from infra import RunMode
+from utils import record_model_test_properties, runtime_fail
 
 from ..tester import FlaxRobertaForMaskedLMTester
 
 MODEL_PATH = "FacebookAI/roberta-base"
+MODEL_NAME = MODEL_PATH.split("/")[1]
 
 
 # ----- Fixtures -----
@@ -27,16 +31,25 @@ def training_tester() -> FlaxRobertaForMaskedLMTester:
 
 
 @pytest.mark.xfail(
-    reason="Cannot get the device from a tensor with host storage (https://github.com/tenstorrent/tt-xla/issues/171)"
+    reason=runtime_fail(
+        "Cannot get the device from a tensor with host storage "
+        "(https://github.com/tenstorrent/tt-xla/issues/171)"
+    )
 )
 def test_flax_roberta_base_inference(
     inference_tester: FlaxRobertaForMaskedLMTester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MODEL_NAME)
+
     inference_tester.test()
 
 
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_flax_roberta_base_training(
     training_tester: FlaxRobertaForMaskedLMTester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MODEL_NAME)
+
     training_tester.test()

--- a/tests/jax/models/roberta/base/test_roberta_base.py
+++ b/tests/jax/models/roberta/base/test_roberta_base.py
@@ -11,7 +11,7 @@ from utils import record_model_test_properties, runtime_fail
 from ..tester import FlaxRobertaForMaskedLMTester
 
 MODEL_PATH = "FacebookAI/roberta-base"
-MODEL_NAME = MODEL_PATH.split("/")[1]
+MODEL_NAME = "roberta-base"
 
 
 # ----- Fixtures -----

--- a/tests/jax/models/roberta/large/test_roberta_large.py
+++ b/tests/jax/models/roberta/large/test_roberta_large.py
@@ -2,13 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import pytest
 from infra import RunMode
+from utils import record_model_test_properties, runtime_fail
 
 from ..tester import FlaxRobertaForMaskedLMTester
 
 MODEL_PATH = "FacebookAI/roberta-large"
-
+MODEL_NAME = MODEL_PATH.split("/")[1]
 
 # ----- Fixtures -----
 
@@ -27,16 +30,25 @@ def training_tester() -> FlaxRobertaForMaskedLMTester:
 
 
 @pytest.mark.xfail(
-    reason="Cannot get the device from a tensor with host storage (https://github.com/tenstorrent/tt-xla/issues/171)"
+    reason=runtime_fail(
+        "Cannot get the device from a tensor with host storage "
+        "(https://github.com/tenstorrent/tt-xla/issues/171)"
+    )
 )
 def test_flax_roberta_large_inference(
     inference_tester: FlaxRobertaForMaskedLMTester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MODEL_NAME)
+
     inference_tester.test()
 
 
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_flax_roberta_large_training(
     training_tester: FlaxRobertaForMaskedLMTester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MODEL_NAME)
+
     training_tester.test()

--- a/tests/jax/models/roberta/large/test_roberta_large.py
+++ b/tests/jax/models/roberta/large/test_roberta_large.py
@@ -11,7 +11,7 @@ from utils import record_model_test_properties, runtime_fail
 from ..tester import FlaxRobertaForMaskedLMTester
 
 MODEL_PATH = "FacebookAI/roberta-large"
-MODEL_NAME = MODEL_PATH.split("/")[1]
+MODEL_NAME = "roberta-large"
 
 # ----- Fixtures -----
 

--- a/tests/jax/models/squeezebert/test_squeezebert.py
+++ b/tests/jax/models/squeezebert/test_squeezebert.py
@@ -16,7 +16,7 @@ from utils import compile_fail, record_model_test_properties
 from .model_implementation import SqueezeBertConfig, SqueezeBertForMaskedLM
 
 MODEL_PATH = "squeezebert/squeezebert-uncased"
-MODEL_NAME = MODEL_PATH.split("/")[1]
+MODEL_NAME = "squeezebert"
 
 # ----- Tester -----
 

--- a/tests/jax/models/squeezebert/test_squeezebert.py
+++ b/tests/jax/models/squeezebert/test_squeezebert.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict, Sequence
+from typing import Callable, Dict, Sequence
 
 import jax
 import pytest
@@ -11,10 +11,12 @@ from flax import linen as nn
 from huggingface_hub import hf_hub_download
 from infra import ModelTester, RunMode
 from transformers import AutoTokenizer
+from utils import compile_fail, record_model_test_properties
 
 from .model_implementation import SqueezeBertConfig, SqueezeBertForMaskedLM
 
 MODEL_PATH = "squeezebert/squeezebert-uncased"
+MODEL_NAME = MODEL_PATH.split("/")[1]
 
 # ----- Tester -----
 
@@ -73,15 +75,23 @@ def training_tester() -> SqueezeBertTester:
 # ----- Tests -----
 
 
-@pytest.mark.xfail(reason="failed to legalize operation 'ttir.convolution'")
+@pytest.mark.xfail(
+    reason=compile_fail("Failed to legalize operation 'ttir.convolution'")
+)
 def test_squeezebert_inference(
     inference_tester: SqueezeBertTester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MODEL_NAME)
+
     inference_tester.test()
 
 
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_squeezebert_training(
     training_tester: SqueezeBertTester,
+    record_tt_xla_property: Callable,
 ):
+    record_model_test_properties(record_tt_xla_property, MODEL_NAME)
+
     training_tester.test()

--- a/tests/jax/ops/test_abs.py
+++ b/tests/jax/ops/test_abs.py
@@ -2,16 +2,25 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import jax
 import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
+from utils import record_unary_op_test_properties
 
 
-@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)])
-def test_abs(x_shape: tuple):
+@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)], ids=lambda val: f"{val}")
+def test_abs(x_shape: tuple, record_tt_xla_property: Callable):
     def abs(x: jax.Array) -> jax.Array:
         return jnp.abs(x)
+
+    record_unary_op_test_properties(
+        record_tt_xla_property,
+        "jax.numpy.abs",
+        "stablehlo.abs",
+    )
 
     # Test both negative and positive values.
     run_op_test_with_random_inputs(abs, [x_shape], minval=-5.0, maxval=5.0)

--- a/tests/jax/ops/test_add.py
+++ b/tests/jax/ops/test_add.py
@@ -2,10 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import jax
 import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
+from utils import record_binary_op_test_properties
 
 
 @pytest.mark.parametrize(
@@ -14,9 +17,16 @@ from infra import run_op_test_with_random_inputs
         [(32, 32), (32, 32)],
         [(64, 64), (64, 64)],
     ],
+    ids=lambda val: f"{val}",
 )
-def test_add(x_shape: tuple, y_shape: tuple):
+def test_add(x_shape: tuple, y_shape: tuple, record_tt_xla_property: Callable):
     def add(x: jax.Array, y: jax.Array) -> jax.Array:
         return jnp.add(x, y)
+
+    record_binary_op_test_properties(
+        record_tt_xla_property,
+        "jax.numpy.add",
+        "stablehlo.add",
+    )
 
     run_op_test_with_random_inputs(add, [x_shape, y_shape])

--- a/tests/jax/ops/test_broadcast_in_dim.py
+++ b/tests/jax/ops/test_broadcast_in_dim.py
@@ -2,17 +2,27 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
+import jax
 import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
+from utils import record_unary_op_test_properties
 
 
-@pytest.mark.parametrize("input_shapes", [[(2, 1)]])
+@pytest.mark.parametrize("input_shapes", [[(2, 1)]], ids=lambda val: f"{val}")
 @pytest.mark.xfail(
     reason="AssertionError: Atol comparison failed. Calculated: atol=0.804124116897583. Required: atol=0.16"
 )
-def test_broadcast_in_dim(input_shapes):
-    def broadcast(a):
+def test_broadcast_in_dim(input_shapes: tuple, record_tt_xla_property: Callable):
+    def broadcast(a: jax.Array):
         return jnp.broadcast_to(a, (2, 4))
+
+    record_unary_op_test_properties(
+        record_tt_xla_property,
+        "jax.numpy.broadcast_to",
+        "stablehlo.broadcast_in_dim",
+    )
 
     run_op_test_with_random_inputs(broadcast, input_shapes)

--- a/tests/jax/ops/test_cbrt.py
+++ b/tests/jax/ops/test_cbrt.py
@@ -2,15 +2,24 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import jax
 import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
+from utils import record_unary_op_test_properties
 
 
-@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)])
-def test_cbrt(x_shape: tuple):
+@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)], ids=lambda val: f"{val}")
+def test_cbrt(x_shape: tuple, record_tt_xla_property: Callable):
     def cbrt(x: jax.Array) -> jax.Array:
         return jnp.cbrt(x)
+
+    record_unary_op_test_properties(
+        record_tt_xla_property,
+        "jax.numpy.cbrt",
+        "stablehlo.cbrt",
+    )
 
     run_op_test_with_random_inputs(cbrt, [x_shape])

--- a/tests/jax/ops/test_concatenate.py
+++ b/tests/jax/ops/test_concatenate.py
@@ -2,10 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import jax
 import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
+from utils import record_binary_op_test_properties
 
 
 @pytest.mark.parametrize(
@@ -16,9 +19,18 @@ from infra import run_op_test_with_random_inputs
         [(32, 32, 32), (32, 32, 32), 2],
         [(64, 64, 64, 64), (64, 64, 64, 64), 3],
     ],
+    ids=lambda val: f"{val}",
 )
-def test_concatenate(x_shape: tuple, y_shape: tuple, axis: int):
+def test_concatenate(
+    x_shape: tuple, y_shape: tuple, axis: int, record_tt_xla_property: Callable
+):
     def concat(x: jax.Array, y: jax.Array) -> jax.Array:
         return jnp.concatenate([x, y], axis=axis)
+
+    record_binary_op_test_properties(
+        record_tt_xla_property,
+        "jax.numpy.concatenate",
+        "stablehlo.concatenate",
+    )
 
     run_op_test_with_random_inputs(concat, [x_shape, y_shape])

--- a/tests/jax/ops/test_constant.py
+++ b/tests/jax/ops/test_constant.py
@@ -2,30 +2,54 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import jax.numpy as jnp
 import pytest
 from infra import run_op_test
+from utils import record_op_test_properties
 
 
-@pytest.mark.parametrize("shape", [(32, 32), (1, 1)])
-def test_constant_zeros(shape: tuple):
+@pytest.mark.parametrize("shape", [(32, 32), (1, 1)], ids=lambda val: f"{val}")
+def test_constant_zeros(shape: tuple, record_tt_xla_property: Callable):
     def module_constant_zeros():
         return jnp.zeros(shape)
+
+    record_op_test_properties(
+        record_tt_xla_property,
+        "Constant op",
+        "jax.numpy.zeros",
+        "stablehlo.constant",
+    )
 
     run_op_test(module_constant_zeros, [])
 
 
-@pytest.mark.parametrize("shape", [(32, 32), (1, 1)])
-def test_constant_ones(shape: tuple):
+@pytest.mark.parametrize("shape", [(32, 32), (1, 1)], ids=lambda val: f"{val}")
+def test_constant_ones(shape: tuple, record_tt_xla_property: Callable):
     def module_constant_ones():
         return jnp.ones(shape)
+
+    record_op_test_properties(
+        record_tt_xla_property,
+        "Constant op",
+        "jax.numpy.ones",
+        "stablehlo.constant",
+    )
 
     run_op_test(module_constant_ones, [])
 
 
 @pytest.mark.xfail(reason="failed to legalize operation 'ttir.constant'")
-def test_constant_multi_value():
+def test_constant_multi_value(record_tt_xla_property: Callable):
     def module_constant_multi():
         return jnp.array([[1, 2], [3, 4]], dtype=jnp.float32)
+
+    record_op_test_properties(
+        record_tt_xla_property,
+        "Constant op",
+        "jax.numpy.array",
+        "stablehlo.constant",
+    )
 
     run_op_test(module_constant_multi, [])

--- a/tests/jax/ops/test_convert.py
+++ b/tests/jax/ops/test_convert.py
@@ -2,12 +2,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import jax
 import jax.lax as jlx
 import jax.numpy as jnp
 import pytest
 from infra import random_tensor, run_op_test
 from jax._src.typing import DTypeLike
+from utils import record_unary_op_test_properties
 
 
 # TODO we need to parametrize with all supported dtypes.
@@ -30,10 +33,20 @@ from jax._src.typing import DTypeLike
         "float64",
     ],
 )
-@pytest.mark.xfail(reason="https://github.com/tenstorrent/tt-xla/issues/206")
-def test_convert(from_dtype: DTypeLike, to_dtype: DTypeLike):
+@pytest.mark.skip(
+    f"Skipped unconditionally due to many fails. There is ongoing work on rewriting these tests."
+)
+def test_convert(
+    from_dtype: DTypeLike, to_dtype: DTypeLike, record_tt_xla_property: Callable
+):
     def convert(x: jax.Array) -> jax.Array:
         return jlx.convert_element_type(x, new_dtype=jnp.dtype(to_dtype))
+
+    record_unary_op_test_properties(
+        record_tt_xla_property,
+        "jax.lax.convert_element_type",
+        "stablehlo.convert",
+    )
 
     x_shape = (32, 32)  # Shape does not make any impact here, thus not parametrized.
     input = random_tensor(x_shape, dtype=from_dtype)

--- a/tests/jax/ops/test_divide.py
+++ b/tests/jax/ops/test_divide.py
@@ -2,10 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import jax
 import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
+from utils import record_binary_op_test_properties
 
 
 @pytest.mark.parametrize(
@@ -14,9 +17,14 @@ from infra import run_op_test_with_random_inputs
         [(32, 32), (32, 32)],
         [(64, 64), (64, 64)],
     ],
+    ids=lambda val: f"{val}",
 )
-def test_divide(x_shape: tuple, y_shape: tuple):
+def test_divide(x_shape: tuple, y_shape: tuple, record_tt_xla_property: Callable):
     def divide(x: jax.Array, y: jax.Array) -> jax.Array:
         return jnp.divide(x, y)
+
+    record_binary_op_test_properties(
+        record_tt_xla_property, "jax.numpy.divide", "stablehlo.divide"
+    )
 
     run_op_test_with_random_inputs(divide, [x_shape, y_shape])

--- a/tests/jax/ops/test_dot_general.py
+++ b/tests/jax/ops/test_dot_general.py
@@ -2,10 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import jax
-import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
+from utils import record_binary_op_test_properties
 
 
 # Tests for dot_general op where vectors containing indices of contracting dimensions
@@ -19,10 +21,17 @@ from infra import run_op_test_with_random_inputs
         [(2, 32, 64), (2, 32, 64)],
         [(2, 16, 32, 64), (2, 16, 64, 32)],
     ],
+    ids=lambda val: f"{val}",
 )
-def test_dot_general_common(x_shape: tuple, y_shape: tuple):
+def test_dot_general_common(
+    x_shape: tuple, y_shape: tuple, record_tt_xla_property: Callable
+):
     def dot_general(x: jax.Array, y: jax.Array) -> jax.Array:
         return jax.lax.dot_general(x, y, dimension_numbers=((1, 1), (0, 0)))
+
+    record_binary_op_test_properties(
+        record_tt_xla_property, "jax.lax.dot_general", "stablehlo.dot_general"
+    )
 
     run_op_test_with_random_inputs(dot_general, [x_shape, y_shape])
 
@@ -35,9 +44,15 @@ def test_dot_general_common(x_shape: tuple, y_shape: tuple):
         [(2, 32, 64), (2, 64, 64)],
     ],
 )
-def test_dot_general_matmul(x_shape: tuple, y_shape: tuple):
+def test_dot_general_matmul(
+    x_shape: tuple, y_shape: tuple, record_tt_xla_property: Callable
+):
     def dot_general(x: jax.Array, y: jax.Array) -> jax.Array:
         return jax.lax.dot_general(x, y, dimension_numbers=((2, 1), (0, 0)))
+
+    record_binary_op_test_properties(
+        record_tt_xla_property, "jax.lax.dot_general", "stablehlo.dot_general"
+    )
 
     run_op_test_with_random_inputs(dot_general, [x_shape, y_shape])
 
@@ -51,8 +66,14 @@ def test_dot_general_matmul(x_shape: tuple, y_shape: tuple):
         [(2, 8, 8, 16), (2, 8, 16, 8)],
     ],
 )
-def test_dot_general_multiple_contract(x_shape: tuple, y_shape: tuple):
+def test_dot_general_multiple_contract(
+    x_shape: tuple, y_shape: tuple, record_tt_xla_property: Callable
+):
     def dot_general(x: jax.Array, y: jax.Array) -> jax.Array:
         return jax.lax.dot_general(x, y, dimension_numbers=(((1, 3), (1, 2)), (0, 0)))
+
+    record_binary_op_test_properties(
+        record_tt_xla_property, "jax.lax.dot_general", "stablehlo.dot_general"
+    )
 
     run_op_test_with_random_inputs(dot_general, [x_shape, y_shape])

--- a/tests/jax/ops/test_exponential.py
+++ b/tests/jax/ops/test_exponential.py
@@ -2,15 +2,24 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import jax
 import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
+from utils import record_unary_op_test_properties
 
 
-@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)])
-def test_exponential(x_shape: tuple):
+@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)], ids=lambda val: f"{val}")
+def test_exponential(x_shape: tuple, record_tt_xla_property: Callable):
     def exponential(x: jax.Array) -> jax.Array:
         return jnp.exp(x)
+
+    record_unary_op_test_properties(
+        record_tt_xla_property,
+        "jax.numpy.exp",
+        "stablehlo.exponential",
+    )
 
     run_op_test_with_random_inputs(exponential, [x_shape])

--- a/tests/jax/ops/test_exponential_minus_one.py
+++ b/tests/jax/ops/test_exponential_minus_one.py
@@ -2,10 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import jax
 import jax.numpy as jnp
 import pytest
 from infra import ComparisonConfig, run_op_test_with_random_inputs
+from utils import record_unary_op_test_properties
 
 
 @pytest.fixture
@@ -20,10 +23,20 @@ def comparison_config() -> ComparisonConfig:
     return config
 
 
-@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)])
-def test_exponential_minus_one(x_shape: tuple, comparison_config: ComparisonConfig):
+@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)], ids=lambda val: f"{val}")
+def test_exponential_minus_one(
+    x_shape: tuple,
+    comparison_config: ComparisonConfig,
+    record_tt_xla_property: Callable,
+):
     def expm1(x: jax.Array) -> jax.Array:
         return jnp.expm1(x)
+
+    record_unary_op_test_properties(
+        record_tt_xla_property,
+        "jax.numpy.expm1",
+        "stablehlo.exponential_minus_one",
+    )
 
     run_op_test_with_random_inputs(
         expm1, [x_shape], comparison_config=comparison_config

--- a/tests/jax/ops/test_log_plus_one.py
+++ b/tests/jax/ops/test_log_plus_one.py
@@ -2,15 +2,24 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import jax
 import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
+from utils import record_unary_op_test_properties
 
 
-@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)])
-def test_log1p(x_shape: tuple):
+@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)], ids=lambda val: f"{val}")
+def test_log1p(x_shape: tuple, record_tt_xla_property: Callable):
     def log1p(x: jax.Array) -> jax.Array:
         return jnp.log1p(x)
+
+    record_unary_op_test_properties(
+        record_tt_xla_property,
+        "jax.numpy.log1p",
+        "stablehlo.log_plus_one",
+    )
 
     run_op_test_with_random_inputs(log1p, [x_shape])

--- a/tests/jax/ops/test_maximum.py
+++ b/tests/jax/ops/test_maximum.py
@@ -2,10 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import jax
 import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
+from utils import record_binary_op_test_properties
 
 
 @pytest.mark.parametrize(
@@ -14,9 +17,16 @@ from infra import run_op_test_with_random_inputs
         [(32, 32), (32, 32)],
         [(64, 64), (64, 64)],
     ],
+    ids=lambda val: f"{val}",
 )
-def test_maximum(x_shape: tuple, y_shape: tuple):
+def test_maximum(x_shape: tuple, y_shape: tuple, record_tt_xla_property: Callable):
     def maximum(x: jax.Array, y: jax.Array) -> jax.Array:
         return jnp.maximum(x, y)
+
+    record_binary_op_test_properties(
+        record_tt_xla_property,
+        "jax.numpy.maximum",
+        "stablehlo.maximum",
+    )
 
     run_op_test_with_random_inputs(maximum, [x_shape, y_shape])

--- a/tests/jax/ops/test_minimum.py
+++ b/tests/jax/ops/test_minimum.py
@@ -2,10 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import jax
 import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
+from utils import record_binary_op_test_properties
 
 
 @pytest.mark.parametrize(
@@ -14,9 +17,16 @@ from infra import run_op_test_with_random_inputs
         [(32, 32), (32, 32)],
         [(64, 64), (64, 64)],
     ],
+    ids=lambda val: f"{val}",
 )
-def test_minimum(x_shape: tuple, y_shape: tuple):
+def test_minimum(x_shape: tuple, y_shape: tuple, record_tt_xla_property: Callable):
     def minimum(x: jax.Array, y: jax.Array) -> jax.Array:
         return jnp.minimum(x, y)
+
+    record_binary_op_test_properties(
+        record_tt_xla_property,
+        "jax.numpy.minimum",
+        "stablehlo.minimum",
+    )
 
     run_op_test_with_random_inputs(minimum, [x_shape, y_shape])

--- a/tests/jax/ops/test_multiply.py
+++ b/tests/jax/ops/test_multiply.py
@@ -2,10 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import jax
 import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
+from utils import record_binary_op_test_properties
 
 
 @pytest.mark.parametrize(
@@ -14,9 +17,16 @@ from infra import run_op_test_with_random_inputs
         [(32, 32), (32, 32)],
         [(64, 64), (64, 64)],
     ],
+    ids=lambda val: f"{val}",
 )
-def test_multiply(x_shape: tuple, y_shape: tuple):
+def test_multiply(x_shape: tuple, y_shape: tuple, record_tt_xla_property: Callable):
     def multiply(x: jax.Array, y: jax.Array) -> jax.Array:
         return jnp.multiply(x, y)
+
+    record_binary_op_test_properties(
+        record_tt_xla_property,
+        "jax.numpy.multiply",
+        "stablehlo.multiply",
+    )
 
     run_op_test_with_random_inputs(multiply, [x_shape, y_shape])

--- a/tests/jax/ops/test_negate.py
+++ b/tests/jax/ops/test_negate.py
@@ -2,16 +2,25 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import jax
 import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
+from utils import record_unary_op_test_properties
 
 
-@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)])
-def test_negate(x_shape: tuple):
+@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)], ids=lambda val: f"{val}")
+def test_negate(x_shape: tuple, record_tt_xla_property: Callable):
     def negate(x: jax.Array) -> jax.Array:
         return jnp.negative(x)
+
+    record_unary_op_test_properties(
+        record_tt_xla_property,
+        "jax.numpy.negative",
+        "stablehlo.negate",
+    )
 
     # Trying both negative and positive values.
     run_op_test_with_random_inputs(negate, [x_shape], minval=-5.0, maxval=5.0)

--- a/tests/jax/ops/test_reduce.py
+++ b/tests/jax/ops/test_reduce.py
@@ -2,10 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import jax
 import jax.numpy as jnp
 import pytest
 from infra import ComparisonConfig, run_op_test_with_random_inputs
+from utils import record_op_test_properties
 
 
 # TODO investigate why this doesn't pass with default comparison config.
@@ -19,10 +22,21 @@ def comparison_config() -> ComparisonConfig:
 
 
 # TODO axis should be parametrized as well.
-@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)])
-def test_reduce_sum(x_shape: tuple, comparison_config: ComparisonConfig):
+@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)], ids=lambda val: f"{val}")
+def test_reduce_sum(
+    x_shape: tuple,
+    comparison_config: ComparisonConfig,
+    record_tt_xla_property: Callable,
+):
     def reduce_sum(x: jax.Array) -> jax.Array:
         return jnp.sum(x)
+
+    record_op_test_properties(
+        record_tt_xla_property,
+        "Reduce op",
+        "jax.numpy.sum",
+        "stablehlo.reduce{SUM}",
+    )
 
     run_op_test_with_random_inputs(
         reduce_sum, [x_shape], comparison_config=comparison_config
@@ -30,10 +44,21 @@ def test_reduce_sum(x_shape: tuple, comparison_config: ComparisonConfig):
 
 
 # TODO axis should be parametrized as well.
-@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)])
-def test_reduce_max(x_shape: tuple, comparison_config: ComparisonConfig):
+@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)], ids=lambda val: f"{val}")
+def test_reduce_max(
+    x_shape: tuple,
+    comparison_config: ComparisonConfig,
+    record_tt_xla_property: Callable,
+):
     def reduce_max(x: jax.Array) -> jax.Array:
         return jnp.max(x)
+
+    record_op_test_properties(
+        record_tt_xla_property,
+        "Reduce op",
+        "jax.numpy.max",
+        "stablehlo.reduce{MAX}",
+    )
 
     run_op_test_with_random_inputs(
         reduce_max, [x_shape], comparison_config=comparison_config

--- a/tests/jax/ops/test_remainder.py
+++ b/tests/jax/ops/test_remainder.py
@@ -2,10 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import jax
 import jax.lax as jlx
 import pytest
 from infra import run_op_test_with_random_inputs
+from utils import record_binary_op_test_properties
 
 
 @pytest.mark.parametrize(
@@ -14,9 +17,16 @@ from infra import run_op_test_with_random_inputs
         [(32, 32), (32, 32)],
         [(64, 64), (64, 64)],
     ],
+    ids=lambda val: f"{val}",
 )
-def test_remainder(x_shape: tuple, y_shape: tuple):
+def test_remainder(x_shape: tuple, y_shape: tuple, record_tt_xla_property: Callable):
     def remainder(x: jax.Array, y: jax.Array) -> jax.Array:
         return jlx.rem(x, y)
+
+    record_binary_op_test_properties(
+        record_tt_xla_property,
+        "jax.lax.rem",
+        "stablehlo.remainder",
+    )
 
     run_op_test_with_random_inputs(remainder, [x_shape, y_shape])

--- a/tests/jax/ops/test_reshape.py
+++ b/tests/jax/ops/test_reshape.py
@@ -2,10 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import jax
 import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
+from utils import record_unary_op_test_properties
 
 
 @pytest.mark.parametrize(
@@ -15,9 +18,16 @@ from infra import run_op_test_with_random_inputs
         ((8, 32, 32), (1, 2, 4, 32, 32)),
         ((8192, 128), (1, 256, 32, 128)),
     ],
+    ids=lambda val: f"{val}",
 )
-def test_reshape(in_shape: tuple, out_shape: tuple):
+def test_reshape(in_shape: tuple, out_shape: tuple, record_tt_xla_property: Callable):
     def reshape(x: jax.Array):
         return jnp.reshape(x, out_shape)
+
+    record_unary_op_test_properties(
+        record_tt_xla_property,
+        "jax.numpy.reshape",
+        "stablehlo.reshape",
+    )
 
     run_op_test_with_random_inputs(reshape, [in_shape])

--- a/tests/jax/ops/test_rsqrt.py
+++ b/tests/jax/ops/test_rsqrt.py
@@ -2,16 +2,25 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import jax
 import jax.lax as jlx
 import pytest
 from infra import run_op_test_with_random_inputs
+from utils import record_unary_op_test_properties
 
 
-@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)])
-def test_rsqrt(x_shape: tuple):
+@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)], ids=lambda val: f"{val}")
+def test_rsqrt(x_shape: tuple, record_tt_xla_property: Callable):
     def rsqrt(x: jax.Array) -> jax.Array:
         return jlx.rsqrt(x)
+
+    record_unary_op_test_properties(
+        record_tt_xla_property,
+        "jax.lax.rsqrt",
+        "stablehlo.rsqrt",
+    )
 
     # Input must be strictly positive because of sqrt(x).
     run_op_test_with_random_inputs(rsqrt, [x_shape], minval=0.1, maxval=10.0)

--- a/tests/jax/ops/test_sign.py
+++ b/tests/jax/ops/test_sign.py
@@ -2,16 +2,25 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import jax
 import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
+from utils import record_unary_op_test_properties
 
 
-@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)])
-def test_sign(x_shape: tuple):
+@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)], ids=lambda val: f"{val}")
+def test_sign(x_shape: tuple, record_tt_xla_property: Callable):
     def sign(x: jax.Array) -> jax.Array:
         return jnp.sign(x)
+
+    record_unary_op_test_properties(
+        record_tt_xla_property,
+        "jax.numpy.sign",
+        "stablehlo.sign",
+    )
 
     # Trying both negative and positive values.
     run_op_test_with_random_inputs(sign, [x_shape], minval=-5.0, maxval=5.0)

--- a/tests/jax/ops/test_sqrt.py
+++ b/tests/jax/ops/test_sqrt.py
@@ -2,16 +2,25 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import jax
 import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
+from utils import record_unary_op_test_properties
 
 
-@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)])
-def test_sqrt(x_shape: tuple):
+@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)], ids=lambda val: f"{val}")
+def test_sqrt(x_shape: tuple, record_tt_xla_property: Callable):
     def sqrt(x: jax.Array) -> jax.Array:
         return jnp.sqrt(x)
+
+    record_unary_op_test_properties(
+        record_tt_xla_property,
+        "jax.numpy.sqrt",
+        "stablehlo.sqrt",
+    )
 
     # Input must be strictly positive because of sqrt(x).
     run_op_test_with_random_inputs(sqrt, [x_shape], minval=0.1, maxval=10.0)

--- a/tests/jax/ops/test_subtract.py
+++ b/tests/jax/ops/test_subtract.py
@@ -2,10 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import jax
 import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
+from utils import record_binary_op_test_properties
 
 
 @pytest.mark.parametrize(
@@ -14,9 +17,16 @@ from infra import run_op_test_with_random_inputs
         [(32, 32), (32, 32)],
         [(64, 64), (64, 64)],
     ],
+    ids=lambda val: f"{val}",
 )
-def test_subtract(x_shape: tuple, y_shape: tuple):
+def test_subtract(x_shape: tuple, y_shape: tuple, record_tt_xla_property: Callable):
     def subtract(x: jax.Array, y: jax.Array) -> jax.Array:
         return jnp.subtract(x, y)
+
+    record_binary_op_test_properties(
+        record_tt_xla_property,
+        "jax.numpy.subtract",
+        "stablehlo.subtract",
+    )
 
     run_op_test_with_random_inputs(subtract, [x_shape, y_shape])

--- a/tests/jax/ops/test_transpose.py
+++ b/tests/jax/ops/test_transpose.py
@@ -2,15 +2,24 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Callable
+
 import jax
 import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
+from utils import record_unary_op_test_properties
 
 
-@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)])
-def test_transpose(x_shape: tuple):
+@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)], ids=lambda val: f"{val}")
+def test_transpose(x_shape: tuple, record_tt_xla_property: Callable):
     def transpose(x: jax.Array) -> jax.Array:
         return jnp.transpose(x)
+
+    record_unary_op_test_properties(
+        record_tt_xla_property,
+        "jax.numpy.transpose",
+        "stablehlo.transpose",
+    )
 
     run_op_test_with_random_inputs(transpose, [x_shape])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Callable
+
+from conftest import RecordProperties
+
+
+def compile_fail(reason: str) -> str:
+    return f"Compile failed: {reason}"
+
+
+def runtime_fail(reason: str) -> str:
+    return f"Runtime failed: {reason}"
+
+
+def record_unary_op_test_properties(
+    record_property: Callable, framework_op_name: str, op_name: str
+):
+    record_property(RecordProperties.OP_KIND.value, "Unary op")
+    record_property(RecordProperties.FRAMEWORK_OP_NAME.value, framework_op_name)
+    record_property(RecordProperties.OP_NAME.value, op_name)
+
+
+def record_binary_op_test_properties(
+    record_property: Callable, framework_op_name: str, op_name: str
+):
+    record_property(RecordProperties.OP_KIND.value, "Binary op")
+    record_property(RecordProperties.FRAMEWORK_OP_NAME.value, framework_op_name)
+    record_property(RecordProperties.OP_NAME.value, op_name)
+
+
+def record_op_test_properties(
+    record_property: Callable, op_kind: str, framework_op_name: str, op_name: str
+):
+    record_property(RecordProperties.OP_KIND.value, op_kind)
+    record_property(RecordProperties.FRAMEWORK_OP_NAME.value, framework_op_name)
+    record_property(RecordProperties.OP_NAME.value, op_name)
+
+
+def record_model_test_properties(record_property: Callable, model_name: str):
+    record_property(RecordProperties.MODEL_NAME.value, model_name)


### PR DESCRIPTION
- Recorded relevant properties of op and model tests
- Added compile/runtime fail to xfail/skip messages of model inference tests
- Split test_compare into multiple functions
- Added lambda function in each parametrization to generate more informative test descriptions (instead of `some_test[xshape0-yshape0]` it will report `some_test[(32, 32)-(32, 32)]`).