### PR TITLE
Add ljovanovicTT as code owner for vllm_plugin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,4 +31,4 @@ pytest.ini @mrakitaTT @ajakovljevicTT @AleksKnezevic @jameszianxuTT @kmabeeTT @n
 /third_party/tt_forge_models @AleksKnezevic @kmabeeTT @mrakitaTT @nvukobratTT
 
 # Integrations
-/integrations/vllm_plugin/ @AleksKnezevic @LPanosTT @mmanzoorTT
+/integrations/vllm_plugin/ @AleksKnezevic @LPanosTT @mmanzoorTT @ljovanovicTT


### PR DESCRIPTION
@ljovanovicTT is working on integrating the vllm plugin into the inference server. Adding her as a reviewer so she can catch potential breaks up front. 