### PR TITLE
[CI] Fix and add features to "Run Test" workflow

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -80,6 +80,7 @@ jobs:
     if: needs.check-files.outputs.skip == 'false'
     with:
       docker_image: ${{ needs.build-image.outputs.docker-image }}
+      mlir_override: ${{ inputs.mlir_override}}
       debug_build: ${{ matrix.build_type }}
       enable_artifact_upload: ${{ matrix.build_type }}
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -30,14 +30,14 @@ on:
           - 'multichip'
           - 'All'
       dir:
-        description: 'Directory to run tests in'
+        description: |
+          Directory to run tests. Defaults:
+            - 'n150': './tests/jax/single_chip ./tests/torch/single_chip'
+            - 'n300': './tests/jax/multi_chip/n300'
+            - 'llmbox': './tests/jax/multi_chip/llmbox'
+            - 'multichip': './tests/jax/multi_chip'
+            - 'All': run on n150 all singlechip, on llmbox all multichip
         type: string
-        # defaults:
-        # - 'n150': './tests/jax/single_chip ./tests/torch/single_chip'
-        # - 'n300': './tests/jax/multi_chip/n300'
-        # - 'llmbox': './tests/jax/multi_chip/llmbox'
-        # - 'multichip': './tests/jax/multi_chip'
-        # - 'All': run on n150 all singlechip, on llmbox all multichip
 
 permissions:
   packages: write
@@ -80,7 +80,7 @@ jobs:
             local result=""
             local counter=1
             for arg in "$@"; do
-                result+="{ \"runs-on\": \"$runson\",\"name\": \"${name}-${counter}\", \"dir\": \"$arg\" },"
+                result+="{ \"runs-on\": \"$runson\", \"name\": \"${name}-${counter}\", \"dir\": \"$arg\" },"
                 ((counter++))
             done
             echo "${result%,}"
@@ -129,6 +129,7 @@ jobs:
           echo "- Run ID: ${{ steps.set_inputs.outputs.run_id }}" >> $GITHUB_STEP_SUMMARY
           echo "- Test Mark: ${{ steps.set_inputs.outputs.test_mark }}" >> $GITHUB_STEP_SUMMARY
           echo "- Test Matrix:" >> $GITHUB_STEP_SUMMARY
+          echo "Matrix: ${{ steps.set_inputs.outputs.test_matrix }}"
           echo "${{ steps.set_inputs.outputs.test_matrix }}" | jq '.' >> $GITHUB_STEP_SUMMARY
 
   test:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -33,10 +33,10 @@ on:
         description: 'Directory to run tests in'
         type: string
         # defaults:
-        # - 'n150': 'jax/single_chip torch/single_chip'
-        # - 'n300': 'jax/multi_chip/n300'
-        # - 'llmbox': 'jax/multi_chip/llmbox'
-        # - 'multichip': 'jax/multi_chip'
+        # - 'n150': './tests/jax/single_chip ./tests/torch/single_chip'
+        # - 'n300': './tests/jax/multi_chip/n300'
+        # - 'llmbox': './tests/jax/multi_chip/llmbox'
+        # - 'multichip': './tests/jax/multi_chip'
         # - 'All': ignored
 
 jobs:
@@ -70,16 +70,16 @@ jobs:
             echo "test_mark=${{ inputs.preset }}" >> $GITHUB_OUTPUT
           fi
           if [ '${{ inputs.run_on }}' == 'n150' ]; then
-            dir=$(if [ -z '${{ inputs.dir }}' ]; then echo 'jax/single_chip torch/single_chip'; else echo '${{ inputs.dir }}'; fi)
+            dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/single_chip ./tests/torch/single_chip'; else echo '${{ inputs.dir }}'; fi)
             echo "test_matrix=[{\"runs-on\":\"n150\",\"name\":\"run_single_chip\",\"dir\":\"$dir\"}]" >> $GITHUB_OUTPUT
           elif [ '${{ inputs.run_on }}' == 'n300' ]; then
-            dir=$(if [ -z '${{ inputs.dir }}' ]; then echo 'jax/multi_chip/n300'; else echo '${{ inputs.dir }}'; fi)
+            dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/multi_chip/n300'; else echo '${{ inputs.dir }}'; fi)
             echo "test_matrix=[{\"runs-on\":\"n300\",\"name\":\"run_jax_2\",\"dir\":\"$dir\"}]" >> $GITHUB_OUTPUT
           elif [ '${{ inputs.run_on }}' == 'llmbox' ]; then
-            dir=$(if [ -z '${{ inputs.dir }}' ]; then echo 'jax/multi_chip/llmbox'; else echo '${{ inputs.dir }}'; fi)
+            dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/multi_chip/llmbox'; else echo '${{ inputs.dir }}'; fi)
             echo "test_matrix=[{\"runs-on\":\"n300-llmbox\",\"name\":\"run_jax_4_8\",\"dir\":\"$dir\",\"sh-run\":\"true\"}]" >> $GITHUB_OUTPUT
           elif [ '${{ inputs.run_on }}' == 'multichip' ]; then
-            dir=$(if [ -z '${{ inputs.dir }}' ]; then echo 'jax/multi_chip'; else echo '${{ inputs.dir }}'; fi)
+            dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/multi_chip'; else echo '${{ inputs.dir }}'; fi)
             echo "test_matrix=[{\"runs-on\":\"n300-llmbox\",\"name\":\"run_jax_4_8\",\"dir\":\"$dir\",\"sh-run\":\"true\"}]" >> $GITHUB_OUTPUT
           # else do nothiing, leave test_matrix empty and do test default
           fi

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -17,7 +17,6 @@ on:
           - 'Custom'
       test_mark:
         description: 'Test mark to run (if preset is Custom)'
-        required: true
         type: string
 
 jobs:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -37,6 +37,7 @@ jobs:
         run: echo "run_id=$(if [ '${{ inputs.rebuild_xla }}' == 'true' ]; then echo ${{ github.run_id }}; fi;)" >> $GITHUB_OUTPUT
 
   test:
+    if: success() || failure()
     uses: ./.github/workflows/test.yml
     needs: [build-image,build-resolution]
     secrets: inherit

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -7,10 +7,17 @@ on:
         description: 'Rebuild XLA'
         required: false
         type: boolean
+      preset:
+        description: 'Preset to use for the tests'
+        type: choice
+        default: 'nightly'
+        options:
+          - 'push'
+          - 'nightly'
+          - 'Custom'
       test_mark:
-        description: 'Test mark to run (push, nightly, your_own_mark)'
+        description: 'Test mark to run (if preset is Custom)'
         required: true
-        default: 'push'
         type: string
 
 jobs:
@@ -31,10 +38,17 @@ jobs:
     needs: build-xla
     if: always() && !cancelled()
     outputs:
-      run_id: ${{ steps.set_run_id.outputs.run_id }}
+      run_id: ${{ steps.set_inputs.outputs.run_id }}
+      test_mark: ${{ steps.set_inputs.outputs.test_mark }}
     steps:
-      - id: set_run_id
-        run: echo "run_id=$(if [ '${{ inputs.rebuild_xla }}' == 'true' ]; then echo ${{ github.run_id }}; fi;)" >> $GITHUB_OUTPUT
+      - id: set_inputs
+        run: |
+          echo "run_id=$(if [ '${{ inputs.rebuild_xla }}' == 'true' ]; then echo ${{ github.run_id }}; fi;)" >> $GITHUB_OUTPUT
+          if [ '${{ inputs.preset }}' == 'Custom' ]; then
+            echo "test_mark=${{ inputs.test_mark }}" >> $GITHUB_OUTPUT
+          else
+            echo "test_mark=${{ inputs.preset }}" >> $GITHUB_OUTPUT
+          fi
 
   test:
     if: always() && !cancelled()
@@ -43,5 +57,5 @@ jobs:
     secrets: inherit
     with:
       docker_image: ${{ needs.build-image.outputs.docker-image }}
-      test_mark: ${{ inputs.test_mark }}
+      test_mark: ${{ needs.build-resolution.outputs.test_mark }}
       run_id: ${{ needs.build-resolution.outputs.run_id }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -80,7 +80,7 @@ jobs:
             local result=""
             local counter=1
             for arg in "$@"; do
-                result+="{ \"runs-on\": \"$runson\", \"name\": \"${name}-${counter}\", \"dir\": \"$arg\" $(if [ -n '$shrun' ]; then echo '', \"sh-run\": \"true\""; fi)') },"
+                result+="{ \"runs-on\": \"$runson\", \"name\": \"${name}-${counter}\", \"dir\": \"$arg\" $(if [ -n '$shrun' ]; then echo ', \"sh-run\": \"true\""; fi)') },"
                 ((counter++))
             done
             echo "${result%,}"

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -80,7 +80,7 @@ jobs:
             local result=""
             local counter=1
             for arg in "$@"; do
-                result+="{ \"runs-on\": \"$runson\", \"name\": \"${name}-${counter}\", \"dir\": \"$arg\" $(if [ -n '$shrun' ]; then echo ', \"sh-run\": \"true\""; fi)') },"
+                result+="{ \"runs-on\": \"$runson\", \"name\": \"${name}-${counter}\", \"dir\": \"$arg\"$(if [ "$shrun" -ne 0 ]; then echo ', \"sh-run\": \"true\"'; fi) },"
                 ((counter++))
             done
             echo "${result%,}"

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -100,13 +100,13 @@ jobs:
             shrun=0
             echo "test_matrix=[$(make_json_array $dir)]" >> $GITHUB_OUTPUT
           elif [ '${{ inputs.run_on }}' == 'llmbox' ]; then
-            dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/multi_chip/llmbox'; else echo '${{ inputs.dir }}'; fi)
+            dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/multi_chip/llmbox/4_devices ./tests/jax/multi_chip/llmbox/8_devices'; else echo '${{ inputs.dir }}'; fi)
             runson='n300-llmbox'
             name='run_4_8_chip'
             shrun=1
             echo "test_matrix=[$(make_json_array $dir)]" >> $GITHUB_OUTPUT
           elif [ '${{ inputs.run_on }}' == 'multichip' ]; then
-            dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/multi_chip'; else echo '${{ inputs.dir }}'; fi)
+            dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/multi_chip/n300 ./tests/jax/multi_chip/llmbox/4_devices ./tests/jax/multi_chip/llmbox/8_devices'; else echo '${{ inputs.dir }}'; fi)
             runson='n300-llmbox'
             name='run_multi_chip'
             shrun=1
@@ -116,7 +116,7 @@ jobs:
             runson='n150'
             name='run_single_chip'
             sc=$(make_json_array $dir)
-            dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/multi_chip'; else echo '${{ inputs.dir }}'; fi)
+            dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/multi_chip/n300 ./tests/jax/multi_chip/llmbox/4_devices ./tests/jax/multi_chip/llmbox/8_devices'; else echo '${{ inputs.dir }}'; fi)
             runson='n300-llmbox'
             name='run_multi_chip'
             shrun=1

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -37,13 +37,13 @@ on:
         # - 'n300': './tests/jax/multi_chip/n300'
         # - 'llmbox': './tests/jax/multi_chip/llmbox'
         # - 'multichip': './tests/jax/multi_chip'
-        # - 'All': run on n150 all singlechip, llmbox all multichip
+        # - 'All': run on n150 all singlechip, on llmbox all multichip
 
 permissions:
   packages: write
   checks: write
 
-run-name: 'Test (Rebuild: ${{ inputs.rebuild_xla }} - Preset: ${{ inputs.preset }} - Mark: ${{ inputs.test_mark }} - Run-on: "${{ inputs.run_on }}" - Dir: "${{ inputs.dir }}"'
+run-name: 'Test (Rebuild: ${{ inputs.rebuild_xla }} - Preset: ${{ inputs.preset }} - Mark: ${{ inputs.test_mark }} - Run-on: "${{ inputs.run_on }}" - Dir: "${{ inputs.dir }}")'
 
 jobs:
   build-image:
@@ -58,7 +58,7 @@ jobs:
     with:
       docker_image: ${{ needs.build-image.outputs.docker-image }}
 
-  build-resolution:
+  test-setup:
     runs-on: ubuntu-latest
     needs: build-xla
     if: always() && !cancelled()
@@ -128,7 +128,8 @@ jobs:
           echo "### Evaluated run parameters" >> $GITHUB_STEP_SUMMARY
           echo "- Run ID: ${{ steps.set_inputs.outputs.run_id }}" >> $GITHUB_STEP_SUMMARY
           echo "- Test Mark: ${{ steps.set_inputs.outputs.test_mark }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Test Matrix: ${{ steps.set_inputs.outputs.test_matrix }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Test Matrix:" >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.set_inputs.outputs.test_matrix }}" | jq '.' >> $GITHUB_STEP_SUMMARY
 
   test:
     if: always() && !cancelled()

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -37,7 +37,7 @@ on:
         # - 'n300': './tests/jax/multi_chip/n300'
         # - 'llmbox': './tests/jax/multi_chip/llmbox'
         # - 'multichip': './tests/jax/multi_chip'
-        # - 'All': ignored
+        # - 'All': run on n150 all singlechip, llmbox all multichip
 
 jobs:
   build-image:
@@ -80,8 +80,11 @@ jobs:
             echo "test_matrix=[{\"runs-on\":\"n300-llmbox\",\"name\":\"run_jax_4_8\",\"dir\":\"$dir\",\"sh-run\":\"true\"}]" >> $GITHUB_OUTPUT
           elif [ '${{ inputs.run_on }}' == 'multichip' ]; then
             dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/multi_chip'; else echo '${{ inputs.dir }}'; fi)
-            echo "test_matrix=[{\"runs-on\":\"n300-llmbox\",\"name\":\"run_jax_4_8\",\"dir\":\"$dir\",\"sh-run\":\"true\"}]" >> $GITHUB_OUTPUT
-          # else do nothiing, leave test_matrix empty and do test default
+            echo "test_matrix=[{\"runs-on\":\"n300-llmbox\",\"name\":\"run_jax_multichip\",\"dir\":\"$dir\",\"sh-run\":\"true\"}]" >> $GITHUB_OUTPUT
+          else
+            dir1=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/single_chip ./tests/torch/single_chip'; else echo '${{ inputs.dir }}'; fi)
+            dir2=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/multi_chip'; else echo '${{ inputs.dir }}'; fi)
+            echo "test_matrix=[{\"runs-on\":\"n150\",\"name\":\"run_single_chip\",\"dir\":\"$dir1\"},{\"runs-on\":\"n300-llmbox\",\"name\":\"run_jax_multichip\",\"dir\":\"$dir2\",\"sh-run\":\"true\"}]" >> $GITHUB_OUTPUT
           fi
 
   test:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -134,10 +134,10 @@ jobs:
   test:
     if: always() && !cancelled()
     uses: ./.github/workflows/test.yml
-    needs: [build-image,build-resolution]
+    needs: [build-image,test-setup]
     secrets: inherit
     with:
       docker_image: ${{ needs.build-image.outputs.docker-image }}
-      test_mark: ${{ needs.build-resolution.outputs.test_mark }}
-      run_id: ${{ needs.build-resolution.outputs.run_id }}
-      test_matrix: ${{ needs.build-resolution.outputs.test_matrix }}
+      test_mark: ${{ needs.test-setup.outputs.test_mark }}
+      run_id: ${{ needs.test-setup.outputs.run_id }}
+      test_matrix: ${{ needs.test-setup.outputs.test_matrix }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -19,6 +19,25 @@ on:
       test_mark:
         description: 'Test mark to run (if preset is Custom)'
         type: string
+      run_on:
+        description: 'Run on specific hardware'
+        type: choice
+        default: 'All'
+        options:
+          - 'n150'
+          - 'n300'
+          - 'llmbox'
+          - 'multichip'
+          - 'All'
+      dir:
+        description: 'Directory to run tests in'
+        type: string
+        # defaults:
+        # - 'n150': 'jax/single_chip torch/single_chip'
+        # - 'n300': 'jax/multi_chip/n300'
+        # - 'llmbox': 'jax/multi_chip/llmbox'
+        # - 'multichip': 'jax/multi_chip'
+        # - 'All': ignored
 
 jobs:
   build-image:
@@ -40,6 +59,7 @@ jobs:
     outputs:
       run_id: ${{ steps.set_inputs.outputs.run_id }}
       test_mark: ${{ steps.set_inputs.outputs.test_mark }}
+      test_matrix: ${{ steps.set_inputs.outputs.test_matrix }}
     steps:
       - id: set_inputs
         run: |
@@ -48,6 +68,20 @@ jobs:
             echo "test_mark=${{ inputs.test_mark }}" >> $GITHUB_OUTPUT
           else
             echo "test_mark=${{ inputs.preset }}" >> $GITHUB_OUTPUT
+          fi
+          if [ '${{ inputs.run_on }}' == 'n150' ]; then
+            dir=$(if [ -z '${{ inputs.dir }}' ]; then echo 'jax/single_chip torch/single_chip'; else echo '${{ inputs.dir }}'; fi)
+            echo "test_matrix=[{\"runs-on\":\"n150\",\"name\":\"run_single_chip\",\"dir\":\"$dir\"}]" >> $GITHUB_OUTPUT
+          elif [ '${{ inputs.run_on }}' == 'n300' ]; then
+            dir=$(if [ -z '${{ inputs.dir }}' ]; then echo 'jax/multi_chip/n300'; else echo '${{ inputs.dir }}'; fi)
+            echo "test_matrix=[{\"runs-on\":\"n300\",\"name\":\"run_jax_2\",\"dir\":\"$dir\"}]" >> $GITHUB_OUTPUT
+          elif [ '${{ inputs.run_on }}' == 'llmbox' ]; then
+            dir=$(if [ -z '${{ inputs.dir }}' ]; then echo 'jax/multi_chip/llmbox'; else echo '${{ inputs.dir }}'; fi)
+            echo "test_matrix=[{\"runs-on\":\"n300-llmbox\",\"name\":\"run_jax_4_8\",\"dir\":\"$dir\",\"sh-run\":\"true\"}]" >> $GITHUB_OUTPUT
+          elif [ '${{ inputs.run_on }}' == 'multichip' ]; then
+            dir=$(if [ -z '${{ inputs.dir }}' ]; then echo 'jax/multi_chip'; else echo '${{ inputs.dir }}'; fi)
+            echo "test_matrix=[{\"runs-on\":\"n300-llmbox\",\"name\":\"run_jax_4_8\",\"dir\":\"$dir\",\"sh-run\":\"true\"}]" >> $GITHUB_OUTPUT
+          # else do nothiing, leave test_matrix empty and do test default
           fi
 
   test:
@@ -59,3 +93,4 @@ jobs:
       docker_image: ${{ needs.build-image.outputs.docker-image }}
       test_mark: ${{ needs.build-resolution.outputs.test_mark }}
       run_id: ${{ needs.build-resolution.outputs.run_id }}
+      test_matrix: ${{ needs.build-resolution.outputs.test_matrix }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -19,7 +19,7 @@ jobs:
     secrets: inherit
 
   build-xla:
-    if: inputs.rebuild_xla == 'true'
+    if: inputs.rebuild_xla
     uses: ./.github/workflows/build.yml
     secrets: inherit
     needs: build-image

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -43,7 +43,7 @@ permissions:
   packages: write
   checks: write
 
-run-name: "Test (Rebuild: ${{ inputs.rebuild_xla }} - Preset: ${{ inputs.preset }} - Mark: ${{ inputs.test_mark }} - ${{ inputs.run_on }} - ${{ inputs.dir }}"
+run-name: 'Test (Rebuild: ${{ inputs.rebuild_xla }} - Preset: ${{ inputs.preset }} - Mark: ${{ inputs.test_mark }} - Run-on: "${{ inputs.run_on }}" - Dir: "${{ inputs.dir }}"'
 
 jobs:
   build-image:
@@ -127,7 +127,7 @@ jobs:
           echo "- Directory: ${{ inputs.dir }}" >> $GITHUB_STEP_SUMMARY
           echo "### Evaluated run parameters" >> $GITHUB_STEP_SUMMARY
           echo "- Run ID: ${{ steps.set_inputs.outputs.run_id }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Test Mark: ${{ steps.set_inputs.outputs.test_mark }}" >> $GITHUB
+          echo "- Test Mark: ${{ steps.set_inputs.outputs.test_mark }}" >> $GITHUB_STEP_SUMMARY
           echo "- Test Matrix: ${{ steps.set_inputs.outputs.test_matrix }}" >> $GITHUB_STEP_SUMMARY
 
   test:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -80,8 +80,9 @@ jobs:
             local result=""
             local counter=1
             for arg in "$@"; do
-                result+="{ \"runs-on\": \"$runson\", \"name\": \"${name}-${counter}\", \"dir\": \"$arg\"$(if [ "$shrun" -ne 0 ]; then echo ', \"sh-run\": \"true\"'; fi) },"
-                ((counter++))
+              local shr=$(if [ "$shrun" -ne 0 ]; then echo ", \"sh-run\": \"true\""; fi)
+              result+="{ \"runs-on\": \"$runson\", \"name\": \"${name}-${counter}\", \"dir\": \"$arg\"$shr },"
+              ((counter++))
             done
             echo "${result%,}"
           }

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -90,22 +90,22 @@ jobs:
             dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/single_chip ./tests/torch/single_chip'; else echo '${{ inputs.dir }}'; fi)
             runson='n150'
             name='run_single_chip'
-            echo "test_matrix=[$(make_json_array $dir)]" >> $GITHUB_OUTPUT
+            echo "test_matrix='[$(make_json_array $dir)]'" >> $GITHUB_OUTPUT
           elif [ '${{ inputs.run_on }}' == 'n300' ]; then
             dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/multi_chip/n300'; else echo '${{ inputs.dir }}'; fi)
             runson='n300'
             name='run_2chip'
-            echo "test_matrix=[$(make_json_array $dir)]" >> $GITHUB_OUTPUT
+            echo "test_matrix='[$(make_json_array $dir)]'" >> $GITHUB_OUTPUT
           elif [ '${{ inputs.run_on }}' == 'llmbox' ]; then
             dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/multi_chip/llmbox'; else echo '${{ inputs.dir }}'; fi)
             runson='n300-llmbox'
             name='run_4_8_chip'
-            echo "test_matrix=[$(make_json_array $dir)]" >> $GITHUB_OUTPUT
+            echo "test_matrix='[$(make_json_array $dir)]'" >> $GITHUB_OUTPUT
           elif [ '${{ inputs.run_on }}' == 'multichip' ]; then
             dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/multi_chip'; else echo '${{ inputs.dir }}'; fi)
             runson='n300-llmbox'
             name='run_multi_chip'
-            echo "test_matrix=[$(make_json_array $dir)]" >> $GITHUB_OUTPUT
+            echo "test_matrix='[$(make_json_array $dir)]'" >> $GITHUB_OUTPUT
           else
             dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/single_chip ./tests/torch/single_chip'; else echo '${{ inputs.dir }}'; fi)
             runson='n150'
@@ -114,7 +114,7 @@ jobs:
             dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/multi_chip'; else echo '${{ inputs.dir }}'; fi)
             runson='n300-llmbox'
             name='run_multi_chip'
-            echo "test_matrix=[$sc,$(make_json_array $dir)]" >> $GITHUB_OUTPUT
+            echo "test_matrix='[$sc,$(make_json_array $dir)]'" >> $GITHUB_OUTPUT
           fi
       - name: Create job summary
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -32,11 +32,11 @@ on:
       dir:
         description: |
           Directory to run tests. Defaults:
-            - 'n150': './tests/jax/single_chip ./tests/torch/single_chip'
-            - 'n300': './tests/jax/multi_chip/n300'
-            - 'llmbox': './tests/jax/multi_chip/llmbox'
-            - 'multichip': './tests/jax/multi_chip'
-            - 'All': run on n150 all singlechip, on llmbox all multichip
+            - n150: 'jax/single_chip torch/single_chip'
+            - n300: 'jax/multi_chip/n300'
+            - llmbox: 'jax/multi_chip/llmbox'
+            - multichip: 'jax/multi_chip'
+            - All: run on n150 all singlechip, on llmbox all multichip
         type: string
 
 permissions:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -90,22 +90,24 @@ jobs:
             dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/single_chip ./tests/torch/single_chip'; else echo '${{ inputs.dir }}'; fi)
             runson='n150'
             name='run_single_chip'
-            echo "test_matrix='[$(make_json_array $dir)]'" >> $GITHUB_OUTPUT
+            echo "[$(make_json_array $dir)]"
+            echo "test_matrix=[$(make_json_array $dir)]" >> $GITHUB_OUTPUT
           elif [ '${{ inputs.run_on }}' == 'n300' ]; then
             dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/multi_chip/n300'; else echo '${{ inputs.dir }}'; fi)
             runson='n300'
             name='run_2chip'
-            echo "test_matrix='[$(make_json_array $dir)]'" >> $GITHUB_OUTPUT
+            echo "[$(make_json_array $dir)]"
+            echo "test_matrix=[$(make_json_array $dir)]" >> $GITHUB_OUTPUT
           elif [ '${{ inputs.run_on }}' == 'llmbox' ]; then
             dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/multi_chip/llmbox'; else echo '${{ inputs.dir }}'; fi)
             runson='n300-llmbox'
             name='run_4_8_chip'
-            echo "test_matrix='[$(make_json_array $dir)]'" >> $GITHUB_OUTPUT
+            echo "test_matrix=[$(make_json_array $dir)]" >> $GITHUB_OUTPUT
           elif [ '${{ inputs.run_on }}' == 'multichip' ]; then
             dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/multi_chip'; else echo '${{ inputs.dir }}'; fi)
             runson='n300-llmbox'
             name='run_multi_chip'
-            echo "test_matrix='[$(make_json_array $dir)]'" >> $GITHUB_OUTPUT
+            echo "test_matrix=[$(make_json_array $dir)]" >> $GITHUB_OUTPUT
           else
             dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/single_chip ./tests/torch/single_chip'; else echo '${{ inputs.dir }}'; fi)
             runson='n150'
@@ -114,7 +116,7 @@ jobs:
             dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/multi_chip'; else echo '${{ inputs.dir }}'; fi)
             runson='n300-llmbox'
             name='run_multi_chip'
-            echo "test_matrix='[$sc,$(make_json_array $dir)]'" >> $GITHUB_OUTPUT
+            echo "test_matrix=[$sc,$(make_json_array $dir)]" >> $GITHUB_OUTPUT
           fi
       - name: Create job summary
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -37,9 +37,9 @@ jobs:
         run: echo "run_id=$(if [ '${{ inputs.rebuild_xla }}' == 'true' ]; then echo ${{ github.run_id }}; fi;)" >> $GITHUB_OUTPUT
 
   test:
-    if: success() || failure()
+    if: always() && !cancelled()
     uses: ./.github/workflows/test.yml
-    needs: [build-image,build-xla,build-resolution]
+    needs: [build-image,build-resolution]
     secrets: inherit
     with:
       docker_image: ${{ needs.build-image.outputs.docker-image }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -90,13 +90,11 @@ jobs:
             dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/single_chip ./tests/torch/single_chip'; else echo '${{ inputs.dir }}'; fi)
             runson='n150'
             name='run_single_chip'
-            echo "[$(make_json_array $dir)]"
             echo "test_matrix=[$(make_json_array $dir)]" >> $GITHUB_OUTPUT
           elif [ '${{ inputs.run_on }}' == 'n300' ]; then
             dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/multi_chip/n300'; else echo '${{ inputs.dir }}'; fi)
             runson='n300'
             name='run_2chip'
-            echo "[$(make_json_array $dir)]"
             echo "test_matrix=[$(make_json_array $dir)]" >> $GITHUB_OUTPUT
           elif [ '${{ inputs.run_on }}' == 'llmbox' ]; then
             dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/multi_chip/llmbox'; else echo '${{ inputs.dir }}'; fi)
@@ -130,9 +128,7 @@ jobs:
           echo "### Evaluated run parameters" >> $GITHUB_STEP_SUMMARY
           echo "- Run ID: ${{ steps.set_inputs.outputs.run_id }}" >> $GITHUB_STEP_SUMMARY
           echo "- Test Mark: ${{ steps.set_inputs.outputs.test_mark }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Test Matrix:" >> $GITHUB_STEP_SUMMARY
-          echo "Matrix: ${{ steps.set_inputs.outputs.test_matrix }}"
-          echo "${{ steps.set_inputs.outputs.test_matrix }}" | jq '.' >> $GITHUB_STEP_SUMMARY
+          echo "- Test Matrix: ${{ steps.set_inputs.outputs.test_matrix }}" >> $GITHUB_STEP_SUMMARY
 
   test:
     if: always() && !cancelled()

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -39,6 +39,12 @@ on:
         # - 'multichip': './tests/jax/multi_chip'
         # - 'All': run on n150 all singlechip, llmbox all multichip
 
+permissions:
+  packages: write
+  checks: write
+
+run-name: "Test (Rebuild: ${{ inputs.rebuild_xla }} - Preset: ${{ inputs.preset }} - Mark: ${{ inputs.test_mark }} - ${{ inputs.run_on }} - ${{ inputs.dir }}"
+
 jobs:
   build-image:
     uses: ./.github/workflows/build-image.yml
@@ -69,23 +75,60 @@ jobs:
           else
             echo "test_mark=${{ inputs.preset }}" >> $GITHUB_OUTPUT
           fi
+
+          make_json_array() {
+            local result=""
+            local counter=1
+            for arg in "$@"; do
+                result+="{ \"runs-on\": \"$runson\",\"name\": \"$name_$counter\", \"dir\": \"$arg\" },"
+                ((counter++))
+            done
+            echo "${result%,}"
+          }
+
           if [ '${{ inputs.run_on }}' == 'n150' ]; then
             dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/single_chip ./tests/torch/single_chip'; else echo '${{ inputs.dir }}'; fi)
-            echo "test_matrix=[{\"runs-on\":\"n150\",\"name\":\"run_single_chip\",\"dir\":\"$dir\"}]" >> $GITHUB_OUTPUT
+            runson='n150'
+            name='run_single_chip'
+            echo "test_matrix=[$(make_json_array $dir)]" >> $GITHUB_OUTPUT
           elif [ '${{ inputs.run_on }}' == 'n300' ]; then
             dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/multi_chip/n300'; else echo '${{ inputs.dir }}'; fi)
-            echo "test_matrix=[{\"runs-on\":\"n300\",\"name\":\"run_jax_2\",\"dir\":\"$dir\"}]" >> $GITHUB_OUTPUT
+            runson='n300'
+            name='run_2chip'
+            echo "test_matrix=[$(make_json_array $dir)]" >> $GITHUB_OUTPUT
           elif [ '${{ inputs.run_on }}' == 'llmbox' ]; then
             dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/multi_chip/llmbox'; else echo '${{ inputs.dir }}'; fi)
-            echo "test_matrix=[{\"runs-on\":\"n300-llmbox\",\"name\":\"run_jax_4_8\",\"dir\":\"$dir\",\"sh-run\":\"true\"}]" >> $GITHUB_OUTPUT
+            runson='n300-llmbox'
+            name='run_4_8_chip'
+            echo "test_matrix=[$(make_json_array $dir)]" >> $GITHUB_OUTPUT
           elif [ '${{ inputs.run_on }}' == 'multichip' ]; then
             dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/multi_chip'; else echo '${{ inputs.dir }}'; fi)
-            echo "test_matrix=[{\"runs-on\":\"n300-llmbox\",\"name\":\"run_jax_multichip\",\"dir\":\"$dir\",\"sh-run\":\"true\"}]" >> $GITHUB_OUTPUT
+            runson='n300-llmbox'
+            name='run_multi_chip'
+            echo "test_matrix=[$(make_json_array $dir)]" >> $GITHUB_OUTPUT
           else
-            dir1=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/single_chip ./tests/torch/single_chip'; else echo '${{ inputs.dir }}'; fi)
-            dir2=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/multi_chip'; else echo '${{ inputs.dir }}'; fi)
-            echo "test_matrix=[{\"runs-on\":\"n150\",\"name\":\"run_single_chip\",\"dir\":\"$dir1\"},{\"runs-on\":\"n300-llmbox\",\"name\":\"run_jax_multichip\",\"dir\":\"$dir2\",\"sh-run\":\"true\"}]" >> $GITHUB_OUTPUT
+            dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/single_chip ./tests/torch/single_chip'; else echo '${{ inputs.dir }}'; fi)
+            runson='n150'
+            name='run_single_chip'
+            sc=$(make_json_array $dir)
+            dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/multi_chip'; else echo '${{ inputs.dir }}'; fi)
+            runson='n300-llmbox'
+            name='run_multi_chip'
+            echo "test_matrix=[$sc,$(make_json_array $dir)]" >> $GITHUB_OUTPUT
           fi
+      - name: Create job summary
+        run: |
+          echo "## Input Parameters" >> $GITHUB_STEP_SUMMARY
+          echo "- Branch: ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Rebuild: ${{ inputs.rebuild_xla }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Preset: ${{ inputs.preset }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Test Mark: ${{ inputs.test_mark }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Run On: ${{ inputs.run_on }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Directory: ${{ inputs.dir }}" >> $GITHUB_STEP_SUMMARY
+          echo "### Evaluated run parameters" >> $GITHUB_STEP_SUMMARY
+          echo "- Run ID: ${{ steps.set_inputs.outputs.run_id }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Test Mark: ${{ steps.set_inputs.outputs.test_mark }}" >> $GITHUB
+          echo "- Test Matrix: ${{ steps.set_inputs.outputs.test_matrix }}" >> $GITHUB_STEP_SUMMARY
 
   test:
     if: always() && !cancelled()

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -14,6 +14,7 @@ on:
         options:
           - 'push'
           - 'nightly'
+          - 'model_test'
           - 'Custom'
       test_mark:
         description: 'Test mark to run (if preset is Custom)'

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -29,7 +29,7 @@ jobs:
   build-resolution:
     runs-on: ubuntu-latest
     needs: build-xla
-    if: always()
+    if: always() && !cancelled()
     outputs:
       run_id: ${{ steps.set_run_id.outputs.run_id }}
     steps:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -80,7 +80,7 @@ jobs:
             local result=""
             local counter=1
             for arg in "$@"; do
-                result+="{ \"runs-on\": \"$runson\",\"name\": \"$name_$counter\", \"dir\": \"$arg\" },"
+                result+="{ \"runs-on\": \"$runson\",\"name\": \"${name}-${counter}\", \"dir\": \"$arg\" },"
                 ((counter++))
             done
             echo "${result%,}"

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -80,7 +80,7 @@ jobs:
             local result=""
             local counter=1
             for arg in "$@"; do
-                result+="{ \"runs-on\": \"$runson\", \"name\": \"${name}-${counter}\", \"dir\": \"$arg\" },"
+                result+="{ \"runs-on\": \"$runson\", \"name\": \"${name}-${counter}\", \"dir\": \"$arg\" $(if [ -n '$shrun' ]; then echo '', \"sh-run\": \"true\""; fi)') },"
                 ((counter++))
             done
             echo "${result%,}"
@@ -90,21 +90,25 @@ jobs:
             dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/single_chip ./tests/torch/single_chip'; else echo '${{ inputs.dir }}'; fi)
             runson='n150'
             name='run_single_chip'
+            shrun=0
             echo "test_matrix=[$(make_json_array $dir)]" >> $GITHUB_OUTPUT
           elif [ '${{ inputs.run_on }}' == 'n300' ]; then
             dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/multi_chip/n300'; else echo '${{ inputs.dir }}'; fi)
             runson='n300'
             name='run_2chip'
+            shrun=0
             echo "test_matrix=[$(make_json_array $dir)]" >> $GITHUB_OUTPUT
           elif [ '${{ inputs.run_on }}' == 'llmbox' ]; then
             dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/multi_chip/llmbox'; else echo '${{ inputs.dir }}'; fi)
             runson='n300-llmbox'
             name='run_4_8_chip'
+            shrun=1
             echo "test_matrix=[$(make_json_array $dir)]" >> $GITHUB_OUTPUT
           elif [ '${{ inputs.run_on }}' == 'multichip' ]; then
             dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/multi_chip'; else echo '${{ inputs.dir }}'; fi)
             runson='n300-llmbox'
             name='run_multi_chip'
+            shrun=1
             echo "test_matrix=[$(make_json_array $dir)]" >> $GITHUB_OUTPUT
           else
             dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/single_chip ./tests/torch/single_chip'; else echo '${{ inputs.dir }}'; fi)
@@ -114,6 +118,7 @@ jobs:
             dir=$(if [ -z '${{ inputs.dir }}' ]; then echo './tests/jax/multi_chip'; else echo '${{ inputs.dir }}'; fi)
             runson='n300-llmbox'
             name='run_multi_chip'
+            shrun=1
             echo "test_matrix=[$sc,$(make_json_array $dir)]" >> $GITHUB_OUTPUT
           fi
       - name: Create job summary

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -39,7 +39,7 @@ jobs:
   test:
     if: success() || failure()
     uses: ./.github/workflows/test.yml
-    needs: [build-image,build-resolution]
+    needs: [build-image,build-xla,build-resolution]
     secrets: inherit
     with:
       docker_image: ${{ needs.build-image.outputs.docker-image }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,11 +26,11 @@ on:
         type: string
         default: |
           [
-            { "runs-on": "n150",        "name": "run_jax",           "dir": "jax/single_chip" },
-            { "runs-on": "n150",        "name": "run_torch",         "dir": "torch/single_chip" },
-            { "runs-on": "n300",        "name": "run_jax",           "dir": "jax/multi_chip/n300", "codecov": "true" },
-            { "runs-on": "n300-llmbox", "name": "run_jax_4_devices", "dir": "jax/multi_chip/llmbox/4_devices", "sh-run": "true" },
-            { "runs-on": "n300-llmbox", "name": "run_jax_8_devices", "dir": "jax/multi_chip/llmbox/8_devices", "sh-run": "true" }
+            { "runs-on": "n150",        "name": "run_jax",           "dir": "./tests/jax/single_chip" },
+            { "runs-on": "n150",        "name": "run_torch",         "dir": "./tests/torch/single_chip" },
+            { "runs-on": "n300",        "name": "run_jax",           "dir": "./tests/jax/multi_chip/n300", "codecov": "true" },
+            { "runs-on": "n300-llmbox", "name": "run_jax_4_devices", "dir": "./tests/jax/multi_chip/llmbox/4_devices", "sh-run": "true" },
+            { "runs-on": "n300-llmbox", "name": "run_jax_8_devices", "dir": "./tests/jax/multi_chip/llmbox/8_devices", "sh-run": "true" }
           ]
 
 jobs:
@@ -135,7 +135,7 @@ jobs:
       run: |
         source venv/activate
         pytest  --log-memory -sv \
-                ./tests/${{ matrix.build.dir }}  \
+                ${{ matrix.build.dir }}  \
                 -m "${{ inputs.test_mark }}" \
                 --junitxml=${{ steps.strings.outputs.test_report_path }} \
                 2>&1 | tee pytest.log

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,11 +25,13 @@ on:
         required: false
         type: string
         default: |
-          [{ "runs-on": "n150",        "name": "run_jax",           "dir": "jax/single_chip" },
+          [
+            { "runs-on": "n150",        "name": "run_jax",           "dir": "jax/single_chip" },
             { "runs-on": "n150",        "name": "run_torch",         "dir": "torch/single_chip" },
             { "runs-on": "n300",        "name": "run_jax",           "dir": "jax/multi_chip/n300", "codecov": "true" },
             { "runs-on": "n300-llmbox", "name": "run_jax_4_devices", "dir": "jax/multi_chip/llmbox/4_devices", "sh-run": "true" },
-            { "runs-on": "n300-llmbox", "name": "run_jax_8_devices", "dir": "jax/multi_chip/llmbox/8_devices", "sh-run": "true" }]
+            { "runs-on": "n300-llmbox", "name": "run_jax_8_devices", "dir": "jax/multi_chip/llmbox/8_devices", "sh-run": "true" }
+          ]
 
 jobs:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,13 +36,13 @@ jobs:
       matrix:
         build: |
           ${{ inputs.test_matrix && fromJson(inputs.test_matrix) ||
-          '[
+          fromJson('[
             { "runs-on": "n150",        "name": "run_jax",           "dir": "jax/single_chip" },
             { "runs-on": "n150",        "name": "run_torch",         "dir": "torch/single_chip" },
             { "runs-on": "n300",        "name": "run_jax",           "dir": "jax/multi_chip/n300", codecov: true },
             { "runs-on": "n300-llmbox", "name": "run_jax_4_devices", "dir": "jax/multi_chip/llmbox/4_devices", sh-run: true },
             { "runs-on": "n300-llmbox", "name": "run_jax_8_devices", "dir": "jax/multi_chip/llmbox/8_devices", sh-run: true }
-          ]' }}
+          ]') }}
 
     runs-on: ${{ matrix.build.sh-run && format('tt-beta-ubuntu-2204-{0}-large-stable', matrix.build.runs-on) || fromJson(format('["{0}", "in-service"]', matrix.build.runs-on)) }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,8 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build: |
-          ${{ fromJson(inputs.test_matrix) }}
+        build: ${{ fromJson(inputs.test_matrix) }}
 
     runs-on: ${{ matrix.build.sh-run && format('tt-beta-ubuntu-2204-{0}-large-stable', matrix.build.runs-on) || fromJson(format('["{0}", "in-service"]', matrix.build.runs-on)) }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,13 +25,11 @@ on:
         required: false
         type: string
         default: |
-          '[
-              { "runs-on": "n150",        "name": "run_jax",           "dir": "jax/single_chip" },
-              { "runs-on": "n150",        "name": "run_torch",         "dir": "torch/single_chip" },
-              { "runs-on": "n300",        "name": "run_jax",           "dir": "jax/multi_chip/n300", "codecov": true },
-              { "runs-on": "n300-llmbox", "name": "run_jax_4_devices", "dir": "jax/multi_chip/llmbox/4_devices", "sh-run": true },
-              { "runs-on": "n300-llmbox", "name": "run_jax_8_devices", "dir": "jax/multi_chip/llmbox/8_devices", "sh-run": true }
-           ]'
+          '[{ "runs-on": "n150",        "name": "run_jax",           "dir": "jax/single_chip" },
+            { "runs-on": "n150",        "name": "run_torch",         "dir": "torch/single_chip" },
+            { "runs-on": "n300",        "name": "run_jax",           "dir": "jax/multi_chip/n300", "codecov": true },
+            { "runs-on": "n300-llmbox", "name": "run_jax_4_devices", "dir": "jax/multi_chip/llmbox/4_devices", "sh-run": true },
+            { "runs-on": "n300-llmbox", "name": "run_jax_8_devices", "dir": "jax/multi_chip/llmbox/8_devices", "sh-run": true }]'
 
 jobs:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,9 @@ on:
         default: |
           '[{ "runs-on": "n150",        "name": "run_jax",           "dir": "jax/single_chip" },
             { "runs-on": "n150",        "name": "run_torch",         "dir": "torch/single_chip" },
-            { "runs-on": "n300",        "name": "run_jax",           "dir": "jax/multi_chip/n300", "codecov": true },
-            { "runs-on": "n300-llmbox", "name": "run_jax_4_devices", "dir": "jax/multi_chip/llmbox/4_devices", "sh-run": true },
-            { "runs-on": "n300-llmbox", "name": "run_jax_8_devices", "dir": "jax/multi_chip/llmbox/8_devices", "sh-run": true }]'
+            { "runs-on": "n300",        "name": "run_jax",           "dir": "jax/multi_chip/n300", "codecov": "true" },
+            { "runs-on": "n300-llmbox", "name": "run_jax_4_devices", "dir": "jax/multi_chip/llmbox/4_devices", "sh-run": "true" },
+            { "runs-on": "n300-llmbox", "name": "run_jax_8_devices", "dir": "jax/multi_chip/llmbox/8_devices", "sh-run": "true" }]'
 
 jobs:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ on:
               { "runs-on": "n300",        "name": "run_jax",           "dir": "jax/multi_chip/n300", "codecov": true },
               { "runs-on": "n300-llmbox", "name": "run_jax_4_devices", "dir": "jax/multi_chip/llmbox/4_devices", "sh-run": true },
               { "runs-on": "n300-llmbox", "name": "run_jax_8_devices", "dir": "jax/multi_chip/llmbox/8_devices", "sh-run": true }
-          ]'
+           ]'
 
 jobs:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,11 +25,11 @@ on:
         required: false
         type: string
         default: |
-          '[{ "runs-on": "n150",        "name": "run_jax",           "dir": "jax/single_chip" },
+          [{ "runs-on": "n150",        "name": "run_jax",           "dir": "jax/single_chip" },
             { "runs-on": "n150",        "name": "run_torch",         "dir": "torch/single_chip" },
             { "runs-on": "n300",        "name": "run_jax",           "dir": "jax/multi_chip/n300", "codecov": "true" },
             { "runs-on": "n300-llmbox", "name": "run_jax_4_devices", "dir": "jax/multi_chip/llmbox/4_devices", "sh-run": "true" },
-            { "runs-on": "n300-llmbox", "name": "run_jax_8_devices", "dir": "jax/multi_chip/llmbox/8_devices", "sh-run": "true" }]'
+            { "runs-on": "n300-llmbox", "name": "run_jax_8_devices", "dir": "jax/multi_chip/llmbox/8_devices", "sh-run": "true" }]
 
 jobs:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,13 @@ on:
         required: false
         type: string
         default: |
+          [
+            { "runs-on": "n150",        "name": "run_jax",           "dir": "./tests/jax/single_chip" },
+            { "runs-on": "n150",        "name": "run_torch",         "dir": "./tests/torch/single_chip" },
+            { "runs-on": "n300",        "name": "run_jax",           "dir": "./tests/jax/multi_chip/n300", "codecov": "true" },
+            { "runs-on": "n300-llmbox", "name": "run_jax_4_devices", "dir": "./tests/jax/multi_chip/llmbox/4_devices", "sh-run": "true" },
+            { "runs-on": "n300-llmbox", "name": "run_jax_8_devices", "dir": "./tests/jax/multi_chip/llmbox/8_devices", "sh-run": "true" }
+          ]
 
 jobs:
 
@@ -35,16 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build: |
-          ${{ inputs.test_matrix && fromJson(inputs.test_matrix) || fromJson('
-          [
-            { "runs-on": "n150",        "name": "run_jax",           "dir": "./tests/jax/single_chip" },
-            { "runs-on": "n150",        "name": "run_torch",         "dir": "./tests/torch/single_chip" },
-            { "runs-on": "n300",        "name": "run_jax",           "dir": "./tests/jax/multi_chip/n300", "codecov": "true" },
-            { "runs-on": "n300-llmbox", "name": "run_jax_4_devices", "dir": "./tests/jax/multi_chip/llmbox/4_devices", "sh-run": "true" },
-            { "runs-on": "n300-llmbox", "name": "run_jax_8_devices", "dir": "./tests/jax/multi_chip/llmbox/8_devices", "sh-run": "true" }
-          ]
-          ')}}
+        build: ${{ fromJson(inputs.test_matrix) }}
 
     runs-on: ${{ matrix.build.sh-run && format('tt-beta-ubuntu-2204-{0}-large-stable', matrix.build.runs-on) || fromJson(format('["{0}", "in-service"]', matrix.build.runs-on)) }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,7 +135,7 @@ jobs:
       run: |
         source venv/activate
         pytest  --log-memory -sv \
-                .tests/${{ matrix.build.dir }}  \
+                ./tests/${{ matrix.build.dir }}  \
                 -m "${{ inputs.test_mark }}" \
                 --junitxml=${{ steps.strings.outputs.test_report_path }} \
                 2>&1 | tee pytest.log

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,14 @@ on:
         description: 'Test job matrix to use'
         required: false
         type: string
+        default: |
+          '[
+              { "runs-on": "n150",        "name": "run_jax",           "dir": "jax/single_chip" },
+              { "runs-on": "n150",        "name": "run_torch",         "dir": "torch/single_chip" },
+              { "runs-on": "n300",        "name": "run_jax",           "dir": "jax/multi_chip/n300", "codecov": true },
+              { "runs-on": "n300-llmbox", "name": "run_jax_4_devices", "dir": "jax/multi_chip/llmbox/4_devices", "sh-run": true },
+              { "runs-on": "n300-llmbox", "name": "run_jax_8_devices", "dir": "jax/multi_chip/llmbox/8_devices", "sh-run": true }
+          ]'
 
 jobs:
 
@@ -35,14 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         build: |
-          ${{ inputs.test_matrix && fromJson(inputs.test_matrix) ||
-          fromJson('[
-            { "runs-on": "n150",        "name": "run_jax",           "dir": "jax/single_chip" },
-            { "runs-on": "n150",        "name": "run_torch",         "dir": "torch/single_chip" },
-            { "runs-on": "n300",        "name": "run_jax",           "dir": "jax/multi_chip/n300", "codecov": true },
-            { "runs-on": "n300-llmbox", "name": "run_jax_4_devices", "dir": "jax/multi_chip/llmbox/4_devices", "sh-run": true },
-            { "runs-on": "n300-llmbox", "name": "run_jax_8_devices", "dir": "jax/multi_chip/llmbox/8_devices", "sh-run": true }
-          ]') }}
+          ${{ fromJson(inputs.test_matrix) }}
 
     runs-on: ${{ matrix.build.sh-run && format('tt-beta-ubuntu-2204-{0}-large-stable', matrix.build.runs-on) || fromJson(format('["{0}", "in-service"]', matrix.build.runs-on)) }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,9 +39,9 @@ jobs:
           fromJson('[
             { "runs-on": "n150",        "name": "run_jax",           "dir": "jax/single_chip" },
             { "runs-on": "n150",        "name": "run_torch",         "dir": "torch/single_chip" },
-            { "runs-on": "n300",        "name": "run_jax",           "dir": "jax/multi_chip/n300", codecov: true },
-            { "runs-on": "n300-llmbox", "name": "run_jax_4_devices", "dir": "jax/multi_chip/llmbox/4_devices", sh-run: true },
-            { "runs-on": "n300-llmbox", "name": "run_jax_8_devices", "dir": "jax/multi_chip/llmbox/8_devices", sh-run: true }
+            { "runs-on": "n300",        "name": "run_jax",           "dir": "jax/multi_chip/n300", "codecov": true },
+            { "runs-on": "n300-llmbox", "name": "run_jax_4_devices", "dir": "jax/multi_chip/llmbox/4_devices", "sh-run": true },
+            { "runs-on": "n300-llmbox", "name": "run_jax_8_devices", "dir": "jax/multi_chip/llmbox/8_devices", "sh-run": true }
           ]') }}
 
     runs-on: ${{ matrix.build.sh-run && format('tt-beta-ubuntu-2204-{0}-large-stable', matrix.build.runs-on) || fromJson(format('["{0}", "in-service"]', matrix.build.runs-on)) }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,10 @@ on:
         description: 'Enable codecov upload'
         required: false
         type: boolean
+      test_matrix:
+        description: 'Test job matrix to use'
+        required: false
+        type: string
 
 jobs:
 
@@ -30,13 +34,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build: [
-          { "runs-on": "n150",        "name": "run_jax",           "dir": "./tests/jax/single_chip" },
-          { "runs-on": "n150",        "name": "run_torch",         "dir": "./tests/torch/single_chip" },
-          { "runs-on": "n300",        "name": "run_jax",           "dir": "./tests/jax/multi_chip/n300", codecov: true },
-          { "runs-on": "n300-llmbox", "name": "run_jax_4_devices", "dir": "./tests/jax/multi_chip/llmbox/4_devices", sh-run: true },
-          { "runs-on": "n300-llmbox", "name": "run_jax_8_devices", "dir": "./tests/jax/multi_chip/llmbox/8_devices", sh-run: true }
-        ]
+        build: |
+          ${{ inputs.test_matrix && fromJson(inputs.test_matrix) ||
+          '[
+            { "runs-on": "n150",        "name": "run_jax",           "dir": "jax/single_chip" },
+            { "runs-on": "n150",        "name": "run_torch",         "dir": "torch/single_chip" },
+            { "runs-on": "n300",        "name": "run_jax",           "dir": "jax/multi_chip/n300", codecov: true },
+            { "runs-on": "n300-llmbox", "name": "run_jax_4_devices", "dir": "jax/multi_chip/llmbox/4_devices", sh-run: true },
+            { "runs-on": "n300-llmbox", "name": "run_jax_8_devices", "dir": "jax/multi_chip/llmbox/8_devices", sh-run: true }
+          ]' }}
 
     runs-on: ${{ matrix.build.sh-run && format('tt-beta-ubuntu-2204-{0}-large-stable', matrix.build.runs-on) || fromJson(format('["{0}", "in-service"]', matrix.build.runs-on)) }}
 
@@ -129,7 +135,7 @@ jobs:
       run: |
         source venv/activate
         pytest  --log-memory -sv \
-                ${{ matrix.build.dir }}  \
+                .tests/${{ matrix.build.dir }}  \
                 -m "${{ inputs.test_mark }}" \
                 --junitxml=${{ steps.strings.outputs.test_report_path }} \
                 2>&1 | tee pytest.log

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,13 +25,6 @@ on:
         required: false
         type: string
         default: |
-          [
-            { "runs-on": "n150",        "name": "run_jax",           "dir": "./tests/jax/single_chip" },
-            { "runs-on": "n150",        "name": "run_torch",         "dir": "./tests/torch/single_chip" },
-            { "runs-on": "n300",        "name": "run_jax",           "dir": "./tests/jax/multi_chip/n300", "codecov": "true" },
-            { "runs-on": "n300-llmbox", "name": "run_jax_4_devices", "dir": "./tests/jax/multi_chip/llmbox/4_devices", "sh-run": "true" },
-            { "runs-on": "n300-llmbox", "name": "run_jax_8_devices", "dir": "./tests/jax/multi_chip/llmbox/8_devices", "sh-run": "true" }
-          ]
 
 jobs:
 
@@ -42,7 +35,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build: ${{ fromJson(inputs.test_matrix) }}
+        build: |
+          ${{ inputs.test_matrix && fromJson(inputs.test_matrix) || fromJson('
+          [
+            { "runs-on": "n150",        "name": "run_jax",           "dir": "./tests/jax/single_chip" },
+            { "runs-on": "n150",        "name": "run_torch",         "dir": "./tests/torch/single_chip" },
+            { "runs-on": "n300",        "name": "run_jax",           "dir": "./tests/jax/multi_chip/n300", "codecov": "true" },
+            { "runs-on": "n300-llmbox", "name": "run_jax_4_devices", "dir": "./tests/jax/multi_chip/llmbox/4_devices", "sh-run": "true" },
+            { "runs-on": "n300-llmbox", "name": "run_jax_8_devices", "dir": "./tests/jax/multi_chip/llmbox/8_devices", "sh-run": "true" }
+          ]
+          ')}}
 
     runs-on: ${{ matrix.build.sh-run && format('tt-beta-ubuntu-2204-{0}-large-stable', matrix.build.runs-on) || fromJson(format('["{0}", "in-service"]', matrix.build.runs-on)) }}
 


### PR DESCRIPTION
### Ticket

### Problem description
Follow-up on https://github.com/tenstorrent/tt-xla/pull/791
Fix and upgrade "Run Test" workflow.
Fix passing of mlir_override to build job.

### What's changed
You can find "Run Test" workflow in "Actions":

<img width="626" height="342" alt="Screenshot 2025-07-10 at 15 13 40" src="https://github.com/user-attachments/assets/09e10fa0-0c4f-4f11-af19-29c514b33bc0" />

Click on "Run Workflow" on the right:

<img width="324" height="612" alt="Screenshot 2025-07-10 at 15 14 51" src="https://github.com/user-attachments/assets/81e11ef7-deff-4f66-92b7-c229bc6f95d5" />

Options:
- The first option is branch tests run on. This will be probably set to your working branch.
- If you check "Rebuild XLA" xla would be rebuilt. In most cases when you develop/debug tests this won't be needed, the workflow will take latest version from main branch.
- Next option is preset. This is quick way to run push, nightly or models test marks they run on PR and Nightlies.
- If you select 'Custom' you can fill test mark. This is useful when you debug tests. You can mark them in your dev branch with some custom mark and run just these in CI, much quicker than running full batch.
- You can select machine you want your tests to run. It would be single chip (n150), multi chip variants (n300, limbox), all multi chip, or 'All'.
- Finally you can optionally provide "Directory to run tests". You can provide multiple space-separated directories and each of these will run as separate job. If you leave this field blank, default directory will be used based on selected machines:
  - n150: will run './tests/jax/single_chip' and './tests/torch/single_chip'
  - n300: './tests/jax/multi_chip/n300'
  - llmbox: './tests/jax/multi_chip/llmbox/4_devices' and './tests/jax/multi_chip/llmbox/8_devices'
  - multichip: n300 + llmbox 
  - All: run on n150 all singlechip, on llmbox all multichip tests.

### Checklist
- [ ] New/Existing tests provide coverage for changes
