### PR TITLE
Add test duration calculation workflow

### DIFF
--- a/.github/workflows/get_test_duration_from_junit_xmls.py
+++ b/.github/workflows/get_test_duration_from_junit_xmls.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import os
+import xml.etree.ElementTree as ET
+import json
+import sys
+
+
+def extract_test_case_info(xml_file):
+    """
+    Extract test case names and their execution times from a JUnit XML report.
+
+    Args:
+        xml_file (str): Path to the XML file.
+
+    Returns:
+        dict: A dictionary with test case names as keys and their execution time in seconds as values.
+    """
+    try:
+        tree = ET.parse(xml_file)
+        root = tree.getroot()
+        test_cases_info = {}
+
+        for testsuite in root.findall("testsuite"):
+            # Iterate over all <testcase> elements within the current <testsuite>
+            for testcase in testsuite.findall("testcase"):
+                try:
+                    path = testcase.get("classname").replace(".", "/")
+                    name = testcase.get("name")
+                    test_cases_info[f"{path}.py::{name}"] = float(
+                        testcase.get("time", 0)
+                    )
+                except ValueError:
+                    print(
+                        f"Warning: Non-numeric time value encountered in {xml_file} for test case '{name}'"
+                    )
+
+    except ET.ParseError as e:
+        print(f"Error parsing XML file {xml_file}: {e}")
+
+    return test_cases_info
+
+
+def process_directory(directory):
+    """
+    Process all JUnit XML files in the directory and subdirectories.
+
+    Args:
+        directory (str): Path to the root directory.
+
+    Returns:
+        dict: A dictionary with test case names as keys and their execution times as values across all files.
+    """
+    all_test_cases = {}
+
+    for subdir, _, files in os.walk(directory):
+        for file in files:
+            if file.endswith(".xml"):
+                xml_file_path = os.path.join(subdir, file)
+                # Check if it's a JUnit XML report by looking for <testsuite> tag
+                try:
+                    test_cases_info = extract_test_case_info(xml_file_path)
+                    all_test_cases.update(test_cases_info)
+                except Exception as e:
+                    print(f"Error reading file {xml_file_path}: {e}")
+
+    return all_test_cases
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(
+            "Usage: python .github/workflows/get_test_duration_from_junit_xmls.py <directory> <json_output>"
+        )
+        sys.exit(1)
+
+    root_directory = sys.argv[1]
+    output_file = sys.argv[2]
+    print(f"Dir to process {root_directory}, output file {output_file}")
+
+    test_case_data = process_directory(root_directory)
+    json_output = json.dumps(test_case_data, indent=4)
+
+    with open(output_file, "w") as f:
+        f.write(json_output)
+
+    print(f"Test case data has been written to {output_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/update-test-durations.yml
+++ b/.github/workflows/update-test-durations.yml
@@ -1,0 +1,105 @@
+name: Update Test Durations
+
+description: |
+  This workflow updates test durations based on the latest nightly and push workflow runs.
+  It processes the JUnit XML reports from the last successful nightly and push workflows,
+  calculates the test durations, and creates a pull request to update the `.test_durations` file.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  packages: write
+  checks: write
+
+jobs:
+  update_test_durations:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # ref: main
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Process nightly test durations
+        id: get-test-durations
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          repo="tenstorrent/tt-xla"
+
+          get_test_results_from_wf() {
+            local wf_name="$1"
+            local conclusions="$2"
+            local num=5
+
+            # get json of the last $num workflow runs
+            gh run list --workflow $wf_name -R $repo -b main -L $num --status completed --json attempt,conclusion,databaseId >runs.json
+
+            counter=0
+            while true; do
+              # Check the status of 'conclusion'
+              conclusion=$(jq -r ".[$counter].conclusion" runs.json)
+
+              if echo "$conclusions" | grep -q -w "$conclusion"; then
+                break
+              else
+                ((counter++))
+
+                # Exit if the counter reaches $num
+                if [ $counter -ge $num ]; then
+                  echo "ERROR: Did not found good workflow within last $num. Exiting."
+                  exit 1
+                fi
+              fi
+            done
+            curr_wf_id=$(jq -r ".[$counter].databaseId" runs.json)
+            curr_wf_att=$(jq -r ".[$counter].attempt" runs.json)
+            echo "curr_$3_wf_link=\"https://github.com/$repo/actions/runs/$curr_wf_id/attempts/$curr_wf_att\"" >> "$GITHUB_OUTPUT"
+            rm -f runs.json
+
+            gh run download $curr_wf_id --pattern "test-reports-*" -R $repo -D ${{runner.temp}}/reports
+          }
+
+          # get test results from the last nightly that was success or failure
+          get_test_results_from_wf "on-nightly.yml" "success,failure" "nightly"
+
+          # get test results from the last successful push
+          get_test_results_from_wf "on-push.yml" "success" "push"
+
+          python .github/workflows/get_test_duration_from_junit_xmls.py ${{runner.temp}}/reports .test_durations
+          echo "" >> .test_durations
+          echo "----- NEW DURATIONS"
+          cat .test_durations
+
+          echo "TODAY=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        id: create-pr
+        with:
+          branch: test-durations-update
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
+          base: main
+          commit-message: "Update test durations based on latest nightly ${{ steps.get-test-durations.outputs.TODAY }}"
+          title: "Update test durations based on latest nightly ${{ steps.get-test-durations.outputs.TODAY }}"
+          body: "This PR updates test durations based on latest nightly (${{ steps.get-test-durations.outputs.curr_nightly_wf_link }}) and latest push (${{ steps.get-test-durations.outputs.curr_push_wf_link }})"
+          labels: tooling
+          delete-branch: true
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Enable Pull Request Automerge
+        if: ${{ steps.create-pr.outputs.pull-request-number }}
+        run: gh pr merge --squash --auto "${{ steps.create-pr.outputs.pull-request-number }}"
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      - name: Generate Summary
+        run: |
+          echo "## Test duration report" >> $GITHUB_STEP_SUMMARY
+          echo "Used [Nightly](${{ steps.get-test-durations.outputs.curr_nightly_wf_link }})" >> $GITHUB_STEP_SUMMARY
+          echo "And [Push](${{ steps.get-test-durations.outputs.curr_push_wf_link }})" >> $GITHUB_STEP_SUMMARY
+          echo "Generated test durations in [Pull Request](${{ steps.create-pr.outputs.pull-request-url }})" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
### Ticket
Added a workflow that created a .test_duration file.
It collects the data from previous test runs (on-nightly and on-push) and automatically created a PR for adding the new file.

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] New/Existing tests provide coverage for changes
