### PR TITLE
Add inference test config for DeepSeekOCR model

### DIFF
--- a/tests/runner/test_config/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/test_config_inference_single_device.yaml
@@ -1194,6 +1194,11 @@ test_config:
   deepseek/deepseek_coder/pytorch-1_3b_instruct-single_device-full-inference:
     status: EXPECTED_PASSING
 
+  deepseek/deepseek_ocr/pytorch-deepseek_ocr-single_device-full-inference:
+    status: KNOWN_FAILURE_XFAIL
+    reason: "RuntimeError: a Tensor with 3145728 elements cannot be converted to Scalar - https://github.com/tenstorrent/tt-xla/issues/1772"
+    bringup_status: FAILED_FE_COMPILATION
+
   deepseek/pytorch-single_device-full-inference:
     status: KNOWN_FAILURE_XFAIL  # Exposed by "Remove host-side consteval" change
     reason: "error: failed to legalize operation 'ttir.scatter' - https://github.com/tenstorrent/tt-xla/issues/1266"


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/1751

### Problem description

- Add inference test config for DeepSeekOCR model

### What's changed

- This PR adds inference test config for DeepSeekOCR model & tracks this [changes](https://github.com/tenstorrent/tt-forge-models/pull/209).

### Checklist
- [x] verified the changes through local testing

### Logs

- [oct28_deepseek_ocr_cpu.log](https://github.com/user-attachments/files/23182627/oct28_ocr_cpu.log)
- [oct28_deepseek_ocr_xla_1.log](https://github.com/user-attachments/files/23182628/oct28_ocr_xla_1.log)

