### PR TITLE
Remove xfail marker from resnet float32 optimization level 0 test

### DIFF
--- a/tests/torch/single_chip/models/resnet/test_resnet.py
+++ b/tests/torch/single_chip/models/resnet/test_resnet.py
@@ -103,13 +103,7 @@ def training_tester() -> ResnetTester:
             ),
         ),
         pytest.param("float32", 1),
-        pytest.param(
-            "float32",
-            0,
-            marks=pytest.mark.xfail(
-                reason="PCC comparison < 0.99 (observed ~0.9875). Small, mentioned here anyways: https://github.com/tenstorrent/tt-xla/issues/1673"
-            ),
-        ),
+        pytest.param("float32", 0),
     ],
     ids=[
         "optimization_level_1-bfp8",


### PR DESCRIPTION
### Ticket
None

### Problem description
PR #2278 added an xfail marker to `test_torch_resnet_inference[optimization_level_0-float32]` because it was failing with PCC ~0.9875 (below the 0.99 threshold).

### What's changed
The test now passes consistently with PCC >= 0.99, so the xfail marker has been removed. This improves test coverage and indicates the underlying issue has been resolved.

### Checklist
- [x] New/Existing tests provide coverage for changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)