### PR TITLE
Uplift third_party/tt-mlir to 33e790d7ef0bb039f0b89a10f5929ccd91c20c16 2025-06-10

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-set(TT_MLIR_VERSION "9eb8ee1cb68adacaf7fcf46432a172444dcffd6c")
+set(TT_MLIR_VERSION "33e790d7ef0bb039f0b89a10f5929ccd91c20c16")
 set(LOGURU_VERSION "4adaa185883e3c04da25913579c451d3c32cfac1")
 
 if (TOOLCHAIN STREQUAL "ON")


### PR DESCRIPTION
This PR uplifts the third_party/tt-mlir to the 33e790d7ef0bb039f0b89a10f5929ccd91c20c16