### PR TITLE
Skip all resnet model variants

### DIFF
--- a/tests/jax/single_chip/models/resnet_v1_5/resnet_18/test_resnet_18.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/resnet_18/test_resnet_18.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_ttmlir_compilation,
+    failed_fe_compilation,
 )
 
 from ..tester import ResNetTester, ResNetVariant
@@ -50,11 +50,11 @@ def training_tester() -> ResNetTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
+    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
 )
-@pytest.mark.xfail(
-    reason=failed_ttmlir_compilation(
-        "failed to legalize operation 'stablehlo.reduce_window'"
+@pytest.mark.skip(
+    reason=failed_fe_compilation(
+        "Crashes in CI https://github.com/tenstorrent/tt-xla/issues/560"
     )
 )
 def test_resnet_v1_5_18_inference(inference_tester: ResNetTester):

--- a/tests/jax/single_chip/models/resnet_v1_5/resnet_26/test_resnet_26.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/resnet_26/test_resnet_26.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_ttmlir_compilation,
+    failed_fe_compilation,
 )
 
 from ..tester import ResNetTester, ResNetVariant
@@ -49,11 +49,11 @@ def training_tester() -> ResNetTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
+    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
 )
-@pytest.mark.xfail(
-    reason=failed_ttmlir_compilation(
-        "failed to legalize operation 'stablehlo.reduce_window'"
+@pytest.mark.skip(
+    reason=failed_fe_compilation(
+        "Crashes in CI https://github.com/tenstorrent/tt-xla/issues/560"
     )
 )
 def test_resnet_v1_5_26_inference(inference_tester: ResNetTester):

--- a/tests/jax/single_chip/models/resnet_v1_5/resnet_34/test_resnet_34.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/resnet_34/test_resnet_34.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_ttmlir_compilation,
+    failed_fe_compilation,
 )
 
 from ..tester import ResNetTester, ResNetVariant
@@ -49,11 +49,11 @@ def training_tester() -> ResNetTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
+    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
 )
-@pytest.mark.xfail(
-    reason=failed_ttmlir_compilation(
-        "failed to legalize operation 'stablehlo.reduce_window'"
+@pytest.mark.skip(
+    reason=failed_fe_compilation(
+        "Crashes in CI https://github.com/tenstorrent/tt-xla/issues/560"
     )
 )
 def test_resnet_v1_5_34_inference(inference_tester: ResNetTester):

--- a/tests/jax/single_chip/models/resnet_v1_5/resnet_50/test_resnet_50.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/resnet_50/test_resnet_50.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_ttmlir_compilation,
+    failed_fe_compilation,
 )
 
 from ..tester import ResNetTester, ResNetVariant
@@ -49,11 +49,11 @@ def training_tester() -> ResNetTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
+    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
 )
-@pytest.mark.xfail(
-    reason=failed_ttmlir_compilation(
-        "failed to legalize operation 'stablehlo.reduce_window'"
+@pytest.mark.skip(
+    reason=failed_fe_compilation(
+        "Crashes in CI https://github.com/tenstorrent/tt-xla/issues/560"
     )
 )
 def test_resnet_v1_5_50_inference(inference_tester: ResNetTester):


### PR DESCRIPTION
Resnet model variants are killed in CI. So skipped all resnet variants .

Ref : https://github.com/tenstorrent/tt-xla/issues/560


