### PR TITLE
Uplift third_party/tt-mlir to 4daf7e2b7759d16fff7ee9deba89aefff46ac285 2025-03-20

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set(TT_MLIR_VERSION "ea91b3c399b67bb55ec98f78f7e651132869cf66")
+set(TT_MLIR_VERSION "4daf7e2b7759d16fff7ee9deba89aefff46ac285")
 set(LOGURU_VERSION "4adaa185883e3c04da25913579c451d3c32cfac1")
 
 if (TOOLCHAIN STREQUAL "ON")


### PR DESCRIPTION
This PR uplifts the third_party/tt-mlir to the 4daf7e2b7759d16fff7ee9deba89aefff46ac285