### PR TITLE
Remove batchnorm decomposition

### DIFF
--- a/python_package/tt_torch/backend/decompositions.py
+++ b/python_package/tt_torch/backend/decompositions.py
@@ -271,10 +271,6 @@ def _get_default_decomposition_ops() -> DecompositionOpsList:
         aten.masked_fill.Scalar,
         aten.t,
         aten.addmm,
-        # decompositions that aid us in handling nn.BatchNorm2d
-        aten._native_batch_norm_legit,
-        aten._native_batch_norm_legit.no_stats,
-        aten._native_batch_norm_legit_no_training,
         aten.squeeze.dims,
         # decompositions for miscellaneous ops that are not handled in torch-mlir but have available decompositions
         aten.grid_sampler_2d,


### PR DESCRIPTION
### Problem description
* Decomposing batchnorm results in a graph with a lot more ops which reduces performance.
* A better version of batchnorm decomposition (which allows for fusing of the decomposed ops) exists in TTIR , so there is not need for it in torch passes

### What's changed
* Removed batchnorm decomposition from torch passes

Note: I'm not 100% sure how this will affect batchnorm for training, but to my knowledge we are not training any models trough torch with batchnorm currently. If this becomes a problem, support for lowering training batchnorm to TTIR should be added.

### Checklist
- [ ] New/Existing tests provide coverage for changes
