### PR TITLE
Fix duplicated nightly job names

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -163,7 +163,8 @@ jobs:
       - in-service
       - ${{ matrix.build.runs-on }}
 
-    name: "${{ github.job }} ${{ inputs.test_mark }} (${{ matrix.build.runs-on }}, ${{ matrix.build.name }})"
+    # Keep this name in sync with the fetch-job-id step
+    name: "build-and-run-tests ${{ inputs.test_mark }} (${{ matrix.build.runs-on }}, ${{ matrix.build.name }})"
 
     container:
       image: ${{ needs.build-image.outputs.docker-image }}
@@ -193,7 +194,7 @@ jobs:
       id: fetch-job-id
       uses: tenstorrent/tt-github-actions/.github/actions/job_id@main
       with:
-        job_name: "${{ github.job }} ${{ inputs.test_mark }} (${{ matrix.build.runs-on }}, ${{ matrix.build.name }})"
+        job_name: "build-and-run-tests ${{ inputs.test_mark }} (${{ matrix.build.runs-on }}, ${{ matrix.build.name }})"
 
     - name: Set reusable strings
       id: strings

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -163,6 +163,8 @@ jobs:
       - in-service
       - ${{ matrix.build.runs-on }}
 
+    name: "${{ github.job }} ${{ inputs.test_mark }} (${{ matrix.build.runs-on }}, ${{ matrix.build.name }})"
+
     container:
       image: ${{ needs.build-image.outputs.docker-image }}
       options: --device /dev/tenstorrent/0
@@ -191,7 +193,7 @@ jobs:
       id: fetch-job-id
       uses: tenstorrent/tt-github-actions/.github/actions/job_id@main
       with:
-        job_name: "${{ github.job }} (${{ matrix.build.runs-on }}, ${{ matrix.build.name }})"
+        job_name: "${{ github.job }} ${{ inputs.test_mark }} (${{ matrix.build.runs-on }}, ${{ matrix.build.name }})"
 
     - name: Set reusable strings
       id: strings


### PR DESCRIPTION
### Ticket
/

### Problem description
PR https://github.com/tenstorrent/tt-xla/pull/314 split nightly pipeline into two jobs, using the same workflow script, leading to having duplicated job names in the pipeline. This causes [failures](https://github.com/tenstorrent/tt-xla/actions/runs/13731509163/job/38410230326) when the second job is run, because `fetch-job-id` step expects to find a single job id when querying jobs with a given name.

### What's changed
Added a `test_mark` into the `build-and-test` job name, to differentiate between the runs.

### Checklist
- [x] New/Existing tests provide coverage for changes
