### PR TITLE
Fix Training Tests for Nightly

### DIFF
--- a/.github/workflows/test-matrix-presets/model-test-xfail.json
+++ b/.github/workflows/test-matrix-presets/model-test-xfail.json
@@ -5,8 +5,8 @@
   { "runs-on": "p150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "not weekly and p150 and (known_failure_xfail or not_supported_skip) and large", "parallel-groups": 1, "shared-runners": "true" },
   { "runs-on": "n150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "inference and not weekly and n150 and (known_failure_xfail or not_supported_skip) and not large", "parallel-groups": 3 },
   { "runs-on": "p150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "inference and not weekly and p150 and (known_failure_xfail or not_supported_skip) and not large", "parallel-groups": 3 },
-  { "runs-on": "n150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "training and nightly and n150 and (known_failure_xfail or not_supported_skip) and not large", "parallel-groups": 1 },
-  { "runs-on": "p150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "training and nightly and p150 and (known_failure_xfail or not_supported_skip) and not large", "parallel-groups": 1 },
+  { "runs-on": "n150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "training and not weekly and n150 and (known_failure_xfail or not_supported_skip) and not large", "parallel-groups": 1 },
+  { "runs-on": "p150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "training and not weekly and p150 and (known_failure_xfail or not_supported_skip) and not large", "parallel-groups": 1 },
   { "runs-on": "p150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_placeholder_models", "test-mark": "placeholder", "parallel-groups": 1 },
   { "runs-on": "n150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_placeholder_models", "test-mark": "placeholder", "parallel-groups": 1 }
 ]

--- a/tests/runner/test_config/torch/test_config_training_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_training_single_device.yaml
@@ -5,11 +5,11 @@
 test_config:
   mnist/image_classification/pytorch-cnn_dropout-single_device-full-training:
     status: KNOWN_FAILURE_XFAIL
-    markers: [push, nightly]
+    markers: [push]
 
   mnist/image_classification/pytorch-cnn_nodropout-single_device-full-training:
     status: KNOWN_FAILURE_XFAIL
-    markers: [push, nightly]
+    markers: [push]
 
   autoencoder/pytorch-linear-single_device-full-training:
     status: EXPECTED_PASSING
@@ -103,11 +103,9 @@ test_config:
 
   phi1_5/token_classification/pytorch-microsoft/phi-1_5-single_device-full-training:
     status: KNOWN_FAILURE_XFAIL
-    markers: [nightly]
 
   phi1/token_classification/pytorch-microsoft/phi-1-single_device-full-training:
     status: KNOWN_FAILURE_XFAIL
-    markers: [nightly]
 
   nanogpt/pytorch-FinancialSupport/NanoGPT-single_device-full-training:
     status: KNOWN_FAILURE_XFAIL
@@ -1382,7 +1380,6 @@ test_config:
 
   albert/token_classification/pytorch-base_v2-single_device-full-training:
     status: KNOWN_FAILURE_XFAIL
-    markers: [nightly]
 
   albert/token_classification/pytorch-large_v2-single_device-full-training:
     status: KNOWN_FAILURE_XFAIL


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Currently push training tests are not being run in the CI. Also, we have difference between inference and training tests on how we filter for nightly.

### What's changed
We need to follow inference case where we filter on not weekly and to update tags.

### Checklist
- [ ] New/Existing tests provide coverage for changes
