### PR TITLE
Add inference test config for boltz2 and update unet status

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -1593,6 +1593,11 @@ test_config:
     reason: "Hangs or takes forever to run - not known to be compile clean anyways."
     bringup_status: FAILED_FE_COMPILATION
 
+  boltz2/pytorch-boltz2-single_device-full-inference:
+    status: NOT_SUPPORTED_SKIP
+    reason: "Hangs or takes forever to run"
+    bringup_status: FAILED_RUNTIME
+
   qwen_3/embedding/pytorch-embedding_8b-single_device-full-inference:
     status: EXPECTED_PASSING
     arch_overrides:
@@ -2225,7 +2230,6 @@ test_config:
 
   unet/pytorch-smp_unet_resnet101-single_device-full-inference:
     status: KNOWN_FAILURE_XFAIL
-    reason: "ModuleNotFoundError: No module named segmentation_models_pytorch"
 
   sam/pytorch-facebook/sam-vit-large-single_device-full-inference:
     status: KNOWN_FAILURE_XFAIL

--- a/tests/runner/test_config/torch/test_config_placeholders.yaml
+++ b/tests/runner/test_config/torch/test_config_placeholders.yaml
@@ -57,8 +57,6 @@ PLACEHOLDER_MODELS:
     bringup_status: NOT_STARTED
   Gaussian Splatting:
     bringup_status: NOT_STARTED
-  Boltz2:
-    bringup_status: NOT_STARTED
   Qwen/Qwen-Image:
     bringup_status: NOT_STARTED
   WhisperX:


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/2133

### Problem description

- Add inference test config for boltz2 pytorch model

### What's changed

- Added inference test config for boltz2 pytorch mode. This test executes for a runtime of two hours which might affect nightly pipeline hence it is skipped for now.

- Removed xfail for `unet/pytorch-smp_unet_resnet101-single_device-full-inference` test since the `ModuleNotFoundError: No module named segmentation_models_pytorch` is solved and model now fails with OOM error which should be automatically tracked.

### Logs 
[boltz_xla.zip](https://github.com/user-attachments/files/23700669/boltz_xla_final.zip)
[smp_unet.log](https://github.com/user-attachments/files/23792767/smp_unet.log)
