### PR TITLE
Remove BringupStatus.INCORRECT_RESULT and enable PCC check in 34x generality tests w/ high pcc

### DIFF
--- a/tests/runner/test_config/test_config_inference_single_device.py
+++ b/tests/runner/test_config/test_config_inference_single_device.py
@@ -313,6 +313,7 @@ test_config = {
     },
     "densenet/pytorch-densenet161-single_device-full-inference": {
         "status": ModelTestStatus.EXPECTED_PASSING,
+        "required_pcc": 0.985,  # 0.990 for BH, 0.989 for WH
     },
     "densenet/pytorch-densenet169-single_device-full-inference": {
         # AssertionError: PCC comparison failed. Calculated: pcc=0.9880856871604919. Required: pcc=0.99.


### PR DESCRIPTION
### Ticket
None

### Problem description
- A bunch of generality models with PCC checking disabled have 0.99+ PCC lately and can have PCC checking enabled.

### What's changed
- Update 34x generality models for wh, bh or both to have PCC enabled, they are in good shape as reported by new PCC infra released yesterday
- Set PCC to 0.985 for densenet/pytorch-densenet161-single_device-full-inference it hits 0.990 for BH and 0.989 for WH

### Checklist
- [x] Tested on branch this change: https://github.com/tenstorrent/tt-xla/actions/runs/18577976515, ran test that didn't finish in time locally, and adjusted PCC on single fail.  Passing onPR (though not really related to changes): https://github.com/tenstorrent/tt-xla/actions/runs/18577835891
