### PR TITLE
XFail the torch hrnet test because of BH PCC issues

### DIFF
--- a/tests/torch/single_chip/models/autoencoder_linear/test_autoencoder_linear.py
+++ b/tests/torch/single_chip/models/autoencoder_linear/test_autoencoder_linear.py
@@ -52,7 +52,7 @@ def training_tester() -> AutoencoderLinearTester:
 )
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "failing only in BlackHole HW. PCC comparison failed. Calculated: pcc=0.039223916828632355. Required: pcc=0.99"
+        "PCC comparison failed on Blackhole. Calculated: pcc=0.039223916828632355. Required: pcc=0.99."
         "https://github.com/tenstorrent/tt-xla/issues/1038"
     )
 )

--- a/tests/torch/single_chip/models/hrnet/test_hrnet.py
+++ b/tests/torch/single_chip/models/hrnet/test_hrnet.py
@@ -11,6 +11,7 @@ from utils import (
     ModelSource,
     ModelTask,
     build_model_name,
+    incorrect_result,
 )
 
 from third_party.tt_forge_models.hrnet.pytorch import ModelVariant
@@ -50,7 +51,13 @@ def training_tester() -> HRNetTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.PASSED,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
+)
+@pytest.mark.xfail(
+    reason=incorrect_result(
+        "PCC comparison failed on Blackhole. Calculated: pcc=0.03922387957572937. Required: pcc=0.99."
+        "https://github.com/tenstorrent/tt-xla/issues/1038"
+    )
 )
 def test_torch_hrnet_inference(inference_tester: HRNetTester):
     inference_tester.test()


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/1038

### Problem description
`test_torch_hrnet_inference` test is failing on Blackhole with bad PCC.

### What's changed
XFailing the test.

### Checklist
- [x] New/Existing tests provide coverage for changes
