### PR TITLE
Remove fixture decorator from whisper training test

### DIFF
--- a/tests/torch/single_chip/models/whisper/test_whisper.py
+++ b/tests/torch/single_chip/models/whisper/test_whisper.py
@@ -84,7 +84,7 @@ def inference_tester(request) -> WhisperTester:
     return WhisperTester(variant)
 
 
-# ----- Fixtures -----
+# ----- Tests -----
 
 
 @pytest.mark.nightly


### PR DESCRIPTION
It seems that there's a fixure decorator on a training test for whisper. We may want to remove it, which this PR does.