### PR TITLE
Upload the code coverage and test reports to codecov

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -268,3 +268,18 @@ jobs:
         lcov --directory build --capture --output-file coverage.info
         lcov --extract coverage.info '**/src/*' --output-file coverage.info
         lcov --list coverage.info
+
+    - name: Upload coverage reports to Codecov
+      if: success() || failure()
+      uses: codecov/codecov-action@v5
+      with:
+        files: coverage.info
+        disable_search: true
+        token: ${{ secrets.CODECOV_TOKEN }}
+
+    - name: Upload test results to Codecov
+      if: success() || failure()
+      uses: codecov/test-results-action@v1
+      with:
+        files: ${{ steps.strings.outputs.test_report_path }}
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -264,13 +264,15 @@ jobs:
         group_suite: true
 
     - name: Prepare code coverage report
+      if: (success() || failure()) && ${{ matrix.build.runs-on == 'n300' }}
       run: |
         lcov --directory build --capture --output-file coverage.info
-        lcov --extract coverage.info '**/src/*' --output-file coverage.info
+        lcov --extract coverage.info '**/tt-xla/src/*' --output-file coverage.infoo
+        sed -i 's|SF:/__w/tt-xla/tt-xla/src/|SF:src/|' coverage.info
         lcov --list coverage.info
 
     - name: Upload coverage reports to Codecov
-      if: success() || failure()
+      if: (success() || failure()) && ${{ matrix.build.runs-on == 'n300' }}
       uses: codecov/codecov-action@v5
       with:
         files: coverage.info
@@ -282,4 +284,5 @@ jobs:
       uses: codecov/test-results-action@v1
       with:
         files: ${{ steps.strings.outputs.test_report_path }}
+        disable_search: true
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -264,15 +264,15 @@ jobs:
         group_suite: true
 
     - name: Prepare code coverage report
-      if: (success() || failure()) && ${{ matrix.build.runs-on == 'n300' }}
+      if: matrix.build.runs-on == 'n300' && (success() || failure())
       run: |
         lcov --directory build --capture --output-file coverage.info
-        lcov --extract coverage.info '**/tt-xla/src/*' --output-file coverage.infoo
+        lcov --extract coverage.info '**/tt-xla/src/*' --output-file coverage.info
         sed -i 's|SF:/__w/tt-xla/tt-xla/src/|SF:src/|' coverage.info
         lcov --list coverage.info
 
     - name: Upload coverage reports to Codecov
-      if: (success() || failure()) && ${{ matrix.build.runs-on == 'n300' }}
+      if: matrix.build.runs-on == 'n300' && (success() || failure())
       uses: codecov/codecov-action@v5
       with:
         files: coverage.info


### PR DESCRIPTION
### Ticket
N/A

### Problem description
We want to visualize and track history of code coverage using codecov platform

### What's changed
Added steps to build and test workflow to upload code coverage and test reports to codecov
Upload code coverage only from n300 run
Fiter coverage stats to show only tt-xla/src
<img width="951" alt="image" src="https://github.com/user-attachments/assets/edda1232-875f-4d32-bd05-6af8f220ddd1" />

### Checklist
- [x] New/Existing tests provide coverage for changes



