### PR TITLE
Update CODEOWNERS to include third_party folder for few folks including NA timezone

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,3 +13,6 @@
 
 # Python package
 /python_package/ @ajakovljevicTT @mrakitaTT @pilkicTT @AleksKnezevic
+
+# Third Party
+/third_party/ @ajakovljevicTT @mrakitaTT @kmabeeTT @jameszianxuTT @AleksKnezevic


### PR DESCRIPTION
### Ticket
None

### Problem description
- Would be nice to be able to do third_party uplifts like tt-forge-models and be able to get approval in NA timezone

### What's changed
- Add Aleks, James, Kyle as additional owners to third_party folder, now explicitly listed in CODEOWNERS

### Checklist
- [x] This CODEOWNERS file is valid.
