### PR TITLE
Update JAX tests for T5 and XGLM

### DIFF
--- a/tests/jax/single_chip/models/t5/base/test_t5_base.py
+++ b/tests/jax/single_chip/models/t5/base/test_t5_base.py
@@ -11,16 +11,15 @@ from utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    incorrect_result,
 )
-
+from third_party.tt_forge_models.t5.summarization.jax.loader import ModelVariant
 from ..tester import T5Tester
 
-MODEL_PATH = "google-t5/t5-base"
+VARIANT_NAME = ModelVariant.BASE
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "t5",
-    "base",
+    str(VARIANT_NAME),
     ModelTask.NLP_SUMMARIZATION,
     ModelSource.HUGGING_FACE,
 )
@@ -30,12 +29,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> T5Tester:
-    return T5Tester(MODEL_PATH)
+    return T5Tester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> T5Tester:
-    return T5Tester(MODEL_PATH, run_mode=RunMode.TRAINING)
+    return T5Tester(VARIANT_NAME, run_mode=RunMode.TRAINING)
 
 
 # ----- Tests -----
@@ -48,13 +47,7 @@ def training_tester() -> T5Tester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.INCORRECT_RESULT,
-)
-@pytest.mark.xfail(
-    reason=incorrect_result(
-        "PCC comparison failed. Calculated: pcc=-0.0016425212379544973. Required: pcc=0.99 "
-        "https://github.com/tenstorrent/tt-xla/issues/379"
-    )
+    bringup_status=BringupStatus.PASSED,
 )
 def test_t5_base_inference(inference_tester: T5Tester):
     inference_tester.test()

--- a/tests/jax/single_chip/models/t5/large/test_t5_large.py
+++ b/tests/jax/single_chip/models/t5/large/test_t5_large.py
@@ -11,16 +11,15 @@ from utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    incorrect_result,
 )
-
+from third_party.tt_forge_models.t5.summarization.jax.loader import ModelVariant
 from ..tester import T5Tester
 
-MODEL_PATH = "google-t5/t5-large"
+VARIANT_NAME = ModelVariant.LARGE
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "t5",
-    "large",
+    str(VARIANT_NAME),
     ModelTask.NLP_SUMMARIZATION,
     ModelSource.HUGGING_FACE,
 )
@@ -30,12 +29,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> T5Tester:
-    return T5Tester(MODEL_PATH)
+    return T5Tester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> T5Tester:
-    return T5Tester(MODEL_PATH, run_mode=RunMode.TRAINING)
+    return T5Tester(VARIANT_NAME, run_mode=RunMode.TRAINING)
 
 
 # ----- Tests -----
@@ -48,13 +47,7 @@ def training_tester() -> T5Tester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.INCORRECT_RESULT,
-)
-@pytest.mark.xfail(
-    reason=incorrect_result(
-        "PCC comparison failed. Calculated: pcc=-0.09189048409461975. Required: pcc=0.99 "
-        "https://github.com/tenstorrent/tt-xla/issues/379"
-    )
+    bringup_status=BringupStatus.PASSED,
 )
 def test_t5_large_inference(inference_tester: T5Tester):
     inference_tester.test()

--- a/tests/jax/single_chip/models/t5/small/test_t5_small.py
+++ b/tests/jax/single_chip/models/t5/small/test_t5_small.py
@@ -11,16 +11,15 @@ from utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    incorrect_result,
 )
-
+from third_party.tt_forge_models.t5.summarization.jax.loader import ModelVariant
 from ..tester import T5Tester
 
-MODEL_PATH = "google-t5/t5-small"
+VARIANT_NAME = ModelVariant.SMALL
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "t5",
-    "small",
+    str(VARIANT_NAME),
     ModelTask.NLP_SUMMARIZATION,
     ModelSource.HUGGING_FACE,
 )
@@ -30,12 +29,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> T5Tester:
-    return T5Tester(MODEL_PATH)
+    return T5Tester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> T5Tester:
-    return T5Tester(MODEL_PATH, run_mode=RunMode.TRAINING)
+    return T5Tester(VARIANT_NAME, run_mode=RunMode.TRAINING)
 
 
 # ----- Tests -----
@@ -48,13 +47,7 @@ def training_tester() -> T5Tester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.INCORRECT_RESULT,
-)
-@pytest.mark.xfail(
-    reason=incorrect_result(
-        "PCC comparison failed. Calculated: pcc=0.5672792792320251. Required: pcc=0.99 "
-        "https://github.com/tenstorrent/tt-xla/issues/379"
-    )
+    bringup_status=BringupStatus.PASSED,
 )
 def test_t5_small_inference(inference_tester: T5Tester):
     inference_tester.test()

--- a/tests/jax/single_chip/models/t5/tester.py
+++ b/tests/jax/single_chip/models/t5/tester.py
@@ -5,12 +5,10 @@
 from typing import Dict
 
 import jax
-from infra import ComparisonConfig, JaxModelTester, RunMode
-from jaxtyping import PyTree
-from transformers import (
-    AutoTokenizer,
-    FlaxPreTrainedModel,
-    FlaxT5ForConditionalGeneration,
+from infra import ComparisonConfig, JaxModelTester, RunMode, Model
+from third_party.tt_forge_models.t5.summarization.jax.loader import (
+    ModelVariant,
+    ModelLoader,
 )
 
 
@@ -19,36 +17,20 @@ class T5Tester(JaxModelTester):
 
     def __init__(
         self,
-        model_path: str,
+        variant: ModelVariant,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        self._model_path = model_path
+        self._model_loader = ModelLoader(variant)
         super().__init__(comparison_config, run_mode)
 
     # @override
-    def _get_model(self) -> FlaxPreTrainedModel:
-        return FlaxT5ForConditionalGeneration.from_pretrained(self._model_path)
+    def _get_model(self) -> Model:
+        return self._model_loader.load_model()
 
     # @override
     def _get_input_activations(self) -> Dict[str, jax.Array]:
-        tokenizer = AutoTokenizer.from_pretrained(self._model_path)
-        inputs = tokenizer(
-            " My friends are cool but they eat too many carbs.", return_tensors="jax"
-        )
-        return inputs
-
-    # @overridde
-    def _get_forward_method_kwargs(self) -> Dict[str, PyTree]:
-        tokenizer = AutoTokenizer.from_pretrained(self._model_path)
-        decoder_input_ids = tokenizer(
-            text_target="I eat less carbs.", return_tensors="jax"
-        ).input_ids
-        return {
-            "params": self._input_parameters,
-            "decoder_input_ids": decoder_input_ids,
-            **self._input_activations,
-        }
+        return self._model_loader.load_inputs()
 
     # @override
     def _get_static_argnames(self):

--- a/tests/jax/single_chip/models/xglm/xglm_564m/test_xglm_564m.py
+++ b/tests/jax/single_chip/models/xglm/xglm_564m/test_xglm_564m.py
@@ -12,14 +12,14 @@ from utils import (
     ModelTask,
     build_model_name,
 )
-
+from third_party.tt_forge_models.xglm.causal_lm.jax.loader import ModelVariant
 from ..tester import XGLMTester
 
-MODEL_PATH = "facebook/xglm-564M"
+VARIANT_NAME = ModelVariant._564M
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "xglm",
-    "564m",
+    str(VARIANT_NAME),
     ModelTask.NLP_CAUSAL_LM,
     ModelSource.HUGGING_FACE,
 )
@@ -29,12 +29,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> XGLMTester:
-    return XGLMTester(MODEL_PATH)
+    return XGLMTester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> XGLMTester:
-    return XGLMTester(MODEL_PATH, run_mode=RunMode.TRAINING)
+    return XGLMTester(VARIANT_NAME, run_mode=RunMode.TRAINING)
 
 
 # ----- Tests -----


### PR DESCRIPTION
### Ticket
 closes https://github.com/tenstorrent/tt-xla/issues/1170

### Problem description
update T5 and XGLM models JAX tests to use ModelLoader & ModelVariant from tt-forge-models

### Checklist
- [x] New/Existing tests provide coverage for changes

[t5_base.log](https://github.com/user-attachments/files/22040812/t5_base.log)
[t5_large.log](https://github.com/user-attachments/files/22040842/t5_large.log)
[t5_small.log](https://github.com/user-attachments/files/22040844/t5_small.log)
[xglm.log](https://github.com/user-attachments/files/22040845/xglm.log)
