### PR TITLE
Fix Bloom model test failures in nightly CI

### DIFF
--- a/tests/jax/single_chip/models/bloom/bloom_560m/test_560m.py
+++ b/tests/jax/single_chip/models/bloom/bloom_560m/test_560m.py
@@ -12,6 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
+    incorrect_result,
 )
 
 from ..tester import BloomTester
@@ -48,7 +49,13 @@ def training_tester() -> BloomTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.PASSED,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
+)
+@pytest.mark.xfail(
+    reason=incorrect_result(
+        "PCC comparison failed. Calculated: pcc=0.26489052176475525. Required: pcc=0.99"
+        "https://github.com/tenstorrent/tt-xla/issues/379"
+    )
 )
 def test_bloom_560m_inference(inference_tester: BloomTester):
     inference_tester.test()


### PR DESCRIPTION
### Problem description
Avoid CI failure caused by PCC drop in Bloom model tests.

### What's changed
Added xfail marker to Bloom test.

### Checklist
- [x] New/Existing tests provide coverage for changes
