### PR TITLE
Added WA to run SPMD mode all the time

### DIFF
--- a/python_package/tt_torch/backend/backend.py
+++ b/python_package/tt_torch/backend/backend.py
@@ -1,7 +1,8 @@
 # SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Tuple
+from types import DynamicClassAttribute
+from typing import Tuple, Optional
 import torch
 from torch.export import ExportedProgram
 
@@ -22,7 +23,48 @@ from torch.export.graph_signature import InputKind
 from torch._dynamo import register_backend
 
 import torch_xla
+import torch_xla.distributed.spmd as xs
+import torch_xla.runtime as xr
+import numpy as np
+from torch_xla.distributed.spmd import Mesh, ShardingType
 
+
+class DynamoBackendOptions:
+    def __init__(self, mesh: Optional[Mesh]):
+        self.mesh = mesh
+        self.remove_dummy_io = False
+
+# This function inspects all tensors in the state_dict of the given GraphModule,
+# as well as the provided example inputs, to determine if any of them have a sharding
+# annotation that is not fully replicated.
+def has_sharded_inputs(gm: torch.fx.GraphModule, example_inputs: Tuple[torch.Tensor]) -> bool:
+    tensors = list(gm.state_dict().values())
+    tensors.extend(example_inputs)
+    for tensor in tensors:
+        if torch_xla._XLAC._get_xla_sharding_type(tensor) is not None and torch_xla._XLAC._get_xla_sharding_type(tensor) != ShardingType.REPLICATED:
+            return True
+    return False
+
+# Add a dummy srarded input and output to the graph. This is needed because currently, fully sharded graphs
+# are not represented correctly by torch-xla and we get a graph without a mesh op. This is a temporary 
+# workaround until https://github.com/tenstorrent/tt-xla/issues/1487 is resolved.
+def add_dummy_sharded_io(gm: torch.fx.GraphModule, options: DynamoBackendOptions, device: torch.device) -> torch.fx.GraphModule:
+    dummy_io = torch.randn(32 * options.mesh.mesh_shape[0], 32 * options.mesh.mesh_shape[1], dtype=torch.bfloat16)
+    gm.register_parameter("dummy_io", torch.nn.Parameter(dummy_io))
+    gm = gm.to(device)
+    xs.mark_sharding(gm.dummy_io, options.mesh, (options.mesh.axis_names[0], options.mesh.axis_names[1]))
+    for node in gm.graph.nodes:
+        if node.op == "placeholder":
+            with gm.graph.inserting_before(node):
+                input_node = gm.graph.get_attr("dummy_io")
+        if node.op == "output":
+            with gm.graph.inserting_before(node):
+                current_outputs = list(node.args[0])
+                node.args = (tuple(current_outputs + [input_node]), )
+            break
+
+    options.remove_dummy_io = True
+    return gm
 
 # This function runs a series of passes on a torch GraphModule.
 # The passes here may be necessary (depending on the model) to
@@ -30,9 +72,15 @@ import torch_xla
 def torch_pass_pipeline(
     gm: torch.fx.GraphModule,
     example_inputs: Tuple[torch.Tensor],
+    options: DynamoBackendOptions,
 ) -> torch.fx.GraphModule:
     decompositions = torch._decomp.core_aten_decompositions()
     decompositions.update(CUSTOM_DECOMPOSITION_TABLE)
+
+    # dummy input needed for replicated inputs in SPMD mode.See comment in add_dummy_sharded_io
+    num_devices = options.mesh.mesh_shape[0] * options.mesh.mesh_shape[1]
+    if num_devices > 1 and not has_sharded_inputs(gm, example_inputs):
+        gm = add_dummy_sharded_io(gm, options, example_inputs[0].device)
 
     # We use `export_for_training` here as we plan to use this flow to compile training graphs.
     # In addition to that, the functionality in `export_for_training` will become the default
@@ -65,14 +113,16 @@ class XLAExecutor:
     2. Signalling to torch-xla to cut the graph at the model output.
     """
 
-    def __init__(self, module: torch.fx.GraphModule):
+    def __init__(self, module: torch.fx.GraphModule, options: DynamoBackendOptions):
         self.module = module
+        self.options = options
 
         # Collect all devices this model will use. This device list is used to
         # signal to torch xla which devices are involved in computing the output
         # tensors, so that we may cut the graph on the output tensors correctly.
         self.devices = set()
         self.devices_tracked = False
+        self.module = module
         for _, tensor in module.state_dict().items():
             self.devices.add(tensor.device.type)
 
@@ -81,18 +131,21 @@ class XLAExecutor:
             for arg in args:
                 if arg.device.type not in self.devices:
                     self.devices.add(arg.device.type)
+
             self.devices = list(self.devices)
             self.devices_tracked = True
-
         output = self.module(*args)
-        # This tells torch-xla to cut the graph at only what is required to
-        # compute all tensors in the `output` list.
-        torch_xla._XLAC._xla_sync_multi(list(output), self.devices, wait=False)
+        torch_xla.sync()
+        if self.options.remove_dummy_io:
+            output = output[:-1]
+
         return output
 
 
 @register_backend(name="tt")
-def xla_backend(gm, example_inputs, options=None):
-
-    module = torch_pass_pipeline(gm, example_inputs)
-    return XLAExecutor(module)
+def xla_backend(gm, example_inputs, options=DynamoBackendOptions(None)):
+    if options.mesh is None:
+        options.mesh = xs.get_global_mesh()
+        assert options.mesh is not None
+    module = torch_pass_pipeline(gm, example_inputs, options)
+    return XLAExecutor(module, options)

--- a/tests/infra/runners/torch_device_runner.py
+++ b/tests/infra/runners/torch_device_runner.py
@@ -57,9 +57,8 @@ class TorchDeviceRunner(DeviceRunner):
             else workload.shard_spec_function(workload.model)
         )
         if shard_specs is not None and device.type != "cpu":
-            assert workload.mesh is not None
             for tensor, shard_spec in shard_specs.items():
-                xs.mark_sharding(tensor, workload.mesh, shard_spec)
+                xs.mark_sharding(tensor, xs.get_global_mesh(), shard_spec)
 
         return Workload(
             framework=workload.framework,

--- a/tests/infra/testers/single_chip/model/model_tester.py
+++ b/tests/infra/testers/single_chip/model/model_tester.py
@@ -74,11 +74,6 @@ class ModelTester(BaseTester, ABC):
         raise NotImplementedError("Subclasses must implement this method.")
 
     @abstractmethod
-    def _get_mesh(self) -> Mesh:
-        """Returns mesh."""
-        raise NotImplementedError("Subclasses must implement this method.")
-
-    @abstractmethod
     def _get_model(self) -> Model:
         """Returns model instance."""
         raise NotImplementedError("Subclasses must implement this method.")

--- a/tests/infra/testers/single_chip/model/model_tester.py
+++ b/tests/infra/testers/single_chip/model/model_tester.py
@@ -67,8 +67,6 @@ class ModelTester(BaseTester, ABC):
         self._cache_model_inputs()
         # Get shard specs.
         self._shard_spec_function = self._get_shard_specs_function()
-        # Get mesh.
-        self._mesh = self._get_mesh()
 
     @abstractmethod
     def _get_shard_specs_function(self) -> Callable[[Model], ShardSpec]:

--- a/tests/infra/testers/single_chip/model/torch_model_tester.py
+++ b/tests/infra/testers/single_chip/model/torch_model_tester.py
@@ -13,6 +13,7 @@ from infra.utilities import Framework
 from infra.workloads import Workload
 
 from .model_tester import ModelTester, RunMode
+import torch_xla.distributed.spmd as xs
 
 
 class TorchModelTester(ModelTester):
@@ -75,7 +76,6 @@ class TorchModelTester(ModelTester):
             framework=self._framework, model=self._model, args=args, kwargs=kwargs
         )
         self._workload.shard_spec_function = self._get_shard_specs_function()
-        self._workload.mesh = self._get_mesh()
 
     # @override
     def _get_forward_method_args(self) -> Sequence[Any]:

--- a/tests/infra/testers/single_chip/model/torch_model_tester.py
+++ b/tests/infra/testers/single_chip/model/torch_model_tester.py
@@ -13,7 +13,6 @@ from infra.utilities import Framework
 from infra.workloads import Workload
 
 from .model_tester import ModelTester, RunMode
-import torch_xla.distributed.spmd as xs
 
 
 class TorchModelTester(ModelTester):

--- a/tests/infra/workloads/workload.py
+++ b/tests/infra/workloads/workload.py
@@ -51,7 +51,6 @@ class Workload:
         self.static_argnames = static_argnames or []
 
         self.shard_spec_function = None
-        self.mesh = None
 
     @property
     def is_jax(self) -> bool:

--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -15,6 +15,7 @@ from tests.utils import BringupStatus, Category
 
 import torch_xla.runtime as xr
 from torch_xla.distributed.spmd import Mesh
+import torch_xla.distributed.spmd as xs
 import numpy as np
 
 
@@ -255,10 +256,12 @@ class DynamicTorchModelTester(TorchModelTester):
 
     def _get_model(self):
         sig = inspect.signature(self.loader.load_model)
-        self._set_global_mesh()
         if "dtype_override" in sig.parameters:
-            return self.loader.load_model(dtype_override=torch.bfloat16)
-        return self.loader.load_model()
+            model = self.loader.load_model(dtype_override=torch.bfloat16)
+        else:
+            model = self.loader.load_model()
+        self._set_global_mesh()
+        return model
 
     def _get_input_activations(self):
         sig = inspect.signature(self.loader.load_inputs)

--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -255,6 +255,7 @@ class DynamicTorchModelTester(TorchModelTester):
 
     def _get_model(self):
         sig = inspect.signature(self.loader.load_model)
+        self._set_global_mesh()
         if "dtype_override" in sig.parameters:
             return self.loader.load_model(dtype_override=torch.bfloat16)
         return self.loader.load_model()
@@ -268,14 +269,14 @@ class DynamicTorchModelTester(TorchModelTester):
     def _get_shard_specs_function(self):
         return self.loader.load_shard_spec
 
-    def _get_mesh(self):
+    def _set_global_mesh(self):
         num_devices = xr.global_runtime_device_count()
         mesh_shape, mesh_names = self.loader.get_mesh_config(num_devices)
         device_ids = np.array(range(num_devices))
         mesh = (
             Mesh(device_ids, mesh_shape, mesh_names) if mesh_shape is not None else None
         )
-        return mesh
+        xs.set_global_mesh(mesh)
 
 
 def setup_models_path(project_root):

--- a/tests/torch/single_chip/test_torch_xla_basic.py
+++ b/tests/torch/single_chip/test_torch_xla_basic.py
@@ -8,8 +8,12 @@ from tests.infra.comparators.comparison_config import (
 )
 import torch
 import torch_xla.core.xla_model as xm
-
+import torch_xla.runtime as xr
+import numpy as np
 import pytest
+import torch_xla.distributed.spmd as xs
+from torch_xla.distributed.spmd import Mesh
+
 
 from infra.comparators.torch_comparator import TorchComparator
 

--- a/tests/torch/single_chip/test_torch_xla_basic.py
+++ b/tests/torch/single_chip/test_torch_xla_basic.py
@@ -8,12 +8,6 @@ from tests.infra.comparators.comparison_config import (
 )
 import torch
 import torch_xla.core.xla_model as xm
-import torch_xla.runtime as xr
-import numpy as np
-import pytest
-import torch_xla.distributed.spmd as xs
-from torch_xla.distributed.spmd import Mesh
-
 
 from infra.comparators.torch_comparator import TorchComparator
 


### PR DESCRIPTION
### Ticket
#1487 

### Problem description
torch-xla does not pass `sdy.mesh` ops when all inputs are replicated even though the mesh size is known. This runs all programs on single chip.

### What's changed
Added a WA to add a dummy passthrough IO to the graph in case of SPMD and all replicated inputs. This can be removed once we add a fix to torch-xla

### Checklist
- [x] New/Existing tests provide coverage for changes
