### PR TITLE
Uplift third_party/tt-mlir to 0abe29ab96c4cfb2b19c1c22b57c1d3b569c89c6 2025-11-15

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -5,7 +5,7 @@
 option(USE_CUSTOM_TT_MLIR_VERSION "Flag to use TT_MLIR_VERSION set by the user" OFF)
 
 if (NOT DEFINED TT_MLIR_VERSION OR NOT USE_CUSTOM_TT_MLIR_VERSION)
-    set(TT_MLIR_VERSION "1bf542419d06eaba4bab02f02a6b4e502742ab70")
+    set(TT_MLIR_VERSION "0abe29ab96c4cfb2b19c1c22b57c1d3b569c89c6")
 endif()
 
 set(PROTOBUF_VERSION "v21.12") # same version as tt-metal uses


### PR DESCRIPTION
This PR uplifts the third_party/tt-mlir to the 0abe29ab96c4cfb2b19c1c22b57c1d3b569c89c6