### PR TITLE
Decrease PCC threshold for hrnet/pytorch-hrnetv2_w48_osmr-full-inference due to nightly regression

### DIFF
--- a/tests/runner/test_config.py
+++ b/tests/runner/test_config.py
@@ -2454,5 +2454,10 @@ test_config = {
     },
     "hrnet/pytorch-hrnetv2_w48_osmr-full-inference": {
         "status": ModelTestStatus.EXPECTED_PASSING,
+        "arch_overrides": {
+            "n150": {
+                "required_pcc": 0.985,  # Decreased Sept 26th - https://github.com/tenstorrent/tt-xla/issues/1491
+            },
+        },
     },
 }


### PR DESCRIPTION
### Ticket
#1491 

### Problem description
- PCC in hrnet/pytorch-hrnetv2_w48_osmr-full-inference (recently added model) dropped slightly for WH from 0.990 to 0.989 on Sept 26 bisected due to commit d1173d8b #1470 

### What's changed
- Seems reasonable and extremely small, decrease PCC threshold from 0.99 to 0.985 for n150

### Checklist
- [x] Tested locally
