### PR TITLE
Fixing mesh issue in PJRT when opening devices

### DIFF
--- a/inc/common/pjrt_implementation/executable_image.h
+++ b/inc/common/pjrt_implementation/executable_image.h
@@ -36,6 +36,7 @@ public:
       const std::vector<mlir::tt::sharding_utils::MeshSharding> &input_sharding,
       const std::vector<mlir::tt::sharding_utils::MeshSharding>
           &output_sharding,
+      const std::vector<std::uint32_t> &mesh_shape,
       const std::vector<bool> &is_output_scalar);
 
   operator PJRT_Executable *() {
@@ -68,6 +69,10 @@ public:
   PJRT_Buffer_Type *get_output_types() { return m_output_types.data(); }
 
   size_t get_num_outputs() const { return m_output_types.size(); }
+
+  const std::vector<std::uint32_t> &get_mesh_shape() const {
+    return m_mesh_shape;
+  }
 
   // Checks if the output on the i-th index is a scalar.
   bool isOutputScalar(size_t index) const;
@@ -137,6 +142,9 @@ private:
 
   // Hold the sharding information for each output.
   const std::vector<mlir::tt::sharding_utils::MeshSharding> m_output_sharding;
+
+  // Device mesh shape required by this image.
+  const std::vector<std::uint32_t> m_mesh_shape;
 };
 
 } // namespace tt::pjrt

--- a/src/common/module_builder.cc
+++ b/src/common/module_builder.cc
@@ -7,6 +7,7 @@
 
 // c++ standard library includes
 #include <cstdlib>
+#include <optional>
 
 // loguru includes
 #include "loguru/loguru.hpp"
@@ -111,6 +112,8 @@ ModuleBuilder::buildModule(const std::string_view &code,
   if (!tt_pjrt_status_is_ok(m_status)) {
     return m_status;
   }
+
+  collectMeshShape(mlir_module);
 
   convertFromTTIRToTTNN(system_descriptor_path, mlir_module);
   if (!tt_pjrt_status_is_ok(m_status)) {
@@ -492,6 +495,34 @@ std::optional<mlir::sdy::MeshOp> ModuleBuilder::getFirstShardyMeshOp(
     return mlir::WalkResult::interrupt();
   });
   return mesh_op;
+}
+
+void ModuleBuilder::collectMeshShape(
+    const mlir::OwningOpRef<mlir::ModuleOp> &module) {
+  mlir::tt::MeshesAttr meshesAttr =
+      module.get()->getAttrOfType<mlir::tt::MeshesAttr>(
+          mlir::tt::MeshesAttr::name);
+  if (!meshesAttr || meshesAttr.getMeshes().empty()) {
+    // If we dont infer a mesh, we can still go through the inputs to get the
+    // mesh.
+    for (const mlir::tt::sharding_utils::MeshSharding &input_sharding :
+         m_input_shardings) {
+      if (input_sharding.getShardType() == mlir::tt::MeshShardType::Devices) {
+        m_mesh_shape =
+            std::vector<std::uint32_t>(input_sharding.getMeshShape().begin(),
+                                       input_sharding.getMeshShape().end());
+        return;
+      }
+    }
+    m_mesh_shape = {1, 1};
+    return;
+  }
+  llvm::ArrayRef<mlir::tt::MeshAttr> meshAttr = meshesAttr.getMeshes();
+
+  // For now, use the first meshShape (same as what is used in tt-mlir).
+  llvm::ArrayRef<int64_t> meshFromMeshes = meshAttr[0].getShape();
+  m_mesh_shape =
+      std::vector<std::uint32_t>(meshFromMeshes.begin(), meshFromMeshes.end());
 }
 
 } // namespace tt::pjrt

--- a/src/common/module_builder.cc
+++ b/src/common/module_builder.cc
@@ -514,7 +514,10 @@ void ModuleBuilder::collectMeshShape(
         return;
       }
     }
+
+    // Assuming single device if there are no inputs sharded on device.
     m_mesh_shape = {1, 1};
+
     return;
   }
   llvm::ArrayRef<mlir::tt::MeshAttr> meshAttr = meshesAttr.getMeshes();

--- a/src/common/module_builder.h
+++ b/src/common/module_builder.h
@@ -52,6 +52,10 @@ public:
     return m_output_shardings;
   }
 
+  const std::vector<std::uint32_t> &getMeshShape() const {
+    return m_mesh_shape;
+  }
+
 private:
   // Creates VHLO module from the input program code.
   mlir::OwningOpRef<mlir::ModuleOp>
@@ -111,6 +115,9 @@ private:
   // Checks if the jax is using the Shardy mlir dialect.
   bool isUsingShardy(const mlir::OwningOpRef<mlir::ModuleOp> &module);
 
+  // Collect the mesh shape needed by the module.
+  void collectMeshShape(const mlir::OwningOpRef<mlir::ModuleOp> &module);
+
   // Takes a vector of string attributes representing GSPMD sharding and fills
   // the vector of tt_mlir Sharding with the appropriate corresponding values.
   mlir::LogicalResult createShardingsFromGSPMD(
@@ -153,6 +160,9 @@ private:
 
   // For every output, holds the sharding information.
   std::vector<mlir::tt::sharding_utils::MeshSharding> m_output_shardings;
+
+  // Device mesh shape required by this module.
+  std::vector<std::uint32_t> m_mesh_shape;
 };
 
 } // namespace tt::pjrt

--- a/src/common/pjrt_implementation/client_instance.cc
+++ b/src/common/pjrt_implementation/client_instance.cc
@@ -213,6 +213,7 @@ PJRT_Error *ClientInstance::Compile(const PJRT_Program *program,
                           std::string(program->code, program->code_size),
                           module_builder_->getInputShardings(),
                           module_builder_->getOutputShardings(),
+                          module_builder_->getMeshShape(),
                           module_builder_->getIsOutputScalar()),
       addressable_devices_, module_builder_->getNumDevicesToUtilize());
   *out_executable = executable.release();

--- a/src/common/pjrt_implementation/executable_image.cc
+++ b/src/common/pjrt_implementation/executable_image.cc
@@ -24,10 +24,11 @@ ExecutableImage::ExecutableImage(
     const tt::runtime::Binary &binary, std::string code,
     const std::vector<mlir::tt::sharding_utils::MeshSharding> &input_sharding,
     const std::vector<mlir::tt::sharding_utils::MeshSharding> &output_sharding,
+    const std::vector<std::uint32_t> &mesh_shape,
     const std::vector<bool> &is_output_scalar)
     : m_ref_count(1), m_binary(binary), m_code(code),
       m_input_sharding(input_sharding), m_output_sharding(output_sharding),
-      m_is_output_scalar(is_output_scalar) {
+      m_mesh_shape(mesh_shape), m_is_output_scalar(is_output_scalar) {
 
   std::vector<tt::runtime::TensorDesc> output_specs =
       m_binary.getProgramOutputs(0);

--- a/src/common/pjrt_implementation/loaded_executable_instance.cc
+++ b/src/common/pjrt_implementation/loaded_executable_instance.cc
@@ -121,7 +121,7 @@ LoadedExecutableInstance::Execute(PJRT_LoadedExecutable_Execute_Args *args) {
 
   tt::runtime::MeshDeviceOptions options;
   options.deviceIds = device_ids;
-  const std::vector<std::uint32_t> mesh_shape = image_->get_mesh_shape();
+  const std::vector<std::uint32_t> &mesh_shape = image_->get_mesh_shape();
   tt::runtime::Device device = tt::runtime::openMeshDevice(mesh_shape, options);
   std::vector<tt::runtime::Tensor> input_tensors;
   int size_inputs = rt_inputs.size();

--- a/src/common/pjrt_implementation/loaded_executable_instance.cc
+++ b/src/common/pjrt_implementation/loaded_executable_instance.cc
@@ -120,9 +120,8 @@ LoadedExecutableInstance::Execute(PJRT_LoadedExecutable_Execute_Args *args) {
       args->argument_lists, addressable_devices_, args->num_args, num_devices);
 
   tt::runtime::MeshDeviceOptions options;
-  const std::vector<uint32_t> mesh_shape = {
-      1, static_cast<uint32_t>(device_ids.size())};
   options.deviceIds = device_ids;
+  const std::vector<std::uint32_t> mesh_shape = image_->get_mesh_shape();
   tt::runtime::Device device = tt::runtime::openMeshDevice(mesh_shape, options);
   std::vector<tt::runtime::Tensor> input_tensors;
   int size_inputs = rt_inputs.size();


### PR DESCRIPTION
Currently, we could only open 1x<num_of_devices> in PJRT since the runtime changes. This PR takes the inferred mesh shape from the MLIR code and uses that to open devices.

Fixes https://github.com/tenstorrent/tt-xla/issues/458