### PR TITLE
Explicilty return gradinets from torch_xla in test infra

### DIFF
--- a/tests/infra/testers/single_chip/model/torch_model_tester.py
+++ b/tests/infra/testers/single_chip/model/torch_model_tester.py
@@ -216,7 +216,7 @@ class TorchModelTester(ModelTester):
         wanted_grads = [p.grad for p in self._model.parameters() if p.grad is not None]
         torch_xla._XLAC._xla_sync_multi(
             wanted_grads,
-            set([p.device for p in wanted_grads]),
+            list(set([p.device.type for p in wanted_grads])),
             wait=True,
         )
         tt_grads, tt_none_grads = self._extract_grads(self._model)

--- a/tests/runner/test_config/torch/test_config_training_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_training_single_device.yaml
@@ -25,8 +25,8 @@ test_config:
 
   falcon/pytorch-tiiuae/Falcon3-1B-Base-single_device-full-training:
     status: KNOWN_FAILURE_XFAIL
-    bringup_status: FAILED_RUNTIME
-    reason: "Not enough space to allocate DRAM"
+    bringup_status: INCORRECT_RESULT
+    reason: "AssertionError: Comparison result 0 failed: PCC comparison failed. Calculated: pcc=0.869604229927063. Required: pcc=0.99."
 
   deepcogito/pytorch-v1_preview_llama_3b-single_device-full-training:
     status: NOT_SUPPORTED_SKIP


### PR DESCRIPTION
### Ticket

### Problem description
Workaround for: https://github.com/tenstorrent/tt-xla/issues/1466

### What's changed
Set `torch_xla.sync` to return only the necessary gradients similar to `XLAExecutor`

### Checklist
- [ ] Note: changed the base of the pr while waiting for #1915 to be merged
