### PR TITLE
Fix few PJRT Buffer Instance bugs

### DIFF
--- a/inc/common/pjrt_implementation/buffer_instance.h
+++ b/inc/common/pjrt_implementation/buffer_instance.h
@@ -11,6 +11,7 @@
 // c++ standard library includes
 #include <memory>
 #include <mutex>
+#include <thread>
 #include <vector>
 
 // PJRT C API includes
@@ -187,6 +188,9 @@ private:
 
   // Mutex guarding buffer data deletion.
   std::mutex m_data_deleted_mutex;
+
+  // Thread for copying data to host.
+  std::unique_ptr<std::thread> m_copy_to_host_thread;
 };
 
 namespace internal {


### PR DESCRIPTION
### Problem description
Fixing two bugs found in `BufferInstance` PJRT class:
- Runtime tensor can be uninitialized if something breaks between input buffer creation and copying data from host (for example if buffer has unsupported data format), so we have to check if handle is set before deallocating tensor. This had lead to segfault in models with unsupported data formats.
- `copyToHost` creates thread for copying data and immediately joins on it, I did that as a first step when I was adding the async implementation and forgot to finish it later.

### What's changed
- Added check if handle is set before deallocating tensor.
- Added member variable for `copyToHost` thread, which we now leave to run in the background and join only during destruction of buffer instance.

### Checklist
- [x] New/Existing tests provide coverage for changes
