### PR TITLE
skip gpt_neo_125m to fix nightly_02072025

### DIFF
--- a/tests/jax/single_chip/models/gpt_neo/gpt_neo_125m/test_gpt_neo_125m.py
+++ b/tests/jax/single_chip/models/gpt_neo/gpt_neo_125m/test_gpt_neo_125m.py
@@ -11,6 +11,7 @@ from utils import (
     ModelSource,
     ModelTask,
     build_model_name,
+    incorrect_result,
 )
 
 from ..tester import GPTNeoTester
@@ -46,7 +47,13 @@ def training_tester() -> GPTNeoTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.PASSED,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
+)
+@pytest.mark.xfail(
+    reason=incorrect_result(
+        "PCC comparison failed. Calculated: pcc=0.18604311347007751. Required: pcc=0.99. "
+        "https://github.com/tenstorrent/tt-xla/issues/379 "
+    )
 )
 def test_gpt_neo_125m_inference(inference_tester: GPTNeoTester):
     inference_tester.test()


### PR DESCRIPTION
### Problem description
 gpt_neo_125m test was failing on Nightly 02072025 due to PCC drop. This was blocking CI.

### What's changed
Skipped the  gpt_neo_125m test to unblock the CI pipeline .

### Checklist
- [x] New/Existing tests provide coverage for changes

I have attached the logs for your reference:
[test_gpt_neo_125m.log](https://github.com/user-attachments/files/21011343/test_gpt_neo_125m.log)


