### PR TITLE
Collecting sharding information from Shardy attirbutes

### DIFF
--- a/src/common/module_builder.cc
+++ b/src/common/module_builder.cc
@@ -227,11 +227,7 @@ void ModuleBuilder::collectInputShardingsGSPMD(
 
 void ModuleBuilder::collectInputShardingsShardy(
     const mlir::OwningOpRef<mlir::ModuleOp> &module) {
-  std::optional<mlir::sdy::MeshOp> mesh_op;
-  module.get().walk([&](mlir::sdy::MeshOp op) {
-    mesh_op = op;
-    return mlir::WalkResult::interrupt();
-  });
+  std::optional<mlir::sdy::MeshOp> mesh_op = getFirstShardyMeshOp(module);
   // Since this function is called only when we are using the shardy dialect,
   // this op should always be present.
   if (!mesh_op.has_value()) {
@@ -281,11 +277,7 @@ void ModuleBuilder::collectOutputShardingsGSPMD(
 
 void ModuleBuilder::collectOutputShardingsShardy(
     const mlir::OwningOpRef<mlir::ModuleOp> &module) {
-  std::optional<mlir::sdy::MeshOp> mesh_op;
-  module.get().walk([&](mlir::sdy::MeshOp op) {
-    mesh_op = op;
-    return mlir::WalkResult::interrupt();
-  });
+  std::optional<mlir::sdy::MeshOp> mesh_op = getFirstShardyMeshOp(module);
   // Since this function is called only when we are using the shardy dialect,
   // this op should always be present.
   if (!mesh_op.has_value()) {
@@ -487,13 +479,19 @@ bool ModuleBuilder::isUsingShardy(
 
   // After running through the SdyRoundTripImportPipeline, the module which uses
   // shardy dialect will have the sdy.mesh op.
-  bool has_mesh_op = false;
+  std::optional<mlir::sdy::MeshOp> mesh_op = getFirstShardyMeshOp(module);
+
+  return mesh_op.has_value();
+}
+
+std::optional<mlir::sdy::MeshOp> ModuleBuilder::getFirstShardyMeshOp(
+    const mlir::OwningOpRef<mlir::ModuleOp> &module) {
+  std::optional<mlir::sdy::MeshOp> mesh_op;
   module.get().walk([&](mlir::sdy::MeshOp op) {
-    has_mesh_op = true;
+    mesh_op = op;
     return mlir::WalkResult::interrupt();
   });
-
-  return has_mesh_op;
+  return mesh_op;
 }
 
 } // namespace tt::pjrt

--- a/src/common/module_builder.cc
+++ b/src/common/module_builder.cc
@@ -175,11 +175,7 @@ void ModuleBuilder::convertFromVHLOToSHLO(
   // from openXLA. Once openXLA natively supports Shardy, we can remove
   // following import passes. https://github.com/tenstorrent/tt-xla/issues/284
   // Detect Shardy by looking at the meshes attribute in module.
-  bool is_shardy_dialect =
-      mlir::sdy::tryGetFrontendAttr<mlir::DictionaryAttr>(
-          mlir_module.get(), mlir::sdy::kMeshesRoundTripAttr)
-          .has_value();
-  if (is_shardy_dialect) {
+  if (isUsingShardy(mlir_module)) {
     mlir::PassManager shardy_pm(mlir_module.get()->getName());
     mlir::sdy::addSdyRoundTripImportPipeline(shardy_pm);
     if (mlir::failed(shardy_pm.run(mlir_module.get()))) {
@@ -189,15 +185,29 @@ void ModuleBuilder::convertFromVHLOToSHLO(
       return;
     }
   }
-
   DLOG_F(LOG_DEBUG, "SHLO Module:");
+
   printModule(mlir_module);
+}
+
+void ModuleBuilder::collectOutputShardings(
+    const mlir::OwningOpRef<mlir::ModuleOp> &module) {
+  DLOG_F(LOG_DEBUG, "ModuleBuilder::collectOutputShardings");
+  m_output_shardings.clear();
+  isUsingShardy(module) ? collectOutputShardingsShardy(module)
+                        : collectOutputShardingsGSPMD(module);
 }
 
 void ModuleBuilder::collectInputShardings(
     const mlir::OwningOpRef<mlir::ModuleOp> &module) {
   DLOG_F(LOG_DEBUG, "ModuleBuilder::collectInputShardings");
   m_input_shardings.clear();
+  isUsingShardy(module) ? collectInputShardingsShardy(module)
+                        : collectInputShardingsGSPMD(module);
+}
+
+void ModuleBuilder::collectInputShardingsGSPMD(
+    const mlir::OwningOpRef<mlir::ModuleOp> &module) {
 
   std::vector<mlir::func::FuncOp> publicFuncOps = getPublicFuncOps(module);
   std::vector<mlir::StringAttr> gspmd_attributes;
@@ -215,11 +225,43 @@ void ModuleBuilder::collectInputShardings(
   }
 }
 
-void ModuleBuilder::collectOutputShardings(
+void ModuleBuilder::collectInputShardingsShardy(
     const mlir::OwningOpRef<mlir::ModuleOp> &module) {
-  DLOG_F(LOG_DEBUG, "ModuleBuilder::collectOutputShardings");
-  m_output_shardings.clear();
+  std::optional<mlir::sdy::MeshOp> mesh_op;
+  module.get().walk([&](mlir::sdy::MeshOp op) {
+    mesh_op = op;
+    return mlir::WalkResult::interrupt();
+  });
+  // Since this function is called only when we are using the shardy dialect,
+  // this op should always be present.
+  if (!mesh_op.has_value()) {
+    DLOG_F(ERROR, "Failed to find mesh op in the module");
+    m_status = tt_pjrt_status::kInternal;
+    return;
+  }
 
+  mlir::sdy::MeshAttr shardy_mesh = mesh_op->getMesh();
+  std::vector<mlir::func::FuncOp> publicFuncOps = getPublicFuncOps(module);
+  std::vector<mlir::sdy::TensorShardingAttr> shardy_attributes;
+
+  for (mlir::func::FuncOp &func_op : publicFuncOps) {
+    for (unsigned int arg_index = 0; arg_index < func_op.getNumArguments();
+         ++arg_index) {
+      shardy_attributes.push_back(
+          func_op.getArgAttrOfType<mlir::sdy::TensorShardingAttr>(
+              arg_index, mlir::sdy::kShardingAttr));
+    }
+  }
+
+  mlir::LogicalResult result = createShardingsFromShardy(
+      shardy_attributes, shardy_mesh, m_input_shardings);
+  if (result.failed()) {
+    m_status = tt_pjrt_status::kInternal;
+  }
+}
+
+void ModuleBuilder::collectOutputShardingsGSPMD(
+    const mlir::OwningOpRef<mlir::ModuleOp> &module) {
   std::vector<mlir::func::FuncOp> publicFuncOps = getPublicFuncOps(module);
   std::vector<mlir::StringAttr> gspmd_attributes;
   for (mlir::func::FuncOp &func_op : publicFuncOps) {
@@ -232,6 +274,40 @@ void ModuleBuilder::collectOutputShardings(
 
   mlir::LogicalResult result =
       createShardingsFromGSPMD(gspmd_attributes, m_output_shardings);
+  if (result.failed()) {
+    m_status = tt_pjrt_status::kInternal;
+  }
+}
+
+void ModuleBuilder::collectOutputShardingsShardy(
+    const mlir::OwningOpRef<mlir::ModuleOp> &module) {
+  std::optional<mlir::sdy::MeshOp> mesh_op;
+  module.get().walk([&](mlir::sdy::MeshOp op) {
+    mesh_op = op;
+    return mlir::WalkResult::interrupt();
+  });
+  // Since this function is called only when we are using the shardy dialect,
+  // this op should always be present.
+  if (!mesh_op.has_value()) {
+    DLOG_F(ERROR, "Failed to find mesh op in the module");
+    m_status = tt_pjrt_status::kInternal;
+    return;
+  }
+
+  mlir::sdy::MeshAttr shardy_mesh = mesh_op->getMesh();
+  std::vector<mlir::func::FuncOp> publicFuncOps = getPublicFuncOps(module);
+  std::vector<mlir::sdy::TensorShardingAttr> shardy_attributes;
+  for (mlir::func::FuncOp &func_op : publicFuncOps) {
+    for (unsigned int result_index = 0; result_index < func_op.getNumResults();
+         ++result_index) {
+      shardy_attributes.push_back(
+          func_op.getResultAttrOfType<mlir::sdy::TensorShardingAttr>(
+              result_index, mlir::sdy::kShardingAttr));
+    }
+  }
+
+  mlir::LogicalResult result = createShardingsFromShardy(
+      shardy_attributes, shardy_mesh, m_output_shardings);
   if (result.failed()) {
     m_status = tt_pjrt_status::kInternal;
   }
@@ -306,6 +382,35 @@ mlir::LogicalResult ModuleBuilder::createShardingsFromGSPMD(
   return llvm::LogicalResult::success();
 }
 
+mlir::LogicalResult ModuleBuilder::createShardingsFromShardy(
+    std::vector<mlir::sdy::TensorShardingAttr> &shardy_attributes,
+    mlir::sdy::MeshAttr &shardy_mesh,
+    std::vector<mlir::tt::sharding_utils::MeshSharding> &shardings) {
+  for (const mlir::sdy::TensorShardingAttr &shardy_attr : shardy_attributes) {
+
+    mlir::tt::sharding_utils::MeshSharding mesh_sharding;
+
+    // If there is no sharding attribute, we put the default sharding, marked
+    // as "identity", which means there is no sharding.
+    if (!shardy_attr) {
+      shardings.push_back(mesh_sharding);
+      continue;
+    }
+
+    llvm::Expected<bool> error = mesh_sharding.convertSdyShardingToMeshSharding(
+        shardy_attr, shardy_mesh, mlir::tt::MeshShardDirection::FullToShard);
+    if (llvm::Error e = error.takeError()) {
+      DLOG_F(ERROR, "Failed to convert sharding attribute to mesh sharding");
+
+      return llvm::LogicalResult::failure();
+    }
+
+    shardings.push_back(mesh_sharding);
+  }
+
+  return llvm::LogicalResult::success();
+}
+
 void ModuleBuilder::convertFromSHLOToTTIR(
     mlir::OwningOpRef<mlir::ModuleOp> &mlir_module) {
   // Implicit nesting required to call the stablehlo.composite --> func.call
@@ -365,6 +470,23 @@ void ModuleBuilder::printModule(
   }
 
   mlir_module->dump();
+}
+
+bool ModuleBuilder::isUsingShardy(
+    const mlir::OwningOpRef<mlir::ModuleOp> &module) {
+  if (mlir::sdy::tryGetFrontendAttr<mlir::DictionaryAttr>(
+          module.get(), mlir::sdy::kMeshesRoundTripAttr)
+          .has_value()) {
+    return true;
+  }
+
+  bool has_mesh_op = false;
+  module.get().walk([&](mlir::sdy::MeshOp op) {
+    has_mesh_op = true;
+    return mlir::WalkResult::interrupt();
+  });
+
+  return has_mesh_op;
 }
 
 } // namespace tt::pjrt

--- a/src/common/module_builder.h
+++ b/src/common/module_builder.h
@@ -92,10 +92,37 @@ private:
   // Checks if a particular type is scalar.
   bool isScalarType(mlir::Type type);
 
+  // Collect input sharding if we are using GSPMD.
+  void
+  collectInputShardingsGSPMD(const mlir::OwningOpRef<mlir::ModuleOp> &module);
+
+  // Collect output sharding if we are using GSPMD.
+  void
+  collectOutputShardingsGSPMD(const mlir::OwningOpRef<mlir::ModuleOp> &module);
+
+  // Collect input sharding if we are using Shardy.
+  void
+  collectInputShardingsShardy(const mlir::OwningOpRef<mlir::ModuleOp> &module);
+
+  // Collect output sharding if we are using Shardy.
+  void
+  collectOutputShardingsShardy(const mlir::OwningOpRef<mlir::ModuleOp> &module);
+
+  // Checks if the jax is using the Shardy mlir dialect.
+  bool isUsingShardy(const mlir::OwningOpRef<mlir::ModuleOp> &module);
+
   // Takes a vector of string attributes representing GSPMD sharding and fills
   // the vector of tt_mlir Sharding with the appropriate corresponding values.
   mlir::LogicalResult createShardingsFromGSPMD(
       const std::vector<mlir::StringAttr> &gspmd_attributes,
+      std::vector<mlir::tt::sharding_utils::MeshSharding> &shardings);
+
+  // Takes a vector of Shardy sharding attributes, the overall Shardy mesh and
+  // fills the vector of tt_mlir Sharding with the appropriate corresponding
+  // values.
+  mlir::LogicalResult createShardingsFromShardy(
+      std::vector<mlir::sdy::TensorShardingAttr> &shardy_attributes,
+      mlir::sdy::MeshAttr &shardy_mesh,
       std::vector<mlir::tt::sharding_utils::MeshSharding> &shardings);
 
   // Gets all public functions from the module.

--- a/src/common/module_builder.h
+++ b/src/common/module_builder.h
@@ -129,6 +129,10 @@ private:
   std::vector<mlir::func::FuncOp>
   getPublicFuncOps(const mlir::OwningOpRef<mlir::ModuleOp> &module);
 
+  // Gets the first sdy.Mesh op of a mlir module with shardy dialect enbaled.
+  std::optional<mlir::sdy::MeshOp>
+  getFirstShardyMeshOp(const mlir::OwningOpRef<mlir::ModuleOp> &module);
+
   // MLIR context handle.
   std::unique_ptr<mlir::MLIRContext> m_context;
 

--- a/src/common/module_builder.h
+++ b/src/common/module_builder.h
@@ -118,11 +118,11 @@ private:
       std::vector<mlir::tt::sharding_utils::MeshSharding> &shardings);
 
   // Takes a vector of Shardy sharding attributes, the overall Shardy mesh and
-  // fills the vector of tt_mlir Sharding with the appropriate corresponding
-  // values.
+  // fills the vector of tt_mlir MeshSharding objects with the appropriate
+  // corresponding values.
   mlir::LogicalResult createShardingsFromShardy(
       std::vector<mlir::sdy::TensorShardingAttr> &shardy_attributes,
-      mlir::sdy::MeshAttr &shardy_mesh,
+      const mlir::sdy::MeshAttr &shardy_mesh,
       std::vector<mlir::tt::sharding_utils::MeshSharding> &shardings);
 
   // Gets all public functions from the module.

--- a/src/common/pjrt_implementation/loaded_executable_instance.cc
+++ b/src/common/pjrt_implementation/loaded_executable_instance.cc
@@ -124,8 +124,9 @@ LoadedExecutableInstance::Execute(PJRT_LoadedExecutable_Execute_Args *args) {
   // mesh starting with the minimum device id offset.
   options.meshOffset = {0, static_cast<std::uint32_t>(*std::min_element(
                                device_ids.begin(), device_ids.end()))};
-  tt::runtime::Device device =
-      tt::runtime::openMeshDevice({1, device_ids.size()}, options);
+  const std::vector<uint32_t> mesh_shape = {
+      1, static_cast<uint32_t>(device_ids.size())};
+  tt::runtime::Device device = tt::runtime::openMeshDevice(mesh_shape, options);
   std::vector<tt::runtime::Tensor> input_tensors;
   int size_inputs = rt_inputs.size();
 

--- a/tests/jax/multi_chip/n300/graphs/tensor_parallel/test_dot_psum.py
+++ b/tests/jax/multi_chip/n300/graphs/tensor_parallel/test_dot_psum.py
@@ -20,10 +20,7 @@ from tests.utils import failed_ttmlir_compilation
 @pytest.mark.parametrize(
     "use_shardy",
     [
-        pytest.param(
-            True,
-            marks=pytest.mark.skip(reason="Shardy sharding not supported (issue #383)"),
-        ),
+        True,
         False,
     ],
 )

--- a/tests/jax/multi_chip/n300/graphs/tensor_parallel/test_dot_psum_scatter.py
+++ b/tests/jax/multi_chip/n300/graphs/tensor_parallel/test_dot_psum_scatter.py
@@ -20,10 +20,7 @@ from tests.utils import failed_ttmlir_compilation
 @pytest.mark.parametrize(
     "use_shardy",
     [
-        pytest.param(
-            True,
-            marks=pytest.mark.skip(reason="Shardy sharding not supported (issue #383)"),
-        ),
+        True,
         False,
     ],
 )

--- a/tests/jax/multi_chip/n300/graphs/tensor_parallel/test_psum_scatter.py
+++ b/tests/jax/multi_chip/n300/graphs/tensor_parallel/test_psum_scatter.py
@@ -20,10 +20,7 @@ from tests.utils import failed_ttmlir_compilation
 @pytest.mark.parametrize(
     "use_shardy",
     [
-        pytest.param(
-            True,
-            marks=pytest.mark.skip(reason="Shardy sharding not supported (issue #383)"),
-        ),
+        True,
         False,
     ],
 )

--- a/tests/jax/multi_chip/n300/ops/data_parallel/batch_sharded/test_all_gather.py
+++ b/tests/jax/multi_chip/n300/ops/data_parallel/batch_sharded/test_all_gather.py
@@ -21,7 +21,9 @@ from tests.utils import failed_ttmlir_compilation
     [
         pytest.param(
             True,
-            marks=pytest.mark.skip(reason="Shardy sharding not supported (issue #383)"),
+            marks=pytest.mark.skip(
+                reason=failed_ttmlir_compilation("Shardy does not support 1D meshes")
+            ),
         ),
         False,
     ],

--- a/tests/jax/multi_chip/n300/ops/data_parallel/batch_sharded/test_psum.py
+++ b/tests/jax/multi_chip/n300/ops/data_parallel/batch_sharded/test_psum.py
@@ -19,10 +19,7 @@ from tests.utils import failed_fe_compilation
 @pytest.mark.parametrize(
     "use_shardy",
     [
-        pytest.param(
-            True,
-            marks=pytest.mark.skip(reason="Shardy sharding not supported (issue #383)"),
-        ),
+        True,
         False,
     ],
 )

--- a/tests/jax/multi_chip/n300/ops/tensor_parallel/test_negative_op.py
+++ b/tests/jax/multi_chip/n300/ops/tensor_parallel/test_negative_op.py
@@ -22,7 +22,7 @@ def conditionally_skip(use_shardy: bool, multichip_mode: ShardingMode):
     if use_shardy and multichip_mode == ShardingMode.INPUTS:
         pytest.xfail(
             failed_fe_compilation(
-                "Shardy automatic parallelization not supported."
+                "Shardy automatic parallelization not supported. "
                 "Issue: https://github.com/tenstorrent/tt-xla/issues/406"
             )
         )
@@ -56,14 +56,14 @@ def conditionally_skip(use_shardy: bool, multichip_mode: ShardingMode):
         ShardingMode.INPUTS,
     ],
 )
-def test_unary_eltwise(
+def test_negative_op(
     use_shardy: bool,
     input_shape: tuple,
     mesh_shape: tuple,
     axis_names: tuple,
     sharding_mode: ShardingMode,
 ):
-    conditionally_skip(use_shardy, multichip_mode)
+    conditionally_skip(use_shardy, sharding_mode)
 
     def fwd(a_block):
         b_block = jnp.negative(a_block)

--- a/tests/jax/multi_chip/n300/ops/tensor_parallel/test_negative_op.py
+++ b/tests/jax/multi_chip/n300/ops/tensor_parallel/test_negative_op.py
@@ -18,13 +18,7 @@ from tests.utils import failed_fe_compilation
 @pytest.mark.parametrize(
     "use_shardy",
     [
-        pytest.param(
-            True,
-            marks=pytest.mark.xfail(
-                reason="Shardy sharding not supported (issue #383)"
-            ),
-        ),
-        False,
+        True,
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/jax/multi_chip/n300/ops/tensor_parallel/test_negative_op.py
+++ b/tests/jax/multi_chip/n300/ops/tensor_parallel/test_negative_op.py
@@ -13,12 +13,28 @@ from infra import (
 from tests.utils import failed_fe_compilation
 
 
+def conditionally_skip(use_shardy: bool, multichip_mode: ShardingMode):
+    """
+    Helper function which test parameters combination and skips if unsupported for some reason.
+
+    Extracted here in order not to pollute the test function.
+    """
+    if use_shardy and multichip_mode == ShardingMode.INPUTS:
+        pytest.xfail(
+            failed_fe_compilation(
+                "Shardy automatic parallelization not supported."
+                "Issue: https://github.com/tenstorrent/tt-xla/issues/406"
+            )
+        )
+
+
 @pytest.mark.nightly
 @pytest.mark.push
 @pytest.mark.parametrize(
     "use_shardy",
     [
         True,
+        False,
     ],
 )
 @pytest.mark.parametrize(
@@ -47,6 +63,8 @@ def test_unary_eltwise(
     axis_names: tuple,
     sharding_mode: ShardingMode,
 ):
+    conditionally_skip(use_shardy, multichip_mode)
+
     def fwd(a_block):
         b_block = jnp.negative(a_block)
         return b_block


### PR DESCRIPTION
When determining sizes of shapes for inputs and outputs of a graph, we get information from the StableHLO sharding attributes. Before, we only had support for GSPMD, now we also set support for the Shardy dialect.

Fixes https://github.com/tenstorrent/tt-xla/issues/383


