### PR TITLE
Add unit test for topk op to keep track of pcc drop

### DIFF
--- a/tests/torch/single_chip/ops/test_topk.py
+++ b/tests/torch/single_chip/ops/test_topk.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from infra import Framework, run_op_test_with_random_inputs
+from utils import Category
+
+
+@pytest.mark.nightly
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    torch_op_name="torch.topk",
+)
+@pytest.mark.parametrize(
+    ["input_shape", "k"],
+    [
+        pytest.param((1, 10), 5),
+        pytest.param((1, 20), 5),
+        pytest.param((1, 30), 5),
+        pytest.param(
+            (1, 40),
+            5,
+            marks=pytest.mark.xfail(
+                strict=True,
+                reason="PCC comparison failed. Calculated: pcc=0.22071652114391327. Required: pcc=0.99. - https://github.com/tenstorrent/tt-xla/issues/1714",
+            ),
+        ),
+        pytest.param(
+            (1, 8400),
+            300,
+            marks=pytest.mark.xfail(
+                strict=True,
+                reason="PCC comparison failed. Calculated: pcc=0.054578136652708054. Required: pcc=0.99. - https://github.com/tenstorrent/tt-xla/issues/1714",
+            ),
+        ),
+    ],
+)
+def test_topk_indices(input_shape: tuple, k: int):
+    """Test topk operation returning indices."""
+
+    class TopKIndices(torch.nn.Module):
+        def __init__(self, k):
+            super().__init__()
+            self.k = k
+
+        def forward(self, x):
+            return torch.topk(x, self.k)[1]
+
+    model = TopKIndices(k)
+
+    run_op_test_with_random_inputs(
+        model, [input_shape], dtype=torch.float32, framework=Framework.TORCH
+    )


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-forge-models/pull/201#pullrequestreview-3340837861

### Problem description

- Add unit test for topk op to keep track of pcc drop.

### What's changed
- Added unit test for topk op to keep track of pcc drop.

### Checklist
- [x] Verified the functionality through local testing

### Logs

- [oct15_topk.log](https://github.com/user-attachments/files/22933174/oct15_z_topk_1.log)

