### PR TITLE
Pin python version for pre-commit CI job 

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,6 +14,8 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v5
+        with:
+          python-version: 3.12.0
 
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Pre-commit job started failing in the CI.

### What's changed
The formatter library black was throwing an import error, after pinning python to 3.12 everything works fine.

### Checklist
- [ ] New/Existing tests provide coverage for changes
