### PR TITLE
Adding nightly test run

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,11 +7,24 @@ on:
         description: 'Git SHA of commit in tenstorrent/tt-mlir'
         required: false
         type: string
+      test_mark:
+        description: 'Test mark to run'
+        required: true
+        default: 'push'
+        type: choice
+        options:
+          - push
+          - nightly
   workflow_call:
     inputs:
       mlir_override:
         description: 'Git SHA of commit in tenstorrent/tt-mlir'
         required: false
+        type: string
+      test_mark:
+        description: 'Test mark to run'
+        required: false
+        default: 'push'
         type: string
 
 permissions:

--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -1,0 +1,13 @@
+name: On nightly
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  build-and-test:
+    uses: ./.github/workflows/build-and-test.yml
+    secrets: inherit
+    with:
+      test_mark: 'nightly'


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Adding nightly test run. For start it will run all tests same as PR workflow. Later we can add test marks and label tests as push or nightly to select which test group executes in a workflow. See https://github.com/tenstorrent/tt-forge-fe/blob/main/pytest.ini and https://github.com/tenstorrent/tt-forge-fe/blob/main/.github/workflows/build-and-test.yml

### What's changed
Added nightly run scheduled workflow
Added test_mark inputs for 'Build and Test' workflow

### Checklist
- [x] New/Existing tests provide coverage for changes
