### PR TITLE
Only produce release vllm plugin

### DIFF
--- a/.github/workflows/call-build.yml
+++ b/.github/workflows/call-build.yml
@@ -171,6 +171,7 @@ jobs:
             path: ${{ steps.strings.outputs.work-dir }}/python_package/dist/pjrt_plugin_tt*.whl
 
       - name: Build vllm plugin wheel
+        if: inputs.build_type == 'release'
         shell: bash
         run: |
             source venv/activate
@@ -178,6 +179,7 @@ jobs:
             python setup.py bdist_wheel $(if [ '${{ inputs.debug_build }}' == 'true' ]; then echo '--code-coverage'; fi)
 
       - name: Upload the vllm plugin wheel
+        if: inputs.build_type == 'release'
         id: upload-vllm-tt-wheel
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Build is producing 3 flavors of llm plugin, and we only need release variant
 
vllm-tt-whl-codecov-3db15a4 | 60.3 KB | 
vllm-tt-whl-explorer-3db15a4 | 60.3 KB | 
vllm-tt-whl-release-3db15a4 | 60.3 KB | 

### What's changed
Only create vllm plugin in release configuration

### Checklist
- [ ] New/Existing tests provide coverage for changes
