### PR TITLE
Uplift jax to 0.7.0

### DIFF
--- a/python_package/requirements.txt
+++ b/python_package/requirements.txt
@@ -1,4 +1,4 @@
-jax==0.6.0
-jaxlib==0.6.0
+jax[cpu]==0.7.0
+jaxlib==0.7.0
 torch==2.7.0
 torch_xla==2.7.0


### PR DESCRIPTION
### Ticket
closes #1128 

### Problem description
We want to ingest some shardy changes that come along with jax 0.7.0

### What's changed
Dependency was updated to 0.7.0
Additionally, jax by default installs cuda packages too, we don't want that so I switched the exact dependency to `jax[cpu]`

### Checklist
- [X] New/Existing tests provide coverage for changes
