### PR TITLE
Update links of tt-mlir's build documentation

### DIFF
--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -9,7 +9,7 @@ tt-xla integration with tt-mlir compiler is still in progress. Currently tt-xla 
 ### tt-mlir toolchain
 Before compiling tt-xla, the tt-mlir toolchain needs to be built:
 - Clone [tt-mlir](https://github.com/tenstorrent/tt-mlir) repo
-- Follow tt-mlir [build instructions](https://docs.tenstorrent.com/tt-mlir/build.html) to setup the environment and build the toolchain
+- Follow tt-mlir [build instructions](https://docs.tenstorrent.com/tt-mlir/getting-started.html) to setup the environment and build the toolchain
 
 ### tt-xla
 Before running these commands to build tt-xla, please ensure that the environtment variable `TTMLIR_TOOLCHAIN_DIR` is set to point to the tt-mlir toolchain directory created above as part of tt-mlir environment setup (for example `export TTMLIR_TOOLCHAIN_DIR=/opt/ttmlir-toolchain/`). You can also set `export LOGGER_LEVEL=DEBUG` in order to enable debug logs.
@@ -27,7 +27,7 @@ The tt-xla repo contains various tests in the **tests** directory. To run them a
 
 ## Common Build Errors
 - Building tt-xla requires `clang-17`. Please make sure that `clang-17` is installed on the system and `clang/clang++` links to the correct version of the respective tools.
-- Please also see the tt-mlir [docs](https://docs.tenstorrent.com/tt-mlir/build.html#common-build-errors) for common build errors.
+- Please also see the tt-mlir [docs](https://docs.tenstorrent.com/tt-mlir/getting-started.html#common-build-errors) for common build errors.
 
 ### Pre-Commit
 Pre-Commit applies a git hook to the local repository such that linting is checked and applied on every `git commit` action. Install from the root of the repository using:


### PR DESCRIPTION
This PR updates the outdated link to the tt-mlir's building documentation.