### PR TITLE
Getting number of addressable devices from the mlir module instead of hardcoding

### DIFF
--- a/inc/common/pjrt_implementation/executable_image.h
+++ b/inc/common/pjrt_implementation/executable_image.h
@@ -26,8 +26,7 @@ class ExecutableImage {
 
 public:
   ExecutableImage(const tt::runtime::Binary &binary, std::string code,
-                  const std::vector<bool> &is_output_scalar,
-                  size_t num_addressable_devices);
+                  const std::vector<bool> &is_output_scalar);
 
   operator PJRT_Executable *() {
     return reinterpret_cast<PJRT_Executable *>(this);
@@ -51,10 +50,6 @@ public:
   const tt::runtime::Binary &get_binary() const { return m_binary; }
 
   const std::string &get_code() const { return m_code; }
-
-  const size_t get_num_addressable_devices() const {
-    return m_num_addressable_devices;
-  }
 
   const std::vector<std::uint32_t> &get_output_shape(const size_t index) const;
 
@@ -91,7 +86,6 @@ private:
 
   size_t m_arg_count;
   size_t m_result_count;
-  size_t m_num_addressable_devices;
 
   // For every output, holds if the type is a scalar or not.
   std::vector<bool> m_is_output_scalar;

--- a/inc/common/pjrt_implementation/loaded_executable_instance.h
+++ b/inc/common/pjrt_implementation/loaded_executable_instance.h
@@ -29,9 +29,11 @@ class LoadedExecutableInstance {
 public:
   LoadedExecutableInstance(
       ClientInstance &client, ExecutableImage *image,
-      const std::vector<DeviceInstance *> &addressable_devices)
+      const std::vector<DeviceInstance *> &addressable_devices,
+      size_t num_devices_to_utilize)
       : client_(client), image_(image),
-        addressable_devices_(addressable_devices) {}
+        addressable_devices_(addressable_devices),
+        num_devices_to_utilize_(num_devices_to_utilize) {}
   ~LoadedExecutableInstance();
 
   operator PJRT_LoadedExecutable *() {
@@ -46,6 +48,8 @@ public:
     return addressable_devices_;
   }
 
+  size_t get_num_devices_to_utilize() const { return num_devices_to_utilize_; }
+
   // Loads all executables to addressable devices.
   tt_pjrt_status LoadAll();
 
@@ -59,6 +63,7 @@ private:
   ClientInstance &client_;
   ExecutableImage *image_; // Ref-counted semantics.
   std::vector<DeviceInstance *> addressable_devices_;
+  size_t num_devices_to_utilize_;
   std::vector<ResidentExecutable> resident_executables_;
 };
 

--- a/src/common/module_builder.h
+++ b/src/common/module_builder.h
@@ -36,14 +36,17 @@ public:
     return m_is_output_scalar;
   };
 
-  // This needs to return the number of addressable devices from the StableHLO
-  // code. Currently hardcoded to one, as we only support one-chip execution.
-  size_t getNumAddressableDevices() const { return 1; }
+  size_t getNumDevicesToUtilize() const { return m_num_devices_to_utilize; }
 
 private:
   // Creates VHLO module from the input program code.
   mlir::OwningOpRef<mlir::ModuleOp>
   createVHLOModule(const std::string_view &code);
+
+  // Gets the number of devices the binary is intended to run on from the VHLO
+  // module.
+  void
+  collectNumDevicesToUtilize(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module);
 
   // Converts VHLO module to StableHLO module.
   void convertFromVHLOToSHLO(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module);
@@ -79,6 +82,9 @@ private:
 
   // For every output, holds if the type is a scalar or not.
   std::vector<bool> m_is_output_scalar;
+
+  // Number of devices the binary is intended to run on.
+  size_t m_num_devices_to_utilize;
 };
 
 } // namespace tt::pjrt

--- a/src/common/pjrt_implementation/client_instance.cc
+++ b/src/common/pjrt_implementation/client_instance.cc
@@ -163,8 +163,8 @@ tt_pjrt_status ClientInstance::PopulateDevices() {
 
   devices_.resize(devices_count);
   for (size_t i = 0; i < devices_count; ++i) {
-    devices_[i] =
-        new DeviceInstance(i, *this, system_desc->chip_descs()->Get(i)->arch());
+    devices_[i] = new DeviceInstance(chip_ids[i], *this,
+                                     system_desc->chip_descs()->Get(i)->arch());
   }
 
   // For now, just make all devices addressable.
@@ -191,11 +191,9 @@ PJRT_Error *ClientInstance::Compile(const PJRT_Program *program,
       *this,
       new ExecutableImage(module_builder_->getBinary(),
                           std::string(program->code, program->code_size),
-                          module_builder_->getIsOutputScalar(),
-                          module_builder_->getNumAddressableDevices()),
-      addressable_devices_);
+                          module_builder_->getIsOutputScalar()),
+      addressable_devices_, module_builder_->getNumDevicesToUtilize());
   *out_executable = executable.release();
-
   return nullptr;
 }
 

--- a/src/common/pjrt_implementation/executable_image.cc
+++ b/src/common/pjrt_implementation/executable_image.cc
@@ -22,12 +22,9 @@ const std::string_view kMlirFormat = "mlir";
 
 ExecutableImage::ExecutableImage(const tt::runtime::Binary &binary,
                                  std::string code,
-                                 const std::vector<bool> &is_output_scalar,
-                                 size_t num_addressable_devices)
+                                 const std::vector<bool> &is_output_scalar)
     : m_ref_count(1), m_binary(binary), m_code(code),
-      m_is_output_scalar(is_output_scalar),
-      m_num_addressable_devices(num_addressable_devices) {
-
+      m_is_output_scalar(is_output_scalar) {
   std::vector<tt::runtime::TensorDesc> output_specs =
       m_binary.getProgramOutputs(0);
   m_result_count = output_specs.size();


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/229

### Problem description
Number of addressable devices is hardcoded to 1, which is a problem for multichip.

### What's changed
- Now we get the number of addressable devices from the `mhlo.num_partitions` attribute in VHLO module.
- Changed device_id to be the same as chip_id from `getCurrentSystemDesc`, for less convoluted code.
- Moved `num_addressable_devices` from `ExecutableImage` to `LoadedExecutableInstance` because it is related to `addressable_devices_` of the `LoadedExecutableInstance`.

### Checklist
- [x] New/Existing tests provide coverage for changes
