### PR TITLE
Adding memory logging and garbage collecting between pytest runs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -186,7 +186,8 @@ jobs:
       run: |
         export LD_LIBRARY_PATH="/opt/ttmlir-toolchain/lib/:${{ steps.strings.outputs.install-output-dir }}/lib:${LD_LIBRARY_PATH}"
         source venv/activate
-        pytest ${{ matrix.build.dir }}  \
+        pytest  --log-memory \
+                ${{ matrix.build.dir }}  \
                 -m "${{ inputs.test_mark }}" \
                 --junitxml=${{ steps.strings.outputs.test_report_path }} \
                 2>&1 | tee pytest.log

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -186,7 +186,7 @@ jobs:
       run: |
         export LD_LIBRARY_PATH="/opt/ttmlir-toolchain/lib/:${{ steps.strings.outputs.install-output-dir }}/lib:${LD_LIBRARY_PATH}"
         source venv/activate
-        pytest  --log-memory \
+        pytest  --log-memory -sv \
                 ${{ matrix.build.dir }}  \
                 -m "${{ inputs.test_mark }}" \
                 --junitxml=${{ steps.strings.outputs.test_report_path }} \

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,10 +10,12 @@ jaxlib==0.5.0
 jaxtyping
 librosa
 lit
+loguru
 ml_collections
 ninja
 pillow
 pre-commit
+psutil
 pybind11
 pytest
 sentencepiece

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,6 +125,11 @@ def pytest_collection_modifyitems(items):
 
 
 def pytest_addoption(parser):
+    """
+    Custom CLI pytest option to enable memory usage tracking in tests.
+
+    Use it when calling pytest like `pytest --log-memory ...`.
+    """
     parser.addoption(
         "--log-memory",
         action="store_true",


### PR DESCRIPTION
Adding manual garbage cleaning and running the `malloc_trim` system call between pytest run to free up memory. Also added a logger for tracking memory usage during runs, guarded by the `--log-memory` flag. Example:
<img width="1241" alt="Screenshot 2025-05-28 at 15 31 05" src="https://github.com/user-attachments/assets/8c2280da-d34e-4ff9-9a5c-22944bd73ade" />
