### PR TITLE
Runtime change and test xfails in preparation for uplift

### DIFF
--- a/src/common/pjrt_implementation/loaded_executable_instance.cc
+++ b/src/common/pjrt_implementation/loaded_executable_instance.cc
@@ -158,6 +158,7 @@ LoadedExecutableInstance::execute(PJRT_LoadedExecutable_Execute_Args *args) {
   }
 
   tt::runtime::closeMeshDevice(*runtime_device);
+  tt::runtime::setFabricConfig(tt::runtime::FabricConfig::DISABLED);
 
   return tt_pjrt_status::kSuccess;
 }
@@ -200,6 +201,12 @@ LoadedExecutableInstance::openDevices(PJRT_Buffer *const *const *argument_lists,
 
   tt::runtime::MeshDeviceOptions mesh_device_options;
   mesh_device_options.meshShape = devices_mesh_shape;
+  
+  if (mesh_shape_num_devices > 1) {
+    tt::runtime::setFabricConfig(tt::runtime::FabricConfig::FABRIC_1D);
+  } else {
+    tt::runtime::setFabricConfig(tt::runtime::FabricConfig::DISABLED);
+  }
 
   return tt::runtime::openMeshDevice(mesh_device_options);
 }

--- a/tests/jax/multi_chip/llmbox/4_devices/graphs/tensor_parallel/test_dot_psum.py
+++ b/tests/jax/multi_chip/llmbox/4_devices/graphs/tensor_parallel/test_dot_psum.py
@@ -10,7 +10,7 @@ from infra import (
     make_partition_spec,
     run_jax_multichip_graph_test_with_random_inputs,
 )
-from utils import failed_fe_compilation
+from utils import failed_fe_compilation, incorrect_result
 
 
 @pytest.mark.nightly
@@ -32,7 +32,10 @@ from utils import failed_fe_compilation
 @pytest.mark.parametrize(
     "sharding_mode",
     [
-        ShardingMode.INPUTS_AND_MODULE,
+        pytest.param(
+            ShardingMode.INPUTS_AND_MODULE,
+            marks=pytest.mark.xfail(reason=incorrect_result("PCC comparison failed")),
+        ),
         pytest.param(
             ShardingMode.MODULE,
             marks=pytest.mark.xfail(

--- a/tests/jax/multi_chip/llmbox/4_devices/graphs/tensor_parallel/test_dot_psum_scatter.py
+++ b/tests/jax/multi_chip/llmbox/4_devices/graphs/tensor_parallel/test_dot_psum_scatter.py
@@ -10,7 +10,7 @@ from infra import (
     make_partition_spec,
     run_jax_multichip_graph_test_with_random_inputs,
 )
-from utils import failed_fe_compilation
+from utils import failed_fe_compilation, incorrect_result
 
 
 @pytest.mark.nightly
@@ -31,7 +31,10 @@ from utils import failed_fe_compilation
 @pytest.mark.parametrize(
     "sharding_mode",
     [
-        ShardingMode.INPUTS_AND_MODULE,
+        pytest.param(
+            ShardingMode.INPUTS_AND_MODULE,
+            marks=pytest.mark.xfail(reason=incorrect_result("PCC comparison failed")),
+        ),
         pytest.param(
             ShardingMode.MODULE,
             marks=pytest.mark.xfail(

--- a/tests/jax/multi_chip/llmbox/8_devices/graphs/tensor_parallel/test_dot_psum.py
+++ b/tests/jax/multi_chip/llmbox/8_devices/graphs/tensor_parallel/test_dot_psum.py
@@ -10,7 +10,7 @@ from infra import (
     make_partition_spec,
     run_jax_multichip_graph_test_with_random_inputs,
 )
-from utils import failed_fe_compilation
+from utils import failed_fe_compilation, incorrect_result
 
 
 @pytest.mark.nightly
@@ -25,7 +25,10 @@ from utils import failed_fe_compilation
 @pytest.mark.parametrize(
     ("batch_shape", "W1_shape", "B1_shape", "mesh_shape", "axis_names"),
     [
-        ((8192, 784), (784, 2048), (2048,), (1, 8), ("batch", "model")),
+        pytest.param(
+            ((8192, 784), (784, 2048), (2048,), (1, 8), ("batch", "model")),
+            marks=pytest.mark.xfail(reason=incorrect_result("PCC comparison failed")),
+        ),
         ((8192, 784), (784, 2048), (2048,), (2, 4), ("batch", "model")),
     ],
 )

--- a/tests/jax/multi_chip/llmbox/8_devices/graphs/tensor_parallel/test_dot_psum_scatter.py
+++ b/tests/jax/multi_chip/llmbox/8_devices/graphs/tensor_parallel/test_dot_psum_scatter.py
@@ -10,7 +10,7 @@ from infra import (
     make_partition_spec,
     run_jax_multichip_graph_test_with_random_inputs,
 )
-from utils import failed_fe_compilation
+from utils import failed_fe_compilation, incorrect_result
 
 
 @pytest.mark.nightly
@@ -31,7 +31,10 @@ from utils import failed_fe_compilation
 @pytest.mark.parametrize(
     "sharding_mode",
     [
-        ShardingMode.INPUTS_AND_MODULE,
+        pytest.param(
+            ShardingMode.INPUTS_AND_MODULE,
+            marks=pytest.mark.xfail(reason=incorrect_result("PCC comparison failed")),
+        ),
         pytest.param(
             ShardingMode.MODULE,
             marks=pytest.mark.xfail(

--- a/tests/jax/multi_chip/n300/graphs/tensor_parallel/test_dot_psum.py
+++ b/tests/jax/multi_chip/n300/graphs/tensor_parallel/test_dot_psum.py
@@ -10,7 +10,7 @@ from infra import (
     make_partition_spec,
     run_jax_multichip_graph_test_with_random_inputs,
 )
-from utils import failed_fe_compilation
+from utils import failed_fe_compilation, incorrect_result
 
 
 @pytest.mark.nightly
@@ -32,7 +32,10 @@ from utils import failed_fe_compilation
 @pytest.mark.parametrize(
     "sharding_mode",
     [
-        ShardingMode.INPUTS_AND_MODULE,
+        pytest.param(
+            ShardingMode.INPUTS_AND_MODULE,
+            marks=pytest.mark.xfail(reason=incorrect_result("PCC comparison failed")),
+        ),
         pytest.param(
             ShardingMode.MODULE,
             marks=pytest.mark.xfail(

--- a/tests/jax/multi_chip/n300/graphs/tensor_parallel/test_dot_psum_scatter.py
+++ b/tests/jax/multi_chip/n300/graphs/tensor_parallel/test_dot_psum_scatter.py
@@ -10,7 +10,7 @@ from infra import (
     make_partition_spec,
     run_jax_multichip_graph_test_with_random_inputs,
 )
-from utils import failed_fe_compilation
+from utils import failed_fe_compilation, incorrect_result
 
 
 @pytest.mark.nightly
@@ -28,7 +28,10 @@ from utils import failed_fe_compilation
 @pytest.mark.parametrize(
     "sharding_mode",
     [
-        ShardingMode.INPUTS_AND_MODULE,
+        pytest.param(
+            ShardingMode.INPUTS_AND_MODULE,
+            marks=pytest.mark.xfail(reason=incorrect_result("PCC comparison failed")),
+        ),
         pytest.param(
             ShardingMode.MODULE,
             marks=pytest.mark.xfail(


### PR DESCRIPTION
### Ticket
Related to https://github.com/tenstorrent/tt-xla/issues/1161

### Problem description
We have a runtime change to make in preparation for an upcomping uplift. In addition, some tests will be brought down.

### What's changed
Fixed the runtime(thanks Brata!)
Xfailed tests

### Checklist
- [X] New/Existing tests provide coverage for changes
