### PR TITLE
[pytest] mark xpass tests as failed

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,8 @@
 [pytest]
 
+# Fail on xpassed
+xfail_strict=true
+
 markers =
     push: marks tests as push, to be executed on PR pipeline
     nightly: marks tests as nightly, to be executed on nightly pipeline


### PR DESCRIPTION
### Problem description
`@pytest.mark.xfail` hides expected failures, but when such test unexpectedly passes (XPASS), its still treated as success. This lets stale `xfails` accumulate.

### What's changed
Enabled `xfail_strict = true` so XPASS is now treated as a test failure.
