### PR TITLE
Mark mutated buffers as input, non mutated buffers as constant

### DIFF
--- a/python_package/tt_torch/backend/passes.py
+++ b/python_package/tt_torch/backend/passes.py
@@ -29,7 +29,7 @@ def insert_argument_type_markers(
         type_str = None
         if in_spec.kind == InputKind.USER_INPUT:
             type_str = "input"
-        # We do not model these argument types in tt-mlir. To avoid graph transformations (consteval) that would
+        # We do not model these argument types in tt-mlir. To avoid graph transformations that would
         # impact how these inputs are handled (i.e. consteval), we will mark them as "input".
         elif in_spec.kind in [InputKind.TOKEN, InputKind.CUSTOM_OBJ]:
             type_str = "input"


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- KV caches are marked as buffers by PyTorch. 
- We currently mark PyTorch buffers as "input" and do not consteval them. This is because constevaling a KV cache tensor results in the re-use of a cached KV cache tensor and produces poor data.
- Batchnorm mean/var are also marked as buffers, but we should consteval these as they are not mutated and do not change between **inference** iterations.

### What's changed
- If a buffer is mutated, then that input is also marked as a _bufffer mutation_ in the ExportedProgram's `output_signature`.
- Using this information, we will now conditionally mark the buffer as "input" if it is mutated, or "constant" if it is not. Thus allowing KV cache tensors to persist while also constevaling batch norm mean/var.

### Checklist
- [X] New/Existing tests provide coverage for changes
