### PR TITLE
modify import statement according to tt-forge models repo

### DIFF
--- a/tests/torch/single_chip/models/bert/tester.py
+++ b/tests/torch/single_chip/models/bert/tester.py
@@ -4,7 +4,9 @@
 
 from typing import Any, Dict, Sequence
 from infra import ComparisonConfig, Model, RunMode, TorchModelTester
-from third_party.tt_forge_models.bert.pytorch.loader import ModelLoader
+from third_party.tt_forge_models.bert.question_answering.pytorch.loader import (
+    ModelLoader,
+)
 
 
 class BertTester(TorchModelTester):

--- a/tests/torch/single_chip/models/detr/tester.py
+++ b/tests/torch/single_chip/models/detr/tester.py
@@ -4,7 +4,7 @@
 
 from typing import Any, Dict, Sequence
 from infra import ComparisonConfig, Model, RunMode, TorchModelTester
-from third_party.tt_forge_models.detr.pytorch import ModelLoader
+from third_party.tt_forge_models.detr.object_detection.pytorch import ModelLoader
 
 
 class DETRTester(TorchModelTester):

--- a/tests/torch/single_chip/models/distilbert/tester.py
+++ b/tests/torch/single_chip/models/distilbert/tester.py
@@ -4,7 +4,9 @@
 
 from typing import Any, Dict, Sequence
 from infra import ComparisonConfig, Model, RunMode, TorchModelTester
-from third_party.tt_forge_models.distilbert.pytorch import ModelLoader
+from third_party.tt_forge_models.distilbert.masked_lm.pytorch import (
+    ModelLoader,
+)
 
 
 class DistilBertTester(TorchModelTester):

--- a/tests/torch/single_chip/models/dpr/tester.py
+++ b/tests/torch/single_chip/models/dpr/tester.py
@@ -4,7 +4,7 @@
 
 from typing import Any, Dict, Sequence
 from infra import ComparisonConfig, Model, RunMode, TorchModelTester
-from third_party.tt_forge_models.dpr.pytorch import ModelLoader
+from third_party.tt_forge_models.dpr.context_encoder.pytorch import ModelLoader
 
 
 class DprTester(TorchModelTester):

--- a/tests/torch/single_chip/models/flan_t5/tester.py
+++ b/tests/torch/single_chip/models/flan_t5/tester.py
@@ -4,7 +4,7 @@
 
 from typing import Any, Dict, Sequence
 from infra import ComparisonConfig, Model, RunMode, TorchModelTester
-from third_party.tt_forge_models.flan_t5.pytorch import ModelLoader
+from third_party.tt_forge_models.t5.pytorch import ModelLoader
 
 
 class FlanT5Tester(TorchModelTester):

--- a/tests/torch/single_chip/models/gpt_neo/tester.py
+++ b/tests/torch/single_chip/models/gpt_neo/tester.py
@@ -4,7 +4,7 @@
 
 from typing import Any, Dict, Sequence
 from infra import ComparisonConfig, Model, RunMode, TorchModelTester
-from third_party.tt_forge_models.gpt_neo.pytorch import ModelLoader
+from third_party.tt_forge_models.gpt_neo.causal_lm.pytorch import ModelLoader
 
 
 class GPTNeoTester(TorchModelTester):

--- a/tests/torch/single_chip/models/phi1/tester.py
+++ b/tests/torch/single_chip/models/phi1/tester.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import Any, Dict, Sequence
 from infra import ComparisonConfig, Model, RunMode, TorchModelTester
-from third_party.tt_forge_models.phi1.pytorch import ModelLoader
+from third_party.tt_forge_models.phi1.causal_lm.pytorch import ModelLoader
 
 
 class Phi1Tester(TorchModelTester):

--- a/tests/torch/single_chip/models/phi1_5/tester.py
+++ b/tests/torch/single_chip/models/phi1_5/tester.py
@@ -4,7 +4,7 @@
 
 from typing import Any, Dict, Sequence
 from infra import ComparisonConfig, Model, RunMode, TorchModelTester
-from third_party.tt_forge_models.phi1_5.pytorch import ModelLoader
+from third_party.tt_forge_models.phi1_5.causal_lm.pytorch import ModelLoader
 
 
 class Phi1_5Tester(TorchModelTester):

--- a/tests/torch/single_chip/models/qwen_2/tester.py
+++ b/tests/torch/single_chip/models/qwen_2/tester.py
@@ -4,7 +4,7 @@
 
 from typing import Any, Dict, Sequence
 from infra import ComparisonConfig, Model, RunMode, TorchModelTester
-from third_party.tt_forge_models.qwen.token_classification.pytorch import ModelLoader
+from third_party.tt_forge_models.qwen_2.token_classification.pytorch import ModelLoader
 
 
 class Qwen2Tester(TorchModelTester):

--- a/tests/torch/single_chip/models/qwen_2_5/tester.py
+++ b/tests/torch/single_chip/models/qwen_2_5/tester.py
@@ -4,7 +4,7 @@
 
 from typing import Any, Dict, Sequence
 from infra import ComparisonConfig, Model, RunMode, TorchModelTester
-from third_party.tt_forge_models.qwen.casual_lm.pytorch import ModelLoader
+from third_party.tt_forge_models.qwen_2_5.casual_lm.pytorch import ModelLoader
 
 
 class Qwen2_5Tester(TorchModelTester):

--- a/tests/torch/single_chip/models/vilt/tester.py
+++ b/tests/torch/single_chip/models/vilt/tester.py
@@ -4,7 +4,7 @@
 
 from typing import Any, Dict, Sequence
 from infra import ComparisonConfig, Model, RunMode, TorchModelTester
-from third_party.tt_forge_models.vilt.pytorch import ModelLoader
+from third_party.tt_forge_models.vilt.question_answering.pytorch import ModelLoader
 
 
 class VILTTester(TorchModelTester):


### PR DESCRIPTION
### Problem description
The structure of the TT-Forge models repository has changed. Now, the task directory contains the test file inside it, so we modified the imports to support this new structure.

### What's changed
The model imports have been updated to match the new repository structure.

### Checklist
- [x] New/Existing tests provide coverage for changes

I have attached the logs for your reference:
[test_bert_base.log](https://github.com/user-attachments/files/21681865/test_bert_base.log)
[test_bert_large.log](https://github.com/user-attachments/files/21681866/test_bert_large.log)
[test_detr.log](https://github.com/user-attachments/files/21681867/test_detr.log)
[test_distilbert.log](https://github.com/user-attachments/files/21681869/test_distilbert.log)
[test_dpr.log](https://github.com/user-attachments/files/21681871/test_dpr.log)
[test_flan_t5.log](https://github.com/user-attachments/files/21681872/test_flan_t5.log)
[test_gpt_neo.log](https://github.com/user-attachments/files/21681873/test_gpt_neo.log)
[test_phi1_5.log](https://github.com/user-attachments/files/21681874/test_phi1_5.log)
[test_phi1.log](https://github.com/user-attachments/files/21681875/test_phi1.log)
[test_qwen_2_5.log](https://github.com/user-attachments/files/21681876/test_qwen_2_5.log)
[test_qwen_2.log](https://github.com/user-attachments/files/21681878/test_qwen_2.log)
[test_vilt.log](https://github.com/user-attachments/files/21681879/test_vilt.log)
