### PR TITLE
Add DOCKER_CACHE_ROOT env to test.yml needed for CiV1 s3 mirror access

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,7 @@ on:
 
 env:
   IRD_LF_CACHE: ${{ vars.IRD_LF_CACHE }}
+  DOCKER_CACHE_ROOT: /mnt/dockercache
 
 jobs:
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/1010

### Problem description
- Hit error in test after switch to CiV1 because file not first looked for in DOCKER_CACHE_ROOT  : RuntimeError: wget failed with exit code 1024 when downloading ... mobilenetv2.jpg
- It's because DOCKER_CACHE_ROOT wasn't defined

### What's changed
- Add the env-var used by get_file(path) for look up of s3 mirrored files on CiV1

### Checklist
- [x] Not tested, but it feels right
