### PR TITLE
remove xfail for models passing

### DIFF
--- a/tests/jax/single_chip/models/bloom/bloom_560m/test_560m.py
+++ b/tests/jax/single_chip/models/bloom/bloom_560m/test_560m.py
@@ -11,7 +11,6 @@ from utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    incorrect_result,
 )
 
 from ..tester import BloomTester
@@ -48,13 +47,7 @@ def training_tester() -> BloomTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.INCORRECT_RESULT,
-)
-@pytest.mark.xfail(
-    reason=incorrect_result(
-        "PCC comparison failed. Calculated: pcc=0.26489052176475525. Required: pcc=0.99"
-        "https://github.com/tenstorrent/tt-xla/issues/379"
-    )
+    bringup_status=BringupStatus.PASSED,
 )
 def test_bloom_560m_inference(inference_tester: BloomTester):
     inference_tester.test()

--- a/tests/jax/single_chip/models/opt/opt_1_3b/test_1_3b.py
+++ b/tests/jax/single_chip/models/opt/opt_1_3b/test_1_3b.py
@@ -11,7 +11,6 @@ from utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    incorrect_result,
 )
 
 from ..tester import OPTTester
@@ -47,13 +46,7 @@ def training_tester() -> OPTTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.INCORRECT_RESULT,
-)
-@pytest.mark.xfail(
-    reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=2307070.75. Required: atol=0.16 "
-        "https://github.com/tenstorrent/tt-xla/issues/379"
-    )
+    bringup_status=BringupStatus.PASSED,
 )
 def test_opt_1_3b_inference(inference_tester: OPTTester):
     inference_tester.test()


### PR DESCRIPTION
### Problem description
removed xfail markers for models passing

### What's changed
Removed Xfail markers from blomm_560m and opt_1_3b

### Checklist
- [x] New/Existing tests provide coverage for changes

I have attached the logs for your reference:
[bloom_560m_without_xfail.log](https://github.com/user-attachments/files/20991809/bloom_560m_without_xfail.log)
[opt_1_3b_without_xfail.log](https://github.com/user-attachments/files/20991813/opt_1_3b_without_xfail.log)
