### PR TITLE
Pass submesh to optimizer

### DIFF
--- a/src/common/pjrt_implementation/module_builder/module_builder.cc
+++ b/src/common/pjrt_implementation/module_builder/module_builder.cc
@@ -720,9 +720,14 @@ tt_pjrt_status ModuleBuilder::convertFromTTIRToTTNN(
   // order to avoid closing and reopening the device afterwards.
   tt::runtime::Device runtime_device =
       client_instance->getOrCreateMeshDevice(devices_mesh_shape);
+
+  // TODO(odjuricic, #1503): After compile, execution hangs if the parent mesh
+  // is passed to optimizer.
+  tt::runtime::Device submesh_for_optim =
+      tt::runtime::createSubMeshDevice(runtime_device, devices_mesh_shape);
   options.devicePtr =
       std::static_pointer_cast<tt::tt_metal::distributed::MeshDevice>(
-          runtime_device.handle);
+          submesh_for_optim.handle);
   mlir::tt::ttnn::createTTIRToTTNNBackendPipeline(ttir_to_ttnn_pm, options);
 
   enableVerboseIRPrinting(ttir_to_ttnn_pm);


### PR DESCRIPTION
### Problem description
Execution with optimizer and program cache hangs

### What's changed
Pass a submesh instead of the parent mesh to optimizer.

Further investigation is needed: https://github.com/tenstorrent/tt-xla/issues/1503
