### PR TITLE
Enable running sweeps tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "third_party/tt_forge_models"]
 	path = third_party/tt_forge_models
 	url = https://github.com/tenstorrent/tt-forge-models.git
+[submodule "third_party/tt_forge_sweeps"]
+	path = third_party/tt_forge_sweeps
+	url = git@github.com:tenstorrent/tt-forge-sweeps.git
+#     update = none

--- a/tests/torch/single_chip/operators/README.md
+++ b/tests/torch/single_chip/operators/README.md
@@ -1,0 +1,66 @@
+
+# Sweeps operators tests
+
+Sweeps operator tests resides in repo [TT-Forge-Sweeps](https://github.com/tenstorrent/tt-forge-sweeps). Execution of sweeps tests is fully available from TT-Xla via pytest function `tests/torch/single_chip/operators/test_query.py`.
+
+---
+
+## Setup git submodule
+
+To initialize git submodule run following commands:
+
+```bash
+pushd third_party/tt_forge_sweeps
+git submodule update --init .
+git sparse-checkout init .
+git sparse-checkout set src/sweeps
+popd
+```
+---
+
+## Remove git submodule
+
+To remove tt-forge-sweeps submodule run following commands:
+
+```bash
+git submodule deinit -f third_party/tt_forge_sweeps
+```
+
+Sometimes additional steps needed to cleanup tt-forge-sweeps submodule completely
+
+```bash
+git rm --cached third_party/tt_forge_sweeps
+git config --unset submodule.third_party/tt_forge_sweeps.active
+git config -f .git/config --remove-section submodule.third_party/tt_forge_sweeps
+```
+
+---
+## Execute sweeps tests
+
+Example commands to run sweeps tests:
+
+Run 0.2% of all sweeps tests
+```bash
+SAMPLE=0.2 pytest tests/torch/single_chip/operators/test_query.py -v
+```
+
+Run 1% of conv2d tests
+```bash
+SAMPLE=1 OPERATORS=conv2d pytest tests/torch/single_chip/operators/test_query.py -v
+```
+
+Run all conv2d tests with failing reason BAD_STATUS0R_ACCESS
+```bash
+FAILING_REASONS=BAD_STATUS0R_ACCESS OPERATORS=conv2d pytest tests/torch/single_chip/operators/test_query.py -v
+```
+
+List all conv2d tests with failing reason BAD_STATUS0R_ACCESS
+```bash
+FAILING_REASONS=BAD_STATUS0R_ACCESS OPERATORS=conv2d pytest tests/torch/single_chip/operators/test_query.py --collect-only
+```
+
+Print sweeps help
+```bash
+. third_party/tt_forge_sweeps/src/sweeps/operators/pytorch/test_commands.sh
+PYTHONPATH=$(pwd):$(pwd)/tests print_query_docs
+```

--- a/tests/torch/single_chip/operators/conftest.py
+++ b/tests/torch/single_chip/operators/conftest.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import _pytest
+import _pytest.python
+import _pytest.reports
+import _pytest.runner
+import pytest
+from sweeps.core.logging import SweepsPytestReport
+from sweeps.core.logging.sweeps_property_utils import (
+    ForgePropertyHandler,
+    forge_property_handler_var,
+)
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(
+    item: _pytest.python.Function, call: _pytest.runner.CallInfo
+):
+    outcome = yield
+    report: _pytest.reports.TestReport = outcome.get_result()
+    SweepsPytestReport.adjust_report(item, call, outcome, report)
+
+
+@pytest.fixture(scope="function", autouse=True)
+def forge_property_recorder(request, record_property):
+    # Create a handler that uses the property store; the handler is responsible for recording and managing property details.
+    forge_property_handler = ForgePropertyHandler()
+    token = forge_property_handler_var.set(forge_property_handler)
+
+    yield
+
+    forge_property_handler.record_error(request)
+    forge_property_handler.record_all_properties(record_property)
+    forge_property_handler_var.reset(token)

--- a/tests/torch/single_chip/operators/conftest.py
+++ b/tests/torch/single_chip/operators/conftest.py
@@ -8,6 +8,10 @@ import _pytest.python
 import _pytest.reports
 import _pytest.runner
 import pytest
+import torch
+import torch._dynamo
+import torch_xla.runtime as xr
+from loguru import logger
 from sweeps.core.logging import SweepsPytestReport
 from sweeps.core.logging.sweeps_property_utils import (
     ForgePropertyHandler,
@@ -22,6 +26,30 @@ def pytest_runtest_makereport(
     outcome = yield
     report: _pytest.reports.TestReport = outcome.get_result()
     SweepsPytestReport.adjust_report(item, call, outcome, report)
+
+
+@pytest.fixture(autouse=True)
+def run_around_tests():
+    torch.manual_seed(0)
+    yield
+    torch._dynamo.reset()
+
+
+@pytest.fixture(autouse=True)
+def clear_torchxla_computation_cache():
+    """
+    Clears the TorchXLA computation cache after each test to prevent stale cached
+    compilations from being served with wrong compile options when tests use different
+    compiler configurations. See https://github.com/tenstorrent/tt-xla/issues/3439.
+    """
+    yield
+    try:
+        xr.clear_computation_cache()
+    except Exception as e:
+        logger.warning(f"Failed to clear TorchXLA computation cache: {e}")
+        logger.warning(
+            "This is expected if the test throws an exception, https://github.com/tenstorrent/tt-xla/issues/2814"
+        )
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests/torch/single_chip/operators/pytest.ini
+++ b/tests/torch/single_chip/operators/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+
+pythonpath =
+    ../../../../third_party/tt_forge_sweeps/src
+    ../../../../tests
+    ../../../..

--- a/tests/torch/single_chip/operators/test_query.py
+++ b/tests/torch/single_chip/operators/test_query.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+# Query all test plan via test filters
+
+
+import pytest
+from sweeps.core.plan import TestVector
+from sweeps.operators.pytorch.plan.test_plan import TestQueries, TestVerification
+
+
+@pytest.mark.parametrize(
+    "test_vector", TestQueries.query_filter(TestQueries.query_source()).to_params()
+)
+def test_query(test_vector: TestVector):
+    test_device = None
+    TestVerification.verify(test_vector, test_device)


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Sweeps operator tests resides in separate tt-forge-sweeps repo and are not easily available to tt-xla developers.

### What's changed
tt-forge-sweeps included as submodule in third-party.
Pytest function test_query included to support running sweeps tests directly from tt-xla project.

### Checklist
- [ ] New/Existing tests provide coverage for changes
