### PR TITLE
update failure reason for opt models to fix nightly

### DIFF
--- a/tests/jax/single_chip/models/opt/opt_125m/test_125m.py
+++ b/tests/jax/single_chip/models/opt/opt_125m/test_125m.py
@@ -11,7 +11,7 @@ from utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    passed,
+    incorrect_result,
 )
 
 from ..tester import OPTTester
@@ -46,7 +46,13 @@ def training_tester() -> OPTTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.PASSED,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
+)
+@pytest.mark.xfail(
+    reason=incorrect_result(
+        "PCC comparison failed. Calculated: pcc=0.4767301082611084. Required: pcc=0.99. "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
+    )
 )
 def test_opt_125m_inference(inference_tester: OPTTester):
     inference_tester.test()

--- a/tests/jax/single_chip/models/opt/opt_350m/test_350m.py
+++ b/tests/jax/single_chip/models/opt/opt_350m/test_350m.py
@@ -48,7 +48,13 @@ def training_tester() -> OPTTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.PASSED,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
+)
+@pytest.mark.xfail(
+    reason=incorrect_result(
+        "PCC comparison failed. Calculated: pcc=0.44071146845817566. Required: pcc=0.99. "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
+    )
 )
 def test_opt_350m_inference(inference_tester: OPTTester):
     inference_tester.test()


### PR DESCRIPTION
### Ticket
[Nightly is failed](https://github.com/tenstorrent/tt-xla/actions/runs/16484430977/job/46606512214#step:12:642) for opt_125m & opt_350m models

### Problem description
Opt models are failing in nightly. Test with latest build and update the bringupstatus

### What's changed
* opt125m -> updated the bringupstatus & added incorrect_result reason
* opt350m -> updated the bringupstatus & added incorrect_result reason

### Checklist
- [x] New/Existing tests provide coverage for changes

PFA logs for reference:

before xfail :

[test_125m.log](https://github.com/user-attachments/files/21401094/test_125m.log)
[test_350m.log](https://github.com/user-attachments/files/21401095/test_350m.log)

after xfail : 
[test_125m_xfail.log](https://github.com/user-attachments/files/21401101/test_125m_xfail.log)
[test_350m_xfail.log](https://github.com/user-attachments/files/21401102/test_350m_xfail.log)

