### PR TITLE
Fixing optimizer test in CI

### DIFF
--- a/tests/jax/single_chip/models/resnet_v1_5/resnet_26/test_resnet_26.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/resnet_26/test_resnet_26.py
@@ -44,7 +44,7 @@ def training_tester() -> ResNetTester:
 
 @pytest.fixture
 def inference_tester_optimizer() -> ResNetTester:
-    return ResNetTester(VARIANT_NAME, run_mode=RunMode.INFERENCE, use_optimizer=True)
+    return ResNetTester(VARIANT_NAME, run_mode=RunMode.INFERENCE, compiler_config=CompilerConfig(enable_optimizer=True))
 
 
 # ----- Tests -----
@@ -86,12 +86,6 @@ def test_resnet_v1_5_26_training(training_tester: ResNetTester):
     category=Category.MODEL_TEST,
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
-)
-@pytest.mark.xfail(
-    reason=failed_runtime(
-        "Float32 not supported for ttnn.maxpool_2d op "
-        "https://github.com/tenstorrent/tt-xla/issues/941"
-    )
 )
 def test_resnet_v1_5_26_inference_optimizer(inference_tester_optimizer: ResNetTester):
     inference_tester_optimizer.test()

--- a/tests/jax/single_chip/models/resnet_v1_5/resnet_26/test_resnet_26.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/resnet_26/test_resnet_26.py
@@ -44,7 +44,11 @@ def training_tester() -> ResNetTester:
 
 @pytest.fixture
 def inference_tester_optimizer() -> ResNetTester:
-    return ResNetTester(VARIANT_NAME, run_mode=RunMode.INFERENCE, compiler_config=CompilerConfig(enable_optimizer=True))
+    return ResNetTester(
+        VARIANT_NAME,
+        run_mode=RunMode.INFERENCE,
+        compiler_config=CompilerConfig(enable_optimizer=True),
+    )
 
 
 # ----- Tests -----
@@ -86,6 +90,12 @@ def test_resnet_v1_5_26_training(training_tester: ResNetTester):
     category=Category.MODEL_TEST,
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
+)
+@pytest.mark.xfail(
+    reason=failed_runtime(
+        "Float32 not supported for ttnn.maxpool_2d op "
+        "https://github.com/tenstorrent/tt-xla/issues/941"
+    )
 )
 def test_resnet_v1_5_26_inference_optimizer(inference_tester_optimizer: ResNetTester):
     inference_tester_optimizer.test()

--- a/tests/jax/single_chip/models/resnet_v1_5/tester.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/tester.py
@@ -10,6 +10,7 @@ from third_party.tt_forge_models.resnet.image_classification.jax import (
     ModelLoader,
     ModelVariant,
 )
+from tests.infra.testers.compiler_config import CompilerConfig
 
 
 class ResNetTester(JaxModelTester):
@@ -20,9 +21,10 @@ class ResNetTester(JaxModelTester):
         variant_name: ModelVariant,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
+        compiler_config: CompilerConfig = None,
     ) -> None:
         self._model_loader = ModelLoader(variant_name)
-        super().__init__(comparison_config, run_mode)
+        super().__init__(comparison_config, run_mode, compiler_config)
 
     # @override
     def _get_model(self) -> Model:

--- a/tests/jax/single_chip/models/resnet_v1_5/tester.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/tester.py
@@ -6,11 +6,11 @@ from typing import Dict
 import jax
 
 from infra import ComparisonConfig, JaxModelTester, RunMode, Model
+from infra.testers.compiler_config import CompilerConfig
 from third_party.tt_forge_models.resnet.image_classification.jax import (
     ModelLoader,
     ModelVariant,
 )
-from tests.infra.testers.compiler_config import CompilerConfig
 
 
 class ResNetTester(JaxModelTester):


### PR DESCRIPTION
Due to the changes in the compiler options from the jax side, the CI tests that tested this was not-valid, so fixing that.
