### PR TITLE
Refactoring of ModuleBuilder class

### DIFF
--- a/inc/common/pjrt_implementation/client_instance.h
+++ b/inc/common/pjrt_implementation/client_instance.h
@@ -55,11 +55,6 @@ public:
     return cached_platform_version_;
   }
 
-  // Checks if the output on the i-th index is a scalar.
-  bool isOutputScalar(const size_t index) const {
-    return module_builder_->isOutputScalar(index);
-  }
-
   // Compiles.
   // See TODOs in PJRT_Client_Compile.
   PJRT_Error *

--- a/inc/common/pjrt_implementation/executable_image.h
+++ b/inc/common/pjrt_implementation/executable_image.h
@@ -33,38 +33,38 @@ public:
   }
   static void BindApi(PJRT_Api *api);
 
-  void AddRef() { ref_count.fetch_add(1); }
+  void AddRef() { m_ref_count.fetch_add(1); }
   void DecRef() {
-    if (ref_count.fetch_sub(1) == 0) {
+    if (m_ref_count.fetch_sub(1) == 0) {
       delete this;
     }
   }
 
-  const size_t get_arg_count() const { return arg_count; }
+  const size_t get_arg_count() const { return m_arg_count; }
 
-  const size_t get_result_count() const { return result_count; }
+  const size_t get_result_count() const { return m_result_count; }
 
-  const tt::runtime::Binary &get_binary() const { return binary; }
+  const tt::runtime::Binary &get_binary() const { return m_binary; }
 
-  const std::string &get_code() const { return code; }
+  const std::string &get_code() const { return m_code; }
 
   bool isOutputScalar(size_t index) const;
 
 private:
   // The reference count. Must be disposed when reaching zero.
-  std::atomic<int> ref_count;
+  std::atomic<int> m_ref_count;
 
   // Raw compiler output.
-  tt::runtime::Binary binary;
+  tt::runtime::Binary m_binary;
 
   // Original code fed to the compiler. Stored for debugging.
-  const std::string code;
+  const std::string m_code;
 
-  size_t arg_count;
-  size_t result_count;
+  size_t m_arg_count;
+  size_t m_result_count;
 
   // For every output, holds if the type is a scalar or not.
-  std::vector<bool> is_output_scalar;
+  std::vector<bool> m_is_output_scalar;
 };
 
 } // namespace tt::pjrt

--- a/inc/common/pjrt_implementation/executable_image.h
+++ b/inc/common/pjrt_implementation/executable_image.h
@@ -12,6 +12,7 @@
 #include <memory>
 #include <string>
 
+#include "tt/runtime/types.h"
 #include "xla/pjrt/c/pjrt_c_api.h"
 
 #ifndef TT_XLA_INC_COMMON_PJRT_IMPLEMENTATION_EXECUTABLE_IMAGE_H_
@@ -22,10 +23,10 @@ namespace tt::pjrt {
 class ExecutableImage {
 
 public:
-  ExecutableImage(std::shared_ptr<void> binary, std::string code,
+  ExecutableImage(const tt::runtime::Binary &binary, std::string code,
                   size_t arg_count, size_t result_count)
-      : ref_count(1), binary(std::move(binary)), code(code),
-        arg_count(arg_count), result_count(result_count) {}
+      : ref_count(1), binary(binary), code(code), arg_count(arg_count),
+        result_count(result_count) {}
   operator PJRT_Executable *() {
     return reinterpret_cast<PJRT_Executable *>(this);
   }
@@ -45,7 +46,7 @@ public:
 
   const size_t get_result_count() const { return result_count; }
 
-  std::shared_ptr<void> get_binary() { return binary; }
+  const tt::runtime::Binary &get_binary() const { return binary; }
 
   const std::string &get_code() const { return code; }
 
@@ -54,7 +55,7 @@ private:
   std::atomic<int> ref_count;
 
   // Raw compiler output.
-  std::shared_ptr<void> binary;
+  tt::runtime::Binary binary;
 
   // Original code fed to the compiler. Stored for debugging.
   const std::string code;

--- a/inc/common/pjrt_implementation/executable_image.h
+++ b/inc/common/pjrt_implementation/executable_image.h
@@ -24,10 +24,7 @@ class ExecutableImage {
 
 public:
   ExecutableImage(const tt::runtime::Binary &binary, std::string code,
-                  size_t arg_count, size_t result_count,
-                  const std::vector<bool> &is_output_scalar)
-      : ref_count(1), binary(binary), code(code), arg_count(arg_count),
-        result_count(result_count), is_output_scalar(is_output_scalar) {}
+                  const std::vector<bool> &is_output_scalar);
   operator PJRT_Executable *() {
     return reinterpret_cast<PJRT_Executable *>(this);
   }

--- a/inc/common/pjrt_implementation/executable_image.h
+++ b/inc/common/pjrt_implementation/executable_image.h
@@ -24,9 +24,10 @@ class ExecutableImage {
 
 public:
   ExecutableImage(const tt::runtime::Binary &binary, std::string code,
-                  size_t arg_count, size_t result_count)
+                  size_t arg_count, size_t result_count,
+                  const std::vector<bool> &is_output_scalar)
       : ref_count(1), binary(binary), code(code), arg_count(arg_count),
-        result_count(result_count) {}
+        result_count(result_count), is_output_scalar(is_output_scalar) {}
   operator PJRT_Executable *() {
     return reinterpret_cast<PJRT_Executable *>(this);
   }
@@ -50,6 +51,8 @@ public:
 
   const std::string &get_code() const { return code; }
 
+  bool isOutputScalar(size_t index) const;
+
 private:
   // The reference count. Must be disposed when reaching zero.
   std::atomic<int> ref_count;
@@ -62,6 +65,9 @@ private:
 
   size_t arg_count;
   size_t result_count;
+
+  // For every output, holds if the type is a scalar or not.
+  std::vector<bool> is_output_scalar;
 };
 
 } // namespace tt::pjrt

--- a/inc/common/pjrt_implementation/executable_image.h
+++ b/inc/common/pjrt_implementation/executable_image.h
@@ -12,8 +12,10 @@
 #include <memory>
 #include <string>
 
-#include "tt/runtime/types.h"
 #include "xla/pjrt/c/pjrt_c_api.h"
+
+// tt-mlir includes
+#include "tt/runtime/types.h"
 
 #ifndef TT_XLA_INC_COMMON_PJRT_IMPLEMENTATION_EXECUTABLE_IMAGE_H_
 #define TT_XLA_INC_COMMON_PJRT_IMPLEMENTATION_EXECUTABLE_IMAGE_H_

--- a/inc/common/pjrt_implementation/executable_image.h
+++ b/inc/common/pjrt_implementation/executable_image.h
@@ -48,6 +48,7 @@ public:
 
   const std::string &get_code() const { return m_code; }
 
+  // Checks if the output on the i-th index is a scalar.
   bool isOutputScalar(size_t index) const;
 
 private:

--- a/src/common/module_builder.cc
+++ b/src/common/module_builder.cc
@@ -43,8 +43,7 @@
 namespace tt::pjrt {
 
 ModuleBuilder::ModuleBuilder()
-    : m_status(tt_pjrt_status::kSuccess), m_num_inputs(0), m_num_outputs(0),
-      m_flatbuffer_binary(nullptr) {
+    : m_status(tt_pjrt_status::kSuccess), m_flatbuffer_binary(nullptr) {
   m_context = std::make_unique<mlir::MLIRContext>();
 
   // Register all the required dialects and passes.
@@ -219,17 +218,6 @@ void ModuleBuilder::createFlatbufferBinary(
     DLOG_F(ERROR, "Failed to generate flatbuffer binary");
     m_status = tt_pjrt_status::kInternal;
     return;
-  }
-
-  m_num_inputs = m_flatbuffer_binary.getProgramInputs(0).size();
-  m_num_outputs = m_flatbuffer_binary.getProgramOutputs(0).size();
-
-  if (m_num_outputs != m_is_output_scalar.size()) {
-    DLOG_F(ERROR,
-           "Created flatbuffer binary contains different number of outputs %ld "
-           "than expected %ld",
-           m_num_outputs, m_is_output_scalar.size());
-    m_status = tt_pjrt_status::kInternal;
   }
 }
 

--- a/src/common/module_builder.cc
+++ b/src/common/module_builder.cc
@@ -217,7 +217,6 @@ void ModuleBuilder::createFlatbufferBinary(
   if (m_flatbuffer_binary.handle == nullptr) {
     DLOG_F(ERROR, "Failed to generate flatbuffer binary");
     m_status = tt_pjrt_status::kInternal;
-    return;
   }
 }
 

--- a/src/common/module_builder.cc
+++ b/src/common/module_builder.cc
@@ -67,11 +67,6 @@ ModuleBuilder::ModuleBuilder()
   m_context->appendDialectRegistry(registry);
 }
 
-bool ModuleBuilder::isOutputScalar(const size_t index) const {
-  assert(index < m_is_output_scalar.size() && "Output index out of range");
-  return m_is_output_scalar[index];
-}
-
 tt_pjrt_status ModuleBuilder::buildModule(const std::string_view &code,
                                           const std::string_view &format) {
   DLOG_F(LOG_DEBUG, "ModuleBuilder::buildModule");

--- a/src/common/module_builder.h
+++ b/src/common/module_builder.h
@@ -34,7 +34,9 @@ public:
 
   size_t getNumOutputs() const { return m_num_outputs; };
 
-  bool isOutputScalar(size_t index) const;
+  const std::vector<bool> &getIsOutputScalar() const {
+    return m_is_output_scalar;
+  };
 
 private:
   // Creates VHLO module from the input program code.

--- a/src/common/module_builder.h
+++ b/src/common/module_builder.h
@@ -30,10 +30,6 @@ public:
 
   const tt::runtime::Binary &getBinary() const { return m_flatbuffer_binary; }
 
-  size_t getNumInputs() const { return m_num_inputs; };
-
-  size_t getNumOutputs() const { return m_num_outputs; };
-
   const std::vector<bool> &getIsOutputScalar() const {
     return m_is_output_scalar;
   };
@@ -71,12 +67,6 @@ private:
 
   // Flatbuffer binary.
   tt::runtime::Binary m_flatbuffer_binary;
-
-  // Number of binary program inputs.
-  size_t m_num_inputs;
-
-  // Number of binary program outputs.
-  size_t m_num_outputs;
 
   // Holds status of the last builder action.
   tt_pjrt_status m_status;

--- a/src/common/module_builder.h
+++ b/src/common/module_builder.h
@@ -17,6 +17,7 @@
 
 // tt-xla includes
 #include "status.h"
+#include "tt/runtime/types.h"
 
 namespace tt::pjrt {
 
@@ -27,7 +28,7 @@ public:
   tt_pjrt_status buildModule(const std::string_view &code,
                              const std::string_view &format);
 
-  std::shared_ptr<void> getBinary() const { return m_flatbuffer_binary; }
+  const tt::runtime::Binary &getBinary() const { return m_flatbuffer_binary; }
 
   size_t getNumInputs() const { return m_num_inputs; };
 
@@ -66,8 +67,8 @@ private:
   // MLIR context handle.
   std::unique_ptr<mlir::MLIRContext> m_context;
 
-  // Flatbuffer binary handle.
-  std::shared_ptr<void> m_flatbuffer_binary;
+  // Flatbuffer binary.
+  tt::runtime::Binary m_flatbuffer_binary;
 
   // Number of binary program inputs.
   size_t m_num_inputs;

--- a/src/common/module_builder.h
+++ b/src/common/module_builder.h
@@ -15,9 +15,11 @@
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/OwningOpRef.h"
 
+// tt-mlir includes
+#include "tt/runtime/types.h"
+
 // tt-xla includes
 #include "status.h"
-#include "tt/runtime/types.h"
 
 namespace tt::pjrt {
 

--- a/src/common/pjrt_implementation/client_instance.cc
+++ b/src/common/pjrt_implementation/client_instance.cc
@@ -198,7 +198,8 @@ PJRT_Error *ClientInstance::Compile(const PJRT_Program *program,
       new ExecutableImage(module_builder_->getBinary(),
                           std::string(program->code, program->code_size),
                           module_builder_->getNumInputs(),
-                          module_builder_->getNumOutputs()),
+                          module_builder_->getNumOutputs(),
+                          module_builder_->getIsOutputScalar()),
       addressable_devices_);
   *out_executable = executable.release();
 

--- a/src/common/pjrt_implementation/client_instance.cc
+++ b/src/common/pjrt_implementation/client_instance.cc
@@ -197,8 +197,6 @@ PJRT_Error *ClientInstance::Compile(const PJRT_Program *program,
       *this,
       new ExecutableImage(module_builder_->getBinary(),
                           std::string(program->code, program->code_size),
-                          module_builder_->getNumInputs(),
-                          module_builder_->getNumOutputs(),
                           module_builder_->getIsOutputScalar()),
       addressable_devices_);
   *out_executable = executable.release();

--- a/src/common/pjrt_implementation/executable_image.cc
+++ b/src/common/pjrt_implementation/executable_image.cc
@@ -19,6 +19,22 @@ namespace tt::pjrt {
 
 const std::string_view kMlirFormat = "mlir";
 
+ExecutableImage::ExecutableImage(const tt::runtime::Binary &binary,
+                                 std::string code,
+                                 const std::vector<bool> &is_output_scalar)
+    : ref_count(1), binary(binary), code(code),
+      is_output_scalar(is_output_scalar) {
+  arg_count = binary.getProgramInputs(0).size();
+  result_count = binary.getProgramOutputs(0).size();
+
+  if (result_count != is_output_scalar.size()) {
+    DLOG_F(ERROR,
+           "Created flatbuffer binary contains different number of outputs %ld "
+           "than expected %ld",
+           result_count, is_output_scalar.size());
+  }
+}
+
 void ExecutableImage::BindApi(PJRT_Api *api) {
   api->PJRT_Executable_Destroy =
       +[](PJRT_Executable_Destroy_Args *args) -> PJRT_Error * {

--- a/src/common/pjrt_implementation/executable_image.cc
+++ b/src/common/pjrt_implementation/executable_image.cc
@@ -121,4 +121,9 @@ void ExecutableImage::BindApi(PJRT_Api *api) {
   };
 }
 
+bool ExecutableImage::isOutputScalar(const size_t index) const {
+  assert(index < is_output_scalar.size() && "Output index out of range");
+  return is_output_scalar[index];
+}
+
 } // namespace tt::pjrt

--- a/src/common/pjrt_implementation/executable_image.cc
+++ b/src/common/pjrt_implementation/executable_image.cc
@@ -26,9 +26,9 @@ ExecutableImage::ExecutableImage(const tt::runtime::Binary &binary,
       m_arg_count(binary.getProgramInputs(0).size()),
       m_result_count(binary.getProgramOutputs(0).size()),
       m_is_output_scalar(is_output_scalar) {
-  // TODO: We should throw error instead, otherwise execution will continue and
-  // then crash later.
   if (m_result_count != m_is_output_scalar.size()) {
+    // TODO: We should throw error instead, otherwise execution will continue
+    // and crash later.
     DLOG_F(ERROR,
            "Created flatbuffer binary contains different number of outputs %ld "
            "than expected %ld",

--- a/src/common/pjrt_implementation/loaded_executable_instance.cc
+++ b/src/common/pjrt_implementation/loaded_executable_instance.cc
@@ -82,7 +82,7 @@ LoadedExecutableInstance::Execute(PJRT_LoadedExecutable_Execute_Args *args) {
 
   assert(args->num_devices == 1);
   int dev_index = 0;
-  tt::runtime::Binary binary(image_->get_binary());
+  const tt::runtime::Binary &binary = image_->get_binary();
 
   std::vector<tt::runtime::Tensor> rt_inputs;
   rt_inputs.reserve(args->num_args);

--- a/src/common/pjrt_implementation/loaded_executable_instance.cc
+++ b/src/common/pjrt_implementation/loaded_executable_instance.cc
@@ -102,7 +102,7 @@ LoadedExecutableInstance::Execute(PJRT_LoadedExecutable_Execute_Args *args) {
   assert(rt_outputs.size() == output_specs.size());
 
   for (size_t i = 0; i < output_specs.size(); ++i) {
-    bool is_scalar = client_.isOutputScalar(i);
+    bool is_scalar = image_->isOutputScalar(i);
     // PJRT expects an empty shape for scalars.
     std::vector<std::uint32_t> output_shape =
         is_scalar ? std::vector<std::uint32_t>() : output_specs[i].shape;


### PR DESCRIPTION
### Problem description
Vector `m_is_output_scalar`, that for every output of a binary program, holds if the type is scalar, is related to a binary program and therefore to a specific `ExecutableImage`. We don't store it there with the binary program, but only in `ModuleBuilder` class. 
During `LoadedExecutableInstance::Execute` it is accessed through `ClientInstance` which has a `ModuleBuilder`, and this assumes the `m_is_output_scalar` is the same one we made during `ClientInstance::Compile` when we made the binary. But this can we false, if another program was compiled with the same Client in the meantime, the values are invalid because they have been overwritten.

### What's changed
In `ModuleBuilder`, `m_flatbuffer_binary` is changed to be `tt::runtime::Binary` instead of `std::shared_ptr<void>`. This is because we always cast it to `tt::runtime::Binary`, which has the shared pointer handle inside.

`m_is_output_scalar` has a getter method, so it could be passed to `ExecutableImage` during `ClientInstance::Compile` and stored there together with the binary program. Now in `LoadedExecutableInstance::Execute` we check if a specific output is scalar through the executable image, and not through the client, which solves the overwriting problem.

`m_num_inputs` and `m_num_outputs` are removed from `ModuleBuilder` because they are used only to check if the number of outputs matches the expected number (from `m_is_output_scalar`) and to be passed to `ExecutableImage`. Now `ExecutableImage` gets the number of inputs and outputs from the binary, and does the same check.

### Checklist
- [x] New/Existing tests provide coverage for changes
