### PR TITLE
update torch models to use ModelVariant

### DIFF
--- a/tests/torch/single_chip/models/alexnet/test_alexnet.py
+++ b/tests/torch/single_chip/models/alexnet/test_alexnet.py
@@ -12,10 +12,10 @@ from utils import (
     ModelTask,
     build_model_name,
 )
-
+from third_party.tt_forge_models.alexnet.pytorch.loader import ModelVariant
 from .tester import AlexNetTester
 
-VARIANT_NAME = "alexnet"
+VARIANT_NAME = ModelVariant.ALEXNET_TORCH_HUB
 
 
 MODEL_NAME = build_model_name(

--- a/tests/torch/single_chip/models/alexnet/tester.py
+++ b/tests/torch/single_chip/models/alexnet/tester.py
@@ -4,10 +4,9 @@
 
 from typing import Any, Dict, Sequence
 
-import torch
 from infra import ComparisonConfig, Model, RunMode, TorchModelTester
 
-from third_party.tt_forge_models.alexnet.pytorch.loader import ModelLoader
+from third_party.tt_forge_models.alexnet.pytorch.loader import ModelLoader, ModelVariant
 
 
 class AlexNetTester(TorchModelTester):
@@ -15,7 +14,7 @@ class AlexNetTester(TorchModelTester):
 
     def __init__(
         self,
-        variant_name: str,
+        variant_name: ModelVariant,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:

--- a/tests/torch/single_chip/models/mobilenetv1/test_mobilenetv1.py
+++ b/tests/torch/single_chip/models/mobilenetv1/test_mobilenetv1.py
@@ -12,10 +12,10 @@ from utils import (
     ModelTask,
     build_model_name,
 )
-
+from third_party.tt_forge_models.mobilenetv1.pytorch.loader import ModelVariant
 from .tester import MobileNetV1Tester
 
-VARIANT_NAME = "mobilenet_v1"
+VARIANT_NAME = ModelVariant.MOBILENET_V1_GITHUB
 
 
 MODEL_NAME = build_model_name(
@@ -23,7 +23,7 @@ MODEL_NAME = build_model_name(
     "mobilenet",
     "v1",
     ModelTask.CV_IMAGE_CLS,
-    ModelSource.TORCH_HUB,
+    ModelSource.GITHUB,
 )
 
 

--- a/tests/torch/single_chip/models/mobilenetv1/tester.py
+++ b/tests/torch/single_chip/models/mobilenetv1/tester.py
@@ -4,7 +4,7 @@
 
 from typing import Any, Dict, Sequence
 from infra import ComparisonConfig, Model, RunMode, TorchModelTester
-from third_party.tt_forge_models.mobilenetv1.pytorch import ModelLoader
+from third_party.tt_forge_models.mobilenetv1.pytorch import ModelLoader, ModelVariant
 
 
 class MobileNetV1Tester(TorchModelTester):
@@ -12,7 +12,7 @@ class MobileNetV1Tester(TorchModelTester):
 
     def __init__(
         self,
-        variant_name: str,
+        variant_name: ModelVariant,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:

--- a/tests/torch/single_chip/models/mobilenetv2/test_mobilenetv2.py
+++ b/tests/torch/single_chip/models/mobilenetv2/test_mobilenetv2.py
@@ -12,10 +12,10 @@ from utils import (
     ModelTask,
     build_model_name,
 )
-
+from third_party.tt_forge_models.mobilenetv2.pytorch.loader import ModelVariant
 from .tester import MobileNetV2Tester
 
-VARIANT_NAME = "mobilenet_v2"
+VARIANT_NAME = ModelVariant.MOBILENET_V2_TORCH_HUB
 
 
 MODEL_NAME = build_model_name(

--- a/tests/torch/single_chip/models/mobilenetv2/tester.py
+++ b/tests/torch/single_chip/models/mobilenetv2/tester.py
@@ -4,7 +4,7 @@
 
 from typing import Any, Dict, Sequence
 from infra import ComparisonConfig, Model, RunMode, TorchModelTester
-from third_party.tt_forge_models.mobilenetv2.pytorch import ModelLoader
+from third_party.tt_forge_models.mobilenetv2.pytorch import ModelLoader, ModelVariant
 
 
 class MobileNetV2Tester(TorchModelTester):
@@ -12,7 +12,7 @@ class MobileNetV2Tester(TorchModelTester):
 
     def __init__(
         self,
-        variant_name: str,
+        variant_name: ModelVariant,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -72,6 +72,9 @@ class ModelSource(StrEnum):
     HUGGING_FACE = "huggingface"
     CUSTOM = "custom"
     TORCH_HUB = "torch_hub"
+    GITHUB = "github"
+    TIMM = "timm"
+    TORCHVISION = "torchvision"
 
 
 class BringupStatus(Enum):


### PR DESCRIPTION
### Problem description
Some of torch tests have failed because of recent changes in `tt-forge-models` to use ModelVariant

### What's changed
Updated the below tests to use ModelVariant from tt-forge-models
* alexnet
* mobilenet_v1
* mobilenet_v2

Added Github, TIMM & TorchVision in ModelSource enums as it might be used in future models from tt-forge-models


### Checklist
- [x] New/Existing tests provide coverage for changes

PFA logs for reference:
[alexnet.log](https://github.com/user-attachments/files/21891001/alexnet.log)
[mobilenetv1_github.log](https://github.com/user-attachments/files/21891124/mobilenetv1_github.log)
[mobilenetv2.log](https://github.com/user-attachments/files/21891003/mobilenetv2.log)


