### PR TITLE
Remove "sanitize test_mark" in call-test.yml no longer needed since produce_cicd_data bug fixed

### DIFF
--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -235,27 +235,18 @@ jobs:
                --junitxml=${{ steps.strings.outputs.test_report_path }} \
                2>&1 | tee pytest.log
 
-    # produce_cicd_data silently drops artifacts with spaces in the name, must replace spaces with underscores
-    # until https://github.com/tenstorrent/tt-github-actions/issues/78 is fixed
-    - name: Sanitize test_mark
-      id: sanitize
-      shell: bash
-      run: echo "test_mark=${TEST_MARK// /_}" >> $GITHUB_OUTPUT
-      env:
-        TEST_MARK: ${{ inputs.test_mark }}
-
     - name: Upload Test Log
       uses: actions/upload-artifact@v4
       if: success() || failure()
       with:
-        name: test-log-${{ matrix.build.runs-on }}-${{ steps.sanitize.outputs.test_mark }}-${{ steps.fetch-job-id.outputs.job_id }}
+        name: test-log-${{ matrix.build.runs-on }}-${{ inputs.test_mark }}-${{ steps.fetch-job-id.outputs.job_id }}
         path: pytest.log
 
     - name: Upload Test Report
       uses: actions/upload-artifact@v4
       if: success() || failure()
       with:
-        name: test-reports-${{ matrix.build.runs-on }}-${{ steps.sanitize.outputs.test_mark }}-${{ steps.fetch-job-id.outputs.job_id }}
+        name: test-reports-${{ matrix.build.runs-on }}-${{ inputs.test_mark }}-${{ steps.fetch-job-id.outputs.job_id }}
         path: ${{ steps.strings.outputs.test_report_path }}
 
     - name: Show Test Report


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-github-actions/issues/78

### Problem description
 - produce_cicd_data was tripping up on artifacts with spaces in name, had to put in a temporary workaround to merge previous changes

### What's changed
- The bug got fixed in tt-github-actions today (thx Vladamir), can remove local workaround in tt-xla
- Tested locally on branch with workaround removed can see artifacts parsed and results in superset DB https://github.com/tenstorrent/tt-xla/actions/runs/17593394271/job/49979519823

### Checklist
- [x] Tested small set of affected tests on branch
