### PR TITLE
Extend code owners for failing reasons

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,6 +15,7 @@
 
 # Tests
 /tests/ @mrakitaTT @ajakovljevicTT @AleksKnezevic @jameszianxuTT @kmabeeTT @ndrakulicTT @sdjukicTT @sgligorijevicTT @vzeljkovicTT
+/tests/infra/utilities/failing_reasons/ @mrakitaTT @ajakovljevicTT @AleksKnezevic @jameszianxuTT @kmabeeTT @ndrakulicTT @sdjukicTT @sgligorijevicTT @vzeljkovicTT @vbrkicTT @vobojevicTT @kmilanovicTT @nvukobratTT @dgolubovicTT
 pytest.ini @mrakitaTT @ajakovljevicTT @AleksKnezevic @jameszianxuTT @kmabeeTT @ndrakulicTT @sdjukicTT @sgligorijevicTT @vzeljkovicTT
 .test_durations @mrakitaTT @ajakovljevicTT @AleksKnezevic @jameszianxuTT @kmabeeTT @ndrakulicTT @sdjukicTT @sgligorijevicTT @vzeljkovicTT
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Extend code owners on failing reasons to sweeps developers.

### What's changed
Extend code owners on failing reasons to sweeps developers.

### Checklist
- [ ] New/Existing tests provide coverage for changes
