### PR TITLE
Fix IR dumping

### DIFF
--- a/src/common/pjrt_implementation/module_builder/module_builder.cc
+++ b/src/common/pjrt_implementation/module_builder/module_builder.cc
@@ -959,13 +959,12 @@ tt_pjrt_status ModuleBuilder::checkOutputShardingShapes(
 void ModuleBuilder::printModule(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module,
                                 const std::optional<std::string> &export_path,
                                 const std::string &stage_name) {
-  if (loguru::g_stderr_verbosity < LOG_DEBUG) {
-    return;
+  if (loguru::g_stderr_verbosity >= LOG_DEBUG) {
+    VLOG_F(LOG_DEBUG, "MLIR Module %s:", stage_name.c_str());
+    mlir_module->print(llvm::errs(), mlir::OpPrintingFlags().enableDebugInfo());
+    llvm::errs()
+        << "------------------ END OF MLIR MODULE ------------------\n";
   }
-
-  VLOG_F(LOG_DEBUG, "MLIR Module %s:", stage_name.c_str());
-  mlir_module->print(llvm::errs(), mlir::OpPrintingFlags().enableDebugInfo());
-  llvm::errs() << "------------------ END OF MLIR MODULE ------------------\n";
 
   if (!export_path.has_value()) {
     return;


### PR DESCRIPTION
### Ticket


### Problem description
Dumping IRs required LOGGER_LEVEL=DEBUG unintentionally.

### What's changed
Make sure to not back out of a function too early.

### Checklist
- [ ] New/Existing tests provide coverage for changes
