### PR TITLE
add test_forge_models_push to skip

### DIFF
--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -116,5 +116,5 @@ jobs:
     - name: Check if the needed jobs succeeded or failed
       uses: re-actors/alls-green@release/v1
       with:
-        allowed-skips: build-image, build-ttxla-codecov, build-ttxla-release, test
+        allowed-skips: build-image, build-ttxla-codecov, build-ttxla-release, test, test_forge_models_push
         jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
Allow `test_forge_models_push` job to skip


error:
https://github.com/tenstorrent/tt-xla/actions/runs/17683973905/job/50264467374?pr=1378#step:2:83
