### PR TITLE
Remove option to choose CIv1 or CIv2 runenrs with the input flag

### DIFF
--- a/.github/scripts/generate_test_matrix.py
+++ b/.github/scripts/generate_test_matrix.py
@@ -29,6 +29,10 @@ def map_shared_runner(entry):
         runs_on = entry.get("runs-on")
         if runs_on in shared_runner_mapping:
             entry["runs-on"] = shared_runner_mapping[runs_on]
+        else:
+            raise TypeError(
+                "Expected runs-on attribute to be one of the predefined values"
+            )
     return entry
 
 

--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -12,11 +12,6 @@ on:
         required: false
         default: true
         type: boolean
-      use-shared-runners:
-        description: 'Use shared runners from Civ2'
-        required: false
-        default: false
-        type: boolean
       artifact_release_run_id:
         description: 'Run ID of the artifacts (release)'
         required: true
@@ -70,13 +65,13 @@ jobs:
     runs-on: ${{ (matrix.build.shared-runners == true || matrix.build.shared-runners == 'true') && matrix.build.runs-on || fromJson(format('["{0}", "in-service"]', matrix.build.runs-on)) }}
 
     env:
-      DOCKER_CACHE_ROOT: ${{ (!inputs.use-shared-runners && !matrix.build.shared-runners) && '/mnt/dockercache' || '' }}
+      DOCKER_CACHE_ROOT: ${{ (matrix.build.shared-runners == true || matrix.build.shared-runners == 'true') && '' || '/mnt/dockercache' }}
 
     # Keep this name in sync with the fetch-job-id step
     name: "test ${{ matrix.build.test-mark }} (${{ matrix.build.runs-on }}, ${{ matrix.build.name }}, ${{ strategy.job-index }})"
 
     container:
-      image: ${{ (inputs.use-shared-runners || matrix.build.shared-runners) && format('harbor.ci.tenstorrent.net/{0}', inputs.docker_image) || inputs.docker_image }}
+      image: ${{ (matrix.build.shared-runners == true || matrix.build.shared-runners == 'true') && format('harbor.ci.tenstorrent.net/{0}', inputs.docker_image) || inputs.docker_image }}
       options: --device /dev/tenstorrent
       volumes:
         - /dev/hugepages:/dev/hugepages

--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -89,7 +89,6 @@ jobs:
     with:
       test_suite: model-test-push.json
       docker_image: ${{ needs.build-image.outputs.docker-image }}
-      use-shared-runners: false
       artifact_release_run_id: ${{ needs.build-ttxla-release.outputs.artifacts_run_id }}
       wheel_release_artifact_name: ${{ needs.build-ttxla-release.outputs.wheel_artifact_name }}
 

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -61,7 +61,6 @@ jobs:
     with:
       test_suite: model-test-push.json
       docker_image: ${{ needs.build-image.outputs.docker-image }}
-      use-shared-runners: false
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       wheel_release_artifact_name: ${{ needs.build-ttxla.outputs.wheel_artifact_name }}
 

--- a/.github/workflows/schedule-nightly-experimental.yml
+++ b/.github/workflows/schedule-nightly-experimental.yml
@@ -30,7 +30,6 @@ jobs:
     with:
       test_suite: model-test-experimental.json
       docker_image: ${{ needs.build-image.outputs.docker-image }}
-      use-shared-runners: false # Run full model tests on Civ1
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       wheel_release_artifact_name: ${{ needs.build-ttxla.outputs.wheel_artifact_name }}
 

--- a/.github/workflows/schedule-nightly.yml
+++ b/.github/workflows/schedule-nightly.yml
@@ -30,7 +30,6 @@ jobs:
       test_suite: basic-test-nightly.json
       codecov: false
       docker_image: ${{ needs.build-image.outputs.docker-image-base }}
-      use-shared-runners: false # Run nightly tests on Civ1
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       wheel_release_artifact_name: ${{ needs.build-ttxla.outputs.wheel_artifact_name }}
 
@@ -43,7 +42,6 @@ jobs:
     with:
       test_suite: model-test-full.json
       docker_image: ${{ needs.build-image.outputs.docker-image-base }}
-      use-shared-runners: false # Run full model tests on Civ1
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       wheel_release_artifact_name: ${{ needs.build-ttxla.outputs.wheel_artifact_name }}
 
@@ -57,7 +55,6 @@ jobs:
     with:
       test_suite: model-test-passing.json
       docker_image: ${{ needs.build-image.outputs.docker-image }}
-      use-shared-runners: false # Run full model tests on Civ1
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       wheel_release_artifact_name: ${{ needs.build-ttxla.outputs.wheel_artifact_name }}
 
@@ -71,7 +68,6 @@ jobs:
     with:
       test_suite: model-test-xfail.json
       docker_image: ${{ needs.build-image.outputs.docker-image }}
-      use-shared-runners: false # Run full model tests on Civ1
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       wheel_release_artifact_name: ${{ needs.build-ttxla.outputs.wheel_artifact_name }}
 


### PR DESCRIPTION
### Ticket
/

### Problem description
After the test workflows refactor where we moved the test run specific logic (architecture, paths, flags) away from the workflow logic we had a `use-shared-runners` flag left over.

### What's changed
Removing the `use-shared-runners` flag from `call-test.yml` to respect the logic separation.

Note: The flag was set to false wherever it was referenced so there should be no CI behaviour change.

### Checklist
- [ ] New/Existing tests provide coverage for changes
