### PR TITLE
Add mapping for the new n300-high-memory label

### DIFF
--- a/.github/scripts/generate_test_matrix.py
+++ b/.github/scripts/generate_test_matrix.py
@@ -20,6 +20,7 @@ def map_runner_name(entry):
     shared_runner_mapping = {
         "n150": "tt-ubuntu-2204-n150-stable",
         "n300": "tt-ubuntu-2204-n300-stable",
+        "n300-high-memory": "tt-ubuntu-2204-n300-stable",
         "wormhole_b0": "tt-ubuntu-2204-n300-stable",
         "p150": "tt-ubuntu-2204-p150b-stable",
         "n300-llmbox": "tt-ubuntu-2204-n300-llmbox-stable",


### PR DESCRIPTION
### Ticket
Slack

### Problem description
We have 2 flavours of n300 runners, one with 32GB of memory and one with 48GB of memory.
Developers need to be able to specify which one they want to use for their tests because more memory is sometimes needed.

### What's changed
Introduce the new allowed label value and map it to a CIv2 label variant.

Note: I've also added the n300-high-memory label on adequate machines.

### Checklist
- [ ] New/Existing tests provide coverage for changes
