### PR TITLE
Update CODEOWNERS to treat pytest.ini and .test_durations like tests/ folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,8 @@
 
 # Tests
 /tests/ @sdjukicTT @sgligorijevicTT @ajakovljevicTT @mrakitaTT @kmabeeTT @jameszianxuTT @AleksKnezevic @ndrakulicTT
+pytest.ini @sdjukicTT @sgligorijevicTT @ajakovljevicTT @mrakitaTT @kmabeeTT @jameszianxuTT @AleksKnezevic @ndrakulicTT
+.test_durations @sdjukicTT @sgligorijevicTT @ajakovljevicTT @mrakitaTT @kmabeeTT @jameszianxuTT @AleksKnezevic @ndrakulicTT
 
 # Python package
 /python_package/ @ajakovljevicTT @mrakitaTT @pilkicTT @AleksKnezevic


### PR DESCRIPTION
### Ticket
None

### Problem description
- The files pytest.ini and .test_durations are test related and should follow same owners as tests/ dir which have a few more available warm bodies for reviewing

### What's changed
- Add CODEOWNERS lines for pytest.ini and .test_durations to mimic tests/ folder

### Checklist
- [x] Passes CODEOWNERS legality check, thx github.
