### PR TITLE
Enable argument type population of torch models

### DIFF
--- a/examples/pytorch/explicit_argument_type_annotation_mnist.py
+++ b/examples/pytorch/explicit_argument_type_annotation_mnist.py
@@ -2,31 +2,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import os
-
 import torch
 import torch_xla.core.xla_model as xm
-from torch_xla.experimental import plugins
+import torch_xla.runtime as xr
 import ttxla_tools
 from ttxla_tools import ttxla_tools
 
 from tests.torch.single_chip.models.mnist.cnn.dropout.model_implementation import (
     MNISTCNNDropoutModel,
 )
-
-# --------------------------------
-# Plugin registration
-# --------------------------------
-os.environ["PJRT_DEVICE"] = "TT"
-os.environ["XLA_STABLEHLO_COMPILE"] = "1"
-
-
-class TTPjrtPlugin(plugins.DevicePlugin):
-    def library_path(self):
-        return os.path.join(os.getcwd(), "build/src/tt/pjrt_plugin_tt.so")
-
-
-plugins.register_plugin("TT", TTPjrtPlugin())
 
 
 # --------------------------------
@@ -65,4 +49,5 @@ def mnist_with_consteval():
 # main
 # --------------------------------
 if __name__ == "__main__":
+    xr.set_device_type("TT")
     mnist_with_consteval()

--- a/examples/pytorch/explicit_argument_type_annotation_mnist.py
+++ b/examples/pytorch/explicit_argument_type_annotation_mnist.py
@@ -48,5 +48,7 @@ def mnist_with_consteval():
 # main
 # --------------------------------
 if __name__ == "__main__":
+    # By default torch_xla uses the CPU device so we have to set it to TT device.
     xr.set_device_type("TT")
+
     mnist_with_consteval()

--- a/examples/pytorch/explicit_argument_type_annotation_mnist.py
+++ b/examples/pytorch/explicit_argument_type_annotation_mnist.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+import torch
+import torch_xla.core.xla_model as xm
+from torch_xla.experimental import plugins
+import ttxla_tools
+from ttxla_tools import ttxla_tools
+
+from tests.torch.single_chip.models.mnist.cnn.dropout.model_implementation import (
+    MNISTCNNDropoutModel,
+)
+
+# --------------------------------
+# Plugin registration
+# --------------------------------
+os.environ["PJRT_DEVICE"] = "TT"
+os.environ["XLA_STABLEHLO_COMPILE"] = "1"
+
+
+class TTPjrtPlugin(plugins.DevicePlugin):
+    def library_path(self):
+        return os.path.join(os.getcwd(), "build/src/tt/pjrt_plugin_tt.so")
+
+
+plugins.register_plugin("TT", TTPjrtPlugin())
+
+
+# --------------------------------
+# Test run
+# --------------------------------
+def mnist_with_consteval():
+    # Instantiate model.
+    model: torch.nn.Module = MNISTCNNDropoutModel().to(dtype=torch.bfloat16)
+
+    # Put it in inference mode.
+    model = model.eval()
+
+    # Generate inputs.
+    input = torch.ones((4, 1, 28, 28), dtype=torch.bfloat16)
+
+    # Connect the device.
+    device = xm.xla_device()
+
+    # Move inputs and model to device.
+    input = input.to(device)
+    model = model.to(device)
+
+    # Mark model inputs before compiling. This will allow the compiler to
+    # distinguish between input and parameter arguments, enabling consteval and other optimizations.
+    ttxla_tools.mark_module_user_inputs(model)
+    model.compile(backend="openxla")
+
+    # Run model (with no gradient calculation since we only need inference).
+    with torch.no_grad():
+        output = model(input)
+
+    print(output)
+
+
+# --------------------------------
+# main
+# --------------------------------
+if __name__ == "__main__":
+    mnist_with_consteval()

--- a/examples/pytorch/explicit_argument_type_annotation_mnist.py
+++ b/examples/pytorch/explicit_argument_type_annotation_mnist.py
@@ -5,7 +5,6 @@
 import torch
 import torch_xla.core.xla_model as xm
 import torch_xla.runtime as xr
-import ttxla_tools
 from ttxla_tools import ttxla_tools
 
 from tests.torch.single_chip.models.mnist.cnn.dropout.model_implementation import (

--- a/inc/common/pjrt_implementation/module_builder/frontend_passes/shlo_input_role_propagation.h
+++ b/inc/common/pjrt_implementation/module_builder/frontend_passes/shlo_input_role_propagation.h
@@ -15,27 +15,30 @@
 #include "mlir/IR/OwningOpRef.h"
 #include "mlir/IR/Value.h"
 
+// tt-xla includes
+#include "common/status.h"
+
 namespace tt::pjrt::module_builder::frontend_passes {
 
-extern const std::string c_input_role_attr_name;
-
-// Annotate the attributes of the fucntion arguments (argument type, name) via
+// Annotates the attributes of the function arguments (argument type, name) via
 // observation of the annotation ops inserted by the frontend(s).
-void annotateArgumentAttributes(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module);
+tt_pjrt_status
+annotateArgumentAttributes(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module);
+
 namespace internal {
 
-// Annotates the attributes of the function arguments if the annotatins are
+// Annotates the attributes of the function arguments if the annotations are
 // provided by a custom call.
-void annotateArgumentAttributesFromCustomCall(
+tt_pjrt_status annotateArgumentAttributesFromCustomCall(
     mlir::OwningOpRef<mlir::ModuleOp> &mlir_module);
 
-// Propagates tt.input_role attributes from tt.mark func.call operations upwards
-// to the module root public function arguments.
+// Propagates ttcore.argument_type attributes from tt.mark func.call operations
+// upwards to the module root public function arguments.
 void propagateInputRoleAttributes(
     mlir::OwningOpRef<mlir::ModuleOp> &mlir_module);
 
-// Helper function to recursively propagate tt.input_role attribute upward
-// through call chain.
+// Helper function to recursively propagate ttcore.argument_type attribute
+// upward through call chain.
 void propagateRoleAttribute(mlir::ModuleOp module, mlir::Value argument,
                             mlir::StringAttr roleAttr);
 

--- a/inc/common/pjrt_implementation/module_builder/frontend_passes/shlo_input_role_propagation.h
+++ b/inc/common/pjrt_implementation/module_builder/frontend_passes/shlo_input_role_propagation.h
@@ -19,12 +19,20 @@ namespace tt::pjrt::module_builder::frontend_passes {
 
 extern const std::string c_input_role_attr_name;
 
+// Annotate the attributes of the fucntion arguments (argument type, name) via
+// observation of the annotation ops inserted by the frontend(s).
+void annotateArgumentAttributes(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module);
+namespace internal {
+
+// Annotates the attributes of the function arguments if the annotatins are
+// provided by a custom call.
+void annotateArgumentAttributesFromCustomCall(
+    mlir::OwningOpRef<mlir::ModuleOp> &mlir_module);
+
 // Propagates tt.input_role attributes from tt.mark func.call operations upwards
 // to the module root public function arguments.
 void propagateInputRoleAttributes(
     mlir::OwningOpRef<mlir::ModuleOp> &mlir_module);
-
-namespace internal {
 
 // Helper function to recursively propagate tt.input_role attribute upward
 // through call chain.

--- a/python_package/jax_plugin_tt/monkeypatch.py
+++ b/python_package/jax_plugin_tt/monkeypatch.py
@@ -135,8 +135,8 @@ def _setup_mark_weight_primitive():
                     if hasattr(defining_op, "name") and defining_op.name == "func.call":
                         if hasattr(defining_op, "attributes"):
                             attrs = defining_op.attributes
-                            # Check if callee contains tt.mark and has tt.input_role
-                            if "callee" in attrs and "tt.input_role" in attrs:
+                            # Check if callee contains tt.mark and has ttcore.argument_type
+                            if "callee" in attrs and "ttcore.argument_type" in attrs:
                                 callee_str = str(attrs["callee"])
                                 if "tt.mark" in callee_str:
                                     # Already marked, return as-is
@@ -174,7 +174,7 @@ def _setup_mark_weight_primitive():
                 operands=[x],
                 attributes={
                     "callee": ir.FlatSymbolRefAttr.get(func_name),
-                    "tt.input_role": ir.StringAttr.get("parameter"),
+                    "ttcore.argument_type": ir.StringAttr.get("parameter"),
                 },
             )
         return [op.result]

--- a/python_package/jax_plugin_tt/monkeypatch.py
+++ b/python_package/jax_plugin_tt/monkeypatch.py
@@ -174,7 +174,7 @@ def _setup_mark_weight_primitive():
                 operands=[x],
                 attributes={
                     "callee": ir.FlatSymbolRefAttr.get(func_name),
-                    "tt.input_role": ir.StringAttr.get("weight"),
+                    "tt.input_role": ir.StringAttr.get("parameter"),
                 },
             )
         return [op.result]

--- a/src/common/pjrt_implementation/module_builder/frontend_passes/shlo_input_role_propagation.cc
+++ b/src/common/pjrt_implementation/module_builder/frontend_passes/shlo_input_role_propagation.cc
@@ -208,7 +208,7 @@ struct PopulateArgumentAttrsFromTTMark final
     auto funcOp = mlir::dyn_cast<mlir::func::FuncOp>(parentOp);
     assert(funcOp && "Expected function as parent of block argument");
 
-    // Torch xla allows us to populate a frontend_attributes dictionary to
+    // Torch XLA allows us to populate a frontend_attributes dictionary to
     // custom call ops. This dictionary is used to populate the argument type
     // and name of the argument. We need to extract this information and set the
     // argument type and name of the argument in the function argument

--- a/src/common/pjrt_implementation/module_builder/frontend_passes/shlo_input_role_propagation.cc
+++ b/src/common/pjrt_implementation/module_builder/frontend_passes/shlo_input_role_propagation.cc
@@ -31,7 +31,22 @@
 
 namespace tt::pjrt::module_builder::frontend_passes {
 
-const std::string c_input_role_attr_name = "tt.input_role";
+const std::string c_name_attr_name = "ttir.name";
+const std::string c_mark_argument_function_name = "tt.mark_argument";
+
+tt_pjrt_status
+annotateArgumentAttributes(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module) {
+
+  // Register the ttcore dialect so that ArgumentTypeAttr objects can be
+  // created.
+  mlir::MLIRContext *context = mlir_module->getContext();
+  context->loadDialect<mlir::tt::ttcore::TTCoreDialect>();
+  // If the model being compiled originates from JAX then the argument types
+  // will be annotated using function calls to empty functions, whose attributes
+  // contain the argument type information. This function will handle that case.
+  internal::propagateInputRoleAttributes(mlir_module);
+  return internal::annotateArgumentAttributesFromCustomCall(mlir_module);
+}
 
 namespace internal {
 
@@ -43,8 +58,8 @@ void propagateInputRoleAttributes(
 
   // Propagate role attributes through the call graph
   module.walk([&](mlir::func::CallOp call_op) {
-    auto role_attr =
-        call_op->getAttrOfType<mlir::StringAttr>(c_input_role_attr_name);
+    auto role_attr = call_op->getAttrOfType<mlir::StringAttr>(
+        mlir::tt::ttcore::ArgumentTypeAttr::name);
     if (role_attr) {
       for (mlir::Value operand : call_op.getOperands()) {
         propagateRoleAttribute(module, operand, role_attr);
@@ -78,20 +93,16 @@ void propagateRoleAttribute(mlir::ModuleOp module, mlir::Value argument,
   uint32_t arg_index = block_argument.getArgNumber();
   if (auto parent_func_op = mlir::dyn_cast<mlir::func::FuncOp>(parent_op)) {
 
-    mlir::tt::ttcore::ArgumentType argumentTypeEnum;
-    if (role_attr == "input") {
-      argumentTypeEnum = mlir::tt::ttcore::ArgumentType::Input;
-    } else if (role_attr == "parameter") {
-      argumentTypeEnum = mlir::tt::ttcore::ArgumentType::Parameter;
-    } else if (role_attr == "constant") {
-      argumentTypeEnum = mlir::tt::ttcore::ArgumentType::Constant;
-    } else {
+    std::optional<mlir::tt::ttcore::ArgumentType> argumentTypeEnum =
+        mlir::tt::ttcore::ArgumentTypeStringToEnum(role_attr);
+    if (!argumentTypeEnum) {
       return;
     }
+
     parent_func_op.setArgAttr(
-        arg_index, "ttcore.argument_type",
+        arg_index, mlir::tt::ttcore::ArgumentTypeAttr::name,
         mlir::tt::ttcore::ArgumentTypeAttr::get(parent_func_op.getContext(),
-                                                argumentTypeEnum));
+                                                *argumentTypeEnum));
 
     // In case when graph parts are moved to separate private functions and mark
     // calls end up in some of them, we need to propagate the input role
@@ -156,30 +167,39 @@ bool isTTMarkFunction(const std::string &function_name) {
   return function_name.rfind(c_tt_mark_function_prefix, 0) == 0;
 }
 
-struct ReplaceMarkParameterWithCall final
+// This pattern is used to populate function argument attributes. It looks for
+// calls to `tt.mark_argument` and populates the argument attributes using the
+// attributes of the `tt.mark_argument` call. It then erases the
+// `tt.mark_argument` call and replaces it with the input value.
+//
+// Note: If a `tt.mark_argument` call is not the first operation executed on a
+// function argument, this is an error and the graph which was provided is not
+// valid. This pattern will assert in that case.
+struct PopulateArgumentAttrsFromTTMark final
     : mlir::OpRewritePattern<mlir::stablehlo::CustomCallOp> {
   using mlir::OpRewritePattern<mlir::stablehlo::CustomCallOp>::OpRewritePattern;
 
-  ReplaceMarkParameterWithCall(mlir::MLIRContext *context)
+  PopulateArgumentAttrsFromTTMark(mlir::MLIRContext *context)
       : mlir::OpRewritePattern<mlir::stablehlo::CustomCallOp>(context) {}
 
   mlir::LogicalResult
   matchAndRewrite(mlir::stablehlo::CustomCallOp op,
                   mlir::PatternRewriter &rewriter) const override {
 
-    if (op.getCallTargetName() != "tt.mark_argument") {
+    if (op.getCallTargetName() != c_mark_argument_function_name) {
       return mlir::failure();
     }
 
     assert(op.getNumOperands() == 1 &&
-           "Expected one operand to tt.mark_argument");
+           "Expected one operand to " + c_mark_argument_function_name);
     assert(op.getNumResults() == 1 &&
-           "Expected one result to tt.mark_argument");
+           "Expected one result to " + c_mark_argument_function_name);
 
     // Retrieve input and assert that it is indeed a block argument
     mlir::Value input = op.getOperand(0);
     auto blockArg = mlir::dyn_cast<mlir::BlockArgument>(input);
-    assert(blockArg && "Expected block argument as input to tt.mark_argument");
+    assert(blockArg && "Expected block argument as input to " +
+                           c_mark_argument_function_name);
 
     auto *parentOp = blockArg.getOwner()->getParentOp();
     auto argIndex = blockArg.getArgNumber();
@@ -189,8 +209,8 @@ struct ReplaceMarkParameterWithCall final
     assert(funcOp && "Expected function as parent of block argument");
 
     // Torch xla allows us to populate a frontend_attributes dictionary to
-    // custom call ops This dictionary is used to populate the argument type and
-    // name of the argument We need to extract this information and set the
+    // custom call ops. This dictionary is used to populate the argument type
+    // and name of the argument. We need to extract this information and set the
     // argument type and name of the argument in the function argument
     // attributes.
     mlir::DictionaryAttr frontendAttrs;
@@ -201,7 +221,8 @@ struct ReplaceMarkParameterWithCall final
       return mlir::failure();
     }
 
-    auto argumentType = frontendAttrs.get("argument_type");
+    auto argumentType =
+        frontendAttrs.get(mlir::tt::ttcore::ArgumentTypeAttr::name);
     if (!argumentType) {
       return mlir::failure();
     }
@@ -212,7 +233,7 @@ struct ReplaceMarkParameterWithCall final
       argumentTypeStr = argumentTypeStrAttr.getValue();
     }
 
-    auto nameAttr = frontendAttrs.get("name");
+    auto nameAttr = frontendAttrs.get(c_name_attr_name);
     if (!nameAttr) {
       return mlir::failure();
     }
@@ -223,44 +244,41 @@ struct ReplaceMarkParameterWithCall final
     }
 
     // Determine the argument type enum from the argument type string
-    mlir::tt::ttcore::ArgumentType argumentTypeEnum;
-    if (argumentTypeStr == "input") {
-      argumentTypeEnum = mlir::tt::ttcore::ArgumentType::Input;
-    } else if (argumentTypeStr == "parameter") {
-      argumentTypeEnum = mlir::tt::ttcore::ArgumentType::Parameter;
-    } else if (argumentTypeStr == "constant") {
-      argumentTypeEnum = mlir::tt::ttcore::ArgumentType::Constant;
-    } else {
+    std::optional<mlir::tt::ttcore::ArgumentType> argumentTypeEnum =
+        mlir::tt::ttcore::ArgumentTypeStringToEnum(argumentTypeStr);
+    if (!argumentTypeEnum) {
       return mlir::failure();
     }
 
     // Set argument type for this argument
-    funcOp.setArgAttr(argIndex, "ttcore.argument_type",
+    funcOp.setArgAttr(argIndex, mlir::tt::ttcore::ArgumentTypeAttr::name,
                       mlir::tt::ttcore::ArgumentTypeAttr::get(
-                          funcOp.getContext(), argumentTypeEnum));
+                          funcOp.getContext(), *argumentTypeEnum));
 
     // Set argument name for this argument
-    funcOp.setArgAttr(argIndex, "ttir.name", nameStrAttr);
+    funcOp.setArgAttr(argIndex, c_name_attr_name, nameStrAttr);
 
     // Remove the custom call op and replace it with the input
     // as the information is now embedded in the function argument attributes
     rewriter.replaceOp(op, input);
+
     return mlir::success();
   }
 };
 
-void annotateArgumentAttributesFromCustomCall(
+tt_pjrt_status annotateArgumentAttributesFromCustomCall(
     mlir::OwningOpRef<mlir::ModuleOp> &mlir_module) {
   mlir::MLIRContext *context = mlir_module->getContext();
   mlir::RewritePatternSet patterns(context);
-  patterns.add<internal::ReplaceMarkParameterWithCall>(context);
+  patterns.add<internal::PopulateArgumentAttrsFromTTMark>(context);
 
   if (failed(mlir::applyPatternsGreedily(mlir_module.get(),
                                          std::move(patterns)))) {
-    LOG_F(ERROR, "Failed to uplift mark parameters custom call");
+    DLOG_F(ERROR, "Failed to uplift mark parameters custom call");
+    return tt_pjrt_status::kInternal;
   }
 
-  // In the event that somne of the arguments have not been annotated, IF at
+  // In the event that some of the arguments have not been annotated, IF at
   // least one argument has been annotated as a user input, we can annotate the
   // rest of the arguments as constants
   mlir_module->walk([&](mlir::func::FuncOp funcOp) {
@@ -270,7 +288,8 @@ void annotateArgumentAttributesFromCustomCall(
     for (int64_t i = 0; i < funcOp.getNumArguments(); i++) {
       if (mlir::tt::ttcore::ArgumentTypeAttr argumentTypeAttr =
               mlir::dyn_cast_or_null<mlir::tt::ttcore::ArgumentTypeAttr>(
-                  funcOp.getArgAttr(i, "ttcore.argument_type"));
+                  funcOp.getArgAttr(i,
+                                    mlir::tt::ttcore::ArgumentTypeAttr::name));
           argumentTypeAttr) {
         hasUserInputAnnotation = true;
         break;
@@ -280,40 +299,30 @@ void annotateArgumentAttributesFromCustomCall(
     // If the function has a user input argument annotation, then for every
     // argument, if the argument has an argument type attribute, do nothing, and
     // if it does not have an argument type attribute, set it to constant
+    if (!hasUserInputAnnotation)
+      return;
+
     int64_t annotatedConstCount = 0;
-    if (hasUserInputAnnotation) {
-      for (int64_t i = 0; i < funcOp.getNumArguments(); i++) {
-        if (!funcOp.getArgAttr(i, "ttcore.argument_type")) {
-          funcOp.setArgAttr(i, "ttcore.argument_type",
-                            mlir::tt::ttcore::ArgumentTypeAttr::get(
-                                funcOp.getContext(),
-                                mlir::tt::ttcore::ArgumentType::Constant));
-          funcOp.setArgAttr(
-              i, "ttir.name",
-              mlir::StringAttr::get(funcOp.getContext(),
-                                    "auto_annotated_const_" +
-                                        std::to_string(annotatedConstCount)));
-          annotatedConstCount++;
-        }
-      }
+    for (int64_t i = 0; i < funcOp.getNumArguments(); i++) {
+      if (funcOp.getArgAttr(i, mlir::tt::ttcore::ArgumentTypeAttr::name))
+        continue;
+
+      funcOp.setArgAttr(
+          i, mlir::tt::ttcore::ArgumentTypeAttr::name,
+          mlir::tt::ttcore::ArgumentTypeAttr::get(
+              funcOp.getContext(), mlir::tt::ttcore::ArgumentType::Constant));
+      funcOp.setArgAttr(
+          i, c_name_attr_name,
+          mlir::StringAttr::get(funcOp.getContext(),
+                                "auto_annotated_const_" +
+                                    std::to_string(annotatedConstCount)));
+      annotatedConstCount++;
     }
   });
+
+  return tt_pjrt_status::kSuccess;
 }
 
 } // namespace internal
-
-void annotateArgumentAttributes(
-    mlir::OwningOpRef<mlir::ModuleOp> &mlir_module) {
-
-  // Register the ttcore dialect so that ArgumentTypeAttr objects can be
-  // created.
-  mlir::MLIRContext *context = mlir_module->getContext();
-  context->loadDialect<mlir::tt::ttcore::TTCoreDialect>();
-  // If the model being compiled originates from JAX then the argument types
-  // will be annotated using function calls to empty functions, who's attributes
-  // contain the argument type information. This function will handle that case.
-  internal::propagateInputRoleAttributes(mlir_module);
-  internal::annotateArgumentAttributesFromCustomCall(mlir_module);
-}
 
 } // namespace tt::pjrt::module_builder::frontend_passes

--- a/src/common/pjrt_implementation/module_builder/frontend_passes/shlo_input_role_propagation.cc
+++ b/src/common/pjrt_implementation/module_builder/frontend_passes/shlo_input_role_propagation.cc
@@ -299,13 +299,15 @@ tt_pjrt_status annotateArgumentAttributesFromCustomCall(
     // If the function has a user input argument annotation, then for every
     // argument, if the argument has an argument type attribute, do nothing, and
     // if it does not have an argument type attribute, set it to constant
-    if (!hasUserInputAnnotation)
+    if (!hasUserInputAnnotation) {
       return;
+    }
 
     int64_t annotatedConstCount = 0;
     for (int64_t i = 0; i < funcOp.getNumArguments(); i++) {
-      if (funcOp.getArgAttr(i, mlir::tt::ttcore::ArgumentTypeAttr::name))
+      if (funcOp.getArgAttr(i, mlir::tt::ttcore::ArgumentTypeAttr::name)) {
         continue;
+      }
 
       funcOp.setArgAttr(
           i, mlir::tt::ttcore::ArgumentTypeAttr::name,

--- a/src/common/pjrt_implementation/module_builder/module_builder.cc
+++ b/src/common/pjrt_implementation/module_builder/module_builder.cc
@@ -201,7 +201,8 @@ void ModuleBuilder::convertFromVHLOToSHLO(
 
 void ModuleBuilder::runFrontendSHLOPipeline(
     mlir::OwningOpRef<mlir::ModuleOp> &mlir_module) {
-  frontend_passes::annotateArgumentAttributes(mlir_module);
+
+  m_status = frontend_passes::annotateArgumentAttributes(mlir_module);
 
   DLOG_F(LOG_DEBUG, "SHLO Module after frontend StableHLO pipeline:");
   printModule(mlir_module);
@@ -327,9 +328,9 @@ void ModuleBuilder::collectInputArgumentRoles(
   for (mlir::func::FuncOp &func_op : publicFuncOps) {
     for (unsigned int arg_index = 0; arg_index < func_op.getNumArguments();
          ++arg_index) {
-      // Check for tt.input_role attribute
+      // Check for ttcore.argument_type attribute
       mlir::StringAttr role_attr = func_op.getArgAttrOfType<mlir::StringAttr>(
-          arg_index, frontend_passes::c_input_role_attr_name);
+          arg_index, mlir::tt::ttcore::ArgumentTypeAttr::name);
 
       if (role_attr && role_attr.getValue() == "weight") {
         m_input_argument_roles.push_back(InputArgumentRole::kWeight);
@@ -338,10 +339,10 @@ void ModuleBuilder::collectInputArgumentRoles(
         m_input_argument_roles.push_back(InputArgumentRole::kInput);
       }
 
-      // Remove the tt.input_role attribute after collecting it
+      // Remove the ttcore.argument_type attribute after collecting it
       if (role_attr) {
         func_op.removeArgAttr(arg_index,
-                              frontend_passes::c_input_role_attr_name);
+                              mlir::tt::ttcore::ArgumentTypeAttr::name);
       }
     }
   }

--- a/ttxla_tools/ttxla_tools.py
+++ b/ttxla_tools/ttxla_tools.py
@@ -80,7 +80,7 @@ def mark_argument_attributes(
 ) -> torch.Tensor:
     """
     This function is a custom registered operator accessible as torch.ops.tt.mark_argument_attributes.
-    You may onlyapply this function to a tensor which is on an XLA device.
+    You may only apply this function to a tensor which is on an XLA device.
     This function will annotate the tensor in a compiled program with a "name" and "argument_type" attribute.
     """
     assert isinstance(

--- a/ttxla_tools/ttxla_tools.py
+++ b/ttxla_tools/ttxla_tools.py
@@ -10,6 +10,7 @@ from torch.utils._pytree import tree_map, PyTree
 from jax.experimental import serialize_executable
 import os
 import pickle
+import functools
 
 
 def serialize_function_to_binary(func, binary_file_path, *args, **kwargs):
@@ -79,7 +80,7 @@ def mark_argument_attributes(
 ) -> torch.Tensor:
     """
     This function is a custom registered operator accessible as torch.ops.tt.mark_argument_attributes.
-    You may apply this function to a tensor which is on an XLA device.
+    You may onlyapply this function to a tensor which is on an XLA device.
     This function will annotate the tensor in a compiled program with a "name" and "argument_type" attribute.
     """
     assert isinstance(
@@ -128,14 +129,11 @@ def apply_user_input_markers(tensors: PyTree):
 
     def mark_arg(x):
         global arg_num
-        torch.ops.tt.mark_argument_attributes(x, "input", f"user_input_{arg_num}")
+        x = torch.ops.tt.mark_argument_attributes(x, "input", f"user_input_{arg_num}")
         arg_num += 1
         return x
 
     return tree_map(mark_arg, tensors)
-
-
-import functools
 
 
 def mark_module_user_inputs(module: torch.nn.Module):

--- a/ttxla_tools/ttxla_tools.py
+++ b/ttxla_tools/ttxla_tools.py
@@ -91,16 +91,17 @@ def mark_argument_attributes(
         "parameter",
         "constant",
     ], f"argument_type must be one of 'input', 'parameter', or 'constant', received {argument_type}"
-    frontend_attributes = {"argument_type": argument_type}
+
+    frontend_attributes = {"ttcore.argument_type": argument_type}
     if name is not None:
-        frontend_attributes["name"] = name
+        frontend_attributes["ttir.name"] = name
 
     return stablehlo_custom_call.stablehlo_custom_call(
         [tensor],
         "tt.mark_argument",
         [tensor.shape],
         [tensor.dtype],
-        frontend_attributes={"name": name, "argument_type": argument_type},
+        frontend_attributes=frontend_attributes,
     )
 
 
@@ -122,7 +123,7 @@ torch._dynamo.allow_in_graph(torch.ops.tt.mark_argument_attributes)
 
 def apply_user_input_markers(tensors: PyTree):
     """
-    Marks a PyTree of tesnors as a user input.
+    Marks a PyTree of tensors as a user input.
     """
     arg_num = 0
 

--- a/ttxla_tools/ttxla_tools.py
+++ b/ttxla_tools/ttxla_tools.py
@@ -106,7 +106,7 @@ def mark_argument_attributes(
 
 
 @mark_argument_attributes.register_fake
-def _(tensor: torch.Tensor, name: str, argument_type: str) -> torch.Tensor:
+def _(tensor: torch.Tensor, argument_type: str, name: str = None) -> torch.Tensor:
     """
     FakeTensor implementation of torch.ops.tt.mark_argument_attributes.
     This must be implemented in order for dynamo to trace the function.

--- a/ttxla_tools/ttxla_tools.py
+++ b/ttxla_tools/ttxla_tools.py
@@ -119,16 +119,15 @@ def _(tensor: torch.Tensor, name: str, argument_type: str) -> torch.Tensor:
 # tt.mark_argument_attributes to be represented in a GraphModule.
 torch._dynamo.allow_in_graph(torch.ops.tt.mark_argument_attributes)
 
-arg_num = 0
-
 
 def apply_user_input_markers(tensors: PyTree):
     """
     Marks a PyTree of tesnors as a user input.
     """
+    arg_num = 0
 
     def mark_arg(x):
-        global arg_num
+        nonlocal arg_num
         x = torch.ops.tt.mark_argument_attributes(x, "input", f"user_input_{arg_num}")
         arg_num += 1
         return x

--- a/ttxla_tools/ttxla_tools.py
+++ b/ttxla_tools/ttxla_tools.py
@@ -4,6 +4,9 @@
 
 import io
 import jax
+import torch
+from torch_xla.experimental import stablehlo_custom_call
+from torch.utils._pytree import tree_map, PyTree
 from jax.experimental import serialize_executable
 import os
 import pickle
@@ -66,3 +69,86 @@ def serialize_function_to_binary(func, binary_file_path, *args, **kwargs):
         os.makedirs(dirname, exist_ok=True)
     with open(binary_file_path, "wb") as f:
         f.write(flatbuffer_binary)
+
+
+@torch.library.custom_op(
+    "tt::mark_argument_attributes", mutates_args=[], device_types=["xla"]
+)
+def mark_argument_attributes(
+    tensor: torch.Tensor, argument_type: str, name: str = None
+) -> torch.Tensor:
+    """
+    This function is a custom registered operator accessible as torch.ops.tt.mark_argument_attributes.
+    You may apply this function to a tensor which is on an XLA device.
+    This function will annotate the tensor in a compiled program with a "name" and "argument_type" attribute.
+    """
+    assert isinstance(
+        argument_type, str
+    ), f"argument_type must be a string, received {type(argument_type)}"
+    assert argument_type in [
+        "input",
+        "parameter",
+        "constant",
+    ], f"argument_type must be one of 'input', 'parameter', or 'constant', received {argument_type}"
+    frontend_attributes = {"argument_type": argument_type}
+    if name is not None:
+        frontend_attributes["name"] = name
+
+    return stablehlo_custom_call.stablehlo_custom_call(
+        [tensor],
+        "tt.mark_argument",
+        [tensor.shape],
+        [tensor.dtype],
+        frontend_attributes={"name": name, "argument_type": argument_type},
+    )
+
+
+@mark_argument_attributes.register_fake
+def _(tensor: torch.Tensor, name: str, argument_type: str) -> torch.Tensor:
+    """
+    FakeTensor implementation of torch.ops.tt.mark_argument_attributes.
+    This must be implemented in order for dynamo to trace the function.
+    returns:
+        - tensor: the same tensor that was passed in
+    """
+    return tensor
+
+
+# Allow the torch dynamo to trace our custom operation. This will allow
+# tt.mark_argument_attributes to be represented in a GraphModule.
+torch._dynamo.allow_in_graph(torch.ops.tt.mark_argument_attributes)
+
+arg_num = 0
+
+
+def apply_user_input_markers(tensors: PyTree):
+    """
+    Marks a PyTree of tesnors as a user input.
+    """
+
+    def mark_arg(x):
+        global arg_num
+        torch.ops.tt.mark_argument_attributes(x, "input", f"user_input_{arg_num}")
+        arg_num += 1
+        return x
+
+    return tree_map(mark_arg, tensors)
+
+
+import functools
+
+
+def mark_module_user_inputs(module: torch.nn.Module):
+    """
+    This will override the forward method of a torch.nn.Module by first applying
+    torch.ops.tt.mark_argument_attributes to all of the arguments of the forward method, then calling the original forward method.
+    """
+    orig_forward = module.forward
+
+    @functools.wraps(orig_forward)
+    def wrapped_forward(*args, **kwargs):
+        args = apply_user_input_markers(args)
+        kwargs = apply_user_input_markers(kwargs)
+        return orig_forward(*args, **kwargs)
+
+    module.forward = wrapped_forward


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-xla/issues/1041, closes https://github.com/tenstorrent/tt-xla/issues/856

### Problem description
- We cannot populate the argument types for torch models.

### What's changed
- Added custom torch operator `torch.ops.tt.mark_argument_attributes` which applies a `stablehlo.custom_call` to a tensor : 
    - This operator returns the input tensor.
    - This operator has attributes "argument_type" and "name". (Name is optional)
    - This operation can ONLY be run on an xla device, PyTorch will raise an error if the user attempts to execute this operation on a non-xla device.
    - This op can be captured by the dynamo and is a valid inside a `GraphModule`
- Added a pass to populate the argument types of the SHLO module using this custom call
    - This pass does something special, If at least one argument is populated as an "input", then all un-populated arguments will be automatically defined as "constant".
        - This works under the assumption that every user input is annotated. Users will not be expected to populate the argument types themselves. It will either be done by our `torch.compile` backend or by the utility function we provide: `mark_model_user_inputs`.
- Edited `propagateRoleAttribute` to simply populate the `ttcore.argument_type` arg attribute in the function rather than `tt.input_role`. This way we can bypass PopulateArgumentTypes in tt-mlir entirely as the graph is already populated.
- Deleted the environment variable override for populating argument types as it should no longer be needed.

### Checklist
- [ ] New/Existing tests provide coverage for changes

I didn't add a test because we will not really be able to take advantage of this until the tt_torch backend is merged: https://github.com/tenstorrent/tt-xla/pull/954, I will add a test after both of these are merged.

I did add an example though, using the "openxla" backend.
