### PR TITLE
Fix nightly build fail notification message

### DIFF
--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           payload: |
             {
-              "text": "Bad bad nightly: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}>",
+              "text": "Bad bad nightly: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}>",
               "channel": "C08GYB57C8M"
             }
         env:


### PR DESCRIPTION
### Problem description
Provide context for the problem.

### What's changed
Nightly build fail notification message don't have attempt in link. This makes confusion when nightly is rerun and passes.
Added attempt # to fail notification link
