### PR TITLE
Increase the timeout for manual test dispatch workflow

### DIFF
--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -274,7 +274,7 @@ jobs:
 
         ESTIMATED_DURATION=$(echo "$COLLECTED_OUTPUT" | grep "estimated duration:")
         ESTIMATED_DURATION=$(echo "$ESTIMATED_DURATION" | sed 's/.*estimated duration: \([0-9.]*\)s.*/\1/' | awk '{print int($1)}')
-        ESTIMATED_DURATION=$((ESTIMATED_DURATION * 30))
+        ESTIMATED_DURATION=$((ESTIMATED_DURATION * 2 / 60))
 
         echo "timeout-seconds=$ESTIMATED_DURATION" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -272,10 +272,10 @@ jobs:
         # multiply the estimate with 3 until estimates are more precise
         ESTIMATED_DURATION=$((ESTIMATED_DURATION * 3 / 60))
 
-        echo "timeout-seconds=$ESTIMATED_DURATION" >> "$GITHUB_OUTPUT"
+        echo "timeout-minutes=$ESTIMATED_DURATION" >> "$GITHUB_OUTPUT"
 
     - name: Run tests
-      timeout-minutes: ${{ steps.collect-tests.outputs.timeout-seconds }}
+      timeout-minutes: ${{ steps.collect-tests.outputs.timeout-minutes }}
       env:
         HF_HOME: /mnt/dockercache/huggingface
         GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -67,7 +67,6 @@ jobs:
   # Run tests on TT hardware
   run-tests:
     needs: generate-matrix-test
-    timeout-minutes: ${{ inputs.timeout_minutes || 120 }}
     strategy:
       fail-fast: false
       matrix:
@@ -265,13 +264,21 @@ jobs:
         python -m pytest -vv tests/runner/test_models.py::test_all_models --validate-test-config
 
     - name: Collect Tests
+      id: collect-tests
       shell: bash
       run: |
         source venv/activate
         echo "Collecting tests for group ${{ matrix.build.group-id || 1}}..."
-        python -m pytest --collect-only ${{ env.BASE_PYTEST_CMD }}
+        COLLECTED_OUTPUT=$(python -m pytest --collect-only ${{ env.BASE_PYTEST_CMD }})
+        echo "$COLLECTED_OUTPUT"
+
+        ESTIMATED_DURATION=$(echo "$COLLECT_OUTPUT" | grep "estimated duration:")
+        ESTIMATED_DURATION=$(echo "$ESTIMATED_DURATION" | sed 's/.*estimated duration: \([0-9.]*\)s.*/\1/')
+
+        echo "timeout-seconds=$ESTIMATED_DURATION" >> "$GITHUB_OUTPUT"
 
     - name: Run tests
+      timeout-minutes: ${{ steps.collect-tests.outputs.timeout-seconds || inputs.timeout_minutes }}
       env:
         HF_HOME: /mnt/dockercache/huggingface
         GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -37,11 +37,6 @@ on:
         description: 'Name of the build artifact (codecov)'
         required: false
         type: string
-      timeout_minutes:
-        description: 'Timeout minutes for the test job'
-        required: false
-        default: 120
-        type: number
       test_suite:
         description: 'Test suite preset options or custom'
         required: true

--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -269,7 +269,8 @@ jobs:
 
         ESTIMATED_DURATION=$(echo "$COLLECTED_OUTPUT" | grep "estimated duration:")
         ESTIMATED_DURATION=$(echo "$ESTIMATED_DURATION" | sed 's/.*estimated duration: \([0-9.]*\)s.*/\1/' | awk '{print int($1)}')
-        ESTIMATED_DURATION=$((ESTIMATED_DURATION * 2 / 60))
+        # multiply the estimate with 3 until estimates are more precise
+        ESTIMATED_DURATION=$((ESTIMATED_DURATION * 3 / 60))
 
         echo "timeout-seconds=$ESTIMATED_DURATION" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -272,13 +272,14 @@ jobs:
         COLLECTED_OUTPUT=$(python -m pytest --collect-only ${{ env.BASE_PYTEST_CMD }})
         echo "$COLLECTED_OUTPUT"
 
-        ESTIMATED_DURATION=$(echo "$COLLECT_OUTPUT" | grep "estimated duration:")
-        ESTIMATED_DURATION=$(echo "$ESTIMATED_DURATION" | sed 's/.*estimated duration: \([0-9.]*\)s.*/\1/')
+        ESTIMATED_DURATION=$(echo "$COLLECTED_OUTPUT" | grep "estimated duration:")
+        ESTIMATED_DURATION=$(echo "$ESTIMATED_DURATION" | sed 's/.*estimated duration: \([0-9.]*\)s.*/\1/' | awk '{print int($1)}')
+        ESTIMATED_DURATION=$((ESTIMATED_DURATION * 30))
 
         echo "timeout-seconds=$ESTIMATED_DURATION" >> "$GITHUB_OUTPUT"
 
     - name: Run tests
-      timeout-minutes: ${{ steps.collect-tests.outputs.timeout-seconds || inputs.timeout_minutes }}
+      timeout-minutes: ${{ steps.collect-tests.outputs.timeout-seconds }}
       env:
         HF_HOME: /mnt/dockercache/huggingface
         GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/manual-test.yml
+++ b/.github/workflows/manual-test.yml
@@ -61,3 +61,4 @@ jobs:
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       wheel_release_artifact_name: ${{ needs.build-ttxla.outputs.wheel_artifact_name }}
       codecov: false
+      timeout_minutes: 180

--- a/.github/workflows/manual-test.yml
+++ b/.github/workflows/manual-test.yml
@@ -61,4 +61,3 @@ jobs:
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       wheel_release_artifact_name: ${{ needs.build-ttxla.outputs.wheel_artifact_name }}
       codecov: false
-      timeout_minutes: 180

--- a/.github/workflows/schedule-nightly-experimental.yml
+++ b/.github/workflows/schedule-nightly-experimental.yml
@@ -28,7 +28,6 @@ jobs:
     needs: [ build-image, build-ttxla ]
     if: success() || failure()
     with:
-      timeout_minutes: 180
       test_suite: model-test-experimental.json
       docker_image: ${{ needs.build-image.outputs.docker-image }}
       use-shared-runners: false # Run full model tests on Civ1

--- a/.github/workflows/schedule-nightly.yml
+++ b/.github/workflows/schedule-nightly.yml
@@ -54,7 +54,6 @@ jobs:
     # This ensures the job runs regardless of success or failure of `nightly_tests`:
     if: success() || failure()
     with:
-      timeout_minutes: 180
       test_suite: model-test-passing.json
       docker_image: ${{ needs.build-image.outputs.docker-image }}
       use-shared-runners: false # Run full model tests on Civ1
@@ -69,7 +68,6 @@ jobs:
     # This ensures the job runs regardless of success or failure of `nightly_tests`:
     if: success() || failure()
     with:
-      timeout_minutes: 180
       test_suite: model-test-xfail.json
       docker_image: ${{ needs.build-image.outputs.docker-image }}
       use-shared-runners: false # Run full model tests on Civ1


### PR DESCRIPTION
### Ticket
/

### Problem description
Run Test workflow fails because of the timeout even though the test could be passing.

### What's changed
Increase the timeout for tests ran by Run Test to 3 hours.

### Checklist
- [ ] New/Existing tests provide coverage for changes
