### PR TITLE
Support PyTrees as model outputs in test infra

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pybind11
 pytest
 torch
 transformers
+jaxtyping

--- a/tests/infra/base_tester.py
+++ b/tests/infra/base_tester.py
@@ -8,6 +8,7 @@ from abc import ABC
 from typing import Callable, Sequence
 
 import jax
+from jaxtyping import PyTree
 
 from .comparison import (
     ComparisonConfig,
@@ -61,7 +62,7 @@ class BaseTester(ABC):
                 device_output, golden_output, self._comparison_config.allclose
             )
 
-    def _match_data_types(self, *tensors: Tensor) -> Sequence[Tensor]:
+    def _match_data_types(self, *tensors: PyTree) -> PyTree:
         """
         Casts all tensors to float32 if not already in that format.
 

--- a/tests/infra/base_tester.py
+++ b/tests/infra/base_tester.py
@@ -67,7 +67,9 @@ class BaseTester(ABC):
 
         Tensors need to be in same data format in order to compare them.
         """
-        return [
-            tensor.astype("float32") if tensor.dtype.str != "float32" else tensor
-            for tensor in tensors
-        ]
+        return jax.tree.map(
+            lambda tensor: tensor.astype("float32")
+            if tensor.dtype.str != "float32"
+            else tensor,
+            tensors,
+        )

--- a/tests/infra/comparison.py
+++ b/tests/infra/comparison.py
@@ -8,9 +8,9 @@ from dataclasses import dataclass
 
 import jax
 import jax.numpy as jnp
+from jaxtyping import PyTree
 
 from .device_runner import run_on_cpu
-from .types import Tensor
 
 
 @dataclass
@@ -74,14 +74,14 @@ class ComparisonConfig:
 
 
 @run_on_cpu
-def compare_equal(device_output: Tensor, golden_output: Tensor) -> None:
+def compare_equal(device_output: PyTree, golden_output: PyTree) -> None:
     passed = jax.tree.map(lambda x, y: (x == y).all(), device_output, golden_output)
     assert jax.tree.all(passed), f"Equal comparison failed."
 
 
 @run_on_cpu
 def compare_atol(
-    device_output: Tensor, golden_output: Tensor, atol_config: AtolConfig
+    device_output: PyTree, golden_output: PyTree, atol_config: AtolConfig
 ) -> None:
     leaf_atols = jax.tree.map(
         lambda x, y: jnp.max(jnp.abs(x - y)),
@@ -97,7 +97,7 @@ def compare_atol(
 
 @run_on_cpu
 def compare_pcc(
-    device_output: Tensor, golden_output: Tensor, pcc_config: PccConfig
+    device_output: PyTree, golden_output: PyTree, pcc_config: PccConfig
 ) -> None:
     # Note, minmimum of pccs is not the same as pcc across all elements.
     # If the user wants to compare pcc across all elements, they should concatenate the tensors themselves
@@ -119,7 +119,7 @@ def compare_pcc(
 
 @run_on_cpu
 def compare_allclose(
-    device_output: Tensor, golden_output: Tensor, allclose_config: AllcloseConfig
+    device_output: PyTree, golden_output: PyTree, allclose_config: AllcloseConfig
 ) -> None:
     all_close = jax.tree.map(
         lambda x, y: jnp.allclose(

--- a/tests/infra/comparison.py
+++ b/tests/infra/comparison.py
@@ -88,7 +88,7 @@ def compare_atol(
         device_output,
         golden_output,
     )
-    atol = jax.tree.reduce(lambda x, y: jnp.max(x, y), leaf_atols)
+    atol = jax.tree.reduce(lambda x, y: jnp.maximum(x, y), leaf_atols)
     assert atol <= atol_config.required_atol, (
         f"Atol comparison failed. "
         f"Calculated: atol={atol}. Required: atol={atol_config.required_atol}."
@@ -110,7 +110,7 @@ def compare_pcc(
             device_output,
             golden_output,
         )
-        pcc = jax.tree.reduce(lambda x, y: jnp.min(x, y), leaf_pccs)
+        pcc = jax.tree.reduce(lambda x, y: jnp.minimum(x, y), leaf_pccs)
         assert pcc >= pcc_config.required_pcc, (
             f"PCC comparison failed. "
             f"Calculated: pcc={pcc}. Required: pcc={pcc_config.required_pcc}."


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Some model implementations, primarily from huggingface, return classes with multiple fields as outputs instead of a single jax Array. This causes type errors during comparisons. It is also possible other models might want to have multiple outputs.

### What's changed
This PR changes the test infrastructure to work with arbitrary PyTrees instead of a single tensor, using tree utilities from jax. That includes any custom class a model wants to return as long as it's properly registered as a PyTree node(which includes HF classes).

### Checklist
- [X] New/Existing tests provide coverage for changes
- [X] Update type annotations where appropriate