### PR TITLE
New tt-mlir installation support

### DIFF
--- a/inc/common/pjrt_implementation/device_description.h
+++ b/inc/common/pjrt_implementation/device_description.h
@@ -13,7 +13,7 @@
 #include "xla/pjrt/c/pjrt_c_api.h"
 
 // tt-mlir includes
-#include "types_generated.h"
+#include "ttmlir/Target/Common/types_generated.h"
 
 #ifndef TT_XLA_INC_COMMON_PJRT_IMPLEMENTATION_DEVICE_DESCRIPTION_H_
 #define TT_XLA_INC_COMMON_PJRT_IMPLEMENTATION_DEVICE_DESCRIPTION_H_

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -37,6 +37,8 @@ target_include_directories(TTPJRTCommon PUBLIC
     ${PROJECT_SOURCE_DIR}/third_party/pjrt_c_api
     ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/install/include
     ${TTMLIR_TOOLCHAIN_DIR}/include
+    ${TTMLIR_TOOLCHAIN_DIR}/src/shardy
+    ${TTMLIR_TOOLCHAIN_DIR}/src/stablehlo
 )
 
 target_link_libraries(TTPJRTCommon PUBLIC

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -35,12 +35,7 @@ target_include_directories(TTPJRTCommon PUBLIC
     ${PROJECT_SOURCE_DIR}/inc
     ${PROJECT_SOURCE_DIR}/third_party/loguru/src/loguru-install/include/
     ${PROJECT_SOURCE_DIR}/third_party/pjrt_c_api
-    ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/src/tt-mlir-build/include
-    ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/src/tt-mlir-build/include/ttmlir/Target/Common
-    ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/src/tt-mlir/include
-    ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/src/tt-mlir/runtime/include
-    ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/src/tt-mlir-build/shardy/
-    ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/src/tt-mlir-build/stablehlo/
+    ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/install/include
     ${TTMLIR_TOOLCHAIN_DIR}/include
     ${TTMLIR_TOOLCHAIN_DIR}/src/shardy
     ${TTMLIR_TOOLCHAIN_DIR}/src/stablehlo
@@ -48,8 +43,6 @@ target_include_directories(TTPJRTCommon PUBLIC
 
 target_link_libraries(TTPJRTCommon PUBLIC
     loguru
-    LLVM
-    MLIR
     TTPJRTCommonDylibPlatform
     TTMLIRCompiler
     TTMLIRRuntime
@@ -60,6 +53,5 @@ target_link_libraries(TTPJRTCommon PUBLIC coverage_config)
 target_link_directories(TTPJRTCommon PUBLIC
     ${TTMLIR_TOOLCHAIN_DIR}/lib
     ${PROJECT_SOURCE_DIR}/third_party/loguru/src/loguru-install/lib/
-    ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/src/tt-mlir-build/lib
-    ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/src/tt-mlir-build/lib/SharedLib
+    ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/install/lib
 )

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -37,8 +37,6 @@ target_include_directories(TTPJRTCommon PUBLIC
     ${PROJECT_SOURCE_DIR}/third_party/pjrt_c_api
     ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/install/include
     ${TTMLIR_TOOLCHAIN_DIR}/include
-    ${TTMLIR_TOOLCHAIN_DIR}/src/shardy
-    ${TTMLIR_TOOLCHAIN_DIR}/src/stablehlo
 )
 
 target_link_libraries(TTPJRTCommon PUBLIC

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set(TT_MLIR_VERSION "947aed03c54a92612c9e3bb2f172c252f867b13f")
+set(TT_MLIR_VERSION "bfb88ddfac2d3aaf2ab0525ff177bdeadb2d34e9")
 set(LOGURU_VERSION "4adaa185883e3c04da25913579c451d3c32cfac1")
 
 if (TOOLCHAIN STREQUAL "ON")

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set(TT_MLIR_VERSION "fa8c589842b557042f8c554120b24fdae11d5fd6")
+set(TT_MLIR_VERSION "947aed03c54a92612c9e3bb2f172c252f867b13f")
 set(LOGURU_VERSION "4adaa185883e3c04da25913579c451d3c32cfac1")
 
 if (TOOLCHAIN STREQUAL "ON")
@@ -24,11 +24,15 @@ if (TOOLCHAIN STREQUAL "ON")
 else()
     include(ExternalProject)
     add_subdirectory(pjrt_c_api)
-    set(TTMLIR_LIB_DIR ${TTPJRT_SOURCE_DIR}/install)
+    set(TTMLIR_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/tt-mlir")
+    set(TTMLIR_BUILD_DIR "${TTMLIR_SOURCE_DIR}/build")
+    set(TTMLIR_LIB_DIR ${TTMLIR_SOURCE_DIR}/install)
     ExternalProject_Add(
         tt-mlir
         PREFIX ${TTPJRT_SOURCE_DIR}/third_party/tt-mlir
         CMAKE_GENERATOR Ninja
+        BINARY_DIR ${TTMLIR_BUILD_DIR}
+        INSTALL_COMMAND ${CMAKE_COMMAND} --install ${TTMLIR_BUILD_DIR} --component SharedLib
         CMAKE_ARGS
           -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_C_COMPILER=clang-17
@@ -37,19 +41,16 @@ else()
           -DTT_RUNTIME_ENABLE_TTNN=ON
           -DTTMLIR_ENABLE_STABLEHLO=ON
           -DTTMLIR_ENABLE_RUNTIME=ON
-          -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+          -DTTMLIR_ENABLE_BINDINGS_PYTHON=OFF
+          -DCMAKE_INSTALL_PREFIX=${TTMLIR_LIB_DIR}
         GIT_REPOSITORY https://github.com/tenstorrent/tt-mlir.git
         GIT_TAG ${TT_MLIR_VERSION}
         GIT_PROGRESS ON
     )
 
-    # #TODO: Remove this once we have a proper install target
-    # message(STATUS "Copying ttmetal libraries from ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/src/tt-mlir/third_party/tt-metal/src/tt-metal-build/lib to ${TTMLIR_LIB_DIR}/lib")
-    # execute_process(
-    #     COMMAND /bin/bash -c "mkdir -p ${TTMLIR_LIB_DIR}/lib/ && cp ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/src/tt-mlir/third_party/tt-metal/src/tt-metal-build/lib/* ${TTMLIR_LIB_DIR}/lib/"
-    # )
-
     set_target_properties(tt-mlir PROPERTIES EXCLUDE_FROM_ALL TRUE)
+
+    install(DIRECTORY ${TTMLIR_LIB_DIR}/ DESTINATION "${CMAKE_INSTALL_PREFIX}")
 
     # Link to all TTMLIR libraries in ${TTMLIR_INSTALL_DIR}/install/lib
     set(TTMLIR_LIB_DIR ${TTMLIR_LIB_DIR} PARENT_SCOPE)


### PR DESCRIPTION
Adopt the new way that tt-mlir builds and links:
- Packages all of tt-mlir + downstream tt-metal libs and files into installation prefix for easy deployment
- Statically links `libTTMLIRCompiler.so` and `libTTMLIRRuntime.so`, now FE's only need to link against these 2 binaries and no other deps.

See tt-mlir PR for more information:
https://github.com/tenstorrent/tt-mlir/pull/2108