### PR TITLE
remove PYTHONPATH from build_and_test.yml

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -202,11 +202,11 @@ jobs:
       shell: bash
       run: |
         source venv/activate
-        PYTHONPATH=$PYTHONPATH:$(pwd) pytest  --log-memory -sv \
-                                      ${{ matrix.build.dir }}  \
-                                      -m "${{ inputs.test_mark }}" \
-                                      --junitxml=${{ steps.strings.outputs.test_report_path }} \
-                                      2>&1 | tee pytest.log
+        pytest  --log-memory -sv \
+                ${{ matrix.build.dir }}  \
+                -m "${{ inputs.test_mark }}" \
+                --junitxml=${{ steps.strings.outputs.test_report_path }} \
+                2>&1 | tee pytest.log
 
     - name: Upload Test Log
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
### Ticket
Just a small refactoring

### What's changed
removed `PYTHONPATH=$PYTHONPATH:$(pwd)` from run-tests job from build-and-test.yml 


### Checklist
- [x] New/Existing tests provide coverage for changes
