### PR TITLE
Adding 2x4 mesh to tests

### DIFF
--- a/tests/jax/multi_chip/llmbox/8_devices/graphs/tensor_parallel/test_dot_psum.py
+++ b/tests/jax/multi_chip/llmbox/8_devices/graphs/tensor_parallel/test_dot_psum.py
@@ -28,6 +28,7 @@ from tests.utils import failed_fe_compilation
     ("batch_shape", "W1_shape", "B1_shape", "mesh_shape", "axis_names"),
     [
         ((8192, 784), (784, 2048), (2048), (1, 8), ("batch", "model")),
+        ((8192, 784), (784, 2048), (2048), (2, 4), ("batch", "model")),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/jax/multi_chip/llmbox/8_devices/ops/data_parallel/batch_sharded/test_all_gather.py
+++ b/tests/jax/multi_chip/llmbox/8_devices/ops/data_parallel/batch_sharded/test_all_gather.py
@@ -24,7 +24,11 @@ from tests.utils import failed_fe_compilation
     ],
 )
 @pytest.mark.parametrize(
-    ("x_shape", "mesh_shape", "axis_names"), [((8192, 784), (1, 8), ("batch", "model"))]
+    ("x_shape", "mesh_shape", "axis_names"),
+    [
+        ((8192, 784), (1, 8), ("batch", "model")),
+        ((8192, 784), (2, 4), ("batch", "model")),
+    ],
 )
 @pytest.mark.parametrize(
     "sharding_mode",

--- a/tests/jax/multi_chip/llmbox/8_devices/ops/data_parallel/batch_sharded/test_psum.py
+++ b/tests/jax/multi_chip/llmbox/8_devices/ops/data_parallel/batch_sharded/test_psum.py
@@ -28,6 +28,7 @@ from tests.utils import failed_fe_compilation
     ("batch_shape", "mesh_shape", "axis_names"),
     [
         ((2048, 2048), (1, 8), ("batch", "model")),
+        ((2048, 2048), (2, 4), ("batch", "model")),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/jax/multi_chip/llmbox/8_devices/ops/tensor_parallel/test_negative_op.py
+++ b/tests/jax/multi_chip/llmbox/8_devices/ops/tensor_parallel/test_negative_op.py
@@ -23,7 +23,11 @@ from tests.utils import failed_fe_compilation
     ],
 )
 @pytest.mark.parametrize(
-    ("input_shape", "mesh_shape", "axis_names"), [((256, 256), (1, 8), ("x", "y"))]
+    ("input_shape", "mesh_shape", "axis_names"),
+    [
+        ((256, 256), (2, 4), ("x", "y")),
+        ((256, 256), (1, 8), ("x", "y")),
+    ],
 )
 @pytest.mark.parametrize(
     "multichip_mode",


### PR DESCRIPTION
For tests that are currently running in 1x8 mesh configuration for devices, adding 2x4 tests