### PR TITLE
Add combined test preset for running on-pr manually

### DIFF
--- a/.github/workflows/manual-test.yml
+++ b/.github/workflows/manual-test.yml
@@ -13,6 +13,7 @@ on:
         options:
           - 'basic-test.json'
           - 'basic-test-nightly.json'
+          - 'basic-and-models-push.json'
           - 'model-test-push.json'
           - 'model-test-full.json'
           - 'model-test-passing.json'

--- a/.github/workflows/test-matrix-presets/basic-and-models-push.json
+++ b/.github/workflows/test-matrix-presets/basic-and-models-push.json
@@ -1,0 +1,13 @@
+[
+  { "runs-on": "wormhole_b0",        "name": "run_jax",               "dir": "./tests/jax/single_chip",                 "test-mark": "push and not large", "parallel-groups": 2 },
+  { "runs-on": "wormhole_b0",        "name": "run_torch",             "dir": "./tests/torch/single_chip",               "test-mark": "push", "parallel-groups": 3  },
+  { "runs-on": "n150",               "name": "run_large_jax_models",  "dir": "./tests/jax/single_chip",                 "test-mark": "push and large", "shared-runners": "true" },
+  { "runs-on": "p150",               "name": "run_jax",               "dir": "./tests/jax/single_chip",                 "test-mark": "push and not large", "parallel-groups": 2 },
+  { "runs-on": "p150",               "name": "run_torch",             "dir": "./tests/torch/single_chip",               "test-mark": "push", "parallel-groups": 3  },
+  { "runs-on": "p150",               "name": "run_large_jax_models",  "dir": "./tests/jax/single_chip",                 "test-mark": "push and large", "shared-runners": "true" },
+  { "runs-on": "n300",               "name": "run_jax",               "dir": "./tests/jax/multi_chip/n300",             "test-mark": "push", "codecov": "true" },
+  { "runs-on": "n300-llmbox",        "name": "run_jax_4_devices",     "dir": "./tests/jax/multi_chip/llmbox/4_devices", "test-mark": "push", "shared-runners": "true" },
+  { "runs-on": "n300-llmbox",        "name": "run_jax_8_devices",     "dir": "./tests/jax/multi_chip/llmbox/8_devices", "test-mark": "push", "shared-runners": "true" },
+  { "runs-on": "n150",               "name": "run_forge_models_torch", "dir": "./tests/runner/test_models.py", "test-mark": "n150 and expected_passing and push" },
+  { "runs-on": "p150",               "name": "run_forge_models_torch", "dir": "./tests/runner/test_models.py", "test-mark": "p150 and expected_passing and push" }
+]


### PR DESCRIPTION
### Ticket
None (slack thread)

### Problem description
When testing metal uplift, running equivalent of on-pr tests using manual test workflow (Run Test) required either
- manually copying multiple preset contents, or
- separate CI runs, which duplicated the build process and led to repeated 1-hour build steps (longer if image build is needed and they are run in parallel).

### What's changed
- Create basic-and-models-push.json combining basic-test.json and model-test-push.json
  - This can be selected to test uplift more easily

### Checklist
- [ ] New/Existing tests provide coverage for changes
