### PR TITLE
Enabling more multichip tests

### DIFF
--- a/tests/jax/multi_chip/llmbox/4_devices/graphs/tensor_parallel/test_dot_psum.py
+++ b/tests/jax/multi_chip/llmbox/4_devices/graphs/tensor_parallel/test_dot_psum.py
@@ -21,7 +21,6 @@ from tests.utils import failed_ttmlir_compilation
     "use_shardy",
     [
         True,
-        False,
     ],
 )
 @pytest.mark.parametrize(
@@ -34,15 +33,7 @@ from tests.utils import failed_ttmlir_compilation
     "sharding_mode",
     [
         ShardingMode.INPUTS_AND_MODULE,
-        ShardingMode.MODULE,
-        ShardingMode.INPUTS,
     ],
-)
-@pytest.mark.xfail(
-    reason=failed_ttmlir_compilation(
-        "Coordinate MeshCoordinate([1, 0]) is out of bounds for shape MeshShape([1, 2]) "
-        "(https://github.com/tenstorrent/tt-xla/issues/381)"
-    )
 )
 def test_dot_psum(
     use_shardy: bool,

--- a/tests/jax/multi_chip/llmbox/4_devices/graphs/tensor_parallel/test_dot_psum.py
+++ b/tests/jax/multi_chip/llmbox/4_devices/graphs/tensor_parallel/test_dot_psum.py
@@ -12,7 +12,7 @@ from infra import (
     run_multichip_test_with_random_inputs,
 )
 
-from tests.utils import failed_ttmlir_compilation
+from tests.utils import failed_fe_compilation, failed_ttmlir_compilation
 
 
 @pytest.mark.nightly
@@ -21,6 +21,7 @@ from tests.utils import failed_ttmlir_compilation
     "use_shardy",
     [
         True,
+        False,
     ],
 )
 @pytest.mark.parametrize(
@@ -33,7 +34,22 @@ from tests.utils import failed_ttmlir_compilation
     "sharding_mode",
     [
         ShardingMode.INPUTS_AND_MODULE,
+        pytest.param(
+            ShardingMode.MODULE,
+            marks=pytest.mark.xfail(
+                reason=failed_fe_compilation(
+                    "Cannot get sharding information through the protobuf "
+                    "(https://github.com/tenstorrent/tt-xla/issues/277)"
+                )
+            ),
+        ),
     ],
+)
+@pytest.mark.xfail(
+    reason=failed_ttmlir_compilation(
+        "Get device id issue on 4 chips with LLMbox "
+        "(https://github.com/tenstorrent/tt-xla/issues/484)"
+    )
 )
 def test_dot_psum(
     use_shardy: bool,

--- a/tests/jax/multi_chip/llmbox/4_devices/graphs/tensor_parallel/test_dot_psum.py
+++ b/tests/jax/multi_chip/llmbox/4_devices/graphs/tensor_parallel/test_dot_psum.py
@@ -45,12 +45,6 @@ from tests.utils import failed_fe_compilation, failed_ttmlir_compilation
         ),
     ],
 )
-@pytest.mark.xfail(
-    reason=failed_ttmlir_compilation(
-        "Get device id issue on 4 chips with LLMbox "
-        "(https://github.com/tenstorrent/tt-xla/issues/484)"
-    )
-)
 def test_dot_psum(
     use_shardy: bool,
     batch_shape: tuple,

--- a/tests/jax/multi_chip/llmbox/4_devices/ops/data_parallel/batch_sharded/test_all_gather.py
+++ b/tests/jax/multi_chip/llmbox/4_devices/ops/data_parallel/batch_sharded/test_all_gather.py
@@ -41,12 +41,6 @@ from tests.utils import failed_fe_compilation, failed_ttmlir_compilation
         ),
     ],
 )
-@pytest.mark.xfail(
-    reason=failed_ttmlir_compilation(
-        "Get device id issue on 4 chips with LLMbox "
-        "(https://github.com/tenstorrent/tt-xla/issues/484)"
-    )
-)
 def test_all_gather(
     use_shardy: bool,
     x_shape: tuple,

--- a/tests/jax/multi_chip/llmbox/4_devices/ops/data_parallel/batch_sharded/test_all_gather.py
+++ b/tests/jax/multi_chip/llmbox/4_devices/ops/data_parallel/batch_sharded/test_all_gather.py
@@ -11,7 +11,7 @@ from infra import (
     run_multichip_test_with_random_inputs,
 )
 
-from tests.utils import failed_ttmlir_compilation
+from tests.utils import failed_fe_compilation, failed_ttmlir_compilation
 
 
 @pytest.mark.nightly
@@ -19,30 +19,32 @@ from tests.utils import failed_ttmlir_compilation
 @pytest.mark.parametrize(
     "use_shardy",
     [
-        pytest.param(
-            True,
-            marks=pytest.mark.skip(
-                reason=failed_ttmlir_compilation("Shardy does not support 1D meshes")
-            ),
-        ),
+        True,
         False,
     ],
 )
 @pytest.mark.parametrize(
-    ("x_shape", "mesh_shape", "axis_names"), [((8192, 784), (4,), ("batch",))]
+    ("x_shape", "mesh_shape", "axis_names"), [((8192, 784), (1, 4), ("batch", "model"))]
 )
 @pytest.mark.parametrize(
     "sharding_mode",
     [
         ShardingMode.INPUTS_AND_MODULE,
-        ShardingMode.MODULE,
-        ShardingMode.INPUTS,
+        pytest.param(
+            ShardingMode.MODULE,
+            marks=pytest.mark.xfail(
+                reason=failed_fe_compilation(
+                    "Cannot get sharding information through the protobuf "
+                    "(https://github.com/tenstorrent/tt-xla/issues/277)"
+                )
+            ),
+        ),
     ],
 )
 @pytest.mark.xfail(
     reason=failed_ttmlir_compilation(
-        "Coordinate MeshCoordinate([1, 0]) is out of bounds for shape MeshShape([1, 2]) "
-        "(https://github.com/tenstorrent/tt-xla/issues/381)"
+        "Get device id issue on 4 chips with LLMbox "
+        "(https://github.com/tenstorrent/tt-xla/issues/484)"
     )
 )
 def test_all_gather(
@@ -53,7 +55,7 @@ def test_all_gather(
     sharding_mode: ShardingMode,
 ):
     def fwd(batch):
-        act = jax.lax.all_gather(batch, axis_names, axis=0, tiled=True)
+        act = jax.lax.all_gather(batch, axis_names[1], axis=0, tiled=True)
         return act
 
     in_specs = (make_partition_spec(axis_names),)

--- a/tests/jax/multi_chip/llmbox/4_devices/ops/data_parallel/batch_sharded/test_psum.py
+++ b/tests/jax/multi_chip/llmbox/4_devices/ops/data_parallel/batch_sharded/test_psum.py
@@ -26,21 +26,13 @@ from tests.utils import failed_fe_compilation, failed_runtime
 @pytest.mark.parametrize(
     ("batch_shape", "mesh_shape", "axis_names"),
     [
-        ((256, 256), (1, 4), ("batch", "model")),
+        ((2048, 2048), (1, 4), ("batch", "model")),
     ],
 )
 @pytest.mark.parametrize(
     "sharding_mode",
     [
-        pytest.param(
-            ShardingMode.INPUTS_AND_MODULE,
-            marks=pytest.mark.skip(
-                reason=failed_runtime(
-                    "Problem with CCL ops on llmbox"
-                    "(https://github.com/tenstorrent/tt-xla/issues/484)"
-                )
-            ),
-        ),
+        ShardingMode.INPUTS_AND_MODULE,
         pytest.param(
             ShardingMode.MODULE,
             marks=pytest.mark.xfail(

--- a/tests/jax/multi_chip/llmbox/4_devices/ops/data_parallel/batch_sharded/test_psum.py
+++ b/tests/jax/multi_chip/llmbox/4_devices/ops/data_parallel/batch_sharded/test_psum.py
@@ -45,12 +45,6 @@ from tests.utils import failed_fe_compilation, failed_ttmlir_compilation
         ),
     ],
 )
-@pytest.mark.xfail(
-    reason=failed_ttmlir_compilation(
-        "Get device id issue on 4 chips with LLMbox "
-        "(https://github.com/tenstorrent/tt-xla/issues/484)"
-    )
-)
 def test_psum(
     use_shardy: bool,
     batch_shape: tuple,

--- a/tests/jax/multi_chip/llmbox/4_devices/ops/data_parallel/batch_sharded/test_psum.py
+++ b/tests/jax/multi_chip/llmbox/4_devices/ops/data_parallel/batch_sharded/test_psum.py
@@ -12,9 +12,10 @@ from infra import (
     run_multichip_test_with_random_inputs,
 )
 
-from tests.utils import failed_fe_compilation, failed_runtime
+from tests.utils import failed_fe_compilation, failed_ttmlir_compilation
 
 
+@pytest.mark.nightly
 @pytest.mark.push
 @pytest.mark.parametrize(
     "use_shardy",
@@ -43,6 +44,12 @@ from tests.utils import failed_fe_compilation, failed_runtime
             ),
         ),
     ],
+)
+@pytest.mark.xfail(
+    reason=failed_ttmlir_compilation(
+        "Get device id issue on 4 chips with LLMbox "
+        "(https://github.com/tenstorrent/tt-xla/issues/484)"
+    )
 )
 def test_psum(
     use_shardy: bool,

--- a/tests/jax/multi_chip/llmbox/8_devices/graphs/tensor_parallel/test_dot_psum.py
+++ b/tests/jax/multi_chip/llmbox/8_devices/graphs/tensor_parallel/test_dot_psum.py
@@ -12,7 +12,7 @@ from infra import (
     run_multichip_test_with_random_inputs,
 )
 
-from tests.utils import failed_ttmlir_compilation
+from tests.utils import failed_fe_compilation
 
 
 @pytest.mark.nightly
@@ -34,15 +34,16 @@ from tests.utils import failed_ttmlir_compilation
     "sharding_mode",
     [
         ShardingMode.INPUTS_AND_MODULE,
-        ShardingMode.MODULE,
-        ShardingMode.INPUTS,
+        pytest.param(
+            ShardingMode.MODULE,
+            marks=pytest.mark.xfail(
+                reason=failed_fe_compilation(
+                    "Cannot get sharding information through the protobuf "
+                    "(https://github.com/tenstorrent/tt-xla/issues/277)"
+                )
+            ),
+        ),
     ],
-)
-@pytest.mark.xfail(
-    reason=failed_ttmlir_compilation(
-        "Coordinate MeshCoordinate([1, 0]) is out of bounds for shape MeshShape([1, 2]) "
-        "(https://github.com/tenstorrent/tt-xla/issues/381)"
-    )
 )
 def test_dot_psum(
     use_shardy: bool,

--- a/tests/jax/multi_chip/llmbox/8_devices/ops/data_parallel/batch_sharded/test_all_gather.py
+++ b/tests/jax/multi_chip/llmbox/8_devices/ops/data_parallel/batch_sharded/test_all_gather.py
@@ -11,7 +11,7 @@ from infra import (
     run_multichip_test_with_random_inputs,
 )
 
-from tests.utils import failed_ttmlir_compilation
+from tests.utils import failed_fe_compilation
 
 
 @pytest.mark.nightly
@@ -19,31 +19,27 @@ from tests.utils import failed_ttmlir_compilation
 @pytest.mark.parametrize(
     "use_shardy",
     [
-        pytest.param(
-            True,
-            marks=pytest.mark.skip(
-                reason=failed_ttmlir_compilation("Shardy does not support 1D meshes")
-            ),
-        ),
+        True,
         False,
     ],
 )
 @pytest.mark.parametrize(
-    ("x_shape", "mesh_shape", "axis_names"), [((8192, 784), (8,), ("batch",))]
+    ("x_shape", "mesh_shape", "axis_names"), [((8192, 784), (1, 8), ("batch", "model"))]
 )
 @pytest.mark.parametrize(
     "sharding_mode",
     [
         ShardingMode.INPUTS_AND_MODULE,
-        ShardingMode.MODULE,
-        ShardingMode.INPUTS,
+        pytest.param(
+            ShardingMode.MODULE,
+            marks=pytest.mark.xfail(
+                reason=failed_fe_compilation(
+                    "Cannot get sharding information through the protobuf "
+                    "(https://github.com/tenstorrent/tt-xla/issues/277)"
+                )
+            ),
+        ),
     ],
-)
-@pytest.mark.xfail(
-    reason=failed_ttmlir_compilation(
-        "Coordinate MeshCoordinate([1, 0]) is out of bounds for shape MeshShape([1, 2]) "
-        "(https://github.com/tenstorrent/tt-xla/issues/381)"
-    )
 )
 def test_all_gather(
     use_shardy: bool,
@@ -53,7 +49,7 @@ def test_all_gather(
     sharding_mode: ShardingMode,
 ):
     def fwd(batch):
-        act = jax.lax.all_gather(batch, axis_names, axis=0, tiled=True)
+        act = jax.lax.all_gather(batch, axis_names[1], axis=0, tiled=True)
         return act
 
     in_specs = (make_partition_spec(axis_names),)

--- a/tests/jax/multi_chip/llmbox/8_devices/ops/data_parallel/batch_sharded/test_psum.py
+++ b/tests/jax/multi_chip/llmbox/8_devices/ops/data_parallel/batch_sharded/test_psum.py
@@ -26,21 +26,13 @@ from tests.utils import failed_fe_compilation, failed_runtime
 @pytest.mark.parametrize(
     ("batch_shape", "mesh_shape", "axis_names"),
     [
-        ((256, 256), (1, 8), ("batch", "model")),
+        ((2048, 2048), (1, 8), ("batch", "model")),
     ],
 )
 @pytest.mark.parametrize(
     "sharding_mode",
     [
-        pytest.param(
-            ShardingMode.INPUTS_AND_MODULE,
-            marks=pytest.mark.skip(
-                reason=failed_runtime(
-                    "Problem with CCL ops on llmbox"
-                    "(https://github.com/tenstorrent/tt-xla/issues/484)"
-                )
-            ),
-        ),
+        ShardingMode.INPUTS_AND_MODULE,
         pytest.param(
             ShardingMode.MODULE,
             marks=pytest.mark.xfail(

--- a/tests/jax/multi_chip/llmbox/8_devices/ops/data_parallel/batch_sharded/test_psum.py
+++ b/tests/jax/multi_chip/llmbox/8_devices/ops/data_parallel/batch_sharded/test_psum.py
@@ -12,9 +12,10 @@ from infra import (
     run_multichip_test_with_random_inputs,
 )
 
-from tests.utils import failed_fe_compilation, failed_runtime
+from tests.utils import failed_fe_compilation
 
 
+@pytest.mark.nightly
 @pytest.mark.push
 @pytest.mark.parametrize(
     "use_shardy",

--- a/tests/jax/multi_chip/n300/graphs/tensor_parallel/test_dot_psum.py
+++ b/tests/jax/multi_chip/n300/graphs/tensor_parallel/test_dot_psum.py
@@ -12,7 +12,7 @@ from infra import (
     run_multichip_test_with_random_inputs,
 )
 
-from tests.utils import failed_ttmlir_compilation
+from tests.utils import failed_fe_compilation
 
 
 @pytest.mark.nightly
@@ -34,15 +34,16 @@ from tests.utils import failed_ttmlir_compilation
     "sharding_mode",
     [
         ShardingMode.INPUTS_AND_MODULE,
-        ShardingMode.MODULE,
-        ShardingMode.INPUTS,
+        pytest.param(
+            ShardingMode.MODULE,
+            marks=pytest.mark.xfail(
+                reason=failed_fe_compilation(
+                    "Cannot get sharding information through the protobuf "
+                    "(https://github.com/tenstorrent/tt-xla/issues/277)"
+                )
+            ),
+        ),
     ],
-)
-@pytest.mark.xfail(
-    reason=failed_ttmlir_compilation(
-        "Coordinate MeshCoordinate([1, 0]) is out of bounds for shape MeshShape([1, 2]) "
-        "(https://github.com/tenstorrent/tt-xla/issues/381)"
-    )
 )
 def test_dot_psum(
     use_shardy: bool,

--- a/tests/jax/multi_chip/n300/ops/data_parallel/batch_sharded/test_psum.py
+++ b/tests/jax/multi_chip/n300/ops/data_parallel/batch_sharded/test_psum.py
@@ -15,6 +15,7 @@ from infra import (
 from tests.utils import failed_fe_compilation
 
 
+@pytest.mark.nightly
 @pytest.mark.push
 @pytest.mark.parametrize(
     "use_shardy",
@@ -26,7 +27,7 @@ from tests.utils import failed_fe_compilation
 @pytest.mark.parametrize(
     ("batch_shape", "mesh_shape", "axis_names"),
     [
-        ((256, 256), (1, 2), ("batch", "model")),
+        ((2048, 2048), (1, 2), ("batch", "model")),
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
With the newest uplift of tt-mlir main branch, specifically this (https://github.com/tenstorrent/tt-mlir/pull/2880), solving the issue https://github.com/tenstorrent/tt-mlir/issues/2557, we can enable more tt-xla multichip tests. The 4 device tests will be enabled when uplifting tt-mlir with the PR given here: https://github.com/tenstorrent/tt-mlir/pull/2918