### PR TITLE
Include coverage build on push

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -31,6 +31,16 @@ jobs:
     with:
       docker_image: ${{ needs.build-image.outputs.docker-image }}
 
+  # Building tt-xla with code coverage to generate cached ccache for branches in CI
+  build-ttxla-codecov:
+    uses: ./.github/workflows/call-build.yml
+    name: "Build tt-xla with code coverage"
+    secrets: inherit
+    needs: [ build-image ]
+    with:
+      docker_image: ${{ needs.build-image.outputs.docker-image }}
+      debug_build: true
+
   test:
     needs: [ build-image, build-ttxla ]
     uses: ./.github/workflows/call-test.yml


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Initial runs on branches take much longer time to build because they can't find cached ccache.

### What's changed
Run codecov build on push (main) so they will generate ccache, this should help with CI cache hit rate

### Checklist
- [ ] New/Existing tests provide coverage for changes
