### PR TITLE
Added support for shardy dialects in multichip tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ black
 clang-format
 cmake
 einops
-flax==0.10.2
+flax==0.10.4
 fsspec
 jax==0.5.0
 jaxlib==0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ cmake
 einops
 flax==0.10.2
 fsspec
-jax==0.4.36
-jaxlib==0.4.36
+jax==0.5.0
+jaxlib==0.5.0
 jaxtyping
 lit
 ml_collections

--- a/src/common/module_builder.cc
+++ b/src/common/module_builder.cc
@@ -75,6 +75,11 @@ ModuleBuilder::ModuleBuilder()
   mlir::tt::ttir::registerPasses();
   mlir::tt::ttnn::registerPasses();
 
+  // We need to allow unregistered dialects since shardy uses specific mhlo
+  // dialect attributes, which are not registered in the context and live in the
+  // openXLA repository. See issue:
+  // https://github.com/tenstorrent/tt-xla/issues/355
+  m_context->allowUnregisteredDialects();
   m_context->appendDialectRegistry(registry);
 }
 

--- a/tests/infra/__init__.py
+++ b/tests/infra/__init__.py
@@ -8,4 +8,4 @@ from .graph_tester import run_graph_test, run_graph_test_with_random_inputs
 from .model_tester import ModelTester, RunMode
 from .multichip_tester import run_multichip_test_with_random_inputs
 from .op_tester import run_op_test, run_op_test_with_random_inputs
-from .utils import Framework, make_partition_spec, random_tensor
+from .utils import Framework, make_partition_spec, random_tensor, enable_shardy

--- a/tests/infra/device_runner.py
+++ b/tests/infra/device_runner.py
@@ -135,7 +135,7 @@ class DeviceRunner:
                     key
                 ] = DeviceRunner._put_sharded_tensor_on_multichip_device(
                     value,
-                    multichip_workload.mesh,
+                    multichip_workload.device_mesh,
                     multichip_workload.in_specs[spec_index],
                 )
                 spec_index += 1

--- a/tests/infra/multichip_tester.py
+++ b/tests/infra/multichip_tester.py
@@ -138,10 +138,10 @@ def run_multichip_test_with_random_inputs(
     axis_names: tuple,
     in_specs: Sequence[jax.sharding.PartitionSpec],
     out_specs: jax.sharding.PartitionSpec,
+    use_shardy: bool,
     minval: float = 0.0,
     maxval: float = 1.0,
     comparison_config: ComparisonConfig = ComparisonConfig(),
-    use_shardy: bool = False,
 ) -> None:
     """
     Tests an input executable with random inputs in range [`minval`, `maxval`) by running it on a

--- a/tests/infra/multichip_tester.py
+++ b/tests/infra/multichip_tester.py
@@ -80,8 +80,8 @@ class MultichipTester(BaseTester):
         maxval: float = 1.0,
     ) -> None:
         """
-        Tests an input executable with random inputs in range [`minval`, `maxval`) by running it on 
-        a mesh of TT devices and comparing it to output of the cpu executable ran with the same 
+        Tests an input executable with random inputs in range [`minval`, `maxval`) by running it on
+        a mesh of TT devices and comparing it to output of the cpu executable ran with the same
         input.
         """
         inputs = [
@@ -144,13 +144,12 @@ def run_multichip_test_with_random_inputs(
     use_shardy: bool = False,
 ) -> None:
     """
-    Tests an input executable with random inputs in range [`minval`, `maxval`) by running it on a 
-    mesh of TT devices and comparing it to output of the cpu executable ran with the same input. 
+    Tests an input executable with random inputs in range [`minval`, `maxval`) by running it on a
+    mesh of TT devices and comparing it to output of the cpu executable ran with the same input.
     The xla backend used the shardy dialect if `use_shardy` is True, otherwise it uses GSPMD.
     """
-    with enable_shardy(use_shardy):
-        with device_connector.simulate_cpu_mesh(mesh_shape):
-            tester = MultichipTester(
-                in_specs, out_specs, mesh_shape, axis_names, comparison_config
-            )
-            tester.test_with_random_inputs(executable, input_shapes, minval, maxval)
+    with enable_shardy(use_shardy), device_connector.simulate_cpu_mesh(mesh_shape):
+        tester = MultichipTester(
+            in_specs, out_specs, mesh_shape, axis_names, comparison_config
+        )
+        tester.test_with_random_inputs(executable, input_shapes, minval, maxval)

--- a/tests/jax/multichip/manual/all_gather.py
+++ b/tests/jax/multichip/manual/all_gather.py
@@ -2,19 +2,23 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from infra import make_partition_spec, run_multichip_test_with_random_inputs
 import jax
 import jax.numpy as jnp
 import pytest
-from infra import make_partition_spec, run_multichip_test_with_random_inputs
 
 from tests.utils import failed_fe_compilation
 
 
+@pytest.mark.parametrize("use_shardy", [True, False])
 @pytest.mark.parametrize(
-    ("x_shape", "mesh_shape", "axis_names"), [((8192, 784), (2,), ("batch",))]
+    ("x_shape", "mesh_shape", "axis_names"),
+    [((8192, 784), (2,), ("batch",))],
 )
 @pytest.mark.skip(reason=failed_fe_compilation("Multichip still in development"))
-def test_all_gather(x_shape: tuple, mesh_shape: tuple, axis_names: tuple):
+def test_all_gather(
+    x_shape: tuple, mesh_shape: tuple, axis_names: tuple, use_shardy: bool
+):
     def fwd(batch):
         act = jax.lax.all_gather(batch, axis_names, axis=0, tiled=True)
         return act
@@ -23,5 +27,11 @@ def test_all_gather(x_shape: tuple, mesh_shape: tuple, axis_names: tuple):
     out_specs = make_partition_spec(axis_names)
 
     run_multichip_test_with_random_inputs(
-        fwd, [x_shape], mesh_shape, axis_names, in_specs, out_specs
+        fwd,
+        [x_shape],
+        mesh_shape,
+        axis_names,
+        in_specs,
+        out_specs,
+        use_shardy=use_shardy,
     )

--- a/tests/jax/multichip/manual/all_gather.py
+++ b/tests/jax/multichip/manual/all_gather.py
@@ -17,7 +17,7 @@ from tests.utils import failed_fe_compilation
 )
 @pytest.mark.skip(reason=failed_fe_compilation("Multichip still in development"))
 def test_all_gather(
-    x_shape: tuple, mesh_shape: tuple, axis_names: tuple, use_shardy: bool
+    use_shardy: bool, x_shape: tuple, mesh_shape: tuple, axis_names: tuple
 ):
     def fwd(batch):
         act = jax.lax.all_gather(batch, axis_names, axis=0, tiled=True)

--- a/tests/jax/multichip/manual/all_gather.py
+++ b/tests/jax/multichip/manual/all_gather.py
@@ -33,5 +33,5 @@ def test_all_gather(
         axis_names,
         in_specs,
         out_specs,
-        use_shardy=use_shardy,
+        use_shardy,
     )

--- a/tests/jax/multichip/manual/data_paralelism.py
+++ b/tests/jax/multichip/manual/data_paralelism.py
@@ -2,14 +2,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from infra import make_partition_spec, run_multichip_test_with_random_inputs
 import jax
 import jax.numpy as jnp
 import pytest
-from infra import make_partition_spec, run_multichip_test_with_random_inputs
 
 from tests.utils import failed_fe_compilation
 
 
+@pytest.mark.parametrize("use_shardy", [True, False])
 @pytest.mark.parametrize(
     [
         "batch_shape",
@@ -21,7 +22,7 @@ from tests.utils import failed_fe_compilation
         "axis_names",
     ],
     [
-        [
+        (
             (8192, 784),
             (784, 2048),
             (2048),
@@ -29,7 +30,7 @@ from tests.utils import failed_fe_compilation
             (1024),
             (1, 2),
             ("batch", "model"),
-        ],
+        ),
     ],
 )
 @pytest.mark.skip(reason=failed_fe_compilation("Multichip still in development"))
@@ -41,6 +42,7 @@ def test_data_paralelism(
     B2_shape: tuple,
     mesh_shape: tuple,
     axis_names: tuple,
+    use_shardy: bool,
 ):
     def fwd(batch, W1_block, B1_block, W2_block, B2_block):
         act = jnp.dot(batch, W1_block)
@@ -67,5 +69,6 @@ def test_data_paralelism(
         axis_names,
         in_specs,
         out_specs,
+        use_shardy=use_shardy,
         maxval=0.1,
     )

--- a/tests/jax/multichip/manual/data_paralelism.py
+++ b/tests/jax/multichip/manual/data_paralelism.py
@@ -69,6 +69,6 @@ def test_data_paralelism(
         axis_names,
         in_specs,
         out_specs,
-        use_shardy=use_shardy,
+        use_shardy,
         maxval=0.1,
     )

--- a/tests/jax/multichip/manual/data_paralelism.py
+++ b/tests/jax/multichip/manual/data_paralelism.py
@@ -35,6 +35,7 @@ from tests.utils import failed_fe_compilation
 )
 @pytest.mark.skip(reason=failed_fe_compilation("Multichip still in development"))
 def test_data_paralelism(
+    use_shardy: bool,
     batch_shape: tuple,
     W1_shape: tuple,
     B1_shape: tuple,
@@ -42,7 +43,6 @@ def test_data_paralelism(
     B2_shape: tuple,
     mesh_shape: tuple,
     axis_names: tuple,
-    use_shardy: bool,
 ):
     def fwd(batch, W1_block, B1_block, W2_block, B2_block):
         act = jnp.dot(batch, W1_block)

--- a/tests/jax/multichip/manual/psum.py
+++ b/tests/jax/multichip/manual/psum.py
@@ -46,6 +46,6 @@ def test_psum(
         axis_names,
         in_specs,
         out_specs,
-        use_shardy=use_shardy,
+        use_shardy,
         maxval=0.1,
     )

--- a/tests/jax/multichip/manual/psum.py
+++ b/tests/jax/multichip/manual/psum.py
@@ -19,12 +19,12 @@ from tests.utils import failed_fe_compilation
 )
 @pytest.mark.skip(reason=failed_fe_compilation("Multichip still in development"))
 def test_psum(
+    use_shardy: bool,
     batch_shape: tuple,
     W1_shape: tuple,
     B1_shape: tuple,
     mesh_shape: tuple,
     axis_names: tuple,
-    use_shardy: bool,
 ):
     def fwd(batch, W1_block, B1_block):
         act = jnp.dot(batch, W1_block)

--- a/tests/jax/multichip/manual/psum.py
+++ b/tests/jax/multichip/manual/psum.py
@@ -2,18 +2,19 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from infra import make_partition_spec, run_multichip_test_with_random_inputs
 import jax
 import jax.numpy as jnp
 import pytest
-from infra import make_partition_spec, run_multichip_test_with_random_inputs
 
 from tests.utils import failed_fe_compilation
 
 
+@pytest.mark.parametrize("use_shardy", [True, False])
 @pytest.mark.parametrize(
-    ["batch_shape", "W1_shape", "B1_shape", "mesh_shape", "axis_names"],
+    ("batch_shape", "W1_shape", "B1_shape", "mesh_shape", "axis_names"),
     [
-        [(8192, 784), (784, 2048), (2048), (1, 2), ("batch", "model")],
+        ((8192, 784), (784, 2048), (2048), (1, 2), ("batch", "model")),
     ],
 )
 @pytest.mark.skip(reason=failed_fe_compilation("Multichip still in development"))
@@ -23,6 +24,7 @@ def test_psum(
     B1_shape: tuple,
     mesh_shape: tuple,
     axis_names: tuple,
+    use_shardy: bool,
 ):
     def fwd(batch, W1_block, B1_block):
         act = jnp.dot(batch, W1_block)
@@ -44,5 +46,6 @@ def test_psum(
         axis_names,
         in_specs,
         out_specs,
+        use_shardy=use_shardy,
         maxval=0.1,
     )

--- a/tests/jax/multichip/manual/psum_scatter.py
+++ b/tests/jax/multichip/manual/psum_scatter.py
@@ -46,6 +46,6 @@ def test_psum_scatter(
         axis_names,
         in_specs,
         out_specs,
-        use_shardy=use_shardy,
+        use_shardy,
         maxval=0.1,
     )

--- a/tests/jax/multichip/manual/psum_scatter.py
+++ b/tests/jax/multichip/manual/psum_scatter.py
@@ -2,18 +2,19 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from infra import make_partition_spec, run_multichip_test_with_random_inputs
 import jax
 import jax.numpy as jnp
 import pytest
-from infra import make_partition_spec, run_multichip_test_with_random_inputs
 
 from tests.utils import failed_fe_compilation
 
 
+@pytest.mark.parametrize("use_shardy", [True, False])
 @pytest.mark.parametrize(
-    ["batch_shape", "W1_shape", "B1_shape", "mesh_shape", "axis_names"],
+    ("batch_shape", "W1_shape", "B1_shape", "mesh_shape", "axis_names"),
     [
-        [(8192, 784), (784, 2048), (2048), (1, 2), ("batch", "model")],
+        ((8192, 784), (784, 2048), (2048), (1, 2), ("batch", "model")),
     ],
 )
 @pytest.mark.skip(reason=failed_fe_compilation("Multichip still in development"))
@@ -23,6 +24,7 @@ def test_psum_scatter(
     B1_shape: tuple,
     mesh_shape: tuple,
     axis_names: tuple,
+    use_shardy: bool,
 ):
     def fwd(batch, W1_block, B1_block):
         act = jnp.dot(batch, W1_block)
@@ -44,5 +46,6 @@ def test_psum_scatter(
         axis_names,
         in_specs,
         out_specs,
+        use_shardy=use_shardy,
         maxval=0.1,
     )

--- a/tests/jax/multichip/manual/psum_scatter.py
+++ b/tests/jax/multichip/manual/psum_scatter.py
@@ -19,12 +19,12 @@ from tests.utils import failed_fe_compilation
 )
 @pytest.mark.skip(reason=failed_fe_compilation("Multichip still in development"))
 def test_psum_scatter(
+    use_shardy: bool,
     batch_shape: tuple,
     W1_shape: tuple,
     B1_shape: tuple,
     mesh_shape: tuple,
     axis_names: tuple,
-    use_shardy: bool,
 ):
     def fwd(batch, W1_block, B1_block):
         act = jnp.dot(batch, W1_block)

--- a/tests/jax/multichip/manual/unary_eltwise.py
+++ b/tests/jax/multichip/manual/unary_eltwise.py
@@ -9,19 +9,37 @@ import pytest
 from tests.utils import failed_fe_compilation
 
 
-@pytest.mark.parametrize("use_shardy", [True, False])
+@pytest.mark.parametrize(
+    "use_shardy",
+    [
+        pytest.param(
+            True,
+            marks=pytest.mark.xfail(
+                reason="Shardy sharding not supported (issue #383)"
+            ),
+        ),
+        False,
+    ],
+)
 @pytest.mark.parametrize(
     ("input_shape", "mesh_shape", "axis_names"), [((256, 256), (1, 2), ("x", "y"))]
 )
 @pytest.mark.skip(reason=failed_fe_compilation("Multichip still in development"))
-def test_unary_eltwise(use_shardy: bool, input_shape: tuple, mesh_shape: tuple, axis_names: tuple):
+def test_unary_eltwise(
+    use_shardy: bool, input_shape: tuple, mesh_shape: tuple, axis_names: tuple
+):
     def fwd(a_block):
         b_block = jnp.negative(a_block)
         return b_block
 
     in_specs = (make_partition_spec(axis_names),)
     out_specs = make_partition_spec(axis_names)
-
     run_multichip_test_with_random_inputs(
-        fwd, [input_shape], mesh_shape, axis_names, in_specs, out_specs, use_shardy=use_shardy
+        fwd,
+        [input_shape],
+        mesh_shape,
+        axis_names,
+        in_specs,
+        out_specs,
+        use_shardy=use_shardy,
     )

--- a/tests/jax/multichip/manual/unary_eltwise.py
+++ b/tests/jax/multichip/manual/unary_eltwise.py
@@ -41,5 +41,5 @@ def test_unary_eltwise(
         axis_names,
         in_specs,
         out_specs,
-        use_shardy=use_shardy,
+        use_shardy,
     )

--- a/tests/jax/multichip/manual/unary_eltwise.py
+++ b/tests/jax/multichip/manual/unary_eltwise.py
@@ -2,19 +2,19 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from infra import run_multichip_test_with_random_inputs, make_partition_spec
 import jax
 import jax.numpy as jnp
 import pytest
-from infra import make_partition_spec, run_multichip_test_with_random_inputs
-
 from tests.utils import failed_fe_compilation
 
 
+@pytest.mark.parametrize("use_shardy", [True, False])
 @pytest.mark.parametrize(
     ("input_shape", "mesh_shape", "axis_names"), [((256, 256), (1, 2), ("x", "y"))]
 )
 @pytest.mark.skip(reason=failed_fe_compilation("Multichip still in development"))
-def test_unary_eltwise(input_shape: tuple, mesh_shape: tuple, axis_names: tuple):
+def test_unary_eltwise(use_shardy: bool, input_shape: tuple, mesh_shape: tuple, axis_names: tuple):
     def fwd(a_block):
         b_block = jnp.negative(a_block)
         return b_block
@@ -23,5 +23,5 @@ def test_unary_eltwise(input_shape: tuple, mesh_shape: tuple, axis_names: tuple)
     out_specs = make_partition_spec(axis_names)
 
     run_multichip_test_with_random_inputs(
-        fwd, [input_shape], mesh_shape, axis_names, in_specs, out_specs
+        fwd, [input_shape], mesh_shape, axis_names, in_specs, out_specs, use_shardy=use_shardy
     )


### PR DESCRIPTION
Added support for shardy dialects in multichip tests, as well as allowing unregistered dialects in the creating VHLO function (see issue https://github.com/tenstorrent/tt-xla/issues/355). **These tests are still skipped**

Additionally, updated the version of `jax` and `jaxlib` in the `requirements.txt` file