### PR TITLE
Add workaround to enable program cache

### DIFF
--- a/src/common/pjrt_implementation/client_instance.cc
+++ b/src/common/pjrt_implementation/client_instance.cc
@@ -410,7 +410,16 @@ ClientInstance::openMeshDevice(const std::vector<uint32_t> &mesh_shape) {
     tt::runtime::setFabricConfig(tt::runtime::FabricConfig::DISABLED);
   }
 
+  // TODO(odjuricicTT, #1485): This is a temporary way to enable program cache
+  // until we have a proper way for a user to pass device options. After that
+  // this should be removed. Issue for device options:
+  // https://github.com/tenstorrent/tt-xla/issues/1480
+  bool enableProgramCache =
+      std::getenv("TT_RUNTIME_ENABLE_PROGRAM_CACHE") != nullptr &&
+      std::string(std::getenv("TT_RUNTIME_ENABLE_PROGRAM_CACHE")) == "1";
+
   tt::runtime::MeshDeviceOptions options = tt::runtime::MeshDeviceOptions{
+      .enableProgramCache = enableProgramCache,
       .meshShape = mesh_shape,
   };
 


### PR DESCRIPTION
### Problem description
There is not way for a user to enable program cache. Without program cache all model e2e performance measurements don't make sense as host overhead huge.

### What's changed
This change adds a temporary way to enable program cache. This is **NOT** intended to be widely used or exposed to users! It is a workaround to help unblock perf development and e2e perf measurements.

Progress on a proper solution for this problem is tracked here: https://github.com/tenstorrent/tt-xla/issues/1480
One that is completed, this workaround **WILL** be removed. Tracked here: https://github.com/tenstorrent/tt-xla/issues/1485

### Checklist
- [ ] New/Existing tests provide coverage for changes
