### PR TITLE
update JAX tests for gpt2 and gpt_j

### DIFF
--- a/tests/jax/single_chip/models/gpt2/base/test_gpt2_base.py
+++ b/tests/jax/single_chip/models/gpt2/base/test_gpt2_base.py
@@ -11,12 +11,11 @@ from utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    incorrect_result,
 )
-
+from third_party.tt_forge_models.gpt2.causal_lm.jax import ModelVariant
 from ..tester import GPT2Tester
 
-MODEL_PATH = "openai-community/gpt2"
+MODEL_VARIANT = ModelVariant.BASE
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "gpt2",
@@ -30,12 +29,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> GPT2Tester:
-    return GPT2Tester(MODEL_PATH)
+    return GPT2Tester(MODEL_VARIANT)
 
 
 @pytest.fixture
 def training_tester() -> GPT2Tester:
-    return GPT2Tester(MODEL_PATH, run_mode=RunMode.TRAINING)
+    return GPT2Tester(MODEL_VARIANT, run_mode=RunMode.TRAINING)
 
 
 # ----- Tests -----

--- a/tests/jax/single_chip/models/gpt2/large/test_gpt2_large.py
+++ b/tests/jax/single_chip/models/gpt2/large/test_gpt2_large.py
@@ -11,12 +11,11 @@ from utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    incorrect_result,
 )
-
+from third_party.tt_forge_models.gpt2.causal_lm.jax import ModelVariant
 from ..tester import GPT2Tester
 
-MODEL_PATH = "openai-community/gpt2-large"
+MODEL_VARIANT = ModelVariant.LARGE
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "gpt2",
@@ -31,12 +30,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> GPT2Tester:
-    return GPT2Tester(MODEL_PATH)
+    return GPT2Tester(MODEL_VARIANT)
 
 
 @pytest.fixture
 def training_tester() -> GPT2Tester:
-    return GPT2Tester(MODEL_PATH, run_mode=RunMode.TRAINING)
+    return GPT2Tester(MODEL_VARIANT, run_mode=RunMode.TRAINING)
 
 
 # ----- Tests -----

--- a/tests/jax/single_chip/models/gpt2/medium/test_gpt2_medium.py
+++ b/tests/jax/single_chip/models/gpt2/medium/test_gpt2_medium.py
@@ -11,12 +11,11 @@ from utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    incorrect_result,
 )
-
+from third_party.tt_forge_models.gpt2.causal_lm.jax import ModelVariant
 from ..tester import GPT2Tester
 
-MODEL_PATH = "openai-community/gpt2-medium"
+MODEL_VARIANT = ModelVariant.MEDIUM
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "gpt2",
@@ -31,12 +30,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> GPT2Tester:
-    return GPT2Tester(MODEL_PATH)
+    return GPT2Tester(MODEL_VARIANT)
 
 
 @pytest.fixture
 def training_tester() -> GPT2Tester:
-    return GPT2Tester(MODEL_PATH, run_mode=RunMode.TRAINING)
+    return GPT2Tester(MODEL_VARIANT, run_mode=RunMode.TRAINING)
 
 
 # ----- Tests -----

--- a/tests/jax/single_chip/models/gpt2/tester.py
+++ b/tests/jax/single_chip/models/gpt2/tester.py
@@ -5,8 +5,8 @@
 from typing import Dict
 
 import jax
-from infra import ComparisonConfig, JaxModelTester, RunMode
-from transformers import AutoTokenizer, FlaxGPT2LMHeadModel, FlaxPreTrainedModel
+from infra import ComparisonConfig, JaxModelTester, RunMode, Model
+from third_party.tt_forge_models.gpt2.causal_lm.jax import ModelLoader, ModelVariant
 
 
 class GPT2Tester(JaxModelTester):
@@ -14,19 +14,17 @@ class GPT2Tester(JaxModelTester):
 
     def __init__(
         self,
-        model_path: str,
+        model_path: ModelVariant,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        self._model_path = model_path
+        self._model_loader = ModelLoader(model_path)
         super().__init__(comparison_config, run_mode)
 
     # @override
-    def _get_model(self) -> FlaxPreTrainedModel:
-        return FlaxGPT2LMHeadModel.from_pretrained(self._model_path)
+    def _get_model(self) -> Model:
+        return self._model_loader.load_model()
 
     # @override
     def _get_input_activations(self) -> Dict[str, jax.Array]:
-        tokenizer = AutoTokenizer.from_pretrained(self._model_path)
-        inputs = tokenizer("Hello there fellow traveler", return_tensors="jax")
-        return inputs
+        return self._model_loader.load_inputs()

--- a/tests/jax/single_chip/models/gpt2/xl/test_gpt2_xl.py
+++ b/tests/jax/single_chip/models/gpt2/xl/test_gpt2_xl.py
@@ -12,10 +12,10 @@ from utils import (
     ModelTask,
     build_model_name,
 )
-
+from third_party.tt_forge_models.gpt2.causal_lm.jax import ModelVariant
 from ..tester import GPT2Tester
 
-MODEL_PATH = "openai-community/gpt2-xl"
+MODEL_VARIANT = ModelVariant.XL
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "gpt2",
@@ -30,12 +30,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> GPT2Tester:
-    return GPT2Tester(MODEL_PATH)
+    return GPT2Tester(MODEL_VARIANT)
 
 
 @pytest.fixture
 def training_tester() -> GPT2Tester:
-    return GPT2Tester(MODEL_PATH, run_mode=RunMode.TRAINING)
+    return GPT2Tester(MODEL_VARIANT, run_mode=RunMode.TRAINING)
 
 
 # ----- Tests -----

--- a/tests/jax/single_chip/models/gpt_j/gpt_j_6b/test_gpt_j_6b.py
+++ b/tests/jax/single_chip/models/gpt_j/gpt_j_6b/test_gpt_j_6b.py
@@ -14,9 +14,10 @@ from utils import (
     failed_runtime,
 )
 
+from third_party.tt_forge_models.gpt_j.causal_lm.jax import ModelVariant
 from ..tester import GPTJTester
 
-MODEL_PATH = "EleutherAI/gpt-j-6B"
+MODEL_VARIANT = ModelVariant.GPT_J_6B
 MODEL_NAME = build_model_name(
     Framework.JAX, "gpt-j", "6b", ModelTask.NLP_CAUSAL_LM, ModelSource.HUGGING_FACE
 )
@@ -27,12 +28,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> GPTJTester:
-    return GPTJTester(MODEL_PATH)
+    return GPTJTester(MODEL_VARIANT)
 
 
 @pytest.fixture
 def training_tester() -> GPTJTester:
-    return GPTJTester(MODEL_PATH, run_mode=RunMode.TRAINING)
+    return GPTJTester(MODEL_VARIANT, run_mode=RunMode.TRAINING)
 
 
 # ----- Tests -----

--- a/tests/jax/single_chip/models/gpt_j/tester.py
+++ b/tests/jax/single_chip/models/gpt_j/tester.py
@@ -5,8 +5,8 @@
 from typing import Dict
 
 import jax
-from infra import ComparisonConfig, JaxModelTester, RunMode
-from transformers import AutoTokenizer, FlaxGPTJForCausalLM, FlaxPreTrainedModel
+from infra import ComparisonConfig, JaxModelTester, RunMode, Model
+from third_party.tt_forge_models.gpt_j.causal_lm.jax import ModelLoader, ModelVariant
 
 
 class GPTJTester(JaxModelTester):
@@ -14,23 +14,17 @@ class GPTJTester(JaxModelTester):
 
     def __init__(
         self,
-        model_path: str,
+        model_path: ModelVariant,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        self._model_path = model_path
+        self._model_loader = ModelLoader(model_path)
         super().__init__(comparison_config, run_mode)
 
     # @override
-    def _get_model(self) -> FlaxPreTrainedModel:
-        return FlaxGPTJForCausalLM.from_pretrained(self._model_path)
+    def _get_model(self) -> Model:
+        return self._model_loader.load_model()
 
     # @override
     def _get_input_activations(self) -> Dict[str, jax.Array]:
-        tokenizer = AutoTokenizer.from_pretrained(self._model_path)
-        inputs = tokenizer("Hello, my dog is cute", return_tensors="jax")
-        return inputs
-
-    # @override
-    def _get_static_argnames(self):
-        return ["train"]
+        return self._model_loader.load_inputs()


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-xla/issues/1045

### Problem description
update `GPT2` and `GPT_J` models to use ModelLoader and ModelVariant from tt-forge-models repo


### Checklist
- [x] New/Existing tests provide coverage for changes

PFA logs for reference: 

[gpt_j_6b.log](https://github.com/user-attachments/files/21889385/gpt_j_6b.log)
[gpt2_large.log](https://github.com/user-attachments/files/21889387/gpt2_large.log)
[gpt2_medium.log](https://github.com/user-attachments/files/21889390/gpt2_medium.log)
[gpt2_xl.log](https://github.com/user-attachments/files/21889396/gpt2_xl.log)
[gpt2base.log](https://github.com/user-attachments/files/21889397/gpt2base.log)
