### PR TITLE
Fix torchvision to v0.22.0 to prevent installation of higher torch version

### DIFF
--- a/venv/requirements-dev.txt
+++ b/venv/requirements-dev.txt
@@ -29,7 +29,8 @@ setuptools
 soundfile
 tabulate
 timm
-torchvision
+# torchvision 0.23.0 causes torch v2.8.0 to be installed, which isn't supported by our torch_xla whl
+torchvision==0.22.0
 torchxrayvision
 transformers
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
torchvision v0.23.0 caused tt-xla to install torch v2.8.0 instead of v2.7.0 that is specified in the [requirements.txt](https://github.com/tenstorrent/tt-xla/blob/main/python_package/requirements.txt#L3) file. This further causes issues when trying to import torch_xla, since torch_xla v2.7.0 doesn't support torch v2.8.0

More context and investigation: https://tenstorrent.slack.com/archives/C08H2NCQGHJ/p1756418158328669

### What's changed
Fixing torchvision to v0.22.0 to prevent any issues.

### Checklist
- [x] New/Existing tests provide coverage for changes
