### PR TITLE
Skip ResNet-26 due to CI failure; fix import in EfficientNet model

### DIFF
--- a/tests/jax/single_chip/models/resnet_v1_5/resnet_26/test_resnet_26.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/resnet_26/test_resnet_26.py
@@ -11,7 +11,7 @@ from utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    incorrect_result,
+    failed_fe_compilation,
 )
 
 from ..tester import ResNetTester, ResNetVariant
@@ -50,10 +50,9 @@ def training_tester() -> ResNetTester:
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.INCORRECT_RESULT,
 )
-@pytest.mark.xfail(
-    reason=incorrect_result(
-        "PCC comparison failed. Calculated: pcc=-0.002165748504921794. Required: pcc=0.99 "
-        "https://github.com/tenstorrent/tt-xla/issues/379"
+@pytest.mark.skip(
+    reason=failed_fe_compilation(
+        "Test killed in CI https://github.com/tenstorrent/tt-xla/issues/714"
     )
 )
 def test_resnet_v1_5_26_inference(inference_tester: ResNetTester):

--- a/tests/torch/single_chip/models/efficientnet/test_efficientnet.py
+++ b/tests/torch/single_chip/models/efficientnet/test_efficientnet.py
@@ -15,12 +15,12 @@ from utils import (
 
 from .tester import EfficientNetTester
 
-VARIANT_NAME = "base"
+VARIANT_NAME = "efficientnet_b0"
 
 MODEL_NAME = build_model_name(
     Framework.TORCH,
     "efficientnet",
-    "base",
+    "b0",
     ModelTask.CV_IMAGE_CLS,
     ModelSource.TORCH_HUB,
 )

--- a/tests/torch/single_chip/models/efficientnet/tester.py
+++ b/tests/torch/single_chip/models/efficientnet/tester.py
@@ -4,7 +4,7 @@
 
 from typing import Any, Dict, Sequence
 from infra import ComparisonConfig, Model, RunMode, TorchModelTester
-from third_party.tt_forge_models.codegen.pytorch import ModelLoader
+from third_party.tt_forge_models.efficientnet.pytorch import ModelLoader
 
 
 class EfficientNetTester(TorchModelTester):


### PR DESCRIPTION
### Problem description
Some ResNet variants have previously encountered the same issue and failed in CI; the[ issue](https://github.com/tenstorrent/tt-xla/issues/714) is already known and being tracked. Now, resnet_26 is also failing in CI so It has been temporarily skipped. Additionally, there was an incorrect import statement in the EfficientNet model, which has now been corrected.

### What's changed
- Modified the resnet_26 model file to skip it during CI.
- Fixed an incorrect import statement in the efficientnet model.

### Checklist
- [x] New/Existing tests provide coverage for changes

I have attached the logs for your reference:
[test_efficientnet.log](https://github.com/user-attachments/files/21196386/test_efficientnet.log)
[test_resnet_26.log](https://github.com/user-attachments/files/21196387/test_resnet_26.log)
