### PR TITLE
Uplift third_party/tt-mlir to 0c6f9d56769d0a3836c95b4c47b41517f0cc8144 2025-03-21

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set(TT_MLIR_VERSION "4daf7e2b7759d16fff7ee9deba89aefff46ac285")
+set(TT_MLIR_VERSION "0c6f9d56769d0a3836c95b4c47b41517f0cc8144")
 set(LOGURU_VERSION "4adaa185883e3c04da25913579c451d3c32cfac1")
 
 if (TOOLCHAIN STREQUAL "ON")


### PR DESCRIPTION
This PR uplifts the third_party/tt-mlir to the 0c6f9d56769d0a3836c95b4c47b41517f0cc8144