### PR TITLE
Fix Error Messages in PyTorch Training Tests

### DIFF
--- a/tests/runner/test_config/torch/test_config_training_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_training_single_device.yaml
@@ -1568,7 +1568,7 @@ test_config:
   mlp_mixer/lucidrains/pytorch-base-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_RUNTIME
-    reason: "Statically allocated circular buffers on core range [(x=0,y=0) - (x=7,y=7)] grow to 2723168 B which is beyond max L1 size of 1499136 B"
+    reason: "Out of Memory: Not enough space in L1"
 
   perceiver/pytorch-deepmind/language-perceiver-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
@@ -1583,7 +1583,7 @@ test_config:
   openpose/v2/pytorch-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 128 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 128 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   hrnet/pytorch-hrnet_w18_small-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
@@ -1643,22 +1643,22 @@ test_config:
   hrnet/pytorch-hrnet_w18_small_v2_osmr-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttnn.avg_pool2d' op Kernel height 7 is greater than input height 1. This ttnn.avg_pool2d configuration is invalid."
+    reason: "error: 'ttnn.avg_pool2d' op Kernel height 7 is greater than input height 1. This ttnn.avg_pool2d configuration is invalid. https://github.com/tenstorrent/tt-mlir/issues/5785"
 
   hrnet/pytorch-hrnetv2_w18_osmr-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttnn.avg_pool2d' op Kernel height 7 is greater than input height 1. This ttnn.avg_pool2d configuration is invalid."
+    reason: "error: 'ttnn.avg_pool2d' op Kernel height 7 is greater than input height 1. This ttnn.avg_pool2d configuration is invalid. https://github.com/tenstorrent/tt-mlir/issues/5785"
 
   hrnet/pytorch-hrnetv2_w30_osmr-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttnn.avg_pool2d' op Kernel height 7 is greater than input height 1. This ttnn.avg_pool2d configuration is invalid."
+    reason: "error: 'ttnn.avg_pool2d' op Kernel height 7 is greater than input height 1. This ttnn.avg_pool2d configuration is invalid. https://github.com/tenstorrent/tt-mlir/issues/5785"
 
   hrnet/pytorch-hrnetv2_w32_osmr-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttnn.avg_pool2d' op Kernel height 7 is greater than input height 1. This ttnn.avg_pool2d configuration is invalid."
+    reason: "error: 'ttnn.avg_pool2d' op Kernel height 7 is greater than input height 1. This ttnn.avg_pool2d configuration is invalid. https://github.com/tenstorrent/tt-mlir/issues/5785"
 
   hrnet/pytorch-hrnetv2_w40_osmr-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
@@ -1673,12 +1673,12 @@ test_config:
   hrnet/pytorch-hrnetv2_w48_osmr-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttnn.avg_pool2d' op Kernel height 7 is greater than input height 1. This ttnn.avg_pool2d configuration is invalid."
+    reason: "error: 'ttnn.avg_pool2d' op Kernel height 7 is greater than input height 1. This ttnn.avg_pool2d configuration is invalid. https://github.com/tenstorrent/tt-mlir/issues/5785"
 
   hrnet/pytorch-hrnetv2_w64_osmr-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttnn.avg_pool2d' op Kernel height 7 is greater than input height 1. This ttnn.avg_pool2d configuration is invalid."
+    reason: "error: 'ttnn.avg_pool2d' op Kernel height 7 is greater than input height 1. This ttnn.avg_pool2d configuration is invalid. https://github.com/tenstorrent/tt-mlir/issues/5785"
 
   glpn_kitti/pytorch-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
@@ -1693,32 +1693,32 @@ test_config:
   segformer/pytorch-mit_b0-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1024 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1024 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   segformer/pytorch-mit_b1-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 2048 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 2048 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   segformer/pytorch-mit_b2-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 2048 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 2048 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   segformer/pytorch-mit_b3-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 2048 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 2048 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   segformer/pytorch-mit_b4-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 2048 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 2048 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   segformer/pytorch-mit_b5-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 2048 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 2048 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   ghostnet/pytorch-ghostnet_100-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
@@ -1738,157 +1738,157 @@ test_config:
   efficientnet_lite/pytorch-tf_efficientnet_lite0.in1k-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1152 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1152 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   efficientnet_lite/pytorch-tf_efficientnet_lite1.in1k-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1152 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1152 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   efficientnet_lite/pytorch-tf_efficientnet_lite2.in1k-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1248 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1248 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   efficientnet_lite/pytorch-tf_efficientnet_lite3.in1k-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1392 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1392 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   efficientnet_lite/pytorch-tf_efficientnet_lite4.in1k-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1632 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1632 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   monodepth2/pytorch-mono_640x192-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_RUNTIME
-    reason: "Failed to find a path for this model."
+    reason: "Out of Memory: Not enough space in L1"
 
   monodepth2/pytorch-stereo_640x192-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_RUNTIME
-    reason: "Failed to find a path for this model."
+    reason: "Out of Memory: Not enough space in L1"
 
   monodepth2/pytorch-mono+stereo_640x192-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_RUNTIME
-    reason: "Failed to find a path for this model."
+    reason: "Out of Memory: Not enough space in L1"
 
   monodepth2/pytorch-mono_no_pt_640x192-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_RUNTIME
-    reason: "Failed to find a path for this model."
+    reason: "Out of Memory: Not enough space in L1"
 
   monodepth2/pytorch-stereo_no_pt_640x192-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_RUNTIME
-    reason: "Failed to find a path for this model."
+    reason: "Out of Memory: Not enough space in L1"
 
   monodepth2/pytorch-mono+stereo_no_pt_640x192-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_RUNTIME
-    reason: "Failed to find a path for this model."
+    reason: "Out of Memory: Not enough space in L1"
 
   monodepth2/pytorch-mono_1024x320-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_RUNTIME
-    reason: "Failed to find a path for this model."
+    reason: "Out of Memory: Not enough space in L1"
 
   monodepth2/pytorch-stereo_1024x320-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_RUNTIME
-    reason: "Failed to find a path for this model."
+    reason: "Out of Memory: Not enough space in L1"
 
   monodepth2/pytorch-mono+stereo_1024x320-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_RUNTIME
-    reason: "Failed to find a path for this model."
+    reason: "Out of Memory: Not enough space in L1"
 
   efficientnet/pytorch-efficientnet_b0-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1152 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1152 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   efficientnet/pytorch-efficientnet_b1-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1920 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1920 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   efficientnet/pytorch-efficientnet_b2-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 3072 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 3072 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   efficientnet/pytorch-efficientnet_b3-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 3840 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 3840 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   efficientnet/pytorch-efficientnet_b4-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 3072 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 3072 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   efficientnet/pytorch-efficientnet_b5-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 3072 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 3072 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   efficientnet/pytorch-efficientnet_b6-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 3456 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 3456 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   efficientnet/pytorch-efficientnet_b7-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 3072 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 3072 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   efficientnet/pytorch-timm_efficientnet_b0-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 2688 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 2688 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   efficientnet/pytorch-timm_efficientnet_b4-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 2688 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 2688 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   efficientnet/pytorch-hf_hub_timm_efficientnet_b0_ra_in1k-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1152 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1152 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   efficientnet/pytorch-hf_hub_timm_efficientnet_b4_ra2_in1k-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 2688 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 2688 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   efficientnet/pytorch-hf_hub_timm_efficientnet_b5_in12k_ft_in1k-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 2688 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 2688 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   efficientnet/pytorch-hf_hub_timm_tf_efficientnet_b0_aa_in1k-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 2688 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 2688 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   efficientnet/pytorch-hf_hub_timm_efficientnetv2_rw_s_ra2_in1k-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1632 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1632 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   efficientnet/pytorch-hf_hub_timm_tf_efficientnetv2_s_in21k-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 2688 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 2688 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   mobilenetv1/pytorch-mobilenet_v1-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1024 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1024 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   mobilenetv1/pytorch-mobilenetv1_100.ra4_e3600_r224_in1k-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
@@ -1902,33 +1902,33 @@ test_config:
 
   whisper/pytorch-openai/whisper-tiny-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "Failed to find a path for this model."
+    bringup_status: FAILED_FE_COMPILATION
+    reason: "ValueError: You have to specify either decoder_input_ids or decoder_inputs_embeds."
 
   whisper/pytorch-openai/whisper-base-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "Failed to find a path for this model."
+    bringup_status: FAILED_FE_COMPILATION
+    reason: "ValueError: You have to specify either decoder_input_ids or decoder_inputs_embeds."
 
   whisper/pytorch-openai/whisper-small-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "Failed to find a path for this model."
+    bringup_status: FAILED_FE_COMPILATION
+    reason: "ValueError: You have to specify either decoder_input_ids or decoder_inputs_embeds."
 
   whisper/pytorch-openai/whisper-medium-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "Failed to find a path for this model."
+    bringup_status: FAILED_FE_COMPILATION
+    reason: "ValueError: You have to specify either decoder_input_ids or decoder_inputs_embeds."
 
   whisper/pytorch-openai/whisper-large-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "No path found for this model."
+    bringup_status: FAILED_FE_COMPILATION
+    reason: "ValueError: You have to specify either decoder_input_ids or decoder_inputs_embeds."
 
   whisper/pytorch-openai/whisper-large-v3-turbo-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "Failed to find a path for this model."
+    bringup_status: FAILED_FE_COMPILATION
+    reason: "ValueError: You have to specify either decoder_input_ids or decoder_inputs_embeds."
 
   mobilenetv3/pytorch-mobilenet_v3_large-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
@@ -1938,27 +1938,27 @@ test_config:
   mobilenetv3/pytorch-mobilenet_v3_small-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 576 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 576 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   mobilenetv3/pytorch-mobilenetv3_large_100-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 960 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 960 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   mobilenetv3/pytorch-mobilenetv3_small_100-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 576 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 576 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   xception/pytorch-xception41-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1536 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1536 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   xception/pytorch-xception65-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1536 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1536 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   xception/pytorch-xception71-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
@@ -1968,22 +1968,22 @@ test_config:
   xception/pytorch-xception71.tf_in1k-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1536 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1536 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   regnet/pytorch-regnet_y_040-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1088 input channels and 64 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1088 input channels and 64 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   regnet/pytorch-regnet_y_064-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1296 input channels and 72 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1296 input channels and 72 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   regnet/pytorch-regnet_y_080-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 2016 input channels and 56 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 2016 input channels and 56 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   regnet/pytorch-regnet_y_120-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
@@ -1993,7 +1993,7 @@ test_config:
   regnet/pytorch-regnet_y_160-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 3024 input channels and 112 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 3024 input channels and 112 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   regnet/pytorch-regnet_y_320-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
@@ -2003,7 +2003,7 @@ test_config:
   regnet/pytorch-regnet_y_400mf-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 440 input channels and 8 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 440 input channels and 8 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   regnet/pytorch-regnet_y_800mf-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
@@ -2013,27 +2013,27 @@ test_config:
   regnet/pytorch-regnet_y_1_6gf-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 888 input channels and 24 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 888 input channels and 24 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   regnet/pytorch-regnet_y_3_2gf-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1512 input channels and 24 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1512 input channels and 24 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   regnet/pytorch-regnet_y_8gf-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 3456 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 3456 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   regnet/pytorch-regnet_y_16gf-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 3024 input channels and 112 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 3024 input channels and 112 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   regnet/pytorch-regnet_y_32gf-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 3712 input channels and 232 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 3712 input channels and 232 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   regnet/pytorch-regnet_y_128gf-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
@@ -2043,12 +2043,12 @@ test_config:
   regnet/pytorch-regnet_x_400mf-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 400 input channels and 16 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 400 input channels and 16 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   regnet/pytorch-regnet_x_800mf-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 672 input channels and 16 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 672 input channels and 16 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   regnet/pytorch-regnet_x_1_6gf-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
@@ -2063,12 +2063,12 @@ test_config:
   regnet/pytorch-regnet_x_8gf-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1920 input channels and 120 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1920 input channels and 120 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   regnet/pytorch-regnet_x_16gf-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 2048 input channels and 128 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 2048 input channels and 128 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   regnet/pytorch-regnet_x_32gf-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
@@ -2077,33 +2077,33 @@ test_config:
 
   mobilenetv2/pytorch-mobilenet_v2-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "Failed to find a path for this model."
+    bringup_status: FAILED_TTMLIR_COMPILATION
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 960 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   mobilenetv2/pytorch-google/mobilenet_v2_0.35_96-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 336 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 336 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   mobilenetv2/pytorch-google/mobilenet_v2_0.75_160-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 720 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 720 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   mobilenetv2/pytorch-google/mobilenet_v2_1.0_224-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_RUNTIME
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 960 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 960 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   mobilenetv2/pytorch-mobilenetv2_100-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 960 input channels and 1 in the weight tensor."
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 960 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   mobilenetv2/pytorch-mobilenet_v2_torchvision-single_device-full-training:
-    status: EXPECTED_PASSING
-    bringup_status: FAILED_RUNTIME
-    reason: "Failed to find a path for this model."
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_TTMLIR_COMPILATION
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 960 input channels and 1 in the weight tensor. https://github.com/tenstorrent/tt-mlir/issues/5784"
 
   qwen_3/causal_lm/pytorch-1_7b-single_device-full-training:
     status: NOT_SUPPORTED_SKIP


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Couple of MLIR issue fixes have landed. Current error messages for PyTorch training tests are not up-to-date.

Problems that appeared in updated messages:
- tt-mlir:

1. stablehlo.select_and_scatter (https://github.com/tenstorrent/tt-mlir/issues/4794)
2. ttir.conv_transpose2d (https://github.com/tenstorrent/tt-mlir/issues/5784)
3. ttnn.avg_pool2d (https://github.com/tenstorrent/tt-mlir/issues/5785)

- tt-metal:

1. OOMs on DRAM and L1
2. Input X dimension (32) must be divisible by 64 for tiling.

- infra:

1. ValueError: Node arity mismatch; expected X, but got X-1.
2. tt-forge-models doesn't implement unpack_forward_output for this model.
3. AssertionError: CPU and TT have different None grad parameters: set() != {'predictions.bias'}
4. RuntimeError: Index put requires the source and destination dtypes match, got Float for the destination and BFloat16 for the source.
5. ValueError: You have to specify either decoder_input_ids or decoder_inputs_embeds.

### What's changed
This PR updates error messages for training tests. It mainly focuses on batch norm training fix, but it also touches other ops as well.
