### PR TITLE
Run llmbox tests on shared runner

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,6 +19,7 @@ on:
         description: >
           Build options for each run, like:
           - machine
+          - flag for running on shared runners
           - directory to run tests on
           - the name of the run which can be used to differentiate unique runs
         required: true
@@ -38,6 +39,7 @@ on:
         description: >
           Build options for each run, like:
           - machine
+          - flag for running on shared runners
           - directory to run tests on
           - the name of the run which can be used to differentiate unique runs
         required: true
@@ -125,8 +127,7 @@ jobs:
       matrix:
         build: ${{ fromJson(inputs.build_options) }}
 
-    runs-on:
-      - ${{ matrix.build.runs-on }}
+    runs-on: ${{ matrix.build.sh-run && format('tt-beta-ubuntu-2204-{0}-large-stable', matrix.build.runs-on) || fromJson(format('["{0}", "in-service"]', matrix.build.runs-on)) }}
 
     # Keep this name in sync with the fetch-job-id step
     name: "run-tests ${{ inputs.test_mark }} (${{ matrix.build.runs-on }}, ${{ matrix.build.name }})"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -252,7 +252,7 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Upload test results to Codecov
-      if: success() || failure()
+      if: matrix.build.sh-run == false && (success() || failure())
       uses: codecov/test-results-action@v1
       with:
         files: ${{ steps.strings.outputs.test_report_path }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -126,7 +126,6 @@ jobs:
         build: ${{ fromJson(inputs.build_options) }}
 
     runs-on:
-      - in-service
       - ${{ matrix.build.runs-on }}
 
     # Keep this name in sync with the fetch-job-id step

--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -17,11 +17,11 @@ jobs:
       test_mark: 'nightly'
       build_options: |
         [
-          {"runs-on": "n150", "name": "run_jax", "dir": "./tests/jax/single_chip"},
-          {"runs-on": "n150", "name": "run_torch", "dir": "./tests/torch/single_chip"},
-          {"runs-on": "n300", "name": "run_jax", "dir": "./tests/jax/multi_chip/n300"},
-          {"runs-on": "llmbox", "name": "run_jax_4_devices", "dir": "./tests/jax/multi_chip/llmbox/4_devices"},
-          {"runs-on": "llmbox", "name": "run_jax_8_devices", "dir": "./tests/jax/multi_chip/llmbox/8_devices"}
+          {"runs-on": "n150", sh-run: false, "name": "run_jax", "dir": "./tests/jax/single_chip"},
+          {"runs-on": "n150", sh-run: false, "name": "run_torch", "dir": "./tests/torch/single_chip"},
+          {"runs-on": "n300", sh-run: false, "name": "run_jax", "dir": "./tests/jax/multi_chip/n300"},
+          {"runs-on": "n300-llmbox", sh-run: true, "name": "run_jax_4_devices", "dir": "./tests/jax/multi_chip/llmbox/4_devices"},
+          {"runs-on": "n300-llmbox", sh-run: true, "name": "run_jax_8_devices", "dir": "./tests/jax/multi_chip/llmbox/8_devices"}
         ]
 
   test_full_model:
@@ -33,11 +33,11 @@ jobs:
       test_mark: 'model_test'
       build_options: |
         [
-          {"runs-on": "n150", "name": "run_jax", "dir": "./tests/jax/single_chip"},
-          {"runs-on": "n150", "name": "run_torch", "dir": "./tests/torch/single_chip"},
-          {"runs-on": "n300", "name": "run_jax", "dir": "./tests/jax/multi_chip/n300"},
-          {"runs-on": "llmbox", "name": "run_jax_4_devices", "dir": "./tests/jax/multi_chip/llmbox/4_devices"},
-          {"runs-on": "llmbox", "name": "run_jax_8_devices", "dir": "./tests/jax/multi_chip/llmbox/8_devices"}
+          {"runs-on": "n150", sh-run: false, "name": "run_jax", "dir": "./tests/jax/single_chip"},
+          {"runs-on": "n150", sh-run: false, "name": "run_torch", "dir": "./tests/torch/single_chip"},
+          {"runs-on": "n300", sh-run: false, "name": "run_jax", "dir": "./tests/jax/multi_chip/n300"},
+          {"runs-on": "n300-llmbox", sh-run: true, "name": "run_jax_4_devices", "dir": "./tests/jax/multi_chip/llmbox/4_devices"},
+          {"runs-on": "n300-llmbox", sh-run: true, "name": "run_jax_8_devices", "dir": "./tests/jax/multi_chip/llmbox/8_devices"}
         ]
 
   fail-notify:

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -70,9 +70,6 @@ jobs:
       test_mark: 'push'
       build_options: |
         [
-          {"runs-on": "n150", "name": "run_jax", "dir": "./tests/jax/single_chip"},
-          {"runs-on": "n150", "name": "run_torch", "dir": "./tests/torch/single_chip"},
-          {"runs-on": "n300", "name": "run_jax", "dir": "./tests/jax/multi_chip/n300"},
           {"runs-on": "tt-beta-ubuntu-2204-n300-llmbox-large-stable", "name": "run_jax_4_devices", "dir": "./tests/jax/multi_chip/llmbox/4_devices"},
           {"runs-on": "tt-beta-ubuntu-2204-n300-llmbox-large-stable", "name": "run_jax_8_devices", "dir": "./tests/jax/multi_chip/llmbox/8_devices"}
         ]

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -70,8 +70,11 @@ jobs:
       test_mark: 'push'
       build_options: |
         [
-          {"runs-on": "tt-beta-ubuntu-2204-n300-llmbox-large-stable", "name": "run_jax_4_devices", "dir": "./tests/jax/multi_chip/llmbox/4_devices"},
-          {"runs-on": "tt-beta-ubuntu-2204-n300-llmbox-large-stable", "name": "run_jax_8_devices", "dir": "./tests/jax/multi_chip/llmbox/8_devices"}
+          {"runs-on": "n150", sh-run: false, "name": "run_jax", "dir": "./tests/jax/single_chip"},
+          {"runs-on": "n150", sh-run: false, "name": "run_torch", "dir": "./tests/torch/single_chip"},
+          {"runs-on": "n300", sh-run: false, "name": "run_jax", "dir": "./tests/jax/multi_chip/n300"},
+          {"runs-on": "n300-llmbox", sh-run: true, "name": "run_jax_4_devices", "dir": "./tests/jax/multi_chip/llmbox/4_devices"},
+          {"runs-on": "n300-llmbox", sh-run: true, "name": "run_jax_8_devices", "dir": "./tests/jax/multi_chip/llmbox/8_devices"}
         ]
 
   check-all-green:

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -73,8 +73,8 @@ jobs:
           {"runs-on": "n150", "name": "run_jax", "dir": "./tests/jax/single_chip"},
           {"runs-on": "n150", "name": "run_torch", "dir": "./tests/torch/single_chip"},
           {"runs-on": "n300", "name": "run_jax", "dir": "./tests/jax/multi_chip/n300"},
-          {"runs-on": "llmbox", "name": "run_jax_4_devices", "dir": "./tests/jax/multi_chip/llmbox/4_devices"},
-          {"runs-on": "llmbox", "name": "run_jax_8_devices", "dir": "./tests/jax/multi_chip/llmbox/8_devices"}
+          {"runs-on": "tt-beta-ubuntu-2204-n300-llmbox-large-stable", "name": "run_jax_4_devices", "dir": "./tests/jax/multi_chip/llmbox/4_devices"},
+          {"runs-on": "tt-beta-ubuntu-2204-n300-llmbox-large-stable", "name": "run_jax_8_devices", "dir": "./tests/jax/multi_chip/llmbox/8_devices"}
         ]
 
   check-all-green:

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -30,9 +30,9 @@ jobs:
       test_mark: 'push'
       build_options: |
         [
-          {"runs-on": "n150", "name": "run_jax", "dir": "./tests/jax/single_chip"},
-          {"runs-on": "n150", "name": "run_torch", "dir": "./tests/torch/single_chip"},
-          {"runs-on": "n300", "name": "run_jax", "dir": "./tests/jax/multi_chip/n300"},
-          {"runs-on": "llmbox", "name": "run_jax_4_devices", "dir": "./tests/jax/multi_chip/llmbox/4_devices"},
-          {"runs-on": "llmbox", "name": "run_jax_8_devices", "dir": "./tests/jax/multi_chip/llmbox/8_devices"}
+          {"runs-on": "n150", sh-run: false, "name": "run_jax", "dir": "./tests/jax/single_chip"},
+          {"runs-on": "n150", sh-run: false, "name": "run_torch", "dir": "./tests/torch/single_chip"},
+          {"runs-on": "n300", sh-run: false, "name": "run_jax", "dir": "./tests/jax/multi_chip/n300"},
+          {"runs-on": "n300-llmbox", sh-run: true, "name": "run_jax_4_devices", "dir": "./tests/jax/multi_chip/llmbox/4_devices"},
+          {"runs-on": "n300-llmbox", sh-run: true, "name": "run_jax_8_devices", "dir": "./tests/jax/multi_chip/llmbox/8_devices"}
         ]


### PR DESCRIPTION
### Ticket
/

### What's changed
Move llmbox tests to the shared runners pool (CIv2).
The change is temporary due to the llmbox-2 runner not working, but if the CI speed improves it can stay permanent.

### Checklist
- [ ] New/Existing tests provide coverage for changes
