### PR TITLE
Uplift third_party/tt-mlir to 48ade5e60b133d9d5d0bf3c7c5c8ac4e85c649c3 2025-02-04

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set(TT_MLIR_VERSION "32f72e625d1250ab5c047d85ce27ed08eb17cfb2")
+set(TT_MLIR_VERSION "48ade5e60b133d9d5d0bf3c7c5c8ac4e85c649c3")
 set(LOGURU_VERSION "4adaa185883e3c04da25913579c451d3c32cfac1")
 
 if (TOOLCHAIN STREQUAL "ON")


### PR DESCRIPTION
This PR uplifts the third_party/tt-mlir to the 48ade5e60b133d9d5d0bf3c7c5c8ac4e85c649c3