### PR TITLE
Add llama rms norm unit test

### DIFF
--- a/tests/torch/single_chip/graphs/test_rms_norm.py
+++ b/tests/torch/single_chip/graphs/test_rms_norm.py
@@ -1,25 +1,12 @@
 # SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
-
-from typing import Callable
-
-import numpy as np
 import pytest
 import torch
 import torch_xla
-import torch_xla.core.xla_model as xm
 import torch_xla.runtime as xr
 from infra import Framework, run_graph_test
 from infra.comparators.comparison_config import ComparisonConfig, PccConfig
-from torch_xla.distributed.spmd import Mesh
-from transformers import CacheConfig
-from transformers.cache_utils import StaticCache
-from transformers.models.llama.modeling_llama import (
-    ALL_ATTENTION_FUNCTIONS,
-    eager_attention_forward,
-)
-from utils import failed_runtime
 
 from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
     ModelLoader as LlamaModelLoader,


### PR DESCRIPTION
### Ticket
N/A

### Problem description
We want to add a unit test for [LlamaRMSNorm](https://github.com/huggingface/transformers/blob/5689dd6b8ed0257c6c43c0937d0d224d05774ecc/src/transformers/models/llama/modeling_llama.py#L62).

### What's changed
Added `test_llama_rms_norm` unit test to new `tests/torch/single_chip/graphs/test_rms_norm.py` following same structure as attention unit tests.

### Checklist
- [x] New/Existing tests provide coverage for changes
