### PR TITLE
Fix Build tt-xla job in CI

### DIFF
--- a/.github/workflows/call-build.yml
+++ b/.github/workflows/call-build.yml
@@ -88,7 +88,7 @@ jobs:
     needs: check-existing-artifact
     if: ${{ !needs.check-existing-artifact.outputs.artifacts_run_id }}
     timeout-minutes: 120
-    runs-on: ubuntu-latest
+    runs-on: tt-ubuntu-2204-large-stable
     name: "Build tt-xla"
     container:
       image: ${{ inputs.docker_image }}
@@ -120,17 +120,6 @@ jobs:
             echo "work-dir=$(pwd)" >> "$GITHUB_OUTPUT"
             echo "build-output-dir=$(pwd)/build" >> "$GITHUB_OUTPUT"
             echo "build-name=$(if [ '${{ inputs.debug_build }}' == 'true' ]; then echo 'codecov'; else echo 'release'; fi)" >> "$GITHUB_OUTPUT"
-
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: true
-          swap-storage: true
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2


### PR DESCRIPTION
### Ticket
#1730 

### Problem description
`Build tt-xla` job is failing in the CI because tt-xla wheel size has increased above the available space on the `ubuntu-latest` runner.

### What's changed
`Build tt-xla` job is now executing on `tt-ubuntu-2204-large-stable` runners (CIv2).

### Checklist
- [ ] New/Existing tests provide coverage for changes
