### PR TITLE
Add tests for reduce OP with and,or,mul,min inner OPs

### DIFF
--- a/tests/jax/single_chip/ops/test_reduce.py
+++ b/tests/jax/single_chip/ops/test_reduce.py
@@ -7,7 +7,7 @@ import jax.numpy as jnp
 import pytest
 from infra import ComparisonConfig, run_op_test_with_random_inputs
 
-from tests.utils import Category
+from tests.utils import Category, failed_runtime
 
 
 # TODO investigate why this doesn't pass with default comparison config.
@@ -56,4 +56,89 @@ def test_reduce_max(x_shape: tuple, comparison_config: ComparisonConfig):
     )
 
 
-# TODO add tests for reduce `and` and reduce `or`.
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    jax_op_name="jax.numpy.all",
+    shlo_op_name="stablehlo.reduce{AND}",
+)
+@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)], ids=lambda val: f"{val}")
+@pytest.mark.xfail(
+    reason=failed_runtime(
+        "i1 (boolean) output type mismatch on TTNN backend"
+        "https://github.com/tenstorrent/tt-xla/issues/668"
+    )
+)
+def test_reduce_and(x_shape: tuple, comparison_config: ComparisonConfig):
+    def reduce_and(x: jax.Array) -> jax.Array:
+        x_bool = x > 0.5
+        return jnp.all(x_bool)
+
+    run_op_test_with_random_inputs(
+        reduce_and, [x_shape], comparison_config=comparison_config
+    )
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    jax_op_name="jax.numpy.any",
+    shlo_op_name="stablehlo.reduce{OR}",
+)
+@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)], ids=lambda val: f"{val}")
+@pytest.mark.xfail(
+    reason=failed_runtime(
+        "i1 (boolean) output type mismatch on TTNN backend"
+        "https://github.com/tenstorrent/tt-xla/issues/668"
+    )
+)
+def test_reduce_or(x_shape: tuple, comparison_config: ComparisonConfig):
+    def reduce_or(x: jax.Array) -> jax.Array:
+        x_bool = x > 0.5
+        return jnp.any(x_bool)
+
+    run_op_test_with_random_inputs(
+        reduce_or, [x_shape], comparison_config=comparison_config
+    )
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    jax_op_name="jax.numpy.prod",
+    shlo_op_name="stablehlo.reduce{MULTIPLY}",
+)
+@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)], ids=lambda val: f"{val}")
+@pytest.mark.xfail(
+    reason=failed_runtime(
+        "'ttnn.prod' op TTNN only supports Reduce(prod) along all dimensions for bfloat16 datatype"
+        "https://github.com/tenstorrent/tt-xla/issues/669"
+    )
+)
+def test_reduce_multiply(x_shape: tuple, comparison_config: ComparisonConfig):
+    def reduce_multiply(x: jax.Array) -> jax.Array:
+        return jnp.prod(x, axis=None)
+
+    run_op_test_with_random_inputs(
+        reduce_multiply, [x_shape], comparison_config=comparison_config
+    )
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    jax_op_name="jax.numpy.min",
+    shlo_op_name="stablehlo.reduce{MIN}",
+)
+@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)], ids=lambda val: f"{val}")
+def test_reduce_min(x_shape: tuple, comparison_config: ComparisonConfig):
+    def reduce_min(x: jax.Array) -> jax.Array:
+        return jnp.min(x)
+
+    run_op_test_with_random_inputs(
+        reduce_min, [x_shape], comparison_config=comparison_config
+    )


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-xla/issues/665

### Problem description
add test for reduce op with and,or,mul and min inner OPs

### What's changed
Modified the test file to test the `jnp.all`,`jnp.any`,`jnp.prod`,`jnp.min` op

### Checklist
- [x] New/Existing tests provide coverage for changes

I have attached the log for your reference:
[reduce_and_or_mul_min.log](https://github.com/user-attachments/files/20552717/reduce_and_or_mul_min.log)
