### PR TITLE
Promote a couple passing models (gemma2-2b, vit_h_14) no longer hitting L1 or DRAM OOM

### DIFF
--- a/tests/runner/test_config.py
+++ b/tests/runner/test_config.py
@@ -1400,16 +1400,12 @@ test_config = {
         "status": ModelTestStatus.EXPECTED_PASSING,
     },
     "vit/pytorch-vit_h_14-full-inference": {
-        # "status": ModelTestStatus.EXPECTED_PASSING,
-        # "arch_overrides": {
-        #     "p150": {
-        #         "required_pcc": 0.98,
-        #     },
-        # },
-        # Exposed by "Remove host-side consteval" change
-        "status": ModelTestStatus.KNOWN_FAILURE_XFAIL,
-        "reason": "Out of Memory: Not enough space to allocate 224460800 B DRAM buffer across 12 banks, where each bank needs to store 18706432 B - https://github.com/tenstorrent/tt-xla/issues/1244",
-        "bringup_status": BringupStatus.FAILED_FE_COMPILATION,
+        "status": ModelTestStatus.EXPECTED_PASSING,
+        "arch_overrides": {
+            "p150": {
+                "required_pcc": 0.98,
+            },
+        },
     },
     "vit/pytorch-vit_l_16-full-inference": {
         "status": ModelTestStatus.EXPECTED_PASSING,

--- a/tests/runner/test_config.py
+++ b/tests/runner/test_config.py
@@ -1758,11 +1758,7 @@ test_config = {
         "bringup_status": BringupStatus.INCORRECT_RESULT,
     },
     "gemma/pytorch-google/gemma-2-2b-it-full-inference": {
-        # "required_pcc": 0.97,
-        # Exposed by "Remove host-side consteval" change
-        "status": ModelTestStatus.KNOWN_FAILURE_XFAIL,
-        "reason": "Statically allocated circular buffers on core range [(x=0,y=0) - (x=7,y=7)] grow to 2148032 B which is beyond max L1 size of 1499136 B - https://github.com/tenstorrent/tt-xla/issues/1244",
-        "bringup_status": BringupStatus.FAILED_FE_COMPILATION,
+        "status": ModelTestStatus.EXPECTED_PASSING,
     },
     "wide_resnet/pytorch-wide_resnet50_2.timm-full-inference": {
         "required_pcc": 0.98,


### PR DESCRIPTION
### Ticket
None

### Problem description
- Two tests (red) gemma/pytorch-google/gemma-2-2b-it-full-inference and (generality) vit/pytorch-vit_h_14-full-inference recently regressed to hitting DRAM or L1 OOM after host-side consteval was removed (right before these tests were added)
- Tried them today locally against WH and they are passing again

### What's changed
- Re-enable the tests by setting back to EXPECTED_PASSING 

### Checklist
- [x] Run locally and running on CI here against WH+BH, temporarily included in push for testing purposes: https://github.com/tenstorrent/tt-xla/actions/runs/17927419760
