### PR TITLE
Fix torch tests and add them to CI

### DIFF
--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -17,11 +17,11 @@ jobs:
       test_mark: 'nightly'
       build_options: |
         [
-          {"runs-on": "n150", "name": "run", "dir": "./tests/jax/single_chip"},
-          {"runs-on": "n150", "name": "run", "dir": "./tests/torch/single_chip"},
-          {"runs-on": "n300", "name": "run", "dir": "./tests/jax/multi_chip/n300"},
-          {"runs-on": "llmbox", "name": "run_4", "dir": "./tests/jax/multi_chip/llmbox/4_devices"},
-          {"runs-on": "llmbox", "name": "run_8", "dir": "./tests/jax/multi_chip/llmbox/8_devices"}
+          {"runs-on": "n150", "name": "run_jax", "dir": "./tests/jax/single_chip"},
+          {"runs-on": "n150", "name": "run_torch", "dir": "./tests/torch/single_chip"},
+          {"runs-on": "n300", "name": "run_jax", "dir": "./tests/jax/multi_chip/n300"},
+          {"runs-on": "llmbox", "name": "run_jax_4_devices", "dir": "./tests/jax/multi_chip/llmbox/4_devices"},
+          {"runs-on": "llmbox", "name": "run_jax_8_devices", "dir": "./tests/jax/multi_chip/llmbox/8_devices"}
         ]
 
   test_full_model:
@@ -33,11 +33,11 @@ jobs:
       test_mark: 'model_test'
       build_options: |
         [
-          {"runs-on": "n150", "name": "run", "dir": "./tests/jax/single_chip"},
-          {"runs-on": "n150", "name": "run", "dir": "./tests/torch/single_chip"},
-          {"runs-on": "n300", "name": "run", "dir": "./tests/jax/multi_chip/n300"},
-          {"runs-on": "llmbox", "name": "run_4", "dir": "./tests/jax/multi_chip/llmbox/4_devices"},
-          {"runs-on": "llmbox", "name": "run_8", "dir": "./tests/jax/multi_chip/llmbox/8_devices"}
+          {"runs-on": "n150", "name": "run_jax", "dir": "./tests/jax/single_chip"},
+          {"runs-on": "n150", "name": "run_torch", "dir": "./tests/torch/single_chip"},
+          {"runs-on": "n300", "name": "run_jax", "dir": "./tests/jax/multi_chip/n300"},
+          {"runs-on": "llmbox", "name": "run_jax_4_devices", "dir": "./tests/jax/multi_chip/llmbox/4_devices"},
+          {"runs-on": "llmbox", "name": "run_jax_8_devices", "dir": "./tests/jax/multi_chip/llmbox/8_devices"}
         ]
 
   fail-notify:

--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -18,6 +18,7 @@ jobs:
       build_options: |
         [
           {"runs-on": "n150", "name": "run", "dir": "./tests/jax/single_chip"},
+          {"runs-on": "n150", "name": "run", "dir": "./tests/torch/single_chip"},
           {"runs-on": "n300", "name": "run", "dir": "./tests/jax/multi_chip/n300"},
           {"runs-on": "llmbox", "name": "run_4", "dir": "./tests/jax/multi_chip/llmbox/4_devices"},
           {"runs-on": "llmbox", "name": "run_8", "dir": "./tests/jax/multi_chip/llmbox/8_devices"}
@@ -33,6 +34,7 @@ jobs:
       build_options: |
         [
           {"runs-on": "n150", "name": "run", "dir": "./tests/jax/single_chip"},
+          {"runs-on": "n150", "name": "run", "dir": "./tests/torch/single_chip"},
           {"runs-on": "n300", "name": "run", "dir": "./tests/jax/multi_chip/n300"},
           {"runs-on": "llmbox", "name": "run_4", "dir": "./tests/jax/multi_chip/llmbox/4_devices"},
           {"runs-on": "llmbox", "name": "run_8", "dir": "./tests/jax/multi_chip/llmbox/8_devices"}

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -71,6 +71,7 @@ jobs:
       build_options: |
         [
           {"runs-on": "n150", "name": "run", "dir": "./tests/jax/single_chip"},
+          {"runs-on": "n150", "name": "run", "dir": "./tests/torch/single_chip"},
           {"runs-on": "n300", "name": "run", "dir": "./tests/jax/multi_chip/n300"},
           {"runs-on": "llmbox", "name": "run_4", "dir": "./tests/jax/multi_chip/llmbox/4_devices"},
           {"runs-on": "llmbox", "name": "run_8", "dir": "./tests/jax/multi_chip/llmbox/8_devices"}

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -70,11 +70,11 @@ jobs:
       test_mark: 'push'
       build_options: |
         [
-          {"runs-on": "n150", "name": "run", "dir": "./tests/jax/single_chip"},
-          {"runs-on": "n150", "name": "run", "dir": "./tests/torch/single_chip"},
-          {"runs-on": "n300", "name": "run", "dir": "./tests/jax/multi_chip/n300"},
-          {"runs-on": "llmbox", "name": "run_4", "dir": "./tests/jax/multi_chip/llmbox/4_devices"},
-          {"runs-on": "llmbox", "name": "run_8", "dir": "./tests/jax/multi_chip/llmbox/8_devices"}
+          {"runs-on": "n150", "name": "run_jax", "dir": "./tests/jax/single_chip"},
+          {"runs-on": "n150", "name": "run_torch", "dir": "./tests/torch/single_chip"},
+          {"runs-on": "n300", "name": "run_jax", "dir": "./tests/jax/multi_chip/n300"},
+          {"runs-on": "llmbox", "name": "run_jax_4_devices", "dir": "./tests/jax/multi_chip/llmbox/4_devices"},
+          {"runs-on": "llmbox", "name": "run_jax_8_devices", "dir": "./tests/jax/multi_chip/llmbox/8_devices"}
         ]
 
   check-all-green:

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -30,9 +30,9 @@ jobs:
       test_mark: 'push'
       build_options: |
         [
-          {"runs-on": "n150", "name": "run", "dir": "./tests/jax/single_chip"},
-          {"runs-on": "n150", "name": "run", "dir": "./tests/torch/single_chip"},
-          {"runs-on": "n300", "name": "run", "dir": "./tests/jax/multi_chip/n300"},
-          {"runs-on": "llmbox", "name": "run_4", "dir": "./tests/jax/multi_chip/llmbox/4_devices"},
-          {"runs-on": "llmbox", "name": "run_8", "dir": "./tests/jax/multi_chip/llmbox/8_devices"}
+          {"runs-on": "n150", "name": "run_jax", "dir": "./tests/jax/single_chip"},
+          {"runs-on": "n150", "name": "run_torch", "dir": "./tests/torch/single_chip"},
+          {"runs-on": "n300", "name": "run_jax", "dir": "./tests/jax/multi_chip/n300"},
+          {"runs-on": "llmbox", "name": "run_jax_4_devices", "dir": "./tests/jax/multi_chip/llmbox/4_devices"},
+          {"runs-on": "llmbox", "name": "run_jax_8_devices", "dir": "./tests/jax/multi_chip/llmbox/8_devices"}
         ]

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -31,6 +31,7 @@ jobs:
       build_options: |
         [
           {"runs-on": "n150", "name": "run", "dir": "./tests/jax/single_chip"},
+          {"runs-on": "n150", "name": "run", "dir": "./tests/torch/single_chip"},
           {"runs-on": "n300", "name": "run", "dir": "./tests/jax/multi_chip/n300"},
           {"runs-on": "llmbox", "name": "run_4", "dir": "./tests/jax/multi_chip/llmbox/4_devices"},
           {"runs-on": "llmbox", "name": "run_8", "dir": "./tests/jax/multi_chip/llmbox/8_devices"}

--- a/python_package/__init__.py
+++ b/python_package/__init__.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 import jax._src.xla_bridge as xb
 
+TT_PJRT_PLUGIN_NAME = "pjrt_plugin_tt.so"
+
 
 def initialize():
     # Register bundled PJRT plugin.

--- a/python_package/setup.py
+++ b/python_package/setup.py
@@ -14,6 +14,8 @@ from setuptools import setup
 from setuptools.command.build_py import build_py
 from wheel.bdist_wheel import bdist_wheel
 
+from python_package import TT_PJRT_PLUGIN_NAME
+
 THIS_DIR = Path(os.path.realpath(os.path.dirname(__file__)))
 REPO_DIR = Path(os.path.join(THIS_DIR, "..")).resolve()
 
@@ -118,7 +120,7 @@ class SetupConfig:
     @property
     def pjrt_plugin_path(self) -> Path:
         """Full path to custom TT PJRT plugin."""
-        return REPO_DIR / f"build/src/tt/pjrt_plugin_tt.so"
+        return REPO_DIR / f"build/src/tt/{TT_PJRT_PLUGIN_NAME}"
 
     @property
     def tt_mlir_install_dir(self) -> Path:
@@ -152,7 +154,7 @@ class SetupConfig:
     @property
     def pjrt_plugin_copied(self) -> bool:
         """Returns True if .so file is already copied to destination."""
-        return (self.jax_plugin_target_dir / "pjrt_plugin_tt.so").exists()
+        return (self.jax_plugin_target_dir / TT_PJRT_PLUGIN_NAME).exists()
 
     @property
     def jax_plugin_init(self) -> Path:
@@ -351,7 +353,7 @@ setup(
     long_description=config.long_description,
     name="pjrt-plugin-tt",
     packages=["jax_plugins.pjrt_plugin_tt"],
-    package_data={"jax_plugins.pjrt_plugin_tt": ["pjrt_plugin_tt.so"]},
+    package_data={"jax_plugins.pjrt_plugin_tt": [TT_PJRT_PLUGIN_NAME]},
     package_dir={f"jax_plugins.pjrt_plugin_tt": "jax_plugins/pjrt_plugin_tt"},
     python_requires=">=3.10, <3.11",
     url="https://github.com/tenstorrent/tt-xla",

--- a/tests/infra/testers/multichip/model/jax_multichip_model_tester.py
+++ b/tests/infra/testers/multichip/model/jax_multichip_model_tester.py
@@ -119,24 +119,6 @@ class JaxMultichipModelTester(JaxModelTester, ABC):
         self._input_parameters = self._get_input_parameters()
 
     # @override
-    def _test_inference(self) -> None:
-        """
-        Tests the model by running inference on TT device and on CPU and comparing the
-        results.
-        """
-        compiled_device_workload = self._compile(
-            self._create_multichip_workload(self._device_mesh)
-        )
-        compiled_cpu_workload = self._compile(
-            self._create_multichip_workload(self._cpu_mesh)
-        )
-
-        cpu_res = self._run_on_multichip_device(compiled_cpu_workload)
-        device_res = self._run_on_multichip_device(compiled_device_workload)
-
-        self._compare(device_res, cpu_res)
-
-    # @override
     def _compile(self, workload: Workload) -> Workload:
         """
         Sets up `workload.executable` for just-in-time compile and execution.
@@ -161,6 +143,26 @@ class JaxMultichipModelTester(JaxModelTester, ABC):
             static_argnames=workload.static_argnames,
         )
         return workload
+
+    # @override
+    def _compile_for_cpu(self, workload: Workload) -> Workload:
+        """Compiles `workload` for CPU."""
+        return self._compile(self._create_multichip_workload(self._cpu_mesh))
+
+    # @override
+    def _compile_for_tt_device(self, workload: Workload) -> Workload:
+        """Compiles `workload` for TT device."""
+        return self._compile(self._create_multichip_workload(self._device_mesh))
+
+    # @override
+    def _run_on_cpu(self, compiled_workload: Workload) -> Tensor:
+        """Runs workload on CPU."""
+        return self._run_on_multichip_device(compiled_workload)
+
+    # @override
+    def _run_on_tt_device(self, compiled_workload: Workload) -> Tensor:
+        """Runs workload on TT device."""
+        return self._run_on_multichip_device(compiled_workload)
 
     # --- Convenience methods ---
 

--- a/tests/infra/testers/single_chip/model/jax_model_tester.py
+++ b/tests/infra/testers/single_chip/model/jax_model_tester.py
@@ -172,3 +172,13 @@ class JaxModelTester(ModelTester):
             workload.executable, static_argnames=workload.static_argnames
         )
         return workload
+
+    # @override
+    def _compile_for_cpu(self, workload: Workload) -> Workload:
+        """Compiles `workload` for CPU."""
+        return self._compile(workload)
+
+    # @override
+    def _compile_for_tt_device(self, workload: Workload) -> Workload:
+        """Compiles `workload` for TT device."""
+        return self._compile(workload)

--- a/tests/infra/testers/single_chip/model/model_tester.py
+++ b/tests/infra/testers/single_chip/model/model_tester.py
@@ -114,6 +114,16 @@ class ModelTester(BaseTester, ABC):
         """Configures `model` for training."""
         raise NotImplementedError("Subclasses must implement this method")
 
+    @abstractmethod
+    def _compile_for_cpu(self, workload: Workload) -> Workload:
+        """Compiles `workload` for CPU."""
+        raise NotImplementedError("Subclasses must implement this method.")
+
+    @abstractmethod
+    def _compile_for_tt_device(self, workload: Workload) -> Workload:
+        """Compiles `workload` for TT device."""
+        raise NotImplementedError("Subclasses must implement this method.")
+
     # -------------------- Private methods --------------------
 
     def _configure_model(self) -> None:
@@ -153,10 +163,11 @@ class ModelTester(BaseTester, ABC):
         Tests the model by running inference on TT device and on CPU and comparing the
         results.
         """
-        compiled_workload = self._compile(self._workload)
+        compiled_cpu_workload = self._compile_for_cpu(self._workload)
+        cpu_res = self._run_on_cpu(compiled_cpu_workload)
 
-        tt_res = self._run_on_tt_device(compiled_workload)
-        cpu_res = self._run_on_cpu(compiled_workload)
+        compiled_device_workload = self._compile_for_tt_device(self._workload)
+        tt_res = self._run_on_tt_device(compiled_device_workload)
 
         self._compare(tt_res, cpu_res)
 

--- a/tests/infra/testers/single_chip/model/model_tester.py
+++ b/tests/infra/testers/single_chip/model/model_tester.py
@@ -121,7 +121,7 @@ class ModelTester(BaseTester, ABC):
         Configures model for inference *or* training, depending on chosen run mode.
         """
         if self._run_mode == RunMode.INFERENCE:
-            self._configure_model_for_training(self._model)
+            self._configure_model_for_inference(self._model)
         else:
             self._configure_model_for_training(self._model)
 

--- a/tests/infra/testers/single_chip/model/torch_model_tester.py
+++ b/tests/infra/testers/single_chip/model/torch_model_tester.py
@@ -79,8 +79,25 @@ class TorchModelTester(ModelTester):
 
     # @override
     def _compile(self, workload: Workload) -> Workload:
+        """JIT-compiles model's forward pass into optimized kernels.
+
+        Compiles for inductor backend by default.
+        """
+        return self._compile_for_backend(workload, backend="inductor")
+
+    # @override
+    def _compile_for_cpu(self, workload: Workload) -> Workload:
+        """Compiles `workload` for CPU."""
+        return self._compile(workload)
+
+    # @override
+    def _compile_for_tt_device(self, workload: Workload) -> Workload:
+        """Compiles `workload` for TT device."""
+        return self._compile_for_backend(workload, backend="openxla")
+
+    def _compile_for_backend(self, workload: Workload, backend: str) -> Workload:
         """JIT-compiles model into optimized kernels."""
         assert isinstance(workload, TorchWorkload) and workload.model is not None
 
-        workload.model.compile(backend="openxla")
+        workload.model.compile(backend=backend)
         return workload

--- a/tests/torch/single_chip/models/mnist/cnn/dropout/test_mnist_cnn_dropout.py
+++ b/tests/torch/single_chip/models/mnist/cnn/dropout/test_mnist_cnn_dropout.py
@@ -13,7 +13,6 @@ from utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_fe_compilation,
 )
 
 from ..tester import MNISTCNNTester
@@ -51,12 +50,7 @@ def training_tester() -> MNISTCNNTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
-)
-@pytest.mark.xfail(
-    reason=failed_fe_compilation(
-        "failed to legalize operation 'stablehlo.rng_bit_generator'"
-    )
+    bringup_status=BringupStatus.PASSED,
 )
 def test_mnist_cnn_dropout_inference(inference_tester: MNISTCNNTester):
     inference_tester.test()

--- a/tests/torch/single_chip/models/mnist/cnn/dropout/test_mnist_cnn_dropout.py
+++ b/tests/torch/single_chip/models/mnist/cnn/dropout/test_mnist_cnn_dropout.py
@@ -52,7 +52,7 @@ def training_tester() -> MNISTCNNTester:
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.PASSED,
 )
-def test_mnist_cnn_dropout_inference(inference_tester: MNISTCNNTester):
+def test_torch_mnist_cnn_dropout_inference(inference_tester: MNISTCNNTester):
     inference_tester.test()
 
 
@@ -65,5 +65,5 @@ def test_mnist_cnn_dropout_inference(inference_tester: MNISTCNNTester):
     run_mode=RunMode.TRAINING,
 )
 @pytest.mark.skip(reason="Support for training not implemented")
-def test_mnist_cnn_dropout_training(training_tester: MNISTCNNTester):
+def test_torch_mnist_cnn_dropout_training(training_tester: MNISTCNNTester):
     training_tester.test()

--- a/tests/torch/single_chip/models/mnist/cnn/nodropout/test_mnist_cnn_nodropout.py
+++ b/tests/torch/single_chip/models/mnist/cnn/nodropout/test_mnist_cnn_nodropout.py
@@ -58,7 +58,7 @@ def training_tester() -> MNISTCNNTester:
         "failed to legalize operation 'stablehlo.batch_norm_inference'"
     )
 )
-def test_mnist_cnn_nodropout_inference(inference_tester: MNISTCNNTester):
+def test_torch_mnist_cnn_nodropout_inference(inference_tester: MNISTCNNTester):
     inference_tester.test()
 
 
@@ -71,5 +71,5 @@ def test_mnist_cnn_nodropout_inference(inference_tester: MNISTCNNTester):
     run_mode=RunMode.TRAINING,
 )
 @pytest.mark.skip(reason="Support for training not implemented")
-def test_mnist_cnn_nodropout_training(training_tester: MNISTCNNTester):
+def test_torch_mnist_cnn_nodropout_training(training_tester: MNISTCNNTester):
     training_tester.test()

--- a/tests/torch/single_chip/models/mnist/cnn/tester.py
+++ b/tests/torch/single_chip/models/mnist/cnn/tester.py
@@ -2,10 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Sequence, Type
+from typing import Any, Dict, Sequence, Type
 
 import torch
-import torch.nn as nn
 from infra import ComparisonConfig, Model, RunMode, TorchModelTester
 
 
@@ -22,18 +21,10 @@ class MNISTCNNTester(TorchModelTester):
         super().__init__(comparison_config, run_mode)
 
     # @override
-    def _get_model(self) -> nn.Module:
+    def _get_model(self) -> Model:
         return self._model_class().to(dtype=torch.bfloat16)
 
     # @override
-    def _get_forward_method_name(self) -> str:
-        return "forward"
-
-    # @override
-    def _get_input_activations(self) -> torch.Tensor:
+    def _get_input_activations(self) -> Dict | Sequence[Any]:
         # Channels is 1 as MNIST is in grayscale.
         return torch.ones((4, 1, 28, 28), dtype=torch.bfloat16)  # B, C, H, W
-
-    # @override
-    def _get_forward_method_args(self) -> Sequence[torch.Tensor]:
-        return [self._get_input_activations()]


### PR DESCRIPTION
### What's changed
- Fixed bug introduced in https://github.com/tenstorrent/tt-xla/pull/573 where models were always configured in training mode
- Added torch tests to be run in CI
- Fixed plugin loading from wheel in torch tests
- Torch tests were giving warning because model compiled for openxla backend is run with CPU inputs. Added separate compilation functions for CPU and TT for model testers.

### Checklist
- [x] New/Existing tests provide coverage for changes
