### PR TITLE
Lower PCC from 0.99 to 0.985 for hrnet/pytorch-hrnetv2_w48_osmr-full-inference in BH to match WH

### DIFF
--- a/tests/runner/test_config/test_config_inference.py
+++ b/tests/runner/test_config/test_config_inference.py
@@ -2433,11 +2433,9 @@ test_config = {
         "bringup_status": BringupStatus.FAILED_RUNTIME,
     },
     "hrnet/pytorch-hrnetv2_w48_osmr-full-inference": {
+        "assert_pcc": False,
         "status": ModelTestStatus.EXPECTED_PASSING,
-        "arch_overrides": {
-            "n150": {
-                "required_pcc": 0.985,  # Decreased Sept 26th - https://github.com/tenstorrent/tt-xla/issues/1491
-            },
-        },
+        "reason": "PCC failure - https://github.com/tenstorrent/tt-xla/issues/1491",
+        "bringup_status": BringupStatus.INCORRECT_RESULT,
     },
 }

--- a/tests/runner/test_config/test_config_inference.py
+++ b/tests/runner/test_config/test_config_inference.py
@@ -2433,9 +2433,7 @@ test_config = {
         "bringup_status": BringupStatus.FAILED_RUNTIME,
     },
     "hrnet/pytorch-hrnetv2_w48_osmr-full-inference": {
-        "assert_pcc": False,
+        "required_pcc": 0.985,  # https://github.com/tenstorrent/tt-xla/issues/1491
         "status": ModelTestStatus.EXPECTED_PASSING,
-        "reason": "PCC failure - https://github.com/tenstorrent/tt-xla/issues/1491",
-        "bringup_status": BringupStatus.INCORRECT_RESULT,
     },
 }


### PR DESCRIPTION
Currently, `hrnet/pytorch-hrnetv2_w48_osmr-full-inference` is failing due to incorrect PCC, so changing tests/runner/test_config.py to xfail that file.

Edit: After offline talk with @kmabeeTT , just lowered the PCC threshold to match the n150 one, as they are now exactly the same, and he already pinpointed the reason for the drop in issue: https://github.com/tenstorrent/tt-xla/issues/1491