### PR TITLE
Skip ResNet101 test to fix failure on Nightly 220625

### DIFF
--- a/tests/jax/single_chip/models/resnet_v1_5/resnet_101/test_resnet_101.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/resnet_101/test_resnet_101.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    incorrect_result,
+    failed_fe_compilation,
 )
 
 from ..tester import ResNetTester, ResNetVariant
@@ -49,12 +49,11 @@ def training_tester() -> ResNetTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.INCORRECT_RESULT,
+    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
 )
-@pytest.mark.xfail(
-    reason=incorrect_result(
-        "PCC comparison failed. Calculated: pcc=-0.08088425546884537. Required: pcc=0.99 "
-        "https://github.com/tenstorrent/tt-xla/issues/379"
+@pytest.mark.skip(
+    reason=failed_fe_compilation(
+        "Test killed in CI " "https://github.com/tenstorrent/tt-xla/issues/714"
     )
 )
 def test_resnet_v1_5_101_inference(inference_tester: ResNetTester):


### PR DESCRIPTION
### Problem Description
ResNet101 test was failing on Nightly 220625 due to OOM. This was blocking CI.

### What's changed
Skipped the ResNet101 test to unblock the CI pipeline .

I have attached the logs for your reference:
[resnet101.log](https://github.com/user-attachments/files/20864557/resnet101.log)
