### PR TITLE
Fixed upload test log job to have unique name

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -262,7 +262,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: success() || failure()
       with:
-        name: test-log-${{ matrix.build.runs-on }}-${{ matrix.test_group_id }}
+        name: test-log-${{ matrix.build.runs-on }}-${{ matrix.test_group_id }}-${{ steps.fetch-job-id.outputs.job_id }}
         path: pytest.log
 
     - name: Upload Test Report


### PR DESCRIPTION
### Ticket
Link to Github Issue
/

### Problem description
After [PR](https://github.com/tenstorrent/tt-xla/pull/324) nightly still [fails](https://github.com/tenstorrent/tt-xla/actions/runs/13762193612) due to non-unique artifact name.

### What's changed
Added `${{ steps.fetch-job-id.outputs.job_id }}` to the end which is guaranteed to make it unique.

