### PR TITLE
Adding implementation for PJRT_Executable_OutputElementTypes and PJRT_Executable_OutputDimensions

### DIFF
--- a/inc/common/pjrt_implementation/executable_image.h
+++ b/inc/common/pjrt_implementation/executable_image.h
@@ -56,22 +56,26 @@ public:
     return m_num_addressable_devices;
   }
 
-  const std::vector<std::uint32_t> &get_output_shape(size_t index) const;
+  const std::vector<std::uint32_t> &get_output_shape(const size_t index) const;
 
+  PJRT_Buffer_Type *get_output_types() { return m_output_types.data(); }
+
+  size_t get_num_output_types() const { return m_output_types.size(); }
+
+private:
+  // Retrieves pointers to the concatenated list of output dimensions and the
+  // corresponding list of ranks (number of dimensions per output tensor).
   void get_output_dims_concatenated(const size_t **dim_sizes,
                                     const int64_t **dims);
 
-  PJRT_Buffer_Type *get_output_types() { return m_output_types.data(); }
-  size_t num_output_types() { return m_output_types.size(); }
-
-private:
-  // Checks whether m_output_dim_sizes and m_output_dims_concatenated have been
-  // filled.
-  bool areOutputDimsConcatinated() const {
+  // Checks if the concatenated output dimensions and the corresponding rank
+  // list have been initialized.
+  bool areOutputDimsConcatenated() const {
     return m_output_dim_sizes && m_output_dims_concatenated;
   }
 
-  // Fills the m_output_dim_sizes and m_output_dims_concatenated array.
+  // Populates the concatenated list of output dimensions and the corresponding
+  // list of ranks.
   void populateOutputDimsConcatenated();
 
   // The reference count. Must be disposed when reaching zero.
@@ -96,12 +100,12 @@ private:
   // For every output, holds a list of its dimensions.
   std::vector<std::vector<uint32_t>> m_output_dims;
 
-  // For every output, holds how many dimensions it has. Nullptr until getter
-  // get_output_dims_concatenated is called.
+  // For every output, stores rank (number of dimensions). Nullptr until its
+  // getter is called.
   std::unique_ptr<size_t[]> m_output_dim_sizes;
 
-  // Holds all output dimensions concatenated. Nullptr until getter
-  // get_output_dims_concatenated is called.
+  // Stores all output dimensions concatenated in a flat array. Nullptr until
+  // its getter is called.
   std::unique_ptr<int64_t[]> m_output_dims_concatenated;
 };
 

--- a/inc/common/pjrt_implementation/executable_image.h
+++ b/inc/common/pjrt_implementation/executable_image.h
@@ -58,9 +58,11 @@ public:
 
   const std::vector<std::uint32_t> &get_output_shape(const size_t index) const;
 
+  const std::vector<std::uint32_t> &get_output_stride(const size_t index) const;
+
   PJRT_Buffer_Type *get_output_types() { return m_output_types.data(); }
 
-  size_t get_num_output_types() const { return m_output_types.size(); }
+  size_t get_num_outputs() const { return m_output_types.size(); }
 
 private:
   // Retrieves pointers to the concatenated list of output dimensions and the
@@ -107,6 +109,9 @@ private:
   // Stores all output dimensions concatenated in a flat array. Nullptr until
   // its getter is called.
   std::unique_ptr<int64_t[]> m_output_dims_concatenated;
+
+  // For every output, holds its stride.
+  std::vector<std::vector<uint32_t>> m_output_strides;
 };
 
 } // namespace tt::pjrt

--- a/src/common/pjrt_implementation/executable_image.cc
+++ b/src/common/pjrt_implementation/executable_image.cc
@@ -10,6 +10,7 @@
 
 #include "common/pjrt_implementation/executable_image.h"
 
+#include <memory>
 #include <string>
 
 #include "common/pjrt_implementation/utils.h"
@@ -25,9 +26,13 @@ ExecutableImage::ExecutableImage(const tt::runtime::Binary &binary,
                                  size_t num_addressable_devices)
     : m_ref_count(1), m_binary(binary), m_code(code),
       m_arg_count(binary.getProgramInputs(0).size()),
-      m_result_count(binary.getProgramOutputs(0).size()),
       m_is_output_scalar(is_output_scalar),
       m_num_addressable_devices(num_addressable_devices) {
+
+  std::vector<tt::runtime::TensorDesc> output_specs =
+      m_binary.getProgramOutputs(0);
+  m_result_count = output_specs.size();
+
   if (m_result_count != m_is_output_scalar.size()) {
     // TODO: We should throw error instead, otherwise execution will continue
     // and crash later.
@@ -35,6 +40,17 @@ ExecutableImage::ExecutableImage(const tt::runtime::Binary &binary,
            "Created flatbuffer binary contains different number of outputs %ld "
            "than expected %ld",
            m_result_count, m_is_output_scalar.size());
+  }
+
+  m_output_types.resize(m_result_count);
+  m_output_dims.resize(m_result_count);
+  for (int i = 0; i < m_result_count; i++) {
+    m_output_types[i] = tt::pjrt::utils::convertElementTypeToBufferType(
+        output_specs[i].dataType);
+
+    // PJRT expects an empty shape for scalars.
+    m_output_dims[i] = m_is_output_scalar[i] ? std::vector<std::uint32_t>()
+                                             : output_specs[i].shape;
   }
 }
 
@@ -100,11 +116,61 @@ void ExecutableImage::BindApi(PJRT_Api *api) {
     }
     return nullptr;
   };
+  api->PJRT_Executable_OutputElementTypes =
+      +[](PJRT_Executable_OutputElementTypes_Args *args) -> PJRT_Error * {
+    DLOG_F(LOG_DEBUG, "ExecutableImage::PJRT_Executable_OutputElementTypes");
+    ExecutableImage *exec = ExecutableImage::Unwrap(args->executable);
+    // There is a possibility that this method should return unique types, and
+    // not a type for every output.
+    args->output_types = exec->get_output_types();
+    args->num_output_types = exec->num_output_types();
+    return nullptr;
+  };
+  api->PJRT_Executable_OutputDimensions =
+      +[](PJRT_Executable_OutputDimensions_Args *args) -> PJRT_Error * {
+    DLOG_F(LOG_DEBUG, "ExecutableImage::PJRT_Executable_OutputDimensions_Args");
+    ExecutableImage *exec = ExecutableImage::Unwrap(args->executable);
+
+    args->num_outputs = exec->get_result_count();
+    exec->get_output_dims_concatenated(&args->dim_sizes, &args->dims);
+
+    return nullptr;
+  };
 }
 
-bool ExecutableImage::isOutputScalar(const size_t index) const {
-  assert(index < m_is_output_scalar.size() && "Output index out of range");
-  return m_is_output_scalar[index];
+const std::vector<std::uint32_t> &
+ExecutableImage::get_output_shape(const size_t index) const {
+  assert(index < m_output_dims.size() && "Output index out of range");
+  return m_output_dims[index];
+}
+
+void ExecutableImage::populateOutputDimsConcatenated() {
+  size_t num_dims = 0;
+
+  m_output_dim_sizes = std::make_unique<size_t[]>(m_result_count);
+  for (size_t i = 0; i < m_result_count; i++) {
+    m_output_dim_sizes[i] = m_output_dims[i].size();
+    num_dims += m_output_dim_sizes[i];
+  }
+
+  m_output_dims_concatenated = std::make_unique<int64_t[]>(num_dims);
+  size_t dims_index = 0;
+  for (size_t i = 0; i < m_result_count; i++) {
+    for (size_t j = 0; j < m_output_dim_sizes[i]; j++) {
+      m_output_dims_concatenated[dims_index + j] = m_output_dims[i][j];
+    }
+    dims_index += m_output_dim_sizes[i];
+  }
+}
+
+void ExecutableImage::get_output_dims_concatenated(const size_t **dim_sizes,
+                                                   const int64_t **dims) {
+  if (!areOutputDimsConcatinated()) {
+    populateOutputDimsConcatenated();
+  }
+
+  *dim_sizes = m_output_dim_sizes.get();
+  *dims = m_output_dims_concatenated.get();
 }
 
 } // namespace tt::pjrt

--- a/src/common/pjrt_implementation/executable_image.cc
+++ b/src/common/pjrt_implementation/executable_image.cc
@@ -25,13 +25,13 @@ ExecutableImage::ExecutableImage(const tt::runtime::Binary &binary,
                                  const std::vector<bool> &is_output_scalar,
                                  size_t num_addressable_devices)
     : m_ref_count(1), m_binary(binary), m_code(code),
-      m_arg_count(binary.getProgramInputs(0).size()),
       m_is_output_scalar(is_output_scalar),
       m_num_addressable_devices(num_addressable_devices) {
 
   std::vector<tt::runtime::TensorDesc> output_specs =
       m_binary.getProgramOutputs(0);
   m_result_count = output_specs.size();
+  m_arg_count = m_binary.getProgramInputs(0).size();
 
   if (m_result_count != m_is_output_scalar.size()) {
     // TODO: We should throw error instead, otherwise execution will continue
@@ -120,10 +120,8 @@ void ExecutableImage::BindApi(PJRT_Api *api) {
       +[](PJRT_Executable_OutputElementTypes_Args *args) -> PJRT_Error * {
     DLOG_F(LOG_DEBUG, "ExecutableImage::PJRT_Executable_OutputElementTypes");
     ExecutableImage *exec = ExecutableImage::Unwrap(args->executable);
-    // There is a possibility that this method should return unique types, and
-    // not a type for every output.
     args->output_types = exec->get_output_types();
-    args->num_output_types = exec->num_output_types();
+    args->num_output_types = exec->get_num_output_types();
     return nullptr;
   };
   api->PJRT_Executable_OutputDimensions =

--- a/src/common/pjrt_implementation/loaded_executable_instance.cc
+++ b/src/common/pjrt_implementation/loaded_executable_instance.cc
@@ -114,16 +114,12 @@ LoadedExecutableInstance::Execute(PJRT_LoadedExecutable_Execute_Args *args) {
   assert(rt_outputs.size() == output_specs.size());
 
   for (size_t i = 0; i < output_specs.size(); ++i) {
-    bool is_scalar = image_->isOutputScalar(i);
-    // PJRT expects an empty shape for scalars.
-    std::vector<std::uint32_t> output_shape =
-        is_scalar ? std::vector<std::uint32_t>() : output_specs[i].shape;
 
     tt::runtime::Tensor untilized_output_tensor =
         tt::runtime::toHost(rt_outputs[i], /*untilize=*/true);
     auto result_buffer = std::make_unique<BufferInstance>(
         *this->addressable_devices_[dev_index], untilized_output_tensor,
-        output_shape, output_specs[i].stride);
+        image_->get_output_shape(i), output_specs[i].stride);
     tt::runtime::deallocateTensor(rt_outputs[i], /*force=*/true);
 
     result_buffer->setType(tt::pjrt::utils::convertElementTypeToBufferType(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/164

### Problem description
`PJRT_Executable_OutputElementTypes` and `PJRT_Executable_OutputDimensions` were unimplemented.

### What's changed
In `LoadedExecutableInstance::Execute` we got the shape for every `PJRT_Buffer` output from `binary.getProgramOutputs` and `image_->isOutputScalar`. Now we store the shape in `ExecutableImage` class and have a getter for the final shape, and not `isOutputScalar`.

Adding a vector that stores `PJRT_Buffer_Type` for every output in `ExecutableImage`, as well as a getter, for the implementation of `PJRT_Executable_OutputElementTypes`.

`PJRT_Executable_OutputDimensions` requires the dimensions to be in a different format. It returns an array of output dimension sizes and an array of concatenated dimensions, so we also store that type of pointer in `ExecutableImage`. We store it because we are responsible for memory deallocation, and not the caller of `PJRT_Executable_OutputDimensions`. But because concatenated dimensions are rarely needed, these fields are `nullptr` until `get_output_dims_concatenated` is called.

### Notes
It is possible that `PJRT_Executable_OutputElementTypes` should return only different unique PJRT_Buffer_Types, and not a type for every output.

We might want to store information about stride of every output in `ExecutableImage` as well, so `binary.getProgramOutput` wouldn't have to be called in `LoadedExecutableInstance::Execute`, and all the information about outputs would be at one place.

### Checklist
- [ ] New/Existing tests provide coverage for changes
