### PR TITLE
Dgolubovic/enable lower df

### DIFF
--- a/inc/common/pjrt_implementation/module_builder/compile_options.h
+++ b/inc/common/pjrt_implementation/module_builder/compile_options.h
@@ -13,6 +13,7 @@ struct CompileOptions {
   // Enables the ttmlir optimizer, i.e. the optimization passes and memory
   // layout analysis.
   bool enable_optimizer = false;
+  bool enable_bfp8_conversion = false;
 
   static CompileOptions
   parse(const std::unordered_map<std::string, std::string> &compile_options);

--- a/src/common/pjrt_implementation/module_builder/compile_options.cc
+++ b/src/common/pjrt_implementation/module_builder/compile_options.cc
@@ -15,6 +15,8 @@ CompileOptions CompileOptions::parse(
 
   options.enable_optimizer =
       internal::parseBoolOption(compile_options, "optimize");
+  options.enable_bfp8_conversion =
+      internal::parseBoolOption(compile_options, "bfp8");
 
   return options;
 }

--- a/src/common/pjrt_implementation/module_builder/module_builder.cc
+++ b/src/common/pjrt_implementation/module_builder/module_builder.cc
@@ -593,7 +593,7 @@ void ModuleBuilder::convertFromTTIRToTTNN(
 
   options.optimizerPassEnabled = compile_options.enable_optimizer;
   options.memoryLayoutAnalysisEnabled = compile_options.enable_optimizer;
-
+  options.enableBfp8Conversion = compile_options.enable_bfp8_conversion;
   options.systemDescPath = system_descriptor_path.data();
 
   // TODO(@LPanosTT): https://github.com/tenstorrent/tt-xla/issues/856

--- a/tests/infra/compiler_config.py
+++ b/tests/infra/compiler_config.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass
+class CompilerConfig:
+    """
+    Configuration for compiler options passed to the TT device compilation.
+    
+    This class encapsulates various compiler knobs and optimizations that can be
+    applied during model compilation for TT device.
+    """
+    
+    # Enable BFP8 conversion in MLIR
+    enable_bfp8_conversion: bool = False
+    
+    # Enable optimizer passes
+    enable_optimizer: bool = False
+    
+    def to_jax_compiler_options(self) -> Dict[str, str]:
+        """
+        Convert CompilerConfig to JAX compiler_options dictionary format.
+        
+        Returns:
+            Dictionary of compiler options in the format expected by jax.jit()
+        """
+        options = {}
+        
+        if self.enable_bfp8_conversion:
+            options["bfp8"] = "true"
+        
+        if self.enable_optimizer:
+            options["optimize"] = "true"
+        
+        return options

--- a/tests/infra/testers/multichip/model/jax_multichip_model_tester.py
+++ b/tests/infra/testers/multichip/model/jax_multichip_model_tester.py
@@ -90,17 +90,17 @@ class JaxMultichipModelTester(JaxModelTester, ABC):
         )
 
     # @override
-    def _compile_for_cpu(self, workload: Workload) -> Workload:
+    def _compile_for_cpu(self, workload: Workload) -> None:
         """Compiles `workload` for CPU."""
-        return self._compile(self._create_multichip_workload(self._cpu_mesh))
+        self._compile(self._create_multichip_workload(self._cpu_mesh))
 
     # @override
-    def _compile_for_tt_device(self, workload: Workload) -> Workload:
+    def _compile_for_tt_device(self, workload: Workload) -> None:
         """Compiles `workload` for TT device."""
-        return self._compile(self._create_multichip_workload(self._device_mesh))
+        self._compile(self._create_multichip_workload(self._device_mesh))
 
     # @override
-    def _compile(self, workload: Workload) -> Workload:
+    def _compile(self, workload: Workload) -> None:
         """
         Sets up `workload.executable` for just-in-time compile and execution.
 
@@ -123,7 +123,6 @@ class JaxMultichipModelTester(JaxModelTester, ABC):
             out_shardings=output_sharding,
             static_argnames=workload.static_argnames,
         )
-        return workload
 
     def _create_multichip_workload(
         self, mesh: jax.sharding.Mesh

--- a/tests/infra/testers/multichip/op/jax_multichip_op_tester.py
+++ b/tests/infra/testers/multichip/op/jax_multichip_op_tester.py
@@ -112,17 +112,17 @@ class JaxMultichipOpTester(BaseTester):
         comparing the results.
         """
         with self._device_mesh:
-            compiled_device_workload = self._compile(device_workload)
-            device_res = self._run_on_multichip_device(compiled_device_workload)
+            self._compile(device_workload)
+            device_res = self._run_on_multichip_device(device_workload)
 
         with self._cpu_mesh:
-            compiled_cpu_workload = self._compile(cpu_workload)
-            cpu_res = self._run_on_multichip_device(compiled_cpu_workload)
+            self._compile(cpu_workload)
+            cpu_res = self._run_on_multichip_device(cpu_workload)
 
         self._comparator.compare(device_res, cpu_res)
 
     # @override
-    def _compile(self, workload: Workload) -> Workload:
+    def _compile(self, workload: Workload) -> None:
         """
         Sets up `workload.executable` for just-in-time compile and execution.
 
@@ -147,7 +147,6 @@ class JaxMultichipOpTester(BaseTester):
             out_shardings=output_sharding,
             static_argnames=workload.static_argnames,
         )
-        return workload
 
     # --- Convenience wrappers ---
 

--- a/tests/infra/testers/single_chip/model/jax_model_tester.py
+++ b/tests/infra/testers/single_chip/model/jax_model_tester.py
@@ -171,22 +171,20 @@ class JaxModelTester(ModelTester):
                 logger.warning(f"Error during cache cleanup in __del__: {e}")
 
     # @override
-    def _compile_for_tt_device(self, workload: Workload) -> Workload:
+    def _compile_for_tt_device(self, workload: Workload) -> None:
         """JIT-compiles model's forward pass into optimized kernels."""
         assert isinstance(workload, JaxWorkload)
         workload.executable = jax.jit(
             workload.executable,
             static_argnames=workload.static_argnames,
-            compiler_options={"optimize": str(self._use_optimizer)},
+            compiler_options={"optimize": str(self._use_optimizer)}
         )
-        return workload
 
     # @override
-    def _compile_for_cpu(self, workload: Workload) -> Workload:
+    def _compile_for_cpu(self, workload: Workload) -> None:
         """JIT-compiles model's forward pass into optimized kernels."""
         assert isinstance(workload, JaxWorkload)
         workload.executable = jax.jit(
             workload.executable,
             static_argnames=workload.static_argnames,
         )
-        return workload

--- a/tests/infra/testers/single_chip/model/model_tester.py
+++ b/tests/infra/testers/single_chip/model/model_tester.py
@@ -9,6 +9,7 @@ from enum import Enum
 from typing import Any, Dict, Mapping, Sequence
 
 from infra.comparators import ComparisonConfig
+from infra.compiler_config import CompilerConfig
 from infra.utilities import Framework, Model, Tensor
 from infra.workloads import Workload
 
@@ -31,8 +32,12 @@ class ModelTester(BaseTester, ABC):
         comparison_config: ComparisonConfig,
         run_mode: RunMode,
         framework: Framework,
+        compiler_config: CompilerConfig = None,
     ) -> None:
         """Protected constructor for subclasses to use."""
+        if compiler_config is None:
+            compiler_config = CompilerConfig()
+        self._compiler_config = compiler_config
         self._run_mode = run_mode
 
         self._model: Model = None

--- a/tests/infra/testers/single_chip/model/model_tester.py
+++ b/tests/infra/testers/single_chip/model/model_tester.py
@@ -116,16 +116,16 @@ class ModelTester(BaseTester, ABC):
         Tests the model by running inference on TT device and on CPU and comparing the
         results.
         """
-        compiled_cpu_workload = self._compile_for_cpu(self._workload)
-        cpu_res = self._run_on_cpu(compiled_cpu_workload)
+        self._compile_for_cpu(self._workload)
+        cpu_res = self._run_on_cpu(self._workload)
 
-        compiled_device_workload = self._compile_for_tt_device(self._workload)
-        tt_res = self._run_on_tt_device(compiled_device_workload)
+        self.do(self._workload)
+        tt_res = self._run_on_tt_device(self._workload)
 
         self._compare(tt_res, cpu_res)
 
     @abstractmethod
-    def _compile_for_cpu(self, workload: Workload) -> Workload:
+    def _compile_for_cpu(self, workload: Workload) -> None:
         """Compiles `workload` for CPU."""
         raise NotImplementedError("Subclasses must implement this method.")
 
@@ -134,7 +134,7 @@ class ModelTester(BaseTester, ABC):
         return self._device_runner.run_on_cpu(compiled_workload)
 
     @abstractmethod
-    def _compile_for_tt_device(self, workload: Workload) -> Workload:
+    def _compile_for_tt_device(self, workload: Workload) -> None:
         """Compiles `workload` for TT device."""
         raise NotImplementedError("Subclasses must implement this method.")
 

--- a/tests/infra/testers/single_chip/model/torch_model_tester.py
+++ b/tests/infra/testers/single_chip/model/torch_model_tester.py
@@ -7,7 +7,8 @@ from typing import Any, Dict, Mapping, Sequence
 
 import torch
 from infra.comparators import ComparisonConfig
-from infra.utilities import Framework, Model
+from infra.compiler_config import CompilerConfig
+from infra.utilities import Framework
 from infra.workloads import TorchWorkload, Workload, WorkloadFactory
 
 from .model_tester import ModelTester, RunMode
@@ -30,11 +31,12 @@ class TorchModelTester(ModelTester):
         self,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
+        compiler_config: CompilerConfig = None,
     ) -> None:
 
         self._input_activations: Dict | Sequence[Any] = None
 
-        super().__init__(comparison_config, run_mode, Framework.TORCH)
+        super().__init__(comparison_config, run_mode, Framework.TORCH, compiler_config)
 
     # @override
     def _configure_model_for_inference(self) -> None:

--- a/tests/infra/testers/single_chip/model/torch_model_tester.py
+++ b/tests/infra/testers/single_chip/model/torch_model_tester.py
@@ -79,25 +79,24 @@ class TorchModelTester(ModelTester):
         return {}
 
     # @override
-    def _compile_for_cpu(self, workload: Workload) -> Workload:
+    def _compile_for_cpu(self, workload: Workload) -> None:
         """Compiles `workload` for CPU."""
-        return self._compile(workload)
+        self._compile(workload)
 
-    def _compile(self, workload: Workload) -> Workload:
+    def _compile(self, workload: Workload) -> None:
         """JIT-compiles model's forward pass into optimized kernels.
 
         Compiles for inductor backend by default.
         """
-        return self._compile_for_backend(workload, backend="inductor")
+        self._compile_for_backend(workload, backend="inductor")
 
     # @override
-    def _compile_for_tt_device(self, workload: Workload) -> Workload:
+    def _compile_for_tt_device(self, workload: Workload) -> None:
         """Compiles `workload` for TT device."""
-        return self._compile_for_backend(workload, backend="openxla")
+        self._compile_for_backend(workload, backend="openxla")
 
-    def _compile_for_backend(self, workload: Workload, backend: str) -> Workload:
+    def _compile_for_backend(self, workload: Workload, backend: str) -> None:
         """JIT-compiles model into optimized kernels."""
         assert isinstance(workload, TorchWorkload) and workload.model is not None
 
         workload.model.compile(backend=backend)
-        return workload

--- a/tests/infra/testers/single_chip/op/op_tester.py
+++ b/tests/infra/testers/single_chip/op/op_tester.py
@@ -9,50 +9,87 @@ from typing import Callable, Sequence
 import jax
 import torch
 from infra.comparators import ComparisonConfig
+from infra.compiler_config import CompilerConfig
 from infra.utilities import Framework, Tensor, random_tensor
 from infra.workloads import JaxWorkload, TorchWorkload, Workload, WorkloadFactory
+from jax._src.typing import DTypeLike
 
 from ...base_tester import BaseTester
+from copy import deepcopy
+
 
 
 class OpTester(BaseTester):
     """Specific single chip tester for ops."""
 
+    def __init__(
+        self,
+        comparison_config: ComparisonConfig = ComparisonConfig(),
+        framework: Framework = Framework.JAX,
+        compiler_config: CompilerConfig = None,
+    ) -> None:
+        """Protected constructor for subclasses to use."""
+        if compiler_config is None:
+            compiler_config = CompilerConfig()
+        self._compiler_config = compiler_config
+        super().__init__(comparison_config, framework)
+
     def test(self, workload: Workload) -> None:
         """
         Runs test by running `workload` on TT device and CPU and comparing the results.
         """
-        compiled_workload = self._compile(workload)
-
-        tt_res = self._device_runner.run_on_tt_device(compiled_workload)
-        cpu_res = self._device_runner.run_on_cpu(compiled_workload)
+        self._compile_for_tt_device(workload)
+        tt_res = self._device_runner.run_on_tt_device(workload)
+        self._compile_for_cpu(workload)
+        cpu_res = self._device_runner.run_on_cpu(workload)
 
         self._comparator.compare(tt_res, cpu_res)
 
-    def _compile(self, workload: Workload) -> Workload:
+    def _compile_for_tt_device(self, workload: Workload) -> None:
         """
         Compiles executable carried in `workload` based on framework.
-
-        Returns compiled workload.
         """
 
-        def compile_jax_workload(workload: JaxWorkload) -> Workload:
+        def compile_jax_workload(workload: JaxWorkload) -> None:
+            compile_options = self._compiler_config.to_jax_compiler_options()
             workload.executable = jax.jit(
-                workload.executable, static_argnames=workload.static_argnames
+                workload.executable,
+                static_argnames=workload.static_argnames,
+                compiler_options=compile_options,
             )
-            return workload
 
-        def compile_torch_workload(workload: TorchWorkload) -> Workload:
+        def compile_torch_workload(workload: TorchWorkload) -> None:
             assert workload.executable is not None
             workload.executable = torch.compile(workload.executable, backend="openxla")
-            return workload
 
         if self._framework == Framework.JAX:
             assert isinstance(workload, JaxWorkload)
-            return compile_jax_workload(workload)
+            compile_jax_workload(workload)
         else:
             assert isinstance(workload, TorchWorkload)
-            return compile_torch_workload(workload)
+            compile_torch_workload(workload)
+
+    def _compile_for_cpu(self, workload: Workload) -> None:
+        """
+        Compiles executable carried in `workload` for CPU based on framework.
+        """
+
+        def compile_jax_workload(workload: JaxWorkload) -> None:
+            workload.executable = jax.jit(
+                workload.executable,
+                static_argnames=workload.static_argnames,
+            )
+
+        def compile_torch_workload(workload: TorchWorkload) -> None:
+            assert workload.executable is not None
+            workload.executable = torch.compile(workload.executable, backend="openxla")
+
+        if self._framework == Framework.JAX:
+            assert isinstance(workload, JaxWorkload)
+            compile_jax_workload(workload)
+        else:
+            assert isinstance(workload, TorchWorkload)
+            compile_torch_workload(workload)
 
     def test_with_random_inputs(
         self,
@@ -60,6 +97,7 @@ class OpTester(BaseTester):
         input_shapes: Sequence[tuple],
         minval: float = 0.0,
         maxval: float = 1.0,
+        dtype: str | DTypeLike | torch.dtype = "float32",
     ) -> None:
         """
         Tests `f` by running it with random inputs in range [`minval`, `maxval`) on
@@ -70,6 +108,7 @@ class OpTester(BaseTester):
                 shape,
                 minval=minval,
                 maxval=maxval,
+                dtype=dtype,
                 framework=self._framework,
             )
             for shape in input_shapes
@@ -85,12 +124,15 @@ def run_op_test(
     inputs: Sequence[Tensor],
     comparison_config: ComparisonConfig = ComparisonConfig(),
     framework: Framework = Framework.JAX,
+    compiler_config: CompilerConfig = None,
 ) -> None:
     """
     Tests `op` with `inputs` by running it on TT device and CPU and comparing the
     results based on `comparison_config`.
     """
-    tester = OpTester(comparison_config, framework)
+    if compiler_config is None:
+        compiler_config = CompilerConfig()
+    tester = OpTester(comparison_config, framework, compiler_config=compiler_config)
     workload = WorkloadFactory.create_workload(framework, executable=op, args=inputs)
     tester.test(workload)
 
@@ -100,12 +142,16 @@ def run_op_test_with_random_inputs(
     input_shapes: Sequence[tuple],
     minval: float = 0.0,
     maxval: float = 1.0,
+    dtype: str | DTypeLike | torch.dtype = "float32",
     comparison_config: ComparisonConfig = ComparisonConfig(),
     framework: Framework = Framework.JAX,
+    compiler_config: CompilerConfig = None,
 ) -> None:
     """
     Tests `op` with random inputs in range [`minval`, `maxval`) by running it on
     TT device and CPU and comparing the results based on `comparison_config`.
     """
-    tester = OpTester(comparison_config, framework)
-    tester.test_with_random_inputs(op, input_shapes, minval, maxval)
+    if compiler_config is None:
+        compiler_config = CompilerConfig()
+    tester = OpTester(comparison_config, framework, compiler_config=compiler_config)
+    tester.test_with_random_inputs(op, input_shapes, minval, maxval, dtype)

--- a/tests/jax/single_chip/ops/test_abs.py
+++ b/tests/jax/single_chip/ops/test_abs.py
@@ -6,6 +6,7 @@ import jax
 import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
+from infra.compiler_config import CompilerConfig
 from utils import Category
 
 
@@ -23,3 +24,24 @@ def test_abs(x_shape: tuple):
 
     # Test both negative and positive values.
     run_op_test_with_random_inputs(abs, [x_shape], minval=-5.0, maxval=5.0)
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    jax_op_name="jax.numpy.abs",
+    shlo_op_name="stablehlo.abs",
+)
+@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)], ids=lambda val: f"{val}")
+@pytest.mark.parametrize("format", ["bfloat16", "bfp8"])
+def test_abs_lower_df(x_shape: tuple, format: str):
+    def abs(x: jax.Array) -> jax.Array:
+        return jnp.abs(x)
+
+    if format == "bfloat16":
+        compiler_config = CompilerConfig()
+    else:  # bfp8
+        compiler_config = CompilerConfig(enable_bfp8_conversion=True)
+    
+    run_op_test_with_random_inputs(abs, [x_shape], minval=-5.0, maxval=5.0, dtype=jnp.bfloat16, compiler_config=compiler_config)

--- a/tests/jax/single_chip/ops/test_add.py
+++ b/tests/jax/single_chip/ops/test_add.py
@@ -6,6 +6,7 @@ import jax
 import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
+from infra.compiler_config import CompilerConfig
 from utils import Category
 
 
@@ -29,3 +30,31 @@ def test_add(x_shape: tuple, y_shape: tuple):
         return jnp.add(x, y)
 
     run_op_test_with_random_inputs(add, [x_shape, y_shape])
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    jax_op_name="jax.numpy.add",
+    shlo_op_name="stablehlo.add",
+)
+@pytest.mark.parametrize(
+    ["x_shape", "y_shape"],
+    [
+        [(32, 32), (32, 32)],
+        [(64, 64), (64, 64)],
+    ],
+    ids=lambda val: f"{val}",
+)
+@pytest.mark.parametrize("format", ["bfloat16", "bfp8"])
+def test_add_lower_df(x_shape: tuple, y_shape: tuple, format: str):
+    def add(x: jax.Array, y: jax.Array) -> jax.Array:
+        return jnp.add(x, y)
+
+    if format == "bfloat16":
+        compiler_config = CompilerConfig()
+    else:  # bfp8
+        compiler_config = CompilerConfig(enable_bfp8_conversion=True)
+    
+    run_op_test_with_random_inputs(add, [x_shape, y_shape], dtype=jnp.bfloat16, compiler_config=compiler_config)

--- a/tests/jax/single_chip/ops/test_cosine.py
+++ b/tests/jax/single_chip/ops/test_cosine.py
@@ -6,6 +6,7 @@ import jax
 import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
+from infra.compiler_config import CompilerConfig
 from utils import Category
 
 
@@ -22,3 +23,24 @@ def test_cos(x_shape: tuple):
         return jnp.cos(x)
 
     run_op_test_with_random_inputs(cos, [x_shape])
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    jax_op_name="jax.numpy.cos",
+    shlo_op_name="stablehlo.cosine",
+)
+@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)], ids=lambda val: f"{val}")
+@pytest.mark.parametrize("format", ["bfloat16", "bfp8"])
+def test_cos_lower_df(x_shape: tuple, format: str):
+    def cos(x: jax.Array) -> jax.Array:
+        return jnp.cos(x)
+
+    if format == "bfloat16":
+        compiler_config = CompilerConfig()
+    else:  # bfp8
+        compiler_config = CompilerConfig(enable_bfp8_conversion=True)
+    
+    run_op_test_with_random_inputs(cos, [x_shape], dtype=jnp.bfloat16, compiler_config=compiler_config)

--- a/tests/jax/single_chip/ops/test_divide.py
+++ b/tests/jax/single_chip/ops/test_divide.py
@@ -6,6 +6,7 @@ import jax
 import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
+from infra.compiler_config import CompilerConfig
 from utils import Category
 
 
@@ -29,3 +30,31 @@ def test_divide(x_shape: tuple, y_shape: tuple):
         return jnp.divide(x, y)
 
     run_op_test_with_random_inputs(divide, [x_shape, y_shape])
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    jax_op_name="jax.numpy.divide",
+    shlo_op_name="stablehlo.divide",
+)
+@pytest.mark.parametrize(
+    ["x_shape", "y_shape"],
+    [
+        [(32, 32), (32, 32)],
+        [(64, 64), (64, 64)],
+    ],
+    ids=lambda val: f"{val}",
+)
+@pytest.mark.parametrize("format", ["bfloat16", "bfp8"])
+def test_divide_lower_df(x_shape: tuple, y_shape: tuple, format: str):
+    def divide(x: jax.Array, y: jax.Array) -> jax.Array:
+        return jnp.divide(x, y)
+    
+    if format == "bfloat16":
+        compiler_config = CompilerConfig()
+    else:  # bfp8
+        compiler_config = CompilerConfig(enable_bfp8_conversion=True)
+    
+    run_op_test_with_random_inputs(divide, [x_shape, y_shape], minval=1e-2, dtype=jnp.bfloat16, compiler_config=compiler_config)

--- a/tests/jax/single_chip/ops/test_exponential.py
+++ b/tests/jax/single_chip/ops/test_exponential.py
@@ -6,6 +6,7 @@ import jax
 import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
+from infra.compiler_config import CompilerConfig
 from utils import Category
 
 
@@ -22,3 +23,24 @@ def test_exponential(x_shape: tuple):
         return jnp.exp(x)
 
     run_op_test_with_random_inputs(exponential, [x_shape])
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    jax_op_name="jax.numpy.exp",
+    shlo_op_name="stablehlo.exponential",
+)
+@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)], ids=lambda val: f"{val}")
+@pytest.mark.parametrize("format", ["bfloat16", "bfp8"])
+def test_exponential_lower_df(x_shape: tuple, format: str):
+    def exponential(x: jax.Array) -> jax.Array:
+        return jnp.exp(x)
+
+    if format == "bfloat16":
+        compiler_config = CompilerConfig()
+    else:  # bfp8
+        compiler_config = CompilerConfig(enable_bfp8_conversion=True)
+    
+    run_op_test_with_random_inputs(exponential, [x_shape], dtype=jnp.bfloat16, compiler_config=compiler_config)

--- a/tests/jax/single_chip/ops/test_log.py
+++ b/tests/jax/single_chip/ops/test_log.py
@@ -7,7 +7,7 @@ import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
 from infra.compiler_config import CompilerConfig
-from utils import Category, incorrect_result
+from utils import Category
 
 
 @pytest.mark.push

--- a/tests/jax/single_chip/ops/test_log.py
+++ b/tests/jax/single_chip/ops/test_log.py
@@ -6,6 +6,7 @@ import jax
 import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
+from infra.compiler_config import CompilerConfig
 from utils import Category, incorrect_result
 
 
@@ -22,3 +23,24 @@ def test_log(x_shape: tuple):
         return jnp.log(x)
 
     run_op_test_with_random_inputs(log, [x_shape])
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    jax_op_name="jax.numpy.log",
+    shlo_op_name="stablehlo.log",
+)
+@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)], ids=lambda val: f"{val}")
+@pytest.mark.parametrize("format", ["bfloat16", "bfp8"])
+def test_log_lower_df(x_shape: tuple, format: str):
+    def log(x: jax.Array) -> jax.Array:
+        return jnp.log(x)
+
+    if format == "bfloat16":
+        compiler_config = CompilerConfig()
+    else:  # bfp8
+        compiler_config = CompilerConfig(enable_bfp8_conversion=True)
+    
+    run_op_test_with_random_inputs(log, [x_shape], minval=1e-2, dtype=jnp.bfloat16, compiler_config=compiler_config)

--- a/tests/jax/single_chip/ops/test_maximum.py
+++ b/tests/jax/single_chip/ops/test_maximum.py
@@ -6,6 +6,7 @@ import jax
 import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
+from infra.compiler_config import CompilerConfig
 from utils import Category
 
 
@@ -29,3 +30,31 @@ def test_maximum(x_shape: tuple, y_shape: tuple):
         return jnp.maximum(x, y)
 
     run_op_test_with_random_inputs(maximum, [x_shape, y_shape])
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    jax_op_name="jax.numpy.maximum",
+    shlo_op_name="stablehlo.maximum",
+)
+@pytest.mark.parametrize(
+    ["x_shape", "y_shape"],
+    [
+        [(32, 32), (32, 32)],
+        [(64, 64), (64, 64)],
+    ],
+    ids=lambda val: f"{val}",
+)
+@pytest.mark.parametrize("format", ["bfloat16", "bfp8"])
+def test_maximum_lower_df(x_shape: tuple, y_shape: tuple, format: str):
+    def maximum(x: jax.Array, y: jax.Array) -> jax.Array:
+        return jnp.maximum(x, y)
+
+    if format == "bfloat16":
+        compiler_config = CompilerConfig()
+    else:  # bfp8
+        compiler_config = CompilerConfig(enable_bfp8_conversion=True)
+    
+    run_op_test_with_random_inputs(maximum, [x_shape, y_shape], dtype=jnp.bfloat16, compiler_config=compiler_config)

--- a/tests/jax/single_chip/ops/test_minimum.py
+++ b/tests/jax/single_chip/ops/test_minimum.py
@@ -6,6 +6,7 @@ import jax
 import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
+from infra.compiler_config import CompilerConfig
 from utils import Category
 
 
@@ -29,3 +30,31 @@ def test_minimum(x_shape: tuple, y_shape: tuple):
         return jnp.minimum(x, y)
 
     run_op_test_with_random_inputs(minimum, [x_shape, y_shape])
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    jax_op_name="jax.numpy.minimum",
+    shlo_op_name="stablehlo.minimum",
+)
+@pytest.mark.parametrize(
+    ["x_shape", "y_shape"],
+    [
+        [(32, 32), (32, 32)],
+        [(64, 64), (64, 64)],
+    ],
+    ids=lambda val: f"{val}",
+)
+@pytest.mark.parametrize("format", ["bfloat16", "bfp8"])
+def test_minimum_lower_df(x_shape: tuple, y_shape: tuple, format: str):
+    def minimum(x: jax.Array, y: jax.Array) -> jax.Array:
+        return jnp.minimum(x, y)
+
+    if format == "bfloat16":
+        compiler_config = CompilerConfig()
+    else:  # bfp8
+        compiler_config = CompilerConfig(enable_bfp8_conversion=True)
+    
+    run_op_test_with_random_inputs(minimum, [x_shape, y_shape], dtype=jnp.bfloat16, compiler_config=compiler_config)

--- a/tests/jax/single_chip/ops/test_multiply.py
+++ b/tests/jax/single_chip/ops/test_multiply.py
@@ -6,6 +6,7 @@ import jax
 import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
+from infra.compiler_config import CompilerConfig
 from utils import Category
 
 
@@ -29,3 +30,31 @@ def test_multiply(x_shape: tuple, y_shape: tuple):
         return jnp.multiply(x, y)
 
     run_op_test_with_random_inputs(multiply, [x_shape, y_shape])
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    jax_op_name="jax.numpy.multiply",
+    shlo_op_name="stablehlo.multiply",
+)
+@pytest.mark.parametrize(
+    ["x_shape", "y_shape"],
+    [
+        [(32, 32), (32, 32)],
+        [(64, 64), (64, 64)],
+    ],
+    ids=lambda val: f"{val}",
+)
+@pytest.mark.parametrize("format", ["bfloat16", "bfp8"])
+def test_multiply_lower_df(x_shape: tuple, y_shape: tuple, format: str):
+    def multiply(x: jax.Array, y: jax.Array) -> jax.Array:
+        return jnp.multiply(x, y)
+
+    if format == "bfloat16":
+        compiler_config = CompilerConfig()
+    else:  # bfp8
+        compiler_config = CompilerConfig(enable_bfp8_conversion=True)
+    
+    run_op_test_with_random_inputs(multiply, [x_shape, y_shape], dtype=jnp.bfloat16, compiler_config=compiler_config)

--- a/tests/jax/single_chip/ops/test_negate.py
+++ b/tests/jax/single_chip/ops/test_negate.py
@@ -6,6 +6,7 @@ import jax
 import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
+from infra.compiler_config import CompilerConfig
 from utils import Category
 
 
@@ -23,3 +24,24 @@ def test_negate(x_shape: tuple):
 
     # Trying both negative and positive values.
     run_op_test_with_random_inputs(negate, [x_shape], minval=-5.0, maxval=5.0)
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    jax_op_name="jax.numpy.negative",
+    shlo_op_name="stablehlo.negative",
+)
+@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)], ids=lambda val: f"{val}")
+@pytest.mark.parametrize("format", ["bfloat16", "bfp8"])
+def test_negate_lower_df(x_shape: tuple, format: str):
+    def negate(x: jax.Array) -> jax.Array:
+        return jnp.negative(x)
+
+    if format == "bfloat16":
+        compiler_config = CompilerConfig()
+    else:  # bfp8
+        compiler_config = CompilerConfig(enable_bfp8_conversion=True)
+    
+    run_op_test_with_random_inputs(negate, [x_shape], minval=-5.0, maxval=5.0, dtype=jnp.bfloat16, compiler_config=compiler_config)

--- a/tests/jax/single_chip/ops/test_power.py
+++ b/tests/jax/single_chip/ops/test_power.py
@@ -6,6 +6,7 @@ import jax
 import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
+from infra.compiler_config import CompilerConfig
 from utils import Category
 
 
@@ -29,3 +30,31 @@ def test_power(x_shape: tuple, y_shape: tuple):
         return jnp.power(x, y)
 
     run_op_test_with_random_inputs(power, [x_shape, y_shape])
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    jax_op_name="jax.numpy.power",
+    shlo_op_name="stablehlo.power",
+)
+@pytest.mark.parametrize(
+    ["x_shape", "y_shape"],
+    [
+        [(32, 32), (32, 32)],
+        [(64, 64), (64, 64)],
+    ],
+    ids=lambda val: f"{val}",
+)
+@pytest.mark.parametrize("format", ["bfloat16", "bfp8"])
+def test_power_lower_df(x_shape: tuple, y_shape: tuple, format: str):
+    def power(x: jax.Array, y: jax.Array) -> jax.Array:
+        return jnp.power(x, y)
+
+    if format == "bfloat16":
+        compiler_config = CompilerConfig()
+    else:  # bfp8
+        compiler_config = CompilerConfig(enable_bfp8_conversion=True)
+    
+    run_op_test_with_random_inputs(power, [x_shape, y_shape], dtype=jnp.bfloat16, compiler_config=compiler_config)

--- a/tests/jax/single_chip/ops/test_rsqrt.py
+++ b/tests/jax/single_chip/ops/test_rsqrt.py
@@ -4,8 +4,10 @@
 
 import jax
 import jax.lax as jlx
+import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
+from infra.compiler_config import CompilerConfig
 from utils import Category
 
 
@@ -23,3 +25,25 @@ def test_rsqrt(x_shape: tuple):
 
     # Input must be strictly positive because of sqrt(x).
     run_op_test_with_random_inputs(rsqrt, [x_shape], minval=0.1, maxval=10.0)
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    jax_op_name="jax.lax.rsqrt",
+    shlo_op_name="stablehlo.rsqrt",
+)
+@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)], ids=lambda val: f"{val}")
+@pytest.mark.parametrize("format", ["bfloat16", "bfp8"])
+def test_rsqrt_lower_df(x_shape: tuple, format: str):
+    def rsqrt(x: jax.Array) -> jax.Array:
+        return jlx.rsqrt(x)
+
+    if format == "bfloat16":
+        compiler_config = CompilerConfig()
+    else:  # bfp8
+        compiler_config = CompilerConfig(enable_bfp8_conversion=True)
+    
+    # Input must be strictly positive because of sqrt(x).
+    run_op_test_with_random_inputs(rsqrt, [x_shape], minval=0.1, maxval=10.0, dtype=jnp.bfloat16, compiler_config=compiler_config)

--- a/tests/jax/single_chip/ops/test_sine.py
+++ b/tests/jax/single_chip/ops/test_sine.py
@@ -6,6 +6,7 @@ import jax
 import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
+from infra.compiler_config import CompilerConfig
 from utils import Category
 
 
@@ -22,3 +23,24 @@ def test_sin(x_shape: tuple):
         return jnp.sin(x)
 
     run_op_test_with_random_inputs(sin, [x_shape])
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    jax_op_name="jax.numpy.sin",
+    shlo_op_name="stablehlo.sine",
+)
+@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)], ids=lambda val: f"{val}")
+@pytest.mark.parametrize("format", ["bfloat16", "bfp8"])
+def test_sin_lower_df(x_shape: tuple, format: str):
+    def sin(x: jax.Array) -> jax.Array:
+        return jnp.sin(x)
+
+    if format == "bfloat16":
+        compiler_config = CompilerConfig()
+    else:  # bfp8
+        compiler_config = CompilerConfig(enable_bfp8_conversion=True)
+    
+    run_op_test_with_random_inputs(sin, [x_shape], dtype=jnp.bfloat16, compiler_config=compiler_config)

--- a/tests/jax/single_chip/ops/test_sqrt.py
+++ b/tests/jax/single_chip/ops/test_sqrt.py
@@ -6,6 +6,7 @@ import jax
 import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
+from infra.compiler_config import CompilerConfig
 from utils import Category
 
 
@@ -23,3 +24,25 @@ def test_sqrt(x_shape: tuple):
 
     # Input must be strictly positive because of sqrt(x).
     run_op_test_with_random_inputs(sqrt, [x_shape], minval=0.1, maxval=10.0)
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    jax_op_name="jax.numpy.sqrt",
+    shlo_op_name="stablehlo.sqrt",
+)
+@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)], ids=lambda val: f"{val}")
+@pytest.mark.parametrize("format", ["bfloat16", "bfp8"])
+def test_sqrt_lower_df(x_shape: tuple, format: str):
+    def sqrt(x: jax.Array) -> jax.Array:
+        return jnp.sqrt(x)
+
+    if format == "bfloat16":
+        compiler_config = CompilerConfig()
+    else:  # bfp8
+        compiler_config = CompilerConfig(enable_bfp8_conversion=True)
+    
+    # Input must be strictly positive because of sqrt(x).
+    run_op_test_with_random_inputs(sqrt, [x_shape], minval=0.1, maxval=10.0, dtype=jnp.bfloat16, compiler_config=compiler_config)

--- a/tests/jax/single_chip/ops/test_subtract.py
+++ b/tests/jax/single_chip/ops/test_subtract.py
@@ -6,6 +6,7 @@ import jax
 import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
+from infra.compiler_config import CompilerConfig
 from utils import Category
 
 
@@ -29,3 +30,31 @@ def test_subtract(x_shape: tuple, y_shape: tuple):
         return jnp.subtract(x, y)
 
     run_op_test_with_random_inputs(subtract, [x_shape, y_shape])
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    jax_op_name="jax.numpy.subtract",
+    shlo_op_name="stablehlo.subtract",
+)
+@pytest.mark.parametrize(
+    ["x_shape", "y_shape"],
+    [
+        [(32, 32), (32, 32)],
+        [(64, 64), (64, 64)],
+    ],
+    ids=lambda val: f"{val}",
+)
+@pytest.mark.parametrize("format", ["bfloat16", "bfp8"])
+def test_subtract_lower_df(x_shape: tuple, y_shape: tuple, format: str):
+    def subtract(x: jax.Array, y: jax.Array) -> jax.Array:
+        return jnp.subtract(x, y)
+
+    if format == "bfloat16":
+        compiler_config = CompilerConfig()
+    else:  # bfp8
+        compiler_config = CompilerConfig(enable_bfp8_conversion=True)
+    
+    run_op_test_with_random_inputs(subtract, [x_shape, y_shape], dtype=jnp.bfloat16, compiler_config=compiler_config)

--- a/tests/jax/single_chip/ops/test_tanh.py
+++ b/tests/jax/single_chip/ops/test_tanh.py
@@ -7,6 +7,7 @@ import jax
 import jax.numpy as jnp
 import pytest
 from infra import run_op_test_with_random_inputs
+from infra.compiler_config import CompilerConfig
 from utils import Category
 
 
@@ -23,3 +24,24 @@ def test_tanh(x_shape: tuple):
         return jnp.tanh(x)
 
     run_op_test_with_random_inputs(tanh, [x_shape])
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    jax_op_name="jax.numpy.tanh",
+    shlo_op_name="stablehlo.tanh",
+)
+@pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)], ids=lambda val: f"{val}")
+@pytest.mark.parametrize("format", ["bfloat16", "bfp8"])
+def test_tanh_lower_df(x_shape: tuple, format: str):
+    def tanh(x: jax.Array) -> jax.Array:
+        return jnp.tanh(x)
+
+    if format == "bfloat16":
+        compiler_config = CompilerConfig()
+    else:  # bfp8
+        compiler_config = CompilerConfig(enable_bfp8_conversion=True)
+    
+    run_op_test_with_random_inputs(tanh, [x_shape], dtype=jnp.bfloat16, compiler_config=compiler_config)


### PR DESCRIPTION
### Ticket


### Problem description


### What's changed
 - Add CompilerConfig and propagate it to compile methods in tester classes
 - Add new compile option enable_bfp8_conversion that enables block fp8 in MLIR. For this to work TTIR graph has to be in bfloat16. Final graph will have input and output nodes in bfloat16 and everything else in bfp8. Essentially adding type casts at the beginning and in the end of the graph, while all intermediate results are in bfp8. This bfloat16 wrapping is done to enable comparisom with golden, because block formats are TT hardware specific, and user should provide and get tensors of common dtype.
 - Make all compile methods void - they change workload object inplace so they don't have to return it. Change is in all tester classes: OpTester, ModelTester, JaxModelTester, JaxMultichipModelTester, TorchModelTester, JaxMultichipOpTester
- Add lower dataformat tests (bfloat16 and bfp8) for jax ops that have float inputs. 



