### PR TITLE
add --pre flag info

### DIFF
--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -69,6 +69,7 @@ pip install pjrt-plugin-tt --extra-index-url https://pypi.eng.aws.tenstorrent.co
 
 >**NOTE:** You can pull pre-releases (these may not be stable, so proceed with caution) by adding the `--pre` flag
 > directly after `pip install`.
+> You can also choose a wheel from the [nightly release page](https://github.com/tenstorrent/tt-xla/releases).
 
 3. You are now ready to try running a model. Navigate to the section of the [TT-Forge repo that contains TT-XLA demos](https://github.com/tenstorrent/tt-forge/tree/main/demos/tt-xla).
 

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -67,6 +67,9 @@ source .xla-venv/bin/activate
 pip install pjrt-plugin-tt --extra-index-url https://pypi.eng.aws.tenstorrent.com/
 ```
 
+>**NOTE:** You can pull pre-releases (these may not be stable, so proceed with caution) by adding the `--pre` flag
+> directly after `pip install`.
+
 3. You are now ready to try running a model. Navigate to the section of the [TT-Forge repo that contains TT-XLA demos](https://github.com/tenstorrent/tt-forge/tree/main/demos/tt-xla).
 
 4. For this walkthrough, the [demo in the **gpt2** folder](https://github.com/tenstorrent/tt-forge/tree/main/demos/tt-xla/gpt2) is used. In the **gpt2** folder, in the **requirements.txt** file, you can see that **flax** and **transformers** are necessary to run the demo. Install them:


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-forge/issues/327?issue=tenstorrent%7Ctt-forge%7C459)

### Problem description
In TT-XLA on the getting_started page, it's explained how to download a wheel, but not how to get one that's pre-release. 

### What's changed
Describe the approach used to solve the problem.
Provide a note that explains how users can use the --pre flag to grab a pre-release wheel with the understanding that it may not be stable yet. 

### Checklist
- [ ] New/Existing tests provide coverage for changes
