### PR TITLE
Mistral small implementation for testing tensor parallelism

### DIFF
--- a/tests/jax/multi_chip/bounties/mistral_small/README.md
+++ b/tests/jax/multi_chip/bounties/mistral_small/README.md
@@ -1,0 +1,61 @@
+mistral_nnx is a Flax NNX implementation of Mistral models.
+
+Copied from https://github.com/yiding/mistral-nnx
+
+## Support
+
+The model has been tested with mistral-small and ministral-8b. Note that
+Ministral-8b uses sliding window, which is not supported, so long sequences may
+not behave correctly.
+
+### Supported Features
+
+Attention: Grouped Query Attention (GQA), but implementation should also support MHA.
+
+Sliding window: not supported.
+
+KV Cache: Very rudimentary KV Cache, supports batch-size 1.
+
+## Usage
+
+### Config
+
+The model uses configuration from the model repo from Huggingface Hub.
+
+### Weights
+
+Model supports loading the safetensor weights from huggingface hub. Weights
+loaded this way need to be transposed or reshaped before usage. There's
+additional code to save the transformed weights into an orbax checkpoint, which
+loads much faster.
+
+### Inference
+
+MistralModel supports basic forward pass using `MistralModel.__call__()`, which
+takes an array of a batch of tokens `(batch_size, seq_len)`.
+
+It also supports KV cache with batch-size 1 using `MistralModel.decode()`.
+`generate.py` contains code to setup and run inference with kv cache.
+
+### Parallelism
+
+The model parameter initializers has been annotated with Flax [local axis
+annotations](https://flax.readthedocs.io/en/latest/guides/flax_gspmd.html#logical-axis-annotation).
+
+The parameter loading functions `MistralModel.load` and
+`MistralModel.load_from_hf_pt_model` can be passed a `mesh` and `sharding_rules`
+mapping that maps the logical axis names to mesh axis names, this annotates the
+parameter arrays with jax sharding constraints and ensure the params are loaded
+to the correct devices.
+
+An example usage is provided in `test_model_implementation.py`.
+
+
+### JIT
+
+`nnx.jit` has high CPU overhead, and has been observed to sometimes have high
+memory overhead as well. A more performant alternative is to use `jax.jit` with
+`nnx.split`.
+
+Examples of this method are provided in `generate.py` and
+`test_model_implementation.py`.

--- a/tests/jax/multi_chip/bounties/mistral_small/convert_hf_model.py
+++ b/tests/jax/multi_chip/bounties/mistral_small/convert_hf_model.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Convert Mistral HF model to model loadable by NNX model.
+
+This will load the hf model, reshape and transform parameter arrays as needed,
+and then save them using orbax checkpointer. It will also write model and
+tokenizer configs.
+"""
+
+import argparse
+import mistral_nnx
+from pathlib import Path
+from transformers import AutoTokenizer
+import shutil
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert HF Mistral model to NNX model."
+    )
+    parser.add_argument("HF_MODEL", type=str)
+    parser.add_argument("OUTPUT_DIR", type=Path)
+    args = parser.parse_args()
+
+    mistral_nnx.convert_hf_model(args.HF_MODEL, args.OUTPUT_DIR)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/jax/multi_chip/bounties/mistral_small/mistral_nnx/__init__.py
+++ b/tests/jax/multi_chip/bounties/mistral_small/mistral_nnx/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .model import *

--- a/tests/jax/multi_chip/bounties/mistral_small/mistral_nnx/embedding.py
+++ b/tests/jax/multi_chip/bounties/mistral_small/mistral_nnx/embedding.py
@@ -1,0 +1,127 @@
+# Copyright 2024 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-FileCopyrightText: Copyright 2024 Google LLC.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Rotary embedding implementation.
+
+This implementation expects the features to be ordered in odds and evens.
+
+From flaxformers/components/embedding.py
+"""
+
+import functools
+
+import jax
+import jax.numpy as jnp
+
+
+def rotate_half(x):
+    """Helper that splits a tensor at last dim into half and rotate it."""
+    x1, x2 = jnp.split(x, 2, axis=-1)
+    x = jnp.concatenate([-x2, x1], axis=-1)
+    return x
+
+
+@functools.partial(jax.jit, static_argnums=(4,))
+def apply_rotary_embedding(q, k, cos, sin, decode=False, rotary_index=None):
+    """Helper function to apply Rotary Embeddings."""
+    if len(k.shape) == 3:
+        # for multi query attention
+        k = jnp.expand_dims(k, 2)
+        multiquery = True
+    else:
+        multiquery = False
+
+    batch, qlen, qheads, d = q.shape
+    kbatch, klen, kheads, kd = k.shape
+    assert batch == kbatch, f"{batch} != {kbatch}"
+    assert d == kd, f"{d} != {kd}"
+
+    # cos: [len, d]
+    # sin: [len, d]
+    # rotary_index: [batch]
+
+    if decode and qlen == 1 and rotary_index is not None:
+        # we check qlen == 1 so that we don't do this when initializing cache.
+        qcos = cos[rotary_index, :]
+        qsin = sin[rotary_index, :]
+        # qcos, qsin: [batch, d]
+        qcos = jax.lax.broadcast_in_dim(qcos, (batch, qlen, qheads, d), (0, 3))
+        qsin = jax.lax.broadcast_in_dim(qsin, (batch, qlen, qheads, d), (0, 3))
+        # qcos, qsin: [batch, qlen, qheads, d]
+    else:
+        qcos, qsin = cos[:qlen, :], sin[:qlen, :]
+        # qcos, qsin: [qlen, d]
+        qcos = jax.lax.broadcast_in_dim(qcos, (batch, qlen, qheads, d), (1, 3))
+        qsin = jax.lax.broadcast_in_dim(qsin, (batch, qlen, qheads, d), (1, 3))
+        # qcos, qsin: [batch, qlen, qheads, d]
+
+    kcos, ksin = cos[:klen, :], sin[:klen, :]
+    # kcos, ksin: [klen, d]
+    kcos = jax.lax.broadcast_in_dim(kcos, (batch, klen, kheads, d), (1, 3))
+    ksin = jax.lax.broadcast_in_dim(ksin, (batch, klen, kheads, d), (1, 3))
+    # kcos, ksin: [batch, klen, kheads, d]
+
+    out_q = (q * qcos) + (rotate_half(q) * qsin)
+    out_k = (k * kcos) + (rotate_half(k) * ksin)
+    if multiquery:
+        out_k = jnp.squeeze(out_k, 2)
+    return out_q, out_k
+
+
+def generate_fixed_pos_embedding(
+    features, length, min_timescale=1.0, max_timescale=10000.0
+):
+    """Generate Sin/Cos for Rotary Embeddings.
+
+    Generates sinusoids at (features//2) different timescales, where the
+    timescales form a gemetric series from min_timescale to max_timescale
+    (max_timescale is not included, but would be the next element in the series).
+
+    Sinusoids are evaluated at integer positions i in [0, length).
+
+    The outputs are computed as:
+
+      output_sin[i, j] = sin(i / timescale[j])
+      output_cos[i, j] = cos(i / timescale[j])
+
+    Finally, the outputs are tiled twice in the features dimension.
+
+    Args:
+      features: an integer
+      length: an integer
+      min_timescale: an optional float
+      max_timescale: an optional float
+
+    Returns:
+      output_sin: a float32 Tensor with shape [length, features]
+      output_cos: a float32 Tensor with shape [length, features]
+    """
+    fraction = jnp.arange(0, features, 2, dtype=jnp.float32) / features
+    timescale = min_timescale * (max_timescale / min_timescale) ** fraction
+    rotational_frequency = 1.0 / timescale
+    # Must use high precision einsum here, since rounding off to a bfloat16 is
+    # catastrophic. bfloat16 rounds 257 to 256, but sin(257) is very different
+    # from sin(256).
+    sinusoid_inp = jnp.einsum(
+        "i , j -> i j",
+        jnp.arange(length, dtype=jnp.float32),
+        rotational_frequency,
+        precision=jax.lax.Precision.HIGHEST,
+    )
+    sinusoid_inp = jnp.concatenate([sinusoid_inp, sinusoid_inp], axis=-1)
+
+    return jnp.sin(sinusoid_inp), jnp.cos(sinusoid_inp)

--- a/tests/jax/multi_chip/bounties/mistral_small/mistral_nnx/generate.py
+++ b/tests/jax/multi_chip/bounties/mistral_small/mistral_nnx/generate.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from dataclasses import dataclass
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+from jax import Array
+from jax.sharding import Mesh
+from jaxtyping import Float, Integer
+
+from .model import MistralModel
+
+
+def sample_best(logits: Float[Array, "*B V"]) -> Integer[Array, "*B"]:
+    return jnp.argmax(logits, axis=-1)
+
+
+def sample_top_p(
+    logits: Float[Array, "*B V"],
+    *,
+    temperature: float,
+    top_p: float,
+    key: Array,
+) -> Integer[Array, "*B"]:
+    """Top-p sampling.
+
+    Args:
+        key: RNG key
+    """
+    probs = nnx.softmax(logits / temperature, axis=-1)
+    return _sample_top_p(probs, top_p, key=key)
+
+
+def _sample_top_p(
+    probs: Float[Array, "*B V"], p: float, key: Array
+) -> Float[Array, "*B"]:
+    """Sample a token using top-p sampling."""
+    # From flax/examples/gemma/sampler.py
+    probs_sorted, indices = jax.lax.top_k(probs, k=probs.shape[-1])
+    cumsum_probs = jnp.cumsum(probs_sorted, axis=-1)
+    mask = cumsum_probs - probs_sorted > p
+    probs_sorted = jnp.where(mask, 0.0, probs_sorted)
+    probs_sorted /= jnp.sum(probs_sorted, axis=-1, keepdims=True)
+
+    next_token = jax.random.categorical(key, logits=jnp.log(probs_sorted))
+
+    next_token = jnp.take_along_axis(indices, next_token[..., None], axis=-1)
+    next_token = jnp.squeeze(next_token, axis=-1)
+    return next_token
+
+
+@dataclass
+class GenerateResult:
+    tokens: list[int]
+
+    # all logits, including those from input tokens
+    logits: Float[Array, "S V"]
+
+
+class Generator:
+    """Token generator using the mistral model.
+
+    - Holds on to a jitted function for running the model.
+    - Instantiates and uses KV cache to do incremental decoding.
+    """
+
+    def __init__(self, model: MistralModel, max_seqlen: int):
+        """
+        Args:
+            model: Mistral model.
+            max_seqlen: Maximum sequence length (input + max_tokens). This
+                controls the size of the allocated KV cache.
+
+        Note: max_seqlen is fixed at startup to prevent excessive jitting with
+        different kv cache sizes.
+        """
+        self.model = model
+        self.max_seqlen = max_seqlen
+
+        # Use jax.jit with pre-split model to avoid nnx.jit's cpu and memory
+        # overhead.
+        self.graphdef, self.state = nnx.split(self.model)
+        self._jit_decode = jax.jit(
+            self._jit_decode_impl,
+            donate_argnames=("cache",),
+        )
+
+        # Use nnx jit for this one to handle rngs, which is simple enough.
+        self._jit_sample_top_p = nnx.jit(sample_top_p)
+
+    @staticmethod
+    def _jit_decode_impl(graphdef, state, input, cache):
+        model = nnx.merge(graphdef, state)
+        logits, cache = model.decode(input, cache)
+        return logits, cache
+
+    def generate(
+        self,
+        input_ids: list[int],
+        *,
+        rngs: nnx.Rngs,
+        max_tokens: int = 20,
+        temperature: float = 1.0,
+        top_p: float = 0.8,
+        eos_id: int | None = 2,
+        mesh: Mesh | None = None,
+    ) -> GenerateResult:
+        """Generate output with simple greedy search.
+
+        Args:
+            input_ids: Sequence of tokens to generate from.
+            rngs: rng. The stream named 'sample' is used.
+            mesh: mesh used to shard kv cache, should be the same as what's used for the model.
+
+        Returns:
+            sequnece of generated tokens
+
+        """
+        max_tokens = max(len(input_ids), max_tokens)
+        assert max_tokens < self.max_seqlen
+        result = list(input_ids)
+
+        cache = self.model.create_cache(1, self.max_seqlen, mesh)
+        all_logits: list[Float[Array, "1 1 V"]] = []
+
+        # prefill cache and get first token
+        input = jnp.array(input_ids, dtype="int32")
+        input = input.reshape(1, -1)
+        logits = None
+        for i in range(input.shape[1]):
+            logits, cache = self._jit_decode(
+                self.graphdef,
+                self.state,
+                input[1, i].reshape(1, 1),
+                cache,
+            )
+            all_logits.append(logits)
+        assert logits is not None
+
+        for _ in range(max_tokens):
+            last_chosen = self._jit_sample_top_p(
+                logits[0, -1, :],
+                temperature=temperature,
+                top_p=top_p,
+                key=rngs.sample(),
+            )
+            assert len(last_chosen.shape) == 0
+            result.append(last_chosen.item())
+            if eos_id != None and last_chosen.item() == eos_id:
+                break
+
+            logits, cache = self._jit_decode(
+                self.graphdef,
+                self.state,
+                last_chosen.reshape(1, 1),
+                cache,
+            )
+            all_logits.append(logits)
+
+        return GenerateResult(
+            tokens=result,
+            logits=jnp.stack([x.reshape(-1) for x in all_logits]),
+        )

--- a/tests/jax/multi_chip/bounties/mistral_small/mistral_nnx/model.py
+++ b/tests/jax/multi_chip/bounties/mistral_small/mistral_nnx/model.py
@@ -1,0 +1,838 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Mistral inference implemented in Flax NNX.
+
+Can load weights from huggingface model.
+
+Conventions used for axis labeling:
+
+- B: batch
+- S: seqlen
+- V: vocab
+- E: embed
+- D: head_dim
+- H: num_heads
+- HQ: num_q_heads
+- K: num_kv_heads
+
+Note: The rotary embedding implementation used here is from flaxformers, which
+is same as hugginface transformers'. This is not compatible with
+mistral-inference's implementation. The order of the features must be swapped if
+using mistral weights. More details in class `RotaryEmbedding`.
+
+Not supported:
+- Sliding window
+
+"""
+
+import functools
+import os
+from contextlib import ExitStack
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable, Optional, Sequence
+
+import flax.core.spmd
+import flax.struct
+import jax
+import jax.numpy as jnp
+import orbax.checkpoint as ocp
+from flax import nnx
+from flax.typing import Dtype, Initializer, LogicalRules
+from jax import Array, ShapeDtypeStruct
+from jax.sharding import Mesh, NamedSharding, PartitionSpec, SingleDeviceSharding
+from jaxtyping import Float, Integer
+from safetensors import safe_open
+from transformers import MistralConfig
+from transformers.utils.hub import cached_file, get_checkpoint_shard_files
+
+from .embedding import apply_rotary_embedding, generate_fixed_pos_embedding
+from .util import keystr_simple, update_sharding
+
+PARAM_INDEX_FILE = "model.safetensors.index.json"
+
+
+class Axis(str, Enum):
+    EMBED = "embed"
+    MLP = "mlp"
+    HEAD = "head"
+    QHEAD = "qhead"
+    KVHEAD = "kvhead"
+    VOCAB = "vocab"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+@flax.struct.dataclass
+class KVCacheLayer:
+    cache_k: Float[Array, "B S H D"]
+    cache_v: Float[Array, "B S H D"]
+    index: Integer[Array, ""]
+
+    @property
+    def max_seqlen(self) -> int:
+        return self.cache_k.shape[1]
+
+    @classmethod
+    def create(
+        cls,
+        shape: tuple[int, ...],
+        dtype: Dtype,
+        mesh: Mesh | None = None,
+        sharding_rules: LogicalRules | None = None,
+    ) -> "KVCacheLayer":
+        assert len(shape) == 4, f"shape should be (B,S,H,D), got: {shape}"
+
+        # KV cache takes the output of K and V projections, which is sharded by
+        # KVHEAD, HEAD_DIM.  The KV cache itself should be sharded the same way.
+        if sharding_rules is None and mesh is None:
+            sharding = SingleDeviceSharding(jax.devices("cpu")[0])
+        elif sharding_rules is not None and mesh is not None:
+            rules_dict = {k: v for k, v in sharding_rules}
+            sharding = NamedSharding(
+                mesh,
+                PartitionSpec(
+                    None, None, rules_dict[Axis.KVHEAD], rules_dict[Axis.HEAD]
+                ),
+            )
+        else:
+            raise ValueError("mesh and sharding_rules must be both None or both set")
+
+        return cls(
+            cache_k=jnp.zeros(shape, dtype=dtype, device=sharding),
+            cache_v=jnp.zeros(shape, dtype=dtype, device=sharding),
+            index=jnp.array(0, dtype="int32"),
+        )
+
+    def update(
+        self, k: Float[Array, "B S H D"], v: Float[Array, "B S H D"]
+    ) -> "KVCacheLayer":
+        """Update the cache at the given index.
+
+        Can be used for prefill by passing array with seqlen > 1.
+
+        Args:
+            k: key array of shape (seqlen, num_kv_heads, head_dim)
+            v: value array of same shape
+
+        Returns:
+            updated cache layer with seqlen incremented by the amount from input.
+        """
+        KB, KS, _KH, _KD = k.shape
+        VB, VS, _VH, _VD = v.shape
+        assert (KB, KS) == (
+            VB,
+            VS,
+        ), f"k and v should have same batch,seqlen: {(KB, KS)} != {(VB,VS)}"
+        Z = jnp.array(0, dtype=self.index.dtype)
+        return KVCacheLayer(
+            cache_k=jax.lax.dynamic_update_slice(
+                self.cache_k, k, (Z, self.index, Z, Z)
+            ),
+            cache_v=jax.lax.dynamic_update_slice(
+                self.cache_v, v, (Z, self.index, Z, Z)
+            ),
+            index=self.index + KS,
+        )
+
+
+@flax.struct.dataclass
+class KVCache:
+    layers: list[KVCacheLayer]
+
+    @classmethod
+    def create(
+        cls,
+        num_layers: int,
+        batch_size: int,
+        max_seqlen: int,
+        num_kv_heads: int,
+        head_dim: int,
+        *,
+        dtype: Dtype,
+        mesh: Mesh | None = None,
+        sharding_rules: LogicalRules | None = None,
+    ) -> "KVCache":
+        shape = (batch_size, max_seqlen, num_kv_heads, head_dim)
+        return cls(
+            layers=[
+                KVCacheLayer.create(shape, dtype, mesh, sharding_rules)
+                for _ in range(num_layers)
+            ]
+        )
+
+
+class RotaryEmbedding(nnx.Module):
+    def __init__(self, features: int, length: int, theta: float):
+        """
+        Args:
+            features: Number of features
+            length: Max context length
+            theta: RoPE theta term
+        """
+        sin, cos = generate_fixed_pos_embedding(features, length, max_timescale=theta)
+        self.sin = nnx.Variable(sin)
+        self.cos = nnx.Variable(cos)
+
+    def __call__(
+        self,
+        q: Float[Array, "B S HQ D"],
+        k: Float[Array, "B S K D"],
+        index: Optional[Integer[Array, "B"]] = None,
+    ) -> tuple[Float[Array, "B S HQ D"], Float[Array, "B S K D"]]:
+        """Apply rotary embedding to query and key arrays.
+
+        Args:
+            q: query of shape (batch, seqlen, heads, head_dim)
+            k: key of shape (batch, seqlen, heads, head_dim)
+            index: position offset of query shape (batch,).
+                Used for incremental decoding w/ kv cache. seqlen==1 required
+                for q if this is set.
+
+        Returns:
+            (q, k) with embedding applied.
+
+        Note: This expects features to be ordered in odds and evens, i.e.
+        `x1, x3, x5 ... x2, x4, x6 ...`.
+
+        The weights for the whole model should be in this order. If using
+        weights that expect features to be (i.e. the mistral weights as used by
+        mistral-inference lib), it has to be converted into this order.
+        """
+        # Limitation of flaxformers apply_rotary_embedding
+        assert index is None or q.shape[1] == 1, "seqlen==1 required when index is set"
+        out_q, out_k = apply_rotary_embedding(
+            q,
+            k,
+            self.cos.value,
+            self.sin.value,
+            decode=index is not None,
+            rotary_index=index,
+        )
+        return out_q.astype(q.dtype), out_k.astype(k.dtype)
+
+
+def _init_with_sharding(
+    init_fn: Initializer,
+) -> Callable[[tuple[Axis, ...]], Initializer]:
+    """Returns a function that when invoked, returns an annotated initializer
+    when given logical axis annotations.
+    """
+
+    def init(sharding):
+        return nnx.with_partitioning(init_fn, sharding=sharding)
+
+    return init
+
+
+class FeedForward(nnx.Module):
+    def __init__(
+        self, dim: int, hidden_dim: int, dtype: Any, param_dtype: Dtype, rngs: nnx.Rngs
+    ):
+        self.dim = dim
+        self.hidden_dim = hidden_dim
+        self.param_dtype = param_dtype
+
+        init = _init_with_sharding(nnx.initializers.lecun_normal())
+
+        self.w1 = nnx.LinearGeneral(
+            self.dim,
+            self.hidden_dim,
+            kernel_init=init((Axis.EMBED, Axis.MLP)),
+            use_bias=False,
+            dtype=dtype,
+            rngs=rngs,
+            param_dtype=param_dtype,
+        )
+        self.w2 = nnx.LinearGeneral(
+            self.hidden_dim,
+            self.dim,
+            kernel_init=init((Axis.MLP, Axis.EMBED)),
+            use_bias=False,
+            dtype=dtype,
+            rngs=rngs,
+            param_dtype=param_dtype,
+        )
+        self.w3 = nnx.LinearGeneral(
+            self.dim,
+            self.hidden_dim,
+            kernel_init=init((Axis.EMBED, Axis.MLP)),
+            use_bias=False,
+            dtype=dtype,
+            rngs=rngs,
+            param_dtype=param_dtype,
+        )
+
+    def __call__(self, x: Float[Array, "B S E"]) -> Float[Array, "B S E"]:
+        return self.w2(nnx.silu(self.w1(x)) * self.w3(x))
+
+
+class Attention(nnx.Module):
+    """Mistral attention supports different number of Q heads vs KV heads."""
+
+    dim: int
+    n_q_heads: int
+    head_dim: int
+    n_kv_heads: int
+    dtype: Any
+
+    wq: nnx.LinearGeneral
+    wk: nnx.LinearGeneral
+    wv: nnx.LinearGeneral
+    wo: nnx.LinearGeneral
+
+    def __init__(
+        self,
+        dim: int,
+        n_q_heads: int,
+        head_dim: int,
+        n_kv_heads: int,
+        rope: RotaryEmbedding,
+        dtype: Dtype,
+        param_dtype: Dtype,
+        rngs: nnx.Rngs,
+    ):
+        self.dim = dim
+        self.n_q_heads = n_q_heads
+        self.head_dim = head_dim
+        self.n_kv_heads = n_kv_heads
+        self.rope = rope
+        self.dtype = dtype
+
+        init = _init_with_sharding(nnx.initializers.lecun_normal())
+
+        self.wq = nnx.LinearGeneral(
+            self.dim,
+            (self.n_q_heads, self.head_dim),
+            use_bias=False,
+            kernel_init=init((Axis.EMBED, Axis.QHEAD, Axis.HEAD)),
+            dtype=dtype,
+            param_dtype=param_dtype,
+            rngs=rngs,
+        )
+        self.wk = nnx.LinearGeneral(
+            self.dim,
+            (self.n_kv_heads, self.head_dim),
+            kernel_init=init((Axis.EMBED, Axis.KVHEAD, Axis.HEAD)),
+            use_bias=False,
+            dtype=dtype,
+            param_dtype=param_dtype,
+            rngs=rngs,
+        )
+        self.wv = nnx.LinearGeneral(
+            self.dim,
+            (self.n_kv_heads, self.head_dim),
+            kernel_init=init((Axis.EMBED, Axis.KVHEAD, Axis.HEAD)),
+            use_bias=False,
+            dtype=dtype,
+            param_dtype=param_dtype,
+            rngs=rngs,
+        )
+        self.wo = nnx.LinearGeneral(
+            (self.n_q_heads, self.head_dim),
+            self.dim,
+            axis=(-2, -1),
+            kernel_init=init((Axis.QHEAD, Axis.HEAD, Axis.EMBED)),
+            use_bias=False,
+            dtype=dtype,
+            param_dtype=param_dtype,
+            rngs=rngs,
+        )
+
+    @property
+    def _queries_per_head(self) -> int:
+        return self.n_q_heads // self.n_kv_heads
+
+    def __call__(self, x: Float[Array, "B S E"]) -> Array:
+        """
+        Args:
+          x: Array of shape (batch, seqlen, dim)
+        """
+        xq, xk, xv = self.wq(x), self.wk(x), self.wv(x)
+        xq, xk = self.rope(xq, xk)
+
+        out = jax.nn.dot_product_attention(xq, xk, xv, is_causal=True)
+        out = self.wo(out)
+        return out
+
+    def decode(
+        self,
+        x: Float[Array, "B S E"],
+        cache: KVCacheLayer,
+    ) -> tuple[Float[Array, "B S E"], KVCacheLayer]:
+        """Decode using KV cache.
+
+        Args:
+            x: The next items in the sequence. Shape (batch, seqlen, dim)
+
+        Returns:
+            (output, cache_layer) the output and updated cache layer.
+        """
+        B, T, _E = x.shape
+        assert B == 1, "only batch size 1 supported for now"
+        assert T == 1, "decode takes one token at a time"
+
+        xq, xk, xv = self.wq(x), self.wk(x), self.wv(x)
+        cache = cache.update(xk, xv)
+        xk = cache.cache_k
+        xv = cache.cache_v
+
+        index = jnp.array([cache.index - T], dtype="int32")
+        xq, xk = self.rope(xq, xk, index=index)
+
+        out = jax.nn.dot_product_attention(
+            xq,
+            xk,
+            xv,
+            query_seq_lengths=jnp.array([T], dtype="int32"),
+            key_value_seq_lengths=cache.index.reshape(B),
+        )
+        out = self.wo(out)
+        return out, cache
+
+
+class TransformerBlock(nnx.Module):
+    def __init__(
+        self,
+        *,
+        dim: int,
+        hidden_dim: int,
+        n_q_heads: int,
+        n_kv_heads: int,
+        head_dim: int,
+        norm_eps: float,
+        rope: RotaryEmbedding,
+        dtype: Any,
+        param_dtype: Dtype,
+        rngs: nnx.Rngs,
+    ):
+        init = _init_with_sharding(nnx.initializers.ones_init())
+
+        self.n_q_heads = n_q_heads
+        self.dim = dim
+        self.attention = Attention(
+            dim=dim,
+            n_q_heads=n_q_heads,
+            n_kv_heads=n_kv_heads,
+            head_dim=head_dim,
+            rope=rope,
+            dtype=dtype,
+            param_dtype=param_dtype,
+            rngs=rngs,
+        )
+        self.attention_norm = nnx.RMSNorm(
+            dim,
+            epsilon=norm_eps,
+            scale_init=init((Axis.EMBED,)),
+            dtype=dtype,
+            param_dtype=param_dtype,
+            rngs=rngs,
+        )
+        self.ffn_norm = nnx.RMSNorm(
+            dim,
+            epsilon=norm_eps,
+            scale_init=init((Axis.EMBED,)),
+            dtype=dtype,
+            param_dtype=param_dtype,
+            rngs=rngs,
+        )
+        self.mlp = FeedForward(
+            dim=dim,
+            hidden_dim=hidden_dim,
+            dtype=dtype,
+            param_dtype=param_dtype,
+            rngs=rngs,
+        )
+
+    def __call__(self, x: Float[Array, "B S E"]) -> Float[Array, "B S E"]:
+        r = self.attention(self.attention_norm(x))
+        h = x + r
+        r = self.mlp(self.ffn_norm(h))
+        return h + r
+
+    def decode(
+        self,
+        x: Float[Array, "B S E"],
+        cache: KVCacheLayer,
+    ) -> tuple[Float[Array, "B S E"], KVCacheLayer]:
+        r, cache = self.attention.decode(self.attention_norm(x), cache)
+        h = x + r
+        r = self.mlp(self.ffn_norm(h))
+        return h + r, cache
+
+
+class MistralModel(nnx.Module):
+    layers: list[TransformerBlock]
+    config: MistralConfig
+    sharding_rules: LogicalRules | None
+
+    def __init__(
+        self,
+        config: MistralConfig,
+        *,
+        dtype: Dtype,
+        param_dtype: Dtype,
+        rngs: nnx.Rngs,
+        sharding_rules: LogicalRules | None = None,
+    ):
+        self.config = config
+        self.dtype = dtype
+        self.sharding_rules = sharding_rules  # keep track of sharding rules for creating compatible kv cache
+
+        embed_init = _init_with_sharding(nnx.initializers.lecun_normal())
+        norm_init = _init_with_sharding(nnx.initializers.zeros_init())
+        linear_init = _init_with_sharding(nnx.initializers.lecun_normal())
+
+        head_dim = config.head_dim
+        assert type(head_dim) is int
+
+        rope = RotaryEmbedding(
+            features=head_dim,
+            length=config.max_position_embeddings,
+            theta=config.rope_theta,
+        )
+        self.embed = nnx.Embed(
+            config.vocab_size,
+            config.hidden_size,
+            embedding_init=embed_init((Axis.VOCAB, Axis.EMBED)),
+            param_dtype=param_dtype,
+            dtype=dtype,
+            rngs=rngs,
+        )
+        self.norm = nnx.RMSNorm(
+            config.hidden_size,
+            scale_init=norm_init((Axis.EMBED,)),
+            epsilon=config.rms_norm_eps,
+            param_dtype=param_dtype,
+            dtype=dtype,
+            rngs=rngs,
+        )
+        self.output = nnx.Linear(
+            config.hidden_size,
+            config.vocab_size,
+            kernel_init=linear_init((Axis.EMBED, Axis.VOCAB)),
+            use_bias=False,
+            param_dtype=param_dtype,
+            dtype=dtype,
+            rngs=rngs,
+        )
+        self.layers = [
+            TransformerBlock(
+                dim=config.hidden_size,
+                hidden_dim=config.intermediate_size,
+                n_q_heads=config.num_attention_heads,
+                n_kv_heads=config.num_key_value_heads,
+                head_dim=head_dim,
+                norm_eps=config.rms_norm_eps,
+                rope=rope,
+                param_dtype=param_dtype,
+                dtype=dtype,
+                rngs=rngs,
+            )
+            for _ in range(0, config.num_hidden_layers)
+        ]
+
+    def __call__(self, input_ids: Integer[Array, "B S"]) -> Float[Array, "B S V"]:
+        """
+        Args:
+            input_ids: Array of shape (batch, seqlen)
+        Returns:
+            array of shape (batch, seqlen, vocab_size)
+        """
+        h = self.embed(input_ids)
+        for layer in self.layers:
+            h = layer(h)
+        h = self.norm(h)
+        logits = self.output(h)
+        return logits
+
+    def decode(
+        self,
+        input_ids: Integer[Array, "B S"],
+        cache: KVCache,
+    ) -> tuple[Float[Array, "B S V"], KVCache]:
+        """Inference mode using kvcache.
+
+        Args:
+            input_ids: Array of shape (batch, seqlen)
+            cache: the KV Cache, for incremental decoding.
+        Returns:
+            array of shape (batch, seqlen, vocab_size)
+        """
+        h = self.embed(input_ids)
+        for i, layer in enumerate(self.layers):
+            h, cache.layers[i] = layer.decode(h, cache.layers[i])
+        h = self.norm(h)
+        logits = self.output(h)
+        return logits, cache
+
+    def create_cache(
+        self, batch_size: int, max_seqlen: int, mesh: Mesh | None = None
+    ) -> KVCache:
+        head_dim = self.config.head_dim
+        assert type(head_dim) is int
+        return KVCache.create(
+            len(self.layers),
+            batch_size=batch_size,
+            max_seqlen=max_seqlen,
+            num_kv_heads=self.config.num_key_value_heads,
+            head_dim=head_dim,
+            dtype=self.dtype,
+            mesh=mesh,
+            sharding_rules=self.sharding_rules,
+        )
+
+    def save_orbax(self, ckpt_dir: Path):
+        """Save model parameters with orbax."""
+        state = nnx.state(self, nnx.OfType(nnx.Param))
+        with ocp.StandardCheckpointer() as checkpointer:
+            checkpointer.save(ckpt_dir.absolute(), state)
+            checkpointer.wait_until_finished()
+
+    @classmethod
+    def _load_with(
+        cls,
+        loader: Callable[[nnx.State], nnx.State],
+        config: MistralConfig,
+        dtype: Dtype,
+        param_dtype: Dtype,
+        mesh: jax.sharding.Mesh | None = None,
+        sharding_rules: LogicalRules | None = None,
+    ):
+        """Create a model instance using the specific weight loading function.
+
+        Args:
+            loader: weight loading function that takes abstract Param state and
+                returns loaded Params.
+            mesh: if specified with sharding rules, load to assigned devices.
+                Otherwise, load to `SingleDeviceSharding(jax.devices("cpu")[0])`.
+        """
+        abs_model = nnx.eval_shape(
+            lambda: cls(
+                config,
+                dtype=dtype,
+                param_dtype=param_dtype,
+                rngs=nnx.Rngs(0),
+                sharding_rules=sharding_rules,
+            )
+        )
+        graphdef = nnx.graphdef(abs_model)
+        abs_params = nnx.state(abs_model, nnx.OfType(nnx.Param))
+
+        # annotate abstract params with sharding
+        if sharding_rules is not None and mesh is not None:
+            # this is a bit awkward, can probably be done within eval_shape.
+            with flax.core.spmd.logical_axis_rules(sharding_rules):
+                pspecs = nnx.get_partition_spec(abs_params)
+
+            def add_sharding(param: ShapeDtypeStruct, p):
+                return update_sharding(param, jax.sharding.NamedSharding(mesh, p))
+
+            abs_params = jax.tree.map(add_sharding, abs_params, pspecs)
+        elif sharding_rules is None and mesh is None:
+            single = jax.sharding.SingleDeviceSharding(jax.devices("cpu")[0])
+            abs_params = jax.tree.map(lambda x: update_sharding(x, single), abs_params)
+        else:
+            raise ValueError(
+                "sharding_rules and mesh should both be specified or both None"
+            )
+
+        # Initialize non-param states from an actual new instance.
+        # The non-returned arrays should be eliminated by jit.
+        # This gets things like precomputed rope-embedding constants.
+        @jax.jit
+        def non_param():
+            model = cls(
+                config,
+                dtype=dtype,
+                param_dtype=param_dtype,
+                rngs=nnx.Rngs(0),
+                sharding_rules=sharding_rules,
+            )
+            return nnx.state(model, nnx.Not(nnx.OfType(nnx.Param)))
+
+        non_params = jax.block_until_ready(non_param())
+        params = loader(abs_params)
+
+        return nnx.merge(graphdef, non_params, params)
+
+    @classmethod
+    def load(
+        cls,
+        model_dir: Path,
+        dtype="float32",
+        param_dtype="bfloat16",
+        mesh: jax.sharding.Mesh | None = None,
+        sharding_rules: Sequence[tuple[str, str]] | None = None,
+    ) -> "MistralModel":
+        """Load converted hf model.
+
+        Args:
+            model_dir: path to the pre-converted model.
+            dtype: computation dtype
+            param_dtype: dtype of the parameters
+            mesh: mesh used for sharding, should be set with sharding_rules.
+            sharding_rules:
+                If set, load the weights with the correct sharding, otherwise,
+                weights are loaded as unsharded single device (jax default).
+        """
+        config = MistralConfig.from_pretrained(model_dir)
+        assert isinstance(config, MistralConfig)
+
+        return cls._load_with(
+            functools.partial(_load_orbax, model_dir / "orbax"),
+            config,
+            dtype,
+            param_dtype,
+            mesh,
+            sharding_rules,
+        )
+
+    @classmethod
+    def load_from_hf_pt_model(
+        cls,
+        model_name: str,
+        dtype: Dtype = jnp.float32,
+        param_dtype: Dtype = jnp.bfloat16,
+        mesh: jax.sharding.Mesh | None = None,
+        sharding_rules: Sequence[tuple[str, str]] | None = None,
+    ) -> "MistralModel":
+        """Load model from HF pytorch model.
+
+        Renames, transposes, and reshapes tensors as necessary.
+
+        Args:
+            model_name: HF model name
+            dtype: computation dtype
+            param_dtype: dtype of the parameters
+            sharding_rules:
+                If set, load the weights with the correct sharding, otherwise,
+                weights are loaded as unsharded single device (jax default).
+
+        Returns:
+            MistralModel with loaded weights.
+        """
+        config = MistralConfig.from_pretrained(model_name)
+        assert isinstance(config, MistralConfig)
+
+        return cls._load_with(
+            functools.partial(_load_hf_pt_params, model_name),
+            config,
+            dtype,
+            param_dtype,
+            mesh,
+            sharding_rules,
+        )
+
+
+def _load_orbax(ckpt_dir: Path, abs_state: nnx.State) -> nnx.State:
+    """Load model from orbax checkpoint."""
+    with ocp.StandardCheckpointer() as checkpointer:
+        return checkpointer.restore(ckpt_dir.absolute(), abs_state)
+
+
+def _load_hf_pt_params(hf_model: str, abs_state: nnx.State) -> nnx.State:
+    """Load model from HF pytorch model.
+
+    Renames, transposes, and reshapes tensors as necessary.
+
+    Args:
+        hf_model: HF model name or path.
+        abs_state: abstract state of nnx.Params of the model.
+
+    Returns:
+        nnx.State with actual param arrays that can be `nnx.merge`d into the
+        model.
+    """
+    PARAM_INDEX_FILE = "model.safetensors.index.json"
+    index = cached_file(hf_model, PARAM_INDEX_FILE)
+    shard_paths, meta = get_checkpoint_shard_files(hf_model, index)
+    assert isinstance(shard_paths, list)
+
+    with ExitStack() as stack:
+        shards = {
+            os.path.basename(s): stack.enter_context(safe_open(s, "flax"))
+            for s in shard_paths
+        }
+
+        def transpose_only(param: jax.Array, _abs_param):
+            return param.transpose()
+
+        def transpose_reshape(param: jax.Array, abs_param):
+            return param.transpose().reshape(abs_param.shape)
+
+        def identity(param: jax.Array, _abs_param):
+            return param
+
+        def load_one(path, abs_param):
+            # Map to hf pt model (name, need_transpose)
+            name_map = {
+                "embed/embedding/value": ("model.embed_tokens.weight", identity),
+                "output/kernel/value": ("lm_head.weight", transpose_only),
+                "norm/scale/value": ("model.norm.weight", identity),
+            }
+            layer_name_map = {
+                "attention/wq/kernel/value": (
+                    "self_attn.q_proj.weight",
+                    transpose_reshape,
+                ),
+                "attention/wk/kernel/value": (
+                    "self_attn.k_proj.weight",
+                    transpose_reshape,
+                ),
+                "attention/wv/kernel/value": (
+                    "self_attn.v_proj.weight",
+                    transpose_reshape,
+                ),
+                "attention/wo/kernel/value": (
+                    "self_attn.o_proj.weight",
+                    transpose_reshape,
+                ),
+                "attention_norm/scale/value": ("input_layernorm.weight", identity),
+                "mlp/w1/kernel/value": ("mlp.gate_proj.weight", transpose_only),
+                "mlp/w2/kernel/value": ("mlp.down_proj.weight", transpose_only),
+                "mlp/w3/kernel/value": ("mlp.up_proj.weight", transpose_only),
+                "ffn_norm/scale/value": (
+                    "post_attention_layernorm.weight",
+                    identity,
+                ),
+            }
+            if path[0].key == "layers":
+                idx = path[1].key
+                layer_name, postprocess = layer_name_map[
+                    keystr_simple(path[2:], separator="/")
+                ]
+                name = f"model.layers.{idx}.{layer_name}"
+            else:
+                name, postprocess = name_map[keystr_simple(path, separator="/")]
+
+            param = shards[meta["weight_map"][name]].get_tensor(name)
+            param = postprocess(param, abs_param)
+            assert (
+                param.shape == abs_param.shape
+            ), f"Wrong shape for {keystr_simple(path, separator='/')}. Expected: {abs_param.shape}, actual: {param.shape}"
+            sharding = abs_param.sharding
+            assert isinstance(sharding, jax.sharding.Sharding)
+            return jax.device_put(param.astype(abs_param.dtype), device=sharding)
+
+        return jax.tree_util.tree_map_with_path(load_one, abs_state)
+
+
+def convert_hf_model(hf_model: str, output_path: Path, param_dtype=jnp.bfloat16):
+    import shutil
+
+    from transformers import AutoTokenizer
+
+    model = MistralModel.load_from_hf_pt_model(hf_model, param_dtype=param_dtype)
+
+    output_path.mkdir(exist_ok=True)
+    checkpoint_dir: Path = (output_path / "orbax").absolute()
+    if checkpoint_dir.exists():
+        shutil.rmtree(checkpoint_dir)
+    model.save_orbax(checkpoint_dir)
+
+    # Config and tokenizer
+    model.config.save_pretrained(output_path)
+    AutoTokenizer.from_pretrained(hf_model).save_pretrained(output_path)

--- a/tests/jax/multi_chip/bounties/mistral_small/mistral_nnx/util.py
+++ b/tests/jax/multi_chip/bounties/mistral_small/mistral_nnx/util.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import time
+from contextlib import contextmanager
+from typing import Generator
+
+from jax import ShapeDtypeStruct
+from jax.tree_util import DictKey, FlattenedIndexKey, GetAttrKey, KeyPath, SequenceKey
+
+
+@contextmanager
+def timer(desc: str) -> Generator[None, None, None]:
+    """
+    A context manager to time the execution of a code block.
+
+    Args:
+        description (str): A description for the code block being timed.
+                           This will be included in the output message.
+    """
+    start_time = time.perf_counter()
+    try:
+        yield
+    finally:
+        end_time = time.perf_counter()
+        elapsed_time = end_time - start_time
+        print(f"{elapsed_time:4.4f}s elapsed for {desc}")
+
+
+def keystr_simple(keypath: KeyPath, separator: str = "") -> str:
+    """Backported equivalent to jax.treeutil.keystr(keypath,simple=True, delimiter=...)."""
+
+    def simple(k):
+        if isinstance(k, SequenceKey):
+            return str(k.idx)
+        elif isinstance(k, DictKey):
+            return str(k.key)
+        elif isinstance(k, GetAttrKey):
+            return str(k.name)
+        elif isinstance(k, FlattenedIndexKey):
+            return str(k.index)
+        else:
+            return str(k)
+
+    return separator.join(simple(k) for k in keypath)
+
+
+def update_sharding(abs_array: ShapeDtypeStruct, sharding) -> ShapeDtypeStruct:
+    """Update sharding on a ShapeDtypeStruct.
+
+    Equivalent to `a.update(sharding=sharding)` on newer Jax versions.
+    """
+    return ShapeDtypeStruct(
+        shape=abs_array.shape,
+        dtype=abs_array.dtype,
+        sharding=sharding,
+        weak_type=abs_array.weak_type,
+    )

--- a/tests/jax/multi_chip/bounties/mistral_small/test_model_implementation.py
+++ b/tests/jax/multi_chip/bounties/mistral_small/test_model_implementation.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Tests the model implementation itself.
+
+Can be run with multiple devices, e.g. via
+
+    XLA_FLAGS=--xla_force_host_platform_device_count=4
+"""
+
+from pathlib import Path
+
+import flax.nnx as nnx
+import jax
+import jax.numpy as jnp
+import pytest
+import transformers
+from transformers import PreTrainedTokenizer
+
+import mistral_nnx
+import mistral_nnx.generate
+from mistral_nnx.util import timer
+
+
+MODEL = "mistralai/Mistral-Small-24B-Instruct-2501"
+
+SHARDING_RULES = list(
+    {
+        mistral_nnx.Axis.EMBED: None,
+        mistral_nnx.Axis.MLP: "x",
+        mistral_nnx.Axis.HEAD: "x",
+        mistral_nnx.Axis.QHEAD: None,
+        mistral_nnx.Axis.KVHEAD: None,
+        mistral_nnx.Axis.VOCAB: None,
+    }.items()
+)
+
+
+@pytest.fixture(scope="module")
+def tokenizer() -> PreTrainedTokenizer:
+    return transformers.AutoTokenizer.from_pretrained(MODEL)
+
+
+@pytest.fixture(scope="module")
+def mesh():
+    devices = jax.devices("cpu")
+    return jax.make_mesh((len(devices),), axis_names=("x",), devices=devices)
+
+
+@pytest.fixture(scope="module")
+def nnx_model(mesh: jax.sharding.Mesh) -> nnx.Module:
+    with timer("NNX model loading"):
+        return mistral_nnx.MistralModel.load_from_hf_pt_model(
+            MODEL,
+            dtype=jnp.float32,
+            mesh=mesh,
+            sharding_rules=SHARDING_RULES,
+        )
+
+
+def load_hf_model() -> transformers.MistralForCausalLM:
+    with timer("HF model loading"):
+        return transformers.AutoModelForCausalLM.from_pretrained(MODEL)
+
+
+def test_compare_hf(tokenizer, mesh, nnx_model):
+    """Compare model implementation output vs huggingface torch model.
+
+    HF model is loaded and discarded to reduce memory usage.
+    """
+    input = "[INST]What is the name of the largest planet in our solar system?[/INST] Jupiter"
+
+    def get_nnx_result():
+        @jax.jit
+        def jit_model(graphdef, state, input):
+            model = nnx.merge(graphdef, state)
+            return model(input)
+
+        graphdef, state = nnx.split(nnx_model)
+        tokens = tokenizer(input, return_tensors="jax")["input_ids"]
+
+        with timer("test_compare_hf - jit compile"), mesh:
+            compiled_model = jit_model.lower(graphdef, state, tokens).compile()
+
+        with timer("test_compare_hf - nnx forward pass"), mesh:
+            nnx_result = compiled_model(graphdef, state, tokens)
+            nnx_result.block_until_ready()
+            return nnx_result
+
+    nnx_result = get_nnx_result()
+
+    def get_hf_result():
+        tokens = tokenizer(input, return_tensors="pt")
+        with timer("test_compare_hf - hf forward pass"):
+            logits = load_hf_model().forward(**tokens).logits
+            assert logits is not None
+            return jnp.array(logits.detach())
+
+    hf_result = get_hf_result()
+
+    # Check that the results are close enough.
+    diff = hf_result - nnx_result
+    abs_max_diff = jnp.abs(diff).max()
+    print(f"max(|diff|) = {abs_max_diff}")
+    assert abs_max_diff < 1e-4, f"expected max(|diff|) < 1e-4"
+
+    # Check argmax are the same
+    hf_argmax = jnp.argmax(hf_result, axis=-1)
+    nnx_argmax = jnp.argmax(nnx_result, axis=-1)
+    print(f"hf_argmax  = {hf_argmax}")
+    print(f"nnx_argmax = {nnx_argmax}")
+    assert hf_argmax.tolist() == nnx_argmax.tolist(), "expected argmax to match."
+
+
+def test_generate(tokenizer, mesh, nnx_model):
+    """Compare output using the kv-cache decoding `Generator` to the simple forward pass."""
+    input = "[INST]31 * 12 = [/INST] "
+    generator = mistral_nnx.generate.Generator(nnx_model, max_seqlen=30)
+    tokens = tokenizer(input)["input_ids"]
+    rngs = nnx.Rngs(0)
+
+    with timer("test_generate - Decoding w/ kv cache"):
+        result = generator.generate(tokens, rngs=rngs, max_tokens=10, mesh=mesh)
+    S, V = result.logits.shape
+
+    # run tokens through forward pass
+    all_tokens = jnp.array(result.tokens[0:S])[None, ...]
+
+    @jax.jit
+    def jit_model(graphdef, state, input):
+        model = nnx.merge(graphdef, state)
+        return model(input)
+
+    graphdef, state = nnx.split(nnx_model)
+
+    with timer("test_generate - jit compile forward pass"):
+        compiled_model = jit_model.lower(graphdef, state, all_tokens).compile()
+
+    with timer("test_generate - run forward pass"):
+        all_logits = compiled_model(graphdef, state, all_tokens)
+        all_logits.block_until_ready()
+
+    assert jnp.allclose(
+        all_logits, result.logits[None, ...], atol=1e-4
+    ), "expected kv-cache generated logits to match forward pass."


### PR DESCRIPTION

### Ticket
https://github.com/tenstorrent/tt-forge/issues/56

### Problem description
Add a Tensor Parallel JAX Mistral-small Model to TT-xla Model Demos

### What's changed
This pr adds a bespoke implementation of mistral inference code using Flax NNX.

Tensor parallelism is achieved by adding logical axis annotations to the weight initializers, which are then applied as sharding constraints to the loaded parameter arrays. This should serve to constrain jax jit to generate tensor parallel code.

### Checklist
- [X] New/Existing tests provide coverage for changes
