### PR TITLE
Remove assert_pcc=False from yolov10 variants as it now have pcc>0.99 after disabling endtoend mode

### DIFF
--- a/tests/runner/test_config/test_config_inference_single_device.py
+++ b/tests/runner/test_config/test_config_inference_single_device.py
@@ -1603,14 +1603,10 @@ test_config = {
         "status": ModelTestStatus.EXPECTED_PASSING,
     },
     "yolov10/pytorch-yolov10x-single_device-full-inference": {
-        "assert_pcc": False,
         "status": ModelTestStatus.EXPECTED_PASSING,
-        "bringup_status": BringupStatus.INCORRECT_RESULT,
     },
     "yolov10/pytorch-yolov10n-single_device-full-inference": {
-        "assert_pcc": False,
         "status": ModelTestStatus.EXPECTED_PASSING,
-        "bringup_status": BringupStatus.INCORRECT_RESULT,
     },
     "gemma/pytorch-google/gemma-2b-single_device-full-inference": {
         "assert_pcc": False,


### PR DESCRIPTION
### Ticket

- Fixes https://github.com/tenstorrent/tt-xla/issues/1692
- Fixes https://github.com/tenstorrent/tt-xla/issues/1195


### Problem description

- Remove assert_pcc=False from yolov10 variants as it now have pcc>0.99 after disabling endtoend mode

### What's changed

- This PR removes assert_pcc=False from yolov10 variants.

### Checklist
- [x]  verified the functionality through local testing

### logs

Before fix

- [oct14_yolov10n.log](https://github.com/user-attachments/files/22923199/oct14_yolov10n.log)
- [oct14_yolov10x.log](https://github.com/user-attachments/files/22923201/oct14_yolov10x.log)

After Fix

- [oct15_yolov10_n_x_after_fix.log](https://github.com/user-attachments/files/22923209/oct15_yolov10_n_x_after_fix.log)

