### PR TITLE
Make tt-mlir inherit the build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
 
 option(TTMLIR_ENABLE_PERF_TRACE "Enable performance tracing in tt-mlir" OFF)
+option(TTMLIR_BUILD_TYPE "Build type for tt-mlir" Release)
 option(TTXLA_ENABLE_EXPLORER "Enable Explorer feature in tt-mlir" OFF)
 
 if(TTXLA_ENABLE_EXPLORER)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -90,7 +90,7 @@ else()
         INSTALL_COMMAND ${CMAKE_COMMAND} --install <BINARY_DIR> --component SharedLib
 
         CMAKE_ARGS
-          -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+          -DCMAKE_BUILD_TYPE=${TTMLIR_BUILD_TYPE}
           -DCMAKE_C_COMPILER=clang-17
           -DCMAKE_CXX_COMPILER=clang++-17
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache


### PR DESCRIPTION
### Ticket
Closes #232 

### Problem description
Multiple people asked for a convenient way to have tt-mlir built in debug.

### What's changed
Added a `TTMLIR_BUILD_TYPE` flag to allow setting build type for mlir

### Checklist
- [ ] New/Existing tests provide coverage for changes
