### PR TITLE
Training tests for a torch models from tt_forge_models

### DIFF
--- a/tests/runner/test_config/torch/test_config_training_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_training_single_device.yaml
@@ -508,6 +508,11 @@ test_config:
     bringup_status: FAILED_TTMLIR_COMPILATION
     reason: "error: failed to legalize operation 'stablehlo.pad' https://github.com/tenstorrent/tt-mlir/issues/5305"
 
+  squeezebert/pytorch-squeezebert-mnli-single_device-full-training:
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_TTMLIR_COMPILATION
+    reason: "error: failed to legalize operation 'stablehlo.dynamic_update_slice' https://github.com/tenstorrent/tt-mlir/issues/5527"
+
   distilbert/sequence_classification/pytorch-distilbert-base-uncased-finetuned-sst-2-english-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

Here is compilation of new unique reasons that models are failing:
```
KNOWN_FAILURE_XFAIL INCORRECT_RESULT reson:"Calculated: X. Required: pcc=Y."
NOT_SUPPORTED_SKIP FAILED_TTMLIR_COMPILATION reson:"error: 'ttnn.matmul' op Output shape dimension[2](X) doesn't match the expected output shape dimension[2](Y) https://github.com/tenstorrent/tt-mlir/issues/5662"
NOT_SUPPORTED_SKIP FAILED_RUNTIME reson:"Out of Memory: Not enough space in L1"
NOT_SUPPORTED_SKIP FAILED_FE_COMPILATION reson:"AssertionError: targets should not be none when in training mode"
NOT_SUPPORTED_SKIP FAILED_FE_COMPILATION reson:"RuntimeError: Cannot find callable resnext101_64x4d in hubconf"
NOT_SUPPORTED_SKIP FAILED_FE_COMPILATION reson:"RuntimeError: The tensor has a non-zero number of elements, but its data is not allocated yet."
NOT_SUPPORTED_SKIP FAILED_FE_COMPILATION reson:"AttributeError: 'NoneType' object has no attribute 'max'"
NOT_SUPPORTED_SKIP FAILED_FE_COMPILATION reson:"TypeError: AutoShape.forward() takes from 2 to 5 positional arguments but 7 were given"
NOT_SUPPORTED_SKIP FAILED_FE_COMPILATION reson:"RuntimeError: Could not load libtorchcodec. Likely causes:"
NOT_SUPPORTED_SKIP FAILED_FE_COMPILATION reson:"EOFError: Ran out of input"
NOT_SUPPORTED_SKIP FAILED_FE_COMPILATION reson:"ModuleNotFoundError: No module named 'segmentation_models_pytorch'"
NOT_SUPPORTED_SKIP FAILED_FE_COMPILATION reson:"ValueError: Expected more than 1 value per channel when training, got input size torch.Size([1, 256, 1, 1])"
NOT_SUPPORTED_SKIP FAILED_FE_COMPILATION reson:"loader.load_model() does not return `nn.Module`"
NOT_SUPPORTED_SKIP FAILED_FE_COMPILATION reson:"Model expects targets to be passed while in training mode"
NOT_SUPPORTED_SKIP FAILED_FE_COMPILATION reson:"tt-forge-models doesn't implement unpack_forward_output for this model."
NOT_SUPPORTED_SKIP FAILED_TTMLIR_COMPILATION reson:"error: failed to legalize operation 'stablehlo.pad' https://github.com/tenstorrent/tt-mlir/issues/5305"
NOT_SUPPORTED_SKIP FAILED_TTMLIR_COMPILATION reson:"error: failed to legalize operation 'stablehlo.dynamic_update_slice' https://github.com/tenstorrent/tt-mlir/issues/5527"
NOT_SUPPORTED_SKIP FAILED_TTMLIR_COMPILATION reson:"error: failed to legalize operation 'stablehlo.select_and_scatter' https://github.com/tenstorrent/tt-mlir/issues/4794"
NOT_SUPPORTED_SKIP FAILED_RUNTIME reson:"Batch norm with training=true hangs for channels > 64: https://github.com/tenstorrent/tt-metal/issues/30279"
```
