### PR TITLE
[vLLM plugin] Use scale attribute for SDPA op

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/attention.py
+++ b/integrations/vllm_plugin/vllm_tt/attention.py
@@ -319,6 +319,7 @@ class TTAttentionBackendImpl(AttentionImpl):
                 value,
                 is_causal=attn_metadata.is_causal,
                 attn_mask=attn_metadata.attn_mask,
+                scale=self.scale,
             ).transpose(-3, -2)
             if is_batched:
                 return output.reshape(


### PR DESCRIPTION
### Ticket
closes #2342 

### Problem description
SDPA op is not using 'scale' attribute in attention layer.

### What's changed
Add 'scale' attribute for SDPA op

### Checklist
- [X] Existing tests provide coverage for changes
