### PR TITLE
remove xfail marker from test_mnist_cnn_dropout

### DIFF
--- a/tests/torch/single_chip/models/mnist/cnn/dropout/test_mnist_cnn_dropout.py
+++ b/tests/torch/single_chip/models/mnist/cnn/dropout/test_mnist_cnn_dropout.py
@@ -52,9 +52,6 @@ def training_tester() -> MNISTCNNTester:
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.PASSED,
 )
-@pytest.mark.xfail(
-    reason="This test fails due to torch_xla/csrc/xla_graph_executor.cpp:689 : Check failed: tensor_data."
-)
 def test_torch_mnist_cnn_dropout_inference(inference_tester: MNISTCNNTester):
     inference_tester.test()
 


### PR DESCRIPTION
### Problem description
While reviewing the CI [logs](https://github.com/tenstorrent/tt-xla/actions/runs/16458168315/job/46520266621#step:12:62), we noticed that the test_mnist_cnn_dropout was xpassing. After testing it with the latest changes and removing the xfail marker, the test passed successfully, so we have removed the xfail marker.

### What's changed
modified mnist_cnn_dropout test file 

### Checklist
- [x] New/Existing tests provide coverage for changes

I have attached the logs for your reference:
[test_mnist_cnn_dropout.log](https://github.com/user-attachments/files/21383075/test_mnist_cnn_dropout.log)
