### PR TITLE
Uplift mlir and add shardy to dependencies

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -40,8 +40,10 @@ target_include_directories(TTPJRTCommon PUBLIC
     ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/src/tt-mlir/include
     ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/src/tt-mlir/runtime/include
     ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/src/tt-mlir-build/stablehlo/
+    ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/src/tt-mlir-build/shardy/
     ${TTMLIR_TOOLCHAIN_DIR}/include
     ${TTMLIR_TOOLCHAIN_DIR}/src/stablehlo
+    ${TTMLIR_TOOLCHAIN_DIR}/src/shardy
 )
 
 set(STABLEHLO_LIBS
@@ -98,6 +100,8 @@ StablehloReferenceAxes
 StablehloReferenceNumPy
 StablehloReferenceScope
 StablehloReferenceValue
+SdyDialect
+SdyRegister
 )
 
 target_link_libraries(TTPJRTCommon PUBLIC

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set(TT_MLIR_VERSION "ad93092841542d104b8bacba6b92d97678ccd94e")
+set(TT_MLIR_VERSION "73efb5cd3e25215d3ee23c5af39c0b5dfe200a28")
 set(LOGURU_VERSION "4adaa185883e3c04da25913579c451d3c32cfac1")
 
 if (TOOLCHAIN STREQUAL "ON")


### PR DESCRIPTION
### Ticket


### Problem description
tt-xla fails to build with newer tt-mlir versions that depend on shardy

### What's changed
This PR updates cmake files to correctly include shardy. 

### Checklist
- [X] New/Existing tests provide coverage for changes
