### PR TITLE
Enable or Tighten PCC checking for handful of RED models

### DIFF
--- a/tests/runner/test_config/test_config_inference_single_device.py
+++ b/tests/runner/test_config/test_config_inference_single_device.py
@@ -940,7 +940,6 @@ test_config = {
     },
     "yolov8/pytorch-yolov8x-single_device-full-inference": {
         "status": ModelTestStatus.EXPECTED_PASSING,
-        "required_pcc": 0.98,
     },
     "albert/token_classification/pytorch-base_v2-single_device-full-inference": {
         "assert_pcc": False,
@@ -1072,7 +1071,6 @@ test_config = {
     },
     "qwen_3/embedding/pytorch-embedding_4b-single_device-full-inference": {
         "status": ModelTestStatus.EXPECTED_PASSING,
-        "required_pcc": 0.98,
     },
     "yolov5/pytorch-yolov5n-single_device-full-inference": {
         # Newly exposed in Aug26 tt-forge-models uplift.
@@ -1225,7 +1223,6 @@ test_config = {
         "status": ModelTestStatus.EXPECTED_PASSING,
     },
     "llama/causal_lm/pytorch-llama_3_2_1b_instruct-single_device-full-inference": {
-        "required_pcc": 0.98,
         "status": ModelTestStatus.EXPECTED_PASSING,
     },
     "qwen_2_5/casual_lm/pytorch-0_5b_instruct-single_device-full-inference": {


### PR DESCRIPTION
### Ticket
None

### Problem description
- Some RED models have improved recently and have high PCC for WH+BH, here were a few easy ones I found.

### What's changed
- Adjust test_config entries to enable PCC checking for 4 models and remove decreased threshold for 3 models

### Checklist
- [x] Tested locally for WH+BH and CI here: https://github.com/tenstorrent/tt-xla/actions/runs/18510124816
