### PR TITLE
Add xfailed Torch models to the nightly run.

### DIFF
--- a/.github/workflows/test-matrix-presets/model-test-xfail.json
+++ b/.github/workflows/test-matrix-presets/model-test-xfail.json
@@ -3,6 +3,6 @@
   { "runs-on": "p150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "p150 and (known_failure_xfail or not_supported_skip) and not large", "parallel-groups": 3 },
   { "runs-on": "n150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "n150 and (known_failure_xfail or not_supported_skip) and large", "parallel-groups": 1, "shared-runners": "true" },
   { "runs-on": "p150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "p150 and (known_failure_xfail or not_supported_skip) and large", "parallel-groups": 1, "shared-runners": "true" },
-  { "runs-on": "n150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "n150 and (known_failure_xfail or not_supported_skip) and not large", "parallel-groups": 3 },
-  { "runs-on": "p150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "p150 and (known_failure_xfail or not_supported_skip) and not large", "parallel-groups": 3 }
+  { "runs-on": "n150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "(n150 and (known_failure_xfail or not_supported_skip) and not large) or placeholder", "parallel-groups": 3 },
+  { "runs-on": "p150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "(p150 and (known_failure_xfail or not_supported_skip) and not large) or placeholder", "parallel-groups": 3 }
 ]


### PR DESCRIPTION
### What's changed
By mistake torch xfail/skip models did not run in nightly CI. Returned them to the test matrix.

[Link](https://github.com/tenstorrent/tt-xla/actions/runs/19301026243) to Action to test generation of tests
