### PR TITLE
Uplift third_party/tt-mlir to 2977ed60f7f890eb14ccdcec3d6a89a244364c91 2025-12-03

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -5,7 +5,7 @@
 option(USE_CUSTOM_TT_MLIR_VERSION "Flag to use TT_MLIR_VERSION set by the user" OFF)
 
 if (NOT DEFINED TT_MLIR_VERSION OR NOT USE_CUSTOM_TT_MLIR_VERSION)
-    set(TT_MLIR_VERSION "8b2e9321d7e8c1d666b94dda1d27017213eae8cc")
+    set(TT_MLIR_VERSION "2977ed60f7f890eb14ccdcec3d6a89a244364c91")
 endif()
 
 set(PROTOBUF_VERSION "v21.12") # same version as tt-metal uses


### PR DESCRIPTION
This PR uplifts the third_party/tt-mlir to the 2977ed60f7f890eb14ccdcec3d6a89a244364c91