### PR TITLE
Handle runtime failure case for test result reporting where no comparison result is returned

### DIFF
--- a/tests/runner/test_models.py
+++ b/tests/runner/test_models.py
@@ -91,6 +91,8 @@ def test_all_models(
 
         succeeded = False
         comparison_result = None
+        tester = None
+
         try:
             # Only run the actual model test if not marked for skip. The record properties
             # function in finally block will always be called and handles the pytest.skip.
@@ -126,6 +128,8 @@ def test_all_models(
                     )
                 comparison_result = comparison_result[0]
 
+            comparison_config = tester._comparison_config if tester else None
+
             # If we mark tests with xfail at collection time, then this isn't hit.
             # Always record properties and handle skip/xfail cases uniformly
             record_model_test_properties(
@@ -137,7 +141,7 @@ def test_all_models(
                 parallelism=parallelism,
                 test_passed=succeeded,
                 comparison_result=comparison_result,
-                comparison_config=tester._comparison_config,
+                comparison_config=comparison_config,
             )
 
 


### PR DESCRIPTION
### Ticket
Follow up to #1542

### Problem description
Missed case where models xfail and therefore no comparisonResult is returned, leading to invalid len() call on None object. Issue is scoped to test_models.py runner infra.

### What's changed
Add safety checks before getting len() of comparisonResult.

### Checklist
- [x] Run models xfail test group against this branch. [PASSED](https://github.com/tenstorrent/tt-xla/actions/runs/18502919143)
