### PR TITLE
[test] remove monkeypatch initialization in tests

### DIFF
--- a/examples/jax/alexnet_multichip.py
+++ b/examples/jax/alexnet_multichip.py
@@ -26,19 +26,6 @@ jax.config.update("jax_num_cpu_devices", 8)
 jax.config.update("jax_use_shardy_partitioner", False)
 
 
-def register_pjrt_plugin():
-    """Registers TT PJRT plugin."""
-
-    plugin_path = os.path.join(
-        os.path.dirname(__file__), "../build/src/tt/pjrt_plugin_tt.so"
-    )
-    if not os.path.exists(plugin_path):
-        raise FileNotFoundError(f"Could not find TT PJRT plugin at {plugin_path}")
-
-    xb.register_plugin("tt", library_path=plugin_path)
-    jax.config.update("jax_platforms", "cpu,tt")
-
-
 def generate_inputs_on_cpu(prng_key: jax.Array) -> Sequence[jax.Array]:
     """Generates inputs on CPU."""
 
@@ -81,8 +68,6 @@ def initialize_parameters(
 
 
 def run_alexnet():
-    register_pjrt_plugin()
-
     tt_devices = jax.devices("tt")
     num_tt_devices = len(jax.devices("tt"))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,8 +16,6 @@ from loguru import logger
 from pathlib import Path
 from typing import Any
 
-from jax_plugin_tt.monkeypatch import setup_monkey_patches
-
 
 def pytest_configure(config: pytest.Config):
     """
@@ -248,10 +246,3 @@ def initialize_device_connectors():
     """
     DeviceConnectorFactory.create_connector(Framework.JAX)
     DeviceConnectorFactory.create_connector(Framework.TORCH)
-
-
-# Monkeypatch libraries to use our versions of functions, which will wrap operations in a StableHLO CompositeOp
-@pytest.fixture(autouse=True)
-def monkeypatch_import(request):
-    setup_monkey_patches()
-    yield


### PR DESCRIPTION
This initialization is automatically performed on plugin registration - hence it is not needed to do it again; also, it creates issues (#1159).

Removing the initialization from tests and also removing left-over plugin registration code in the examples. Plugin registration is automatic since #1008 for both jax and pytorch.

Closes #1159