### PR TITLE
Fixing example reference in emitpy codegen tutorial

### DIFF
--- a/docs/src/emitpy_tutorial.md
+++ b/docs/src/emitpy_tutorial.md
@@ -80,12 +80,12 @@ Choose your framework and run the example:
 
 **PyTorch:**
 ```bash
-python examples/pytorch/codegen/codegen_via_options_example.py
+python examples/pytorch/codegen/custom_module.py
 ```
 
 **JAX:**
 ```bash
-python examples/jax/codegen/codegen_via_options_example.py
+python examples/jax/codegen/custom_module.py
 ```
 
 #### What Happens During Code Generation


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The example reference is incorrect in the EmitPy tutorial.

### What's changed
Fixing the problematic reference.

### Checklist
- [ ] New/Existing tests provide coverage for changes
