### PR TITLE
Upgrade python to 3.11

### DIFF
--- a/python_package/setup.py
+++ b/python_package/setup.py
@@ -358,7 +358,7 @@ setup(
         f"jax_plugins.pjrt_plugin_tt": "jax_plugins/pjrt_plugin_tt",
         "ttxla_tools": os.path.join("..", "ttxla_tools"),
     },
-    python_requires=">=3.10, <3.11",
+    python_requires=">=3.11, <3.12",
     url="https://github.com/tenstorrent/tt-xla",
     version=config.version,
     # Needs to reference embedded shared libraries (i.e. .so file), so not zip safe.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,8 @@ datasets
 einops
 flax==0.10.4
 fsspec
-jax==0.6.0
-jaxlib==0.6.0
+jax==0.7.0
+jaxlib==0.7.0
 jaxtyping
 librosa
 lit

--- a/venv/activate
+++ b/venv/activate
@@ -13,7 +13,7 @@ else
     [ -f $TTMLIR_VENV_DIR/bin/activate ] && source $TTMLIR_VENV_DIR/bin/activate
   else
     echo "Creating virtual environment in $TTMLIR_VENV_DIR"
-    python3.10 -m venv $TTMLIR_VENV_DIR
+    python3.11 -m venv $TTMLIR_VENV_DIR
     source $TTMLIR_VENV_DIR/bin/activate
     pip install --upgrade pip
     # Requirements for third party projects are installed during their build in `CMakeLists.txt`


### PR DESCRIPTION
We are upgrading the tt-xla stack to Python 3.11, while keeping tt-mlir on Python 3.10 for now.
**Motivation**
Multi-chip support
`torch-xla` compatibility
`EasyDel` library