### PR TITLE
Re-Enable PCC Check for qwen_3/causal_lm models after padding fix in tt-forge-models

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -1823,9 +1823,8 @@ test_config:
   qwen_3/causal_lm/pytorch-14b-single_device-full-inference:
     arch_overrides:
       p150:
-        assert_pcc: false
         status: EXPECTED_PASSING
-        reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.48546990752220154. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/1474"
+        required_pcc: 0.98
       n150:
         status: NOT_SUPPORTED_SKIP
         reason: "Too large for single chip"

--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -63,28 +63,24 @@ test_config:
   qwen_3/causal_lm/pytorch-0_6b-tensor_parallel-full-inference:
     supported_archs: [n300-llmbox]
     status: EXPECTED_PASSING
-    assert_pcc: false
 
   qwen_3/causal_lm/pytorch-14b-tensor_parallel-full-inference:
     supported_archs: [n300-llmbox]
     status: EXPECTED_PASSING
-    assert_pcc: false
+    required_pcc: 0.98 # 0.9860
 
   qwen_3/causal_lm/pytorch-1_7b-tensor_parallel-full-inference:
     supported_archs: [n300-llmbox]
     status: EXPECTED_PASSING
-    assert_pcc: false
 
   qwen_3/causal_lm/pytorch-32b-tensor_parallel-full-inference:
     supported_archs: [n300-llmbox]
     status: EXPECTED_PASSING
-    assert_pcc: false
-    bringup_status: INCORRECT_RESULT # https://github.com/tenstorrent/tt-xla/issues/1474
+    required_pcc: 0.98 # 0.9899
 
   qwen_3/causal_lm/pytorch-8b-tensor_parallel-full-inference:
     supported_archs: [n300-llmbox]
     status: EXPECTED_PASSING
-    assert_pcc: false
 
   qwen_3/embedding/pytorch-embedding_8b-tensor_parallel-full-inference:
     supported_archs: [n300-llmbox]


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/1474

### Problem description
There was a noticeable drop in PCC for the Qwen models. After updating the evaluation to compute PCC using only the valid tokens from the input (https://github.com/tenstorrent/tt-forge-models/pull/282), the PCC improved across all variants and parallelisms (0.7 => 0.99 on average). See PR for full details.

### What's changed

- Enable PCC on all affected variants/parallelisms of qwen_3/causal_lm models 

### Checklist
- [x] Branch CI run with affected tests and PCC enabled, passing: https://github.com/tenstorrent/tt-xla/actions/runs/19512655544
