### PR TITLE
fix xfail that crashes

### DIFF
--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -286,11 +286,11 @@ def record_model_test_properties(
 
     if test_metadata.status == ModelTestStatus.NOT_SUPPORTED_SKIP:
         bringup_status = config_bringup_status
-        reason = getattr(test_metadata, "reason", None)
+        reason = getattr(test_metadata, "reason", "")
 
     elif config_bringup_status == BringupStatus.NOT_STARTED:
         bringup_status = config_bringup_status
-        reason = getattr(test_metadata, "reason", None)
+        reason = getattr(test_metadata, "reason", "")
 
     elif comparison_result is not None:
         pcc = comparison_result.pcc


### PR DESCRIPTION
### Ticket
fixes: #2142

### Problem description
explained in #2142

### What's changed
When tests pass, they dont have reason set (meaning they stay `None`), and that crashes the whole pytest run
