### PR TITLE
Tensor parallel multi-chip support for model loader/tester w/ initial tests (gemma, falcon) for n300-llmbox in CI

### DIFF
--- a/.github/workflows/test-matrix-presets/model-test-passing.json
+++ b/.github/workflows/test-matrix-presets/model-test-passing.json
@@ -1,4 +1,5 @@
 [
-  { "runs-on": "n150", "name": "run_forge_models_torch", "dir": "./tests/runner/test_models.py", "test-mark": "expected_passing", "parallel-groups": 10 },
-  { "runs-on": "p150", "name": "run_forge_models_torch", "dir": "./tests/runner/test_models.py", "test-mark": "expected_passing", "parallel-groups": 10 }
+  { "runs-on": "n150", "name": "run_forge_models_torch", "dir": "./tests/runner/test_models.py", "test-mark": "n150 and expected_passing", "parallel-groups": 10 },
+  { "runs-on": "p150", "name": "run_forge_models_torch", "dir": "./tests/runner/test_models.py", "test-mark": "p150 and expected_passing", "parallel-groups": 10 },
+  { "runs-on": "n300-llmbox", "name": "run_forge_models_torch", "dir": "./tests/runner/test_models.py", "test-mark": "n300-llmbox and expected_passing", "parallel-groups": 1 }
 ]

--- a/.github/workflows/test-matrix-presets/model-test-push.json
+++ b/.github/workflows/test-matrix-presets/model-test-push.json
@@ -1,4 +1,4 @@
 [
-  { "runs-on": "n150", "name": "run_forge_models_torch", "dir": "./tests/runner/test_models.py", "test-mark": "expected_passing and push" },
-  { "runs-on": "p150", "name": "run_forge_models_torch", "dir": "./tests/runner/test_models.py", "test-mark": "expected_passing and push" }
+  { "runs-on": "n150", "name": "run_forge_models_torch", "dir": "./tests/runner/test_models.py", "test-mark": "n150 and expected_passing and push" },
+  { "runs-on": "p150", "name": "run_forge_models_torch", "dir": "./tests/runner/test_models.py", "test-mark": "p150 and expected_passing and push" }
 ]

--- a/.github/workflows/test-matrix-presets/model-test-xfail.json
+++ b/.github/workflows/test-matrix-presets/model-test-xfail.json
@@ -1,4 +1,4 @@
 [
-  { "runs-on": "n150", "name": "run_forge_models_torch", "dir": "./tests/runner/test_models.py", "test-mark": "known_failure_xfail or not_supported_skip or placeholder", "parallel-groups": 3 },
-  { "runs-on": "p150", "name": "run_forge_models_torch", "dir": "./tests/runner/test_models.py", "test-mark": "known_failure_xfail or not_supported_skip or placeholder", "parallel-groups": 3 }
+  { "runs-on": "n150", "name": "run_forge_models_torch", "dir": "./tests/runner/test_models.py", "test-mark": "n150 and (known_failure_xfail or not_supported_skip or placeholder)", "parallel-groups": 3 },
+  { "runs-on": "p150", "name": "run_forge_models_torch", "dir": "./tests/runner/test_models.py", "test-mark": "p150 and (known_failure_xfail or not_supported_skip or placeholder)", "parallel-groups": 3 }
 ]

--- a/python_package/torch_plugin_tt/__init__.py
+++ b/python_package/torch_plugin_tt/__init__.py
@@ -7,6 +7,7 @@ import os
 
 from torch_xla.experimental.plugins import DevicePlugin
 from pjrt_plugin_tt import get_library_path, setup_tt_metal_home
+import torch_xla.runtime as xr
 
 import torch
 import tt_torch  # registers "tt" backend for torch.compile
@@ -36,6 +37,8 @@ class TTPlugin(DevicePlugin):
         print(
             f"WARNING: TT plugin is setting XLA_STABLEHLO_COMPILE to 1. This is required for TT PJRT plugin to work correctly."
         )
+        os.environ["CONVERT_SHLO_TO_SHARDY"] = "1"
+        xr.use_spmd()
 
     def library_path(self) -> str:
         """Return the path to the TT PJRT plugin binary."""

--- a/python_package/torch_plugin_tt/__init__.py
+++ b/python_package/torch_plugin_tt/__init__.py
@@ -7,7 +7,6 @@ import os
 
 from torch_xla.experimental.plugins import DevicePlugin
 from pjrt_plugin_tt import get_library_path, setup_tt_metal_home
-import torch_xla.runtime as xr
 
 import torch
 import tt_torch  # registers "tt" backend for torch.compile
@@ -37,8 +36,6 @@ class TTPlugin(DevicePlugin):
         print(
             f"WARNING: TT plugin is setting XLA_STABLEHLO_COMPILE to 1. This is required for TT PJRT plugin to work correctly."
         )
-        os.environ["CONVERT_SHLO_TO_SHARDY"] = "1"
-        xr.use_spmd()
 
     def library_path(self) -> str:
         """Return the path to the TT PJRT plugin binary."""

--- a/tests/infra/testers/single_chip/model/model_tester.py
+++ b/tests/infra/testers/single_chip/model/model_tester.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Any, Dict, Mapping, Sequence, Callable
+from typing import Any, Dict, Mapping, Sequence, Callable, Optional
 
 from infra.comparators import ComparisonConfig
 from tests.infra.testers.compiler_config import CompilerConfig
@@ -42,8 +42,6 @@ class ModelTester(BaseTester, ABC):
 
         self._model: Model = None
         self._workload: Workload = None
-        self._shard_spec_function = None
-        self._mesh = None
 
         super().__init__(comparison_config, framework)
         self._initialize_components()
@@ -65,20 +63,14 @@ class ModelTester(BaseTester, ABC):
         self._configure_model()
         # Cache model inputs.
         self._cache_model_inputs()
-        # Get shard specs.
-        self._shard_spec_function = self._get_shard_specs_function()
-        # Get mesh.
-        self._mesh = self._get_mesh()
 
-    @abstractmethod
-    def _get_shard_specs_function(self) -> Callable[[Model], ShardSpec]:
-        """Returns shard specs function."""
-        raise NotImplementedError("Subclasses must implement this method.")
+    def _get_shard_specs_function(self) -> Optional[Callable[[Model], ShardSpec]]:
+        """Optional: returns shard specs function if required; otherwise None."""
+        return None
 
-    @abstractmethod
-    def _get_mesh(self) -> Mesh:
-        """Returns mesh."""
-        raise NotImplementedError("Subclasses must implement this method.")
+    def _get_mesh(self) -> Optional[Mesh]:
+        """Optional: returns mesh if required; otherwise None."""
+        return None
 
     @abstractmethod
     def _get_model(self) -> Model:
@@ -137,7 +129,7 @@ class ModelTester(BaseTester, ABC):
         Tests the model by running inference on TT device and on CPU and comparing the
         results.
         """
-        # self._compile_for_cpu(self._workload)
+        self._compile_for_cpu(self._workload)
         cpu_res = self._run_on_cpu(self._workload)
 
         self._compile_for_tt_device(self._workload)

--- a/tests/infra/testers/single_chip/model/torch_model_tester.py
+++ b/tests/infra/testers/single_chip/model/torch_model_tester.py
@@ -74,6 +74,8 @@ class TorchModelTester(ModelTester):
         self._workload = Workload(
             framework=self._framework, model=self._model, args=args, kwargs=kwargs
         )
+        self._workload.shard_spec_function = self._get_shard_specs_function()
+        self._workload.mesh = self._get_mesh()
 
     # @override
     def _get_forward_method_args(self) -> Sequence[Any]:

--- a/tests/infra/testers/single_chip/model/torch_model_tester.py
+++ b/tests/infra/testers/single_chip/model/torch_model_tester.py
@@ -7,10 +7,13 @@ from typing import Any, Dict, Mapping, Sequence
 
 import torch
 import torch_xla
+import torch_xla.runtime as xr
+
 from infra.comparators import ComparisonConfig
 from tests.infra.testers.compiler_config import CompilerConfig
 from infra.utilities import Framework
 from infra.workloads import Workload
+import os
 
 from .model_tester import ModelTester, RunMode
 
@@ -74,8 +77,20 @@ class TorchModelTester(ModelTester):
         self._workload = Workload(
             framework=self._framework, model=self._model, args=args, kwargs=kwargs
         )
-        self._workload.shard_spec_function = self._get_shard_specs_function()
         self._workload.mesh = self._get_mesh()
+        self._workload.shard_spec_fn = self._get_shard_specs_function()
+
+        self._enable_xla_spmd_if_needed()
+
+    # If model has shard specs and running on multichip mesh, then convert StableHLO
+    # to Shardy dialect and initialize XLA SPMD runtime.
+    def _enable_xla_spmd_if_needed(self) -> None:
+        has_shard_specs = self._workload.shard_spec_fn is not None
+        is_multichip = self._workload.mesh and len(self._workload.mesh.device_ids) > 1
+
+        if has_shard_specs and is_multichip:
+            os.environ["CONVERT_SHLO_TO_SHARDY"] = "1"
+            xr.use_spmd()
 
     # @override
     def _get_forward_method_args(self) -> Sequence[Any]:

--- a/tests/infra/utilities/__init__.py
+++ b/tests/infra/utilities/__init__.py
@@ -9,5 +9,5 @@ from .jax_multichip_utils import (
     make_flax_linen_parameters_partition_specs_on_cpu,
     make_partition_spec,
 )
-from .types import Device, Framework, Model, PyTree, Tensor
+from .types import Device, Framework, Model, PyTree, Tensor, Mesh, ShardSpec
 from .utils import random_image, random_tensor

--- a/tests/infra/utilities/types.py
+++ b/tests/infra/utilities/types.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Union
+from typing import Union, Dict, Tuple
 
 import jax
 import torch
@@ -13,6 +13,7 @@ from flax import linen, nnx
 from jaxtyping import PyTree as jax_pytree
 from torch.utils._pytree import PyTree as torch_pytree
 from transformers import FlaxPreTrainedModel
+from torch_xla.distributed.spmd import Mesh
 
 # Convenience alias. Used to jointly represent tensors from different frameworks.
 Tensor = Union[jax.Array, torch.Tensor]
@@ -29,6 +30,10 @@ Device = Union[jax.Device, torch.device]
 
 # Convenience alias.
 PyTree = Union[jax_pytree, torch_pytree]
+
+Mesh = Mesh
+
+ShardSpec = Dict[Tensor, Tuple[str, ...]]
 
 
 class Framework(Enum):

--- a/tests/infra/workloads/workload.py
+++ b/tests/infra/workloads/workload.py
@@ -50,7 +50,7 @@ class Workload:
         # Consider reworking _safely_put_workload_on_device to eliminate the need for static_argnames in Workload.
         self.static_argnames = static_argnames or []
 
-        self.shard_spec_function = None
+        self.shard_spec_fn = None
         self.mesh = None
 
     @property

--- a/tests/infra/workloads/workload.py
+++ b/tests/infra/workloads/workload.py
@@ -50,6 +50,9 @@ class Workload:
         # Consider reworking _safely_put_workload_on_device to eliminate the need for static_argnames in Workload.
         self.static_argnames = static_argnames or []
 
+        self.shard_spec_function = None
+        self.mesh = None
+
     @property
     def is_jax(self) -> bool:
         return self.framework == Framework.JAX

--- a/tests/runner/test_config.py
+++ b/tests/runner/test_config.py
@@ -1857,10 +1857,9 @@ test_config = {
                 "bringup_status": BringupStatus.INCORRECT_RESULT,
                 "reason": "AssertionError: PCC comparison failed. Calculated: pcc=0.976563572883606. Required: pcc=0.99",
             },
-            "n150": {
-                "status": ModelTestStatus.KNOWN_FAILURE_XFAIL,
-                "reason": "Too large for single chip",
-                "bringup_status": BringupStatus.FAILED_RUNTIME,
+            "t3k": {
+                "status": ModelTestStatus.EXPECTED_PASSING,
+                "required_pcc": 0.97,
             },
         },
     },

--- a/tests/runner/test_config.py
+++ b/tests/runner/test_config.py
@@ -274,32 +274,22 @@ test_config = {
         "bringup_status": BringupStatus.INCORRECT_RESULT,
     },
     "falcon/pytorch-tiiuae/Falcon3-7B-Base-full-inference": {
+        "supported_archs": ["p150", "n300-llmbox"],
         "status": ModelTestStatus.EXPECTED_PASSING,
-        "arch_overrides": {
-            "n150": {
-                "status": ModelTestStatus.NOT_SUPPORTED_SKIP,
-                "reason": "Too large for single chip",
-                "bringup_status": BringupStatus.FAILED_RUNTIME,
-            },
-        },
+        "required_pcc": 0.98,
     },
     "falcon/pytorch-tiiuae/Falcon3-10B-Base-full-inference": {
+        "supported_archs": ["p150", "n300-llmbox"],
         "status": ModelTestStatus.EXPECTED_PASSING,
-        "arch_overrides": {
-            "n150": {
-                "status": ModelTestStatus.NOT_SUPPORTED_SKIP,
-                "reason": "Too large for single chip",
-                "bringup_status": BringupStatus.FAILED_RUNTIME,
-            },
-        },
     },
     "falcon/pytorch-tiiuae/Falcon3-Mamba-7B-Base-full-inference": {
+        "supported_archs": ["p150", "n300-llmbox"],
         "status": ModelTestStatus.EXPECTED_PASSING,
         "arch_overrides": {
-            "n150": {
-                "status": ModelTestStatus.NOT_SUPPORTED_SKIP,
-                "reason": "Too large for single chip",
-                "bringup_status": BringupStatus.FAILED_RUNTIME,
+            "n300-llmbox": {
+                "status": ModelTestStatus.KNOWN_FAILURE_XFAIL,
+                "reason": " Error: loc('compare.1209'): error: Compare operation is not supported in stablehlo-pipeline for meshes not 1x1 - https://github.com/tenstorrent/tt-mlir/issues/3497",
+                "bringup_status": BringupStatus.FAILED_TTMLIR_COMPILATION,
             },
         },
     },
@@ -1850,16 +1840,16 @@ test_config = {
         "bringup_status": BringupStatus.FAILED_FE_COMPILATION,
     },
     "gemma/pytorch-google/gemma-1.1-7b-it-full-inference": {
+        "supported_archs": ["p150", "n300-llmbox"],
+        "assert_pcc": False,
+        "status": ModelTestStatus.EXPECTED_PASSING,
+        "bringup_status": BringupStatus.INCORRECT_RESULT,
         "arch_overrides": {
             "p150": {
-                "assert_pcc": False,
-                "status": ModelTestStatus.EXPECTED_PASSING,
-                "bringup_status": BringupStatus.INCORRECT_RESULT,
                 "reason": "AssertionError: PCC comparison failed. Calculated: pcc=0.976563572883606. Required: pcc=0.99",
             },
-            "t3k": {
-                "status": ModelTestStatus.EXPECTED_PASSING,
-                "required_pcc": 0.97,
+            "n300-llmbox": {
+                "reason": "AssertionError: PCC comparison failed. Calculated: pcc=0.9626210927963257. Required: pcc=0.97",
             },
         },
     },
@@ -2394,21 +2384,17 @@ test_config = {
         "bringup_status": BringupStatus.FAILED_RUNTIME,
     },
     "gemma/pytorch-google/gemma-2-9b-it-full-inference": {
+        "supported_archs": ["p150", "n300-llmbox"],
         "status": ModelTestStatus.EXPECTED_PASSING,
-        "arch_overrides": {
-            "n150": {
-                "status": ModelTestStatus.NOT_SUPPORTED_SKIP,
-                "reason": "Too large for single chip",
-                "bringup_status": BringupStatus.FAILED_RUNTIME,
-            },
-        },
     },
     "gemma/pytorch-google/gemma-2-27b-it-full-inference": {
+        "supported_archs": ["p150", "n300-llmbox"],
         "status": ModelTestStatus.NOT_SUPPORTED_SKIP,
-        "reason": "Too large for single chip",
+        "reason": "Too large for single chip or even n300-llmbox either, needs debug - https://github.com/tenstorrent/tt-xla/issues/1494",
         "bringup_status": BringupStatus.FAILED_RUNTIME,
     },
     "falcon/pytorch-tiiuae/falcon-7b-instruct-full-inference": {
+        "supported_archs": ["p150", "n300-llmbox"],
         "arch_overrides": {
             "p150": {
                 "assert_pcc": False,
@@ -2416,10 +2402,8 @@ test_config = {
                 "bringup_status": BringupStatus.INCORRECT_RESULT,
                 "reason": "AssertionError: PCC comparison failed. Calculated: pcc=0.9418849945068359. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/1475",
             },
-            "n150": {
-                "status": ModelTestStatus.NOT_SUPPORTED_SKIP,
-                "reason": "Too large for single chip",
-                "bringup_status": BringupStatus.FAILED_RUNTIME,
+            "n300-llmbox": {
+                "status": ModelTestStatus.EXPECTED_PASSING,
             },
         },
     },

--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -12,6 +12,7 @@ import collections
 from dataclasses import dataclass
 from infra import ComparisonConfig, RunMode, TorchModelTester
 from tests.utils import BringupStatus, Category
+from third_party.tt_forge_models.config import Parallelism
 
 import torch_xla.runtime as xr
 from torch_xla.distributed.spmd import Mesh
@@ -400,6 +401,15 @@ def record_model_test_properties(
             bringup_status = BringupStatus.UNKNOWN
             reason = "Not specified"
 
+    # TODO (kmabee) - This is temporary workaround to populate parallelism tag for superset
+    # database correctly in very short term for newly added TP models on n300-llmbox.
+    # This will be replaced by something more robust in near future.
+    arch = request.config.getoption("--arch")
+    if "llmbox" in arch:
+        parallelism = Parallelism.TENSOR_PARALLEL
+    else:
+        parallelism = Parallelism.SINGLE_DEVICE
+
     tags = {
         "test_name": str(request.node.originalname),
         "specific_test_case": str(request.node.name),
@@ -408,6 +418,7 @@ def record_model_test_properties(
         "model_info": model_info.to_report_dict(),
         "run_mode": str(run_mode),
         "bringup_status": str(bringup_status),
+        "parallelism": str(parallelism),
     }
 
     # If we have an explanatory reason, include it as a top-level property too for DB visibility

--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -64,6 +64,11 @@ class ModelTestConfig:
         # Optional list of pytest markers to apply (e.g. ["push", "nightly"]) - normalized to list[str]
         self.markers = self._normalize_markers(self._resolve("markers", default=[]))
 
+        # Optional list of supported architectures (e.g. ["p150", "n300", "n300-llmbox"]) - normalized to list[str]
+        self.supported_archs = self._normalize_markers(
+            self._resolve("supported_archs", default=[])
+        )
+
     def _resolve(self, key, default=None):
         overrides = self.data.get("arch_overrides", {})
         if self.arch in overrides and key in overrides[self.arch]:


### PR DESCRIPTION
### Link to issue
#975 

### Problem description
- We need to add support for TP models through the model tester and tt-forge-models

### What's changed
- Uplift to latest tt-forge-models which brings support for gemma/falcon models with shard_specs, mesh_config defined via https://github.com/tenstorrent/tt-forge-models/pull/166
- Pipe shard_spec and mesh_config from tt-forge-models through TorchModelTester to set needed shard spec before executing. We can't mark the base model before returning to the user since the marked tensors need to be on device
- CI/Infra : Expand ALLOWED_ARCHES to include n300, n300-llmbox (useful for TP) and add optional supported_archs key to ModelTestConfig (default to n150, p150) to allow models to target n300-llmbox.
- CI/Infra: Add n300-llmbox group to model-test-passing.json for nightly job to run TP models
- Add 5x RED passing/e2e-running TP model variants from gemma/falcon for WH (were already running on p150). More models in follow up PRs.

### Checklist
- [x] Tested locally on n300-llmbox and on CI branch (https://github.com/tenstorrent/tt-xla/actions/runs/18087929082). New tests added to Nightly.
