### PR TITLE
removed xfail marker for constant op test

### DIFF
--- a/tests/jax/single_chip/ops/test_constant.py
+++ b/tests/jax/single_chip/ops/test_constant.py
@@ -46,9 +46,6 @@ def test_constant_ones(shape: tuple):
     jax_op_name="jax.numpy.array",
     shlo_op_name="stablehlo.constant",
 )
-@pytest.mark.xfail(
-    reason=failed_ttmlir_compilation("failed to legalize operation 'ttir.constant'")
-)
 def test_constant_multi_value():
     def module_constant_multi():
         return jnp.array([[1, 2], [3, 4]], dtype=jnp.float32)


### PR DESCRIPTION
### Problem description
Removed Xfail marker in constant op

### What's changed
changed test file for constant op

### Checklist
- [x] New/Existing tests provide coverage for changes

I have attached the logs for your reference:
[constant_fix.log](https://github.com/user-attachments/files/20769257/constant_fix.log)
[ops_test.log](https://github.com/user-attachments/files/20769258/ops_test.log)


