### PR TITLE
Fix the logic in ci

### DIFF
--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -62,16 +62,16 @@ jobs:
       matrix:
         build: ${{ fromJson(needs.generate-matrix-test.outputs.test_matrix) }}
 
-    runs-on: ${{ (matrix.build.shared-runners == true || matrix.build.shared-runners == 'true') && matrix.build.runs-on || fromJson(format('["{0}", "in-service"]', matrix.build.runs-on)) }}
+    runs-on: ${{ !matrix.build.shared-runners && fromJson(format('["{0}", "in-service"]', matrix.build.runs-on)) || matrix.build.runs-on  }}
 
     env:
-      DOCKER_CACHE_ROOT: ${{ (matrix.build.shared-runners == true || matrix.build.shared-runners == 'true') && '' || '/mnt/dockercache' }}
+      DOCKER_CACHE_ROOT: ${{ !matrix.build.shared-runners && '/mnt/dockercache' || '' }}
 
     # Keep this name in sync with the fetch-job-id step
     name: "test ${{ matrix.build.test-mark }} (${{ matrix.build.runs-on }}, ${{ matrix.build.name }}, ${{ strategy.job-index }})"
 
     container:
-      image: ${{ (matrix.build.shared-runners == true || matrix.build.shared-runners == 'true') && format('harbor.ci.tenstorrent.net/{0}', inputs.docker_image) || inputs.docker_image }}
+      image: ${{ !matrix.build.shared-runners && inputs.docker_image || format('harbor.ci.tenstorrent.net/{0}', inputs.docker_image) }}
       options: --device /dev/tenstorrent
       volumes:
         - /dev/hugepages:/dev/hugepages


### PR DESCRIPTION
### Ticket
/

### Problem description
When running the tests on shared runners the DOCKER_CACHE_ROOT expression still resolved to `/mnt/dockercache` so the cache cleanup didn't work.

### What's changed
Fix the logic.

### Checklist
- [ ] New/Existing tests provide coverage for changes
