### PR TITLE
Apply bringup_status as pytest markers in tests/runner/conftest.py for pytest filtering

### DIFF
--- a/tests/runner/conftest.py
+++ b/tests/runner/conftest.py
@@ -92,6 +92,16 @@ def pytest_collection_modifyitems(config, items):
         for marker_name in getattr(meta, "markers", []) or []:
             item.add_marker(getattr(pytest.mark, marker_name))
 
+        # Apply marker based on bringup_status to enable filtering like: -m incorrect_result
+        bringup_status = getattr(meta, "bringup_status", None)
+        if bringup_status:
+            # Normalize enum or string to a pytest-safe, lowercase marker name
+            status_str = str(bringup_status)
+            # In case string includes enum class name, keep the last segment
+            status_str = status_str.split(".")[-1]
+            normalized_marker = status_str.lower()
+            item.add_marker(getattr(pytest.mark, normalized_marker))
+
         # Define default set of supported archs, which can be optionally overridden in test_config files
         # by a model (ie. n300, n300-llmbox), and are applied as markers for filtering tests on CI.
         default_archs = ["n150", "p150"]


### PR DESCRIPTION
### Ticket
None

### Problem description
- Sometimes it is useful to collect all tests marked bringup_status=INCORRECT_RESULT to test possible PCC fixes against but currently there is no easy way

### What's changed
- Add some logic to make bringup_status set as custom markers, similar to how other custom markers are set in same function
- Now we can do this to find the 12 single chip red tests failing with low PCC: 
- TT_XLA_RED_ONLY=1 pytest -vv tests/runner/test_models.py::test_all_models_torch -m "expected_passing and n150 and inference and single_device and incorrect_result" |& tee tests.log

### Checklist
- [x] Tested locally works good - When https://github.com/tenstorrent/tt-xla/pull/2058 is merged, would be able to use on CI via "Run Test Single" workflow too.
