### PR TITLE
Uplift third_party/tt-mlir to becbe0ab7c71655f9f1191b9197850b3dff167dc 2025-11-26

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -5,7 +5,7 @@
 option(USE_CUSTOM_TT_MLIR_VERSION "Flag to use TT_MLIR_VERSION set by the user" OFF)
 
 if (NOT DEFINED TT_MLIR_VERSION OR NOT USE_CUSTOM_TT_MLIR_VERSION)
-    set(TT_MLIR_VERSION "83ad36534f9a92af70b5d58ac1803a5217e6b063")
+    set(TT_MLIR_VERSION "becbe0ab7c71655f9f1191b9197850b3dff167dc")
 endif()
 
 set(PROTOBUF_VERSION "v21.12") # same version as tt-metal uses


### PR DESCRIPTION
This PR uplifts the third_party/tt-mlir to the becbe0ab7c71655f9f1191b9197850b3dff167dc