### PR TITLE
Added tests for ceil, floor & clamp ops

### DIFF
--- a/tests/jax/ops/test_ceil.py
+++ b/tests/jax/ops/test_ceil.py
@@ -1,5 +1,23 @@
 # SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
+import jax
+import pytest
 
-# TODO add tests for `stablehlo.ceil`.
+from infra import run_op_test_with_random_inputs
+from tests.utils import Category
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    jax_op_name="jax.lax.ceil",
+    shlo_op_name="stablehlo.ceil",
+)
+@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)], ids=lambda val: f"{val}")
+def test_ceil(x_shape: tuple):
+    def ceil(x: jax.Array) -> jax.Array:
+        return jax.lax.ceil(x)
+
+    run_op_test_with_random_inputs(ceil, [x_shape], minval=-5.0, maxval=5.0)

--- a/tests/jax/ops/test_clamp.py
+++ b/tests/jax/ops/test_clamp.py
@@ -2,4 +2,30 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# TODO add tests for `stablehlo.clamp`.
+import jax
+import pytest
+
+from infra import run_op_test_with_random_inputs
+from tests.utils import Category
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    jax_op_name="jax.lax.clamp",
+    shlo_op_name="stablehlo.clamp",
+)
+@pytest.mark.parametrize(
+    ["x_shape", "min_shape", "max_shape"],
+    [
+        [(32, 32), (32, 32), (32, 32)],
+        [(64, 64), (64, 64), (64, 64)],
+    ],
+    ids=lambda val: f"{val}",
+)
+def test_clamp(x_shape: tuple, min_shape: tuple, max_shape: tuple):
+    def clamp(x: jax.Array, min: jax.Array, max: jax.Array) -> jax.Array:
+        return jax.lax.clamp(min, x, max)
+
+    run_op_test_with_random_inputs(clamp, [x_shape, min_shape, max_shape])

--- a/tests/jax/ops/test_floor.py
+++ b/tests/jax/ops/test_floor.py
@@ -2,4 +2,23 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# TODO add tests for `stablehlo.floor`.
+import jax
+import pytest
+
+from infra import run_op_test_with_random_inputs
+from tests.utils import Category
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    jax_op_name="jax.lax.floor",
+    shlo_op_name="stablehlo.floor",
+)
+@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)], ids=lambda val: f"{val}")
+def test_floor(x_shape: tuple):
+    def floor(x: jax.Array) -> jax.Array:
+        return jax.lax.floor(x)
+
+    run_op_test_with_random_inputs(floor, [x_shape])


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/329
https://github.com/tenstorrent/tt-xla/issues/330
https://github.com/tenstorrent/tt-xla/issues/331

### Problem description
Tests has to be added for ops like ceil, floor and clamp

### What's changed
Test files for each op is added inside  tests/jax/ops directory namely
* test_ceil.py
* test_clamp.py
* test_floor.py

### Checklist
- [x] New/Existing tests provide coverage for changes
