### PR TITLE
Put up a fix for data parallel gpt2

### DIFF
--- a/.github/workflows/test-matrix-presets/model-test-passing.json
+++ b/.github/workflows/test-matrix-presets/model-test-passing.json
@@ -6,7 +6,8 @@
   { "runs-on": "n150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "n150 and expected_passing and not large", "parallel-groups": 3 },
   { "runs-on": "p150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "p150 and expected_passing and not large", "parallel-groups": 3 },
   { "runs-on": "n300-llmbox", "name": "run_forge_models_multichip", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "tensor_parallel and n300-llmbox and expected_passing", "parallel-groups": 1 },
-  { "runs-on": "n300", "name": "run_forge_models_multichip", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "data_parallel and expected_passing", "parallel-groups": 1 },
+  { "runs-on": "n300", "name": "run_forge_models_multichip", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "data_parallel and expected_passing and not large", "parallel-groups": 1 },
+  { "runs-on": "n300", "name": "run_forge_models_multichip", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "data_parallel and expected_passing and large", "parallel-groups": 1, "shared-runners": "true" },
   { "runs-on": "n150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "n150 and expected_passing and large", "shared-runners": "true" },
   { "runs-on": "p150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "p150 and expected_passing and large", "shared-runners": "true" }
 ]

--- a/tests/runner/test_config/jax/test_config_inference_data_parallel.yaml
+++ b/tests/runner/test_config/jax/test_config_inference_data_parallel.yaml
@@ -15,3 +15,4 @@ test_config:
   gpt2/causal_lm/jax-xl-data_parallel-full-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
+    markers: [large]


### PR DESCRIPTION
GPT2 xl data parallel has large memory requirements, so marking it as large