### PR TITLE
Add decomposition for clamp const inputs

### DIFF
--- a/python_package/tt_torch/backend/decompositions.py
+++ b/python_package/tt_torch/backend/decompositions.py
@@ -273,7 +273,6 @@ def create_constant_tensor(scalar, dtype, device):
 # If possible, we will represent min/max values as tensors which will be lowered as constants.
 # NOTE: see `create_constant_tensor()`
 def clamp(input, min_val=None, max_val=None):
-def clamp(input, min_val=None, max_val=None):
     if (
         min_val is not None
         and type(min_val) == int

--- a/python_package/tt_torch/backend/decompositions.py
+++ b/python_package/tt_torch/backend/decompositions.py
@@ -269,7 +269,10 @@ def create_constant_tensor(scalar, dtype, device):
     return result
 
 
-# If clamp inputs are integers or floats, convert them to tensors.
+# Decomposition needed because min/max values don't get lowered to constants properly.
+# If possible, we will represent min/max values as tensors which will be lowered as constants.
+# NOTE: see `create_constant_tensor()`
+def clamp(input, min_val=None, max_val=None):
 def clamp(input, min_val=None, max_val=None):
     if (
         min_val is not None


### PR DESCRIPTION
### Problem description
Because torch constants created with `torch.ops.aten.scalar_tensor(x)` (where x!=0 and x!=1) are lowered to vhlo as graph inputs we are not able to perform fusing in mlir. This causes performance problems. The issue for this is here: https://github.com/tenstorrent/tt-xla/issues/1519

### What's changed
Add a decomposition in torch passes to represent integer constants as additions for multiple ones. This gets optimized insto a single `vhlo.constant` later.

### Checklist
- [ ] New/Existing tests provide coverage for changes
