### PR TITLE
Replace "fetch job id" with job.check_run_id

### DIFF
--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -107,21 +107,13 @@ jobs:
         submodules: recursive
         lfs: true
 
-    - name: Fetch job id
-      id: fetch-job-id
-      uses: tenstorrent/tt-github-actions/.github/actions/job_id@main
-      with:
-        job_name: "test ${{ inputs.test_mark }} (${{ matrix.build.runs-on }}, ${{ matrix.build.name }}, ${{ strategy.job-index }})"
-
     - name: Set reusable strings
       id: strings
       shell: bash
-      env:
-        JOB_ID: ${{ steps.fetch-job-id.outputs.job_id }}
       run: |
         echo "work-dir=$(pwd)" >> "$GITHUB_OUTPUT"
         echo "build-output-dir=$(pwd)/build" >> "$GITHUB_OUTPUT"
-        echo "test_report_path=report_$JOB_ID.xml" >> "$GITHUB_OUTPUT"
+        echo "test_report_path=report_${{ job.check_run_id }}.xml" >> "$GITHUB_OUTPUT"
         if [[ "${{ inputs.codecov }}" == "true" && "${{ matrix.build.codecov }}" == "true" ]]; then
           echo "do_codecov=true" >> "$GITHUB_OUTPUT"
           echo "wheel_artifact_name=${{ inputs.wheel_codecov_artifact_name }}" >> "$GITHUB_OUTPUT"
@@ -250,14 +242,14 @@ jobs:
       uses: actions/upload-artifact@v4
       if: success() || failure()
       with:
-        name: test-log-${{ matrix.build.runs-on }}-${{ steps.sanitize.outputs.test_mark }}-${{ steps.fetch-job-id.outputs.job_id }}
+        name: test-log-${{ matrix.build.runs-on }}-${{ steps.sanitize.outputs.test_mark }}-${{ job.check_run_id }}
         path: pytest.log
 
     - name: Upload Test Report
       uses: actions/upload-artifact@v4
       if: success() || failure()
       with:
-        name: test-reports-${{ matrix.build.runs-on }}-${{ steps.sanitize.outputs.test_mark }}-${{ steps.fetch-job-id.outputs.job_id }}
+        name: test-reports-${{ matrix.build.runs-on }}-${{ steps.sanitize.outputs.test_mark }}-${{ job.check_run_id }}
         path: ${{ steps.strings.outputs.test_report_path }}
 
     - name: Show Test Report


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Github has added support for getting job_id (job.check_run_id). We can switch to this from our custom implementation hack.

### What's changed
Replace "fetch job id" with job.check_run_id

### Checklist
- [x] New/Existing tests provide coverage for changes
