### PR TITLE
Fail earlier and add new asserts if running TP model without shard specs

### DIFF
--- a/tests/infra/testers/single_chip/model/torch_model_tester.py
+++ b/tests/infra/testers/single_chip/model/torch_model_tester.py
@@ -99,9 +99,13 @@ class TorchModelTester(ModelTester):
         )
 
         if self._parallelism == Parallelism.TENSOR_PARALLEL:
-            assert (
-                self._workload.shard_spec_fn is not None
-            ), "Tensor parallel requires shard specs function"
+            # Not all models/variants' loaders have load_shard_spec() defined or returning shard specs, verify here.
+            fn = self._workload.shard_spec_fn
+            assert callable(fn), "Tensor parallel requires shard specs function"
+            assert bool(
+                fn(self._model)
+            ), "Tensor parallel requires shard specs function to return shard specs"
+
             assert (
                 self._workload.mesh and len(self._workload.mesh.device_ids) > 1
             ), "Tensor parallel requires multi-chip mesh"

--- a/tests/infra/testers/single_chip/model/torch_model_tester.py
+++ b/tests/infra/testers/single_chip/model/torch_model_tester.py
@@ -99,16 +99,7 @@ class TorchModelTester(ModelTester):
         )
 
         if self._parallelism == Parallelism.TENSOR_PARALLEL:
-            # Not all models/variants' loaders have load_shard_spec() defined or returning shard specs, verify here.
-            fn = self._workload.shard_spec_fn
-            assert callable(fn), "Tensor parallel requires shard specs function"
-            assert bool(
-                fn(self._model)
-            ), "Tensor parallel requires shard specs function to return shard specs"
-
-            assert (
-                self._workload.mesh and len(self._workload.mesh.device_ids) > 1
-            ), "Tensor parallel requires multi-chip mesh"
+            self._assert_tensor_parallel_valid()
 
     # @override
     def _get_forward_method_args(self) -> Sequence[Any]:
@@ -140,6 +131,23 @@ class TorchModelTester(ModelTester):
     def _compile_for_tt_device(self, workload: Workload) -> None:
         """Compiles `workload` for TT device."""
         self._compile_for_backend(workload, backend="tt")
+
+    def _assert_tensor_parallel_valid(self) -> bool:
+        """Ensure the workload supports tensor parallelism (multi-chip mesh and shard specs)."""
+        fn = self._workload.shard_spec_fn
+        assert callable(fn), "Tensor parallel requires shard specs function"
+
+        shard_specs = fn(self._model)
+        assert (
+            shard_specs
+        ), "Tensor parallel requires shard specs function to return non-empty specs"
+
+        mesh = self._workload.mesh
+        assert (
+            mesh and len(mesh.device_ids) > 1
+        ), "Tensor parallel requires multi-chip mesh"
+
+        return True
 
     def _compile_for_backend(self, workload: Workload, backend: str) -> None:
         """JIT-compiles model into optimized kernels."""

--- a/tests/infra/workloads/torch_workload.py
+++ b/tests/infra/workloads/torch_workload.py
@@ -49,8 +49,10 @@ class TorchWorkload(Workload):
     # If model has shard specs and running on multichip mesh, then convert StableHLO
     # to Shardy dialect and initialize XLA SPMD runtime.
     def _enable_xla_spmd_if_needed(self) -> None:
-        has_shard_specs = self.shard_spec_fn is not None
-        is_multichip = self.mesh and len(self.mesh.device_ids) > 1
+        is_multichip = bool(self.mesh and len(self.mesh.device_ids) > 1)
+        has_shard_specs = False
+        if callable(self.shard_spec_fn) and self.model is not None:
+            has_shard_specs = bool(self.shard_spec_fn(self.model))
 
         if has_shard_specs and is_multichip:
             enable_spmd()

--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -323,13 +323,7 @@ class DynamicTorchModelTester(TorchModelTester):
 
             return load_shard_spec
         else:
-
-            # Only provide a shard spec function if the loader overrides the base implementation
-            return (
-                self.loader.load_shard_spec
-                if ("load_shard_spec" in type(self.loader).__dict__)
-                else None
-            )
+            return self.loader.load_shard_spec
 
     def _get_mesh(self):
         num_devices = xr.global_runtime_device_count()

--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -323,7 +323,13 @@ class DynamicTorchModelTester(TorchModelTester):
 
             return load_shard_spec
         else:
-            return self.loader.load_shard_spec
+
+            # Only provide a shard spec function if the loader overrides the base implementation
+            return (
+                self.loader.load_shard_spec
+                if ("load_shard_spec" in type(self.loader).__dict__)
+                else None
+            )
 
     def _get_mesh(self):
         num_devices = xr.global_runtime_device_count()


### PR DESCRIPTION
### Ticket
#1809 

### Problem description
- Existing logic has issues to catch when tests run in TensorParallel mode but model/variant doesn't define optional shard specs, allows test to enable SPMD and try and run in tensor parallel, and maybe fail in cryptic way (see issue).

### What's changed
- Enhance asserts for TP mode to require not just shard_spec function, but for it to return non-empty shard specs. Catches cases where models define load_shard_spec() but none returned for some variants. Refactor asserts inside _assert_tensor_parallel_valid()
- Fix torch_workload.py _enable_xla_spmd_if_needed() conditions to look for non-zero shard specs not just shard_spec_fn being non-zero.

### Checklist
- [x] Tested locally with previously affected cases of tests without shard specs, and against bunch of newly improved (with shard specs) models on CI here: https://github.com/tenstorrent/tt-xla/actions/runs/18824205892 (some hit new asserts as expected).  Rerun with updated changes here: https://github.com/tenstorrent/tt-xla/actions/runs/18859291876
