### PR TITLE
[pjrt] ensure client destruction on process exit

### DIFF
--- a/pjrt_implementation/inc/api/client_instance.h
+++ b/pjrt_implementation/inc/api/client_instance.h
@@ -47,14 +47,14 @@ class ModuleBuilder;
 class GlobalClientInstanceSingleton {
 public:
   static ClientInstance *getClientInstance();
-  static PJRT_Error *init_client();
-  static void destroy_client();
+  static PJRT_Error *initClient();
+  static void destroyClient();
 
 private:
   GlobalClientInstanceSingleton(std::unique_ptr<ClientInstance> client_instance)
       : m_client_instance(std::move(client_instance)) {}
 
-  bool is_initialized() const { return m_client_instance != nullptr; }
+  bool isInitialized() const { return m_client_instance != nullptr; }
 
   static GlobalClientInstanceSingleton &getInstance();
   std::unique_ptr<ClientInstance> m_client_instance;

--- a/pjrt_implementation/src/api/client_instance.cc
+++ b/pjrt_implementation/src/api/client_instance.cc
@@ -37,7 +37,7 @@
 
 namespace tt::pjrt {
 
-PJRT_Error *GlobalClientInstanceSingleton::init_client() {
+PJRT_Error *GlobalClientInstanceSingleton::initClient() {
   std::unique_ptr<ClientInstance> client = std::make_unique<ClientInstance>();
   PJRT_Error *error = client->initialize();
   if (error) {
@@ -50,9 +50,9 @@ PJRT_Error *GlobalClientInstanceSingleton::init_client() {
   return nullptr;
 }
 
-void GlobalClientInstanceSingleton::destroy_client() {
+void GlobalClientInstanceSingleton::destroyClient() {
   GlobalClientInstanceSingleton &singleton_instance = getInstance();
-  if (singleton_instance.is_initialized()) {
+  if (singleton_instance.isInitialized()) {
     singleton_instance.m_client_instance.reset();
   }
 }
@@ -89,9 +89,7 @@ ClientInstance::ClientInstance()
 ClientInstance::~ClientInstance() {
   DLOG_F(LOG_DEBUG, "ClientInstance::~ClientInstance");
 
-  if (m_optimizer_submesh.has_value()) {
-    tt::runtime::releaseSubMeshDevice(*m_optimizer_submesh);
-  }
+  closeOptimizerSubmesh();
 
   if (m_parent_mesh.has_value()) {
     tt::runtime::closeMeshDevice(*m_parent_mesh);
@@ -525,7 +523,7 @@ PJRT_Error *onClientCreate(PJRT_Client_Create_Args *args) {
            args->create_options[i].name);
   }
 
-  PJRT_Error *error = GlobalClientInstanceSingleton::init_client();
+  PJRT_Error *error = GlobalClientInstanceSingleton::initClient();
 
   if (error) {
     DLOG_F(ERROR, "Failed to initialize PJRT client instance");
@@ -547,7 +545,7 @@ PJRT_Error *onClientDestroy(PJRT_Client_Destroy_Args *args) {
   ClientInstance *global_client_instance =
       GlobalClientInstanceSingleton::getClientInstance();
   assert(client_instance == global_client_instance);
-  GlobalClientInstanceSingleton::destroy_client();
+  GlobalClientInstanceSingleton::destroyClient();
   return nullptr;
 }
 

--- a/pjrt_implementation/src/api/module_builder/module_builder.cc
+++ b/pjrt_implementation/src/api/module_builder/module_builder.cc
@@ -860,11 +860,13 @@ tt_pjrt_status ModuleBuilder::convertFromTTIRToTTNN(
 
   enableVerboseIRPrinting(ttir_to_ttnn_pm);
 
+  // Run the pass manager.
+  mlir::LogicalResult mlir_result = ttir_to_ttnn_pm.run(mlir_module.get());
+
   // Close the optimizer submesh now that the compilation is complete.
   client_instance->closeOptimizerSubmesh();
 
-  // Run the pass manager.
-  if (mlir::failed(ttir_to_ttnn_pm.run(mlir_module.get()))) {
+  if (mlir::failed(mlir_result)) {
     DLOG_F(ERROR, "Failed to convert from TTIR to TTNN module");
     return tt_pjrt_status::kInternal;
   }


### PR DESCRIPTION
`torch_xla` doesn't call `PJRT_ClientDestroy` properly. This means that we are not closing the devices properly.

Recently, this started causing hangs on `n300` boards on subsequent execution of tests.

This PR introduces a global singleton object which will ensure that we are properly destroying the client instance on process shutdown. The singleton serves as a fallback mechanism if the framework doesn't call `PJRT_ClientDestroy` - like in the case of `torch_xla`.

Additionally, optimizer sub-meshes are now closed after each compilation; this previously was needed to avoid hangs, but now it causes them. Leaving the mechanism of persisting optimizer submesh in the code base, so that we can play with it if needed. Obviously, we need to dig deep into these issues to fix them properly.

NOTE: this does not solve the case when the process terminates abruptly, e.g. in case of `SIGSEGV` (segmentation fault). For this, ideally we would want a fix on `tt-metal` side.

Closes #1824
