### PR TITLE
Dump per-pass IR with LOGGER_LEVEL=VERBOSE

### DIFF
--- a/docs/src/getting_started_build_from_source.md
+++ b/docs/src/getting_started_build_from_source.md
@@ -126,7 +126,7 @@ Before compiling TT-XLA, the TT-MLIR toolchain needs to be built:
 - Follow the TT-MLIR [build instructions](https://github.com/tenstorrent/tt-mlir/blob/main/docs/src/getting-started.md) to set up the environment and build the toolchain.
 
 ### Building TT-XLA
-Before running these commands to build TT-XLA, please ensure that the environment variable `TTMLIR_TOOLCHAIN_DIR` is set to point to the TT-MLIR toolchain directory created above as part of the TT-MLIR environment setup (for example `export TTMLIR_TOOLCHAIN_DIR=/opt/ttmlir-toolchain/`). You can also set `export LOGGER_LEVEL=DEBUG` in order to enable debug logs. To build TT-XLA do the following:
+Before running these commands to build TT-XLA, please ensure that the environment variable `TTMLIR_TOOLCHAIN_DIR` is set to point to the TT-MLIR toolchain directory created above as part of the TT-MLIR environment setup (for example `export TTMLIR_TOOLCHAIN_DIR=/opt/ttmlir-toolchain/`). You can also set `export LOGGER_LEVEL=DEBUG` in order to enable debug logs, or `export LOGGER_LEVEL=DEBUG_IR` to enable both debug logs and verbose IR dumping between compiler passes. To build TT-XLA do the following:
 
 1. Make sure you are not in the TT-MLIR build directory, and you are in the location where you want TT-XLA to install.
 

--- a/docs/src/getting_started_build_from_source.md
+++ b/docs/src/getting_started_build_from_source.md
@@ -126,7 +126,7 @@ Before compiling TT-XLA, the TT-MLIR toolchain needs to be built:
 - Follow the TT-MLIR [build instructions](https://github.com/tenstorrent/tt-mlir/blob/main/docs/src/getting-started.md) to set up the environment and build the toolchain.
 
 ### Building TT-XLA
-Before running these commands to build TT-XLA, please ensure that the environment variable `TTMLIR_TOOLCHAIN_DIR` is set to point to the TT-MLIR toolchain directory created above as part of the TT-MLIR environment setup (for example `export TTMLIR_TOOLCHAIN_DIR=/opt/ttmlir-toolchain/`). You can also set `export LOGGER_LEVEL=DEBUG` in order to enable debug logs, or `export LOGGER_LEVEL=DEBUG_IR` to enable both debug logs and verbose IR dumping between compiler passes. To build TT-XLA do the following:
+Before running these commands to build TT-XLA, please ensure that the environment variable `TTMLIR_TOOLCHAIN_DIR` is set to point to the TT-MLIR toolchain directory created above as part of the TT-MLIR environment setup (for example `export TTMLIR_TOOLCHAIN_DIR=/opt/ttmlir-toolchain/`). You can also set `export LOGGER_LEVEL=DEBUG` in order to enable debug logs, or `export LOGGER_LEVEL=VERBOSE` to enable both debug logs and verbose IR dumping between compiler passes. To build TT-XLA do the following:
 
 1. Make sure you are not in the TT-MLIR build directory, and you are in the location where you want TT-XLA to install.
 

--- a/inc/common/pjrt_implementation/module_builder/module_builder.h
+++ b/inc/common/pjrt_implementation/module_builder/module_builder.h
@@ -170,7 +170,7 @@ private:
   // Prints module to console for debug purposes.
   static void printModule(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module);
 
-  // Enable printing of IR between passes if the log level for debug purposes
+  // Enables IR printing between passes with VERBOSE or higher logger level.
   static void enableVerboseIRPrinting(mlir::PassManager &pm);
 
   // Checks if a particular type is scalar.

--- a/inc/common/pjrt_implementation/module_builder/module_builder.h
+++ b/inc/common/pjrt_implementation/module_builder/module_builder.h
@@ -17,6 +17,7 @@
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/OwningOpRef.h"
 #include "mlir/IR/Value.h"
+#include "mlir/Pass/PassManager.h"
 
 // PJRT C API includes
 #include "xla/pjrt/c/pjrt_c_api.h"
@@ -168,6 +169,9 @@ private:
 
   // Prints module to console for debug purposes.
   static void printModule(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module);
+
+  // Enable printing of IR between passes if the log level for debug purposes
+  static void enableVerboseIRPrinting(mlir::PassManager &pm);
 
   // Checks if a particular type is scalar.
   bool isScalarType(mlir::Type type);

--- a/src/common/pjrt_implementation/module_builder/module_builder.cc
+++ b/src/common/pjrt_implementation/module_builder/module_builder.cc
@@ -174,6 +174,8 @@ void ModuleBuilder::convertFromVHLOToSHLO(
 
   mlir::stablehlo::createStablehloDeserializePipeline(vhlo_to_shlo_pm);
 
+  enableVerboseIRPrinting(vhlo_to_shlo_pm);
+
   if (mlir::failed(vhlo_to_shlo_pm.run(mlir_module.get()))) {
     DLOG_F(ERROR, "Failed to convert from VHLO to SHLO module");
     m_status = tt_pjrt_status::kInternal;
@@ -454,6 +456,9 @@ void ModuleBuilder::runCompilerStableHLOPipeline(
   mlir::tt::stablehlo::StableHLOPipelineOptions stablehlo_pipeline_options;
   mlir::tt::stablehlo::createStableHLOPipeline(stablehlo_pipeline_pm,
                                                stablehlo_pipeline_options);
+
+  enableVerboseIRPrinting(stablehlo_pipeline_pm);
+
   if (mlir::failed(stablehlo_pipeline_pm.run(mlir_module.get()))) {
     DLOG_F(ERROR, "Failed to run stablehlo pipeline");
     m_status = tt_pjrt_status::kInternal;
@@ -476,10 +481,7 @@ void ModuleBuilder::convertFromSHLOToTTIR(
   shlo_options.legalizeCompositeToCallEnabled = true;
   mlir::tt::ttir::createStableHLOToTTIRPipeline(shlo_to_ttir_pm, shlo_options);
 
-  if (loguru::g_stderr_verbosity >= LOG_DEBUG_IR) {
-    shlo_to_ttir_pm.getContext()->disableMultithreading();
-    shlo_to_ttir_pm.enableIRPrinting();
-  }
+  enableVerboseIRPrinting(shlo_to_ttir_pm);
 
   if (mlir::failed(shlo_to_ttir_pm.run(mlir_module.get()))) {
     DLOG_F(ERROR, "Failed to convert from SHLO to TTIR module");
@@ -598,10 +600,7 @@ void ModuleBuilder::convertFromTTIRToTTNN(
   options.meshShape = {m_devices_mesh_shape[0], m_devices_mesh_shape[1]};
   mlir::tt::ttnn::createTTIRToTTNNBackendPipeline(ttir_to_ttnn_pm, options);
 
-  if (loguru::g_stderr_verbosity >= LOG_DEBUG_IR) {
-    ttir_to_ttnn_pm.getContext()->disableMultithreading();
-    ttir_to_ttnn_pm.enableIRPrinting();
-  }
+  enableVerboseIRPrinting(ttir_to_ttnn_pm);
 
   // Run the pass manager.
   if (mlir::failed(ttir_to_ttnn_pm.run(mlir_module.get()))) {
@@ -715,6 +714,17 @@ void ModuleBuilder::printModule(
   mlir_module->dump();
 }
 
+void ModuleBuilder::enableVerboseIRPrinting(mlir::PassManager &pm) {
+  if (loguru::g_stderr_verbosity < LOG_VERBOSE) {
+    return;
+  }
+
+  // Multithreading must be disabled when printing at module scope
+  // to avoid interleaved output.
+  pm.getContext()->disableMultithreading();
+  pm.enableIRPrinting();
+}
+
 bool ModuleBuilder::isUsingShardy(
     const mlir::OwningOpRef<mlir::ModuleOp> &module) {
   // If the module is using the Shardy dielect, it should have the
@@ -793,4 +803,5 @@ ModuleBuilder::createArgumentTypeMap(
 
   return argTypesMap;
 }
+
 } // namespace tt::pjrt::module_builder

--- a/src/common/pjrt_implementation/module_builder/module_builder.cc
+++ b/src/common/pjrt_implementation/module_builder/module_builder.cc
@@ -476,6 +476,11 @@ void ModuleBuilder::convertFromSHLOToTTIR(
   shlo_options.legalizeCompositeToCallEnabled = true;
   mlir::tt::ttir::createStableHLOToTTIRPipeline(shlo_to_ttir_pm, shlo_options);
 
+  if (loguru::g_stderr_verbosity >= LOG_DEBUG_IR) {
+    shlo_to_ttir_pm.getContext()->disableMultithreading();
+    shlo_to_ttir_pm.enableIRPrinting();
+  }
+
   if (mlir::failed(shlo_to_ttir_pm.run(mlir_module.get()))) {
     DLOG_F(ERROR, "Failed to convert from SHLO to TTIR module");
     m_status = tt_pjrt_status::kInternal;
@@ -592,6 +597,11 @@ void ModuleBuilder::convertFromTTIRToTTNN(
 
   options.meshShape = {m_devices_mesh_shape[0], m_devices_mesh_shape[1]};
   mlir::tt::ttnn::createTTIRToTTNNBackendPipeline(ttir_to_ttnn_pm, options);
+
+  if (loguru::g_stderr_verbosity >= LOG_DEBUG_IR) {
+    ttir_to_ttnn_pm.getContext()->disableMultithreading();
+    ttir_to_ttnn_pm.enableIRPrinting();
+  }
 
   // Run the pass manager.
   if (mlir::failed(ttir_to_ttnn_pm.run(mlir_module.get()))) {
@@ -783,5 +793,4 @@ ModuleBuilder::createArgumentTypeMap(
 
   return argTypesMap;
 }
-
 } // namespace tt::pjrt::module_builder

--- a/src/common/platform.cc
+++ b/src/common/platform.cc
@@ -34,7 +34,9 @@ void Platform::InitializeLogging() {
     return;
   }
 
-  if (strcmp(loguru_verbosity, "DEBUG") == 0) {
+  if (strcmp(loguru_verbosity, "DEBUG_IR") == 0) {
+    loguru::g_stderr_verbosity = LOG_DEBUG_IR;
+  } else if (strcmp(loguru_verbosity, "DEBUG") == 0) {
     loguru::g_stderr_verbosity = LOG_DEBUG;
   } else if (strcmp(loguru_verbosity, "INFO") == 0) {
     loguru::g_stderr_verbosity = loguru::NamedVerbosity::Verbosity_INFO;

--- a/src/common/platform.cc
+++ b/src/common/platform.cc
@@ -34,8 +34,8 @@ void Platform::InitializeLogging() {
     return;
   }
 
-  if (strcmp(loguru_verbosity, "DEBUG_IR") == 0) {
-    loguru::g_stderr_verbosity = LOG_DEBUG_IR;
+  if (strcmp(loguru_verbosity, "VERBOSE") == 0) {
+    loguru::g_stderr_verbosity = LOG_VERBOSE;
   } else if (strcmp(loguru_verbosity, "DEBUG") == 0) {
     loguru::g_stderr_verbosity = LOG_DEBUG;
   } else if (strcmp(loguru_verbosity, "INFO") == 0) {

--- a/src/common/status.h
+++ b/src/common/status.h
@@ -11,6 +11,7 @@
 // Loguru doesn't have debug named verbosity and the next verbosity after INFO
 // is called `Verbosity_1`, so defining this to avoid doing `DLOG_F(1, ...)`.
 #define LOG_DEBUG 1
+#define LOG_DEBUG_IR 2
 
 // TODO(mrakita): Move into `tt::pjrt::status` namespace, rename enum class and
 // `tt_pjrt_status_is_ok` function.

--- a/src/common/status.h
+++ b/src/common/status.h
@@ -11,7 +11,7 @@
 // Loguru doesn't have debug named verbosity and the next verbosity after INFO
 // is called `Verbosity_1`, so defining this to avoid doing `DLOG_F(1, ...)`.
 #define LOG_DEBUG 1
-#define LOG_DEBUG_IR 2
+#define LOG_VERBOSE 2
 
 // TODO(mrakita): Move into `tt::pjrt::status` namespace, rename enum class and
 // `tt_pjrt_status_is_ok` function.


### PR DESCRIPTION
### Ticket
None

### Problem description
There is no way to dump all IR between all compiler passes, which is useful when a minor compiler pass fails (i.e something other than a dialect-dialect conversion). For example, if a TTIRFusion pass fails, the current LOGGER_LEVEL=DEBUG will only show the TTIR before any passes are run, which is hard to debug.

### What's changed
Add higher LOGGER_LEVEL=VERBOSE which will verbosely dump IR at each compiler pass using mlir::PassManager::enableIRPrinting. This also dumps all DEBUG logs. 

### Checklist
- [x] New/Existing tests provide coverage for changes
