### PR TITLE
fix nightly 03092025

### DIFF
--- a/tests/jax/multi_chip/llmbox/8_devices/graphs/tensor_parallel/test_dot_psum.py
+++ b/tests/jax/multi_chip/llmbox/8_devices/graphs/tensor_parallel/test_dot_psum.py
@@ -11,7 +11,7 @@ from infra import (
     run_jax_multichip_graph_test_with_random_inputs,
 )
 from infra.comparators import ComparisonConfig, PccConfig
-from utils import failed_fe_compilation
+from utils import failed_fe_compilation, incorrect_result
 
 
 @pytest.mark.nightly
@@ -34,7 +34,15 @@ from utils import failed_fe_compilation
 @pytest.mark.parametrize(
     "sharding_mode",
     [
-        ShardingMode.INPUTS_AND_MODULE,
+        pytest.param(
+            ShardingMode.INPUTS_AND_MODULE,
+            marks=pytest.mark.xfail(
+                reason=incorrect_result(
+                    "PCC comparison failed on nightly "
+                    "https://github.com/tenstorrent/tt-xla/issues/1270)"
+                )
+            ),
+        ),
         pytest.param(
             ShardingMode.MODULE,
             marks=pytest.mark.xfail(

--- a/tests/jax/multi_chip/llmbox/8_devices/graphs/tensor_parallel/test_dot_psum_scatter.py
+++ b/tests/jax/multi_chip/llmbox/8_devices/graphs/tensor_parallel/test_dot_psum_scatter.py
@@ -11,7 +11,7 @@ from infra import (
     run_jax_multichip_graph_test_with_random_inputs,
 )
 from infra.comparators import ComparisonConfig, PccConfig
-from utils import failed_fe_compilation
+from utils import failed_fe_compilation, incorrect_result
 
 
 @pytest.mark.nightly
@@ -32,7 +32,15 @@ from utils import failed_fe_compilation
 @pytest.mark.parametrize(
     "sharding_mode",
     [
-        ShardingMode.INPUTS_AND_MODULE,
+        pytest.param(
+            ShardingMode.INPUTS_AND_MODULE,
+            marks=pytest.mark.xfail(
+                reason=incorrect_result(
+                    "PCC comparison failed on nightly "
+                    "https://github.com/tenstorrent/tt-xla/issues/1270)"
+                )
+            ),
+        ),
         pytest.param(
             ShardingMode.MODULE,
             marks=pytest.mark.xfail(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/1270

### Problem description
Nightly is failing and this is blocking the build for new PR's  since [nightly](https://github.com/tenstorrent/tt-xla/actions/runs/17419476247/attempts/2) fails.

### What's changed
modified xfail reasons for graphs failing 

### Checklist
- [x] New/Existing tests provide coverage for changes
