### PR TITLE
Adding input sharding collection in ModuleBuilder

### DIFF
--- a/inc/common/pjrt_implementation/executable_image.h
+++ b/inc/common/pjrt_implementation/executable_image.h
@@ -17,6 +17,10 @@
 // tt-mlir includes
 #include "tt/runtime/types.h"
 
+// tt-mlir includes
+#define TTMLIR_ENABLE_STABLEHLO 1
+#include "ttmlir/Conversion/StableHLOToTTIR/ShardingUtils.h"
+
 #ifndef TT_XLA_INC_COMMON_PJRT_IMPLEMENTATION_EXECUTABLE_IMAGE_H_
 #define TT_XLA_INC_COMMON_PJRT_IMPLEMENTATION_EXECUTABLE_IMAGE_H_
 
@@ -25,8 +29,12 @@ namespace tt::pjrt {
 class ExecutableImage {
 
 public:
-  ExecutableImage(const tt::runtime::Binary &binary, std::string code,
-                  const std::vector<bool> &is_output_scalar);
+  ExecutableImage(
+      const tt::runtime::Binary &binary, std::string code,
+      const std::vector<mlir::tt::sharding_utils::MeshSharding> &input_sharding,
+      const std::vector<mlir::tt::sharding_utils::MeshSharding>
+          &output_sharding,
+      const std::vector<bool> &is_output_scalar);
 
   operator PJRT_Executable *() {
     return reinterpret_cast<PJRT_Executable *>(this);
@@ -106,6 +114,12 @@ private:
 
   // For every output, holds its stride.
   std::vector<std::vector<uint32_t>> m_output_strides;
+
+  // Hold the sharding information for each input.
+  const std::vector<mlir::tt::sharding_utils::MeshSharding> m_input_sharding;
+
+  // Hold the sharding information for each output.
+  const std::vector<mlir::tt::sharding_utils::MeshSharding> m_output_sharding;
 };
 
 } // namespace tt::pjrt

--- a/inc/common/pjrt_implementation/executable_image.h
+++ b/inc/common/pjrt_implementation/executable_image.h
@@ -15,10 +15,8 @@
 #include "xla/pjrt/c/pjrt_c_api.h"
 
 // tt-mlir includes
-#include "tt/runtime/types.h"
-
-// tt-mlir includes
 #define TTMLIR_ENABLE_STABLEHLO 1
+#include "tt/runtime/types.h"
 #include "ttmlir/Conversion/StableHLOToTTIR/ShardingUtils.h"
 
 #ifndef TT_XLA_INC_COMMON_PJRT_IMPLEMENTATION_EXECUTABLE_IMAGE_H_

--- a/src/common/module_builder.h
+++ b/src/common/module_builder.h
@@ -69,10 +69,10 @@ private:
   // scalar or not.
   void collectOutputTypes(const mlir::OwningOpRef<mlir::ModuleOp> &module);
 
-  // Collects the information about the sharding of specifc inputs.
+  // Collects the information about the sharding of specific inputs.
   void collectInputShardings(const mlir::OwningOpRef<mlir::ModuleOp> &module);
 
-  // Collects the information about the sharding of specifc outputs.
+  // Collects the information about the sharding of specific outputs.
   void collectOutputShardings(const mlir::OwningOpRef<mlir::ModuleOp> &module);
 
   // Converts StableHLO module to TTIR module.
@@ -92,11 +92,15 @@ private:
   // Checks if a particular type is scalar.
   bool isScalarType(mlir::Type type);
 
-  // Fills sharding_utils::MeshSharding object with sharding info stored in a
-  // StringAttribute.
-  mlir::LogicalResult fillMeshShardingFromGSPMDString(
-      mlir::StringAttr shardingStr,
-      mlir::tt::sharding_utils::MeshSharding &meshSharding);
+  // Takes a vector of string attributes representing GSPMD sharding and fills
+  // the vector of tt_mlir Sharding with the appropriate corresponding values.
+  mlir::LogicalResult createShardingsFromGSPMD(
+      const std::vector<mlir::StringAttr> &gspmd_attributes,
+      std::vector<mlir::tt::sharding_utils::MeshSharding> &shardings);
+
+  // Gets all public functions from the module.
+  std::vector<mlir::func::FuncOp>
+  getPublicFuncOps(const mlir::OwningOpRef<mlir::ModuleOp> &module);
 
   // MLIR context handle.
   std::unique_ptr<mlir::MLIRContext> m_context;

--- a/src/common/pjrt_implementation/client_instance.cc
+++ b/src/common/pjrt_implementation/client_instance.cc
@@ -211,6 +211,8 @@ PJRT_Error *ClientInstance::Compile(const PJRT_Program *program,
       *this,
       new ExecutableImage(module_builder_->getBinary(),
                           std::string(program->code, program->code_size),
+                          module_builder_->getInputShardings(),
+                          module_builder_->getOutputShardings(),
                           module_builder_->getIsOutputScalar()),
       addressable_devices_, module_builder_->getNumDevicesToUtilize());
   *out_executable = executable.release();

--- a/src/common/pjrt_implementation/executable_image.cc
+++ b/src/common/pjrt_implementation/executable_image.cc
@@ -20,11 +20,15 @@ namespace tt::pjrt {
 
 const std::string_view kMlirFormat = "mlir";
 
-ExecutableImage::ExecutableImage(const tt::runtime::Binary &binary,
-                                 std::string code,
-                                 const std::vector<bool> &is_output_scalar)
+ExecutableImage::ExecutableImage(
+    const tt::runtime::Binary &binary, std::string code,
+    const std::vector<mlir::tt::sharding_utils::MeshSharding> &input_sharding,
+    const std::vector<mlir::tt::sharding_utils::MeshSharding> &output_sharding,
+    const std::vector<bool> &is_output_scalar)
     : m_ref_count(1), m_binary(binary), m_code(code),
+      m_input_sharding(input_sharding), m_output_sharding(output_sharding),
       m_is_output_scalar(is_output_scalar) {
+
   std::vector<tt::runtime::TensorDesc> output_specs =
       m_binary.getProgramOutputs(0);
   m_result_count = output_specs.size();


### PR DESCRIPTION
As part of adding support for multichip, adding collection of the information about the device sharding of the inputs of the the StableHLO graph during compilation. That way, we will know how to create MultiDevice input tensors when executing.

Edit: Also added output sharding collection.