### PR TITLE
add test for gather op

### DIFF
--- a/tests/jax/single_chip/ops/test_gather.py
+++ b/tests/jax/single_chip/ops/test_gather.py
@@ -2,4 +2,47 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# TODO add tests for `stablehlo.gather`.
+import jax
+import jax.numpy as jnp
+import jax.lax as lax
+import pytest
+from infra import run_op_test_with_random_inputs
+
+from tests.utils import Category
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    jax_op_name="jax.lax.gather",
+    shlo_op_name="stablehlo.gather",
+)
+@pytest.mark.parametrize(
+    "data_shape, indices_shape",
+    [
+        ((32, 32), (16, 1)),
+        ((64, 64), (32, 1)),
+    ],
+    ids=lambda val: f"shape={val}",
+)
+def test_gather(data_shape, indices_shape):
+    def gather(data: jnp.ndarray, indices: jnp.ndarray) -> jnp.ndarray:
+        # Gather needs these arguments:
+        # - offset_dims: which output dims stay unchanged
+        # - collapsed_slice_dims: input dims to remove after slicing
+        # - start_index_map: tells which input dims the indices apply to
+        dnums = lax.GatherDimensionNumbers(
+            offset_dims=(1,),
+            collapsed_slice_dims=(0,),
+            start_index_map=(0,),
+        )
+        slice_sizes = (1, data.shape[1])
+        return lax.gather(
+            data,
+            indices.astype(jnp.int32),
+            dimension_numbers=dnums,
+            slice_sizes=slice_sizes,
+        )
+
+    run_op_test_with_random_inputs(gather, input_shapes=[data_shape, indices_shape])


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-xla/issues/594

### Problem description

Add test for gather operation

### What's changed

Modified the test file to test the 'jax.lax.gather' op

### Checklist
- [x] New/Existing tests provide coverage for changes

I have attached the logs below 
[test_gather.log](https://github.com/user-attachments/files/20478987/test_gather.log)
