### PR TITLE
Uplift third_party/tt-mlir to 4b6791a3421cd9f227dc8f90acc7fc4d6eb19268 2025-02-21

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set(TT_MLIR_VERSION "2838c64cc65be1bd1cedfd34ddbc72c3b8ec9636")
+set(TT_MLIR_VERSION "4b6791a3421cd9f227dc8f90acc7fc4d6eb19268")
 set(LOGURU_VERSION "4adaa185883e3c04da25913579c451d3c32cfac1")
 
 if (TOOLCHAIN STREQUAL "ON")


### PR DESCRIPTION
This PR uplifts the third_party/tt-mlir to the 4b6791a3421cd9f227dc8f90acc7fc4d6eb19268