### PR TITLE
Vllm wheel fix in nightly CI

### DIFF
--- a/.github/workflows/schedule-nightly.yml
+++ b/.github/workflows/schedule-nightly.yml
@@ -32,6 +32,7 @@ jobs:
       docker_image: ${{ needs.build-image.outputs.docker-image-base }}
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       wheel_release_artifact_name: ${{ needs.build-ttxla.outputs.wheel_artifact_name }}
+      wheel_release_vllm_tt_artifact_name: ${{ needs.build-ttxla.outputs.wheel_release_vllm_tt_artifact_name }}
 
   test_full_model:
     uses: ./.github/workflows/call-test.yml


### PR DESCRIPTION
The name of the wheel was not passed correctly in vllm tests, so fixing that.