### PR TITLE
Reschedule the nigthly tests for 3 hours earlier

### DIFF
--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -16,7 +16,7 @@ on:
           - "5"
           - "8"
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 21 * * *'
 
 permissions:
   packages: write


### PR DESCRIPTION
### Ticket
[Issue](https://github.com/tenstorrent/tt-forge/issues/371)

### Problem description
TT-Forge nightly performance benchmark results need to be available earlier, so nightly tests on frontends need to be 3 hours earlier.

### What's changed
The nightly tests have been rescheduled to run 3 hours earlier.

### Checklist
- [ ] New/Existing tests provide coverage for changes
