### PR TITLE
[vLLM] Add llama3_3b generative test

### DIFF
--- a/tests/integrations/vllm_plugin/generative/test_llama3_3b_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_llama3_3b_generation.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import vllm
+
+
+@pytest.mark.nightly
+def test_llama3_3b_generation():
+    prompts = [
+        "I like taking walks in the",
+    ]
+    sampling_params = vllm.SamplingParams(temperature=0.8, top_p=0.95, max_tokens=32)
+    llm_args = {
+        "model": "meta-llama/Llama-3.2-3B",
+        "max_num_batched_tokens": 128,
+        "max_num_seqs": 1,
+        "max_model_len": 128,
+        "gpu_memory_utilization": 0.002,
+        "additional_config": {
+            "enable_const_eval": False,
+            "min_context_len": 32,
+        },
+    }
+    llm = vllm.LLM(**llm_args)
+
+    output_text = llm.generate(prompts, sampling_params)[0].outputs[0].text
+    print(f"prompt: {prompts[0]}, output: {output_text}")


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/2252

### Problem description
We want to bring up a generative version of llama3 3b on N150 through vLLM.

### What's changed
Added a generative test for llama3_3b through vLLM following the same test structure as `test_opt_generation.py`. Only differences for llama are: 
- `"gpu_memory_utilization": 0.001` is too small and needed to be increased to `0.002`
- test marked for `nightly` instead of `push`

### Checklist
- [x] New/Existing tests provide coverage for changes
