### PR TITLE
Promote passing models from experimental to nightly

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -251,6 +251,8 @@ test_config:
     status: EXPECTED_PASSING
 
   dla/pytorch-dla169-single_device-full-inference:
+    required_pcc: 0.98  # PCC comparison failed with pcc=0.9898209571838379 in n150 and pcc=0.9885705709457397 in p150.
+    reason: "AssertionError: Comparison result 0 failed: PCC comparison failed - https://github.com/tenstorrent/tt-xla/issues/2010"
     status: EXPECTED_PASSING
 
   dla/pytorch-dla34-single_device-full-inference:
@@ -2336,3 +2338,6 @@ test_config:
     status: KNOWN_FAILURE_XFAIL
     bringup_status: FAILED_TTMLIR_COMPILATION
     reason: "error: 'ttnn.matmul' op Output shape dimension[2](64) doesn't match the expected output shape dimension[2](16) - https://github.com/tenstorrent/tt-xla/issues/1955"
+
+  yolov12/pytorch-yolo12n-single_device-full-inference:
+    status: EXPECTED_PASSING


### PR DESCRIPTION
### Problem description
Some models in [experimental nightly](https://github.com/tenstorrent/tt-xla/actions/runs/19124518132/attempts/1) are passing. Added those models to main nightly

### What's changed
Added the passed models to test_config file
`dla/pytorch-dla169-single_device-full-inference` model is failing in [nightly](https://github.com/tenstorrent/tt-xla/actions/runs/19120384195/attempts/2) with pcc issue.  

### Checklist
- [x] New/Existing tests provide coverage for changes
