### PR TITLE
Putting a large model from skip to xfail

### DIFF
--- a/tests/jax/single_chip/models/gpt_j/gpt_j_6b/test_gpt_j_6b.py
+++ b/tests/jax/single_chip/models/gpt_j/gpt_j_6b/test_gpt_j_6b.py
@@ -48,7 +48,7 @@ def training_tester() -> GPTJTester:
     bringup_status=BringupStatus.FAILED_RUNTIME,
 )
 @pytest.mark.large
-@pytest.mark.skip(
+@pytest.mark.xfail(
     reason=failed_runtime(
         "Out of Memory: Not enough space to allocate 268435456 B DRAM buffer across 12 banks, "
         "where each bank needs to store 22372352 B "


### PR DESCRIPTION
After this commit (https://github.com/tenstorrent/tt-xla/commit/bda136ca6d7d2cc04554f1bd7d55813e6ab4fc09), we have re-enabled the cleanup of cache on CIv2, on un-skipping some large models that have failed previously due to low disk space.