### PR TITLE
Skip xlm_roberta_base model

### DIFF
--- a/tests/jax/single_chip/models/xlm_roberta/large/test_xlm_roberta_large.py
+++ b/tests/jax/single_chip/models/xlm_roberta/large/test_xlm_roberta_large.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    incorrect_result,
+    failed_fe_compilation,
 )
 
 from ..tester import XLMRobertaTester
@@ -48,12 +48,11 @@ def training_tester() -> XLMRobertaTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.INCORRECT_RESULT,
+    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
 )
-@pytest.mark.xfail(
-    reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=131073.1875. Required: atol=0.16. "
-        "https://github.com/tenstorrent/tt-xla/issues/379"
+@pytest.mark.skip(
+    reason=failed_fe_compilation(
+        "OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186)"
     )
 )
 def test_xlm_roberta_large_inference(inference_tester: XLMRobertaTester):


### PR DESCRIPTION
### Problem description
xlm_robert_base test is killed in [CI](https://github.com/tenstorrent/tt-xla/actions/runs/15057562514/job/42327012308)

### What's changed
updated the marker to skip in test_xlm_roberta_base file

### Checklist
- [x] New/Existing tests provide coverage for changes
