### PR TITLE
Fix incorrect wheel file path in getting_started.md

### DIFF
--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -30,7 +30,7 @@ To build a wheel run
 >> python setup.py bdist_wheel
 ```
 
-this will output `python_package/jax_plugins/pjrt_plugin_tt/dist/pjrt_plugin_tt*.whl` file which is self-contained and can be installed using
+this will output `python_package/dist/pjrt_plugin_tt*.whl` file which is self-contained and can be installed using
 
 ```bash
 pip install pjrt_plugin_tt*.whl


### PR DESCRIPTION
### Problem description
The original path to the .whl file in getting_started.md was incorrect

### What's changed
Updated the wheel file path in the documentation to the correct location

### Checklist
- [x] New/Existing tests provide coverage for changes
