### PR TITLE
Remove assert_pcc=false from yolov8n as it passes with PCC > 0.99 on main

### DIFF
--- a/tests/runner/test_config/test_config_inference_single_device.py
+++ b/tests/runner/test_config/test_config_inference_single_device.py
@@ -982,10 +982,7 @@ test_config = {
         "reason": "AssertionError: PCC comparison failed. Calculated: pcc=0.9410670165223607. Required: pcc=0.99",
     },
     "yolov8/pytorch-yolov8n-single_device-full-inference": {
-        "assert_pcc": False,
         "status": ModelTestStatus.EXPECTED_PASSING,
-        "bringup_status": BringupStatus.INCORRECT_RESULT,
-        "reason": "AssertionError: PCC comparison failed. Calculated: pcc=0.9296823098857484. Required: pcc=0.99",
     },
     "stereo/pytorch-small-single_device-full-inference": {
         "assert_pcc": False,


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/1530

### Problem description

- assert_pcc=false was previously set for yolov8n. The test now passes with PCC > 0.99 on the current main branch, so it is no longer needed.

### What's changed

- Removed assert_pcc=false from yolov8n as it passes with PCC > 0.99 on main

### Checklist
- [x] verified the functionality through local testing 

### Logs

- [oct14_yolov8n.log](https://github.com/user-attachments/files/22898769/oct14_yolov8n_after_fix.log)

