### PR TITLE
Add xfail reason for topk failed cases

### DIFF
--- a/tests/torch/single_chip/ops/test_topk.py
+++ b/tests/torch/single_chip/ops/test_topk.py
@@ -16,9 +16,30 @@ from utils import Category
 @pytest.mark.parametrize(
     ["input_shape", "k"],
     [
-        pytest.param((1, 10), 5),
-        pytest.param((1, 20), 5),
-        pytest.param((1, 30), 5),
+        pytest.param(
+            (1, 10),
+            5,
+            marks=pytest.mark.xfail(
+                strict=True,
+                reason="PCC comparison failed. Calculated: pcc=0.0042618513107299805. Required: pcc=0.99. - https://github.com/tenstorrent/tt-xla/issues/1714",
+            ),
+        ),
+        pytest.param(
+            (1, 20),
+            5,
+            marks=pytest.mark.xfail(
+                strict=True,
+                reason="PCC comparison failed. Calculated: pcc=-0.3680523633956909. Required: pcc=0.99. - https://github.com/tenstorrent/tt-xla/issues/1714",
+            ),
+        ),
+        pytest.param(
+            (1, 30),
+            5,
+            marks=pytest.mark.xfail(
+                strict=True,
+                reason="PCC comparison failed. Calculated: pcc=0.45831882953643. Required: pcc=0.99. - https://github.com/tenstorrent/tt-xla/issues/1714",
+            ),
+        ),
         pytest.param(
             (1, 40),
             5,


### PR DESCRIPTION
Ref : https://github.com/tenstorrent/tt-xla/issues/1714

### Problem description
[Nightly](https://github.com/tenstorrent/tt-xla/actions/runs/18701564091/job/53371599925) is failing for this topk op test

### What's changed
added xfail reasons for the corresponding failing cases

### Checklist
- [x] New/Existing tests provide coverage for changes

PFA  logs for reference
[topk_xfail.log](https://github.com/user-attachments/files/23057436/topk_xfail.log)
[topk.log](https://github.com/user-attachments/files/23057438/topk.log)

