### PR TITLE
Added multichip support for fully manual sharding

### DIFF
--- a/inc/common/pjrt_implementation/buffer_instance.h
+++ b/inc/common/pjrt_implementation/buffer_instance.h
@@ -25,11 +25,13 @@ class BufferInstance {
 public:
   BufferInstance(DeviceInstance &device, tt::runtime::Tensor &tensor,
                  const std::vector<std::uint32_t> &shape,
-                 const std::vector<std::uint32_t> &stride);
+                 const std::vector<std::uint32_t> &stride,
+                 std::pair<tt::target::DataType, size_t> tt_buffer_type);
 
   BufferInstance(DeviceInstance &device, tt::runtime::Tensor &tensor,
                  const std::vector<std::uint32_t> &shape,
                  const std::vector<std::uint32_t> &stride,
+                 std::pair<tt::target::DataType, size_t> tt_buffer_type,
                  std::shared_ptr<void> host_buffer_ptr);
   BufferInstance(DeviceInstance &device);
   ~BufferInstance();
@@ -58,10 +60,15 @@ public:
                             EventInstance **done_event);
 
   const int64_t *dims() { return dims_.data(); }
+  const std::vector<std::uint32_t> get_shape();
   size_t num_dims() { return dims_.size(); }
   void setType(PJRT_Buffer_Type Type) { DataType = Type; }
   std::optional<PJRT_Buffer_Type> getType() { return DataType; }
-
+  std::shared_ptr<void> get_host_buffer_ptr() { return host_buffer_ptr_; }
+  std::vector<std::uint32_t> get_stride() { return stride_; }
+  std::pair<tt::target::DataType, size_t> get_tt_buffer_type() {
+    return tt_buffer_type_;
+  }
   // Get the data type for a tensor through runtime if DataType is not set.
   PJRT_Buffer_Type getRuntimeType();
 
@@ -80,6 +87,7 @@ private:
   std::vector<int64_t> dims_;
   std::vector<std::uint32_t> stride_;
   tt::runtime::Tensor tensor_;
+  std::pair<tt::target::DataType, size_t> tt_buffer_type_;
 
   std::vector<int64_t> minor_to_major_;
   std::vector<int64_t> tile_dims_;

--- a/inc/common/pjrt_implementation/buffer_instance.h
+++ b/inc/common/pjrt_implementation/buffer_instance.h
@@ -42,7 +42,8 @@ public:
   static void BindApi(PJRT_Api *api);
 
   // iree_hal_buffer_view_t* buffer_view() { return buffer_view_.get(); }
-  DeviceInstance &device() const { return device_; }
+  DeviceInstance &device() { return device_; }
+  const DeviceInstance &device() const { return device_; }
   tt_pjrt_status AsyncDeallocate();
   tt_pjrt_status Delete();
   bool is_deleted() { return is_deleted_; }
@@ -59,14 +60,18 @@ public:
   tt_pjrt_status CopyToHost(void *dst, size_t dst_size,
                             EventInstance **done_event);
 
-  const int64_t *dims() { return dims_.data(); }
-  const std::vector<std::uint32_t> get_shape();
+  const int64_t *getRawDimensions() { return dims_.data(); }
+  const std::vector<std::uint32_t> getDimensions() const {
+    return std::vector<std::uint32_t>(dims_.begin(), dims_.end());
+  }
   size_t num_dims() { return dims_.size(); }
   void setType(PJRT_Buffer_Type Type) { DataType = Type; }
   std::optional<PJRT_Buffer_Type> getType() { return DataType; }
-  std::shared_ptr<void> get_host_buffer_ptr() { return host_buffer_ptr_; }
-  std::vector<std::uint32_t> get_stride() { return stride_; }
-  std::pair<tt::target::DataType, size_t> get_tt_buffer_type() {
+  const std::shared_ptr<void> get_host_buffer_ptr() const {
+    return host_buffer_ptr_;
+  }
+  const std::vector<std::uint32_t> get_stride() const { return stride_; }
+  std::pair<tt::target::DataType, size_t> get_tt_buffer_type() const {
     return tt_buffer_type_;
   }
   // Get the data type for a tensor through runtime if DataType is not set.

--- a/inc/common/pjrt_implementation/buffer_instance.h
+++ b/inc/common/pjrt_implementation/buffer_instance.h
@@ -42,7 +42,7 @@ public:
   static void BindApi(PJRT_Api *api);
 
   // iree_hal_buffer_view_t* buffer_view() { return buffer_view_.get(); }
-  DeviceInstance &device() { return device_; }
+  DeviceInstance &device() const { return device_; }
   tt_pjrt_status AsyncDeallocate();
   tt_pjrt_status Delete();
   bool is_deleted() { return is_deleted_; }
@@ -72,7 +72,7 @@ public:
   // Get the data type for a tensor through runtime if DataType is not set.
   PJRT_Buffer_Type getRuntimeType();
 
-  int unique_id() { return unique_id_; }
+  int unique_id() const { return unique_id_; }
 
 private:
   static int id_counter_;

--- a/inc/common/pjrt_implementation/buffer_instance.h
+++ b/inc/common/pjrt_implementation/buffer_instance.h
@@ -61,7 +61,7 @@ public:
                             EventInstance **done_event);
 
   const int64_t *getRawDimensions() { return dims_.data(); }
-  const std::vector<std::uint32_t> getDimensions() const {
+  std::vector<std::uint32_t> getDimensions() const {
     return std::vector<std::uint32_t>(dims_.begin(), dims_.end());
   }
   size_t num_dims() { return dims_.size(); }

--- a/inc/common/pjrt_implementation/buffer_instance.h
+++ b/inc/common/pjrt_implementation/buffer_instance.h
@@ -67,10 +67,10 @@ public:
   size_t num_dims() { return dims_.size(); }
   void setType(PJRT_Buffer_Type Type) { DataType = Type; }
   std::optional<PJRT_Buffer_Type> getType() { return DataType; }
-  const std::shared_ptr<void> get_host_buffer_ptr() const {
+  const std::shared_ptr<void> &get_host_buffer_ptr() const {
     return host_buffer_ptr_;
   }
-  const std::vector<std::uint32_t> get_stride() const { return stride_; }
+  const std::vector<std::uint32_t> &get_stride() const { return stride_; }
   std::pair<tt::target::DataType, size_t> get_tt_buffer_type() const {
     return tt_buffer_type_;
   }

--- a/inc/common/pjrt_implementation/device_instance.h
+++ b/inc/common/pjrt_implementation/device_instance.h
@@ -65,6 +65,7 @@ public:
                      BufferInstance **out_buffer);
 
   DeviceDescription *device_description() { return &description_; }
+  const DeviceDescription *device_description() const { return &description_; }
 
 private:
   tt_pjrt_status OpenDevice();

--- a/inc/common/pjrt_implementation/executable_image.h
+++ b/inc/common/pjrt_implementation/executable_image.h
@@ -19,6 +19,10 @@
 #include "tt/runtime/types.h"
 #include "ttmlir/Conversion/StableHLOToTTIR/ShardingUtils.h"
 
+// tt-mlir includes
+#define TTMLIR_ENABLE_STABLEHLO 1
+#include "ttmlir/Conversion/StableHLOToTTIR/ShardingUtils.h"
+
 #ifndef TT_XLA_INC_COMMON_PJRT_IMPLEMENTATION_EXECUTABLE_IMAGE_H_
 #define TT_XLA_INC_COMMON_PJRT_IMPLEMENTATION_EXECUTABLE_IMAGE_H_
 
@@ -64,6 +68,21 @@ public:
   PJRT_Buffer_Type *get_output_types() { return m_output_types.data(); }
 
   size_t get_num_outputs() const { return m_output_types.size(); }
+
+  // Checks if the output on the i-th index is a scalar.
+  bool isOutputScalar(size_t index) const;
+
+  // Returns the sharding information for the i-th input.
+  const mlir::tt::sharding_utils::MeshSharding &
+  getInputSharding(size_t index) const {
+    return m_input_sharding[index];
+  }
+
+  // Returns the sharding information for the i-th output.
+  const mlir::tt::sharding_utils::MeshSharding &
+  getOutputSharding(size_t index) const {
+    return m_output_sharding[index];
+  }
 
 private:
   // Retrieves pointers to the concatenated list of output dimensions and the

--- a/inc/common/pjrt_implementation/loaded_executable_instance.h
+++ b/inc/common/pjrt_implementation/loaded_executable_instance.h
@@ -67,9 +67,10 @@ private:
   size_t num_devices_to_utilize_;
   std::vector<ResidentExecutable> resident_executables_;
 
-  std::unordered_map<std::string, std::string> getStrategyMapFromSharding(
+  tt_pjrt_status fillStrategyMapFromSharding(
       const mlir::tt::sharding_utils::MeshSharding &meshSharding,
-      size_t num_devices);
+      size_t num_devices,
+      std::unordered_map<std::string, std::string> &strategy);
 
   tt::runtime::Tensor getTensorFromStrategy(
       const std::unordered_map<std::string, std::string> &strategy,
@@ -78,7 +79,7 @@ private:
   std::vector<std::uint32_t> getOuputShape(size_t index, size_t num_devices);
 
   // Returns is output on the specified index replicated.
-  bool isOutputReplicated(size_t index);
+  bool isOutputReplicated(size_t index) const;
 
   void fillPJRTOutputLists(
       const std::vector<std::vector<tt::runtime::Tensor>> &rt_outputs,
@@ -89,6 +90,17 @@ private:
   getDeviceIds(PJRT_Buffer *const *const *argument_lists,
                const std::vector<DeviceInstance *> &addressable_devices,
                size_t num_args, size_t num_devices);
+
+  // Given an output list, return the number of outputs of an executable.
+  size_t getNumberOfOutputs(const std::vector<std::vector<tt::runtime::Tensor>>
+                                &rt_outputs_list) const;
+
+  // Return a tensor representing an output on a particular device with a
+  // particular index.
+  tt::runtime::Tensor
+  getOuputTensor(size_t device_index, size_t output_index,
+                 const std::vector<std::vector<tt::runtime::Tensor>>
+                     &rt_outputs_list) const;
 };
 
 } // namespace tt::pjrt

--- a/inc/common/pjrt_implementation/loaded_executable_instance.h
+++ b/inc/common/pjrt_implementation/loaded_executable_instance.h
@@ -80,10 +80,10 @@ private:
   // Returns is output on the specified index replicated.
   bool isOutputReplicated(size_t index);
 
-  void
-  fillPJRTOutputLists(std::vector<std::vector<tt::runtime::Tensor>> &rt_outputs,
-                      const std::vector<tt::runtime::TensorDesc> &output_specs,
-                      size_t num_devices, PJRT_Buffer **const *output_lists);
+  void fillPJRTOutputLists(
+      const std::vector<std::vector<tt::runtime::Tensor>> &rt_outputs,
+      const std::vector<tt::runtime::TensorDesc> &output_specs,
+      size_t num_devices, PJRT_Buffer **const *output_lists);
 
   std::vector<int>
   getDeviceIds(PJRT_Buffer *const *const *argument_lists,

--- a/inc/common/pjrt_implementation/loaded_executable_instance.h
+++ b/inc/common/pjrt_implementation/loaded_executable_instance.h
@@ -81,10 +81,14 @@ private:
   bool isOutputReplicated(size_t index);
 
   void
-  fillPJRTOutputLists(PJRT_Buffer **const *output_lists,
-                      std::vector<std::vector<tt::runtime::Tensor>> &rt_outputs,
+  fillPJRTOutputLists(std::vector<std::vector<tt::runtime::Tensor>> &rt_outputs,
                       const std::vector<tt::runtime::TensorDesc> &output_specs,
-                      size_t num_devices);
+                      size_t num_devices, PJRT_Buffer **const *output_lists);
+
+  std::vector<int>
+  getDeviceIds(PJRT_Buffer *const *const *argument_lists,
+               const std::vector<DeviceInstance *> &addressable_devices,
+               size_t num_args, size_t num_devices);
 };
 
 } // namespace tt::pjrt

--- a/inc/common/pjrt_implementation/loaded_executable_instance.h
+++ b/inc/common/pjrt_implementation/loaded_executable_instance.h
@@ -67,25 +67,34 @@ private:
   size_t num_devices_to_utilize_;
   std::vector<ResidentExecutable> resident_executables_;
 
+  // Fills a std::map<std::string, std::string>, represeting the strategy of
+  // multichip tensor creation (replidated, sharded etc.) from the meshSharding
+  // object.
   tt_pjrt_status fillStrategyMapFromSharding(
       const mlir::tt::sharding_utils::MeshSharding &meshSharding,
       size_t num_devices,
       std::unordered_map<std::string, std::string> &strategy);
 
+  // Returns a runtime tensor given a creation strategy and a vestor of pointers
+  // to data.
   tt::runtime::Tensor getTensorFromStrategy(
       const std::unordered_map<std::string, std::string> &strategy,
       BufferInstance *buffer, std::vector<std::shared_ptr<void>> &data);
 
+  // Returns the shape of the output on the specified index.
   std::vector<std::uint32_t> getOuputShape(size_t index, size_t num_devices);
 
   // Returns is output on the specified index replicated.
   bool isOutputReplicated(size_t index) const;
 
+  // Fills the output lists of the PJRT API with the outputs of tt runtime
+  // execution.
   void fillPJRTOutputLists(
       const std::vector<std::vector<tt::runtime::Tensor>> &rt_outputs,
       const std::vector<tt::runtime::TensorDesc> &output_specs,
       size_t num_devices, PJRT_Buffer **const *output_lists);
 
+  // Gets the device ids from the addressable devices.
   std::vector<int>
   getDeviceIds(PJRT_Buffer *const *const *argument_lists,
                const std::vector<DeviceInstance *> &addressable_devices,

--- a/inc/common/pjrt_implementation/loaded_executable_instance.h
+++ b/inc/common/pjrt_implementation/loaded_executable_instance.h
@@ -34,6 +34,7 @@ public:
       : client_(client), image_(image),
         addressable_devices_(addressable_devices),
         num_devices_to_utilize_(num_devices_to_utilize) {}
+
   ~LoadedExecutableInstance();
 
   operator PJRT_LoadedExecutable *() {
@@ -65,6 +66,24 @@ private:
   std::vector<DeviceInstance *> addressable_devices_;
   size_t num_devices_to_utilize_;
   std::vector<ResidentExecutable> resident_executables_;
+
+  std::unordered_map<std::string, std::string> getStrategyMapFromSharding(
+      const mlir::tt::sharding_utils::MeshSharding &meshSharding,
+      size_t num_devices);
+
+  tt::runtime::Tensor getTensorFromStrategy(
+      const std::unordered_map<std::string, std::string> &strategy,
+      BufferInstance *buffer, std::vector<std::shared_ptr<void>> &data);
+
+  std::vector<std::uint32_t> getOuputShape(size_t index, size_t num_devices);
+
+  bool isOutputReplicated(size_t index);
+
+  void
+  fillPJRTOutputLists(PJRT_Buffer **const *output_lists,
+                      std::vector<std::vector<tt::runtime::Tensor>> &rt_outputs,
+                      const std::vector<tt::runtime::TensorDesc> &output_specs,
+                      size_t num_devices);
 };
 
 } // namespace tt::pjrt

--- a/inc/common/pjrt_implementation/loaded_executable_instance.h
+++ b/inc/common/pjrt_implementation/loaded_executable_instance.h
@@ -77,6 +77,7 @@ private:
 
   std::vector<std::uint32_t> getOuputShape(size_t index, size_t num_devices);
 
+  // Returns is output on the specified index replicated.
   bool isOutputReplicated(size_t index);
 
   void

--- a/src/common/module_builder.cc
+++ b/src/common/module_builder.cc
@@ -257,14 +257,14 @@ void ModuleBuilder::collectOutputTypes(
 
 std::vector<mlir::func::FuncOp> ModuleBuilder::getPublicFuncOps(
     const mlir::OwningOpRef<mlir::ModuleOp> &module) {
-  std::vector<mlir::func::FuncOp> publicFuncOps;
+  std::vector<mlir::func::FuncOp> public_func_ops;
   module.get().walk([&](mlir::Operation *op) {
     mlir::func::FuncOp funcOp = mlir::dyn_cast<mlir::func::FuncOp>(op);
     if (funcOp && funcOp.isPublic()) {
-      publicFuncOps.push_back(funcOp);
+      public_func_ops.push_back(funcOp);
     }
   });
-  return publicFuncOps;
+  return public_func_ops;
 }
 
 bool ModuleBuilder::isScalarType(mlir::Type type) {
@@ -287,7 +287,7 @@ mlir::LogicalResult ModuleBuilder::createShardingsFromGSPMD(
     mlir::tt::sharding_utils::MeshSharding mesh_sharding;
 
     // If there is no sharding attribute, we put the default sharding, marked
-    // as "manual", which means there is no sharding.
+    // as "identity", which means there is no sharding.
     if (!gspmd_attr) {
       shardings.push_back(mesh_sharding);
       continue;

--- a/src/common/module_builder.cc
+++ b/src/common/module_builder.cc
@@ -194,12 +194,9 @@ void ModuleBuilder::collectInputShardings(
   DLOG_F(LOG_DEBUG, "ModuleBuilder::collectInputShardings");
   m_input_shardings.clear();
 
-  std::vector<mlir::StringAttr> gspmd_attributes;
-
   std::vector<mlir::func::FuncOp> publicFuncOps = getPublicFuncOps(module);
-
+  std::vector<mlir::StringAttr> gspmd_attributes;
   for (mlir::func::FuncOp &func_op : publicFuncOps) {
-
     for (unsigned int i = 0; i < func_op.getNumArguments(); ++i) {
       gspmd_attributes.push_back(llvm::dyn_cast_if_present<mlir::StringAttr>(
           func_op.getArgAttr(i, mlir::tt::sharding_utils::kXlaShardingAttr)));
@@ -218,12 +215,9 @@ void ModuleBuilder::collectOutputShardings(
   DLOG_F(LOG_DEBUG, "ModuleBuilder::collectOutputShardings");
   m_output_shardings.clear();
 
-  std::vector<mlir::StringAttr> gspmd_attributes;
-
   std::vector<mlir::func::FuncOp> publicFuncOps = getPublicFuncOps(module);
-
+  std::vector<mlir::StringAttr> gspmd_attributes;
   for (mlir::func::FuncOp &func_op : publicFuncOps) {
-
     for (unsigned int i = 0; i < func_op.getNumResults(); ++i) {
       gspmd_attributes.push_back(
           llvm::dyn_cast_if_present<mlir::StringAttr>(func_op.getResultAttr(

--- a/src/common/pjrt_implementation/buffer_instance.cc
+++ b/src/common/pjrt_implementation/buffer_instance.cc
@@ -165,7 +165,7 @@ BufferInstance::GetMemoryLayout(PJRT_Buffer_GetMemoryLayout_Args *args) {
   tile_dim_sizes_[0] = rank;
   tile_dims_.resize(rank);
   for (size_t i = 0; i < rank; i++) {
-    tile_dims_[i] = getRawDimensions()[i];
+    tile_dims_[i] = dims_[i];
   }
   args->layout.tiled.minor_to_major_size = rank;
   args->layout.tiled.minor_to_major = minor_to_major_.data();

--- a/src/common/pjrt_implementation/buffer_instance.cc
+++ b/src/common/pjrt_implementation/buffer_instance.cc
@@ -18,18 +18,21 @@ int BufferInstance::id_counter_ = 0;
 
 BufferInstance::~BufferInstance() = default;
 
-BufferInstance::BufferInstance(DeviceInstance &device,
-                               tt::runtime::Tensor &tensor,
-                               const std::vector<std::uint32_t> &shape,
-                               const std::vector<std::uint32_t> &stride)
-    : BufferInstance(device, tensor, shape, stride, nullptr) {}
+BufferInstance::BufferInstance(
+    DeviceInstance &device, tt::runtime::Tensor &tensor,
+    const std::vector<std::uint32_t> &shape,
+    const std::vector<std::uint32_t> &stride,
+    std::pair<tt::target::DataType, size_t> tt_buffer_type)
+    : BufferInstance(device, tensor, shape, stride, tt_buffer_type, nullptr) {}
 
-BufferInstance::BufferInstance(DeviceInstance &device,
-                               tt::runtime::Tensor &tensor,
-                               const std::vector<std::uint32_t> &shape,
-                               const std::vector<std::uint32_t> &stride,
-                               std::shared_ptr<void> host_buffer_ptr)
-    : device_(device), tensor_(tensor), host_buffer_ptr_(host_buffer_ptr) {
+BufferInstance::BufferInstance(
+    DeviceInstance &device, tt::runtime::Tensor &tensor,
+    const std::vector<std::uint32_t> &shape,
+    const std::vector<std::uint32_t> &stride,
+    std::pair<tt::target::DataType, size_t> tt_buffer_type,
+    std::shared_ptr<void> host_buffer_ptr)
+    : device_(device), tensor_(tensor), host_buffer_ptr_(host_buffer_ptr),
+      tt_buffer_type_(tt_buffer_type) {
   DLOG_F(LOG_DEBUG, "BufferInstance::BufferInstance");
   dims_.resize(shape.size());
   for (int i = 0; i < shape.size(); i++) {
@@ -222,6 +225,15 @@ PJRT_Buffer_Type BufferInstance::getRuntimeType() {
   DLOG_F(LOG_DEBUG, "BufferInstance::element_type");
   tt::target::DataType Type = tt::runtime::getTensorDataType(getTensor());
   return tt::pjrt::utils::convertElementTypeToBufferType(Type);
+}
+
+const std::vector<std::uint32_t> BufferInstance::get_shape() {
+  DLOG_F(LOG_DEBUG, "BufferInstance::get_shape");
+  std::vector<std::uint32_t> shape;
+  for (int i = 0; i < dims_.size(); i++) {
+    shape.push_back(dims_[i]);
+  }
+  return shape;
 }
 
 } // namespace tt::pjrt

--- a/src/common/pjrt_implementation/device_instance.cc
+++ b/src/common/pjrt_implementation/device_instance.cc
@@ -8,6 +8,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // https://llvm.org/LICENSE.txt
 
+#include <memory>
 #include <numeric>
 
 #include "common/pjrt_implementation/device_instance.h"
@@ -102,11 +103,14 @@ std::unique_ptr<BufferInstance> DeviceInstance::MakeDeviceBuffer(
 
   std::memcpy(new_memory.get(), data, tensor_size);
 
-  tt::runtime::Tensor device_tensor = tt::runtime::createTensor(
+  tt::runtime::Tensor device_tensor = tt::runtime::createOwnedTensor(
       new_memory, shape, strides, element_size, element_type);
 
+  std::pair<tt::target::DataType, size_t> tt_buffer_type = {element_type,
+                                                            element_size};
+
   return std::make_unique<BufferInstance>(*this, device_tensor, shape, strides,
-                                          new_memory);
+                                          tt_buffer_type, new_memory);
 }
 
 } // namespace tt::pjrt

--- a/src/common/pjrt_implementation/loaded_executable_instance.cc
+++ b/src/common/pjrt_implementation/loaded_executable_instance.cc
@@ -110,7 +110,8 @@ LoadedExecutableInstance::Execute(PJRT_LoadedExecutable_Execute_Args *args) {
   tt::runtime::Device device = tt::runtime::openDevice(device_ids);
   std::vector<tt::runtime::Tensor> input_tensors;
   int size_inputs = rt_inputs.size();
-  auto workaround_env = tt::runtime::workaround::Env::get(true, true, false, true);
+  auto workaround_env =
+      tt::runtime::workaround::Env::get(true, true, false, true);
   std::vector<tt::runtime::Tensor> rt_outputs =
       tt::runtime::submit(device, binary, 0, rt_inputs);
   std::vector<tt::runtime::TensorDesc> output_specs =

--- a/src/common/pjrt_implementation/loaded_executable_instance.cc
+++ b/src/common/pjrt_implementation/loaded_executable_instance.cc
@@ -200,9 +200,9 @@ tt_pjrt_status LoadedExecutableInstance::fillStrategyMapFromSharding(
   return tt_pjrt_status::kSuccess;
 }
 
-// We are using std::maps with strings as that is the way it is definet in the
-// tt::runtime, instead of a more structured approach with structs and/or enums.
-// See issue: https://github.com/tenstorrent/tt-mlir/issues/2513
+// TODO: We are using std::maps with strings as that is the way it is defined in
+// the tt::runtime, instead of a more structured approach with structs and/or
+// enums. See issue: https://github.com/tenstorrent/tt-mlir/issues/2513
 tt::runtime::Tensor LoadedExecutableInstance::getTensorFromStrategy(
     const std::unordered_map<std::string, std::string> &strategy,
     BufferInstance *buffer, std::vector<std::shared_ptr<void>> &data) {

--- a/src/common/pjrt_implementation/loaded_executable_instance.cc
+++ b/src/common/pjrt_implementation/loaded_executable_instance.cc
@@ -13,6 +13,9 @@
 #include <string>
 #include <unordered_map>
 
+// tt-mlir includes
+#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
+
 #include "common/pjrt_implementation/buffer_instance.h"
 #include "common/pjrt_implementation/client_instance.h"
 #include "common/pjrt_implementation/error_instance.h"
@@ -83,23 +86,12 @@ LoadedExecutableInstance::Execute(PJRT_LoadedExecutable_Execute_Args *args) {
 
   // Check that the number of devices matches the number of devices counted
   // from the VHLO module.
-  assert(args->num_devices == num_devices_to_utilize_);
+  size_t num_devices = args->num_devices;
+  assert(num_devices == num_devices_to_utilize_);
 
   const tt::runtime::Binary &binary = image_->get_binary();
-  size_t num_devices = args->num_devices;
 
   std::vector<tt::runtime::Tensor> rt_inputs;
-
-  std::vector<int> device_ids;
-
-  for (size_t i = 0; args->num_args && i < num_devices; i++) {
-    BufferInstance *buffer = BufferInstance::Unwrap(args->argument_lists[i][0]);
-    int64_t buffer_device_id =
-        buffer->device().device_description()->getDeviceId();
-    device_ids.push_back(buffer_device_id);
-    DLOG_F(INFO, "Runtime input id: %d", buffer->unique_id());
-  }
-
   for (size_t i = 0; i < args->num_args; ++i) {
     std::vector<std::shared_ptr<void>> data;
     BufferInstance *buffer;
@@ -112,13 +104,8 @@ LoadedExecutableInstance::Execute(PJRT_LoadedExecutable_Execute_Args *args) {
     rt_inputs.push_back(getTensorFromStrategy(strategy, buffer, data));
   }
 
-  // If there are no input buffers, we still want to run on a device.
-  // TODO: Now we will run only on the first one, but this should be somehow
-  // explicit.
-  if (device_ids.size() == 0) {
-    device_ids.push_back(
-        addressable_devices_[0]->device_description()->getDeviceId());
-  }
+  std::vector<int> device_ids = getDeviceIds(
+      args->argument_lists, addressable_devices_, args->num_args, num_devices);
 
   tt::runtime::Device device = tt::runtime::openDevice(device_ids);
   std::vector<tt::runtime::Tensor> input_tensors;
@@ -138,8 +125,8 @@ LoadedExecutableInstance::Execute(PJRT_LoadedExecutable_Execute_Args *args) {
     }
   }
 
-  fillPJRTOutputLists(args->output_lists, rt_outputs_list, output_specs,
-                      num_devices);
+  fillPJRTOutputLists(rt_outputs_list, output_specs, num_devices,
+                      args->output_lists);
 
   for (size_t i = 0; i < rt_outputs.size(); ++i) {
     tt::runtime::deallocateTensor(rt_outputs[i], /*force=*/true);
@@ -234,10 +221,9 @@ bool LoadedExecutableInstance::isOutputReplicated(size_t index) {
 }
 
 void LoadedExecutableInstance::fillPJRTOutputLists(
-    PJRT_Buffer **const *output_lists,
     std::vector<std::vector<tt::runtime::Tensor>> &rt_outputs_list,
     const std::vector<tt::runtime::TensorDesc> &output_specs,
-    size_t num_devices) {
+    size_t num_devices, PJRT_Buffer **const *output_lists) {
   std::vector<bool> is_replicated;
   size_t num_outputs = rt_outputs_list[0].size();
   for (size_t i = 0; i < rt_outputs_list.size(); i++) {
@@ -260,10 +246,35 @@ void LoadedExecutableInstance::fillPJRTOutputLists(
           output_specs[i].stride, type_pair);
       result_buffer->setType(tt::pjrt::utils::convertElementTypeToBufferType(
           output_specs[i].dataType));
-      DLOG_F(INFO, "Runtime output id: %d", result_buffer->unique_id());
+      DLOG_F(DEBUG, "Runtime output id: %d", result_buffer->unique_id());
       output_lists[k][i] = *(result_buffer.release());
     }
   }
+}
+
+std::vector<int> LoadedExecutableInstance::getDeviceIds(
+    PJRT_Buffer *const *const *argument_lists,
+    const std::vector<DeviceInstance *> &addressable_devices, size_t num_args,
+    size_t num_devices) {
+  std::vector<int> device_ids;
+
+  for (size_t i = 0; num_args && i < num_devices; i++) {
+    const BufferInstance *buffer = BufferInstance::Unwrap(argument_lists[i][0]);
+    int64_t buffer_device_id =
+        buffer->device().device_description()->getDeviceId();
+    device_ids.push_back(buffer_device_id);
+    DLOG_F(DEBUG, "Runtime input id: %d", buffer->unique_id());
+  }
+
+  // If there are no input buffers, we still want to run on a device.
+  // TODO: Now we will run only on the first one, but this should be somehow
+  // explicit.
+  if (device_ids.size() == 0) {
+    device_ids.push_back(
+        addressable_devices_[0]->device_description()->getDeviceId());
+  }
+
+  return device_ids;
 }
 
 } // namespace tt::pjrt

--- a/tests/infra/device_runner.py
+++ b/tests/infra/device_runner.py
@@ -97,9 +97,7 @@ class DeviceRunner:
         TODO: This can be omitted when we find a way to get sharding information from the StableHLO
         code back to jax through a protobuf (issue #227).
         """
-        none_tuple = (None,) * len(in_spec)
-        none_spec = PartitionSpec(*none_tuple)
-        return jax.device_put(tensor, NamedSharding(mesh, none_spec), may_alias=True)
+        return jax.device_put(tensor, NamedSharding(mesh, in_spec), may_alias=True)
 
     @staticmethod
     def _put_on_device(

--- a/tests/infra/device_runner.py
+++ b/tests/infra/device_runner.py
@@ -91,7 +91,7 @@ class DeviceRunner:
         tensor: Tensor, mesh: jax.sharding.Mesh, in_spec: jax.sharding.PartitionSpec
     ) -> Tensor:
         """
-        Needed for multichip: Uses put_device to give inputs shardings correspindong to the ones in
+        Needed for multichip: Uses put_device to give inputs shardings corresponding to the ones in
         shard_map() function.
         """
         return jax.device_put(tensor, NamedSharding(mesh, in_spec), may_alias=True)

--- a/tests/infra/device_runner.py
+++ b/tests/infra/device_runner.py
@@ -91,11 +91,8 @@ class DeviceRunner:
         tensor: Tensor, mesh: jax.sharding.Mesh, in_spec: jax.sharding.PartitionSpec
     ) -> Tensor:
         """
-        Needed for multichip: Uses put_device to give inputs shardings.
-        We just put dummy sharding equal to none, since jax needs to have some notion of sharding
-        when running graph with these buffers as input.
-        TODO: This can be omitted when we find a way to get sharding information from the StableHLO
-        code back to jax through a protobuf (issue #227).
+        Needed for multichip: Uses put_device to give inputs shardings correspindong to the ones in
+        shard_map() function.
         """
         return jax.device_put(tensor, NamedSharding(mesh, in_spec), may_alias=True)
 

--- a/tests/jax/multichip/manual/unary_eltwise.py
+++ b/tests/jax/multichip/manual/unary_eltwise.py
@@ -7,10 +7,13 @@ import jax.numpy as jnp
 import pytest
 from infra import make_partition_spec, run_multichip_test_with_random_inputs
 
+from tests.utils import failed_fe_compilation
+
 
 @pytest.mark.parametrize(
     ("input_shape", "mesh_shape", "axis_names"), [((256, 256), (1, 2), ("x", "y"))]
 )
+@pytest.mark.skip(reason=failed_fe_compilation("Multichip still in development"))
 def test_unary_eltwise(input_shape: tuple, mesh_shape: tuple, axis_names: tuple):
     def fwd(a_block):
         b_block = jnp.negative(a_block)

--- a/tests/jax/multichip/manual/unary_eltwise.py
+++ b/tests/jax/multichip/manual/unary_eltwise.py
@@ -7,10 +7,11 @@ import jax.numpy as jnp
 import pytest
 from infra import make_partition_spec, run_multichip_test_with_random_inputs
 
+
 @pytest.mark.parametrize(
-    ("x_shape", "mesh_shape", "axis_names"), [((256, 256), (1, 2), ("x", "y"))]
+    ("input_shape", "mesh_shape", "axis_names"), [((256, 256), (1, 2), ("x", "y"))]
 )
-def test_unary_eltwise(x_shape: tuple, mesh_shape: tuple, axis_names: tuple):
+def test_unary_eltwise(input_shape: tuple, mesh_shape: tuple, axis_names: tuple):
     def fwd(a_block):
         b_block = jnp.negative(a_block)
         return b_block
@@ -19,5 +20,5 @@ def test_unary_eltwise(x_shape: tuple, mesh_shape: tuple, axis_names: tuple):
     out_specs = make_partition_spec(axis_names)
 
     run_multichip_test_with_random_inputs(
-        fwd, [x_shape], mesh_shape, axis_names, in_specs, out_specs
+        fwd, [input_shape], mesh_shape, axis_names, in_specs, out_specs
     )

--- a/tests/jax/multichip/manual/unary_eltwise.py
+++ b/tests/jax/multichip/manual/unary_eltwise.py
@@ -7,13 +7,9 @@ import jax.numpy as jnp
 import pytest
 from infra import make_partition_spec, run_multichip_test_with_random_inputs
 
-from tests.utils import failed_fe_compilation
-
-
 @pytest.mark.parametrize(
     ("x_shape", "mesh_shape", "axis_names"), [((256, 256), (1, 2), ("x", "y"))]
 )
-@pytest.mark.skip(reason=failed_fe_compilation("Multichip still in development"))
 def test_unary_eltwise(x_shape: tuple, mesh_shape: tuple, axis_names: tuple):
     def fwd(a_block):
         b_block = jnp.negative(a_block)


### PR DESCRIPTION
Adding PJRT support for fully manual sharding, with one test for eltwise ops on multichip architectures. 

Currently in draft until the tt-mlir changes go through.

High level overview:

- We now have information on the sharding from the StableHLO graph
- That information is used to create MultiDevice runtime input tensors, with strategies (as defined by tt-mlir) corresponding to those shardings. 
- The input tensors are then passed to the tt runtime `submit()` function.
- Now, the return tensors of the function can be sharded or replicated tensor, or a single device tensor
- The single device tensors goes through the same path as before
- If the tensor is just replicated, we feed to the xla backend the pointer to the tensor on the first device, as that is how it expects the input
- If it is sharded, we feed the invidual shards per device. 

- For now, please ignore the changes to the tt-mlir hash, as there are some changes waiting to be approved and merged on that side.
- Tests will be enabled in a future PR.