### PR TITLE
[vLLM plugin] Add precompilation for all batch size

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -35,6 +35,7 @@ class TTConfig:
     enable_const_eval: bool = True
     min_context_len: int = 128
     batch_size: int = 1
+    enable_precompile_all: bool = True
 
     def get_pjrt_compile_config(self) -> dict:
         return {


### PR DESCRIPTION
### Ticket
closes #2093 

### Problem description
vLLM plugin pre-compile the graphs for [batch_size x input_seqs]; however vLLM can pass different number of inputs to plugin (different batch_size) and triggers compilation for a new shape. This defeats the purpose of pre-compilation.

### What's changed
- Update pre-compilation to generate graphs for all batch size variants [1, 2, .., batch_size]
- Add enable_precompile_all flag to control this behaviour [default: True]

### Checklist
- [X] Existing tests provide coverage for changes
