### PR TITLE
Skipped test_gpt_neo_125m_inference

### DIFF
--- a/tests/jax/models/gpt_neo/gpt_neo_125m/test_gpt_neo_125m.py
+++ b/tests/jax/models/gpt_neo/gpt_neo_125m/test_gpt_neo_125m.py
@@ -5,7 +5,7 @@
 from typing import Callable
 
 import pytest
-from infra import ModelTester, RunMode
+from infra import RunMode
 from utils import record_model_test_properties, runtime_fail
 
 from ..tester import GPTNeoTester
@@ -23,14 +23,14 @@ def inference_tester() -> GPTNeoTester:
 
 @pytest.fixture
 def training_tester() -> GPTNeoTester:
-    return GPTNeoTester(ModelTester, run_mode=RunMode.TRAINING)
+    return GPTNeoTester(MODEL_PATH, run_mode=RunMode.TRAINING)
 
 
 # ----- Tests -----
 
 
 @pytest.mark.nightly
-@pytest.mark.xfail(
+@pytest.mark.skip(
     reason=runtime_fail(
         "Host data with total size 4B does not match expected size 2B of device buffer!"
     )

--- a/tests/jax/models/gpt_neo/gpt_neo_1_3b/test_gpt_neo_1_3b.py
+++ b/tests/jax/models/gpt_neo/gpt_neo_1_3b/test_gpt_neo_1_3b.py
@@ -5,7 +5,7 @@
 from typing import Callable
 
 import pytest
-from infra import ModelTester, RunMode
+from infra import RunMode
 from utils import record_model_test_properties, runtime_fail
 
 from ..tester import GPTNeoTester
@@ -23,14 +23,14 @@ def inference_tester() -> GPTNeoTester:
 
 @pytest.fixture
 def training_tester() -> GPTNeoTester:
-    return GPTNeoTester(ModelTester, run_mode=RunMode.TRAINING)
+    return GPTNeoTester(MODEL_PATH, run_mode=RunMode.TRAINING)
 
 
 # ----- Tests -----
 
 
 @pytest.mark.nightly
-@pytest.mark.xfail(
+@pytest.mark.skip(
     reason=runtime_fail(
         "Host data with total size 4B does not match expected size 2B of device buffer!"
     )

--- a/tests/jax/models/gpt_neo/gpt_neo_2_7b/test_gpt_neo_2_7b.py
+++ b/tests/jax/models/gpt_neo/gpt_neo_2_7b/test_gpt_neo_2_7b.py
@@ -5,7 +5,7 @@
 from typing import Callable
 
 import pytest
-from infra import ModelTester, RunMode
+from infra import RunMode
 from utils import record_model_test_properties
 
 from ..tester import GPTNeoTester
@@ -23,7 +23,7 @@ def inference_tester() -> GPTNeoTester:
 
 @pytest.fixture
 def training_tester() -> GPTNeoTester:
-    return GPTNeoTester(ModelTester, run_mode=RunMode.TRAINING)
+    return GPTNeoTester(MODEL_PATH, run_mode=RunMode.TRAINING)
 
 
 # ----- Tests -----


### PR DESCRIPTION
Had to skip it instead of xfailing it due to our nightly run failing for a couple of days because of some unexpected errors during run. 

Also passed `MODEL_PATH` properly to `GPTNeoTester` for training which mistakingly was receiving base class.