### PR TITLE
Adding full RAM logging to our tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,6 @@ import transformers
 import transformers.modeling_flax_utils
 from infra import DeviceConnectorFactory, Framework
 from loguru import logger
-from sympy import Dict
 
 
 def pytest_configure(config: pytest.Config):
@@ -198,10 +197,11 @@ def memory_usage_tracker(request):
         def track_memory():
             nonlocal min_mem, max_mem, total_mem, count
             while tracking:
-                current_mem = process.memory_info().rss / (1024 * 1024)
-                min_mem = min(min_mem, current_mem)
-                max_mem = max(max_mem, current_mem)
-                total_mem += current_mem
+                vm = psutil.virtual_memory()
+                used = (vm.total - vm.available) / (1024 * 1024)
+                min_mem = min(min_mem, used)
+                max_mem = max(max_mem, used)
+                total_mem += used
                 count += 1
                 time.sleep(0.1)
 

--- a/tests/jax/single_chip/models/resnet_v1_5/resnet_101/test_resnet_101.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/resnet_101/test_resnet_101.py
@@ -50,6 +50,11 @@ def training_tester() -> ResNetTester:
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.FAILED_FE_COMPILATION,
 )
+@pytest.mark.skip(
+    reason=failed_fe_compilation(
+        "Test killed in CI https://github.com/tenstorrent/tt-xla/issues/714"
+    )
+)
 def test_resnet_v1_5_101_inference(inference_tester: ResNetTester):
     inference_tester.test()
 

--- a/tests/jax/single_chip/models/resnet_v1_5/resnet_101/test_resnet_101.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/resnet_101/test_resnet_101.py
@@ -50,11 +50,6 @@ def training_tester() -> ResNetTester:
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.FAILED_FE_COMPILATION,
 )
-@pytest.mark.skip(
-    reason=failed_fe_compilation(
-        "Test killed in CI https://github.com/tenstorrent/tt-xla/issues/714"
-    )
-)
 def test_resnet_v1_5_101_inference(inference_tester: ResNetTester):
     inference_tester.test()
 


### PR DESCRIPTION
Currently, the tests logged RAM usage only inside the pytest process. This was less useful then looking at the full RAM usage, so changing that in this PR.