### PR TITLE
Skipped mistral model due to OOM fail on CI

### DIFF
--- a/tests/jax/models/mistral/mistral_7b/v0_1/test_mistral_7b_v0_1.py
+++ b/tests/jax/models/mistral/mistral_7b/v0_1/test_mistral_7b_v0_1.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_ttmlir_compilation,
+    failed_fe_compilation,
 )
 
 from ..tester import MistralTester
@@ -47,12 +47,11 @@ def training_tester() -> MistralTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
+    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
 )
-@pytest.mark.xfail(
-    reason=failed_ttmlir_compilation(
-        "failed to legalize operation 'ttir.gather' "
-        "https://github.com/tenstorrent/tt-xla/issues/318"
+@pytest.mark.skip(
+    reason=failed_fe_compilation(
+        "OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186)"
     )
 )
 def test_mistral_7b_v0_1_inference(inference_tester: MistralTester):

--- a/tests/jax/models/vit/vit_large_patch32_384/test_vit_large_patch32_384.py
+++ b/tests/jax/models/vit/vit_large_patch32_384/test_vit_large_patch32_384.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Callable
 
 import pytest
 from infra import Framework, RunMode
@@ -53,10 +52,9 @@ def training_tester() -> ViTTester:
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.FAILED_FE_COMPILATION,
 )
-@pytest.mark.xfail(
+@pytest.mark.skip(
     reason=failed_fe_compilation(
-        "Test fails due to unimplemented resharding. (JAX XlaRuntimeError: Error code 12)"
-        "(https://github.com/tenstorrent/tt-xla/issues/358)"
+        "OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186)"
     )
 )
 def test_vit_large_patch32_384_inference(


### PR DESCRIPTION
Due to failing pipelines:
https://github.com/tenstorrent/tt-xla/actions/runs/13912292685/job/38929358699
https://github.com/tenstorrent/tt-xla/actions/runs/13919437668/job/38949908192
had to skip some tests.
Now it passes https://github.com/tenstorrent/tt-xla/actions/runs/13920293282.