### PR TITLE
Enable designs affected by early matmul -> linear fusion errors. [#1781]

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -83,14 +83,10 @@ test_config:
         bringup_status: INCORRECT_RESULT
 
   xglm/pytorch-xglm-564M-single_device-full-inference:
-    status: KNOWN_FAILURE_XFAIL
-    reason: "loc(\"add.1846_decomp_matmul\"(\"add.1846\")): error: 'ttnn.matmul' op Output shape dimension[2](64) doesn't match the expected output shape dimension[2](256) - https://github.com/tenstorrent/tt-xla/issues/1781"
-    bringup_status: FAILED_TTMLIR_COMPILATION
+    status: EXPECTED_PASSING
 
   xglm/pytorch-xglm-1.7B-single_device-full-inference:
-    status: KNOWN_FAILURE_XFAIL
-    reason: "loc(\"add.1846_decomp_matmul\"(\"add.1846\")): error: 'ttnn.matmul' op Output shape dimension[2](64) doesn't match the expected output shape dimension[2](256) - https://github.com/tenstorrent/tt-xla/issues/1781"
-    bringup_status: FAILED_TTMLIR_COMPILATION
+    status: EXPECTED_PASSING
 
   resnet/pytorch-resnet_50_hf-single_device-full-inference:
     required_pcc: 0.98
@@ -135,9 +131,7 @@ test_config:
     status: EXPECTED_PASSING
 
   musicgen_small/pytorch-single_device-full-inference:
-    status: KNOWN_FAILURE_XFAIL
-    reason: "loc(\"add.1846_decomp_matmul\"(\"add.1846\")): error: 'ttnn.matmul' op Output shape dimension[2](64) doesn't match the expected output shape dimension[2](256) - https://github.com/tenstorrent/tt-xla/issues/1781"
-    bringup_status: FAILED_TTMLIR_COMPILATION
+    status: EXPECTED_PASSING
 
   falcon/pytorch-tiiuae/Falcon3-1B-Base-single_device-full-inference:
     status: EXPECTED_PASSING
@@ -180,9 +174,7 @@ test_config:
     status: EXPECTED_PASSING
 
   bart/pytorch-large-single_device-full-inference:
-    status: KNOWN_FAILURE_XFAIL
-    reason: "loc(\"add.1846_decomp_matmul\"(\"add.1846\")): error: 'ttnn.matmul' op Output shape dimension[2](64) doesn't match the expected output shape dimension[2](256) - https://github.com/tenstorrent/tt-xla/issues/1781"
-    bringup_status: FAILED_TTMLIR_COMPILATION
+    status: EXPECTED_PASSING
 
   bert/question_answering/pytorch-phiyodr/bert-large-finetuned-squad2-single_device-full-inference:
     status: EXPECTED_PASSING


### PR DESCRIPTION
### Ticket
#1781 

### Problem description
Early version of matmul + add -> linear fusion pattern included errors when the pattern was matmul -> reshape -> linear for certain models. 
This was resolved in tt-mlir recently: https://github.com/tenstorrent/tt-mlir/pull/5525
tt-xla uplifted this tt-mlir commit recently: https://github.com/tenstorrent/tt-xla/pull/2022 

### What's changed
Designs disabled due to #1781 run locally, and are marked passing.  

### Checklist
- [X] New/Existing tests provide coverage for changes
