### PR TITLE
adding sdxl unet test to test infra

### DIFF
--- a/tests/runner/test_config/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/test_config_inference_single_device.yaml
@@ -1136,7 +1136,7 @@ test_config:
   stable_diffusion_unet/pytorch-base-single_device-full-inference:
     status: KNOWN_FAILURE_XFAIL
     reason: "OOM on device when doing avg_pool - https://github.com/tenstorrent/tt-xla/issues/1433"
-  
+
   unet_for_conditional_generation/pytorch-base-single_device-full-inference:
     status: EXPECTED_PASSING
 


### PR DESCRIPTION
## TL;DR
UNet part of the Stable Diffusion was recently enabled through tt-xla compiler (on n150 chip) so we're adding this model to test infra

## Dependencies

First, this PR https://github.com/tenstorrent/tt-forge-models/pull/192 in tt-forge models needs to be merged. After that, this PR can point to that new Unet model in tt-forge-models