### PR TITLE
Uplift third_party/tt-mlir to be97d17850a4b3a07dcf62b5172f6d6a4f3d64d7 2025-10-07

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -5,7 +5,7 @@
 option(USE_CUSTOM_TT_MLIR_VERSION "Flag to use TT_MLIR_VERSION set by the user" OFF)
 
 if (NOT DEFINED TT_MLIR_VERSION OR NOT USE_CUSTOM_TT_MLIR_VERSION)
-    set(TT_MLIR_VERSION "2c3883e3bc5a872d470536cf032578c675c09f7e")
+    set(TT_MLIR_VERSION "be97d17850a4b3a07dcf62b5172f6d6a4f3d64d7")
 endif()
 
 set(PROTOBUF_VERSION "v21.12") # same version as tt-metal uses


### PR DESCRIPTION
This PR uplifts the third_party/tt-mlir to the be97d17850a4b3a07dcf62b5172f6d6a4f3d64d7