### PR TITLE
Add Arnold models to test_config

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -2302,3 +2302,15 @@ test_config:
   llama/llama_3_2_vision/pytorch-llama_3_2_11b_vision_instruct-single_device-full-inference:
     status: KNOWN_FAILURE_XFAIL
     reason: "RuntimeError('Check failed: handle->HasValue(): Trying to access XLA data for tensor while an async operation is in flight: UNKNOWN_SCALAR[]')"
+
+  arnold/pytorch-deathmatch_shotgun_rnn-single_device-full-inference:
+    status: EXPECTED_PASSING
+
+  arnold/pytorch-vizdoom_2017_track1_rnn-single_device-full-inference:
+    status: EXPECTED_PASSING
+
+  arnold/pytorch-defend_the_center_ff-single_device-full-inference:
+    status: EXPECTED_PASSING
+
+  arnold/pytorch-vizdoom_2017_track2_rnn-single_device-full-inference:
+    status: EXPECTED_PASSING


### PR DESCRIPTION
### Problem description
Arnold model variants are passing in [experimental nightly](https://github.com/tenstorrent/tt-xla/actions/runs/19320240420/job/55260162674)

### What's changed
4 variants of arnold model are passing in experimental nightly
Their config is added to test_config file

* arnold/pytorch-deathmatch_shotgun_rnn
* arnold/pytorch-vizdoom_2017_track1_rnn
* arnold/pytorch-defend_the_center_ff
* arnold/pytorch-vizdoom_2017_track2_rnn

### Checklist
- [x] New/Existing tests provide coverage for changes

PFA logs for reference:
[arn_deathmatch_shotgun_rnn.log](https://github.com/user-attachments/files/23521604/arn_deathmatch_shotgun_rnn.log)
[arn_def_the_center_ff.log](https://github.com/user-attachments/files/23521610/arn_def_the_center_ff.log)
[arn_viz_2017_t1_rnn.log](https://github.com/user-attachments/files/23521611/arn_viz_2017_t1_rnn.log)
[arn_viz_2017_t2_rnn.log](https://github.com/user-attachments/files/23521613/arn_viz_2017_t2_rnn.log)
