### PR TITLE
Update getting started docs for submodules initialization command

### DIFF
--- a/docs/src/getting_started_build_from_source.md
+++ b/docs/src/getting_started_build_from_source.md
@@ -126,7 +126,7 @@ Before compiling TT-XLA, the TT-MLIR toolchain needs to be built:
 - Follow the TT-MLIR [build instructions](https://github.com/tenstorrent/tt-mlir/blob/main/docs/src/getting-started.md) to set up the environment and build the toolchain.
 
 ### Building TT-XLA
-Before running these commands to build TT-XLA, please ensure that the environment variable `TTMLIR_TOOLCHAIN_DIR` is set to point to the TT-MLIR toolchain directory created above as part of the TT-MLIR environment setup (for example `export TTMLIR_TOOLCHAIN_DIR=/opt/ttmlir-toolchain/`). You can also set `export LOGGER_LEVEL=DEBUG` in order to enable debug logs, or `export LOGGER_LEVEL=VERBOSE` to enable both debug logs and verbose IR dumping between compiler passes. To build TT-XLA do the following:
+Before running these commands to build TT-XLA, please ensure that the environment variable `TTMLIR_TOOLCHAIN_DIR` is set to point to the TT-MLIR toolchain directory created above as part of the TT-MLIR environment setup (for example `export TTMLIR_TOOLCHAIN_DIR=/opt/ttmlir-toolchain/`). You can also set `export LOGGER_LEVEL=DEBUG` in order to enable debug logs, or `export LOGGER_LEVEL=VERBOSE` to enable even more verbose logs like printing intermediate IR in compiler passes. To build TT-XLA do the following:
 
 1. Make sure you are not in the TT-MLIR build directory, and you are in the location where you want TT-XLA to install.
 
@@ -142,7 +142,13 @@ git clone https://github.com/tenstorrent/tt-xla.git
 cd tt-xla
 ```
 
-4. Run the following set of commands to build TT-XLA (this will build the PJRT plugin and install it into `venv`):
+4. Initialize third-party submodules:
+
+```bash
+git submodule update --init --recursive
+```
+
+5. Run the following set of commands to build TT-XLA (this will build the PJRT plugin and install it into `venv`):
 
 ```bash
 source venv/activate
@@ -150,7 +156,7 @@ cmake -G Ninja -B build # -DCMAKE_BUILD_TYPE=Debug in case you want debug build
 cmake --build build
 ```
 
-5. To verify that everything is working correctly, run the following command:
+6. To verify that everything is working correctly, run the following command:
 
 ```bash
 python -c "import jax; print(jax.devices('tt'))"
@@ -158,7 +164,7 @@ python -c "import jax; print(jax.devices('tt'))"
 
 The command should output all available TT devices, e.g. `[TTDevice(id=0, arch=Wormhole_b0)]`
 
-6. (optional) If you want to build the TT-XLA wheel, run the following command:
+7. (optional) If you want to build the TT-XLA wheel, run the following command:
 
 ```bash
 cd python_package


### PR DESCRIPTION
### Problem description
After we've changed tt-forge-models to be git submodule we didn't update getting started docs to reflect that now `git submodule update --init --recursive` command needs to be run to initialize submodules.

### What's changed
Added missing command into getting started docs.
