### PR TITLE
Add permissions to push workflow to publish docs

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -10,8 +10,12 @@ on:
       - 'LICENSE'
 
 permissions:
+  contents: read
   packages: write
   checks: write
+  pages: write
+  id-token: write
+  deployments: write
 
 jobs:
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Push workflow is lacking permissions to publish docs

### What's changed
Add permissions to push workflow to publish docs

### Checklist
- [ ] New/Existing tests provide coverage for changes
