### PR TITLE
Store binary as shared_ptr, add mutable ref accessor

### DIFF
--- a/inc/common/pjrt_implementation/executable_image.h
+++ b/inc/common/pjrt_implementation/executable_image.h
@@ -34,7 +34,7 @@ public:
   // Creates new executable image instance from the information given by the
   // compiler.
   static std::shared_ptr<ExecutableImage> createInstance(
-      const tt::runtime::Binary &flatbuffer_binary,
+      std::shared_ptr<tt::runtime::Binary> flatbuffer_binary,
       std::string &&optimized_mlir_code, std::string &&executable_name,
       size_t num_partitions, size_t num_replicas, size_t num_devices_to_utilize,
       const std::vector<std::uint32_t> &devices_mesh_shape,
@@ -45,12 +45,10 @@ public:
 
   // Returns flatbuffer binary produced by the compiler.
   const tt::runtime::Binary &getFlatbufferBinary() const {
-    return m_flatbuffer_binary;
+    return *m_flatbuffer_binary;
   }
 
-  tt::runtime::Binary &getFlatbufferBinary() {
-    return m_flatbuffer_binary;
-  }
+  tt::runtime::Binary &getFlatbufferBinary() { return *m_flatbuffer_binary; }
 
   // Returns optimized mlir code produced by the compiler.
   const std::string &getOptimizedMlirCode() const {
@@ -106,7 +104,7 @@ private:
   // Constructs executable image instance from the information given by the
   // compiler.
   ExecutableImage(
-      const tt::runtime::Binary &flatbuffer_binary,
+      std::shared_ptr<tt::runtime::Binary> flatbuffer_binary,
       std::string &&optimized_mlir_code, std::string &&executable_name,
       size_t num_partitions, size_t num_replicas, size_t num_devices_to_utilize,
       const std::vector<std::uint32_t> &devices_mesh_shape,
@@ -116,7 +114,7 @@ private:
       const std::vector<bool> &is_output_scalar);
 
   // Flatbuffer binary produced by the compiler.
-  tt::runtime::Binary m_flatbuffer_binary;
+  std::shared_ptr<tt::runtime::Binary> m_flatbuffer_binary;
 
   // Optimized mlir code produced by the compiler, stored for debugging
   // purposes.

--- a/inc/common/pjrt_implementation/executable_image.h
+++ b/inc/common/pjrt_implementation/executable_image.h
@@ -48,6 +48,10 @@ public:
     return m_flatbuffer_binary;
   }
 
+  tt::runtime::Binary &getFlatbufferBinary() {
+    return m_flatbuffer_binary;
+  }
+
   // Returns optimized mlir code produced by the compiler.
   const std::string &getOptimizedMlirCode() const {
     return m_optimized_mlir_code;

--- a/src/common/module_builder.cc
+++ b/src/common/module_builder.cc
@@ -519,14 +519,17 @@ void ModuleBuilder::convertFromTTIRToTTNN(
 
 void ModuleBuilder::createFlatbufferBinary(
     const mlir::OwningOpRef<mlir::ModuleOp> &mlir_module) {
-  tt::runtime::Binary binary = mlir::tt::ttnn::ttnnToFlatbuffer(mlir_module.get());
-  m_flatbuffer_binary = std::make_shared<tt::runtime::Binary>(std::move(binary));
+  tt::runtime::Binary binary =
+      mlir::tt::ttnn::ttnnToFlatbuffer(mlir_module.get());
+  m_flatbuffer_binary =
+      std::make_shared<tt::runtime::Binary>(std::move(binary));
 
   verifyCreatedFlatbufferBinary();
 }
 
 void ModuleBuilder::verifyCreatedFlatbufferBinary() {
-  if (m_flatbuffer_binary == nullptr || m_flatbuffer_binary->handle == nullptr) {
+  if (m_flatbuffer_binary == nullptr ||
+      m_flatbuffer_binary->handle == nullptr) {
     DLOG_F(ERROR, "Failed to generate flatbuffer binary");
     m_status = tt_pjrt_status::kInternal;
     return;

--- a/src/common/module_builder.h
+++ b/src/common/module_builder.h
@@ -37,6 +37,11 @@ public:
 
   // Returns compiled flatbuffer binary.
   const tt::runtime::Binary &getFlatbufferBinary() const {
+    return *m_flatbuffer_binary;
+  }
+
+  // Returns a shared_ptr to the compiled flatbuffer binary.
+  std::shared_ptr<tt::runtime::Binary> getSharedFlatbufferBinary() const {
     return m_flatbuffer_binary;
   }
 
@@ -173,7 +178,7 @@ private:
   std::unique_ptr<mlir::MLIRContext> m_context;
 
   // Compiled flatbuffer binary.
-  tt::runtime::Binary m_flatbuffer_binary;
+  std::shared_ptr<tt::runtime::Binary> m_flatbuffer_binary;
 
   // Holds status of the last builder action.
   tt_pjrt_status m_status;

--- a/src/common/pjrt_implementation/client_instance.cc
+++ b/src/common/pjrt_implementation/client_instance.cc
@@ -144,7 +144,7 @@ ClientInstance::compileMlirProgram(const PJRT_Program *mlir_program,
 
   std::shared_ptr<ExecutableImage> executable_image =
       ExecutableImage::createInstance(
-          m_module_builder->getFlatbufferBinary(),
+          m_module_builder->getSharedFlatbufferBinary(),
           std::move(optimized_mlir_code), std::move(executable_name),
           m_module_builder->getNumPartitions(),
           m_module_builder->getNumReplicas(),

--- a/src/common/pjrt_implementation/executable_image.cc
+++ b/src/common/pjrt_implementation/executable_image.cc
@@ -15,7 +15,7 @@
 namespace tt::pjrt {
 
 std::shared_ptr<ExecutableImage> ExecutableImage::createInstance(
-    const tt::runtime::Binary &flatbuffer_binary,
+    std::shared_ptr<tt::runtime::Binary> flatbuffer_binary,
     std::string &&optimized_mlir_code, std::string &&executable_name,
     size_t num_partitions, size_t num_replicas, size_t num_devices_to_utilize,
     const std::vector<std::uint32_t> &devices_mesh_shape,
@@ -24,7 +24,7 @@ std::shared_ptr<ExecutableImage> ExecutableImage::createInstance(
     const std::vector<bool> &is_output_scalar) {
   struct make_shared_enabler : public ExecutableImage {
     make_shared_enabler(
-        const tt::runtime::Binary &flatbuffer_binary,
+        std::shared_ptr<tt::runtime::Binary> flatbuffer_binary,
         std::string &&optimized_mlir_code, std::string &&executable_name,
         size_t num_partitions, size_t num_replicas,
         size_t num_devices_to_utilize,
@@ -34,7 +34,7 @@ std::shared_ptr<ExecutableImage> ExecutableImage::createInstance(
         const std::vector<mlir::tt::sharding_utils::MeshSharding>
             &output_sharding,
         const std::vector<bool> &is_output_scalar)
-        : ExecutableImage(flatbuffer_binary, std::move(optimized_mlir_code),
+        : ExecutableImage(std::move(flatbuffer_binary), std::move(optimized_mlir_code),
                           std::move(executable_name), num_partitions,
                           num_replicas, num_devices_to_utilize,
                           devices_mesh_shape, input_sharding, output_sharding,
@@ -42,21 +42,21 @@ std::shared_ptr<ExecutableImage> ExecutableImage::createInstance(
   };
 
   return std::make_shared<make_shared_enabler>(
-      flatbuffer_binary, std::move(optimized_mlir_code),
+      std::move(flatbuffer_binary), std::move(optimized_mlir_code),
       std::move(executable_name), num_partitions, num_replicas,
       num_devices_to_utilize, devices_mesh_shape, input_sharding,
       output_sharding, is_output_scalar);
 }
 
 ExecutableImage::ExecutableImage(
-    const tt::runtime::Binary &flatbuffer_binary,
+    std::shared_ptr<tt::runtime::Binary> flatbuffer_binary,
     std::string &&optimized_mlir_code, std::string &&executable_name,
     size_t num_partitions, size_t num_replicas, size_t num_devices_to_utilize,
     const std::vector<std::uint32_t> &devices_mesh_shape,
     const std::vector<mlir::tt::sharding_utils::MeshSharding> &input_sharding,
     const std::vector<mlir::tt::sharding_utils::MeshSharding> &output_sharding,
     const std::vector<bool> &is_output_scalar)
-    : m_flatbuffer_binary(flatbuffer_binary),
+    : m_flatbuffer_binary(std::move(flatbuffer_binary)),
       m_optimized_mlir_code(std::move(optimized_mlir_code)),
       m_executable_name(std::move(executable_name)),
       m_num_partitions(num_partitions), m_num_replicas(num_replicas),
@@ -66,9 +66,9 @@ ExecutableImage::ExecutableImage(
 
   // Assuming only one program per flatbuffer for now.
   std::uint32_t program_index = 0;
-  m_num_inputs = m_flatbuffer_binary.getProgramInputs(program_index).size();
+  m_num_inputs = m_flatbuffer_binary->getProgramInputs(program_index).size();
   std::vector<tt::runtime::TensorDesc> output_specs =
-      m_flatbuffer_binary.getProgramOutputs(program_index);
+      m_flatbuffer_binary->getProgramOutputs(program_index);
   m_num_outputs = output_specs.size();
 
   // We expect that these conditions are satisfied and checked in module builder

--- a/src/common/pjrt_implementation/executable_image.cc
+++ b/src/common/pjrt_implementation/executable_image.cc
@@ -34,11 +34,11 @@ std::shared_ptr<ExecutableImage> ExecutableImage::createInstance(
         const std::vector<mlir::tt::sharding_utils::MeshSharding>
             &output_sharding,
         const std::vector<bool> &is_output_scalar)
-        : ExecutableImage(std::move(flatbuffer_binary), std::move(optimized_mlir_code),
-                          std::move(executable_name), num_partitions,
-                          num_replicas, num_devices_to_utilize,
-                          devices_mesh_shape, input_sharding, output_sharding,
-                          is_output_scalar) {}
+        : ExecutableImage(
+              std::move(flatbuffer_binary), std::move(optimized_mlir_code),
+              std::move(executable_name), num_partitions, num_replicas,
+              num_devices_to_utilize, devices_mesh_shape, input_sharding,
+              output_sharding, is_output_scalar) {}
   };
 
   return std::make_shared<make_shared_enabler>(


### PR DESCRIPTION
### Problem description
This tt-mlir PR: https://github.com/tenstorrent/tt-mlir/pull/2756  makes it so `submit()` takes a reference to a binary instead of a value.  We need a new accessor s.t. we can pass a mutable ref into submit, and we want to share the same binary object throughout code, because `submit()` can modify the object's cache now.

### What's changed
non-const ref accessor for binary so that we can use it with submit(), changed binary to be stored + passed as `std::shared_ptr` to ensure the same underlying object is used everywhere

### Checklist
- [x] New/Existing tests provide coverage for changes
