### PR TITLE
Update JAX Albert variants to use ModelLoader from tt-forge-models

### DIFF
--- a/tests/jax/single_chip/models/albert_v2/base/test_albert_base.py
+++ b/tests/jax/single_chip/models/albert_v2/base/test_albert_base.py
@@ -11,12 +11,12 @@ from utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    incorrect_result,
 )
 
 from ..tester import AlbertV2Tester
+from third_party.tt_forge_models.albert.masked_lm.jax import ModelVariant
 
-MODEL_PATH = "albert/albert-base-v2"
+VARIANT_NAME = ModelVariant.BASE_V2
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "albert_v2",
@@ -31,12 +31,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> AlbertV2Tester:
-    return AlbertV2Tester(MODEL_PATH)
+    return AlbertV2Tester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> AlbertV2Tester:
-    return AlbertV2Tester(MODEL_PATH, RunMode.TRAINING)
+    return AlbertV2Tester(VARIANT_NAME, RunMode.TRAINING)
 
 
 # ----- Tests -----

--- a/tests/jax/single_chip/models/albert_v2/large/test_albert_large.py
+++ b/tests/jax/single_chip/models/albert_v2/large/test_albert_large.py
@@ -11,12 +11,12 @@ from utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    incorrect_result,
 )
 
 from ..tester import AlbertV2Tester
+from third_party.tt_forge_models.albert.masked_lm.jax import ModelVariant
 
-MODEL_PATH = "albert/albert-large-v2"
+VARIANT_NAME = ModelVariant.LARGE_V2
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "albert_v2",
@@ -31,12 +31,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> AlbertV2Tester:
-    return AlbertV2Tester(MODEL_PATH)
+    return AlbertV2Tester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> AlbertV2Tester:
-    return AlbertV2Tester(MODEL_PATH, RunMode.TRAINING)
+    return AlbertV2Tester(VARIANT_NAME, RunMode.TRAINING)
 
 
 # ----- Tests -----
@@ -48,14 +48,7 @@ def training_tester() -> AlbertV2Tester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.INCORRECT_RESULT,
-)
-@pytest.mark.xfail(
-    reason=incorrect_result(
-        "PCC comparison failed. Calculated: pcc=0.9827062487602234. Required: pcc=0.99 "
-        "Issue due to the fusing of the softmax op "
-        "https://github.com/tenstorrent/tt-xla/issues/927"
-    )
+    bringup_status=BringupStatus.PASSED,
 )
 def test_flax_albert_v2_large_inference(inference_tester: AlbertV2Tester):
     inference_tester.test()

--- a/tests/jax/single_chip/models/albert_v2/tester.py
+++ b/tests/jax/single_chip/models/albert_v2/tester.py
@@ -3,10 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Dict
-
 import jax
-from infra import ComparisonConfig, JaxModelTester, RunMode
-from transformers import AutoTokenizer, FlaxAlbertForMaskedLM, FlaxPreTrainedModel
+
+from infra import ComparisonConfig, JaxModelTester, RunMode, Model
+from third_party.tt_forge_models.albert.masked_lm.jax import ModelLoader, ModelVariant
 
 
 class AlbertV2Tester(JaxModelTester):
@@ -14,26 +14,20 @@ class AlbertV2Tester(JaxModelTester):
 
     def __init__(
         self,
-        model_path: str,
+        variant_name: ModelVariant,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        self._model_path = model_path
+        self._model_loader = ModelLoader(variant_name)
         super().__init__(comparison_config, run_mode)
 
     # @override
-    def _get_model(self) -> FlaxPreTrainedModel:
-        return FlaxAlbertForMaskedLM.from_pretrained(self._model_path)
+    def _get_model(self) -> Model:
+        return self._model_loader.load_model()
 
     # @override
     def _get_input_activations(self) -> Dict[str, jax.Array]:
-        tokenizer = AutoTokenizer.from_pretrained(self._model_path)
-        inputs = tokenizer("Hello [MASK].", return_tensors="jax")
-        return inputs
-
-    # @ override
-    def _get_static_argnames(self):
-        return ["train"]
+        return self._model_loader.load_inputs()
 
 
 # TODO(stefan): Add testers for Albert when used as a question answering or sentiment analysis model.

--- a/tests/jax/single_chip/models/albert_v2/xlarge/test_albert_xlarge.py
+++ b/tests/jax/single_chip/models/albert_v2/xlarge/test_albert_xlarge.py
@@ -15,8 +15,9 @@ from utils import (
 )
 
 from ..tester import AlbertV2Tester
+from third_party.tt_forge_models.albert.masked_lm.jax import ModelVariant
 
-MODEL_PATH = "albert/albert-xlarge-v2"
+VARIANT_NAME = ModelVariant.XLARGE_V2
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "albert_v2",
@@ -30,12 +31,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> AlbertV2Tester:
-    return AlbertV2Tester(MODEL_PATH)
+    return AlbertV2Tester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> AlbertV2Tester:
-    return AlbertV2Tester(MODEL_PATH, RunMode.TRAINING)
+    return AlbertV2Tester(VARIANT_NAME, RunMode.TRAINING)
 
 
 # ----- Tests -----
@@ -51,7 +52,7 @@ def training_tester() -> AlbertV2Tester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "PCC comparison failed. Calculated: pcc=0.9865921139717102. Required: pcc=0.99 "
+        "PCC comparison failed. Calculated: pcc=0.9897431135177612. Required: pcc=0.99 "
         "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )

--- a/tests/jax/single_chip/models/albert_v2/xxlarge/test_albert_xxlarge.py
+++ b/tests/jax/single_chip/models/albert_v2/xxlarge/test_albert_xxlarge.py
@@ -16,8 +16,9 @@ from utils import (
 )
 
 from ..tester import AlbertV2Tester
+from third_party.tt_forge_models.albert.masked_lm.jax import ModelVariant
 
-MODEL_PATH = "albert/albert-xxlarge-v2"
+VARIANT_NAME = ModelVariant.XXLARGE_V2
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "albert_v2",
@@ -32,12 +33,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> AlbertV2Tester:
-    return AlbertV2Tester(MODEL_PATH)
+    return AlbertV2Tester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> AlbertV2Tester:
-    return AlbertV2Tester(MODEL_PATH, RunMode.TRAINING)
+    return AlbertV2Tester(VARIANT_NAME, RunMode.TRAINING)
 
 
 # ----- Tests -----
@@ -53,7 +54,7 @@ def training_tester() -> AlbertV2Tester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=131022.7578125. Required: atol=0.16 "
+        "PCC comparison failed. Calculated: pcc=0.9695068001747131. Required: pcc=0.99 "
         "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-xla/issues/939

### Problem description
Update JAX tests of Albert to use ModelLoader

### What's changed
4 variants of Albert_v2 is modified to use ModelLoader from tt-forge-models
* xlarge & xxlarge variants resulted in new pcc. Updated the error message for them

### Checklist
- [x] New/Existing tests provide coverage for changes

PFA logs for reference
[basev2.log](https://github.com/user-attachments/files/21611545/basev2.log)
[large_v2.log](https://github.com/user-attachments/files/21611550/large_v2.log)
[xlarge_v2_xfail.log](https://github.com/user-attachments/files/21611552/xlarge_v2_xfail.log)
before xfail : [xlarge_v2.log](https://github.com/user-attachments/files/21611553/xlarge_v2.log)
[xxlarge_v2_xfail.log](https://github.com/user-attachments/files/21611554/xxlarge_v2_xfail.log)
before xfail : [xxlarge_v2.log](https://github.com/user-attachments/files/21611555/xxlarge_v2.log)
