### PR TITLE
Add Tests for VisionTextDualEncoder model

### DIFF
--- a/tests/infra/__init__.py
+++ b/tests/infra/__init__.py
@@ -8,5 +8,5 @@ from .graph_tester import run_graph_test, run_graph_test_with_random_inputs
 from .model_tester import ModelTester, RunMode
 from .multichip_tester import run_multichip_test_with_random_inputs
 from .op_tester import run_op_test, run_op_test_with_random_inputs
-from .utils import Framework, random_tensor
+from .utils import Framework, random_tensor, create_random_input_image
 from .multichip_utils import make_partition_spec, enable_shardy, ShardingMode

--- a/tests/infra/utils.py
+++ b/tests/infra/utils.py
@@ -23,6 +23,13 @@ def _str_to_dtype(dtype_str: str, framework: Framework = Framework.JAX):
         raise ValueError(f"Unsupported framework: {framework.value}.")
 
 
+def create_random_input_image(image_size: int) -> jax.Array:
+    """Create a random input image with the given image size."""
+    return random_tensor(
+        (image_size, image_size, 3), dtype=jnp.uint8, minval=0, maxval=256
+    )
+
+
 @run_on_cpu
 def random_tensor(
     shape: tuple,

--- a/tests/jax/single_chip/models/dinov2/tester.py
+++ b/tests/jax/single_chip/models/dinov2/tester.py
@@ -7,7 +7,7 @@ from typing import Dict, Sequence
 import jax
 import jax.numpy as jnp
 import jax.random as random
-from infra import ComparisonConfig, ModelTester, RunMode
+from infra import ComparisonConfig, ModelTester, RunMode, create_random_input_image
 from transformers import (
     AutoImageProcessor,
     Dinov2Config,
@@ -36,10 +36,7 @@ class Dinov2Tester(ModelTester):
     def _get_input_activations(self) -> jax.Array:
         model_config = Dinov2Config.from_pretrained(self._model_path)
         image_size = model_config.image_size
-        key = random.PRNGKey(0)
-        random_image = random.randint(
-            key, (image_size, image_size, 3), 0, 256, dtype=jnp.uint8
-        )
+        random_image = create_random_input_image(image_size)
 
         processor = AutoImageProcessor.from_pretrained(self._model_path)
         inputs = processor(images=random_image, return_tensors="jax")

--- a/tests/jax/single_chip/models/visiontextdualencoder/test_visiontextdualencoder.py
+++ b/tests/jax/single_chip/models/visiontextdualencoder/test_visiontextdualencoder.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from infra import Framework, RunMode
+
+from tests.utils import (
+    BringupStatus,
+    Category,
+    ModelGroup,
+    ModelSource,
+    ModelTask,
+    build_model_name,
+    incorrect_result,
+)
+
+from .tester import VisionTextDualEncoderTester
+
+IMAGE_MODEL_PATH = "google/vit-base-patch16-224"
+TEXT_MODEL_PATH = "google-bert/bert-base-uncased"
+MODEL_NAME = build_model_name(
+    Framework.JAX,
+    "vision_text_dual_encoder",
+    "vit_base_patch16_224_bert_base",
+    ModelTask.MM_IMAGE_TTT,
+    ModelSource.HUGGING_FACE,
+)
+
+# ----- Fixtures -----
+
+
+@pytest.fixture
+def inference_tester() -> VisionTextDualEncoderTester:
+    return VisionTextDualEncoderTester(IMAGE_MODEL_PATH, TEXT_MODEL_PATH)
+
+
+@pytest.fixture
+def training_tester() -> VisionTextDualEncoderTester:
+    return VisionTextDualEncoderTester(
+        IMAGE_MODEL_PATH, TEXT_MODEL_PATH, RunMode.TRAINING
+    )
+
+
+# ----- Tests -----
+
+
+@pytest.mark.model_test
+@pytest.mark.record_test_properties(
+    category=Category.MODEL_TEST,
+    model_name=MODEL_NAME,
+    model_group=ModelGroup.GENERALITY,
+    run_mode=RunMode.INFERENCE,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
+)
+@pytest.mark.xfail(
+    reason=incorrect_result(
+        "Atol comparison failed. Calculated: atol=6632.052734375. Required: atol=0.16. "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
+    )
+)
+def test_vision_text_dual_encoder_inference(
+    inference_tester: VisionTextDualEncoderTester,
+):
+    inference_tester.test()
+
+
+@pytest.mark.nightly
+@pytest.mark.record_test_properties(
+    category=Category.MODEL_TEST,
+    model_name=MODEL_NAME,
+    model_group=ModelGroup.GENERALITY,
+    run_mode=RunMode.TRAINING,
+)
+@pytest.mark.skip(reason="Support for training not implemented")
+def test_vision_text_dual_encoder_training(
+    training_tester: VisionTextDualEncoderTester,
+):
+    training_tester.test()

--- a/tests/jax/single_chip/models/visiontextdualencoder/tester.py
+++ b/tests/jax/single_chip/models/visiontextdualencoder/tester.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Dict, Sequence
+
+import jax
+import jax.numpy as jnp
+import jax.random as random
+from infra import ComparisonConfig, ModelTester, RunMode, create_random_input_image
+from transformers import (
+    FlaxPreTrainedModel,
+    FlaxVisionTextDualEncoderModel,
+    VisionTextDualEncoderProcessor,
+    AutoImageProcessor,
+    AutoTokenizer,
+    ViTConfig,
+)
+
+
+class VisionTextDualEncoderTester(ModelTester):
+    """Tester for Vision-Text Dual Encoder (VTDE) model."""
+
+    def __init__(
+        self,
+        vision_model_path: str,
+        text_model_path: str,
+        comparison_config: ComparisonConfig = ComparisonConfig(),
+        run_mode: RunMode = RunMode.INFERENCE,
+    ) -> None:
+        self._vision_model_path = vision_model_path
+        self._text_model_path = text_model_path
+        super().__init__(comparison_config, run_mode)
+
+    # @override
+    def _get_model(self) -> FlaxPreTrainedModel:
+        return FlaxVisionTextDualEncoderModel.from_vision_text_pretrained(
+            self._vision_model_path, self._text_model_path
+        )
+
+    # @override
+    def _get_input_activations(self) -> Dict[str, jax.Array]:
+        model_config = ViTConfig.from_pretrained(self._vision_model_path)
+        image_size = model_config.image_size
+        random_image = create_random_input_image(image_size)
+
+        tokenizer = AutoTokenizer.from_pretrained(self._text_model_path)
+        image_processor = AutoImageProcessor.from_pretrained(self._vision_model_path)
+        processor = VisionTextDualEncoderProcessor(image_processor, tokenizer)
+
+        inputs = processor(
+            text="Some random image", images=random_image, return_tensors="jax"
+        )
+        return inputs
+
+    # @override
+    def _get_forward_method_kwargs(self) -> Dict[str, jax.Array]:
+        assert hasattr(self._get_model(), "params")
+        return {
+            "params": self._get_model().params,
+            **self._get_input_activations(),
+        }
+
+    # @override
+    def _get_static_argnames(self) -> Sequence[str]:
+        return ["train"]

--- a/tests/jax/single_chip/models/vit/tester.py
+++ b/tests/jax/single_chip/models/vit/tester.py
@@ -7,7 +7,7 @@ from typing import Dict, Sequence
 import jax
 import jax.numpy as jnp
 import jax.random as random
-from infra import ComparisonConfig, ModelTester, RunMode
+from infra import ComparisonConfig, ModelTester, RunMode, create_random_input_image
 from transformers import (
     FlaxPreTrainedModel,
     FlaxViTForImageClassification,
@@ -40,10 +40,7 @@ class ViTTester(ModelTester):
     def _get_input_activations(self) -> jax.Array:
         model_config = ViTConfig.from_pretrained(self._model_path)
         image_size = model_config.image_size
-        key = random.PRNGKey(0)
-        random_image = random.randint(
-            key, (image_size, image_size, 3), 0, 256, dtype=jnp.uint8
-        )
+        random_image = create_random_input_image(image_size)
 
         processor = ViTImageProcessor.from_pretrained(self._model_path)
         inputs = processor(images=random_image, return_tensors="jax")


### PR DESCRIPTION
### Ticket
closes #575 

### Problem description
Add tests forVisionTextDualEncoder model

### What's changed
A tester class is added which includes a text model and a vision model to test `VisionTextDualEncoderModel`

### Changes made in revision2:
* created create_random_input_image function inside input_utils.py file
* updated all vision tester files to use create_random_input_image function

### Checklist
- [x] New/Existing tests provide coverage for changes


Logs are attached:

[dinov2_large.log](https://github.com/user-attachments/files/20155015/dinov2_large.log)
[VTDE.log](https://github.com/user-attachments/files/20155018/VTDE.log)
[vit_large_patch16.log](https://github.com/user-attachments/files/20155023/vit_large_patch16.log)

