### PR TITLE
Implemented composite ops for torch.

### DIFF
--- a/python_package/tt_torch/backend/backend.py
+++ b/python_package/tt_torch/backend/backend.py
@@ -11,6 +11,7 @@ from .decompositions import (
 )
 import os
 from .passes import (
+    handle_composite_ops,
     bypass_redundant_getitem,
     bypass_dtype_promotion_and_redundant_cast,
     insert_argument_type_markers,
@@ -30,6 +31,9 @@ def torch_pass_pipeline(
     gm: torch.fx.GraphModule,
     example_inputs: Tuple[torch.Tensor],
 ) -> torch.fx.GraphModule:
+
+    handle_composite_ops(gm)
+
     decompositions = torch._decomp.core_aten_decompositions()
     decompositions.update(CUSTOM_DECOMPOSITION_TABLE)
 

--- a/python_package/tt_torch/backend/passes.py
+++ b/python_package/tt_torch/backend/passes.py
@@ -3,6 +3,19 @@
 # SPDX-License-Identifier: Apache-2.0
 import torch
 from torch.export.graph_signature import InputKind, OutputKind
+from tt_torch import composite_ops
+
+
+def handle_composite_ops(gm: torch.fx.GraphModule) -> None:
+    """
+    Replaces torch ops with composite ops if we have a proper replacement.
+
+    This must be done before graph decompositions because we are replacing
+    torch operations directly.
+    """
+    for node in gm.graph.nodes:
+        if node.target in composite_ops.replacements:
+            node.target = composite_ops.replacements[node.target]
 
 
 def insert_argument_type_markers(

--- a/python_package/tt_torch/composite_ops.py
+++ b/python_package/tt_torch/composite_ops.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+from torch import Tensor
+from torch_xla.experimental.mark_pattern_utils import StableHLOCompositeBuilder
+
+"""
+From XLA documentation: '(Composite operation) Encapsulates an operation made up (composed) of
+other StableHLO operations, taking inputs and composite_attributes and producing results.
+The semantics of the op are implemented by the decomposition attribute. The composite op can be
+replaced with its decomposition without changing program semantics.'
+
+So, composite op is made because of high-level ops that are decomposed into dozens stable HLO
+operations. It enables custom backends to handle op however they want. Since we have a native
+support for, let's say, gelu operation in ttir, we will wrap torch gelu op into gelu composite
+op and handle it in XLA without decompostions, enabling our device to execute custom gelu implementation.
+
+Since we want to run torch models wihout modifying them, we will substitute torch operations
+(that we have a direct support for) with composite ops. This way, user will not have to change
+anything in model in order to get performance improvement.
+"""
+
+
+def composite_gelu(input: Tensor, approximate: str = "none") -> Tensor:
+    """
+    Creates composite gelu operation for torch xla using StableHLOCompositeBuilder.
+    Note that operation name must be tenstorrent.gelu[_tanh] for MLIR to handle it.
+
+    Returns a tensor.
+    """
+    tanh = approximate == "tanh"
+    name = "tenstorrent.gelu" + ("_tanh" if tanh else "")
+    attr = {"approximate": "tanh"} if tanh else None
+
+    builder = StableHLOCompositeBuilder(name=name, attr=attr)
+
+    input = builder.mark_inputs(input)
+    input = torch.nn.functional.gelu(input, approximate=approximate)
+    input = builder.mark_outputs(input)
+
+    return input
+
+
+"""
+Dictionary holding replacement composite functions for torch functions.
+"""
+replacements = {torch.nn.functional.gelu: composite_gelu}

--- a/tests/torch/single_chip/ops/test_composite_ops.py
+++ b/tests/torch/single_chip/ops/test_composite_ops.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from tt_torch.composite_ops import composite_gelu
+
+import torch
+from torch.nn import functional as F
+import torch_xla.core.xla_model as xm
+
+from infra.comparators.torch_comparator import TorchComparator
+from tests.infra.comparators.comparison_config import ComparisonConfig
+from infra.utilities.types import Framework
+from tests.infra.testers.single_chip.op.op_tester import run_op_test_with_random_inputs
+
+
+@pytest.mark.parametrize("approx", ["none", "tanh"])
+def test_composite_gelu(approx):
+    """
+    Tests example model that has a composite gelu operation.
+    """
+
+    class MM(torch.nn.Module):
+        def forward(self, x):
+            return composite_gelu(x, approx)
+
+    input = torch.randn(32, 32)
+
+    model = MM()
+    golden = model(input)
+
+    device = xm.xla_device()
+    model = torch.compile(model.to(device), backend="tt")
+
+    output = model(input.to(device))
+
+    comparator = TorchComparator(ComparisonConfig())
+    comparator.compare(output, golden)
+
+
+@pytest.mark.parametrize("approx", ["none", "tanh"])
+def test_composite_gelu_eager(approx):
+    """
+    Tests example model in eager mode that has a composite gelu operation.
+    """
+
+    class MM(torch.nn.Module):
+        def forward(self, x):
+            return composite_gelu(x, approx)
+
+    input = torch.randn(32, 32)
+
+    model = MM()
+    golden = model(input)
+
+    device = xm.xla_device()
+    model = model.to(device)
+    input = input.to(device)
+
+    output = model(input).to("cpu")
+
+    comparator = TorchComparator(ComparisonConfig())
+    comparator.compare(output, golden)
+
+
+@pytest.mark.parametrize("approx", ["none", "tanh"])
+def test_patched_gelu(approx):
+    """
+    Tests example model that has a gelu operation (replaced with our composite gelu
+    operation in (tt-xla/python_package/torch_plugin_tt/__init__.py).
+    """
+
+    class MM(torch.nn.Module):
+        def forward(self, x):
+            return F.gelu(input=x, approximate=approx)
+
+    input = torch.randn(32, 32)
+
+    model = MM()
+    golden = model(input)
+
+    device = xm.xla_device()
+    model = torch.compile(model.to(device), backend="tt")
+
+    output = model(input.to(device))
+
+    comparator = TorchComparator(ComparisonConfig())
+    comparator.compare(output, golden)
+
+
+@pytest.mark.parametrize("approx", ["none", "tanh"])
+def test_patched_gelu_eager(approx):
+    """
+    Tests example model in eager mode that has a gelu operation (replaced with our composite gelu
+    operation in (tt-xla/python_package/torch_plugin_tt/__init__.py).
+    """
+
+    class MM(torch.nn.Module):
+        def forward(self, x):
+            return F.gelu(input=x, approximate=approx)
+
+    input = torch.randn(32, 32)
+
+    model = MM()
+    golden = model(input)
+
+    device = xm.xla_device()
+    model = model.to(device)
+    input = input.to(device)
+
+    output = model(input).to("cpu")
+
+    comparator = TorchComparator(ComparisonConfig())
+    comparator.compare(output, golden)
+
+
+@pytest.mark.parametrize("approx", ["none", "tanh"])
+def test_patched_gelu_op_test(approx):
+    """
+    Tests torch gelu operation (replaced with our composite gelu operation in
+    (tt-xla/python_package/torch_plugin_tt/__init__.py) using run_op_test_with_random_inputs utility.
+    """
+
+    def gelu_with_approx(x):
+        return F.gelu(x, approximate=approx)
+
+    run_op_test_with_random_inputs(
+        gelu_with_approx, [(32, 32)], framework=Framework.TORCH
+    )


### PR DESCRIPTION
Composite op is a mechanism that enables propagation of complex ops directly to device without decompositions.

Similar to jax implementation, this change adds support for composite ops in torch. It uses stableHLOCompositeBuilder for wrapping torch ops in composite ops, and substitutes torch native functions with composite function wrappers. This way, user does not have to change model in order to get performance improvement.

Stable HLO looks like this:
   ...
   %1 = stablehlo.reshape %0 : (tensor<1x32x32xf32>) -> tensor<32x32xf32> loc(#loc3)
   %2 = stablehlo.composite "tenstorrent.gelu" %1 {decomposition = @tenstorrent.gelu.impl} : (tensor<32x32xf32>) -> tensor<32x32xf32> loc(#loc4)
   return %2 : tensor<32x32xf32> loc(#loc)
   ...

IR (before fusing) like this:
   ...
   %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, ...
   %1 = "ttnn.empty"(%0) <{dtype = #ttcore.supportedDataTypes<f32>, ...
   %2 = "ttnn.gelu"(%arg0) : (tensor<32x32xf32, #ttnn_layout>) -> tensor<32x32xf32, #ttnn_layout>
   return %2 : tensor<32x32xf32, #ttnn_layout>
   ....
