### PR TITLE
Changed the frontend pass so that the default argument is input

### DIFF
--- a/inc/common/pjrt_implementation/module_builder/frontend_passes/shlo_input_role_propagation.h
+++ b/inc/common/pjrt_implementation/module_builder/frontend_passes/shlo_input_role_propagation.h
@@ -27,10 +27,6 @@ annotateArgumentAttributes(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module);
 
 namespace internal {
 
-// Annotates the attributes of the function arguments.
-tt_pjrt_status annotateArgumentAttributesFromCustomCall(
-    mlir::OwningOpRef<mlir::ModuleOp> &mlir_module);
-
 // Propagates ttcore.argument_type attributes from tt.mark func.call operations
 // upwards to the module root public function arguments.
 void propagateInputRoleAttributes(
@@ -48,8 +44,14 @@ void inlineTTMarkFunctions(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module);
 // Check is the function is tt_mark.
 bool isTTMarkFunction(const std::string &function_name);
 
-// Returns a vector of block arguments that traces from a given mlir::Value.
-mlir::SmallVector<mlir::BlockArgument> getBlockArguments(mlir::Value value);
+// Annotates the attributes of the function arguments.
+tt_pjrt_status annotateArgumentAttributesFromCustomCall(
+    mlir::OwningOpRef<mlir::ModuleOp> &mlir_module);
+
+// Sets default role for function arguments that have not been annotated.
+// Currently the default role is Input.
+void setDefaultRoleForUnannotatedArguments(
+    mlir::OwningOpRef<mlir::ModuleOp> &mlir_module);
 
 } // namespace internal
 

--- a/inc/common/pjrt_implementation/module_builder/frontend_passes/shlo_input_role_propagation.h
+++ b/inc/common/pjrt_implementation/module_builder/frontend_passes/shlo_input_role_propagation.h
@@ -27,8 +27,7 @@ annotateArgumentAttributes(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module);
 
 namespace internal {
 
-// Annotates the attributes of the function arguments if the annotations are
-// provided by a custom call.
+// Annotates the attributes of the function arguments.
 tt_pjrt_status annotateArgumentAttributesFromCustomCall(
     mlir::OwningOpRef<mlir::ModuleOp> &mlir_module);
 

--- a/inc/common/pjrt_implementation/module_builder/module_builder.h
+++ b/inc/common/pjrt_implementation/module_builder/module_builder.h
@@ -222,10 +222,6 @@ private:
   std::optional<mlir::sdy::MeshOp>
   getFirstShardyMeshOp(const mlir::OwningOpRef<mlir::ModuleOp> &module);
 
-  // Creates argument type map based on collected input argument roles.
-  llvm::StringMap<llvm::SmallVector<mlir::tt::ttcore::ArgumentType>>
-  createArgumentTypeMap(const mlir::OwningOpRef<mlir::ModuleOp> &module);
-
   // MLIR context handle.
   std::unique_ptr<mlir::MLIRContext> m_context;
 

--- a/src/common/pjrt_implementation/module_builder/frontend_passes/shlo_input_role_propagation.cc
+++ b/src/common/pjrt_implementation/module_builder/frontend_passes/shlo_input_role_propagation.cc
@@ -320,13 +320,6 @@ tt_pjrt_status annotateArgumentAttributesFromCustomCall(
       }
     }
 
-    // If the function has a user input argument annotation, then for every
-    // argument, if the argument has an argument type attribute, do nothing, and
-    // if it does not have an argument type attribute, set it to constant
-    if (!hasUserInputAnnotation) {
-      return;
-    }
-
     int64_t annotatedConstCount = 0;
     for (int64_t i = 0; i < funcOp.getNumArguments(); i++) {
       if (funcOp.getArgAttr(i, mlir::tt::ttcore::ArgumentTypeAttr::name)) {
@@ -336,13 +329,7 @@ tt_pjrt_status annotateArgumentAttributesFromCustomCall(
       funcOp.setArgAttr(
           i, mlir::tt::ttcore::ArgumentTypeAttr::name,
           mlir::tt::ttcore::ArgumentTypeAttr::get(
-              funcOp.getContext(), mlir::tt::ttcore::ArgumentType::Constant));
-      funcOp.setArgAttr(
-          i, c_name_attr_name,
-          mlir::StringAttr::get(funcOp.getContext(),
-                                "auto_annotated_const_" +
-                                    std::to_string(annotatedConstCount)));
-      annotatedConstCount++;
+              funcOp.getContext(), mlir::tt::ttcore::ArgumentType::Input));
     }
   });
 

--- a/src/common/pjrt_implementation/module_builder/frontend_passes/shlo_input_role_propagation.cc
+++ b/src/common/pjrt_implementation/module_builder/frontend_passes/shlo_input_role_propagation.cc
@@ -302,25 +302,9 @@ tt_pjrt_status annotateArgumentAttributesFromCustomCall(
     return tt_pjrt_status::kInternal;
   }
 
-  // In the event that some of the arguments have not been annotated, IF at
-  // least one argument has been annotated as a user input, we can annotate the
-  // rest of the arguments as constants
+  // In the event that some of the arguments have not been annotated,
+  // we annotate them to default, which is Input.
   mlir_module->walk([&](mlir::func::FuncOp funcOp) {
-    // If the function has even one user input argument, that means we can
-    // annotate the rest of the arguments as constants
-    bool hasUserInputAnnotation = false;
-    for (int64_t i = 0; i < funcOp.getNumArguments(); i++) {
-      if (mlir::tt::ttcore::ArgumentTypeAttr argumentTypeAttr =
-              mlir::dyn_cast_or_null<mlir::tt::ttcore::ArgumentTypeAttr>(
-                  funcOp.getArgAttr(i,
-                                    mlir::tt::ttcore::ArgumentTypeAttr::name));
-          argumentTypeAttr) {
-        hasUserInputAnnotation = true;
-        break;
-      }
-    }
-
-    int64_t annotatedConstCount = 0;
     for (int64_t i = 0; i < funcOp.getNumArguments(); i++) {
       if (funcOp.getArgAttr(i, mlir::tt::ttcore::ArgumentTypeAttr::name)) {
         continue;

--- a/src/common/pjrt_implementation/module_builder/module_builder.cc
+++ b/src/common/pjrt_implementation/module_builder/module_builder.cc
@@ -755,37 +755,4 @@ std::optional<mlir::sdy::MeshOp> ModuleBuilder::getFirstShardyMeshOp(
   return mesh_op;
 }
 
-llvm::StringMap<llvm::SmallVector<mlir::tt::ttcore::ArgumentType>>
-ModuleBuilder::createArgumentTypeMap(
-    const mlir::OwningOpRef<mlir::ModuleOp> &module) {
-  llvm::StringMap<llvm::SmallVector<mlir::tt::ttcore::ArgumentType>>
-      argTypesMap;
-
-  if (m_input_argument_roles.empty()) {
-    return argTypesMap;
-  }
-
-  std::vector<mlir::func::FuncOp> publicFuncOps = getPublicFuncOps(module);
-  size_t arg_offset = 0;
-
-  for (mlir::func::FuncOp &func_op : publicFuncOps) {
-    llvm::SmallVector<mlir::tt::ttcore::ArgumentType> argTypes;
-    for (unsigned int i = 0; i < func_op.getNumArguments(); ++i) {
-      assert(arg_offset + i < m_input_argument_roles.size() &&
-             "TTIR module should have the same number of input arguments as "
-             "the SHLO module");
-      if (m_input_argument_roles[arg_offset + i] ==
-          InputArgumentRole::kWeight) {
-        argTypes.push_back(mlir::tt::ttcore::ArgumentType::Constant);
-      } else {
-        argTypes.push_back(mlir::tt::ttcore::ArgumentType::Input);
-      }
-    }
-    argTypesMap[func_op.getName().str()] = argTypes;
-    arg_offset += func_op.getNumArguments();
-  }
-
-  return argTypesMap;
-}
-
 } // namespace tt::pjrt::module_builder


### PR DESCRIPTION
As described in https://github.com/tenstorrent/tt-xla/issues/1357, we currently mark arguments to functions as constants, which makes the compiler consteval the whole graph, it would be better to mark it by default as 'input', which this PR does.

Fixes https://github.com/tenstorrent/tt-xla/issues/1357