### PR TITLE
Nov5 Don't assert pcc on mamba models to protect nightly

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -352,12 +352,12 @@ test_config:
     status: EXPECTED_PASSING
 
   mamba/pytorch-mamba-1.4b-hf-single_device-full-inference:
-    assert_pcc: false # -0.0130 WH / -0.0888 BH as of Nov 5 2025 right after an uplift which contained newer LLVM
+    assert_pcc: false # -0.0130 WH / -0.0888 BH as of Nov 5 2025 right after an uplift which contained newer LLVM https://github.com/tenstorrent/tt-xla/issues/2000
     status: EXPECTED_PASSING
     bringup_status: INCORRECT_RESULT
 
   mamba/pytorch-mamba-370m-hf-single_device-full-inference:
-    assert_pcc: false # -0.0327 WH / 0.3821 BH as of Nov 5 2025 right after an uplift which contained newer LLVM
+    assert_pcc: false # -0.0327 WH / 0.3821 BH as of Nov 5 2025 right after an uplift which contained newer LLVM https://github.com/tenstorrent/tt-xla/issues/2000
     status: EXPECTED_PASSING
     bringup_status: INCORRECT_RESULT
 


### PR DESCRIPTION
### Ticket
Info in #2000

### Problem description
Running the nighhtly suite of tests after an uplift revealed model that will fail on nightly.

### What's changed
Models were marked as having incorrect results to protect nightly. Investigation and fixes to come later

### Checklist
- [ ] New/Existing tests provide coverage for changes
