### PR TITLE
Add latest tag to the tt-xla docker ird image as well

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 /src/ @sdjukicTT @sgligorijevicTT @ajakovljevicTT @mrakitaTT
 
 # CI
-/.github/ @vmilosevic @jmcgrathTT @nsumrakTT @ajakovljevicTT @mrakitaTT
+/.github/ @vmilosevic @jmcgrathTT @nsumrakTT @ajakovljevicTT @mrakitaTT @vvukomanTT
 
 # Tests
 /tests/ @sdjukicTT @sgligorijevicTT @ajakovljevicTT @mrakitaTT

--- a/.github/workflows/call-build-docker.yml
+++ b/.github/workflows/call-build-docker.yml
@@ -75,11 +75,11 @@ jobs:
 
           CI_IMAGE_NAME=$(echo $DOCKER_CI_IMAGE | sed 's/:.*//')
           echo "Setting latest tag on the image $CI_IMAGE_NAME:$DOCKER_TAG"
-          skopeo copy "docker://$CI_IMAGE_NAME:$DOCKER_TAG" "docker://$CI_IMAGE_NAME:test02092025"
+          skopeo copy "docker://$CI_IMAGE_NAME:$DOCKER_TAG" "docker://$CI_IMAGE_NAME:latest"
 
           IRD_IMAGE_NAME=$(echo $DOCKER_CI_IMAGE | sed 's/:.*//' | sed 's/-ci-/-ird-/')
           echo "Setting latest tag on the image $IRD_IMAGE_NAME:$DOCKER_TAG"
-          skopeo copy "docker://$IRD_IMAGE_NAME:$DOCKER_TAG" "docker://$IRD_IMAGE_NAME:test02092025"
+          skopeo copy "docker://$IRD_IMAGE_NAME:$DOCKER_TAG" "docker://$IRD_IMAGE_NAME:latest"
 
   build-image:
     needs: check-if-docker-exist

--- a/.github/workflows/call-build-docker.yml
+++ b/.github/workflows/call-build-docker.yml
@@ -64,7 +64,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ github.token }}
       - name: Set latest tag on the image
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           DOCKER_CI_IMAGE=${{ steps.check.outputs.docker-image }}
           if [ -z "$DOCKER_CI_IMAGE" ]; then
@@ -75,11 +74,11 @@ jobs:
 
           CI_IMAGE_NAME=$(echo $DOCKER_CI_IMAGE | sed 's/:.*//')
           echo "Setting latest tag on the image $CI_IMAGE_NAME:$DOCKER_TAG"
-          skopeo copy "docker://$CI_IMAGE_NAME:$DOCKER_TAG" "docker://$CI_IMAGE_NAME:latest"
+          skopeo copy "docker://$CI_IMAGE_NAME:$DOCKER_TAG" "docker://$CI_IMAGE_NAME:test02092025"
 
           IRD_IMAGE_NAME=$(echo $DOCKER_CI_IMAGE | sed 's/:.*//' | sed 's/-ci-/-ird-/')
           echo "Setting latest tag on the image $IRD_IMAGE_NAME:$DOCKER_TAG"
-          skopeo copy "docker://$IRD_IMAGE_NAME:$DOCKER_TAG" "docker://$IRD_IMAGE_NAME:latest"
+          skopeo copy "docker://$IRD_IMAGE_NAME:$DOCKER_TAG" "docker://$IRD_IMAGE_NAME:test02092025"
 
   build-image:
     needs: check-if-docker-exist

--- a/.github/workflows/call-build-docker.yml
+++ b/.github/workflows/call-build-docker.yml
@@ -57,12 +57,14 @@ jobs:
 
       # Run the next steps only when pushed to main. Docker image must already exist, tag it as latest
       - name: Log in to GitHub Container Registry
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ github.token }}
       - name: Set latest tag on the image
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           DOCKER_CI_IMAGE=${{ steps.check.outputs.docker-image }}
           if [ -z "$DOCKER_CI_IMAGE" ]; then

--- a/.github/workflows/call-build-docker.yml
+++ b/.github/workflows/call-build-docker.yml
@@ -72,9 +72,14 @@ jobs:
             exit 1
           fi
           DOCKER_TAG=$(echo $DOCKER_CI_IMAGE | sed 's/^.*://')
-          IMAGE_NAME=$(echo $DOCKER_CI_IMAGE | sed 's/:.*//')
-          echo "Setting latest tag on the image $IMAGE_NAME:$DOCKER_TAG"
-          skopeo copy "docker://$IMAGE_NAME:$DOCKER_TAG" "docker://$IMAGE_NAME:latest"
+
+          CI_IMAGE_NAME=$(echo $DOCKER_CI_IMAGE | sed 's/:.*//')
+          echo "Setting latest tag on the image $CI_IMAGE_NAME:$DOCKER_TAG"
+          skopeo copy "docker://$CI_IMAGE_NAME:$DOCKER_TAG" "docker://$CI_IMAGE_NAME:latest"
+
+          IRD_IMAGE_NAME=$(echo $DOCKER_CI_IMAGE | sed 's/:.*//' | sed 's/-ci-/-ird-/')
+          echo "Setting latest tag on the image $IRD_IMAGE_NAME:$DOCKER_TAG"
+          skopeo copy "docker://$IRD_IMAGE_NAME:$DOCKER_TAG" "docker://$IRD_IMAGE_NAME:latest"
 
   build-image:
     needs: check-if-docker-exist

--- a/.github/workflows/call-build-docker.yml
+++ b/.github/workflows/call-build-docker.yml
@@ -57,7 +57,6 @@ jobs:
 
       # Run the next steps only when pushed to main. Docker image must already exist, tag it as latest
       - name: Log in to GitHub Container Registry
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io


### PR DESCRIPTION
### Ticket
/

### Problem description
The `latest` tag was only being added to the `ci` variant of the tt-xla Docker image.

### What's changed
The job which adds the `latest` tag is now expanded to also add the tag to the `ird` variant of the Docker image.

Note: I have also added myself as a CODEOWNER for the `/.github` directory.

### Checklist
- [ ] New/Existing tests provide coverage for changes
