### PR TITLE
Fix incorrect wheel file path in getting_started_build_from_source.md

### DIFF
--- a/docs/src/getting_started_build_from_source.md
+++ b/docs/src/getting_started_build_from_source.md
@@ -31,7 +31,7 @@ To build a wheel run
 >> python setup.py bdist_wheel
 ```
 
-this will output a `python_package/jax_plugins/pjrt_plugin_tt/dist/pjrt_plugin_tt*.whl` file which is self-contained and can be installed using:
+this will output a `python_package/dist/pjrt_plugin_tt*.whl` file which is self-contained and can be installed using:
 
 ```bash
 pip install pjrt_plugin_tt*.whl


### PR DESCRIPTION
### Problem description
The original path to the .whl file in getting_started_build_from_source.md was incorrect. It was already corrected in [this PR](https://github.com/tenstorrent/tt-xla/pull/720) in the Getting Started section, but it is now incorrect again in the getting_started_build_from_source.md file.

### What's changed
Updated the wheel file path in the documentation to the correct location

### Checklist
- [x] New/Existing tests provide coverage for changes
