### PR TITLE
Add pillow as a dependency to fix BEiT and CLIP tests

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -195,3 +195,4 @@ The following dependencies are utilized by this project but are not explicitly
 distributed as part of the software:
 
 - xla/pjrt/c/pjrt_c_api.h - https://github.com/openxla/xla/blob/main/LICENSE
+- pillow - Custom License (https://github.com/python-pillow/Pillow/blob/main/LICENSE)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,14 +6,13 @@ flax==0.10.2
 fsspec
 jax==0.4.36
 jaxlib==0.4.36
+jaxtyping
 lit
 ml_collections
 ninja
+pillow
 pre-commit
 pybind11
 pytest
 torch
 transformers
-ml_collections
-jaxtyping
-pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ torch
 transformers
 ml_collections
 jaxtyping
+pillow


### PR DESCRIPTION
### Problem description
Preprocessor classes depend on the pillow library and error out if it is not installed.
I didn't catch this before as apparently I had pillow installed in my env.

### What's changed
~~I removed the use of preprocessor classes to avoid taking an extra dependency.~~
PR has been repurposed for adding pillow as a dependency

### Checklist
- [X] New/Existing tests provide coverage for changes
