### PR TITLE
Add support for parsing custom compiler options in PJRT backend compile

### DIFF
--- a/inc/common/pjrt_implementation/client_instance.h
+++ b/inc/common/pjrt_implementation/client_instance.h
@@ -82,9 +82,9 @@ public:
       const std::unordered_map<std::string, std::string> &compile_options);
 
   // Gets custom compile options from the given compile options protobuf.
-  static std::unordered_map<std::string, std::string>
-  getCompileOptions(const char *compile_options_data,
-                    size_t compile_options_size);
+  static tt_pjrt_status getCompileOptions(
+      const char *compile_options_data, size_t compile_options_size,
+      std::unordered_map<std::string, std::string> &out_compile_options);
 
 protected:
   std::string cached_platform_name_;
@@ -137,9 +137,9 @@ private:
 
   // Extracts custom protobuf fields from an UnknownFieldSet of all protobuf
   // fields.
-  static std::unordered_map<std::string, std::string>
-  extractCustomProtobufFields(
-      const google::protobuf::UnknownFieldSet &unknown_fields);
+  static tt_pjrt_status extractCustomProtobufFields(
+      const google::protobuf::UnknownFieldSet &unknown_fields,
+      std::unordered_map<std::string, std::string> &out_compile_options);
 };
 
 namespace internal {

--- a/src/common/pjrt_implementation/client_instance.cc
+++ b/src/common/pjrt_implementation/client_instance.cc
@@ -216,9 +216,9 @@ tt_pjrt_status ClientInstance::compileMlirProgram(
   return tt_pjrt_status::kSuccess;
 }
 
-std::unordered_map<std::string, std::string>
-ClientInstance::getCompileOptions(const char *compile_options_data,
-                                  size_t compile_options_size) {
+tt_pjrt_status ClientInstance::getCompileOptions(
+    const char *compile_options_data, size_t compile_options_size,
+    std::unordered_map<std::string, std::string> &out_compile_options) {
 
   google::protobuf::io::CodedInputStream cis(
       reinterpret_cast<const uint8_t *>(compile_options_data),
@@ -226,113 +226,139 @@ ClientInstance::getCompileOptions(const char *compile_options_data,
   google::protobuf::UnknownFieldSet unknown_fields;
 
   if (!unknown_fields.MergeFromCodedStream(&cis)) {
-    return {};
+    DLOG_F(ERROR, "Failed to parse the unknown fields set from the compile "
+                  "options protobuf data");
+    return tt_pjrt_status::kInternal;
   }
-  std::unordered_map<std::string, std::string> compile_options_map =
-      ClientInstance::extractCustomProtobufFields(unknown_fields);
 
-  return compile_options_map;
+  return ClientInstance::extractCustomProtobufFields(unknown_fields,
+                                                     out_compile_options);
 }
 
-std::unordered_map<std::string, std::string>
-ClientInstance::extractCustomProtobufFields(
-    const google::protobuf::UnknownFieldSet &unknown_fields) {
-  std::unordered_map<std::string, std::string> result;
-  constexpr int kCustomCompilerOptionsFieldNumber = 7;
-  constexpr int kMapKeyFieldNumber = 1;   // string key
-  constexpr int kMapValueFieldNumber = 2; // OptionOverrideProto (value)
+tt_pjrt_status ClientInstance::extractCustomProtobufFields(
+    const google::protobuf::UnknownFieldSet &unknown_fields,
+    std::unordered_map<std::string, std::string> &out_compile_options) {
 
-  // Loop over all unknown fields
+  // The custom compiler options that are passed in through the `jax.jit()`
+  // or `torch_xla.set_custom_compile_options()` are stored in the field
+  // number 7 in the UnknownFieldSet, which is defined as:
+  // `env_option_overrides (map<string, OptionOverrideProto>)`.
+  // Each map entry is a nested message with key/value inside.
+  constexpr int kCustomCompilerOptionsFieldNumber = 7;
+
+  // Field number corresponding to the string key of the compile options map
+  // entry.
+  constexpr int kMapKeyFieldNumber = 1;
+
+  // Field number corresponding to the OptionOverrideProto value of the compile
+  // options map entry.
+  constexpr int kMapValueFieldNumber = 2;
+
   for (int i = 0; i < unknown_fields.field_count(); ++i) {
     const google::protobuf::UnknownField &field = unknown_fields.field(i);
 
-    // Currently, we only support the custom compiler options field that are in
-    // the form of a dictionary, which is represented as a length_delimited
-    // field.
-    // Field #7: env_option_overrides (map<string, OptionOverrideProto>)
-    // Each map entry is a nested message with key/value inside.
-    if (field.number() == kCustomCompilerOptionsFieldNumber &&
-        field.type() == google::protobuf::UnknownField::TYPE_LENGTH_DELIMITED) {
-      const std::string &bytes = field.length_delimited();
+    // Currently, we only support custom compiler options serialized in the
+    // `kCustomCompilerOptionsFieldNumber` field. In case we encounter
+    // options being serialized into some other field we will need to update
+    // this to support them.
+    if (field.number() != kCustomCompilerOptionsFieldNumber ||
+        field.type() != google::protobuf::UnknownField::TYPE_LENGTH_DELIMITED) {
+      continue;
+    }
 
-      google::protobuf::io::CodedInputStream cis(
-          reinterpret_cast<const uint8_t *>(bytes.data()), bytes.size());
+    const std::string &bytes = field.length_delimited();
+    google::protobuf::io::CodedInputStream cis(
+        reinterpret_cast<const uint8_t *>(bytes.data()), bytes.size());
 
-      google::protobuf::UnknownFieldSet map_entry_fields;
-      if (!map_entry_fields.MergeFromCodedStream(&cis)) {
-        DLOG_F(WARNING, "Failed to parse map entry fields");
-        continue;
-      }
+    google::protobuf::UnknownFieldSet map_entry_fields;
+    if (!map_entry_fields.MergeFromCodedStream(&cis)) {
+      DLOG_F(ERROR, "Failed to parse the map entry fields from the custom "
+                    "compile options protobuf data");
+      return tt_pjrt_status::kInternal;
+    }
 
-      std::string key;
-      std::string value;
+    std::string key;
+    std::string value;
 
-      for (int j = 0; j < map_entry_fields.field_count(); ++j) {
-        const auto &entry_field = map_entry_fields.field(j);
+    for (int j = 0; j < map_entry_fields.field_count(); ++j) {
+      const google::protobuf::UnknownField &entry_field =
+          map_entry_fields.field(j);
+      // In the inner field set, first field is the key and second field is the
+      // value. We expect both to be length-delimited fields (coming from a
+      // dictionary).
+      if (entry_field.number() == kMapKeyFieldNumber &&
+          entry_field.type() ==
+              google::protobuf::UnknownField::TYPE_LENGTH_DELIMITED) {
+        key = entry_field.length_delimited();
+      } else if (entry_field.number() == kMapValueFieldNumber &&
+                 entry_field.type() ==
+                     google::protobuf::UnknownField::TYPE_LENGTH_DELIMITED) {
+        const std::string &override_bytes = entry_field.length_delimited();
+        google::protobuf::io::CodedInputStream override_stream(
+            reinterpret_cast<const uint8_t *>(override_bytes.data()),
+            override_bytes.size());
 
-        if (entry_field.number() == kMapKeyFieldNumber &&
-            entry_field.type() ==
-                google::protobuf::UnknownField::TYPE_LENGTH_DELIMITED) {
-          // Case: map key (string)
-          // For example, user sets an option like "enable_optimizations" =
-          // "true" key = "enable_optimizations"
-          key = entry_field.length_delimited();
-        } else if (entry_field.number() == kMapValueFieldNumber &&
-                   entry_field.type() ==
-                       google::protobuf::UnknownField::TYPE_LENGTH_DELIMITED) {
-          // Case: map value (OptionOverrideProto)
-          // For example, user sets an option like "enable_optimizations" =
-          // "true" value = "true"
-          const std::string &override_bytes = entry_field.length_delimited();
-          google::protobuf::io::CodedInputStream override_stream(
-              reinterpret_cast<const uint8_t *>(override_bytes.data()),
-              override_bytes.size());
+        google::protobuf::UnknownFieldSet value_fields;
+        if (!value_fields.MergeFromCodedStream(&override_stream)) {
+          DLOG_F(ERROR, "Failed to parse the map entry field value from the "
+                        "custom compile options protobuf data");
+          return tt_pjrt_status::kInternal;
+        }
 
-          google::protobuf::UnknownFieldSet value_fields;
-          if (value_fields.MergeFromCodedStream(&override_stream)) {
-            for (int k = 0; k < value_fields.field_count(); ++k) {
-              const auto &value_field = value_fields.field(k);
-              // https://github.com/openxla/xla/blob/main/xla/pjrt/proto/compile_options.proto#L151C1-L158C2
-              // Field numbers and types for OptionOverrideProto
-              // message OptionOverrideProto {
-              //   oneof value {
-              //     string string_field = 1;
-              //     bool bool_field = 2;
-              //     int64 int_field = 3;
-              //     double double_field = 4;
-              //   }
-              // }
-              switch (value_field.number()) {
-              case 1:
-                value = value_field.length_delimited();
-                break;
-              case 2:
-                value = value_field.varint() ? "true" : "false";
-                break;
-              case 3:
-                value = std::to_string(value_field.varint());
-                break;
-              case 4:
-                value = std::to_string(value_field.fixed64());
-                break;
-              default:
-                DLOG_F(ERROR, "Unknown field number in OptionOverrideProto: %d",
-                       value_field.number());
-                break;
-              }
-            }
-          }
+        // https://github.com/openxla/xla/blob/main/xla/pjrt/proto/compile_options.proto#L151C1-L158C2
+        // Field numbers and types for OptionOverrideProto
+        // message OptionOverrideProto {
+        //   oneof value {
+        //     string string_field = 1;
+        //     bool bool_field = 2;
+        //     int64 int_field = 3;
+        //     double double_field = 4;
+        //   }
+        // }
+        if (value_fields.field_count() != 1) {
+          DLOG_F(
+              ERROR,
+              "Expected exactly one field in OptionOverrideProto, but got %d",
+              value_fields.field_count());
+          return tt_pjrt_status::kInternal;
+        }
+
+        const google::protobuf::UnknownField &value_field =
+            value_fields.field(0);
+        switch (value_field.number()) {
+        case 1: {
+          value = value_field.length_delimited();
+          break;
+        }
+        case 2: {
+          value = value_field.varint() ? "true" : "false";
+          break;
+        }
+        case 3: {
+          value = std::to_string(value_field.varint());
+          break;
+        }
+        case 4: {
+          value = std::to_string(value_field.fixed64());
+          break;
+        }
+        default: {
+          DLOG_F(ERROR, "Unknown field number in OptionOverrideProto: %d",
+                 value_field.number());
+          return tt_pjrt_status::kInternal;
+        }
         }
       }
+    }
 
-      if (!key.empty()) {
-        result[key] = value;
-      }
+    if (!key.empty()) {
+      out_compile_options[key] = value;
     }
   }
 
-  return result;
+  return tt_pjrt_status::kSuccess;
 }
+
 namespace internal {
 
 PJRT_Error *onClientDestroy(PJRT_Client_Destroy_Args *args) {
@@ -453,9 +479,14 @@ onClientAddressableMemories(PJRT_Client_AddressableMemories_Args *args) {
 
 PJRT_Error *onClientCompile(PJRT_Client_Compile_Args *args) {
   DLOG_F(LOG_DEBUG, "ClientInstance::PJRT_Client_Compile");
-  std::unordered_map<std::string, std::string> compile_options_map =
-      ClientInstance::getCompileOptions(args->compile_options,
-                                        args->compile_options_size);
+  std::unordered_map<std::string, std::string> compile_options_map;
+
+  tt_pjrt_status compile_option_status = ClientInstance::getCompileOptions(
+      args->compile_options, args->compile_options_size, compile_options_map);
+  if (!tt_pjrt_status_is_ok(compile_option_status)) {
+    return *ErrorInstance::makeError(compile_option_status).release();
+  }
+
   std::string_view program_format(args->program->format,
                                   args->program->format_size);
   if (program_format != module_builder::c_mlir_format_name) {

--- a/tests/infra/testers/compiler_config.py
+++ b/tests/infra/testers/compiler_config.py
@@ -43,3 +43,15 @@ class CompilerConfig:
             options["enable_bfp8_conversion"] = "true"
 
         return options
+
+    def to_torch_compile_options(self) -> Dict[str, str]:
+        """
+        Convert CompilerConfig to Torch compile options dictionary format.
+
+        Returns:
+            Dictionary of compiler options in the format expected by torch_xla.set_custom_compile_options()
+        """
+
+        # Currently, the options are the same as JAX. But keeping separate method
+        # in case of future differences.
+        return self.to_jax_compiler_options()

--- a/tests/infra/testers/single_chip/model/torch_model_tester.py
+++ b/tests/infra/testers/single_chip/model/torch_model_tester.py
@@ -6,6 +6,7 @@ import collections
 from typing import Any, Dict, Mapping, Sequence
 
 import torch
+import torch_xla
 from infra.comparators import ComparisonConfig
 from tests.infra.testers.compiler_config import CompilerConfig
 from infra.utilities import Framework
@@ -37,6 +38,12 @@ class TorchModelTester(ModelTester):
         self._input_activations: Dict | Sequence[Any] = None
 
         super().__init__(comparison_config, run_mode, Framework.TORCH, compiler_config)
+        # Set custom compile options if provided.
+        # Use explicit API for passing compiler options.
+        if compiler_config is not None:
+            torch_xla.set_custom_compile_options(
+                compiler_config.to_torch_compile_options()
+            )
 
     # @override
     def _configure_model_for_inference(self) -> None:

--- a/tests/torch/single_chip/models/resnet/test_resnet.py
+++ b/tests/torch/single_chip/models/resnet/test_resnet.py
@@ -16,6 +16,7 @@ from utils import (
 
 from .tester import ResnetTester
 from third_party.tt_forge_models.resnet.pytorch import ModelVariant
+from tests.infra.testers.compiler_config import CompilerConfig
 
 VARIANT_NAME = ModelVariant.RESNET_50_HF
 
@@ -34,7 +35,8 @@ MODEL_NAME = build_model_name(
 
 @pytest.fixture
 def inference_tester() -> ResnetTester:
-    return ResnetTester(VARIANT_NAME)
+    compiler_config = CompilerConfig(enable_optimizer=True)
+    return ResnetTester(VARIANT_NAME, compiler_config=compiler_config)
 
 
 @pytest.fixture
@@ -45,6 +47,7 @@ def training_tester() -> ResnetTester:
 # ----- Tests -----
 
 
+@pytest.mark.push
 @pytest.mark.model_test
 @pytest.mark.record_test_properties(
     category=Category.MODEL_TEST,

--- a/tests/torch/single_chip/models/resnet/tester.py
+++ b/tests/torch/single_chip/models/resnet/tester.py
@@ -5,6 +5,7 @@
 from typing import Any, Dict, Sequence
 from infra import ComparisonConfig, Model, RunMode, TorchModelTester
 from third_party.tt_forge_models.resnet.pytorch import ModelLoader
+from tests.infra.testers.compiler_config import CompilerConfig
 
 
 class ResnetTester(TorchModelTester):
@@ -15,9 +16,10 @@ class ResnetTester(TorchModelTester):
         variant_name: str,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
+        compiler_config: CompilerConfig = None,
     ) -> None:
         self._model_loader = ModelLoader(variant_name)
-        super().__init__(comparison_config, run_mode)
+        super().__init__(comparison_config, run_mode, compiler_config)
 
     # @override
     def _get_model(self) -> Model:


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/1003)

### Problem description
In torch pass, there was no way to passing user's compile options to pjrt backend.

### What's changed
User can pass compiler options using torch_xla.set_compile_options(opt) before compile model. For example,
```
CompilerOptions option
option.enable_optimizer = True
torch_xla. set_custom_compile_options(option)
torch.compile(model, ....)
```
Or, if torch_xla.compile is used
```
CompilerOptions option
option.enable_optimizer = True
torch_xla.compile(model, custom_compile_options=option)
```

Note that torch.compile(model, options=options) is not supported yet

### Checklist
- [ ] New/Existing tests provide coverage for changes
