### PR TITLE
Enable fusing pass

### DIFF
--- a/tests/jax/single_chip/models/albert_v2/large/test_albert_large.py
+++ b/tests/jax/single_chip/models/albert_v2/large/test_albert_large.py
@@ -4,7 +4,6 @@
 
 import pytest
 from infra import Framework, RunMode
-from tests.infra.comparators.comparison_config import ComparisonConfig, PccConfig
 from utils import (
     BringupStatus,
     Category,
@@ -32,9 +31,7 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> AlbertV2Tester:
-    return AlbertV2Tester(
-        MODEL_PATH, ComparisonConfig(pcc=PccConfig(required_pcc=0.982))
-    )
+    return AlbertV2Tester(MODEL_PATH)
 
 
 @pytest.fixture

--- a/tests/jax/single_chip/models/albert_v2/xlarge/test_albert_xlarge.py
+++ b/tests/jax/single_chip/models/albert_v2/xlarge/test_albert_xlarge.py
@@ -4,7 +4,6 @@
 
 import pytest
 from infra import Framework, RunMode
-from tests.infra.comparators.comparison_config import ComparisonConfig, PccConfig
 from utils import (
     BringupStatus,
     Category,
@@ -30,9 +29,7 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> AlbertV2Tester:
-    return AlbertV2Tester(
-        MODEL_PATH, ComparisonConfig(pcc=PccConfig(required_pcc=0.986))
-    )
+    return AlbertV2Tester(MODEL_PATH)
 
 
 @pytest.fixture


### PR DESCRIPTION
### Ticket
N/A

### Nightly
https://github.com/tenstorrent/tt-xla/actions/runs/16506603435

### Problem description
Torch-xla decomposes average pool into two reduce-window ops. There is a fusion pattern in tt-mlir that creates an average pool, but it is currently disabled. One of those two `ttir.pooling` ops cannot be lowered as its input is rank-2, which has no corresponding valid pooling op as all require a channel and batch dim. So, this must be fused.

### What's changed
set `options.enableFusing = true` in the `TTIRToTTNNBackendPipelineOptions`


**NOTE:** The PCC of models which use softmax may drop a small amount (ie Albert). This is because fusing the operations that make up softmax, to a softmax results in the IR using the `ttnn.softmax` operation. In its default configuration (the one used by runtime) it can be less accurate than the element wise decomposition of it.
