### PR TITLE
[vLLM plugin] Update logger to use the env variable

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/attention.py
+++ b/integrations/vllm_plugin/vllm_tt/attention.py
@@ -22,10 +22,11 @@ from vllm.attention.backends.abstract import (
 )
 from vllm.attention.backends.utils import CommonAttentionState
 from vllm.config import VllmConfig
-from vllm.logger import init_logger
 from vllm.utils import cdiv, next_power_of_2
 
-logger = init_logger(__name__)
+from .logger import tt_init_logger
+
+logger = tt_init_logger(__name__)
 
 # TT requires the head size to be a multiple of 32.
 TT_HEAD_SIZE_ALIGNMENT = 32

--- a/integrations/vllm_plugin/vllm_tt/logger.py
+++ b/integrations/vllm_plugin/vllm_tt/logger.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Portions (c) 2025 Tenstorrent AI ULC
+
+import os
+
+from vllm.logger import init_logger
+
+
+def tt_init_logger(name: str):
+    # Read log level from environment; default to "WARN" if not set.
+    # Convert to uppercase for consistency.
+    raw_level = os.getenv("LOGGER_LEVEL", "WARN").upper()
+
+    # vLLM does not support "VERBOSE" level so treating it as "DEBUG" level.
+    logger_level = {"VERBOSE": "DEBUG"}.get(raw_level, raw_level)
+
+    if not logger_level in ["ERROR", "FATAL", "WARN", "WARNING", "INFO", "DEBUG"]:
+        print(
+            f"WARNING: Invalid logger_level={logger_level}; setting logger_level to 'WARN'."
+        )
+        logger_level = "WARN"
+
+    # Create or retrieve a logger with the given name and set desired logging level.
+    logger = init_logger(name)
+    logger.setLevel(logger_level)
+
+    return logger

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -30,7 +30,6 @@ from vllm.config import (
 )
 from vllm.distributed.kv_transfer import get_kv_transfer_group, has_kv_transfer_group
 from vllm.forward_context import get_forward_context, set_forward_context
-from vllm.logger import init_logger
 from vllm.lora.layers import BaseLayerWithLoRA
 from vllm.model_executor.model_loader import get_model_loader
 from vllm.model_executor.model_loader.default_loader import DefaultModelLoader
@@ -85,6 +84,7 @@ from .attention import (
     TTMetadata,
     get_page_size_bytes,
 )
+from .logger import tt_init_logger
 from .platform import TTConfig
 
 
@@ -122,7 +122,7 @@ def add_kv_sharing_layers_to_kv_cache_groups(
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
 
-logger = init_logger(__name__)
+logger = tt_init_logger(__name__)
 
 INVALID_TOKEN_ID = -1
 # Smallest output size

--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Optional, Union, cast
 
 import torch
 from vllm.inputs import ProcessorInputs, PromptType
-from vllm.logger import init_logger
 from vllm.platforms.interface import Platform, PlatformEnum, _Backend
 from vllm.sampling_params import SamplingParams, SamplingType
 from vllm.utils import DEFAULT_MAX_NUM_BATCHED_TOKENS
@@ -21,9 +20,11 @@ else:
     VllmConfig = None
     PoolingParams = None
 
-logger = init_logger(__name__)
-
 from torch_xla import runtime as xrt
+
+from .logger import tt_init_logger
+
+logger = tt_init_logger(__name__)
 
 
 @dataclass

--- a/integrations/vllm_plugin/vllm_tt/pooling_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/pooling_runner.py
@@ -30,7 +30,6 @@ from vllm.config import (
 )
 from vllm.distributed.kv_transfer import get_kv_transfer_group, has_kv_transfer_group
 from vllm.forward_context import set_forward_context
-from vllm.logger import init_logger
 from vllm.lora.layers import BaseLayerWithLoRA
 from vllm.model_executor.model_loader import get_model_loader
 from vllm.model_executor.model_loader.tpu import TPUModelLoader
@@ -84,6 +83,7 @@ from .attention import (
     TTMetadata,
     get_page_size_bytes,
 )
+from .logger import tt_init_logger
 from .platform import TTConfig
 from .pooling_input_batch import CachedRequestState, InputBatch
 
@@ -122,7 +122,7 @@ def add_kv_sharing_layers_to_kv_cache_groups(
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
 
-logger = init_logger(__name__)
+logger = tt_init_logger(__name__)
 
 INVALID_TOKEN_ID = -1
 # Smallest output size

--- a/integrations/vllm_plugin/vllm_tt/worker.py
+++ b/integrations/vllm_plugin/vllm_tt/worker.py
@@ -24,7 +24,6 @@ from vllm.distributed.kv_transfer import (
     ensure_kv_transfer_initialized,
     has_kv_transfer_group,
 )
-from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.model_executor import set_random_seed
 from vllm.platforms import current_platform
@@ -37,10 +36,11 @@ from vllm.v1.utils import report_usage_stats
 from vllm.v1.worker.utils import bind_kv_cache
 
 from .attention import TT_HEAD_SIZE_ALIGNMENT
+from .logger import tt_init_logger
 from .model_runner import TTModelRunner
 from .pooling_runner import TTPoolingModelRunner
 
-logger = init_logger(__name__)
+logger = tt_init_logger(__name__)
 
 
 class TTWorker:


### PR DESCRIPTION
### Ticket
closes #2190 

### Problem description
vLLM plugin is using default `WARN` logging level all the time.

### What's changed
- Use LOGGER_LEVEL env variable (same as tt-xla) to control logging level.
- Defaults to WARN if env variable is not set
- vLLM does not support VERBOSE; so treating it as DEBUG
