### PR TITLE
Add most models that are too big to be ran on single_chip n150

### DIFF
--- a/tests/runner/test_config/torch/test_config_training_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_training_single_device.yaml
@@ -512,13 +512,3 @@ test_config:
     status: NOT_SUPPORTED_SKIP
     reason: "Too large for single chip"
     bringup_status: FAILED_RUNTIME
-
-  gemma/pytorch-google/gemma-2b-single_device-full-training:
-    status: NOT_SUPPORTED_SKIP
-    reason: "Too large for single chip"
-    bringup_status: FAILED_RUNTIME
-
-  gemma/pytorch-google/gemma-2b-it-single_device-full-training:
-    status: NOT_SUPPORTED_SKIP
-    reason: "Too large for single chip"
-    bringup_status: FAILED_RUNTIME


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Update single_chip yaml with models that are too big for single chip fwd+bwd testing (models that are >=3B

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] New/Existing tests provide coverage for changes
