### PR TITLE
Remove decomp for clamp, tell torch_xla to treat all scalars as constants

### DIFF
--- a/python_package/torch_plugin_tt/__init__.py
+++ b/python_package/torch_plugin_tt/__init__.py
@@ -11,6 +11,8 @@ from pjrt_plugin_tt import get_library_path, setup_tt_metal_home
 import torch
 import tt_torch  # registers "tt" backend for torch.compile
 
+import torch_xla
+
 
 class TTPlugin(DevicePlugin):
     """
@@ -36,6 +38,7 @@ class TTPlugin(DevicePlugin):
         print(
             f"WARNING: TT plugin is setting XLA_STABLEHLO_COMPILE to 1. This is required for TT PJRT plugin to work correctly."
         )
+        torch_xla._XLAC._set_xla_all_numbers_special_scalars(True)
 
     def library_path(self) -> str:
         """Return the path to the TT PJRT plugin binary."""

--- a/python_package/tt_torch/backend/decompositions.py
+++ b/python_package/tt_torch/backend/decompositions.py
@@ -257,44 +257,6 @@ def squeeze(input, dims):
     return input.reshape(newshape)
 
 
-# TODO(#1519): Constants other then 0 and 1 get lowered to vhlo as inputs.
-# Workaround this by adding 1s together which gets optimized out as a single constant later.
-def create_constant_tensor(scalar, dtype, device):
-    result = torch.ops.aten.scalar_tensor(0)
-    result = result.to(dtype).to(device)
-    ones = torch.ops.aten.scalar_tensor(1)
-    ones = ones.to(dtype).to(device)
-    for _ in range(int(scalar)):
-        result = result + ones
-    return result
-
-
-# Decomposition needed because min/max values don't get lowered to constants properly.
-# If possible, we will represent min/max values as tensors which will be lowered as constants.
-# NOTE: see `create_constant_tensor()`
-def clamp(input, min_val=None, max_val=None):
-    if (
-        min_val is not None
-        and type(min_val) == int
-        or type(min_val) == float
-        and min_val.is_integer()
-    ):
-        min_val = create_constant_tensor(min_val, input.dtype, input.device)
-    if (
-        max_val is not None
-        and type(max_val) == int
-        or type(max_val) == float
-        and max_val.is_integer()
-    ):
-        max_val = create_constant_tensor(max_val, input.dtype, input.device)
-
-    return torch.clamp(input, min_val, max_val)
-
-
-def hardtanh(input, min_val, max_val):
-    return clamp(input, min_val, max_val)
-
-
 # TODO: DO we ever need this?
 def _get_default_decomposition_ops() -> DecompositionOpsList:
     aten = torch.ops.aten
@@ -352,8 +314,6 @@ def _get_custom_decompositions() -> DecompositionTable:
         aten.split_with_sizes.default: split_with_sizes,
         aten.masked_fill.Tensor: masked_fill_tensor,
         torch.ops.prims.squeeze.default: squeeze,
-        aten.hardtanh.default: hardtanh,
-        aten.clamp.default: clamp,
     }
 
 

--- a/tests/torch/single_chip/test_torch_xla_basic.py
+++ b/tests/torch/single_chip/test_torch_xla_basic.py
@@ -75,6 +75,29 @@ def test_simple_mm_eager(bias):
     comparator.compare(output, golden)
 
 
+def test_relu6():
+    class Relu6(torch.nn.Module):
+        def forward(self, x):
+            return torch.nn.functional.relu6(x)
+
+    input_x = torch.randn(32, 32, dtype=torch.bfloat16)
+
+    model = Relu6()
+    golden = model(input_x)
+
+    device = xm.xla_device()
+    model = torch.compile(model.to(device), backend="tt")
+
+    output = model(input_x.to(device))
+
+    comparator = TorchComparator(
+        ComparisonConfig(
+            atol=AtolConfig(required_atol=0.02),
+        )
+    )
+    comparator.compare(output, golden)
+
+
 def test_silu():
     class Silu(torch.nn.Module):
         def forward(self, x):
@@ -115,6 +138,29 @@ def test_silu_with_dtype_promotion():
     comparator = TorchComparator(
         ComparisonConfig(
             atol=AtolConfig(required_atol=0.04),
+        )
+    )
+    comparator.compare(output, golden)
+
+
+def test_relu6():
+    class Relu6(torch.nn.Module):
+        def forward(self, x):
+            return torch.nn.functional.relu6(x)
+
+    input_x = torch.randn(32, 32, dtype=torch.bfloat16)
+
+    model = Relu6()
+    golden = model(input_x)
+
+    device = xm.xla_device()
+    model = torch.compile(model.to(device), backend="tt")
+
+    output = model(input_x.to(device))
+
+    comparator = TorchComparator(
+        ComparisonConfig(
+            atol=AtolConfig(required_atol=0.02),
         )
     )
     comparator.compare(output, golden)


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/1519)

### Problem description
Constant scalars (other than 0 and 1) were being issued by torch-xla as args, and not being inlined in the graph. 

### What's changed
Added `torch_xla._XLAC._set_xla_all_numbers_special_scalars(True)` to inline all scalars. Removed decomposition of clamp op which did effectively the same thing. 
Added test_relu6 which now produces:

```
module @SyncTensorsGraph.11 attributes {mhlo.cross_program_prefetches = [], mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
  func.func @main(%arg0: tensor<32x32xbf16> loc("xla__device_data")) -> tensor<32x32xbf16> {
    %cst = stablehlo.constant dense<6.000000e+00> : tensor<32x32xbf16> loc(#loc)
    %cst_0 = stablehlo.constant dense<0.000000e+00> : tensor<32x32xbf16> loc(#loc2)
    %0 = stablehlo.reshape %arg0 : (tensor<32x32xbf16>) -> tensor<1x32x32xbf16> loc(#loc3)
    %1 = stablehlo.custom_call @tt.mark_argument(%0) {api_version = 0 : i32, mhlo.frontend_attributes = {ttcore.argument_type = "input", ttir.name = "args_0"}} : (tensor<1x32x32xbf16>) -> tensor<1x32x32xbf16> loc(#loc4)
    %2 = stablehlo.reshape %1 : (tensor<1x32x32xbf16>) -> tensor<32x32xbf16> loc(#loc3)
    %3 = stablehlo.clamp %cst_0, %2, %cst : tensor<32x32xbf16> loc(#loc2)
    return %3 : tensor<32x32xbf16> loc(#loc)
  } loc(#loc)
} loc(#loc)
```

Instead of:
```
module @SyncTensorsGraph.11 attributes {mhlo.cross_program_prefetches = [], mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
  func.func @main(%arg0: tensor<bf16> loc("xla__device_data"), %arg1: tensor<32x32xbf16> loc("xla__device_data")) -> tensor<32x32xbf16> {
    %cst = stablehlo.constant dense<0.000000e+00> : tensor<32x32xbf16> loc(#loc2)
    %0 = stablehlo.reshape %arg1 : (tensor<32x32xbf16>) -> tensor<1x32x32xbf16> loc(#loc3)
    %1 = stablehlo.custom_call @tt.mark_argument(%0) {api_version = 0 : i32, mhlo.frontend_attributes = {ttcore.argument_type = "input", ttir.name = "args_0"}} : (tensor<1x32x32xbf16>) -> tensor<1x32x32xbf16> loc(#loc4)
    %2 = stablehlo.reshape %1 : (tensor<1x32x32xbf16>) -> tensor<32x32xbf16> loc(#loc3)
    %3 = stablehlo.broadcast_in_dim %arg0, dims = [] : (tensor<bf16>) -> tensor<32x32xbf16> loc(#loc2)
    %4 = stablehlo.clamp %cst, %2, %3 : tensor<32x32xbf16> loc(#loc2)
    return %4 : tensor<32x32xbf16> loc(#loc)
  } loc(#loc)
} loc(#loc)
```

### Checklist
- [ ] New/Existing tests provide coverage for changes

We need #1535 to be able to validate IR from the FE to properly test these things. 
