### PR TITLE
Aliasing filecheck

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -22,6 +22,7 @@ COPY python_package/requirements.txt /tmp/requirements.txt
 COPY venv/requirements-dev.txt /tmp/requirements-dev.txt
 
 # Now do the actual installation
+RUN ln -sf /usr/bin/FileCheck-17 /usr/bin/FileCheck
 RUN python3.11 -m pip install --upgrade pip --no-cache-dir && \
     python3.11 -m pip install --index-url https://download.pytorch.org/whl/cpu $(grep 'torch==' /tmp/requirements.txt) && \
     python3.11 -m pip install --index-url https://download.pytorch.org/whl/cpu $(grep 'torchvision==' /tmp/requirements-dev.txt) && \

--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -114,9 +114,6 @@ jobs:
           tests
           venv
 
-    - name: Create FileCheck symlink
-      run: sudo ln -sf /usr/bin/FileCheck-17 /usr/bin/FileCheck
-
     - name: Fetch job id
       id: fetch-job-id
       uses: tenstorrent/tt-github-actions/.github/actions/job_id@main


### PR DESCRIPTION
In our test CI docker, we have FileCheck-17, while the test itself calls FileCheck, leading to an error in uplift. Adding a step which aliases these two to circumvent this.