### PR TITLE
Match test job name with name passed to fetch-job-id step

### DIFF
--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -107,7 +107,7 @@ jobs:
       id: fetch-job-id
       uses: tenstorrent/tt-github-actions/.github/actions/job_id@main
       with:
-        job_name: "test ${{ inputs.test_mark }} (${{ matrix.build.runs-on }}, ${{ matrix.build.name }}, ${{ strategy.job-index }})"
+        job_name: "test ${{ matrix.build.test-mark }} (${{ matrix.build.runs-on }}, ${{ matrix.build.name }}, ${{ strategy.job-index }})"
 
     - name: Set reusable strings
       id: strings


### PR DESCRIPTION
### Ticket
/

### Problem description
The fetch job id step is failing because the job name passed to it doesn't match the actual job name.

### What's changed
Change the name passed to the fetch job id step to match the actual job name.

### Checklist
- [ ] New/Existing tests provide coverage for changes
