### PR TITLE
skip whisper to rescue nightly

### DIFF
--- a/tests/torch/single_chip/models/whisper/test_whisper.py
+++ b/tests/torch/single_chip/models/whisper/test_whisper.py
@@ -41,6 +41,11 @@ def _variant_param(v):
     # Mark large model variants
     if v == ModelVariant.WHISPER_LARGE_V3:
         marks.append(pytest.mark.large)
+        marks.append(
+            pytest.mark.skip(
+                reason="Skipping whisper_large_v3 - can't find weights on CIv2 - https://github.com/tenstorrent/tt-xla/issues/2223"
+            )
+        )
 
     marks.extend(
         [


### PR DESCRIPTION
### Ticket
eventual unskipping tracked in #2223

### Problem description
There is a CIv2 failure with pulling down weights from the cache.

### What's changed
Temporarily skipped to rescue nightly

### Checklist
- [ ] New/Existing tests provide coverage for changes
