### PR TITLE
Model `tt.paged_update_cache` as custom op

### DIFF
--- a/tests/torch/single_chip/ops/test_custom_ops.py
+++ b/tests/torch/single_chip/ops/test_custom_ops.py
@@ -130,16 +130,21 @@ def test_scaled_dot_product_attention_decode(
         framework=Framework.TORCH,
     )
 
+
 @pytest.mark.parametrize("num_users", [8, 16, 24, 32])
 @pytest.mark.parametrize("max_num_blocks_per_seq", [16, 32])
 @pytest.mark.parametrize("num_heads", [1, 8, 32])
 @pytest.mark.parametrize("block_size", [32, 64, 128])
 @pytest.mark.parametrize("head_dim", [128, 256])
-def test_paged_update_cache(num_users, max_num_blocks_per_seq, num_heads, block_size, head_dim):
+def test_paged_update_cache(
+    num_users, max_num_blocks_per_seq, num_heads, block_size, head_dim
+):
     max_num_blocks = max_num_blocks_per_seq * num_users
     max_seq_len = max_num_blocks_per_seq * block_size
 
-    cache = torch.zeros(max_num_blocks, num_heads, block_size, head_dim, dtype=torch.bfloat16)
+    cache = torch.zeros(
+        max_num_blocks, num_heads, block_size, head_dim, dtype=torch.bfloat16
+    )
     fill_value = torch.randn(1, num_users, num_heads, head_dim, dtype=torch.bfloat16)
 
     # Fill value head dim must be explicitly padded to 32, not only relying on tile layout.
@@ -149,7 +154,9 @@ def test_paged_update_cache(num_users, max_num_blocks_per_seq, num_heads, block_
     cache_idxs = torch.randperm(max_seq_len)[:num_users]
     permutation = torch.randperm(max_num_blocks)
     reverse_permutation = torch.argsort(permutation)
-    page_table = reverse_permutation.reshape(num_users, max_num_blocks_per_seq).to(torch.int32)
+    page_table = reverse_permutation.reshape(num_users, max_num_blocks_per_seq).to(
+        torch.int32
+    )
 
     run_op_test(
         torch.ops.tt.paged_update_cache,


### PR DESCRIPTION
### Ticket
N/A
### Problem description
`ttnn.paged_update_cache` is now modelled in tt-mlir, will be included in next uplift.

This op is required for implementing paged attention/cache in the vllm plugin.

### What's changed
Model `tt.paged_update_cache` as a custom torch op with underlying stablehlo custom call. Model CPU implementation of the op for testing.

Add a unit test suite for the op

### Checklist
- [X] New/Existing tests provide coverage for changes
