### PR TITLE
Add permission needed for tt-forge's perf benchmark workflow

### DIFF
--- a/.github/workflows/manual-benchmark.yml
+++ b/.github/workflows/manual-benchmark.yml
@@ -28,6 +28,7 @@ permissions:
   packages: write
   checks: write
   contents: write
+  id-token: write
 
 jobs:
   docker-build:

--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -8,6 +8,7 @@ permissions:
   packages: write
   checks: write
   pull-requests: write
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
### Ticket
[Issue](https://github.com/tenstorrent/tt-forge/issues/344)

### Problem description
Even though tt-xla doesn't have the new performance benchmark regression check yet, the workflow call will fail without the added permisson.

### What's changed
Added the needed permission.

### Checklist
- [ ] New/Existing tests provide coverage for changes
