### PR TITLE
Uplift third_party/tt-mlir to 3ddc7163edabd4e5cc9be802a54f4de95b6395d2 2025-06-13

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-set(TT_MLIR_VERSION "79da9666afe9bb7791675f2462c4fc1dbeec0e85")
+set(TT_MLIR_VERSION "3ddc7163edabd4e5cc9be802a54f4de95b6395d2")
 set(LOGURU_VERSION "4adaa185883e3c04da25913579c451d3c32cfac1")
 
 if (TOOLCHAIN STREQUAL "ON")


### PR DESCRIPTION
This PR uplifts the third_party/tt-mlir to the 3ddc7163edabd4e5cc9be802a54f4de95b6395d2