### PR TITLE
Added shardy passes to propagate input shardings when not doing fully automatic sharding

### DIFF
--- a/src/common/module_builder.cc
+++ b/src/common/module_builder.cc
@@ -165,9 +165,10 @@ void ModuleBuilder::convertFromVHLOToSHLO(
   if (isUsingShardy(mlir_module)) {
     mlir::PassManager shardy_pm(mlir_module.get()->getName());
     mlir::sdy::addSdyRoundTripImportPipeline(shardy_pm);
-    // If we are not using SHardy manual computation, we run the following
+    // If we are not using Shardy manual computation, we run the following
     // Shardy passes to propagate the shardings.
     if (!isUsingShardyManualComputation(mlir_module)) {
+      shardy_pm.addPass(mlir::createInlinerPass());
       shardy_pm.addPass(mlir::sdy::createBasicPropagationPass());
       shardy_pm.addPass(mlir::sdy::createCloseShardingsPass());
     }

--- a/src/common/module_builder.cc
+++ b/src/common/module_builder.cc
@@ -651,6 +651,7 @@ bool ModuleBuilder::isUsingShardyManualComputation(
   if (!isUsingShardy(module)) {
     return false;
   }
+
   bool is_using_shardy_manual_computation = false;
   module.get().walk([&](mlir::sdy::ManualComputationOp op) {
     is_using_shardy_manual_computation = true;

--- a/src/common/module_builder.cc
+++ b/src/common/module_builder.cc
@@ -165,8 +165,9 @@ void ModuleBuilder::convertFromVHLOToSHLO(
   if (isUsingShardy(mlir_module)) {
     mlir::PassManager shardy_pm(mlir_module.get()->getName());
     mlir::sdy::addSdyRoundTripImportPipeline(shardy_pm);
-    // If we are not using Shardy manual computation, we run the following
-    // Shardy passes to propagate the shardings.
+    // The following Shardy passes are only needed for automatic computation,
+    // since manual computation already has propagated shardings, leading to an
+    // error in that case.
     if (!isUsingShardyManualComputation(mlir_module)) {
       shardy_pm.addPass(mlir::createInlinerPass());
       shardy_pm.addPass(mlir::sdy::createBasicPropagationPass());

--- a/src/common/module_builder.cc
+++ b/src/common/module_builder.cc
@@ -37,6 +37,8 @@
 // shardy includes
 #include "shardy/dialect/sdy/ir/dialect.h"
 #include "shardy/dialect/sdy/ir/register.h"
+#include "shardy/dialect/sdy/transforms/export/passes.h"
+#include "shardy/dialect/sdy/transforms/propagation/basic_propagation.h"
 #include "shardy/round_trip_import/constants.h"
 #include "shardy/round_trip_import/pipelines.h"
 #include "shardy/round_trip_import/utils.h"
@@ -163,6 +165,12 @@ void ModuleBuilder::convertFromVHLOToSHLO(
   if (isUsingShardy(mlir_module)) {
     mlir::PassManager shardy_pm(mlir_module.get()->getName());
     mlir::sdy::addSdyRoundTripImportPipeline(shardy_pm);
+    // If we are not using SHardy manual computation, we run the following
+    // Shardy passes to propagate the shardings.
+    if (!isUsingShardyManualComputation(mlir_module)) {
+      shardy_pm.addPass(mlir::sdy::createBasicPropagationPass());
+      shardy_pm.addPass(mlir::sdy::createCloseShardingsPass());
+    }
     if (mlir::failed(shardy_pm.run(mlir_module.get()))) {
       DLOG_F(ERROR,
              "Failed to convert from Shardy roundtrip import pass module");
@@ -634,6 +642,21 @@ bool ModuleBuilder::isUsingShardy(
   std::optional<mlir::sdy::MeshOp> mesh_op = getFirstShardyMeshOp(module);
 
   return mesh_op.has_value();
+}
+
+bool ModuleBuilder::isUsingShardyManualComputation(
+    const mlir::OwningOpRef<mlir::ModuleOp> &module) {
+  if (!isUsingShardy(module)) {
+    return false;
+  }
+  bool is_using_shardy_manual_computation = false;
+  module.get().walk([&](mlir::sdy::ManualComputationOp op) {
+    is_using_shardy_manual_computation = true;
+
+    return mlir::WalkResult::interrupt();
+  });
+
+  return is_using_shardy_manual_computation;
 }
 
 std::optional<mlir::sdy::MeshOp> ModuleBuilder::getFirstShardyMeshOp(

--- a/src/common/module_builder.h
+++ b/src/common/module_builder.h
@@ -151,8 +151,8 @@ private:
   // Checks if the StableHLO code is using the Shardy mlir dialect.
   bool isUsingShardy(const mlir::OwningOpRef<mlir::ModuleOp> &module);
 
-  // Checks if the StableHLO code is using manual compution of the Shardy mlir
-  // dialect.
+  // Checks if the StableHLO code is using manual computation ops of the Shardy
+  // mlir dialect.
   bool isUsingShardyManualComputation(
       const mlir::OwningOpRef<mlir::ModuleOp> &module);
 

--- a/src/common/module_builder.h
+++ b/src/common/module_builder.h
@@ -148,8 +148,13 @@ private:
   void
   collectOutputShardingsShardy(const mlir::OwningOpRef<mlir::ModuleOp> &module);
 
-  // Checks if the jax is using the Shardy mlir dialect.
+  // Checks if the StableHLO code is using the Shardy mlir dialect.
   bool isUsingShardy(const mlir::OwningOpRef<mlir::ModuleOp> &module);
+
+  // Checks if the StableHLO code is using manual compution of the Shardy mlir
+  // dialect.
+  bool isUsingShardyManualComputation(
+      const mlir::OwningOpRef<mlir::ModuleOp> &module);
 
   // Takes a vector of string attributes representing GSPMD sharding and fills
   // the vector of tt_mlir Sharding with the appropriate corresponding values.


### PR DESCRIPTION
As per issue https://github.com/tenstorrent/tt-xla/issues/600, we can run `--sdy-basic-propagate` and `--sdy-close-shardings` passes on the graph that only has sharding annotated inputs with shardy dialect to propagate it for all ops (including the output). Adding this for easier compilation in tt-mlir.

Closes https://github.com/tenstorrent/tt-xla/issues/600