### PR TITLE
add test for log op

### DIFF
--- a/tests/jax/single_chip/ops/test_log.py
+++ b/tests/jax/single_chip/ops/test_log.py
@@ -2,4 +2,30 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# TODO add tests for `stablehlo.log`.
+import jax
+import jax.numpy as jnp
+import pytest
+from infra import run_op_test_with_random_inputs
+
+from tests.utils import Category, incorrect_result
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    jax_op_name="jax.numpy.log",
+    shlo_op_name="stablehlo.log",
+)
+@pytest.mark.xfail(
+    reason=incorrect_result(
+        "Allclose comparison failed. Required: atol=0.01, rtol=0.01"
+        "https://github.com/tenstorrent/tt-xla/issues/659"
+    )
+)
+@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)], ids=lambda val: f"{val}")
+def test_log(x_shape: tuple):
+    def log(x: jax.Array) -> jax.Array:
+        return jnp.log(x)
+
+    run_op_test_with_random_inputs(log, [x_shape])


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-xla/issues/660

### Problem description
Add test for log operation

### What's changed
Modified the test file to test the 'jax.numpy.log' op

### Checklist
- [x] New/Existing tests provide coverage for changes

I have attached log for your reference:
[log_op_log.log](https://github.com/user-attachments/files/20517966/log_op_log.log)

