### PR TITLE
Update JAX tests for Roberta models

### DIFF
--- a/tests/jax/single_chip/models/roberta/large/test_roberta_large.py
+++ b/tests/jax/single_chip/models/roberta/large/test_roberta_large.py
@@ -3,38 +3,30 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from infra import Framework, RunMode
+from infra import RunMode
 from utils import (
     BringupStatus,
     Category,
-    ModelGroup,
-    ModelSource,
-    ModelTask,
-    build_model_name,
 )
 
 from ..tester import FlaxRobertaForMaskedLMTester
+from third_party.tt_forge_models.config import Parallelism
+from third_party.tt_forge_models.roberta.masked_lm.jax import ModelVariant, ModelLoader
 
-MODEL_PATH = "FacebookAI/roberta-large"
-MODEL_NAME = build_model_name(
-    Framework.JAX,
-    "roberta",
-    "large",
-    ModelTask.NLP_MASKED_LM,
-    ModelSource.HUGGING_FACE,
-)
+VARIANT_NAME = ModelVariant.LARGE
+MODEL_INFO = ModelLoader._get_model_info(VARIANT_NAME)
 
 # ----- Fixtures -----
 
 
 @pytest.fixture
 def inference_tester() -> FlaxRobertaForMaskedLMTester:
-    return FlaxRobertaForMaskedLMTester(MODEL_PATH)
+    return FlaxRobertaForMaskedLMTester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> FlaxRobertaForMaskedLMTester:
-    return FlaxRobertaForMaskedLMTester(MODEL_PATH, RunMode.TRAINING)
+    return FlaxRobertaForMaskedLMTester(VARIANT_NAME, RunMode.TRAINING)
 
 
 # ----- Tests -----
@@ -43,8 +35,8 @@ def training_tester() -> FlaxRobertaForMaskedLMTester:
 @pytest.mark.model_test
 @pytest.mark.record_test_properties(
     category=Category.MODEL_TEST,
-    model_name=MODEL_NAME,
-    model_group=ModelGroup.GENERALITY,
+    model_info=MODEL_INFO,
+    parallelism=Parallelism.SINGLE_DEVICE,
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.PASSED,
 )
@@ -55,8 +47,8 @@ def test_flax_roberta_large_inference(inference_tester: FlaxRobertaForMaskedLMTe
 @pytest.mark.nightly
 @pytest.mark.record_test_properties(
     category=Category.MODEL_TEST,
-    model_name=MODEL_NAME,
-    model_group=ModelGroup.GENERALITY,
+    model_info=MODEL_INFO,
+    parallelism=Parallelism.SINGLE_DEVICE,
     run_mode=RunMode.TRAINING,
 )
 @pytest.mark.skip(reason="Support for training not implemented")

--- a/tests/jax/single_chip/models/roberta/tester.py
+++ b/tests/jax/single_chip/models/roberta/tester.py
@@ -5,8 +5,10 @@
 from typing import Dict
 
 import jax
-from infra import ComparisonConfig, JaxModelTester, RunMode
-from transformers import AutoTokenizer, FlaxPreTrainedModel, FlaxRobertaForMaskedLM
+
+from infra import ComparisonConfig, JaxModelTester, Model, RunMode
+
+from third_party.tt_forge_models.roberta.masked_lm.jax import ModelLoader, ModelVariant
 
 
 class FlaxRobertaForMaskedLMTester(JaxModelTester):
@@ -16,23 +18,21 @@ class FlaxRobertaForMaskedLMTester(JaxModelTester):
 
     def __init__(
         self,
-        model_path: str,
+        variant_name: ModelVariant,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        self._model_path = model_path
+        self._model_loader = ModelLoader(variant_name)
         super().__init__(comparison_config, run_mode)
 
     # @override
-    def _get_model(self) -> FlaxPreTrainedModel:
-        return FlaxRobertaForMaskedLM.from_pretrained(self._model_path)
+    def _get_model(self) -> Model:
+        return self._model_loader.load_model()
 
     # @override
     def _get_input_activations(self) -> Dict[str, jax.Array]:
-        tokenizer = AutoTokenizer.from_pretrained(self._model_path)
-        inputs = tokenizer("Hello <mask>.", return_tensors="jax")
-        return inputs
+        return self._model_loader.load_inputs()
 
-    # @ override
+    # @override
     def _get_static_argnames(self):
         return ["train"]

--- a/tests/jax/single_chip/models/roberta_prelayernorm/efficient_mlm_m0_40/test_efficient_mlm_m0_40.py
+++ b/tests/jax/single_chip/models/roberta_prelayernorm/efficient_mlm_m0_40/test_efficient_mlm_m0_40.py
@@ -6,29 +6,21 @@ from typing import Dict
 
 import jax
 import pytest
-from infra import ComparisonConfig, Framework, JaxModelTester, RunMode
-from transformers import (
-    AutoTokenizer,
-    FlaxPreTrainedModel,
-    FlaxRobertaPreLayerNormForMaskedLM,
-)
+
+from infra import ComparisonConfig, JaxModelTester, Model, RunMode
 from utils import (
     BringupStatus,
     Category,
-    ModelGroup,
-    ModelSource,
-    ModelTask,
-    build_model_name,
 )
 
-MODEL_PATH = "andreasmadsen/efficient_mlm_m0.40"
-MODEL_NAME = build_model_name(
-    Framework.JAX,
-    "roberta_prelayernorm",
-    "efficient_mlm_m0.40",
-    ModelTask.NLP_MASKED_LM,
-    ModelSource.HUGGING_FACE,
+from third_party.tt_forge_models.config import Parallelism
+from third_party.tt_forge_models.roberta_prelayernorm.masked_lm.jax import (
+    ModelLoader,
+    ModelVariant,
 )
+
+VARIANT_NAME = ModelVariant.EFFICIENT_MLM_M0_40
+MODEL_INFO = ModelLoader._get_model_info(VARIANT_NAME)
 
 
 class FlaxRobertaPreLayerNormForMaskedLMTester(JaxModelTester):
@@ -36,26 +28,22 @@ class FlaxRobertaPreLayerNormForMaskedLMTester(JaxModelTester):
 
     def __init__(
         self,
-        model_path: str,
+        variant_name: ModelVariant,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        self._model_path = model_path
+        self._model_loader = ModelLoader(variant_name)
         super().__init__(comparison_config, run_mode)
 
     # @override
-    def _get_model(self) -> FlaxPreTrainedModel:
-        return FlaxRobertaPreLayerNormForMaskedLM.from_pretrained(
-            self._model_path, from_pt=True
-        )
+    def _get_model(self) -> Model:
+        return self._model_loader.load_model()
 
     # @override
     def _get_input_activations(self) -> Dict[str, jax.Array]:
-        tokenizer = AutoTokenizer.from_pretrained(self._model_path)
-        inputs = tokenizer("Hello <mask>.", return_tensors="jax")
-        return inputs
+        return self._model_loader.load_inputs()
 
-    # @ override
+    # @override
     def _get_static_argnames(self):
         return ["train"]
 
@@ -65,12 +53,12 @@ class FlaxRobertaPreLayerNormForMaskedLMTester(JaxModelTester):
 
 @pytest.fixture
 def inference_tester() -> FlaxRobertaPreLayerNormForMaskedLMTester:
-    return FlaxRobertaPreLayerNormForMaskedLMTester(MODEL_PATH)
+    return FlaxRobertaPreLayerNormForMaskedLMTester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> FlaxRobertaPreLayerNormForMaskedLMTester:
-    return FlaxRobertaPreLayerNormForMaskedLMTester(MODEL_PATH, RunMode.TRAINING)
+    return FlaxRobertaPreLayerNormForMaskedLMTester(VARIANT_NAME, RunMode.TRAINING)
 
 
 # ----- Tests -----
@@ -79,8 +67,8 @@ def training_tester() -> FlaxRobertaPreLayerNormForMaskedLMTester:
 @pytest.mark.model_test
 @pytest.mark.record_test_properties(
     category=Category.MODEL_TEST,
-    model_name=MODEL_NAME,
-    model_group=ModelGroup.GENERALITY,
+    model_info=MODEL_INFO,
+    parallelism=Parallelism.SINGLE_DEVICE,
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.PASSED,
 )
@@ -93,8 +81,8 @@ def test_flax_roberta_prelayernorm_inference(
 @pytest.mark.nightly
 @pytest.mark.record_test_properties(
     category=Category.MODEL_TEST,
-    model_name=MODEL_NAME,
-    model_group=ModelGroup.GENERALITY,
+    model_info=MODEL_INFO,
+    parallelism=Parallelism.SINGLE_DEVICE,
     run_mode=RunMode.TRAINING,
 )
 @pytest.mark.skip(reason="Support for training not implemented")


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-xla/issues/1119

### Problem description
Update JAX tests for Roberta and Roberta PreLayerNorm to use ModelLoader & ModelVariant from tt-forge-models

### Checklist
- [x] New/Existing tests provide coverage for changes

[rob_base_xfail.log](https://github.com/user-attachments/files/22598859/rob_base_xfail.log)
[rob_base.log](https://github.com/user-attachments/files/22664389/rob_base.log)
[rob_large.log](https://github.com/user-attachments/files/22664391/rob_large.log)
[rob_prelayernorm.log](https://github.com/user-attachments/files/22664392/rob_prelayernorm.log)


