### PR TITLE
Introducted new nightly job test_full_model

### DIFF
--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -6,8 +6,16 @@ on:
     - cron: '0 0 * * *'
 
 jobs:
-  build-and-test:
+  nightly_tests:
     uses: ./.github/workflows/build-and-test.yml
     secrets: inherit
     with:
       test_mark: 'nightly'
+
+  test_full_model:
+    uses: ./.github/workflows/build-and-test.yml
+    secrets: inherit
+    needs: nightly_tests
+    if: always()  # This ensures the job runs regardless of success or failure of `nightly_tests`
+    with:
+      test_mark: 'model_test'

--- a/tests/jax/models/albert/v2/base/test_albert_base.py
+++ b/tests/jax/models/albert/v2/base/test_albert_base.py
@@ -30,7 +30,7 @@ def training_tester() -> AlbertV2Tester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.xfail(
     reason=(
         runtime_fail(
@@ -47,7 +47,7 @@ def test_flax_albert_v2_base_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_flax_albert_v2_base_training(
     training_tester: AlbertV2Tester,

--- a/tests/jax/models/albert/v2/large/test_albert_large.py
+++ b/tests/jax/models/albert/v2/large/test_albert_large.py
@@ -30,7 +30,7 @@ def training_tester() -> AlbertV2Tester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.xfail(
     reason=(
         runtime_fail(
@@ -47,7 +47,7 @@ def test_flax_albert_v2_large_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_flax_albert_v2_large_training(
     training_tester: AlbertV2Tester,

--- a/tests/jax/models/albert/v2/xlarge/test_albert_xlarge.py
+++ b/tests/jax/models/albert/v2/xlarge/test_albert_xlarge.py
@@ -30,7 +30,7 @@ def training_tester() -> AlbertV2Tester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.xfail(
     reason=(
         runtime_fail(
@@ -47,7 +47,7 @@ def test_flax_albert_v2_xlarge_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_flax_albert_v2_xlarge_training(
     training_tester: AlbertV2Tester,

--- a/tests/jax/models/albert/v2/xxlarge/test_albert_xxlarge.py
+++ b/tests/jax/models/albert/v2/xxlarge/test_albert_xxlarge.py
@@ -30,7 +30,7 @@ def training_tester() -> AlbertV2Tester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.xfail(
     reason=(
         runtime_fail(
@@ -47,7 +47,7 @@ def test_flax_albert_v2_xxlarge_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_flax_albert_v2_xxlarge_training(
     training_tester: AlbertV2Tester,

--- a/tests/jax/models/bart/base/test_bart_base.py
+++ b/tests/jax/models/bart/base/test_bart_base.py
@@ -30,7 +30,7 @@ def training_tester() -> FlaxBartForCausalLMTester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.xfail(
     reason=(
         runtime_fail(
@@ -48,7 +48,7 @@ def test_flax_bart_base_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_flax_bart_base_training(
     training_tester: FlaxBartForCausalLMTester,

--- a/tests/jax/models/bart/large/test_bart_large.py
+++ b/tests/jax/models/bart/large/test_bart_large.py
@@ -30,7 +30,7 @@ def training_tester() -> FlaxBartForCausalLMTester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.xfail(
     reason=compile_fail(
         "Unsupported data type (https://github.com/tenstorrent/tt-xla/issues/214)"
@@ -45,7 +45,7 @@ def test_flax_bart_large_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_flax_bart_large_training(
     training_tester: FlaxBartForCausalLMTester,

--- a/tests/jax/models/beit/base/test_beit_base.py
+++ b/tests/jax/models/beit/base/test_beit_base.py
@@ -31,7 +31,7 @@ def training_tester() -> FlaxBeitForImageClassificationTester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.xfail(reason=compile_fail("failed to legalize operation 'ttir.gather'"))
 def test_flax_beit_base_inference(
     inference_tester: FlaxBeitForImageClassificationTester,
@@ -42,7 +42,7 @@ def test_flax_beit_base_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_flax_beit_base_training(
     training_tester: FlaxBeitForImageClassificationTester,

--- a/tests/jax/models/beit/large/test_beit_large.py
+++ b/tests/jax/models/beit/large/test_beit_large.py
@@ -30,7 +30,7 @@ def training_tester() -> FlaxBeitForImageClassificationTester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.xfail(reason=compile_fail("failed to legalize operation 'ttir.gather'"))
 def test_flax_beit_large_inference(
     inference_tester: FlaxBeitForImageClassificationTester,
@@ -41,7 +41,7 @@ def test_flax_beit_large_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_flax_beit_large_training(
     training_tester: FlaxBeitForImageClassificationTester,

--- a/tests/jax/models/bert/base/test_bert_base.py
+++ b/tests/jax/models/bert/base/test_bert_base.py
@@ -30,7 +30,7 @@ def training_tester() -> FlaxBertForMaskedLMTester:
 
 
 @pytest.mark.push
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.xfail(
     reason=(
         runtime_fail(
@@ -48,7 +48,7 @@ def test_flax_bert_base_inference(
 
 
 @pytest.mark.push
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_flax_bert_base_training(
     training_tester: FlaxBertForMaskedLMTester,

--- a/tests/jax/models/bert/large/test_bert_large.py
+++ b/tests/jax/models/bert/large/test_bert_large.py
@@ -29,7 +29,7 @@ def training_tester() -> FlaxBertForMaskedLMTester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.xfail(
     reason=runtime_fail(
         "Atol comparison failed. Calculated: atol=131037.828125. Required: atol=0.16."
@@ -44,7 +44,7 @@ def test_flax_bert_large_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_flax_bert_large_training(
     training_tester: FlaxBertForMaskedLMTester,

--- a/tests/jax/models/bloom/bloom_1b1/test_1b1.py
+++ b/tests/jax/models/bloom/bloom_1b1/test_1b1.py
@@ -33,7 +33,7 @@ def training_tester() -> BloomTester:
 # The error message seems to happen before the compile even begins
 # And then then compile segfaults with no useful information
 # It is highly likely that both are caused by the same root cause
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason=compile_fail("Unsupported data type"))  # segfault
 def test_bloom_1b1_inference(
     inference_tester: BloomTester,
@@ -44,7 +44,7 @@ def test_bloom_1b1_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_bloom_1b1_training(
     training_tester: BloomTester,

--- a/tests/jax/models/bloom/bloom_1b7/test_1b7.py
+++ b/tests/jax/models/bloom/bloom_1b7/test_1b7.py
@@ -30,7 +30,7 @@ def training_tester() -> BloomTester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason=compile_fail("Unsupported data type"))  # segfault
 def test_bloom_1b7_inference(
     inference_tester: BloomTester,
@@ -41,7 +41,7 @@ def test_bloom_1b7_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_bloom_1b7_training(
     training_tester: BloomTester,

--- a/tests/jax/models/bloom/bloom_3b/test_3b.py
+++ b/tests/jax/models/bloom/bloom_3b/test_3b.py
@@ -30,7 +30,7 @@ def training_tester() -> BloomTester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason=compile_fail("Unsupported data type"))  # segfault
 def test_bloom_3b_inference(
     inference_tester: BloomTester,
@@ -41,7 +41,7 @@ def test_bloom_3b_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_bloom_3b_training(
     training_tester: BloomTester,

--- a/tests/jax/models/bloom/bloom_560m/test_560m.py
+++ b/tests/jax/models/bloom/bloom_560m/test_560m.py
@@ -30,7 +30,7 @@ def training_tester() -> BloomTester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason=compile_fail("Unsupported data type"))  # segfault
 def test_bloom_560m_inference(
     inference_tester: BloomTester,
@@ -41,7 +41,7 @@ def test_bloom_560m_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_bloom_560m_training(
     training_tester: BloomTester,

--- a/tests/jax/models/bloom/bloom_7b/test_7b.py
+++ b/tests/jax/models/bloom/bloom_7b/test_7b.py
@@ -29,7 +29,7 @@ def training_tester() -> BloomTester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason=compile_fail("Unsupported data type"))  # segfault
 def test_bloom_7b_inference(
     inference_tester: BloomTester,
@@ -40,7 +40,7 @@ def test_bloom_7b_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_bloom_7b_training(
     training_tester: BloomTester,

--- a/tests/jax/models/clip/base_patch16/test_clip_base_patch16.py
+++ b/tests/jax/models/clip/base_patch16/test_clip_base_patch16.py
@@ -32,7 +32,7 @@ def training_tester() -> FlaxCLIPTester:
 
 
 @pytest.mark.push
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.xfail(
     reason=compile_fail(
         "failed to legalize operation 'ttir.gather' that was explicitly marked illegal"

--- a/tests/jax/models/clip/base_patch32/test_clip_base_patch32.py
+++ b/tests/jax/models/clip/base_patch32/test_clip_base_patch32.py
@@ -31,7 +31,7 @@ def training_tester() -> FlaxCLIPTester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.xfail(
     reason=compile_fail(
         "failed to legalize operation 'ttir.gather' that was explicitly marked illegal"

--- a/tests/jax/models/clip/large_patch14/test_clip_large_patch14.py
+++ b/tests/jax/models/clip/large_patch14/test_clip_large_patch14.py
@@ -31,7 +31,7 @@ def training_tester() -> FlaxCLIPTester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.xfail(
     reason=compile_fail("failed to legalize operation 'stablehlo.reduce'")
 )

--- a/tests/jax/models/clip/large_patch14_336/test_clip_large_patch14_336.py
+++ b/tests/jax/models/clip/large_patch14_336/test_clip_large_patch14_336.py
@@ -31,7 +31,7 @@ def training_tester() -> FlaxCLIPTester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.xfail(
     reason=compile_fail("failed to legalize operation 'stablehlo.reduce'")
 )

--- a/tests/jax/models/distilbert/test_distilbert.py
+++ b/tests/jax/models/distilbert/test_distilbert.py
@@ -54,7 +54,7 @@ def training_tester() -> FlaxDistilBertForMaskedLMTester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.xfail(
     reason=(
         runtime_fail(
@@ -72,7 +72,7 @@ def test_flax_distilbert_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_flax_distilbert_training(
     training_tester: FlaxDistilBertForMaskedLMTester,

--- a/tests/jax/models/example_model/mixed_args_and_kwargs/test_example_model_mixed_args_and_kwargs.py
+++ b/tests/jax/models/example_model/mixed_args_and_kwargs/test_example_model_mixed_args_and_kwargs.py
@@ -79,7 +79,7 @@ def training_tester() -> ExampleModelMixedArgsAndKwargsTester:
 
 
 @pytest.mark.push
-@pytest.mark.nightly
+@pytest.mark.model_test
 def test_example_model_inference(
     inference_tester: ExampleModelMixedArgsAndKwargsTester,
 ):
@@ -87,7 +87,7 @@ def test_example_model_inference(
 
 
 @pytest.mark.push
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_example_model_training(training_tester: ExampleModelMixedArgsAndKwargsTester):
     training_tester.test()

--- a/tests/jax/models/example_model/only_args/test_example_model_only_args.py
+++ b/tests/jax/models/example_model/only_args/test_example_model_only_args.py
@@ -74,13 +74,13 @@ def training_tester() -> ExampleModelOnlyArgsTester:
 
 
 @pytest.mark.push
-@pytest.mark.nightly
+@pytest.mark.model_test
 def test_example_model_inference(inference_tester: ExampleModelOnlyArgsTester):
     inference_tester.test()
 
 
 @pytest.mark.push
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_example_model_training(training_tester: ExampleModelOnlyArgsTester):
     training_tester.test()

--- a/tests/jax/models/example_model/only_kwargs/test_example_model_only_kwargs.py
+++ b/tests/jax/models/example_model/only_kwargs/test_example_model_only_kwargs.py
@@ -74,13 +74,13 @@ def training_tester() -> ExampleModelOnlyKwargsTester:
 
 
 @pytest.mark.push
-@pytest.mark.nightly
+@pytest.mark.model_test
 def test_example_model_inference(inference_tester: ExampleModelOnlyKwargsTester):
     inference_tester.test()
 
 
 @pytest.mark.push
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_example_model_training(training_tester: ExampleModelOnlyKwargsTester):
     training_tester.test()

--- a/tests/jax/models/gpt2/base/test_gpt2_base.py
+++ b/tests/jax/models/gpt2/base/test_gpt2_base.py
@@ -30,7 +30,7 @@ def training_tester() -> GPT2Tester:
 
 
 @pytest.mark.push
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.xfail(
     reason=runtime_fail(
         "Invalid arguments to reshape "
@@ -47,7 +47,7 @@ def test_gpt2_base_inference(
 
 
 @pytest.mark.push
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_gpt2_base_training(
     training_tester: GPT2Tester,

--- a/tests/jax/models/gpt2/large/test_gpt2_large.py
+++ b/tests/jax/models/gpt2/large/test_gpt2_large.py
@@ -30,7 +30,7 @@ def training_tester() -> GPT2Tester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.xfail(
     reason=runtime_fail(
         "Invalid arguments to reshape "
@@ -46,7 +46,7 @@ def test_gpt2_large_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_gpt2_large_training(
     training_tester: GPT2Tester,

--- a/tests/jax/models/gpt2/medium/test_gpt2_medium.py
+++ b/tests/jax/models/gpt2/medium/test_gpt2_medium.py
@@ -30,7 +30,7 @@ def training_tester() -> GPT2Tester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.xfail(
     reason=runtime_fail(
         "Invalid arguments to reshape "
@@ -46,7 +46,7 @@ def test_gpt2_medium_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_gpt2_medium_training(
     training_tester: GPT2Tester,

--- a/tests/jax/models/gpt2/xl/test_gpt2_xl.py
+++ b/tests/jax/models/gpt2/xl/test_gpt2_xl.py
@@ -30,7 +30,7 @@ def training_tester() -> GPT2Tester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(
     reason="OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186)"
 )
@@ -43,7 +43,7 @@ def test_gpt2_xl_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_gpt2_xl_training(
     training_tester: GPT2Tester,

--- a/tests/jax/models/gpt_neo/gpt_neo_125m/test_gpt_neo_125m.py
+++ b/tests/jax/models/gpt_neo/gpt_neo_125m/test_gpt_neo_125m.py
@@ -29,7 +29,7 @@ def training_tester() -> GPTNeoTester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.xfail(
     reason=runtime_fail(
         "Host data with total size 4B does not match expected size 2B of device buffer!"
@@ -44,7 +44,7 @@ def test_gpt_neo_125m_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_gpt_neo_125m_training(
     training_tester: GPTNeoTester,

--- a/tests/jax/models/gpt_neo/gpt_neo_1_3b/test_gpt_neo_1_3b.py
+++ b/tests/jax/models/gpt_neo/gpt_neo_1_3b/test_gpt_neo_1_3b.py
@@ -29,7 +29,7 @@ def training_tester() -> GPTNeoTester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason=runtime_fail("OOMs in CI"))
 def test_gpt_neo_1_3b_inference(
     inference_tester: GPTNeoTester,
@@ -40,7 +40,7 @@ def test_gpt_neo_1_3b_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_gpt_neo_1_3b_training(
     training_tester: GPTNeoTester,

--- a/tests/jax/models/gpt_neo/gpt_neo_2_7b/test_gpt_neo_2_7b.py
+++ b/tests/jax/models/gpt_neo/gpt_neo_2_7b/test_gpt_neo_2_7b.py
@@ -29,7 +29,7 @@ def training_tester() -> GPTNeoTester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="OOMs in CI.")
 def test_gpt_neo_2_7b_inference(
     inference_tester: GPTNeoTester,
@@ -40,7 +40,7 @@ def test_gpt_neo_2_7b_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_gpt_neo_2_7b_training(
     training_tester: GPTNeoTester,

--- a/tests/jax/models/llama/openllama_3b_v2/test_openllama_3b_v2.py
+++ b/tests/jax/models/llama/openllama_3b_v2/test_openllama_3b_v2.py
@@ -30,7 +30,7 @@ def training_tester() -> LLamaTester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(
     reason="OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186)"
 )
@@ -43,7 +43,7 @@ def test_openllama3b_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_openllama3b_training(
     training_tester: LLamaTester,

--- a/tests/jax/models/mlpmixer/test_mlpmixer.py
+++ b/tests/jax/models/mlpmixer/test_mlpmixer.py
@@ -89,7 +89,7 @@ def training_tester() -> MlpMixerTester:
 
 
 @pytest.mark.push
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(
     reason=runtime_fail(
         "Statically allocated circular buffers in program 16 clash with L1 buffers "
@@ -108,7 +108,7 @@ def test_mlpmixer_inference(
 
 
 @pytest.mark.push
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_mlpmixer_training(
     training_tester: MlpMixerTester,

--- a/tests/jax/models/mnist/cnn/dropout/test_mnist_cnn_dropout.py
+++ b/tests/jax/models/mnist/cnn/dropout/test_mnist_cnn_dropout.py
@@ -28,7 +28,7 @@ def training_tester() -> MNISTCNNTester:
 
 
 @pytest.mark.push
-@pytest.mark.nightly
+@pytest.mark.model_test
 def test_mnist_cnn_dropout_inference(
     inference_tester: MNISTCNNTester,
     record_tt_xla_property: Callable,
@@ -39,7 +39,7 @@ def test_mnist_cnn_dropout_inference(
 
 
 @pytest.mark.push
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_mnist_cnn_nodropout_training(
     training_tester: MNISTCNNTester,

--- a/tests/jax/models/mnist/cnn/nodropout/test_mnist_cnn_nodropout.py
+++ b/tests/jax/models/mnist/cnn/nodropout/test_mnist_cnn_nodropout.py
@@ -28,7 +28,7 @@ def training_tester() -> MNISTCNNTester:
 
 
 @pytest.mark.push
-@pytest.mark.nightly
+@pytest.mark.model_test
 def test_mnist_cnn_nodropout_inference(
     inference_tester: MNISTCNNTester,
     record_tt_xla_property: Callable,
@@ -39,7 +39,7 @@ def test_mnist_cnn_nodropout_inference(
 
 
 @pytest.mark.push
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_mnist_cnn_nodropout_training(
     training_tester: MNISTCNNTester,

--- a/tests/jax/models/mnist/mlp/test_mnist_mlp.py
+++ b/tests/jax/models/mnist/mlp/test_mnist_mlp.py
@@ -66,7 +66,7 @@ def training_tester(request) -> MNISTMLPTester:
 
 
 @pytest.mark.push
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.parametrize(
     "inference_tester",
     [
@@ -90,7 +90,7 @@ def test_mnist_mlp_inference(
 
 
 @pytest.mark.push
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_mnist_mlp_training(
     training_tester: MNISTMLPTester,

--- a/tests/jax/models/opt/opt_125m/test_125m.py
+++ b/tests/jax/models/opt/opt_125m/test_125m.py
@@ -30,7 +30,7 @@ def training_tester() -> OPTTester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason=compile_fail("Unsupported data type"))  # segfault
 def test_opt_125m_inference(
     inference_tester: OPTTester,
@@ -41,7 +41,7 @@ def test_opt_125m_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_opt_125m_training(
     training_tester: OPTTester,

--- a/tests/jax/models/opt/opt_1_3b/test_1_3b.py
+++ b/tests/jax/models/opt/opt_1_3b/test_1_3b.py
@@ -30,7 +30,7 @@ def training_tester() -> OPTTester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason=compile_fail("Unsupported data type"))  # segfault
 def test_opt_1_3b_inference(
     inference_tester: OPTTester,
@@ -41,7 +41,7 @@ def test_opt_1_3b_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_opt_1_3b_training(
     training_tester: OPTTester,

--- a/tests/jax/models/opt/opt_2_7b/test_2_7b.py
+++ b/tests/jax/models/opt/opt_2_7b/test_2_7b.py
@@ -30,7 +30,7 @@ def training_tester() -> OPTTester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason=compile_fail("Unsupported data type"))  # segfault
 def test_opt_2_7b_inference(
     inference_tester: OPTTester,
@@ -41,7 +41,7 @@ def test_opt_2_7b_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_opt_2_7b_training(
     training_tester: OPTTester,

--- a/tests/jax/models/opt/opt_350m/test_350m.py
+++ b/tests/jax/models/opt/opt_350m/test_350m.py
@@ -30,7 +30,7 @@ def training_tester() -> OPTTester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason=compile_fail("Unsupported data type"))  # segfault
 def test_opt_350m_inference(
     inference_tester: OPTTester,
@@ -41,7 +41,7 @@ def test_opt_350m_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_opt_350m_training(
     training_tester: OPTTester,

--- a/tests/jax/models/opt/opt_6_7b/test_6_7b.py
+++ b/tests/jax/models/opt/opt_6_7b/test_6_7b.py
@@ -30,7 +30,7 @@ def training_tester() -> OPTTester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason=compile_fail("Unsupported data type"))  # segfault
 def test_opt_6_7b_inference(
     inference_tester: OPTTester,
@@ -41,7 +41,7 @@ def test_opt_6_7b_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_opt_6_7b_training(
     training_tester: OPTTester,

--- a/tests/jax/models/resnet/resnet_101/test_resnet_101.py
+++ b/tests/jax/models/resnet/resnet_101/test_resnet_101.py
@@ -29,7 +29,7 @@ def training_tester() -> ResNetTester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.xfail(
     reason=compile_fail("failed to legalize operation 'stablehlo.reduce_window'")
 )
@@ -42,7 +42,7 @@ def test_resnet_101_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_resnet_101_training(
     training_tester: ResNetTester,

--- a/tests/jax/models/resnet/resnet_152/test_resnet_152.py
+++ b/tests/jax/models/resnet/resnet_152/test_resnet_152.py
@@ -29,7 +29,7 @@ def training_tester() -> ResNetTester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.xfail(
     reason=compile_fail("failed to legalize operation 'stablehlo.reduce_window'")
 )
@@ -42,7 +42,7 @@ def test_resnet_152_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_resnet_152_training(
     training_tester: ResNetTester,

--- a/tests/jax/models/resnet/resnet_18/test_resnet_18.py
+++ b/tests/jax/models/resnet/resnet_18/test_resnet_18.py
@@ -30,7 +30,7 @@ def training_tester() -> ResNetTester:
 
 
 @pytest.mark.push
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.xfail(
     reason=compile_fail("failed to legalize operation 'stablehlo.reduce_window'")
 )
@@ -44,7 +44,7 @@ def test_resnet_18_inference(
 
 
 @pytest.mark.push
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_resnet_18_training(
     training_tester: ResNetTester,

--- a/tests/jax/models/resnet/resnet_26/test_resnet_26.py
+++ b/tests/jax/models/resnet/resnet_26/test_resnet_26.py
@@ -29,7 +29,7 @@ def training_tester() -> ResNetTester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.xfail(
     reason=compile_fail("failed to legalize operation 'stablehlo.reduce_window'")
 )
@@ -42,7 +42,7 @@ def test_resnet_26_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_resnet_26_training(
     training_tester: ResNetTester,

--- a/tests/jax/models/resnet/resnet_34/test_resnet_34.py
+++ b/tests/jax/models/resnet/resnet_34/test_resnet_34.py
@@ -29,7 +29,7 @@ def training_tester() -> ResNetTester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.xfail(
     reason=compile_fail("failed to legalize operation 'stablehlo.reduce_window'")
 )
@@ -42,7 +42,7 @@ def test_resnet_34_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_resnet_34_training(
     training_tester: ResNetTester,

--- a/tests/jax/models/resnet/resnet_50/test_resnet_50.py
+++ b/tests/jax/models/resnet/resnet_50/test_resnet_50.py
@@ -29,7 +29,7 @@ def training_tester() -> ResNetTester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.xfail(
     reason=compile_fail("failed to legalize operation 'stablehlo.reduce_window'")
 )
@@ -42,7 +42,7 @@ def test_resnet_50_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_resnet_50_training(
     training_tester: ResNetTester,

--- a/tests/jax/models/roberta/base/test_roberta_base.py
+++ b/tests/jax/models/roberta/base/test_roberta_base.py
@@ -30,7 +30,7 @@ def training_tester() -> FlaxRobertaForMaskedLMTester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.xfail(
     reason=runtime_fail(
         "Atol comparison failed. Calculated: atol=131044.359375. Required: atol=0.16"
@@ -45,7 +45,7 @@ def test_flax_roberta_base_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_flax_roberta_base_training(
     training_tester: FlaxRobertaForMaskedLMTester,

--- a/tests/jax/models/roberta/large/test_roberta_large.py
+++ b/tests/jax/models/roberta/large/test_roberta_large.py
@@ -29,7 +29,7 @@ def training_tester() -> FlaxRobertaForMaskedLMTester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.xfail(
     reason=runtime_fail(
         "Atol comparison failed. Calculated: atol=131078.359375. Required: atol=0.16"
@@ -44,7 +44,7 @@ def test_flax_roberta_large_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_flax_roberta_large_training(
     training_tester: FlaxRobertaForMaskedLMTester,

--- a/tests/jax/models/roberta_prelayernorm/efficient_mlm_m0_40/test_efficient_mlm_m0_40.py
+++ b/tests/jax/models/roberta_prelayernorm/efficient_mlm_m0_40/test_efficient_mlm_m0_40.py
@@ -71,7 +71,7 @@ def training_tester() -> FlaxRobertaPreLayerNormForMaskedLMTester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.xfail(
     reason=runtime_fail(
         "Atol comparison failed. Calculated: atol=131048.65625. Required: atol=0.16"
@@ -86,7 +86,7 @@ def test_flax_roberta_prelayernorm_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_flax_roberta_prelayernorm_training(
     training_tester: FlaxRobertaPreLayerNormForMaskedLMTester,

--- a/tests/jax/models/squeezebert/test_squeezebert.py
+++ b/tests/jax/models/squeezebert/test_squeezebert.py
@@ -75,7 +75,7 @@ def training_tester() -> SqueezeBertTester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.xfail(
     reason=compile_fail("Failed to legalize operation 'ttir.convolution'")
 )
@@ -88,7 +88,7 @@ def test_squeezebert_inference(
     inference_tester.test()
 
 
-@pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_squeezebert_training(
     training_tester: SqueezeBertTester,


### PR DESCRIPTION
This new job runs only tests marked with `@pytest.mark.model_test`. 

`@pytest.mark.nightly` marker still exists for other tests which we want to run in nightlies.
