### PR TITLE
Decrease usage on matrix.build.name in call-test.yml to allow test_models.py to work via "Run Test Single" workflow

### DIFF
--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -139,6 +139,13 @@ jobs:
           echo "artifact_run_id=${{ inputs.artifact_release_run_id }}" >> "$GITHUB_OUTPUT"
         fi
 
+        # Precompute forge models detection as a reusable output
+        if [[ "${{ matrix.build.dir }}" == *"tests/runner/test_models.py"* ]]; then
+          echo "forge-models-test=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "forge-models-test=false" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Download and install wheels
       shell: bash
       run: |
@@ -239,7 +246,7 @@ jobs:
 
         # Pass arch to forge models tests to resolve arch_overrides in test_config files.
         ARCH=""
-        if [[ "${{ matrix.build.name }}" == 'run_forge_models' || "${{ matrix.build.name }}" == 'run_forge_models_multichip' ]]; then
+        if [[ "${{ steps.strings.outputs.forge-models-test }}" == "true" ]]; then
           ARCH="--arch ${{ matrix.build['runs-on-original'] || matrix.build.runs-on }}"
         fi
 
@@ -267,7 +274,7 @@ jobs:
         echo "VERBOSITY=$VERBOSITY" >> $GITHUB_ENV
 
     - name: Install System Deps for Forge Models Tests
-      if: ${{ matrix.build.name == 'run_forge_models' || matrix.build.name == 'run_forge_models_multichip' }}
+      if: ${{ steps.strings.outputs.forge-models-test == 'true' }}
       shell: bash
       run: |
         apt-get update
@@ -276,7 +283,7 @@ jobs:
     # Ensure test_config files for tt-forge-models test are valid, especially on PR's for uplifting tt-forge-models
     # but still run tests even in case of failure here, will still treat overall job as failed.
     - name: Validate Forge Models Tests test config file
-      if: ${{ (matrix.build.name == 'run_forge_models' || matrix.build.name == 'run_forge_models_multichip') && strategy.job-index == 0 }}
+      if: ${{ steps.strings.outputs.forge-models-test == 'true' && strategy.job-index == 0 }}
       shell: bash
       run: |
         source venv/activate


### PR DESCRIPTION
### Ticket
Closes #2055 

### Problem description
- More details in linked ticket, but basically hardcoded check on matrix.build.name for a few things needed by forge models tests via test_models.py are not engaged when running through "Run Test Single" workflow (manual-test-single.yml) which does not provide the same build names and would lead to false failures, so needed to remove them and replace with looking at matrix.build.dir instead

### What's changed
 - Set steps.strings.outputs.forge-models-test true if running tests/runner/test_models.py
 - Remove looking at matrix.build.name being run_forge_models or run_forge_models_multichip when providing --arch, validating config file, installing deps, instead use new forge-models-test reusable variable
 - Leave --forked logic alone, it is safer to not set it when running manual-test-single.yml which may target single or multichip machines.

### Checklist
- [x] Tested on branch here, works now (can see deps installed, --arch provided), previously this same run would fail https://github.com/tenstorrent/tt-xla/actions/runs/19176390775
