### PR TITLE
Skipping optimizer test in nightly CI

### DIFF
--- a/tests/jax/single_chip/models/resnet_v1_5/resnet_26/test_resnet_26.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/resnet_26/test_resnet_26.py
@@ -87,7 +87,7 @@ def test_resnet_v1_5_26_training(training_tester: ResNetTester):
 )
 @pytest.mark.skip(
     reason=failed_runtime(
-        "Optimizer test hangs as part of a test suite - works when run standalone ",
+        "Optimizer test hangs as part of a test suite - works when run standalone "
         "https://github.com/tenstorrent/tt-xla/issues/1547",
     )
 )

--- a/tests/jax/single_chip/models/resnet_v1_5/resnet_26/test_resnet_26.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/resnet_26/test_resnet_26.py
@@ -85,10 +85,10 @@ def test_resnet_v1_5_26_training(training_tester: ResNetTester):
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
 )
-@pytest.mark.xfail(
+@pytest.mark.skip(
     reason=failed_runtime(
-        "Float32 not supported for ttnn.maxpool_2d op "
-        "https://github.com/tenstorrent/tt-xla/issues/941"
+        "Optimizer test hangs as part of a test suite - works when run standalone ",
+        "https://github.com/tenstorrent/tt-xla/issues/1547",
     )
 )
 def test_resnet_v1_5_26_inference_optimizer(inference_tester_optimizer: ResNetTester):


### PR DESCRIPTION
Optimizer test currently hangs in our nightly CI, skipping them while we debug the issue.