### PR TITLE
Update JAX Training Tests Error Messages

### DIFF
--- a/tests/runner/test_config/jax/test_config_training_single_device.yaml
+++ b/tests/runner/test_config/jax/test_config_training_single_device.yaml
@@ -420,19 +420,19 @@ test_config:
   regnet/image_classification/jax-y-040-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: failed to legalize operation 'ttir.reverse' that was explicitly marked illegal"
+    reason: "error: 'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 1088 input channels and 64 in the weight tensor."
     execution_pass: BACKWARD
 
   regnet/image_classification/jax-y-160-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: failed to legalize operation 'ttir.reverse' that was explicitly marked illegal"
+    bringup_status: FAILED_RUNTIME
+    reason: "Out of Memory"
     execution_pass: FORWARD
 
   regnet/image_classification/jax-y-320-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "error: failed to legalize operation 'ttir.reverse' that was explicitly marked illegal"
+    bringup_status: FAILED_RUNTIME
+    reason: "Out of Memory"
     execution_pass: FORWARD
 
   resnet/image_classification/jax-resnet-101-single_device-full-training:


### PR DESCRIPTION
### Ticket
N/A

### Problem description
In transfering training JAX tests to the existing infra, we forgot to update one of the error messages.

### What's changed
Update for error messages.

### Checklist
- [x] New/Existing tests provide coverage for changes
