### PR TITLE
add jax test for resnet and regnet

### DIFF
--- a/tests/jax/single_chip/models/regnet/regnet_y_040/test_regnet_y_040.py
+++ b/tests/jax/single_chip/models/regnet/regnet_y_040/test_regnet_y_040.py
@@ -11,12 +11,13 @@ from utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_runtime,
+    incorrect_result,
 )
 
 from ..tester import RegNetTester
+from third_party.tt_forge_models.regnet.image_classification.jax import ModelVariant
 
-MODEL_PATH = "facebook/regnet-y-040"
+VARIANT_NAME = ModelVariant.REGNET_Y_040
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "regnet",
@@ -31,12 +32,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> RegNetTester:
-    return RegNetTester(MODEL_PATH)
+    return RegNetTester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> RegNetTester:
-    return RegNetTester(MODEL_PATH, RunMode.TRAINING)
+    return RegNetTester(VARIANT_NAME, RunMode.TRAINING)
 
 
 # ----- Tests -----
@@ -48,13 +49,12 @@ def training_tester() -> RegNetTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_RUNTIME,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
 )
 @pytest.mark.xfail(
-    reason=failed_runtime(
-        "Out of Memory: Not enough space to allocate 802816 B L1 buffer "
-        "across 1 banks, where each bank needs to store 802816 B "
-        "(https://github.com/tenstorrent/tt-xla/issues/187)"
+    reason=incorrect_result(
+        "PCC comparison failed. Calculated: pcc=0.3722558617591858. Required: pcc=0.99 "
+        "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )
 def test_regnet_y_040_inference(inference_tester: RegNetTester):

--- a/tests/jax/single_chip/models/regnet/regnet_y_160/test_regnet_y_160.py
+++ b/tests/jax/single_chip/models/regnet/regnet_y_160/test_regnet_y_160.py
@@ -15,8 +15,9 @@ from utils import (
 )
 
 from ..tester import RegNetTester
+from third_party.tt_forge_models.regnet.image_classification.jax import ModelVariant
 
-MODEL_PATH = "facebook/regnet-y-160"
+VARIANT_NAME = ModelVariant.REGNET_Y_160
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "regnet",
@@ -31,12 +32,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> RegNetTester:
-    return RegNetTester(MODEL_PATH)
+    return RegNetTester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> RegNetTester:
-    return RegNetTester(MODEL_PATH, RunMode.TRAINING)
+    return RegNetTester(VARIANT_NAME, RunMode.TRAINING)
 
 
 # ----- Tests -----
@@ -52,8 +53,8 @@ def training_tester() -> RegNetTester:
 )
 @pytest.mark.xfail(
     reason=failed_runtime(
-        "Out of Memory: Not enough space to allocate 1404928 B L1 buffer "
-        "across 1 banks, where each bank needs to store 1404928 B "
+        "Out of Memory: Not enough space to allocate 15259926528 B B L1 buffer "
+        "across 1 banks, where each bank needs to store 1271660544 B  "
         "(https://github.com/tenstorrent/tt-xla/issues/187)"
     )
 )

--- a/tests/jax/single_chip/models/regnet/regnet_y_320/test_regnet_y_320.py
+++ b/tests/jax/single_chip/models/regnet/regnet_y_320/test_regnet_y_320.py
@@ -15,8 +15,9 @@ from utils import (
 )
 
 from ..tester import RegNetTester
+from third_party.tt_forge_models.regnet.image_classification.jax import ModelVariant
 
-MODEL_PATH = "facebook/regnet-y-320"
+VARIANT_NAME = ModelVariant.REGNET_Y_320
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "regnet",
@@ -31,12 +32,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> RegNetTester:
-    return RegNetTester(MODEL_PATH)
+    return RegNetTester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> RegNetTester:
-    return RegNetTester(MODEL_PATH, RunMode.TRAINING)
+    return RegNetTester(VARIANT_NAME, RunMode.TRAINING)
 
 
 # ----- Tests -----
@@ -52,8 +53,8 @@ def training_tester() -> RegNetTester:
 )
 @pytest.mark.xfail(
     reason=failed_runtime(
-        "Out of Memory: Not enough space to allocate 1455104 B L1 buffer "
-        "across 1 banks, where each bank needs to store 1455104 B "
+        "Out of Memory: Not enough space to allocate 56438554624 B L1 buffer "
+        "across 1 banks, where each bank needs to store 4703215616 B "
         "(https://github.com/tenstorrent/tt-xla/issues/187)"
     )
 )

--- a/tests/jax/single_chip/models/regnet/tester.py
+++ b/tests/jax/single_chip/models/regnet/tester.py
@@ -2,14 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Mapping, Sequence
-
+from typing import Dict
 import jax
-from infra import ComparisonConfig, JaxModelTester, RunMode, random_image
-from transformers import (
-    AutoImageProcessor,
-    FlaxPreTrainedModel,
-    FlaxRegNetForImageClassification,
+
+from infra import ComparisonConfig, JaxModelTester, RunMode, Model
+from third_party.tt_forge_models.regnet.image_classification.jax import (
+    ModelLoader,
+    ModelVariant,
 )
 
 
@@ -18,35 +17,17 @@ class RegNetTester(JaxModelTester):
 
     def __init__(
         self,
-        model_path: str,
+        variant_name: ModelVariant,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        self._model_path = model_path
+        self._model_loader = ModelLoader(variant_name)
         super().__init__(comparison_config, run_mode)
 
     # @override
-    def _get_model(self) -> FlaxPreTrainedModel:
-        return FlaxRegNetForImageClassification.from_pretrained(
-            self._model_path, from_pt="True"
-        )
+    def _get_model(self) -> Model:
+        return self._model_loader.load_model()
 
     # @override
-    def _get_input_activations(self) -> jax.Array:
-        image_size = 224  # default image size for vision models
-        random_image = random_image(image_size)
-
-        processor = AutoImageProcessor.from_pretrained(self._model_path)
-        inputs = processor(images=random_image, return_tensors="jax")
-        return inputs["pixel_values"]
-
-    # @override
-    def _get_forward_method_kwargs(self) -> Mapping[str, Any]:
-        return {
-            "params": self._input_parameters,
-            "pixel_values": self._input_activations,
-        }
-
-    # @override
-    def _get_static_argnames(self) -> Sequence[str]:
-        return ["train"]
+    def _get_input_activations(self) -> Dict[str, jax.Array]:
+        return self._model_loader.load_inputs()

--- a/tests/jax/single_chip/models/resnet_v1_5/resnet_101/test_resnet_101.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/resnet_101/test_resnet_101.py
@@ -14,9 +14,10 @@ from utils import (
     incorrect_result,
 )
 
-from ..tester import ResNetTester, ResNetVariant
+from ..tester import ResNetTester
+from third_party.tt_forge_models.resnet.image_classification.jax import ModelVariant
 
-MODEL_VARIANT = ResNetVariant.RESNET_101
+VARIANT_NAME = ModelVariant.RESNET_101
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "resnet_v1.5",
@@ -31,12 +32,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> ResNetTester:
-    return ResNetTester(MODEL_VARIANT)
+    return ResNetTester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> ResNetTester:
-    return ResNetTester(MODEL_VARIANT, RunMode.TRAINING)
+    return ResNetTester(VARIANT_NAME, RunMode.TRAINING)
 
 
 # ----- Tests -----
@@ -54,7 +55,7 @@ def training_tester() -> ResNetTester:
 @pytest.mark.xfail(
     reason=incorrect_result(
         "AssertionError: PCC comparison failed. "
-        "Calculated: pcc=-0.08085238188505173. Required: pcc=0.99. "
+        "Calculated: pcc=0.0068986243568360806. Required: pcc=0.99. "
         "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )

--- a/tests/jax/single_chip/models/resnet_v1_5/resnet_152/test_resnet_152.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/resnet_152/test_resnet_152.py
@@ -14,9 +14,10 @@ from utils import (
     incorrect_result,
 )
 
-from ..tester import ResNetTester, ResNetVariant
+from ..tester import ResNetTester
+from third_party.tt_forge_models.resnet.image_classification.jax import ModelVariant
 
-MODEL_VARIANT = ResNetVariant.RESNET_152
+VARIANT_NAME = ModelVariant.RESNET_152
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "resnet_v1.5",
@@ -31,12 +32,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> ResNetTester:
-    return ResNetTester(MODEL_VARIANT)
+    return ResNetTester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> ResNetTester:
-    return ResNetTester(MODEL_VARIANT, RunMode.TRAINING)
+    return ResNetTester(VARIANT_NAME, RunMode.TRAINING)
 
 
 # ----- Tests -----
@@ -54,7 +55,7 @@ def training_tester() -> ResNetTester:
 @pytest.mark.xfail(
     reason=incorrect_result(
         "AssertionError: PCC comparison failed. "
-        "Calculated: pcc=-0.00785880908370018. Required: pcc=0.99. "
+        "Calculated: pcc=0.0746539905667305. Required: pcc=0.99. "
         "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )

--- a/tests/jax/single_chip/models/resnet_v1_5/resnet_18/test_resnet_18.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/resnet_18/test_resnet_18.py
@@ -13,9 +13,10 @@ from utils import (
     build_model_name,
 )
 
-from ..tester import ResNetTester, ResNetVariant
+from ..tester import ResNetTester
+from third_party.tt_forge_models.resnet.image_classification.jax import ModelVariant
 
-MODEL_VARIANT = ResNetVariant.RESNET_18
+VARIANT_NAME = ModelVariant.RESNET_18
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "resnet_v1.5",
@@ -30,12 +31,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> ResNetTester:
-    return ResNetTester(MODEL_VARIANT)
+    return ResNetTester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> ResNetTester:
-    return ResNetTester(MODEL_VARIANT, RunMode.TRAINING)
+    return ResNetTester(VARIANT_NAME, RunMode.TRAINING)
 
 
 # ----- Tests -----

--- a/tests/jax/single_chip/models/resnet_v1_5/resnet_26/test_resnet_26.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/resnet_26/test_resnet_26.py
@@ -16,9 +16,10 @@ from utils import (
     failed_runtime,
 )
 
-from ..tester import ResNetTester, ResNetVariant
+from ..tester import ResNetTester
+from third_party.tt_forge_models.resnet.image_classification.jax import ModelVariant
 
-MODEL_VARIANT = ResNetVariant.RESNET_26
+VARIANT_NAME = ModelVariant.RESNET_26
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "resnet_v1.5",
@@ -33,20 +34,17 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> ResNetTester:
-    return ResNetTester(MODEL_VARIANT)
+    return ResNetTester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> ResNetTester:
-    return ResNetTester(MODEL_VARIANT, RunMode.TRAINING)
+    return ResNetTester(VARIANT_NAME, RunMode.TRAINING)
 
 
 @pytest.fixture
 def inference_tester_optimizer() -> ResNetTester:
-    compiler_config = CompilerConfig(enable_optimizer=True)
-    return ResNetTester(
-        MODEL_VARIANT, run_mode=RunMode.INFERENCE, compiler_config=compiler_config
-    )
+    return ResNetTester(VARIANT_NAME, run_mode=RunMode.INFERENCE, use_optimizer=True)
 
 
 # ----- Tests -----
@@ -63,7 +61,7 @@ def inference_tester_optimizer() -> ResNetTester:
 @pytest.mark.large
 @pytest.mark.xfail(
     reason=incorrect_result(
-        "Calculated: pcc=-0.00282002380117774. Required: pcc=0.99. "
+        "Calculated: pcc=-0.05205399543046951. Required: pcc=0.99. "
         "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )

--- a/tests/jax/single_chip/models/resnet_v1_5/resnet_34/test_resnet_34.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/resnet_34/test_resnet_34.py
@@ -13,9 +13,10 @@ from utils import (
     build_model_name,
 )
 
-from ..tester import ResNetTester, ResNetVariant
+from ..tester import ResNetTester
+from third_party.tt_forge_models.resnet.image_classification.jax import ModelVariant
 
-MODEL_VARIANT = ResNetVariant.RESNET_34
+VARIANT_NAME = ModelVariant.RESNET_34
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "resnet_v1.5",
@@ -30,12 +31,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> ResNetTester:
-    return ResNetTester(MODEL_VARIANT)
+    return ResNetTester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> ResNetTester:
-    return ResNetTester(MODEL_VARIANT, RunMode.TRAINING)
+    return ResNetTester(VARIANT_NAME, RunMode.TRAINING)
 
 
 # ----- Tests -----

--- a/tests/jax/single_chip/models/resnet_v1_5/resnet_50/test_resnet_50.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/resnet_50/test_resnet_50.py
@@ -14,9 +14,10 @@ from utils import (
     incorrect_result,
 )
 
-from ..tester import ResNetTester, ResNetVariant
+from ..tester import ResNetTester
+from third_party.tt_forge_models.resnet.image_classification.jax import ModelVariant
 
-MODEL_VARIANT = ResNetVariant.RESNET_50
+VARIANT_NAME = ModelVariant.RESNET_50
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "resnet_v1.5",
@@ -31,12 +32,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> ResNetTester:
-    return ResNetTester(MODEL_VARIANT)
+    return ResNetTester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> ResNetTester:
-    return ResNetTester(MODEL_VARIANT, RunMode.TRAINING)
+    return ResNetTester(VARIANT_NAME, RunMode.TRAINING)
 
 
 # ----- Tests -----
@@ -55,7 +56,7 @@ def training_tester() -> ResNetTester:
 @pytest.mark.xfail(
     reason=incorrect_result(
         "AssertionError: PCC comparison failed. "
-        "Calculated: pcc=-0.06640016287565231. Required: pcc=0.99. "
+        "Calculated: pcc=-0.03391769528388977. Required: pcc=0.99. "
         "https://github.com/tenstorrent/tt-xla/issues/379"
     )
 )

--- a/tests/jax/single_chip/models/resnet_v1_5/tester.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/tester.py
@@ -2,121 +2,32 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict, List, Sequence, Tuple, Union
-
+from typing import Dict
 import jax
-import torch
-from huggingface_hub import hf_hub_download
-from infra import ComparisonConfig, JaxModelTester, RunMode
-from tests.infra.testers.compiler_config import CompilerConfig
-from safetensors import safe_open
-from transformers import (
-    FlaxPreTrainedModel,
-    FlaxResNetForImageClassification,
-    ResNetConfig,
+
+from infra import ComparisonConfig, JaxModelTester, RunMode, Model
+from third_party.tt_forge_models.resnet.image_classification.jax import (
+    ModelLoader,
+    ModelVariant,
 )
-from utils import StrEnum
-
-from tests.jax.single_chip.models.model_utils import torch_statedict_to_pytree
-
-
-# Variants should be the same between all versions of resnet.
-# Therefore the version is not included
-class ResNetVariant(StrEnum):
-    RESNET_18 = "resnet-18"
-    RESNET_26 = "resnet-26"
-    RESNET_34 = "resnet-34"
-    RESNET_50 = "resnet-50"
-    RESNET_101 = "resnet-101"
-    RESNET_152 = "resnet-152"
 
 
 class ResNetTester(JaxModelTester):
-    "Tester for ResNet family of models."
+    """Tester for ResNet family of models."""
 
     def __init__(
         self,
-        model_variant: ResNetVariant,
+        variant_name: ModelVariant,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
-        compiler_config: CompilerConfig = None,
     ) -> None:
-        self._model_variant = model_variant
-        super().__init__(comparison_config, run_mode, compiler_config)
-
-    @staticmethod
-    def _get_renaming_patterns(variant: ResNetVariant) -> List[Tuple[str, str]]:
-        PATTERNS = [
-            (r"convolution.weight", r"convolution.kernel"),
-            (r"normalization.running_mean", r"normalization.mean"),
-            (r"normalization.running_var", r"normalization.var"),
-            (r"normalization.weight", r"normalization.scale"),
-            (r"classifier\.(\d+).weight", r"classifier.\1.kernel"),
-        ]
-
-        if variant in (ResNetVariant.RESNET_18, ResNetVariant.RESNET_34):
-            PATTERNS.append((r"layer\.(\d+)\.", r"layer.layer_\1."))
-
-        return PATTERNS
-
-    @staticmethod
-    def _get_banned_subkeys() -> List[str]:
-        return ["num_batches_tracked"]
-
-    @staticmethod
-    def _download_weights(
-        model_variant: ResNetVariant,
-    ) -> Union[Dict[str, jax.Array], Dict[str, torch.Tensor]]:
-        filename = "model.safetensors"
-        if model_variant == ResNetVariant.RESNET_101:
-            filename = "pytorch_model.bin"
-
-        hf_path = f"microsoft/{model_variant}"
-        ckpt_path = hf_hub_download(repo_id=hf_path, filename=filename)
-
-        if filename == "model.safetensors":
-            with safe_open(ckpt_path, framework="flax", device="cpu") as f:
-                return {key: f.get_tensor(key) for key in f.keys()}
-        else:  # filename == "pytorch_model.bin"
-            return torch.load(ckpt_path, map_location="cpu")
+        self._model_loader = ModelLoader(variant_name)
+        super().__init__(comparison_config, run_mode)
 
     # @override
-    def _get_model(self) -> FlaxPreTrainedModel:
-        # Resnet-50 has a flax checkpoint on HF, so we can just load it directly.
-        hf_path = f"microsoft/{self._model_variant}"
-        if self._model_variant == ResNetVariant.RESNET_50:
-            return FlaxResNetForImageClassification.from_pretrained(hf_path)
-
-        # We would ideally rely on 'from_pt' functionality in HF,
-        # however, it is broken for resnet.
-        # All the weights fail to load because of a naming mismatch.
-        # We have to load the weights manually and apply a few conversions.
-        model_config = ResNetConfig.from_pretrained(hf_path)
-        model = FlaxResNetForImageClassification(model_config)
-
-        state_dict = self._download_weights(self._model_variant)
-
-        variables = torch_statedict_to_pytree(
-            state_dict,
-            patterns=self._get_renaming_patterns(self._model_variant),
-            banned_subkeys=self._get_banned_subkeys(),
-        )
-
-        model.params = variables
-
-        return model
+    def _get_model(self) -> Model:
+        return self._model_loader.load_model()
 
     # @override
-    def _get_input_activations(self) -> jax.Array:
-        return jax.random.uniform(jax.random.PRNGKey(0), (1, 3, 224, 224))
-
-    # @override
-    def _get_forward_method_kwargs(self) -> Dict[str, jax.Array]:
-        return {
-            "params": self._input_parameters,
-            "pixel_values": self._input_activations,
-        }
-
-    # @override
-    def _get_static_argnames(self) -> Sequence[str]:
-        return ["train"]
+    def _get_input_activations(self) -> Dict[str, jax.Array]:
+        return self._model_loader.load_inputs()


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-xla/issues/1237

### Problem description
Update JAX tests of resnet and regnet models to use ModelLoader and ModelVariant from tt-forge-models

### Checklist
- [x] New/Existing tests provide coverage for changes

I have attached the logs for your reference:
[test_regnet_y_040_without_xfail.log](https://github.com/user-attachments/files/22047702/test_regnet_y_040_without_xfail.log)
[test_regnet_y_160_without_xfail.log](https://github.com/user-attachments/files/22047706/test_regnet_y_160_without_xfail.log)
[test_regnet_y_320_without_xfail.log](https://github.com/user-attachments/files/22047707/test_regnet_y_320_without_xfail.log)
[test_resnet_18_without_xfail.log](https://github.com/user-attachments/files/22047709/test_resnet_18_without_xfail.log)
[test_resnet_26_without_xfail.log](https://github.com/user-attachments/files/22047713/test_resnet_26_without_xfail.log)
[test_resnet_34_without_xfail.log](https://github.com/user-attachments/files/22047715/test_resnet_34_without_xfail.log)
[test_resnet_50_without_xfail.log](https://github.com/user-attachments/files/22047716/test_resnet_50_without_xfail.log)
[test_resnet_101_without_xfail.log](https://github.com/user-attachments/files/22047717/test_resnet_101_without_xfail.log)
[test_resnet_152_without_xfai.log](https://github.com/user-attachments/files/22047718/test_resnet_152_without_xfai.log)
