### PR TITLE
Persist submesh to fix hangs

### DIFF
--- a/inc/common/pjrt_implementation/client_instance.h
+++ b/inc/common/pjrt_implementation/client_instance.h
@@ -86,6 +86,16 @@ public:
   tt::runtime::Device
   getOrCreateMeshDevice(const std::vector<uint32_t> &target_mesh_shape);
 
+  // Returns the optimizer submesh device of the provided shape. If there is
+  // already opened optimizer submesh and its shape matches the provided shape,
+  // it is returned. Otherwise, we close any previously opened optimizer submesh
+  // and create a new one with the provided shape.
+  //
+  // NOTE: this method is not thread-safe and we will need to revisit this when
+  // adding support for parallel execution.
+  tt::runtime::Device
+  getOrCreateOptimizerSubmesh(const std::vector<uint32_t> &target_mesh_shape);
+
   // Compiles given mlir program.
   tt_pjrt_status compileMlirProgram(
       const PJRT_Program *mlir_program,
@@ -152,6 +162,9 @@ private:
 
   // Currently in-use mesh device.
   std::optional<tt::runtime::Device> m_parent_mesh;
+
+  // Optimizer submesh device (created from m_parent_mesh for optimizer passes).
+  std::optional<tt::runtime::Device> m_optimizer_submesh;
 
   // Extracts custom protobuf fields from an UnknownFieldSet of all protobuf
   // fields.

--- a/src/common/pjrt_implementation/client_instance.cc
+++ b/src/common/pjrt_implementation/client_instance.cc
@@ -58,6 +58,10 @@ ClientInstance::ClientInstance(std::unique_ptr<Platform> platform)
 ClientInstance::~ClientInstance() {
   DLOG_F(LOG_DEBUG, "ClientInstance::~ClientInstance");
 
+  if (m_optimizer_submesh.has_value()) {
+    tt::runtime::releaseSubMeshDevice(*m_optimizer_submesh);
+  }
+
   if (m_parent_mesh.has_value()) {
     tt::runtime::closeMeshDevice(*m_parent_mesh);
   }
@@ -389,6 +393,10 @@ tt::runtime::Device ClientInstance::getOrCreateMeshDevice(
   // parallel). However, similar as to the case with reshape API, there were
   // some issues when testing sub-meshes, so for now we are always closing and
   // re-opening the whole mesh.
+  if (m_optimizer_submesh.has_value()) {
+    tt::runtime::releaseSubMeshDevice(*m_optimizer_submesh);
+    m_optimizer_submesh.reset();
+  }
   tt::runtime::closeMeshDevice(*m_parent_mesh);
   m_parent_mesh = openMeshDevice(target_mesh_shape);
 
@@ -436,6 +444,36 @@ ClientInstance::openMeshDevice(const std::vector<uint32_t> &mesh_shape) {
   };
 
   return tt::runtime::openMeshDevice(options);
+}
+
+tt::runtime::Device ClientInstance::getOrCreateOptimizerSubmesh(
+    const std::vector<uint32_t> &target_mesh_shape) {
+
+  // Ensure parent mesh exists with the correct shape
+  tt::runtime::Device parent_mesh = getOrCreateMeshDevice(target_mesh_shape);
+
+  if (m_optimizer_submesh.has_value()) {
+    std::vector<uint32_t> optimizer_submesh_shape =
+        tt::runtime::getMeshShape(*m_optimizer_submesh);
+
+    if (optimizer_submesh_shape == target_mesh_shape) {
+      DLOG_F(LOG_DEBUG, "ClientInstance::getOrCreateOptimizerSubmesh - reusing "
+                        "already created optimizer submesh");
+      return *m_optimizer_submesh;
+    }
+
+    // If shape changed, parent mesh was closed and reopened in
+    // getOrCreateMeshDevice, which automatically closed the submesh.
+    // Clear the stale reference.
+    m_optimizer_submesh.reset();
+  }
+
+  DLOG_F(LOG_DEBUG, "ClientInstance::getOrCreateOptimizerSubmesh - "
+                    "creating optimizer submesh");
+  m_optimizer_submesh =
+      tt::runtime::createSubMeshDevice(parent_mesh, target_mesh_shape);
+
+  return *m_optimizer_submesh;
 }
 
 namespace internal {

--- a/src/common/pjrt_implementation/module_builder/module_builder.cc
+++ b/src/common/pjrt_implementation/module_builder/module_builder.cc
@@ -842,13 +842,8 @@ tt_pjrt_status ModuleBuilder::convertFromTTIRToTTNN(
 
   // Use the `options.devicePtr` to pass the device pointer to the optimizer in
   // order to avoid closing and reopening the device afterwards.
-  tt::runtime::Device runtime_device =
-      client_instance->getOrCreateMeshDevice(devices_mesh_shape);
-
-  // TODO(odjuricic, #1503): After compile, execution hangs if the parent mesh
-  // is passed to optimizer.
   tt::runtime::Device submesh_for_optim =
-      tt::runtime::createSubMeshDevice(runtime_device, devices_mesh_shape);
+      client_instance->getOrCreateOptimizerSubmesh(devices_mesh_shape);
   options.devicePtr =
       std::static_pointer_cast<tt::tt_metal::distributed::MeshDevice>(
           submesh_for_optim.handle);


### PR DESCRIPTION
We have been seeing hangs when optimizer is enabled. Turns out XLA may split models in multiple modules which are compiled/executed independently, and we opened submesh device each time which leads to some undefined behaviour in tt-metal. Solution is to have only one `MeshDevice` and one `SubMeshDevice` (for a given mesh shape) opened at the time.

I ran torch-xla model tests with optimizer enabled here https://github.com/tenstorrent/tt-xla/actions/runs/18409884286/job/52459871861. None of them hung.