### PR TITLE
Update skip reason for dinov2 giant model

### DIFF
--- a/tests/jax/single_chip/models/dinov2/giant/test_dinov2_giant.py
+++ b/tests/jax/single_chip/models/dinov2/giant/test_dinov2_giant.py
@@ -53,8 +53,7 @@ def training_tester() -> Dinov2Tester:
 )
 @pytest.mark.skip(
     reason=failed_fe_compilation(
-        'AttributeError: "FlaxDinov2SwiGLUFFN" object has no attribute "hidden_features" '
-        "(https://github.com/tenstorrent/tt-xla/issues/567)"
+        "OOM in CI (https://github.com/tenstorrent/tt-xla/issues/186)"
     )
 )
 def test_dinov2_giant_inference(inference_tester: Dinov2Tester):


### PR DESCRIPTION
Flax issue in Dino V2 is resolved. Tested it again and checked that it is crossing the threshold memory limit.

updated the test with skip marker

### Checklist
- [x] New/Existing tests provide coverage for changes
