### PR TITLE
Fix tt-mlir override commit in the workflow log

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -103,7 +103,7 @@ jobs:
       continue-on-error: true
       shell: bash
       run: |
-          cd third_party/tt-mlir
+          cd third_party/tt-mlir/src/tt-mlir
           branch_name=$(git rev-parse --abbrev-ref HEAD)
           commit_sha=$(git rev-parse HEAD)
           commit_title=$(git log -1 --pretty=%s)

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -107,10 +107,11 @@ jobs:
           branch_name=$(git rev-parse --abbrev-ref HEAD)
           commit_sha=$(git rev-parse HEAD)
           commit_title=$(git log -1 --pretty=%s)
+          repo_name=$(git config --get remote.origin.url | sed 's/.*\/\([^\/]*\)\.git$/\1/')
           echo "Branch name: $branch_name"
           echo "Commit SHA: $commit_sha"
           echo "Commit title: $commit_title"
-          echo "::notice::Using tt-mlir: $branch_name, commit: $commit_sha, title: $commit_title"
+          echo "::notice::Using tt-mlir (or actually $repo_name): $branch_name, commit: $commit_sha, title: $commit_title"
 
 
   # # Run tests on TT hardware

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -107,7 +107,6 @@ jobs:
           branch_name=$(git rev-parse --abbrev-ref HEAD)
           commit_sha=$(git rev-parse HEAD)
           commit_title=$(git log -1 --pretty=%s)
-          repo_name=$(git config --get remote.origin.url | sed 's/.*\/\([^\/]*\)\.git$/\1/')
           echo "Branch name: $branch_name"
           echo "Commit SHA: $commit_sha"
           echo "Commit title: $commit_title"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -111,7 +111,7 @@ jobs:
           echo "Branch name: $branch_name"
           echo "Commit SHA: $commit_sha"
           echo "Commit title: $commit_title"
-          echo "::notice::Using tt-mlir (or actually $repo_name): $branch_name, commit: $commit_sha, title: $commit_title"
+          echo "::notice::Using tt-mlir: $branch_name, commit: $commit_sha, title: $commit_title"
 
 
   # # Run tests on TT hardware
@@ -321,7 +321,7 @@ jobs:
       continue-on-error: true
       shell: bash
       run: |
-          cd third_party/tt-mlir
+          cd third_party/tt-mlir/src/tt-mlir
           branch_name=$(git rev-parse --abbrev-ref HEAD)
           commit_sha=$(git rev-parse HEAD)
           commit_title=$(git log -1 --pretty=%s)


### PR DESCRIPTION
### Ticket
/

### Problem description
Workflow logged out tt-xla's commit instead of the submodule's (tt-mlir's) commit.
That happened because wrong git context was used.

### What's changed
I have corrected the path to tt-mlir.
Now the directory is the actual tt-mlir so the git context is correct.

### Checklist
- [ ] New/Existing tests provide coverage for changes
