### PR TITLE
Fix null pointer crash when TT_MLIR_HOME is not set

### DIFF
--- a/pjrt_implementation/src/api/module_builder/module_builder.cc
+++ b/pjrt_implementation/src/api/module_builder/module_builder.cc
@@ -98,6 +98,9 @@ TTAlchemistHandler::~TTAlchemistHandler() {
 
 std::optional<std::string> TTAlchemistHandler::findTTAlchemistLibraryPath() {
   const char *mlir_home = std::getenv("TT_MLIR_HOME");
+  if (mlir_home == nullptr) {
+    return std::nullopt;
+  }
 
   std::string alchemist_lib_path =
       std::string(mlir_home) + "/build/lib/libtt-alchemist-lib.so";


### PR DESCRIPTION
## Summary
- Add null check for `getenv("TT_MLIR_HOME")` before using it in string construction

## Problem
When `TT_MLIR_HOME` environment variable is not set, `std::getenv()` returns `nullptr`. The code was passing this null pointer directly to `std::string()` constructor, which causes undefined behavior and crashes with:

```
RuntimeError: basic_string: construction from null is not valid
```

This was causing the tt-xla perf benchmarks to fail during PJRT plugin initialization, as seen in:
- https://github.com/tenstorrent/tt-forge/actions/runs/19917338344/job/57099876584
- Related issue: https://github.com/tenstorrent/tt-forge/issues/721

## Fix
Add a null check that returns `std::nullopt` early if `TT_MLIR_HOME` is not set, which is the expected behavior since the function already returns `std::optional<std::string>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)