### PR TITLE
Remove AWQ related deps and tests recently added, not needed.

### DIFF
--- a/tests/runner/test_config/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/test_config_inference_single_device.yaml
@@ -830,16 +830,6 @@ test_config:
       reason: "error: failed to legalize operation 'ttir.convolution' - https://github.com/tenstorrent/tt-xla/issues/1662"
       bringup_status: FAILED_TTMLIR_COMPILATION
 
-  qwen_2_5_vl/pytorch-3b_instruct_awq-single_device-full-inference:
-      status: KNOWN_FAILURE_XFAIL
-      reason: "error: failed to legalize operation 'ttir.convolution' - https://github.com/tenstorrent/tt-xla/issues/1662"
-      bringup_status: FAILED_TTMLIR_COMPILATION
-
-  qwen_2_5_vl/pytorch-7b_instruct_awq-single_device-full-inference:
-      status: KNOWN_FAILURE_XFAIL
-      reason: "error: failed to legalize operation 'ttir.convolution' - https://github.com/tenstorrent/tt-xla/issues/1662"
-      bringup_status: FAILED_TTMLIR_COMPILATION
-
   llama/sequence_classification/pytorch-llama_3_2_1b-single_device-full-inference:
     status: EXPECTED_PASSING
 

--- a/venv/requirements-dev.txt
+++ b/venv/requirements-dev.txt
@@ -66,8 +66,3 @@ qwen-vl-utils[decord]==0.0.8
 
 # whisper and wav2vec2 models
 torchcodec
-
-# Qwen2.5 VL AWQ variants
-triton==3.3.0
-intel_extension_for_pytorch==2.7.0
-autoawq[cpu]==0.2.9


### PR DESCRIPTION
### Ticket
#1529 

### Problem description
- These AWQ + triton deps added in tt-xla are questionable and causing pip-install errors for folks locally in some cases "ERROR: Cannot install torch==2.7.1 and triton==3.3.0 because these package versions have conflicting dependencies."
- We wanted to have them added as per-model reqs in tt-forge-models but ran into issues
- Turns out these qwen2.5 AWQ variants are not actually requested by customer, were just added because they existed. 

### What's changed
- Let's not run the AWQ versions of the test if they are not customer requested for now. 
- Remove the new awq, triton, intel_extension_for_pytorch deps from venv/requirements-dev.txt
- Remove the 2 test config entries from the awq models so they aren't run in nightly (can be removed from tt-forge-models as follow up step if we agree)

### Checklist
- [ ] New/Existing tests provide coverage for changes
