### PR TITLE
Added some more model info in model tests reports

### DIFF
--- a/tests/jax/single_chip/models/albert_v2/base/test_albert_base.py
+++ b/tests/jax/single_chip/models/albert_v2/base/test_albert_base.py
@@ -9,21 +9,22 @@ from tests.utils import (
     BringupStatus,
     Category,
     ModelGroup,
+    ModelInfo,
     ModelSource,
     ModelTask,
-    build_model_name,
     incorrect_result,
 )
 
 from ..tester import AlbertV2Tester
 
-MODEL_PATH = "albert/albert-base-v2"
-MODEL_NAME = build_model_name(
-    Framework.JAX,
+info = ModelInfo(
     "albert_v2",
     "base",
+    "albert/albert-base-v2",
+    ModelGroup.GENERALITY,
     ModelTask.NLP_MASKED_LM,
     ModelSource.HUGGING_FACE,
+    Framework.JAX,
 )
 
 
@@ -32,12 +33,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> AlbertV2Tester:
-    return AlbertV2Tester(MODEL_PATH)
+    return AlbertV2Tester(info.path)
 
 
 @pytest.fixture
 def training_tester() -> AlbertV2Tester:
-    return AlbertV2Tester(MODEL_PATH, RunMode.TRAINING)
+    return AlbertV2Tester(info.path, RunMode.TRAINING)
 
 
 # ----- Tests -----
@@ -46,10 +47,9 @@ def training_tester() -> AlbertV2Tester:
 @pytest.mark.model_test
 @pytest.mark.record_test_properties(
     category=Category.MODEL_TEST,
-    model_name=MODEL_NAME,
-    model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.INCORRECT_RESULT,
+    model_info=info,
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
@@ -64,9 +64,8 @@ def test_flax_albert_v2_base_inference(inference_tester: AlbertV2Tester):
 @pytest.mark.nightly
 @pytest.mark.record_test_properties(
     category=Category.MODEL_TEST,
-    model_name=MODEL_NAME,
-    model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.TRAINING,
+    model_info=info,
 )
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_flax_albert_v2_base_training(training_tester: AlbertV2Tester):


### PR DESCRIPTION
### Problem description
We needed some more info about model under test in `tags` dict in pytest report in our reporting infra to display in superset charts.

### What's changed
- [x] Created new util data structure `ModelInfo` which wraps all important model test properties
- [x] Updated `conftest.py` to parse passed model info properly
- [ ] Updated all model tests to use new way of reporting

Here are differences between new and old report

<img width="1641" alt="image" src="https://github.com/user-attachments/assets/12e42b84-daf4-4644-8068-95c9707fdec5" />


### Checklist
- [x] New/Existing tests provide coverage for changes
