### PR TITLE
Fixing the calculation of the output shape for multidevice runs

### DIFF
--- a/inc/common/pjrt_implementation/loaded_executable_instance.h
+++ b/inc/common/pjrt_implementation/loaded_executable_instance.h
@@ -132,8 +132,7 @@ private:
       size_t num_devices, PJRT_Buffer **const *output_lists);
 
   // Returns the shape of the output on the specified index.
-  std::vector<std::uint32_t> getOutputShape(size_t output_index,
-                                            size_t num_devices);
+  std::vector<std::uint32_t> getOutputShape(size_t output_index);
 
   // Executable image instance which is shared between executable and loaded
   // executable instances.


### PR DESCRIPTION
Currently, we reliad on the `sharding_strategy` map to calculate what is the output of the individual output shards of our program. This can be wrong for shardings of tensors of rank bigger than 2, and incorrect for some usages in `torchax`. Switched to using `shard_shape` from `sharding_utils::MeshSharding` to calculate the output shard shape.

Closes https://github.com/tenstorrent/tt-xla/issues/526