### PR TITLE
[pjrt] reuse device if possible

### DIFF
--- a/inc/common/pjrt_implementation/client_instance.h
+++ b/inc/common/pjrt_implementation/client_instance.h
@@ -11,6 +11,7 @@
 #include "xla/pjrt/c/pjrt_c_api.h"
 
 // c++ standard library includes
+#include <cstdlib>
 #include <memory>
 #include <string>
 #include <vector>
@@ -75,6 +76,15 @@ public:
     return m_addressable_memories_raw;
   }
 
+  tt::runtime::Device getParentMesh() const { return *m_parent_mesh; }
+
+  // Returns the mesh device of the provided shape. If there is already opened
+  // mesh device within this client instance and its shape matches the provided
+  // shape, it is returned. Otherwise, we close any previously opened mesh
+  // device and open a new one with the provided shape.
+  tt::runtime::Device
+  getOrCreateMeshDevice(const std::vector<uint32_t> &target_mesh_shape);
+
   // Compiles given mlir program.
   tt_pjrt_status compileMlirProgram(
       const PJRT_Program *mlir_program,
@@ -93,6 +103,11 @@ protected:
 private:
   tt_pjrt_status populateDevices();
   tt_pjrt_status populateMemories();
+
+  // Wrapper method around `tt::runtime::openMeshDevice` that also handles
+  // setting fabric config when needed.
+  tt::runtime::Device
+  openMeshDevice(::tt::runtime::MeshDeviceOptions options = {});
 
   std::unique_ptr<Platform> platform_;
 
@@ -140,6 +155,8 @@ private:
   static std::unordered_map<std::string, std::string>
   extractCustomProtobufFields(
       const google::protobuf::UnknownFieldSet &unknown_fields);
+
+  std::optional<tt::runtime::Device> m_parent_mesh;
 };
 
 namespace internal {

--- a/inc/common/pjrt_implementation/loaded_executable_instance.h
+++ b/inc/common/pjrt_implementation/loaded_executable_instance.h
@@ -33,6 +33,8 @@
 
 namespace tt::pjrt {
 
+class ClientInstance;
+
 // Represents `PJRT_LoadedExecutable` structure and the functionality around it.
 // It is the in-memory loaded executable which is ready for input arguments to
 // execute.
@@ -41,7 +43,8 @@ public:
   // Creates new loaded executable instance from the executable image.
   static std::unique_ptr<LoadedExecutableInstance>
   createInstance(std::shared_ptr<ExecutableImage> executable_image,
-                 std::vector<DeviceInstance *> &&addressable_devices);
+                 std::vector<DeviceInstance *> &&addressable_devices,
+                 ClientInstance *client_instance);
 
   // Binds PJRT API functions implementation related to PJRT_LoadedExecutable
   // structure.
@@ -82,16 +85,11 @@ private:
   // Creates loaded executable instance from the executable image.
   LoadedExecutableInstance(
       std::shared_ptr<ExecutableImage> executable_image,
-      const std::vector<DeviceInstance *> &addressable_devices)
+      const std::vector<DeviceInstance *> &addressable_devices,
+      ClientInstance *client_instance)
       : m_executable_image(std::move(executable_image)),
-        m_addressable_devices(addressable_devices), m_deleted(false) {}
-
-  // Opens devices on which input arguments are placed, which we assume are the
-  // the devices where computation will run, if their count is equal to the
-  // corresponding devices count in the mesh shape estimated by the compiler.
-  std::optional<tt::runtime::Device>
-  openDevices(PJRT_Buffer *const *const *argument_lists, size_t num_args,
-              size_t num_devices, PJRT_Device *pjrt_device);
+        m_addressable_devices(addressable_devices), m_deleted(false),
+        m_client_instance(client_instance) {}
 
   // Collects device ids from the addressable devices.
   std::unordered_set<int>
@@ -155,6 +153,9 @@ private:
 
   // Mutex guarding loaded executable deletion.
   std::mutex m_deleted_mutex;
+
+  // Client instance that created this loaded executable.
+  ClientInstance *m_client_instance;
 };
 
 namespace internal {

--- a/src/common/pjrt_implementation/client_instance.cc
+++ b/src/common/pjrt_implementation/client_instance.cc
@@ -13,9 +13,12 @@
 // c++ standard library includes
 #include <cstddef>
 #include <filesystem>
+#include <optional>
+#include <sstream>
 
 // tt-mlir includes
 #include "tt/runtime/runtime.h"
+#include "tt/runtime/types.h"
 
 // third-party includes
 #include <google/protobuf/io/coded_stream.h>
@@ -34,7 +37,8 @@ namespace tt::pjrt {
 
 ClientInstance::ClientInstance(std::unique_ptr<Platform> platform)
     : platform_(std::move(platform)), m_system_descriptor(nullptr),
-      m_module_builder(std::make_unique<module_builder::ModuleBuilder>()) {
+      m_module_builder(std::make_unique<module_builder::ModuleBuilder>()),
+      m_parent_mesh(std::nullopt) {
   DLOG_F(LOG_DEBUG, "ClientInstance::ClientInstance");
 
   // TODO(mrakita): Add support for multi-process environment. Process index is
@@ -51,6 +55,10 @@ ClientInstance::ClientInstance(std::unique_ptr<Platform> platform)
 
 ClientInstance::~ClientInstance() {
   DLOG_F(LOG_DEBUG, "ClientInstance::~ClientInstance");
+
+  if (m_parent_mesh.has_value()) {
+    tt::runtime::closeMeshDevice(*m_parent_mesh);
+  }
 
   std::remove(m_cached_system_descriptor_path.data());
 }
@@ -130,7 +138,32 @@ tt_pjrt_status ClientInstance::populateDevices() {
     return tt_pjrt_status::kInternal;
   }
 
+  m_parent_mesh = openMeshDevice();
+
   return tt_pjrt_status::kSuccess;
+}
+
+tt::runtime::Device
+ClientInstance::openMeshDevice(::tt::runtime::MeshDeviceOptions options) {
+  auto num_devices = m_devices.size();
+  if (options.meshShape.has_value()) {
+    num_devices = static_cast<size_t>(
+        std::accumulate(options.meshShape->begin(), options.meshShape->end(), 1,
+                        std::multiplies<std::uint32_t>{}));
+  }
+
+  // NOTES:
+  // - this should probably be set automatically by the mlir runtime.
+  // - it looks like metal context is being reinitialized each time we
+  // open/close the device, so we need to set the fabric config each time
+  // (even if we always set it to the same value).
+  if (num_devices > 1) {
+    tt::runtime::setFabricConfig(tt::runtime::FabricConfig::FABRIC_1D);
+  } else {
+    tt::runtime::setFabricConfig(tt::runtime::FabricConfig::DISABLED);
+  }
+
+  return tt::runtime::openMeshDevice(options);
 }
 
 tt_pjrt_status ClientInstance::populateMemories() {
@@ -166,6 +199,7 @@ tt_pjrt_status ClientInstance::compileMlirProgram(
 
   tt_pjrt_status compile_status = m_module_builder->buildModule(
       mlir_code, m_cached_system_descriptor_path, compile_options);
+
   if (!tt_pjrt_status_is_ok(compile_status)) {
     return compile_status;
   }
@@ -206,8 +240,8 @@ tt_pjrt_status ClientInstance::compileMlirProgram(
           m_module_builder->getNumDevicesToUtilize());
 
   std::unique_ptr<LoadedExecutableInstance> executable =
-      LoadedExecutableInstance::createInstance(executable_image,
-                                               std::move(addressable_devices));
+      LoadedExecutableInstance::createInstance(
+          executable_image, std::move(addressable_devices), this);
 
   // Releasing the ownership to the PJRT API caller since the caller is
   // responsible for calling `PJRT_LoadedExecutable_Destroy` on the executable.
@@ -303,6 +337,54 @@ ClientInstance::extractCustomProtobufFields(
   }
 
   return result;
+}
+
+template <typename T> std::string to_string(const std::vector<T> vec) {
+  std::stringstream res;
+  res << "[";
+  for (size_t i = 0; i < vec.size(); i++) {
+    res << vec[i] << (i + 1 < vec.size() ? ", " : "");
+  }
+  res << "]";
+  return res.str();
+}
+
+tt::runtime::Device ClientInstance::getOrCreateMeshDevice(
+    const std::vector<uint32_t> &target_mesh_shape) {
+
+  assert(m_parent_mesh.has_value() &&
+         "At this point we should have an opened parent mesh device");
+  auto parent_mesh_shape = tt::runtime::getMeshShape(*m_parent_mesh);
+
+  if (parent_mesh_shape == target_mesh_shape) {
+    DLOG_F(LOG_DEBUG,
+           "ClientInstance::getOrCreateMeshDevice - reusing "
+           "already opened mesh device %s",
+           to_string(parent_mesh_shape).c_str());
+    return *m_parent_mesh;
+  }
+
+  DLOG_F(LOG_DEBUG,
+         "ClientInstance::getOrCreateMeshDevice - "
+         "reshaping mesh device - %s -> %s",
+         to_string(parent_mesh_shape).c_str(),
+         to_string(target_mesh_shape).c_str());
+
+  // NOTE: Due to some issues hit when testing, instead of using the reshape
+  // mesh API, we are closing and re-opening the device with the wanted mesh
+  // shape. This should be revisited in the future.
+  //
+  // Additionally, we are supposed to utilize sub-meshes if the target mesh
+  // shape is is contained within the already opened parent mesh. Also, in case
+  // we are running multiple models on different parts of the mesh (pipeline
+  // parallel). However, similar as to the case with reshape API, there were
+  // some issues when testing sub-meshes, so for now we are always closing and
+  // re-opening the whole mesh.
+  tt::runtime::closeMeshDevice(*m_parent_mesh);
+
+  auto options = tt::runtime::MeshDeviceOptions{.meshShape = target_mesh_shape};
+  m_parent_mesh = openMeshDevice(options);
+  return *m_parent_mesh;
 }
 
 namespace internal {

--- a/src/common/pjrt_implementation/loaded_executable_instance.cc
+++ b/src/common/pjrt_implementation/loaded_executable_instance.cc
@@ -9,8 +9,10 @@
 // https://llvm.org/LICENSE.txt
 
 #include "common/pjrt_implementation/loaded_executable_instance.h"
+#include "common/status.h"
 
 // c++ standard library includes
+#include <cassert>
 #include <numeric>
 
 // tt-mlir includes
@@ -22,6 +24,7 @@
 
 // tt-xla includes
 #include "common/pjrt_implementation/buffer_instance.h"
+#include "common/pjrt_implementation/client_instance.h"
 #include "common/pjrt_implementation/error_instance.h"
 
 namespace tt::pjrt {
@@ -29,16 +32,20 @@ namespace tt::pjrt {
 std::unique_ptr<LoadedExecutableInstance>
 LoadedExecutableInstance::createInstance(
     std::shared_ptr<ExecutableImage> executable_image,
-    std::vector<DeviceInstance *> &&addressable_devices) {
+    std::vector<DeviceInstance *> &&addressable_devices,
+    ClientInstance *client_instance) {
   struct make_unique_enabler : public LoadedExecutableInstance {
     make_unique_enabler(std::shared_ptr<ExecutableImage> executable_image,
-                        std::vector<DeviceInstance *> &&addressable_devices)
+                        std::vector<DeviceInstance *> &&addressable_devices,
+                        ClientInstance *client_instance)
         : LoadedExecutableInstance(std::move(executable_image),
-                                   std::move(addressable_devices)) {}
+                                   std::move(addressable_devices),
+                                   client_instance) {}
   };
 
   return std::make_unique<make_unique_enabler>(std::move(executable_image),
-                                               std::move(addressable_devices));
+                                               std::move(addressable_devices),
+                                               client_instance);
 }
 
 void LoadedExecutableInstance::bindApi(PJRT_Api *api) {
@@ -96,13 +103,35 @@ LoadedExecutableInstance::execute(PJRT_LoadedExecutable_Execute_Args *args) {
     return tt_pjrt_status::kInternal;
   }
 
-  std::optional<tt::runtime::Device> runtime_device =
-      openDevices(args->argument_lists, args->num_args, args->num_devices,
-                  args->execute_device);
-  if (!runtime_device) {
-    // Logging is done inside `openDevices`.
+  std::unordered_set<int> device_ids =
+      getDeviceIds(args->argument_lists, args->num_args, args->num_devices);
+
+  const std::vector<std::uint32_t> &devices_mesh_shape =
+      m_executable_image->getDevicesMeshShape();
+  size_t mesh_shape_num_devices = static_cast<size_t>(
+      std::accumulate(devices_mesh_shape.begin(), devices_mesh_shape.end(), 1,
+                      std::multiplies<std::uint32_t>{}));
+
+  if (device_ids.size() != mesh_shape_num_devices) {
+    DLOG_F(ERROR,
+           "Input buffers are placed on a different number of devices (%zu) "
+           "than in the mesh shape estimated by the compiler (%zu)",
+           device_ids.size(), mesh_shape_num_devices);
     return tt_pjrt_status::kInternal;
   }
+
+  DeviceInstance *device_instance =
+      DeviceInstance::unwrap(args->execute_device);
+  if (device_instance &&
+      !(device_ids.size() == 1 &&
+        *device_ids.begin() == device_instance->getGlobalDeviceId())) {
+    DLOG_F(ERROR, "Input buffers are placed on a different device than the one "
+                  "specified in the execute_device argument");
+    return tt_pjrt_status::kInternal;
+  }
+
+  tt::runtime::Device runtime_device =
+      m_client_instance->getOrCreateMeshDevice(devices_mesh_shape);
 
   // Assuming only one program per flatbuffer for now.
   std::uint32_t program_index = 0;
@@ -110,14 +139,14 @@ LoadedExecutableInstance::execute(PJRT_LoadedExecutable_Execute_Args *args) {
   std::vector<tt::runtime::Tensor> input_tensors;
   input_tensors.reserve(args->num_args);
   tt_pjrt_status status = getInputRuntimeTensors(
-      args->argument_lists, args->num_args, args->num_devices, *runtime_device,
+      args->argument_lists, args->num_args, args->num_devices, runtime_device,
       program_index, input_tensors);
   if (!tt_pjrt_status_is_ok(status)) {
     return status;
   }
 
   std::vector<tt::runtime::Tensor> output_tensors = tt::runtime::submit(
-      *runtime_device, m_executable_image->getFlatbufferBinary(), program_index,
+      runtime_device, m_executable_image->getFlatbufferBinary(), program_index,
       input_tensors);
 
   if (output_tensors.size() != m_executable_image->getNumOutputs()) {
@@ -157,58 +186,7 @@ LoadedExecutableInstance::execute(PJRT_LoadedExecutable_Execute_Args *args) {
     }
   }
 
-  tt::runtime::closeMeshDevice(*runtime_device);
-  tt::runtime::setFabricConfig(tt::runtime::FabricConfig::DISABLED);
-
   return tt_pjrt_status::kSuccess;
-}
-
-std::optional<tt::runtime::Device>
-LoadedExecutableInstance::openDevices(PJRT_Buffer *const *const *argument_lists,
-                                      size_t num_args, size_t num_devices,
-                                      PJRT_Device *pjrt_device) {
-  std::unordered_set<int> device_ids =
-      getDeviceIds(argument_lists, num_args, num_devices);
-
-  const std::vector<std::uint32_t> &devices_mesh_shape =
-      m_executable_image->getDevicesMeshShape();
-  size_t mesh_shape_num_devices = static_cast<size_t>(
-      std::accumulate(devices_mesh_shape.begin(), devices_mesh_shape.end(), 1,
-                      std::multiplies<std::uint32_t>{}));
-
-  if (device_ids.size() != mesh_shape_num_devices) {
-    DLOG_F(ERROR,
-           "Input buffers are placed on a different number of devices (%zu) "
-           "than in the mesh shape estimated by the compiler (%zu)",
-           device_ids.size(), mesh_shape_num_devices);
-    return std::nullopt;
-  }
-
-  DeviceInstance *device_instance = DeviceInstance::unwrap(pjrt_device);
-  if (device_instance &&
-      !(device_ids.size() == 1 &&
-        *device_ids.begin() == device_instance->getGlobalDeviceId())) {
-    DLOG_F(ERROR, "Input buffers are placed on a different device than the one "
-                  "specified in the execute_device argument");
-    return std::nullopt;
-  }
-
-  // TODO(mrakita): Currently runtime doesn't allow us to open specific devices
-  // subset, we can only open contiguous subset of devices starting from some
-  // offset. We need to keep track of opened devices in Client and map the
-  // buffers devices to these devices.
-  // https://github.com/tenstorrent/tt-xla/issues/502
-
-  tt::runtime::MeshDeviceOptions mesh_device_options;
-  mesh_device_options.meshShape = devices_mesh_shape;
-
-  if (mesh_shape_num_devices > 1) {
-    tt::runtime::setFabricConfig(tt::runtime::FabricConfig::FABRIC_1D);
-  } else {
-    tt::runtime::setFabricConfig(tt::runtime::FabricConfig::DISABLED);
-  }
-
-  return tt::runtime::openMeshDevice(mesh_device_options);
 }
 
 std::unordered_set<int> LoadedExecutableInstance::getDeviceIds(


### PR DESCRIPTION
We are currently opening/closing the device on each `LoadedExecutableInstance::execute()` call.

This change enables us to open the device in advance and reuse it, for example across multiple executions of the same model. This will allow us to leave tensors (weights/constants) on the device, improving the performance on subsequent executions - avoid constantly transferring tensors from host to device.

We open the device when creating the `ClientInstance`. Then when executing the models, in `LoadedExecutableInstance::execute()`, we verify the wanted mesh shape for the device. If the device mesh shape matches the target mesh shape, we simply reuse the previously opened mesh device. In case we need a different mesh shape, we will close and reopen the mesh device with wanted mesh shape.

There were issues with using sub-meshes and also with reshaping mesh device. Hence, I've decided to go with the simplest approach which works.

Issue #952
Closes #1415