### PR TITLE
Adding more multichip tests with manual sharding

### DIFF
--- a/tests/infra/device_runner.py
+++ b/tests/infra/device_runner.py
@@ -9,6 +9,7 @@ from typing import Callable, Sequence
 
 
 from .device_connector import DeviceType, device_connector
+from .workload import MultichipWorkload
 from .types import Tensor
 from .workload import MultichipWorkload, Workload
 
@@ -121,7 +122,7 @@ class DeviceRunner:
                 args_on_device.append(
                     DeviceRunner._put_sharded_tensor_on_multichip_device(
                         arg,
-                        multichip_workload.mesh,
+                        multichip_workload.device_mesh,
                         multichip_workload.in_specs[spec_index],
                     )
                 )
@@ -145,7 +146,7 @@ class DeviceRunner:
             multichip_workload.executable,
             args_on_device,
             kwargs_on_device,
-            mesh=multichip_workload.mesh,
+            device_mesh=multichip_workload.device_mesh,
             in_specs=multichip_workload.in_specs,
         )
 

--- a/tests/infra/multichip_tester.py
+++ b/tests/infra/multichip_tester.py
@@ -110,7 +110,10 @@ class MultichipTester(BaseTester):
             for shape in input_shapes
         ]
         device_workload = MultichipWorkload(
-            device_executable, inputs, mesh=self.device_mesh, in_specs=self.in_specs
+            device_executable,
+            inputs,
+            device_mesh=self.device_mesh,
+            in_specs=self.in_specs,
         )
         cpu_workload = Workload(cpu_executable, inputs)
         self.test(device_workload, cpu_workload)

--- a/tests/jax/multichip/manual/all_gather.py
+++ b/tests/jax/multichip/manual/all_gather.py
@@ -7,12 +7,13 @@ import jax.numpy as jnp
 from infra import run_multichip_test_with_random_inputs, make_partition_spec
 import pytest
 from utils import compile_fail
-from tests.utils import make_partition_spec
 
 
-@pytest.mark.parametrize(("x_shape", "axis_names"), [((8192, 784), ("batch",))])
+@pytest.mark.parametrize(
+    ("x_shape", "mesh_shape", "axis_names"), [((8192, 784), (2,), ("batch",))]
+)
 @pytest.mark.skip(reason=compile_fail("Multichip still in development"))
-def test_all_gather(x_shape: tuple, axis_names: tuple):
+def test_all_gather(x_shape: tuple, mesh_shape: tuple, axis_names: tuple):
     def fwd(batch):
         act = jax.lax.all_gather(batch, axis_names, axis=0, tiled=True)
         return act
@@ -24,5 +25,5 @@ def test_all_gather(x_shape: tuple, axis_names: tuple):
     out_specs = make_partition_spec(axis_names)
 
     run_multichip_test_with_random_inputs(
-        fwd, golden_fwd, [x_shape], (2,), axis_names, in_specs, out_specs
+        fwd, golden_fwd, [x_shape], mesh_shape, axis_names, in_specs, out_specs
     )

--- a/tests/jax/multichip/manual/data_paralelism.py
+++ b/tests/jax/multichip/manual/data_paralelism.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from infra import run_multichip_test_with_random_inputs, make_partition_spec
+import jax
+import jax.numpy as jnp
+from utils import compile_fail
+import pytest
+
+
+@pytest.mark.parametrize(
+    [
+        "batch_shape",
+        "W1_shape",
+        "B1_shape",
+        "W2_shape",
+        "B2_shape",
+        "mesh_shape",
+        "axis_names",
+    ],
+    [
+        [
+            (8192, 784),
+            (784, 2048),
+            (2048),
+            (2048, 1024),
+            (1024),
+            (1, 2),
+            ("batch", "model"),
+        ],
+    ],
+)
+@pytest.mark.skip(reason=compile_fail("Multichip still in development"))
+def test_data_paralelism(
+    batch_shape: tuple,
+    W1_shape: tuple,
+    B1_shape: tuple,
+    W2_shape: tuple,
+    B2_shape: tuple,
+    mesh_shape: tuple,
+    axis_names: tuple,
+):
+    def fwd(batch, W1_block, B1_block, W2_block, B2_block):
+        act = jnp.dot(batch, W1_block)
+        act = jax.lax.psum_scatter(act, "model", scatter_dimension=1, tiled=True)
+        act = act + B1_block
+        act = jnp.dot(act, W2_block)
+        act = jax.lax.psum_scatter(act, "model", scatter_dimension=1, tiled=True)
+        act = act + B2_block
+        return act
+
+    def golden_fwd(batch, W1, B1, W2, B2):
+        act = jnp.dot(batch, W1)
+        act = act + B1
+        act = jnp.dot(act, W2)
+        act = act + B2
+        return act
+
+    in_specs = (
+        make_partition_spec(axis_names),
+        make_partition_spec((axis_names[1], None)),
+        make_partition_spec((axis_names[1],)),
+        make_partition_spec((axis_names[1], None)),
+        make_partition_spec((axis_names[1],)),
+    )
+    out_specs = make_partition_spec(axis_names)
+
+    run_multichip_test_with_random_inputs(
+        fwd,
+        golden_fwd,
+        [batch_shape, W1_shape, B1_shape, W2_shape, B2_shape],
+        mesh_shape,
+        axis_names,
+        in_specs,
+        out_specs,
+        maxval=0.1,
+    )

--- a/tests/jax/multichip/manual/psum.py
+++ b/tests/jax/multichip/manual/psum.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import jax
+import jax.numpy as jnp
+from infra import run_multichip_test_with_random_inputs, make_partition_spec
+import pytest
+from utils import compile_fail
+
+
+@pytest.mark.parametrize(
+    ["batch_shape", "W1_shape", "B1_shape", "mesh_shape", "axis_names"],
+    [
+        [(8192, 784), (784, 2048), (2048), (1, 2), ("batch", "model")],
+    ],
+)
+@pytest.mark.skip(reason=compile_fail("Multichip still in development"))
+def test_psum(
+    batch_shape: tuple,
+    W1_shape: tuple,
+    B1_shape: tuple,
+    mesh_shape: tuple,
+    axis_names: tuple,
+):
+    def fwd(batch, W1_block, B1_block):
+        act = jnp.dot(batch, W1_block)
+        act = jax.lax.psum(act, axis_names[1])
+        act = act + B1_block
+        return act
+
+    def fwd_single_device(batch, W1, B1):
+        act = jnp.dot(batch, W1)
+        act = act + B1
+        return act
+
+    in_specs = (
+        make_partition_spec(axis_names),
+        make_partition_spec((axis_names[1], None)),
+        make_partition_spec((None,)),
+    )
+    out_specs = make_partition_spec((axis_names[0],))
+
+    run_multichip_test_with_random_inputs(
+        fwd,
+        fwd_single_device,
+        [batch_shape, W1_shape, B1_shape],
+        mesh_shape,
+        axis_names,
+        in_specs,
+        out_specs,
+        maxval=0.1,
+    )

--- a/tests/jax/multichip/manual/psum_scatter.py
+++ b/tests/jax/multichip/manual/psum_scatter.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from infra import run_multichip_test_with_random_inputs, make_partition_spec
+import jax
+import jax.numpy as jnp
+import pytest
+from utils import compile_fail
+
+
+@pytest.mark.parametrize(
+    ["batch_shape", "W1_shape", "B1_shape", "mesh_shape", "axis_names"],
+    [
+        [(8192, 784), (784, 2048), (2048), (1, 2), ("batch", "model")],
+    ],
+)
+@pytest.mark.skip(reason=compile_fail("Multichip still in development"))
+def test_psum_scatter(
+    batch_shape: tuple,
+    W1_shape: tuple,
+    B1_shape: tuple,
+    mesh_shape: tuple,
+    axis_names: tuple,
+):
+    def fwd(batch, W1_block, B1_block):
+        act = jnp.dot(batch, W1_block)
+        act = jax.lax.psum_scatter(act, "model", scatter_dimension=1, tiled=True)
+        act = act + B1_block
+        return act
+
+    def golden_fwd(batch, W1, B1):
+        act = jnp.dot(batch, W1)
+        act = act + B1
+        return act
+
+    in_specs = (
+        make_partition_spec(axis_names),
+        make_partition_spec((axis_names[1], None)),
+        make_partition_spec((axis_names[1],)),
+    )
+    out_specs = make_partition_spec(axis_names)
+
+    run_multichip_test_with_random_inputs(
+        fwd,
+        golden_fwd,
+        [batch_shape, W1_shape, B1_shape],
+        mesh_shape,
+        axis_names,
+        in_specs,
+        out_specs,
+        maxval=0.1,
+    )

--- a/tests/jax/multichip/manual/unary_eltwise.py
+++ b/tests/jax/multichip/manual/unary_eltwise.py
@@ -2,17 +2,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from infra import run_multichip_test_with_random_inputs, make_partition_spec
 import jax
 import jax.numpy as jnp
-from infra import run_multichip_test_with_random_inputs, make_partition_spec
 import pytest
 from utils import compile_fail
-from tests.utils import make_partition_spec
 
 
-@pytest.mark.parametrize(("x_shape", "axis_names"), [((256, 256), ("x", "y"))])
+@pytest.mark.parametrize(
+    ("x_shape", "mesh_shape", "axis_names"), [((256, 256), (1, 2), ("x", "y"))]
+)
 @pytest.mark.skip(reason=compile_fail("Multichip still in development"))
-def test_unary_eltwise(x_shape: tuple, axis_names: tuple):
+def test_unary_eltwise(x_shape: tuple, mesh_shape: tuple, axis_names: tuple):
     def fwd(a_block):
         b_block = jnp.negative(a_block)
         stitched_result = jax.lax.psum(b_block, axis_names)
@@ -30,5 +31,5 @@ def test_unary_eltwise(x_shape: tuple, axis_names: tuple):
     out_specs = make_partition_spec((None, None))
 
     run_multichip_test_with_random_inputs(
-        fwd, fwd_single_device, [x_shape], (1, 2), axis_names, in_specs, out_specs
+        fwd, fwd_single_device, [x_shape], mesh_shape, axis_names, in_specs, out_specs
     )


### PR DESCRIPTION
### Ticket
Part of issue https://github.com/tenstorrent/tt-xla/issues/209

With the addition of the multichip testing infrastructure in the repo, adding multiple tests for manual sharding, all of which are currently skipped, since we do not have support.
