### PR TITLE
Add PYTHONPATHs for TT-NN lib

### DIFF
--- a/venv/activate
+++ b/venv/activate
@@ -9,8 +9,10 @@ if [ -z "$TTMLIR_TOOLCHAIN_DIR" ]; then
 fi
 export LD_LIBRARY_PATH=$TTMLIR_TOOLCHAIN_DIR/lib:$LD_LIBRARY_PATH
 export SYSTEM_DIST_PACKAGES="/usr/local/lib/python3.11/dist-packages"
-# pytest alias for venv interpreter
-alias pytest='python -m pytest'
+
+export TT_MLIR_HOME="$(pwd)/third_party/tt-mlir/src/tt-mlir/"
+METAL_PATH_IN_SOURCE="${TT_MLIR_HOME}/third_party/tt-metal/src/tt-metal"
+export PYTHONPATH="$(pwd):$(pwd)/tests:$SYSTEM_DIST_PACKAGES:$(pwd)/integrations/vllm_plugin:${TT_MLIR_HOME}/build/python_packages:${METAL_PATH_IN_SOURCE}/ttnn:${METAL_PATH_IN_SOURCE}/tools"
 
 export TTMLIR_VENV_DIR="$(pwd)/venv"
 if [ -d $TTMLIR_VENV_DIR/bin ]; then
@@ -32,9 +34,7 @@ export TTXLA_ENV_ACTIVATED=1
 export TTMLIR_ENV_ACTIVATED=1
 export TT_METAL_LOGGER_LEVEL="ERROR"
 export ARCH_NAME="${ARCH_NAME:-wormhole_b0}"
-export TT_MLIR_HOME="$(pwd)/third_party/tt-mlir/src/tt-mlir/"
 export PATH=$TTMLIR_TOOLCHAIN_DIR/bin:${TT_MLIR_HOME}/build/bin:$PATH
 
-METAL_PATH_IN_SOURCE="${TT_MLIR_HOME}/third_party/tt-metal/src/tt-metal"
-
-export PYTHONPATH="$(pwd):$(pwd)/tests:$SYSTEM_DIST_PACKAGES:$(pwd)/integrations/vllm_plugin:${TT_MLIR_HOME}/build/python_packages:${METAL_PATH_IN_SOURCE}/ttnn:${METAL_PATH_IN_SOURCE}/tools"
+# pytest alias for venv interpreter
+alias pytest='python -m pytest'


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/1978

### Problem description
TT-NN lib isn't visible in current environment.
```
python -c "import ttnn"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'ttnn'
```

### What's changed
Added relevant paths to PYTHONPATH
```
python -c "import ttnn"
2025-12-03 10:40:45.406 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
...
```

### Checklist
- [ ] New/Existing tests provide coverage for changes
