### PR TITLE
Fix composite patching and mark albert xlarge as passing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -297,7 +297,10 @@ monkeypatches = [
             x
         ),
         post_patch=lambda: transformers.modeling_flax_utils.ACT2FN.update(
-            {"gelu": partial(jax.nn.gelu, approximate=False)}
+            {
+                "gelu": partial(jax.nn.gelu, approximate=False),
+                "gelu_new": partial(jax.nn.gelu, approximate=True),
+            }
         ),
     )
 ]

--- a/tests/jax/single_chip/models/albert_v2/xlarge/test_albert_xlarge.py
+++ b/tests/jax/single_chip/models/albert_v2/xlarge/test_albert_xlarge.py
@@ -11,7 +11,6 @@ from utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    incorrect_result,
 )
 
 from ..tester import AlbertV2Tester
@@ -47,12 +46,7 @@ def training_tester() -> AlbertV2Tester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.INCORRECT_RESULT,
-)
-@pytest.mark.xfail(
-    reason=incorrect_result(
-        "PCC regressed to 0.98, https://github.com/tenstorrent/tt-xla/issues/739"
-    )
+    bringup_status=BringupStatus.PASSED,
 )
 def test_flax_albert_v2_xlarge_inference(inference_tester: AlbertV2Tester):
     inference_tester.test()


### PR DESCRIPTION
### Ticket
Closes #739 by fixing the model, the exact cause of the regression was not found.

### Problem description
Code was missing in post_patch for wrapping gelu in composite to also patch gelu_new inside huggingface libraries on replacement

### What's changed
The relevant code was added.
This change makes Albert xlarge go from failing by a tiny margin(pcc 0.989) to passing, so it was marked as such

### Checklist
- [X] New/Existing tests provide coverage for changes
