### PR TITLE
fix nightly 14102025

### DIFF
--- a/tests/runner/test_config/test_config_inference_single_device.py
+++ b/tests/runner/test_config/test_config_inference_single_device.py
@@ -879,7 +879,10 @@ test_config = {
         "status": ModelTestStatus.EXPECTED_PASSING,
     },
     "albert/masked_lm/pytorch-xxlarge_v1-single_device-full-inference": {
+        "assert_pcc": False,
         "status": ModelTestStatus.EXPECTED_PASSING,
+        "bringup_status": BringupStatus.INCORRECT_RESULT,
+        "reason": "AssertionError: PCC comparison failed. Calculated: pcc=0.9889796376228333. Required: pcc=0.99 - http://github.com/tenstorrent/tt-xla/issues/1402",
     },
     "albert/question_answering/pytorch-squad2-single_device-full-inference": {
         "status": ModelTestStatus.EXPECTED_PASSING,
@@ -1376,8 +1379,10 @@ test_config = {
         "status": ModelTestStatus.EXPECTED_PASSING,
     },
     "vit/pytorch-vit_l_32-single_device-full-inference": {
-        "required_pcc": 0.98,
+        "assert_pcc": False,
         "status": ModelTestStatus.EXPECTED_PASSING,
+        "bringup_status": BringupStatus.INCORRECT_RESULT,
+        "reason": "AssertionError: PCC comparison failed. Calculated: pcc=0.9611120820045471. Required: pcc=0.99 - http://github.com/tenstorrent/tt-xla/issues/1402",
     },
     "mobilenetv1/pytorch-mobilenetv1_100.ra4_e3600_r224_in1k-single_device-full-inference": {
         # AssertionError: PCC comparison failed. Calculated: pcc=0.9673609137535095. Required: pcc=0.97.


### PR DESCRIPTION
### Problem description
Most of the models in today’s nightly were failing due to this [issue](https://github.com/tenstorrent/tt-xla/issues/1676), so we are working on fixing it. We have xfailed the models that were failing due to reasons other than this issue.

### Checklist
- [x] New/Existing tests provide coverage for changes

I have attached the logs for your reference:
[albert_xxlarge_v1.log](https://github.com/user-attachments/files/22905222/albert_xxlarge_v1.log)
[hrnet_w18_small_v1.log](https://github.com/user-attachments/files/22905223/hrnet_w18_small_v1.log)
[hrnetv2_w64.log](https://github.com/user-attachments/files/22905224/hrnetv2_w64.log)
[pytorch-densenet169-single_device-full-inference_without_xfail.log](https://github.com/user-attachments/files/22905226/pytorch-densenet169-single_device-full-inference_without_xfail.log)
[pytorch-ghostnetv2_100.in1k-single_device-full-inference_without_xfail.log](https://github.com/user-attachments/files/22905228/pytorch-ghostnetv2_100.in1k-single_device-full-inference_without_xfail.log)
[pytorch-hrnetv2_w40_osmr-single_device-full-inference_without_xfail.log](https://github.com/user-attachments/files/22905230/pytorch-hrnetv2_w40_osmr-single_device-full-inference_without_xfail.log)
[pytorch-hrnetv2_w44_osmr-single_device-full-inference_without_xfail.log](https://github.com/user-attachments/files/22905232/pytorch-hrnetv2_w44_osmr-single_device-full-inference_without_xfail.log)
[pytorch-hrnetv2_w48_osmr-single_device-full-inference_without_xfail.log](https://github.com/user-attachments/files/22905233/pytorch-hrnetv2_w48_osmr-single_device-full-inference_without_xfail.log)
[pytorch-inceptionv4-single_device-full-inference_without_xfail.log](https://github.com/user-attachments/files/22905234/pytorch-inceptionv4-single_device-full-inference_without_xfail.log)
[pytorch-pytorch-hrnetv2_w18_osmr-single_device-full-inference_without_xfail.log](https://github.com/user-attachments/files/22905235/pytorch-pytorch-hrnetv2_w18_osmr-single_device-full-inference_without_xfail.log)
[pytorch-pytorchpytorch-hrnetv2_w32_osmr-single_device-full-inference_without_xfail.log](https://github.com/user-attachments/files/22905238/pytorch-pytorchpytorch-hrnetv2_w32_osmr-single_device-full-inference_without_xfail.log)
[pytorch-resnext101_64x4d_osmr-single_device-full-inference_without_xfail.log](https://github.com/user-attachments/files/22905239/pytorch-resnext101_64x4d_osmr-single_device-full-inference_without_xfail.log)
[pytorch-vit_b_16-single_device-full-inference_without_xfail.log](https://github.com/user-attachments/files/22905240/pytorch-vit_b_16-single_device-full-inference_without_xfail.log)
[resnext14_32x4d.log](https://github.com/user-attachments/files/22905241/resnext14_32x4d.log)
[resnext50_32x4d.log](https://github.com/user-attachments/files/22905242/resnext50_32x4d.log)
[test_albert_wwithout_xfail.log](https://github.com/user-attachments/files/22905243/test_albert_wwithout_xfail.log)
[test_densenett121_without_xfail.log](https://github.com/user-attachments/files/22905244/test_densenett121_without_xfail.log)
[test_densenett161_without_xfail.log](https://github.com/user-attachments/files/22905245/test_densenett161_without_xfail.log)
[test_densenett201_without_xfail.log](https://github.com/user-attachments/files/22905246/test_densenett201_without_xfail.log)
[test_hrnet__v2_w30__v2_without_xfail.log](https://github.com/user-attachments/files/22905248/test_hrnet__v2_w30__v2_without_xfail.log)
[test_hrnet_w18_small_v2_without_xfail.log](https://github.com/user-attachments/files/22905250/test_hrnet_w18_small_v2_without_xfail.log)
[test_hrnet_w18_without_xfail.log](https://github.com/user-attachments/files/22905251/test_hrnet_w18_without_xfail.log)
[test_hrnet_wwithout_xfail.log](https://github.com/user-attachments/files/22905252/test_hrnet_wwithout_xfail.log)
[test_resnext_t26_32x4d_without_xfail.log](https://github.com/user-attachments/files/22905266/test_resnext_t26_32x4d_without_xfail.log)
[test_resnext_without_xfail.log](https://github.com/user-attachments/files/22905267/test_resnext_without_xfail.log)
[test_vit_pytorch_without_xfail.log](https://github.com/user-attachments/files/22905268/test_vit_pytorch_without_xfail.log)
[test_vovnet_without_xfail.log](https://github.com/user-attachments/files/22905269/test_vovnet_without_xfail.log)
[test_vovnet57_without_xfail.log](https://github.com/user-attachments/files/22905270/test_vovnet57_without_xfail.log)
[vovnet27s.log](https://github.com/user-attachments/files/22905275/vovnet27s.log)
[vovnet39.log](https://github.com/user-attachments/files/22905276/vovnet39.log)
