### PR TITLE
Moved some attention tests to n300

### DIFF
--- a/.github/workflows/test-matrix-presets/basic-test-nightly.json
+++ b/.github/workflows/test-matrix-presets/basic-test-nightly.json
@@ -1,12 +1,13 @@
 [
   { "runs-on": "wormhole_b0",        "name": "run_jax",               "dir": "./tests/jax/single_chip",                 "test-mark": "nightly and not large", "parallel-groups": 2 },
-  { "runs-on": "n150",               "name": "run_torch",             "dir": "./tests/torch/single_chip",               "test-mark": "nightly and not llmbox" },
+  { "runs-on": "n150",               "name": "run_torch",             "dir": "./tests/torch/single_chip",               "test-mark": "nightly and not llmbox and not dual_chip" },
   { "runs-on": "p150",               "name": "run_jax",               "dir": "./tests/jax/single_chip",                 "test-mark": "nightly and not large", "parallel-groups": 2 },
-  { "runs-on": "p150",               "name": "run_torch",             "dir": "./tests/torch/single_chip",               "test-mark": "nightly and not llmbox"  },
+  { "runs-on": "p150",               "name": "run_torch",             "dir": "./tests/torch/single_chip",               "test-mark": "nightly and not llmbox and not dual_chip"  },
   { "runs-on": "n300",               "name": "run_jax",               "dir": "./tests/jax/multi_chip/n300",             "test-mark": "nightly", "codecov": "true" },
   { "runs-on": "n300",               "name": "torch_multichip",       "dir": "./tests/torch/multi_chip/n300",           "test-mark": "nightly"  },
+  { "runs-on": "n300",               "name": "run_torch_dual_chip",   "dir": "./tests/torch/single_chip",               "test-mark": "nightly and dual_chip" },
   { "runs-on": "n300-llmbox",        "name": "run_jax_4_devices",     "dir": "./tests/jax/multi_chip/llmbox/4_devices", "test-mark": "nightly", "shared-runners": "true" },
   { "runs-on": "n300-llmbox",        "name": "run_jax_8_devices",     "dir": "./tests/jax/multi_chip/llmbox/8_devices", "test-mark": "nightly", "shared-runners": "true" },
-  { "runs-on": "n300-llmbox",        "name": "run_torch_multi_chip",  "dir": "./tests/torch/single_chip",               "test-mark": "nightly and llmbox", "shared-runners": "true" },
+  { "runs-on": "n300-llmbox",        "name": "run_torch_multi_chip",  "dir": "./tests/torch/single_chip",               "test-mark": "nightly and llmbox and not dual_chip", "shared-runners": "true" },
   { "runs-on": "n150",               "name": "run_vllm_n150_tests",   "dir": "./tests/integrations/vllm_plugin",        "test-mark": "nightly", "shared-runners": "true" }
 ]

--- a/tests/torch/single_chip/graphs/test_attention.py
+++ b/tests/torch/single_chip/graphs/test_attention.py
@@ -21,7 +21,7 @@ from transformers.models.llama.modeling_llama import (
 )
 from utils import failed_runtime
 
-from tests.utils import is_llmbox
+from tests.utils import is_dual_chip, is_llmbox
 from third_party.tt_forge_models.bert.masked_lm.pytorch.loader import (
     ModelLoader as BertModelLoader,
 )
@@ -355,7 +355,7 @@ def test_llama_create_heads(variant, variant_config, seq_len, request):
 
 
 @pytest.mark.nightly
-@pytest.mark.llmbox
+@pytest.mark.dual_chip
 @pytest.mark.parametrize("seq_len", [1024])
 @pytest.mark.parametrize(
     "variant,variant_config",
@@ -363,7 +363,7 @@ def test_llama_create_heads(variant, variant_config, seq_len, request):
     ids=[str(k) for k in get_available_variants("llama").keys()],
 )
 def test_llama_attention(variant, variant_config, seq_len, request):
-    if "70b" in str(variant) and not is_llmbox(request):
+    if "70b" in str(variant) and not is_dual_chip(request):
         pytest.xfail("70B models don't fit on device")
 
     if "405b" in str(variant):
@@ -423,7 +423,7 @@ def test_llama_attention(variant, variant_config, seq_len, request):
     dropout = 0.0
     scaling = attention.scaling
 
-    if is_llmbox(request):
+    if is_dual_chip(request):
         num_devices = xr.global_runtime_device_count()
         mesh_shape = (1, num_devices)
         device_ids = np.array(range(num_devices))
@@ -1065,7 +1065,7 @@ def test_bert_create_heads(variant, variant_config, seq_len):
 
 
 @pytest.mark.nightly
-@pytest.mark.llmbox
+@pytest.mark.dual_chip
 @pytest.mark.parametrize("seq_len", [1024])
 @pytest.mark.parametrize(
     "variant,variant_config",
@@ -1073,7 +1073,7 @@ def test_bert_create_heads(variant, variant_config, seq_len):
     ids=[str(k) for k in get_available_variants("qwen2_5").keys()],
 )
 def test_qwen2_5_attention_prefill(seq_len, variant, variant_config, request):
-    if not is_llmbox(request) and (
+    if not is_dual_chip(request) and (
         str(variant) == "72b_instruct" or str(variant) == "32b_instruct"
     ):
         pytest.xfail("Variant doesn't fit on device")
@@ -1085,7 +1085,7 @@ def test_qwen2_5_attention_prefill(seq_len, variant, variant_config, request):
     attention = model.model.layers[0].self_attn
 
     # Determine batch size and mesh configuration based on attention heads
-    if is_llmbox(request):
+    if is_dual_chip(request):
         num_devices = xr.global_runtime_device_count()
         num_heads = model.config.num_attention_heads
 
@@ -1243,14 +1243,14 @@ def test_qwen2_5_attention_prefill_push(seq_len, variant, is_llmbox):
 
 
 @pytest.mark.nightly
-@pytest.mark.llmbox
+@pytest.mark.dual_chip
 @pytest.mark.parametrize(
     "variant,variant_config",
     get_available_variants("qwen2_5").items(),
     ids=[str(k) for k in get_available_variants("qwen2_5").keys()],
 )
 def test_qwen2_5_attention_decode(variant, variant_config, request):
-    if not is_llmbox(request) and (
+    if not is_dual_chip(request) and (
         str(variant) == "72b_instruct" or str(variant) == "32b_instruct"
     ):
         pytest.xfail("Variant doesn't fit on device")
@@ -1262,7 +1262,7 @@ def test_qwen2_5_attention_decode(variant, variant_config, request):
     attention = model.model.layers[0].self_attn
 
     # Determine batch size and mesh configuration based on attention heads
-    if is_llmbox(request):
+    if is_dual_chip(request):
         num_devices = xr.global_runtime_device_count()
         num_heads = model.config.num_attention_heads
 
@@ -1339,7 +1339,7 @@ def test_qwen2_5_attention_decode(variant, variant_config, request):
 
 
 @pytest.mark.nightly
-@pytest.mark.llmbox
+@pytest.mark.dual_chip
 @pytest.mark.parametrize("seq_len", [1024])
 @pytest.mark.parametrize(
     "variant,variant_config",
@@ -1347,7 +1347,7 @@ def test_qwen2_5_attention_decode(variant, variant_config, request):
     ids=[str(k) for k in get_available_variants("qwen2_5").keys()],
 )
 def test_qwen2_5_attention(variant, variant_config, seq_len, request):
-    if not is_llmbox(request) and (
+    if not is_dual_chip(request) and (
         str(variant) == "72b_instruct" or str(variant) == "32b_instruct"
     ):
         pytest.xfail("Variant doesn't fit on device")
@@ -1386,7 +1386,7 @@ def test_qwen2_5_attention(variant, variant_config, seq_len, request):
     attention = model.model.layers[0].self_attn
 
     # Determine batch size and mesh configuration based on attention heads
-    if is_llmbox(request):
+    if is_dual_chip(request):
         num_devices = xr.global_runtime_device_count()
         num_heads = model.config.num_attention_heads
 
@@ -1475,7 +1475,7 @@ def test_qwen2_5_attention(variant, variant_config, seq_len, request):
 
 
 @pytest.mark.nightly
-@pytest.mark.llmbox
+@pytest.mark.dual_chip
 @pytest.mark.parametrize("seq_len", [1024])
 @pytest.mark.parametrize(
     "variant,variant_config",
@@ -1483,7 +1483,7 @@ def test_qwen2_5_attention(variant, variant_config, seq_len, request):
     ids=[str(k) for k in get_available_variants("gemma").keys()],
 )
 def test_gemma_attention_prefill(seq_len, variant, variant_config, request):
-    if not is_llmbox(request) and (str(variant) == "google/gemma-2-27b-it"):
+    if not is_dual_chip(request) and (str(variant) == "google/gemma-2-27b-it"):
         pytest.xfail("Variant doesn't fit on device")
 
     xr.set_device_type("TT")
@@ -1505,7 +1505,7 @@ def test_gemma_attention_prefill(seq_len, variant, variant_config, request):
 
     past_key_states = None
 
-    if is_llmbox(request):
+    if is_dual_chip(request):
         num_devices = xr.global_runtime_device_count()
         mesh_shape = (1, num_devices)
         device_ids = np.array(range(num_devices))
@@ -1597,14 +1597,14 @@ def test_gemma_attention_prefill_push(seq_len, variant, is_llmbox):
 
 
 @pytest.mark.nightly
-@pytest.mark.llmbox
+@pytest.mark.dual_chip
 @pytest.mark.parametrize(
     "variant,variant_config",
     get_available_variants("gemma").items(),
     ids=[str(k) for k in get_available_variants("gemma").keys()],
 )
 def test_gemma_attention_decode(variant, variant_config, request):
-    if not is_llmbox(request) and (str(variant) == "google/gemma-2-27b-it"):
+    if not is_dual_chip(request) and (str(variant) == "google/gemma-2-27b-it"):
         pytest.xfail("Variant doesn't fit on device")
 
     xr.set_device_type("TT")
@@ -1635,7 +1635,7 @@ def test_gemma_attention_decode(variant, variant_config, request):
     )
     past_key_states = static_cache
 
-    if is_llmbox(request):
+    if is_dual_chip(request):
         num_devices = xr.global_runtime_device_count()
         mesh_shape = (1, num_devices)
         device_ids = np.array(range(num_devices))
@@ -1663,7 +1663,7 @@ def test_gemma_attention_decode(variant, variant_config, request):
 
 
 @pytest.mark.nightly
-@pytest.mark.llmbox
+@pytest.mark.dual_chip
 @pytest.mark.parametrize("seq_len", [1024])
 @pytest.mark.parametrize(
     "variant,variant_config",
@@ -1671,7 +1671,7 @@ def test_gemma_attention_decode(variant, variant_config, request):
     ids=[str(k) for k in get_available_variants("gemma").keys()],
 )
 def test_gemma_attention(variant, variant_config, seq_len, request):
-    if not is_llmbox(request) and (str(variant) == "google/gemma-2-27b-it"):
+    if not is_dual_chip(request) and (str(variant) == "google/gemma-2-27b-it"):
         pytest.xfail("Variant doesn't fit on device")
 
     xr.set_device_type("TT")
@@ -1728,7 +1728,7 @@ def test_gemma_attention(variant, variant_config, seq_len, request):
     dropout = 0.0
     scaling = attention.scaling
 
-    if is_llmbox(request):
+    if is_dual_chip(request):
         num_devices = xr.global_runtime_device_count()
         mesh_shape = (1, num_devices)
         device_ids = np.array(range(num_devices))


### PR DESCRIPTION
Some of the attention tests were failing because we were trying to shard them on the number of devices on llmbox, which is 8, where tensors have less then 8 size of the corresponding axis. This PR moves those kinds of tests to n300.