### PR TITLE
Changed the inputs to the build-and-test.yml 

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,8 +15,12 @@ on:
         options:
           - push
           - nightly
-      machine_and_dir:
-        description: 'Machine and directory to run tests on'
+      build_options:
+        description: >
+          Build options for each run, like:
+          - machine
+          - directory to run tests on
+          - the name of the run which can be used to differentiate unique runs
         required: true
         type: string
   workflow_call:
@@ -30,8 +34,12 @@ on:
         required: false
         default: 'push'
         type: string
-      machine_and_dir:
-        description: 'Machine and directory to run tests on'
+      build_options:
+        description: >
+          Build options for each run, like:
+          - machine
+          - directory to run tests on
+          - the name of the run which can be used to differentiate unique runs
         required: true
         type: string
 
@@ -162,7 +170,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build: ${{ fromJson(inputs.machine_and_dir) }}
+        build: ${{ fromJson(inputs.build_options) }}
 
     runs-on:
       - in-service

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -169,7 +169,7 @@ jobs:
       - ${{ matrix.build.runs-on }}
 
     # Keep this name in sync with the fetch-job-id step
-    name: "build-and-run-tests ${{ inputs.test_mark }} (${{ matrix.build.runs-on }}, run)"
+    name: "build-and-run-tests ${{ inputs.test_mark }} (${{ matrix.build.runs-on }}, ${{ matrix.build.name }})"
 
     container:
       image: ${{ needs.build-image.outputs.docker-image }}
@@ -199,7 +199,7 @@ jobs:
       id: fetch-job-id
       uses: tenstorrent/tt-github-actions/.github/actions/job_id@main
       with:
-        job_name: "build-and-run-tests ${{ inputs.test_mark }} (${{ matrix.build.runs-on }}, run)"
+        job_name: "build-and-run-tests ${{ inputs.test_mark }} (${{ matrix.build.runs-on }}, ${{ matrix.build.name }})"
 
     - name: Set reusable strings
       id: strings

--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -13,8 +13,8 @@ jobs:
       test_mark: 'nightly'
       machine_and_dir: |
         [
-          {"runs-on": "n150", "dir": "./tests/jax/single_chip"},
-          {"runs-on": "n300", "dir": "./tests/jax/multi_chip/n300"}
+          {"runs-on": "n150", "name": "run", "dir": "./tests/jax/single_chip"},
+          {"runs-on": "n300", "name": "run", "dir": "./tests/jax/multi_chip/n300"}
         ]
 
   test_full_model:
@@ -26,7 +26,7 @@ jobs:
       test_mark: 'model_test'
       machine_and_dir: |
         [
-          {"runs-on": "n150", "dir": "./tests/jax/single_chip"},
+          {"runs-on": "n150", "name": "run", "dir": "./tests/jax/single_chip"},
         ]
 
   fail-notify:

--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -11,7 +11,7 @@ jobs:
     secrets: inherit
     with:
       test_mark: 'nightly'
-      machine_and_dir: |
+      build_options: |
         [
           {"runs-on": "n150", "name": "run", "dir": "./tests/jax/single_chip"},
           {"runs-on": "n300", "name": "run", "dir": "./tests/jax/multi_chip/n300"}
@@ -24,7 +24,7 @@ jobs:
     if: always()  # This ensures the job runs regardless of success or failure of `nightly_tests`
     with:
       test_mark: 'model_test'
-      machine_and_dir: |
+      build_options: |
         [
           {"runs-on": "n150", "name": "run", "dir": "./tests/jax/single_chip"},
         ]

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -63,7 +63,7 @@ jobs:
     with:
       mlir_override: ${{ inputs.mlir_override }}
       test_mark: 'push'
-      machine_and_dir: |
+      build_options: |
         [
           {"runs-on": "n150", "name": "run", "dir": "./tests/jax/single_chip"},
           {"runs-on": "n300", "name": "run", "dir": "./tests/jax/multi_chip/n300"}

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -65,8 +65,8 @@ jobs:
       test_mark: 'push'
       machine_and_dir: |
         [
-          {"runs-on": "n150", "dir": "./tests/jax/single_chip"},
-          {"runs-on": "n300", "dir": "./tests/jax/multi_chip/n300"}
+          {"runs-on": "n150", "name": "run", "dir": "./tests/jax/single_chip"},
+          {"runs-on": "n300", "name": "run", "dir": "./tests/jax/multi_chip/n300"}
         ]
 
   check-all-green:

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -25,6 +25,6 @@ jobs:
     with:
       machine_and_dir: |
         [
-          {"runs-on": "n150", "dir": "./tests/jax/single_chip"},
-          {"runs-on": "n300", "dir": "./tests/jax/multi_chip/n300"}
+          {"runs-on": "n150", "name": "run", "dir": "./tests/jax/single_chip"},
+          {"runs-on": "n300", "name": "run", "dir": "./tests/jax/multi_chip/n300"}
         ]

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -23,7 +23,7 @@ jobs:
     uses: ./.github/workflows/build-and-test.yml
     secrets: inherit
     with:
-      machine_and_dir: |
+      build_options: |
         [
           {"runs-on": "n150", "name": "run", "dir": "./tests/jax/single_chip"},
           {"runs-on": "n300", "name": "run", "dir": "./tests/jax/multi_chip/n300"}


### PR DESCRIPTION
Changed the input structure of the `build-and-test.yml` to include name (currently only set to run), to differentiate between different builds during testing. 