### PR TITLE
Fix CI permissions issue

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,10 +43,6 @@ on:
         required: true
         type: string
 
-permissions:
-  packages: write
-  checks: write
-
 jobs:
 
   build-image:


### PR DESCRIPTION
### Ticket
/

### Problem description
Github actions have started throwing an error about missing permissions for the build-and-test workflow.

### What's changed
Removing the specified permissions in the build-and-test workflow resolves the issue.

### Checklist
- [ ] On PR workflow is passing

<img width="1542" alt="image" src="https://github.com/user-attachments/assets/ddd9530d-72ca-4580-9832-78d5ada05d6e" />
