### PR TITLE
add credentials for perf data upload

### DIFF
--- a/.github/workflows/workflow-run-collect-data.yml
+++ b/.github/workflows/workflow-run-collect-data.yml
@@ -40,6 +40,8 @@ jobs:
           run_attempt: ${{ github.event.workflow_run.run_attempt }}
           sftp_host: ${{ secrets.SFTP_CICD_WRITER_HOSTNAME }}
           sftp_user: ${{ secrets.SFTP_CICD_WRITER_USERNAME }}
+          sftp_perf_host: ${{ secrets.SFTP_PERF_WRITER_HOSTNAME }}
+          sftp_perf_user: ${{ secrets.SFTP_PERF_WRITER_USERNAME }}
           ssh-private-key: ${{ secrets.SFTP_CICD_WRITER_KEY }}
 
       - name: Collect CI/CD data (from workflow_dispatch)
@@ -51,4 +53,6 @@ jobs:
           run_attempt: ${{ github.event.inputs.run_attempt }}
           sftp_host: ${{ secrets.SFTP_CICD_WRITER_HOSTNAME }}
           sftp_user: ${{ secrets.SFTP_CICD_WRITER_USERNAME }}
+          sftp_perf_host: ${{ secrets.SFTP_PERF_WRITER_HOSTNAME }}
+          sftp_perf_user: ${{ secrets.SFTP_PERF_WRITER_USERNAME }}
           ssh-private-key: ${{ secrets.SFTP_CICD_WRITER_KEY }}


### PR DESCRIPTION
### Ticket
[Issue](https://github.com/tenstorrent/tt-forge/issues/618)

### Problem description
Performance report data isn't uploaded to superset in tt-xla.

### What's changed
Add `sftp_perf_host` and `sftp_perf_user` when calling the job which collects and uploads the data.
This is allow for the perf related data to be uploaded to superset as well.

### Checklist
- [ ] New/Existing tests provide coverage for changes
