### PR TITLE
skip pegasus xsum test for OOM issue

### DIFF
--- a/tests/jax/single_chip/models/pegasus/xsum/test_pegasus_xsum.py
+++ b/tests/jax/single_chip/models/pegasus/xsum/test_pegasus_xsum.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_ttmlir_compilation,
+    failed_fe_compilation,
 )
 
 from ..tester import PegasusTester
@@ -48,12 +48,11 @@ def training_tester() -> PegasusTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
+    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
 )
-@pytest.mark.xfail(
-    reason=failed_ttmlir_compilation(
-        "'ttir.scatter' op Dimension size to slice into must be 1 "
-        "https://github.com/tenstorrent/tt-xla/issues/386 "
+@pytest.mark.skip(
+    reason=failed_fe_compilation(
+        "OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186)"
     )
 )
 def test_pegasus_xsum_inference(inference_tester: PegasusTester):


### PR DESCRIPTION
### Problem description
OOM issue occured for `test_pegasus_xsum.py`

### What's changed
updated the test with skip marker

### Checklist
- [x] New/Existing tests provide coverage for changes
