### PR TITLE
Fix docker mlir_override input

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -128,6 +128,13 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Override tt-mlir SHA mlir_override is set
+        if: ${{ inputs.mlir_override }}
+        shell: bash
+        run: |
+            # Update the CMakeLists.txt file with the new SHA
+            sed -i "s/set(TT_MLIR_VERSION \".*\")/set(TT_MLIR_VERSION \"${{ inputs.mlir_override }}\")/" third_party/CMakeLists.txt
+
       - name: Build Docker images and output the image name
         id: build
         shell: bash


### PR DESCRIPTION
### Ticket
Link to Github Issue
https://github.com/tenstorrent/tt-xla/issues/266

### Problem description
 The`inputs.mlir_override` on `.github/workflows/build-and-test.yml` did not honor the commit that was being supplied.
REF: https://tenstorrent.slack.com/archives/C07V0EQG98Q/p1739986947069349
### What's changed

- Fixed `inputs.mlir_override` to use the supplied commit id in docker image tag.

### Testing:

#### Triggered On-PR workflow dispatch to call `.github/workflows/build-and-test.yml`

##### Triggered without args (default) with skip step `Override tt-mlir SHA mlir_override is set`
https://github.com/tenstorrent/tt-xla/actions/runs/13439299354/job/37549449556?pr=267 

##### Triggered with commit id: 813663c16c23677a245261f3e1d16efd58a426c0  and runs step` Override tt-mlir SHA mlir_override is set`
https://github.com/tenstorrent/tt-xla/actions/runs/13439342698/job/37549539654#step:6:3

