### PR TITLE
Change tensor memory output kinds to 'tt_device'

### DIFF
--- a/src/common/pjrt_implementation/executable_image.cc
+++ b/src/common/pjrt_implementation/executable_image.cc
@@ -107,9 +107,9 @@ ExecutableImage::ExecutableImage(
   // PJRT_LoadedExecutable_Execute.
   for (size_t output_index = 0; output_index < m_num_outputs; ++output_index) {
     m_output_memory_kinds.emplace_back(
-        MemoryInstance::c_host_memory_kind_name.c_str());
+        MemoryInstance::c_device_memory_kind_name.c_str());
     m_output_memory_kinds_sizes.emplace_back(
-        MemoryInstance::c_host_memory_kind_name.size());
+        MemoryInstance::c_device_memory_kind_name.size());
   }
 }
 

--- a/src/common/pjrt_implementation/loaded_executable_instance.cc
+++ b/src/common/pjrt_implementation/loaded_executable_instance.cc
@@ -337,7 +337,8 @@ void LoadedExecutableInstance::fillPJRTOutputLists(
       std::unique_ptr<BufferInstance> output_buffer =
           BufferInstance::createOutputBufferInstance(
               output_tensor, std::move(output_shape),
-              m_addressable_devices[device_index], m_host_memory);
+              m_addressable_devices[device_index],
+              m_addressable_devices[device_index]->getDefaultMemory());
 
       output_buffer->markAsDataReady();
 


### PR DESCRIPTION
Currently, we have set all output memory kinds to be 'tt_host', as we put the output tensors on host after the execution. However, jax expects the output buffer memory kind to be 'device' if the buffer is sharded, leading to a mismatch and fails in the jax library. This PR fixes that.