### PR TITLE
Add test config for resnet50 for target input size (1280x800)

### DIFF
--- a/tests/runner/test_config/test_config_inference_single_device.py
+++ b/tests/runner/test_config/test_config_inference_single_device.py
@@ -1596,6 +1596,19 @@ test_config = {
         "required_pcc": 0.97,
         "status": ModelTestStatus.EXPECTED_PASSING,
     },
+    # High res variants (1280x800)
+    "resnet/pytorch-resnet_50_hf_high_res-single_device-full-inference": {
+        "status": ModelTestStatus.EXPECTED_PASSING,
+    },
+    "resnet/pytorch-resnet50_timm_high_res-single_device-full-inference": {
+        "status": ModelTestStatus.EXPECTED_PASSING,
+    },
+    "resnet/pytorch-resnet50_high_res-single_device-full-inference": {
+        "status": ModelTestStatus.EXPECTED_PASSING,
+        "reason": "AssertionError: PCC comparison failed. Calculated: pcc=0.9867953658103943. Required: pcc=0.99.",
+        "assert_pcc": False,
+        "bringup_status": BringupStatus.INCORRECT_RESULT,
+    },
     "hrnet/pytorch-hrnetv2_w44_osmr-single_device-full-inference": {
         # AssertionError: PCC comparison failed. Calculated: pcc=0.9663628935813904. Required: pcc=0.97.
         # Exposed by removal of consteval on host: https://github.com/tenstorrent/tt-xla/issues/1242


### PR DESCRIPTION
### Ticket

- Fixes https://github.com/tenstorrent/tt-xla/issues/1190

### Problem description

- Add test config for resnet50 for target input size (1280x800)

### What's changed

- This PR adds test config for resnet50 for target input size (1280x800) 
- Note: PCC improved on target input size cases. 

| Variant         | Old Res (224x224) | Target (1280x800)|
|-----------------|--------------------------|---------------------------|
| RESNET_50_HF    | 0.9831361174583435       | >= 0.99                   |
| RESNET_50_TIMM  | 0.9834800362586975       | >= 0.99                   |
| RESNET_50       | 0.9850628972053528       | 0.9867953658103943        |

### Checklist
- [x] verified the changes by local testing

### Logs
- [oct7_resnet_results.log](https://github.com/user-attachments/files/22741709/oct7_z_resent.log)



