### PR TITLE
Single test 'contains' feature

### DIFF
--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -239,7 +239,7 @@ jobs:
           ${{ matrix.build.dir }} \
           $ARCH \
           -m \"$MARKS\" \
-          ${{ matrix.build.args }} \
+          $(printf '%q' '${{ matrix.build.args }}') \
           $PYTEST_SPLITS"
         echo "BASE_PYTEST_CMD=$BASE_PYTEST_CMD" >> $GITHUB_ENV
 

--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -238,8 +238,8 @@ jobs:
           --durations=0 \
           ${{ matrix.build.dir }} \
           $ARCH \
-          -m \"$MARKS\" \
-          $(printf '%q' '${{ matrix.build.args }}') \
+          -m \"$MARKS\" ${{ matrix.build.args }} \
+          -k "$(printf '%q' '${{ matrix.build.contains }}')" \
           $PYTEST_SPLITS"
         echo "BASE_PYTEST_CMD=$BASE_PYTEST_CMD" >> $GITHUB_ENV
 

--- a/.github/workflows/manual-test-single.yml
+++ b/.github/workflows/manual-test-single.yml
@@ -8,11 +8,11 @@ on:
         required: true
         type: string
       mark:
-        description: 'Mark passed to pytest'
+        description: 'Mark passed to pytest (-m)'
         required: false
         type: string
       contains:
-        description: 'Execute test that contains the specified string'
+        description: 'Execute test that contains the specified string (-k)'
         required: false
         type: string
       args:

--- a/.github/workflows/manual-test-single.yml
+++ b/.github/workflows/manual-test-single.yml
@@ -77,12 +77,12 @@ jobs:
       - id: generate
         run: |
           TEST_CONFIG=$(jq -n \
-            --arg runs_on "${{ inputs.runs_on }}" \
-            --arg dir "${{ inputs.dir }}" \
-            --arg mark "${{ inputs.mark }}" \
-            --arg shared_runners "${{ inputs.shared_runners }}" \
-            --arg args "${{ inputs.args }}" \
-            --argjson parallel_groups "${{ inputs.parallel_groups }}" \
+            --arg runs_on '${{ inputs.runs_on }}' \
+            --arg dir '${{ inputs.dir }}' \
+            --arg mark '${{ inputs.mark }}' \
+            --arg shared_runners '${{ inputs.shared_runners }}' \
+            --arg args '${{ inputs.args }}' \
+            --argjson parallel_groups '${{ inputs.parallel_groups }}' \
             '[{"runs-on": $runs_on,"name": "Test","dir": $dir,"test-mark": $mark,"shared-runners": $shared_runners,"args": $args,"parallel-groups": $parallel_groups}]')
 
           echo $TEST_CONFIG

--- a/.github/workflows/manual-test-single.yml
+++ b/.github/workflows/manual-test-single.yml
@@ -11,6 +11,10 @@ on:
         description: 'Mark passed to pytest'
         required: false
         type: string
+      contains:
+        description: 'Execute test that contains the specified string'
+        required: false
+        type: string
       args:
         description: 'Additional arguments passed to pytest'
         required: false
@@ -82,8 +86,9 @@ jobs:
             --arg mark '${{ inputs.mark }}' \
             --arg shared_runners '${{ inputs.shared_runners }}' \
             --arg args '${{ inputs.args }}' \
+            --arg contains '${{ inputs.contains }}' \
             --argjson parallel_groups '${{ inputs.parallel_groups }}' \
-            '[{"runs-on": $runs_on,"name": "Test","dir": $dir,"test-mark": $mark,"shared-runners": $shared_runners,"args": $args,"parallel-groups": $parallel_groups}]')
+            '[{"runs-on": $runs_on,"name": "Test","dir": $dir,"test-mark": $mark,"shared-runners": $shared_runners,"args": $args,"contains": $contains,"parallel-groups": $parallel_groups}]')
 
           echo $TEST_CONFIG
 

--- a/.github/workflows/manual-test-single.yml
+++ b/.github/workflows/manual-test-single.yml
@@ -76,17 +76,14 @@ jobs:
     steps:
       - id: generate
         run: |
-          TEST_CONFIG='[
-            {
-              "runs-on": "${{ inputs.runs_on }}",
-              "name": "Test",
-              "dir": "${{ inputs.dir }}",
-              "test-mark": "${{ inputs.mark }}",
-              "shared-runners": "${{ inputs.shared_runners }}",
-              "args": "${{ inputs.args }}",
-              "parallel-groups": ${{ fromJSON(inputs.parallel_groups) }}
-            }
-          ]'
+          TEST_CONFIG=$(jq -n \
+            --arg runs_on "${{ inputs.runs_on }}" \
+            --arg dir "${{ inputs.dir }}" \
+            --arg mark "${{ inputs.mark }}" \
+            --arg shared_runners "${{ inputs.shared_runners }}" \
+            --arg args "${{ inputs.args }}" \
+            --argjson parallel_groups "${{ inputs.parallel_groups }}" \
+            '[{"runs-on": $runs_on,"name": "Test","dir": $dir,"test-mark": $mark,"shared-runners": $shared_runners,"args": $args,"parallel-groups": $parallel_groups}]')
 
           echo $TEST_CONFIG
 


### PR DESCRIPTION
### Ticket
slack

### Problem description
Single test workflow has 'additional arguments' field.
But when used with -k option (which is the most used option in this field) with quotes (such as -k "yolo or bert") it fails because quotes are part of json and it is quite hard to escape them. 

### What's changed
Added new field 'contains' that is -k argument for pytest. Use without quotes.

### Checklist
https://github.com/tenstorrent/tt-xla/actions/runs/18004769745/job/51222760340
- [ ] New/Existing tests provide coverage for changes
