### PR TITLE
Add inference test config for openvla finetuned variants

### DIFF
--- a/tests/runner/test_config/test_config_inference_single_device.py
+++ b/tests/runner/test_config/test_config_inference_single_device.py
@@ -2563,4 +2563,24 @@ test_config = {
         "reason": "Out of Memory: Not enough space to allocate 90177536 B DRAM buffer across 12 banks, where each bank needs to store 7516160 B, but bank size is only 1073741792 B",
         "bringup_status": BringupStatus.FAILED_RUNTIME,
     },
+    "openvla/pytorch-openvla_7b_finetuned_libero_10-single_device-full-inference": {
+        "status": ModelTestStatus.KNOWN_FAILURE_XFAIL,
+        "reason": "Out of Memory: Not enough space to allocate 90177536 B DRAM buffer across 12 banks, where each bank needs to store 7516160 B, but bank size is only 1073741792 B",
+        "bringup_status": BringupStatus.FAILED_RUNTIME,
+    },
+    "openvla/pytorch-openvla_7b_finetuned_libero_goal-single_device-full-inference": {
+        "status": ModelTestStatus.KNOWN_FAILURE_XFAIL,
+        "reason": "Out of Memory: Not enough space to allocate 90177536 B DRAM buffer across 12 banks, where each bank needs to store 7516160 B, but bank size is only 1073741792 B",
+        "bringup_status": BringupStatus.FAILED_RUNTIME,
+    },
+    "openvla/pytorch-openvla_7b_finetuned_libero_object-single_device-full-inference": {
+        "status": ModelTestStatus.KNOWN_FAILURE_XFAIL,
+        "reason": "Out of Memory: Not enough space to allocate 90177536 B DRAM buffer across 12 banks, where each bank needs to store 7516160 B, but bank size is only 1073741792 B",
+        "bringup_status": BringupStatus.FAILED_RUNTIME,
+    },
+    "openvla/pytorch-openvla_7b_finetuned_libero_spatial-single_device-full-inference": {
+        "status": ModelTestStatus.KNOWN_FAILURE_XFAIL,
+        "reason": "Out of Memory: Not enough space to allocate 90177536 B DRAM buffer across 12 banks, where each bank needs to store 7516160 B, but bank size is only 1073741792 B",
+        "bringup_status": BringupStatus.FAILED_RUNTIME,
+    },
 }


### PR DESCRIPTION
### Ticket
- Fixes https://github.com/tenstorrent/tt-xla/issues/1528

### Problem description
- Add inference test config for below openvla finetuned variants
  - openvla_7b_finetuned_libero_10
  - openvla_7b_finetuned_libero_goal
  - openvla_7b_finetuned_libero_object
  - openvla_7b_finetuned_libero_spatial

### What's changed
- This PR adds test config for mentioned variants.

### Checklist
- [x] verified the functionality through local testing

### Logs
- [ft_logs.zip](https://github.com/user-attachments/files/22841180/ft_logs.zip)
