### PR TITLE
Set HF_HOME folder

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -165,6 +165,7 @@ jobs:
         - /etc/udev/rules.d:/etc/udev/rules.d
         - /lib/modules:/lib/modules
         - /opt/tt_metal_infra/provisioning/provisioning_env:/opt/tt_metal_infra/provisioning/provisioning_env
+        - /mnt/dockercache:/mnt/dockercache
 
     steps:
     - uses: actions/checkout@v4
@@ -238,6 +239,8 @@ jobs:
           cd ../..
 
     - name: Run tests
+      env:
+        HF_HOME: /mnt/dockercache/huggingface
       shell: bash
       run: |
         export LD_LIBRARY_PATH="/opt/ttmlir-toolchain/lib/:${{ steps.strings.outputs.install-output-dir }}/lib:${LD_LIBRARY_PATH}"


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Loading models from Hugging face can be slow for large models, we want to use shared volume to optimize loding HF models.

### What's changed
Added volume mount for docker containers /mnt/dockercache:/mnt/dockercache
Set Huggingface cache folder HF_HOME=/mnt/dockercache/huggingface
With this HF models cache will be on a shared volume, used by tt-forge-fe, tt-torch and tt-xla runners.

### Checklist
- [x] New/Existing tests provide coverage for changes
