### PR TITLE
Changing serialization to flatbuffer

### DIFF
--- a/inc/common/pjrt_implementation/executable_image.h
+++ b/inc/common/pjrt_implementation/executable_image.h
@@ -35,9 +35,8 @@ public:
   // compiler.
   static std::shared_ptr<ExecutableImage> createInstance(
       const tt::runtime::Binary &flatbuffer_binary,
-      std::string &&original_mlir_code, std::string &&ttir_mlir_code,
-      std::string &&executable_name, size_t num_partitions, size_t num_replicas,
-      size_t num_devices_to_utilize,
+      std::string &&original_mlir_code, std::string &&executable_name,
+      size_t num_partitions, size_t num_replicas, size_t num_devices_to_utilize,
       const std::vector<std::uint32_t> &devices_mesh_shape,
       const std::vector<mlir::tt::sharding_utils::MeshSharding> &input_sharding,
       const std::vector<mlir::tt::sharding_utils::MeshSharding>
@@ -54,9 +53,6 @@ public:
   const std::string &getOriginalMlirCode() const {
     return m_original_mlir_code;
   }
-
-  // Returns TTIR code produced by the compiler, stored for serialization.
-  const std::string &getTTIRMlirCode() const { return m_ttir_mlir_code; }
 
   // Returns a name that identifies the executable.
   const std::string &getExecutableName() const { return m_executable_name; }
@@ -121,9 +117,8 @@ private:
   // compiler.
   ExecutableImage(
       const tt::runtime::Binary &flatbuffer_binary,
-      std::string &&original_mlir_code, std::string &&ttir_mlir_code,
-      std::string &&executable_name, size_t num_partitions, size_t num_replicas,
-      size_t num_devices_to_utilize,
+      std::string &&original_mlir_code, std::string &&executable_name,
+      size_t num_partitions, size_t num_replicas, size_t num_devices_to_utilize,
       const std::vector<std::uint32_t> &devices_mesh_shape,
       const std::vector<mlir::tt::sharding_utils::MeshSharding> &input_sharding,
       const std::vector<mlir::tt::sharding_utils::MeshSharding>
@@ -137,9 +132,6 @@ private:
   // Original mlir code produced by the compiler, stored for debugging
   // purposes.
   std::string m_original_mlir_code;
-
-  // TTIR code produced by the compiler, stored for serialization purposes.
-  std::string m_ttir_mlir_code;
 
   // A name that identifies the executable.
   std::string m_executable_name;

--- a/inc/common/pjrt_implementation/serialized_executable_instance.h
+++ b/inc/common/pjrt_implementation/serialized_executable_instance.h
@@ -53,18 +53,12 @@ public:
     return m_serialized_flatbuffer.size();
   }
 
-  // Gets the TTIR code of the executable image.
-  const std::string &getTTIRCode() const { return m_ttir_code; }
-
 private:
   // Creates serialized executable instance from the executable image.
   SerializedExecutableInstance(const ExecutableImage *executable_image);
 
   // Serialized flatbuffer binary data.
   std::vector<std::byte> m_serialized_flatbuffer;
-
-  // TTIR representation of the executable image.
-  const std::string m_ttir_code;
 };
 
 } // namespace tt::pjrt

--- a/src/common/module_builder.cc
+++ b/src/common/module_builder.cc
@@ -118,8 +118,6 @@ tt_pjrt_status ModuleBuilder::buildModule(
     return m_status;
   }
 
-  collectTTIRCode(mlir_module);
-
   collectMeshShape(mlir_module);
   collectNumDevicesToUtilize(mlir_module);
 
@@ -325,13 +323,6 @@ void ModuleBuilder::collectOutputTypes(
           tt::pjrt::data_type_utils::convertMLIRToPJRTDataType(returnType));
     }
   }
-}
-
-void ModuleBuilder::collectTTIRCode(
-    const mlir::OwningOpRef<mlir::ModuleOp> &mlir_module) {
-  m_ttir_code.clear();
-  llvm::raw_string_ostream os(m_ttir_code);
-  mlir_module.get()->print(os);
 }
 
 std::vector<mlir::func::FuncOp> ModuleBuilder::getPublicFuncOps(

--- a/src/common/module_builder.h
+++ b/src/common/module_builder.h
@@ -87,9 +87,6 @@ public:
   // MLIR program format name. This would ideally be defined in PJRT API header.
   static const std::string c_mlir_format_name;
 
-  // Returns TTIR code of the module.
-  const std::string &getTTIRCode() const { return m_ttir_code; }
-
 private:
   // Creates VHLO module from the input program code.
   mlir::OwningOpRef<mlir::ModuleOp>
@@ -166,9 +163,6 @@ private:
   void
   collectOutputShardingsShardy(const mlir::OwningOpRef<mlir::ModuleOp> &module);
 
-  // Collect the mlir code of the module in TTIR format.
-  void collectTTIRCode(const mlir::OwningOpRef<mlir::ModuleOp> &mlir_module);
-
   // Checks if the StableHLO code is using the Shardy mlir dialect.
   bool isUsingShardy(const mlir::OwningOpRef<mlir::ModuleOp> &module);
 
@@ -233,9 +227,6 @@ private:
 
   // For every output, holds the sharding information.
   std::vector<mlir::tt::sharding_utils::MeshSharding> m_output_shardings;
-
-  // Hold the ttir code of the module.
-  std::string m_ttir_code;
 };
 
 } // namespace tt::pjrt

--- a/src/common/pjrt_implementation/client_instance.cc
+++ b/src/common/pjrt_implementation/client_instance.cc
@@ -177,8 +177,6 @@ tt_pjrt_status ClientInstance::compileMlirProgram(
   // VHLO/SHLO module. Passing original program code for now.
   std::string original_mlir_code(mlir_code);
 
-  std::string ttir_mlir_code(m_module_builder->getTTIRCode());
-
   // TODO(mrakita): Use the VHLO module name from the module builder, if it has
   // a name, otherwise some default string like the current one.
   std::string executable_name = "tt_executable";
@@ -186,8 +184,8 @@ tt_pjrt_status ClientInstance::compileMlirProgram(
   std::shared_ptr<ExecutableImage> executable_image =
       ExecutableImage::createInstance(
           m_module_builder->getFlatbufferBinary(),
-          std::move(original_mlir_code), std::move(ttir_mlir_code),
-          std::move(executable_name), m_module_builder->getNumPartitions(),
+          std::move(original_mlir_code), std::move(executable_name),
+          m_module_builder->getNumPartitions(),
           m_module_builder->getNumReplicas(),
           m_module_builder->getNumDevicesToUtilize(),
           m_module_builder->getDevicesMeshShape(),

--- a/src/common/pjrt_implementation/executable_image.cc
+++ b/src/common/pjrt_implementation/executable_image.cc
@@ -18,9 +18,8 @@ namespace tt::pjrt {
 
 std::shared_ptr<ExecutableImage> ExecutableImage::createInstance(
     const tt::runtime::Binary &flatbuffer_binary,
-    std::string &&original_mlir_code, std::string &&ttir_mlir_code,
-    std::string &&executable_name, size_t num_partitions, size_t num_replicas,
-    size_t num_devices_to_utilize,
+    std::string &&original_mlir_code, std::string &&executable_name,
+    size_t num_partitions, size_t num_replicas, size_t num_devices_to_utilize,
     const std::vector<std::uint32_t> &devices_mesh_shape,
     const std::vector<mlir::tt::sharding_utils::MeshSharding> &input_sharding,
     const std::vector<mlir::tt::sharding_utils::MeshSharding> &output_sharding,
@@ -29,9 +28,9 @@ std::shared_ptr<ExecutableImage> ExecutableImage::createInstance(
   struct make_shared_enabler : public ExecutableImage {
     make_shared_enabler(
         const tt::runtime::Binary &flatbuffer_binary,
-        std::string &&original_mlir_code, std::string &&ttir_mlir_code,
-        std::string &&executable_name, size_t num_partitions,
-        size_t num_replicas, size_t num_devices_to_utilize,
+        std::string &&original_mlir_code, std::string &&executable_name,
+        size_t num_partitions, size_t num_replicas,
+        size_t num_devices_to_utilize,
         const std::vector<std::uint32_t> &devices_mesh_shape,
         const std::vector<mlir::tt::sharding_utils::MeshSharding>
             &input_sharding,
@@ -40,24 +39,23 @@ std::shared_ptr<ExecutableImage> ExecutableImage::createInstance(
         const std::vector<bool> &is_output_scalar,
         const std::vector<PJRT_Buffer_Type> &expected_output_data_types)
         : ExecutableImage(flatbuffer_binary, std::move(original_mlir_code),
-                          std::move(ttir_mlir_code), std::move(executable_name),
-                          num_partitions, num_replicas, num_devices_to_utilize,
+                          std::move(executable_name), num_partitions,
+                          num_replicas, num_devices_to_utilize,
                           devices_mesh_shape, input_sharding, output_sharding,
                           is_output_scalar, expected_output_data_types) {}
   };
 
   return std::make_shared<make_shared_enabler>(
       flatbuffer_binary, std::move(original_mlir_code),
-      std::move(ttir_mlir_code), std::move(executable_name), num_partitions,
-      num_replicas, num_devices_to_utilize, devices_mesh_shape, input_sharding,
+      std::move(executable_name), num_partitions, num_replicas,
+      num_devices_to_utilize, devices_mesh_shape, input_sharding,
       output_sharding, is_output_scalar, expected_output_data_types);
 }
 
 ExecutableImage::ExecutableImage(
     const tt::runtime::Binary &flatbuffer_binary,
-    std::string &&original_mlir_code, std::string &&ttir_mlir_code,
-    std::string &&executable_name, size_t num_partitions, size_t num_replicas,
-    size_t num_devices_to_utilize,
+    std::string &&original_mlir_code, std::string &&executable_name,
+    size_t num_partitions, size_t num_replicas, size_t num_devices_to_utilize,
     const std::vector<std::uint32_t> &devices_mesh_shape,
     const std::vector<mlir::tt::sharding_utils::MeshSharding> &input_sharding,
     const std::vector<mlir::tt::sharding_utils::MeshSharding> &output_sharding,
@@ -65,7 +63,6 @@ ExecutableImage::ExecutableImage(
     const std::vector<PJRT_Buffer_Type> &expected_output_data_types)
     : m_flatbuffer_binary(flatbuffer_binary),
       m_original_mlir_code(std::move(original_mlir_code)),
-      m_ttir_mlir_code(std::move(ttir_mlir_code)),
       m_executable_name(std::move(executable_name)),
       m_num_partitions(num_partitions), m_num_replicas(num_replicas),
       m_num_devices_to_utilize(num_devices_to_utilize),

--- a/src/common/pjrt_implementation/executable_instance.cc
+++ b/src/common/pjrt_implementation/executable_instance.cc
@@ -226,8 +226,9 @@ PJRT_Error *onExecutableSerialize(PJRT_Executable_Serialize_Args *args) {
       SerializedExecutableInstance::createInstance(executable_image);
 
   args->serialized_bytes = reinterpret_cast<const char *>(
-      serialized_executable->getTTIRCode().data());
-  args->serialized_bytes_size = serialized_executable->getTTIRCode().size();
+      serialized_executable->getSerializedFlatbuffer().data());
+  args->serialized_bytes_size =
+      serialized_executable->getSerializedFlatbuffer().size();
   args->serialized_executable_deleter = [](PJRT_SerializedExecutable *exec) {
     delete SerializedExecutableInstance::unwrap(exec);
   };

--- a/src/common/pjrt_implementation/serialized_executable_instance.cc
+++ b/src/common/pjrt_implementation/serialized_executable_instance.cc
@@ -27,8 +27,7 @@ SerializedExecutableInstance::createInstance(
 }
 
 SerializedExecutableInstance::SerializedExecutableInstance(
-    const ExecutableImage *executable_image)
-    : m_ttir_code(executable_image->getTTIRMlirCode()) {
+    const ExecutableImage *executable_image) {
   const tt::runtime::Binary &flatbuffer_binary =
       executable_image->getFlatbufferBinary();
   flatbuffer_binary.storeToMemory(m_serialized_flatbuffer);

--- a/ttxla_tools/__init__.py
+++ b/ttxla_tools/__init__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from .ttxla_tools import serialize_function_to_mlir
+from .ttxla_tools import serialize_function_to_binary

--- a/ttxla_tools/ttxla_tools.py
+++ b/ttxla_tools/ttxla_tools.py
@@ -9,13 +9,13 @@ import os
 import pickle
 
 
-def serialize_function_to_mlir(func, binary_file_path, *args, **kwargs):
+def serialize_function_to_binary(func, binary_file_path, *args, **kwargs):
     """
     Serialize a JAX function to binary format.
 
     Args:
-        func: The function to write mlir for
-        binary_file_path: Path to save the mlir code
+        func: The function to serialize to binary
+        binary_file_path: Path to save the binary data
         *args: Sample arguments for compilation
         **kwargs: Sample keyword arguments for compilation
     """
@@ -60,8 +60,9 @@ def serialize_function_to_mlir(func, binary_file_path, *args, **kwargs):
     unloaded_executable, _, _ = unpickler.load()
 
     flatbuffer_binary = unloaded_executable.xla_executable
-    decoded_str = flatbuffer_binary.decode("utf-8")
 
-    os.makedirs(os.path.dirname(binary_file_path), exist_ok=True)
-    with open(binary_file_path, "w") as f:
-        f.write(decoded_str)
+    dirname = os.path.dirname(binary_file_path)
+    if dirname:
+        os.makedirs(dirname, exist_ok=True)
+    with open(binary_file_path, "wb") as f:
+        f.write(flatbuffer_binary)


### PR DESCRIPTION
In line with the needs of `tt-forge`, changing the python serialization function to output the flatbuffer instead of ttir code.