### PR TITLE
Add a semi-automatic shard reshape test

### DIFF
--- a/tests/infra/multichip_tester.py
+++ b/tests/infra/multichip_tester.py
@@ -133,7 +133,6 @@ class MultichipTester(BaseTester):
                 mesh=self.cpu_mesh,
                 in_specs=self.in_specs,
                 out_specs=self.out_specs,
-                check_rep=False,
             )
             if sharding_mode.requires_shard_map
             else executable
@@ -158,7 +157,6 @@ class MultichipTester(BaseTester):
                 mesh=self.device_mesh,
                 in_specs=self.in_specs,
                 out_specs=self.out_specs,
-                check_rep=False,
             )
             if sharding_mode.requires_shard_map
             else executable

--- a/tests/infra/multichip_tester.py
+++ b/tests/infra/multichip_tester.py
@@ -133,6 +133,7 @@ class MultichipTester(BaseTester):
                 mesh=self.cpu_mesh,
                 in_specs=self.in_specs,
                 out_specs=self.out_specs,
+                check_rep=False,
             )
             if sharding_mode.requires_shard_map
             else executable
@@ -157,6 +158,7 @@ class MultichipTester(BaseTester):
                 mesh=self.device_mesh,
                 in_specs=self.in_specs,
                 out_specs=self.out_specs,
+                check_rep=False,
             )
             if sharding_mode.requires_shard_map
             else executable

--- a/tests/jax/multi_chip/n300/ops/tensor_parallel/test_reshard.py
+++ b/tests/jax/multi_chip/n300/ops/tensor_parallel/test_reshard.py
@@ -13,27 +13,28 @@ from infra import (
 
 from tests.utils import failed_ttmlir_compilation, incorrect_result
 
+
 def conditionally_skip(use_shardy: bool, sharding_mode: ShardingMode):
     """
     Helper function which checks test input combinations and xfails if necessary.
 
     Extracted here in order not to pollute the test function.
     """
-    if (not use_shardy and sharding_mode == ShardingMode.INPUTS):
-         pytest.xfail(
+    if not use_shardy and sharding_mode == ShardingMode.INPUTS:
+        pytest.xfail(
             failed_ttmlir_compilation(
                 "Sharding constraint not supported in tt-mlir "
                 "(https://github.com/tenstorrent/tt-xla/issues/563)"
             )
         )
-    if (not use_shardy and sharding_mode == ShardingMode.INPUTS_AND_MODULE):
+    if not use_shardy and sharding_mode == ShardingMode.INPUTS_AND_MODULE:
         pytest.xfail(
             incorrect_result(
                 "GSPMD sharding compilation has problems with reshaping "
                 "(https://github.com/tenstorrent/tt-xla/issues/564)"
             )
         )
-    
+
 
 @pytest.mark.nightly
 @pytest.mark.push
@@ -49,7 +50,7 @@ def conditionally_skip(use_shardy: bool, sharding_mode: ShardingMode):
                 )
             ),
         ),
-        False
+        False,
     ],
 )
 @pytest.mark.parametrize(
@@ -72,7 +73,9 @@ def test_add_reshard(
     conditionally_skip(use_shardy, sharding_mode)
 
     def fwd(a_block):
-        b_block = jax.lax.with_sharding_constraint(a_block, make_partition_spec([None, None]))
+        b_block = jax.lax.with_sharding_constraint(
+            a_block, make_partition_spec([None, None])
+        )
         return b_block
 
     in_specs = (make_partition_spec(axis_names),)

--- a/tests/jax/multi_chip/n300/ops/tensor_parallel/test_reshard.py
+++ b/tests/jax/multi_chip/n300/ops/tensor_parallel/test_reshard.py
@@ -27,13 +27,6 @@ def conditionally_skip(use_shardy: bool, sharding_mode: ShardingMode):
                 "(https://github.com/tenstorrent/tt-xla/issues/563)"
             )
         )
-    if not use_shardy and sharding_mode == ShardingMode.INPUTS_AND_MODULE:
-        pytest.xfail(
-            incorrect_result(
-                "GSPMD sharding compilation has problems with reshaping "
-                "(https://github.com/tenstorrent/tt-xla/issues/564)"
-            )
-        )
 
 
 @pytest.mark.nightly
@@ -79,7 +72,7 @@ def test_add_reshard(
         return b_block
 
     in_specs = (make_partition_spec(axis_names),)
-    out_specs = make_partition_spec([None, None])
+    out_specs = make_partition_spec([axis_names[1], axis_names[0]])
 
     run_multichip_test_with_random_inputs(
         fwd,


### PR DESCRIPTION
As part of the efforts to include semi-automatic sharding support in tt-xla, with `jax.lax.with_sharding_constraint()` calls, needed for `torchax, adding a (currently xfailed) semi-automatic sharding test, with the appropriate issues opened for fixing the current errors.