### PR TITLE
Change capfd -> capteesys

### DIFF
--- a/tests/runner/test_models.py
+++ b/tests/runner/test_models.py
@@ -41,7 +41,7 @@ MODELS_ROOT, test_entries = setup_test_discovery(PROJECT_ROOT)
     ids=create_test_id_generator(MODELS_ROOT),
 )
 def test_all_models(
-    test_entry, run_mode, op_by_op, record_property, test_metadata, request, capfd
+    test_entry, run_mode, op_by_op, record_property, test_metadata, request, capteesys
 ):
 
     loader_path = test_entry.path
@@ -70,7 +70,7 @@ def test_all_models(
                 succeeded = True
 
         except Exception as e:
-            err = capfd.readouterr().err
+            err = capteesys.readouterr().err
             # Record runtime failure info so it can be reflected in report properties
             update_test_metadata_for_exception(test_metadata, e, stderr=err)
             raise


### PR DESCRIPTION
### Problem description
Right not capfd overwrites -s arguments when calling tests locally. This disables live printing in console.
Also if the test fails, stdout and stderr gets captured by capfd, and they are never printed to terminal.

### What's changed
Changed `capfd` -> `capteesys`.
This enables printing simulteniosly to terminal and also capturing the `sys.stdout` and `sys.stderr`.

CI runs:
[with capfd:](https://github.com/tenstorrent/tt-xla/actions/runs/17697691934/job/50299394461)
[with capteesys:](https://github.com/tenstorrent/tt-xla/actions/runs/17765567498/job/50488578309?pr=1339)
Checkout seciton: `Captured stdout teardown` and `Captured stderr call`

### Drawback:
```
def test_sys_vs_fd(capfd):
    import os, sys
    print("py")          # sys-level
    os.write(1, b"fd\n") # FD-level

    # capfd sees both
    out_fd, _ = capfd.readouterr()
    assert out_fd.splitlines() == ["py", "fd"]

def test_sys_vs_fd_2(capteesys):
    import os, sys
    print("py")          # sys-level
    os.write(1, b"fd\n") # FD-level

    # capteesys sees only Python-level writes
    out_sys, _ = capteesys.readouterr()
    assert out_sys.strip() == "py"

```
Here is example where capteesys fails to captures everything but pretty sure that this is not necessary for our current use case. 
