### PR TITLE
Mark n150 version of mistral/pixtral/pytorch-full-inference as SKIP to avoid crash on low memory machine

### DIFF
--- a/tests/runner/test_config.py
+++ b/tests/runner/test_config.py
@@ -1729,8 +1729,10 @@ test_config = {
                 "reason": "AssertionError: PCC comparison failed. Calculated: pcc=-8.055820217123255e-06. Required: pcc=0.99",
             },
             "n150": {
-                "status": ModelTestStatus.KNOWN_FAILURE_XFAIL,
-                "reason": "RuntimeError: Out of Memory: Not enough space to allocate 146800640 B DRAM buffer across 12 banks",
+                # Have to skip host OOM-killed tests since xfail marker happens after test is run which is too late.
+                "status": ModelTestStatus.NOT_SUPPORTED_SKIP,
+                # "status": ModelTestStatus.KNOWN_FAILURE_XFAIL,
+                # "reason": "RuntimeError: Out of Memory: Not enough space to allocate 146800640 B DRAM buffer across 12 banks",
                 "bringup_status": BringupStatus.FAILED_RUNTIME,
             },
         },


### PR DESCRIPTION
### Ticket
None

### Problem description
- Newly added pixtral test apparently non-deterministically gets killed on machine for using too much memory probably, link: https://github.com/tenstorrent/tt-xla/actions/runs/17633296319/job/50105186582

### What's changed
- Mark test with ModelTestStatus.NOT_SUPPORTED_SKIP and message, will get pytest.skipped, but still report on dashboard.

### Checklist
- [x] Eyeball check
