### PR TITLE
Add infra to enable trace, add resnet50 trace test

### DIFF
--- a/examples/pytorch/mnist_trace.py
+++ b/examples/pytorch/mnist_trace.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+os.environ["TT_RUNTIME_ENABLE_PROGRAM_CACHE"] = "1"
+os.environ["TT_RUNTIME_TRACE_REGION_SIZE"] = "10000000"
+
+import torch
+import torch_xla
+import torch_xla.core.xla_model as xm
+import torch_xla.runtime as xr
+
+from tests.torch.single_chip.models.mnist.cnn.dropout.model_implementation import (
+    MNISTCNNDropoutModel,
+)
+
+
+# --------------------------------
+# Test run
+# --------------------------------
+def mnist_trace():
+    options = {
+        "enable_optimizer": "true",
+        "enable_trace": "true",
+    }
+
+    torch_xla.set_custom_compile_options(options)
+
+    # Instantiate model.
+    model: torch.nn.Module = MNISTCNNDropoutModel().to(dtype=torch.bfloat16)
+
+    # Put it in inference mode and compile it.
+    model = model.eval()
+    model.compile(backend="tt")
+
+    # Generate inputs.
+    input = torch.ones((4, 1, 28, 28), dtype=torch.bfloat16)
+
+    # Connect the device.
+    device = xm.xla_device()
+
+    # Move inputs and model to device.
+    input = input.to(device)
+    model = model.to(device)
+
+    # Run model (with no gradient calculation since we only need inference).
+    with torch.no_grad():
+        output = model(input)
+
+    print(output)
+
+
+# --------------------------------
+# main
+# --------------------------------
+if __name__ == "__main__":
+    # By default torch_xla uses the CPU device so we have to set it to TT device.
+    xr.set_device_type("TT")
+
+    mnist_trace()

--- a/inc/common/pjrt_implementation/compile_options.h
+++ b/inc/common/pjrt_implementation/compile_options.h
@@ -57,6 +57,13 @@ struct CompileOptions {
   // Backend runtime which should be targeted for compilation and execution.
   BackendRuntime backend = BackendRuntime::TTNNFlatbuffer;
 
+  // Enables trace hoisting for TTNN pipeline.
+  // This is supported only when all non-consteval ops are on device.
+  // This is a performance optimization feature that will eliminate
+  // host overhead for creating and dispatching operations
+  // that are repeated multiple times.
+  bool enable_trace = false;
+
   static CompileOptions
   parse(const std::unordered_map<std::string, std::string> &compile_options);
 };

--- a/src/common/pjrt_implementation/client_instance.cc
+++ b/src/common/pjrt_implementation/client_instance.cc
@@ -420,9 +420,19 @@ ClientInstance::openMeshDevice(const std::vector<uint32_t> &mesh_shape) {
       std::getenv("TT_RUNTIME_ENABLE_PROGRAM_CACHE") != nullptr &&
       std::string(std::getenv("TT_RUNTIME_ENABLE_PROGRAM_CACHE")) == "1";
 
+  // TODO(jnie-TT, #1485): This is a temporary way to set trace region size
+  // until we have a proper way for a user to pass device options. After that
+  // this should be removed. Issue for device options:
+  // https://github.com/tenstorrent/tt-xla/issues/1480
+  std::optional<size_t> traceRegionSize = std::nullopt;
+  if (std::getenv("TT_RUNTIME_TRACE_REGION_SIZE") != nullptr) {
+    traceRegionSize = std::stoull(std::getenv("TT_RUNTIME_TRACE_REGION_SIZE"));
+  }
+
   tt::runtime::MeshDeviceOptions options = tt::runtime::MeshDeviceOptions{
       .enableProgramCache = enableProgramCache,
       .meshShape = mesh_shape,
+      .traceRegionSize = traceRegionSize,
   };
 
   return tt::runtime::openMeshDevice(options);

--- a/src/common/pjrt_implementation/compile_options.cc
+++ b/src/common/pjrt_implementation/compile_options.cc
@@ -34,6 +34,9 @@ CompileOptions CompileOptions::parse(
           .value_or(false);
   options.backend = internal::parseBackendOption(compile_options, "backend")
                         .value_or(BackendRuntime::TTNNFlatbuffer);
+  options.enable_trace =
+      internal::parseBoolOption(compile_options, "enable_trace")
+          .value_or(false);
 
   return options;
 }

--- a/src/common/pjrt_implementation/executable_image.cc
+++ b/src/common/pjrt_implementation/executable_image.cc
@@ -253,6 +253,7 @@ std::string ExecutableImage::generateFingerprint() const {
   data_to_hash << "enable_fusing_conv2d_with_multiply_pattern:"
                << m_compile_options.enable_fusing_conv2d_with_multiply_pattern
                << "\n";
+  data_to_hash << "enable_trace:" << m_compile_options.enable_trace << "\n";
 
   return data_to_hash.str();
 }

--- a/src/common/pjrt_implementation/module_builder/module_builder.cc
+++ b/src/common/pjrt_implementation/module_builder/module_builder.cc
@@ -712,6 +712,7 @@ tt_pjrt_status ModuleBuilder::convertFromTTIRToTTNN(
   options.enableBfp8Conversion = compile_options.enable_bfp8_conversion;
   options.enableFusingConv2dWithMultiplyPattern =
       compile_options.enable_fusing_conv2d_with_multiply_pattern;
+  options.enableTrace = compile_options.enable_trace;
   options.systemDescPath = system_descriptor_path.data();
 
   if (devices_mesh_shape.size() != 2) {

--- a/tests/infra/testers/compiler_config.py
+++ b/tests/infra/testers/compiler_config.py
@@ -41,6 +41,9 @@ class CompilerConfig:
     # issue https://github.com/tenstorrent/tt-mlir/issues/4628 is fixed.
     enable_fusing_conv2d_with_multiply_pattern: bool = False
 
+    # Enables trace hoisting for TTNN pipeline.
+    enable_trace: bool = False
+
     def to_jax_compiler_options(self) -> Dict[str, str]:
         """
         Convert CompilerConfig to JAX compiler_options dictionary format.
@@ -64,6 +67,9 @@ class CompilerConfig:
 
         if self.enable_fusing_conv2d_with_multiply_pattern:
             options["enable_fusing_conv2d_with_multiply_pattern"] = "true"
+
+        if self.enable_trace:
+            options["enable_trace"] = "true"
 
         return options
 

--- a/tests/torch/single_chip/models/resnet/test_resnet.py
+++ b/tests/torch/single_chip/models/resnet/test_resnet.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+from pytest import MonkeyPatch
 from infra import Framework, RunMode
 from utils import (
     BringupStatus,
@@ -40,6 +41,15 @@ def inference_tester() -> ResnetTester:
 
 
 @pytest.fixture
+def trace_tester(monkeypatch: MonkeyPatch) -> ResnetTester:
+    monkeypatch.setenv("TT_RUNTIME_ENABLE_PROGRAM_CACHE", "1")
+    monkeypatch.setenv("TT_RUNTIME_TRACE_REGION_SIZE", "10000000")
+
+    compiler_config = CompilerConfig(enable_optimizer=True, enable_trace=True)
+    return ResnetTester(VARIANT_NAME, compiler_config=compiler_config)
+
+
+@pytest.fixture
 def training_tester() -> ResnetTester:
     return ResnetTester(VARIANT_NAME, run_mode=RunMode.TRAINING)
 
@@ -64,6 +74,25 @@ def training_tester() -> ResnetTester:
 )
 def test_torch_resnet_inference(inference_tester: ResnetTester):
     inference_tester.test()
+
+
+@pytest.mark.push
+@pytest.mark.model_test
+@pytest.mark.record_test_properties(
+    category=Category.MODEL_TEST,
+    model_name=MODEL_NAME,
+    model_group=ModelGroup.GENERALITY,
+    run_mode=RunMode.INFERENCE,
+    bringup_status=BringupStatus.INCORRECT_RESULT,
+)
+@pytest.mark.xfail(
+    reason=incorrect_result(
+        "PCC comparison failed. Calculated: pcc=nan. Required: pcc=0.99 "
+        "https://github.com/tenstorrent/tt-xla/issues/1384"
+    )
+)
+def test_torch_resnet_inference_trace(trace_tester: ResnetTester):
+    trace_tester.test()
 
 
 @pytest.mark.nightly


### PR DESCRIPTION
### Ticket
Related to #1098 

### Problem description
We want to enable trace for performance-critical models

### What's changed
* Added infra to enable trace e2e.
* Added Resnet50 trace test

### TODOs
* Add tests for other performance-critical models and fix any issues along the way
* Once runtime stitching is supported we should add multi-loop support to our testing infra such that we can test trace replay as well. 

FYI @odjuricicTT 

### Checklist
- [X] New/Existing tests provide coverage for changes
