### PR TITLE
Changing the multichip testing infrastructure to support virtualized CPU meshes

### DIFF
--- a/tests/infra/multichip_tester.py
+++ b/tests/infra/multichip_tester.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import jax
-from jax.sharding import NamedSharding, PartitionSpec
+from jax.sharding import NamedSharding
 from jax.experimental.shard_map import shard_map
 from typing import Callable, Sequence
 
@@ -44,6 +44,7 @@ class MultichipTester(BaseTester):
         self.in_specs = in_specs
         self.out_specs = out_specs
         self.device_mesh = device_connector.get_tt_device_mesh(mesh_shape, axis_names)
+        self.cpu_mesh = device_connector.get_cpu_device_mesh(mesh_shape, axis_names)
 
     def test(
         self, multichip_workload: MultichipWorkload, cpu_workload: Workload
@@ -72,8 +73,7 @@ class MultichipTester(BaseTester):
 
     def test_with_random_inputs(
         self,
-        device_executable: Callable,
-        cpu_executable: Callable,
+        executable: Callable,
         input_shapes: Sequence[tuple],
         minval: float = 0.0,
         maxval: float = 1.0,
@@ -89,37 +89,19 @@ class MultichipTester(BaseTester):
             for shape in input_shapes
         ]
         device_workload = MultichipWorkload(
-            device_executable,
+            executable,
             inputs,
             device_mesh=self.device_mesh,
             in_specs=self.in_specs,
         )
-        cpu_workload = Workload(cpu_executable, inputs)
+        cpu_workload = MultichipWorkload(
+            executable,
+            inputs,
+            device_mesh=self.cpu_mesh,
+            in_specs=self.in_specs,
+        )
+
         self.test(device_workload, cpu_workload)
-
-
-def run_multichip_test_with_random_inputs(
-    device_executable: Callable,
-    cpu_executable: Callable,
-    input_shapes: Sequence[tuple],
-    mesh_shape: tuple,
-    axis_names: tuple,
-    in_specs: Sequence[jax.sharding.PartitionSpec],
-    out_specs: jax.sharding.PartitionSpec,
-    minval: float = 0.0,
-    maxval: float = 1.0,
-    comparison_config: ComparisonConfig = ComparisonConfig(),
-) -> None:
-    """
-    Tests an input executable with random inputs in range [`minval`, `maxval`) by running it on a mesh of
-    TT devices and comparing it to output of the cpu executable ran with the same input.
-    """
-    tester = MultichipTester(
-        in_specs, out_specs, mesh_shape, axis_names, comparison_config
-    )
-    tester.test_with_random_inputs(
-        device_executable, cpu_executable, input_shapes, minval, maxval
-    )
 
     # ---------- Private methods ----------
 
@@ -145,3 +127,25 @@ def run_multichip_test_with_random_inputs(
             out_shardings=output_sharding,
             static_argnames=static_argnames,
         )
+
+
+def run_multichip_test_with_random_inputs(
+    executable: Callable,
+    input_shapes: Sequence[tuple],
+    mesh_shape: tuple,
+    axis_names: tuple,
+    in_specs: Sequence[jax.sharding.PartitionSpec],
+    out_specs: jax.sharding.PartitionSpec,
+    minval: float = 0.0,
+    maxval: float = 1.0,
+    comparison_config: ComparisonConfig = ComparisonConfig(),
+) -> None:
+    """
+    Tests an input executable with random inputs in range [`minval`, `maxval`) by running it on a mesh of
+    TT devices and comparing it to output of the cpu executable ran with the same input.
+    """
+    with device_connector.simulate_cpu_mesh(mesh_shape):
+        tester = MultichipTester(
+            in_specs, out_specs, mesh_shape, axis_names, comparison_config
+        )
+        tester.test_with_random_inputs(executable, input_shapes, minval, maxval)

--- a/tests/jax/multichip/manual/all_gather.py
+++ b/tests/jax/multichip/manual/all_gather.py
@@ -18,12 +18,9 @@ def test_all_gather(x_shape: tuple, mesh_shape: tuple, axis_names: tuple):
         act = jax.lax.all_gather(batch, axis_names, axis=0, tiled=True)
         return act
 
-    def golden_fwd(batch):
-        return jnp.tile(batch, (2, 1))
-
     in_specs = (make_partition_spec(axis_names),)
     out_specs = make_partition_spec(axis_names)
 
     run_multichip_test_with_random_inputs(
-        fwd, golden_fwd, [x_shape], mesh_shape, axis_names, in_specs, out_specs
+        fwd, [x_shape], mesh_shape, axis_names, in_specs, out_specs
     )

--- a/tests/jax/multichip/manual/data_paralelism.py
+++ b/tests/jax/multichip/manual/data_paralelism.py
@@ -50,13 +50,6 @@ def test_data_paralelism(
         act = act + B2_block
         return act
 
-    def golden_fwd(batch, W1, B1, W2, B2):
-        act = jnp.dot(batch, W1)
-        act = act + B1
-        act = jnp.dot(act, W2)
-        act = act + B2
-        return act
-
     in_specs = (
         make_partition_spec(axis_names),
         make_partition_spec((axis_names[1], None)),
@@ -68,7 +61,6 @@ def test_data_paralelism(
 
     run_multichip_test_with_random_inputs(
         fwd,
-        golden_fwd,
         [batch_shape, W1_shape, B1_shape, W2_shape, B2_shape],
         mesh_shape,
         axis_names,

--- a/tests/jax/multichip/manual/psum.py
+++ b/tests/jax/multichip/manual/psum.py
@@ -29,11 +29,6 @@ def test_psum(
         act = act + B1_block
         return act
 
-    def fwd_single_device(batch, W1, B1):
-        act = jnp.dot(batch, W1)
-        act = act + B1
-        return act
-
     in_specs = (
         make_partition_spec(axis_names),
         make_partition_spec((axis_names[1], None)),
@@ -43,7 +38,6 @@ def test_psum(
 
     run_multichip_test_with_random_inputs(
         fwd,
-        fwd_single_device,
         [batch_shape, W1_shape, B1_shape],
         mesh_shape,
         axis_names,

--- a/tests/jax/multichip/manual/psum_scatter.py
+++ b/tests/jax/multichip/manual/psum_scatter.py
@@ -29,11 +29,6 @@ def test_psum_scatter(
         act = act + B1_block
         return act
 
-    def golden_fwd(batch, W1, B1):
-        act = jnp.dot(batch, W1)
-        act = act + B1
-        return act
-
     in_specs = (
         make_partition_spec(axis_names),
         make_partition_spec((axis_names[1], None)),
@@ -43,7 +38,6 @@ def test_psum_scatter(
 
     run_multichip_test_with_random_inputs(
         fwd,
-        golden_fwd,
         [batch_shape, W1_shape, B1_shape],
         mesh_shape,
         axis_names,

--- a/tests/jax/multichip/manual/unary_eltwise.py
+++ b/tests/jax/multichip/manual/unary_eltwise.py
@@ -16,20 +16,11 @@ from utils import compile_fail
 def test_unary_eltwise(x_shape: tuple, mesh_shape: tuple, axis_names: tuple):
     def fwd(a_block):
         b_block = jnp.negative(a_block)
-        stitched_result = jax.lax.psum(b_block, axis_names)
-        return stitched_result
-
-    def fwd_single_device(a_block):
-        a1, a2 = jnp.split(a_block, 2, axis=1)
-
-        b1, b2 = jnp.negative(a1), jnp.negative(a2)
-
-        stitched_result = b1 + b2
-        return stitched_result
+        return b_block
 
     in_specs = (make_partition_spec(axis_names),)
-    out_specs = make_partition_spec((None, None))
+    out_specs = make_partition_spec(axis_names)
 
     run_multichip_test_with_random_inputs(
-        fwd, fwd_single_device, [x_shape], mesh_shape, axis_names, in_specs, out_specs
+        fwd, [x_shape], mesh_shape, axis_names, in_specs, out_specs
     )


### PR DESCRIPTION
Currently in the multichip testing infra, we are required the writer of the tests to write a separate, single device golden function for testing. This PR adds support for virtualizing cpu into multiple devices and making a CPU mesh, so only the function that is tested needs to be written.