### PR TITLE
Update torch tests to use ModelVariant as variant_name Set 2

### DIFF
--- a/tests/torch/single_chip/models/flan_t5/test_flan_t5.py
+++ b/tests/torch/single_chip/models/flan_t5/test_flan_t5.py
@@ -13,10 +13,10 @@ from utils import (
     build_model_name,
     failed_ttmlir_compilation,
 )
-
+from third_party.tt_forge_models.t5.pytorch import ModelVariant
 from .tester import FlanT5Tester
 
-VARIANT_NAME = "google/flan-t5-small"
+VARIANT_NAME = ModelVariant.FLAN_T5_SMALL
 
 
 MODEL_NAME = build_model_name(

--- a/tests/torch/single_chip/models/flan_t5/tester.py
+++ b/tests/torch/single_chip/models/flan_t5/tester.py
@@ -4,7 +4,7 @@
 
 from typing import Any, Dict, Sequence
 from infra import ComparisonConfig, Model, RunMode, TorchModelTester
-from third_party.tt_forge_models.t5.pytorch import ModelLoader
+from third_party.tt_forge_models.t5.pytorch import ModelLoader, ModelVariant
 
 
 class FlanT5Tester(TorchModelTester):
@@ -12,7 +12,7 @@ class FlanT5Tester(TorchModelTester):
 
     def __init__(
         self,
-        variant_name: str,
+        variant_name: ModelVariant,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:

--- a/tests/torch/single_chip/models/mamba/test_mamba.py
+++ b/tests/torch/single_chip/models/mamba/test_mamba.py
@@ -13,10 +13,10 @@ from utils import (
     build_model_name,
     failed_ttmlir_compilation,
 )
-
+from third_party.tt_forge_models.mamba.pytorch import ModelVariant
 from .tester import MambaTester
 
-VARIANT_NAME = "state-spaces/mamba-790m-hf"
+VARIANT_NAME = ModelVariant.MAMBA_790M
 
 MODEL_NAME = build_model_name(
     Framework.TORCH,

--- a/tests/torch/single_chip/models/mamba/tester.py
+++ b/tests/torch/single_chip/models/mamba/tester.py
@@ -4,7 +4,7 @@
 
 from typing import Any, Dict, Sequence
 from infra import ComparisonConfig, Model, RunMode, TorchModelTester
-from third_party.tt_forge_models.mamba.pytorch import ModelLoader
+from third_party.tt_forge_models.mamba.pytorch import ModelLoader, ModelVariant
 
 
 class MambaTester(TorchModelTester):
@@ -12,7 +12,7 @@ class MambaTester(TorchModelTester):
 
     def __init__(
         self,
-        variant_name: str,
+        variant_name: ModelVariant,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:

--- a/tests/torch/single_chip/models/mlp_mixer/test_mlp_mixer.py
+++ b/tests/torch/single_chip/models/mlp_mixer/test_mlp_mixer.py
@@ -13,10 +13,10 @@ from utils import (
     build_model_name,
     failed_ttmlir_compilation,
 )
-
+from third_party.tt_forge_models.mlp_mixer.pytorch import ModelVariant
 from .tester import MLPMixerTester
 
-VARIANT_NAME = "mixer_s32_224"
+VARIANT_NAME = ModelVariant.MIXER_S32_224
 
 
 MODEL_NAME = build_model_name(

--- a/tests/torch/single_chip/models/mlp_mixer/tester.py
+++ b/tests/torch/single_chip/models/mlp_mixer/tester.py
@@ -4,7 +4,7 @@
 
 from typing import Any, Dict, Sequence
 from infra import ComparisonConfig, Model, RunMode, TorchModelTester
-from third_party.tt_forge_models.mlp_mixer.pytorch import ModelLoader
+from third_party.tt_forge_models.mlp_mixer.pytorch import ModelLoader, ModelVariant
 
 
 class MLPMixerTester(TorchModelTester):
@@ -12,7 +12,7 @@ class MLPMixerTester(TorchModelTester):
 
     def __init__(
         self,
-        variant_name: str,
+        variant_name: ModelVariant,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:

--- a/tests/torch/single_chip/models/qwen_2_5/test_qwen_2_5.py
+++ b/tests/torch/single_chip/models/qwen_2_5/test_qwen_2_5.py
@@ -13,10 +13,10 @@ from utils import (
     build_model_name,
     failed_ttmlir_compilation,
 )
-
+from third_party.tt_forge_models.qwen_2_5.casual_lm.pytorch import ModelVariant
 from .tester import Qwen2_5Tester
 
-VARIANT_NAME = "Qwen/Qwen2.5-1.5B"
+VARIANT_NAME = ModelVariant.QWEN_2_5_1_5B
 
 MODEL_NAME = build_model_name(
     Framework.TORCH,

--- a/tests/torch/single_chip/models/qwen_2_5/tester.py
+++ b/tests/torch/single_chip/models/qwen_2_5/tester.py
@@ -4,7 +4,10 @@
 
 from typing import Any, Dict, Sequence
 from infra import ComparisonConfig, Model, RunMode, TorchModelTester
-from third_party.tt_forge_models.qwen_2_5.casual_lm.pytorch import ModelLoader
+from third_party.tt_forge_models.qwen_2_5.casual_lm.pytorch import (
+    ModelLoader,
+    ModelVariant,
+)
 
 
 class Qwen2_5Tester(TorchModelTester):
@@ -12,7 +15,7 @@ class Qwen2_5Tester(TorchModelTester):
 
     def __init__(
         self,
-        variant_name: str,
+        variant_name: ModelVariant,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:

--- a/tests/torch/single_chip/models/regnet/test_regnet.py
+++ b/tests/torch/single_chip/models/regnet/test_regnet.py
@@ -13,10 +13,10 @@ from utils import (
     build_model_name,
     failed_ttmlir_compilation,
 )
-
+from third_party.tt_forge_models.regnet.pytorch import ModelVariant
 from .tester import RegnetTester
 
-VARIANT_NAME = "facebook/regnet-y-040"
+VARIANT_NAME = ModelVariant.Y_040
 
 
 MODEL_NAME = build_model_name(

--- a/tests/torch/single_chip/models/regnet/tester.py
+++ b/tests/torch/single_chip/models/regnet/tester.py
@@ -4,7 +4,7 @@
 
 from typing import Any, Dict, Sequence
 from infra import ComparisonConfig, Model, RunMode, TorchModelTester
-from third_party.tt_forge_models.regnet.pytorch import ModelLoader
+from third_party.tt_forge_models.regnet.pytorch import ModelLoader, ModelVariant
 
 
 class RegnetTester(TorchModelTester):
@@ -12,7 +12,7 @@ class RegnetTester(TorchModelTester):
 
     def __init__(
         self,
-        variant_name: str,
+        variant_name: ModelVariant,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:

--- a/tests/torch/single_chip/models/segformer/test_segformer.py
+++ b/tests/torch/single_chip/models/segformer/test_segformer.py
@@ -13,10 +13,10 @@ from utils import (
     build_model_name,
     failed_ttmlir_compilation,
 )
-
+from third_party.tt_forge_models.segformer.pytorch import ModelVariant
 from .tester import SegformerTester
 
-VARIANT_NAME = "nvidia/mit-b0"
+VARIANT_NAME = ModelVariant.MIT_B0
 
 MODEL_NAME = build_model_name(
     Framework.TORCH,

--- a/tests/torch/single_chip/models/segformer/tester.py
+++ b/tests/torch/single_chip/models/segformer/tester.py
@@ -4,7 +4,7 @@
 
 from typing import Any, Dict, Sequence
 from infra import ComparisonConfig, Model, RunMode, TorchModelTester
-from third_party.tt_forge_models.segformer.pytorch import ModelLoader
+from third_party.tt_forge_models.segformer.pytorch import ModelLoader, ModelVariant
 
 
 class SegformerTester(TorchModelTester):
@@ -12,7 +12,7 @@ class SegformerTester(TorchModelTester):
 
     def __init__(
         self,
-        variant_name: str,
+        variant_name: ModelVariant,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/963

### Problem description
As per the latest changes in tt-forge-models, variant_name should be passed as `ModelVariant`

### What's changed

For  below xfailed Models, variant_name is updated to `ModelVariant` 
* Flan t5  [flant5.log](https://github.com/user-attachments/files/21729225/flant5.log)
* Mamba [mamba.log](https://github.com/user-attachments/files/21729247/mamba.log)
* Mlp_mixer  [mlp_mixer.log](https://github.com/user-attachments/files/21729252/mlp_mixer.log)
* Qwen2.5 [qwen2_5.log](https://github.com/user-attachments/files/21729253/qwen2_5.log)
* Regnet [regnet.log](https://github.com/user-attachments/files/21729255/regnet.log)
* Segformer [segformer.log](https://github.com/user-attachments/files/21729258/segformer.log)


### Checklist
- [x] New/Existing tests provide coverage for changes

