### PR TITLE
Fixes for nightly 7 Nov 2025

### DIFF
--- a/tests/torch/single_chip/graphs/test_attention.py
+++ b/tests/torch/single_chip/graphs/test_attention.py
@@ -1406,7 +1406,7 @@ def test_qwen2_5_attention(variant, variant_config, seq_len, request):
                 shard_specs[args[4]] = (None, None, None, None)  # attention_mask
                 return shard_specs
 
-        else:
+        elif num_heads % 4 == 0:
             # Use 2x4 mesh when heads not divisible by 8
             batch_size = 2
             mesh_shape = (2, num_devices // 2)
@@ -1421,6 +1421,11 @@ def test_qwen2_5_attention(variant, variant_config, seq_len, request):
                 shard_specs[args[3]] = ("batch", "model", None, None)  # value_states
                 shard_specs[args[4]] = ("batch", None, None, None)  # attention_mask
                 return shard_specs
+
+        else:
+            pytest.skip(
+                "No suitable mesh configuration for the number of attention heads"
+            )
 
     else:
         batch_size = 1


### PR DESCRIPTION
Providing a set of fixes for nightly in attention tests:
- missing request parameter in one test
- wrong number of attention heads for sharding on 8 devices