### PR TITLE
Fix XLA inference issue in PETR by skipping class types in to_device() and add inference test config

### DIFF
--- a/tests/infra/runners/torch_device_runner.py
+++ b/tests/infra/runners/torch_device_runner.py
@@ -24,6 +24,7 @@ def to_device(x, device, depth=5):
     - PyTorch tensors and models (objects with .to() method)
     - Custom objects with attributes (recursively processes all fields)
     - None values and other primitives (returned unchanged)
+    - Class types (returned unchanged as metadata)
 
     Args:
         x: The data structure or object to move to device
@@ -50,6 +51,8 @@ def to_device(x, device, depth=5):
     elif isinstance(x, dict):
         return {k: to_device(v, device, depth - 1) for k, v in x.items()}
     elif hasattr(x, "to"):
+        if isinstance(x, type):
+            return x
         return x.to(device)
     # Handle objects with attributes by recursively processing all fields.
     # This is done in-place.

--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -2310,3 +2310,23 @@ test_config:
 
   arnold/pytorch-vizdoom_2017_track2_rnn-single_device-full-inference:
     status: EXPECTED_PASSING
+
+  petr/pytorch-vovnet_gridmask_p4_800x320-single_device-full-inference:
+    status: KNOWN_FAILURE_XFAIL
+    reason: "Out of Memory: Not enough space to allocate 57952512 B L1 buffer across 72 banks, where each bank needs to store 804896 B, but bank size is only 1331936 B"
+    bringup_status: FAILED_RUNTIME
+
+  petr/pytorch-vovnet_gridmask_p4_1600x640-single_device-full-inference:
+    status: KNOWN_FAILURE_XFAIL
+    reason: "Out of Memory: Not enough space to allocate 138461184 B L1 buffer across 72 banks, where each bank needs to store 1923072 B, but bank size is only 1331936 B"
+    bringup_status: FAILED_RUNTIME
+
+  petr/pytorch-r50dcn_gridmask_c5-single_device-full-inference:
+    status: KNOWN_FAILURE_XFAIL
+    reason: "Out of Memory: Not enough space to allocate 138461184 B L1 buffer across 72 banks, where each bank needs to store 1923072 B, but bank size is only 1331936 B"
+    bringup_status: FAILED_RUNTIME
+
+  petr/pytorch-r50dcn_gridmask_p4-single_device-full-inference:
+    status: KNOWN_FAILURE_XFAIL
+    reason: "Out of Memory: Not enough space to allocate 138461184 B L1 buffer across 72 banks, where each bank needs to store 1923072 B, but bank size is only 1331936 B"
+    bringup_status: FAILED_RUNTIME


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/2175
- https://github.com/tenstorrent/tt-xla/issues/1894

### Problem description

- PETR model inference fails on XLA with: **TypeError: BaseInstance3DBoxes.to() missing 1 required positional argument: 'device'.** [nov14_petr_xla.log](https://github.com/user-attachments/files/23541994/nov14_petr_xla.log)
- Add inference test config for PETR variants

### Root cause 


The issue occurs due to how the device runner handles class types vs instances:

1. PETR's input structure: The model stores [LiDARInstance3DBoxes](https://github.com/tenstorrent/tt-forge-models/blob/8225a98159272926d8b0471b595a5eef0fdde0f1/petr/pytorch/src/petr.py#L4870) (a class inheriting from [BaseInstance3DBoxes](https://github.com/tenstorrent/tt-forge-models/blob/8225a98159272926d8b0471b595a5eef0fdde0f1/petr/pytorch/src/petr.py#L4832C1-L4832C35)) as metadata in [img_metas["box_type_3d"]](https://github.com/tenstorrent/tt-forge-models/blob/8225a98159272926d8b0471b595a5eef0fdde0f1/petr/pytorch/loader.py#L196C25-L196C61). This class reference is used later as a factory to create actual bounding box instances during the [forward pass](https://github.com/tenstorrent/tt-forge-models/blob/8225a98159272926d8b0471b595a5eef0fdde0f1/petr/pytorch/src/petr.py#L4138).
2. [BaseInstance3DBoxes](https://github.com/tenstorrent/tt-forge-models/blob/8225a98159272926d8b0471b595a5eef0fdde0f1/petr/pytorch/src/petr.py#L4832C1-L4832C35) class : A wrapper class that converts raw tensor predictions into structured 3D bounding box objects. It has a .to(device) instance method for device management.
3. Device runner behavior: The existing to_device() function in torch_device_runner.py only checks hasattr(x, "to") and calls x.to(device) on any object with that attribute, without distinguishing between:
   - Classes (type objects) - which are metadata/templates
   - Instances (actual objects) - which have data to move
4. The failure: As runner moves inputs before inference, it encounters LiDARInstance3DBoxes (the class itself, not an instance) and attempts to call .to(device) on it. Since class methods require self as the first parameter and calling on a class doesn't provide it, the error occurs.
**Key distinction:**
   - instance.to(device) → Works (Python passes instance as self)
   - ClassType.to(device) → Fails (No self, device goes to wrong parameter)


### What's changed

- Added an isinstance(x, type) check in to_device() to skip class types before attempting device conversion
- Added inference test config for PETR variants

### Checklist
- [x] Verified the changes through local testing

### Logs

- [nov14_petr_xla_before_fix.log](https://github.com/user-attachments/files/23542179/nov14_petr_xla.log)
- [nov14_petr_xla_after_fix.log](https://github.com/user-attachments/files/23542175/nov14_petr_xla_after_fix.log)


