### PR TITLE
Add a separator to IR printing and always print module names

### DIFF
--- a/src/common/pjrt_implementation/module_builder/module_builder.cc
+++ b/src/common/pjrt_implementation/module_builder/module_builder.cc
@@ -15,9 +15,6 @@
 // POSIX includes
 #include <dlfcn.h>
 
-// loguru includes
-#include "loguru/loguru.hpp"
-
 // llvm includes
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/LogicalResult.h"
@@ -334,7 +331,7 @@ tt_pjrt_status ModuleBuilder::createVHLOModule(
     return tt_pjrt_status::kInternal;
   }
 
-  DLOG_F(LOG_DEBUG, "VHLO Module:");
+  VLOG_F(LOG_DEBUG, "VHLO Module:");
   printModule(vhlo_module);
 
   return tt_pjrt_status::kSuccess;
@@ -353,7 +350,7 @@ tt_pjrt_status ModuleBuilder::convertFromVHLOToSHLO(
     return tt_pjrt_status::kInternal;
   }
 
-  DLOG_F(LOG_DEBUG, "SHLO Module:");
+  VLOG_F(LOG_DEBUG, "SHLO Module:");
   printModule(mlir_module);
 
   return tt_pjrt_status::kSuccess;
@@ -365,7 +362,7 @@ tt_pjrt_status ModuleBuilder::runFrontendSHLOPipeline(
   tt_pjrt_status status =
       frontend_passes::annotateArgumentAttributes(mlir_module);
 
-  DLOG_F(LOG_DEBUG, "SHLO Module after frontend StableHLO pipeline:");
+  VLOG_F(LOG_DEBUG, "SHLO Module after frontend StableHLO pipeline:");
   printModule(mlir_module);
 
   return status;
@@ -682,7 +679,7 @@ tt_pjrt_status ModuleBuilder::runCompilerStableHLOPipeline(
     return tt_pjrt_status::kInternal;
   }
 
-  DLOG_F(LOG_DEBUG, "SHLO Module after compiler StableHLO pipeline:");
+  VLOG_F(LOG_DEBUG, "SHLO Module after compiler StableHLO pipeline:");
   printModule(mlir_module);
 
   if (!tt_pjrt_status_is_ok(
@@ -715,7 +712,7 @@ tt_pjrt_status ModuleBuilder::convertFromSHLOToTTIR(
 
   ttir_mlir = getMlirCode(mlir_module);
 
-  DLOG_F(LOG_DEBUG, "TTIR Module:");
+  VLOG_F(LOG_DEBUG, "TTIR Module:");
   printModule(mlir_module);
 
   return tt_pjrt_status::kSuccess;
@@ -864,7 +861,7 @@ tt_pjrt_status ModuleBuilder::convertFromTTIRToTTNN(
 
   ttnn_mlir = getMlirCode(mlir_module);
 
-  DLOG_F(LOG_DEBUG, "TTNN Module:");
+  VLOG_F(LOG_DEBUG, "TTNN Module:");
   printModule(mlir_module);
 
   return tt_pjrt_status::kSuccess;
@@ -969,6 +966,7 @@ void ModuleBuilder::printModule(
   }
 
   mlir_module->print(llvm::errs(), mlir::OpPrintingFlags().enableDebugInfo());
+  llvm::errs() << "------------------ END OF MLIR MODULE ------------------\n";
 }
 
 void ModuleBuilder::enableVerboseIRPrinting(mlir::PassManager &pm) {


### PR DESCRIPTION
### Ticket
None

### Problem description
Multiple people at multiple times complained to me that IR dumps were completely unreadable in release mode, as locs from the end of one module were not separated from locs from the beginning of another module.

### What's changed
Added a separator print right after loc dumping.
Changed logger calls from debug logger calls to regular logger calls, so module names are also printed in release.

### Checklist
- [ ] New/Existing tests provide coverage for changes
