### PR TITLE
refactored models to use modelinfo 

### DIFF
--- a/tests/jax/multi_chip/llmbox/4_devices/models/tensor_parallel/alexnet/test_alexnet_llmbox_1x4.py
+++ b/tests/jax/multi_chip/llmbox/4_devices/models/tensor_parallel/alexnet/test_alexnet_llmbox_1x4.py
@@ -4,19 +4,16 @@
 
 import pytest
 from infra import RunMode, enable_shardy
-from utils import (
-    BringupStatus,
-    Category,
-)
-from third_party.tt_forge_models.config import Parallelism
+from utils import BringupStatus, Category
 
 from tests.jax.multi_chip.n300.models.tensor_parallel.alexnet.tester import (
     AlexNetMultichipTester,
 )
-from third_party.tt_forge_models.alexnet.jax import (
-    ModelVariant,
+from third_party.tt_forge_models.alexnet.image_classification.jax import (
     ModelLoader,
+    ModelVariant,
 )
+from third_party.tt_forge_models.config import Parallelism
 
 VARIANT_NAME = ModelVariant.CUSTOM_1X4
 MODEL_INFO = ModelLoader.get_model_info(VARIANT_NAME)

--- a/tests/jax/multi_chip/llmbox/4_devices/models/tensor_parallel/mnist_mlp/test_mnist_mlp.py
+++ b/tests/jax/multi_chip/llmbox/4_devices/models/tensor_parallel/mnist_mlp/test_mnist_mlp.py
@@ -4,18 +4,15 @@
 
 import pytest
 from infra import RunMode, enable_shardy
-from utils import (
-    BringupStatus,
-    Category,
-)
-from third_party.tt_forge_models.config import Parallelism
+from utils import BringupStatus, Category
 
 from tests.jax.multi_chip.n300.models.tensor_parallel.mnist_mlp.tester import (
     MnistMLPMultichipTester,
 )
+from third_party.tt_forge_models.config import Parallelism
 from third_party.tt_forge_models.mnist.image_classification.jax import (
-    ModelVariant,
     ModelLoader,
+    ModelVariant,
 )
 
 VARIANT_NAME = ModelVariant.MLP_CUSTOM_1X4

--- a/tests/jax/multi_chip/llmbox/8_devices/models/tensor_parallel/alexnet/test_alexnet_llmbox_1x8.py
+++ b/tests/jax/multi_chip/llmbox/8_devices/models/tensor_parallel/alexnet/test_alexnet_llmbox_1x8.py
@@ -4,19 +4,16 @@
 
 import pytest
 from infra import RunMode, enable_shardy
-from utils import (
-    BringupStatus,
-    Category,
-)
-from third_party.tt_forge_models.config import Parallelism
+from utils import BringupStatus, Category
 
 from tests.jax.multi_chip.n300.models.tensor_parallel.alexnet.tester import (
     AlexNetMultichipTester,
 )
-from third_party.tt_forge_models.alexnet.jax import (
-    ModelVariant,
+from third_party.tt_forge_models.alexnet.image_classification.jax import (
     ModelLoader,
+    ModelVariant,
 )
+from third_party.tt_forge_models.config import Parallelism
 
 VARIANT_NAME = ModelVariant.CUSTOM_1X8
 MODEL_INFO = ModelLoader.get_model_info(VARIANT_NAME)

--- a/tests/jax/multi_chip/llmbox/8_devices/models/tensor_parallel/mnist_mlp/test_mnist_mlp.py
+++ b/tests/jax/multi_chip/llmbox/8_devices/models/tensor_parallel/mnist_mlp/test_mnist_mlp.py
@@ -4,18 +4,15 @@
 
 import pytest
 from infra import RunMode, enable_shardy
-from utils import (
-    BringupStatus,
-    Category,
-)
-from third_party.tt_forge_models.config import Parallelism
+from utils import BringupStatus, Category
 
 from tests.jax.multi_chip.n300.models.tensor_parallel.mnist_mlp.tester import (
     MnistMLPMultichipTester,
 )
+from third_party.tt_forge_models.config import Parallelism
 from third_party.tt_forge_models.mnist.image_classification.jax import (
-    ModelVariant,
     ModelLoader,
+    ModelVariant,
 )
 
 VARIANT_NAME = ModelVariant.MLP_CUSTOM_1X8

--- a/tests/jax/multi_chip/n300/models/tensor_parallel/alexnet/test_alexnet_n300.py
+++ b/tests/jax/multi_chip/n300/models/tensor_parallel/alexnet/test_alexnet_n300.py
@@ -4,17 +4,15 @@
 
 import pytest
 from infra import RunMode, enable_shardy
-from utils import (
-    BringupStatus,
-    Category,
+from utils import BringupStatus, Category
+
+from third_party.tt_forge_models.alexnet.image_classification.jax import (
+    ModelLoader,
+    ModelVariant,
 )
 from third_party.tt_forge_models.config import Parallelism
 
 from .tester import AlexNetMultichipTester
-from third_party.tt_forge_models.alexnet.jax import (
-    ModelVariant,
-    ModelLoader,
-)
 
 VARIANT_NAME = ModelVariant.CUSTOM_1X2
 MODEL_INFO = ModelLoader.get_model_info(VARIANT_NAME)

--- a/tests/jax/multi_chip/n300/models/tensor_parallel/mnist_mlp/test_mnist_mlp.py
+++ b/tests/jax/multi_chip/n300/models/tensor_parallel/mnist_mlp/test_mnist_mlp.py
@@ -4,17 +4,15 @@
 
 import pytest
 from infra import RunMode, enable_shardy
-from utils import (
-    BringupStatus,
-    Category,
-)
+from utils import BringupStatus, Category
+
 from third_party.tt_forge_models.config import Parallelism
+from third_party.tt_forge_models.mnist.image_classification.jax import (
+    ModelLoader,
+    ModelVariant,
+)
 
 from .tester import MnistMLPMultichipTester
-from third_party.tt_forge_models.mnist.image_classification.jax import (
-    ModelVariant,
-    ModelLoader,
-)
 
 VARIANT_NAME = ModelVariant.MLP_CUSTOM_1X2
 MODEL_INFO = ModelLoader.get_model_info(VARIANT_NAME)

--- a/tests/jax/single_chip/models/albert_v2/base/test_albert_base.py
+++ b/tests/jax/single_chip/models/albert_v2/base/test_albert_base.py
@@ -4,16 +4,10 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-)
-from third_party.tt_forge_models.config import Parallelism
+from utils import BringupStatus, Category
 
-from third_party.tt_forge_models.albert.masked_lm.jax import (
-    ModelVariant,
-    ModelLoader,
-)
+from third_party.tt_forge_models.albert.masked_lm.jax import ModelLoader, ModelVariant
+from third_party.tt_forge_models.config import Parallelism
 
 from ..tester import AlbertV2Tester
 

--- a/tests/jax/single_chip/models/albert_v2/large/test_albert_large.py
+++ b/tests/jax/single_chip/models/albert_v2/large/test_albert_large.py
@@ -4,16 +4,10 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-)
-from third_party.tt_forge_models.config import Parallelism
+from utils import BringupStatus, Category
 
-from third_party.tt_forge_models.albert.masked_lm.jax import (
-    ModelVariant,
-    ModelLoader,
-)
+from third_party.tt_forge_models.albert.masked_lm.jax import ModelLoader, ModelVariant
+from third_party.tt_forge_models.config import Parallelism
 
 from ..tester import AlbertV2Tester
 

--- a/tests/jax/single_chip/models/albert_v2/xlarge/test_albert_xlarge.py
+++ b/tests/jax/single_chip/models/albert_v2/xlarge/test_albert_xlarge.py
@@ -4,19 +4,10 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    incorrect_result,
-)
-from third_party.tt_forge_models.config import Parallelism
+from utils import BringupStatus, Category, incorrect_result
 
-from third_party.tt_forge_models.albert.masked_lm.jax import ModelVariant
-from ..tester import AlbertV2Tester
-from third_party.tt_forge_models.albert.masked_lm.jax import (
-    ModelVariant,
-    ModelLoader,
-)
+from third_party.tt_forge_models.albert.masked_lm.jax import ModelLoader, ModelVariant
+from third_party.tt_forge_models.config import Parallelism
 
 from ..tester import AlbertV2Tester
 

--- a/tests/jax/single_chip/models/albert_v2/xxlarge/test_albert_xxlarge.py
+++ b/tests/jax/single_chip/models/albert_v2/xxlarge/test_albert_xxlarge.py
@@ -4,15 +4,12 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    incorrect_result,
-)
+from utils import BringupStatus, Category, incorrect_result
+
+from third_party.tt_forge_models.albert.masked_lm.jax import ModelLoader, ModelVariant
 from third_party.tt_forge_models.config import Parallelism
 
 from ..tester import AlbertV2Tester
-from third_party.tt_forge_models.albert.masked_lm.jax import ModelVariant
 
 VARIANT_NAME = ModelVariant.XXLARGE_V2
 

--- a/tests/jax/single_chip/models/alexnet/test_alexnet.py
+++ b/tests/jax/single_chip/models/alexnet/test_alexnet.py
@@ -5,28 +5,19 @@
 # TODO: Refactor to use ModelLoader.get_model_info() once the PR in tt-forge-models is merged
 
 import pytest
-from infra import Framework, RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    ModelGroup,
-    ModelSource,
-    ModelTask,
-    build_model_name,
-    failed_ttmlir_compilation,
+from infra import RunMode
+from utils import BringupStatus, Category, failed_ttmlir_compilation
+
+from third_party.tt_forge_models.alexnet.image_classification.jax import (
+    ModelLoader,
+    ModelVariant,
 )
 from third_party.tt_forge_models.config import Parallelism
+
 from .tester import AlexNetTester
 
-
-MODEL_PATH = "alexnet"
-MODEL_NAME = build_model_name(
-    Framework.JAX,
-    "alexnet",
-    "custom",
-    ModelTask.CV_IMAGE_CLS,
-    ModelSource.CUSTOM,
-)
+VARIANT_NAME = ModelVariant.CUSTOM
+MODEL_INFO = ModelLoader.get_model_info(VARIANT_NAME)
 
 # ----- Fixtures -----
 
@@ -47,8 +38,7 @@ def training_tester() -> AlexNetTester:
 @pytest.mark.model_test
 @pytest.mark.record_test_properties(
     category=Category.MODEL_TEST,
-    model_name=MODEL_NAME,
-    model_group=ModelGroup.GENERALITY,
+    model_info=MODEL_INFO,
     run_mode=RunMode.INFERENCE,
     parallelism=Parallelism.SINGLE_DEVICE,
     bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
@@ -66,8 +56,7 @@ def test_alexnet_inference(inference_tester: AlexNetTester):
 @pytest.mark.nightly
 @pytest.mark.record_test_properties(
     category=Category.MODEL_TEST,
-    model_name=MODEL_NAME,
-    model_group=ModelGroup.GENERALITY,
+    model_info=MODEL_INFO,
     run_mode=RunMode.TRAINING,
     parallelism=Parallelism.SINGLE_DEVICE,
 )

--- a/tests/jax/single_chip/models/bart/base/test_bart_base.py
+++ b/tests/jax/single_chip/models/bart/base/test_bart_base.py
@@ -4,17 +4,12 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-)
+from utils import BringupStatus, Category
+
+from third_party.tt_forge_models.bart.causal_lm.jax import ModelLoader, ModelVariant
 from third_party.tt_forge_models.config import Parallelism
 
 from ..tester import FlaxBartForCausalLMTester
-from third_party.tt_forge_models.bart.causal_lm.jax import (
-    ModelVariant,
-    ModelLoader,
-)
 
 VARIANT_NAME = ModelVariant.BASE
 

--- a/tests/jax/single_chip/models/bart/large/test_bart_large.py
+++ b/tests/jax/single_chip/models/bart/large/test_bart_large.py
@@ -4,18 +4,12 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    incorrect_result,
-)
+from utils import BringupStatus, Category, incorrect_result
+
+from third_party.tt_forge_models.bart.causal_lm.jax import ModelLoader, ModelVariant
 from third_party.tt_forge_models.config import Parallelism
 
 from ..tester import FlaxBartForCausalLMTester
-from third_party.tt_forge_models.bart.causal_lm.jax import (
-    ModelVariant,
-    ModelLoader,
-)
 
 VARIANT_NAME = ModelVariant.LARGE
 

--- a/tests/jax/single_chip/models/beit/base/test_beit_base.py
+++ b/tests/jax/single_chip/models/beit/base/test_beit_base.py
@@ -4,18 +4,15 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    incorrect_result,
+from utils import BringupStatus, Category, incorrect_result
+
+from third_party.tt_forge_models.beit.image_classification.jax import (
+    ModelLoader,
+    ModelVariant,
 )
 from third_party.tt_forge_models.config import Parallelism
 
 from ..tester import FlaxBeitForImageClassificationTester
-from third_party.tt_forge_models.beit.image_classification.jax import (
-    ModelVariant,
-    ModelLoader,
-)
 
 VARIANT_NAME = ModelVariant.BASE
 

--- a/tests/jax/single_chip/models/beit/large/test_beit_large.py
+++ b/tests/jax/single_chip/models/beit/large/test_beit_large.py
@@ -4,18 +4,15 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    incorrect_result,
+from utils import BringupStatus, Category, incorrect_result
+
+from third_party.tt_forge_models.beit.image_classification.jax import (
+    ModelLoader,
+    ModelVariant,
 )
 from third_party.tt_forge_models.config import Parallelism
 
 from ..tester import FlaxBeitForImageClassificationTester
-from third_party.tt_forge_models.beit.image_classification.jax import (
-    ModelVariant,
-    ModelLoader,
-)
 
 VARIANT_NAME = ModelVariant.LARGE
 

--- a/tests/jax/single_chip/models/bert/base/test_bert_base.py
+++ b/tests/jax/single_chip/models/bert/base/test_bert_base.py
@@ -4,15 +4,11 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-)
+from utils import BringupStatus, Category
+
+from third_party.tt_forge_models.bert.masked_lm.jax import ModelLoader, ModelVariant
 from third_party.tt_forge_models.config import Parallelism
-from third_party.tt_forge_models.bert.masked_lm.jax import (
-    ModelVariant,
-    ModelLoader,
-)
+
 from ..tester import FlaxBertForMaskedLMTester
 
 VARIANT_NAME = ModelVariant.BASE

--- a/tests/jax/single_chip/models/bert/large/test_bert_large.py
+++ b/tests/jax/single_chip/models/bert/large/test_bert_large.py
@@ -4,15 +4,11 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-)
+from utils import BringupStatus, Category
+
+from third_party.tt_forge_models.bert.masked_lm.jax import ModelLoader, ModelVariant
 from third_party.tt_forge_models.config import Parallelism
-from third_party.tt_forge_models.bert.masked_lm.jax import (
-    ModelVariant,
-    ModelLoader,
-)
+
 from ..tester import FlaxBertForMaskedLMTester
 
 VARIANT_NAME = ModelVariant.LARGE

--- a/tests/jax/single_chip/models/bloom/bloom_1b1/test_1b1.py
+++ b/tests/jax/single_chip/models/bloom/bloom_1b1/test_1b1.py
@@ -4,18 +4,12 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    incorrect_result,
-)
+from utils import BringupStatus, Category, incorrect_result
+
+from third_party.tt_forge_models.bloom.causal_lm.jax import ModelLoader, ModelVariant
 from third_party.tt_forge_models.config import Parallelism
 
 from ..tester import BloomTester
-from third_party.tt_forge_models.bloom.causal_lm.jax import (
-    ModelVariant,
-    ModelLoader,
-)
 
 VARIANT_NAME = ModelVariant.BLOOM_1B1
 

--- a/tests/jax/single_chip/models/bloom/bloom_1b7/test_1b7.py
+++ b/tests/jax/single_chip/models/bloom/bloom_1b7/test_1b7.py
@@ -4,18 +4,12 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    incorrect_result,
-)
+from utils import BringupStatus, Category, incorrect_result
+
+from third_party.tt_forge_models.bloom.causal_lm.jax import ModelLoader, ModelVariant
 from third_party.tt_forge_models.config import Parallelism
 
 from ..tester import BloomTester
-from third_party.tt_forge_models.bloom.causal_lm.jax import (
-    ModelVariant,
-    ModelLoader,
-)
 
 VARIANT_NAME = ModelVariant.BLOOM_1B7
 

--- a/tests/jax/single_chip/models/bloom/bloom_3b/test_3b.py
+++ b/tests/jax/single_chip/models/bloom/bloom_3b/test_3b.py
@@ -4,17 +4,12 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-)
+from utils import BringupStatus, Category
+
+from third_party.tt_forge_models.bloom.causal_lm.jax import ModelLoader, ModelVariant
 from third_party.tt_forge_models.config import Parallelism
 
 from ..tester import BloomTester
-from third_party.tt_forge_models.bloom.causal_lm.jax import (
-    ModelVariant,
-    ModelLoader,
-)
 
 VARIANT_NAME = ModelVariant.BLOOM_3B
 

--- a/tests/jax/single_chip/models/bloom/bloom_560m/test_560m.py
+++ b/tests/jax/single_chip/models/bloom/bloom_560m/test_560m.py
@@ -4,16 +4,11 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    incorrect_result,
-)
+from utils import BringupStatus, Category, incorrect_result
+
+from third_party.tt_forge_models.bloom.causal_lm.jax import ModelLoader, ModelVariant
 from third_party.tt_forge_models.config import Parallelism
-from third_party.tt_forge_models.bloom.causal_lm.jax import (
-    ModelVariant,
-    ModelLoader,
-)
+
 from ..tester import BloomTester
 
 VARIANT_NAME = ModelVariant.BLOOM_560M

--- a/tests/jax/single_chip/models/bloom/bloom_7b/test_7b.py
+++ b/tests/jax/single_chip/models/bloom/bloom_7b/test_7b.py
@@ -4,18 +4,12 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    failed_runtime,
-)
+from utils import BringupStatus, Category, failed_runtime
+
+from third_party.tt_forge_models.bloom.causal_lm.jax import ModelLoader, ModelVariant
 from third_party.tt_forge_models.config import Parallelism
 
 from ..tester import BloomTester
-from third_party.tt_forge_models.bloom.causal_lm.jax import (
-    ModelVariant,
-    ModelLoader,
-)
 
 VARIANT_NAME = ModelVariant.BLOOM_7B
 

--- a/tests/jax/single_chip/models/clip/base_patch16/test_clip_base_patch16.py
+++ b/tests/jax/single_chip/models/clip/base_patch16/test_clip_base_patch16.py
@@ -4,16 +4,13 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    incorrect_result,
+from utils import BringupStatus, Category, incorrect_result
+
+from third_party.tt_forge_models.clip.image_classification.jax import (
+    ModelLoader,
+    ModelVariant,
 )
 from third_party.tt_forge_models.config import Parallelism
-from third_party.tt_forge_models.clip.image_classification.jax import (
-    ModelVariant,
-    ModelLoader,
-)
 
 from ..tester import FlaxCLIPTester
 

--- a/tests/jax/single_chip/models/clip/base_patch32/test_clip_base_patch32.py
+++ b/tests/jax/single_chip/models/clip/base_patch32/test_clip_base_patch32.py
@@ -4,16 +4,13 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    failed_runtime,
+from utils import BringupStatus, Category, failed_runtime
+
+from third_party.tt_forge_models.clip.image_classification.jax import (
+    ModelLoader,
+    ModelVariant,
 )
 from third_party.tt_forge_models.config import Parallelism
-from third_party.tt_forge_models.clip.image_classification.jax import (
-    ModelVariant,
-    ModelLoader,
-)
 
 from ..tester import FlaxCLIPTester
 

--- a/tests/jax/single_chip/models/clip/large_patch14/test_clip_large_patch14.py
+++ b/tests/jax/single_chip/models/clip/large_patch14/test_clip_large_patch14.py
@@ -4,16 +4,13 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    incorrect_result,
+from utils import BringupStatus, Category, incorrect_result
+
+from third_party.tt_forge_models.clip.image_classification.jax import (
+    ModelLoader,
+    ModelVariant,
 )
 from third_party.tt_forge_models.config import Parallelism
-from third_party.tt_forge_models.clip.image_classification.jax import (
-    ModelVariant,
-    ModelLoader,
-)
 
 from ..tester import FlaxCLIPTester
 

--- a/tests/jax/single_chip/models/clip/large_patch14_336/test_clip_large_patch14_336.py
+++ b/tests/jax/single_chip/models/clip/large_patch14_336/test_clip_large_patch14_336.py
@@ -4,16 +4,13 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    incorrect_result,
+from utils import BringupStatus, Category, incorrect_result
+
+from third_party.tt_forge_models.clip.image_classification.jax import (
+    ModelLoader,
+    ModelVariant,
 )
 from third_party.tt_forge_models.config import Parallelism
-from third_party.tt_forge_models.clip.image_classification.jax import (
-    ModelVariant,
-    ModelLoader,
-)
 
 from ..tester import FlaxCLIPTester
 

--- a/tests/jax/single_chip/models/distilbert/test_distilbert.py
+++ b/tests/jax/single_chip/models/distilbert/test_distilbert.py
@@ -6,13 +6,10 @@ from typing import Dict
 
 import jax
 import pytest
-from infra import ComparisonConfig, Framework, JaxModelTester, Model, RunMode
-from utils import (
-    BringupStatus,
-    Category,
-)
-from third_party.tt_forge_models.config import Parallelism
+from infra import ComparisonConfig, JaxModelTester, Model, RunMode
+from utils import BringupStatus, Category
 
+from third_party.tt_forge_models.config import Parallelism
 from third_party.tt_forge_models.distilbert.masked_lm.jax import (
     ModelLoader,
     ModelVariant,

--- a/tests/jax/single_chip/models/electra/base_discriminator/test_electra_base_discriminator.py
+++ b/tests/jax/single_chip/models/electra/base_discriminator/test_electra_base_discriminator.py
@@ -4,17 +4,10 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-)
-from third_party.tt_forge_models.config import Parallelism
+from utils import BringupStatus, Category
 
-from ..tester import ElectraTester
-from third_party.tt_forge_models.electra.causal_lm.jax import (
-    ModelVariant,
-    ModelLoader,
-)
+from third_party.tt_forge_models.config import Parallelism
+from third_party.tt_forge_models.electra.causal_lm.jax import ModelLoader, ModelVariant
 
 from ..tester import ElectraTester
 

--- a/tests/jax/single_chip/models/electra/base_generator/test_electra_base_generator.py
+++ b/tests/jax/single_chip/models/electra/base_generator/test_electra_base_generator.py
@@ -4,17 +4,10 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-)
-from third_party.tt_forge_models.config import Parallelism
+from utils import BringupStatus, Category
 
-from ..tester import ElectraTester
-from third_party.tt_forge_models.electra.causal_lm.jax import (
-    ModelVariant,
-    ModelLoader,
-)
+from third_party.tt_forge_models.config import Parallelism
+from third_party.tt_forge_models.electra.causal_lm.jax import ModelLoader, ModelVariant
 
 from ..tester import ElectraTester
 

--- a/tests/jax/single_chip/models/electra/large_discriminator/test_electra_large_discriminator.py
+++ b/tests/jax/single_chip/models/electra/large_discriminator/test_electra_large_discriminator.py
@@ -4,18 +4,10 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-)
+from utils import BringupStatus, Category
+
 from third_party.tt_forge_models.config import Parallelism
-
-from ..tester import ElectraTester
-
-from third_party.tt_forge_models.electra.causal_lm.jax import (
-    ModelVariant,
-    ModelLoader,
-)
+from third_party.tt_forge_models.electra.causal_lm.jax import ModelLoader, ModelVariant
 
 from ..tester import ElectraTester
 

--- a/tests/jax/single_chip/models/electra/small_discriminator/test_electra_small_discriminator.py
+++ b/tests/jax/single_chip/models/electra/small_discriminator/test_electra_small_discriminator.py
@@ -4,17 +4,10 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-)
-from third_party.tt_forge_models.config import Parallelism
+from utils import BringupStatus, Category
 
-from ..tester import ElectraTester
-from third_party.tt_forge_models.electra.causal_lm.jax import (
-    ModelVariant,
-    ModelLoader,
-)
+from third_party.tt_forge_models.config import Parallelism
+from third_party.tt_forge_models.electra.causal_lm.jax import ModelLoader, ModelVariant
 
 from ..tester import ElectraTester
 

--- a/tests/jax/single_chip/models/gpt2/base/test_gpt2_base.py
+++ b/tests/jax/single_chip/models/gpt2/base/test_gpt2_base.py
@@ -4,17 +4,11 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    ExecutionPass,
-    failed_ttmlir_compilation,
-)
+from utils import BringupStatus, Category, ExecutionPass, failed_ttmlir_compilation
+
 from third_party.tt_forge_models.config import Parallelism
-from third_party.tt_forge_models.gpt2.causal_lm.jax import (
-    ModelVariant,
-    ModelLoader,
-)
+from third_party.tt_forge_models.gpt2.causal_lm.jax import ModelLoader, ModelVariant
+
 from ..tester import GPT2Tester
 
 VARIANT_NAME = ModelVariant.BASE

--- a/tests/jax/single_chip/models/gpt2/large/test_gpt2_large.py
+++ b/tests/jax/single_chip/models/gpt2/large/test_gpt2_large.py
@@ -4,16 +4,11 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-)
-from third_party.tt_forge_models.config import Parallelism
+from utils import BringupStatus, Category
 
-from third_party.tt_forge_models.gpt2.causal_lm.jax import (
-    ModelVariant,
-    ModelLoader,
-)
+from third_party.tt_forge_models.config import Parallelism
+from third_party.tt_forge_models.gpt2.causal_lm.jax import ModelLoader, ModelVariant
+
 from ..tester import GPT2Tester
 
 VARIANT_NAME = ModelVariant.LARGE

--- a/tests/jax/single_chip/models/gpt2/medium/test_gpt2_medium.py
+++ b/tests/jax/single_chip/models/gpt2/medium/test_gpt2_medium.py
@@ -4,16 +4,11 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-)
-from third_party.tt_forge_models.config import Parallelism
+from utils import BringupStatus, Category
 
-from third_party.tt_forge_models.gpt2.causal_lm.jax import (
-    ModelVariant,
-    ModelLoader,
-)
+from third_party.tt_forge_models.config import Parallelism
+from third_party.tt_forge_models.gpt2.causal_lm.jax import ModelLoader, ModelVariant
+
 from ..tester import GPT2Tester
 
 VARIANT_NAME = ModelVariant.MEDIUM

--- a/tests/jax/single_chip/models/gpt2/xl/test_gpt2_xl.py
+++ b/tests/jax/single_chip/models/gpt2/xl/test_gpt2_xl.py
@@ -4,16 +4,11 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-)
-from third_party.tt_forge_models.config import Parallelism
+from utils import BringupStatus, Category
 
-from third_party.tt_forge_models.gpt2.causal_lm.jax import (
-    ModelVariant,
-    ModelLoader,
-)
+from third_party.tt_forge_models.config import Parallelism
+from third_party.tt_forge_models.gpt2.causal_lm.jax import ModelLoader, ModelVariant
+
 from ..tester import GPT2Tester
 
 VARIANT_NAME = ModelVariant.XL

--- a/tests/jax/single_chip/models/gpt_j/gpt_j_6b/test_gpt_j_6b.py
+++ b/tests/jax/single_chip/models/gpt_j/gpt_j_6b/test_gpt_j_6b.py
@@ -4,17 +4,11 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    failed_runtime,
-)
-from third_party.tt_forge_models.config import Parallelism
+from utils import BringupStatus, Category, failed_runtime
 
-from third_party.tt_forge_models.gpt_j.causal_lm.jax import (
-    ModelVariant,
-    ModelLoader,
-)
+from third_party.tt_forge_models.config import Parallelism
+from third_party.tt_forge_models.gpt_j.causal_lm.jax import ModelLoader, ModelVariant
+
 from ..tester import GPTJTester
 
 VARIANT_NAME = ModelVariant._6B

--- a/tests/jax/single_chip/models/gpt_neo/gpt_neo_125m/test_gpt_neo_125m.py
+++ b/tests/jax/single_chip/models/gpt_neo/gpt_neo_125m/test_gpt_neo_125m.py
@@ -4,15 +4,11 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-)
+from utils import BringupStatus, Category
+
 from third_party.tt_forge_models.config import Parallelism
-from third_party.tt_forge_models.gpt_neo.causal_lm.jax import (
-    ModelVariant,
-    ModelLoader,
-)
+from third_party.tt_forge_models.gpt_neo.causal_lm.jax import ModelLoader, ModelVariant
+
 from ..tester import GPTNeoTester
 
 VARIANT_NAME = ModelVariant.GPT_NEO_125M

--- a/tests/jax/single_chip/models/gpt_neo/gpt_neo_1_3b/test_gpt_neo_1_3b.py
+++ b/tests/jax/single_chip/models/gpt_neo/gpt_neo_1_3b/test_gpt_neo_1_3b.py
@@ -4,15 +4,10 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-)
+from utils import BringupStatus, Category
+
 from third_party.tt_forge_models.config import Parallelism
-from third_party.tt_forge_models.gpt_neo.causal_lm.jax import (
-    ModelVariant,
-    ModelLoader,
-)
+from third_party.tt_forge_models.gpt_neo.causal_lm.jax import ModelLoader, ModelVariant
 
 from ..tester import GPTNeoTester
 

--- a/tests/jax/single_chip/models/gpt_neo/gpt_neo_2_7b/test_gpt_neo_2_7b.py
+++ b/tests/jax/single_chip/models/gpt_neo/gpt_neo_2_7b/test_gpt_neo_2_7b.py
@@ -4,15 +4,10 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-)
+from utils import BringupStatus, Category
+
 from third_party.tt_forge_models.config import Parallelism
-from third_party.tt_forge_models.gpt_neo.causal_lm.jax import (
-    ModelVariant,
-    ModelLoader,
-)
+from third_party.tt_forge_models.gpt_neo.causal_lm.jax import ModelLoader, ModelVariant
 
 from ..tester import GPTNeoTester
 

--- a/tests/jax/single_chip/models/gpt_sw3/instruct_1_3b/test_gpt_sw3_1_3b_instruct.py
+++ b/tests/jax/single_chip/models/gpt_sw3/instruct_1_3b/test_gpt_sw3_1_3b_instruct.py
@@ -4,17 +4,12 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-)
+from utils import BringupStatus, Category
+
 from third_party.tt_forge_models.config import Parallelism
+from third_party.tt_forge_models.gpt_sw3.causal_lm.jax import ModelLoader, ModelVariant
 
 from ..tester import GPTSw3Tester
-from third_party.tt_forge_models.gpt_sw3.causal_lm.jax import (
-    ModelVariant,
-    ModelLoader,
-)
 
 VARIANT_NAME = ModelVariant.INSTRUCT_1_3B
 

--- a/tests/jax/single_chip/models/llama/openllama_3b_v2/test_openllama_3b_v2.py
+++ b/tests/jax/single_chip/models/llama/openllama_3b_v2/test_openllama_3b_v2.py
@@ -4,17 +4,11 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    failed_runtime,
-)
-from third_party.tt_forge_models.config import Parallelism
+from utils import BringupStatus, Category, failed_runtime
 
-from third_party.tt_forge_models.llama.causal_lm.jax import (
-    ModelVariant,
-    ModelLoader,
-)
+from third_party.tt_forge_models.config import Parallelism
+from third_party.tt_forge_models.llama.causal_lm.jax import ModelLoader, ModelVariant
+
 from ..tester import LLamaTester
 
 VARIANT_NAME = ModelVariant._3B_V2

--- a/tests/jax/single_chip/models/longt5/base_tglobal/test_longt5_base_tglobal.py
+++ b/tests/jax/single_chip/models/longt5/base_tglobal/test_longt5_base_tglobal.py
@@ -4,17 +4,14 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    failed_runtime,
-)
-from third_party.tt_forge_models.config import Parallelism
+from utils import BringupStatus, Category, failed_runtime
 
+from third_party.tt_forge_models.config import Parallelism
 from third_party.tt_forge_models.longt5.text_classification.jax import (
-    ModelVariant,
     ModelLoader,
+    ModelVariant,
 )
+
 from ..tester import LongT5Tester
 
 VARIANT_NAME = ModelVariant.BASE_TGLOBAL

--- a/tests/jax/single_chip/models/longt5/large_local/test_longt5_large_local.py
+++ b/tests/jax/single_chip/models/longt5/large_local/test_longt5_large_local.py
@@ -4,17 +4,14 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    failed_runtime,
-)
-from third_party.tt_forge_models.config import Parallelism
+from utils import BringupStatus, Category, failed_runtime
 
+from third_party.tt_forge_models.config import Parallelism
 from third_party.tt_forge_models.longt5.text_classification.jax import (
-    ModelVariant,
     ModelLoader,
+    ModelVariant,
 )
+
 from ..tester import LongT5Tester
 
 VARIANT_NAME = ModelVariant.LARGE_LOCAL

--- a/tests/jax/single_chip/models/longt5/xl_tglobal/test_longt5_xl_tglobal.py
+++ b/tests/jax/single_chip/models/longt5/xl_tglobal/test_longt5_xl_tglobal.py
@@ -4,17 +4,14 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    failed_runtime,
-)
-from third_party.tt_forge_models.config import Parallelism
+from utils import BringupStatus, Category, failed_runtime
 
+from third_party.tt_forge_models.config import Parallelism
 from third_party.tt_forge_models.longt5.text_classification.jax import (
-    ModelVariant,
     ModelLoader,
+    ModelVariant,
 )
+
 from ..tester import LongT5Tester
 
 VARIANT_NAME = ModelVariant.XL_TGLOBAL

--- a/tests/jax/single_chip/models/marian/opus_mt_en_de/test_marian_opus_mt_en_de.py
+++ b/tests/jax/single_chip/models/marian/opus_mt_en_de/test_marian_opus_mt_en_de.py
@@ -4,17 +4,14 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    failed_ttmlir_compilation,
-)
-from third_party.tt_forge_models.config import Parallelism
+from utils import BringupStatus, Category, failed_ttmlir_compilation
 
+from third_party.tt_forge_models.config import Parallelism
 from third_party.tt_forge_models.marian_mt.text_classification.jax import (
-    ModelVariant,
     ModelLoader,
+    ModelVariant,
 )
+
 from ..tester import MarianTester
 
 VARIANT_NAME = ModelVariant.OPUS_MT_EN_DE

--- a/tests/jax/single_chip/models/mbart50/large_many_to_many/test_mbart50_large_many_to_many.py
+++ b/tests/jax/single_chip/models/mbart50/large_many_to_many/test_mbart50_large_many_to_many.py
@@ -15,6 +15,7 @@ from utils import (
     build_model_name,
     failed_ttmlir_compilation,
 )
+
 from third_party.tt_forge_models.config import Parallelism
 
 from ..tester import MBartTester

--- a/tests/jax/single_chip/models/pegasus/large/test_pegasus_large.py
+++ b/tests/jax/single_chip/models/pegasus/large/test_pegasus_large.py
@@ -4,17 +4,12 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    failed_ttmlir_compilation,
-)
-from third_party.tt_forge_models.config import Parallelism
+from utils import BringupStatus, Category, failed_ttmlir_compilation
 
-from ..tester import PegasusTester
+from third_party.tt_forge_models.config import Parallelism
 from third_party.tt_forge_models.pegasus.summarization.jax import (
-    ModelVariant,
     ModelLoader,
+    ModelVariant,
 )
 
 from ..tester import PegasusTester

--- a/tests/jax/single_chip/models/pegasus/xsum/test_pegasus_xsum.py
+++ b/tests/jax/single_chip/models/pegasus/xsum/test_pegasus_xsum.py
@@ -4,17 +4,12 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    failed_ttmlir_compilation,
-)
-from third_party.tt_forge_models.config import Parallelism
+from utils import BringupStatus, Category, failed_ttmlir_compilation
 
-from ..tester import PegasusTester
+from third_party.tt_forge_models.config import Parallelism
 from third_party.tt_forge_models.pegasus.summarization.jax import (
-    ModelVariant,
     ModelLoader,
+    ModelVariant,
 )
 
 from ..tester import PegasusTester

--- a/tests/jax/single_chip/models/regnet/regnet_y_040/test_regnet_y_040.py
+++ b/tests/jax/single_chip/models/regnet/regnet_y_040/test_regnet_y_040.py
@@ -4,18 +4,15 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    incorrect_result,
-)
+from utils import BringupStatus, Category, incorrect_result
+
 from third_party.tt_forge_models.config import Parallelism
+from third_party.tt_forge_models.regnet.image_classification.jax import (
+    ModelLoader,
+    ModelVariant,
+)
 
 from ..tester import RegNetTester
-from third_party.tt_forge_models.regnet.image_classification.jax import (
-    ModelVariant,
-    ModelLoader,
-)
 
 VARIANT_NAME = ModelVariant.REGNET_Y_040
 MODEL_INFO = ModelLoader.get_model_info(VARIANT_NAME)

--- a/tests/jax/single_chip/models/regnet/regnet_y_160/test_regnet_y_160.py
+++ b/tests/jax/single_chip/models/regnet/regnet_y_160/test_regnet_y_160.py
@@ -4,18 +4,15 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    failed_runtime,
-)
+from utils import BringupStatus, Category, failed_runtime
+
 from third_party.tt_forge_models.config import Parallelism
+from third_party.tt_forge_models.regnet.image_classification.jax import (
+    ModelLoader,
+    ModelVariant,
+)
 
 from ..tester import RegNetTester
-from third_party.tt_forge_models.regnet.image_classification.jax import (
-    ModelVariant,
-    ModelLoader,
-)
 
 VARIANT_NAME = ModelVariant.REGNET_Y_160
 MODEL_INFO = ModelLoader.get_model_info(VARIANT_NAME)

--- a/tests/jax/single_chip/models/regnet/regnet_y_320/test_regnet_y_320.py
+++ b/tests/jax/single_chip/models/regnet/regnet_y_320/test_regnet_y_320.py
@@ -4,18 +4,15 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    failed_runtime,
-)
+from utils import BringupStatus, Category, failed_runtime
+
 from third_party.tt_forge_models.config import Parallelism
+from third_party.tt_forge_models.regnet.image_classification.jax import (
+    ModelLoader,
+    ModelVariant,
+)
 
 from ..tester import RegNetTester
-from third_party.tt_forge_models.regnet.image_classification.jax import (
-    ModelVariant,
-    ModelLoader,
-)
 
 VARIANT_NAME = ModelVariant.REGNET_Y_320
 MODEL_INFO = ModelLoader.get_model_info(VARIANT_NAME)

--- a/tests/jax/single_chip/models/resnet_v1_5/resnet_101/test_resnet_101.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/resnet_101/test_resnet_101.py
@@ -4,18 +4,15 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    incorrect_result,
-)
+from utils import BringupStatus, Category, incorrect_result
+
 from third_party.tt_forge_models.config import Parallelism
+from third_party.tt_forge_models.resnet.image_classification.jax import (
+    ModelLoader,
+    ModelVariant,
+)
 
 from ..tester import ResNetTester
-from third_party.tt_forge_models.resnet.image_classification.jax import (
-    ModelVariant,
-    ModelLoader,
-)
 
 VARIANT_NAME = ModelVariant.RESNET_101
 MODEL_INFO = ModelLoader.get_model_info(VARIANT_NAME)

--- a/tests/jax/single_chip/models/resnet_v1_5/resnet_152/test_resnet_152.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/resnet_152/test_resnet_152.py
@@ -4,18 +4,15 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    incorrect_result,
-)
+from utils import BringupStatus, Category, incorrect_result
+
 from third_party.tt_forge_models.config import Parallelism
+from third_party.tt_forge_models.resnet.image_classification.jax import (
+    ModelLoader,
+    ModelVariant,
+)
 
 from ..tester import ResNetTester
-from third_party.tt_forge_models.resnet.image_classification.jax import (
-    ModelVariant,
-    ModelLoader,
-)
 
 VARIANT_NAME = ModelVariant.RESNET_152
 MODEL_INFO = ModelLoader.get_model_info(VARIANT_NAME)

--- a/tests/jax/single_chip/models/resnet_v1_5/resnet_18/test_resnet_18.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/resnet_18/test_resnet_18.py
@@ -4,17 +4,15 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-)
+from utils import BringupStatus, Category
+
 from third_party.tt_forge_models.config import Parallelism
+from third_party.tt_forge_models.resnet.image_classification.jax import (
+    ModelLoader,
+    ModelVariant,
+)
 
 from ..tester import ResNetTester
-from third_party.tt_forge_models.resnet.image_classification.jax import (
-    ModelVariant,
-    ModelLoader,
-)
 
 VARIANT_NAME = ModelVariant.RESNET_18
 MODEL_INFO = ModelLoader.get_model_info(VARIANT_NAME)

--- a/tests/jax/single_chip/models/resnet_v1_5/resnet_26/test_resnet_26.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/resnet_26/test_resnet_26.py
@@ -4,23 +4,20 @@
 
 import pytest
 from infra import RunMode
+from utils import BringupStatus, Category, failed_runtime
+
 from tests.infra.testers.compiler_config import CompilerConfig
-from utils import (
-    BringupStatus,
-    Category,
-    failed_runtime,
-    incorrect_result,
-)
 from third_party.tt_forge_models.config import Parallelism
+from third_party.tt_forge_models.resnet.image_classification.jax import (
+    ModelLoader,
+    ModelVariant,
+)
 
 from ..tester import ResNetTester
-from third_party.tt_forge_models.resnet.image_classification.jax import (
-    ModelVariant,
-    ModelLoader,
-)
 
 VARIANT_NAME = ModelVariant.RESNET_26
 MODEL_INFO = ModelLoader.get_model_info(VARIANT_NAME)
+
 
 # ----- Fixtures -----
 
@@ -51,8 +48,8 @@ def inference_tester_optimizer() -> ResNetTester:
 @pytest.mark.record_test_properties(
     category=Category.MODEL_TEST,
     model_info=MODEL_INFO,
-    run_mode=RunMode.INFERENCE,
     parallelism=Parallelism.SINGLE_DEVICE,
+    run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.PASSED,
 )
 @pytest.mark.large
@@ -64,8 +61,8 @@ def test_resnet_v1_5_26_inference(inference_tester: ResNetTester):
 @pytest.mark.record_test_properties(
     category=Category.MODEL_TEST,
     model_info=MODEL_INFO,
-    run_mode=RunMode.TRAINING,
     parallelism=Parallelism.SINGLE_DEVICE,
+    run_mode=RunMode.TRAINING,
 )
 @pytest.mark.skip(reason="Support for training not implemented")
 def test_resnet_v1_5_26_training(training_tester: ResNetTester):

--- a/tests/jax/single_chip/models/resnet_v1_5/resnet_34/test_resnet_34.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/resnet_34/test_resnet_34.py
@@ -4,17 +4,15 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-)
+from utils import BringupStatus, Category
+
 from third_party.tt_forge_models.config import Parallelism
+from third_party.tt_forge_models.resnet.image_classification.jax import (
+    ModelLoader,
+    ModelVariant,
+)
 
 from ..tester import ResNetTester
-from third_party.tt_forge_models.resnet.image_classification.jax import (
-    ModelVariant,
-    ModelLoader,
-)
 
 VARIANT_NAME = ModelVariant.RESNET_34
 MODEL_INFO = ModelLoader.get_model_info(VARIANT_NAME)

--- a/tests/jax/single_chip/models/resnet_v1_5/resnet_50/test_resnet_50.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/resnet_50/test_resnet_50.py
@@ -3,20 +3,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from pytest import MonkeyPatch
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    incorrect_result,
-)
-from third_party.tt_forge_models.config import Parallelism
+from pytest import MonkeyPatch
+from utils import BringupStatus, Category, ModelGroup
 
-from ..tester import ResNetTester
+from third_party.tt_forge_models.config import Parallelism
 from third_party.tt_forge_models.resnet.image_classification.jax import (
-    ModelVariant,
     ModelLoader,
+    ModelVariant,
 )
+
+from ..tester import CompilerConfig, ResNetTester
 
 VARIANT_NAME = ModelVariant.RESNET_50
 MODEL_INFO = ModelLoader.get_model_info(VARIANT_NAME)
@@ -65,8 +62,9 @@ def test_resnet_v1_5_50_inference(inference_tester: ResNetTester):
 @pytest.mark.model_test
 @pytest.mark.record_test_properties(
     category=Category.MODEL_TEST,
-    model_name=MODEL_NAME,
+    model_info=MODEL_INFO,
     model_group=ModelGroup.RED,
+    parallelism=Parallelism.SINGLE_DEVICE,
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.PASSED,
 )

--- a/tests/jax/single_chip/models/t5/base/test_t5_base.py
+++ b/tests/jax/single_chip/models/t5/base/test_t5_base.py
@@ -4,16 +4,11 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    incorrect_result,
-)
+from utils import BringupStatus, Category, incorrect_result
+
 from third_party.tt_forge_models.config import Parallelism
-from third_party.tt_forge_models.t5.summarization.jax import (
-    ModelVariant,
-    ModelLoader,
-)
+from third_party.tt_forge_models.t5.summarization.jax import ModelLoader, ModelVariant
+
 from ..tester import T5Tester
 
 VARIANT_NAME = ModelVariant.BASE

--- a/tests/jax/single_chip/models/t5/large/test_t5_large.py
+++ b/tests/jax/single_chip/models/t5/large/test_t5_large.py
@@ -4,16 +4,11 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    incorrect_result,
-)
+from utils import BringupStatus, Category, incorrect_result
+
 from third_party.tt_forge_models.config import Parallelism
-from third_party.tt_forge_models.t5.summarization.jax import (
-    ModelVariant,
-    ModelLoader,
-)
+from third_party.tt_forge_models.t5.summarization.jax import ModelLoader, ModelVariant
+
 from ..tester import T5Tester
 
 VARIANT_NAME = ModelVariant.LARGE

--- a/tests/jax/single_chip/models/t5/small/test_t5_small.py
+++ b/tests/jax/single_chip/models/t5/small/test_t5_small.py
@@ -4,16 +4,11 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    incorrect_result,
-)
+from utils import BringupStatus, Category, incorrect_result
+
 from third_party.tt_forge_models.config import Parallelism
-from third_party.tt_forge_models.t5.summarization.jax import (
-    ModelVariant,
-    ModelLoader,
-)
+from third_party.tt_forge_models.t5.summarization.jax import ModelLoader, ModelVariant
+
 from ..tester import T5Tester
 
 VARIANT_NAME = ModelVariant.SMALL

--- a/tests/jax/single_chip/models/xglm/xglm_564m/test_xglm_564m.py
+++ b/tests/jax/single_chip/models/xglm/xglm_564m/test_xglm_564m.py
@@ -4,17 +4,11 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    failed_runtime,
-)
+from utils import BringupStatus, Category, failed_runtime
+
 from third_party.tt_forge_models.config import Parallelism
-from third_party.tt_forge_models.xglm.causal_lm.jax.loader import ModelVariant
-from third_party.tt_forge_models.xglm.causal_lm.jax import (
-    ModelVariant,
-    ModelLoader,
-)
+from third_party.tt_forge_models.xglm.causal_lm.jax import ModelLoader, ModelVariant
+
 from ..tester import XGLMTester
 
 VARIANT_NAME = ModelVariant._564M

--- a/tests/jax/single_chip/models/xlm_roberta/base/test_xlm_roberta_base.py
+++ b/tests/jax/single_chip/models/xlm_roberta/base/test_xlm_roberta_base.py
@@ -4,16 +4,14 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    failed_runtime,
-)
+from utils import BringupStatus, Category, failed_runtime
+
 from third_party.tt_forge_models.config import Parallelism
 from third_party.tt_forge_models.xlm_roberta.causal_lm.jax import (
-    ModelVariant,
     ModelLoader,
+    ModelVariant,
 )
+
 from ..tester import XLMRobertaTester
 
 VARIANT_NAME = ModelVariant.BASE

--- a/tests/jax/single_chip/models/xlm_roberta/large/test_xlm_roberta_large.py
+++ b/tests/jax/single_chip/models/xlm_roberta/large/test_xlm_roberta_large.py
@@ -4,16 +4,14 @@
 
 import pytest
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    failed_runtime,
-)
+from utils import BringupStatus, Category, failed_runtime
+
 from third_party.tt_forge_models.config import Parallelism
 from third_party.tt_forge_models.xlm_roberta.causal_lm.jax import (
-    ModelVariant,
     ModelLoader,
+    ModelVariant,
 )
+
 from ..tester import XLMRobertaTester
 
 VARIANT_NAME = ModelVariant.LARGE


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/1332

### Problem description
JAX models should be updated to use model info from TT_forge models.

### What's changed
all the JAX tests  updated to use model info from TT_forge models.

### Checklist
- [x] New/Existing tests provide coverage for changes

I have attached the logs for your reference:
[log.zip](https://github.com/user-attachments/files/22231338/log.zip)

