### PR TITLE
Remove failure reasons for Owl-ViT and Llama-3.2 Vision base models, as fixes for the old issues are now tracked on main

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -2318,7 +2318,6 @@ test_config:
 
   owl_vit/pytorch-base_patch32-single_device-full-inference:
     status: KNOWN_FAILURE_XFAIL
-    reason: "error: 'ttnn.matmul' op Output shape dimension[2](64) doesn't match the expected output shape dimension[2](16) - https://github.com/tenstorrent/tt-xla/issues/1955"
 
   # yolov12/pytorch-yolo12n-single_device-full-inference:
   #   status: EXPECTED_PASSING
@@ -2367,7 +2366,6 @@ test_config:
 
   llama/llama_3_2_vision/pytorch-llama_3_2_11b_vision-single_device-full-inference:
     status: KNOWN_FAILURE_XFAIL
-    reason: "ValueError: Cannot use chat template functions because tokenizer.chat_template is not set and no template argument was passed"
 
   llama/llama_3_2_vision/pytorch-llama_3_2_11b_vision_instruct-single_device-full-inference:
     status: KNOWN_FAILURE_XFAIL


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/1861
- fixes https://github.com/tenstorrent/tt-xla/issues/2238

### Problem description

- Owl-ViT initially failed due to invalid data size error - https://github.com/tenstorrent/tt-xla/issues/2238
  - The required fix has now been tracked on main: https://github.com/tenstorrent/tt-mlir/pull/5980
- Llama-3.2-11B-Vision failed due to this chat template error `ValueError: Cannot use chat template functions because tokenizer.chat_template is not set and no template argument was passed!`
  - The required fix has now been tracked on main: https://github.com/tenstorrent/tt-forge-models/pull/298
- Since both fixes are now tracked on main, the failure reasons need to be removed as it is automatically tracked now.

### What's changed

- Removed the failure reasons for Owl-ViT and Llama-3.2 Vision base models based on issues on current main

### Checklist
- [x] verified the changes through local testing

### Logs

- [nov26_llama_3_2_v_base.log](https://github.com/user-attachments/files/23775351/nov26_llama_3_2_v_base.log)
- [nov26_owl_vit_1.log](https://github.com/user-attachments/files/23775354/nov26_owl_vit_1.log)

