### PR TITLE
Ingest TTNN via alchemist

### DIFF
--- a/inc/common/pjrt_implementation/module_builder/module_builder.h
+++ b/inc/common/pjrt_implementation/module_builder/module_builder.h
@@ -336,7 +336,7 @@ private:
   // Invokes tt-alchemist to generate a ready-to-run solution (C++ or Python)
   // independently of the frontend. In the future, this will also prepare
   // everything to generate an .so file for execution.
-  tt_pjrt_status performCodegen(std::string_view ttir_mlir,
+  tt_pjrt_status performCodegen(std::string_view ttnn_mlir,
                                 const CompileOptions &compile_options);
 
   // MLIR context handle.

--- a/src/common/pjrt_implementation/module_builder/module_builder.cc
+++ b/src/common/pjrt_implementation/module_builder/module_builder.cc
@@ -1095,7 +1095,7 @@ ModuleBuilder::buildModuleForTTNNCodegen(
     std::vector<const char *> &&output_memory_kinds,
     std::vector<size_t> &&output_memory_kinds_sizes,
     CompileOptions &&compile_options) {
-  tt_pjrt_status status = performCodegen(ttir_mlir, compile_options);
+  tt_pjrt_status status = performCodegen(ttnn_mlir, compile_options);
   if (!tt_pjrt_status_is_ok(status)) {
     return {status, nullptr};
   }
@@ -1114,7 +1114,7 @@ ModuleBuilder::buildModuleForTTNNCodegen(
 }
 
 tt_pjrt_status
-ModuleBuilder::performCodegen(std::string_view ttir_mlir,
+ModuleBuilder::performCodegen(std::string_view ttnn_mlir,
                               const CompileOptions &compile_options) {
   assert(compile_options.export_path.has_value() &&
          "export_path compile option is not set.");
@@ -1127,9 +1127,9 @@ ModuleBuilder::performCodegen(std::string_view ttir_mlir,
   std::string folder = compile_options.export_path.value();
   std::filesystem::create_directories(folder);
 
-  std::ofstream ttir_file(folder + "/ttir.mlir");
-  ttir_file << ttir_mlir;
-  ttir_file.close();
+  std::ofstream ttnn_file(folder + "/ttnn.mlir");
+  ttnn_file << ttnn_mlir;
+  ttnn_file.close();
 
   void *instance = m_tt_alchemist_handler.getInstanceFunc()();
   if (!instance) {
@@ -1137,7 +1137,7 @@ ModuleBuilder::performCodegen(std::string_view ttir_mlir,
     return tt_pjrt_status::kInternal;
   }
 
-  std::string input_file = folder + "/ttir.mlir";
+  std::string input_file = folder + "/ttnn.mlir";
   // Controls wether the generated solution is designed
   // for standalone execution(is_local=false)
   // or for execution within an existing development environment that already


### PR DESCRIPTION
### Ticket
No ticket on XLA, but required for optimizer trough Codegen

### Problem description
Options shouldn't be hardcoded for codegen

### What's changed
Make codegen reuse the same options handling by using TTNN(with compile options already applied) for tt-alchemist

### Checklist
- [ ] New/Existing tests provide coverage for changes
