### PR TITLE
Fixing nightly 30-10-2025

### DIFF
--- a/tests/runner/test_config/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/test_config_inference_single_device.yaml
@@ -492,7 +492,9 @@ test_config:
     status: EXPECTED_PASSING
 
   roberta/masked_lm/pytorch-xlm_base-single_device-full-inference:
-    status: EXPECTED_PASSING
+    status: KNOWN_FAILURE_XFAIL
+    reason: "failed to legalize operation 'ttir.gather' that was explicitly marked illegal - https://github.com/tenstorrent/tt-xla/issues/1884"
+    bringup_status: FAILED_TTMLIR_COMPILATION
 
   mamba/pytorch-mamba-2.8b-hf-single_device-full-inference:
     status: EXPECTED_PASSING
@@ -575,7 +577,9 @@ test_config:
     status: EXPECTED_PASSING
 
   roberta/pytorch-cardiffnlp/twitter-roberta-base-sentiment-single_device-full-inference:
-    status: EXPECTED_PASSING
+    status: KNOWN_FAILURE_XFAIL
+    reason: "failed to legalize operation 'ttir.gather' that was explicitly marked illegal - https://github.com/tenstorrent/tt-xla/issues/1884"
+    bringup_status: FAILED_TTMLIR_COMPILATION
 
   bert/token_classification/pytorch-dbmdz/bert-large-cased-finetuned-conll03-english-single_device-full-inference:
     status: EXPECTED_PASSING
@@ -2128,9 +2132,9 @@ test_config:
 
   transfuser/pytorch-single_device-full-inference:
     assert_pcc: false
-    status: EXPECTED_PASSING
-    bringup_status: INCORRECT_RESULT
-    reason: "AssertionError: Comparison result 0 failed: PCC comparison failed. Calculated: pcc=-0.7157331705093384. Required: pcc=0.99."
+    status: KNOWN_FAILURE_XFAIL
+    bringup_status: FAILED_TTMLIR_COMPILATION
+    reason: "failed to legalize operation 'ttir.gather' that was explicitly marked illegal - https://github.com/tenstorrent/tt-xla/issues/1884"
 
   yolov11/pytorch-yolo11n-single_device-full-inference:
     status: EXPECTED_PASSING

--- a/tests/torch/single_chip/graphs/test_attention.py
+++ b/tests/torch/single_chip/graphs/test_attention.py
@@ -148,6 +148,12 @@ def test_llama_attention_decode(variant, variant_config):
 )
 def test_llama_concat_heads(variant, variant_config, seq_len):
 
+    if (
+        str(variant) == "llama_3_1_405b-1024"
+        or str(variant) == "llama_3_1_405b_instruct-1024"
+    ):
+        pytest.xfail("Variant doesn't fit on device")
+
     def concat_heads(attn_output, input_shape):
         attn_output = attn_output.transpose(1, 2).contiguous()
         return attn_output.reshape(*input_shape, -1).contiguous()

--- a/tests/torch/single_chip/models/bge_m3/test_bge_m3_custom_encode.py
+++ b/tests/torch/single_chip/models/bge_m3/test_bge_m3_custom_encode.py
@@ -18,7 +18,7 @@ import torch_xla.runtime as xr
 from infra import ComparisonConfig, Framework, RunMode
 from infra.comparators.torch_comparator import TorchComparator
 from torch.utils._pytree import tree_map
-from utils import BringupStatus, Category, incorrect_result
+from utils import BringupStatus, Category, failed_ttmlir_compilation
 
 from third_party.tt_forge_models.bge_m3.pytorch.loader import ModelLoader, ModelVariant
 
@@ -194,7 +194,12 @@ def bge_m3_encode():
     category=Category.MODEL_TEST,
     model_info=MODEL_INFO,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.INCORRECT_RESULT,
+    bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
+)
+@pytest.mark.xfail(
+    reason=failed_ttmlir_compilation(
+        "failed to legalize operation 'ttir.gather' that was explicitly marked illegal - https://github.com/tenstorrent/tt-xla/issues/1884"
+    )
 )
 def test_bge_m3_custom_encode():
     """Run BGE-M3 encode on TT device and validate PCC outputs are finite and bounded."""

--- a/tests/torch/single_chip/models/bge_m3/test_bge_m3_encode.py
+++ b/tests/torch/single_chip/models/bge_m3/test_bge_m3_encode.py
@@ -16,7 +16,7 @@ import torch_xla.runtime as xr
 from infra import ComparisonConfig, Framework, RunMode
 from infra.comparators.torch_comparator import TorchComparator
 from torch.utils._pytree import tree_map
-from utils import BringupStatus, Category, incorrect_result
+from utils import BringupStatus, Category, failed_ttmlir_compilation
 
 from third_party.tt_forge_models.bge_m3.encode.pytorch.loader import (
     ModelLoader,
@@ -144,7 +144,12 @@ def bge_m3_encode():
     category=Category.MODEL_TEST,
     model_info=MODEL_INFO,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.INCORRECT_RESULT,
+    bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
+)
+@pytest.mark.xfail(
+    reason=failed_ttmlir_compilation(
+        "failed to legalize operation 'ttir.gather' that was explicitly marked illegal - https://github.com/tenstorrent/tt-xla/issues/1884"
+    )
 )
 def test_bge_m3_encode():
     """Run BGE-M3 encode on TT device and validate PCC outputs are finite and bounded."""


### PR DESCRIPTION
In the newest nightly CI, there was a set of models failing compile on `ttir.gather` op, xfailing it for now, while we are looking at a root cause.