### PR TITLE
Deleting the destructor in JaxModelTester

### DIFF
--- a/tests/infra/testers/single_chip/model/jax_model_tester.py
+++ b/tests/infra/testers/single_chip/model/jax_model_tester.py
@@ -176,17 +176,3 @@ class JaxModelTester(ModelTester):
             workload.executable,
             static_argnames=workload.static_argnames,
         )
-
-    def __del__(self):
-        if hasattr(self, "_model_path"):
-            try:
-                cache_dir = snapshot_download(self._model_path, local_files_only=True)
-                if cache_dir and os.path.exists(cache_dir):
-                    print(f"Deleting HF cache at: {cache_dir}")
-                    shutil.rmtree(cache_dir)
-            except NameError as e:
-                logger.warning(
-                    f"NameError in __del__ during snapshot_download (likely path not defined during shutdown): {e}"
-                )
-            except Exception as e:
-                logger.warning(f"Error during cache cleanup in __del__: {e}")


### PR DESCRIPTION
Currently we have a destructor which deletes the huggingface files from the cache when the model test has finished running. This cache is shared with other CI runners and as such, can influence their tests. Additionally, this does not relieve pressure on the disk, as huggingface cache is not stored in local disk space of a runner. Becuse of these reasons, deleting that destructor.