### PR TITLE
Update JAX tests for MT5 and Opt

### DIFF
--- a/tests/jax/single_chip/models/mt5/large/test_mt5_large.py
+++ b/tests/jax/single_chip/models/mt5/large/test_mt5_large.py
@@ -3,23 +3,22 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from infra import Framework, RunMode
+from infra import RunMode
 from utils import (
     BringupStatus,
     Category,
-    ModelGroup,
-    ModelSource,
-    ModelTask,
-    build_model_name,
-    failed_runtime,
+    incorrect_result,
 )
 
 from ..tester import MT5Tester
-
-MODEL_PATH = "google/mt5-large"
-MODEL_NAME = build_model_name(
-    Framework.JAX, "mt5", "large", ModelTask.NLP_SUMMARIZATION, ModelSource.HUGGING_FACE
+from third_party.tt_forge_models.config import Parallelism
+from third_party.tt_forge_models.mt5.nlp_summarization.jax import (
+    ModelVariant,
+    ModelLoader,
 )
+
+VARIANT_NAME = ModelVariant.LARGE
+MODEL_INFO = ModelLoader._get_model_info(VARIANT_NAME)
 
 
 # ----- Fixtures -----
@@ -27,12 +26,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> MT5Tester:
-    return MT5Tester(MODEL_PATH)
+    return MT5Tester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> MT5Tester:
-    return MT5Tester(MODEL_PATH, run_mode=RunMode.TRAINING)
+    return MT5Tester(VARIANT_NAME, run_mode=RunMode.TRAINING)
 
 
 # ----- Tests -----
@@ -41,14 +40,15 @@ def training_tester() -> MT5Tester:
 @pytest.mark.model_test
 @pytest.mark.record_test_properties(
     category=Category.MODEL_TEST,
-    model_name=MODEL_NAME,
-    model_group=ModelGroup.GENERALITY,
+    model_info=MODEL_INFO,
+    parallelism=Parallelism.SINGLE_DEVICE,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_RUNTIME,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
 )
-@pytest.mark.skip(
-    reason=failed_runtime(
-        "Hangs in the runtime (https://github.com/tenstorrent/tt-xla/issues/539)"
+@pytest.mark.xfail(
+    reason=incorrect_result(
+        "PCC comparison failed. Calculated: pcc=0.6492372155189514. Required: pcc=0.99. "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_mt5_large_inference(inference_tester: MT5Tester):
@@ -58,8 +58,8 @@ def test_mt5_large_inference(inference_tester: MT5Tester):
 @pytest.mark.nightly
 @pytest.mark.record_test_properties(
     category=Category.MODEL_TEST,
-    model_name=MODEL_NAME,
-    model_group=ModelGroup.GENERALITY,
+    model_info=MODEL_INFO,
+    parallelism=Parallelism.SINGLE_DEVICE,
     run_mode=RunMode.TRAINING,
 )
 @pytest.mark.skip(reason="Support for training not implemented")

--- a/tests/jax/single_chip/models/mt5/tester.py
+++ b/tests/jax/single_chip/models/mt5/tester.py
@@ -5,13 +5,13 @@
 from typing import Dict
 
 import jax
-import jax.numpy as jnp
-from infra import ComparisonConfig, JaxModelTester, RunMode
 from jaxtyping import PyTree
-from transformers import (
-    AutoTokenizer,
-    FlaxMT5ForConditionalGeneration,
-    FlaxPreTrainedModel,
+
+from infra import ComparisonConfig, JaxModelTester, Model, RunMode
+
+from third_party.tt_forge_models.mt5.nlp_summarization.jax import (
+    ModelLoader,
+    ModelVariant,
 )
 
 
@@ -20,39 +20,25 @@ class MT5Tester(JaxModelTester):
 
     def __init__(
         self,
-        model_path: str,
+        variant_name: ModelVariant,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        self._model_path = model_path
+        self._model_loader = ModelLoader(variant_name)
         super().__init__(comparison_config, run_mode)
 
     # @override
-    def _get_model(self) -> FlaxPreTrainedModel:
-        model = FlaxMT5ForConditionalGeneration.from_pretrained(
-            self._model_path, dtype=jnp.bfloat16
-        )
-        model.params = model.to_bf16(model.params)
-        return model
+    def _get_model(self) -> Model:
+        return self._model_loader.load_model(dtype_override=jax.numpy.bfloat16)
 
     # @override
     def _get_input_activations(self) -> Dict[str, jax.Array]:
-        tokenizer = AutoTokenizer.from_pretrained(self._model_path)
-        inputs = tokenizer(
-            "UN Offizier sagt, dass weiter verhandelt werden muss in Syrien.",
-            return_tensors="jax",
-        )
-        return inputs
+        return self._model_loader.load_inputs(dtype_override=jax.numpy.bfloat16)
 
     # @overridde
     def _get_forward_method_kwargs(self) -> Dict[str, PyTree]:
-        tokenizer = AutoTokenizer.from_pretrained(self._model_path)
-        decoder_input_ids = tokenizer(
-            text_target="Weiter Verhandlung in Syrien.", return_tensors="jax"
-        ).input_ids
         return {
             "params": self._input_parameters,
-            "decoder_input_ids": decoder_input_ids,
             **self._input_activations,
         }
 

--- a/tests/jax/single_chip/models/mt5/xl/test_mt5_xl.py
+++ b/tests/jax/single_chip/models/mt5/xl/test_mt5_xl.py
@@ -3,23 +3,22 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from infra import Framework, RunMode
+from infra import RunMode
 from utils import (
     BringupStatus,
     Category,
-    ModelGroup,
-    ModelSource,
-    ModelTask,
-    build_model_name,
     incorrect_result,
 )
 
 from ..tester import MT5Tester
-
-MODEL_PATH = "google/mt5-xl"
-MODEL_NAME = build_model_name(
-    Framework.JAX, "mt5", "xl", ModelTask.NLP_SUMMARIZATION, ModelSource.HUGGING_FACE
+from third_party.tt_forge_models.config import Parallelism
+from third_party.tt_forge_models.mt5.nlp_summarization.jax import (
+    ModelVariant,
+    ModelLoader,
 )
+
+VARIANT_NAME = ModelVariant.XL
+MODEL_INFO = ModelLoader._get_model_info(VARIANT_NAME)
 
 
 # ----- Fixtures -----
@@ -27,12 +26,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> MT5Tester:
-    return MT5Tester(MODEL_PATH)
+    return MT5Tester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> MT5Tester:
-    return MT5Tester(MODEL_PATH, run_mode=RunMode.TRAINING)
+    return MT5Tester(VARIANT_NAME, run_mode=RunMode.TRAINING)
 
 
 # ----- Tests -----
@@ -41,15 +40,15 @@ def training_tester() -> MT5Tester:
 @pytest.mark.model_test
 @pytest.mark.record_test_properties(
     category=Category.MODEL_TEST,
-    model_name=MODEL_NAME,
-    model_group=ModelGroup.GENERALITY,
+    model_info=MODEL_INFO,
+    parallelism=Parallelism.SINGLE_DEVICE,
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.INCORRECT_RESULT,
 )
 @pytest.mark.large
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "PCC comparison failed. Calculated: pcc=0.009299473837018013. Required: pcc=0.99. "
+        "PCC comparison failed. Calculated: pcc=0.886627197265625. Required: pcc=0.99. "
         "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
@@ -60,8 +59,8 @@ def test_mt5_xl_inference(inference_tester: MT5Tester):
 @pytest.mark.nightly
 @pytest.mark.record_test_properties(
     category=Category.MODEL_TEST,
-    model_name=MODEL_NAME,
-    model_group=ModelGroup.GENERALITY,
+    model_info=MODEL_INFO,
+    parallelism=Parallelism.SINGLE_DEVICE,
     run_mode=RunMode.TRAINING,
 )
 @pytest.mark.large

--- a/tests/jax/single_chip/models/opt/opt_125m/test_125m.py
+++ b/tests/jax/single_chip/models/opt/opt_125m/test_125m.py
@@ -3,37 +3,31 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from infra import Framework, RunMode
+from infra import RunMode
 from utils import (
     BringupStatus,
     Category,
-    ModelGroup,
-    ModelSource,
-    ModelTask,
-    build_model_name,
 )
 
 from ..tester import OPTTester
+from third_party.tt_forge_models.config import Parallelism
+from third_party.tt_forge_models.opt.causal_lm.jax import ModelVariant, ModelLoader
 
-MODEL_PATH = "facebook/opt-125m"
-MODEL_NAME = build_model_name(
-    Framework.JAX,
-    "opt",
-    "125m",
-    ModelTask.NLP_CAUSAL_LM,
-    ModelSource.HUGGING_FACE,
-)
+VARIANT_NAME = ModelVariant._125M
+MODEL_INFO = ModelLoader._get_model_info(VARIANT_NAME)
+
+
 # ----- Fixtures -----
 
 
 @pytest.fixture
 def inference_tester() -> OPTTester:
-    return OPTTester(MODEL_PATH)
+    return OPTTester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> OPTTester:
-    return OPTTester(MODEL_PATH, run_mode=RunMode.TRAINING)
+    return OPTTester(VARIANT_NAME, run_mode=RunMode.TRAINING)
 
 
 # ----- Tests -----
@@ -42,8 +36,8 @@ def training_tester() -> OPTTester:
 @pytest.mark.model_test
 @pytest.mark.record_test_properties(
     category=Category.MODEL_TEST,
-    model_name=MODEL_NAME,
-    model_group=ModelGroup.GENERALITY,
+    model_info=MODEL_INFO,
+    parallelism=Parallelism.SINGLE_DEVICE,
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.PASSED,
 )
@@ -54,8 +48,8 @@ def test_opt_125m_inference(inference_tester: OPTTester):
 @pytest.mark.nightly
 @pytest.mark.record_test_properties(
     category=Category.MODEL_TEST,
-    model_name=MODEL_NAME,
-    model_group=ModelGroup.GENERALITY,
+    model_info=MODEL_INFO,
+    parallelism=Parallelism.SINGLE_DEVICE,
     run_mode=RunMode.TRAINING,
 )
 @pytest.mark.skip(reason="Support for training not implemented")

--- a/tests/jax/single_chip/models/opt/opt_2_7b/test_2_7b.py
+++ b/tests/jax/single_chip/models/opt/opt_2_7b/test_2_7b.py
@@ -3,28 +3,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from infra import Framework, RunMode
+from infra import RunMode
 from utils import (
     BringupStatus,
     Category,
-    ModelGroup,
-    ModelSource,
-    ModelTask,
-    build_model_name,
     failed_runtime,
-    incorrect_result,
 )
 
 from ..tester import OPTTester
+from third_party.tt_forge_models.config import Parallelism
+from third_party.tt_forge_models.opt.causal_lm.jax import ModelVariant, ModelLoader
 
-MODEL_PATH = "facebook/opt-2.7b"
-MODEL_NAME = build_model_name(
-    Framework.JAX,
-    "opt",
-    "2.7b",
-    ModelTask.NLP_CAUSAL_LM,
-    ModelSource.HUGGING_FACE,
-)
+VARIANT_NAME = ModelVariant._2_7B
+MODEL_INFO = ModelLoader._get_model_info(VARIANT_NAME)
 
 
 # ----- Fixtures -----
@@ -32,12 +23,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> OPTTester:
-    return OPTTester(MODEL_PATH)
+    return OPTTester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> OPTTester:
-    return OPTTester(MODEL_PATH, run_mode=RunMode.TRAINING)
+    return OPTTester(VARIANT_NAME, run_mode=RunMode.TRAINING)
 
 
 # ----- Tests -----
@@ -46,8 +37,8 @@ def training_tester() -> OPTTester:
 @pytest.mark.model_test
 @pytest.mark.record_test_properties(
     category=Category.MODEL_TEST,
-    model_name=MODEL_NAME,
-    model_group=ModelGroup.GENERALITY,
+    model_info=MODEL_INFO,
+    parallelism=Parallelism.SINGLE_DEVICE,
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.FAILED_RUNTIME,
 )
@@ -64,8 +55,8 @@ def test_opt_2_7b_inference(inference_tester: OPTTester):
 @pytest.mark.nightly
 @pytest.mark.record_test_properties(
     category=Category.MODEL_TEST,
-    model_name=MODEL_NAME,
-    model_group=ModelGroup.GENERALITY,
+    model_info=MODEL_INFO,
+    parallelism=Parallelism.SINGLE_DEVICE,
     run_mode=RunMode.TRAINING,
 )
 @pytest.mark.large

--- a/tests/jax/single_chip/models/opt/opt_350m/test_350m.py
+++ b/tests/jax/single_chip/models/opt/opt_350m/test_350m.py
@@ -3,26 +3,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from infra import Framework, RunMode
+from infra import RunMode
 from utils import (
     BringupStatus,
     Category,
-    ModelGroup,
-    ModelSource,
-    ModelTask,
-    build_model_name,
 )
 
 from ..tester import OPTTester
+from third_party.tt_forge_models.config import Parallelism
+from third_party.tt_forge_models.opt.causal_lm.jax import ModelVariant, ModelLoader
 
-MODEL_PATH = "facebook/opt-350m"
-MODEL_NAME = build_model_name(
-    Framework.JAX,
-    "opt",
-    "350m",
-    ModelTask.NLP_CAUSAL_LM,
-    ModelSource.HUGGING_FACE,
-)
+VARIANT_NAME = ModelVariant._350M
+MODEL_INFO = ModelLoader._get_model_info(VARIANT_NAME)
 
 
 # ----- Fixtures -----
@@ -30,12 +22,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> OPTTester:
-    return OPTTester(MODEL_PATH)
+    return OPTTester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> OPTTester:
-    return OPTTester(MODEL_PATH, run_mode=RunMode.TRAINING)
+    return OPTTester(VARIANT_NAME, run_mode=RunMode.TRAINING)
 
 
 # ----- Tests -----
@@ -44,8 +36,8 @@ def training_tester() -> OPTTester:
 @pytest.mark.model_test
 @pytest.mark.record_test_properties(
     category=Category.MODEL_TEST,
-    model_name=MODEL_NAME,
-    model_group=ModelGroup.GENERALITY,
+    model_info=MODEL_INFO,
+    parallelism=Parallelism.SINGLE_DEVICE,
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.PASSED,
 )
@@ -56,8 +48,8 @@ def test_opt_350m_inference(inference_tester: OPTTester):
 @pytest.mark.nightly
 @pytest.mark.record_test_properties(
     category=Category.MODEL_TEST,
-    model_name=MODEL_NAME,
-    model_group=ModelGroup.GENERALITY,
+    model_info=MODEL_INFO,
+    parallelism=Parallelism.SINGLE_DEVICE,
     run_mode=RunMode.TRAINING,
 )
 @pytest.mark.skip(reason="Support for training not implemented")

--- a/tests/jax/single_chip/models/opt/opt_6_7b/test_6_7b.py
+++ b/tests/jax/single_chip/models/opt/opt_6_7b/test_6_7b.py
@@ -3,39 +3,31 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from infra import Framework, RunMode
+from infra import RunMode
 from utils import (
     BringupStatus,
     Category,
-    ModelGroup,
-    ModelSource,
-    ModelTask,
-    build_model_name,
     failed_runtime,
 )
 
 from ..tester import OPTTester
+from third_party.tt_forge_models.config import Parallelism
+from third_party.tt_forge_models.opt.causal_lm.jax import ModelVariant, ModelLoader
 
-MODEL_PATH = "facebook/opt-6.7b"
-MODEL_NAME = build_model_name(
-    Framework.JAX,
-    "opt",
-    "6.7b",
-    ModelTask.NLP_CAUSAL_LM,
-    ModelSource.HUGGING_FACE,
-)
+VARIANT_NAME = ModelVariant._6_7B
+MODEL_INFO = ModelLoader._get_model_info(VARIANT_NAME)
 
 # ----- Fixtures -----
 
 
 @pytest.fixture
 def inference_tester() -> OPTTester:
-    return OPTTester(MODEL_PATH)
+    return OPTTester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> OPTTester:
-    return OPTTester(MODEL_PATH, run_mode=RunMode.TRAINING)
+    return OPTTester(VARIANT_NAME, run_mode=RunMode.TRAINING)
 
 
 # ----- Tests -----
@@ -44,8 +36,8 @@ def training_tester() -> OPTTester:
 @pytest.mark.model_test
 @pytest.mark.record_test_properties(
     category=Category.MODEL_TEST,
-    model_name=MODEL_NAME,
-    model_group=ModelGroup.GENERALITY,
+    model_info=MODEL_INFO,
+    parallelism=Parallelism.SINGLE_DEVICE,
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.FAILED_RUNTIME,
 )
@@ -64,8 +56,8 @@ def test_opt_6_7b_inference(inference_tester: OPTTester):
 @pytest.mark.nightly
 @pytest.mark.record_test_properties(
     category=Category.MODEL_TEST,
-    model_name=MODEL_NAME,
-    model_group=ModelGroup.GENERALITY,
+    model_info=MODEL_INFO,
+    parallelism=Parallelism.SINGLE_DEVICE,
     run_mode=RunMode.TRAINING,
 )
 @pytest.mark.large


### PR DESCRIPTION
### Ticket
closes #1113 

### Problem description
Update JAX tests for MT5 and Opt to use ModelLoader & ModelVariant from tt-forge-models

### Checklist
- [x] New/Existing tests provide coverage for changes

PFA logs for reference
[mt5_base.log](https://github.com/user-attachments/files/22664238/mt5_base.log)
[mt5_large.log](https://github.com/user-attachments/files/22664239/mt5_large.log)
[mt5_xl.log](https://github.com/user-attachments/files/22664240/mt5_xl.log)
[opt_1_3b.log](https://github.com/user-attachments/files/22664241/opt_1_3b.log)
[opt_27b.log](https://github.com/user-attachments/files/22664242/opt_27b.log)
[opt67b.log](https://github.com/user-attachments/files/22664249/opt67b.log)
[opt125m.log](https://github.com/user-attachments/files/22664250/opt125m.log)
[opt350m.log](https://github.com/user-attachments/files/22664260/opt350m.log)
