### PR TITLE
Update fail reasons and workaround fp16 problems

### DIFF
--- a/tests/jax/models/bart/base/test_bart_base.py
+++ b/tests/jax/models/bart/base/test_bart_base.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_runtime,
+    incorrect_result,
 )
 
 from ..tester import FlaxBartForCausalLMTester
@@ -49,12 +49,11 @@ def training_tester() -> FlaxBartForCausalLMTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_RUNTIME,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
 )
 @pytest.mark.xfail(
-    reason=failed_runtime(
-        "Invalid arguments to reshape "
-        "(https://github.com/tenstorrent/tt-xla/issues/307)"
+    reason=incorrect_result(
+        "Atol comparison failed. Calculated: atol=323375.3125. Required: atol=0.16"
     )
 )
 def test_flax_bart_base_inference(inference_tester: FlaxBartForCausalLMTester):

--- a/tests/jax/models/bart/large/test_bart_large.py
+++ b/tests/jax/models/bart/large/test_bart_large.py
@@ -13,7 +13,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_runtime,
+    incorrect_result,
 )
 
 from ..tester import FlaxBartForCausalLMTester
@@ -50,12 +50,11 @@ def training_tester() -> FlaxBartForCausalLMTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_RUNTIME,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
 )
 @pytest.mark.xfail(
-    reason=failed_runtime(
-        "Invalid arguments to reshape "
-        "(https://github.com/tenstorrent/tt-xla/issues/307)"
+    reason=incorrect_result(
+        "Atol comparison failed. Calculated: atol=371601.96875. Required: atol=0.16"
     )
 )
 def test_flax_bart_large_inference(inference_tester: FlaxBartForCausalLMTester):

--- a/tests/jax/models/bart/tester.py
+++ b/tests/jax/models/bart/tester.py
@@ -26,9 +26,6 @@ class FlaxBartForCausalLMTester(ModelTester):
     # @override
     def _get_model(self) -> FlaxPreTrainedModel:
         model = FlaxBartForCausalLM.from_pretrained(self._model_name)
-        # TODO(mrakita): This model uses fp16 type which is currently not well
-        # supported in our runtime, so converting to bfp16 until runtime support is
-        # good.
         model.params = model.to_bf16(model.params)
         return model
 

--- a/tests/jax/models/bloom/bloom_1b1/test_1b1.py
+++ b/tests/jax/models/bloom/bloom_1b1/test_1b1.py
@@ -49,7 +49,7 @@ def training_tester() -> BloomTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_RUNTIME,
+    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
 )
 @pytest.mark.skip(
     reason=failed_fe_compilation(

--- a/tests/jax/models/bloom/bloom_1b1/test_1b1.py
+++ b/tests/jax/models/bloom/bloom_1b1/test_1b1.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_runtime,
+    failed_fe_compilation,
 )
 
 from ..tester import BloomTester
@@ -43,10 +43,6 @@ def training_tester() -> BloomTester:
 # ----- Tests -----
 
 
-# This is an interesting one.
-# The error message seems to happen before the compile even begins
-# And then then compile segfaults with no useful information
-# It is highly likely that both are caused by the same root cause
 @pytest.mark.model_test
 @pytest.mark.record_test_properties(
     category=Category.MODEL_TEST,
@@ -55,7 +51,11 @@ def training_tester() -> BloomTester:
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.FAILED_RUNTIME,
 )
-@pytest.mark.skip(reason=failed_runtime("Unsupported data type (segfault)"))
+@pytest.mark.skip(
+    reason=failed_fe_compilation(
+        "OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186"
+    )
+)
 def test_bloom_1b1_inference(inference_tester: BloomTester):
     inference_tester.test()
 

--- a/tests/jax/models/bloom/bloom_1b1/test_1b1.py
+++ b/tests/jax/models/bloom/bloom_1b1/test_1b1.py
@@ -49,7 +49,7 @@ def training_tester() -> BloomTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
 )
 @pytest.mark.xfail(
     reason=incorrect_result(

--- a/tests/jax/models/bloom/bloom_1b1/test_1b1.py
+++ b/tests/jax/models/bloom/bloom_1b1/test_1b1.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_fe_compilation,
+    incorrect_result,
 )
 
 from ..tester import BloomTester
@@ -51,9 +51,9 @@ def training_tester() -> BloomTester:
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.FAILED_FE_COMPILATION,
 )
-@pytest.mark.skip(
-    reason=failed_fe_compilation(
-        "OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186"
+@pytest.mark.xfail(
+    reason=incorrect_result(
+        "Atol comparison failed. Calculated: atol=12.176290512084961. Required: atol=0.16"
     )
 )
 def test_bloom_1b1_inference(inference_tester: BloomTester):

--- a/tests/jax/models/bloom/bloom_1b7/test_1b7.py
+++ b/tests/jax/models/bloom/bloom_1b7/test_1b7.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_fe_compilation,
+    incorrect_result,
 )
 
 from ..tester import BloomTester
@@ -51,9 +51,9 @@ def training_tester() -> BloomTester:
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.FAILED_FE_COMPILATION,
 )
-@pytest.mark.skip(
-    reason=failed_fe_compilation(
-        "OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186"
+@pytest.mark.xfail(
+    reason=incorrect_result(
+        "Atol comparison failed. Calculated: atol=25.83220100402832. Required: atol=0.16"
     )
 )
 def test_bloom_1b7_inference(inference_tester: BloomTester):

--- a/tests/jax/models/bloom/bloom_1b7/test_1b7.py
+++ b/tests/jax/models/bloom/bloom_1b7/test_1b7.py
@@ -49,7 +49,7 @@ def training_tester() -> BloomTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_RUNTIME,
+    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
 )
 @pytest.mark.skip(
     reason=failed_fe_compilation(

--- a/tests/jax/models/bloom/bloom_1b7/test_1b7.py
+++ b/tests/jax/models/bloom/bloom_1b7/test_1b7.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_runtime,
+    failed_fe_compilation,
 )
 
 from ..tester import BloomTester
@@ -51,7 +51,11 @@ def training_tester() -> BloomTester:
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.FAILED_RUNTIME,
 )
-@pytest.mark.skip(reason=failed_runtime("Unsupported data type (segfault)"))
+@pytest.mark.skip(
+    reason=failed_fe_compilation(
+        "OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186"
+    )
+)
 def test_bloom_1b7_inference(inference_tester: BloomTester):
     inference_tester.test()
 

--- a/tests/jax/models/bloom/bloom_1b7/test_1b7.py
+++ b/tests/jax/models/bloom/bloom_1b7/test_1b7.py
@@ -49,7 +49,7 @@ def training_tester() -> BloomTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
 )
 @pytest.mark.xfail(
     reason=incorrect_result(

--- a/tests/jax/models/bloom/bloom_3b/test_3b.py
+++ b/tests/jax/models/bloom/bloom_3b/test_3b.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_runtime,
+    failed_fe_compilation,
 )
 
 from ..tester import BloomTester
@@ -51,7 +51,11 @@ def training_tester() -> BloomTester:
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.FAILED_RUNTIME,
 )
-@pytest.mark.skip(reason=failed_runtime("Unsupported data type (segfault)"))
+@pytest.mark.skip(
+    reason=failed_fe_compilation(
+        "OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186"
+    )
+)
 def test_bloom_3b_inference(inference_tester: BloomTester):
     inference_tester.test()
 

--- a/tests/jax/models/bloom/bloom_3b/test_3b.py
+++ b/tests/jax/models/bloom/bloom_3b/test_3b.py
@@ -49,7 +49,7 @@ def training_tester() -> BloomTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_RUNTIME,
+    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
 )
 @pytest.mark.skip(
     reason=failed_fe_compilation(

--- a/tests/jax/models/bloom/bloom_560m/test_560m.py
+++ b/tests/jax/models/bloom/bloom_560m/test_560m.py
@@ -51,7 +51,12 @@ def training_tester() -> BloomTester:
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.FAILED_RUNTIME,
 )
-@pytest.mark.skip(reason=failed_runtime("Unsupported data type (segfault)"))
+@pytest.mark.xfail(
+    reason=failed_runtime(
+        "Invalid arguments to reshape "
+        "(https://github.com/tenstorrent/tt-xla/issues/307)"
+    )
+)
 def test_bloom_560m_inference(inference_tester: BloomTester):
     inference_tester.test()
 

--- a/tests/jax/models/bloom/bloom_560m/test_560m.py
+++ b/tests/jax/models/bloom/bloom_560m/test_560m.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_runtime,
+    incorrect_result,
 )
 
 from ..tester import BloomTester
@@ -49,12 +49,11 @@ def training_tester() -> BloomTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_RUNTIME,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
 )
 @pytest.mark.xfail(
-    reason=failed_runtime(
-        "Invalid arguments to reshape "
-        "(https://github.com/tenstorrent/tt-xla/issues/307)"
+    reason=incorrect_result(
+        "Atol comparison failed. Calculated: atol=327.8369445800781. Required: atol=0.16"
     )
 )
 def test_bloom_560m_inference(inference_tester: BloomTester):

--- a/tests/jax/models/bloom/bloom_7b/test_7b.py
+++ b/tests/jax/models/bloom/bloom_7b/test_7b.py
@@ -48,7 +48,7 @@ def training_tester() -> BloomTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_RUNTIME,
+    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
 )
 @pytest.mark.skip(
     reason=failed_fe_compilation(

--- a/tests/jax/models/bloom/bloom_7b/test_7b.py
+++ b/tests/jax/models/bloom/bloom_7b/test_7b.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_runtime,
+    failed_fe_compilation,
 )
 
 from ..tester import BloomTester
@@ -50,7 +50,11 @@ def training_tester() -> BloomTester:
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.FAILED_RUNTIME,
 )
-@pytest.mark.skip(reason=failed_runtime("Unsupported data type (segfault)"))
+@pytest.mark.skip(
+    reason=failed_fe_compilation(
+        "OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186"
+    )
+)
 def test_bloom_7b_inference(inference_tester: BloomTester):
     inference_tester.test()
 

--- a/tests/jax/models/bloom/tester.py
+++ b/tests/jax/models/bloom/tester.py
@@ -23,7 +23,12 @@ class BloomTester(ModelTester):
 
     # @override
     def _get_model(self) -> FlaxPreTrainedModel:
-        return FlaxBloomForCausalLM.from_pretrained(self._model_name, from_pt=True)
+        # todo(sgligorijevic): Bloom weights come in fp16.
+        # Our runtime does not have good support for fp16, so we convert them to bf16.
+        # We should remove this workaround once we have better support for fp16.
+        model = FlaxBloomForCausalLM.from_pretrained(self._model_name, from_pt=True)
+        model.params = model.to_bf16(model.params)
+        return model
 
     # @override
     def _get_input_activations(self) -> Sequence[jax.Array]:

--- a/tests/jax/models/bloom/tester.py
+++ b/tests/jax/models/bloom/tester.py
@@ -23,9 +23,6 @@ class BloomTester(ModelTester):
 
     # @override
     def _get_model(self) -> FlaxPreTrainedModel:
-        # todo(sgligorijevic): Bloom weights come in fp16.
-        # Our runtime does not have good support for fp16, so we convert them to bf16.
-        # We should remove this workaround once we have better support for fp16.
         model = FlaxBloomForCausalLM.from_pretrained(self._model_name, from_pt=True)
         model.params = model.to_bf16(model.params)
         return model

--- a/tests/jax/models/distilbert/test_distilbert.py
+++ b/tests/jax/models/distilbert/test_distilbert.py
@@ -16,7 +16,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_runtime,
+    incorrect_result,
 )
 
 MODEL_PATH = "distilbert/distilbert-base-uncased"
@@ -75,12 +75,11 @@ def training_tester() -> FlaxDistilBertForMaskedLMTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_RUNTIME,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
 )
 @pytest.mark.xfail(
-    reason=failed_runtime(
-        "Invalid arguments to reshape "
-        "(https://github.com/tenstorrent/tt-xla/issues/307)"
+    reason=incorrect_result(
+        "Atol comparison failed. Calculated: atol=131036.078125. Required: atol=0.16"
     )
 )
 def test_flax_distilbert_inference(inference_tester: FlaxDistilBertForMaskedLMTester):

--- a/tests/jax/models/gpt2/base/test_gpt2_base.py
+++ b/tests/jax/models/gpt2/base/test_gpt2_base.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_runtime,
+    incorrect_result,
 )
 
 from ..tester import GPT2Tester
@@ -49,12 +49,11 @@ def training_tester() -> GPT2Tester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_RUNTIME,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
 )
 @pytest.mark.xfail(
-    reason=failed_runtime(
-        "Invalid arguments to reshape "
-        "(https://github.com/tenstorrent/tt-xla/issues/307)"
+    reason=incorrect_result(
+        "Atol comparison failed. Calculated: atol=37.821876525878906. Required: atol=0.16"
     )
 )
 def test_gpt2_base_inference(inference_tester: GPT2Tester):

--- a/tests/jax/models/gpt2/large/test_gpt2_large.py
+++ b/tests/jax/models/gpt2/large/test_gpt2_large.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_runtime,
+    incorrect_result,
 )
 
 from ..tester import GPT2Tester
@@ -49,12 +49,11 @@ def training_tester() -> GPT2Tester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_RUNTIME,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
 )
 @pytest.mark.xfail(
-    reason=failed_runtime(
-        "Invalid arguments to reshape "
-        "(https://github.com/tenstorrent/tt-xla/issues/307)"
+    reason=incorrect_result(
+        "Atol comparison failed. Calculated: atol=9.953690528869629. Required: atol=0.16"
     )
 )
 def test_gpt2_large_inference(inference_tester: GPT2Tester):

--- a/tests/jax/models/gpt2/medium/test_gpt2_medium.py
+++ b/tests/jax/models/gpt2/medium/test_gpt2_medium.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_runtime,
+    incorrect_result,
 )
 
 from ..tester import GPT2Tester
@@ -49,12 +49,11 @@ def training_tester() -> GPT2Tester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_RUNTIME,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
 )
 @pytest.mark.xfail(
-    reason=failed_runtime(
-        "Invalid arguments to reshape "
-        "(https://github.com/tenstorrent/tt-xla/issues/307)"
+    reason=incorrect_result(
+        "Atol comparison failed. Calculated: atol=13.961490631103516. Required: atol=0.16"
     )
 )
 def test_gpt2_medium_inference(inference_tester: GPT2Tester):

--- a/tests/jax/models/gpt_neo/gpt_neo_125m/test_gpt_neo_125m.py
+++ b/tests/jax/models/gpt_neo/gpt_neo_125m/test_gpt_neo_125m.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_runtime,
+    incorrect_result,
 )
 
 from ..tester import GPTNeoTester
@@ -48,12 +48,11 @@ def training_tester() -> GPTNeoTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_RUNTIME,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
 )
 @pytest.mark.xfail(
-    reason=failed_runtime(
-        "Invalid arguments to reshape "
-        "(https://github.com/tenstorrent/tt-xla/issues/307)"
+    reason=incorrect_result(
+        "Atol comparison failed. Calculated: atol=15.864267349243164. Required: atol=0.16"
     )
 )
 def test_gpt_neo_125m_inference(inference_tester: GPTNeoTester):

--- a/tests/jax/models/mlpmixer/test_mlpmixer.py
+++ b/tests/jax/models/mlpmixer/test_mlpmixer.py
@@ -114,11 +114,10 @@ def training_tester() -> MlpMixerTester:
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.FAILED_RUNTIME,
 )
-@pytest.mark.skip(
+@pytest.mark.xfail(
     reason=failed_runtime(
-        "Statically allocated circular buffers in program 16 clash with L1 buffers "
-        "on core range [(x=0,y=0) - (x=6,y=0)]. L1 buffer allocated at 475136 and "
-        "static circular buffer region ends at 951136 (segfault)"
+        "Out of Memory: Not enough space to allocate 12500992 B L1 buffer "
+        "across 7 banks, where each bank needs to store 1785856 B"
         "(https://github.com/tenstorrent/tt-xla/issues/187)"
     )
 )

--- a/tests/jax/models/model_utils.py
+++ b/tests/jax/models/model_utils.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import re
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple, Optional
 
 import flax.traverse_util
 import jax
@@ -35,6 +35,7 @@ def torch_statedict_to_pytree(
     state_dict: Dict[str, Any],
     patterns: List[Tuple[str, str]],
     banned_subkeys: List[str],
+    dtype: Optional[jnp.dtype] = None,
 ) -> PyTree:
     """
     Helper function to convert a PyTorch state dict to a JAX pytree.
@@ -58,7 +59,7 @@ def torch_statedict_to_pytree(
     # ---- Logic starts here ----
 
     state_dict = {
-        rewrite_key(k): jnp.array(v)
+        rewrite_key(k): jnp.array(v, dtype=dtype) if dtype is not None else jnp.array(v)
         for k, v in state_dict.items()
         if not is_banned_key(k)
     }

--- a/tests/jax/models/opt/opt_125m/test_125m.py
+++ b/tests/jax/models/opt/opt_125m/test_125m.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_runtime,
+    incorrect_result,
 )
 
 from ..tester import OPTTester
@@ -49,7 +49,11 @@ def training_tester() -> OPTTester:
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.FAILED_RUNTIME,
 )
-@pytest.mark.skip(reason=failed_runtime("Unsupported data type (segfault)"))
+@pytest.mark.xfail(
+    reason=incorrect_result(
+        "Atol comparison failed. Calculated: atol=4121164.25. Required: atol=0.16."
+    )
+)
 def test_opt_125m_inference(inference_tester: OPTTester):
     inference_tester.test()
 

--- a/tests/jax/models/opt/opt_125m/test_125m.py
+++ b/tests/jax/models/opt/opt_125m/test_125m.py
@@ -47,7 +47,7 @@ def training_tester() -> OPTTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_RUNTIME,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
 )
 @pytest.mark.xfail(
     reason=incorrect_result(

--- a/tests/jax/models/opt/opt_1_3b/test_1_3b.py
+++ b/tests/jax/models/opt/opt_1_3b/test_1_3b.py
@@ -48,7 +48,7 @@ def training_tester() -> OPTTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
 )
 @pytest.mark.xfail(
     reason=incorrect_result(

--- a/tests/jax/models/opt/opt_1_3b/test_1_3b.py
+++ b/tests/jax/models/opt/opt_1_3b/test_1_3b.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_runtime,
+    failed_fe_compilation,
 )
 
 from ..tester import OPTTester
@@ -50,7 +50,11 @@ def training_tester() -> OPTTester:
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.FAILED_RUNTIME,
 )
-@pytest.mark.skip(reason=failed_runtime("Unsupported data type (segfault)"))
+@pytest.mark.skip(
+    reason=failed_fe_compilation(
+        "OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186"
+    )
+)
 def test_opt_1_3b_inference(inference_tester: OPTTester):
     inference_tester.test()
 

--- a/tests/jax/models/opt/opt_1_3b/test_1_3b.py
+++ b/tests/jax/models/opt/opt_1_3b/test_1_3b.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_fe_compilation,
+    incorrect_result,
 )
 
 from ..tester import OPTTester
@@ -50,9 +50,9 @@ def training_tester() -> OPTTester:
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.FAILED_FE_COMPILATION,
 )
-@pytest.mark.skip(
-    reason=failed_fe_compilation(
-        "OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186"
+@pytest.mark.xfail(
+    reason=incorrect_result(
+        "Atol comparison failed. Calculated: atol=2307070.75. Required: atol=0.16"
     )
 )
 def test_opt_1_3b_inference(inference_tester: OPTTester):

--- a/tests/jax/models/opt/opt_1_3b/test_1_3b.py
+++ b/tests/jax/models/opt/opt_1_3b/test_1_3b.py
@@ -48,7 +48,7 @@ def training_tester() -> OPTTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_RUNTIME,
+    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
 )
 @pytest.mark.skip(
     reason=failed_fe_compilation(

--- a/tests/jax/models/opt/opt_2_7b/test_2_7b.py
+++ b/tests/jax/models/opt/opt_2_7b/test_2_7b.py
@@ -13,7 +13,6 @@ from tests.utils import (
     ModelTask,
     build_model_name,
     failed_fe_compilation,
-    failed_runtime,
 )
 
 from ..tester import OPTTester
@@ -52,7 +51,11 @@ def training_tester() -> OPTTester:
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.FAILED_RUNTIME,
 )
-@pytest.mark.skip(reason=failed_runtime("Unsupported data type (segfault)"))
+@pytest.mark.skip(
+    reason=failed_fe_compilation(
+        "OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186"
+    )
+)
 def test_opt_2_7b_inference(inference_tester: OPTTester):
     inference_tester.test()
 

--- a/tests/jax/models/opt/opt_2_7b/test_2_7b.py
+++ b/tests/jax/models/opt/opt_2_7b/test_2_7b.py
@@ -49,7 +49,7 @@ def training_tester() -> OPTTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_RUNTIME,
+    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
 )
 @pytest.mark.skip(
     reason=failed_fe_compilation(

--- a/tests/jax/models/opt/opt_350m/test_350m.py
+++ b/tests/jax/models/opt/opt_350m/test_350m.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_runtime,
+    incorrect_result,
 )
 
 from ..tester import OPTTester
@@ -51,7 +51,11 @@ def training_tester() -> OPTTester:
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.FAILED_RUNTIME,
 )
-@pytest.mark.skip(reason=failed_runtime("Unsupported data type (segfault)"))
+@pytest.mark.xfail(
+    reason=incorrect_result(
+        "Atol comparison failed. Calculated: atol=2040517.5. Required: atol=0.16."
+    )
+)
 def test_opt_350m_inference(inference_tester: OPTTester):
     inference_tester.test()
 

--- a/tests/jax/models/opt/opt_350m/test_350m.py
+++ b/tests/jax/models/opt/opt_350m/test_350m.py
@@ -49,7 +49,7 @@ def training_tester() -> OPTTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_RUNTIME,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
 )
 @pytest.mark.xfail(
     reason=incorrect_result(

--- a/tests/jax/models/opt/opt_6_7b/test_6_7b.py
+++ b/tests/jax/models/opt/opt_6_7b/test_6_7b.py
@@ -48,7 +48,7 @@ def training_tester() -> OPTTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_RUNTIME,
+    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
 )
 @pytest.mark.skip(
     reason=failed_fe_compilation(

--- a/tests/jax/models/opt/opt_6_7b/test_6_7b.py
+++ b/tests/jax/models/opt/opt_6_7b/test_6_7b.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_runtime,
+    failed_fe_compilation,
 )
 
 from ..tester import OPTTester
@@ -50,7 +50,11 @@ def training_tester() -> OPTTester:
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.FAILED_RUNTIME,
 )
-@pytest.mark.skip(reason=failed_runtime("Unsupported data type (segfault)"))
+@pytest.mark.skip(
+    reason=failed_fe_compilation(
+        "OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186"
+    )
+)
 def test_opt_6_7b_inference(inference_tester: OPTTester):
     inference_tester.test()
 

--- a/tests/jax/models/opt/tester.py
+++ b/tests/jax/models/opt/tester.py
@@ -23,7 +23,9 @@ class OPTTester(ModelTester):
 
     # @override
     def _get_model(self) -> FlaxPreTrainedModel:
-        return FlaxOPTForCausalLM.from_pretrained(self._model_name)
+        model = FlaxOPTForCausalLM.from_pretrained(self._model_name)
+        model.params = model.to_bf16(model.params)
+        return model
 
     # @override
     def _get_input_activations(self) -> Sequence[jax.Array]:

--- a/tests/jax/models/squeezebert/model_implementation.py
+++ b/tests/jax/models/squeezebert/model_implementation.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import einops
 import jax
@@ -340,9 +340,12 @@ class SqueezeBertForMaskedLM(nn.Module):
         return ["cls.seq_relationship"]
 
     @staticmethod
-    def init_from_pytorch_statedict(state_dict: Dict[str, Any]) -> PyTree:
+    def init_from_pytorch_statedict(
+        state_dict: Dict[str, Any], dtype: Optional[jnp.dtype] = None
+    ) -> PyTree:
         return torch_statedict_to_pytree(
             state_dict,
             patterns=SqueezeBertForMaskedLM._get_renaming_patterns(),
             banned_subkeys=SqueezeBertForMaskedLM._get_banned_subkeys(),
+            dtype=dtype,
         )

--- a/tests/jax/models/squeezebert/test_squeezebert.py
+++ b/tests/jax/models/squeezebert/test_squeezebert.py
@@ -19,7 +19,6 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_fe_compilation,
     failed_ttmlir_compilation,
 )
 
@@ -100,7 +99,7 @@ def training_tester() -> SqueezeBertTester:
     bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
 )
 @pytest.mark.xfail(
-    reason=failed_ttmlir_compilation("failed to legalize operation 'ttir.convolution'")
+    reason=failed_ttmlir_compilation("failed to legalize operation 'ttir.gather'")
 )
 def test_squeezebert_inference(inference_tester: SqueezeBertTester):
     inference_tester.test()

--- a/tests/jax/models/squeezebert/test_squeezebert.py
+++ b/tests/jax/models/squeezebert/test_squeezebert.py
@@ -5,6 +5,7 @@
 from typing import Dict, Sequence
 
 import jax
+import jax.numpy as jnp
 import pytest
 import torch
 from flax import linen as nn
@@ -61,7 +62,7 @@ class SqueezeBertTester(ModelTester):
         )
         state_dict = torch.load(model_file, weights_only=True)
 
-        params = self._model.init_from_pytorch_statedict(state_dict)
+        params = self._model.init_from_pytorch_statedict(state_dict, dtype=jnp.bfloat16)
 
         return {
             "variables": params,  # JAX frameworks have a convention of passing weights as the first argument


### PR DESCRIPTION
closes #214, closes #307, closes #316, closes #319 

### What's changed
I updated fail reasons where applicable
Convolution OOM in Metal no longer segfaults so I switched the marker from skip to xfail
Im a few models using fp16 I casted the parameters to bf16 to workaround lack of support for fp16 in MLIR runtime
