### PR TITLE
Add torch tests for Segformer

### DIFF
--- a/tests/torch/single_chip/models/segformer/test_segformer.py
+++ b/tests/torch/single_chip/models/segformer/test_segformer.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from infra import Framework, RunMode
+from utils import (
+    BringupStatus,
+    Category,
+    ModelGroup,
+    ModelSource,
+    ModelTask,
+    build_model_name,
+    failed_ttmlir_compilation,
+)
+
+from .tester import SegformerTester
+
+VARIANT_NAME = "nvidia/mit-b0"
+
+MODEL_NAME = build_model_name(
+    Framework.TORCH,
+    "segformer",
+    "b0",
+    ModelTask.CV_IMAGE_SEG,
+    ModelSource.HUGGING_FACE,
+)
+
+# ----- Fixtures -----
+
+
+@pytest.fixture
+def inference_tester() -> SegformerTester:
+    return SegformerTester(VARIANT_NAME)
+
+
+@pytest.fixture
+def training_tester() -> SegformerTester:
+    return SegformerTester(VARIANT_NAME, run_mode=RunMode.TRAINING)
+
+
+# ----- Tests -----
+
+
+@pytest.mark.model_test
+@pytest.mark.record_test_properties(
+    category=Category.MODEL_TEST,
+    model_name=MODEL_NAME,
+    model_group=ModelGroup.GENERALITY,
+    run_mode=RunMode.INFERENCE,
+    bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
+)
+@pytest.mark.xfail(
+    reason=failed_ttmlir_compilation(
+        "error: failed to legalize operation 'stablehlo.batch_norm_training' "
+        "https://github.com/tenstorrent/tt-xla/issues/735"
+    )
+)
+def test_torch_segformer_inference(inference_tester: SegformerTester):
+    inference_tester.test()
+
+
+@pytest.mark.nightly
+@pytest.mark.record_test_properties(
+    category=Category.MODEL_TEST,
+    model_name=MODEL_NAME,
+    model_group=ModelGroup.GENERALITY,
+    run_mode=RunMode.TRAINING,
+)
+@pytest.mark.skip(reason="Support for training not implemented")
+def test_torch_segformer_training(training_tester: SegformerTester):
+    training_tester.test()

--- a/tests/torch/single_chip/models/segformer/tester.py
+++ b/tests/torch/single_chip/models/segformer/tester.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any, Dict, Sequence
+from infra import ComparisonConfig, Model, RunMode, TorchModelTester
+from third_party.tt_forge_models.segformer.pytorch import ModelLoader
+
+
+class SegformerTester(TorchModelTester):
+    """Tester for Segformer model."""
+
+    def __init__(
+        self,
+        variant_name: str,
+        comparison_config: ComparisonConfig = ComparisonConfig(),
+        run_mode: RunMode = RunMode.INFERENCE,
+    ) -> None:
+        self._model_loader = ModelLoader(variant_name)
+        super().__init__(comparison_config, run_mode)
+
+    # @override
+    def _get_model(self) -> Model:
+        return self._model_loader.load_model()
+
+    # @override
+    def _get_input_activations(self) -> Dict | Sequence[Any]:
+        return self._model_loader.load_inputs()


### PR DESCRIPTION
Add torch test for `Segformer` model from tt-forge-model repo

* model_name used is `nvidia/mit-b0`


### Checklist
- [x] New/Existing tests provide coverage for changes

PFA logs for reference

[segformer_xfail.log](https://github.com/user-attachments/files/21231486/segformer_xfail.log)
[segformer.log](https://github.com/user-attachments/files/21231487/segformer.log)
