### PR TITLE
Run extended tests on PR with mlir version change

### DIFF
--- a/.github/actions/inspect-changes/action.yml
+++ b/.github/actions/inspect-changes/action.yml
@@ -32,6 +32,7 @@ runs:
         run_perf_tests=false
         only_run_forge_models=false
         run_uplift_model_tests=false
+        tt_mlir_version_changed=false
         if [ "${{ github.event_name }}" = "pull_request" ]; then
           CHANGED_FILES=$(gh pr diff ${{ github.event.pull_request.number }} --name-only --repo ${{ github.repository }})
           echo "Changed files:"
@@ -93,13 +94,22 @@ runs:
             done
           fi
 
+          # Detect TT-MLIR dependency updates in PRs.
+          if echo "$CHANGED_FILES" | grep -q "^third_party/CMakeLists.txt$"; then
+            TT_MLIR_DIFF=$(gh pr diff ${{ github.event.pull_request.number }} --repo ${{ github.repository }} -- third_party/CMakeLists.txt || true)
+            if echo "$TT_MLIR_DIFF" | grep -qE '^[+-][[:space:]]*set\(TT_MLIR_VERSION'; then
+              echo "Detected TT_MLIR_VERSION change in PR diff."
+              tt_mlir_version_changed=true
+            fi
+          fi
+
         else
           skip_build_and_test=false
           run_pr_tests=true
         fi
 
-        # Check if branch name is "uplift" or "uplift-forge-models"
-        if [[ "${GITHUB_HEAD_REF}" == "uplift" || "${GITHUB_HEAD_REF}" == "uplift-forge-models" ]]; then
+        if [[ "$tt_mlir_version_changed" == "true" ]]; then
+          echo "Enabling uplift model tests due to TT-MLIR dependency change."
           run_uplift_model_tests=true
         fi
 


### PR DESCRIPTION
### Ticket
slack

### Problem description
Update logic for running extended tests, instead of branch name = 'uplift' trigger tests if PR contains changed tt-mlir version.

### Checklist
- [ ] New/Existing tests provide coverage for changes
