### PR TITLE
Add support for #skip-onpr-tests used sparingly for no-risk changes in PR where build + tests is not appropriate

### DIFF
--- a/.github/actions/inspect-changes/action.yml
+++ b/.github/actions/inspect-changes/action.yml
@@ -25,6 +25,16 @@ runs:
         run_pr_tests=false
         run_perf_tests=false
         if [ "${{ github.event_name }}" = "pull_request" ]; then
+          # Check for skip flag in PR head commit message
+          git fetch origin ${{ github.event.pull_request.head.sha }}
+          COMMIT_MSG=$(git log -1 --pretty=%B ${{ github.event.pull_request.head.sha }})
+          if [[ "$COMMIT_MSG" == *"#skip-onpr-tests"* ]]; then
+            echo "User requested skip via commit message."
+            echo "skip-build-and-test=true" >> "$GITHUB_OUTPUT"
+            echo "run-pr-tests=false" >> "$GITHUB_OUTPUT"
+            echo "run-perf-tests=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           CHANGED_FILES=$(gh pr diff ${{ github.event.pull_request.number }} --name-only --repo ${{ github.repository }})
           for file in $CHANGED_FILES; do
             # Only allow docs, markdown, gitignore, LICENSE, CODEOWNERS to skip build/test


### PR DESCRIPTION
### Ticket
#1796

### Problem description
- We occasionally make initial or followup changes for a PR that are no-risk or that onPR set of tests provides zero coverage/benefit for, but can still take hours.  Examples: adding a comment, xfailing a nightly test, decreasing PCC, adjusting a failing reason, addressing a no-risk PR feedback nit, etc. Guilt and broken hearts arise when a comment change causes onPR to have to rerun for an otherwise approved and ready PR, or when xfailing a nightly test and we're stuck running push tests.

### What's changed
- Change to skip build and tests if string #skip-onpr-tests is in commit description. This opt-in feature, used sparingly and only when appropriate, we had in tt-torch for 6 months and relied on to reduce CI usage in cases that made sense like above.  It still runs pre-commit to lint code.
- No more guilt to suggest or make a nitpick if user can avoid needing to rerun CI.

### Checklist
- [x] Tested this change on branch here, works: https://github.com/tenstorrent/tt-xla/actions/runs/18751777388
