### PR TITLE
Add Qwen3 and BGE-M3 attention unit tests

### DIFF
--- a/tests/torch/single_chip/graphs/test_attention.py
+++ b/tests/torch/single_chip/graphs/test_attention.py
@@ -87,9 +87,15 @@ def test_llama_attention_prefill(seq_len, variant, variant_config):
 
     device = torch_xla.device()
     compiled_fn = torch.compile(attention.to(device), backend="tt")
-    position_embeddings = (position_embeddings[0].to(device), position_embeddings[1].to(device))
+    position_embeddings = (
+        position_embeddings[0].to(device),
+        position_embeddings[1].to(device),
+    )
     output = compiled_fn(
-        hidden_states.to(device), position_embeddings, attention_mask.to(device), past_key_states
+        hidden_states.to(device),
+        position_embeddings,
+        attention_mask.to(device),
+        past_key_states,
     )
 
     comparator = TorchComparator(
@@ -142,9 +148,15 @@ def test_llama_attention_decode(variant, variant_config):
         past_key_states.key_cache = [k.to(device) for k in static_cache.key_cache]
         past_key_states.value_cache = [v.to(device) for v in static_cache.value_cache]
         compiled_fn = torch.compile(attention.to(device), backend="tt")
-        position_embeddings = (position_embeddings[0].to(device), position_embeddings[1].to(device))
+        position_embeddings = (
+            position_embeddings[0].to(device),
+            position_embeddings[1].to(device),
+        )
         output = compiled_fn(
-            hidden_states.to(device), position_embeddings, attention_mask.to(device), past_key_states
+            hidden_states.to(device),
+            position_embeddings,
+            attention_mask.to(device),
+            past_key_states,
         )
 
     comparator = TorchComparator(
@@ -254,7 +266,7 @@ def test_llama_create_heads(variant, variant_config, seq_len):
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("seq_len", [1024]) 
+@pytest.mark.parametrize("seq_len", [1024])
 @pytest.mark.parametrize(
     "variant,variant_config",
     get_available_variants("llama").items(),
@@ -351,7 +363,7 @@ def test_llama_sdpa(variant, variant_config, seq_len):
 
 
 """Qwen3 attention tests"""
-# TODO: Only create heads is different from Llama, consider merging the two.
+
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("seq_len", [1024])
@@ -363,7 +375,7 @@ def test_llama_sdpa(variant, variant_config, seq_len):
 def test_qwen3_attention_prefill(seq_len, variant, variant_config):
     if "qwq_32b" in str(variant):
         pytest.xfail("QWQ_32B varaiant is actually Qwen2, which has a different config")
-    
+
     xr.set_device_type("TT")
 
     loader = QwenModelLoader(variant=variant)
@@ -384,9 +396,15 @@ def test_qwen3_attention_prefill(seq_len, variant, variant_config):
 
     device = torch_xla.device()
     compiled_fn = torch.compile(attention.to(device), backend="tt")
-    position_embeddings = (position_embeddings[0].to(device), position_embeddings[1].to(device))
+    position_embeddings = (
+        position_embeddings[0].to(device),
+        position_embeddings[1].to(device),
+    )
     output = compiled_fn(
-        hidden_states.to(device), position_embeddings, attention_mask.to(device), past_key_states
+        hidden_states.to(device),
+        position_embeddings,
+        attention_mask.to(device),
+        past_key_states,
     )
 
     comparator = TorchComparator(
@@ -394,7 +412,7 @@ def test_qwen3_attention_prefill(seq_len, variant, variant_config):
             pcc=PccConfig(required_pcc=0.99),
         )
     )
-    
+
     comparator.compare(output[0].cpu(), golden[0])
     comparator.compare(output[1].cpu(), golden[1])
 
@@ -444,9 +462,15 @@ def test_qwen3_attention_decode(variant, variant_config):
         past_key_states.key_cache = [k.to(device) for k in static_cache.key_cache]
         past_key_states.value_cache = [v.to(device) for v in static_cache.value_cache]
         compiled_fn = torch.compile(attention.to(device), backend="tt")
-        position_embeddings = (position_embeddings[0].to(device), position_embeddings[1].to(device))
+        position_embeddings = (
+            position_embeddings[0].to(device),
+            position_embeddings[1].to(device),
+        )
         output = compiled_fn(
-            hidden_states.to(device), position_embeddings, attention_mask.to(device), past_key_states
+            hidden_states.to(device),
+            position_embeddings,
+            attention_mask.to(device),
+            past_key_states,
         )
 
     comparator = TorchComparator(
@@ -456,7 +480,6 @@ def test_qwen3_attention_decode(variant, variant_config):
     )
     comparator.compare(output[0].cpu(), golden[0])
     comparator.compare(output[1].cpu(), golden[1])
-    
 
 
 @pytest.mark.nightly
@@ -515,7 +538,9 @@ def test_qwen3_create_heads(variant, variant_config, seq_len):
 
     xr.set_device_type("TT")
 
-    def create_heads(hidden_states, hidden_shape, q_proj, k_proj, v_proj, q_norm, k_norm):
+    def create_heads(
+        hidden_states, hidden_shape, q_proj, k_proj, v_proj, q_norm, k_norm
+    ):
         # Key difference from Llama - Q/K normalization
         query_states = q_norm(q_proj(hidden_states).view(hidden_shape)).transpose(1, 2)
         key_states = k_norm(k_proj(hidden_states).view(hidden_shape)).transpose(1, 2)
@@ -544,7 +569,9 @@ def test_qwen3_create_heads(variant, variant_config, seq_len):
     q_norm = attention.q_norm
     k_norm = attention.k_norm
 
-    golden = create_heads(hidden_states, hidden_shape, q_proj, k_proj, v_proj, q_norm, k_norm)
+    golden = create_heads(
+        hidden_states, hidden_shape, q_proj, k_proj, v_proj, q_norm, k_norm
+    )
 
     device = torch_xla.device()
     compiled_fn = torch.compile(create_heads, backend="tt")
@@ -578,7 +605,7 @@ def test_qwen3_create_heads(variant, variant_config, seq_len):
 def test_qwen3_sdpa(variant, variant_config, seq_len):
     if "qwq_32b" in str(variant):
         pytest.xfail("QWQ_32B varaiant is actually Qwen2, which has a different config")
-        
+
     xr.set_device_type("TT")
 
     def sdpa(
@@ -604,7 +631,9 @@ def test_qwen3_sdpa(variant, variant_config, seq_len):
             attention_mask,
             dropout=dropout,
             scaling=scaling,
-            sliding_window=getattr(attention_module, 'sliding_window', None),  # Qwen3 specific
+            sliding_window=getattr(
+                attention_module, "sliding_window", None
+            ),  # Qwen3 specific
         )
         return attn_output, attn_weights
 

--- a/tests/torch/single_chip/graphs/test_attention.py
+++ b/tests/torch/single_chip/graphs/test_attention.py
@@ -27,6 +27,9 @@ from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
 from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import (
     ModelLoader as QwenModelLoader,
 )
+from third_party.tt_forge_models.bge_m3.pytorch.loader import (
+    ModelLoader as BgeModelLoader,
+)
 
 
 # To see all available models and variants, run:
@@ -35,6 +38,7 @@ from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import (
 MODEL_LOADER_MAP = {
     "llama": LlamaModelLoader,
     "qwen3": QwenModelLoader,
+    "bge_m3": BgeModelLoader,
 }
 
 
@@ -373,8 +377,10 @@ def test_llama_sdpa(variant, variant_config, seq_len):
     ids=[str(k) for k in get_available_variants("qwen3").keys()],
 )
 def test_qwen3_attention_prefill(seq_len, variant, variant_config):
-    if "qwq_32b" in str(variant):
+    if str(variant) == "qwq_32b":
         pytest.xfail("QWQ_32B varaiant is actually Qwen2, which has a different config")
+    if str(variant) == "32b" or str(variant) == "30b_a3b":
+        pytest.xfail("Variant doesn't fit on device")
 
     xr.set_device_type("TT")
 
@@ -424,8 +430,10 @@ def test_qwen3_attention_prefill(seq_len, variant, variant_config):
     ids=[str(k) for k in get_available_variants("qwen3").keys()],
 )
 def test_qwen3_attention_decode(variant, variant_config):
-    if "qwq_32b" in str(variant):
+    if str(variant) == "qwq_32b":
         pytest.xfail("QWQ_32B varaiant is actually Qwen2, which has a different config")
+    if str(variant) == "32b" or str(variant) == "30b_a3b":
+        pytest.xfail("Variant doesn't fit on device")
 
     xr.set_device_type("TT")
 
@@ -490,8 +498,10 @@ def test_qwen3_attention_decode(variant, variant_config):
     ids=[str(k) for k in get_available_variants("qwen3").keys()],
 )
 def test_qwen3_concat_heads(variant, variant_config, seq_len):
-    if "qwq_32b" in str(variant):
+    if str(variant) == "qwq_32b":
         pytest.xfail("QWQ_32B varaiant is actually Qwen2, which has a different config")
+    if str(variant) == "32b" or str(variant) == "30b_a3b":
+        pytest.xfail("Variant doesn't fit on device")
 
     xr.set_device_type("TT")
 
@@ -533,8 +543,10 @@ def test_qwen3_concat_heads(variant, variant_config, seq_len):
     ids=[str(k) for k in get_available_variants("qwen3").keys()],
 )
 def test_qwen3_create_heads(variant, variant_config, seq_len):
-    if "qwq_32b" in str(variant):
+    if str(variant) == "qwq_32b":
         pytest.xfail("QWQ_32B varaiant is actually Qwen2, which has a different config")
+    if str(variant) == "32b" or str(variant) == "30b_a3b":
+        pytest.xfail("Variant doesn't fit on device")
 
     xr.set_device_type("TT")
 
@@ -603,8 +615,10 @@ def test_qwen3_create_heads(variant, variant_config, seq_len):
     ids=[str(k) for k in get_available_variants("qwen3").keys()],
 )
 def test_qwen3_sdpa(variant, variant_config, seq_len):
-    if "qwq_32b" in str(variant):
+    if str(variant) == "qwq_32b":
         pytest.xfail("QWQ_32B varaiant is actually Qwen2, which has a different config")
+    if str(variant) == "32b" or str(variant) == "30b_a3b":
+        pytest.xfail("Variant doesn't fit on device")
 
     xr.set_device_type("TT")
 

--- a/tests/torch/single_chip/graphs/test_attention.py
+++ b/tests/torch/single_chip/graphs/test_attention.py
@@ -553,7 +553,6 @@ def test_qwen3_create_heads(variant, variant_config, seq_len):
     def create_heads(
         hidden_states, hidden_shape, q_proj, k_proj, v_proj, q_norm, k_norm
     ):
-        # Key difference from Llama - Q/K normalization
         query_states = q_norm(q_proj(hidden_states).view(hidden_shape)).transpose(1, 2)
         key_states = k_norm(k_proj(hidden_states).view(hidden_shape)).transpose(1, 2)
         value_states = v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
@@ -645,9 +644,7 @@ def test_qwen3_sdpa(variant, variant_config, seq_len):
             attention_mask,
             dropout=dropout,
             scaling=scaling,
-            sliding_window=getattr(
-                attention_module, "sliding_window", None
-            ),  # Qwen3 specific
+            sliding_window=getattr(attention_module, "sliding_window", None),
         )
         return attn_output, attn_weights
 

--- a/tests/torch/single_chip/graphs/test_attention.py
+++ b/tests/torch/single_chip/graphs/test_attention.py
@@ -24,6 +24,9 @@ from infra.comparators.torch_comparator import TorchComparator
 from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
     ModelLoader as LlamaModelLoader,
 )
+from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import (
+    ModelLoader as QwenModelLoader,
+)
 
 
 # To see all available models and variants, run:
@@ -31,6 +34,7 @@ from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
 
 MODEL_LOADER_MAP = {
     "llama": LlamaModelLoader,
+    "qwen3": QwenModelLoader,
 }
 
 
@@ -83,9 +87,9 @@ def test_llama_attention_prefill(seq_len, variant, variant_config):
 
     device = torch_xla.device()
     compiled_fn = torch.compile(attention.to(device), backend="tt")
-
-    output = attention(
-        hidden_states.to(device), position_embeddings, attention_mask, past_key_states
+    position_embeddings = (position_embeddings[0].to(device), position_embeddings[1].to(device))
+    output = compiled_fn(
+        hidden_states.to(device), position_embeddings, attention_mask.to(device), past_key_states
     )
 
     comparator = TorchComparator(
@@ -134,13 +138,14 @@ def test_llama_attention_decode(variant, variant_config):
     )
 
     device = torch_xla.device()
-    past_key_states.key_cache = [k.to(device) for k in static_cache.key_cache]
-    past_key_states.value_cache = [v.to(device) for v in static_cache.value_cache]
-    compiled_fn = torch.compile(attention.to(device), backend="tt")
-
-    output = attention(
-        hidden_states.to(device), position_embeddings, attention_mask, past_key_states
-    )
+    with torch.no_grad():
+        past_key_states.key_cache = [k.to(device) for k in static_cache.key_cache]
+        past_key_states.value_cache = [v.to(device) for v in static_cache.value_cache]
+        compiled_fn = torch.compile(attention.to(device), backend="tt")
+        position_embeddings = (position_embeddings[0].to(device), position_embeddings[1].to(device))
+        output = compiled_fn(
+            hidden_states.to(device), position_embeddings, attention_mask.to(device), past_key_states
+        )
 
     comparator = TorchComparator(
         ComparisonConfig(
@@ -285,6 +290,311 @@ def test_llama_sdpa(variant, variant_config, seq_len):
         return attn_output, attn_weights
 
     loader = LlamaModelLoader(variant=variant)
+    model = loader.load_model(dtype_override=torch.bfloat16)
+    attention = model.model.layers[0].self_attn
+
+    batch_size = 1
+    hidden_size = model.config.hidden_size
+    num_heads = model.config.num_attention_heads
+    num_key_value_heads = getattr(model.config, "num_key_value_heads", num_heads)
+    head_dim = model.config.head_dim
+
+    query_states = torch.randn(
+        (batch_size, num_heads, seq_len, head_dim), dtype=torch.bfloat16
+    )
+    key_states = torch.randn(
+        (batch_size, num_key_value_heads, seq_len, head_dim), dtype=torch.bfloat16
+    )
+    value_states = torch.randn(
+        (batch_size, num_key_value_heads, seq_len, head_dim), dtype=torch.bfloat16
+    )
+
+    attention_mask = torch.rand(1, 1, seq_len, seq_len, dtype=torch.bfloat16)
+
+    dropout = 0.0
+    scaling = attention.scaling
+
+    golden = sdpa(
+        attention,
+        query_states,
+        key_states,
+        value_states,
+        attention_mask,
+        dropout,
+        scaling,
+    )
+
+    device = torch_xla.device()
+    compiled_fn = torch.compile(sdpa, backend="tt")
+
+    output = compiled_fn(
+        attention.to(device),
+        query_states.to(device),
+        key_states.to(device),
+        value_states.to(device),
+        attention_mask.to(device),
+        dropout,
+        scaling,
+    )
+
+    comparator = TorchComparator(
+        ComparisonConfig(
+            pcc=PccConfig(required_pcc=0.99),
+        )
+    )
+
+    for i, (out_tensor, golden_tensor) in enumerate(zip(output, golden)):
+        if (
+            out_tensor is not None and golden_tensor is not None
+        ):  # attn_weights might be None
+            comparator.compare(out_tensor.cpu(), golden_tensor)
+
+
+"""Qwen3 attention tests"""
+# TODO: Only create heads is different from Llama, consider merging the two.
+
+@pytest.mark.nightly
+@pytest.mark.parametrize("seq_len", [1024])
+@pytest.mark.parametrize(
+    "variant,variant_config",
+    get_available_variants("qwen3").items(),
+    ids=[str(k) for k in get_available_variants("qwen3").keys()],
+)
+def test_qwen3_attention_prefill(seq_len, variant, variant_config):
+    xr.set_device_type("TT")
+
+    loader = QwenModelLoader(variant=variant)
+    model = loader.load_model(dtype_override=torch.bfloat16)
+    attention = model.model.layers[0].self_attn
+
+    hidden_states = torch.randn(
+        (1, seq_len, model.config.hidden_size), dtype=torch.bfloat16
+    )
+    cos_sin = torch.rand(1, seq_len, model.config.head_dim, dtype=torch.bfloat16)
+    position_embeddings = (cos_sin, cos_sin)
+    attention_mask = torch.rand(1, 1, seq_len, seq_len, dtype=torch.bfloat16)
+
+    past_key_states = None
+    golden = attention(
+        hidden_states, position_embeddings, attention_mask, past_key_states
+    )
+
+    device = torch_xla.device()
+    compiled_fn = torch.compile(attention.to(device), backend="tt")
+    position_embeddings = (position_embeddings[0].to(device), position_embeddings[1].to(device))
+    output = compiled_fn(
+        hidden_states.to(device), position_embeddings, attention_mask.to(device), past_key_states
+    )
+
+    comparator = TorchComparator(
+        ComparisonConfig(
+            pcc=PccConfig(required_pcc=0.99),
+        )
+    )
+    
+    comparator.compare(output[0].cpu(), golden[0])
+    comparator.compare(output[1].cpu(), golden[1])
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize(
+    "variant,variant_config",
+    get_available_variants("qwen3").items(),
+    ids=[str(k) for k in get_available_variants("qwen3").keys()],
+)
+def test_qwen3_attention_decode(variant, variant_config):
+    xr.set_device_type("TT")
+
+    loader = QwenModelLoader(variant=variant)
+    model = loader.load_model(dtype_override=torch.bfloat16)
+    attention = model.model.layers[0].self_attn
+
+    seq_len = 1
+    hidden_states = torch.randn(
+        (1, seq_len, model.config.hidden_size), dtype=torch.bfloat16
+    )
+    cos_sin = torch.rand(1, seq_len, model.config.head_dim, dtype=torch.bfloat16)
+    position_embeddings = (cos_sin, cos_sin)
+    attention_mask = torch.rand(1, 1, seq_len, seq_len, dtype=torch.bfloat16)
+
+    batch_size = 1
+    max_cache_len = 16
+    static_cache: StaticCache = StaticCache(
+        config=model.config,
+        max_batch_size=batch_size,
+        max_cache_len=max_cache_len,
+        device="cpu",
+        dtype=torch.bfloat16,
+    )
+    cache_position = torch.tensor([0])
+    past_key_states = static_cache
+
+    golden = attention(
+        hidden_states, position_embeddings, attention_mask, past_key_states
+    )
+
+    device = torch_xla.device()
+    with torch.no_grad():
+        past_key_states.key_cache = [k.to(device) for k in static_cache.key_cache]
+        past_key_states.value_cache = [v.to(device) for v in static_cache.value_cache]
+        compiled_fn = torch.compile(attention.to(device), backend="tt")
+        position_embeddings = (position_embeddings[0].to(device), position_embeddings[1].to(device))
+        output = compiled_fn(
+            hidden_states.to(device), position_embeddings, attention_mask.to(device), past_key_states
+        )
+
+    comparator = TorchComparator(
+        ComparisonConfig(
+            pcc=PccConfig(required_pcc=0.99),
+        )
+    )
+    comparator.compare(output[0].cpu(), golden[0])
+    comparator.compare(output[1].cpu(), golden[1])
+    
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize("seq_len", [1024])
+@pytest.mark.parametrize(
+    "variant,variant_config",
+    get_available_variants("qwen3").items(),
+    ids=[str(k) for k in get_available_variants("qwen3").keys()],
+)
+def test_qwen3_concat_heads(variant, variant_config, seq_len):
+    xr.set_device_type("TT")
+
+    def concat_heads(attn_output, input_shape):
+        return attn_output.reshape(*input_shape, -1).contiguous()
+
+    loader = QwenModelLoader(variant=variant)
+    model = loader.load_model(dtype_override=torch.bfloat16)
+
+    batch_size = 1
+    num_heads = model.config.num_attention_heads
+    head_dim = model.config.head_dim
+    hidden_size = model.config.hidden_size
+
+    attn_output = torch.randn(
+        (batch_size, num_heads, seq_len, head_dim), dtype=torch.bfloat16
+    )
+    input_shape = (batch_size, seq_len)
+
+    golden = concat_heads(attn_output, input_shape)
+
+    device = torch_xla.device()
+    compiled_fn = torch.compile(concat_heads, backend="tt")
+    output = compiled_fn(attn_output.to(device), input_shape)
+
+    comparator = TorchComparator(
+        ComparisonConfig(
+            pcc=PccConfig(required_pcc=0.99),
+        )
+    )
+    comparator.compare(output.cpu(), golden)
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize("seq_len", [1024])
+@pytest.mark.parametrize(
+    "variant,variant_config",
+    get_available_variants("qwen3").items(),
+    ids=[str(k) for k in get_available_variants("qwen3").keys()],
+)
+def test_qwen3_create_heads(variant, variant_config, seq_len):
+    """Test Qwen3's normalized query/key head creation"""
+    xr.set_device_type("TT")
+
+    def create_normalized_heads(hidden_states, hidden_shape, q_proj, k_proj, v_proj, q_norm, k_norm):
+        # Key difference from Llama - Q/K normalization
+        query_states = q_norm(q_proj(hidden_states).view(hidden_shape)).transpose(1, 2)
+        key_states = k_norm(k_proj(hidden_states).view(hidden_shape)).transpose(1, 2)
+        value_states = v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+        return query_states, key_states, value_states
+
+    loader = QwenModelLoader(variant=variant)
+    model = loader.load_model(dtype_override=torch.bfloat16)
+    attention = model.model.layers[0].self_attn
+
+    batch_size = 1
+    hidden_size = model.config.hidden_size
+    num_heads = model.config.num_attention_heads
+    head_dim = model.config.head_dim
+
+    hidden_states = torch.randn(
+        (batch_size, seq_len, hidden_size), dtype=torch.bfloat16
+    )
+
+    input_shape = hidden_states.shape[:-1]
+    hidden_shape = (*input_shape, -1, head_dim)
+
+    q_proj = attention.q_proj
+    k_proj = attention.k_proj
+    v_proj = attention.v_proj
+    q_norm = attention.q_norm
+    k_norm = attention.k_norm
+
+    golden = create_normalized_heads(hidden_states, hidden_shape, q_proj, k_proj, v_proj, q_norm, k_norm)
+
+    device = torch_xla.device()
+    compiled_fn = torch.compile(create_normalized_heads, backend="tt")
+
+    output = compiled_fn(
+        hidden_states.to(device),
+        hidden_shape,
+        q_proj.to(device),
+        k_proj.to(device),
+        v_proj.to(device),
+        q_norm.to(device),
+        k_norm.to(device),
+    )
+
+    comparator = TorchComparator(
+        ComparisonConfig(
+            pcc=PccConfig(required_pcc=0.99),
+        )
+    )
+    for i, (out_tensor, golden_tensor) in enumerate(zip(output, golden)):
+        comparator.compare(out_tensor.cpu(), golden_tensor)
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize("seq_len", [1024])  # 4096 causes OOM on CPU
+@pytest.mark.parametrize(
+    "variant,variant_config",
+    get_available_variants("qwen3").items(),
+    ids=[str(k) for k in get_available_variants("qwen3").keys()],
+)
+def test_qwen3_sdpa(variant, variant_config, seq_len):
+    xr.set_device_type("TT")
+
+    def sdpa(
+        attention_module,
+        query_states,
+        key_states,
+        value_states,
+        attention_mask,
+        dropout,
+        scaling,
+    ):
+        attention_interface: Callable = eager_attention_forward
+        if attention_module.config._attn_implementation != "eager":
+            attention_interface = ALL_ATTENTION_FUNCTIONS[
+                attention_module.config._attn_implementation
+            ]
+
+        attn_output, attn_weights = attention_interface(
+            attention_module,
+            query_states,
+            key_states,
+            value_states,
+            attention_mask,
+            dropout=dropout,
+            scaling=scaling,
+            sliding_window=getattr(attention_module, 'sliding_window', None),  # Qwen3 specific
+        )
+        return attn_output, attn_weights
+
+    loader = QwenModelLoader(variant=variant)
     model = loader.load_model(dtype_override=torch.bfloat16)
     attention = model.model.layers[0].self_attn
 

--- a/tests/torch/single_chip/graphs/test_attention.py
+++ b/tests/torch/single_chip/graphs/test_attention.py
@@ -710,3 +710,158 @@ def test_qwen3_sdpa(variant, variant_config, seq_len):
             out_tensor is not None and golden_tensor is not None
         ):  # attn_weights might be None
             comparator.compare(out_tensor.cpu(), golden_tensor)
+
+
+"""BGE-M3 attention (XLM-RoBERTa attention) tests"""
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize("seq_len", [1024])
+@pytest.mark.parametrize(
+    "variant,variant_config",
+    get_available_variants("bge_m3").items(),
+    ids=[str(k) for k in get_available_variants("bge_m3").keys()],
+)
+def test_bge_m3_attention_prefill(seq_len, variant, variant_config):
+    xr.set_device_type("TT")
+
+    loader = BgeModelLoader(variant=variant)
+    model = loader.load_model()
+    attention = model.model.encoder.layer[0].attention
+
+    batch_size = 1
+    hidden_size = model.config.hidden_size
+    hidden_states = torch.randn((batch_size, seq_len, hidden_size), dtype=torch.float32)
+    attention_mask = torch.zeros((batch_size, 1, 1, seq_len), dtype=torch.float32)
+
+    past_key_value = None
+    golden = attention(
+        hidden_states,
+        attention_mask=attention_mask,
+        past_key_value=past_key_value,
+    )
+
+    device = torch_xla.device()
+    compiled_fn = torch.compile(attention.to(device), backend="tt")
+    output = compiled_fn(
+        hidden_states.to(device),
+        attention_mask=attention_mask.to(device),
+        past_key_value=past_key_value,
+    )
+
+    comparator = TorchComparator(
+        ComparisonConfig(
+            pcc=PccConfig(required_pcc=0.99),
+        )
+    )
+    comparator.compare(output[0].cpu(), golden[0])
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize("seq_len", [1024])
+@pytest.mark.parametrize(
+    "variant,variant_config",
+    get_available_variants("bge_m3").items(),
+    ids=[str(k) for k in get_available_variants("bge_m3").keys()],
+)
+def test_bge_m3_concat_heads(seq_len, variant, variant_config):
+    xr.set_device_type("TT")
+
+    def concat_heads(context_layer, all_head_size):
+        context_layer = context_layer.permute(0, 2, 1, 3).contiguous()
+        new_context_layer_shape = context_layer.size()[:-2] + (all_head_size,)
+        context_layer = context_layer.view(new_context_layer_shape)
+        return context_layer
+
+    loader = BgeModelLoader(variant=variant)
+    model = loader.load_model()
+
+    batch_size = 1
+    num_heads = model.config.num_attention_heads
+    head_dim = model.config.hidden_size // model.config.num_attention_heads
+    all_head_size = model.config.hidden_size
+    context_layer = torch.randn(
+        (batch_size, num_heads, seq_len, head_dim), dtype=torch.float32
+    )
+
+    golden = concat_heads(context_layer, all_head_size)
+
+    device = torch_xla.device()
+    compiled_fn = torch.compile(concat_heads, backend="tt")
+    output = compiled_fn(context_layer.to(device), all_head_size)
+
+    comparator = TorchComparator(
+        ComparisonConfig(
+            pcc=PccConfig(required_pcc=0.99),
+        )
+    )
+    comparator.compare(output.cpu(), golden)
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize("seq_len", [1024])
+@pytest.mark.parametrize(
+    "variant,variant_config",
+    get_available_variants("bge_m3").items(),
+    ids=[str(k) for k in get_available_variants("bge_m3").keys()],
+)
+def test_bge_m3_create_heads(seq_len, variant, variant_config):
+    xr.set_device_type("TT")
+
+    def create_heads(
+        hidden_states,
+        query_layer,
+        key_layer,
+        value_layer,
+        num_attention_heads,
+        attention_head_size,
+    ):
+        def transpose_for_scores(x):
+            new_x_shape = x.size()[:-1] + (num_attention_heads, attention_head_size)
+            x = x.view(new_x_shape)
+            return x.permute(0, 2, 1, 3)
+
+        query_states = transpose_for_scores(query_layer(hidden_states))
+        key_states = transpose_for_scores(key_layer(hidden_states))
+        value_states = transpose_for_scores(value_layer(hidden_states))
+
+        return query_states, key_states, value_states
+
+    loader = BgeModelLoader(variant=variant)
+    model = loader.load_model()
+    attention = model.model.encoder.layer[0].attention.self
+
+    batch_size = 1
+    hidden_size = model.config.hidden_size
+    num_heads = model.config.num_attention_heads
+    head_dim = model.config.hidden_size // model.config.num_attention_heads
+
+    hidden_states = torch.randn((batch_size, seq_len, hidden_size), dtype=torch.float32)
+
+    query_layer = attention.query
+    key_layer = attention.key
+    value_layer = attention.value
+
+    golden = create_heads(
+        hidden_states, query_layer, key_layer, value_layer, num_heads, head_dim
+    )
+
+    device = torch_xla.device()
+    compiled_fn = torch.compile(create_heads, backend="tt")
+
+    output = compiled_fn(
+        hidden_states.to(device),
+        query_layer.to(device),
+        key_layer.to(device),
+        value_layer.to(device),
+        num_heads,
+        head_dim,
+    )
+
+    comparator = TorchComparator(
+        ComparisonConfig(
+            pcc=PccConfig(required_pcc=0.99),
+        )
+    )
+    for i, (out_tensor, golden_tensor) in enumerate(zip(output, golden)):
+        comparator.compare(out_tensor.cpu(), golden_tensor)

--- a/tests/torch/single_chip/graphs/test_attention.py
+++ b/tests/torch/single_chip/graphs/test_attention.py
@@ -254,7 +254,7 @@ def test_llama_create_heads(variant, variant_config, seq_len):
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("seq_len", [1024])  # 4096 causes OOM on CPU
+@pytest.mark.parametrize("seq_len", [1024]) 
 @pytest.mark.parametrize(
     "variant,variant_config",
     get_available_variants("llama").items(),
@@ -361,6 +361,9 @@ def test_llama_sdpa(variant, variant_config, seq_len):
     ids=[str(k) for k in get_available_variants("qwen3").keys()],
 )
 def test_qwen3_attention_prefill(seq_len, variant, variant_config):
+    if "qwq_32b" in str(variant):
+        pytest.xfail("QWQ_32B varaiant is actually Qwen2, which has a different config")
+    
     xr.set_device_type("TT")
 
     loader = QwenModelLoader(variant=variant)
@@ -403,6 +406,9 @@ def test_qwen3_attention_prefill(seq_len, variant, variant_config):
     ids=[str(k) for k in get_available_variants("qwen3").keys()],
 )
 def test_qwen3_attention_decode(variant, variant_config):
+    if "qwq_32b" in str(variant):
+        pytest.xfail("QWQ_32B varaiant is actually Qwen2, which has a different config")
+
     xr.set_device_type("TT")
 
     loader = QwenModelLoader(variant=variant)
@@ -461,6 +467,9 @@ def test_qwen3_attention_decode(variant, variant_config):
     ids=[str(k) for k in get_available_variants("qwen3").keys()],
 )
 def test_qwen3_concat_heads(variant, variant_config, seq_len):
+    if "qwq_32b" in str(variant):
+        pytest.xfail("QWQ_32B varaiant is actually Qwen2, which has a different config")
+
     xr.set_device_type("TT")
 
     def concat_heads(attn_output, input_shape):
@@ -501,10 +510,12 @@ def test_qwen3_concat_heads(variant, variant_config, seq_len):
     ids=[str(k) for k in get_available_variants("qwen3").keys()],
 )
 def test_qwen3_create_heads(variant, variant_config, seq_len):
-    """Test Qwen3's normalized query/key head creation"""
+    if "qwq_32b" in str(variant):
+        pytest.xfail("QWQ_32B varaiant is actually Qwen2, which has a different config")
+
     xr.set_device_type("TT")
 
-    def create_normalized_heads(hidden_states, hidden_shape, q_proj, k_proj, v_proj, q_norm, k_norm):
+    def create_heads(hidden_states, hidden_shape, q_proj, k_proj, v_proj, q_norm, k_norm):
         # Key difference from Llama - Q/K normalization
         query_states = q_norm(q_proj(hidden_states).view(hidden_shape)).transpose(1, 2)
         key_states = k_norm(k_proj(hidden_states).view(hidden_shape)).transpose(1, 2)
@@ -533,10 +544,10 @@ def test_qwen3_create_heads(variant, variant_config, seq_len):
     q_norm = attention.q_norm
     k_norm = attention.k_norm
 
-    golden = create_normalized_heads(hidden_states, hidden_shape, q_proj, k_proj, v_proj, q_norm, k_norm)
+    golden = create_heads(hidden_states, hidden_shape, q_proj, k_proj, v_proj, q_norm, k_norm)
 
     device = torch_xla.device()
-    compiled_fn = torch.compile(create_normalized_heads, backend="tt")
+    compiled_fn = torch.compile(create_heads, backend="tt")
 
     output = compiled_fn(
         hidden_states.to(device),
@@ -558,13 +569,16 @@ def test_qwen3_create_heads(variant, variant_config, seq_len):
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("seq_len", [1024])  # 4096 causes OOM on CPU
+@pytest.mark.parametrize("seq_len", [1024])
 @pytest.mark.parametrize(
     "variant,variant_config",
     get_available_variants("qwen3").items(),
     ids=[str(k) for k in get_available_variants("qwen3").keys()],
 )
 def test_qwen3_sdpa(variant, variant_config, seq_len):
+    if "qwq_32b" in str(variant):
+        pytest.xfail("QWQ_32B varaiant is actually Qwen2, which has a different config")
+        
     xr.set_device_type("TT")
 
     def sdpa(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/1538

### Problem description
We want unit tests for attention layers of models that will benefit from the ops being [fused](https://github.com/tenstorrent/tt-mlir/issues/4214) specifically for LLM perf. These should test attention prefill/decode, concat heads, split heads (create heads) and SDPA.

### What's changed
Added attention prefill/decode, concat heads, create heads and SDPA unit tests for Qwen3Attention. These tests skip 3 variants that are too large to load or using Qwen2Attention

Added attention prefill, concat heads and create heads unit tests for BGE-M3 (XLMRobertaSelfAttention).

Fixed attention prefill/decode for llama where compiled version of attention was not being called.

### Checklist
- [x] New/Existing tests provide coverage for changes
