### PR TITLE
bug: only trigger in on-push workflow and not in build-docker-images.sh also

### DIFF
--- a/.github/build-docker-images.sh
+++ b/.github/build-docker-images.sh
@@ -20,14 +20,10 @@ IRD_IMAGE_NAME=ghcr.io/$REPO/tt-xla-ird-ubuntu-22-04
 DOCKER_TAG=$(./.github/get-docker-tag.sh)
 echo "Docker tag: $DOCKER_TAG"
 
-# Are we on main branch
-ON_MAIN=$(git branch --show-current | grep -q main && echo "true" || echo "false")
-
 build_and_push() {
     local image_name=$1
     local dockerfile=$2
-    local on_main=$3
-    local target_image=$4
+    local target_image=$3
 
     IMAGE_EXISTS=false
     if docker manifest inspect $image_name:$DOCKER_TAG > /dev/null; then
@@ -59,15 +55,11 @@ build_and_push() {
         docker push $image_name:$DOCKER_TAG
     fi
 
-    if [ "$on_main" = "true" ]; then
-        echo "Pushing latest tag for $image_name"
-        docker buildx imagetools create $image_name:$DOCKER_TAG --tag $image_name:latest --tag $image_name:$DOCKER_TAG
-    fi
 }
 
-build_and_push $BASE_IMAGE_NAME .github/Dockerfile.base $ON_MAIN
-build_and_push $CI_IMAGE_NAME .github/Dockerfile.ci $ON_MAIN ci
-build_and_push $IRD_IMAGE_NAME .github/Dockerfile.ci $ON_MAIN ird
+build_and_push $BASE_IMAGE_NAME .github/Dockerfile.base
+build_and_push $CI_IMAGE_NAME .github/Dockerfile.ci ci
+build_and_push $IRD_IMAGE_NAME .github/Dockerfile.ci ird
 
 echo "All images built and pushed successfully"
 echo "CI_IMAGE_NAME:"


### PR DESCRIPTION
Issue:

Caused by an IRD image rebuild that happened on the main branch, that was meant only for testing but got the lastest image tag.

```bash
#2 0.668 pushing sha256:311f4cdbe2e32da3c070de1620a4c2435d3cdc54fe3a027557c87b6f3aac1a6f to ghcr.io/tenstorrent/tt-xla/tt-xla-ird-ubuntu-22-04:latest
#2 DONE 1.1s

#1 [internal] pushing ghcr.io/tenstorrent/tt-xla/tt-xla-ird-ubuntu-22-04:dt-f9ded32056edac4a8478e2b8afe17ba539c08d00481264f6246802df7f38be3a
#1 DONE 1.2s
All images built and pushed successfully
CI_IMAGE_NAME:
ghcr.io/tenstorrent/tt-xla/tt-xla-ci-ubuntu-22-04:dt-f9ded32056edac4a8478e2b8afe17ba539c08d00481264f6246802df7f38be3a
DOCKER_CI_IMAGE ghcr.io/tenstorrent/tt-xla/tt-xla-ci-ubuntu-22-04:dt-f9ded32056edac4a8478e2b8afe17ba539c08d00481264f6246802df7f38be3a
```
https://github.com/tenstorrent/tt-xla/actions/runs/19072479421/job/54478845707#step:7:53798

Changes:
- Make it so the latest image tags don't happen in the image build. Only when [latest tag action](https://github.com/tenstorrent/tt-xla/blob/main/.github/workflows/call-build-docker.yml#L99-L131) is called.
- Only make this happen for the On push workflow to main once a PR merges.