### PR TITLE
Add BufferInstance session-unique global ID 

### DIFF
--- a/pjrt_implementation/inc/api/buffer_instance.h
+++ b/pjrt_implementation/inc/api/buffer_instance.h
@@ -181,8 +181,12 @@ private:
   calculateStrides(size_t num_dims, const std::int64_t *byte_strides,
                    size_t num_byte_strides, std::uint32_t element_size);
 
-  // Static atomic counter for generating unique buffer IDs.
-  static std::atomic<uint64_t> s_next_uid;
+  // Gets next UID for buffer instances, used in buffer instance constructor
+  // to assign unique identifier to each buffer instance.
+  static uint64_t nextUID() {
+    static std::atomic<uint64_t> uid{0};
+    return uid.fetch_add(1, std::memory_order_relaxed);
+  }
 
   // Unique identifier for this buffer instance.
   const uint64_t m_uid;

--- a/pjrt_implementation/src/api/buffer_instance.cc
+++ b/pjrt_implementation/src/api/buffer_instance.cc
@@ -32,9 +32,6 @@
 
 namespace tt::pjrt {
 
-// Initialize the static UID counter
-std::atomic<uint64_t> BufferInstance::s_next_uid{0};
-
 std::unique_ptr<BufferInstance> BufferInstance::createInputBufferInstance(
     PJRT_Buffer_Type data_type, const std::int64_t *dims, size_t num_dims,
     DeviceInstance *device, MemoryInstance *memory) {
@@ -69,19 +66,17 @@ std::unique_ptr<BufferInstance> BufferInstance::createOutputBufferInstance(
 BufferInstance::BufferInstance(PJRT_Buffer_Type data_type,
                                const std::int64_t *dims, size_t num_dims,
                                DeviceInstance *device, MemoryInstance *memory)
-    : m_uid(s_next_uid.fetch_add(1, std::memory_order_relaxed)),
-      m_data_type(data_type), m_dimensions(dims, dims + num_dims),
-      m_device(device), m_memory(memory), m_host_runtime_tensor(std::nullopt),
-      m_data_ready(false), m_data_ready_event(nullptr),
-      m_done_with_host_buffer_event(nullptr), m_data_deleted(false),
-      m_prepared_runtime_tensor(std::nullopt) {}
+    : m_uid(nextUID()), m_data_type(data_type),
+      m_dimensions(dims, dims + num_dims), m_device(device), m_memory(memory),
+      m_host_runtime_tensor(std::nullopt), m_data_ready(false),
+      m_data_ready_event(nullptr), m_done_with_host_buffer_event(nullptr),
+      m_data_deleted(false), m_prepared_runtime_tensor(std::nullopt) {}
 
 BufferInstance::BufferInstance(const tt::runtime::Tensor &tensor,
                                const std::vector<std::uint32_t> &dimensions,
                                DeviceInstance *device, MemoryInstance *memory,
                                PJRT_Buffer_Type data_type)
-    : m_uid(s_next_uid.fetch_add(1, std::memory_order_relaxed)),
-      m_data_type(data_type),
+    : m_uid(nextUID()), m_data_type(data_type),
       m_dimensions(dimensions.begin(), dimensions.end()), m_device(device),
       m_memory(memory), m_host_runtime_tensor(tensor), m_data_ready(false),
       m_data_ready_event(nullptr), m_done_with_host_buffer_event(nullptr),


### PR DESCRIPTION
### Ticket
None

### Problem description
It's hard to tell if two BufferInstances are the same, which can help for memory leak and tensor persistence debug investigations. BufferInstance pointers are highly unstable as they are deallocated unpredictably by the framework and reused at subsequent allocations.

### What's changed
Add BufferInstance UID system to attach a session-unique, atomically incrementing uint64_t ID to each bufferInstance. This implementation mimics tt-mlir runtime's [global tensor ID implementation](https://github.com/tenstorrent/tt-mlir/blob/00d3097a44e7007ba8194d7bb146ebc40a3012d0/runtime/lib/common/types.cpp#L127-L130) with a static atomic counter incremented with atomic fetch_add.

Access via bufferInstance member function `getUID()` returning uint64_t

### Checklist
- [x] New/Existing tests provide coverage for changes
