### PR TITLE
Add inference test config for Qwen2.5-VL-7B-Instruct & AWQ variants

### DIFF
--- a/tests/runner/test_config/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/test_config_inference_single_device.yaml
@@ -820,7 +820,22 @@ test_config:
   qwen_2_5_vl/pytorch-3b_instruct-single_device-full-inference:
     status: KNOWN_FAILURE_XFAIL
     reason: "error: failed to legalize operation 'ttir.convolution' - https://github.com/tenstorrent/tt-xla/issues/1662"
-    bringup_status: FAILED_RUNTIME
+    bringup_status: FAILED_TTMLIR_COMPILATION
+
+  qwen_2_5_vl/pytorch-7b_instruct-single_device-full-inference:
+      status: KNOWN_FAILURE_XFAIL
+      reason: "error: failed to legalize operation 'ttir.convolution' - https://github.com/tenstorrent/tt-xla/issues/1662"
+      bringup_status: FAILED_TTMLIR_COMPILATION
+
+  qwen_2_5_vl/pytorch-3b_instruct_awq-single_device-full-inference:
+      status: KNOWN_FAILURE_XFAIL
+      reason: "error: failed to legalize operation 'ttir.convolution' - https://github.com/tenstorrent/tt-xla/issues/1662"
+      bringup_status: FAILED_TTMLIR_COMPILATION
+
+  qwen_2_5_vl/pytorch-7b_instruct_awq-single_device-full-inference:
+      status: KNOWN_FAILURE_XFAIL
+      reason: "error: failed to legalize operation 'ttir.convolution' - https://github.com/tenstorrent/tt-xla/issues/1662"
+      bringup_status: FAILED_TTMLIR_COMPILATION
 
   llama/sequence_classification/pytorch-llama_3_2_1b-single_device-full-inference:
     status: EXPECTED_PASSING

--- a/tests/runner/test_config/test_config_placeholders.yaml
+++ b/tests/runner/test_config/test_config_placeholders.yaml
@@ -17,8 +17,6 @@ PLACEHOLDER_MODELS:
     bringup_status: NOT_STARTED
   deepseek-ai/DeepSeek-V3:
     bringup_status: NOT_STARTED
-  Qwen/Qwen2.5-VL-3B-Instruct:
-    bringup_status: NOT_STARTED
   meta-llama/Llama-3.2-11B-Vision-Instruct:
     bringup_status: NOT_STARTED
   meta-llama/Llama-3.2-90B-Vision-Instruct:
@@ -48,8 +46,6 @@ PLACEHOLDER_MODELS:
   genmo/mochi-1-preview:
     bringup_status: NOT_STARTED
   openbmb/MiniCPM-o-2_6:
-    bringup_status: NOT_STARTED
-  Qwen/Qwen2.5-VL-7B-Instruct:
     bringup_status: NOT_STARTED
   mistralai/Mixtral-8x7B-Instruct-v0.1:
     bringup_status: NOT_STARTED

--- a/venv/requirements-dev.txt
+++ b/venv/requirements-dev.txt
@@ -66,3 +66,8 @@ qwen-vl-utils[decord]==0.0.8
 
 # whisper and wav2vec2 models
 torchcodec
+
+# Qwen2.5 VL AWQ variants
+triton==3.3.0
+intel_extension_for_pytorch==2.7.0
+autoawq[cpu]==0.2.9


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/1529
- Fixes https://github.com/tenstorrent/tt-xla/issues/1712

### Problem description

- Add inference test config for Qwen2.5-VL-3B-Instruct & AWQ variants.

### What's changed

- This PR adds inference test config for below variants 
  - Qwen/Qwen2.5-VL-7B-Instruct
  - Qwen/Qwen2.5-VL-3B-Instruct-AWQ
  - Qwen/Qwen2.5-VL-7B-Instruct-AWQ
- Removes placeholder configs of Qwen2.5-VL-7B-Instruct & Qwen2.5-VL-3B-Instruct

### Checklist

- [x] Verified the functionality through local testing.

### Logs

- [oct16_qwen_2_5_vl_7b_xla.log](https://github.com/user-attachments/files/22948772/oct16_qwen_2_5_vl_7b_xla_1.log)
- [oct22_qwen_2_5_vl_3b_awq_xla.log](https://github.com/user-attachments/files/23048454/oct22_3b_awq_xla_4.log)
- [oct22_qwen_2_5_vl_7b_awq_xla.log](https://github.com/user-attachments/files/23048455/oct22_7b_awq_xla.log)



