### PR TITLE
Add runtime multihost infra, add multihost llama test

### DIFF
--- a/.github/workflows/test-matrix-presets/basic-test.json
+++ b/.github/workflows/test-matrix-presets/basic-test.json
@@ -9,5 +9,6 @@
   { "runs-on": "n300-llmbox",        "name": "run_jax_4_devices",     "dir": "./tests/jax/multi_chip/llmbox/4_devices", "test-mark": "push", "shared-runners": "true" },
   { "runs-on": "n300-llmbox",        "name": "run_jax_8_devices",     "dir": "./tests/jax/multi_chip/llmbox/8_devices", "test-mark": "push", "shared-runners": "true" },
   { "runs-on": "n300-llmbox",        "name": "run_torch_multi_chip",  "dir": "./tests/torch/single_chip",               "test-mark": "push and llmbox", "shared-runners": "true" },
+  { "runs-on": "n300-llmbox",        "name": "run_torch_multi_host",  "dir": "./tests/torch/multi_host",                "test-mark": "push and llmbox", "shared-runners": "true" },
   { "runs-on": "n150",               "name": "run_vllm_n150_tests",   "dir": "./tests/integrations/vllm_plugin",        "test-mark": "push", "shared-runners": "true" }
 ]

--- a/pjrt_implementation/src/api/buffer_instance.cc
+++ b/pjrt_implementation/src/api/buffer_instance.cc
@@ -188,6 +188,9 @@ void BufferInstance::copyFromHost(
   std::unique_ptr<EventInstance> done_with_host_buffer_event =
       EventInstance::createInstance();
 
+  // In distributed runtime, we always create owned host tensor because we
+  // cannot alias the host buffer.
+  //
   // In case when input host buffer has a semantic `ImmutableOnlyDuringCall`
   // we are not allowed to alias it directly, so we have to create owned host
   // tensor which copies buffer data. In JAX this semantic is used only for
@@ -199,7 +202,9 @@ void BufferInstance::copyFromHost(
   // supported by runtime/ttnn, then we must create an owned tensor as runtime
   // must case the data inside the host buffer into a supported data type. Thus,
   // the buffer cannot be borrowed.
-  if (host_buffer_semantics ==
+  if (::tt::runtime::getCurrentHostRuntime() ==
+          tt::runtime::HostRuntime::Distributed ||
+      host_buffer_semantics ==
           PJRT_HostBufferSemantics_kImmutableOnlyDuringCall ||
       !::tt::runtime::utils::isSupportedDataType(runtime_data_type)) {
 

--- a/pjrt_implementation/src/api/client_instance.cc
+++ b/pjrt_implementation/src/api/client_instance.cc
@@ -37,6 +37,83 @@
 
 namespace tt::pjrt {
 
+static std::string getRankBindingPath(const std::string &metal_home) {
+  static std::unordered_map<std::string, std::string> rank_binding_paths = {
+      {"2x4_multiprocess",
+       "tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml"},
+  };
+
+  const char *rank_binding = std::getenv("TT_DISTRIBUTED_RANK_BINDING");
+  if (!rank_binding) {
+    DLOG_F(ERROR,
+           "TT_DISTRIBUTED_RANK_BINDING environment variable is not set");
+    return "";
+  }
+  if (rank_binding_paths.find(rank_binding) == rank_binding_paths.end()) {
+    DLOG_F(ERROR, "Invalid rank binding: %s", rank_binding);
+    return "";
+  }
+
+  std::filesystem::path rank_binding_path =
+      std::filesystem::path(metal_home) / rank_binding_paths.at(rank_binding);
+
+  if (std::filesystem::exists(rank_binding_path) == false) {
+    DLOG_F(ERROR, "Rank binding file does not exist at path: %s",
+           rank_binding_path.c_str());
+    return "";
+  }
+
+  return rank_binding_path.string();
+}
+
+static std::string getDistributedWorkerPath() {
+  const char *distributed_worker_path =
+      std::getenv("TT_DISTRIBUTED_WORKER_PATH");
+  if (!distributed_worker_path) {
+    DLOG_F(ERROR, "TT_DISTRIBUTED_WORKER_PATH environment variable is not set");
+    return "";
+  }
+
+  if (std::filesystem::exists(distributed_worker_path) == false) {
+    DLOG_F(ERROR, "Distributed worker file does not exist at path: %s",
+           distributed_worker_path);
+    return "";
+  }
+
+  return distributed_worker_path;
+}
+
+static tt_pjrt_status launchDistributedRuntime() {
+  const char *metal_home = std::getenv("TT_METAL_RUNTIME_ROOT");
+  if (!metal_home) {
+    DLOG_F(ERROR, "TT_METAL_RUNTIME_ROOT environment variable is not set");
+    return tt_pjrt_status::kInternal;
+  }
+  tt::runtime::setMetalHome(metal_home);
+
+  std::string rank_binding_path = getRankBindingPath(metal_home);
+  if (rank_binding_path.empty()) {
+    return tt_pjrt_status::kInternal;
+  }
+
+  std::string distributed_worker_path = getDistributedWorkerPath();
+  if (distributed_worker_path.empty()) {
+    return tt_pjrt_status::kInternal;
+  }
+
+  tt::runtime::DistributedOptions distributed_options;
+  distributed_options.mode = tt::runtime::DistributedMode::MultiProcess;
+  distributed_options.workerPath = distributed_worker_path;
+  distributed_options.multiProcessArgs =
+      tt::runtime::MultiProcessArgs::create(rank_binding_path)
+          .withAllowRunAsRoot(true);
+
+  tt::runtime::setCurrentHostRuntime(tt::runtime::HostRuntime::Distributed);
+  tt::runtime::launchDistributedRuntime(distributed_options);
+
+  return tt_pjrt_status::kSuccess;
+}
+
 PJRT_Error *GlobalClientInstanceSingleton::initClient() {
   std::unique_ptr<ClientInstance> client = std::make_unique<ClientInstance>();
   PJRT_Error *error = client->initialize();
@@ -100,6 +177,18 @@ ClientInstance::~ClientInstance() {
 
 PJRT_Error *ClientInstance::initialize() {
   DLOG_F(LOG_DEBUG, "ClientInstance::Initialize");
+
+  bool distributed_runtime =
+      std::getenv("TT_RUNTIME_ENABLE_DISTRIBUTED") != nullptr &&
+      std::string(std::getenv("TT_RUNTIME_ENABLE_DISTRIBUTED")) != "0";
+
+  if (distributed_runtime) {
+    tt_pjrt_status launch_result = launchDistributedRuntime();
+    if (!tt_pjrt_status_is_ok(launch_result)) {
+      return *ErrorInstance::makeError(launch_result).release();
+    }
+  }
+
   tt_pjrt_status device_status = populateDevices();
   if (!tt_pjrt_status_is_ok(device_status)) {
     return *ErrorInstance::makeError(device_status).release();
@@ -132,7 +221,9 @@ void ClientInstance::bindApi(PJRT_Api *api) {
 }
 
 tt_pjrt_status ClientInstance::populateDevices() {
+
   m_system_descriptor = tt::runtime::getCurrentSystemDesc();
+
   m_system_descriptor.store(m_cached_system_descriptor_path.data());
   if (std::filesystem::exists(m_cached_system_descriptor_path) == false) {
     DLOG_F(ERROR,

--- a/python_package/jax_plugin_tt/__init__.py
+++ b/python_package/jax_plugin_tt/__init__.py
@@ -6,12 +6,17 @@ import os
 from pathlib import Path
 
 import jax._src.xla_bridge as xb
-from pjrt_plugin_tt import get_library_path, setup_tt_metal_home
+from pjrt_plugin_tt import (
+    get_library_path,
+    setup_tt_metal_home,
+    setup_tt_pjrt_plugin_dir,
+)
 
 from .monkeypatch import setup_monkey_patches
 
 
 def initialize():
+    setup_tt_pjrt_plugin_dir()
     setup_tt_metal_home()
     library_path = get_library_path()
 

--- a/python_package/pjrt_plugin_tt/__init__.py
+++ b/python_package/pjrt_plugin_tt/__init__.py
@@ -15,6 +15,37 @@ from pathlib import Path
 TT_PJRT_PLUGIN_NAME = "pjrt_plugin_tt.so"
 
 
+def setup_tt_pjrt_plugin_dir():
+    """
+    Setup the `TT_PJRT_PLUGIN_DIR` environment variable by looking for the `pjrt_plugin_tt.so` file.
+    If user already has set the `TT_PJRT_PLUGIN_DIR` environment variable, we will not override it - we
+    will only verify that the path exists and raise an error if it does not.
+    """
+    user_override = os.getenv("TT_PJRT_PLUGIN_DIR")
+    if user_override is not None:
+        if Path(user_override).exists():
+            print(
+                f"Using PJRT plugin directory from environment variable: {user_override}"
+            )
+            return
+        raise FileNotFoundError(
+            f"ERROR: PJRT plugin directory not found at {user_override}. "
+            f"This location was specified by the TT_PJRT_PLUGIN_DIR environment variable, "
+            f"please check that the path is correct."
+        )
+
+    plugin_dir = Path(__file__).resolve().parent
+    if plugin_dir.exists():
+        os.environ["TT_PJRT_PLUGIN_DIR"] = str(plugin_dir)
+        print(f"Using PJRT plugin directory: {plugin_dir}")
+        return
+
+    raise FileNotFoundError(
+        f"ERROR: PJRT plugin directory could not be found. This most likely indicates an issue with how {__package__} "
+        f"was built or installed."
+    )
+
+
 def setup_tt_metal_home():
     """
     Setup the `TT_METAL_RUNTIME_ROOT` environment variable by looking for the `tt-metal` installation.

--- a/python_package/torch_plugin_tt/__init__.py
+++ b/python_package/torch_plugin_tt/__init__.py
@@ -8,7 +8,11 @@ from logging import Logger
 import torch
 import torch_xla
 import tt_torch  # registers "tt" backend for torch.compile
-from pjrt_plugin_tt import get_library_path, setup_tt_metal_home
+from pjrt_plugin_tt import (
+    get_library_path,
+    setup_tt_metal_home,
+    setup_tt_pjrt_plugin_dir,
+)
 from torch_xla.experimental.plugins import DevicePlugin
 
 
@@ -23,6 +27,7 @@ class TTPlugin(DevicePlugin):
 
     def __init__(self):
         super().__init__()
+        setup_tt_pjrt_plugin_dir()
         setup_tt_metal_home()
 
         # For using the PJRT plugin with `torch_xla` we need to set

--- a/tests/torch/multi_host/__init__.py
+++ b/tests/torch/multi_host/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/torch/multi_host/llmbox/__init__.py
+++ b/tests/torch/multi_host/llmbox/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/torch/multi_host/llmbox/test_multihost.py
+++ b/tests/torch/multi_host/llmbox/test_multihost.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+# This test file is a proxy to tests/runner/test_models.py.
+# It runs models through test_models.py on a subprocess with distributed runtime enabled.
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def get_distributed_worker_path():
+    worker_path = os.environ.get("TT_DISTRIBUTED_WORKER_PATH")
+    if worker_path:
+        assert os.path.exists(worker_path), (
+            "Distributed worker file does not exist at path: " + worker_path
+        )
+        return worker_path
+
+    pjrt_plugin_dir = os.environ.get("TT_PJRT_PLUGIN_DIR")
+    assert pjrt_plugin_dir, "TT_PJRT_PLUGIN_DIR environment variable is not set"
+
+    worker_path = os.path.join(pjrt_plugin_dir, "bin/ttmlir/runtime/distributed/worker")
+    assert os.path.exists(worker_path), (
+        "Distributed worker file does not exist at path: " + worker_path
+    )
+
+    return worker_path
+
+
+@pytest.mark.push
+@pytest.mark.llmbox
+@pytest.mark.parametrize(
+    "model_variant",
+    ["llama/causal_lm/pytorch-llama_3_1_8b-tensor_parallel-full-inference"],
+)
+def test_multihost_models(model_variant):
+    distributed_env = os.environ.copy()
+    distributed_env["TT_RUNTIME_ENABLE_PROGRAM_CACHE"] = "1"
+    distributed_env["TT_DISTRIBUTED_WORKER_PATH"] = get_distributed_worker_path()
+    distributed_env["TT_RUNTIME_ENABLE_DISTRIBUTED"] = "1"
+    distributed_env["TT_DISTRIBUTED_RANK_BINDING"] = "2x4_multiprocess"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-ssv",
+            f"tests/runner/test_models.py::test_all_models_torch[{model_variant}]",
+        ],
+        env=distributed_env,
+        cwd=os.getcwd(),
+    )
+
+    assert (
+        result.returncode == 0
+    ), f"Failed to run multihost test for model variant: {model_variant}"

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -88,6 +88,7 @@ else()
         COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --target tt-alchemist
 
         INSTALL_COMMAND ${CMAKE_COMMAND} --install <BINARY_DIR> --component SharedLib
+        COMMAND ${CMAKE_COMMAND} --install <BINARY_DIR> --component DistributedRuntime
 
         CMAKE_ARGS
           -DCMAKE_BUILD_TYPE=${TTMLIR_BUILD_TYPE}


### PR DESCRIPTION
### Ticket
#1917 

### Problem description
We want to integrate distributed runtime into tt-xla.

### What's changed
* Added distributed runtime code path in tt-xla guarded by env var `TT_RUNTIME_ENABLE_DISTRIBUTED`
* Added test proxy to run multi host tests on subprocesses `tests/torch/multi_host/llmbox/test_multihost.py`.
  * Added llama 8b test that runs through multihost llmbox.

### Checklist
- [X] New/Existing tests provide coverage for changes
