### PR TITLE
Updated all models with OOM markers with the latest results

### DIFF
--- a/tests/jax/single_chip/models/blenderbot/blenderbot_3b/test_blenderbot_3b.py
+++ b/tests/jax/single_chip/models/blenderbot/blenderbot_3b/test_blenderbot_3b.py
@@ -12,7 +12,6 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_fe_compilation,
 )
 
 from ..tester import BlenderBotTester
@@ -48,12 +47,7 @@ def training_tester() -> BlenderBotTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
-)
-@pytest.mark.skip(
-    reason=failed_fe_compilation(
-        "OOM in CI (https://github.com/tenstorrent/tt-xla/issues/186)"
-    )
+    bringup_status=BringupStatus.PASSED,
 )
 def test_blenderbot_3b_inference(inference_tester: BlenderBotTester):
     inference_tester.test()

--- a/tests/jax/single_chip/models/blenderbot/distill_1b/test_blenderbot_1b_distill.py
+++ b/tests/jax/single_chip/models/blenderbot/distill_1b/test_blenderbot_1b_distill.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_fe_compilation,
+    failed_ttmlir_compilation,
 )
 
 from ..tester import BlenderBotTester
@@ -48,11 +48,12 @@ def training_tester() -> BlenderBotTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
+    bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
 )
-@pytest.mark.skip(
-    reason=failed_fe_compilation(
-        "OOM in CI (https://github.com/tenstorrent/tt-xla/issues/186)"
+@pytest.mark.xfail(
+    reason=failed_ttmlir_compilation(
+        "'ttir.scatter' op Dimension size to slice into must be 1 "
+        "https://github.com/tenstorrent/tt-xla/issues/386"
     )
 )
 def test_blenderbot_1b_distill_inference(inference_tester: BlenderBotTester):

--- a/tests/jax/single_chip/models/dinov2/giant/test_dinov2_giant.py
+++ b/tests/jax/single_chip/models/dinov2/giant/test_dinov2_giant.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_fe_compilation,
+    failed_runtime,
 )
 
 from ..tester import Dinov2Tester
@@ -49,11 +49,12 @@ def training_tester() -> Dinov2Tester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
+    bringup_status=BringupStatus.FAILED_RUNTIME,
 )
-@pytest.mark.skip(
-    reason=failed_fe_compilation(
-        "OOM in CI (https://github.com/tenstorrent/tt-xla/issues/186)"
+@pytest.mark.xfail(
+    reason=failed_runtime(
+        "input_tensor_a.get_padded_shape().rank() == this->slice_start.rank() && this->slice_start.rank() == this->slice_end.rank() "
+        "(https://github.com/tenstorrent/tt-xla/issues/535)"
     )
 )
 def test_dinov2_giant_inference(inference_tester: Dinov2Tester):

--- a/tests/jax/single_chip/models/gpt2/xl/test_gpt2_xl.py
+++ b/tests/jax/single_chip/models/gpt2/xl/test_gpt2_xl.py
@@ -12,7 +12,6 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_fe_compilation,
 )
 
 from ..tester import GPT2Tester
@@ -49,12 +48,7 @@ def training_tester() -> GPT2Tester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
-)
-@pytest.mark.skip(
-    reason=failed_fe_compilation(
-        "OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186)"
-    )
+    bringup_status=BringupStatus.PASSED,
 )
 def test_gpt2_xl_inference(inference_tester: GPT2Tester):
     inference_tester.test()

--- a/tests/jax/single_chip/models/gpt_j/gpt_j_6b/test_gpt_j_6b.py
+++ b/tests/jax/single_chip/models/gpt_j/gpt_j_6b/test_gpt_j_6b.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_fe_compilation,
+    failed_runtime,
 )
 
 from ..tester import GPTJTester
@@ -45,17 +45,12 @@ def training_tester() -> GPTJTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
+    bringup_status=BringupStatus.FAILED_RUNTIME,
 )
-# @pytest.mark.xfail(
-#     reason=failed_ttmlir_compilation(
-#         "failed to legalize operation 'ttir.gather' that was explicitly marked illegal "
-#         "https://github.com/tenstorrent/tt-xla/issues/318 "
-#     )
-# )
-@pytest.mark.skip(
-    reason=failed_fe_compilation(
-        "OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186)"
+@pytest.mark.xfail(
+    reason=failed_runtime(
+        "Out of Memory: Not enough space to allocate 268435456 B DRAM buffer across 12 banks, where each bank needs to store 22372352 B"
+        "(https://github.com/tenstorrent/tt-xla/issues/187)"
     )
 )
 def test_gpt_j_6b_inference(inference_tester: GPTJTester):

--- a/tests/jax/single_chip/models/gpt_neo/gpt_neo_1_3b/test_gpt_neo_1_3b.py
+++ b/tests/jax/single_chip/models/gpt_neo/gpt_neo_1_3b/test_gpt_neo_1_3b.py
@@ -12,7 +12,6 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_fe_compilation,
 )
 
 from ..tester import GPTNeoTester
@@ -49,12 +48,7 @@ def training_tester() -> GPTNeoTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
-)
-@pytest.mark.skip(
-    reason=failed_fe_compilation(
-        "OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186)"
-    )
+    bringup_status=BringupStatus.PASSED,
 )
 def test_gpt_neo_1_3b_inference(inference_tester: GPTNeoTester):
     inference_tester.test()

--- a/tests/jax/single_chip/models/gpt_sw3/instruct_1_3b/test_gpt_sw3_1_3b_instruct.py
+++ b/tests/jax/single_chip/models/gpt_sw3/instruct_1_3b/test_gpt_sw3_1_3b_instruct.py
@@ -12,7 +12,7 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_fe_compilation,
+    incorrect_result,
 )
 
 from ..tester import GPTSw3Tester
@@ -49,11 +49,12 @@ def training_tester() -> GPTSw3Tester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
 )
-@pytest.mark.skip(
-    reason=failed_fe_compilation(
-        "OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186)"
+@pytest.mark.xfail(
+    reason=incorrect_result(
+        "PCC comparison failed. Calculated: pcc=0.16696356236934662. Required: pcc=0.99"
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_gpt_sw3_1_3b_instruct_inference(inference_tester: GPTSw3Tester):

--- a/tests/jax/single_chip/models/opt/opt_2_7b/test_2_7b.py
+++ b/tests/jax/single_chip/models/opt/opt_2_7b/test_2_7b.py
@@ -12,7 +12,6 @@ from tests.utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_fe_compilation,
 )
 
 from ..tester import OPTTester
@@ -49,12 +48,7 @@ def training_tester() -> OPTTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
-)
-@pytest.mark.skip(
-    reason=failed_fe_compilation(
-        "OOMs in CI (https://github.com/tenstorrent/tt-xla/issues/186)"
-    )
+    bringup_status=BringupStatus.PASSED,
 )
 def test_opt_2_7b_inference(inference_tester: OPTTester):
     inference_tester.test()


### PR DESCRIPTION
### Problem description
There are a total of 19 models that were previously marked with xfail due to OOM (Out-Of-Memory) errors. These models needed to be retested to validate whether the OOM issues still persist on the latest release and to update the failure reasons if required.

### What's changed
All 19 models were retested using the latest release. I have used a memory usage threshold of `20GB`, considering that the CI machines have `32GB` of total memory and allocating approximately `12GB` for system processes. Based on this threshold, the models that didn't exceeded `20GB` during execution were marked with xfail and updated with the latest observed failure reasons.

### Checklist
- [x] New/Existing tests provide coverage for changes

I have attached the logs for your reference.:
**Note**: Since the logs for the Mistral models were too large, I have uploaded them to Google Drive and included the link
[blender_bot_1b.log](https://github.com/user-attachments/files/20900866/blender_bot_1b.log)
[blender_bot_3b.log](https://github.com/user-attachments/files/20900869/blender_bot_3b.log)
[bloom_3b.log](https://github.com/user-attachments/files/20900871/bloom_3b.log)
[bloom_7b.log](https://github.com/user-attachments/files/20900872/bloom_7b.log)
[dinov2.log](https://github.com/user-attachments/files/20900873/dinov2.log)
[gpt_2_xl.log](https://github.com/user-attachments/files/20900875/gpt_2_xl.log)
[gpt_j_6b.log](https://github.com/user-attachments/files/20900877/gpt_j_6b.log)
[gpt_neo_1_3b.log](https://github.com/user-attachments/files/20900878/gpt_neo_1_3b.log)
[gpt_neo_2_7b.log](https://github.com/user-attachments/files/20900879/gpt_neo_2_7b.log)
[gpt_sw_1_3b.log](https://github.com/user-attachments/files/20900881/gpt_sw_1_3b.log)
[mt5_xl.log](https://github.com/user-attachments/files/20900884/mt5_xl.log)
[op_6_7b.log](https://github.com/user-attachments/files/20900885/op_6_7b.log)
[openllama3b_v2.log](https://github.com/user-attachments/files/20900886/openllama3b_v2.log)
[opt_2_7b.log](https://github.com/user-attachments/files/20900887/opt_2_7b.log)
[whispher_large_v3.log](https://github.com/user-attachments/files/20900889/whispher_large_v3.log)
[xlm_roberta.log](https://github.com/user-attachments/files/20900890/xlm_roberta.log)
[mistral7b_v02.log](https://drive.google.com/file/d/1wX5oX6EGYM7mWfb872unRmA6JtiF0024/view?usp=share_link)
[mistral7b_v01.log](https://drive.google.com/file/d/1cBz18dYtxB9zEDMLHyVd5w9v9kmfjOCz/view?usp=share_link)
[mistral7b_v03.log](https://drive.google.com/file/d/1erzKoGEIhujEKkIN-0rxGSDw5_bknHfq/view?usp=share_link)