### PR TITLE
feature: many linux

### DIFF
--- a/.github/workflows/call-build.yml
+++ b/.github/workflows/call-build.yml
@@ -149,13 +149,65 @@ jobs:
             cd ${{ steps.strings.outputs.work-dir }}/python_package
             python setup.py bdist_wheel --build-type ${{ inputs.build_type }}
 
+      - name: convert the wheel to manylinux wheel
+        shell: bash
+        run: |
+            source venv/activate
+            cd ${{ steps.strings.outputs.work-dir }}/python_package
+            apt-get install -y patchelf zip
+            pip install auditwheel
+
+            # Exclude tt-metal libs to prevent auditwheel from creating duplicates.
+            # Without --exclude, auditwheel bundles copies from CI build paths into .libs/,
+            # causing protobuf symbol conflicts at runtime ("CHECK failed: file != nullptr").
+            # See: https://github.com/tenstorrent/tt-xla/pull/2426#issuecomment-3629829349
+            auditwheel repair \
+              --exclude libtt_metal.so \
+              --exclude libdevice.so \
+              --exclude libtracy.so \
+              --exclude libtt_stl.so \
+              --exclude _ttnncpp.so \
+              --plat manylinux_2_35_x86_64 dist/pjrt_plugin_tt*.whl -w wheelhouse/
+
+            # Fix duplicate Root-Is-Purelib entries created by auditwheel.
+            # Upstream issue: https://github.com/pypa/auditwheel/issues/642
+            # Details: https://github.com/tenstorrent/tt-xla/pull/2426#issuecomment-3629829349
+            cd wheelhouse
+            whl=$(ls pjrt_plugin_tt*.whl)
+            echo "Fixing WHEEL metadata in $whl"
+            tmpdir=$(mktemp -d)
+            unzip -q "$whl" -d "$tmpdir"
+
+            # Find and fix the WHEEL file - replace Root-Is-Purelib value and remove duplicates
+            wheel_file=$(find "$tmpdir" -name "WHEEL" -path "*dist-info*")
+            echo "Original WHEEL file:"
+            cat "$wheel_file"
+            # Replace first Root-Is-Purelib with correct value, remove any duplicates
+            awk '/Root-Is-Purelib/ { if (!seen) { print "Root-Is-Purelib: false"; seen=1 } next } { print }' "$wheel_file" > "${wheel_file}.tmp"
+            mv "${wheel_file}.tmp" "$wheel_file"
+            echo "Fixed WHEEL file contents:"
+            cat "$wheel_file"
+
+            # Repack the wheel using absolute path
+            whl_abs="$(pwd)/$whl"
+            rm "$whl"
+            cd "$tmpdir"
+            zip -rq "$whl_abs" .
+            cd -
+            rm -rf "$tmpdir"
+            cd ..
+
+            # Delete the original wheel in favor of the manylinux wheel in wheelhouse directory
+            rm -rf ${{ steps.strings.outputs.work-dir }}/python_package/dist/*.whl
+
       - name: Validate build type of wheel build
         shell: bash
         run: |
             source venv/activate
+            cd ${{ steps.strings.outputs.work-dir }}/python_package/wheelhouse
             #Inspect the wheel build type on wheel file without installing the wheel
             pip install wheel-inspect
-            wheel_summary=$(wheel2json ${{ steps.strings.outputs.work-dir }}/python_package/dist/pjrt_plugin_tt*.whl | jq -r '.dist_info.metadata.summary')
+            wheel_summary=$(wheel2json pjrt_plugin_tt*.whl | jq -r '.dist_info.metadata.summary')
             match=$(echo "$wheel_summary" | grep -oP "build-type=${{ inputs.build_type }}" || true)
             echo "Wheel summary: $wheel_summary"
             if [ -z "$match" ]; then
@@ -168,7 +220,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
             name: ${{ needs.check-existing-artifact.outputs.wheel_artifact_name }}
-            path: ${{ steps.strings.outputs.work-dir }}/python_package/dist/pjrt_plugin_tt*.whl
+            path: ${{ steps.strings.outputs.work-dir }}/python_package/wheelhouse/*.whl
 
       - name: Build vllm plugin wheel
         if: inputs.build_type == 'release'

--- a/python_package/setup.py
+++ b/python_package/setup.py
@@ -214,8 +214,12 @@ class BdistWheel(bdist_wheel):
         config.build_type = self.build_type
         config.enable_explorer = self.build_type == "explorer"
 
-        bdist_wheel.finalize_options(self)
+        # Set root_is_pure BEFORE calling parent finalize_options.
+        # This ensures the wheel is built as platlib (platform-specific) rather than
+        # purelib (pure Python), which is required for auditwheel to process it correctly.
         self.root_is_pure = False
+
+        bdist_wheel.finalize_options(self)
 
     def run(self):
         # Update the description with version info after options are finalized (e.g. self.build_type)


### PR DESCRIPTION
## Summary

This PR adds **manylinux wheel support** for tt-xla, making the wheel portable across different Linux distributions.

### Why manylinux?

The current `linux_x86_64` wheel has **hardcoded CI build paths** baked into the shared libraries:

```
RUNPATH: /__w/tt-xla/tt-xla/third_party/tt-mlir/.../tt-metal/build/lib
```

This means:
- ❌ The wheel only works on machines with identical paths (i.e., CI runners)
- ❌ Users installing via `pip install` get broken wheels
- ❌ Libraries fail to load with "cannot open shared object file" errors

### What manylinux provides

A manylinux wheel:
- ✅ Bundles all non-system dependencies inside the wheel
- ✅ Uses `$ORIGIN`-relative RPATHs so libraries find each other
- ✅ Works on any Linux distribution meeting the manylinux spec
- ✅ Enables proper `pip install` distribution

### Issues Fixed

1. **Duplicate library bundling** - auditwheel was creating duplicate copies of tt-metal libraries (e.g., `libtt_metal.so` in both `lib/` and `.libs/`), causing protobuf symbol conflicts at runtime.
   - **Fix:** Added `--exclude` flags for libraries already in the wheel

2. **Duplicate Root-Is-Purelib metadata** - auditwheel appends duplicate entries instead of replacing
   - **Fix:** Post-process WHEEL file to deduplicate
   - **Upstream issue:** https://github.com/pypa/auditwheel/issues/642

### Testing

- [x] Wheel installs successfully via `pip install`
- [x] `jax.devices('tt')` returns TT devices without crashes
- [x] All existing tests pass

### Related

- Closes #798
- Upstream auditwheel bug: https://github.com/pypa/auditwheel/issues/642

---

See [detailed root cause analysis](https://github.com/tenstorrent/tt-xla/pull/2426#issuecomment-3629829349) for reproduction steps and technical details.

