### PR TITLE
[decompositions] Remove unused decompositions

### DIFF
--- a/python_package/tt_torch/backend/decompositions.py
+++ b/python_package/tt_torch/backend/decompositions.py
@@ -14,6 +14,7 @@ DecompositionOpsList = Sequence[
     Union[torch._ops.OperatorBase, torch._ops.OpOverloadPacket]
 ]
 
+
 # This method is derived from the implementation of jax.image.resize in JAX:
 #     https://github.com/jax-ml/jax/blob/354bd5271077654af983965c8e01ee462ce4ce91/jax/_src/image/scale.py#L52
 #
@@ -261,10 +262,6 @@ def _get_default_decomposition_ops() -> DecompositionOpsList:
     aten = torch.ops.aten
     # default decompositions pulled from SHARK / torch._decomp
     return [
-        aten.embedding_dense_backward,
-        aten.native_layer_norm_backward,
-        aten.slice_backward,
-        aten.select_backward,
         aten.norm.ScalarOpt_dim,
         aten.native_group_norm,
         aten.split.Tensor,
@@ -275,35 +272,18 @@ def _get_default_decomposition_ops() -> DecompositionOpsList:
         aten.t,
         aten.addmm,
         # decompositions that aid us in handling nn.BatchNorm2d
-        aten._native_batch_norm_legit_functional,
         aten._native_batch_norm_legit,
         aten._native_batch_norm_legit.no_stats,
         aten._native_batch_norm_legit_no_training,
         aten.squeeze.dims,
         # decompositions for miscellaneous ops that are not handled in torch-mlir but have available decompositions
-        aten.soft_margin_loss,
-        aten.im2col,
-        aten._euclidean_dist,
-        aten.index_copy,
-        aten.index_copy_,
         aten.grid_sampler_2d,
-        aten.log_sigmoid_forward,
-        aten.unsafe_split.Tensor,
-        aten.binary_cross_entropy,
-        aten.dot,
         aten._adaptive_avg_pool2d,
-        aten._prelu_kernel,
         aten.full,
         aten._log_softmax,
-        aten.nll_loss_forward,
-        aten.nll_loss_backward,
         aten._to_copy,
-        aten._log_softmax_backward_data,
         aten.lift_fresh_copy.default,
         aten._unsafe_index.Tensor,
-        aten.unbind.int,
-        aten.linspace.Tensor_Tensor,
-        aten._scaled_dot_product_flash_attention_for_cpu.default,
         aten.slice_scatter,
     ]
 


### PR DESCRIPTION
### Problem description
As part of the effort to determine what should remain in `torch-xla` under `torch.compile` and what should instead be handled in `mlir`, we first need to remove unused decompositions.

I generated a list by running extensive logging on nightly `torch-xla` models, capturing information about which decompositions were called, in which models, and how many times. The decompositions listed below were not called a single time in these models, so I am removing them.

To support this claim, I also ran the [nightly](https://github.com/tenstorrent/tt-xla/actions/runs/17909888392/job/50920127685) tests a second time to confirm that nothing breaks.

### What's changed
21 decompositions removed from `_get_default_decomposition_ops()`:
```
aten._euclidean_dist
aten._log_softmax_backward_data
aten._native_batch_norm_legit_functional
aten._prelu_kernel
aten._scaled_dot_product_flash_attention_for_cpu.default
aten.binary_cross_entropy
aten.dot
aten.embedding_dense_backward
aten.im2col
aten.index_copy_
aten.index_copy
aten.linspace.Tensor_Tensor
aten.log_sigmoid_forward
aten.native_layer_norm_backward
aten.nll_loss_backward
aten.nll_loss_forward
aten.select_backward
aten.slice_backward
aten.soft_margin_loss
aten.unbind.int
aten.unsafe_split.Tensor
```
