### PR TITLE
update torch tests for runtime binary op issue

### DIFF
--- a/tests/runner/test_config/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/test_config_inference_single_device.yaml
@@ -498,7 +498,6 @@ test_config:
 
   mistral/pytorch-ministral_3b_instruct-single_device-full-inference:
     status: KNOWN_FAILURE_XFAIL
-    assert_pcc: false
     reason: "Unsupported binary op for FPU BinaryOpType::BITWISE_OR. - https://github.com/tenstorrent/tt-xla/issues/1783"
     bringup_status: FAILED_RUNTIME
 
@@ -1388,7 +1387,6 @@ test_config:
     bringup_status: INCORRECT_RESULT
 
   phi3/phi_3_5/pytorch-mini_instruct-single_device-full-inference:
-    assert_pcc: false
     status: KNOWN_FAILURE_XFAIL
     reason: "Unsupported binary op for FPU BinaryOpType::BITWISE_OR. - https://github.com/tenstorrent/tt-xla/issues/1783"
     bringup_status: FAILED_RUNTIME
@@ -1496,19 +1494,16 @@ test_config:
     reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.4519438147544861. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/1443"
 
   phi3/token_cls/pytorch-microsoft/Phi-3-mini-128k-instruct-single_device-full-inference:
-    assert_pcc: false
     status: KNOWN_FAILURE_XFAIL
     bringup_status: FAILED_RUNTIME
     reason: "Unsupported binary op for FPU BinaryOpType::BITWISE_OR. - https://github.com/tenstorrent/tt-xla/issues/1783"
 
   phi3/token_cls/pytorch-microsoft/Phi-3-mini-4k-instruct-single_device-full-inference:
-    assert_pcc: false
     status: KNOWN_FAILURE_XFAIL
     reason: "Unsupported binary op for FPU BinaryOpType::BITWISE_OR. - https://github.com/tenstorrent/tt-xla/issues/1783"
     bringup_status: FAILED_RUNTIME
 
   phi3/seq_cls/pytorch-microsoft/Phi-3-mini-128k-instruct-single_device-full-inference:
-    assert_pcc: false
     status: KNOWN_FAILURE_XFAIL
     reason: "Unsupported binary op for FPU BinaryOpType::BITWISE_OR. - https://github.com/tenstorrent/tt-xla/issues/1783"
     bringup_status: FAILED_RUNTIME
@@ -1688,7 +1683,6 @@ test_config:
   mistral/pytorch-7b-single_device-full-inference:
     arch_overrides:
       p150:
-        assert_pcc: false
         status: KNOWN_FAILURE_XFAIL
         reason: "Unsupported binary op for FPU BinaryOpType::BITWISE_OR. - https://github.com/tenstorrent/tt-xla/issues/1783"
         bringup_status: FAILED_RUNTIME
@@ -1708,7 +1702,6 @@ test_config:
   mistral/pytorch-ministral_8b_instruct-single_device-full-inference:
     arch_overrides:
       p150:
-        assert_pcc: false
         status: KNOWN_FAILURE_XFAIL
         reason: "Unsupported binary op for FPU BinaryOpType::BITWISE_OR. - https://github.com/tenstorrent/tt-xla/issues/1783"
         bringup_status: FAILED_RUNTIME


### PR DESCRIPTION
### Ticket
Ref : https://github.com/tenstorrent/tt-xla/issues/1783

### Problem description
* Phi3 models are failing with `Unsupported binary op for FPU BinaryOpType::BITWISE_OR` issue 
* 2 of the Mistral variants are failing with the above issue in p150

### What's changed
* updated the status, bringup_status and reason for the model and xfailed them


### Checklist
- [x] New/Existing tests provide coverage for changes

PFA  log for reference
[phi3_seq_cls_mini4k_mlir_3f8fb25e6.log](https://github.com/user-attachments/files/23102039/phi3_seq_cls_mini4k_mlir_3f8fb25e6.log)
[phi3_seq_cls_mini4k_xfail.log](https://github.com/user-attachments/files/23102055/phi3_seq_cls_mini4k_xfail.log)
[phi3_5_mini_xfail.log](https://github.com/user-attachments/files/23102527/phi3_5_mini_xfail.log)
[phi3_seq_3_mini128k_xfail.log](https://github.com/user-attachments/files/23102529/phi3_seq_3_mini128k_xfail.log)


