### PR TITLE
Adding support for BufferInstance::copyToDevice and BufferInstance::copyToMemory

### DIFF
--- a/inc/common/pjrt_implementation/buffer_instance.h
+++ b/inc/common/pjrt_implementation/buffer_instance.h
@@ -116,7 +116,7 @@ public:
                     PJRT_HostBufferSemantics host_buffer_semantics,
                     EventInstance **out_done_with_host_buffer_event);
 
-  // Asynchronously copies the buffer's data into a preallocated host buffer.
+  // Asynchronously copies this buffer's data into a preallocated host buffer.
   tt_pjrt_status copyToHost(void *host_buffer, size_t host_buffer_size,
                             EventInstance **out_copy_done_event);
 
@@ -128,11 +128,11 @@ public:
   // already created for this buffer.
   tt_pjrt_status createDataReadyEvent(EventInstance **out_event);
 
-  // Copies the buffer's data to the device and its memory specified in the
+  // Copies this buffer's data to the device and its memory specified in the
   // arguments.
-  tt_pjrt_status copyToDevice(DeviceInstance *dst_device,
-                              MemoryInstance *dst_memory,
-                              BufferInstance **dst_buffer);
+  tt_pjrt_status copyToDeviceMemory(DeviceInstance *dst_device,
+                                    MemoryInstance *dst_memory,
+                                    BufferInstance **dst_buffer);
 
 private:
   // Constructor used for the input buffers.

--- a/inc/common/pjrt_implementation/buffer_instance.h
+++ b/inc/common/pjrt_implementation/buffer_instance.h
@@ -120,6 +120,12 @@ public:
   tt_pjrt_status copyToHost(void *host_buffer, size_t host_buffer_size,
                             EventInstance **out_copy_done_event);
 
+  // Copies this buffer's data to the device and its memory specified in the
+  // arguments.
+  tt_pjrt_status copyToDeviceMemory(DeviceInstance *dst_device,
+                                    MemoryInstance *dst_memory,
+                                    BufferInstance **dst_buffer);
+
   // Sets that buffer data is ready (transferred from host or computed on
   // device) and marks data ready event as ready (if it is already created).
   void markAsDataReady();
@@ -127,12 +133,6 @@ public:
   // Creates data ready event. Returns error status if data ready event was
   // already created for this buffer.
   tt_pjrt_status createDataReadyEvent(EventInstance **out_event);
-
-  // Copies this buffer's data to the device and its memory specified in the
-  // arguments.
-  tt_pjrt_status copyToDeviceMemory(DeviceInstance *dst_device,
-                                    MemoryInstance *dst_memory,
-                                    BufferInstance **dst_buffer);
 
 private:
   // Constructor used for the input buffers.

--- a/inc/common/pjrt_implementation/buffer_instance.h
+++ b/inc/common/pjrt_implementation/buffer_instance.h
@@ -128,7 +128,7 @@ public:
   // already created for this buffer.
   tt_pjrt_status createDataReadyEvent(EventInstance **out_event);
 
-  // Copyies the buffer's data to the device and its memory specified in the
+  // Copies the buffer's data to the device and its memory specified in the
   // arguments.
   tt_pjrt_status copyToDevice(DeviceInstance *dst_device,
                               MemoryInstance *dst_memory,

--- a/inc/common/pjrt_implementation/buffer_instance.h
+++ b/inc/common/pjrt_implementation/buffer_instance.h
@@ -221,6 +221,12 @@ PJRT_Error *onBufferDelete(PJRT_Buffer_Delete_Args *args);
 // Implements PJRT_Buffer_IsDeleted API function.
 PJRT_Error *onBufferIsDeleted(PJRT_Buffer_IsDeleted_Args *args);
 
+// Implements PJRT_Buffer_CopyToDevice API function.
+PJRT_Error *onBufferCopyToDevice(PJRT_Buffer_CopyToDevice_Args *args);
+
+// Implements PJRT_Buffer_CopyToMemory API function.
+PJRT_Error *onBufferCopyToMemory(PJRT_Buffer_CopyToMemory_Args *args);
+
 // Implements PJRT_Buffer_IsOnCpu API function.
 PJRT_Error *onBufferIsOnCpu(PJRT_Buffer_IsOnCpu_Args *args);
 

--- a/inc/common/pjrt_implementation/buffer_instance.h
+++ b/inc/common/pjrt_implementation/buffer_instance.h
@@ -128,6 +128,12 @@ public:
   // already created for this buffer.
   tt_pjrt_status createDataReadyEvent(EventInstance **out_event);
 
+  // Copyies the buffer's data to the device and its memory specified in the
+  // arguments.
+  tt_pjrt_status copyToDevice(DeviceInstance *dst_device,
+                              MemoryInstance *dst_memory,
+                              BufferInstance **dst_buffer);
+
 private:
   // Constructor used for the input buffers.
   BufferInstance(PJRT_Buffer_Type data_type, const std::int64_t *dims,

--- a/inc/common/pjrt_implementation/buffer_instance.h
+++ b/inc/common/pjrt_implementation/buffer_instance.h
@@ -145,6 +145,9 @@ private:
                  const std::vector<std::uint32_t> &dimensions,
                  DeviceInstance *device, MemoryInstance *memory);
 
+  // Copies the tensor inside the src_buffer to the tensor of this buffer.
+  void copyFromBuffer(const BufferInstance *src_buffer);
+
   // Calculates required tensor shape.
   static std::vector<std::uint32_t> calculateShape(const std::int64_t *dims,
                                                    size_t num_dims);

--- a/src/common/pjrt_implementation/buffer_instance.cc
+++ b/src/common/pjrt_implementation/buffer_instance.cc
@@ -89,8 +89,8 @@ void BufferInstance::bindApi(PJRT_Api *api) {
   api->PJRT_Buffer_ToHostBuffer = internal::onBufferToHostBuffer;
   api->PJRT_Buffer_Delete = internal::onBufferDelete;
   api->PJRT_Buffer_IsDeleted = internal::onBufferIsDeleted;
-  api->PJRT_Buffer_CopyToMemory = internal::onBufferCopyToMemory;
   api->PJRT_Buffer_CopyToDevice = internal::onBufferCopyToDevice;
+  api->PJRT_Buffer_CopyToMemory = internal::onBufferCopyToMemory;
   api->PJRT_Buffer_IsOnCpu = internal::onBufferIsOnCpu;
   api->PJRT_Buffer_Device = internal::onBufferDevice;
   api->PJRT_Buffer_ReadyEvent = internal::onBufferReadyEvent;
@@ -455,6 +455,7 @@ PJRT_Error *onBufferCopyToDevice(PJRT_Buffer_CopyToDevice_Args *args) {
                 .release();
   }
   MemoryInstance *dst_memory = dst_device->getDefaultMemory();
+
   src_buffer->copyToDevice(
       dst_device, dst_memory,
       reinterpret_cast<BufferInstance **>(&args->dst_buffer));

--- a/src/common/pjrt_implementation/buffer_instance.cc
+++ b/src/common/pjrt_implementation/buffer_instance.cc
@@ -335,7 +335,7 @@ tt_pjrt_status BufferInstance::copyToDevice(DeviceInstance *dst_device,
   std::unique_ptr<BufferInstance> dst_buffer_instance =
       BufferInstance::createInputBufferInstance(
           getDataType(), getDimensionsRaw(), getNumberOfDimensions(),
-          dst_device, dst_device->getDefaultMemory());
+          dst_device, dst_memory);
   void *host_memory = malloc(memory_size);
   runtime::memcpy(host_memory, getRuntimeTensor());
   std::unique_ptr<EventInstance> done_with_host_buffer_event =

--- a/src/common/pjrt_implementation/stubs.inc
+++ b/src/common/pjrt_implementation/stubs.inc
@@ -34,17 +34,6 @@
   _STUB(PJRT_Buffer_OnDeviceSizeInBytes);
   _STUB(PJRT_Buffer_CopyRawToHost);
 
-  // XLA client is not currently using this, but we should implement it, it
-  // shouldn't be too hard. It should just create the output buffer by copying
-  // the input buffer (its parameters and underlying tensor) and setting given
-  // device.
-  // https://github.com/tenstorrent/tt-xla/issues/467
-  _STUB(PJRT_Buffer_CopyToDevice);
-
-  // PJRT_Buffer_CopyToMemory is not used in JAX or PyTorch client, but should be implemented.
-  // https://github.com/tenstorrent/tt-xla/issues/537
-  _STUB(PJRT_Buffer_CopyToMemory);
-
   // Can be used in combination with `PJRT_Buffer_IsOnCpu` to enable certain
   // optimizations (avoids memory copy), but currently all our inputs are
   // transferred to device where computation runs and we can't return the


### PR DESCRIPTION
Adding support for previously unimplemented `BufferInstance::copyToDevice` and `BufferInstance::copyToMemory` functions. 

Fixes https://github.com/tenstorrent/tt-xla/issues/542
Fixes https://github.com/tenstorrent/tt-xla/issues/537
Fixes https://github.com/tenstorrent/tt-xla/issues/467