### PR TITLE
PJRT_Executable_Fingerprint refactor

### DIFF
--- a/inc/common/pjrt_implementation/executable_image.h
+++ b/inc/common/pjrt_implementation/executable_image.h
@@ -47,7 +47,7 @@ public:
           &output_sharding,
       const std::vector<bool> &is_output_scalar,
       const std::vector<PJRT_Buffer_Type> &expected_output_data_types,
-      module_builder::CompileOptions &&compile_options);
+      const module_builder::CompileOptions &compile_options);
 
   // Returns flatbuffer binary produced by the compiler.
   const tt::runtime::Binary &getFlatbufferBinary() const {
@@ -138,7 +138,7 @@ private:
           &output_sharding,
       const std::vector<bool> &is_output_scalar,
       const std::vector<PJRT_Buffer_Type> &expected_output_data_types,
-      module_builder::CompileOptions &&compile_options);
+      const module_builder::CompileOptions &compile_options);
 
   // Generates the fingerprint for this executable based on compilation inputs.
   std::string generateFingerprint() const;

--- a/inc/common/pjrt_implementation/executable_image.h
+++ b/inc/common/pjrt_implementation/executable_image.h
@@ -121,11 +121,6 @@ public:
     return m_output_memory_kinds_sizes;
   }
 
-  // Returns the compile options used to create this executable.
-  const module_builder::CompileOptions &getCompileOptions() const {
-    return m_compile_options;
-  }
-
   // Returns the fingerprint for this executable.
   const std::string &getFingerprint() const { return m_fingerprint; }
 

--- a/inc/common/pjrt_implementation/executable_instance.h
+++ b/inc/common/pjrt_implementation/executable_instance.h
@@ -94,6 +94,9 @@ PJRT_Error *onExecutableNumOutputs(PJRT_Executable_NumOutputs_Args *args);
 PJRT_Error *onExecutableSizeOfGeneratedCodeInBytes(
     PJRT_Executable_SizeOfGeneratedCodeInBytes_Args *args);
 
+// Implements PJRT_Executable_Fingerprint API function.
+PJRT_Error *onExecutableFingerprint(PJRT_Executable_Fingerprint_Args *args);
+
 // Implements PJRT_Executable_OutputElementTypes API function.
 PJRT_Error *
 onExecutableOutputElementTypes(PJRT_Executable_OutputElementTypes_Args *args);
@@ -108,9 +111,6 @@ onExecutableOutputMemoryKinds(PJRT_Executable_OutputMemoryKinds_Args *args);
 
 // Implements PJRT_Executable_Serialize API function.
 PJRT_Error *onExecutableSerialize(PJRT_Executable_Serialize_Args *args);
-
-// Implements PJRT_Executable_Fingerprint API function.
-PJRT_Error *onExecutableFingerprint(PJRT_Executable_Fingerprint_Args *args);
 
 } // namespace internal
 

--- a/inc/common/pjrt_implementation/module_builder/compile_options.h
+++ b/inc/common/pjrt_implementation/module_builder/compile_options.h
@@ -28,6 +28,9 @@ struct CompileOptions {
 
   static CompileOptions
   parse(const std::unordered_map<std::string, std::string> &compile_options);
+
+  // Returns string representation of compile options.
+  std::string toString() const;
 };
 
 namespace internal {

--- a/inc/common/pjrt_implementation/module_builder/module_builder.h
+++ b/inc/common/pjrt_implementation/module_builder/module_builder.h
@@ -111,6 +111,11 @@ public:
     return m_input_argument_roles;
   }
 
+  // Returns parsed compile options.
+  const CompileOptions &getParsedCompileOptions() const {
+    return m_parsed_compile_options;
+  }
+
 private:
   // Creates VHLO module from the input program code.
   mlir::OwningOpRef<mlir::ModuleOp>
@@ -278,6 +283,9 @@ private:
 
   // For every input, holds the argument role (weight vs input).
   std::vector<InputArgumentRole> m_input_argument_roles;
+
+  // Parsed compile options.
+  CompileOptions m_parsed_compile_options;
 };
 
 } // namespace tt::pjrt::module_builder

--- a/src/common/pjrt_implementation/client_instance.cc
+++ b/src/common/pjrt_implementation/client_instance.cc
@@ -174,9 +174,9 @@ tt_pjrt_status ClientInstance::compileMlirProgram(
   // a name, otherwise some default string like the current one.
   std::string executable_name = "tt_executable";
 
-  // Parse compile options for fingerprint generation.
+  // Get parsed compile options from module builder.
   module_builder::CompileOptions parsed_compile_options =
-      module_builder::CompileOptions::parse(compile_options);
+      m_module_builder->getParsedCompileOptions();
 
   std::shared_ptr<ExecutableImage> executable_image =
       ExecutableImage::createInstance(

--- a/src/common/pjrt_implementation/client_instance.cc
+++ b/src/common/pjrt_implementation/client_instance.cc
@@ -175,7 +175,7 @@ tt_pjrt_status ClientInstance::compileMlirProgram(
   std::string executable_name = "tt_executable";
 
   // Get parsed compile options from module builder.
-  module_builder::CompileOptions parsed_compile_options =
+  const module_builder::CompileOptions &parsed_compile_options =
       m_module_builder->getParsedCompileOptions();
 
   std::shared_ptr<ExecutableImage> executable_image =
@@ -190,8 +190,7 @@ tt_pjrt_status ClientInstance::compileMlirProgram(
           m_module_builder->getInputShardings(),
           m_module_builder->getOutputShardings(),
           m_module_builder->getIsOutputScalar(),
-          m_module_builder->getOutputDataTypes(),
-          std::move(parsed_compile_options));
+          m_module_builder->getOutputDataTypes(), parsed_compile_options);
 
   // TODO(mrakita): Currently there is no way to determine addressable devices
   // from the mlir code. XLA parses device assignment from the `compile_options`

--- a/src/common/pjrt_implementation/client_instance.cc
+++ b/src/common/pjrt_implementation/client_instance.cc
@@ -174,7 +174,7 @@ tt_pjrt_status ClientInstance::compileMlirProgram(
   // a name, otherwise some default string like the current one.
   std::string executable_name = "tt_executable";
 
-  // Parse compile options for fingerprint generation
+  // Parse compile options for fingerprint generation.
   module_builder::CompileOptions parsed_compile_options =
       module_builder::CompileOptions::parse(compile_options);
 

--- a/src/common/pjrt_implementation/executable_image.cc
+++ b/src/common/pjrt_implementation/executable_image.cc
@@ -161,10 +161,7 @@ std::string ExecutableImage::generateFingerprint() const {
   data_to_hash << "mlir:" << m_original_mlir_code << "\n";
 
   // 2. Add compile options
-  data_to_hash << "enable_optimizer:" << m_compile_options.enable_optimizer
-               << "\n";
-  data_to_hash << "enable_bfp8_conversion:"
-               << m_compile_options.enable_bfp8_conversion << "\n";
+  data_to_hash << m_compile_options.toString() << "\n";
 
   // 3. Add compiler version
   data_to_hash << "ttmlir_version:" << m_flatbuffer_binary.getVersion() << "\n";

--- a/src/common/pjrt_implementation/executable_image.cc
+++ b/src/common/pjrt_implementation/executable_image.cc
@@ -31,7 +31,7 @@ std::shared_ptr<ExecutableImage> ExecutableImage::createInstance(
     const std::vector<mlir::tt::sharding_utils::MeshSharding> &output_sharding,
     const std::vector<bool> &is_output_scalar,
     const std::vector<PJRT_Buffer_Type> &expected_output_data_types,
-    module_builder::CompileOptions &&compile_options) {
+    const module_builder::CompileOptions &compile_options) {
   struct make_shared_enabler : public ExecutableImage {
     make_shared_enabler(
         const tt::runtime::Binary &flatbuffer_binary,
@@ -46,7 +46,7 @@ std::shared_ptr<ExecutableImage> ExecutableImage::createInstance(
             &output_sharding,
         const std::vector<bool> &is_output_scalar,
         const std::vector<PJRT_Buffer_Type> &expected_output_data_types,
-        module_builder::CompileOptions &&compile_options)
+        const module_builder::CompileOptions &compile_options)
         : ExecutableImage(flatbuffer_binary, std::move(original_mlir_code),
                           std::move(ttir_mlir_code), std::move(ttnn_mlir_code),
                           std::move(executable_name), num_partitions,
@@ -75,7 +75,7 @@ ExecutableImage::ExecutableImage(
     const std::vector<mlir::tt::sharding_utils::MeshSharding> &output_sharding,
     const std::vector<bool> &is_output_scalar,
     const std::vector<PJRT_Buffer_Type> &expected_output_data_types,
-    module_builder::CompileOptions &&compile_options)
+    const module_builder::CompileOptions &compile_options)
     : m_flatbuffer_binary(flatbuffer_binary),
       m_original_mlir_code(std::move(original_mlir_code)),
       m_ttir_mlir(std::move(ttir_mlir_code)),
@@ -86,7 +86,7 @@ ExecutableImage::ExecutableImage(
       m_devices_mesh_shape(devices_mesh_shape),
       m_input_sharding(input_sharding), m_output_sharding(output_sharding),
       m_output_types(expected_output_data_types),
-      m_compile_options(std::move(compile_options)) {
+      m_compile_options(compile_options) {
 
   // Generate fingerprint after all dependencies are initialized
   m_fingerprint = generateFingerprint();

--- a/src/common/pjrt_implementation/module_builder/compile_options.cc
+++ b/src/common/pjrt_implementation/module_builder/compile_options.cc
@@ -6,6 +6,7 @@
 
 // c++ standard library includes
 #include <algorithm>
+#include <sstream>
 
 namespace tt::pjrt::module_builder {
 
@@ -19,6 +20,14 @@ CompileOptions CompileOptions::parse(
       internal::parseBoolOption(compile_options, "enable_bfp8_conversion");
 
   return options;
+}
+
+std::string CompileOptions::toString() const {
+  std::ostringstream oss;
+  oss << "enable_optimizer: " << (enable_optimizer ? "true" : "false")
+      << ", enable_bfp8_conversion: "
+      << (enable_bfp8_conversion ? "true" : "false");
+  return oss.str();
 }
 
 namespace internal {

--- a/src/common/pjrt_implementation/module_builder/module_builder.cc
+++ b/src/common/pjrt_implementation/module_builder/module_builder.cc
@@ -100,7 +100,7 @@ tt_pjrt_status ModuleBuilder::buildModule(
 
   m_status = tt_pjrt_status::kSuccess;
 
-  auto compile_options = CompileOptions::parse(compile_options_map);
+  m_parsed_compile_options = CompileOptions::parse(compile_options_map);
 
   mlir::OwningOpRef<mlir::ModuleOp> mlir_module = createVHLOModule(mlir_code);
   if (!tt_pjrt_status_is_ok(m_status)) {
@@ -135,7 +135,8 @@ tt_pjrt_status ModuleBuilder::buildModule(
   collectMeshShape(mlir_module);
   collectNumDevicesToUtilize(mlir_module);
 
-  convertFromTTIRToTTNN(system_descriptor_path, mlir_module, compile_options);
+  convertFromTTIRToTTNN(system_descriptor_path, mlir_module,
+                        m_parsed_compile_options);
   if (!tt_pjrt_status_is_ok(m_status)) {
     return m_status;
   }
@@ -591,9 +592,11 @@ void ModuleBuilder::convertFromTTIRToTTNN(
 
   mlir::tt::ttnn::TTIRToTTNNBackendPipelineOptions options;
 
-  options.optimizerPassEnabled = compile_options.enable_optimizer;
-  options.memoryLayoutAnalysisEnabled = compile_options.enable_optimizer;
-  options.enableBfp8Conversion = compile_options.enable_bfp8_conversion;
+  options.optimizerPassEnabled = m_parsed_compile_options.enable_optimizer;
+  options.memoryLayoutAnalysisEnabled =
+      m_parsed_compile_options.enable_optimizer;
+  options.enableBfp8Conversion =
+      m_parsed_compile_options.enable_bfp8_conversion;
   options.systemDescPath = system_descriptor_path.data();
 
   if (m_devices_mesh_shape.size() != 2) {

--- a/src/common/pjrt_implementation/module_builder/module_builder.cc
+++ b/src/common/pjrt_implementation/module_builder/module_builder.cc
@@ -101,6 +101,8 @@ tt_pjrt_status ModuleBuilder::buildModule(
   m_status = tt_pjrt_status::kSuccess;
 
   m_parsed_compile_options = CompileOptions::parse(compile_options_map);
+  DLOG_F(LOG_DEBUG, "Compile options: %s",
+         m_parsed_compile_options.toString().c_str());
 
   mlir::OwningOpRef<mlir::ModuleOp> mlir_module = createVHLOModule(mlir_code);
   if (!tt_pjrt_status_is_ok(m_status)) {


### PR DESCRIPTION
### Ticket
Addressing comments from #1311

### What's changed
- `m_parsed_compile_options` added to `ModuleBuilder` to store parsed options
- added `getParsedCompileOptions()` to expose parsed options
- updated `ClientInstance` to remove duplicate parsing, now using getter from `ModuleBuilder`
- `ExecutableImage` now accepts `const CompileOptions&` instead of `&&` since both `ModuleBuilder` and `ExecutableImage` need to keep copies
- Added debug log showing compile options during module building
- centralized `toString()` function inside `module_builder`, ensuring it stays in sync when new options are added
- now using `toString()` for `generateFingerprint() ` instead of creating it there

