### PR TITLE
add test for gliner model

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ datasets
 einops
 flax==0.10.4
 fsspec
+gliner
 jax==0.6.0
 jaxlib==0.6.0
 jaxtyping

--- a/tests/torch/single_chip/models/gliner_model/test_gliner.py
+++ b/tests/torch/single_chip/models/gliner_model/test_gliner.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from infra import Framework, RunMode
+from utils import (
+    BringupStatus,
+    Category,
+    ModelGroup,
+    ModelSource,
+    ModelTask,
+    build_model_name,
+    failed_ttmlir_compilation,
+)
+
+from .tester import GlinerTester
+
+VARIANT_NAME = "urchade/gliner_largev2"
+
+MODEL_NAME = build_model_name(
+    Framework.TORCH,
+    "gliner_model",
+    "largev2",
+    ModelTask.NLP_TOKEN_CLS,
+    ModelSource.TORCH_HUB,
+)
+
+
+# ----- Fixtures -----
+
+
+@pytest.fixture
+def inference_tester() -> GlinerTester:
+    return GlinerTester(VARIANT_NAME)
+
+
+@pytest.fixture
+def training_tester() -> GlinerTester:
+    return GlinerTester(VARIANT_NAME, run_mode=RunMode.TRAINING)
+
+
+# ----- Tests -----
+
+
+@pytest.mark.model_test
+@pytest.mark.record_test_properties(
+    category=Category.MODEL_TEST,
+    model_name=MODEL_NAME,
+    model_group=ModelGroup.GENERALITY,
+    run_mode=RunMode.INFERENCE,
+    bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
+)
+@pytest.mark.xfail(
+    reason=failed_ttmlir_compilation(
+        "error: failed to legalize operation 'stablehlo.batch_norm_training' "
+        "https://github.com/tenstorrent/tt-xla/issues/735"
+    )
+)
+def test_torch_gliner_inference(inference_tester: GlinerTester):
+    inference_tester.test()
+
+
+@pytest.mark.nightly
+@pytest.mark.record_test_properties(
+    category=Category.MODEL_TEST,
+    model_name=MODEL_NAME,
+    model_group=ModelGroup.GENERALITY,
+    run_mode=RunMode.TRAINING,
+)
+@pytest.mark.skip(reason="Support for training not implemented")
+def test_torch_gliner_training(training_tester: GlinerTester):
+    training_tester.test()

--- a/tests/torch/single_chip/models/gliner_model/tester.py
+++ b/tests/torch/single_chip/models/gliner_model/tester.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any, Dict, Sequence
+from infra import ComparisonConfig, Model, RunMode, TorchModelTester
+from third_party.tt_forge_models.gliner_model.pytorch import ModelLoader
+
+
+class GlinerTester(TorchModelTester):
+    """Tester for GLiNER model."""
+
+    def __init__(
+        self,
+        variant_name: str,
+        comparison_config: ComparisonConfig = ComparisonConfig(),
+        run_mode: RunMode = RunMode.INFERENCE,
+    ) -> None:
+        self._model_loader = ModelLoader(variant_name)
+        super().__init__(comparison_config, run_mode)
+
+    def _get_model(self) -> Model:
+        return self._model_loader.load_model()
+
+    def _get_input_activations(self) -> Dict | Sequence[Any]:
+        return self._model_loader.load_inputs()
+
+    # @override
+    def _get_forward_method_args(self) -> Sequence[Any]:
+        inputs = self._get_input_activations()
+        if isinstance(inputs, tuple):
+            return list(inputs)
+        return []


### PR DESCRIPTION
### Problem description
- Attempted to add a test for the gliner PyTorch model using the tt-forge-models repository. However, the load model function was not returning torch.nn module. This caused test failures.
- I have fixed that by returning the model directly I will investgate further and If I retrive model by modifying the tester script itself or I need to raise pr in forge model's repo till that I will keep in draft
### What's changed
Added test files to test gliner model

### Checklist
- [x] New/Existing tests provide coverage for changes
