### PR TITLE
Skip whisper

### DIFF
--- a/tests/jax/single_chip/models/whisper/base/test_whisper_base.py
+++ b/tests/jax/single_chip/models/whisper/base/test_whisper_base.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_ttmlir_compilation,
+    failed_fe_compilation,
 )
 
 from ..tester import WhisperTester
@@ -51,10 +51,9 @@ def training_tester() -> WhisperTester:
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
 )
-@pytest.mark.xfail(
-    reason=failed_ttmlir_compilation(
-        "failed to legalize operation 'ttir.gather' "
-        "https://github.com/tenstorrent/tt-xla/issues/318"
+@pytest.mark.skip(
+    reason=failed_fe_compilation(
+        "Segfault (https://github.com/tenstorrent/tt-xla/issues/546)"
     )
 )
 def test_whisper_base_inference(inference_tester: WhisperTester):

--- a/tests/jax/single_chip/models/whisper/medium/test_whisper_medium.py
+++ b/tests/jax/single_chip/models/whisper/medium/test_whisper_medium.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_ttmlir_compilation,
+    failed_fe_compilation,
 )
 
 from ..tester import WhisperTester
@@ -51,10 +51,9 @@ def training_tester() -> WhisperTester:
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
 )
-@pytest.mark.xfail(
-    reason=failed_ttmlir_compilation(
-        "failed to legalize operation 'ttir.gather' "
-        "https://github.com/tenstorrent/tt-xla/issues/318"
+@pytest.mark.skip(
+    reason=failed_fe_compilation(
+        "Segfault (https://github.com/tenstorrent/tt-xla/issues/546)"
     )
 )
 def test_whisper_medium_inference(inference_tester: WhisperTester):


### PR DESCRIPTION
Tests for Whisper started segfaulting after a recent MLIR uplift. This PR skips Whisper tests to unblock nightly CI runs.

Related issue #546 
