### PR TITLE
Skip Resnet model variants causing segfault

### DIFF
--- a/tests/jax/single_chip/models/resnet_v1_5/resnet_101/test_resnet_101.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/resnet_101/test_resnet_101.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_ttmlir_compilation,
+    failed_fe_compilation,
 )
 
 from ..tester import ResNetTester, ResNetVariant
@@ -49,11 +49,11 @@ def training_tester() -> ResNetTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
+    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
 )
-@pytest.mark.xfail(
-    reason=failed_ttmlir_compilation(
-        "failed to legalize operation 'stablehlo.reduce_window'"
+@pytest.mark.skip(
+    reason=failed_fe_compilation(
+        "Segfault (https://github.com/tenstorrent/tt-xla/issues/558)"
     )
 )
 def test_resnet_v1_5_101_inference(inference_tester: ResNetTester):

--- a/tests/jax/single_chip/models/resnet_v1_5/resnet_152/test_resnet_152.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/resnet_152/test_resnet_152.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_ttmlir_compilation,
+    failed_fe_compilation,
 )
 
 from ..tester import ResNetTester, ResNetVariant
@@ -49,11 +49,11 @@ def training_tester() -> ResNetTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
+    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
 )
-@pytest.mark.xfail(
-    reason=failed_ttmlir_compilation(
-        "failed to legalize operation 'stablehlo.reduce_window'"
+@pytest.mark.skip(
+    reason=failed_fe_compilation(
+        "Segfault (https://github.com/tenstorrent/tt-xla/issues/558)"
     )
 )
 def test_resnet_v1_5_152_inference(inference_tester: ResNetTester):


### PR DESCRIPTION
Tests for Resnet started segfaulting

This PR skips  resnet_152 &resnet_101 variants

Related issue : https://github.com/tenstorrent/tt-xla/issues/558
