### PR TITLE
Update JAX tests for Dinov2 and VIT

### DIFF
--- a/tests/jax/single_chip/models/dinov2/base/test_dinov2_base.py
+++ b/tests/jax/single_chip/models/dinov2/base/test_dinov2_base.py
@@ -11,16 +11,15 @@ from utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_runtime,
 )
-
+from third_party.tt_forge_models.dinov2.image_classification.jax import ModelVariant
 from ..tester import Dinov2Tester
 
-MODEL_PATH = "facebook/dinov2-base"
+VARIANT_NAME = ModelVariant.BASE
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "dinov2",
-    "base",
+    str(VARIANT_NAME),
     ModelTask.CV_IMAGE_CLS,
     ModelSource.HUGGING_FACE,
 )
@@ -31,12 +30,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> Dinov2Tester:
-    return Dinov2Tester(MODEL_PATH)
+    return Dinov2Tester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> Dinov2Tester:
-    return Dinov2Tester(MODEL_PATH, RunMode.TRAINING)
+    return Dinov2Tester(VARIANT_NAME, RunMode.TRAINING)
 
 
 # ----- Tests -----
@@ -48,13 +47,7 @@ def training_tester() -> Dinov2Tester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_RUNTIME,
-)
-@pytest.mark.xfail(
-    reason=failed_runtime(
-        "input_tensor_a.get_padded_shape().rank() == this->slice_start.rank() && this->slice_start.rank() == this->slice_end.rank() "
-        "(https://github.com/tenstorrent/tt-xla/issues/535)"
-    )
+    bringup_status=BringupStatus.PASSED,
 )
 def test_dinov2_base_inference(inference_tester: Dinov2Tester):
     inference_tester.test()

--- a/tests/jax/single_chip/models/dinov2/giant/test_dinov2_giant.py
+++ b/tests/jax/single_chip/models/dinov2/giant/test_dinov2_giant.py
@@ -13,14 +13,14 @@ from utils import (
     build_model_name,
     failed_runtime,
 )
-
+from third_party.tt_forge_models.dinov2.image_classification.jax import ModelVariant
 from ..tester import Dinov2Tester
 
-MODEL_PATH = "facebook/dinov2-giant"
+VARIANT_NAME = ModelVariant.GIANT
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "dinov2",
-    "giant",
+    str(VARIANT_NAME),
     ModelTask.CV_IMAGE_CLS,
     ModelSource.HUGGING_FACE,
 )
@@ -31,12 +31,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> Dinov2Tester:
-    return Dinov2Tester(MODEL_PATH)
+    return Dinov2Tester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> Dinov2Tester:
-    return Dinov2Tester(MODEL_PATH, RunMode.TRAINING)
+    return Dinov2Tester(VARIANT_NAME, RunMode.TRAINING)
 
 
 # ----- Tests -----
@@ -48,16 +48,9 @@ def training_tester() -> Dinov2Tester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_RUNTIME,
+    bringup_status=BringupStatus.PASSED,
 )
 @pytest.mark.large
-@pytest.mark.xfail(
-    reason=failed_runtime(
-        "tt-metal error: input_tensor_a.padded_shape().rank() == this->slice_start.rank() && "
-        "this->slice_start.rank() == this->slice_end.rank() "
-        "https://github.com/tenstorrent/tt-xla/issues/923"
-    )
-)
 def test_dinov2_giant_inference(inference_tester: Dinov2Tester):
     inference_tester.test()
 

--- a/tests/jax/single_chip/models/dinov2/large/test_dinov2_large.py
+++ b/tests/jax/single_chip/models/dinov2/large/test_dinov2_large.py
@@ -11,16 +11,15 @@ from utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    failed_runtime,
 )
-
+from third_party.tt_forge_models.dinov2.image_classification.jax import ModelVariant
 from ..tester import Dinov2Tester
 
-MODEL_PATH = "facebook/dinov2-large"
+VARIANT_NAME = ModelVariant.LARGE
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "dinov2",
-    "large",
+    str(VARIANT_NAME),
     ModelTask.CV_IMAGE_CLS,
     ModelSource.HUGGING_FACE,
 )
@@ -31,12 +30,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> Dinov2Tester:
-    return Dinov2Tester(MODEL_PATH)
+    return Dinov2Tester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> Dinov2Tester:
-    return Dinov2Tester(MODEL_PATH, RunMode.TRAINING)
+    return Dinov2Tester(VARIANT_NAME, RunMode.TRAINING)
 
 
 # ----- Tests -----
@@ -48,13 +47,7 @@ def training_tester() -> Dinov2Tester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_RUNTIME,
-)
-@pytest.mark.xfail(
-    reason=failed_runtime(
-        "input_tensor_a.get_padded_shape().rank() == this->slice_start.rank() && this->slice_start.rank() == this->slice_end.rank() "
-        "(https://github.com/tenstorrent/tt-xla/issues/535)"
-    )
+    bringup_status=BringupStatus.PASSED,
 )
 def test_dinov2_large_inference(inference_tester: Dinov2Tester):
     inference_tester.test()

--- a/tests/jax/single_chip/models/dinov2/tester.py
+++ b/tests/jax/single_chip/models/dinov2/tester.py
@@ -5,12 +5,10 @@
 from typing import Any, Mapping, Sequence
 
 import jax
-from infra import ComparisonConfig, JaxModelTester, RunMode, random_image
-from transformers import (
-    AutoImageProcessor,
-    Dinov2Config,
-    FlaxDinov2ForImageClassification,
-    FlaxPreTrainedModel,
+from infra import ComparisonConfig, JaxModelTester, RunMode, Model
+from third_party.tt_forge_models.dinov2.image_classification.jax.loader import (
+    ModelLoader,
+    ModelVariant,
 )
 
 
@@ -19,33 +17,20 @@ class Dinov2Tester(JaxModelTester):
 
     def __init__(
         self,
-        model_path: str,
+        variant_name: ModelVariant,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        self._model_path = model_path
+        self._model_loader = ModelLoader(variant_name)
         super().__init__(comparison_config, run_mode)
 
     # @override
-    def _get_model(self) -> FlaxPreTrainedModel:
-        return FlaxDinov2ForImageClassification.from_pretrained(self._model_path)
+    def _get_model(self) -> Model:
+        return self._model_loader.load_model()
 
     # @override
     def _get_input_activations(self) -> jax.Array:
-        model_config = Dinov2Config.from_pretrained(self._model_path)
-        image_size = model_config.image_size
-        input_image = random_image(image_size)
-
-        processor = AutoImageProcessor.from_pretrained(self._model_path)
-        inputs = processor(images=input_image, return_tensors="jax")
-        return inputs["pixel_values"]
-
-    # @override
-    def _get_forward_method_kwargs(self) -> Mapping[str, Any]:
-        return {
-            "params": self._input_parameters,
-            "pixel_values": self._input_activations,
-        }
+        return self._model_loader.load_inputs()
 
     # @override
     def _get_static_argnames(self) -> Sequence[str]:

--- a/tests/jax/single_chip/models/vit/tester.py
+++ b/tests/jax/single_chip/models/vit/tester.py
@@ -2,16 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict, Sequence
+from typing import Sequence
 
 import jax
-import jax.numpy as jnp
-from infra import ComparisonConfig, JaxModelTester, RunMode, random_image
-from transformers import (
-    FlaxPreTrainedModel,
-    FlaxViTForImageClassification,
-    ViTConfig,
-    ViTImageProcessor,
+from infra import ComparisonConfig, JaxModelTester, RunMode, Model
+from third_party.tt_forge_models.vit.image_classification.jax import (
+    ModelLoader,
+    ModelVariant,
 )
 
 
@@ -20,37 +17,21 @@ class ViTTester(JaxModelTester):
 
     def __init__(
         self,
-        model_path: str,
+        variant_name: ModelVariant,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
     ) -> None:
-        self._model_path = model_path
+        self._model_loader = ModelLoader(variant_name)
         super().__init__(comparison_config, run_mode)
 
     # @override
-    def _get_model(self) -> FlaxPreTrainedModel:
-        model = FlaxViTForImageClassification.from_pretrained(
-            self._model_path, dtype=jnp.bfloat16
-        )
-        model.params = model.to_bf16(model.params)
+    def _get_model(self) -> Model:
+        model = self._model_loader.load_model()
         return model
 
     # @override
     def _get_input_activations(self) -> jax.Array:
-        model_config = ViTConfig.from_pretrained(self._model_path)
-        image_size = model_config.image_size
-        img = random_image(image_size)
-
-        processor = ViTImageProcessor.from_pretrained(self._model_path)
-        inputs = processor(images=img, return_tensors="jax")
-        return inputs["pixel_values"]
-
-    # @override
-    def _get_forward_method_kwargs(self) -> Dict[str, jax.Array]:
-        return {
-            "params": self._input_parameters,
-            "pixel_values": self._input_activations,
-        }
+        return self._model_loader.load_inputs()
 
     # @override
     def _get_static_argnames(self) -> Sequence[str]:

--- a/tests/jax/single_chip/models/vit/vit_base_patch16_224/test_vit_base_patch16_224.py
+++ b/tests/jax/single_chip/models/vit/vit_base_patch16_224/test_vit_base_patch16_224.py
@@ -12,14 +12,14 @@ from utils import (
     ModelTask,
     build_model_name,
 )
-
+from third_party.tt_forge_models.vit.image_classification.jax import ModelVariant
 from ..tester import ViTTester
 
-MODEL_PATH = "google/vit-base-patch16-224"
+VARIANT_NAME = ModelVariant.BASE_PATCH16_224
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "vit",
-    "base_patch16_224",
+    str(VARIANT_NAME),
     ModelTask.CV_IMAGE_CLS,
     ModelSource.HUGGING_FACE,
 )
@@ -30,12 +30,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> ViTTester:
-    return ViTTester(MODEL_PATH)
+    return ViTTester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> ViTTester:
-    return ViTTester(MODEL_PATH, RunMode.TRAINING)
+    return ViTTester(VARIANT_NAME, RunMode.TRAINING)
 
 
 # ----- Tests -----

--- a/tests/jax/single_chip/models/vit/vit_base_patch16_384/test_vit_base_patch16_384.py
+++ b/tests/jax/single_chip/models/vit/vit_base_patch16_384/test_vit_base_patch16_384.py
@@ -12,16 +12,15 @@ from utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    incorrect_result,
 )
-
+from third_party.tt_forge_models.vit.image_classification.jax import ModelVariant
 from ..tester import ViTTester
 
-MODEL_PATH = "google/vit-base-patch16-384"
+VARIANT_NAME = ModelVariant.BASE_PATCH16_384
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "vit",
-    "base_patch16_384",
+    str(VARIANT_NAME),
     ModelTask.CV_IMAGE_CLS,
     ModelSource.HUGGING_FACE,
 )
@@ -32,12 +31,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> ViTTester:
-    return ViTTester(MODEL_PATH)
+    return ViTTester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> ViTTester:
-    return ViTTester(MODEL_PATH, RunMode.TRAINING)
+    return ViTTester(VARIANT_NAME, RunMode.TRAINING)
 
 
 # ----- Tests -----
@@ -49,13 +48,7 @@ def training_tester() -> ViTTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.INCORRECT_RESULT,
-)
-@pytest.mark.xfail(
-    reason=incorrect_result(
-        "PCC comparison failed. Calculated: pcc=0.9865921139717102. Required: pcc=0.99. "
-        "https://github.com/tenstorrent/tt-xla/issues/929"
-    )
+    bringup_status=BringupStatus.PASSED,
 )
 def test_vit_base_patch16_384_inference(
     inference_tester: ViTTester,

--- a/tests/jax/single_chip/models/vit/vit_base_patch32_224_in21k/test_vit_base_patch32_224_in21k.py
+++ b/tests/jax/single_chip/models/vit/vit_base_patch32_224_in21k/test_vit_base_patch32_224_in21k.py
@@ -12,15 +12,16 @@ from utils import (
     ModelSource,
     ModelTask,
     build_model_name,
+    failed_runtime,
 )
-
+from third_party.tt_forge_models.vit.image_classification.jax import ModelVariant
 from ..tester import ViTTester
 
-MODEL_PATH = "google/vit-base-patch32-224-in21k"
+VARIANT_NAME = ModelVariant.BASE_PATCH32_224_IN_21K
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "vit",
-    "base_patch32_224_in21k",
+    str(VARIANT_NAME),
     ModelTask.CV_IMAGE_CLS,
     ModelSource.HUGGING_FACE,
 )
@@ -31,12 +32,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> ViTTester:
-    return ViTTester(MODEL_PATH)
+    return ViTTester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> ViTTester:
-    return ViTTester(MODEL_PATH, RunMode.TRAINING)
+    return ViTTester(VARIANT_NAME, RunMode.TRAINING)
 
 
 # ----- Tests -----
@@ -48,7 +49,14 @@ def training_tester() -> ViTTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.PASSED,
+    bringup_status=BringupStatus.FAILED_RUNTIME,
+)
+@pytest.mark.xfail(
+    reason=failed_runtime(
+        "Out of Memory: Not enough space to allocate 2287616 B L1 buffer across 2 banks, "
+        "where each bank needs to store 1143808 B "
+        "(https://github.com/tenstorrent/tt-xla/issues/918)"
+    )
 )
 def test_vit_base_patch32_224_in21k_inference(
     inference_tester: ViTTester,

--- a/tests/jax/single_chip/models/vit/vit_base_patch32_384/test_vit_base_patch32_384.py
+++ b/tests/jax/single_chip/models/vit/vit_base_patch32_384/test_vit_base_patch32_384.py
@@ -12,16 +12,16 @@ from utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    incorrect_result,
+    failed_runtime,
 )
-
+from third_party.tt_forge_models.vit.image_classification.jax import ModelVariant
 from ..tester import ViTTester
 
-MODEL_PATH = "google/vit-base-patch32-384"
+VARIANT_NAME = ModelVariant.BASE_PATCH32_384
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "vit",
-    "base_patch32_384",
+    str(VARIANT_NAME),
     ModelTask.CV_IMAGE_CLS,
     ModelSource.HUGGING_FACE,
 )
@@ -32,12 +32,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> ViTTester:
-    return ViTTester(MODEL_PATH)
+    return ViTTester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> ViTTester:
-    return ViTTester(MODEL_PATH, RunMode.TRAINING)
+    return ViTTester(VARIANT_NAME, RunMode.TRAINING)
 
 
 # ----- Tests -----
@@ -49,12 +49,13 @@ def training_tester() -> ViTTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.INCORRECT_RESULT,
+    bringup_status=BringupStatus.FAILED_RUNTIME,
 )
 @pytest.mark.xfail(
-    reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=393216.4375. Required: atol=0.16. "
-        "https://github.com/tenstorrent/tt-xla/issues/379"
+    reason=failed_runtime(
+        "Out of Memory: Not enough space to allocate  7782400 B L1 buffer across 5 banks, "
+        "where each bank needs to store 1556480 B "
+        "(https://github.com/tenstorrent/tt-xla/issues/918)"
     )
 )
 def test_vit_base_patch32_384_inference(

--- a/tests/jax/single_chip/models/vit/vit_huge_patch14_224_in21k/test_vit_huge_patch14_224_in21k.py
+++ b/tests/jax/single_chip/models/vit/vit_huge_patch14_224_in21k/test_vit_huge_patch14_224_in21k.py
@@ -13,14 +13,14 @@ from utils import (
     ModelTask,
     build_model_name,
 )
-
+from third_party.tt_forge_models.vit.image_classification.jax import ModelVariant
 from ..tester import ViTTester
 
-MODEL_PATH = "google/vit-huge-patch14-224-in21k"
+VARIANT_NAME = ModelVariant.HUGE_PATCH14_224_IN_21K
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "vit",
-    "huge_patch14_224_in21k",
+    str(VARIANT_NAME),
     ModelTask.CV_IMAGE_CLS,
     ModelSource.HUGGING_FACE,
 )
@@ -31,12 +31,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> ViTTester:
-    return ViTTester(MODEL_PATH)
+    return ViTTester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> ViTTester:
-    return ViTTester(MODEL_PATH, RunMode.TRAINING)
+    return ViTTester(VARIANT_NAME, RunMode.TRAINING)
 
 
 # ----- Tests -----

--- a/tests/jax/single_chip/models/vit/vit_large_patch16_224/test_vit_large_patch16_224.py
+++ b/tests/jax/single_chip/models/vit/vit_large_patch16_224/test_vit_large_patch16_224.py
@@ -12,16 +12,15 @@ from utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    incorrect_result,
 )
-
+from third_party.tt_forge_models.vit.image_classification.jax import ModelVariant
 from ..tester import ViTTester
 
-MODEL_PATH = "google/vit-large-patch16-224"
+VARIANT_NAME = ModelVariant.LARGE_PATCH16_224
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "vit",
-    "large_patch16_224",
+    str(VARIANT_NAME),
     ModelTask.CV_IMAGE_CLS,
     ModelSource.HUGGING_FACE,
 )
@@ -32,12 +31,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> ViTTester:
-    return ViTTester(MODEL_PATH)
+    return ViTTester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> ViTTester:
-    return ViTTester(MODEL_PATH, RunMode.TRAINING)
+    return ViTTester(VARIANT_NAME, RunMode.TRAINING)
 
 
 # ----- Tests -----
@@ -49,13 +48,7 @@ def training_tester() -> ViTTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.INCORRECT_RESULT,
-)
-@pytest.mark.xfail(
-    reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=311296.0. Required: atol=0.16. "
-        "https://github.com/tenstorrent/tt-xla/issues/379"
-    )
+    bringup_status=BringupStatus.PASSED,
 )
 def test_vit_large_patch16_224_inference(
     inference_tester: ViTTester,

--- a/tests/jax/single_chip/models/vit/vit_large_patch16_384/test_vit_large_patch16_384.py
+++ b/tests/jax/single_chip/models/vit/vit_large_patch16_384/test_vit_large_patch16_384.py
@@ -12,16 +12,15 @@ from utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    incorrect_result,
 )
-
+from third_party.tt_forge_models.vit.image_classification.jax import ModelVariant
 from ..tester import ViTTester
 
-MODEL_PATH = "google/vit-large-patch16-384"
+VARIANT_NAME = ModelVariant.LARGE_PATCH16_384
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "vit",
-    "large_patch16_384",
+    str(VARIANT_NAME),
     ModelTask.CV_IMAGE_CLS,
     ModelSource.HUGGING_FACE,
 )
@@ -32,12 +31,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> ViTTester:
-    return ViTTester(MODEL_PATH)
+    return ViTTester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> ViTTester:
-    return ViTTester(MODEL_PATH, RunMode.TRAINING)
+    return ViTTester(VARIANT_NAME, RunMode.TRAINING)
 
 
 # ----- Tests -----
@@ -49,13 +48,7 @@ def training_tester() -> ViTTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.INCORRECT_RESULT,
-)
-@pytest.mark.xfail(
-    reason=incorrect_result(
-        "Atol comparison failed. Calculated: atol=337919.8125. Required: atol=0.16. "
-        "https://github.com/tenstorrent/tt-xla/issues/379"
-    )
+    bringup_status=BringupStatus.PASSED,
 )
 def test_vit_large_patch16_384_inference(
     inference_tester: ViTTester,

--- a/tests/jax/single_chip/models/vit/vit_large_patch32_224_in21k/test_vit_large_patch32_224_in21k.py
+++ b/tests/jax/single_chip/models/vit/vit_large_patch32_224_in21k/test_vit_large_patch32_224_in21k.py
@@ -12,16 +12,16 @@ from utils import (
     ModelSource,
     ModelTask,
     build_model_name,
-    incorrect_result,
+    failed_runtime,
 )
-
+from third_party.tt_forge_models.vit.image_classification.jax import ModelVariant
 from ..tester import ViTTester
 
-MODEL_PATH = "google/vit-large-patch32-224-in21k"
+VARIANT_NAME = ModelVariant.LARGE_PATCH32_224_IN_21K
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "vit",
-    "large_patch32_224_in21k",
+    str(VARIANT_NAME),
     ModelTask.CV_IMAGE_CLS,
     ModelSource.HUGGING_FACE,
 )
@@ -32,7 +32,7 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> ViTTester:
-    return ViTTester(MODEL_PATH)
+    return ViTTester(VARIANT_NAME)
 
 
 @pytest.fixture
@@ -49,7 +49,14 @@ def training_tester() -> ViTTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.PASSED,
+    bringup_status=BringupStatus.FAILED_RUNTIME,
+)
+@pytest.mark.xfail(
+    reason=failed_runtime(
+        "Out of Memory: Not enough space to allocate  2287616 B L1 buffer across 2 banks, "
+        "where each bank needs to store 1143808 B "
+        "(https://github.com/tenstorrent/tt-xla/issues/918)"
+    )
 )
 def test_vit_large_patch32_224_in21k_inference(
     inference_tester: ViTTester,

--- a/tests/jax/single_chip/models/vit/vit_large_patch32_384/test_vit_large_patch32_384.py
+++ b/tests/jax/single_chip/models/vit/vit_large_patch32_384/test_vit_large_patch32_384.py
@@ -14,14 +14,14 @@ from utils import (
     build_model_name,
     failed_runtime,
 )
-
+from third_party.tt_forge_models.vit.image_classification.jax import ModelVariant
 from ..tester import ViTTester
 
-MODEL_PATH = "google/vit-large-patch32-384"
+VARIANT_NAME = ModelVariant.LARGE_PATCH32_384
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "vit",
-    "large_patch32_384",
+    str(VARIANT_NAME),
     ModelTask.CV_IMAGE_CLS,
     ModelSource.HUGGING_FACE,
 )
@@ -32,12 +32,12 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> ViTTester:
-    return ViTTester(MODEL_PATH)
+    return ViTTester(VARIANT_NAME)
 
 
 @pytest.fixture
 def training_tester() -> ViTTester:
-    return ViTTester(MODEL_PATH, RunMode.TRAINING)
+    return ViTTester(VARIANT_NAME, RunMode.TRAINING)
 
 
 # ----- Tests -----
@@ -53,10 +53,9 @@ def training_tester() -> ViTTester:
 )
 @pytest.mark.xfail(
     reason=failed_runtime(
-        "Statically allocated circular buffers in program 453 clash with L1 "
-        "buffers on core range [(x=0,y=0) - (x=4,y=0)]. L1 buffer allocated at "
-        "622592 and static circular buffer region ends at 654368 "
-        "https://github.com/tenstorrent/tt-xla/issues/187"
+        "Out of Memory: Not enough space to allocate  7782400 B L1 buffer across 5 banks, "
+        "where each bank needs to store 1556480 B "
+        "(https://github.com/tenstorrent/tt-xla/issues/918)"
     )
 )
 def test_vit_large_patch32_384_inference(


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-xla/issues/1252

### Problem description
Update JAX tests of Dinov2  and XLM RoBERTa models to use ModelLoader and ModelVariant from tt-forge-models

### Checklist
- [x] New/Existing tests provide coverage for changes

PFA logs for reference : 
[dino_giant_2.log](https://github.com/user-attachments/files/22087328/dino_giant_2.log)
[dinov2_base.log](https://github.com/user-attachments/files/22087329/dinov2_base.log)
[vit_large_p16_384.log](https://github.com/user-attachments/files/22087335/vit_large_p16_384.log)
[vit_large_p32_224_in21k.log](https://github.com/user-attachments/files/22087336/vit_large_p32_224_in21k.log)
[vit_large_p32_384.log](https://github.com/user-attachments/files/22087337/vit_large_p32_384.log)
[vit_p16_224.log](https://github.com/user-attachments/files/22087338/vit_p16_224.log)
[dinov2_large.log](https://github.com/user-attachments/files/22087330/dinov2_large.log)
[vit_huge_p14_224_in21k.log](https://github.com/user-attachments/files/22087333/vit_huge_p14_224_in21k.log)
[vit_large_p16_224.log](https://github.com/user-attachments/files/22087334/vit_large_p16_224.log)
[vit_p16_384.log](https://github.com/user-attachments/files/22087339/vit_p16_384.log)
[vit_p32_224_in21k.log](https://github.com/user-attachments/files/22087340/vit_p32_224_in21k.log)
[vit_p32_384.log](https://github.com/user-attachments/files/22087341/vit_p32_384.log)
