### PR TITLE
Switch to using purely dynamic libs for tt-mlir

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -46,76 +46,13 @@ target_include_directories(TTPJRTCommon PUBLIC
     ${TTMLIR_TOOLCHAIN_DIR}/src/stablehlo
 )
 
-set(STABLEHLO_LIBS
-StablehloBase
-StablehloReferenceIndex
-StablehloReferenceErrors
-StablehloReferenceElement
-StablehloReferenceAxes
-StablehloReferenceValue
-StablehloReferenceTypes
-StablehloReferenceToken
-StablehloReferenceTensor
-StablehloReferenceScope
-StablehloReferenceProcessGrid
-StablehloReferenceProcess
-StablehloReferenceOps
-StablehloPasses
-ChloOps
-Version
-VhloOps
-VhloTypes
-SdyDialect
-SdyRegister
-StablehloOps
-StablehloRegister
-StablehloReferenceToken
-StablehloLinalgTransforms
-StablehloReferenceValue
-StablehloReferenceScope
-StablehloPasses
-StablehloReferenceOps
-StablehloSerialization
-InterpreterOps
-StablehloPortableApi
-StablehloPasses
-StablehloAssemblyFormat
-StablehloOps
-StablehloReferenceElement
-StablehloReferenceOps
-StablehloReferenceTensor
-StablehloRegister
-StablehloBase
-StablehloPasses
-StablehloReferenceErrors
-StablehloReferenceProcess
-StablehloReferenceToken
-StablehloSerialization
-StablehloBroadcastUtils
-StablehloPortableApi
-StablehloReferenceIndex
-StablehloReferenceProcessGrid
-StablehloReferenceTypes
-StablehloTypeInference
-StablehloLinalgTransforms
-StablehloReferenceAxes
-StablehloReferenceNumPy
-StablehloReferenceScope
-StablehloReferenceValue
-)
-
 target_link_libraries(TTPJRTCommon PUBLIC
     loguru
     LLVM
     MLIR
-    TTMLIR
     TTPJRTCommonDylibPlatform
-    TTMLIRStatic
-    TTMLIRTosaToTTIR
-    TTMLIRTTIRToLinalg
-    MLIRTTIRPipelines
-    TTMLIRStableHLOToTTIR
-    ${STABLEHLO_LIBS}
+    TTMLIRCompiler
+    TTMLIRRuntime
 )
 
 target_link_libraries(TTPJRTCommon PUBLIC coverage_config)

--- a/src/tt/CMakeLists.txt
+++ b/src/tt/CMakeLists.txt
@@ -27,10 +27,11 @@ add_library(TTPJRTTTDylib
     "dylib_entry_point.cc"
 )
 target_include_directories(TTPJRTTTDylib PUBLIC ${PROJECT_SOURCE_DIR}/third_party/pjrt_c_api)
-target_link_libraries(TTPJRTTTDylib PUBLIC TTPJRTTT)
-
-target_link_libraries(TTPJRTTTDylib PUBLIC coverage_config)
-
+target_link_libraries(TTPJRTTTDylib PUBLIC 
+    TTMLIR
+    TTPJRTTT
+    coverage_config
+)
 # # Output to the project wide python binary directory tree.
 set_target_properties(TTPJRTTTDylib
     PROPERTIES

--- a/src/tt/CMakeLists.txt
+++ b/src/tt/CMakeLists.txt
@@ -27,11 +27,10 @@ add_library(TTPJRTTTDylib
     "dylib_entry_point.cc"
 )
 target_include_directories(TTPJRTTTDylib PUBLIC ${PROJECT_SOURCE_DIR}/third_party/pjrt_c_api)
-target_link_libraries(TTPJRTTTDylib PUBLIC 
-    TTMLIR
-    TTPJRTTT
-    coverage_config
-)
+target_link_libraries(TTPJRTTTDylib PUBLIC TTPJRTTT)
+
+target_link_libraries(TTPJRTTTDylib PUBLIC coverage_config)
+
 # # Output to the project wide python binary directory tree.
 set_target_properties(TTPJRTTTDylib
     PROPERTIES

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set(TT_MLIR_VERSION "4e5447d8ae8635c6b7e25f163f4576fe0cdda3fb")
+set(TT_MLIR_VERSION "62517e0e97a923809fb7eeaed6ae31e59501bfd7")
 set(LOGURU_VERSION "4adaa185883e3c04da25913579c451d3c32cfac1")
 
 if (TOOLCHAIN STREQUAL "ON")

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set(TT_MLIR_VERSION "5dde571ff7a685ed92b32d7e9ddfa25d52c621cd")
+set(TT_MLIR_VERSION "4e5447d8ae8635c6b7e25f163f4576fe0cdda3fb")
 set(LOGURU_VERSION "4adaa185883e3c04da25913579c451d3c32cfac1")
 
 if (TOOLCHAIN STREQUAL "ON")


### PR DESCRIPTION
### Problem description
We want to change our linking strategy for tt-mlir to use dynamic linking. For some reason, this breaks CI for this repo. We fix by making stablehlo deps embedded in dylib, and also remove various static tt-mlir lib linking here (since components have been folded into the shared lib).

Related to: https://github.com/tenstorrent/tt-mlir/pull/1947

### What's changed
Simplifies how we import tt-mlir by folding everything into shared-lib target--remove links to all static tt-mlir libs, including stablehlo + shardy.

Checklist
[X] successful on-pr run
