### PR TITLE
Add an env var to make TorchXLA give useful locs

### DIFF
--- a/python_package/torch_plugin_tt/__init__.py
+++ b/python_package/torch_plugin_tt/__init__.py
@@ -29,6 +29,9 @@ class TTPlugin(DevicePlugin):
         # `XLA_STABLEHLO_COMPILE` env variable to `1` to enable stablehlo compilation.
         # NOTE: This variable should soon be on by-default in `torch_xla`, but for now we need it.
         os.environ["XLA_STABLEHLO_COMPILE"] = "1"
+        # HLO Debug is required for TorchXLA to attach useful location information to IR
+        # We rely on this for Codegen exporting
+        os.environ["XLA_HLO_DEBUG"] = "1"
         print(
             f"WARNING: TT plugin is setting XLA_STABLEHLO_COMPILE to 1. This is required for TT PJRT plugin to work correctly."
         )

--- a/python_package/torch_plugin_tt/__init__.py
+++ b/python_package/torch_plugin_tt/__init__.py
@@ -29,8 +29,8 @@ class TTPlugin(DevicePlugin):
         # `XLA_STABLEHLO_COMPILE` env variable to `1` to enable stablehlo compilation.
         # NOTE: This variable should soon be on by-default in `torch_xla`, but for now we need it.
         os.environ["XLA_STABLEHLO_COMPILE"] = "1"
-        # HLO Debug is required for TorchXLA to attach useful location information to IR
-        # We rely on this for Codegen exporting
+        # HLO Debug is required for TorchXLA to attach useful location information to IR.
+        # We rely on this for Codegen exporting.
         os.environ["XLA_HLO_DEBUG"] = "1"
         print(
             f"WARNING: TT plugin is setting XLA_STABLEHLO_COMPILE to 1. This is required for TT PJRT plugin to work correctly."

--- a/python_package/torch_plugin_tt/__init__.py
+++ b/python_package/torch_plugin_tt/__init__.py
@@ -29,9 +29,10 @@ class TTPlugin(DevicePlugin):
         # `XLA_STABLEHLO_COMPILE` env variable to `1` to enable stablehlo compilation.
         # NOTE: This variable should soon be on by-default in `torch_xla`, but for now we need it.
         os.environ["XLA_STABLEHLO_COMPILE"] = "1"
-        # HLO Debug is required for TorchXLA to attach useful location information to IR.
+        # HLO Debug and IR Debug flags are required for TorchXLA to attach useful location information to IR.
         # We rely on this for Codegen exporting.
         os.environ["XLA_HLO_DEBUG"] = "1"
+        os.environ["XLA_IR_DEBUG"] = "1"
         print(
             f"WARNING: TT plugin is setting XLA_STABLEHLO_COMPILE to 1. This is required for TT PJRT plugin to work correctly."
         )


### PR DESCRIPTION
### Ticket
Small part of #946 

### Problem description
Torchxla by default attaches locs that are basically useless.

### What's changed
An enviroment variable is now set upon loading the PJRT plugin registration code for Torch, that causes TorchXLA to attach much more useful locs.

### Checklist
- [ ] New/Existing tests provide coverage for changes
