### PR TITLE
Revert "update torch tests for runtime binary op issue (#1786)"

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -510,9 +510,9 @@ test_config:
     bringup_status: FAILED_RUNTIME
 
   mistral/pytorch-ministral_3b_instruct-single_device-full-inference:
-    status: KNOWN_FAILURE_XFAIL
-    reason: "Unsupported binary op for FPU BinaryOpType::BITWISE_OR. - https://github.com/tenstorrent/tt-xla/issues/1783"
-    bringup_status: FAILED_RUNTIME
+    status: EXPECTED_PASSING
+    assert_pcc: false
+    bringup_status: INCORRECT_RESULT
 
   mlp_mixer/pytorch-mixer_b16_224-single_device-full-inference:
     status: EXPECTED_PASSING
@@ -1417,9 +1417,9 @@ test_config:
     bringup_status: INCORRECT_RESULT
 
   phi3/phi_3_5/pytorch-mini_instruct-single_device-full-inference:
-    status: KNOWN_FAILURE_XFAIL
-    reason: "Unsupported binary op for FPU BinaryOpType::BITWISE_OR. - https://github.com/tenstorrent/tt-xla/issues/1783"
-    bringup_status: FAILED_RUNTIME
+    assert_pcc: false
+    status: EXPECTED_PASSING
+    bringup_status: INCORRECT_RESULT
 
   bi_lstm_crf/pytorch-default-single_device-full-inference:
     status: KNOWN_FAILURE_XFAIL
@@ -1524,24 +1524,25 @@ test_config:
     reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.4519438147544861. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/1443"
 
   phi3/token_cls/pytorch-microsoft/Phi-3-mini-128k-instruct-single_device-full-inference:
-    status: KNOWN_FAILURE_XFAIL
-    bringup_status: FAILED_RUNTIME
-    reason: "Unsupported binary op for FPU BinaryOpType::BITWISE_OR. - https://github.com/tenstorrent/tt-xla/issues/1783"
+    assert_pcc: false
+    status: EXPECTED_PASSING
+    bringup_status: INCORRECT_RESULT
+    reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.23872360587120056. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/1443"
 
   phi3/token_cls/pytorch-microsoft/Phi-3-mini-4k-instruct-single_device-full-inference:
-    status: KNOWN_FAILURE_XFAIL
-    reason: "Unsupported binary op for FPU BinaryOpType::BITWISE_OR. - https://github.com/tenstorrent/tt-xla/issues/1783"
-    bringup_status: FAILED_RUNTIME
+    assert_pcc: false
+    status: EXPECTED_PASSING
+    bringup_status: INCORRECT_RESULT
+    reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.3322090804576874. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/1443"
 
   phi3/seq_cls/pytorch-microsoft/Phi-3-mini-128k-instruct-single_device-full-inference:
-    status: KNOWN_FAILURE_XFAIL
-    reason: "Unsupported binary op for FPU BinaryOpType::BITWISE_OR. - https://github.com/tenstorrent/tt-xla/issues/1783"
-    bringup_status: FAILED_RUNTIME
+    assert_pcc: false
+    status: EXPECTED_PASSING
+    bringup_status: INCORRECT_RESULT
+    reason: "AssertionError: PCC comparison failed. Calculated: pcc=-1.0000001192092896. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/1443"
 
   phi3/seq_cls/pytorch-microsoft/Phi-3-mini-4k-instruct-single_device-full-inference:
-    status: KNOWN_FAILURE_XFAIL
-    reason: "Unsupported binary op for FPU BinaryOpType::BITWISE_OR. - https://github.com/tenstorrent/tt-xla/issues/1783"
-    bringup_status: FAILED_RUNTIME
+    status: EXPECTED_PASSING
 
   glpn_kitti/pytorch-single_device-full-inference:
     arch_overrides:
@@ -1718,9 +1719,10 @@ test_config:
   mistral/pytorch-7b-single_device-full-inference:
     arch_overrides:
       p150:
-        status: KNOWN_FAILURE_XFAIL
-        reason: "Unsupported binary op for FPU BinaryOpType::BITWISE_OR. - https://github.com/tenstorrent/tt-xla/issues/1783"
-        bringup_status: FAILED_RUNTIME
+        assert_pcc: false
+        status: EXPECTED_PASSING
+        bringup_status: INCORRECT_RESULT
+        reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.35885828733444214. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/1473"
       n150:
         status: NOT_SUPPORTED_SKIP
         reason: "Too large for single chip"
@@ -1737,9 +1739,10 @@ test_config:
   mistral/pytorch-ministral_8b_instruct-single_device-full-inference:
     arch_overrides:
       p150:
-        status: KNOWN_FAILURE_XFAIL
-        reason: "Unsupported binary op for FPU BinaryOpType::BITWISE_OR. - https://github.com/tenstorrent/tt-xla/issues/1783"
-        bringup_status: FAILED_RUNTIME
+        assert_pcc: false
+        status: EXPECTED_PASSING
+        bringup_status: INCORRECT_RESULT
+        reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.2924256920814514. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/1473"
 
       n150:
         status: NOT_SUPPORTED_SKIP


### PR DESCRIPTION
This reverts commit 5360c06b9c14268bef4a70fde297481e1e266e82.

### Ticket
closes #1783 

### Problem description
Models were marked xfailed due to bitwise op failure.

### What's changed
Revert the status of these tests back to previous state.

### Checklist
- [X] Tests passing on CI for n150/p150 again here: https://github.com/tenstorrent/tt-xla/actions/runs/19013896800
