### PR TITLE
Fixing attribute name in the ExecutableImage class and adding an event to BufferInstance

### DIFF
--- a/inc/common/pjrt_implementation/buffer_instance.h
+++ b/inc/common/pjrt_implementation/buffer_instance.h
@@ -82,6 +82,9 @@ private:
 
   // Underlying datatype of tensor.
   std::optional<PJRT_Buffer_Type> DataType;
+
+  // OnReady event - currently not used.
+  EventInstance *on_ready_event_;
 };
 
 } // namespace tt::pjrt

--- a/inc/common/pjrt_implementation/executable_image.h
+++ b/inc/common/pjrt_implementation/executable_image.h
@@ -9,7 +9,6 @@
 // https://llvm.org/LICENSE.txt
 
 #include <atomic>
-#include <memory>
 #include <string>
 
 #include "xla/pjrt/c/pjrt_c_api.h"
@@ -56,7 +55,7 @@ public:
   bool isOutputScalar(size_t index) const;
 
   const size_t get_num_addressable_devices() const {
-    return num_addressable_devices;
+    return m_num_addressable_devices;
   }
 
 private:
@@ -71,7 +70,7 @@ private:
 
   size_t m_arg_count;
   size_t m_result_count;
-  size_t num_addressable_devices;
+  size_t m_num_addressable_devices;
 
   // For every output, holds if the type is a scalar or not.
   std::vector<bool> m_is_output_scalar;

--- a/src/common/pjrt_implementation/buffer_instance.cc
+++ b/src/common/pjrt_implementation/buffer_instance.cc
@@ -131,7 +131,9 @@ void BufferInstance::BindApi(PJRT_Api *api) {
   api->PJRT_Buffer_ReadyEvent =
       +[](PJRT_Buffer_ReadyEvent_Args *args) -> PJRT_Error * {
     DLOG_F(LOG_DEBUG, "BufferInstance::PJRT_Buffer_ReadyEvent");
-    args->event = *(new EventInstance());
+    BufferInstance *buffer = BufferInstance::Unwrap(args->buffer);
+    buffer->on_ready_event_ = new EventInstance();
+    args->event = *buffer->on_ready_event_;
     return nullptr;
   };
   // TODO: Rework the API to be Aliases(b1, b2) to let the plugin explicitly

--- a/src/common/pjrt_implementation/buffer_instance.cc
+++ b/src/common/pjrt_implementation/buffer_instance.cc
@@ -131,6 +131,7 @@ void BufferInstance::BindApi(PJRT_Api *api) {
   api->PJRT_Buffer_ReadyEvent =
       +[](PJRT_Buffer_ReadyEvent_Args *args) -> PJRT_Error * {
     DLOG_F(LOG_DEBUG, "BufferInstance::PJRT_Buffer_ReadyEvent");
+    args->event = *(new EventInstance());
     return nullptr;
   };
   // TODO: Rework the API to be Aliases(b1, b2) to let the plugin explicitly

--- a/src/common/pjrt_implementation/executable_image.cc
+++ b/src/common/pjrt_implementation/executable_image.cc
@@ -27,7 +27,7 @@ ExecutableImage::ExecutableImage(const tt::runtime::Binary &binary,
       m_arg_count(binary.getProgramInputs(0).size()),
       m_result_count(binary.getProgramOutputs(0).size()),
       m_is_output_scalar(is_output_scalar),
-      num_addressable_devices(num_addressable_devices) {
+      m_num_addressable_devices(num_addressable_devices) {
   if (m_result_count != m_is_output_scalar.size()) {
     // TODO: We should throw error instead, otherwise execution will continue
     // and crash later.


### PR DESCRIPTION
My previous merge had an error in the naming of `num_addressable_devices` attribute, so this PR changes that. In addition, the multichip xla execution requires that the BufferInstance has a `ready_event`, even if it now used used, so I also added this in this PR.