### PR TITLE
Unskip models that fit under 32GB RAM

### DIFF
--- a/tests/jax/single_chip/models/alexnet/test_alexnet.py
+++ b/tests/jax/single_chip/models/alexnet/test_alexnet.py
@@ -114,8 +114,8 @@ def training_tester() -> AlexNetTester:
 )
 @pytest.mark.xfail(
     reason=failed_ttmlir_compilation(
-        "error: failed to legalize operation 'ttir.gather'"
-        "(https://github.com/tenstorrent/tt-xla/issues/318)"
+        "failed to legalize operation 'ttir.gather' "
+        "https://github.com/tenstorrent/tt-xla/issues/318"
     )
 )
 def test_alexnet_inference(inference_tester: AlexNetTester):

--- a/tests/jax/single_chip/models/beit/base/test_beit_base.py
+++ b/tests/jax/single_chip/models/beit/base/test_beit_base.py
@@ -52,7 +52,10 @@ def training_tester() -> FlaxBeitForImageClassificationTester:
     bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
 )
 @pytest.mark.xfail(
-    reason=failed_ttmlir_compilation("failed to legalize operation 'ttir.gather'")
+    reason=failed_ttmlir_compilation(
+        "failed to legalize operation 'ttir.gather' "
+        "https://github.com/tenstorrent/tt-xla/issues/318"
+    )
 )
 def test_flax_beit_base_inference(
     inference_tester: FlaxBeitForImageClassificationTester,

--- a/tests/jax/single_chip/models/beit/large/test_beit_large.py
+++ b/tests/jax/single_chip/models/beit/large/test_beit_large.py
@@ -52,7 +52,10 @@ def training_tester() -> FlaxBeitForImageClassificationTester:
     bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
 )
 @pytest.mark.xfail(
-    reason=failed_ttmlir_compilation("failed to legalize operation 'ttir.gather'")
+    reason=failed_ttmlir_compilation(
+        "failed to legalize operation 'ttir.gather' "
+        "https://github.com/tenstorrent/tt-xla/issues/318"
+    )
 )
 def test_flax_beit_large_inference(
     inference_tester: FlaxBeitForImageClassificationTester,

--- a/tests/jax/single_chip/models/bigbird/roberta_base/test_bigbird_roberta_base.py
+++ b/tests/jax/single_chip/models/bigbird/roberta_base/test_bigbird_roberta_base.py
@@ -2,10 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import pytest
 from typing import Dict
 
 import jax
+import pytest
 from infra import ComparisonConfig, Framework, RunMode
 from transformers import (
     AutoTokenizer,
@@ -81,10 +81,10 @@ def training_tester() -> BigBirdBaseTester:
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
 )
-@pytest.mark.skip(
+@pytest.mark.xfail(
     reason=failed_ttmlir_compilation(
-        "failed to legalize unresolved materialization from ('tensor<1x16x1xbf16>') to ('tensor<1x16x1xi1>') that remained live after conversion "
-        "https://github.com/tenstorrent/tt-xla/issues/476"
+        "'ttir.scatter' op Dimension size to slice into must be 1 "
+        "https://github.com/tenstorrent/tt-xla/issues/386"
     )
 )
 def test_bigbird_roberta_base_inference(inference_tester: BigBirdBaseTester):

--- a/tests/jax/single_chip/models/bigbird/roberta_large/test_bigbird_roberta_large.py
+++ b/tests/jax/single_chip/models/bigbird/roberta_large/test_bigbird_roberta_large.py
@@ -2,10 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import pytest
 from typing import Dict
 
 import jax
+import pytest
 from infra import ComparisonConfig, Framework, RunMode
 from transformers import AutoTokenizer, FlaxBigBirdForCausalLM, FlaxPreTrainedModel
 
@@ -84,7 +84,7 @@ def training_tester() -> BigBirdLargeTester:
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
 )
-@pytest.mark.skip(
+@pytest.mark.xfail(
     reason=failed_ttmlir_compilation(
         "failed to legalize operation 'stablehlo.dynamic_slice' "
         "https://github.com/tenstorrent/tt-xla/issues/404"

--- a/tests/jax/single_chip/models/clip/base_patch16/test_clip_base_patch16.py
+++ b/tests/jax/single_chip/models/clip/base_patch16/test_clip_base_patch16.py
@@ -53,7 +53,10 @@ def training_tester() -> FlaxCLIPTester:
     bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
 )
 @pytest.mark.xfail(
-    reason=failed_ttmlir_compilation("failed to legalize operation 'ttir.gather'")
+    reason=failed_ttmlir_compilation(
+        "failed to legalize operation 'ttir.gather' "
+        "https://github.com/tenstorrent/tt-xla/issues/318"
+    )
 )
 def test_clip_base_patch16_inference(inference_tester: FlaxCLIPTester):
     inference_tester.test()

--- a/tests/jax/single_chip/models/clip/base_patch32/test_clip_base_patch32.py
+++ b/tests/jax/single_chip/models/clip/base_patch32/test_clip_base_patch32.py
@@ -52,7 +52,10 @@ def training_tester() -> FlaxCLIPTester:
     bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
 )
 @pytest.mark.xfail(
-    reason=failed_ttmlir_compilation("failed to legalize operation 'ttir.gather'")
+    reason=failed_ttmlir_compilation(
+        "failed to legalize operation 'ttir.gather' "
+        "https://github.com/tenstorrent/tt-xla/issues/318"
+    )
 )
 def test_clip_base_patch32_inference(inference_tester: FlaxCLIPTester):
     inference_tester.test()

--- a/tests/jax/single_chip/models/clip/large_patch14/test_clip_large_patch14.py
+++ b/tests/jax/single_chip/models/clip/large_patch14/test_clip_large_patch14.py
@@ -52,7 +52,10 @@ def training_tester() -> FlaxCLIPTester:
     bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
 )
 @pytest.mark.xfail(
-    reason=failed_ttmlir_compilation("failed to legalize operation 'ttir.gather'")
+    reason=failed_ttmlir_compilation(
+        "failed to legalize operation 'ttir.gather' "
+        "https://github.com/tenstorrent/tt-xla/issues/318"
+    )
 )
 def test_clip_large_patch14_inference(inference_tester: FlaxCLIPTester):
     inference_tester.test()

--- a/tests/jax/single_chip/models/clip/large_patch14_336/test_clip_large_patch14_336.py
+++ b/tests/jax/single_chip/models/clip/large_patch14_336/test_clip_large_patch14_336.py
@@ -52,7 +52,10 @@ def training_tester() -> FlaxCLIPTester:
     bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
 )
 @pytest.mark.xfail(
-    reason=failed_ttmlir_compilation("failed to legalize operation 'ttir.gather'")
+    reason=failed_ttmlir_compilation(
+        "failed to legalize operation 'ttir.gather' "
+        "https://github.com/tenstorrent/tt-xla/issues/318"
+    )
 )
 def test_clip_large_patch14_336_inference(inference_tester: FlaxCLIPTester):
     inference_tester.test()

--- a/tests/jax/single_chip/models/marian/opus_mt_en_de/test_marian_opus_mt_en_de.py
+++ b/tests/jax/single_chip/models/marian/opus_mt_en_de/test_marian_opus_mt_en_de.py
@@ -51,7 +51,7 @@ def training_tester() -> MarianTester:
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
 )
-@pytest.mark.skip(
+@pytest.mark.xfail(
     reason=failed_ttmlir_compilation(
         "'ttir.scatter' op Dimension size to slice into must be 1 "
         "https://github.com/tenstorrent/tt-xla/issues/386"

--- a/tests/jax/single_chip/models/mbart50/large_many_to_many/test_mbart50_large_many_to_many.py
+++ b/tests/jax/single_chip/models/mbart50/large_many_to_many/test_mbart50_large_many_to_many.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_fe_compilation,
+    failed_ttmlir_compilation,
 )
 
 from ..tester import MBartTester
@@ -47,9 +47,14 @@ def training_tester() -> MBartTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
+    bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
 )
-@pytest.mark.skip(reason=failed_fe_compilation("OOMs in CI"))
+@pytest.mark.xfail(
+    reason=failed_ttmlir_compilation(
+        "'ttir.scatter' op Dimension size to slice into must be 1 "
+        "https://github.com/tenstorrent/tt-xla/issues/386"
+    )
+)
 def test_mbart50_large_many_to_many_inference(inference_tester: MBartTester):
     inference_tester.test()
 

--- a/tests/jax/single_chip/models/mistral_7b/v0_1_tiny/test_mistral_7b_tiny_v0_1.py
+++ b/tests/jax/single_chip/models/mistral_7b/v0_1_tiny/test_mistral_7b_tiny_v0_1.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_fe_compilation,
+    failed_ttmlir_compilation,
 )
 
 from ..tester import Mistral7BTester
@@ -48,11 +48,12 @@ def training_tester() -> Mistral7BTester:
     model_name=MODEL_NAME,
     model_group=MODEL_GROUP,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
+    bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
 )
 @pytest.mark.xfail(
-    reason=failed_fe_compilation(
-        "OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186)"
+    reason=failed_ttmlir_compilation(
+        "failed to legalize operation 'ttir.gather' "
+        "https://github.com/tenstorrent/tt-xla/issues/318"
     )
 )
 def test_mistral_7b_v0_1_tiny_inference(inference_tester: Mistral7BTester):

--- a/tests/jax/single_chip/models/pegasus/xsum/test_pegasus_xsum.py
+++ b/tests/jax/single_chip/models/pegasus/xsum/test_pegasus_xsum.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_fe_compilation,
+    failed_ttmlir_compilation,
 )
 
 from ..tester import PegasusTester
@@ -48,11 +48,12 @@ def training_tester() -> PegasusTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
+    bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
 )
-@pytest.mark.skip(
-    reason=failed_fe_compilation(
-        "OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186)"
+@pytest.mark.xfail(
+    reason=failed_ttmlir_compilation(
+        "'ttir.scatter' op Dimension size to slice into must be 1 "
+        "https://github.com/tenstorrent/tt-xla/issues/386"
     )
 )
 def test_pegasus_xsum_inference(inference_tester: PegasusTester):

--- a/tests/jax/single_chip/models/roformer/chinese_base/test_roformer_chinese_base.py
+++ b/tests/jax/single_chip/models/roformer/chinese_base/test_roformer_chinese_base.py
@@ -50,9 +50,9 @@ def training_tester() -> RoFormerTester:
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
 )
-@pytest.mark.skip(
+@pytest.mark.xfail(
     reason=failed_ttmlir_compilation(
-        "failed to legalize operation 'ttir.gather' that was explicitly marked illegal "
+        "failed to legalize operation 'ttir.gather' "
         "https://github.com/tenstorrent/tt-xla/issues/318"
     )
 )

--- a/tests/jax/single_chip/models/roformer/chinese_char_small/test_roformer_chinese_char_small.py
+++ b/tests/jax/single_chip/models/roformer/chinese_char_small/test_roformer_chinese_char_small.py
@@ -50,9 +50,9 @@ def training_tester() -> RoFormerTester:
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
 )
-@pytest.mark.skip(
+@pytest.mark.xfail(
     reason=failed_ttmlir_compilation(
-        "failed to legalize operation 'ttir.gather' that was explicitly marked illegal "
+        "failed to legalize operation 'ttir.gather' "
         "https://github.com/tenstorrent/tt-xla/issues/318"
     )
 )

--- a/tests/jax/single_chip/models/roformer/chinese_small/test_roformer_chinese_small.py
+++ b/tests/jax/single_chip/models/roformer/chinese_small/test_roformer_chinese_small.py
@@ -50,9 +50,9 @@ def training_tester() -> RoFormerTester:
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
 )
-@pytest.mark.skip(
+@pytest.mark.xfail(
     reason=failed_ttmlir_compilation(
-        "failed to legalize operation 'ttir.gather' that was explicitly marked illegal "
+        "failed to legalize operation 'ttir.gather' "
         "https://github.com/tenstorrent/tt-xla/issues/318"
     )
 )

--- a/tests/jax/single_chip/models/squeezebert/test_squeezebert.py
+++ b/tests/jax/single_chip/models/squeezebert/test_squeezebert.py
@@ -11,8 +11,8 @@ import torch
 from flax import linen as nn
 from huggingface_hub import hf_hub_download
 from infra import Framework, ModelTester, RunMode
-from transformers import AutoTokenizer
 from jaxtyping import PyTree
+from transformers import AutoTokenizer
 
 from tests.utils import (
     BringupStatus,
@@ -101,7 +101,10 @@ def training_tester() -> SqueezeBertTester:
     bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
 )
 @pytest.mark.xfail(
-    reason=failed_ttmlir_compilation("failed to legalize operation 'ttir.gather'")
+    reason=failed_ttmlir_compilation(
+        "failed to legalize operation 'ttir.gather' "
+        "https://github.com/tenstorrent/tt-xla/issues/318"
+    )
 )
 def test_squeezebert_inference(inference_tester: SqueezeBertTester):
     inference_tester.test()

--- a/tests/jax/single_chip/models/t5/base/test_t5_base.py
+++ b/tests/jax/single_chip/models/t5/base/test_t5_base.py
@@ -51,7 +51,7 @@ def training_tester() -> T5Tester:
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.FAILED_RUNTIME,
 )
-@pytest.mark.skip(
+@pytest.mark.xfail(
     reason=failed_runtime(
         "ttnn::operations::binary::BinaryDeviceOperation: unsupported broadcast "
         "(https://github.com/tenstorrent/tt-xla/issues/505)"

--- a/tests/jax/single_chip/models/t5/large/test_t5_large.py
+++ b/tests/jax/single_chip/models/t5/large/test_t5_large.py
@@ -51,7 +51,7 @@ def training_tester() -> T5Tester:
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.FAILED_RUNTIME,
 )
-@pytest.mark.skip(
+@pytest.mark.xfail(
     reason=failed_runtime(
         "ttnn::operations::binary::BinaryDeviceOperation: unsupported broadcast "
         "(https://github.com/tenstorrent/tt-xla/issues/505)"

--- a/tests/jax/single_chip/models/t5/small/test_t5_small.py
+++ b/tests/jax/single_chip/models/t5/small/test_t5_small.py
@@ -51,7 +51,7 @@ def training_tester() -> T5Tester:
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.FAILED_RUNTIME,
 )
-@pytest.mark.skip(
+@pytest.mark.xfail(
     reason=failed_runtime(
         "ttnn::operations::binary::BinaryDeviceOperation: unsupported broadcast "
         "(https://github.com/tenstorrent/tt-xla/issues/505)"

--- a/tests/jax/single_chip/models/vit/tester.py
+++ b/tests/jax/single_chip/models/vit/tester.py
@@ -2,13 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from infra import ComparisonConfig, ModelTester, RunMode
+from typing import Dict, Sequence
 
+import jax
 import jax.numpy as jnp
 import jax.random as random
-import jax
-
-from typing import Dict, List, Sequence, Tuple, Union
+from infra import ComparisonConfig, ModelTester, RunMode
 from transformers import (
     FlaxPreTrainedModel,
     FlaxViTForImageClassification,
@@ -31,7 +30,11 @@ class ViTTester(ModelTester):
 
     # @override
     def _get_model(self) -> FlaxPreTrainedModel:
-        return FlaxViTForImageClassification.from_pretrained(self._model_path)
+        model = FlaxViTForImageClassification.from_pretrained(
+            self._model_path, dtype=jnp.bfloat16
+        )
+        model.params = model.to_bf16(model.params)
+        return model
 
     # @override
     def _get_input_activations(self) -> jax.Array:

--- a/tests/jax/single_chip/models/vit/vit_base_patch16_224/test_vit_base_patch16_224.py
+++ b/tests/jax/single_chip/models/vit/vit_base_patch16_224/test_vit_base_patch16_224.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_fe_compilation,
+    incorrect_result,
 )
 
 from ..tester import ViTTester
@@ -49,11 +49,12 @@ def training_tester() -> ViTTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
 )
-@pytest.mark.skip(
-    reason=failed_fe_compilation(
-        "OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186)"
+@pytest.mark.xfail(
+    reason=incorrect_result(
+        "Atol comparison failed. Calculated: atol=327681.15625. Required: atol=0.16. "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_vit_base_patch16_224_inference(

--- a/tests/jax/single_chip/models/vit/vit_base_patch16_384/test_vit_base_patch16_384.py
+++ b/tests/jax/single_chip/models/vit/vit_base_patch16_384/test_vit_base_patch16_384.py
@@ -13,7 +13,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_fe_compilation,
+    incorrect_result,
 )
 
 from ..tester import ViTTester
@@ -50,11 +50,12 @@ def training_tester() -> ViTTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
 )
-@pytest.mark.skip(
-    reason=failed_fe_compilation(
-        "OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186)"
+@pytest.mark.xfail(
+    reason=incorrect_result(
+        "Atol comparison failed. Calculated: atol=354305.75. Required: atol=0.16. "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_vit_base_patch16_384_inference(

--- a/tests/jax/single_chip/models/vit/vit_base_patch32_224_in21k/test_vit_base_patch32_224_in21k.py
+++ b/tests/jax/single_chip/models/vit/vit_base_patch32_224_in21k/test_vit_base_patch32_224_in21k.py
@@ -13,7 +13,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_fe_compilation,
+    incorrect_result,
 )
 
 from ..tester import ViTTester
@@ -50,11 +50,12 @@ def training_tester() -> ViTTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
 )
-@pytest.mark.skip(
-    reason=failed_fe_compilation(
-        "OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186)"
+@pytest.mark.xfail(
+    reason=incorrect_result(
+        "Atol comparison failed. Calculated: atol=795.9999389648438. Required: atol=0.16. "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_vit_base_patch32_224_in21k_inference(

--- a/tests/jax/single_chip/models/vit/vit_base_patch32_384/test_vit_base_patch32_384.py
+++ b/tests/jax/single_chip/models/vit/vit_base_patch32_384/test_vit_base_patch32_384.py
@@ -13,7 +13,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_fe_compilation,
+    incorrect_result,
 )
 
 from ..tester import ViTTester
@@ -50,11 +50,12 @@ def training_tester() -> ViTTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
 )
-@pytest.mark.skip(
-    reason=failed_fe_compilation(
-        "OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186)"
+@pytest.mark.xfail(
+    reason=incorrect_result(
+        "Atol comparison failed. Calculated: atol=393216.4375. Required: atol=0.16. "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_vit_base_patch32_384_inference(

--- a/tests/jax/single_chip/models/vit/vit_huge_patch14_224_in21k/test_vit_huge_patch14_224_in21k.py
+++ b/tests/jax/single_chip/models/vit/vit_huge_patch14_224_in21k/test_vit_huge_patch14_224_in21k.py
@@ -13,7 +13,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_fe_compilation,
+    incorrect_result,
 )
 
 from ..tester import ViTTester
@@ -50,11 +50,12 @@ def training_tester() -> ViTTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
 )
-@pytest.mark.skip(
-    reason=failed_fe_compilation(
-        "OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186)"
+@pytest.mark.xfail(
+    reason=incorrect_result(
+        "Atol comparison failed. Calculated: atol=4800.00048828125. Required: atol=0.16. "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_vit_huge_patch14_224_in21k_inference(

--- a/tests/jax/single_chip/models/vit/vit_large_patch16_224/test_vit_large_patch16_224.py
+++ b/tests/jax/single_chip/models/vit/vit_large_patch16_224/test_vit_large_patch16_224.py
@@ -13,7 +13,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_fe_compilation,
+    incorrect_result,
 )
 
 from ..tester import ViTTester
@@ -50,11 +50,12 @@ def training_tester() -> ViTTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
 )
-@pytest.mark.skip(
-    reason=failed_fe_compilation(
-        "OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186)"
+@pytest.mark.xfail(
+    reason=incorrect_result(
+        "Atol comparison failed. Calculated: atol=311296.0. Required: atol=0.16. "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_vit_large_patch16_224_inference(

--- a/tests/jax/single_chip/models/vit/vit_large_patch16_384/test_vit_large_patch16_384.py
+++ b/tests/jax/single_chip/models/vit/vit_large_patch16_384/test_vit_large_patch16_384.py
@@ -13,7 +13,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_fe_compilation,
+    incorrect_result,
 )
 
 from ..tester import ViTTester
@@ -50,11 +50,12 @@ def training_tester() -> ViTTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
 )
-@pytest.mark.skip(
-    reason=failed_fe_compilation(
-        "OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186)"
+@pytest.mark.xfail(
+    reason=incorrect_result(
+        "Atol comparison failed. Calculated: atol=337919.8125. Required: atol=0.16. "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_vit_large_patch16_384_inference(

--- a/tests/jax/single_chip/models/vit/vit_large_patch32_224_in21k/test_vit_large_patch32_224_in21k.py
+++ b/tests/jax/single_chip/models/vit/vit_large_patch32_224_in21k/test_vit_large_patch32_224_in21k.py
@@ -13,7 +13,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_fe_compilation,
+    incorrect_result,
 )
 
 from ..tester import ViTTester
@@ -50,11 +50,12 @@ def training_tester() -> ViTTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
 )
-@pytest.mark.skip(
-    reason=failed_fe_compilation(
-        "OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186)"
+@pytest.mark.xfail(
+    reason=incorrect_result(
+        "Atol comparison failed. Calculated: atol=1351.9998779296875. Required: atol=0.16. "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_vit_large_patch32_224_in21k_inference(

--- a/tests/jax/single_chip/models/vit/vit_large_patch32_384/test_vit_large_patch32_384.py
+++ b/tests/jax/single_chip/models/vit/vit_large_patch32_384/test_vit_large_patch32_384.py
@@ -13,7 +13,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_fe_compilation,
+    failed_runtime,
 )
 
 from ..tester import ViTTester
@@ -50,11 +50,14 @@ def training_tester() -> ViTTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
+    bringup_status=BringupStatus.FAILED_RUNTIME,
 )
-@pytest.mark.skip(
-    reason=failed_fe_compilation(
-        "OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186)"
+@pytest.mark.xfail(
+    reason=failed_runtime(
+        "Statically allocated circular buffers in program 453 clash with L1 "
+        "buffers on core range [(x=0,y=0) - (x=4,y=0)]. L1 buffer allocated at "
+        "622592 and static circular buffer region ends at 654368 "
+        "https://github.com/tenstorrent/tt-xla/issues/187"
     )
 )
 def test_vit_large_patch32_384_inference(

--- a/tests/jax/single_chip/models/whisper/base/test_whisper_base.py
+++ b/tests/jax/single_chip/models/whisper/base/test_whisper_base.py
@@ -51,9 +51,9 @@ def training_tester() -> WhisperTester:
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
 )
-@pytest.mark.skip(
+@pytest.mark.xfail(
     reason=failed_ttmlir_compilation(
-        "failed to legalize operation 'ttir.gather' that was explicitly marked illegal "
+        "failed to legalize operation 'ttir.gather' "
         "https://github.com/tenstorrent/tt-xla/issues/318"
     )
 )

--- a/tests/jax/single_chip/models/whisper/large_v3/test_whisper_large_v3.py
+++ b/tests/jax/single_chip/models/whisper/large_v3/test_whisper_large_v3.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_ttmlir_compilation,
+    failed_fe_compilation,
 )
 
 from ..tester import WhisperTester
@@ -50,12 +50,11 @@ def training_tester() -> WhisperTester:
     model_name=MODEL_NAME,
     model_group=MODEL_GROUP,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
+    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
 )
 @pytest.mark.skip(
-    reason=failed_ttmlir_compilation(
-        "failed to legalize operation 'ttir.gather' that was explicitly marked illegal "
-        "https://github.com/tenstorrent/tt-xla/issues/318"
+    reason=failed_fe_compilation(
+        "OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186)"
     )
 )
 def test_whisper_large_v3_inference(inference_tester: WhisperTester):

--- a/tests/jax/single_chip/models/whisper/medium/test_whisper_medium.py
+++ b/tests/jax/single_chip/models/whisper/medium/test_whisper_medium.py
@@ -51,9 +51,9 @@ def training_tester() -> WhisperTester:
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
 )
-@pytest.mark.skip(
+@pytest.mark.xfail(
     reason=failed_ttmlir_compilation(
-        "failed to legalize operation 'ttir.gather' that was explicitly marked illegal "
+        "failed to legalize operation 'ttir.gather' "
         "https://github.com/tenstorrent/tt-xla/issues/318"
     )
 )

--- a/tests/jax/single_chip/models/xlm_roberta/large/test_xlm_roberta_large.py
+++ b/tests/jax/single_chip/models/xlm_roberta/large/test_xlm_roberta_large.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_fe_compilation,
+    incorrect_result,
 )
 
 from ..tester import XLMRobertaTester
@@ -48,11 +48,12 @@ def training_tester() -> XLMRobertaTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
 )
-@pytest.mark.skip(
-    reason=failed_fe_compilation(
-        "OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186)"
+@pytest.mark.xfail(
+    reason=incorrect_result(
+        "Atol comparison failed. Calculated: atol=131073.1875. Required: atol=0.16. "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_xlm_roberta_large_inference(inference_tester: XLMRobertaTester):


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/186

### Problem description
We were skipping all new model tests until my change for host memory improvements lands, now those tests that fit under 32GB RAM can be unskipped. I've used 28GB as a conservative threshold to make sure nightly will be stable.

### What's changed
Unskipped all tests that fit under 28GB RAM usage.

### Checklist
- [x] New/Existing tests provide coverage for changes
- [x] Nightly CI [passed](https://github.com/tenstorrent/tt-xla/actions/runs/14565468175) on branch
