### PR TITLE
Add tag "latest" to the newest docker image pushed from main

### DIFF
--- a/.github/build-docker-images.sh
+++ b/.github/build-docker-images.sh
@@ -30,18 +30,14 @@ build_and_push() {
             --progress=plain \
             --build-arg FROM_TAG=$DOCKER_TAG \
             -t $image_name:$DOCKER_TAG \
-            -t $image_name:latest \
+            -t $image_name:wip-testing \
             -f $dockerfile .
 
         echo "Pushing image $image_name:$DOCKER_TAG"
         docker push $image_name:$DOCKER_TAG
-
-        # If we are on main branch also push the latest tag
-        if [ "$on_main" = "true" ]; then
-            echo "Pushing image $image_name:latest"
-            docker push $image_name:latest
-        fi
     fi
+
+    docker buildx imagetools create $image_name:$DOCKER_TAG --tag $image_name:wip-testing --tag $image_name:$DOCKER_TAG
 }
 
 build_and_push $BASE_IMAGE_NAME .github/Dockerfile.base $ON_MAIN

--- a/.github/build-docker-images.sh
+++ b/.github/build-docker-images.sh
@@ -30,14 +30,17 @@ build_and_push() {
             --progress=plain \
             --build-arg FROM_TAG=$DOCKER_TAG \
             -t $image_name:$DOCKER_TAG \
-            -t $image_name:wip-testing \
+            -t $image_name:latest \
             -f $dockerfile .
 
         echo "Pushing image $image_name:$DOCKER_TAG"
         docker push $image_name:$DOCKER_TAG
     fi
 
-    docker buildx imagetools create $image_name:$DOCKER_TAG --tag $image_name:wip-testing --tag $image_name:$DOCKER_TAG
+    if [ "$on_main" = "true"]; then
+        echo "Pushing latest tag for $image_name"
+        docker buildx imagetools create $image_name:$DOCKER_TAG --tag $image_name:latest --tag $image_name:$DOCKER_TAG
+    fi
 }
 
 build_and_push $BASE_IMAGE_NAME .github/Dockerfile.base $ON_MAIN


### PR DESCRIPTION
### Ticket
/

### Problem description
The "latest" tag doesn't exist for tt-xla's docker images.

### What's changed
Every docker image build process on main will add the tag `latest` to the docker image in it, so the newest image built on main will have the tag `latest`.
`Latest` tag can now be used to pull the tt-xla's newest docker image.
Tag is added for convenience and because a similar thing exists for other frontends.

### Checklist
- [ ] New/Existing tests provide coverage for changes
