### PR TITLE
set tensor retain on graph outputs-aliased-to-inputs for SOLoadedExecutableInstance

### DIFF
--- a/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
@@ -88,12 +88,12 @@ FlatbufferLoadedExecutableInstance::prepareInputTensor(
   if (has_expected_layout) {
     DLOG_F(LOG_DEBUG,
            "Reusing already prepared input tensor for argument index %zu with "
-           "shape %s",
-           arg_index, arg_buffers[0]->toShapeStr().c_str());
+           "shape %s and UID %zu",
+           arg_index, arg_buffers[0]->toShapeStr().c_str(),
+           arg_buffers[0]->getUID());
 
     // This prepared tensor may be from a previous graph output aliased to
-    // input, so
-    //  we should set its retention flag to true.
+    // input, so  we should set its retention flag to true.
     if (tt::runtime::getTensorRetain(*prepared_tensor) == false) {
       DLOG_F(LOG_DEBUG,
              "Prepared tensor for argument index %zu with shape %s had "

--- a/pjrt_implementation/src/api/so_loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/so_loaded_executable_instance.cc
@@ -205,8 +205,21 @@ SOLoadedExecutableInstance::prepareInputTensor(
   // As a hack, we'll always use whatever we have prepared.
   if (prepared_tensor.has_value()) {
     DLOG_F(LOG_DEBUG,
-           "Reusing already prepared input tensor for argument index %zu",
-           arg_index);
+           "Reusing already prepared input tensor for argument index %zu with "
+           "shape %s and buffer UID %zu",
+           arg_index, arg_buffers[0]->toShapeStr().c_str(),
+           arg_buffers[0]->getUID());
+
+    // This prepared tensor may be from a previous graph output aliased to
+    // input, so  we should set its retention flag to true.
+    if (tt::runtime::getTensorRetain(*prepared_tensor) == false) {
+      DLOG_F(LOG_DEBUG,
+             "Prepared tensor for argument index %zu with shape %s had "
+             "retain=false; setting "
+             "to true to avoid deallocation during execution.",
+             arg_index, arg_buffers[0]->toShapeStr().c_str());
+    }
+    tt::runtime::setTensorRetain(*prepared_tensor, /*retain=*/true);
     return *prepared_tensor;
   }
 


### PR DESCRIPTION
### Ticket
Partial resolution to #2383

### Problem description
SOLoadedExecutableInstance::prepareInputTensor was missing the output-alias-to-input tensor retention setting leading to error:
> Prepared input tensor should have retain=true or it may be deallocated during execution.

Under specific runtime-stitching scenarios. This failure mode was originally encountered during bringup of FlatbufferLoadedExecutableInstance and patched for that class, but not for the SO* class, and the above error log was added as an additional safety check.

### What's changed
Port patch prepareInputTensor from FlatbufferLoadedExecutableInstance to SOLoadedExecutableInstance. This ensures that whichever codepath we source input tensors from - either from host or from outputs of previous execution - the tensor is retained and not accidentally deallocated during execution.

### Checklist
- [x] New/Existing tests provide coverage for changes
