### PR TITLE
Add test configs for openvla_oft

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -1203,6 +1203,10 @@ test_config:
 
   vovnet/pytorch-ese_vovnet39b-single_device-full-inference:
     status: EXPECTED_PASSING
+    arch_overrides:
+      p150:
+        assert_pcc: false
+        reason: "PCC comparison failed. Calculated: pcc=0.9872968792915344. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/2201"
 
   vovnet/pytorch-ese_vovnet19b_dw.ra_in1k-single_device-full-inference:
     status: EXPECTED_PASSING
@@ -2440,3 +2444,47 @@ test_config:
 
   ultra_fast_lane_detection/pytorch-tusimple_resnet34-single_device-full-inference:
     status: EXPECTED_PASSING
+
+
+  openvla_oft/pytorch-openvla_oft_finetuned_libero_10-single_device-full-inference:
+    status: EXPECTED_PASSING
+    arch_overrides:
+      n150:
+        status: KNOWN_FAILURE_XFAIL
+        reason: "Out of Memory: Not enough space to allocate 90177536 B DRAM buffer across 12 banks, where each bank needs to store 7516160 B, but bank size is only 1073741792 B - https://github.com/tenstorrent/tt-xla/issues/2328"
+
+
+  openvla_oft/pytorch-openvla_oft_finetuned_libero_spatial-single_device-full-inference:
+    status: EXPECTED_PASSING
+    arch_overrides:
+      n150:
+        status: KNOWN_FAILURE_XFAIL
+        reason: "Out of Memory: Not enough space to allocate 90177536 B DRAM buffer across 12 banks, where each bank needs to store 7516160 B, but bank size is only 1073741792 B - https://github.com/tenstorrent/tt-xla/issues/2328"
+
+  openvla_oft/pytorch-openvla_oft_finetuned_libero_goal-single_device-full-inference:
+    status: EXPECTED_PASSING
+    arch_overrides:
+      n150:
+        status: KNOWN_FAILURE_XFAIL
+        reason: "Out of Memory: Not enough space to allocate 90177536 B DRAM buffer across 12 banks, where each bank needs to store 7516160 B, but bank size is only 1073741792 B - https://github.com/tenstorrent/tt-xla/issues/2328"
+
+  openvla_oft/pytorch-openvla_oft_finetuned_libero_object-single_device-full-inference:
+    status: EXPECTED_PASSING
+    arch_overrides:
+      n150:
+        status: KNOWN_FAILURE_XFAIL
+        reason: "Out of Memory: Not enough space to allocate 90177536 B DRAM buffer across 12 banks, where each bank needs to store 7516160 B, but bank size is only 1073741792 B - https://github.com/tenstorrent/tt-xla/issues/2328"
+
+  openvla_oft/pytorch-openvla_oft_finetuned_libero_spatial_object_goal_10-single_device-full-inference:
+    status: EXPECTED_PASSING
+    arch_overrides:
+      n150:
+        status: KNOWN_FAILURE_XFAIL
+        reason: "Out of Memory: Not enough space to allocate 90177536 B DRAM buffer across 12 banks, where each bank needs to store 7516160 B, but bank size is only 1073741792 B - https://github.com/tenstorrent/tt-xla/issues/2328"
+
+  mistral/pytorch-mistral_nemo_instruct_2407-single_device-full-inference:
+    status: EXPECTED_PASSING
+    arch_overrides:
+      n150:
+        status: KNOWN_FAILURE_XFAIL
+        reason: "Out of Memory: Not enough space to allocate 146800640 B DRAM buffer across 12 banks, where each bank needs to store 12234752 B, but bank size is only 1073741792 B - https://github.com/tenstorrent/tt-xla/issues/2328"


### PR DESCRIPTION
### Ticket
Ref : https://github.com/tenstorrent/tt-xla/issues/2328

### Problem description
Openvla & mistral models are passing in [experimental nightly](https://github.com/tenstorrent/tt-xla/actions/runs/19657964903/job/56298632508). Add their configs to main nightly

* `vovnet/pytorch-ese_vovnet39b-single_device-full-inference` is failing in nightly for p150 alone

### What's changed

- All openvla & mistral variants are passing in p150 but failing in n150 with OOM issue. 
- updated the model status with the issue
- updated the config for ese_vovnet39b 


### Checklist
- [x] New/Existing tests provide coverage for changes


PFA logs for refernce:
n150 : 
[mistral_nemo_instruct_2407_n150.log](https://github.com/user-attachments/files/23762495/mistral_nemo_instruct_2407_n150.log)
[oft_libero_10_n150.log](https://github.com/user-attachments/files/23762497/oft_libero_10_n150.log)
[oft_libero_goal_n150.log](https://github.com/user-attachments/files/23762498/oft_libero_goal_n150.log)
[oft_libero_spatial_goal_10_n150.log](https://github.com/user-attachments/files/23762499/oft_libero_spatial_goal_10_n150.log)
[oft_libero_spatial_n150.log](https://github.com/user-attachments/files/23762500/oft_libero_spatial_n150.log)

p150 : 
[mistral_nemo_instruct_2407_p150.log](https://github.com/user-attachments/files/23762521/mistral_nemo_instruct_2407_p150.log)
[oft_libero_10_p150.log](https://github.com/user-attachments/files/23762526/oft_libero_10_p150.log)
[oft_libero_goal_p150.log](https://github.com/user-attachments/files/23762528/oft_libero_goal_p150.log)
[oft_libero_spatial_goal_10_p150.log](https://github.com/user-attachments/files/23762531/oft_libero_spatial_goal_10_p150.log)
[oft_libero_spatial_p150.log](https://github.com/user-attachments/files/23762534/oft_libero_spatial_p150.log)

