### PR TITLE
Update fail reasons

### DIFF
--- a/tests/jax/single_chip/models/albert_v2/xlarge/test_albert_xlarge.py
+++ b/tests/jax/single_chip/models/albert_v2/xlarge/test_albert_xlarge.py
@@ -12,7 +12,6 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    incorrect_result,
 )
 
 from ..tester import AlbertV2Tester
@@ -48,13 +47,7 @@ def training_tester() -> AlbertV2Tester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.INCORRECT_RESULT,
-)
-@pytest.mark.xfail(
-    reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=131030.6953125. Required: atol=0.16 "
-        "https://github.com/tenstorrent/tt-xla/issues/379"
-    )
+    bringup_status=BringupStatus.PASSED,
 )
 def test_flax_albert_v2_xlarge_inference(inference_tester: AlbertV2Tester):
     inference_tester.test()

--- a/tests/jax/single_chip/models/resnet_v1_5/resnet_101/test_resnet_101.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/resnet_101/test_resnet_101.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_fe_compilation,
+    incorrect_result,
 )
 
 from ..tester import ResNetTester, ResNetVariant
@@ -49,11 +49,12 @@ def training_tester() -> ResNetTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
 )
-@pytest.mark.skip(
-    reason=failed_fe_compilation(
-        "Segfault (https://github.com/tenstorrent/tt-xla/issues/558)"
+@pytest.mark.xfail(
+    reason=incorrect_result(
+        "PCC comparison failed. Calculated: pcc=-0.08088425546884537. Required: pcc=0.99 "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_resnet_v1_5_101_inference(inference_tester: ResNetTester):

--- a/tests/jax/single_chip/models/resnet_v1_5/resnet_152/test_resnet_152.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/resnet_152/test_resnet_152.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_fe_compilation,
+    incorrect_result,
 )
 
 from ..tester import ResNetTester, ResNetVariant
@@ -49,11 +49,12 @@ def training_tester() -> ResNetTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
 )
-@pytest.mark.skip(
-    reason=failed_fe_compilation(
-        "Segfault (https://github.com/tenstorrent/tt-xla/issues/558)"
+@pytest.mark.xfail(
+    reason=incorrect_result(
+        "PCC comparison failed. Calculated: pcc=-0.00827054027467966. Required: pcc=0.99 "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_resnet_v1_5_152_inference(inference_tester: ResNetTester):

--- a/tests/jax/single_chip/models/resnet_v1_5/resnet_18/test_resnet_18.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/resnet_18/test_resnet_18.py
@@ -12,7 +12,6 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_fe_compilation,
 )
 
 from ..tester import ResNetTester, ResNetVariant
@@ -50,12 +49,7 @@ def training_tester() -> ResNetTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
-)
-@pytest.mark.skip(
-    reason=failed_fe_compilation(
-        "Crashes in CI https://github.com/tenstorrent/tt-xla/issues/560"
-    )
+    bringup_status=BringupStatus.PASSED,
 )
 def test_resnet_v1_5_18_inference(inference_tester: ResNetTester):
     inference_tester.test()

--- a/tests/jax/single_chip/models/resnet_v1_5/resnet_26/test_resnet_26.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/resnet_26/test_resnet_26.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_fe_compilation,
+    incorrect_result,
 )
 
 from ..tester import ResNetTester, ResNetVariant
@@ -49,11 +49,12 @@ def training_tester() -> ResNetTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
 )
-@pytest.mark.skip(
-    reason=failed_fe_compilation(
-        "Crashes in CI https://github.com/tenstorrent/tt-xla/issues/560"
+@pytest.mark.xfail(
+    reason=incorrect_result(
+        "PCC comparison failed. Calculated: pcc=-0.002165748504921794. Required: pcc=0.99 "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_resnet_v1_5_26_inference(inference_tester: ResNetTester):

--- a/tests/jax/single_chip/models/resnet_v1_5/resnet_34/test_resnet_34.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/resnet_34/test_resnet_34.py
@@ -12,7 +12,6 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_fe_compilation,
 )
 
 from ..tester import ResNetTester, ResNetVariant
@@ -49,12 +48,7 @@ def training_tester() -> ResNetTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
-)
-@pytest.mark.skip(
-    reason=failed_fe_compilation(
-        "Crashes in CI https://github.com/tenstorrent/tt-xla/issues/560"
-    )
+    bringup_status=BringupStatus.PASSED,
 )
 def test_resnet_v1_5_34_inference(inference_tester: ResNetTester):
     inference_tester.test()

--- a/tests/jax/single_chip/models/resnet_v1_5/resnet_50/test_resnet_50.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/resnet_50/test_resnet_50.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_fe_compilation,
+    incorrect_result,
 )
 
 from ..tester import ResNetTester, ResNetVariant
@@ -49,11 +49,12 @@ def training_tester() -> ResNetTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
 )
-@pytest.mark.skip(
-    reason=failed_fe_compilation(
-        "Crashes in CI https://github.com/tenstorrent/tt-xla/issues/560"
+@pytest.mark.xfail(
+    reason=incorrect_result(
+        "PCC comparison failed. Calculated: pcc=-0.06595536321401596. Required: pcc=0.99 "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_resnet_v1_5_50_inference(inference_tester: ResNetTester):


### PR DESCRIPTION
### What's changed
Albert xlarge is now passing, so marked it as such.
Resnet models are no longer crashing so I unskipped them.

### Checklist
- [X] New/Existing tests provide coverage for changes
