### PR TITLE
xfail falcon/pytorch-tiiuae/falcon-7b-instruct-tensor_parallel-full-inference DRAM oom test from nightly

### DIFF
--- a/tests/runner/test_config/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/test_config_inference_tensor_parallel.yaml
@@ -38,4 +38,6 @@ test_config:
 
   falcon/pytorch-tiiuae/falcon-7b-instruct-tensor_parallel-full-inference:
     supported_archs: [n300-llmbox]
-    status: EXPECTED_PASSING
+    status: KNOWN_FAILURE_XFAIL
+    reason: "Not enough space to allocate 41295872 B DRAM buffer across 12 banks, where each bank needs to store 3442688 B - https://github.com/tenstorrent/tt-xla/issues/1755"
+    bringup_status: FAILED_RUNTIME


### PR DESCRIPTION
Skipping a single tensor parallel test to unblock nightly - opened https://github.com/tenstorrent/tt-xla/issues/1755