### PR TITLE
Removed redundant PJRT api bindings for unimplemented methods

### DIFF
--- a/src/common/pjrt_implementation/buffer_instance.cc
+++ b/src/common/pjrt_implementation/buffer_instance.cc
@@ -114,11 +114,6 @@ void BufferInstance::BindApi(PJRT_Api *api) {
     args->is_deleted = buffer->is_deleted();
     return nullptr;
   };
-  api->PJRT_Buffer_CopyToDevice =
-      +[](PJRT_Buffer_CopyToDevice_Args *args) -> PJRT_Error * {
-    DLOG_F(LOG_DEBUG, "BufferInstance::PJRT_Buffer_CopyToDevice");
-    return ErrorInstance::MakeError(tt_pjrt_status::kUnimplemented);
-  };
   api->PJRT_Buffer_IsOnCpu =
       +[](PJRT_Buffer_IsOnCpu_Args *args) -> PJRT_Error * {
     DLOG_F(LOG_DEBUG, "BufferInstance::PJRT_Buffer_IsOnCpu");
@@ -129,10 +124,6 @@ void BufferInstance::BindApi(PJRT_Api *api) {
     DLOG_F(LOG_DEBUG, "BufferInstance::PJRT_Buffer_Device");
     args->device = BufferInstance::Unwrap(args->buffer)->device();
     return nullptr;
-  };
-  api->PJRT_Buffer_Memory = +[](PJRT_Buffer_Memory_Args *args) -> PJRT_Error * {
-    DLOG_F(LOG_DEBUG, "BufferInstance::PJRT_Buffer_Memory");
-    return ErrorInstance::MakeError(tt_pjrt_status::kUnimplemented);
   };
   api->PJRT_Buffer_ReadyEvent =
       +[](PJRT_Buffer_ReadyEvent_Args *args) -> PJRT_Error * {

--- a/src/common/pjrt_implementation/client_instance.cc
+++ b/src/common/pjrt_implementation/client_instance.cc
@@ -154,11 +154,6 @@ void ClientInstance::BindApi(PJRT_Api *api) {
                 reinterpret_cast<BufferInstance **>(&args->buffer));
     return ErrorInstance::MakeError(status);
   };
-  api->PJRT_LoadedExecutable_Fingerprint =
-      +[](PJRT_LoadedExecutable_Fingerprint_Args *args) -> PJRT_Error * {
-    DLOG_F(LOG_DEBUG, "ClientInstance::PJRT_LoadedExecutable_Fingerprint");
-    return ErrorInstance::MakeError(tt_pjrt_status::kUnimplemented);
-  };
 }
 
 tt_pjrt_status ClientInstance::PopulateDevices() {

--- a/src/common/pjrt_implementation/device_instance.cc
+++ b/src/common/pjrt_implementation/device_instance.cc
@@ -35,16 +35,6 @@ void DeviceInstance::BindApi(PJRT_Api *api) {
         DeviceInstance::Unwrap(args->device)->local_hardware_id();
     return nullptr;
   };
-  api->PJRT_Device_AddressableMemories =
-      +[](PJRT_Device_AddressableMemories_Args *args) -> PJRT_Error * {
-    DLOG_F(LOG_DEBUG, "DeviceInstance::PJRT_Device_AddressableMemories");
-    return ErrorInstance::MakeError(tt_pjrt_status::kUnimplemented);
-  };
-  api->PJRT_Device_DefaultMemory =
-      +[](PJRT_Device_DefaultMemory_Args *args) -> PJRT_Error * {
-    DLOG_F(LOG_DEBUG, "DeviceInstance::PJRT_Device_DefaultMemory");
-    return ErrorInstance::MakeError(tt_pjrt_status::kUnimplemented);
-  };
   api->PJRT_Device_GetDescription =
       +[](PJRT_Device_GetDescription_Args *args) -> PJRT_Error * {
     DLOG_F(LOG_DEBUG, "DeviceInstance::PJRT_Device_GetDescription");

--- a/src/common/pjrt_implementation/event_instance.cc
+++ b/src/common/pjrt_implementation/event_instance.cc
@@ -83,10 +83,6 @@ void EventInstance::BindApi(PJRT_Api *api) {
     DLOG_F(LOG_DEBUG, "EventInstance::PJRT_Event_Error");
     return (PJRT_Error *)EventInstance::Unwrap(args->event)->error();
   };
-  api->PJRT_Event_Await = +[](PJRT_Event_Await_Args *args) -> PJRT_Error * {
-    DLOG_F(LOG_DEBUG, "EventInstance::PJRT_Event_Await");
-    return ErrorInstance::MakeError(tt_pjrt_status::kUnimplemented);
-  };
   api->PJRT_Event_OnReady = +[](PJRT_Event_OnReady_Args *args) -> PJRT_Error * {
     DLOG_F(LOG_DEBUG, "EventInstance::PJRT_Event_OnReady");
     return ErrorInstance::MakeError(

--- a/src/common/pjrt_implementation/executable_image.cc
+++ b/src/common/pjrt_implementation/executable_image.cc
@@ -82,22 +82,6 @@ void ExecutableImage::BindApi(PJRT_Api *api) {
     args->num_replicas = 1;
     return nullptr;
   };
-  api->PJRT_Executable_Serialize =
-      +[](PJRT_Executable_Serialize_Args *args) -> PJRT_Error * {
-    DLOG_F(LOG_DEBUG, "ExecutableImage::PJRT_Executable_Serialize");
-    return ErrorInstance::MakeError(tt_pjrt_status::kUnimplemented);
-  };
-  api->PJRT_Executable_DeserializeAndLoad =
-      +[](PJRT_Executable_DeserializeAndLoad_Args *args) -> PJRT_Error * {
-    DLOG_F(LOG_DEBUG,
-           "ExecutableImage::PJRT_Executable_DeserializeAndLoad_Args");
-    return ErrorInstance::MakeError(tt_pjrt_status::kUnimplemented);
-  };
-  api->PJRT_Executable_Serialize =
-      +[](PJRT_Executable_Serialize_Args *args) -> PJRT_Error * {
-    DLOG_F(LOG_DEBUG, "ExecutableImage::PJRT_Executable_Serialize_Args");
-    return ErrorInstance::MakeError(tt_pjrt_status::kUnimplemented);
-  };
   api->PJRT_Executable_OptimizedProgram =
       +[](PJRT_Executable_OptimizedProgram_Args *args) -> PJRT_Error * {
     DLOG_F(LOG_DEBUG, "ExecutableImage::PJRT_Executable_OptimizedProgram");
@@ -115,27 +99,6 @@ void ExecutableImage::BindApi(PJRT_Api *api) {
       std::memcpy(program->code, executable->get_code().c_str(), code_size);
     }
     return nullptr;
-  };
-  api->PJRT_Executable_GetCostAnalysis =
-      +[](PJRT_Executable_GetCostAnalysis_Args *args) -> PJRT_Error * {
-    DLOG_F(LOG_DEBUG, "ExecutableImage::PJRT_Executable_GetCostAnalysis_Args");
-    return ErrorInstance::MakeError(tt_pjrt_status::kUnimplemented);
-  };
-  api->PJRT_Executable_OutputElementTypes =
-      +[](PJRT_Executable_OutputElementTypes_Args *args) -> PJRT_Error * {
-    DLOG_F(LOG_DEBUG,
-           "ExecutableImage::PJRT_Executable_OutputElementTypes_Args");
-    return ErrorInstance::MakeError(tt_pjrt_status::kUnimplemented);
-  };
-  api->PJRT_Executable_OutputDimensions =
-      +[](PJRT_Executable_OutputDimensions_Args *args) -> PJRT_Error * {
-    DLOG_F(LOG_DEBUG, "ExecutableImage::PJRT_Executable_OutputDimensions_Args");
-    return ErrorInstance::MakeError(tt_pjrt_status::kUnimplemented);
-  };
-  api->PJRT_Executable_OutputMemoryKinds =
-      +[](PJRT_Executable_OutputMemoryKinds_Args *args) -> PJRT_Error * {
-    DLOG_F(LOG_DEBUG, "ExecutableImage::PJRT_Executable_OutputMemoryKinds");
-    return ErrorInstance::MakeError(tt_pjrt_status::kUnimplemented);
   };
 }
 

--- a/src/common/pjrt_implementation/loaded_executable_instance.cc
+++ b/src/common/pjrt_implementation/loaded_executable_instance.cc
@@ -45,17 +45,6 @@ void LoadedExecutableInstance::BindApi(PJRT_Api *api) {
     args->num_addressable_devices = num_addressable_devices;
     return nullptr;
   };
-  api->PJRT_LoadedExecutable_Delete =
-      +[](PJRT_LoadedExecutable_Delete_Args *args) -> PJRT_Error * {
-    DLOG_F(LOG_DEBUG, "LoadedExecutableInstance::PJRT_LoadedExecutable_Delete");
-    return ErrorInstance::MakeError(tt_pjrt_status::kUnimplemented);
-  };
-  api->PJRT_LoadedExecutable_IsDeleted =
-      +[](PJRT_LoadedExecutable_IsDeleted_Args *args) -> PJRT_Error * {
-    DLOG_F(LOG_DEBUG,
-           "LoadedExecutableInstance::PJRT_LoadedExecutable_IsDeleted_Args");
-    return ErrorInstance::MakeError(tt_pjrt_status::kUnimplemented);
-  };
   api->PJRT_LoadedExecutable_Execute =
       +[](PJRT_LoadedExecutable_Execute_Args *args) -> PJRT_Error * {
     DLOG_F(LOG_DEBUG,


### PR DESCRIPTION
### Problem description
There are redundant api bindings for some unimplemented PJRT methods that are already in the `stubs.inc` file.

### What's changed
Removed them to make files easier to read.

### Checklist
- [ ] New/Existing tests provide coverage for changes
