### PR TITLE
Correct the tt-mlir path in get-docker-tag.sh

### DIFF
--- a/.github/get-docker-tag.sh
+++ b/.github/get-docker-tag.sh
@@ -11,13 +11,15 @@ set -e
 
 # Execute this in a separate bash process
 (
-    # Read tt-mlir version from third_party/CMakeLists.txt and clone third_party/tt-mlir
+    # Read tt-mlir version from third_party/CMakeLists.txt
+    # clone tt-mlir version to tmp/third_party/tt-mlir
     # Get the MLIR docker tag
+    TT_MLIR_PATH=third_party/tt-mlir/src/tt-mlir
     TT_MLIR_VERSION=$(grep -oP 'set\(TT_MLIR_VERSION "\K[^"]+' third_party/CMakeLists.txt)
-    if [ ! -d "third_party/tt-mlir" ]; then
-        git clone https://github.com/tenstorrent/tt-mlir.git third_party/tt-mlir --quiet
+    if [ ! -d $TT_MLIR_PATH ]; then
+        git clone https://github.com/tenstorrent/tt-mlir.git $TT_MLIR_PATH --quiet
     fi
-    cd third_party/tt-mlir
+    cd $TT_MLIR_PATH
     git fetch --quiet
     git checkout $TT_MLIR_VERSION --quiet
     if [ -f ".github/get-docker-tag.sh" ]; then
@@ -25,7 +27,6 @@ set -e
     else
         MLIR_DOCKER_TAG="default-tag"
     fi
-    cd ../..
 )
 
 DOCKERFILE_HASH_FILES=".github/Dockerfile.base .github/Dockerfile.ci"

--- a/.github/get-docker-tag.sh
+++ b/.github/get-docker-tag.sh
@@ -8,9 +8,7 @@
 
 # Exit immediately if a command exits with a non-zero status
 set -e
-
-# Execute this in a separate bash process
-(
+MLIR_DOCKER_TAG=$(
     # Read tt-mlir version from third_party/CMakeLists.txt
     # clone tt-mlir version to tmp/third_party/tt-mlir
     # Get the MLIR docker tag
@@ -23,12 +21,11 @@ set -e
     git fetch --quiet
     git checkout $TT_MLIR_VERSION --quiet
     if [ -f ".github/get-docker-tag.sh" ]; then
-        MLIR_DOCKER_TAG=$(.github/get-docker-tag.sh)
+        .github/get-docker-tag.sh
     else
-        MLIR_DOCKER_TAG="default-tag"
+        echo "default-tag"
     fi
 )
-
-DOCKERFILE_HASH_FILES=".github/Dockerfile.base .github/Dockerfile.ci"
-DOCKERFILE_HASH=$( (echo $MLIR_DOCKER_TAG; sha256sum $DOCKERFILE_HASH_FILES) | sha256sum | cut -d ' ' -f 1)
-echo dt-$DOCKERFILE_HASH
+DOCKERFILE_HASH=$( (cat .github/Dockerfile.base .github/Dockerfile.ci | sha256sum) | cut -d ' ' -f 1)
+COMBINED_HASH=$( (echo $DOCKERFILE_HASH $MLIR_DOCKER_TAG | sha256sum) | cut -d ' ' -f 1)
+echo dt-$COMBINED_HASH

--- a/.github/get-docker-tag.sh
+++ b/.github/get-docker-tag.sh
@@ -12,7 +12,7 @@ MLIR_DOCKER_TAG=$(
     # Read tt-mlir version from third_party/CMakeLists.txt
     # clone tt-mlir version to tmp/third_party/tt-mlir
     # Get the MLIR docker tag
-    TT_MLIR_PATH=third_party/tt-mlir/src/tt-mlir
+    TT_MLIR_PATH=tmp/third_party/tt-mlir
     TT_MLIR_VERSION=$(grep -oP 'set\(TT_MLIR_VERSION "\K[^"]+' third_party/CMakeLists.txt)
     if [ ! -d $TT_MLIR_PATH ]; then
         git clone https://github.com/tenstorrent/tt-mlir.git $TT_MLIR_PATH --quiet


### PR DESCRIPTION
Script get-docker-tag.sh was incorrectly generating docker tag, it didn't take into account tt-mlir docker tag change.
Correct the path to match path where cmake ExternalProject_Add clones tt-mlir to gix the docker tag.