### PR TITLE
convert the weights of Blenderbot to bf16

### DIFF
--- a/tests/jax/single_chip/models/blenderbot/tester.py
+++ b/tests/jax/single_chip/models/blenderbot/tester.py
@@ -28,9 +28,11 @@ class BlenderBotTester(ModelTester):
 
     # @override
     def _get_model(self) -> FlaxPreTrainedModel:
-        return FlaxBlenderbotForConditionalGeneration.from_pretrained(
+        model = FlaxBlenderbotForConditionalGeneration.from_pretrained(
             self._model_path, from_pt=True
         )
+        model.params = model.to_bf16(model.params)
+        return model
 
     # @override
     def _get_input_activations(self) -> Dict[str, jax.Array]:


### PR DESCRIPTION
### Problem description
update the weight of blenderbot model to bf16() as current weights are not supported

### Checklist
- [x] New/Existing tests provide coverage for changes

Attaching the logs

[bb400m_distill.log](https://github.com/user-attachments/files/19865662/bb400m_distill.log)
