### PR TITLE
Refactor tests to pass everything from the tokenizer in LM tests

### DIFF
--- a/tests/jax/single_chip/models/albert_v2/base/test_albert_base.py
+++ b/tests/jax/single_chip/models/albert_v2/base/test_albert_base.py
@@ -53,7 +53,7 @@ def training_tester() -> AlbertV2Tester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=131036.078125. Required: atol=0.16 "
+        "Atol comparison failed. Calculated: atol=34.321659088134766. Required: atol=0.16 "
         "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )

--- a/tests/jax/single_chip/models/albert_v2/tester.py
+++ b/tests/jax/single_chip/models/albert_v2/tester.py
@@ -7,6 +7,7 @@ from typing import Dict, Sequence
 import jax
 from infra import ComparisonConfig, ModelTester, RunMode
 from transformers import AutoTokenizer, FlaxAlbertForMaskedLM, FlaxPreTrainedModel
+from jaxtyping import PyTree
 
 
 class AlbertV2Tester(ModelTester):
@@ -26,17 +27,17 @@ class AlbertV2Tester(ModelTester):
         return FlaxAlbertForMaskedLM.from_pretrained(self._model_name)
 
     # @override
-    def _get_input_activations(self) -> Sequence[jax.Array]:
+    def _get_input_activations(self) -> Dict[str, jax.Array]:
         tokenizer = AutoTokenizer.from_pretrained(self._model_name)
-        inputs = tokenizer("Hello [MASK].", return_tensors="np")
-        return inputs["input_ids"]
+        inputs = tokenizer("Hello [MASK].", return_tensors="jax")
+        return inputs
 
     # @override
-    def _get_forward_method_kwargs(self) -> Dict[str, jax.Array]:
+    def _get_forward_method_kwargs(self) -> Dict[str, PyTree]:
         assert hasattr(self._model, "params")
         return {
             "params": self._model.params,
-            "input_ids": self._get_input_activations(),
+            **self._get_input_activations(),
         }
 
     # @ override

--- a/tests/jax/single_chip/models/bart/base/test_bart_base.py
+++ b/tests/jax/single_chip/models/bart/base/test_bart_base.py
@@ -53,7 +53,7 @@ def training_tester() -> FlaxBartForCausalLMTester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=323375.3125. Required: atol=0.16 "
+        "Atol comparison failed. Calculated: atol=299478.09375. Required: atol=0.16 "
         "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )

--- a/tests/jax/single_chip/models/bart/large/test_bart_large.py
+++ b/tests/jax/single_chip/models/bart/large/test_bart_large.py
@@ -54,7 +54,7 @@ def training_tester() -> FlaxBartForCausalLMTester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=371601.96875. Required: atol=0.16 "
+        "Atol comparison failed. Calculated: atol=365204.0. Required: atol=0.16 "
         "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )

--- a/tests/jax/single_chip/models/bart/tester.py
+++ b/tests/jax/single_chip/models/bart/tester.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict, Sequence
+from typing import Dict
 
 import jax
 from infra import ComparisonConfig, ModelTester, RunMode
 from transformers import AutoTokenizer, FlaxBartForCausalLM, FlaxPreTrainedModel
+from jaxtyping import PyTree
 
 
 class FlaxBartForCausalLMTester(ModelTester):
@@ -30,15 +31,15 @@ class FlaxBartForCausalLMTester(ModelTester):
         return model
 
     # @override
-    def _get_input_activations(self) -> Sequence[jax.Array]:
+    def _get_input_activations(self) -> Dict[str, jax.Array]:
         tokenizer = AutoTokenizer.from_pretrained(self._model_name)
-        inputs = tokenizer("Hello", return_tensors="np")
-        return inputs["input_ids"]
+        inputs = tokenizer("Hello there fellow traveler", return_tensors="jax")
+        return inputs
 
     # @override
-    def _get_forward_method_kwargs(self) -> Dict[str, jax.Array]:
+    def _get_forward_method_kwargs(self) -> Dict[str, PyTree]:
         assert hasattr(self._model, "params")
         return {
             "params": self._model.params,
-            "input_ids": self._get_input_activations(),
+            **self._get_input_activations(),
         }

--- a/tests/jax/single_chip/models/beit/tester.py
+++ b/tests/jax/single_chip/models/beit/tester.py
@@ -36,7 +36,7 @@ class FlaxBeitForImageClassificationTester(ModelTester):
         preprocessor = BeitImageProcessor.from_pretrained(
             self._model_name, do_rescale=False
         )
-        inputs = preprocessor(image, return_tensors="np")
+        inputs = preprocessor(image, return_tensors="jax")
         return inputs
 
     # @override

--- a/tests/jax/single_chip/models/bert/tester.py
+++ b/tests/jax/single_chip/models/bert/tester.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict, Sequence
+from typing import Dict
 
 import jax
 from infra import ComparisonConfig, ModelTester, RunMode
 from transformers import AutoTokenizer, FlaxBertForMaskedLM, FlaxPreTrainedModel
+from jaxtyping import PyTree
 
 
 class FlaxBertForMaskedLMTester(ModelTester):
@@ -26,15 +27,15 @@ class FlaxBertForMaskedLMTester(ModelTester):
         return FlaxBertForMaskedLM.from_pretrained(self._model_name)
 
     # @override
-    def _get_input_activations(self) -> Sequence[jax.Array]:
+    def _get_input_activations(self) -> Dict[str, jax.Array]:
         tokenizer = AutoTokenizer.from_pretrained(self._model_name)
-        inputs = tokenizer("Hello [MASK]", return_tensors="np")
-        return inputs["input_ids"]
+        inputs = tokenizer("Hello [MASK]", return_tensors="jax")
+        return inputs
 
     # @override
-    def _get_forward_method_kwargs(self) -> Dict[str, jax.Array]:
+    def _get_forward_method_kwargs(self) -> Dict[str, PyTree]:
         assert hasattr(self._model, "params")
         return {
             "params": self._model.params,
-            "input_ids": self._get_input_activations(),
+            **self._get_input_activations(),
         }

--- a/tests/jax/single_chip/models/bloom/bloom_1b1/test_1b1.py
+++ b/tests/jax/single_chip/models/bloom/bloom_1b1/test_1b1.py
@@ -53,7 +53,7 @@ def training_tester() -> BloomTester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=12.176290512084961. Required: atol=0.16 "
+        "Atol comparison failed. Calculated: atol=650936.75. Required: atol=0.16 "
         "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )

--- a/tests/jax/single_chip/models/bloom/bloom_1b7/test_1b7.py
+++ b/tests/jax/single_chip/models/bloom/bloom_1b7/test_1b7.py
@@ -53,7 +53,7 @@ def training_tester() -> BloomTester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=25.83220100402832. Required: atol=0.16 "
+        "Atol comparison failed. Calculated: atol=783750.125. Required: atol=0.16 "
         "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )

--- a/tests/jax/single_chip/models/bloom/bloom_560m/test_560m.py
+++ b/tests/jax/single_chip/models/bloom/bloom_560m/test_560m.py
@@ -53,7 +53,7 @@ def training_tester() -> BloomTester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=327.8369445800781. Required: atol=0.16 "
+        "Atol comparison failed. Calculated: atol=509579.03125. Required: atol=0.16 "
         "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )

--- a/tests/jax/single_chip/models/bloom/tester.py
+++ b/tests/jax/single_chip/models/bloom/tester.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict, Sequence
+from typing import Dict
 
 import jax
 from infra import ComparisonConfig, ModelTester, RunMode
 from transformers import AutoTokenizer, FlaxBloomForCausalLM, FlaxPreTrainedModel
+from jaxtyping import PyTree
 
 
 class BloomTester(ModelTester):
@@ -28,15 +29,15 @@ class BloomTester(ModelTester):
         return model
 
     # @override
-    def _get_input_activations(self) -> Sequence[jax.Array]:
+    def _get_input_activations(self) -> Dict[str, jax.Array]:
         tokenizer = AutoTokenizer.from_pretrained(self._model_name)
-        inputs = tokenizer("Hello", return_tensors="np")
-        return inputs["input_ids"]
+        inputs = tokenizer("Hello there fellow traveler", return_tensors="jax")
+        return inputs
 
     # @override
-    def _get_forward_method_kwargs(self) -> Dict[str, jax.Array]:
+    def _get_forward_method_kwargs(self) -> Dict[str, PyTree]:
         assert hasattr(self._model, "params")
         return {
             "params": self._model.params,
-            "input_ids": self._get_input_activations(),
+            **self._get_input_activations(),
         }

--- a/tests/jax/single_chip/models/clip/tester.py
+++ b/tests/jax/single_chip/models/clip/tester.py
@@ -34,7 +34,7 @@ class FlaxCLIPTester(ModelTester):
         inputs = preprocessor(
             text=["a photo of a cat", "a photo of a dog"],
             images=image,
-            return_tensors="np",
+            return_tensors="jax",
         )
         return inputs
 

--- a/tests/jax/single_chip/models/distilbert/test_distilbert.py
+++ b/tests/jax/single_chip/models/distilbert/test_distilbert.py
@@ -2,12 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict, Sequence
+from typing import Dict
 
 import jax
 import pytest
 from infra import Framework, ModelTester, RunMode
 from transformers import AutoTokenizer, FlaxDistilBertForMaskedLM, FlaxPreTrainedModel
+from jaxtyping import PyTree
 
 from tests.utils import (
     BringupStatus,
@@ -39,17 +40,17 @@ class FlaxDistilBertForMaskedLMTester(ModelTester):
         return FlaxDistilBertForMaskedLM.from_pretrained(MODEL_PATH)
 
     # @override
-    def _get_input_activations(self) -> Sequence[jax.Array]:
+    def _get_input_activations(self) -> Dict[str, jax.Array]:
         tokenizer = AutoTokenizer.from_pretrained(MODEL_PATH)
-        inputs = tokenizer("Hello [MASK].", return_tensors="np")
-        return inputs["input_ids"]
+        inputs = tokenizer("Hello [MASK].", return_tensors="jax")
+        return inputs
 
     # @override
-    def _get_forward_method_kwargs(self) -> Dict[str, jax.Array]:
+    def _get_forward_method_kwargs(self) -> Dict[str, PyTree]:
         assert hasattr(self._model, "params")
         return {
             "params": self._model.params,
-            "input_ids": self._get_input_activations(),
+            **self._get_input_activations(),
         }
 
 

--- a/tests/jax/single_chip/models/gpt2/base/test_gpt2_base.py
+++ b/tests/jax/single_chip/models/gpt2/base/test_gpt2_base.py
@@ -53,7 +53,7 @@ def training_tester() -> GPT2Tester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=37.821876525878906. Required: atol=0.16 "
+        "Atol comparison failed. Calculated: atol=3745453.0. Required: atol=0.16 "
         "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )

--- a/tests/jax/single_chip/models/gpt2/large/test_gpt2_large.py
+++ b/tests/jax/single_chip/models/gpt2/large/test_gpt2_large.py
@@ -53,7 +53,7 @@ def training_tester() -> GPT2Tester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=9.953690528869629. Required: atol=0.16 "
+        "Atol comparison failed. Calculated: atol=4874108.0. Required: atol=0.16 "
         "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )

--- a/tests/jax/single_chip/models/gpt2/medium/test_gpt2_medium.py
+++ b/tests/jax/single_chip/models/gpt2/medium/test_gpt2_medium.py
@@ -53,7 +53,7 @@ def training_tester() -> GPT2Tester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=13.961490631103516. Required: atol=0.16 "
+        "Atol comparison failed. Calculated: atol=4570688.5. Required: atol=0.16 "
         "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )

--- a/tests/jax/single_chip/models/gpt2/tester.py
+++ b/tests/jax/single_chip/models/gpt2/tester.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict, Sequence
+from typing import Dict
 
 import jax
 from infra import ComparisonConfig, ModelTester, RunMode
 from transformers import AutoTokenizer, FlaxGPT2LMHeadModel, FlaxPreTrainedModel
+from jaxtyping import PyTree
 
 
 class GPT2Tester(ModelTester):
@@ -26,15 +27,15 @@ class GPT2Tester(ModelTester):
         return FlaxGPT2LMHeadModel.from_pretrained(self._model_name)
 
     # @override
-    def _get_input_activations(self) -> Sequence[jax.Array]:
+    def _get_input_activations(self) -> Dict[str, jax.Array]:
         tokenizer = AutoTokenizer.from_pretrained(self._model_name)
-        inputs = tokenizer("Hello", return_tensors="np")
-        return inputs["input_ids"]
+        inputs = tokenizer("Hello there fellow traveler", return_tensors="jax")
+        return inputs
 
     # @override
-    def _get_forward_method_kwargs(self) -> Dict[str, jax.Array]:
+    def _get_forward_method_kwargs(self) -> Dict[str, PyTree]:
         assert hasattr(self._model, "params")
         return {
             "params": self._model.params,
-            "input_ids": self._get_input_activations(),
+            **self._get_input_activations(),
         }

--- a/tests/jax/single_chip/models/gpt_j/tester.py
+++ b/tests/jax/single_chip/models/gpt_j/tester.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict, Sequence
+from typing import Dict
 
 import jax
 from infra import ComparisonConfig, ModelTester, RunMode
@@ -11,6 +11,7 @@ from transformers import (
     FlaxPreTrainedModel,
     FlaxGPTJForCausalLM,
 )
+from jaxtyping import PyTree
 
 
 class GPTJTester(ModelTester):
@@ -30,17 +31,17 @@ class GPTJTester(ModelTester):
         return FlaxGPTJForCausalLM.from_pretrained(self._model_name)
 
     # @override
-    def _get_input_activations(self) -> Sequence[jax.Array]:
+    def _get_input_activations(self) -> Dict[str, jax.Array]:
         tokenizer = AutoTokenizer.from_pretrained(self._model_name)
-        inputs = tokenizer("Hello, my dog is cute", return_tensors="np")
-        return inputs["input_ids"]
+        inputs = tokenizer("Hello, my dog is cute", return_tensors="jax")
+        return inputs
 
     # @overridde
-    def _get_forward_method_kwargs(self) -> Dict[str, jax.Array]:
+    def _get_forward_method_kwargs(self) -> Dict[str, PyTree]:
         assert hasattr(self._model, "params")
         return {
             "params": self._model.params,
-            "input_ids": self._get_input_activations(),
+            **self._get_input_activations(),
         }
 
     # @override

--- a/tests/jax/single_chip/models/gpt_neo/gpt_neo_125m/test_gpt_neo_125m.py
+++ b/tests/jax/single_chip/models/gpt_neo/gpt_neo_125m/test_gpt_neo_125m.py
@@ -52,7 +52,7 @@ def training_tester() -> GPTNeoTester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=15.864267349243164. Required: atol=0.16 "
+        "Atol comparison failed. Calculated: atol=2801730.0. Required: atol=0.16 "
         "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )

--- a/tests/jax/single_chip/models/gpt_neo/tester.py
+++ b/tests/jax/single_chip/models/gpt_neo/tester.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict, Sequence
+from typing import Dict
 
 import jax
 from infra import ComparisonConfig, ModelTester, RunMode
 from transformers import AutoTokenizer, FlaxGPTNeoForCausalLM, FlaxPreTrainedModel
+from jaxtyping import PyTree
 
 
 class GPTNeoTester(ModelTester):
@@ -26,15 +27,15 @@ class GPTNeoTester(ModelTester):
         return FlaxGPTNeoForCausalLM.from_pretrained(self._model_name)
 
     # @override
-    def _get_input_activations(self) -> Sequence[jax.Array]:
+    def _get_input_activations(self) -> Dict[str, jax.Array]:
         tokenizer = AutoTokenizer.from_pretrained(self._model_name)
-        inputs = tokenizer("Hello", return_tensors="np")
-        return inputs["input_ids"]
+        inputs = tokenizer("Hello there fellow traveler", return_tensors="jax")
+        return inputs
 
     # @override
-    def _get_forward_method_kwargs(self) -> Dict[str, jax.Array]:
+    def _get_forward_method_kwargs(self) -> Dict[str, PyTree]:
         assert hasattr(self._model, "params")
         return {
             "params": self._model.params,
-            "input_ids": self._get_input_activations(),
+            **self._get_input_activations(),
         }

--- a/tests/jax/single_chip/models/gpt_sw3/tester.py
+++ b/tests/jax/single_chip/models/gpt_sw3/tester.py
@@ -7,6 +7,7 @@ from typing import Dict, Sequence
 import jax
 from infra import ComparisonConfig, ModelTester, RunMode
 from transformers import GPTSw3Tokenizer, FlaxPreTrainedModel, FlaxGPT2LMHeadModel
+from jaxtyping import PyTree
 
 
 class GPTSw3Tester(ModelTester):
@@ -29,16 +30,16 @@ class GPTSw3Tester(ModelTester):
     def _get_input_activations(self) -> Sequence[jax.Array]:
         tokenizer = GPTSw3Tokenizer.from_pretrained(self._model_name)
         inputs = tokenizer(
-            "Träd är fina för att", return_tensors="np"
+            "Träd är fina för att", return_tensors="jax"
         )  # input is a swedish statement
-        return inputs["input_ids"]
+        return inputs
 
     # @override
-    def _get_forward_method_kwargs(self) -> Dict[str, jax.Array]:
+    def _get_forward_method_kwargs(self) -> Dict[str, PyTree]:
         assert hasattr(self._model, "params")
         return {
             "params": self._model.params,
-            "input_ids": self._get_input_activations(),
+            **self._get_input_activations(),
         }
 
     # @override

--- a/tests/jax/single_chip/models/llama/tester.py
+++ b/tests/jax/single_chip/models/llama/tester.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict, Sequence
+from typing import Dict
 
 import jax
 from infra import ComparisonConfig, ModelTester, RunMode
 from transformers import FlaxLlamaForCausalLM, FlaxPreTrainedModel, LlamaTokenizer
+from jaxtyping import PyTree
 
 
 class LLamaTester(ModelTester):
@@ -28,15 +29,15 @@ class LLamaTester(ModelTester):
         return FlaxLlamaForCausalLM.from_pretrained(self._model_name, from_pt=True)
 
     # @override
-    def _get_input_activations(self) -> Sequence[jax.Array]:
+    def _get_input_activations(self) -> Dict[str, jax.Array]:
         tokenizer = LlamaTokenizer.from_pretrained(self._model_name)
-        inputs = tokenizer("Hello", return_tensors="np")
-        return inputs["input_ids"]
+        inputs = tokenizer("Hello there fellow traveler", return_tensors="jax")
+        return inputs
 
     # @override
-    def _get_forward_method_kwargs(self) -> Dict[str, jax.Array]:
+    def _get_forward_method_kwargs(self) -> Dict[str, PyTree]:
         assert hasattr(self._model, "params")
         return {
             "params": self._model.params,
-            "input_ids": self._get_input_activations(),
+            **self._get_input_activations(),
         }

--- a/tests/jax/single_chip/models/mbart50/tester.py
+++ b/tests/jax/single_chip/models/mbart50/tester.py
@@ -10,6 +10,7 @@ from transformers import (
     FlaxMBartForConditionalGeneration,
     FlaxPreTrainedModel,
 )
+from jaxtyping import PyTree
 
 
 class MBartTester(ModelTester):
@@ -29,17 +30,17 @@ class MBartTester(ModelTester):
         return FlaxMBartForConditionalGeneration.from_pretrained(self._model_name)
 
     # @override
-    def _get_input_activations(self) -> Sequence[jax.Array]:
+    def _get_input_activations(self) -> Dict[str, jax.Array]:
         tokenizer = AutoTokenizer.from_pretrained(self._model_name)
         inputs = tokenizer("Hello, my dog is cute.", return_tensors="jax")
-        return inputs["input_ids"]
+        return inputs
 
     # @override
-    def _get_forward_method_kwargs(self) -> Dict[str, jax.Array]:
+    def _get_forward_method_kwargs(self) -> Dict[str, PyTree]:
         assert hasattr(self._model, "params")
         return {
             "params": self._model.params,
-            "input_ids": self._get_input_activations(),
+            **self._get_input_activations(),
         }
 
     # override

--- a/tests/jax/single_chip/models/mistral_7b/tester.py
+++ b/tests/jax/single_chip/models/mistral_7b/tester.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict, Sequence
+from typing import Dict
 
 import jax
 from infra import ComparisonConfig, ModelTester, RunMode
@@ -12,6 +12,7 @@ from transformers import (
     FlaxPreTrainedModel,
     MistralConfig,
 )
+from jaxtyping import PyTree
 
 
 class Mistral7BTester(ModelTester):
@@ -31,17 +32,17 @@ class Mistral7BTester(ModelTester):
         return FlaxMistralForCausalLM.from_pretrained(self._model_name)
 
     # @override
-    def _get_input_activations(self) -> Sequence[jax.Array]:
+    def _get_input_activations(self) -> Dict[str, jax.Array]:
         tokenizer = AutoTokenizer.from_pretrained(self._model_name)
-        inputs = tokenizer("Hello ", return_tensors="np")
-        return inputs["input_ids"]
+        inputs = tokenizer("Hello there fellow traveler", return_tensors="jax")
+        return inputs
 
     # @override
-    def _get_forward_method_kwargs(self) -> Dict[str, jax.Array]:
+    def _get_forward_method_kwargs(self) -> Dict[str, PyTree]:
         assert hasattr(self._model, "params")
         return {
             "params": self._model.params,
-            "input_ids": self._get_input_activations(),
+            **self._get_input_activations(),
         }
 
 

--- a/tests/jax/single_chip/models/opt/opt_125m/test_125m.py
+++ b/tests/jax/single_chip/models/opt/opt_125m/test_125m.py
@@ -51,7 +51,7 @@ def training_tester() -> OPTTester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=4121164.25. Required: atol=0.16 "
+        "Atol comparison failed. Calculated: atol=4121167.75. Required: atol=0.16 "
         "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )

--- a/tests/jax/single_chip/models/opt/tester.py
+++ b/tests/jax/single_chip/models/opt/tester.py
@@ -7,6 +7,7 @@ from typing import Dict, Sequence
 import jax
 from infra import ComparisonConfig, ModelTester, RunMode
 from transformers import AutoTokenizer, FlaxOPTForCausalLM, FlaxPreTrainedModel
+from jaxtyping import PyTree
 
 
 class OPTTester(ModelTester):
@@ -28,15 +29,15 @@ class OPTTester(ModelTester):
         return model
 
     # @override
-    def _get_input_activations(self) -> Sequence[jax.Array]:
+    def _get_input_activations(self) -> Dict[str, jax.Array]:
         tokenizer = AutoTokenizer.from_pretrained(self._model_name)
-        inputs = tokenizer("Hello", return_tensors="np")
-        return inputs["input_ids"]
+        inputs = tokenizer("Hello there fellow traveler", return_tensors="jax")
+        return inputs
 
     # @override
-    def _get_forward_method_kwargs(self) -> Dict[str, jax.Array]:
+    def _get_forward_method_kwargs(self) -> Dict[str, PyTree]:
         assert hasattr(self._model, "params")
         return {
             "params": self._model.params,
-            "input_ids": self._get_input_activations(),
+            **self._get_input_activations(),
         }

--- a/tests/jax/single_chip/models/pegasus/tester.py
+++ b/tests/jax/single_chip/models/pegasus/tester.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict, Sequence
+from typing import Dict
 
 import jax
 from infra import ComparisonConfig, ModelTester, RunMode
@@ -11,6 +11,7 @@ from transformers import (
     FlaxPreTrainedModel,
     FlaxPegasusForConditionalGeneration,
 )
+from jaxtyping import PyTree
 
 
 class PegasusTester(ModelTester):
@@ -30,21 +31,21 @@ class PegasusTester(ModelTester):
         return FlaxPegasusForConditionalGeneration.from_pretrained(self._model_name)
 
     # @override
-    def _get_input_activations(self) -> Sequence[jax.Array]:
+    def _get_input_activations(self) -> Dict[str, jax.Array]:
         tokenizer = AutoTokenizer.from_pretrained(self._model_name)
         inputs = tokenizer(
             "My friends are cool but they eat too many carbs.",
             truncation=True,
-            return_tensors="np",
+            return_tensors="jax",
         )
-        return inputs["input_ids"]
+        return inputs
 
     # @override
-    def _get_forward_method_kwargs(self) -> Dict[str, jax.Array]:
+    def _get_forward_method_kwargs(self) -> Dict[str, PyTree]:
         assert hasattr(self._model, "params")
         return {
             "params": self._model.params,
-            "input_ids": self._get_input_activations(),
+            **self._get_input_activations(),
         }
 
     # @override

--- a/tests/jax/single_chip/models/roberta/tester.py
+++ b/tests/jax/single_chip/models/roberta/tester.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict, Sequence
+from typing import Dict
 
 import jax
 from infra import ComparisonConfig, ModelTester, RunMode
 from transformers import AutoTokenizer, FlaxPreTrainedModel, FlaxRobertaForMaskedLM
+from jaxtyping import PyTree
 
 
 class FlaxRobertaForMaskedLMTester(ModelTester):
@@ -28,17 +29,17 @@ class FlaxRobertaForMaskedLMTester(ModelTester):
         return FlaxRobertaForMaskedLM.from_pretrained(self._model_name)
 
     # @override
-    def _get_input_activations(self) -> Sequence[jax.Array]:
+    def _get_input_activations(self) -> Dict[str, jax.Array]:
         tokenizer = AutoTokenizer.from_pretrained(self._model_name)
-        inputs = tokenizer("Hello <mask>.", return_tensors="np")
-        return inputs["input_ids"]
+        inputs = tokenizer("Hello <mask>.", return_tensors="jax")
+        return inputs
 
     # @override
-    def _get_forward_method_kwargs(self) -> Dict[str, jax.Array]:
+    def _get_forward_method_kwargs(self) -> Dict[str, PyTree]:
         assert hasattr(self._model, "params")
         return {
             "params": self._model.params,
-            "input_ids": self._get_input_activations(),
+            **self._get_input_activations(),
         }
 
     # @ override

--- a/tests/jax/single_chip/models/roberta_prelayernorm/efficient_mlm_m0_40/test_efficient_mlm_m0_40.py
+++ b/tests/jax/single_chip/models/roberta_prelayernorm/efficient_mlm_m0_40/test_efficient_mlm_m0_40.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict, Sequence
+from typing import Dict
 
 import jax
 import pytest
 from infra import ComparisonConfig, Framework, ModelTester, RunMode
+from jaxtyping import PyTree
 from transformers import (
     AutoTokenizer,
     FlaxPreTrainedModel,
@@ -20,7 +21,6 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_fe_compilation,
     incorrect_result,
 )
 
@@ -53,17 +53,17 @@ class FlaxRobertaPreLayerNormForMaskedLMTester(ModelTester):
         )
 
     # @override
-    def _get_input_activations(self) -> Sequence[jax.Array]:
+    def _get_input_activations(self) -> Dict[str, jax.Array]:
         tokenizer = AutoTokenizer.from_pretrained(self._model_name)
-        inputs = tokenizer("Hello <mask>.", return_tensors="np")
-        return inputs["input_ids"]
+        inputs = tokenizer("Hello <mask>.", return_tensors="jax")
+        return inputs
 
     # @override
-    def _get_forward_method_kwargs(self) -> Dict[str, jax.Array]:
+    def _get_forward_method_kwargs(self) -> Dict[str, PyTree]:
         assert hasattr(self._model, "params")
         return {
             "params": self._model.params,
-            "input_ids": self._get_input_activations(),
+            **self._get_input_activations(),
         }
 
     # @ override

--- a/tests/jax/single_chip/models/xglm/tester.py
+++ b/tests/jax/single_chip/models/xglm/tester.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict, Sequence
+from typing import Dict
 
 import jax
 from infra import ComparisonConfig, ModelTester, RunMode
 from transformers import XGLMTokenizer, FlaxPreTrainedModel, FlaxXGLMForCausalLM
+from jaxtyping import PyTree
 
 
 class XGLMTester(ModelTester):
@@ -28,14 +29,14 @@ class XGLMTester(ModelTester):
         return model
 
     # @override
-    def _get_input_activations(self) -> Sequence[jax.Array]:
+    def _get_input_activations(self) -> Dict[str, jax.Array]:
         tokenizer = XGLMTokenizer.from_pretrained(self._model_name)
-        inputs = tokenizer("Hello, my dog is cute.", return_tensors="np")
-        return inputs["input_ids"]
+        inputs = tokenizer("Hello, my dog is cute.", return_tensors="jax")
+        return inputs
 
-    def _get_forward_method_kwargs(self) -> Dict[str, jax.Array]:
+    def _get_forward_method_kwargs(self) -> Dict[str, PyTree]:
         assert hasattr(self._model, "params")
         return {
             "params": self._model.params,
-            "input_ids": self._get_input_activations(),
+            **self._get_input_activations(),
         }

--- a/tests/jax/single_chip/models/xlm_roberta/tester.py
+++ b/tests/jax/single_chip/models/xlm_roberta/tester.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict, Sequence
+from typing import Dict
 
 import jax
 from infra import ComparisonConfig, ModelTester, RunMode
 from transformers import AutoTokenizer, FlaxXLMRobertaForCausalLM, FlaxPreTrainedModel
+from jaxtyping import PyTree
 
 
 class XLMRobertaTester(ModelTester):
@@ -26,15 +27,15 @@ class XLMRobertaTester(ModelTester):
         return FlaxXLMRobertaForCausalLM.from_pretrained(self._model_name)
 
     # @override
-    def _get_input_activations(self) -> Sequence[jax.Array]:
+    def _get_input_activations(self) -> Dict[str, jax.Array]:
         tokenizer = AutoTokenizer.from_pretrained(self._model_name)
-        inputs = tokenizer("Hello, my dog is cute", return_tensors="np")
-        return inputs["input_ids"]
+        inputs = tokenizer("Hello, my dog is cute", return_tensors="jax")
+        return inputs
 
     # @override
-    def _get_forward_method_kwargs(self) -> Dict[str, jax.Array]:
+    def _get_forward_method_kwargs(self) -> Dict[str, PyTree]:
         assert hasattr(self._model, "params")
         return {
             "params": self._model.params,
-            "input_ids": self._get_input_activations(),
+            **self._get_input_activations(),
         }


### PR DESCRIPTION
### Ticket
N/A

### Problem description
There is a bug in metal which is triggered on the code path for generating the default attention mask for transformers. We want to work around it for now, to make debugging accuracy issues easier.

### What's changed
We no longer take just the `input_ids` from the tokenizer, but rather pass on everything to the model.
I also changed the `return_tensors` to `jax` inside the call to the tokenizer. It's cleaner to work with jax arrays from the get go and it will be more convenient if we ever want to send batched inputs to our tests.

### Checklist
- [X] New/Existing tests provide coverage for changes
- [ ] Update atol values in fail reasons - some values did improve while others didn't, I want to double check this before merging.