### PR TITLE
Convert timeout value to a number in call-test workflow

### DIFF
--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -98,6 +98,7 @@ jobs:
         sparse-checkout: |
           .gitmodules
           .test_durations
+          pytest.ini
           python_package/requirements.txt
           tests
           venv

--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -279,8 +279,9 @@ jobs:
         # multiply the estimate with 3 until estimates are more precise
         ESTIMATED_DURATION=$((ESTIMATED_DURATION * 3 / 60))
 
-        if [ $ESTIMATED_DURATION -lt 30 ]; then
-          ESTIMATED_DURATION=30
+        MIN_TEST_DURATION=30
+        if [ $ESTIMATED_DURATION -lt $MIN_TEST_DURATION ]; then
+          ESTIMATED_DURATION=$MIN_TEST_DURATION
         fi
 
         echo "timeout-minutes=$ESTIMATED_DURATION" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -281,7 +281,7 @@ jobs:
         echo "timeout-minutes=$ESTIMATED_DURATION" >> "$GITHUB_OUTPUT"
 
     - name: Run tests
-      timeout-minutes: ${{ steps.collect-tests.outputs.timeout-minutes }}
+      timeout-minutes: ${{ fromJson(steps.collect-tests.outputs.timeout-minutes) }}
       env:
         HF_HOME: /mnt/dockercache/huggingface
         GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -279,6 +279,10 @@ jobs:
         # multiply the estimate with 3 until estimates are more precise
         ESTIMATED_DURATION=$((ESTIMATED_DURATION * 3 / 60))
 
+        if [ $ESTIMATED_DURATION -lt 30 ]; then
+          ESTIMATED_DURATION=30
+        fi
+
         echo "timeout-minutes=$ESTIMATED_DURATION" >> "$GITHUB_OUTPUT"
 
     - name: Run tests


### PR DESCRIPTION
### Ticket
/

### Problem description
The `Run tests` step throws a warning and it's `timeout-minutes` fallbacks to the default value (360).
This is because `timeout-minutes` input needs a value in number format.
Currently we are passing a string (i.e. '5', '20').

### What's changed
`fromJson()` is added to convert the string representation of a number to a number. ([fromJson docs](https://docs.github.com/en/enterprise-cloud@latest/actions/reference/workflows-and-actions/expressions#fromjson))

### Checklist
- [ ] New/Existing tests provide coverage for changes

### Example
[Example job proving that the warning is gone](https://github.com/tenstorrent/tt-xla/actions/runs/18184873304/job/51767577911)
[Example job proving that the timeout is working](https://github.com/tenstorrent/tt-xla/actions/runs/18185317790/job/51768760590)
