### PR TITLE
Add option to override tt-mlir version

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -246,7 +246,7 @@ jobs:
         report_paths: ${{ steps.strings.outputs.test_report_path }}
         check_name: TT-XLA Tests
         comment: true
-        updateComment: false
+        updateComment: true
         detailed_summary: true
         group_suite: true
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,7 +2,22 @@ name: Build and Test
 
 on:
   workflow_dispatch:
+    inputs:
+      mlir_override:
+        description: 'Git SHA of commit in tenstorrent/tt-mlir'
+        required: false
+        type: string
   workflow_call:
+    inputs:
+      mlir_override:
+        description: 'Git SHA of commit in tenstorrent/tt-mlir'
+        required: false
+        type: string
+
+permissions:
+  packages: write
+  checks: write
+  pull-requests: write
 
 jobs:
   # build-ttxla:
@@ -144,6 +159,13 @@ jobs:
         submodules: recursive
         lfs: true
 
+    - name: Override tt-mlir SHA mlir_override is set
+      if: ${{ inputs.mlir_override }}
+      shell: bash
+      run: |
+          # Update the CMakeLists.txt file with the new SHA
+          sed -i "s/set(TT_MLIR_VERSION \".*\")/set(TT_MLIR_VERSION \"${{ inputs.mlir_override }}\")/" third_party/CMakeLists.txt
+
     - name: Set reusable strings
       id: strings
       shell: bash
@@ -187,6 +209,21 @@ jobs:
         cmake --build ${{ steps.strings.outputs.build-output-dir }}
         cmake --install ${{ steps.strings.outputs.build-output-dir }}
 
+    - name: Verify tt-mlir SHA override
+      if: ${{ inputs.mlir_override }}
+      continue-on-error: true
+      shell: bash
+      run: |
+          cd third_party/tt-mlir
+          branch_name=$(git rev-parse --abbrev-ref HEAD)
+          commit_sha=$(git rev-parse HEAD)
+          commit_title=$(git log -1 --pretty=%s)
+          echo "Branch name: $branch_name"
+          echo "Commit SHA: $commit_sha"
+          echo "Commit title: $commit_title"
+          echo "::notice::Using tt-mlir: $branch_name, commit: $commit_sha, title: $commit_title"
+          cd ../..
+
     - name: Run tests
       shell: bash
       run: |
@@ -203,11 +240,15 @@ jobs:
         path: ${{ steps.strings.outputs.test_report_path }}
 
     - name: Show Test Report
-      uses: mikepenz/action-junit-report@v4
+      uses: mikepenz/action-junit-report@v5
       if: success() || failure()
       with:
         report_paths: ${{ steps.strings.outputs.test_report_path }}
         check_name: TT-XLA Tests
+        comment: true
+        updateComment: false
+        detailed_summary: true
+        group_suite: true
 
     - name: Prepare code coverage report
       run: |

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -2,6 +2,11 @@ name: On PR
 
 on:
   workflow_dispatch:
+    inputs:
+      mlir_override:
+        description: 'Git SHA of commit in tenstorrent/tt-mlir'
+        required: false
+        type: string
   pull_request:
     branches: [ "main" ]
 
@@ -20,3 +25,5 @@ jobs:
     needs: [pre-commit, spdx]
     uses: ./.github/workflows/build-and-test.yml
     secrets: inherit
+    with:
+      mlir_override: ${{ inputs.mlir_override }}


### PR DESCRIPTION
Add option to override tt-mlir version during CI run

- Add option to override tt-mlir version
- Add workflow call and workflow dispatch inputs
- Override and verify tt-mlir version during build and test

In addition to that, update rest reports:

- Update test report action to v5
- Show test report details on failure
- Show test report in PR comments