### PR TITLE
Complete attention concat_heads test

### DIFF
--- a/tests/torch/single_chip/graphs/test_attention.py
+++ b/tests/torch/single_chip/graphs/test_attention.py
@@ -161,6 +161,7 @@ def test_llama_concat_heads(variant, variant_config, seq_len):
     xr.set_device_type("TT")
 
     def concat_heads(attn_output, input_shape):
+        attn_output = attn_output.transpose(1, 2).contiguous()
         return attn_output.reshape(*input_shape, -1).contiguous()
 
     loader = LlamaModelLoader(variant=variant)


### PR DESCRIPTION
### Ticket
None

### Problem description
The concat heads pattern we are interested in is a sequence of permute and reshape. Current concat heads attention layer test is only testing reshape.

### What's changed
Added transpose which becomes a `stablehlo.transpose` --> `ttir.permute`

### Checklist
- [X] New/Existing tests provide coverage for changes
