### PR TITLE
Add issue link for incorrect_result failures

### DIFF
--- a/tests/jax/single_chip/models/albert_v2/base/test_albert_base.py
+++ b/tests/jax/single_chip/models/albert_v2/base/test_albert_base.py
@@ -53,7 +53,8 @@ def training_tester() -> AlbertV2Tester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=131036.078125. Required: atol=0.16"
+        "Atol comparison failed. Calculated: atol=131036.078125. Required: atol=0.16 "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_flax_albert_v2_base_inference(inference_tester: AlbertV2Tester):

--- a/tests/jax/single_chip/models/albert_v2/large/test_albert_large.py
+++ b/tests/jax/single_chip/models/albert_v2/large/test_albert_large.py
@@ -53,7 +53,8 @@ def training_tester() -> AlbertV2Tester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=131026.9375. Required: atol=0.16"
+        "Atol comparison failed. Calculated: atol=131026.9375. Required: atol=0.16 "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_flax_albert_v2_large_inference(inference_tester: AlbertV2Tester):

--- a/tests/jax/single_chip/models/albert_v2/xlarge/test_albert_xlarge.py
+++ b/tests/jax/single_chip/models/albert_v2/xlarge/test_albert_xlarge.py
@@ -52,7 +52,8 @@ def training_tester() -> AlbertV2Tester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=131030.6953125. Required: atol=0.16."
+        "Atol comparison failed. Calculated: atol=131030.6953125. Required: atol=0.16 "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_flax_albert_v2_xlarge_inference(inference_tester: AlbertV2Tester):

--- a/tests/jax/single_chip/models/albert_v2/xxlarge/test_albert_xxlarge.py
+++ b/tests/jax/single_chip/models/albert_v2/xxlarge/test_albert_xxlarge.py
@@ -54,7 +54,8 @@ def training_tester() -> AlbertV2Tester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=131022.7578125. Required: atol=0.16."
+        "Atol comparison failed. Calculated: atol=131022.7578125. Required: atol=0.16 "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_flax_albert_v2_xxlarge_inference(inference_tester: AlbertV2Tester):

--- a/tests/jax/single_chip/models/bart/base/test_bart_base.py
+++ b/tests/jax/single_chip/models/bart/base/test_bart_base.py
@@ -53,7 +53,8 @@ def training_tester() -> FlaxBartForCausalLMTester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=323375.3125. Required: atol=0.16"
+        "Atol comparison failed. Calculated: atol=323375.3125. Required: atol=0.16 "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_flax_bart_base_inference(inference_tester: FlaxBartForCausalLMTester):

--- a/tests/jax/single_chip/models/bart/large/test_bart_large.py
+++ b/tests/jax/single_chip/models/bart/large/test_bart_large.py
@@ -54,7 +54,8 @@ def training_tester() -> FlaxBartForCausalLMTester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=371601.96875. Required: atol=0.16"
+        "Atol comparison failed. Calculated: atol=371601.96875. Required: atol=0.16 "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_flax_bart_large_inference(inference_tester: FlaxBartForCausalLMTester):

--- a/tests/jax/single_chip/models/bert/base/test_bert_base.py
+++ b/tests/jax/single_chip/models/bert/base/test_bert_base.py
@@ -53,7 +53,8 @@ def training_tester() -> FlaxBertForMaskedLMTester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=131025.0078125. Required: atol=0.16."
+        "Atol comparison failed. Calculated: atol=131025.0078125. Required: atol=0.16 "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_flax_bert_base_inference(inference_tester: FlaxBertForMaskedLMTester):

--- a/tests/jax/single_chip/models/bert/large/test_bert_large.py
+++ b/tests/jax/single_chip/models/bert/large/test_bert_large.py
@@ -52,7 +52,8 @@ def training_tester() -> FlaxBertForMaskedLMTester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=131037.828125. Required: atol=0.16."
+        "Atol comparison failed. Calculated: atol=131037.828125. Required: atol=0.16 "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_flax_bert_large_inference(inference_tester: FlaxBertForMaskedLMTester):

--- a/tests/jax/single_chip/models/bloom/bloom_1b1/test_1b1.py
+++ b/tests/jax/single_chip/models/bloom/bloom_1b1/test_1b1.py
@@ -53,7 +53,8 @@ def training_tester() -> BloomTester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=12.176290512084961. Required: atol=0.16"
+        "Atol comparison failed. Calculated: atol=12.176290512084961. Required: atol=0.16 "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_bloom_1b1_inference(inference_tester: BloomTester):

--- a/tests/jax/single_chip/models/bloom/bloom_1b7/test_1b7.py
+++ b/tests/jax/single_chip/models/bloom/bloom_1b7/test_1b7.py
@@ -53,7 +53,8 @@ def training_tester() -> BloomTester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=25.83220100402832. Required: atol=0.16"
+        "Atol comparison failed. Calculated: atol=25.83220100402832. Required: atol=0.16 "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_bloom_1b7_inference(inference_tester: BloomTester):

--- a/tests/jax/single_chip/models/bloom/bloom_560m/test_560m.py
+++ b/tests/jax/single_chip/models/bloom/bloom_560m/test_560m.py
@@ -53,7 +53,8 @@ def training_tester() -> BloomTester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=327.8369445800781. Required: atol=0.16"
+        "Atol comparison failed. Calculated: atol=327.8369445800781. Required: atol=0.16 "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_bloom_560m_inference(inference_tester: BloomTester):

--- a/tests/jax/single_chip/models/distilbert/test_distilbert.py
+++ b/tests/jax/single_chip/models/distilbert/test_distilbert.py
@@ -79,7 +79,8 @@ def training_tester() -> FlaxDistilBertForMaskedLMTester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=131036.078125. Required: atol=0.16"
+        "Atol comparison failed. Calculated: atol=131036.078125. Required: atol=0.16 "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_flax_distilbert_inference(inference_tester: FlaxDistilBertForMaskedLMTester):

--- a/tests/jax/single_chip/models/gpt2/base/test_gpt2_base.py
+++ b/tests/jax/single_chip/models/gpt2/base/test_gpt2_base.py
@@ -53,7 +53,8 @@ def training_tester() -> GPT2Tester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=37.821876525878906. Required: atol=0.16"
+        "Atol comparison failed. Calculated: atol=37.821876525878906. Required: atol=0.16 "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_gpt2_base_inference(inference_tester: GPT2Tester):

--- a/tests/jax/single_chip/models/gpt2/large/test_gpt2_large.py
+++ b/tests/jax/single_chip/models/gpt2/large/test_gpt2_large.py
@@ -53,7 +53,8 @@ def training_tester() -> GPT2Tester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=9.953690528869629. Required: atol=0.16"
+        "Atol comparison failed. Calculated: atol=9.953690528869629. Required: atol=0.16 "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_gpt2_large_inference(inference_tester: GPT2Tester):

--- a/tests/jax/single_chip/models/gpt2/medium/test_gpt2_medium.py
+++ b/tests/jax/single_chip/models/gpt2/medium/test_gpt2_medium.py
@@ -53,7 +53,8 @@ def training_tester() -> GPT2Tester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=13.961490631103516. Required: atol=0.16"
+        "Atol comparison failed. Calculated: atol=13.961490631103516. Required: atol=0.16 "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_gpt2_medium_inference(inference_tester: GPT2Tester):

--- a/tests/jax/single_chip/models/gpt_neo/gpt_neo_125m/test_gpt_neo_125m.py
+++ b/tests/jax/single_chip/models/gpt_neo/gpt_neo_125m/test_gpt_neo_125m.py
@@ -52,7 +52,8 @@ def training_tester() -> GPTNeoTester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=15.864267349243164. Required: atol=0.16"
+        "Atol comparison failed. Calculated: atol=15.864267349243164. Required: atol=0.16 "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_gpt_neo_125m_inference(inference_tester: GPTNeoTester):

--- a/tests/jax/single_chip/models/opt/opt_125m/test_125m.py
+++ b/tests/jax/single_chip/models/opt/opt_125m/test_125m.py
@@ -51,7 +51,8 @@ def training_tester() -> OPTTester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=4121164.25. Required: atol=0.16."
+        "Atol comparison failed. Calculated: atol=4121164.25. Required: atol=0.16 "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_opt_125m_inference(inference_tester: OPTTester):

--- a/tests/jax/single_chip/models/opt/opt_1_3b/test_1_3b.py
+++ b/tests/jax/single_chip/models/opt/opt_1_3b/test_1_3b.py
@@ -52,7 +52,8 @@ def training_tester() -> OPTTester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=2307070.75. Required: atol=0.16"
+        "Atol comparison failed. Calculated: atol=2307070.75. Required: atol=0.16 "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_opt_1_3b_inference(inference_tester: OPTTester):

--- a/tests/jax/single_chip/models/opt/opt_350m/test_350m.py
+++ b/tests/jax/single_chip/models/opt/opt_350m/test_350m.py
@@ -53,7 +53,8 @@ def training_tester() -> OPTTester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=2040517.5. Required: atol=0.16."
+        "Atol comparison failed. Calculated: atol=2040517.5. Required: atol=0.16 "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_opt_350m_inference(inference_tester: OPTTester):

--- a/tests/jax/single_chip/models/roberta/base/test_roberta_base.py
+++ b/tests/jax/single_chip/models/roberta/base/test_roberta_base.py
@@ -53,7 +53,8 @@ def training_tester() -> FlaxRobertaForMaskedLMTester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=131044.359375. Required: atol=0.16"
+        "Atol comparison failed. Calculated: atol=131044.359375. Required: atol=0.16 "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_flax_roberta_base_inference(inference_tester: FlaxRobertaForMaskedLMTester):

--- a/tests/jax/single_chip/models/roberta/large/test_roberta_large.py
+++ b/tests/jax/single_chip/models/roberta/large/test_roberta_large.py
@@ -53,7 +53,8 @@ def training_tester() -> FlaxRobertaForMaskedLMTester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=131078.359375. Required: atol=0.16"
+        "Atol comparison failed. Calculated: atol=131078.359375. Required: atol=0.16 "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_flax_roberta_large_inference(inference_tester: FlaxRobertaForMaskedLMTester):

--- a/tests/jax/single_chip/models/roberta_prelayernorm/efficient_mlm_m0_40/test_efficient_mlm_m0_40.py
+++ b/tests/jax/single_chip/models/roberta_prelayernorm/efficient_mlm_m0_40/test_efficient_mlm_m0_40.py
@@ -97,7 +97,8 @@ def training_tester() -> FlaxRobertaPreLayerNormForMaskedLMTester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=131048.65625. Required: atol=0.16"
+        "Atol comparison failed. Calculated: atol=131048.65625. Required: atol=0.16 "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_flax_roberta_prelayernorm_inference(

--- a/tests/jax/single_chip/models/xglm/xglm_564m/test_xglm_564m.py
+++ b/tests/jax/single_chip/models/xglm/xglm_564m/test_xglm_564m.py
@@ -52,7 +52,8 @@ def training_tester() -> XGLMTester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=8313996.5. Required: atol=0.16."
+        "Atol comparison failed. Calculated: atol=8313996.5. Required: atol=0.16 "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_xglm_564m_inference(inference_tester: XGLMTester):

--- a/tests/jax/single_chip/models/xlm_roberta/base/test_xlm_roberta_base.py
+++ b/tests/jax/single_chip/models/xlm_roberta/base/test_xlm_roberta_base.py
@@ -52,7 +52,8 @@ def training_tester() -> XLMRobertaTester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=131074.375. Required: atol=0.16"
+        "Atol comparison failed. Calculated: atol=131074.375. Required: atol=0.16 "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_xlm_roberta_base_inference(inference_tester: XLMRobertaTester):


### PR DESCRIPTION
### Problem description
Reason for inaccurate_result in xfail marker is missing the issue link.

### What's changed
 https://github.com/tenstorrent/tt-xla/issues/379 This issue link is added to xfail reason for inaccurate_result 

log file for roberta_base after making this change is attached
[roberta_base_xfail.log](https://github.com/user-attachments/files/19584892/roberta_base_xfail.log)
