### PR TITLE
modify CI + uplift mlir

### DIFF
--- a/.github/workflows/test-matrix-presets/basic-test-nightly.json
+++ b/.github/workflows/test-matrix-presets/basic-test-nightly.json
@@ -1,10 +1,10 @@
 [
   { "runs-on": "wormhole_b0",        "name": "run_jax",               "dir": "./tests/jax/single_chip",                 "test-mark": "nightly and not large", "parallel-groups": 2 },
-  { "runs-on": "wormhole_b0",        "name": "run_torch",             "dir": "./tests/torch/single_chip",               "test-mark": "nightly" },
+  { "runs-on": "n150",               "name": "run_torch",             "dir": "./tests/torch/single_chip",               "test-mark": "nightly" },
   { "runs-on": "p150",               "name": "run_jax",               "dir": "./tests/jax/single_chip",                 "test-mark": "nightly and not large", "parallel-groups": 2 },
   { "runs-on": "p150",               "name": "run_torch",             "dir": "./tests/torch/single_chip",               "test-mark": "nightly"  },
   { "runs-on": "n300",               "name": "run_jax",               "dir": "./tests/jax/multi_chip/n300",             "test-mark": "nightly", "codecov": "true" },
-  { "runs-on": "n300",               "name": "run_torch",             "dir": "./tests/torch/multi_chip/n300",           "test-mark": "nightly"  },
+  { "runs-on": "n300",               "name": "torch_multichip",       "dir": "./tests/torch/multi_chip/n300",           "test-mark": "nightly"  },
   { "runs-on": "n300-llmbox",        "name": "run_jax_4_devices",     "dir": "./tests/jax/multi_chip/llmbox/4_devices", "test-mark": "nightly", "shared-runners": "true" },
   { "runs-on": "n300-llmbox",        "name": "run_jax_8_devices",     "dir": "./tests/jax/multi_chip/llmbox/8_devices", "test-mark": "nightly", "shared-runners": "true" }
 ]

--- a/.github/workflows/test-matrix-presets/basic-test.json
+++ b/.github/workflows/test-matrix-presets/basic-test.json
@@ -1,13 +1,13 @@
 [
   { "runs-on": "wormhole_b0",        "name": "run_jax",               "dir": "./tests/jax/single_chip",                 "test-mark": "push and not large", "parallel-groups": 2 },
-  { "runs-on": "wormhole_b0",        "name": "run_torch",             "dir": "./tests/torch/single_chip",               "test-mark": "push", "parallel-groups": 3  },
+  { "runs-on": "n150",               "name": "run_torch",             "dir": "./tests/torch/single_chip",               "test-mark": "push", "parallel-groups": 3, "shared-runners": "true" },
   { "runs-on": "wormhole_b0",        "name": "run_meta_infra_tests",  "dir": "./tests/infra_tests/single_chip",         "test-mark": "push" },
   { "runs-on": "n150",               "name": "run_large_jax_models",  "dir": "./tests/jax/single_chip",                 "test-mark": "push and large", "shared-runners": "true" },
   { "runs-on": "p150",               "name": "run_jax",               "dir": "./tests/jax/single_chip",                 "test-mark": "push and not large", "parallel-groups": 2 },
   { "runs-on": "p150",               "name": "run_torch",             "dir": "./tests/torch/single_chip",               "test-mark": "push", "parallel-groups": 3  },
   { "runs-on": "p150",               "name": "run_large_jax_models",  "dir": "./tests/jax/single_chip",                 "test-mark": "push and large", "shared-runners": "true" },
   { "runs-on": "n300",               "name": "run_jax",               "dir": "./tests/jax/multi_chip/n300",             "test-mark": "push", "codecov": "true" },
-  { "runs-on": "n300",               "name": "run_torch",             "dir": "./tests/torch/multi_chip/n300",           "test-mark": "push" },
+  { "runs-on": "n300",               "name": "torch_multichip",       "dir": "./tests/torch/multi_chip/n300",           "test-mark": "push" },
   { "runs-on": "n300-llmbox",        "name": "run_jax_4_devices",     "dir": "./tests/jax/multi_chip/llmbox/4_devices", "test-mark": "push", "shared-runners": "true" },
   { "runs-on": "n300-llmbox",        "name": "run_jax_8_devices",     "dir": "./tests/jax/multi_chip/llmbox/8_devices", "test-mark": "push", "shared-runners": "true" }
 ]

--- a/.github/workflows/test-matrix-presets/custom-basic-and-models-push.json
+++ b/.github/workflows/test-matrix-presets/custom-basic-and-models-push.json
@@ -1,7 +1,7 @@
 [
   { "_metadata": true, "description": "Combined test preset for manual testing that includes both basic tests and model tests and is equivalent to on-pr tests" },
   { "runs-on": "wormhole_b0",        "name": "run_jax",               "dir": "./tests/jax/single_chip",                 "test-mark": "push and not large", "parallel-groups": 2 },
-  { "runs-on": "wormhole_b0",        "name": "run_torch",             "dir": "./tests/torch/single_chip",               "test-mark": "push", "parallel-groups": 3  },
+  { "runs-on": "n150",               "name": "run_torch",             "dir": "./tests/torch/single_chip",               "test-mark": "push", "parallel-groups": 3  },
   { "runs-on": "n150",               "name": "run_large_jax_models",  "dir": "./tests/jax/single_chip",                 "test-mark": "push and large", "shared-runners": "true" },
   { "runs-on": "p150",               "name": "run_jax",               "dir": "./tests/jax/single_chip",                 "test-mark": "push and not large", "parallel-groups": 2 },
   { "runs-on": "p150",               "name": "run_torch",             "dir": "./tests/torch/single_chip",               "test-mark": "push", "parallel-groups": 3  },

--- a/.github/workflows/test-matrix-presets/model-test-full.json
+++ b/.github/workflows/test-matrix-presets/model-test-full.json
@@ -6,7 +6,7 @@
     { "runs-on": "p150",        "name": "run_torch",            "dir": "./tests/torch/single_chip", "test-mark": "model_test", "parallel-groups": 3 },
     { "runs-on": "p150",        "name": "run_large_jax_models", "dir": "./tests/jax/single_chip", "test-mark": "model_test and large", "shared-runners": "true", "parallel-groups": 3 },
     { "runs-on": "n300",        "name": "run_jax",              "dir": "./tests/jax/multi_chip/n300", "test-mark": "model_test" },
-    { "runs-on": "n300",        "name": "run_torch",            "dir": "./tests/torch/multi_chip/n300", "test-mark": "model_test" },
+    { "runs-on": "n300",        "name": "torch_multichip",      "dir": "./tests/torch/multi_chip/n300", "test-mark": "model_test" },
     { "runs-on": "n300-llmbox", "name": "run_jax_4_devices",    "dir": "./tests/jax/multi_chip/llmbox/4_devices", "test-mark": "model_test", "shared-runners": "true" },
     { "runs-on": "n300-llmbox", "name": "run_jax_8_devices",    "dir": "./tests/jax/multi_chip/llmbox/8_devices", "test-mark": "model_test", "shared-runners": "true" }
 ]

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -5,7 +5,7 @@
 option(USE_CUSTOM_TT_MLIR_VERSION "Flag to use TT_MLIR_VERSION set by the user" OFF)
 
 if (NOT DEFINED TT_MLIR_VERSION OR NOT USE_CUSTOM_TT_MLIR_VERSION)
-    set(TT_MLIR_VERSION "274a5d02bf74aafe8b71247a1da05d75e24bbbde")
+    set(TT_MLIR_VERSION "d903a40ff1c40d509b48830a75e9516666abd606")
 endif()
 
 set(PROTOBUF_VERSION "v21.12") # same version as tt-metal uses


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-xla/issues/1668

### Problem description
A test hangs, which is blocking an uplift. There are important changes in tt-mlir we want uplifted ASAP.

Edit: In the meantime a lot was figured out, TLDR is that pytest --forked kills processes and that completely messes up cleanup in metal, which leads to hangs. 

### What's changed
~~Skipped a test.~~  Edit: In the meantime a lot was figured out, TLDR is that we will A) not fork multichip tests B) run singlechip tests exclusively on n150 to avert a hang, not an ideal solution but it is what it is
Uplifted mlir

### Checklist
- [ ] New/Existing tests provide coverage for changes
