### PR TITLE
Always run comparisons regardless of ComparisonConfig to surface accuracy result in JUnitXML

### DIFF
--- a/tests/infra/comparators/comparator.py
+++ b/tests/infra/comparators/comparator.py
@@ -58,8 +58,6 @@ class Comparator(ABC):
             error_message=None,
         )
 
-        # Always execute comparisons even if disabled in config to gather and report metrics
-        #   Assertion only happens later in _assert_on_results if enabled in config.
         _comparison_result.equal = self._compare_equal(device_output, golden_output)
         _comparison_result.atol = self._compare_atol(
             device_output, golden_output, self._comparison_config.atol


### PR DESCRIPTION
### Ticket

### Problem description
Previously we gated comparison behind the comparisonConfig, because a failing comparison was used as an exit condition and would assert. 

Now that assert is separated from executing the comparison (#1542) we can always execute the comparison (I assume evaluation of PCC/ATOL won't itself throw no matter how degenerate the results are).

### What's changed
Always capture and report accuracy results, even if comparisonConfig enable_accuracy_metric is false. Comparison config enable/disable will only control assertion on PCC/ATOL, rather than the basic evaluation of the results which will now happen in all cases.

### Checklist
- [ ] New/Existing tests provide coverage for changes (if onPR passes)
