### PR TITLE
Use einsum instead of MM for 2d batch inputs (i.e. attention)

### DIFF
--- a/python_package/tt_torch/__init__.py
+++ b/python_package/tt_torch/__init__.py
@@ -8,6 +8,9 @@ import tt_torch.backend.backend
 # Import module so custom operations are registered
 import tt_torch.custom_ops
 
+# Import torch overrides so they are registered
+import tt_torch.torch_overrides
+
 from .codegen import codegen_cpp, codegen_py
 from .serialization import (
     parse_compiled_artifacts_from_cache,

--- a/python_package/tt_torch/backend/backend.py
+++ b/python_package/tt_torch/backend/backend.py
@@ -11,7 +11,7 @@ from torch._dynamo import register_backend
 from torch.export import ExportedProgram
 from torch.export.graph_signature import InputKind, OutputKind
 
-from .decompositions import CUSTOM_DECOMPOSITION_TABLE
+from .decompositions import populate_decompositions
 from .metadata_propagation import MetadataDispatchMode, extract_nodes_info
 from .passes import (
     bypass_assert_tensor_metadata,
@@ -35,8 +35,7 @@ def torch_pass_pipeline(
     # TODO: Fix composite ops to support multi-chip models before uncommenting this.
     # handle_composite_ops(gm)
 
-    decompositions = torch._decomp.core_aten_decompositions()
-    decompositions.update(CUSTOM_DECOMPOSITION_TABLE)
+    decompositions = populate_decompositions()
 
     # We use `export_for_training` here as we plan to use this flow to compile training graphs.
     # In addition to that, the functionality in `export_for_training` will become the default

--- a/python_package/tt_torch/torch_overrides.py
+++ b/python_package/tt_torch/torch_overrides.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+from torch.overrides import TorchFunctionMode
+
+
+class TorchFunctionOverride(TorchFunctionMode):
+    def __torch_function__(self, func, types, args, kwargs=None):
+        if not torch.compiler.is_compiling() and (
+            func.__name__ == "matmul" or func.__name__ == "linear"
+        ):
+            if len(args[0].shape) >= 4 or len(args[1].shape) >= 4:
+                res = torch.einsum("...mk,...kn->...mn", args[0], args[1])
+                if len(args) > 2 and args[2] is not None:
+                    res = res + args[2]
+                return res
+        return func(*args, **(kwargs or {}))
+
+
+torch_function_override = TorchFunctionOverride()
+torch_function_override.__enter__()


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/2363)

### Problem description
When attention is sharded using megatron style shard specs, and there is a batch input, an unnecessary all_gather is introduced because pytorch [folds batch dimensions of bmms](https://github.com/pytorch/pytorch/blob/a5436a5e8e4ee42d1debf52c2786c7ae0043a434/aten/src/ATen/native/LinearAlgebra.cpp#L1999) and so sharding along heads cannot be propagated.

### What's changed
A decomposition was added that will treat 4d@4d matmuls as einsums. 

### Checklist
- [x] New/Existing tests provide coverage for changes
