### PR TITLE
Fix gliner

### DIFF
--- a/tests/infra/testers/single_chip/model/torch_model_tester.py
+++ b/tests/infra/testers/single_chip/model/torch_model_tester.py
@@ -141,7 +141,7 @@ class TorchModelTester(ModelTester):
         """JIT-compiles model into optimized kernels."""
         assert workload.is_torch and workload.model is not None
 
-        workload.model.compile(backend=backend)
+        workload.compiled_executable = torch.compile(workload.model, backend=backend)
 
     def _test_training(self) -> Tuple[ComparisonResult, ...]:
         # Run forward on CPU

--- a/tests/infra/workloads/workload.py
+++ b/tests/infra/workloads/workload.py
@@ -61,10 +61,10 @@ class Workload:
 
     def execute(self) -> Any:
         """Calls callable passing stored args and kwargs directly."""
-        if self.model is not None:
-            return self.model(*self.args, **self.kwargs)
-        elif self.compiled_executable is not None:
+        if self.compiled_executable is not None:
             return self.compiled_executable(*self.args, **self.kwargs)
+        elif self.model is not None:
+            return self.model(*self.args, **self.kwargs)
         elif self.executable is not None:
             return self.executable(*self.args, **self.kwargs)
         else:


### PR DESCRIPTION
GLiner model has a compile function, so compiling inplace with `model.compile` does not work. 

### What's changed
outplace compile with `compiled_executable = torch.compile(model, backend=backend)`

### Checklist
- [x] New/Existing tests provide coverage for changes
  - Passing nightly [run](https://github.com/tenstorrent/tt-xla/actions/runs/18893822057)  
