### PR TITLE
Uncomment YOLOv6 and YOLOv7 test configs as their ultralytics dependency is now removed

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_data_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_data_parallel.yaml
@@ -96,9 +96,9 @@ test_config:
     status: EXPECTED_PASSING
     reason: "PCC comparison failed. Calculated: pcc=0.978430986404419. Required: pcc=0.99. - https://github.com/tenstorrent/tt-xla/issues/1789"
 
-  # yolov6/pytorch-yolov6l-data_parallel-full-inference:
-  #   supported_archs: [n300]
-  #   status: EXPECTED_PASSING
+  yolov6/pytorch-yolov6l-data_parallel-full-inference:
+    supported_archs: [n300]
+    status: EXPECTED_PASSING
 
   vgg/pytorch-torchvision_vgg16-data_parallel-full-inference:
     supported_archs: [n300]

--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -930,43 +930,43 @@ test_config:
   llama/causal_lm/pytorch-llama_3_2_3b_instruct-single_device-full-inference:
     status: EXPECTED_PASSING
 
-  # yolov6/pytorch-yolov6n-single_device-full-inference:
-  #   status: EXPECTED_PASSING
+  yolov6/pytorch-yolov6n-single_device-full-inference:
+    status: EXPECTED_PASSING
 
-  # yolov6/pytorch-yolov6s-single_device-full-inference:
-  #   required_pcc: 0.98  # AssertionError: PCC comparison failed. Calculated: pcc=0.9890339970588684. Required: pcc=0.99. Exposed by removal of consteval on host: https://github.com/tenstorrent/tt-xla/issues/1242
-  #   status: EXPECTED_PASSING
+  yolov6/pytorch-yolov6s-single_device-full-inference:
+    required_pcc: 0.98  # AssertionError: PCC comparison failed. Calculated: pcc=0.9890339970588684. Required: pcc=0.99. Exposed by removal of consteval on host: https://github.com/tenstorrent/tt-xla/issues/1242
+    status: EXPECTED_PASSING
 
-  # yolov6/pytorch-yolov6m-single_device-full-inference:
-  #   required_pcc: 0.98
-  #   status: EXPECTED_PASSING
+  yolov6/pytorch-yolov6m-single_device-full-inference:
+    required_pcc: 0.98
+    status: EXPECTED_PASSING
 
-  # yolov6/pytorch-yolov6l-single_device-full-inference:
-  #   status: EXPECTED_PASSING
+  yolov6/pytorch-yolov6l-single_device-full-inference:
+    status: EXPECTED_PASSING
 
-  # yolov7/pytorch-yolov7x-single_device-full-inference:
-  #   status: EXPECTED_PASSING
+  yolov7/pytorch-yolov7x-single_device-full-inference:
+    status: EXPECTED_PASSING
 
-  # yolov7/pytorch-yolov7-single_device-full-inference:
-  #   reason: "AssertionError: Comparison result 0 failed: PCC comparison failed. Calculated: pcc=0.9570515751838684. Required: pcc=0.99."
-  #   assert_pcc: false
-  #   bringup_status: INCORRECT_RESULT
+  yolov7/pytorch-yolov7-single_device-full-inference:
+    reason: "AssertionError: Comparison result 0 failed: PCC comparison failed. Calculated: pcc=0.9570515751838684. Required: pcc=0.99."
+    assert_pcc: false
+    bringup_status: INCORRECT_RESULT
 
-  # yolov7/pytorch-yolov7-w6-single_device-full-inference:
-  #   status: KNOWN_FAILURE_XFAIL
-  #   reason: "error: 'ttnn.max_pool2d' op Kernel height 13 is greater than input height 10. This ttnn.max_pool2d configuration is invalid - https://github.com/tenstorrent/tt-xla/issues/2007"
+  yolov7/pytorch-yolov7-w6-single_device-full-inference:
+    status: KNOWN_FAILURE_XFAIL
+    reason: "error: 'ttnn.max_pool2d' op Kernel height 13 is greater than input height 10. This ttnn.max_pool2d configuration is invalid - https://github.com/tenstorrent/tt-xla/issues/2007"
 
-  # yolov7/pytorch-yolov7-e6-single_device-full-inference:
-  #   status: KNOWN_FAILURE_XFAIL
-  #   reason: "error: 'ttnn.max_pool2d' op Kernel height 13 is greater than input height 10. This ttnn.max_pool2d configuration is invalid - https://github.com/tenstorrent/tt-xla/issues/2007"
+  yolov7/pytorch-yolov7-e6-single_device-full-inference:
+    status: KNOWN_FAILURE_XFAIL
+    reason: "error: 'ttnn.max_pool2d' op Kernel height 13 is greater than input height 10. This ttnn.max_pool2d configuration is invalid - https://github.com/tenstorrent/tt-xla/issues/2007"
 
-  # yolov7/pytorch-yolov7-d6-single_device-full-inference:
-  #   status: KNOWN_FAILURE_XFAIL
-  #   reason: "error: 'ttnn.max_pool2d' op Kernel height 13 is greater than input height 10. This ttnn.max_pool2d configuration is invalid - https://github.com/tenstorrent/tt-xla/issues/2007"
+  yolov7/pytorch-yolov7-d6-single_device-full-inference:
+    status: KNOWN_FAILURE_XFAIL
+    reason: "error: 'ttnn.max_pool2d' op Kernel height 13 is greater than input height 10. This ttnn.max_pool2d configuration is invalid - https://github.com/tenstorrent/tt-xla/issues/2007"
 
-  # yolov7/pytorch-yolov7-e6e-single_device-full-inference:
-  #   status: KNOWN_FAILURE_XFAIL
-  #   reason: "error: 'ttnn.max_pool2d' op Kernel height 13 is greater than input height 10. This ttnn.max_pool2d configuration is invalid - https://github.com/tenstorrent/tt-xla/issues/2007"
+  yolov7/pytorch-yolov7-e6e-single_device-full-inference:
+    status: KNOWN_FAILURE_XFAIL
+    reason: "error: 'ttnn.max_pool2d' op Kernel height 13 is greater than input height 10. This ttnn.max_pool2d configuration is invalid - https://github.com/tenstorrent/tt-xla/issues/2007"
 
   yolox/pytorch-yolox_nano-single_device-full-inference:
     status: NOT_SUPPORTED_SKIP

--- a/tests/runner/test_config/torch/test_config_training_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_training_single_device.yaml
@@ -379,20 +379,20 @@ test_config:
     bringup_status: FAILED_FE_COMPILATION
     reason: "loader.load_model() does not return `nn.Module`"
 
-  # yolov6/pytorch-yolov6n-single_device-full-training:
-  #   status: NOT_SUPPORTED_SKIP
-  #   bringup_status: FAILED_FE_COMPILATION
-  #   reason: "tt-forge-models doesn't implement unpack_forward_output for this model."
+  yolov6/pytorch-yolov6n-single_device-full-training:
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_FE_COMPILATION
+    reason: "tt-forge-models doesn't implement unpack_forward_output for this model."
 
-  # yolov6/pytorch-yolov6s-single_device-full-training:
-  #   status: NOT_SUPPORTED_SKIP
-  #   bringup_status: FAILED_FE_COMPILATION
-  #   reason: "tt-forge-models doesn't implement unpack_forward_output for this model."
+  yolov6/pytorch-yolov6s-single_device-full-training:
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_FE_COMPILATION
+    reason: "tt-forge-models doesn't implement unpack_forward_output for this model."
 
-  # yolov6/pytorch-yolov6m-single_device-full-training:
-  #   status: NOT_SUPPORTED_SKIP
-  #   bringup_status: FAILED_FE_COMPILATION
-  #   reason: "tt-forge-models doesn't implement unpack_forward_output for this model."
+  yolov6/pytorch-yolov6m-single_device-full-training:
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_FE_COMPILATION
+    reason: "tt-forge-models doesn't implement unpack_forward_output for this model."
 
   distilbert/question_answering/pytorch-distilbert-base-cased-distilled-squad-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
@@ -589,10 +589,10 @@ test_config:
     bringup_status: FAILED_FE_COMPILATION
     reason: "tt-forge-models doesn't implement unpack_forward_output for this model."
 
-  # yolov6/pytorch-yolov6l-single_device-full-training:
-  #   status: NOT_SUPPORTED_SKIP
-  #   bringup_status: FAILED_FE_COMPILATION
-  #   reason: "tt-forge-models doesn't implement unpack_forward_output for this model."
+  yolov6/pytorch-yolov6l-single_device-full-training:
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_FE_COMPILATION
+    reason: "tt-forge-models doesn't implement unpack_forward_output for this model."
 
   maptr/pytorch-tiny_r50_24e_bevformer-single_device-full-training:
     status: NOT_SUPPORTED_SKIP


### PR DESCRIPTION
### Ticket

- Fixes https://github.com/tenstorrent/tt-xla/issues/2163
- Fixes https://github.com/tenstorrent/tt-xla/issues/2164 

### Problem description

- This [PR](https://github.com/tenstorrent/tt-forge-models/pull/278) removed ultralytics dependency from YOLOv7,YOLOv6
- Uncomment the YOLOv6, YOLOv7 test configs

### What's changed

- Uncommented the YOLOv6, YOLOv7 test configs

### Checklist
- [x] Verified the changes through local testing

### Logs

- [nov18_yolov6_single_device_inference.log](https://github.com/user-attachments/files/23603266/nov18_yolov6_single_device_inference.log)
- [nov18_yolov7_single_device_inference.log](https://github.com/user-attachments/files/23603267/nov18_yolov7_single_device_inference.log)
