### PR TITLE
Fix fp16 usage in Bart

### DIFF
--- a/tests/jax/models/bart/large/test_bart_large.py
+++ b/tests/jax/models/bart/large/test_bart_large.py
@@ -30,8 +30,15 @@ def training_tester() -> FlaxBartForCausalLMTester:
 # ----- Tests -----
 
 
-@pytest.mark.push
 @pytest.mark.model_test
+@pytest.mark.xfail(
+    reason=(
+        runtime_fail(
+            "Invalid arguments to reshape "
+            "(https://github.com/tenstorrent/tt-xla/issues/307)"
+        )
+    )
+)
 def test_flax_bart_large_inference(
     inference_tester: FlaxBartForCausalLMTester,
     record_tt_xla_property: Callable,

--- a/tests/jax/models/bart/large/test_bart_large.py
+++ b/tests/jax/models/bart/large/test_bart_large.py
@@ -6,7 +6,7 @@ from typing import Callable
 
 import pytest
 from infra import RunMode
-from utils import compile_fail, record_model_test_properties
+from utils import record_model_test_properties, runtime_fail
 
 from ..tester import FlaxBartForCausalLMTester
 

--- a/tests/jax/models/bart/large/test_bart_large.py
+++ b/tests/jax/models/bart/large/test_bart_large.py
@@ -30,12 +30,8 @@ def training_tester() -> FlaxBartForCausalLMTester:
 # ----- Tests -----
 
 
+@pytest.mark.push
 @pytest.mark.model_test
-@pytest.mark.xfail(
-    reason=compile_fail(
-        "Unsupported data type (https://github.com/tenstorrent/tt-xla/issues/214)"
-    )
-)
 def test_flax_bart_large_inference(
     inference_tester: FlaxBartForCausalLMTester,
     record_tt_xla_property: Callable,

--- a/tests/jax/models/bart/tester.py
+++ b/tests/jax/models/bart/tester.py
@@ -25,7 +25,12 @@ class FlaxBartForCausalLMTester(ModelTester):
 
     # @override
     def _get_model(self) -> FlaxPreTrainedModel:
-        return FlaxBartForCausalLM.from_pretrained(self._model_name)
+        model = FlaxBartForCausalLM.from_pretrained(self._model_name)
+        # TODO(mrakita): This model uses fp16 type which is currently not well
+        # supported in our runtime, so converting to bfp16 until runtime support is
+        # good.
+        model.params = model.to_bf16(model.params)
+        return model
 
     # @override
     def _get_input_activations(self) -> Sequence[jax.Array]:


### PR DESCRIPTION
### Ticket
/

### Problem description
This model uses fp16 type which is currently not well supported in our runtime, so converting to bfp16 until runtime support is good.

### What's changed
Converted model parameters to bfp16 and updated the test xfail reason.

### Checklist
- [x] New/Existing tests provide coverage for changes
