### PR TITLE
Skip jax 1x4 alexnet in nightly CI

### DIFF
--- a/tests/runner/test_config/jax/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/jax/test_config_inference_tensor_parallel.yaml
@@ -14,7 +14,9 @@ test_config:
 
   alexnet/image_classification/jax-custom_1x4-tensor_parallel-full-inference:
     supported_archs: ["n300-llmbox"]
-    status: EXPECTED_PASSING
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_RUNTIME
+    reason: "Hangs in runtime - https://github.com/tenstorrent/tt-xla/issues/2440"
 
   alexnet/image_classification/jax-custom_1x8-tensor_parallel-full-inference:
     supported_archs: ["n300-llmbox"]


### PR DESCRIPTION
1x4 alexnet is haning in nightly CI, skipping for now.