### PR TITLE
Add openmpi to dockerfile for metal uplift

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -54,3 +54,15 @@ RUN git clone https://github.com/google/googletest.git -b release-1.12.1 && \
     make install && \
     cd ../.. && \
     rm -rf googletest
+
+# Install mpi-ulfm from the tenstorrent repository
+RUN set -eux; \
+    apt-get update && \
+    apt-get install -y -f \
+        wget ca-certificates && \
+    TMP_DIR="$(mktemp -d)" && \
+    DEB_URL="https://github.com/dmakoviichuk-tt/mpi-ulfm/releases/download/v5.0.7-ulfm/openmpi-ulfm_5.0.7-1_amd64.deb" && \
+    wget -qO "$TMP_DIR/ompi.deb" "$DEB_URL" && \
+    apt-get install -f -y "$TMP_DIR/ompi.deb" && \
+    rm -rf "$TMP_DIR" && \
+    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
### Ticket
None

### Problem description
Metal uplift needs to add new dependency openmpi to docker build.

### What's changed
Add new dependency openmpi from metal

### Checklist
- [x] New/Existing tests provide coverage for changes
