### PR TITLE
Skip CI on changes to some files

### DIFF
--- a/.github/actions/inspect-changes/action.yml
+++ b/.github/actions/inspect-changes/action.yml
@@ -32,7 +32,6 @@ runs:
           CHANGED_FILES=$(gh pr diff ${{ github.event.pull_request.number }} --name-only --repo ${{ github.repository }})
           echo "Changed files:"
           echo "$CHANGED_FILES"
-          only_run_forge_models=true
 
           # Define patterns for files that can skip build/test
           # Only allow docs, markdown, gitignore, LICENSE, CODEOWNERS, and test config files
@@ -52,6 +51,7 @@ runs:
             ".github/workflows/manual-test.yml"
             ".github/workflows/manual-test-single.yml"
             ".github/workflows/push-main.yml"
+            "tests/runner/*" # This goes with custom logic below.
           )
 
           for file in $CHANGED_FILES; do
@@ -71,16 +71,24 @@ runs:
               run_pr_tests=true
             fi
 
-            # Detect if all changes are strictly under tests/runner/
-            if [[ ! $file =~ ^tests/runner/.* ]]; then
-              only_run_forge_models=false
-            fi
-
             # Example: detect perf uplift (customize as needed)
             if [[ $file == *"perf"* ]]; then
               run_perf_tests=true
             fi
           done
+
+          # Just run forge tests if everything else is skipped but we detect changes under tests/runner/.
+          if [[ "$skip_build_and_test" == "true" ]]; then
+            for file in $CHANGED_FILES; do
+              if [[ $file == tests/runner/* ]]; then
+                echo "Detected only skippable files + tests/runner/, enabling forge-model tests."
+                skip_build_and_test=false
+                only_run_forge_models=true
+                break
+              fi
+            done
+          fi
+
         else
           skip_build_and_test=false
           run_pr_tests=true


### PR DESCRIPTION
### Ticket
slack request

### Problem description
We are often modifying nightly (or now weekly) github yml files or test-matrix preset .json files used only by nightly/weekly but it reruns onPR which is 100% unrelated.  The obvious exclusions: basic-test-nightly.json, model-test-experimental.json, model-test-passing.json, model-test-xfail.json schedule-nightly.yml, schedule-weekly.yml, plus a few others.

### What's changed
- Refactor inspect-changes action
- Skip Ci on changes to some more .github files not used by onPR
- Optimization to combine skip_build_and_test=true and changes to tests/runner/* to trigger only_run_forge_models=true

### Checklist
- [x] Tested on branch several combinations, works good, links in PR.
