### PR TITLE
Add tensor parallel LLaMA 3.1-8B JAX model DRAFT

### DIFF
--- a/tests/jax/models/llama/3_1_8b/.gitignore
+++ b/tests/jax/models/llama/3_1_8b/.gitignore
@@ -1,0 +1,2 @@
+llama_env/
+llama3.1-8B/

--- a/tests/jax/models/llama/3_1_8b/README.md
+++ b/tests/jax/models/llama/3_1_8b/README.md
@@ -1,0 +1,123 @@
+# 🧠 LLaMA 3.1–8B: Tensor Parallel JAX Implementation (Draft PR)
+
+This draft PR adds a tensor-parallel JAX implementation of Meta’s LLaMA 3.1–8B model using a 2×4 device mesh. The code supports both sharded and unsharded execution and matches Hugging Face’s PyTorch reference implementation.
+
+---
+
+## ✅ Setup Instructions
+
+### 1. Install Python and Create Virtual Environment
+```
+sudo apt install python3.12-venv
+mkdir tt
+cd tt
+python3.12 -m venv llama
+source llama/bin/activate
+```
+### 2. Hugging Face Login
+```
+You must log into Hugging Face to download the LLaMA 3.1 weights.
+
+pip install huggingface_hub
+huggingface-cli login
+
+    Make sure you've requested access to the Meta LLaMA 3 model: https://huggingface.co/meta-llama
+```
+### 🌿 Branch for This Implementation
+```
+All changes for this draft PR are in the branch:
+
+llama-3.1.8b-tensor-parallel-draft
+
+Clone the repository and checkout the branch:
+git checkout llama-3.1.8b-tensor-parallel-draft
+
+cd sw/
+```
+
+### 📁 Download and Structure Model Files
+```
+mkdir -p sw/llama3.1-8B/original
+mkdir -p sw/llama3.1-8B/8B
+
+huggingface-cli download meta-llama/Llama-3.1-8B original/tokenizer.model --local-dir sw/llama3.1-8B/original
+huggingface-cli download meta-llama/Llama-3.1-8B original/consolidated.00.pth --local-dir sw/llama3.1-8B
+huggingface-cli download meta-llama/Llama-3.1-8B original/params.json --local-dir sw/llama3.1-8B
+
+mv sw/llama3.1-8B/consolidated.00.pth sw/llama3.1-8B/8B/
+mv sw/llama3.1-8B/params.json sw/llama3.1-8B/8B/
+
+Final structure:
+
+sw/llama3.1-8B/
+├── 8B/
+│   ├── consolidated.00.pth
+│   └── params.json
+└── original/
+    └── tokenizer.model
+```
+
+### 📦 Install Python Dependencies
+```
+Make sure you're using Python ≥3.10 (tested on 3.12):
+
+pip install -r tests/jax/models/llama/3_1_8b/requirements.txt
+```
+
+### ▶️ Running the Scripts
+```
+You can run any of the available generation scripts using:
+
+python3 tests/jax/models/llama/3_1_8b/generate_jax.py
+python3 tests/jax/models/llama/3_1_8b/generate_hf.py
+python3 tests/jax/models/llama/3_1_8b/generate_jax_unsharded.py
+
+    generate_jax.py: Runs the sharded tensor-parallel JAX model (2×4 mesh).
+
+    generate_jax_unsharded.py: Runs the unsharded JAX model.
+
+    generate_hf.py: Runs the Hugging Face PyTorch reference model.
+
+In generate_hf.py and generate_jax_unsharded.py, there are three example prompts commented in the code that can be modified for testing.
+
+✅ All three scripts produce identical outputs for the same input prompt (up to floating point precision).
+```
+
+### ⚠️ Note on generate_jax.py (Tensor-Parallel Sharded)
+
+When running the sharded JAX model on a 2×4 mesh:
+
+❗ RAM usage exceeds 64 GB during sharding and the process is killed.
+
+❓ Questions & Feedback
+
+    Can you try running generate_jax.py on your end with more RAM?
+
+        To confirm memory requirements.
+
+        To verify whether the issue is hardware-related.
+
+    Prompt formatting:
+
+        I'm currently using 2-shot prompting, which ensures consistent outputs between the sharded JAX and Hugging Face PyTorch models.
+
+        ❓ Is it expected that prompting style affects alignment?
+
+    Correctness checks:
+
+        ✅ I have verified that the logits match exactly between:
+
+            Sharded JAX
+
+            Unsharded JAX
+
+            Hugging Face PyTorch
+
+    Memory use:
+
+        ❓ Is it expected that sharding the LLaMA 3.1 8B model exceeds 64 GB RAM?
+
+        Or is there something incorrect in the sharding logic?
+
+Let me know how I can improve this or whether the memory limit is just a system constraint 🙏
+

--- a/tests/jax/models/llama/3_1_8b/generate_hf.py
+++ b/tests/jax/models/llama/3_1_8b/generate_hf.py
@@ -1,0 +1,90 @@
+import torch
+from transformers import AutoTokenizer, AutoModelForCausalLM, GenerationConfig
+import fire
+
+def hf_load(model_id: str = "meta-llama/Meta-Llama-3.1-8B"):
+    print("🔧 Loading Hugging Face model and tokenizer...")
+
+    tokenizer = AutoTokenizer.from_pretrained(model_id, use_fast=False)
+    # Print all special tokens and their IDs
+    for token_name in tokenizer.special_tokens_map:
+        token_str = tokenizer.special_tokens_map[token_name]
+        token_id = tokenizer.convert_tokens_to_ids(token_str)
+        print(f"{token_name}: {token_str} -> {token_id}")
+        
+    model = AutoModelForCausalLM.from_pretrained(
+        model_id,
+        torch_dtype=torch.float16,
+        device_map="auto",
+    )
+    model.eval()
+
+    return tokenizer, model
+
+def main(
+    model_id: str = "meta-llama/Meta-Llama-3.1-8B",
+    prompt: str = (
+    "Q: Janet's ducks lay 16 eggs per day. She eats three for breakfast every morning and bakes muffins for her friends every day with four. "
+    "She sells the remainder at the farmers' market daily for $2 per fresh duck egg. "
+    "How much in dollars does she make every day at the farmers' market?\n"
+    "A: Janet sells 16 - 3 - 4 = <<16-3-4=9>>9 duck eggs a day.\n"
+    "She makes 9 * 2 = $<<9*2=18>>18 every day at the farmer's market.\n"
+    "F: #### 18 \n\n"
+    "Q: Josh decides to try flipping a house. He buys a house for $80,000 and then puts in $50,000 in repairs. This increased the value of the house by 150%. How much profit did he make?\n"
+    "A: The cost of the house and repairs came out to 80,000 + 50,000 = $<<80000+50000=130000>>130,000\n"
+    "He increased the value of the house by 80,000 * 1.5 = <<80000*1.5=120000>>120,000\n"
+    "So the new value of the house is 120,000 + 80,000 = $<<120000+80000=200000>>200,000\n"
+    "So he made a profit of 200,000 - 130,000 = $<<200000-130000=70000>>70,000\n"
+    "F: #### 70000\n\n"
+    "Q: A bumper car rink has 12 red cars. They have 2 fewer green cars than they have red cars. They have 3 times the number of blue cars as they have green cars. The rink also has yellow cars.  If the rink has 75 cars in total how many yellow cars do they have?\n"
+    "A:"
+),
+    max_gen_len: int = 128,
+    temperature: float = 0.01,
+    top_p: float = 0.99
+):
+    
+    #example prompts
+    #In a dance class of 20 students, 20% enrolled in contemporary dance, 25% of the remaining enrolled in jazz dance, and the rest enrolled in hip-hop dance. What percentage of the entire students enrolled in hip-hop dance?
+    #A robe takes 2 bolts of blue fiber and half that much white fiber. How many bolts in total does it take?
+    #A bumper car rink has 12 red cars. They have 2 fewer green cars than they have red cars. They have 3 times the number of blue cars as they have green cars. The rink also has yellow cars.  If the rink has 75 cars in total how many yellow cars do they have?
+    
+    #answers
+    # 60
+    # 3
+    # 23
+    
+    tokenizer, model = hf_load(model_id)
+    print(tokenizer.eos_token, tokenizer.pad_token)
+    print(tokenizer.special_tokens_map)
+
+    inputs = tokenizer(prompt, return_tensors="pt")
+
+    input_ids = inputs.input_ids.to(model.device)
+    attention_mask = inputs.attention_mask.to(model.device)
+    print("eos_token_id in input_ids:", tokenizer.eos_token_id in input_ids[0])
+
+    print("✍️ Generating...")
+    generation_config = GenerationConfig(
+        do_sample=True,
+        temperature=temperature,
+        top_p=top_p,
+        max_new_tokens=max_gen_len,
+        eos_token_id=tokenizer.eos_token_id,
+        pad_token_id=tokenizer.eos_token_id,
+    )
+
+    with torch.no_grad():
+        outputs = model.generate(input_ids,attention_mask=attention_mask, generation_config=generation_config)
+    
+    result = tokenizer.decode(outputs[0], skip_special_tokens=False)
+    if result.startswith("<|begin_of_text|>"):
+        result = result[len("<|begin_of_text|>"):].lstrip()
+
+    if result.startswith(prompt):
+        result = result[len(prompt):].lstrip()
+
+    print("\n🧠 Output:\n", result) 
+
+if __name__ == "__main__":
+    fire.Fire(main)

--- a/tests/jax/models/llama/3_1_8b/generate_jax.py
+++ b/tests/jax/models/llama/3_1_8b/generate_jax.py
@@ -1,0 +1,93 @@
+import os
+os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=8"
+import jax
+import jax.numpy as jnp
+import numpy as np
+import fire
+from flax.core.frozen_dict import freeze
+from jax_llama import FlaxLLaMAForCausalLM, convert_llama_weights
+from jax_llama.llama3_tokenizer import Tokenizer as LLaMA3Tokenizer
+from jax_llama.generation import LLaMA  # your class is here
+from jax.sharding import Mesh
+from flax.traverse_util import flatten_dict
+import jax.debug
+from jax_llama.partition import get_llama_param_partition_spec
+from jax.experimental import pjit as old_pjit
+import gc
+
+def jax_load(ckpt_dir: str, tokenizer_path: str, mesh, max_seq_length: int = 2048) -> LLaMA:
+    print("🔧 Loading tokenizer and weights...")
+    tokenizer = LLaMA3Tokenizer(tokenizer_path)
+
+    params_np, jax_config = convert_llama_weights(
+        ckpt_dir=ckpt_dir,
+        tokenizer=tokenizer,
+        max_seq_len=max_seq_length
+    )
+    jax_params = freeze(jax.tree.map(jnp.asarray, params_np))
+
+    del params_np
+    gc.collect()    
+
+    param_spec = get_llama_param_partition_spec(jax_params)
+    shard_fn = old_pjit.pjit(
+        lambda x: x,
+        None,
+        param_spec
+    )
+
+    with mesh:
+        jax_params = shard_fn(jax_params)
+
+
+    model = FlaxLLaMAForCausalLM(config=jax_config, _do_init=False)
+    llama = LLaMA(params=jax_params, model=model, tokenizer=tokenizer, mesh=mesh)
+
+    return llama
+
+def main(
+    ckpt_dir: str = "/root/tt/sw/llama3.1-8B/8B",
+    tokenizer_path: str = "/root/tt/sw/llama3.1-8B/original/tokenizer.model",
+    prompt: str = (
+    "Q: Josh decides to try flipping a house. He buys a house for $80,000 and then puts in $50,000 in repairs. This increased the value of the house by 150%. How much profit did he make?\n"
+    "A: The cost of the house and repairs came out to 80,000 + 50,000 = $<<80000+50000=130000>>130,000\n"
+    "He increased the value of the house by 80,000 * 1.5 = <<80000*1.5=120000>>120,000\n"
+    "So the new value of the house is 120,000 + 80,000 = $<<120000+80000=200000>>200,000\n"
+    "So he made a profit of 200,000 - 130,000 = $<<200000-130000=70000>>70,000\n"
+    "F: #### 70000\n\n"
+    "Q: A robe takes 2 bolts of blue fiber and half that much white fiber. How many bolts in total does it take?\n"
+    "A:"
+),
+    max_gen_len: int = 16,
+    temperature: float = 0.1,
+    top_p: float = 0.99
+):
+    # Define mesh
+    devices = np.array(jax.devices()).reshape(2, 4)
+    mesh = Mesh(devices, axis_names=("dp", "mp"))
+    print("✅ Mesh initialized:", mesh)
+
+    print("🚀 Loading LLaMA...")
+    llama = jax_load(ckpt_dir, tokenizer_path, mesh=mesh)
+
+    print("\n🔍 Visualizing sharded parameter placements (first few):")
+    flat_params = flatten_dict(llama.params)
+    for k, v in list(flat_params.items())[:5]:
+        print(f"🔹 Param {k} sharding:")
+        jax.debug.visualize_array_sharding(v)
+
+
+    print("✍️ Generating...")
+    with mesh:
+        results = llama.generate_from_str(
+            [prompt],
+            max_gen_len=max_gen_len,
+            temperature=temperature,
+            top_p=top_p,
+        )
+    for i, r in enumerate(results):
+        print(f"\n🧾 Prompt {i + 1}: {prompt}")
+        print("🧠 Output:", r)
+
+if __name__ == "__main__":
+    fire.Fire(main)

--- a/tests/jax/models/llama/3_1_8b/generate_jax_unshraded.py
+++ b/tests/jax/models/llama/3_1_8b/generate_jax_unshraded.py
@@ -1,0 +1,77 @@
+import os
+import jax
+import jax.numpy as jnp
+import numpy as np
+import fire
+from flax.core.frozen_dict import freeze
+from jax_llama import FlaxLLaMAForCausalLM, convert_llama_weights
+from jax_llama.llama3_tokenizer import Tokenizer as LLaMA3Tokenizer
+from jax_llama.generation import LLaMA  # your class is here
+
+def jax_load(ckpt_dir: str, tokenizer_path: str, max_seq_length: int = 2048) -> LLaMA:
+    print("🔧 Loading tokenizer and weights...")
+    tokenizer = LLaMA3Tokenizer(tokenizer_path)
+
+    jax_params, jax_config = convert_llama_weights(
+        ckpt_dir=ckpt_dir,
+        tokenizer=tokenizer,
+        max_seq_len=max_seq_length
+    )
+    jax_params = freeze(jax.tree.map(jnp.asarray, jax_params))
+
+    model = FlaxLLaMAForCausalLM(config=jax_config, _do_init=False)
+    llama = LLaMA(params=jax_params, model=model, tokenizer=tokenizer)
+
+    return llama
+
+def main(
+    ckpt_dir: str = "/root/tt/sw/llama3.1-8B/8B",
+    tokenizer_path: str = "/root/tt/sw/llama3.1-8B/original/tokenizer.model",
+    prompt: str = (
+    "Q: Janet's ducks lay 16 eggs per day. She eats three for breakfast every morning and bakes muffins for her friends every day with four. "
+    "She sells the remainder at the farmers' market daily for $2 per fresh duck egg. "
+    "How much in dollars does she make every day at the farmers' market?\n"
+    "A: Janet sells 16 - 3 - 4 = <<16-3-4=9>>9 duck eggs a day.\n"
+    "She makes 9 * 2 = $<<9*2=18>>18 every day at the farmer's market.\n"
+    "F: #### 18 \n\n"
+    "Q: Josh decides to try flipping a house. He buys a house for $80,000 and then puts in $50,000 in repairs. This increased the value of the house by 150%. How much profit did he make?\n"
+    "A: The cost of the house and repairs came out to 80,000 + 50,000 = $<<80000+50000=130000>>130,000\n"
+    "He increased the value of the house by 80,000 * 1.5 = <<80000*1.5=120000>>120,000\n"
+    "So the new value of the house is 120,000 + 80,000 = $<<120000+80000=200000>>200,000\n"
+    "So he made a profit of 200,000 - 130,000 = $<<200000-130000=70000>>70,000\n"
+    "F: #### 70000\n\n"
+    "Q: A bumper car rink has 12 red cars. They have 2 fewer green cars than they have red cars. They have 3 times the number of blue cars as they have green cars. The rink also has yellow cars.  If the rink has 75 cars in total how many yellow cars do they have?\n"
+    "A:"
+),
+    max_gen_len: int = 128,
+    temperature: float = 0.01,
+    top_p: float = 0.99
+):
+    
+    #example prompts
+    #In a dance class of 20 students, 20% enrolled in contemporary dance, 25% of the remaining enrolled in jazz dance, and the rest enrolled in hip-hop dance. What percentage of the entire students enrolled in hip-hop dance?
+    #A robe takes 2 bolts of blue fiber and half that much white fiber. How many bolts in total does it take?
+    #A bumper car rink has 12 red cars. They have 2 fewer green cars than they have red cars. They have 3 times the number of blue cars as they have green cars. The rink also has yellow cars.  If the rink has 75 cars in total how many yellow cars do they have?
+    
+    #answers
+    # 60
+    # 3
+    # 23
+
+    print("🚀 Loading LLaMA...")
+    llama = jax_load(ckpt_dir, tokenizer_path)
+
+    print("✍️ Generating...")
+    results = llama.generate_from_str(
+        [prompt],
+        max_gen_len=max_gen_len,
+        temperature=temperature,
+        top_p=top_p
+
+    )
+    for i, r in enumerate(results):
+        print(f"\n🧾 Prompt {i + 1}: {prompt}")
+        print("🧠 Output:", r)
+
+if __name__ == "__main__":
+    fire.Fire(main)

--- a/tests/jax/models/llama/3_1_8b/jax_llama/__init__.py
+++ b/tests/jax/models/llama/3_1_8b/jax_llama/__init__.py
@@ -1,0 +1,7 @@
+from .model import FlaxLLaMAForCausalLM, FlaxLLaMAModel
+from .config import LLaMAConfig
+from .convert_weights import convert_llama_weights
+from .generation import LLaMA
+from .partition import get_llama_param_partition_spec, with_named_sharding_constraint, with_sharding_constraint
+from .llama3_tokenizer import Tokenizer as LLaMA3Tokenizer
+

--- a/tests/jax/models/llama/3_1_8b/jax_llama/config.py
+++ b/tests/jax/models/llama/3_1_8b/jax_llama/config.py
@@ -1,0 +1,68 @@
+from transformers.configuration_utils import PretrainedConfig
+from transformers.utils import logging
+
+
+logger = logging.get_logger(__name__)
+
+LLAMA_PRETRAINED_CONFIG_ARCHIVE_MAP = {}
+
+
+class LLaMAConfig(PretrainedConfig):
+    model_type = "llama"
+
+    def __init__(
+    self,
+    vocab_size=128256,
+    hidden_size=4096,
+    intermediate_size=14336,
+    num_hidden_layers=32,
+    num_attention_heads=32,
+    num_key_value_heads=8,
+    max_sequence_length=2048, #131072,
+    rms_norm_eps=1e-5,
+    initializer_range=0.02,
+    use_cache=True,
+    pad_token_id=-1,
+    bos_token_id=128000,
+    eos_token_id=128001,
+    resid_pdrop=0.0,
+    embd_pdrop=0.0,
+    attn_pdrop=0.0,
+    tie_word_embeddings=False,
+    gradient_checkpointing: bool = False,
+    rope_theta: float = 500000.0,
+    rope_scaling=None,
+    **kwargs,
+):
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.initializer_range = initializer_range
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_key_value_heads = num_key_value_heads
+        self.max_sequence_length = max_sequence_length
+        self.max_position_embeddings = max_sequence_length
+        self.rms_norm_eps = rms_norm_eps
+        self.use_cache = use_cache
+        self.resid_pdrop = resid_pdrop
+        self.embd_pdrop = embd_pdrop
+        self.attn_pdrop = attn_pdrop
+        self.gradient_checkpointing = gradient_checkpointing
+        self.rope_theta = rope_theta
+        self.rope_scaling = rope_scaling or {
+            "factor": 8.0,
+            "high_freq_factor": 4.0,
+            "low_freq_factor": 1.0,
+            "original_max_position_embeddings": 8192,
+            "rope_type": "llama3",
+        }
+
+        super().__init__(
+            pad_token_id=pad_token_id,
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
+        )
+

--- a/tests/jax/models/llama/3_1_8b/jax_llama/convert_weights.py
+++ b/tests/jax/models/llama/3_1_8b/jax_llama/convert_weights.py
@@ -1,0 +1,146 @@
+from typing import Union
+from pathlib import Path
+import torch
+import json
+import numpy as np
+from jaxtyping import PyTree
+from jax_llama.config import LLaMAConfig
+from jax_llama.llama3_tokenizer import Tokenizer as LLaMA3Tokenizer
+from typing import Tuple, Optional
+from dataclasses import dataclass
+import os
+import psutil
+
+@dataclass
+class ModelArgs:
+    dim: int = 4096
+    n_layers: int = 32
+    n_heads: int = 32
+    n_kv_heads: Optional[int] = 8
+    vocab_size: int = -1  # defined later by tokenizer
+    multiple_of: int = 256  # make SwiGLU hidden layer size multiple of large power of 2
+    ffn_dim_multiplier: Optional[float] = None
+    norm_eps: float = 1e-5
+    rope_theta: float = 500000.0
+
+    max_batch_size: int = 1
+    max_seq_len: int = 2048
+
+def config_from_params(args: ModelArgs) -> LLaMAConfig:
+    intermediate_size = int(2 * (args.dim * 4) / 3)
+    if args.ffn_dim_multiplier is not None:
+        intermediate_size = int(args.ffn_dim_multiplier * intermediate_size)
+    intermediate_size = args.multiple_of * ((intermediate_size + args.multiple_of - 1) // args.multiple_of)
+    return LLaMAConfig(
+        vocab_size=args.vocab_size, 
+        hidden_size=args.dim, 
+        intermediate_size=intermediate_size, 
+        num_hidden_layers=args.n_layers, 
+        num_attention_heads=args.n_heads, 
+        num_key_value_heads=args.n_kv_heads,
+        max_sequence_length=args.max_seq_len, 
+        rms_norm_eps=args.norm_eps, 
+        rope_theta=args.rope_theta
+    )
+
+def convert_llama_weights(ckpt_dir: str, tokenizer: LLaMA3Tokenizer, max_seq_len: int=2048, verbose: bool=False) -> Tuple[PyTree[np.ndarray], LLaMAConfig]:
+    ckpt_paths = sorted(Path(ckpt_dir).glob("*.pth"))
+    ckpts = {}
+    for i, ckpt_path in enumerate(ckpt_paths):
+        if verbose:
+            print(f"Loading checkpoint {i+1} of {len(ckpt_paths)} ...")
+        checkpoint = torch.load(ckpt_path, map_location="cpu")
+        if verbose:
+            print('Loaded.')
+        ckpts[int(ckpt_path.name.split('.', maxsplit=2)[1])] = checkpoint
+    ckpts = [ckpts[i] for i in sorted(list(ckpts.keys()))]
+    with open(Path(ckpt_dir) / "params.json", "r") as f:
+        params = json.loads(f.read())
+    params.pop("use_scaled_rope", None) 
+
+    jax_weights = {
+        'transformer': {
+            'wte': {'embedding': np.concatenate([ckpt['tok_embeddings.weight'].type(torch.float16).numpy() for ckpt in ckpts], axis=1)}, 
+            'ln_f': {'kernel': ckpts[0]['norm.weight'].type(torch.float16).numpy()}, 
+            'h': {
+                '%d' % (layer): {
+                    'attention': {
+                        'wq': {'kernel': np.concatenate([ckpt['layers.%d.attention.wq.weight' % (layer)].type(torch.float16).numpy() for ckpt in ckpts], axis=0).transpose()}, 
+                        'wk': {'kernel': np.concatenate([ckpt['layers.%d.attention.wk.weight' % (layer)].type(torch.float16).numpy() for ckpt in ckpts], axis=0).transpose()}, 
+                        'wv': {'kernel': np.concatenate([ckpt['layers.%d.attention.wv.weight' % (layer)].type(torch.float16).numpy() for ckpt in ckpts], axis=0).transpose()}, 
+                        'wo': {'kernel': np.concatenate([ckpt['layers.%d.attention.wo.weight' % (layer)].type(torch.float16).numpy() for ckpt in ckpts], axis=1).transpose()}, 
+                    }, 
+                    'feed_forward': {
+                        'w1': {'kernel': np.concatenate([ckpt['layers.%d.feed_forward.w1.weight' % (layer)].type(torch.float16).numpy() for ckpt in ckpts], axis=0).transpose()}, 
+                        'w2': {'kernel': np.concatenate([ckpt['layers.%d.feed_forward.w2.weight' % (layer)].type(torch.float16).numpy() for ckpt in ckpts], axis=1).transpose()}, 
+                        'w3': {'kernel': np.concatenate([ckpt['layers.%d.feed_forward.w3.weight' % (layer)].type(torch.float16).numpy() for ckpt in ckpts], axis=0).transpose()}, 
+                    }, 
+                    'attention_norm': {'kernel': ckpts[0]['layers.%d.attention_norm.weight' % (layer)].type(torch.float16).numpy()}, 
+                    'ffn_norm': {'kernel': ckpts[0]['layers.%d.ffn_norm.weight' % (layer)].type(torch.float16).numpy()}, 
+                }
+            for layer in range(params['n_layers'])}, 
+        }, 
+        'lm_head': {'kernel': np.concatenate([ckpt['output.weight'].type(torch.float16).numpy() for ckpt in ckpts], axis=0).transpose()}, 
+    }
+    
+    params.update({'vocab_size': len(tokenizer), 'max_seq_len': max_seq_len})
+    llama_config = config_from_params(ModelArgs(**params))
+
+    del ckpts
+    torch.cuda.empty_cache()  # Not necessary on CPU, but okay
+    import gc; gc.collect()
+
+
+    process = psutil.Process(os.getpid())
+    mem_mb = process.memory_info().rss / (1024 * 1024)
+
+    print(f"\n✅ Peak memory usage before return from converting: {mem_mb:.2f} MB")
+
+
+    return jax_weights, llama_config
+
+
+def convert_state_dict_keys(state_dict):
+    new_state_dict = {}
+    for key, value in state_dict.items():
+        if key.startswith("tok_embeddings.weight"):
+            new_key = "model.embed_tokens.weight"
+        elif key.startswith("output.weight"):
+            new_key = "lm_head.weight"
+        elif key.startswith("norm.weight"):
+            new_key = "model.norm.weight"
+        elif key.startswith("layers."):
+            parts = key.split('.')
+            layer_num = parts[1]
+            sublayer = parts[2]
+            weight_type = parts[3]
+
+            if sublayer == "attention":
+                if weight_type == "wq":
+                    new_key = f"model.layers.{layer_num}.self_attn.q_proj.weight"
+                elif weight_type == "wk":
+                    new_key = f"model.layers.{layer_num}.self_attn.k_proj.weight"
+                elif weight_type == "wv":
+                    new_key = f"model.layers.{layer_num}.self_attn.v_proj.weight"
+                elif weight_type == "wo":
+                    new_key = f"model.layers.{layer_num}.self_attn.o_proj.weight"
+            elif sublayer == "feed_forward":
+                if weight_type == "w1":
+                    new_key = f"model.layers.{layer_num}.mlp.gate_proj.weight"
+                elif weight_type == "w2":
+                    new_key = f"model.layers.{layer_num}.mlp.down_proj.weight"
+                elif weight_type == "w3":
+                    new_key = f"model.layers.{layer_num}.mlp.up_proj.weight"
+            elif sublayer == "attention_norm":
+                new_key = f"model.layers.{layer_num}.input_layernorm.weight"
+            elif sublayer == "ffn_norm":
+                new_key = f"model.layers.{layer_num}.post_attention_layernorm.weight"
+            else:
+                print(f"⚠️ Unknown sublayer: {key}")
+                continue
+        else:
+            print(f"⚠️ Unknown key: {key}")
+            continue
+
+        new_state_dict[new_key] = value
+    return new_state_dict

--- a/tests/jax/models/llama/3_1_8b/jax_llama/generation.py
+++ b/tests/jax/models/llama/3_1_8b/jax_llama/generation.py
@@ -1,0 +1,70 @@
+import jax
+import jax.numpy as jnp
+from jax_llama import FlaxLLaMAForCausalLM
+from jax_llama.llama3_tokenizer import Tokenizer as LLaMA3Tokenizer
+from transformers.generation import GenerationConfig
+from jax.sharding import Mesh
+from jax_llama.partition import with_named_sharding_constraint
+from jax.sharding import PartitionSpec as P
+from jaxtyping import PyTree
+from flax import struct
+from functools import partial
+from typing import List, Optional, Union
+
+class LLaMA(struct.PyTreeNode):
+    params: PyTree
+    model: FlaxLLaMAForCausalLM = struct.field(pytree_node=False)
+    tokenizer: LLaMA3Tokenizer = struct.field(pytree_node=False)
+    mesh: Optional[Mesh] = struct.field(pytree_node=False, default=None)
+
+    @partial(jax.jit, static_argnums=(3,4,5))
+    def generate(self, tokens: jnp.ndarray, attention_mask: jnp.ndarray, max_gen_len: int, temperature: float = 0.8, top_p: float = 0.95) -> jnp.ndarray:
+        tokens = with_named_sharding_constraint(tokens, self.mesh, P("dp", None))
+        attention_mask = with_named_sharding_constraint(attention_mask, self.mesh, P("dp", None))
+
+        generations = self.model.generate(
+            input_ids=tokens, 
+            attention_mask=attention_mask, 
+            params=self.params, 
+            generation_config=GenerationConfig(
+                num_beams=1, 
+                do_sample=temperature != 0.0, 
+                max_length=max_gen_len+tokens.shape[1], 
+                pad_token_id=self.tokenizer.eos_id, 
+                eos_token_id=self.tokenizer.eos_id, 
+                temperature=temperature, 
+                top_p=top_p
+            )
+        )
+        out_tokens = generations.sequences
+        
+        out_tokens = with_named_sharding_constraint(out_tokens, self.mesh, P("dp", None))
+        return out_tokens
+    
+    def generate_from_str(self, prompts: List[str], max_gen_len: int, temperature: float = 0.1, top_p: float = 0.99):
+        prompt_tokens = [self.tokenizer.encode(x, bos=True, eos=False,  allowed_special="all", disallowed_special=()) for x in prompts]
+
+
+        max_prompt_size = max([len(t) for t in prompt_tokens])
+
+        tokens = jnp.full((len(prompts), max_prompt_size), self.tokenizer.pad_id).astype(jnp.int32)
+        for i, t in enumerate(prompt_tokens):
+            tokens = tokens.at[i, -len(t):].set(t) # left pad
+        attention_mask = (tokens != self.tokenizer.eos_id).astype(jnp.int32)
+
+        out_tokens = self.generate(tokens, attention_mask, max_gen_len, temperature, top_p, do_sample=True)
+        print("safss")
+        decoded = []
+        #save out tokens in txt file
+        for i, t in enumerate(out_tokens.tolist()):
+            
+            try:
+                start_idx = t.index(self.tokenizer.bos_id)
+            except ValueError:
+                start_idx = 0  # fallback if BOS not present
+            t = t[start_idx:]
+
+            decoded.append(self.tokenizer.decode(t))
+        
+
+        return decoded

--- a/tests/jax/models/llama/3_1_8b/jax_llama/llama3_tokenizer.py
+++ b/tests/jax/models/llama/3_1_8b/jax_llama/llama3_tokenizer.py
@@ -1,0 +1,232 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This software may be used and distributed in accordance with the terms of the Llama 3 Community License Agreement.
+
+import os
+from logging import getLogger
+from pathlib import Path
+from typing import (
+    AbstractSet,
+    cast,
+    Collection,
+    Dict,
+    Iterator,
+    List,
+    Literal,
+    Sequence,
+    TypedDict,
+    Union,
+)
+
+import tiktoken
+from tiktoken.load import load_tiktoken_bpe
+
+
+logger = getLogger(__name__)
+
+
+Role = Literal["system", "user", "assistant"]
+
+
+class Message(TypedDict):
+    role: Role
+    content: str
+
+
+Dialog = Sequence[Message]
+
+
+class Tokenizer:
+    """
+    Tokenizing and encoding/decoding text using the Tiktoken tokenizer.
+    """
+
+    special_tokens: Dict[str, int]
+
+    num_reserved_special_tokens = 256
+
+    pat_str = r"(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\r\n\p{L}\p{N}]?\p{L}+|\p{N}{1,3}| ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+(?!\S)|\s+"  # noqa: E501
+
+    def __init__(self, model_path: str):
+        """
+        Initializes the Tokenizer with a Tiktoken model.
+
+        Args:
+            model_path (str): The path to the Tiktoken model file.
+        """
+        assert os.path.isfile(model_path), model_path
+
+        mergeable_ranks = load_tiktoken_bpe(model_path)
+        num_base_tokens = len(mergeable_ranks)
+        special_tokens = [
+            "<|begin_of_text|>",
+            "<|end_of_text|>",
+            "<|reserved_special_token_0|>",
+            "<|reserved_special_token_1|>",
+            "<|reserved_special_token_2|>",
+            "<|reserved_special_token_3|>",
+            "<|start_header_id|>",
+            "<|end_header_id|>",
+            "<|reserved_special_token_4|>",
+            "<|eot_id|>",  # end of turn
+        ] + [
+            f"<|reserved_special_token_{i}|>"
+            for i in range(5, self.num_reserved_special_tokens - 5)
+        ]
+        self.special_tokens = {
+            token: num_base_tokens + i for i, token in enumerate(special_tokens)
+        }
+        self.model = tiktoken.Encoding(
+            name=Path(model_path).name,
+            pat_str=self.pat_str,
+            mergeable_ranks=mergeable_ranks,
+            special_tokens=self.special_tokens,
+        )
+        logger.info(f"Reloaded tiktoken model from {model_path}")
+
+        self.n_words: int = self.model.n_vocab
+        # BOS / EOS token IDs
+        self.bos_id: int = self.special_tokens["<|begin_of_text|>"]
+        self.eos_id: int = self.special_tokens["<|end_of_text|>"]
+        self.pad_id: int = -1
+        self.stop_tokens = {
+            self.special_tokens["<|end_of_text|>"],
+            self.special_tokens["<|eot_id|>"],
+        }
+        logger.info(
+            f"#words: {self.n_words} - BOS ID: {self.bos_id} - EOS ID: {self.eos_id}"
+        )
+
+    def encode(
+        self,
+        s: str,
+        *,
+        bos: bool,
+        eos: bool,
+        allowed_special: Union[Literal["all"], AbstractSet[str]] = set(),
+        disallowed_special: Union[Literal["all"], Collection[str]] = (),
+    ) -> List[int]:
+        """
+        Encodes a string into a list of token IDs.
+
+        Args:
+            s (str): The input string to be encoded.
+            bos (bool): Whether to prepend the beginning-of-sequence token.
+            eos (bool): Whether to append the end-of-sequence token.
+            allowed_tokens ("all"|set[str]): allowed special tokens in string
+            disallowed_tokens ("all"|set[str]): special tokens that raise an error when in string
+
+        Returns:
+            list[int]: A list of token IDs.
+
+        By default, setting disallowed_special=() encodes a string by ignoring
+        special tokens. Specifically:
+        - Setting `disallowed_special` to () will cause all text corresponding
+          to special tokens to be encoded as natural text (insteading of raising
+          an error).
+        - Setting `allowed_special` to "all" will treat all text corresponding
+          to special tokens to be encoded as special tokens.
+        """
+        assert type(s) is str
+
+        # The tiktoken tokenizer can handle <=400k chars without
+        # pyo3_runtime.PanicException.
+        TIKTOKEN_MAX_ENCODE_CHARS = 400_000
+
+        # https://github.com/openai/tiktoken/issues/195
+        # Here we iterate over subsequences and split if we exceed the limit
+        # of max consecutive non-whitespace or whitespace characters.
+        MAX_NO_WHITESPACES_CHARS = 25_000
+
+        substrs = (
+            substr
+            for i in range(0, len(s), TIKTOKEN_MAX_ENCODE_CHARS)
+            for substr in self._split_whitespaces_or_nonwhitespaces(
+                s[i : i + TIKTOKEN_MAX_ENCODE_CHARS], MAX_NO_WHITESPACES_CHARS
+            )
+        )
+        t: List[int] = []
+        for substr in substrs:
+            t.extend(
+                self.model.encode(
+                    substr,
+                    allowed_special=allowed_special,
+                    disallowed_special=disallowed_special,
+                )
+            )
+        if bos:
+            t.insert(0, self.bos_id)
+        if eos:
+            t.append(self.eos_id)
+        return t
+
+    def decode(self, t: Sequence[int]) -> str:
+        """
+        Decodes a list of token IDs into a string.
+
+        Args:
+            t (List[int]): The list of token IDs to be decoded.
+
+        Returns:
+            str: The decoded string.
+        """
+        # Typecast is safe here. Tiktoken doesn't do anything list-related with the sequence.
+        return self.model.decode(cast(List[int], t))
+    
+    def __len__(self):
+        return self.n_words
+
+    @staticmethod
+    def _split_whitespaces_or_nonwhitespaces(
+        s: str, max_consecutive_slice_len: int
+    ) -> Iterator[str]:
+        """
+        Splits the string `s` so that each substring contains no more than `max_consecutive_slice_len`
+        consecutive whitespaces or consecutive non-whitespaces.
+        """
+        current_slice_len = 0
+        current_slice_is_space = s[0].isspace() if len(s) > 0 else False
+        slice_start = 0
+
+        for i in range(len(s)):
+            is_now_space = s[i].isspace()
+
+            if current_slice_is_space ^ is_now_space:
+                current_slice_len = 1
+                current_slice_is_space = is_now_space
+            else:
+                current_slice_len += 1
+                if current_slice_len > max_consecutive_slice_len:
+                    yield s[slice_start:i]
+                    slice_start = i
+                    current_slice_len = 1
+        yield s[slice_start:]
+
+
+class ChatFormat:
+    def __init__(self, tokenizer: Tokenizer):
+        self.tokenizer = tokenizer
+
+    def encode_header(self, message: Message) -> List[int]:
+        tokens = []
+        tokens.append(self.tokenizer.special_tokens["<|start_header_id|>"])
+        tokens.extend(self.tokenizer.encode(message["role"], bos=False, eos=False))
+        tokens.append(self.tokenizer.special_tokens["<|end_header_id|>"])
+        tokens.extend(self.tokenizer.encode("\n\n", bos=False, eos=False))
+        return tokens
+
+    def encode_message(self, message: Message) -> List[int]:
+        tokens = self.encode_header(message)
+        tokens.extend(
+            self.tokenizer.encode(message["content"].strip(), bos=False, eos=False)
+        )
+        tokens.append(self.tokenizer.special_tokens["<|eot_id|>"])
+        return tokens
+
+    def encode_dialog_prompt(self, dialog: Dialog) -> List[int]:
+        tokens = []
+        tokens.append(self.tokenizer.special_tokens["<|begin_of_text|>"])
+        for message in dialog:
+            tokens.extend(self.encode_message(message))
+        # Add the start of an assistant message for the model to complete.
+        tokens.extend(self.encode_header({"role": "assistant", "content": ""}))
+        return tokens

--- a/tests/jax/models/llama/3_1_8b/jax_llama/model.py
+++ b/tests/jax/models/llama/3_1_8b/jax_llama/model.py
@@ -1,0 +1,724 @@
+from functools import partial
+from typing import Optional, Tuple, Union
+
+import flax.linen as nn
+import jax
+import jax.numpy as jnp
+import numpy as np
+from flax.core.frozen_dict import FrozenDict, freeze, unfreeze
+from flax.linen import combine_masks, make_causal_mask
+from flax.linen.attention import dot_product_attention_weights
+from flax.traverse_util import flatten_dict, unflatten_dict
+from jax import lax
+from flax.linen import partitioning as nn_partitioning
+
+from transformers.modeling_flax_outputs import FlaxBaseModelOutput, FlaxCausalLMOutput
+from transformers.modeling_flax_utils import ACT2FN, FlaxPreTrainedModel, append_call_sample_docstring
+from transformers.utils import add_start_docstrings, add_start_docstrings_to_model_forward, logging
+
+from jax_llama.config import LLaMAConfig
+import math
+
+remat = nn_partitioning.remat
+
+logger = logging.get_logger(__name__)
+
+class RMSNorm(nn.Module):
+    dim: int
+    eps: float=1e-6
+    dtype: jnp.dtype=jnp.float32
+    param_dtype: jnp.dtype=jnp.float32
+
+    def setup(self) -> None:
+        self.weight = self.param(
+            'kernel', 
+            nn.initializers.ones, 
+            (self.dim,), 
+            self.param_dtype, 
+        )
+
+    def _norm(self, x: jnp.ndarray) -> jnp.ndarray:
+        return x * jax.lax.rsqrt(jnp.square(x).mean(-1, keepdims=True) + self.eps)
+
+    def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
+        output = self._norm(x.astype(self.dtype)).astype(self.dtype)
+        weight = jnp.asarray(self.weight, self.dtype)
+        return output * weight
+
+def precompute_freqs_cis(dim: int, end: int, theta: float=10000.0, dtype: jnp.dtype=jnp.float32) -> jnp.ndarray:
+    freqs = 1.0 / (theta ** (np.arange(0, dim, 2)[: (dim // 2)].astype(dtype) / dim))
+    t = np.arange(end)  # type: ignore
+    freqs = np.outer(t, freqs).astype(dtype)  # type: ignore
+    sin, cos = np.sin(freqs), np.cos(freqs)
+    freqs_cis = np.complex64(cos + 1j * sin)
+    return jnp.asarray(freqs_cis)
+
+def apply_rotary_emb(
+    xq: jnp.ndarray, 
+    xk: jnp.ndarray, 
+    freqs_cis: jnp.ndarray, 
+    dtype: jnp.dtype=jnp.float32, 
+) -> Tuple[jnp.ndarray, jnp.ndarray]:
+    
+    reshape_xq = xq.astype(jnp.float32).reshape(*xq.shape[:-1], -1, 2)
+    reshape_xk = xk.astype(jnp.float32).reshape(*xk.shape[:-1], -1, 2)
+    
+    xq_ = jax.lax.complex(reshape_xq[..., 0], reshape_xq[..., 1])
+    xk_ = jax.lax.complex(reshape_xk[..., 0], reshape_xk[..., 1])
+
+    # add head dim
+    freqs_cis = jnp.reshape(freqs_cis, (*freqs_cis.shape[:2], 1, *freqs_cis.shape[2:]))
+    
+    xq_out = xq_ * freqs_cis
+    xq_out = jnp.stack((jnp.real(xq_out), jnp.imag(xq_out)), axis=-1).reshape(*xq_out.shape[:-1], -1)
+
+    xk_out = xk_ * freqs_cis
+    xk_out = jnp.stack((jnp.real(xk_out), jnp.imag(xk_out)), axis=-1).reshape(*xk_out.shape[:-1], -1)
+
+    return xq_out.astype(dtype), xk_out.astype(dtype)
+
+def repeat_kv(
+    hidden_states: jnp.ndarray,
+    n_rep: int,
+) -> jnp.ndarray:
+    batch, slen, num_key_value_heads, head_dim = hidden_states.shape
+    if n_rep == 1:
+        return hidden_states
+    hidden_states = hidden_states[:, :, :, None, :]
+    hidden_states = jnp.repeat(hidden_states, n_rep, axis=3)
+    return hidden_states.reshape(batch, slen, num_key_value_heads * n_rep, head_dim)
+
+class FlaxLLaMAAttention(nn.Module):
+    config: LLaMAConfig
+    dtype: jnp.dtype=jnp.float32
+    param_dtype: jnp.dtype=jnp.float32
+    precision: Optional[Union[jax.lax.Precision, str]]=None
+
+    def setup(self):
+        config = self.config
+        self.embed_dim = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.head_dim = self.embed_dim // self.num_heads
+        self.num_key_value_heads = config.num_key_value_heads
+        self.num_key_value_groups = self.num_heads // self.num_key_value_heads
+
+        self.wq = nn.Dense(
+            config.num_attention_heads*self.head_dim, 
+            dtype=self.dtype, 
+            param_dtype=self.param_dtype, 
+            use_bias=False, 
+            kernel_init=jax.nn.initializers.normal(self.config.initializer_range), 
+            precision=self.precision, 
+        )
+        self.wk = nn.Dense(
+            config.num_key_value_heads*self.head_dim, 
+            dtype=self.dtype, 
+            param_dtype=self.param_dtype, 
+            use_bias=False, 
+            kernel_init=jax.nn.initializers.normal(self.config.initializer_range), 
+            precision=self.precision, 
+        )
+        self.wv = nn.Dense(
+            config.num_key_value_heads*self.head_dim, 
+            dtype=self.dtype, 
+            param_dtype=self.param_dtype, 
+            use_bias=False, 
+            kernel_init=jax.nn.initializers.normal(self.config.initializer_range), 
+            precision=self.precision, 
+        )
+        self.wo = nn.Dense(
+            config.hidden_size, 
+            dtype=self.dtype, 
+            param_dtype=self.param_dtype, 
+            use_bias=False, 
+            kernel_init=jax.nn.initializers.normal(self.config.initializer_range), 
+            precision=self.precision, 
+        )
+
+        self.resid_dropout = nn.Dropout(rate=config.resid_pdrop)
+
+        self.causal_mask = make_causal_mask(jnp.ones((1, config.max_sequence_length), dtype="bool"), dtype="bool")
+
+        self.freqs_cis = precompute_freqs_cis(
+            self.head_dim, 
+            config.max_sequence_length * 2, 
+            theta=config.rope_theta,
+            dtype=self.dtype, 
+        )
+    
+    def _split_heads(self, hidden_states, num_heads):
+        return hidden_states.reshape(hidden_states.shape[:2] + (num_heads, self.head_dim))
+
+    def _merge_heads(self, hidden_states):
+        return hidden_states.reshape(hidden_states.shape[:2] + (self.embed_dim,))
+
+    @nn.compact
+    def _concatenate_to_cache(self, key, value, query, attention_mask):
+        """
+        This function takes projected key, value states from a single input token and concatenates the states to cached
+        states from previous steps. This function is slighly adapted from the official Flax repository:
+        https://github.com/google/flax/blob/491ce18759622506588784b4fca0e4bf05f8c8cd/flax/linen/attention.py#L252
+        """
+        # detect if we're initializing by absence of existing cache data.
+        is_initialized = self.has_variable("cache", "cached_key")
+        cached_key = self.variable("cache", "cached_key", jnp.zeros, key.shape, key.dtype)
+        cached_value = self.variable("cache", "cached_value", jnp.zeros, value.shape, value.dtype)
+        cache_index = self.variable("cache", "cache_index", lambda: jnp.array(0, dtype=jnp.int32))
+
+        if is_initialized:
+            *batch_dims, max_length, num_heads, depth_per_head = cached_key.value.shape
+            # update key, value caches with our new 1d spatial slices
+            cur_index = cache_index.value
+            indices = (0,) * len(batch_dims) + (cur_index, 0, 0)
+            key = lax.dynamic_update_slice(cached_key.value, key, indices)
+            value = lax.dynamic_update_slice(cached_value.value, value, indices)
+            cached_key.value = key
+            cached_value.value = value
+            num_updated_cache_vectors = query.shape[1]
+            cache_index.value = cache_index.value + num_updated_cache_vectors
+            # causal mask for cached decoder self-attention: our single query position should only attend to those key positions that have already been generated and cached, not the remaining zero elements.
+            pad_mask = jnp.broadcast_to(
+                jnp.arange(max_length) < cur_index + num_updated_cache_vectors,
+                tuple(batch_dims) + (1, num_updated_cache_vectors, max_length),
+            )
+            attention_mask = combine_masks(pad_mask, attention_mask)
+        return key, value, attention_mask
+
+    def __call__(
+        self,
+        hidden_states,
+        attention_mask,
+        position_ids,
+        deterministic: bool = True,
+        init_cache: bool = False,
+        output_attentions: bool = False,
+    ):
+        xq, xk, xv = self.wq(hidden_states), self.wk(hidden_states), self.wv(hidden_states)
+
+        xq = self._split_heads(xq, self.num_heads)
+        xk = self._split_heads(xk, self.num_key_value_heads)
+        xv = self._split_heads(xv, self.num_key_value_heads)
+
+        freqs_cis = jnp.take(self.freqs_cis, position_ids, axis=0)
+
+        xq, xk = apply_rotary_emb(xq, xk, freqs_cis=freqs_cis, dtype=self.dtype)
+
+        query_length, key_length = xq.shape[1], xk.shape[1]
+        
+        if self.has_variable("cache", "cached_key"):
+            mask_shift = self.variables["cache"]["cache_index"]
+            max_decoder_length = self.variables["cache"]["cached_key"].shape[1]
+            causal_mask = lax.dynamic_slice(
+                self.causal_mask, (0, 0, mask_shift, 0), (1, 1, query_length, max_decoder_length)
+            )
+        else:
+            causal_mask = self.causal_mask[:, :, :query_length, :key_length]
+        
+        batch_size = hidden_states.shape[0]
+        causal_mask = jnp.broadcast_to(causal_mask, (batch_size,) + causal_mask.shape[1:])
+
+        attention_mask = jnp.broadcast_to(jnp.expand_dims(attention_mask, axis=(-3, -2)), causal_mask.shape)
+        attention_mask = combine_masks(attention_mask, causal_mask)
+
+        dropout_rng = None
+        if not deterministic and self.config.attn_pdrop > 0.0:
+            dropout_rng = self.make_rng("dropout")
+        
+        # During fast autoregressive decoding, we feed one position at a time,
+        # and cache the keys and values step by step.
+        if self.has_variable("cache", "cached_key") or init_cache:
+            xk, xv, attention_mask = self._concatenate_to_cache(xk, xv, xq, attention_mask)
+        
+        # transform boolean mask into float mask
+        attention_bias = lax.select(
+            attention_mask > 0,
+            jnp.full(attention_mask.shape, 0.0).astype(self.dtype),
+            jnp.full(attention_mask.shape, jnp.finfo(self.dtype).min).astype(self.dtype),
+        )
+
+        xk = repeat_kv(xk, self.num_key_value_groups)
+        xv = repeat_kv(xv, self.num_key_value_groups)
+
+        # usual dot product attention
+        attn_weights = dot_product_attention_weights(
+            xq, 
+            xk, 
+            bias=attention_bias, 
+            dropout_rng=dropout_rng, 
+            dropout_rate=self.config.attn_pdrop, 
+            deterministic=deterministic, 
+            dtype=self.dtype, 
+            precision=self.precision, 
+        )
+
+        attn_output = jnp.einsum("...hqk,...khd->...qhd", attn_weights, xv, precision=self.precision)
+        attn_output = self._merge_heads(attn_output)
+        attn_output = self.wo(attn_output)
+        attn_output = self.resid_dropout(attn_output, deterministic=deterministic)
+        
+        outputs = (attn_output, attn_weights) if output_attentions else (attn_output,)
+        return outputs
+        
+class FlaxLLaMAMLP(nn.Module):
+    config: LLaMAConfig
+    dtype: jnp.dtype=jnp.float32
+    param_dtype: jnp.dtype=jnp.float32
+    precision: Optional[Union[jax.lax.Precision, str]]=None
+
+    def setup(self) -> None:
+        config = self.config
+
+        self.w1 = nn.Dense(
+            config.intermediate_size, 
+            dtype=self.dtype, 
+            param_dtype=self.param_dtype, 
+            use_bias=False, 
+            kernel_init=jax.nn.initializers.normal(self.config.initializer_range), 
+            precision=self.precision, 
+        )
+        self.w2 = nn.Dense(
+            config.hidden_size, 
+            dtype=self.dtype, 
+            param_dtype=self.param_dtype, 
+            use_bias=False, 
+            kernel_init=jax.nn.initializers.normal(self.config.initializer_range), 
+            precision=self.precision, 
+        )
+        self.w3 = nn.Dense(
+            config.intermediate_size, 
+            dtype=self.dtype, 
+            param_dtype=self.param_dtype, 
+            use_bias=False, 
+            kernel_init=jax.nn.initializers.normal(self.config.initializer_range), 
+            precision=self.precision, 
+        )
+        self.dropout = nn.Dropout(rate=self.config.resid_pdrop)
+
+    def __call__(self, x: jnp.ndarray, deterministic: bool = True) -> jnp.ndarray:
+        x = self.w2(nn.silu(self.w1(x)) * self.w3(x))
+        x = self.dropout(x, deterministic=deterministic)
+        return x
+
+class FlaxLLaMABlock(nn.Module):
+    config: LLaMAConfig
+    dtype: jnp.dtype=jnp.float32
+    param_dtype: jnp.dtype=jnp.float32
+    precision: Optional[Union[jax.lax.Precision, str]]=None
+
+    def setup(self) -> None:
+        self.attention = FlaxLLaMAAttention(
+            self.config, 
+            dtype=self.dtype, 
+            param_dtype=self.param_dtype, 
+            precision=self.precision, 
+        )
+        self.feed_forward = FlaxLLaMAMLP(
+            self.config, 
+            dtype=self.dtype, 
+            param_dtype=self.param_dtype, 
+            precision=self.precision, 
+        )
+        self.attention_norm = RMSNorm(
+            self.config.hidden_size, 
+            eps=self.config.rms_norm_eps, 
+            dtype=self.dtype, 
+            param_dtype=self.param_dtype, 
+        )
+        self.ffn_norm = RMSNorm(
+            self.config.hidden_size, 
+            eps=self.config.rms_norm_eps, 
+            dtype=self.dtype, 
+            param_dtype=self.param_dtype, 
+        )
+    
+    def __call__(
+        self,
+        hidden_states,
+        attention_mask=None,
+        position_ids=None,
+        deterministic: bool = True,
+        init_cache: bool = False,
+        output_attentions: bool = False,
+    ):
+        attn_outputs = self.attention(
+            self.attention_norm(hidden_states), 
+            attention_mask=attention_mask, 
+            position_ids=position_ids, 
+            deterministic=deterministic, 
+            init_cache=init_cache, 
+            output_attentions=output_attentions, 
+        )
+        attn_output = attn_outputs[0]
+        hidden_states = hidden_states + attn_output
+
+        feed_forward_hidden_states = self.feed_forward(
+            self.ffn_norm(hidden_states), 
+            deterministic=deterministic, 
+        )
+        hidden_states = hidden_states + feed_forward_hidden_states
+
+        return (hidden_states,) + attn_outputs[1:]
+
+class FlaxLLaMAPreTrainedModel(FlaxPreTrainedModel):
+    """
+    An abstract class to handle weights initialization and a simple interface for downloading and loading pretrained
+    models.
+    """
+
+    config_class = LLaMAConfig
+    base_model_prefix = "transformer"
+    module_class: nn.Module = None
+
+    def __init__(
+        self,
+        config: LLaMAConfig,
+        input_shape: Tuple = (1, 1),
+        seed: int = 0,
+        dtype: jnp.dtype = jnp.float32,
+        _do_init: bool = True,
+        **kwargs,
+    ):
+        module = self.module_class(config=config, dtype=dtype, **kwargs)
+        super().__init__(config, module, input_shape=input_shape, seed=seed, dtype=dtype, _do_init=_do_init)
+
+    def init_weights(self, rng: jax.random.PRNGKey, input_shape: Tuple, params: FrozenDict = None) -> FrozenDict:
+        # init input tensors
+        input_ids = jnp.zeros(input_shape, dtype="i4")
+        attention_mask = jnp.ones_like(input_ids)
+        position_ids = jnp.broadcast_to(jnp.arange(jnp.atleast_2d(input_ids).shape[-1]), input_shape)
+        params_rng, dropout_rng = jax.random.split(rng)
+        rngs = {"params": params_rng, "dropout": dropout_rng}
+
+        if self.config.add_cross_attention:
+            encoder_hidden_states = jnp.zeros(input_shape + (self.config.hidden_size,))
+            encoder_attention_mask = attention_mask
+            module_init_outputs = self.module.init(
+                rngs,
+                input_ids,
+                attention_mask,
+                position_ids,
+                encoder_hidden_states,
+                encoder_attention_mask,
+                return_dict=False,
+            )
+        else:
+            module_init_outputs = self.module.init(rngs, input_ids, attention_mask, position_ids, return_dict=False)
+
+        random_params = module_init_outputs["params"]
+
+        if params is not None:
+            random_params = flatten_dict(unfreeze(random_params))
+            params = flatten_dict(unfreeze(params))
+            for missing_key in self._missing_keys:
+                params[missing_key] = random_params[missing_key]
+            self._missing_keys = set()
+            return freeze(unflatten_dict(params))
+        else:
+            return random_params
+
+    def init_cache(self, batch_size, max_length):
+        r"""
+        Args:
+            batch_size (`int`):
+                batch_size used for fast auto-regressive decoding. Defines the batch size of the initialized cache.
+            max_length (`int`):
+                maximum possible length for auto-regressive decoding. Defines the sequence length of the initialized
+                cache.
+        """
+        # init input variables to retrieve cache
+        input_ids = jnp.ones((batch_size, max_length))
+        attention_mask = jnp.ones_like(input_ids)
+        position_ids = jnp.broadcast_to(jnp.arange(jnp.atleast_2d(input_ids).shape[-1]), input_ids.shape)
+
+        init_variables = self.module.init(
+            jax.random.PRNGKey(0), input_ids, attention_mask, position_ids, return_dict=False, init_cache=True
+        )
+        return init_variables["cache"]
+
+    @add_start_docstrings_to_model_forward("")
+    def __call__(
+        self,
+        input_ids,
+        attention_mask=None,
+        position_ids=None,
+        params: dict = None,
+        past_key_values: dict = None,
+        dropout_rng: jax.random.PRNGKey = None,
+        train: bool = False,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+    ):
+        output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
+        output_hidden_states = (
+            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        )
+        return_dict = return_dict if return_dict is not None else self.config.return_dict
+
+        batch_size, sequence_length = input_ids.shape
+
+        if position_ids is None:
+            if past_key_values is not None:
+                raise ValueError("Make sure to provide `position_ids` when passing `past_key_values`.")
+
+            position_ids = jnp.broadcast_to(jnp.arange(sequence_length)[None, :], (batch_size, sequence_length))
+
+        if attention_mask is None:
+            attention_mask = jnp.ones((batch_size, sequence_length))
+
+        # Handle any PRNG if needed
+        rngs = {}
+        if dropout_rng is not None:
+            rngs["dropout"] = dropout_rng
+
+        inputs = {"params": params or self.params}
+
+        # if past_key_values are passed then cache is already initialized a private flag init_cache has to be passed down to ensure cache is used. It has to be made sure that cache is marked as mutable so that it can be changed by FlaxGPTJAttention module
+        if past_key_values:
+            inputs["cache"] = past_key_values
+            mutable = ["cache"]
+        else:
+            mutable = False
+
+        outputs = self.module.apply(
+            inputs,
+            jnp.array(input_ids, dtype="i4"),
+            jnp.array(attention_mask, dtype="i4"),
+            jnp.array(position_ids, dtype="i4"),
+            not train,
+            False,
+            output_attentions,
+            output_hidden_states,
+            return_dict,
+            rngs=rngs,
+            mutable=mutable,
+        )
+
+        # add updated cache to model output
+        if past_key_values is not None and return_dict:
+            outputs, past_key_values = outputs
+            outputs["past_key_values"] = unfreeze(past_key_values["cache"])
+            return outputs
+        elif past_key_values is not None and not return_dict:
+            outputs, past_key_values = outputs
+            outputs = outputs[:1] + (unfreeze(past_key_values["cache"]),) + outputs[1:]
+
+        return outputs
+
+class FlaxLLaMABlockCollection(nn.Module):
+    config: LLaMAConfig
+    dtype: jnp.dtype = jnp.float32
+    param_dtype: jnp.dtype=jnp.float32
+    precision: Optional[Union[jax.lax.Precision, str]]=None
+
+    def setup(self):
+        block = FlaxLLaMABlock
+        if self.config.gradient_checkpointing:
+            FlaxLLaMACheckpointBlock = remat(block, static_argnums=(3, 4, 5))
+            block = FlaxLLaMACheckpointBlock
+        self.blocks = [
+            block(self.config, name=str(i), dtype=self.dtype, param_dtype=self.param_dtype, precision=self.precision) for i in range(self.config.num_hidden_layers)
+        ]
+
+    def __call__(
+        self,
+        hidden_states,
+        attention_mask=None,
+        position_ids=None,
+        deterministic: bool = True,
+        init_cache: bool = False,
+        output_attentions: bool = False,
+        output_hidden_states: bool = False,
+        return_dict: bool = True,
+    ):
+        all_attentions = () if output_attentions else None
+        all_hidden_states = () if output_hidden_states else None
+
+        for block in self.blocks:
+            if output_hidden_states:
+                all_hidden_states += (hidden_states,)
+
+            layer_outputs = block(
+                hidden_states, 
+                attention_mask, 
+                position_ids, 
+                deterministic, 
+                init_cache, 
+                output_attentions, 
+            )
+            hidden_states = layer_outputs[0]
+
+            if output_attentions:
+                all_attentions += (layer_outputs[1],)
+
+        # this contains possible `None` values - `FlaxGPTJModule` will filter them out
+        outputs = (hidden_states, all_hidden_states, all_attentions)
+
+        return outputs
+
+class FlaxLLaMAModule(nn.Module):
+    config: LLaMAConfig
+    dtype: jnp.dtype = jnp.float32
+    param_dtype: jnp.dtype=jnp.float32
+    precision: Optional[Union[jax.lax.Precision, str]]=None
+
+    def setup(self):
+        self.embed_dim = self.config.hidden_size
+
+        self.wte = nn.Embed(
+            self.config.vocab_size,
+            self.config.hidden_size,
+            embedding_init=jax.nn.initializers.normal(stddev=self.config.initializer_range),
+            dtype=self.dtype, 
+            param_dtype=self.param_dtype, 
+        )
+        self.dropout = nn.Dropout(rate=self.config.embd_pdrop)
+        self.h = FlaxLLaMABlockCollection(self.config, dtype=self.dtype, param_dtype=self.param_dtype, precision=self.precision)
+        self.ln_f = RMSNorm(self.config.hidden_size, eps=self.config.rms_norm_eps, dtype=self.dtype, param_dtype=self.param_dtype)
+
+    def __call__(
+        self,
+        input_ids,
+        attention_mask,
+        position_ids,
+        deterministic=True,
+        init_cache: bool = False,
+        output_attentions: bool = False,
+        output_hidden_states: bool = False,
+        return_dict: bool = True,
+    ):
+        input_embeds = self.wte(input_ids.astype("i4"))
+
+        hidden_states = self.dropout(input_embeds, deterministic=deterministic)
+
+        outputs = self.h(
+            hidden_states,
+            attention_mask,
+            position_ids=position_ids,
+            deterministic=deterministic,
+            init_cache=init_cache,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+        )
+
+        hidden_states = outputs[0]
+        hidden_states = self.ln_f(hidden_states)
+
+        if output_hidden_states:
+            all_hidden_states = outputs[1] + (hidden_states,)
+            outputs = (hidden_states, all_hidden_states) + outputs[2:]
+        else:
+            outputs = (hidden_states,) + outputs[1:]
+
+        if not return_dict:
+            return tuple(v for v in outputs if v is not None)
+
+        return FlaxBaseModelOutput(
+            last_hidden_state=hidden_states,
+            hidden_states=outputs[1],
+            attentions=outputs[-1],
+        )
+
+@add_start_docstrings("", "")
+class FlaxLLaMAModel(FlaxLLaMAPreTrainedModel):
+    module_class = FlaxLLaMAModule
+
+# append_call_sample_docstring(
+#     FlaxLLaMAModel,
+#     _TOKENIZER_FOR_DOC,
+#     _CHECKPOINT_FOR_DOC,
+#     FlaxCausalLMOutput,
+#     _CONFIG_FOR_DOC,
+# )
+
+class FlaxLLaMAForCausalLMModule(nn.Module):
+    config: LLaMAConfig
+    dtype: jnp.dtype = jnp.float32
+    param_dtype: jnp.dtype=jnp.float32
+    precision: Optional[Union[jax.lax.Precision, str]]=None
+
+    def setup(self):
+        self.transformer = FlaxLLaMAModule(self.config, dtype=self.dtype)
+        self.lm_head = nn.Dense(
+            self.config.vocab_size, 
+            dtype=self.dtype, 
+            param_dtype=self.param_dtype, 
+            use_bias=False, 
+            kernel_init=jax.nn.initializers.normal(stddev=self.config.initializer_range), 
+            precision=self.precision, 
+        )
+
+    def __call__(
+        self,
+        input_ids,
+        attention_mask,
+        position_ids,
+        deterministic: bool = True,
+        init_cache: bool = False,
+        output_attentions: bool = False,
+        output_hidden_states: bool = False,
+        return_dict: bool = True,
+    ):
+        outputs = self.transformer(
+            input_ids,
+            attention_mask,
+            position_ids,
+            deterministic=deterministic,
+            init_cache=init_cache,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+        )
+
+        hidden_states = outputs[0]
+
+        if self.config.tie_word_embeddings:
+            shared_kernel = self.transformer.variables["params"]["wte"]["embedding"].T
+            lm_logits = self.lm_head.apply({"params": {"kernel": shared_kernel}}, hidden_states)
+        else:
+            lm_logits = self.lm_head(hidden_states)
+
+        if not return_dict:
+            return (lm_logits,) + outputs[1:]
+
+        return FlaxCausalLMOutput(logits=lm_logits, hidden_states=outputs.hidden_states, attentions=outputs.attentions)
+
+
+@add_start_docstrings("", "")
+class FlaxLLaMAForCausalLM(FlaxLLaMAPreTrainedModel):
+    module_class = FlaxLLaMAForCausalLMModule
+
+    def prepare_inputs_for_generation(self, input_ids, max_length, attention_mask: Optional[jnp.ndarray] = None):
+        # initializing the cache
+        batch_size, seq_length = input_ids.shape
+
+        past_key_values = self.init_cache(batch_size, max_length)
+        # Note that usually one would have to put 0's in the attention_mask for x > input_ids.shape[-1] and x < cache_length.
+        # But since GPTJ uses a causal mask, those positions are masked anyways.
+        # Thus we can create a single static attention_mask here, which is more efficient for compilation
+        extended_attention_mask = jnp.ones((batch_size, max_length), dtype="i4")
+        if attention_mask is not None:
+            position_ids = attention_mask.cumsum(axis=-1) - 1
+            extended_attention_mask = lax.dynamic_update_slice(extended_attention_mask, attention_mask, (0, 0))
+        else:
+            position_ids = jnp.broadcast_to(jnp.arange(seq_length, dtype="i4")[None, :], (batch_size, seq_length))
+
+        return {
+            "past_key_values": past_key_values,
+            "attention_mask": extended_attention_mask,
+            "position_ids": position_ids,
+        }
+
+    def update_inputs_for_generation(self, model_outputs, model_kwargs):
+        model_kwargs["past_key_values"] = model_outputs.past_key_values
+        model_kwargs["position_ids"] = model_kwargs["position_ids"][:, -1:] + 1
+        return model_kwargs
+
+# append_call_sample_docstring(
+#     FlaxGPTJForCausalLM,
+#     _TOKENIZER_FOR_DOC,
+#     _CHECKPOINT_FOR_DOC,
+#     FlaxCausalLMOutput,
+#     _CONFIG_FOR_DOC,
+# )

--- a/tests/jax/models/llama/3_1_8b/jax_llama/partition.py
+++ b/tests/jax/models/llama/3_1_8b/jax_llama/partition.py
@@ -1,0 +1,98 @@
+import re
+from flax.core.frozen_dict import freeze
+from flax.traverse_util import flatten_dict, unflatten_dict
+from jax.sharding import PartitionSpec as P
+import jax
+from jax.sharding import NamedSharding
+from jaxtyping import PyTree
+
+# Sentinels
+_unmatched = object()
+
+# For specifying empty leaf dict `{}`
+empty_dict = object()
+
+
+def _match(qs, ks):
+    """Return True if regexes in qs match any window of strings in tuple ks."""
+    # compile regexes and force complete match
+    qts = tuple(map(lambda x: re.compile(x + "$"), qs))
+    for i in range(len(ks) - len(qs) + 1):
+        matches = [x.match(y) for x, y in zip(qts, ks[i:])]
+        if matches and all(matches):
+            return True
+    return False
+
+
+def _replacement_rules(rules):
+    def replace(key, val):
+        for rule, replacement in rules:
+            if _match(rule, key):
+                return replacement
+        return val
+
+    return replace
+
+def get_partition_spec(in_dict, rules):
+    replace = _replacement_rules(rules)
+    initd = {k: _unmatched for k in flatten_dict(in_dict)}
+    result = {k: replace(k, v) for k, v in initd.items()}
+    assert _unmatched not in result.values(), "Incomplete partition spec."
+    return freeze(unflatten_dict(result))
+
+def _get_partition_rules_llama(fsdp: bool=False):
+    if fsdp:
+        return [
+            # embeddings
+            (("transformer", "wte", "embedding"), P("mp", "dp")), 
+            # atention
+            (("attention", "(wq|wk|wv)", "kernel"), P("dp", "mp")), 
+            (("attention", "wo", "kernel"), P("mp", "dp")), 
+            # mlp
+            (("feed_forward", "w1", "kernel"), P("dp", "mp")), 
+            (("feed_forward", "w2", "kernel"), P("mp", "dp")), 
+            (("feed_forward", "w3", "kernel"), P("dp", "mp")), 
+            # layer norms
+            (("attention_norm", "kernel"), P(None)),
+            (("ffn_norm", "kernel"), P(None)),
+            # output head
+            (("transformer", "ln_f", "kernel"), P(None)), 
+            (("lm_head", "kernel"), P("dp", "mp")), 
+        ]
+    return [
+        # embeddings
+        (("transformer", "wte", "embedding"), P("mp", None)), 
+        # atention
+        (("attention", "(wq|wk|wv)", "kernel"), P(None, "mp")), 
+        (("attention", "wo", "kernel"), P("mp", None)), 
+        # mlp
+        (("feed_forward", "w1", "kernel"), P(None, "mp")), 
+        (("feed_forward", "w2", "kernel"), P("mp", None)), 
+        (("feed_forward", "w3", "kernel"), P(None, "mp")), 
+        # layer norms
+        (("attention_norm", "kernel"), P(None)),
+        (("ffn_norm", "kernel"), P(None)),
+        # output head
+        (("transformer", "ln_f", "kernel"), P(None)), 
+        (("lm_head", "kernel"), P(None, "mp")), 
+    ]
+
+def get_llama_param_partition_spec(params: PyTree, fsdp: bool=False) -> PyTree:
+    return get_partition_spec(params, _get_partition_rules_llama(fsdp=fsdp))
+
+def global_mesh_defined():
+    """Checks if global xmap/pjit mesh resource environment is defined."""
+    maps_env = jax.experimental.maps.thread_resources.env
+    return maps_env.physical_mesh.devices.shape != ()  # pylint: disable=g-explicit-bool-comparison
+
+def with_sharding_constraint(x, axis_resources):
+    """Wrapper for pjit with_sharding_constraint, no-op on cpu or outside pjit."""
+    if jax.devices()[0].platform == 'cpu' or not global_mesh_defined():
+        return x
+    else:
+        return jax.lax.with_sharding_constraint(x, axis_resources)
+
+def with_named_sharding_constraint(x, mesh, partition_spec):
+    if mesh is not None:
+        return with_sharding_constraint(x, NamedSharding(mesh, partition_spec))
+    return x

--- a/tests/jax/models/llama/3_1_8b/requirements.txt
+++ b/tests/jax/models/llama/3_1_8b/requirements.txt
@@ -1,0 +1,15 @@
+transformers
+torch
+torchvision
+accelerate
+pillow
+qai-hub
+flax
+sentencepiece
+equinox
+tiktoken
+fairscale
+fire
+jax
+blobfile
+scikit-learn


### PR DESCRIPTION
# 🧠 LLaMA 3.1–8B: Tensor Parallel JAX Implementation (Draft PR)

This draft PR adds a tensor-parallel JAX implementation of Meta’s LLaMA 3.1–8B model using a 2×4 device mesh. The code supports both sharded and unsharded execution and matches Hugging Face’s PyTorch reference implementation.

---

## ✅ Setup Instructions

### 1. Install Python and Create Virtual Environment
```
sudo apt install python3.12-venv
mkdir tt
cd tt
python3.12 -m venv llama
source llama/bin/activate
```
### 2. Hugging Face Login
```
You must log into Hugging Face to download the LLaMA 3.1 weights.

pip install huggingface_hub
huggingface-cli login

    Make sure you've requested access to the Meta LLaMA 3 model: https://huggingface.co/meta-llama
```
### 🌿 Branch for This Implementation
```
All changes for this draft PR are in the branch:

llama-3.1.8b-tensor-parallel-draft

Clone the repository and checkout the branch:
git checkout llama-3.1.8b-tensor-parallel-draft

cd sw/
```

### 📁 Download and Structure Model Files
```
mkdir -p sw/llama3.1-8B/original
mkdir -p sw/llama3.1-8B/8B

huggingface-cli download meta-llama/Llama-3.1-8B original/tokenizer.model --local-dir sw/llama3.1-8B/original
huggingface-cli download meta-llama/Llama-3.1-8B original/consolidated.00.pth --local-dir sw/llama3.1-8B
huggingface-cli download meta-llama/Llama-3.1-8B original/params.json --local-dir sw/llama3.1-8B

mv sw/llama3.1-8B/consolidated.00.pth sw/llama3.1-8B/8B/
mv sw/llama3.1-8B/params.json sw/llama3.1-8B/8B/

Final structure:

sw/llama3.1-8B/
├── 8B/
│   ├── consolidated.00.pth
│   └── params.json
└── original/
    └── tokenizer.model
```

### 📦 Install Python Dependencies
```
Make sure you're using Python ≥3.10 (tested on 3.12):

pip install -r tests/jax/models/llama/3_1_8b/requirements.txt
```

### ▶️ Running the Scripts
```
You can run any of the available generation scripts using:

python3 tests/jax/models/llama/3_1_8b/generate_jax.py
python3 tests/jax/models/llama/3_1_8b/generate_hf.py
python3 tests/jax/models/llama/3_1_8b/generate_jax_unsharded.py

    generate_jax.py: Runs the sharded tensor-parallel JAX model (2×4 mesh).

    generate_jax_unsharded.py: Runs the unsharded JAX model.

    generate_hf.py: Runs the Hugging Face PyTorch reference model.

In generate_hf.py and generate_jax_unsharded.py, there are three example prompts commented in the code that can be modified for testing.

✅ All three scripts produce identical outputs for the same input prompt (up to floating point precision).
```

### ⚠️ Note on generate_jax.py (Tensor-Parallel Sharded)

When running the sharded JAX model on a 2×4 mesh:

❗ RAM usage exceeds 64 GB during sharding and the process is killed.

❓ Questions & Feedback

    Can you try running generate_jax.py on your end with more RAM?

        To confirm memory requirements.

        To verify whether the issue is hardware-related.

    Prompt formatting:

        I'm currently using 2-shot prompting, which ensures consistent outputs between the sharded JAX and Hugging Face PyTorch models.

        ❓ Is it expected that prompting style affects alignment?

    Correctness checks:

        ✅ I have verified that the logits match exactly between:

            Sharded JAX

            Unsharded JAX

            Hugging Face PyTorch

    Memory use:

        ❓ Is it expected that sharding the LLaMA 3.1 8B model exceeds 64 GB RAM?

        Or is there something incorrect in the sharding logic?

Let me know how I can improve this or whether the memory limit is just a system constraint 🙏


