### PR TITLE
[CI] Fix IRD docker toolchain permission

### DIFF
--- a/.github/Dockerfile.ci
+++ b/.github/Dockerfile.ci
@@ -17,7 +17,7 @@ FROM ghcr.io/tenstorrent/tt-xla/tt-xla-base-ubuntu-22-04:${FROM_TAG} AS ci
 # Copy the TTMLIR_TOOLCHAIN_DIR from the previous stage
 ENV TTMLIR_TOOLCHAIN_DIR=/opt/ttmlir-toolchain
 RUN echo "Copying from ci-build stage $TTMLIR_TOOLCHAIN_DIR"
-COPY --from=ci-build $TTMLIR_TOOLCHAIN_DIR $TTMLIR_TOOLCHAIN_DIR
+COPY --from=ci-build --chown=root:root --chmod=777 $TTMLIR_TOOLCHAIN_DIR $TTMLIR_TOOLCHAIN_DIR
 
 RUN du -h --max-depth=2 $TTMLIR_TOOLCHAIN_DIR
 
@@ -29,7 +29,7 @@ SHELL ["/bin/bash", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TTMLIR_TOOLCHAIN_DIR=/opt/ttmlir-toolchain
 RUN echo "Copying from ci-build stage $TTMLIR_TOOLCHAIN_DIR"
-COPY --from=ci-build-with-venv $TTMLIR_TOOLCHAIN_DIR $TTMLIR_TOOLCHAIN_DIR
+COPY --from=ci-build-with-venv --chown=root:root --chmod=777 $TTMLIR_TOOLCHAIN_DIR $TTMLIR_TOOLCHAIN_DIR
 
 # Install dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-xla/issues/2423

### Problem description
Failures occur when building due to package writes to a venv inside /opt/ttmlir-toolchain

### What's changed
Set chmod 777 and chown during copying toolchain from tt-mlir image 

### Checklist
- [ ] New/Existing tests provide coverage for changes
