### PR TITLE
[infra] stop cleaning cache on non-CI environments

### DIFF
--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -49,6 +49,7 @@ env:
   IRD_LF_CACHE: ${{ vars.IRD_LF_CACHE }}
   GH_TOKEN: ${{ github.token }} # for gh cli tool
   TTMLIR_TOOLCHAIN_DIR: /opt/ttmlir-toolchain # We don't actually need this, venv/activate expects this to be set
+  TT_XLA_CI: 1
 
 jobs:
   generate-matrix-test:


### PR DESCRIPTION
The code which checks if the various cache dirs (huggingface, jax, etc.) should be cleaned up is wrong - it detects regular user environments outside of IRD as CIv2.

Fixing this by adding `TT_XLA_CI` env variable when running tests on CI. So that we can make sure that the cleanup only happens when we are actually running on CI.

Additionally, cleaning up the code to avoid excesive negations.