### PR TITLE
Add ModelTestStatus.EXCLUDE_MODEL to tag models we don't want to run

### DIFF
--- a/tests/runner/test_config/test_config_inference.py
+++ b/tests/runner/test_config/test_config_inference.py
@@ -2503,4 +2503,12 @@ test_config = {
         "reason": "Out of Memory: Not enough space to allocate 69599232 B L1 buffer across 72 banks, where each bank needs to store 966656 B, but bank size is only 1366016 B - https://github.com/tenstorrent/tt-xla/issues/1497",
         "bringup_status": BringupStatus.FAILED_RUNTIME,
     },
+    "bge_m3/pytorch-base-full-inference": {
+        # This model has a hand written test, don't run via test_models.py
+        "status": ModelTestStatus.EXCLUDE_MODEL,
+    },
+    "bge_m3/encode/pytorch-base-full-inference": {
+        # This model has a hand written test, don't run via test_models.py
+        "status": ModelTestStatus.EXCLUDE_MODEL,
+    },
 }

--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -34,6 +34,8 @@ class ModelTestStatus(Enum):
     NOT_SUPPORTED_SKIP = "not_supported_skip"
     # New model, awaiting triage
     UNSPECIFIED = "unspecified"
+    # Avoid import and auto discovery. Can be used if model test is hand written.
+    EXCLUDE_MODEL = "exclude_model"
 
 
 class ModelTestConfig:


### PR DESCRIPTION
### Ticket
None

### Problem description
- Several models will hand hand written tests and we don't want to discover + run via test_models.py

### What's changed
- Add new status EXCLUDE_MODEL and tag few tests, no longer collected.

### Checklist
- [ ] New/Existing tests provide coverage for changes
