### PR TITLE
Add support for training test jax infra

### DIFF
--- a/python_package/jax_plugin_tt/monkeypatch.py
+++ b/python_package/jax_plugin_tt/monkeypatch.py
@@ -19,6 +19,7 @@ import jax.lax
 import jax.nn
 from jax.extend import core
 from jax.interpreters.mlir import ir, register_lowering
+from jax.interpreters import ad
 
 
 def _is_module_imported(module_name: str) -> bool:
@@ -193,6 +194,16 @@ def _setup_mark_weight_primitive():
             )
         return [op.result]
 
+    # As we added new primitive, we need to define the jvp function: https://docs.jax.dev/en/latest/jax-primitives.html#forward-differentiation
+    # TODO: there is also primitive_transposes, for more info check: https://docs.jax.dev/en/latest/jax-primitives.html#transposition
+    def _mark_weight_jvp(primals, tangents):
+        (x,) = primals
+        (tx,) = tangents
+        return mark_weight_p.bind(x), tx
+
+    ad.primitive_jvps[mark_weight_p] = _mark_weight_jvp
+
+
     mark_weight_p.def_impl(lambda x: x)
     mark_weight_p.def_abstract_eval(lambda x: x)
     register_lowering(mark_weight_p, lowering_mark_weight)
@@ -207,6 +218,27 @@ def _create_gelu_patch_config():
     Returns:
         list[MonkeyPatchConfig]: List containing gelu patch config.
     """
+
+    def patch_gelu(config: MonkeyPatchConfig):
+        def gelu_composite(x, approximate=True):
+            gelu = config.backup
+            composite = jax.lax.composite(
+                lambda x: gelu(x, approximate=approximate),
+                "tenstorrent.gelu_tanh" if approximate else "tenstorrent.gelu",
+            )
+            composite_vjp = jax.custom_vjp(lambda x: composite(x))
+
+            composite_fwd = lambda x: (composite(x), x)
+
+            composite_bwd = jax.lax.composite(
+                lambda x, g: jax.vjp(gelu, x)[1](g),
+                "tenstorrent.gelu_tanh_bwd" if approximate else "tenstorrent.gelu_bwd",
+            )
+            composite_vjp.defvjp(composite_fwd, composite_bwd)
+
+            return composite_vjp(x)
+
+        return gelu_composite
 
     def post_patch_func():
         if _is_module_imported("transformers") and _is_module_imported(
@@ -225,12 +257,7 @@ def _create_gelu_patch_config():
         MonkeyPatchConfig(
             target_module=jax.nn,
             target_function="gelu",
-            replacement_factory=lambda config: lambda x, approximate=True: jax.lax.composite(
-                lambda x: config.backup(x, approximate=approximate),
-                "tenstorrent.gelu_tanh" if approximate else "tenstorrent.gelu",
-            )(
-                x
-            ),
+            replacement_factory=patch_gelu,
             post_patch=post_patch_func,
         )
     ]

--- a/python_package/jax_plugin_tt/monkeypatch.py
+++ b/python_package/jax_plugin_tt/monkeypatch.py
@@ -203,7 +203,6 @@ def _setup_mark_weight_primitive():
 
     ad.primitive_jvps[mark_weight_p] = _mark_weight_jvp
 
-
     mark_weight_p.def_impl(lambda x: x)
     mark_weight_p.def_abstract_eval(lambda x: x)
     register_lowering(mark_weight_p, lowering_mark_weight)

--- a/python_package/jax_plugin_tt/monkeypatch.py
+++ b/python_package/jax_plugin_tt/monkeypatch.py
@@ -18,8 +18,8 @@ import jax
 import jax.lax
 import jax.nn
 from jax.extend import core
-from jax.interpreters.mlir import ir, register_lowering
 from jax.interpreters import ad
+from jax.interpreters.mlir import ir, register_lowering
 
 
 def _is_module_imported(module_name: str) -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,6 +78,7 @@ def pytest_collection_modifyitems(items):
             "run_mode",
             "parallelism",
             "bringup_status",
+            "execution_pass",
             "pcc",
             "atol",
         ]

--- a/tests/infra/testers/single_chip/model/jax_model_tester.py
+++ b/tests/infra/testers/single_chip/model/jax_model_tester.py
@@ -176,3 +176,95 @@ class JaxModelTester(ModelTester):
             workload.executable,
             static_argnames=workload.static_argnames,
         )
+
+    # @override
+    def _test_training(self):
+        """
+        Steps:
+        1. Create partial with static args
+        2. Compile workloads for CPU and TT device
+        3. Create partial with vjp of model
+        4. Run forward on CPU and TT device
+        5. Create random gradient with same shape as output
+        6. Run pullback on CPU and TT device
+        7. Compare forward results and gradients
+        """
+
+        # Wrapper to convert kwargs to args and return logits if model is HF
+        is_hf_model = isinstance(self._model, FlaxPreTrainedModel)
+
+        def wrapper_model(f):
+            def model(args, kwargs):
+                out = f(*args, **kwargs)
+                if is_hf_model:
+                    out = out.logits
+                return out
+
+            return model
+
+        # Create partial with static args
+        partial_executable = jax.tree_util.Partial(
+            self._workload.executable,
+            **{k: self._workload.kwargs[k] for k in self._workload.static_argnames},
+        )
+        training_workload = Workload(
+            framework=self._framework,
+            executable=partial_executable,
+            args=self._workload.args,
+            kwargs={
+                k: self._workload.kwargs[k]
+                for k in self._workload.kwargs
+                if k not in self._workload.static_argnames
+            },
+            static_argnames=[],
+        )
+
+        # Compile workloads for CPU with vjp of model
+        self._compile_for_cpu(training_workload)
+        train_fwd_cpu = Workload(
+            framework=self._framework,
+            executable=jax.tree_util.Partial(
+                jax.vjp, wrapper_model(training_workload.executable)
+            ),
+            args=[training_workload.args, training_workload.kwargs],
+        )
+        cpu_forward_out, cpu_pullback = self._run_on_cpu(train_fwd_cpu)
+
+        # Compile workloads for TT device with vjp of model
+        self._compile_for_tt_device(training_workload)
+        train_fwd_tt = Workload(
+            framework=self._framework,
+            executable=jax.tree_util.Partial(
+                jax.vjp, wrapper_model(training_workload.executable)
+            ),
+            args=[training_workload.args, training_workload.kwargs],
+        )
+        tt_forward_out, tt_pullback = self._run_on_tt_device(train_fwd_tt)
+
+        # Create random gradient with same shape as output
+        with jax.default_device(jax.devices("cpu")[0]):
+            out_tensor = cpu_forward_out
+            key = jax.random.PRNGKey(0)
+            random_grad = jax.random.normal(
+                key, out_tensor.shape, dtype=out_tensor.dtype
+            )
+
+        # Run pullback on CPU
+        pullback_workload_cpu = Workload(
+            framework=self._framework,
+            executable=cpu_pullback,
+            args=[random_grad],
+        )
+        grads_cpu = self._run_on_cpu(pullback_workload_cpu)
+
+        # Run pullback on TT device
+        pullback_workload_tt = Workload(
+            framework=self._framework,
+            executable=tt_pullback,
+            args=[random_grad],
+        )
+        grads_tt = self._run_on_tt_device(pullback_workload_tt)
+
+        # Compare forward results and gradients
+        self._compare(tt_forward_out, cpu_forward_out)
+        self._compare(grads_tt, grads_cpu)

--- a/tests/infra/testers/single_chip/model/jax_model_tester.py
+++ b/tests/infra/testers/single_chip/model/jax_model_tester.py
@@ -140,6 +140,7 @@ class JaxModelTester(ModelTester):
                 **self._input_activations,
             }
 
+        # TODO: add support for model-specific kwargs for different models. https://github.com/tenstorrent/tt-xla/issues/1388
         return {}
 
     def _get_static_argnames(self) -> Optional[Sequence[str]]:

--- a/tests/infra/testers/single_chip/model/jax_model_tester.py
+++ b/tests/infra/testers/single_chip/model/jax_model_tester.py
@@ -140,7 +140,7 @@ class JaxModelTester(ModelTester):
                 **self._input_activations,
             }
 
-        # TODO: add support for model-specific kwargs for different models. https://github.com/tenstorrent/tt-xla/issues/1388
+        # TODO: add support for training-specific kwargs for different types of models. https://github.com/tenstorrent/tt-xla/issues/1388
         return {}
 
     def _get_static_argnames(self) -> Optional[Sequence[str]]:

--- a/tests/infra/testers/single_chip/model/jax_model_tester.py
+++ b/tests/infra/testers/single_chip/model/jax_model_tester.py
@@ -12,7 +12,7 @@ from flax import linen, nnx
 from huggingface_hub import snapshot_download
 from infra.comparators import ComparisonConfig
 from tests.infra.testers.compiler_config import CompilerConfig
-from infra.utilities import Framework, Model, PyTree
+from infra.utilities import Framework, Model, PyTree, random_tensor
 from infra.workloads import Workload
 from loguru import logger
 from transformers.modeling_flax_utils import FlaxPreTrainedModel
@@ -242,12 +242,7 @@ class JaxModelTester(ModelTester):
         tt_forward_out, tt_pullback = self._run_on_tt_device(train_fwd_tt)
 
         # Create random gradient with same shape as output
-        with jax.default_device(jax.devices("cpu")[0]):
-            out_tensor = cpu_forward_out
-            key = jax.random.PRNGKey(0)
-            random_grad = jax.random.normal(
-                key, out_tensor.shape, dtype=out_tensor.dtype
-            )
+        random_grad = random_tensor(cpu_forward_out.shape, dtype=cpu_forward_out.dtype, framework=self._framework)
 
         # Run pullback on CPU
         pullback_workload_cpu = Workload(

--- a/tests/infra/testers/single_chip/model/jax_model_tester.py
+++ b/tests/infra/testers/single_chip/model/jax_model_tester.py
@@ -242,7 +242,11 @@ class JaxModelTester(ModelTester):
         tt_forward_out, tt_pullback = self._run_on_tt_device(train_fwd_tt)
 
         # Create random gradient with same shape as output
-        random_grad = random_tensor(cpu_forward_out.shape, dtype=cpu_forward_out.dtype, framework=self._framework)
+        random_grad = random_tensor(
+            cpu_forward_out.shape,
+            dtype=cpu_forward_out.dtype,
+            framework=self._framework,
+        )
 
         # Run pullback on CPU
         pullback_workload_cpu = Workload(

--- a/tests/infra/testers/single_chip/model/model_tester.py
+++ b/tests/infra/testers/single_chip/model/model_tester.py
@@ -142,5 +142,8 @@ class ModelTester(BaseTester, ABC):
         self._comparator.compare(device_out, golden_out)
 
     def _test_training(self):
-        """TODO"""
-        raise NotImplementedError("Support for training not implemented")
+        """
+        Tests the model by running training on TT device and on CPU and comparing the
+        forward results and gradients. Implementation is framework-specific.
+        """
+        raise NotImplementedError("Subclasses must implement this method.")

--- a/tests/jax/single_chip/models/gpt2/base/test_gpt2_base.py
+++ b/tests/jax/single_chip/models/gpt2/base/test_gpt2_base.py
@@ -61,8 +61,8 @@ def test_gpt2_base_inference(inference_tester: GPT2Tester):
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.TRAINING,
-    bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
     execution_pass=ExecutionPass.BACKWARD,
+    bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
 )
 @pytest.mark.xfail(reason="error: failed to legalize operation 'ttir.scatter'")
 def test_gpt2_base_training(training_tester: GPT2Tester):

--- a/tests/jax/single_chip/models/gpt2/base/test_gpt2_base.py
+++ b/tests/jax/single_chip/models/gpt2/base/test_gpt2_base.py
@@ -7,6 +7,7 @@ from infra import Framework, RunMode
 from utils import (
     BringupStatus,
     Category,
+    ExecutionPass,
     ModelGroup,
     ModelSource,
     ModelTask,
@@ -60,7 +61,9 @@ def test_gpt2_base_inference(inference_tester: GPT2Tester):
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.TRAINING,
+    bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
+    execution_pass=ExecutionPass.BACKWARD,
 )
-@pytest.mark.skip(reason="Support for training not implemented")
+@pytest.mark.xfail(reason="error: failed to legalize operation 'ttir.scatter'")
 def test_gpt2_base_training(training_tester: GPT2Tester):
     training_tester.test()

--- a/tests/jax/single_chip/models/gpt2/base/test_gpt2_base.py
+++ b/tests/jax/single_chip/models/gpt2/base/test_gpt2_base.py
@@ -12,6 +12,7 @@ from utils import (
     ModelSource,
     ModelTask,
     build_model_name,
+    failed_ttmlir_compilation,
 )
 from third_party.tt_forge_models.gpt2.causal_lm.jax import ModelVariant
 from ..tester import GPT2Tester
@@ -64,6 +65,11 @@ def test_gpt2_base_inference(inference_tester: GPT2Tester):
     execution_pass=ExecutionPass.BACKWARD,
     bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
 )
-@pytest.mark.xfail(reason="error: failed to legalize operation 'ttir.scatter'")
+@pytest.mark.xfail(
+    reason=failed_ttmlir_compilation(
+        "error: failed to legalize operation 'ttir.scatter' "
+        "https://github.com/tenstorrent/tt-mlir/issues/4792"
+    )
+)
 def test_gpt2_base_training(training_tester: GPT2Tester):
     training_tester.test()

--- a/tests/jax/single_chip/models/mnist/cnn/dropout/test_mnist_cnn_dropout.py
+++ b/tests/jax/single_chip/models/mnist/cnn/dropout/test_mnist_cnn_dropout.py
@@ -7,6 +7,7 @@ from infra import Framework, RunMode
 from utils import (
     BringupStatus,
     Category,
+    ExecutionPass,
     ModelGroup,
     ModelSource,
     ModelTask,
@@ -64,7 +65,11 @@ def test_mnist_cnn_dropout_inference(inference_tester: MNISTCNNTester):
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.TRAINING,
+    execution_pass=ExecutionPass.FORWARD,
+    bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
 )
-@pytest.mark.skip(reason="Support for training not implemented")
+@pytest.mark.xfail(
+    reason="error: failed to legalize operation 'stablehlo.bitcast_convert'"
+)
 def test_mnist_cnn_dropout_training(training_tester: MNISTCNNTester):
     training_tester.test()

--- a/tests/jax/single_chip/models/mnist/cnn/dropout/test_mnist_cnn_dropout.py
+++ b/tests/jax/single_chip/models/mnist/cnn/dropout/test_mnist_cnn_dropout.py
@@ -12,6 +12,7 @@ from utils import (
     ModelSource,
     ModelTask,
     build_model_name,
+    failed_ttmlir_compilation,
 )
 
 from ..tester import MNISTCNNTester
@@ -69,7 +70,10 @@ def test_mnist_cnn_dropout_inference(inference_tester: MNISTCNNTester):
     bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
 )
 @pytest.mark.xfail(
-    reason="error: failed to legalize operation 'stablehlo.bitcast_convert'"
+    reason=failed_ttmlir_compilation(
+        "error: failed to legalize operation 'stablehlo.bitcast_convert' "
+        "https://github.com/tenstorrent/tt-mlir/issues/979"
+    )
 )
 def test_mnist_cnn_dropout_training(training_tester: MNISTCNNTester):
     training_tester.test()

--- a/tests/jax/single_chip/models/mnist/cnn/nodropout/test_mnist_cnn_nodropout.py
+++ b/tests/jax/single_chip/models/mnist/cnn/nodropout/test_mnist_cnn_nodropout.py
@@ -62,11 +62,11 @@ def test_mnist_cnn_nodropout_inference(inference_tester: MNISTCNNTester):
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.TRAINING,
-    execution_pass=ExecutionPass.BACKWARD,
-    bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
+    execution_pass=ExecutionPass.FORWARD,
+    bringup_status=BringupStatus.FAILED_FE_COMPILATION,
 )
 @pytest.mark.xfail(
-    reason="error: failed to legalize operation 'stablehlo.select_and_scatter'"
+    reason="Cannot update variable 'mean' in '/BatchNorm_0' because collection 'batch_stats' is immutable."
 )
 def test_mnist_cnn_nodropout_training(training_tester: MNISTCNNTester):
     training_tester.test()

--- a/tests/jax/single_chip/models/mnist/cnn/nodropout/test_mnist_cnn_nodropout.py
+++ b/tests/jax/single_chip/models/mnist/cnn/nodropout/test_mnist_cnn_nodropout.py
@@ -12,6 +12,7 @@ from utils import (
     ModelSource,
     ModelTask,
     build_model_name,
+    failed_fe_compilation,
 )
 
 from ..tester import MNISTCNNTester

--- a/tests/jax/single_chip/models/mnist/cnn/nodropout/test_mnist_cnn_nodropout.py
+++ b/tests/jax/single_chip/models/mnist/cnn/nodropout/test_mnist_cnn_nodropout.py
@@ -66,7 +66,10 @@ def test_mnist_cnn_nodropout_inference(inference_tester: MNISTCNNTester):
     bringup_status=BringupStatus.FAILED_FE_COMPILATION,
 )
 @pytest.mark.xfail(
-    reason="Cannot update variable 'mean' in '/BatchNorm_0' because collection 'batch_stats' is immutable."
+    reason=failed_fe_compilation(
+        "Cannot update variable 'mean' in '/BatchNorm_0' because collection 'batch_stats' is immutable."
+        "https://github.com/tenstorrent/tt-xla/issues/1388"
+    )
 )
 def test_mnist_cnn_nodropout_training(training_tester: MNISTCNNTester):
     training_tester.test()

--- a/tests/jax/single_chip/models/mnist/cnn/nodropout/test_mnist_cnn_nodropout.py
+++ b/tests/jax/single_chip/models/mnist/cnn/nodropout/test_mnist_cnn_nodropout.py
@@ -62,11 +62,11 @@ def test_mnist_cnn_nodropout_inference(inference_tester: MNISTCNNTester):
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.TRAINING,
-    bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
     execution_pass=ExecutionPass.BACKWARD,
+    bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
 )
 @pytest.mark.xfail(
-    reason="error: failed to legalize operation 'ttir.select_and_scatter'"
+    reason="error: failed to legalize operation 'stablehlo.select_and_scatter'"
 )
 def test_mnist_cnn_nodropout_training(training_tester: MNISTCNNTester):
     training_tester.test()

--- a/tests/jax/single_chip/models/mnist/cnn/nodropout/test_mnist_cnn_nodropout.py
+++ b/tests/jax/single_chip/models/mnist/cnn/nodropout/test_mnist_cnn_nodropout.py
@@ -7,6 +7,7 @@ from infra import Framework, RunMode
 from utils import (
     BringupStatus,
     Category,
+    ExecutionPass,
     ModelGroup,
     ModelSource,
     ModelTask,
@@ -61,7 +62,11 @@ def test_mnist_cnn_nodropout_inference(inference_tester: MNISTCNNTester):
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.TRAINING,
+    bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
+    execution_pass=ExecutionPass.BACKWARD,
 )
-@pytest.mark.skip(reason="Support for training not implemented")
+@pytest.mark.xfail(
+    reason="error: failed to legalize operation 'ttir.select_and_scatter'"
+)
 def test_mnist_cnn_nodropout_training(training_tester: MNISTCNNTester):
     training_tester.test()

--- a/tests/jax/single_chip/models/mnist/cnn/tester.py
+++ b/tests/jax/single_chip/models/mnist/cnn/tester.py
@@ -45,7 +45,10 @@ class MNISTCNNTester(JaxModelTester):
 
     # @override
     def _get_forward_method_kwargs(self) -> Dict[str, jax.Array]:
-        return {"train": False}
+        kwargs = {"train": (False if self._run_mode == RunMode.INFERENCE else True)}
+        if self._run_mode == RunMode.TRAINING:
+            kwargs["rngs"] = {"dropout": jax.random.key(1)}
+        return kwargs
 
     # @override
     def _get_static_argnames(self):

--- a/tests/jax/single_chip/models/mnist/mlp/test_mnist_mlp.py
+++ b/tests/jax/single_chip/models/mnist/mlp/test_mnist_mlp.py
@@ -89,8 +89,8 @@ def test_mnist_mlp_inference(inference_tester: MNISTMLPTester):
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.TRAINING,
-    bringup_status=BringupStatus.PASSED,
     execution_pass=ExecutionPass.BACKWARD,
+    bringup_status=BringupStatus.PASSED,
 )
 @pytest.mark.parametrize(
     "training_tester", [(256, 128, 64)], indirect=True, ids=lambda val: f"{val}"

--- a/tests/jax/single_chip/models/mnist/mlp/test_mnist_mlp.py
+++ b/tests/jax/single_chip/models/mnist/mlp/test_mnist_mlp.py
@@ -8,6 +8,7 @@ from infra import Framework, RunMode
 from utils import (
     BringupStatus,
     Category,
+    ExecutionPass,
     ModelGroup,
     ModelSource,
     ModelTask,
@@ -88,7 +89,11 @@ def test_mnist_mlp_inference(inference_tester: MNISTMLPTester):
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.TRAINING,
+    bringup_status=BringupStatus.PASSED,
+    execution_pass=ExecutionPass.BACKWARD,
 )
-@pytest.mark.skip(reason="Support for training not implemented")
+@pytest.mark.parametrize(
+    "training_tester", [(256, 128, 64)], indirect=True, ids=lambda val: f"{val}"
+)
 def test_mnist_mlp_training(training_tester: MNISTMLPTester):
     training_tester.test()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -90,6 +90,14 @@ class BringupStatus(Enum):
         return self.name
 
 
+class ExecutionPass(Enum):
+    FORWARD = "forward"
+    BACKWARD = "backward"
+
+    def __str__(self) -> str:
+        return self.name
+
+
 def failed_fe_compilation(reason: str) -> str:
     return f"{BringupStatus.FAILED_FE_COMPILATION}: {reason}"
 


### PR DESCRIPTION
### Ticket
#905 

This pull request introduces support for training and backward pass testing for JAX models on TT devices, including infrastructure for comparing gradients and forward results between CPU and TT executions. It also refactors and improves the monkeypatching of JAX's GELU function to support custom VJP (vector-Jacobian product), and adds the `ExecutionPass` enum to the test utilities for more granular test reporting. Several model tests are updated to include backward pass tests, with appropriate handling for expected failures.

**Training and Backward Pass Support**

* Added `_test_training` implementation in `jax_model_tester.py` to run forward and backward passes on both CPU and TT device, compare outputs and gradients, and generate random gradients for pullback.
* Updated `model_tester.py` to require framework-specific training tests via `_test_training`, replacing previous placeholder.

**Monkeypatching and Differentiation Improvements**

* Enhanced `monkeypatch.py` to register a JVP (Jacobian-vector product) for the custom `mark_weight_p` primitive, enabling forward-mode autodiff. Also refactored GELU patching to support custom VJP with composite lowering.
**Test Infrastructure Enhancements**

* Introduced `ExecutionPass` enum in `utils.py` and added `execution_pass` to test metadata, improving reporting and parametrization for forward/backward passes.

**Model Test Updates**

* Updated GPT2, MNIST CNN, and MNIST MLP tests to include backward pass (`execution_pass=ExecutionPass.BACKWARD`), mark expected failures for unimplemented or failing operations, and parametrize MLP training test.

**Minor Utility and Import Changes**

* Added `random_tensor` import to `jax_model_tester.py` for random gradient generation.

