### PR TITLE
Dump MLIR mechanism in ModuleBuilder - tt-xla

### DIFF
--- a/src/common/module_builder.h
+++ b/src/common/module_builder.h
@@ -227,6 +227,39 @@ private:
 
   // For every output, holds the sharding information.
   std::vector<mlir::tt::sharding_utils::MeshSharding> m_output_shardings;
+
+  // Helper to read model name from environment variable.
+  enum class ModuleType { STABLEHLO, TTIR, TTNN };
+
+  inline const char *getModuleTypeString(ModuleType type) {
+    switch (type) {
+    case ModuleType::STABLEHLO:
+      return "STABLEHLO";
+    case ModuleType::TTIR:
+      return "TTIR";
+    case ModuleType::TTNN:
+      return "TTNN";
+    }
+    return "UNKNOWN";
+  }
+
+  inline const char *getModuleTypeLower(ModuleType type) {
+    switch (type) {
+    case ModuleType::STABLEHLO:
+      return "stablehlo";
+    case ModuleType::TTIR:
+      return "ttir";
+    case ModuleType::TTNN:
+      return "ttnn";
+    }
+    return "unknown";
+  }
+
+  std::string m_model_name;
+  std::string getModelName();
+  void InitializeMLIRFolder();
+  void dumpModuleToFile(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module,
+                        ModuleType module_type);
 };
 
 } // namespace tt::pjrt


### PR DESCRIPTION
### Ticket
None

### Problem description

This is a proof of concept. 

We want a way to dump MLIR from models into a file, which is already supported in tt-torch through torch-mlir. For torch-xla path, I think it's a little more complicated. In this implementation, I am using environment variables to control 
- if and at which stage we will dump MLIR files (DUMP_MLIR)
- model name to save the file for (MODEL_NAME)

This might be a hacky way, but it allows us to be able to save MLIR files through tt-torch as well. Here is a demo of tt-torch: https://github.com/tenstorrent/tt-torch/compare/main...ddilbaz/dumpMLIR Simply, tt-torch will be setting these environment variables through the existing ModelTester/ CompilerConfig framework.

In the eager mode tests though, model name and dump mlir need to be explicitly set.

I tested that this works through tt-torch. Using tt-torch environment variables as we used to is enough. 

### What's changed
- Added MLIR dumping functions to module builder

### Checklist
- [ ] New/Existing tests provide coverage for changes
