### PR TITLE
Update torch tests to use ModelVariant as variant_name Set 3

### DIFF
--- a/tests/torch/single_chip/models/squeezebert/test_squeezebert.py
+++ b/tests/torch/single_chip/models/squeezebert/test_squeezebert.py
@@ -13,10 +13,10 @@ from utils import (
     build_model_name,
     failed_ttmlir_compilation,
 )
-
+from third_party.tt_forge_models.squeezebert.pytorch import ModelVariant
 from .tester import SqueezeBertTester
 
-VARIANT_NAME = "squeezebert/squeezebert-mnli"
+VARIANT_NAME = ModelVariant.MNLI
 
 MODEL_NAME = build_model_name(
     Framework.TORCH,

--- a/tests/torch/single_chip/models/squeezebert/tester.py
+++ b/tests/torch/single_chip/models/squeezebert/tester.py
@@ -4,7 +4,7 @@
 
 from typing import Any, Dict, Sequence
 from infra import ComparisonConfig, Model, RunMode, TorchModelTester
-from third_party.tt_forge_models.squeezebert.pytorch import ModelLoader
+from third_party.tt_forge_models.squeezebert.pytorch import ModelLoader, ModelVariant
 
 
 class SqueezeBertTester(TorchModelTester):
@@ -12,7 +12,7 @@ class SqueezeBertTester(TorchModelTester):
 
     def __init__(
         self,
-        variant_name: str,
+        variant_name: ModelVariant,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:

--- a/tests/torch/single_chip/models/t5/test_t5.py
+++ b/tests/torch/single_chip/models/t5/test_t5.py
@@ -13,10 +13,10 @@ from utils import (
     build_model_name,
     failed_ttmlir_compilation,
 )
-
+from third_party.tt_forge_models.t5.pytorch import ModelVariant
 from .tester import T5Tester
 
-VARIANT_NAME = "t5-small"
+VARIANT_NAME = ModelVariant.SMALL
 
 MODEL_NAME = build_model_name(
     Framework.TORCH,

--- a/tests/torch/single_chip/models/t5/tester.py
+++ b/tests/torch/single_chip/models/t5/tester.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import Any, Dict, Sequence
 from infra import ComparisonConfig, Model, RunMode, TorchModelTester
-from third_party.tt_forge_models.t5.pytorch import ModelLoader
+from third_party.tt_forge_models.t5.pytorch import ModelLoader, ModelVariant
 
 
 class T5Tester(TorchModelTester):
@@ -11,7 +11,7 @@ class T5Tester(TorchModelTester):
 
     def __init__(
         self,
-        variant_name: str,
+        variant_name: ModelVariant,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:

--- a/tests/torch/single_chip/models/vilt/test_vilt.py
+++ b/tests/torch/single_chip/models/vilt/test_vilt.py
@@ -13,10 +13,10 @@ from utils import (
     build_model_name,
     failed_ttmlir_compilation,
 )
-
+from third_party.tt_forge_models.vilt.question_answering.pytorch import ModelVariant
 from .tester import VILTTester
 
-VARIANT_NAME = "dandelin/vilt-b32-finetuned-vqa"
+VARIANT_NAME = ModelVariant.VQA
 
 MODEL_NAME = build_model_name(
     Framework.TORCH,

--- a/tests/torch/single_chip/models/vilt/tester.py
+++ b/tests/torch/single_chip/models/vilt/tester.py
@@ -4,7 +4,10 @@
 
 from typing import Any, Dict, Sequence
 from infra import ComparisonConfig, Model, RunMode, TorchModelTester
-from third_party.tt_forge_models.vilt.question_answering.pytorch import ModelLoader
+from third_party.tt_forge_models.vilt.question_answering.pytorch import (
+    ModelLoader,
+    ModelVariant,
+)
 
 
 class VILTTester(TorchModelTester):
@@ -12,7 +15,7 @@ class VILTTester(TorchModelTester):
 
     def __init__(
         self,
-        variant_name: str,
+        variant_name: ModelVariant,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:

--- a/tests/torch/single_chip/models/vit/test_vit.py
+++ b/tests/torch/single_chip/models/vit/test_vit.py
@@ -13,10 +13,10 @@ from utils import (
     build_model_name,
     failed_ttmlir_compilation,
 )
-
+from third_party.tt_forge_models.vit.pytorch import ModelVariant
 from .tester import VITTester
 
-VARIANT_NAME = "vit-large-patch16-224"
+VARIANT_NAME = ModelVariant.LARGE
 
 MODEL_NAME = build_model_name(
     Framework.TORCH,

--- a/tests/torch/single_chip/models/vit/tester.py
+++ b/tests/torch/single_chip/models/vit/tester.py
@@ -4,7 +4,7 @@
 
 from typing import Any, Dict, Sequence
 from infra import ComparisonConfig, Model, RunMode, TorchModelTester
-from third_party.tt_forge_models.vit.pytorch import ModelLoader
+from third_party.tt_forge_models.vit.pytorch import ModelLoader, ModelVariant
 
 
 class VITTester(TorchModelTester):
@@ -12,7 +12,7 @@ class VITTester(TorchModelTester):
 
     def __init__(
         self,
-        variant_name: str,
+        variant_name: ModelVariant,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:

--- a/tests/torch/single_chip/models/vovnet/test_vovnet.py
+++ b/tests/torch/single_chip/models/vovnet/test_vovnet.py
@@ -11,12 +11,11 @@ from utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_ttmlir_compilation,
 )
-
+from third_party.tt_forge_models.vovnet.pytorch import ModelVariant
 from .tester import VovNetTester
 
-VARIANT_NAME = "vovnet27s"
+VARIANT_NAME = ModelVariant.VOVNET27S
 
 MODEL_NAME = build_model_name(
     Framework.TORCH,
@@ -49,13 +48,7 @@ def training_tester() -> VovNetTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
-)
-@pytest.mark.xfail(
-    reason=failed_ttmlir_compilation(
-        "error: 'ttir.max_pool2d' op output tensor height and width dimension (28, 28) do not match the expected dimensions (27, 28) "
-        "https://github.com/tenstorrent/tt-xla/issues/928"
-    )
+    bringup_status=BringupStatus.PASSED,
 )
 def test_torch_vovnet_inference(inference_tester: VovNetTester):
     inference_tester.test()

--- a/tests/torch/single_chip/models/vovnet/tester.py
+++ b/tests/torch/single_chip/models/vovnet/tester.py
@@ -4,7 +4,7 @@
 
 from typing import Any, Dict, Sequence
 from infra import ComparisonConfig, Model, RunMode, TorchModelTester
-from third_party.tt_forge_models.vovnet.pytorch import ModelLoader
+from third_party.tt_forge_models.vovnet.pytorch import ModelLoader, ModelVariant
 
 
 class VovNetTester(TorchModelTester):
@@ -12,7 +12,7 @@ class VovNetTester(TorchModelTester):
 
     def __init__(
         self,
-        variant_name: str,
+        variant_name: ModelVariant,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:

--- a/tests/torch/single_chip/models/xglm/test_xglm.py
+++ b/tests/torch/single_chip/models/xglm/test_xglm.py
@@ -13,10 +13,10 @@ from utils import (
     build_model_name,
     failed_ttmlir_compilation,
 )
-
+from third_party.tt_forge_models.xglm.pytorch import ModelVariant
 from .tester import XGLMTester
 
-VARIANT_NAME = "base"
+VARIANT_NAME = ModelVariant.XGLM_564M
 
 MODEL_NAME = build_model_name(
     Framework.TORCH,

--- a/tests/torch/single_chip/models/xglm/tester.py
+++ b/tests/torch/single_chip/models/xglm/tester.py
@@ -4,7 +4,7 @@
 
 from typing import Any, Dict, Sequence
 from infra import ComparisonConfig, Model, RunMode, TorchModelTester
-from third_party.tt_forge_models.xglm.pytorch import ModelLoader
+from third_party.tt_forge_models.xglm.pytorch import ModelLoader, ModelVariant
 
 
 class XGLMTester(TorchModelTester):
@@ -12,7 +12,7 @@ class XGLMTester(TorchModelTester):
 
     def __init__(
         self,
-        variant_name: str,
+        variant_name: ModelVariant,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/963

### Problem description
As per the latest changes in tt-forge-models, variant_name should be passed as `ModelVariant`

### What's changed
For  below xfailed models, variant_name is updated to `ModelVariant` 
* Squeezebert  [squeezebert.log](https://github.com/user-attachments/files/21732856/squeezebert.log)
* Vovnet [vovnet.log](https://github.com/user-attachments/files/21732863/vovnet.log)
* Xglm [xglm.log](https://github.com/user-attachments/files/21732865/xglm.log)
* T5 [t5.log](https://github.com/user-attachments/files/21732858/t5.log)
* vilt [vilt.log](https://github.com/user-attachments/files/21732860/vilt.log)
* vit [vit.log](https://github.com/user-attachments/files/21732862/vit.log)

Vovnet is passing end to end, so removed xfail statment

### Checklist
- [x] New/Existing tests provide coverage for changes

