### PR TITLE
Replace incorrect ModelGroups in jax tests

### DIFF
--- a/tests/jax/single_chip/models/mistral_7b/v0_3_instruct/test_mistral_7b_v0_3_instruct.py
+++ b/tests/jax/single_chip/models/mistral_7b/v0_3_instruct/test_mistral_7b_v0_3_instruct.py
@@ -17,7 +17,7 @@ from utils import (
 from ..tester import Mistral7BV02Tester
 
 MODEL_PATH = "unsloth/mistral-7b-instruct-v0.3"
-MODEL_GROUP = ModelGroup.RED
+MODEL_GROUP = ModelGroup.GENERALITY
 MODEL_NAME = build_model_name(
     Framework.JAX,
     "mistral-7b",

--- a/tests/jax/single_chip/models/vit/vit_base_patch16_224/test_vit_base_patch16_224.py
+++ b/tests/jax/single_chip/models/vit/vit_base_patch16_224/test_vit_base_patch16_224.py
@@ -45,7 +45,7 @@ def training_tester() -> ViTTester:
 @pytest.mark.record_test_properties(
     category=Category.MODEL_TEST,
     model_name=MODEL_NAME,
-    model_group=ModelGroup.GENERALITY,
+    model_group=ModelGroup.RED,
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.PASSED,
 )
@@ -59,7 +59,7 @@ def test_vit_base_patch16_224_inference(
 @pytest.mark.record_test_properties(
     category=Category.MODEL_TEST,
     model_name=MODEL_NAME,
-    model_group=ModelGroup.GENERALITY,
+    model_group=ModelGroup.RED,
     run_mode=RunMode.TRAINING,
 )
 @pytest.mark.skip(reason="Support for training not implemented")


### PR DESCRIPTION
Fixes #1370 

## Summary  
This PR fixes incorrect model group assignments by updating the `ModelGroup` property in jax tests.
  
  ### Corrected Mistral Model:  
- `unsloth/mistral-7b-instruct-v0.3` → `ModelGroup.GENERALITY`  

  ### Corrected Vit Model:  
- `google/vit-large-patch16-224` → `ModelGroup.RED`  
