### PR TITLE
Few test_config fixes for duplicate red models

### DIFF
--- a/tests/runner/test_config/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/test_config_inference_single_device.yaml
@@ -1898,9 +1898,7 @@ test_config:
     reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.9418849945068359. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/1475"
     arch_overrides:
       n150:
-        status: NOT_SUPPORTED_SKIP
-        reason: "Too large for single chip"
-        bringup_status: FAILED_RUNTIME
+        status: EXCLUDE_MODEL # This model is run as tensor_parallel already.
 
   d_fine/pytorch-nano-single_device-full-inference:
     status: NOT_SUPPORTED_SKIP

--- a/tests/runner/test_config/test_config_placeholders.yaml
+++ b/tests/runner/test_config/test_config_placeholders.yaml
@@ -69,8 +69,6 @@ PLACEHOLDER_MODELS:
     bringup_status: NOT_STARTED
   Sentencizer:
     bringup_status: NOT_STARTED
-  pointpillars:
-    bringup_status: NOT_STARTED
   MiniMaxAI/MiniMax-Text-01:
     bringup_status: NOT_STARTED
   MiniMaxAI/MiniMax-VL-01:


### PR DESCRIPTION
### Ticket
None

### Problem description
- Spotted some duplicate models introduced with https://github.com/tenstorrent/tt-xla/pull/1653 where Falcon is already run as tensor_parallel, and pointpillars placeholder model wasn't removed when real model was added

### What's changed
- Remove pointpillars from PLACEHOLDER_MODELS and 
- tag Falcon7B n150 as EXCLUDE since already covered by tensor_parallel

### Checklist
- [ ] New/Existing tests provide coverage for changes
