### PR TITLE
Set new uplift commit author

### DIFF
--- a/.github/workflows/nightly-uplift.yml
+++ b/.github/workflows/nightly-uplift.yml
@@ -59,7 +59,6 @@ jobs:
         with:
           branch: uplift
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-          # author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
           author: "ajakovljevicTT <ajakovljevic@tenstorrent.com>"
           base: main
           commit-message: "Uplift ${{ env.TT_MLIR_SUBMODULE_PATH }} to ${{ env.LATEST_TT_MLIR_VERSION }} ${{ env.TODAY }}"


### PR DESCRIPTION
### Ticket
/

### Problem description
The author of the uplift commit was not explicitly set.

### What's changed
Set **ajakovljevicTT** as the uplift commit author.

### Checklist
- [ ] New/Existing tests provide coverage for changes
Note: Here is an example of the new nightly uplift PR. ([example](https://github.com/tenstorrent/tt-xla/pull/871/commits))
