### PR TITLE
Add explicit toLayout calls before submit

### DIFF
--- a/src/common/pjrt_implementation/loaded_executable_instance.cc
+++ b/src/common/pjrt_implementation/loaded_executable_instance.cc
@@ -136,7 +136,7 @@ LoadedExecutableInstance::Execute(PJRT_LoadedExecutable_Execute_Args *args) {
                  std::back_inserter(rt_inputs_with_layout),
                  [&](tt::runtime::Tensor &t) -> tt::runtime::Tensor {
                    tt::runtime::Layout layout =
-                       tt::runtime::getLayout(binary, 0 /* programIndex */,
+                       tt::runtime::getLayout(binary, 0 /* program_index */,
                                               rt_inputs_with_layout.size());
 
                    tt::runtime::Tensor tensor =
@@ -145,7 +145,7 @@ LoadedExecutableInstance::Execute(PJRT_LoadedExecutable_Execute_Args *args) {
                  });
 
   std::vector<tt::runtime::Tensor> rt_outputs = tt::runtime::submit(
-      device, binary, 0 /* programIndex */, rt_inputs_with_layout);
+      device, binary, 0 /* program_index */, rt_inputs_with_layout);
   std::vector<tt::runtime::TensorDesc> output_specs =
       binary.getProgramOutputs(0 /* program_index */);
   std::vector<std::vector<tt::runtime::Tensor>> rt_outputs_list(num_devices);

--- a/src/tt/CMakeLists.txt
+++ b/src/tt/CMakeLists.txt
@@ -27,10 +27,11 @@ add_library(TTPJRTTTDylib
     "dylib_entry_point.cc"
 )
 target_include_directories(TTPJRTTTDylib PUBLIC ${PROJECT_SOURCE_DIR}/third_party/pjrt_c_api)
-target_link_libraries(TTPJRTTTDylib PUBLIC TTPJRTTT)
-
-target_link_libraries(TTPJRTTTDylib PUBLIC coverage_config)
-
+target_link_libraries(TTPJRTTTDylib PUBLIC 
+    TTMLIR
+    TTPJRTTT
+    coverage_config
+)
 # # Output to the project wide python binary directory tree.
 set_target_properties(TTPJRTTTDylib
     PROPERTIES

--- a/src/tt/CMakeLists.txt
+++ b/src/tt/CMakeLists.txt
@@ -27,11 +27,10 @@ add_library(TTPJRTTTDylib
     "dylib_entry_point.cc"
 )
 target_include_directories(TTPJRTTTDylib PUBLIC ${PROJECT_SOURCE_DIR}/third_party/pjrt_c_api)
-target_link_libraries(TTPJRTTTDylib PUBLIC 
-    TTMLIR
-    TTPJRTTT
-    coverage_config
-)
+target_link_libraries(TTPJRTTTDylib PUBLIC TTPJRTTT)
+
+target_link_libraries(TTPJRTTTDylib PUBLIC coverage_config)
+
 # # Output to the project wide python binary directory tree.
 set_target_properties(TTPJRTTTDylib
     PROPERTIES


### PR DESCRIPTION
### Problem description
Changes to tt-mlir make toLayout necessary for updating version ids before submit is called, and remove automatic toLayout calls within submit.  This PR will prevent this from breaking `tt-xla`, which doesn't pre-convert it's input layouts, unlike the other 2 FEs.  Related to: https://github.com/tenstorrent/tt-mlir/pull/2756/

### What's changed
inputs to submit will now call toLayout explicitly beforehand.

### Checklist
- [ ] New/Existing tests provide coverage for changes
