### PR TITLE
update autoencoder_linear failure reason

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,5 +30,12 @@ timm
 torch==2.7.0
 torch_xla==2.7.0
 torchvision
+torchxrayvision
 transformers
 wheel
+
+# vgg model
+vgg_pytorch
+
+# monodepth2 model
+matplotlib

--- a/tests/torch/single_chip/models/autoencoder_linear/test_autoencoder_linear.py
+++ b/tests/torch/single_chip/models/autoencoder_linear/test_autoencoder_linear.py
@@ -11,6 +11,7 @@ from utils import (
     ModelSource,
     ModelTask,
     build_model_name,
+    incorrect_result,
 )
 
 from .tester import AutoencoderLinearTester
@@ -47,7 +48,13 @@ def training_tester() -> AutoencoderLinearTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.PASSED,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
+)
+@pytest.mark.xfail(
+    reason=incorrect_result(
+        "failing only in BlackHole HW. PCC comparison failed. Calculated: pcc=0.039223916828632355. Required: pcc=0.99"
+        "https://github.com/tenstorrent/tt-xla/issues/1038"
+    )
 )
 def test_torch_autoencoder_linear_inference(inference_tester: AutoencoderLinearTester):
     inference_tester.test()

--- a/tests/torch/single_chip/models/swin/tester.py
+++ b/tests/torch/single_chip/models/swin/tester.py
@@ -7,7 +7,10 @@ from typing import Any, Dict, Sequence
 import torch
 
 from infra import ComparisonConfig, Model, RunMode, TorchModelTester
-from third_party.tt_forge_models.swin.pytorch import ModelLoader
+from third_party.tt_forge_models.swin.image_classification.pytorch import (
+    ModelLoader,
+    ModelVariant,
+)
 
 
 class SWINTester(TorchModelTester):


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/1038

### Problem description
Autoencoder linear model failing only in BlackHole HW

### What's changed
* updated the failure reason for autoencoder_linear

