### PR TITLE
Replace model_name to model_path in tester files

### DIFF
--- a/tests/jax/single_chip/models/albert_v2/tester.py
+++ b/tests/jax/single_chip/models/albert_v2/tester.py
@@ -15,20 +15,20 @@ class AlbertV2Tester(ModelTester):
 
     def __init__(
         self,
-        model_name: str,
+        model_path: str,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        self._model_name = model_name
+        self._model_path = model_path
         super().__init__(comparison_config, run_mode)
 
     # @override
     def _get_model(self) -> FlaxPreTrainedModel:
-        return FlaxAlbertForMaskedLM.from_pretrained(self._model_name)
+        return FlaxAlbertForMaskedLM.from_pretrained(self._model_path)
 
     # @override
     def _get_input_activations(self) -> Dict[str, jax.Array]:
-        tokenizer = AutoTokenizer.from_pretrained(self._model_name)
+        tokenizer = AutoTokenizer.from_pretrained(self._model_path)
         inputs = tokenizer("Hello [MASK].", return_tensors="jax")
         return inputs
 

--- a/tests/jax/single_chip/models/bart/tester.py
+++ b/tests/jax/single_chip/models/bart/tester.py
@@ -17,22 +17,22 @@ class FlaxBartForCausalLMTester(ModelTester):
 
     def __init__(
         self,
-        model_name: str,
+        model_path: str,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        self._model_name = model_name
+        self._model_path = model_path
         super().__init__(comparison_config, run_mode)
 
     # @override
     def _get_model(self) -> FlaxPreTrainedModel:
-        model = FlaxBartForCausalLM.from_pretrained(self._model_name)
+        model = FlaxBartForCausalLM.from_pretrained(self._model_path)
         model.params = model.to_bf16(model.params)
         return model
 
     # @override
     def _get_input_activations(self) -> Dict[str, jax.Array]:
-        tokenizer = AutoTokenizer.from_pretrained(self._model_name)
+        tokenizer = AutoTokenizer.from_pretrained(self._model_path)
         inputs = tokenizer("Hello there fellow traveler", return_tensors="jax")
         return inputs
 

--- a/tests/jax/single_chip/models/beit/tester.py
+++ b/tests/jax/single_chip/models/beit/tester.py
@@ -19,22 +19,22 @@ class FlaxBeitForImageClassificationTester(ModelTester):
 
     def __init__(
         self,
-        model_name: str,
+        model_path: str,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        self._model_name = model_name
+        self._model_path = model_path
         super().__init__(comparison_config, run_mode)
 
     # @override
     def _get_model(self) -> FlaxPreTrainedModel:
-        return FlaxBeitForImageClassification.from_pretrained(self._model_name)
+        return FlaxBeitForImageClassification.from_pretrained(self._model_path)
 
     # @override
     def _get_input_activations(self) -> Dict:
         image = jax.random.uniform(jax.random.PRNGKey(42), (1, 3, 224, 224))
         preprocessor = BeitImageProcessor.from_pretrained(
-            self._model_name, do_rescale=False
+            self._model_path, do_rescale=False
         )
         inputs = preprocessor(image, return_tensors="jax")
         return inputs

--- a/tests/jax/single_chip/models/bert/tester.py
+++ b/tests/jax/single_chip/models/bert/tester.py
@@ -15,20 +15,20 @@ class FlaxBertForMaskedLMTester(ModelTester):
 
     def __init__(
         self,
-        model_name: str,
+        model_path: str,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        self._model_name = model_name
+        self._model_path = model_path
         super().__init__(comparison_config, run_mode)
 
     # @override
     def _get_model(self) -> FlaxPreTrainedModel:
-        return FlaxBertForMaskedLM.from_pretrained(self._model_name)
+        return FlaxBertForMaskedLM.from_pretrained(self._model_path)
 
     # @override
     def _get_input_activations(self) -> Dict[str, jax.Array]:
-        tokenizer = AutoTokenizer.from_pretrained(self._model_name)
+        tokenizer = AutoTokenizer.from_pretrained(self._model_path)
         inputs = tokenizer("Hello [MASK]", return_tensors="jax")
         return inputs
 

--- a/tests/jax/single_chip/models/bigbird/roberta_base/test_bigbird_roberta_base.py
+++ b/tests/jax/single_chip/models/bigbird/roberta_base/test_bigbird_roberta_base.py
@@ -38,21 +38,21 @@ MODEL_NAME = build_model_name(
 class BigBirdBaseTester(BigBirdTester):
     def __init__(
         self,
-        model_name: str,
+        model_path: str,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        super().__init__(model_name, comparison_config, run_mode)
+        super().__init__(model_path, comparison_config, run_mode)
 
     # @override
     def _get_model(self) -> FlaxPreTrainedModel:
         return FlaxBigBirdForQuestionAnswering.from_pretrained(
-            self._model_name, attention_type="original_full"
+            self._model_path, attention_type="original_full"
         )
 
     # @override
     def _get_input_activations(self) -> Dict[str, jax.Array]:
-        tokenizer = AutoTokenizer.from_pretrained(self._model_name)
+        tokenizer = AutoTokenizer.from_pretrained(self._model_path)
         question, text = "Who was Jim Henson?", "Jim Henson was a nice puppet"
         inputs = tokenizer(question, text, return_tensors="jax")
         return inputs

--- a/tests/jax/single_chip/models/bigbird/roberta_large/test_bigbird_roberta_large.py
+++ b/tests/jax/single_chip/models/bigbird/roberta_large/test_bigbird_roberta_large.py
@@ -34,19 +34,19 @@ MODEL_NAME = build_model_name(
 class BigBirdLargeTester(BigBirdTester):
     def __init__(
         self,
-        model_name: str,
+        model_path: str,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        super().__init__(model_name, comparison_config, run_mode)
+        super().__init__(model_path, comparison_config, run_mode)
 
     # @override
     def _get_model(self) -> FlaxPreTrainedModel:
-        return FlaxBigBirdForCausalLM.from_pretrained(self._model_name)
+        return FlaxBigBirdForCausalLM.from_pretrained(self._model_path)
 
     # @override
     def _get_input_activations(self) -> Dict[str, jax.Array]:
-        tokenizer = AutoTokenizer.from_pretrained(self._model_name)
+        tokenizer = AutoTokenizer.from_pretrained(self._model_path)
         inputs = tokenizer(
             "**JAX** is an open-source numerical computing library developed by Google, which is primarily used for high-performance machine learning research and other scientific computing tasks. It is built on top of **NumPy**, providing a familiar interface for those already comfortable with it, but with added features for automatic differentiation, GPU/TPU acceleration, and more.1. **NumPy-Compatible**: JAX is designed to be a drop-in replacement for **NumPy**, meaning that the code written in NumPy can often be used directly in JAX with minimal changes.JAX functions (such as `jax.numpy`) are compatible with NumPy syntax, so if you're familiar with NumPy, the learning curve for JAX is shallow.2. **Automatic Differentiation (Autograd)**: One of the core features of JAX is its ability to compute **gradients** (derivatives) of functions.The `jax.grad` function allows for automatic differentiation of scalar or vector-valued functions. This is useful in optimization, machine learning, and physics simulations."
             "JAX can compute gradients for functions written in a **Pythonic** way, without requiring manual derivative computation, making it much more efficient for machine learning and other scientific applications.JAX uses **XLA**, which stands for **Accelerated Linear Algebra**, to perform optimized computation on CPUs, GPUs, and TPUs.With XLA, JAX can execute code much faster by optimizing the computation graph (just-in-time (JIT) compilation) and running it efficiently on hardware accelerators.**Just-In-Time (JIT) compilation** in JAX refers to the process of converting Python code into highly optimized machine code that runs faster. This is achieved through the `jax.jit` decorator, which compiles a function once and reuses the compiled version, speeding up the execution.The result is a substantial boost in performance, especially for large-scale machine learning models or iterative algorithms.JAX allows for the creation of custom gradients for user-defined operations, giving researchers and engineers flexibility to define their own backpropagation rules.It also offers function transformations such as `jax.jit`, `jax.grad`, `jax.vmap`, and `jax.pmap` that help with optimization, parallelization, and differentiation."

--- a/tests/jax/single_chip/models/bigbird/tester.py
+++ b/tests/jax/single_chip/models/bigbird/tester.py
@@ -13,11 +13,11 @@ class BigBirdTester(ModelTester):
 
     def __init__(
         self,
-        model_name: str,
+        model_path: str,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        self._model_name = model_name
+        self._model_path = model_path
         super().__init__(comparison_config, run_mode)
 
     # @override

--- a/tests/jax/single_chip/models/bloom/tester.py
+++ b/tests/jax/single_chip/models/bloom/tester.py
@@ -15,22 +15,22 @@ class BloomTester(ModelTester):
 
     def __init__(
         self,
-        model_name: str,
+        model_path: str,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        self._model_name = model_name
+        self._model_path = model_path
         super().__init__(comparison_config, run_mode)
 
     # @override
     def _get_model(self) -> FlaxPreTrainedModel:
-        model = FlaxBloomForCausalLM.from_pretrained(self._model_name, from_pt=True)
+        model = FlaxBloomForCausalLM.from_pretrained(self._model_path, from_pt=True)
         model.params = model.to_bf16(model.params)
         return model
 
     # @override
     def _get_input_activations(self) -> Dict[str, jax.Array]:
-        tokenizer = AutoTokenizer.from_pretrained(self._model_name)
+        tokenizer = AutoTokenizer.from_pretrained(self._model_path)
         inputs = tokenizer("Hello there fellow traveler", return_tensors="jax")
         return inputs
 

--- a/tests/jax/single_chip/models/clip/tester.py
+++ b/tests/jax/single_chip/models/clip/tester.py
@@ -14,23 +14,23 @@ class FlaxCLIPTester(ModelTester):
 
     def __init__(
         self,
-        model_name: str,
+        model_path: str,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        self._model_name = model_name
+        self._model_path = model_path
         super().__init__(comparison_config, run_mode)
 
     # @override
     def _get_model(self) -> FlaxPreTrainedModel:
-        from_pt = self._model_name == "openai/clip-vit-large-patch14-336"
+        from_pt = self._model_path == "openai/clip-vit-large-patch14-336"
 
-        return FlaxCLIPModel.from_pretrained(self._model_name, from_pt=from_pt)
+        return FlaxCLIPModel.from_pretrained(self._model_path, from_pt=from_pt)
 
     # @override
     def _get_input_activations(self) -> Dict:
         image = jax.random.uniform(jax.random.PRNGKey(42), (1, 3, 224, 224))
-        preprocessor = CLIPProcessor.from_pretrained(self._model_name, do_rescale=False)
+        preprocessor = CLIPProcessor.from_pretrained(self._model_path, do_rescale=False)
         inputs = preprocessor(
             text=["a photo of a cat", "a photo of a dog"],
             images=image,

--- a/tests/jax/single_chip/models/gpt2/tester.py
+++ b/tests/jax/single_chip/models/gpt2/tester.py
@@ -15,20 +15,20 @@ class GPT2Tester(ModelTester):
 
     def __init__(
         self,
-        model_name: str,
+        model_path: str,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        self._model_name = model_name
+        self._model_path = model_path
         super().__init__(comparison_config, run_mode)
 
     # @override
     def _get_model(self) -> FlaxPreTrainedModel:
-        return FlaxGPT2LMHeadModel.from_pretrained(self._model_name)
+        return FlaxGPT2LMHeadModel.from_pretrained(self._model_path)
 
     # @override
     def _get_input_activations(self) -> Dict[str, jax.Array]:
-        tokenizer = AutoTokenizer.from_pretrained(self._model_name)
+        tokenizer = AutoTokenizer.from_pretrained(self._model_path)
         inputs = tokenizer("Hello there fellow traveler", return_tensors="jax")
         return inputs
 

--- a/tests/jax/single_chip/models/gpt_j/tester.py
+++ b/tests/jax/single_chip/models/gpt_j/tester.py
@@ -19,20 +19,20 @@ class GPTJTester(ModelTester):
 
     def __init__(
         self,
-        model_name: str,
+        model_path: str,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        self._model_name = model_name
+        self._model_path = model_path
         super().__init__(comparison_config, run_mode)
 
     # @override
     def _get_model(self) -> FlaxPreTrainedModel:
-        return FlaxGPTJForCausalLM.from_pretrained(self._model_name)
+        return FlaxGPTJForCausalLM.from_pretrained(self._model_path)
 
     # @override
     def _get_input_activations(self) -> Dict[str, jax.Array]:
-        tokenizer = AutoTokenizer.from_pretrained(self._model_name)
+        tokenizer = AutoTokenizer.from_pretrained(self._model_path)
         inputs = tokenizer("Hello, my dog is cute", return_tensors="jax")
         return inputs
 

--- a/tests/jax/single_chip/models/gpt_neo/tester.py
+++ b/tests/jax/single_chip/models/gpt_neo/tester.py
@@ -15,20 +15,20 @@ class GPTNeoTester(ModelTester):
 
     def __init__(
         self,
-        model_name: str,
+        model_path: str,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        self._model_name = model_name
+        self._model_path = model_path
         super().__init__(comparison_config, run_mode)
 
     # @override
     def _get_model(self) -> FlaxPreTrainedModel:
-        return FlaxGPTNeoForCausalLM.from_pretrained(self._model_name)
+        return FlaxGPTNeoForCausalLM.from_pretrained(self._model_path)
 
     # @override
     def _get_input_activations(self) -> Dict[str, jax.Array]:
-        tokenizer = AutoTokenizer.from_pretrained(self._model_name)
+        tokenizer = AutoTokenizer.from_pretrained(self._model_path)
         inputs = tokenizer("Hello there fellow traveler", return_tensors="jax")
         return inputs
 

--- a/tests/jax/single_chip/models/gpt_sw3/tester.py
+++ b/tests/jax/single_chip/models/gpt_sw3/tester.py
@@ -15,20 +15,20 @@ class GPTSw3Tester(ModelTester):
 
     def __init__(
         self,
-        model_name: str,
+        model_path: str,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        self._model_name = model_name
+        self._model_path = model_path
         super().__init__(comparison_config, run_mode)
 
     # @override
     def _get_model(self) -> FlaxPreTrainedModel:
-        return FlaxGPT2LMHeadModel.from_pretrained(self._model_name)
+        return FlaxGPT2LMHeadModel.from_pretrained(self._model_path)
 
     # @override
     def _get_input_activations(self) -> Sequence[jax.Array]:
-        tokenizer = GPTSw3Tokenizer.from_pretrained(self._model_name)
+        tokenizer = GPTSw3Tokenizer.from_pretrained(self._model_path)
         inputs = tokenizer(
             "Träd är fina för att", return_tensors="jax"
         )  # input is a swedish statement

--- a/tests/jax/single_chip/models/llama/tester.py
+++ b/tests/jax/single_chip/models/llama/tester.py
@@ -17,20 +17,20 @@ class LLamaTester(ModelTester):
 
     def __init__(
         self,
-        model_name: str,
+        model_path: str,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        self._model_name = model_name
+        self._model_path = model_path
         super().__init__(comparison_config, run_mode)
 
     # @override
     def _get_model(self) -> FlaxPreTrainedModel:
-        return FlaxLlamaForCausalLM.from_pretrained(self._model_name, from_pt=True)
+        return FlaxLlamaForCausalLM.from_pretrained(self._model_path, from_pt=True)
 
     # @override
     def _get_input_activations(self) -> Dict[str, jax.Array]:
-        tokenizer = LlamaTokenizer.from_pretrained(self._model_name)
+        tokenizer = LlamaTokenizer.from_pretrained(self._model_path)
         inputs = tokenizer("Hello there fellow traveler", return_tensors="jax")
         return inputs
 

--- a/tests/jax/single_chip/models/marian/tester.py
+++ b/tests/jax/single_chip/models/marian/tester.py
@@ -15,20 +15,20 @@ class MarianTester(ModelTester):
 
     def __init__(
         self,
-        model_name: str,
+        model_path: str,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        self._model_name = model_name
+        self._model_path = model_path
         super().__init__(comparison_config, run_mode)
 
     # @override
     def _get_model(self) -> FlaxPreTrainedModel:
-        return FlaxMarianModel.from_pretrained(self._model_name)
+        return FlaxMarianModel.from_pretrained(self._model_path)
 
     # @override
     def _get_input_activations(self) -> Dict[str, jax.Array]:
-        tokenizer = AutoTokenizer.from_pretrained(self._model_name)
+        tokenizer = AutoTokenizer.from_pretrained(self._model_path)
         inputs = tokenizer("Hello, my dog is cute", return_tensors="jax")
         return inputs
 

--- a/tests/jax/single_chip/models/mbart50/tester.py
+++ b/tests/jax/single_chip/models/mbart50/tester.py
@@ -18,20 +18,20 @@ class MBartTester(ModelTester):
 
     def __init__(
         self,
-        model_name: str,
+        model_path: str,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        self._model_name = model_name
+        self._model_path = model_path
         super().__init__(comparison_config, run_mode)
 
     # @override
     def _get_model(self) -> FlaxPreTrainedModel:
-        return FlaxMBartForConditionalGeneration.from_pretrained(self._model_name)
+        return FlaxMBartForConditionalGeneration.from_pretrained(self._model_path)
 
     # @override
     def _get_input_activations(self) -> Dict[str, jax.Array]:
-        tokenizer = AutoTokenizer.from_pretrained(self._model_name)
+        tokenizer = AutoTokenizer.from_pretrained(self._model_path)
         inputs = tokenizer("Hello, my dog is cute.", return_tensors="jax")
         return inputs
 

--- a/tests/jax/single_chip/models/mistral_7b/tester.py
+++ b/tests/jax/single_chip/models/mistral_7b/tester.py
@@ -20,20 +20,20 @@ class Mistral7BTester(ModelTester):
 
     def __init__(
         self,
-        model_name: str,
+        model_path: str,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        self._model_name = model_name
+        self._model_path = model_path
         super().__init__(comparison_config, run_mode)
 
     # @override
     def _get_model(self) -> FlaxPreTrainedModel:
-        return FlaxMistralForCausalLM.from_pretrained(self._model_name)
+        return FlaxMistralForCausalLM.from_pretrained(self._model_path)
 
     # @override
     def _get_input_activations(self) -> Dict[str, jax.Array]:
-        tokenizer = AutoTokenizer.from_pretrained(self._model_name)
+        tokenizer = AutoTokenizer.from_pretrained(self._model_path)
         inputs = tokenizer("Hello there fellow traveler", return_tensors="jax")
         return inputs
 
@@ -59,6 +59,6 @@ class Mistral7BV02Tester(Mistral7BTester):
         # Using custom config in order to change the sliding_window from Null to
         # full context window length, effectively achieving the same result as if there
         # was no sliding window mask.
-        config = MistralConfig.from_pretrained(self._model_name)
+        config = MistralConfig.from_pretrained(self._model_path)
         config.sliding_window = config.max_position_embeddings
         return FlaxMistralForCausalLM(config)

--- a/tests/jax/single_chip/models/opt/tester.py
+++ b/tests/jax/single_chip/models/opt/tester.py
@@ -15,22 +15,22 @@ class OPTTester(ModelTester):
 
     def __init__(
         self,
-        model_name: str,
+        model_path: str,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        self._model_name = model_name
+        self._model_path = model_path
         super().__init__(comparison_config, run_mode)
 
     # @override
     def _get_model(self) -> FlaxPreTrainedModel:
-        model = FlaxOPTForCausalLM.from_pretrained(self._model_name)
+        model = FlaxOPTForCausalLM.from_pretrained(self._model_path)
         model.params = model.to_bf16(model.params)
         return model
 
     # @override
     def _get_input_activations(self) -> Dict[str, jax.Array]:
-        tokenizer = AutoTokenizer.from_pretrained(self._model_name)
+        tokenizer = AutoTokenizer.from_pretrained(self._model_path)
         inputs = tokenizer("Hello there fellow traveler", return_tensors="jax")
         return inputs
 

--- a/tests/jax/single_chip/models/pegasus/tester.py
+++ b/tests/jax/single_chip/models/pegasus/tester.py
@@ -19,20 +19,20 @@ class PegasusTester(ModelTester):
 
     def __init__(
         self,
-        model_name: str,
+        model_path: str,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        self._model_name = model_name
+        self._model_path = model_path
         super().__init__(comparison_config, run_mode)
 
     # @override
     def _get_model(self) -> FlaxPreTrainedModel:
-        return FlaxPegasusForConditionalGeneration.from_pretrained(self._model_name)
+        return FlaxPegasusForConditionalGeneration.from_pretrained(self._model_path)
 
     # @override
     def _get_input_activations(self) -> Dict[str, jax.Array]:
-        tokenizer = AutoTokenizer.from_pretrained(self._model_name)
+        tokenizer = AutoTokenizer.from_pretrained(self._model_path)
         inputs = tokenizer(
             "My friends are cool but they eat too many carbs.",
             truncation=True,

--- a/tests/jax/single_chip/models/roberta/tester.py
+++ b/tests/jax/single_chip/models/roberta/tester.py
@@ -17,20 +17,20 @@ class FlaxRobertaForMaskedLMTester(ModelTester):
 
     def __init__(
         self,
-        model_name: str,
+        model_path: str,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        self._model_name = model_name
+        self._model_path = model_path
         super().__init__(comparison_config, run_mode)
 
     # @override
     def _get_model(self) -> FlaxPreTrainedModel:
-        return FlaxRobertaForMaskedLM.from_pretrained(self._model_name)
+        return FlaxRobertaForMaskedLM.from_pretrained(self._model_path)
 
     # @override
     def _get_input_activations(self) -> Dict[str, jax.Array]:
-        tokenizer = AutoTokenizer.from_pretrained(self._model_name)
+        tokenizer = AutoTokenizer.from_pretrained(self._model_path)
         inputs = tokenizer("Hello <mask>.", return_tensors="jax")
         return inputs
 

--- a/tests/jax/single_chip/models/roberta_prelayernorm/efficient_mlm_m0_40/test_efficient_mlm_m0_40.py
+++ b/tests/jax/single_chip/models/roberta_prelayernorm/efficient_mlm_m0_40/test_efficient_mlm_m0_40.py
@@ -39,22 +39,22 @@ class FlaxRobertaPreLayerNormForMaskedLMTester(ModelTester):
 
     def __init__(
         self,
-        model_name: str,
+        model_path: str,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        self._model_name = model_name
+        self._model_path = model_path
         super().__init__(comparison_config, run_mode)
 
     # @override
     def _get_model(self) -> FlaxPreTrainedModel:
         return FlaxRobertaPreLayerNormForMaskedLM.from_pretrained(
-            self._model_name, from_pt=True
+            self._model_path, from_pt=True
         )
 
     # @override
     def _get_input_activations(self) -> Dict[str, jax.Array]:
-        tokenizer = AutoTokenizer.from_pretrained(self._model_name)
+        tokenizer = AutoTokenizer.from_pretrained(self._model_path)
         inputs = tokenizer("Hello <mask>.", return_tensors="jax")
         return inputs
 

--- a/tests/jax/single_chip/models/roformer/tester.py
+++ b/tests/jax/single_chip/models/roformer/tester.py
@@ -19,20 +19,20 @@ class RoFormerTester(ModelTester):
 
     def __init__(
         self,
-        model_name: str,
+        model_path: str,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        self._model_name = model_name
+        self._model_path = model_path
         super().__init__(comparison_config, run_mode)
 
     # @override
     def _get_model(self) -> FlaxPreTrainedModel:
-        return FlaxRoFormerForMaskedLM.from_pretrained(self._model_name)
+        return FlaxRoFormerForMaskedLM.from_pretrained(self._model_path)
 
     # @override
     def _get_input_activations(self) -> Dict[str, jax.Array]:
-        tokenizer = RoFormerTokenizer.from_pretrained(self._model_name)
+        tokenizer = RoFormerTokenizer.from_pretrained(self._model_path)
         inputs = tokenizer("The capital of France is [MASK].", return_tensors="jax")
         return inputs
 

--- a/tests/jax/single_chip/models/vit/tester.py
+++ b/tests/jax/single_chip/models/vit/tester.py
@@ -22,27 +22,27 @@ class ViTTester(ModelTester):
 
     def __init__(
         self,
-        model_name: str,
+        model_path: str,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        self._model_name = model_name
+        self._model_path = model_path
         super().__init__(comparison_config, run_mode)
 
     # @override
     def _get_model(self) -> FlaxPreTrainedModel:
-        return FlaxViTForImageClassification.from_pretrained(self._model_name)
+        return FlaxViTForImageClassification.from_pretrained(self._model_path)
 
     # @override
     def _get_input_activations(self) -> jax.Array:
-        model_config = ViTConfig.from_pretrained(self._model_name)
+        model_config = ViTConfig.from_pretrained(self._model_path)
         image_size = model_config.image_size
         key = random.PRNGKey(0)
         random_image = random.randint(
             key, (image_size, image_size, 3), 0, 256, dtype=jnp.uint8
         )
 
-        processor = ViTImageProcessor.from_pretrained(self._model_name)
+        processor = ViTImageProcessor.from_pretrained(self._model_path)
         inputs = processor(images=random_image, return_tensors="jax")
         return inputs["pixel_values"]
 

--- a/tests/jax/single_chip/models/xglm/tester.py
+++ b/tests/jax/single_chip/models/xglm/tester.py
@@ -15,22 +15,22 @@ class XGLMTester(ModelTester):
 
     def __init__(
         self,
-        model_name: str,
+        model_path: str,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        self._model_name = model_name
+        self._model_path = model_path
         super().__init__(comparison_config, run_mode)
 
     # @override
     def _get_model(self) -> FlaxPreTrainedModel:
-        model = FlaxXGLMForCausalLM.from_pretrained(self._model_name)
+        model = FlaxXGLMForCausalLM.from_pretrained(self._model_path)
         model.params = model.to_bf16(model.params)
         return model
 
     # @override
     def _get_input_activations(self) -> Dict[str, jax.Array]:
-        tokenizer = XGLMTokenizer.from_pretrained(self._model_name)
+        tokenizer = XGLMTokenizer.from_pretrained(self._model_path)
         inputs = tokenizer("Hello, my dog is cute.", return_tensors="jax")
         return inputs
 

--- a/tests/jax/single_chip/models/xlm_roberta/tester.py
+++ b/tests/jax/single_chip/models/xlm_roberta/tester.py
@@ -15,20 +15,20 @@ class XLMRobertaTester(ModelTester):
 
     def __init__(
         self,
-        model_name: str,
+        model_path: str,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        self._model_name = model_name
+        self._model_path = model_path
         super().__init__(comparison_config, run_mode)
 
     # @override
     def _get_model(self) -> FlaxPreTrainedModel:
-        return FlaxXLMRobertaForCausalLM.from_pretrained(self._model_name)
+        return FlaxXLMRobertaForCausalLM.from_pretrained(self._model_path)
 
     # @override
     def _get_input_activations(self) -> Dict[str, jax.Array]:
-        tokenizer = AutoTokenizer.from_pretrained(self._model_name)
+        tokenizer = AutoTokenizer.from_pretrained(self._model_path)
         inputs = tokenizer("Hello, my dog is cute", return_tensors="jax")
         return inputs
 


### PR DESCRIPTION
### Problem description

Update the constructor argument name from `model_name` to `model_path`  in tester files of the models, as it is actually denoting the path of the model

### What's changed

`model_name` is replaced with `model_path` in tester files of models


