### PR TITLE
update jax test for gpt_sw3 and pegasus

### DIFF
--- a/tests/jax/single_chip/models/gpt_sw3/instruct_1_3b/test_gpt_sw3_1_3b_instruct.py
+++ b/tests/jax/single_chip/models/gpt_sw3/instruct_1_3b/test_gpt_sw3_1_3b_instruct.py
@@ -14,12 +14,13 @@ from utils import (
 )
 
 from ..tester import GPTSw3Tester
+from third_party.tt_forge_models.gpt_sw3.causal_lm.jax import ModelVariant
 
-MODEL_PATH = "AI-Sweden-Models/gpt-sw3-1.3b-instruct"
+VARIANT_NAME = ModelVariant.INSTRUCT_1_3B
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "gpt-sw3",
-    "1.3b_instruct",
+    "1_3b_instruct",
     ModelTask.NLP_CAUSAL_LM,
     ModelSource.HUGGING_FACE,
 )
@@ -30,12 +31,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> GPTSw3Tester:
-    return GPTSw3Tester(MODEL_PATH)
+    return GPTSw3Tester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> GPTSw3Tester:
-    return GPTSw3Tester(MODEL_PATH, run_mode=RunMode.TRAINING)
+    return GPTSw3Tester(VARIANT_NAME, run_mode=RunMode.TRAINING)
 
 
 # ----- Tests -----

--- a/tests/jax/single_chip/models/pegasus/large/test_pegasus_large.py
+++ b/tests/jax/single_chip/models/pegasus/large/test_pegasus_large.py
@@ -15,8 +15,9 @@ from utils import (
 )
 
 from ..tester import PegasusTester
+from third_party.tt_forge_models.pegasus.summarization.jax import ModelVariant
 
-MODEL_PATH = "google/pegasus-large"
+VARIANT_NAME = ModelVariant.LARGE
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "pegasus",
@@ -30,12 +31,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> PegasusTester:
-    return PegasusTester(MODEL_PATH)
+    return PegasusTester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> PegasusTester:
-    return PegasusTester(MODEL_PATH, run_mode=RunMode.TRAINING)
+    return PegasusTester(VARIANT_NAME, run_mode=RunMode.TRAINING)
 
 
 # ----- Tests -----
@@ -51,8 +52,8 @@ def training_tester() -> PegasusTester:
 )
 @pytest.mark.xfail(
     reason=failed_ttmlir_compilation(
-        "'ttir.scatter' op Dimension size to slice into must be 1 "
-        "https://github.com/tenstorrent/tt-xla/issues/386 "
+        "Failed to legalize operation 'ttir.scatter' "
+        "https://github.com/tenstorrent/tt-xla/issues/911"
     )
 )
 def test_pegasus_large_inference(inference_tester: PegasusTester):

--- a/tests/jax/single_chip/models/pegasus/tester.py
+++ b/tests/jax/single_chip/models/pegasus/tester.py
@@ -3,42 +3,31 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Dict
-
 import jax
-from infra import ComparisonConfig, JaxModelTester, RunMode
-from jaxtyping import PyTree
-from transformers import (
-    AutoTokenizer,
-    FlaxPegasusForConditionalGeneration,
-    FlaxPreTrainedModel,
-)
+
+from infra import ComparisonConfig, JaxModelTester, RunMode, Model
+from third_party.tt_forge_models.pegasus.summarization.jax import ModelLoader, ModelVariant
 
 
 class PegasusTester(JaxModelTester):
-    """Tester for Pegasus models."""
+    """Tester for Pegasus model on a text summarization task."""
 
     def __init__(
         self,
-        model_path: str,
+        variant_name: ModelVariant,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        self._model_path = model_path
+        self._model_loader = ModelLoader(variant_name)
         super().__init__(comparison_config, run_mode)
 
     # @override
-    def _get_model(self) -> FlaxPreTrainedModel:
-        return FlaxPegasusForConditionalGeneration.from_pretrained(self._model_path)
+    def _get_model(self) -> Model:
+        return self._model_loader.load_model()
 
     # @override
     def _get_input_activations(self) -> Dict[str, jax.Array]:
-        tokenizer = AutoTokenizer.from_pretrained(self._model_path)
-        inputs = tokenizer(
-            "My friends are cool but they eat too many carbs.",
-            truncation=True,
-            return_tensors="jax",
-        )
-        return inputs
+        return self._model_loader.load_inputs()
 
     # @override
     def _get_static_argnames(self):

--- a/tests/jax/single_chip/models/pegasus/xsum/test_pegasus_xsum.py
+++ b/tests/jax/single_chip/models/pegasus/xsum/test_pegasus_xsum.py
@@ -15,8 +15,9 @@ from utils import (
 )
 
 from ..tester import PegasusTester
+from third_party.tt_forge_models.pegasus.summarization.jax import ModelVariant
 
-MODEL_PATH = "google/pegasus-xsum"
+VARIANT_NAME = ModelVariant.XSUM
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "pegasus",
@@ -30,12 +31,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> PegasusTester:
-    return PegasusTester(MODEL_PATH)
+    return PegasusTester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> PegasusTester:
-    return PegasusTester(MODEL_PATH, run_mode=RunMode.TRAINING)
+    return PegasusTester(VARIANT_NAME, run_mode=RunMode.TRAINING)
 
 
 # ----- Tests -----
@@ -51,8 +52,8 @@ def training_tester() -> PegasusTester:
 )
 @pytest.mark.xfail(
     reason=failed_ttmlir_compilation(
-        "'ttir.scatter' op Dimension size to slice into must be 1 "
-        "https://github.com/tenstorrent/tt-xla/issues/386"
+        "Failed to legalize operation 'ttir.scatter' "
+        "https://github.com/tenstorrent/tt-xla/issues/911"
     )
 )
 def test_pegasus_xsum_inference(inference_tester: PegasusTester):


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-xla/issues/1122

### Problem description
Update JAX tests for  gpt_sw3 and pegasus to use ModelLoader & ModelVariant from tt-forge-models

### Checklist
- [x] New/Existing tests provide coverage for changes

I have attached the logs for your reference:
[test_gpt_sw3.log](https://github.com/user-attachments/files/22040782/test_gpt_sw3.log)
[test_pegasus_large_with_xfail.log](https://github.com/user-attachments/files/22040784/test_pegasus_large_with_xfail.log)
[test_pegasus_large_without_xfail.log](https://github.com/user-attachments/files/22040785/test_pegasus_large_without_xfail.log)
[test_pegasus_xsum_with_xfail.log](https://github.com/user-attachments/files/22040786/test_pegasus_xsum_with_xfail.log)
[test_pegasus_xsum_without_xfail.log](https://github.com/user-attachments/files/22040788/test_pegasus_xsum_without_xfail.log)
