### PR TITLE
Add mlir override to concurrency group

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -11,7 +11,7 @@ on:
     branches: [ "main" ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.mlir_override }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Solves issue with multiple "On PR" CI runs targeting "main" but using different "mlir_override" inputs would collide and cancel earlier job. Adding mlir override input to concurrency group name to resolve this.