### PR TITLE
Fix placeholder models not running on CI need to adjust test-mark parens

### DIFF
--- a/.github/workflows/test-matrix-presets/model-test-xfail.json
+++ b/.github/workflows/test-matrix-presets/model-test-xfail.json
@@ -1,4 +1,4 @@
 [
-  { "runs-on": "n150", "name": "run_forge_models_torch", "dir": "./tests/runner/test_models.py", "test-mark": "n150 and (known_failure_xfail or not_supported_skip or placeholder)", "parallel-groups": 3 },
-  { "runs-on": "p150", "name": "run_forge_models_torch", "dir": "./tests/runner/test_models.py", "test-mark": "p150 and (known_failure_xfail or not_supported_skip or placeholder)", "parallel-groups": 3 }
+  { "runs-on": "n150", "name": "run_forge_models_torch", "dir": "./tests/runner/test_models.py", "test-mark": "(n150 and (known_failure_xfail or not_supported_skip)) or placeholder", "parallel-groups": 3 },
+  { "runs-on": "p150", "name": "run_forge_models_torch", "dir": "./tests/runner/test_models.py", "test-mark": "(p150 and (known_failure_xfail or not_supported_skip)) or placeholder", "parallel-groups": 3 }
 ]


### PR DESCRIPTION
### Ticket
#1567 

### Problem description
- The group of NOT_STARTED placeholder models run in nightly CI recently disappeared unintentionally due to model-test-xfail.json update for TP tests to also require n150 or p150 marker present

### What's changed
- The placeholder tests don't have arch specific (n150 or p150) markers, so exclude that condition by correcting parenthesis, tests are now collected properly again.

### Checklist
- [x] Tested pyest collect locally, tests are back now
