### PR TITLE
[vLLM plugin] Enable Qwen3 tests for larger sequence length

### DIFF
--- a/tests/integrations/vllm_plugin/test_qwen3_embedding.py
+++ b/tests/integrations/vllm_plugin/test_qwen3_embedding.py
@@ -146,9 +146,6 @@ def test_embed_qwen3_reduced_dims():
 
 
 @pytest.mark.push
-@pytest.mark.xfail(
-    reason="Failure due Out of memory https://github.com/tenstorrent/tt-xla/issues/1941"
-)
 def test_embed_qwen3_8K():
     # Enable program cache for better performance
     seq_len = 2**13  # 8192
@@ -177,9 +174,6 @@ def test_embed_qwen3_8K():
 
 
 @pytest.mark.push
-@pytest.mark.xfail(
-    reason="Failure due Out of memory https://github.com/tenstorrent/tt-xla/issues/1941"
-)
 def test_embed_qwen3_16K():
     # Enable program cache for better performance
     seq_len = 2**14  # 16384


### PR DESCRIPTION
### Ticket
closes #1941 

### What's changed
Remove xFail for Qwen3-Embedding tests with larger sequence length.

### Checklist
- [X] New/Existing tests provide coverage for changes
