### PR TITLE
Update test durations from the on weekly workflow as well

### DIFF
--- a/.github/workflows/manual-update-durations.yml
+++ b/.github/workflows/manual-update-durations.yml
@@ -66,7 +66,7 @@ jobs:
           # get test results from the last successful push
           get_test_results_from_wf "push-main.yml" "success" "push"
 
-          # get test results from the last nightly that was success or failure
+          # get test results from the last weekly that was success or failure
           get_test_results_from_wf "schedule-weekly.yml" "success,failure" "weekly"
 
           python .github/scripts/get_test_duration_from_junit_xmls.py ${{runner.temp}}/reports .test_durations


### PR DESCRIPTION
### Ticket
/

### Problem description
We want to persist test durations from the `On weekly` workflow.

### What's changed
`Update Test Durations` now updates durations for tests from the `On weekly` workflow as well. 

### Checklist
- [ ] New/Existing tests provide coverage for changes

### Example
Example PR that gets created after these changes: [here](https://github.com/tenstorrent/tt-xla/pull/2387)
