### PR TITLE
Add github CI yml change to run only test_forge_models_push if tests/runner/ files changed

### DIFF
--- a/.github/actions/inspect-changes/action.yml
+++ b/.github/actions/inspect-changes/action.yml
@@ -11,6 +11,9 @@ outputs:
   run-perf-tests:
     description: "True if performance-related files changed."
     value: ${{ steps.inspect.outputs.run-perf-tests }}
+  only-run-forge-models:
+    description: "True if only forge-models runner files changed."
+    value: ${{ steps.inspect.outputs.only-run-forge-models }}
 runs:
   using: "composite"
   steps:
@@ -24,13 +27,19 @@ runs:
         skip_build_and_test=true
         run_pr_tests=false
         run_perf_tests=false
+        only_run_forge_models=false
         if [ "${{ github.event_name }}" = "pull_request" ]; then
           CHANGED_FILES=$(gh pr diff ${{ github.event.pull_request.number }} --name-only --repo ${{ github.repository }})
+          only_run_forge_models=true
           for file in $CHANGED_FILES; do
             # Only allow docs, markdown, gitignore, LICENSE, CODEOWNERS to skip build/test
             if [[ ! $file =~ ^.*\.(md|gitignore)$ && $file != *"LICENSE"* && $file != docs/* && $file != *"CODEOWNERS"* ]]; then
               skip_build_and_test=false
               run_pr_tests=true
+            fi
+            # Detect if all changes are strictly under tests/runner/
+            if [[ ! $file =~ ^tests/runner/.* ]]; then
+              only_run_forge_models=false
             fi
             # Example: detect perf uplift (customize as needed)
             if [[ $file == *"perf"* ]]; then
@@ -44,3 +53,4 @@ runs:
         echo "skip-build-and-test=$skip_build_and_test" >> "$GITHUB_OUTPUT"
         echo "run-pr-tests=$run_pr_tests" >> "$GITHUB_OUTPUT"
         echo "run-perf-tests=$run_perf_tests" >> "$GITHUB_OUTPUT"
+        echo "only-run-forge-models=$only_run_forge_models" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -26,6 +26,7 @@ jobs:
       skip-build-and-test: ${{ steps.inspect.outputs.skip-build-and-test }}
       run-pr-tests: ${{ steps.inspect.outputs.run-pr-tests }}
       run-perf-tests: ${{ steps.inspect.outputs.run-perf-tests }}
+      only-run-forge-models: ${{ steps.inspect.outputs.only-run-forge-models }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/inspect-changes
@@ -42,7 +43,7 @@ jobs:
     name: "Build tt-xla with code coverage"
     secrets: inherit
     needs: [ inspect-changes, build-image ]
-    if: needs.inspect-changes.outputs.skip-build-and-test == 'false'
+    if: needs.inspect-changes.outputs.skip-build-and-test == 'false' && needs.inspect-changes.outputs.only-run-forge-models != 'true'
     with:
       docker_image: ${{ needs.build-image.outputs.docker-image }}
       debug_build: true
@@ -58,7 +59,7 @@ jobs:
 
   test:
     needs: [ inspect-changes, build-image, build-ttxla-codecov, build-ttxla-release ]
-    if: needs.inspect-changes.outputs.skip-build-and-test == 'false'
+    if: needs.inspect-changes.outputs.skip-build-and-test == 'false' && needs.inspect-changes.outputs.only-run-forge-models != 'true'
     uses: ./.github/workflows/call-test.yml
     secrets: inherit
     with:
@@ -72,7 +73,7 @@ jobs:
       build_artifact_name: ${{ needs.build-ttxla-codecov.outputs.build_artifact_name }}
 
   perf-benchmark:
-    if: needs.inspect-changes.outputs.skip-build-and-test == 'false' && vars.RUN_PERF_ON_UPLIFT == 'true'  && github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'uplift')
+    if: needs.inspect-changes.outputs.skip-build-and-test == 'false' && needs.inspect-changes.outputs.only-run-forge-models != 'true' && vars.RUN_PERF_ON_UPLIFT == 'true'  && github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'uplift')
     needs: [ inspect-changes, build-image, build-ttxla-release ]
     uses: tenstorrent/tt-forge/.github/workflows/perf-benchmark.yml@main
     secrets: inherit


### PR DESCRIPTION
### Ticket
#1796

### Problem description
- We have a lot of changes touching just tests/runner/* files (26 in past month) but it triggers full onPR which can take hours and is often 100% unrelated/not-needed. Let's catch this special case since it is common and benefit from reduced CI.

### What's changed
- Update inspect-changes/action.yml and pr-main.yml to detect when changes in PR only touch tests/runner/ folder and in this case skip everything except the actual affected test_forge_models_push tests and test_config yaml file validation
- Some refactoring of action.yml outputs and usage in pr-main.yml may simplify things if we want to lean more into this concept but that's a bigger scope change so for now keep things as simple as possible.

### Checklist
- [x] Tested this code on branch w/ hack here to see it working: https://github.com/tenstorrent/tt-xla/actions/runs/18782046688
