### PR TITLE
Fixing the return of replicated scalars

### DIFF
--- a/inc/common/pjrt_implementation/loaded_executable_instance.h
+++ b/inc/common/pjrt_implementation/loaded_executable_instance.h
@@ -120,7 +120,7 @@ private:
                       const tt::runtime::Device &runtime_device);
 
   // Untilizes output tensors and transfers them from device to host.
-  static tt_pjrt_status untilizeToHost(
+  tt_pjrt_status untilizeToHost(
       const std::vector<tt::runtime::Tensor> &output_tensors,
       size_t num_devices,
       std::vector<std::vector<tt::runtime::Tensor>> &untilized_output_tensors);


### PR DESCRIPTION
In the new jax 0.6.0, if we are returning a replicated scalar value in a multidevice environment, the StableHLO graph will annotate it as a single-device value, therefore out runtime will produce a single device tensor as output. To make it compatible with PJRT, we need to return this value as output for each device in the multi device environment, which this PR does. 