### PR TITLE
Change check-all-green to check the build-image and build-ttxla jobs

### DIFF
--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -81,7 +81,6 @@ jobs:
       run_id_source: tt-xla
       ref: main
 
-  # return to the old setup
   check-all-green:
     if: always()
     needs:


### PR DESCRIPTION
### Ticket
[Slack issue](https://tenstorrent.slack.com/archives/C08DJEGTNCR/p1757260633967709)

### Problem description
The `check-all-green` job would succeed even when `build-ttxla-release` or `build-ttxla-codecov` jobs fail because it checked for failures only for `pre-commit` and `test` jobs.

### What's changed
The `check-all-green` job now checks for failures of these jobs: 
- pre-commit
- build-image
- build-ttxla-codecov
- build-ttxla-release
- test

and allows skips of these:
- build-image
- build-ttxla-codecov
- build-ttxla-release
- test

### Checklist
- [ ] New/Existing tests provide coverage for changes
