### PR TITLE
Revert Test Configs for Ultralytics-Independent YOLO Models

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -102,13 +102,13 @@ test_config:
       n150:
         required_pcc: 0.98
 
-  # yolov3/pytorch-base-single_device-full-inference:
-  #   required_pcc: 0.97  # AssertionError: PCC comparison failed. Calculated: pcc=0.9725883603096008. Required: pcc=0.98. Exposed by removal of consteval on host: https://github.com/tenstorrent/tt-xla/issues/1242
-  #   status: EXPECTED_PASSING
+  yolov3/pytorch-base-single_device-full-inference:
+    required_pcc: 0.97  # AssertionError: PCC comparison failed. Calculated: pcc=0.9725883603096008. Required: pcc=0.98. Exposed by removal of consteval on host: https://github.com/tenstorrent/tt-xla/issues/1242
+    status: EXPECTED_PASSING
 
-  # yolov4/pytorch-base-single_device-full-inference:
-  #   required_pcc: 0.98  # AssertionError: PCC comparison failed. Calculated: pcc=0.9872550368309021. Required: pcc=0.99. Exposed by removal of consteval on host: https://github.com/tenstorrent/tt-xla/issues/1242
-  #   status: EXPECTED_PASSING
+  yolov4/pytorch-base-single_device-full-inference:
+    required_pcc: 0.98  # AssertionError: PCC comparison failed. Calculated: pcc=0.9872550368309021. Required: pcc=0.99. Exposed by removal of consteval on host: https://github.com/tenstorrent/tt-xla/issues/1242
+    status: EXPECTED_PASSING
 
   t5/pytorch-google/flan-t5-small-single_device-full-inference:
     status: EXPECTED_PASSING
@@ -659,10 +659,10 @@ test_config:
   bert/sentence_embedding_generation/pytorch-emrecan/bert-base-turkish-cased-mean-nli-stsb-tr-single_device-full-inference:
     status: EXPECTED_PASSING
 
-#  yolos/pytorch-single_device-full-inference:
-#    status: EXPECTED_PASSING
-#    assert_pcc: false  # Was 0.96 before here (0.98 in tt-torch) started hitting this on Aug29 : https://github.com/tenstorrent/tt-xla/issues/1168 AssertionError: PCC comparison failed. Calculated: pcc=0.9559887647628784. Required: pcc=0.96. Later on Sept 2 started failing in WH too: AssertionError: PCC comparison failed. Calculated: pcc=0.2700212001800537. Required: pcc=0.99
-#    reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.2700212001800537. Required: pcc=0.99 - Sept 2"
+  yolos/pytorch-single_device-full-inference:
+    status: EXPECTED_PASSING
+    assert_pcc: false  # Was 0.96 before here (0.98 in tt-torch) started hitting this on Aug29 : https://github.com/tenstorrent/tt-xla/issues/1168 AssertionError: PCC comparison failed. Calculated: pcc=0.9559887647628784. Required: pcc=0.96. Later on Sept 2 started failing in WH too: AssertionError: PCC comparison failed. Calculated: pcc=0.2700212001800537. Required: pcc=0.99
+    reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.2700212001800537. Required: pcc=0.99 - Sept 2"
 
   perceiverio_vision/pytorch-deepmind/vision-perceiver-conv-single_device-full-inference:
     required_pcc: 0.98
@@ -958,38 +958,38 @@ test_config:
   #   status: KNOWN_FAILURE_XFAIL
   #   reason: "error: 'ttnn.max_pool2d' op Kernel height 13 is greater than input height 10. This ttnn.max_pool2d configuration is invalid - https://github.com/tenstorrent/tt-xla/issues/2007"
 
-  # yolox/pytorch-yolox_nano-single_device-full-inference:
-  #   status: NOT_SUPPORTED_SKIP
-  #   reason: "Yolo models have issues with loading yolox https://github.com/tenstorrent/tt-xla/issues/1929"
-  #   bringup_status: FAILED_FE_COMPILATION
+  yolox/pytorch-yolox_nano-single_device-full-inference:
+    status: NOT_SUPPORTED_SKIP
+    reason: "Yolo models have issues with loading yolox https://github.com/tenstorrent/tt-xla/issues/1929"
+    bringup_status: FAILED_FE_COMPILATION
 
-  # yolox/pytorch-yolox_tiny-single_device-full-inference:
-  #   status: NOT_SUPPORTED_SKIP
-  #   reason: "Yolo models have issues with loading yolox https://github.com/tenstorrent/tt-xla/issues/1929"
-  #   bringup_status: FAILED_FE_COMPILATION
+  yolox/pytorch-yolox_tiny-single_device-full-inference:
+    status: NOT_SUPPORTED_SKIP
+    reason: "Yolo models have issues with loading yolox https://github.com/tenstorrent/tt-xla/issues/1929"
+    bringup_status: FAILED_FE_COMPILATION
 
-  # yolox/pytorch-yolox_s-single_device-full-inference:
-  #   status: KNOWN_FAILURE_XFAIL  # Exposed by "Remove host-side consteval" change
-  #   reason: "torch._dynamo.exc.TorchRuntimeError: Dynamo failed to run FX node with fake tensors - https://github.com/tenstorrent/tt-xla/issues/1243"
+  yolox/pytorch-yolox_s-single_device-full-inference:
+    status: KNOWN_FAILURE_XFAIL  # Exposed by "Remove host-side consteval" change
+    reason: "torch._dynamo.exc.TorchRuntimeError: Dynamo failed to run FX node with fake tensors - https://github.com/tenstorrent/tt-xla/issues/1243"
 
-  # yolox/pytorch-yolox_m-single_device-full-inference:
-  #   status: KNOWN_FAILURE_XFAIL  # Exposed by "Remove host-side consteval" change
-  #   reason: "torch._dynamo.exc.TorchRuntimeError: Dynamo failed to run FX node with fake tensors - https://github.com/tenstorrent/tt-xla/issues/1243"
+  yolox/pytorch-yolox_m-single_device-full-inference:
+    status: KNOWN_FAILURE_XFAIL  # Exposed by "Remove host-side consteval" change
+    reason: "torch._dynamo.exc.TorchRuntimeError: Dynamo failed to run FX node with fake tensors - https://github.com/tenstorrent/tt-xla/issues/1243"
 
-  # yolox/pytorch-yolox_l-single_device-full-inference:
-  #   status: NOT_SUPPORTED_SKIP  # Exposed by "Remove host-side consteval" change
-  #   reason: "Yolo models have issues with loading yolox https://github.com/tenstorrent/tt-xla/issues/1929"
-  #   bringup_status: FAILED_FE_COMPILATION
+  yolox/pytorch-yolox_l-single_device-full-inference:
+    status: NOT_SUPPORTED_SKIP  # Exposed by "Remove host-side consteval" change
+    reason: "Yolo models have issues with loading yolox https://github.com/tenstorrent/tt-xla/issues/1929"
+    bringup_status: FAILED_FE_COMPILATION
 
-  # yolox/pytorch-yolox_darknet-single_device-full-inference:
-  #   status: NOT_SUPPORTED_SKIP  # Exposed by "Remove host-side consteval" change
-  #   reason: "Yolo models have issues with loading yolox https://github.com/tenstorrent/tt-xla/issues/1929"
-  #   bringup_status: FAILED_FE_COMPILATION
+  yolox/pytorch-yolox_darknet-single_device-full-inference:
+    status: NOT_SUPPORTED_SKIP  # Exposed by "Remove host-side consteval" change
+    reason: "Yolo models have issues with loading yolox https://github.com/tenstorrent/tt-xla/issues/1929"
+    bringup_status: FAILED_FE_COMPILATION
 
-  # yolox/pytorch-yolox_x-single_device-full-inference:
-  #   status: NOT_SUPPORTED_SKIP  # Exposed by "Remove host-side consteval" change
-  #   reason: "Yolo models have issues with loading yolox https://github.com/tenstorrent/tt-xla/issues/1929"
-  #   bringup_status: FAILED_FE_COMPILATION
+  yolox/pytorch-yolox_x-single_device-full-inference:
+    status: NOT_SUPPORTED_SKIP  # Exposed by "Remove host-side consteval" change
+    reason: "Yolo models have issues with loading yolox https://github.com/tenstorrent/tt-xla/issues/1929"
+    bringup_status: FAILED_FE_COMPILATION
 
   mobilenetv2/pytorch-google/deeplabv3_mobilenet_v2_1.0_513-single_device-full-inference:
     status: EXPECTED_PASSING
@@ -2225,20 +2225,20 @@ test_config:
   maskformer_swin_b/pytorch-swin_base_ade-single_device-full-inference:
     status: EXPECTED_PASSING
 
-  # yolos_small/pytorch-small-single_device-full-inference:
-  #   status: KNOWN_FAILURE_XFAIL
-  #   reason: "Out of Memory: Not enough space to allocate 13519872 B L1 buffer across 9 banks, where each bank needs to store 1502208 B, but bank size is only 1331936 B"
+  yolos_small/pytorch-small-single_device-full-inference:
+    status: KNOWN_FAILURE_XFAIL
+    reason: "Out of Memory: Not enough space to allocate 13519872 B L1 buffer across 9 banks, where each bank needs to store 1502208 B, but bank size is only 1331936 B"
 
-  # yolos_small/pytorch-small_dwr-single_device-full-inference:
-  #   status: KNOWN_FAILURE_XFAIL
-  #   reason: "Out of Memory: Not enough space to allocate 13519872 B L1 buffer across 9 banks, where each bank needs to store 1502208 B, but bank size is only 1331936 B"
+  yolos_small/pytorch-small_dwr-single_device-full-inference:
+    status: KNOWN_FAILURE_XFAIL
+    reason: "Out of Memory: Not enough space to allocate 13519872 B L1 buffer across 9 banks, where each bank needs to store 1502208 B, but bank size is only 1331936 B"
 
-  # yolos_small/pytorch-small_300-single_device-full-inference:
-  #   status: KNOWN_FAILURE_XFAIL
-  #   reason: "Out of Memory: Not enough space to allocate 13519872 B L1 buffer across 9 banks, where each bank needs to store 1502208 B, but bank size is only 1331936 B"
+  yolos_small/pytorch-small_300-single_device-full-inference:
+    status: KNOWN_FAILURE_XFAIL
+    reason: "Out of Memory: Not enough space to allocate 13519872 B L1 buffer across 9 banks, where each bank needs to store 1502208 B, but bank size is only 1331936 B"
 
-  # yolop/pytorch-yolop-single_device-full-inference:
-  #   status: KNOWN_FAILURE_XFAIL
+  yolop/pytorch-yolop-single_device-full-inference:
+    status: KNOWN_FAILURE_XFAIL
     reason: "error: 'ttnn.max_pool2d' op Kernel height 13 is greater than input height 12. This ttnn.max_pool2d configuration is invalid - https://github.com/tenstorrent/tt-xla/issues/2007"
 
 

--- a/tests/runner/test_config/torch/test_config_training_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_training_single_device.yaml
@@ -314,10 +314,10 @@ test_config:
     bringup_status: FAILED_FE_COMPILATION
     reason: "RuntimeError: Could not load libtorchcodec. Likely causes:"
 
-  # yolox/pytorch-yolox_x-single_device-full-training:
-  #   status: NOT_SUPPORTED_SKIP
-  #   bringup_status: FAILED_FE_COMPILATION
-  #   reason: "EOFError: Ran out of input"
+  yolox/pytorch-yolox_x-single_device-full-training:
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_FE_COMPILATION
+    reason: "EOFError: Ran out of input"
 
   unet/pytorch-smp_unet_resnet101-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
@@ -344,35 +344,35 @@ test_config:
     bringup_status: FAILED_FE_COMPILATION
     reason: "loader.load_model() does not return `nn.Module`"
 
-  # yolox/pytorch-yolox_nano-single_device-full-training:
-  #   status: NOT_SUPPORTED_SKIP
-  #   bringup_status: FAILED_FE_COMPILATION
-  #   reason: "Model expects targets to be passed while in training mode"
+  yolox/pytorch-yolox_nano-single_device-full-training:
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_FE_COMPILATION
+    reason: "Model expects targets to be passed while in training mode"
 
-  # yolox/pytorch-yolox_tiny-single_device-full-training:
-  #   status: NOT_SUPPORTED_SKIP
-  #   bringup_status: FAILED_FE_COMPILATION
-  #   reason: "Model expects targets to be passed while in training mode"
+  yolox/pytorch-yolox_tiny-single_device-full-training:
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_FE_COMPILATION
+    reason: "Model expects targets to be passed while in training mode"
 
-  # yolox/pytorch-yolox_s-single_device-full-training:
-  #   status: NOT_SUPPORTED_SKIP
-  #   bringup_status: FAILED_FE_COMPILATION
-  #   reason: "Model expects targets to be passed while in training mode"
+  yolox/pytorch-yolox_s-single_device-full-training:
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_FE_COMPILATION
+    reason: "Model expects targets to be passed while in training mode"
 
-  # yolox/pytorch-yolox_m-single_device-full-training:
-  #   status: NOT_SUPPORTED_SKIP
-  #   bringup_status: FAILED_FE_COMPILATION
-  #   reason: "Model expects targets to be passed while in training mode"
+  yolox/pytorch-yolox_m-single_device-full-training:
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_FE_COMPILATION
+    reason: "Model expects targets to be passed while in training mode"
 
-  # yolox/pytorch-yolox_l-single_device-full-training:
-  #   status: NOT_SUPPORTED_SKIP
-  #   bringup_status: FAILED_FE_COMPILATION
-  #   reason: "Model expects targets to be passed while in training mode"
+  yolox/pytorch-yolox_l-single_device-full-training:
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_FE_COMPILATION
+    reason: "Model expects targets to be passed while in training mode"
 
-  # yolox/pytorch-yolox_darknet-single_device-full-training:
-  #   status: NOT_SUPPORTED_SKIP
-  #   bringup_status: FAILED_FE_COMPILATION
-  #   reason: "Model expects targets to be passed while in training mode"
+  yolox/pytorch-yolox_darknet-single_device-full-training:
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_FE_COMPILATION
+    reason: "Model expects targets to be passed while in training mode"
 
   hippynn/pytorch-Hippynn-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
@@ -494,10 +494,10 @@ test_config:
     bringup_status: FAILED_FE_COMPILATION
     reason: "tt-forge-models doesn't implement unpack_forward_output for this model."
 
-  # yolos/pytorch-single_device-full-training:
-  #   status: NOT_SUPPORTED_SKIP
-  #   bringup_status: FAILED_FE_COMPILATION
-  #   reason: "tt-forge-models doesn't implement unpack_forward_output for this model."
+  yolos/pytorch-single_device-full-training:
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_FE_COMPILATION
+    reason: "tt-forge-models doesn't implement unpack_forward_output for this model."
 
   swin/image_classification/pytorch-microsoft/swin-tiny-patch4-window7-224-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
@@ -634,10 +634,10 @@ test_config:
     bringup_status: FAILED_FE_COMPILATION
     reason: "tt-forge-models doesn't implement unpack_forward_output for this model."
 
-  # yolov3/pytorch-base-single_device-full-training:
-  #   status: NOT_SUPPORTED_SKIP
-  #   bringup_status: FAILED_FE_COMPILATION
-  #   reason: "tt-forge-models doesn't implement unpack_forward_output for this model."
+  yolov3/pytorch-base-single_device-full-training:
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_FE_COMPILATION
+    reason: "tt-forge-models doesn't implement unpack_forward_output for this model."
 
   transfuser/pytorch-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
@@ -684,10 +684,10 @@ test_config:
   #   bringup_status: FAILED_FE_COMPILATION
   #   reason: "tt-forge-models doesn't implement unpack_forward_output for this model."
 
-  # yolov4/pytorch-base-single_device-full-training:
-  #   status: NOT_SUPPORTED_SKIP
-  #   bringup_status: FAILED_FE_COMPILATION
-  #   reason: "tt-forge-models doesn't implement unpack_forward_output for this model."
+  yolov4/pytorch-base-single_device-full-training:
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_FE_COMPILATION
+    reason: "tt-forge-models doesn't implement unpack_forward_output for this model."
 
   detr/object_detection/pytorch-resnet_50-single_device-full-training:
     status: NOT_SUPPORTED_SKIP


### PR DESCRIPTION
### Ticket

- [Yolo v3 #2160](https://github.com/tenstorrent/tt-xla/issues/2160)
- [Yolo v4 #2161](https://github.com/tenstorrent/tt-xla/issues/2161)
- ~~[Yolo v7 #2164](https://github.com/tenstorrent/tt-xla/issues/2164)~~
- [Yolo S #2171](https://github.com/tenstorrent/tt-xla/issues/2171)
- [Yolo X #2172](https://github.com/tenstorrent/tt-xla/issues/2172)
- [Yolo P #2173](https://github.com/tenstorrent/tt-xla/issues/2173)

### Problem description

- The test configs for the ultralytics-independent YOLO model variants were previously commented out in https://github.com/tenstorrent/tt-xla/pull/2155
-  Uncomment those test configs.
- Note : YOLOV7 is independent from ultralytics, but facing issues during test collection - [context](https://github.com/tenstorrent/tt-xla/issues/2164#issuecomment-3532063331). Due to this reason, yolov7 is excluded from this quick-restore list

### What's changed

- Restored (uncommented) the test configs for all ultralytics-independent YOLO variants listed above.
