### PR TITLE
Vovnet test should be passing now

### DIFF
--- a/tests/torch/single_chip/models/vovnet/test_vovnet.py
+++ b/tests/torch/single_chip/models/vovnet/test_vovnet.py
@@ -49,13 +49,7 @@ def training_tester() -> VovNetTester:
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
-)
-@pytest.mark.xfail(
-    reason=failed_ttmlir_compilation(
-        "error: 'ttir.max_pool2d' op output tensor height and width dimension (28, 28) do not match the expected dimensions (27, 28) "
-        "https://github.com/tenstorrent/tt-xla/issues/928"
-    )
+    bringup_status=BringupStatus.PASSED,
 )
 def test_torch_vovnet_inference(inference_tester: VovNetTester):
     inference_tester.test()


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-xla/issues/928

### Problem description
The PyTorch Vovnet inference test now passes.

### What's changed
Remove xfail marker and set the tests `BringupStatus` to `PASSED`

### Checklist
- [X] New/Existing tests provide coverage for changes
