### PR TITLE
New schedule-weekly.yml "On weekly" job to be used for less-frequent running of models

### DIFF
--- a/.github/workflows/schedule-weekly.yml
+++ b/.github/workflows/schedule-weekly.yml
@@ -1,0 +1,86 @@
+name: On weekly
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 8 * * 6'
+
+permissions:
+  packages: write
+  checks: write
+
+jobs:
+  build-image:
+    uses: ./.github/workflows/call-build-docker.yml
+    secrets: inherit
+
+  build-ttxla:
+    uses: ./.github/workflows/call-build.yml
+    name: "Build tt-xla"
+    secrets: inherit
+    needs: build-image
+    with:
+      docker_image: ${{ needs.build-image.outputs.docker-image }}
+
+  # This is a single test job that runs all passing tt-forge-models tests.
+  test_forge_models_passing:
+    uses: ./.github/workflows/call-test.yml
+    secrets: inherit
+    needs: [ build-image, build-ttxla ]
+    # This ensures the job runs regardless of success or failure of `weekly_tests`:
+    if: success() || failure()
+    with:
+      test_suite: model-test-passing-weekly.json
+      docker_image: ${{ needs.build-image.outputs.docker-image }}
+      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
+      wheel_release_artifact_name: ${{ needs.build-ttxla.outputs.wheel_artifact_name }}
+
+  fail-notify:
+    if: always()
+    needs:
+      - test_forge_models_passing
+      - build-image
+      - build-ttxla
+    runs-on: Ubuntu-latest
+    outputs:
+      is-main: ${{ steps.branch-check.outputs.IS_MAIN }}
+      failed: ${{ steps.check.outputs.failure }}
+    steps:
+      - name: Check if branch is main
+        id: branch-check
+        run: echo "IS_MAIN=$(if [ '${{ github.ref }}' == 'refs/heads/main' ]; then echo true; else echo false; fi)" >> $GITHUB_OUTPUT
+      - name: Check if the needed jobs succeeded or failed
+        id: check
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}
+
+  fail-send-msg:
+    if: always()
+    needs:
+      - fail-notify
+    runs-on: Ubuntu-latest
+    steps:
+      - name: Send Fail Notification
+        if: ${{ needs.fail-notify.outputs.failed == 'true' && needs.fail-notify.outputs.is-main == 'true' }}
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "Bad bad weekly: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}>",
+              "channel": "C08GYB57C8M"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEEKLY_FAIL }}
+
+      - name: Send Success Notification
+        if: ${{ needs.fail-notify.outputs.failed == 'false' && needs.fail-notify.outputs.is-main == 'true' }}
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "Good weekly: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}>",
+              "channel": "C08GYB57C8M"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEEKLY_SUCCESS }}

--- a/.github/workflows/test-matrix-presets/model-test-passing-weekly.json
+++ b/.github/workflows/test-matrix-presets/model-test-passing-weekly.json
@@ -1,0 +1,4 @@
+[
+  { "runs-on": "n150", "name": "run_forge_models_torch", "dir": "./tests/runner/test_models.py", "test-mark": "weekly and n150 and expected_passing", "parallel-groups": 1 },
+  { "runs-on": "p150", "name": "run_forge_models_torch", "dir": "./tests/runner/test_models.py", "test-mark": "weekly and p150 and expected_passing", "parallel-groups": 1 }
+]

--- a/.github/workflows/test-matrix-presets/model-test-passing.json
+++ b/.github/workflows/test-matrix-presets/model-test-passing.json
@@ -1,6 +1,6 @@
 [
-  { "runs-on": "n150", "name": "run_forge_models_torch", "dir": "./tests/runner/test_models.py", "test-mark": "n150 and expected_passing", "parallel-groups": 10 },
-  { "runs-on": "p150", "name": "run_forge_models_torch", "dir": "./tests/runner/test_models.py", "test-mark": "p150 and expected_passing", "parallel-groups": 10 },
+  { "runs-on": "n150", "name": "run_forge_models_torch", "dir": "./tests/runner/test_models.py", "test-mark": "not weekly and n150 and expected_passing", "parallel-groups": 10 },
+  { "runs-on": "p150", "name": "run_forge_models_torch", "dir": "./tests/runner/test_models.py", "test-mark": "not weekly and p150 and expected_passing", "parallel-groups": 10 },
   { "runs-on": "n300-llmbox", "name": "run_forge_models_torch_multichip", "dir": "./tests/runner/test_models.py", "test-mark": "tensor_parallel and n300-llmbox and expected_passing", "parallel-groups": 4 },
   { "runs-on": "n300", "name": "run_forge_models_torch_multichip", "dir": "./tests/runner/test_models.py", "test-mark": "data_parallel and n300 and expected_passing", "parallel-groups": 3 }
 

--- a/.github/workflows/test-matrix-presets/model-test-xfail-weekly.json
+++ b/.github/workflows/test-matrix-presets/model-test-xfail-weekly.json
@@ -1,0 +1,4 @@
+[
+  { "runs-on": "n150", "name": "run_forge_models_torch", "dir": "./tests/runner/test_models.py", "test-mark": "weekly and n150 and (known_failure_xfail or not_supported_skip)", "parallel-groups": 1 },
+  { "runs-on": "p150", "name": "run_forge_models_torch", "dir": "./tests/runner/test_models.py", "test-mark": "weekly and p150 and (known_failure_xfail or not_supported_skip)", "parallel-groups": 1 }
+]

--- a/.github/workflows/workflow-run-collect-data.yml
+++ b/.github/workflows/workflow-run-collect-data.yml
@@ -7,6 +7,7 @@ on:
       - "On PR"
       - "On push"
       - "On nightly"
+      - "On weekly"
       - "Performance Benchmark"
       - "On nightly Experimental"
       - "Run Test Single"

--- a/tests/runner/test_config/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/test_config_inference_single_device.yaml
@@ -363,11 +363,11 @@ test_config:
     status: EXPECTED_PASSING
     # Set required_pcc here to verify in push that required_pcc set is safe (it wasn't always)
     required_pcc: 0.99
-    markers: ["push"]
+    markers: ["push", "weekly"]
 
   mobilenetv1/pytorch-mobilenet_v1-single_device-full-inference:
     status: EXPECTED_PASSING
-    markers: ["push"]
+    markers: ["push", "weekly"]
 
   mobilenetv2/pytorch-mobilenet_v2-single_device-full-inference:
     status: EXPECTED_PASSING
@@ -1221,7 +1221,7 @@ test_config:
     status: EXPECTED_PASSING
 
   gpt2/pytorch-gpt2-single_device-full-inference:
-    markers: ["push"]
+    markers: ["push", "weekly"]
     status: EXPECTED_PASSING
 
   gpt2/pytorch-gpt2_sequence_classification-single_device-full-inference:
@@ -1298,7 +1298,7 @@ test_config:
 
   vgg/pytorch-hf_vgg19-single_device-full-inference:
     status: EXPECTED_PASSING
-    markers: ["push"]
+    markers: ["push", "weekly"]
 
   segformer/semantic_segmentation/pytorch-b1_finetuned_ade_512_512-single_device-full-inference:
     status: EXPECTED_PASSING


### PR DESCRIPTION
### Ticket
None

### Problem description
- Nightly is about to busier with many 150+ data_parallel models via https://github.com/tenstorrent/tt-xla/pull/1818 that completely overlap with single_device models
- After some discussion, agreed to move duplicately covered single_device models to weekly schedule, update superset dashboard queries to pull from latest weekly too (not just latest nightly)

### What's changed
- Add the new schedule-nightly.yml "On weekly" job, it's copied from schedule-nightly.yml, modified, trimmed to run once per week on Saturday mornings when CI is not busy after discussion with Vladimir.
- Relies on new webhooks secrets.SLACK_WEEKLY_FAIL/PASS which are being created now.
- Add new .json files with weekly filter used here and update existing nightly .json files to exclude weekly tests
- Tag all push inference model tests with weekly marker to start, the job will be loaded w/ hundreds of models starting tomorrow and number of parallel jobs increased.
- Remove xfail job from schedule-weekly.yml, no tests currently and github CI doesn't like empty jobs with no tests collected
- Will launch this weekly job with it's few tests in main once merged so data is available for superset dashboard query.

### Checklist
- [x] Testing this on branch here: https://github.com/tenstorrent/tt-xla/actions/runs/18953551739
