### PR TITLE
Set mesh attr to shlo graph in spmd mode

### DIFF
--- a/.github/workflows/test-matrix-presets/basic-test-nightly.json
+++ b/.github/workflows/test-matrix-presets/basic-test-nightly.json
@@ -6,6 +6,7 @@
   { "runs-on": "p150",               "name": "run_torch",             "dir": "./tests/torch/single_chip",               "test-mark": "nightly"  },
   { "runs-on": "p150",               "name": "run_large_jax_models",  "dir": "./tests/jax/single_chip",                 "test-mark": "nightly and large", "shared-runners": "true" },
   { "runs-on": "n300",               "name": "run_jax",               "dir": "./tests/jax/multi_chip/n300",             "test-mark": "nightly", "codecov": "true" },
+  { "runs-on": "n300",               "name": "run_torch",             "dir": "./tests/torch/multi_chip/n300",           "test-mark": "nightly"  },
   { "runs-on": "n300-llmbox",        "name": "run_jax_4_devices",     "dir": "./tests/jax/multi_chip/llmbox/4_devices", "test-mark": "nightly", "shared-runners": "true" },
   { "runs-on": "n300-llmbox",        "name": "run_jax_8_devices",     "dir": "./tests/jax/multi_chip/llmbox/8_devices", "test-mark": "nightly", "shared-runners": "true" }
 ]

--- a/.github/workflows/test-matrix-presets/basic-test.json
+++ b/.github/workflows/test-matrix-presets/basic-test.json
@@ -6,6 +6,7 @@
   { "runs-on": "p150",               "name": "run_torch",             "dir": "./tests/torch/single_chip",               "test-mark": "push", "parallel-groups": 3  },
   { "runs-on": "p150",               "name": "run_large_jax_models",  "dir": "./tests/jax/single_chip",                 "test-mark": "push and large", "shared-runners": "true" },
   { "runs-on": "n300",               "name": "run_jax",               "dir": "./tests/jax/multi_chip/n300",             "test-mark": "push", "codecov": "true" },
+  { "runs-on": "n300",               "name": "run_torch",             "dir": "./tests/torch/multi_chip/n300",           "test-mark": "push" },
   { "runs-on": "n300-llmbox",        "name": "run_jax_4_devices",     "dir": "./tests/jax/multi_chip/llmbox/4_devices", "test-mark": "push", "shared-runners": "true" },
   { "runs-on": "n300-llmbox",        "name": "run_jax_8_devices",     "dir": "./tests/jax/multi_chip/llmbox/8_devices", "test-mark": "push", "shared-runners": "true" }
 ]

--- a/.github/workflows/test-matrix-presets/model-test-full.json
+++ b/.github/workflows/test-matrix-presets/model-test-full.json
@@ -6,6 +6,7 @@
     { "runs-on": "p150",        "name": "run_torch",            "dir": "./tests/torch/single_chip", "test-mark": "model_test", "parallel-groups": 3 },
     { "runs-on": "p150",        "name": "run_large_jax_models", "dir": "./tests/jax/single_chip", "test-mark": "model_test and large", "shared-runners": "true", "parallel-groups": 3 },
     { "runs-on": "n300",        "name": "run_jax",              "dir": "./tests/jax/multi_chip/n300", "test-mark": "model_test" },
+    { "runs-on": "n300",        "name": "run_torch",            "dir": "./tests/torch/multi_chip/n300", "test-mark": "model_test" },
     { "runs-on": "n300-llmbox", "name": "run_jax_4_devices",    "dir": "./tests/jax/multi_chip/llmbox/4_devices", "test-mark": "model_test", "shared-runners": "true" },
     { "runs-on": "n300-llmbox", "name": "run_jax_8_devices",    "dir": "./tests/jax/multi_chip/llmbox/8_devices", "test-mark": "model_test", "shared-runners": "true" }
 ]

--- a/inc/common/pjrt_implementation/module_builder/frontend_passes/shlo_set_proper_sdy_mesh_attribute.h
+++ b/inc/common/pjrt_implementation/module_builder/frontend_passes/shlo_set_proper_sdy_mesh_attribute.h
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#ifndef TT_XLA_INC_COMMON_PJRT_IMPLEMENTATION_MODULE_BUILDER_FRONTEND_PASSES_SHLO_SET_PROPER_SDY_MESH_ATTRIBUTE_H_
+#define TT_XLA_INC_COMMON_PJRT_IMPLEMENTATION_MODULE_BUILDER_FRONTEND_PASSES_SHLO_SET_PROPER_SDY_MESH_ATTRIBUTE_H_
+
+// llvm mlir includes
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/OwningOpRef.h"
+
+// tt-xla includes
+#include "common/status.h"
+
+namespace tt::pjrt::module_builder::frontend_passes {
+// In torch using SPMD mode, a fully replicated graph may default to a
+// degenerate mesh [1,1], which is not what we want—every device should run with
+// the same inputs/weights. This function detects that case and rewrites the
+// mesh to [1, num_devices] so fully replicated graphs execute as intended.
+tt_pjrt_status setProperSdyMeshAttributeInSpmdMode(
+    mlir::OwningOpRef<mlir::ModuleOp> &mlir_module);
+
+namespace internal {
+// Checks whether the graph is in SPMD mode.
+// If its arguments contain the "mhlo.sharding" attribute, it is considered to
+// be in SPMD mode.
+bool isSpmdMode(const mlir::OwningOpRef<mlir::ModuleOp> &module);
+
+} // namespace internal
+
+} // namespace tt::pjrt::module_builder::frontend_passes
+
+#endif // TT_XLA_INC_COMMON_PJRT_IMPLEMENTATION_MODULE_BUILDER_FRONTEND_PASSES_SHLO_SET_PROPER_SDY_MESH_ATTRIBUTE_H_

--- a/inc/common/pjrt_implementation/module_builder/module_builder.h
+++ b/inc/common/pjrt_implementation/module_builder/module_builder.h
@@ -71,6 +71,12 @@ public:
       const std::unordered_map<std::string, std::string> &compile_options,
       tt::pjrt::ClientInstance *client_instance);
 
+  // Gets the first sdy.Mesh op of a mlir module with shardy dialect enbaled.
+  // Could be used to extract mesh attribute from the module so we can use it as
+  // a utility function.
+  static std::optional<mlir::sdy::MeshOp>
+  getFirstShardyMeshOp(const mlir::OwningOpRef<mlir::ModuleOp> &module);
+
 private:
   // Creates VHLO module from the input program code.
   tt_pjrt_status
@@ -222,10 +228,6 @@ private:
   // Gets all public functions from the module.
   static std::vector<mlir::func::FuncOp>
   getPublicFuncOps(const mlir::OwningOpRef<mlir::ModuleOp> &module);
-
-  // Gets the first sdy.Mesh op of a mlir module with shardy dialect enbaled.
-  static std::optional<mlir::sdy::MeshOp>
-  getFirstShardyMeshOp(const mlir::OwningOpRef<mlir::ModuleOp> &module);
 
   // Builds module for TTNN Flatbuffer backend runtime.
   std::tuple<tt_pjrt_status, std::shared_ptr<ExecutableImage>>

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -46,6 +46,7 @@ add_library(TTPJRTCommon
     "pjrt_implementation/memory_instance.cc"
     "pjrt_implementation/compile_options.cc"
     "pjrt_implementation/module_builder/frontend_passes/shlo_input_role_propagation.cc"
+    "pjrt_implementation/module_builder/frontend_passes/shlo_set_proper_sdy_mesh_attribute.cc"
     "pjrt_implementation/module_builder/module_builder.cc"
     "pjrt_implementation/serialized_executable_instance.cc"
 )

--- a/src/common/pjrt_implementation/module_builder/frontend_passes/shlo_set_proper_sdy_mesh_attribute.cc
+++ b/src/common/pjrt_implementation/module_builder/frontend_passes/shlo_set_proper_sdy_mesh_attribute.cc
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "common/pjrt_implementation/module_builder/frontend_passes/shlo_set_proper_sdy_mesh_attribute.h"
+
+// shardy includes
+#include "shardy/dialect/sdy/ir/dialect.h"
+
+// tt-mlir includes
+#define TTMLIR_ENABLE_STABLEHLO 1
+#include "tt/runtime/runtime.h"
+#include "ttmlir/Dialect/StableHLO/Utils/GSPMDUtils.h"
+
+// tt-xla includes
+#include "common/pjrt_implementation/module_builder/module_builder.h"
+
+namespace tt::pjrt::module_builder::frontend_passes {
+tt_pjrt_status setProperSdyMeshAttributeInSpmdMode(
+    mlir::OwningOpRef<mlir::ModuleOp> &mlir_module) {
+  if (!internal::isSpmdMode(mlir_module)) {
+    return tt_pjrt_status::kSuccess;
+  }
+
+  auto shardy_op = ModuleBuilder::getFirstShardyMeshOp(mlir_module);
+  if (shardy_op.has_value()) {
+    mlir::sdy::MeshAttr mesh_attr = shardy_op->getMesh();
+    auto ctx = mlir_module->getContext();
+    llvm::SmallVector<mlir::sdy::MeshAxisAttr> new_axes;
+    for (auto [i, axis] : llvm::enumerate(mesh_attr.getAxes())) {
+      if (axis.getSize() > 1) {
+        // This axis already has a non-trivial size; leave the mesh as-is.
+        return tt_pjrt_status::kSuccess;
+      }
+      if (i == mesh_attr.getAxes().size() - 1) {
+        // We use the last axis to encode the mesh shape (e.g., [1,
+        // num_devices]).
+        new_axes.push_back(mlir::sdy::MeshAxisAttr::get(
+            ctx, axis.getName(), tt::runtime::getNumAvailableDevices()));
+      } else {
+        new_axes.push_back(axis);
+      }
+    }
+
+    DLOG_F(LOG_DEBUG,
+           "SPMD-enabled mesh has trivial size [1, 1], reshaping to [1, %ld]",
+           tt::runtime::getNumAvailableDevices());
+
+    // Replace the mesh on the op with the updated axes.
+    shardy_op->setMeshAttr(mlir::sdy::MeshAttr::get(ctx, new_axes));
+  }
+
+  return tt_pjrt_status::kSuccess;
+}
+
+namespace internal {
+// Checks whether the graph is in SPMD mode.
+bool isSpmdMode(const mlir::OwningOpRef<mlir::ModuleOp> &module) {
+  bool spmd = false;
+  module.get().walk([&](mlir::func::FuncOp func) {
+    if (func.getNumArguments() &&
+        func.getArgAttr(0, mlir::tt::gspmd_utils::kXlaShardingAttr)) {
+      spmd = true;
+      return mlir::WalkResult::interrupt();
+    }
+    return mlir::WalkResult::advance();
+  });
+
+  return spmd;
+}
+} // namespace internal
+} // namespace tt::pjrt::module_builder::frontend_passes

--- a/src/common/pjrt_implementation/module_builder/module_builder.cc
+++ b/src/common/pjrt_implementation/module_builder/module_builder.cc
@@ -63,6 +63,7 @@
 #include "common/pjrt_implementation/executable_image.h"
 #include "common/pjrt_implementation/memory_instance.h"
 #include "common/pjrt_implementation/module_builder/frontend_passes/shlo_input_role_propagation.h"
+#include "common/pjrt_implementation/module_builder/frontend_passes/shlo_set_proper_sdy_mesh_attribute.h"
 #include "common/status.h"
 #include "xla/pjrt/c/pjrt_c_api.h"
 
@@ -574,6 +575,12 @@ tt_pjrt_status ModuleBuilder::runCompilerStableHLOPipeline(
 
   DLOG_F(LOG_DEBUG, "SHLO Module after compiler StableHLO pipeline:");
   printModule(mlir_module);
+
+  if (!tt_pjrt_status_is_ok(
+          frontend_passes::setProperSdyMeshAttributeInSpmdMode(mlir_module))) {
+    DLOG_F(ERROR, "Failed to set proper sdy.mesh attribute in SPMD mode");
+    return tt_pjrt_status::kInternal;
+  }
 
   return tt_pjrt_status::kSuccess;
 }

--- a/tests/torch/multi_chip/n300/test_torch_xla_multichip_basic.py
+++ b/tests/torch/multi_chip/n300/test_torch_xla_multichip_basic.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import pytest
+from tests.infra import TorchModelTester, RunMode
+import torch_xla
+import torch_xla.core.xla_model as xm
+import torch_xla.runtime as xr
+import torch_xla.distributed.spmd as xs
+from torch_xla.distributed.spmd import Mesh
+import numpy as np
+
+
+class TorchMultichipUnaryModelTester(TorchModelTester):
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        input_shape: tuple,
+        mesh: Mesh,
+        shard_spec_fn=None,
+    ) -> None:
+        self._this_model = model
+        self._input_shape = input_shape
+        self._mesh = mesh
+        self._shard_spec_fn = shard_spec_fn
+        super().__init__()
+
+    def _get_input_activations(self):
+        if self._input_activations is None:
+            self._input_activations = {"input": torch.randn(self._input_shape)}
+        return self._input_activations
+
+    def _get_model(self):
+        return self._this_model
+
+    def _get_forward_method_args(self):
+        return (self._get_input_activations()["input"],)
+
+    def _get_forward_method_kwargs(self):
+        return {}
+
+    def _get_mesh(self):
+        return self._mesh
+
+    def _get_shard_specs_function(self):
+        return self._shard_spec_fn
+
+
+def setup_mesh(mesh_shape, axis_names):
+    device_ids = np.arange(np.prod(mesh_shape))
+    mesh = Mesh(device_ids=device_ids, mesh_shape=mesh_shape, axis_names=axis_names)
+    return mesh
+
+
+@pytest.mark.nightly
+@pytest.mark.push
+@pytest.mark.parametrize("mesh_shape", [(1, 2)])
+@pytest.mark.parametrize("axis_names", [("x", "y")])
+@pytest.mark.parametrize("input_shape", [(32, 32)])
+@pytest.mark.parametrize("sharding_mode", ["fully_replicated", "partially_sharded"])
+def test_linear(mesh_shape, axis_names, input_shape, sharding_mode):
+    class LinearModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(32, 256, bias=False)
+
+        def forward(self, x):
+            return self.linear(x)
+
+    def shard_spec_function(model):
+        if sharding_mode == "partially_sharded":
+            # Shard weight matrix along output dimension (dim 0)
+            return {model.linear.weight: ("y", None)}
+        else:
+            # Do not shard anything, fully replicated
+            return {}
+
+    mesh = setup_mesh(mesh_shape, axis_names)
+    model_tester = TorchMultichipUnaryModelTester(
+        model=LinearModel(),
+        input_shape=input_shape,
+        mesh=mesh,
+        shard_spec_fn=shard_spec_function,
+    )
+
+    model_tester.test()


### PR DESCRIPTION
We couldn't support fully replicated graph in spmd mode, result to runtime error in torch_xla's pjrt client run as it degenerate mesh shape to [1, 1] which is unexpected. This patch sets proper mesh shape attr to shlo graph to resolve this. If sharding is marked by user or automatically, this will no-op so leave mesh shape as is.

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/1487#issuecomment-3349604229)

### Problem description
In SPMD mode, we don’t currently support fully replicated graphs. This results in a runtime error in torch_xla’s PJRT client because the mesh shape degenerates to [1,1], which is unexpected.

### What's changed
- Normalize mesh shape in SPMD mode (uses `[1, num_devices]` instead of `[1,1]` for fully replicated graphs).

### Checklist
- [v ] New/Existing tests provide coverage for changes
