### PR TITLE
Update type annotations

### DIFF
--- a/tests/infra/model_tester.py
+++ b/tests/infra/model_tester.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Any, Callable, Mapping, Sequence
+from typing import Any, Callable, Dict, Mapping, Sequence, Union
 
 from flax import linen, nnx
 from transformers.modeling_flax_utils import FlaxPreTrainedModel
@@ -14,6 +14,7 @@ from transformers.modeling_flax_utils import FlaxPreTrainedModel
 from .base_tester import BaseTester
 from .comparison import ComparisonConfig
 from .device_runner import DeviceRunner
+from .types import Model
 from .workload import Workload
 
 
@@ -79,12 +80,12 @@ class ModelTester(BaseTester, ABC):
         )
 
     @abstractmethod
-    def _get_model(self) -> Any:
+    def _get_model(self) -> Model:
         """Returns model instance."""
         raise NotImplementedError("Subclasses must implement this method.")
 
     @abstractmethod
-    def _get_input_activations(self) -> Any:
+    def _get_input_activations(self) -> Union[Dict, Sequence[Any]]:
         """Returns input activations."""
         raise NotImplementedError("Subclasses must implement this method.")
 

--- a/tests/infra/model_tester.py
+++ b/tests/infra/model_tester.py
@@ -14,7 +14,6 @@ from transformers.modeling_flax_utils import FlaxPreTrainedModel
 from .base_tester import BaseTester
 from .comparison import ComparisonConfig
 from .device_runner import DeviceRunner
-from .types import Model
 from .workload import Workload
 
 
@@ -80,12 +79,12 @@ class ModelTester(BaseTester, ABC):
         )
 
     @abstractmethod
-    def _get_model(self) -> Model:
+    def _get_model(self) -> Any:
         """Returns model instance."""
         raise NotImplementedError("Subclasses must implement this method.")
 
     @abstractmethod
-    def _get_input_activations(self) -> Sequence[Any]:
+    def _get_input_activations(self) -> Any:
         """Returns input activations."""
         raise NotImplementedError("Subclasses must implement this method.")
 

--- a/tests/infra/types.py
+++ b/tests/infra/types.py
@@ -6,9 +6,16 @@ from enum import Enum
 from typing import Union
 
 import jax
+from flax import linen, nnx
+from transformers import FlaxPreTrainedModel
 
 # Convenience alias. Could be used to represent jax.Array, torch.Tensor, np.ndarray, etc.
 Tensor = Union[jax.Array]
+
+# Convenience alias. Could be used to represent nnx.Module, torch.nn.Module, etc.
+# NOTE nnx.Module is the newest API, linen.Module is legacy but it is used in some
+# huggingface models.
+Model = Union[nnx.Module, linen.Module, FlaxPreTrainedModel]
 
 
 class Framework(Enum):

--- a/tests/infra/types.py
+++ b/tests/infra/types.py
@@ -6,15 +6,9 @@ from enum import Enum
 from typing import Union
 
 import jax
-from flax import linen, nnx
 
 # Convenience alias. Could be used to represent jax.Array, torch.Tensor, np.ndarray, etc.
 Tensor = Union[jax.Array]
-
-# Convenience alias. Could be used to represent nnx.Module, torch.nn.Module, etc.
-# NOTE nnx.Module is the newest API, linen.Module is legacy but it is used in some
-# huggingface models.
-Model = Union[nnx.Module, linen.Module]
 
 
 class Framework(Enum):

--- a/tests/jax/models/albert/v2/tester.py
+++ b/tests/jax/models/albert/v2/tester.py
@@ -5,9 +5,8 @@
 from typing import Dict, Sequence
 
 import jax
-from flax import linen as nn
-from infra import ModelTester, RunMode, ComparisonConfig
-from transformers import AutoTokenizer, FlaxAlbertForMaskedLM
+from infra import ComparisonConfig, ModelTester, RunMode
+from transformers import AutoTokenizer, FlaxAlbertForMaskedLM, FlaxPreTrainedModel
 
 
 class AlbertV2Tester(ModelTester):
@@ -23,7 +22,7 @@ class AlbertV2Tester(ModelTester):
         super().__init__(comparison_config, run_mode)
 
     # @override
-    def _get_model(self) -> nn.Module:
+    def _get_model(self) -> FlaxPreTrainedModel:
         return FlaxAlbertForMaskedLM.from_pretrained(self._model_name)
 
     # @override

--- a/tests/jax/models/bart/tester.py
+++ b/tests/jax/models/bart/tester.py
@@ -5,9 +5,8 @@
 from typing import Dict, Sequence
 
 import jax
-from flax import linen as nn
 from infra import ComparisonConfig, ModelTester, RunMode
-from transformers import AutoTokenizer, FlaxBartForCausalLM
+from transformers import AutoTokenizer, FlaxBartForCausalLM, FlaxPreTrainedModel
 
 
 class FlaxBartForCausalLMTester(ModelTester):
@@ -25,7 +24,7 @@ class FlaxBartForCausalLMTester(ModelTester):
         super().__init__(comparison_config, run_mode)
 
     # @override
-    def _get_model(self) -> nn.Module:
+    def _get_model(self) -> FlaxPreTrainedModel:
         return FlaxBartForCausalLM.from_pretrained(self._model_name)
 
     # @override

--- a/tests/jax/models/beit/tester.py
+++ b/tests/jax/models/beit/tester.py
@@ -7,7 +7,11 @@ from typing import Dict
 import jax
 from flax import linen as nn
 from infra import ComparisonConfig, ModelTester, RunMode
-from transformers import BeitImageProcessor, FlaxBeitForImageClassification
+from transformers import (
+    BeitImageProcessor,
+    FlaxBeitForImageClassification,
+    FlaxPreTrainedModel,
+)
 
 
 class FlaxBeitForImageClassificationTester(ModelTester):
@@ -23,7 +27,7 @@ class FlaxBeitForImageClassificationTester(ModelTester):
         super().__init__(comparison_config, run_mode)
 
     # @override
-    def _get_model(self) -> nn.Module:
+    def _get_model(self) -> FlaxPreTrainedModel:
         return FlaxBeitForImageClassification.from_pretrained(self._model_name)
 
     # @override

--- a/tests/jax/models/bert/tester.py
+++ b/tests/jax/models/bert/tester.py
@@ -5,9 +5,8 @@
 from typing import Dict, Sequence
 
 import jax
-from flax import linen as nn
 from infra import ComparisonConfig, ModelTester, RunMode
-from transformers import AutoTokenizer, FlaxBertForMaskedLM
+from transformers import AutoTokenizer, FlaxBertForMaskedLM, FlaxPreTrainedModel
 
 
 class FlaxBertForMaskedLMTester(ModelTester):
@@ -23,7 +22,7 @@ class FlaxBertForMaskedLMTester(ModelTester):
         super().__init__(comparison_config, run_mode)
 
     # @override
-    def _get_model(self) -> nn.Module:
+    def _get_model(self) -> FlaxPreTrainedModel:
         return FlaxBertForMaskedLM.from_pretrained(self._model_name)
 
     # @override

--- a/tests/jax/models/bloom/tester.py
+++ b/tests/jax/models/bloom/tester.py
@@ -5,9 +5,8 @@
 from typing import Dict, Sequence
 
 import jax
-from flax import linen as nn
 from infra import ComparisonConfig, ModelTester, RunMode
-from transformers import AutoTokenizer, FlaxBloomForCausalLM
+from transformers import AutoTokenizer, FlaxBloomForCausalLM, FlaxPreTrainedModel
 
 
 class BloomTester(ModelTester):
@@ -23,7 +22,7 @@ class BloomTester(ModelTester):
         super().__init__(comparison_config, run_mode)
 
     # @override
-    def _get_model(self) -> nn.Module:
+    def _get_model(self) -> FlaxPreTrainedModel:
         return FlaxBloomForCausalLM.from_pretrained(self._model_name, from_pt=True)
 
     # @override

--- a/tests/jax/models/distilbert/test_distilbert.py
+++ b/tests/jax/models/distilbert/test_distilbert.py
@@ -6,9 +6,8 @@ from typing import Callable, Dict, Sequence
 
 import jax
 import pytest
-from flax import linen as nn
 from infra import ModelTester, RunMode
-from transformers import AutoTokenizer, FlaxDistilBertForMaskedLM
+from transformers import AutoTokenizer, FlaxDistilBertForMaskedLM, FlaxPreTrainedModel
 from utils import record_model_test_properties, runtime_fail
 
 MODEL_PATH = "distilbert/distilbert-base-uncased"
@@ -21,7 +20,7 @@ class FlaxDistilBertForMaskedLMTester(ModelTester):
     """Tester for DistilBert model on a masked language modeling task"""
 
     # @override
-    def _get_model(self) -> nn.Module:
+    def _get_model(self) -> FlaxPreTrainedModel:
         return FlaxDistilBertForMaskedLM.from_pretrained(MODEL_PATH)
 
     # @override

--- a/tests/jax/models/gpt2/tester.py
+++ b/tests/jax/models/gpt2/tester.py
@@ -5,9 +5,8 @@
 from typing import Dict, Sequence
 
 import jax
-from flax import linen as nn
 from infra import ComparisonConfig, ModelTester, RunMode
-from transformers import AutoTokenizer, FlaxGPT2LMHeadModel
+from transformers import AutoTokenizer, FlaxGPT2LMHeadModel, FlaxPreTrainedModel
 
 
 class GPT2Tester(ModelTester):
@@ -23,7 +22,7 @@ class GPT2Tester(ModelTester):
         super().__init__(comparison_config, run_mode)
 
     # @override
-    def _get_model(self) -> nn.Module:
+    def _get_model(self) -> FlaxPreTrainedModel:
         return FlaxGPT2LMHeadModel.from_pretrained(self._model_name)
 
     # @override

--- a/tests/jax/models/llama/tester.py
+++ b/tests/jax/models/llama/tester.py
@@ -2,12 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Sequence, Dict
+from typing import Dict, Sequence
 
 import jax
-from flax import linen as nn
-from infra import ModelTester, RunMode, ComparisonConfig
-from transformers import LlamaTokenizer, FlaxLlamaForCausalLM
+from infra import ComparisonConfig, ModelTester, RunMode
+from transformers import FlaxLlamaForCausalLM, FlaxPreTrainedModel, LlamaTokenizer
 
 
 class LLamaTester(ModelTester):
@@ -25,7 +24,7 @@ class LLamaTester(ModelTester):
         super().__init__(comparison_config, run_mode)
 
     # @override
-    def _get_model(self) -> nn.Module:
+    def _get_model(self) -> FlaxPreTrainedModel:
         return FlaxLlamaForCausalLM.from_pretrained(self._model_name, from_pt=True)
 
     # @override

--- a/tests/jax/models/roberta/tester.py
+++ b/tests/jax/models/roberta/tester.py
@@ -5,9 +5,8 @@
 from typing import Dict, Sequence
 
 import jax
-from flax import linen as nn
 from infra import ComparisonConfig, ModelTester, RunMode
-from transformers import AutoTokenizer, FlaxRobertaForMaskedLM
+from transformers import AutoTokenizer, FlaxPreTrainedModel, FlaxRobertaForMaskedLM
 
 
 class FlaxRobertaForMaskedLMTester(ModelTester):
@@ -25,7 +24,7 @@ class FlaxRobertaForMaskedLMTester(ModelTester):
         super().__init__(comparison_config, run_mode)
 
     # @override
-    def _get_model(self) -> nn.Module:
+    def _get_model(self) -> FlaxPreTrainedModel:
         return FlaxRobertaForMaskedLM.from_pretrained(self._model_name)
 
     # @override


### PR DESCRIPTION
### Ticket
#241 

### Problem description
Some type annotations were incorrect

### What's changed
I updated `_get_input_activations` to return `Any` in the base class, because activations might also be a dictionary. In particular, some huggingface classes follow a convention where the output of some preprocessing class is a dict that can be unpacked directly into the call of a model class.
I corrected the wrong `flax.linen.Module` type annotations from `_get_model` inside testers for models on huggingface. Huggingface classes are not themselves modules, but rather have a module as one of their members. I also removed the type annotations inside base, this rendered the `Model` type alias redundant.

### Checklist
- [X] New/Existing tests provide coverage for changes
