### PR TITLE
Add inference test config for Qwen2.5-VL-3B-Instruct

### DIFF
--- a/tests/runner/test_config/test_config_inference_single_device.py
+++ b/tests/runner/test_config/test_config_inference_single_device.py
@@ -1105,6 +1105,11 @@ test_config = {
     "qwen_1_5/causal_lm/pytorch-0_5b_chat-single_device-full-inference": {
         "status": ModelTestStatus.EXPECTED_PASSING,
     },
+    "qwen_2_5_vl/pytorch-3b_instruct-single_device-full-inference": {
+        "status": ModelTestStatus.KNOWN_FAILURE_XFAIL,
+        "reason": "error: failed to legalize operation 'ttir.convolution' - https://github.com/tenstorrent/tt-xla/issues/1662",
+        "bringup_status": BringupStatus.FAILED_RUNTIME,
+    },
     "llama/sequence_classification/pytorch-llama_3_2_1b-single_device-full-inference": {
         "status": ModelTestStatus.EXPECTED_PASSING,
     },

--- a/venv/requirements-dev.txt
+++ b/venv/requirements-dev.txt
@@ -59,3 +59,6 @@ yolov6detect
 
 # bge-m3 model
 FlagEmbedding
+
+# Qwen2.5 VL models
+qwen-vl-utils[decord]==0.0.8


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/1529

### Problem description

- Add inference test config for Qwen2.5-VL-3B-Instruct

### What's changed

- This PR adds inference test config for Qwen2.5-VL-3B-Instruct & tracks [this changes](https://github.com/tenstorrent/tt-forge-models/pull/194).

### Checklist
- [x] verified the functionality through local testing

### Logs

- [oct12_qwen_2_5_vl_3b_xla.log](https://github.com/user-attachments/files/22870360/oct12_qwen_2_5_3b_xla.log)

