### PR TITLE
Add Xfail Preset to Weekly Workflow

### DIFF
--- a/.github/workflows/schedule-weekly.yml
+++ b/.github/workflows/schedule-weekly.yml
@@ -27,8 +27,6 @@ jobs:
     uses: ./.github/workflows/call-test.yml
     secrets: inherit
     needs: [ build-image, build-ttxla ]
-    # This ensures the job runs regardless of success or failure of `weekly_tests`:
-    if: success() || failure()
     with:
       test_suite: model-test-passing-weekly.json
       docker_image: ${{ needs.build-image.outputs.docker-image }}
@@ -39,8 +37,6 @@ jobs:
     uses: ./.github/workflows/call-test.yml
     secrets: inherit
     needs: [ build-image, build-ttxla ]
-    # This ensures the job runs regardless of success or failure of `weekly_tests`:
-    if: success() || failure()
     with:
       test_suite: model-test-xfail-weekly.json
       docker_image: ${{ needs.build-image.outputs.docker-image }}


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Currently, weekly only runs passing tests. Having this in mind, training tests will not be picked up by the current desing.

### What's changed
Adding xfail preset to the weekly job so that we actually follow the nightly structure of running tests.

### Checklist
- [ ] New/Existing tests provide coverage for changes
