### PR TITLE
Added Xfail marker to Bloom and Vit models

### DIFF
--- a/tests/jax/single_chip/models/bloom/bloom_560m/test_560m.py
+++ b/tests/jax/single_chip/models/bloom/bloom_560m/test_560m.py
@@ -43,7 +43,7 @@ def training_tester() -> BloomTester:
 # ----- Tests -----
 
 
-@pytest.mark.push
+@pytest.mark.model_test
 @pytest.mark.record_test_properties(
     category=Category.MODEL_TEST,
     model_name=MODEL_NAME,

--- a/tests/jax/single_chip/models/bloom/bloom_560m/test_560m.py
+++ b/tests/jax/single_chip/models/bloom/bloom_560m/test_560m.py
@@ -43,13 +43,19 @@ def training_tester() -> BloomTester:
 # ----- Tests -----
 
 
-@pytest.mark.model_test
+@pytest.mark.push
 @pytest.mark.record_test_properties(
     category=Category.MODEL_TEST,
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.PASSED,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
+)
+@pytest.mark.xfail(
+    reason=incorrect_result(
+        "PCC comparison failed. Calculated: pcc=0.26489052176475525. Required: pcc=0.99"
+        "https://github.com/tenstorrent/tt-xla/issues/379"
+    )
 )
 def test_bloom_560m_inference(inference_tester: BloomTester):
     inference_tester.test()

--- a/tests/jax/single_chip/models/vit/vit_huge_patch14_224_in21k/test_vit_huge_patch14_224_in21k.py
+++ b/tests/jax/single_chip/models/vit/vit_huge_patch14_224_in21k/test_vit_huge_patch14_224_in21k.py
@@ -44,13 +44,19 @@ def training_tester() -> ViTTester:
 # ----- Tests -----
 
 
-@pytest.mark.model_test
+@pytest.mark.push
 @pytest.mark.record_test_properties(
     category=Category.MODEL_TEST,
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.PASSED,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
+)
+@pytest.mark.xfail(
+    reason=incorrect_result(
+        "PCC comparison failed. Calculated: pcc=-1.0. Required: pcc=0.99"
+        "https://github.com/tenstorrent/tt-xla/issues/379"
+    )
 )
 def test_vit_huge_patch14_224_in21k_inference(
     inference_tester: ViTTester,

--- a/tests/jax/single_chip/models/vit/vit_huge_patch14_224_in21k/test_vit_huge_patch14_224_in21k.py
+++ b/tests/jax/single_chip/models/vit/vit_huge_patch14_224_in21k/test_vit_huge_patch14_224_in21k.py
@@ -44,7 +44,7 @@ def training_tester() -> ViTTester:
 # ----- Tests -----
 
 
-@pytest.mark.push
+@pytest.mark.model_test
 @pytest.mark.record_test_properties(
     category=Category.MODEL_TEST,
     model_name=MODEL_NAME,


### PR DESCRIPTION
This PR temporarily sets pccconfig to false in order to investigate the cause of test failures observed in the CI/CD pipeline for the Bloom and ViT models.