### PR TITLE
Set setup.py python ABI to 3.11

### DIFF
--- a/python_package/setup.py
+++ b/python_package/setup.py
@@ -132,11 +132,11 @@ config = SetupConfig()
 
 class BdistWheel(bdist_wheel):
     """
-    Custom wheel builder for a platform-specific, non-pure Python package.
+    Custom wheel builder for a platform-specific Python package.
 
     - Marks the wheel as non-pure (`root_is_pure = False`) to ensure proper installation
       of native binaries.
-    - Overrides the tag to be Python-version agnostic (`py3-none`) while preserving
+    - Overrides the tag to be Python 3.11-specific (`cp311-cp311`) while preserving
       platform specificity.
     """
 
@@ -159,9 +159,8 @@ class BdistWheel(bdist_wheel):
 
     def get_tag(self):
         python, abi, plat = bdist_wheel.get_tag(self)
-        # We don't contain any python extensions so are version agnostic
-        # but still want to be platform specific.
-        python, abi = "py3", "none"
+        # Force specific Python 3.11 ABI format for the wheel
+        python, abi = "cp311", "cp311"
         return python, abi, plat
 
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description

Adjusts wheel abi to output `pjrt_plugin_tt-*-py3-none-linux_x86_64.whl` to `pjrt_plugin_tt-*cp311-cp311-linux_x86_64.whl`

#### This is needed for a few reasons

The [tt-forge wheel](https://github.com/tenstorrent/tt-forge/blob/main/.github/scripts/template-setup.py#L4) will not build with the proper `abi` which currently produces  [tt_forge-0.4.0.dev20250909-py3-none-any.whl](https://github.com/tenstorrent/tt-forge/releases/download/0.4.0.dev20250909/tt_forge-0.4.0.dev20250909-py3-none-any.whl)

To create a manylinux wheel, auditwheel needs to work on a `platlib` compliant wheel created by `setup.py`. Example output below.
```bash
The wheel has to be platlib compliant in order to be repaired by auditwheel.
```

Lastly, since we are merging with tt-torch now, we should enforce this ABI more strictly now verus before.


