### PR TITLE
Update maxVal while creating boolean inputs

### DIFF
--- a/tests/infra/utils.py
+++ b/tests/infra/utils.py
@@ -60,14 +60,10 @@ def random_tensor(
                 maxval=maxval,
             )
         elif jnp.issubdtype(dtype_converted, jnp.bool):
-            # Generate random tensor of 0s and 1s and interpret is as a bool tensor.
-            return jax.random.randint(
-                key=prng_key,
-                shape=shape,
-                dtype=jnp.int32,
-                minval=0,
-                maxval=1,
-            ).astype(dtype_converted)
+            # Generate random tensor of type bool.
+            return jax.random.choice(
+                key=prng_key, a=jnp.array([False, True]), shape=shape
+            )
         else:
             raise TypeError(f"Unsupported dtype: {dtype}")
     else:


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-xla/issues/301

### Problem description
Random input is created using minVal=0 and maxVal=1. However, the maximum value is not inclusive while creating random numbers. As a result, this randint function will always generate `False` instead of generating either `False` or `True`.

### What's changed
Update boolean random tensor creation process

### Checklist
- [ ] New/Existing tests provide coverage for changes
