### PR TITLE
Xfail or skip nightly failures 05_12

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -139,7 +139,7 @@ test_config:
 
   falcon/pytorch-tiiuae/Falcon3-7B-Base-single_device-full-inference:
     supported_archs: ["p150"]
-    required_pcc: 0.97 # PCC dropped after uplift https://github.com/tenstorrent/tt-xla/issues/1789
+    required_pcc: 0.97 # PCC dropped after uplift https://github.com/tenstorrent/tt-xla/issues/2433
     status: EXPECTED_PASSING
 
   falcon/pytorch-tiiuae/Falcon3-10B-Base-single_device-full-inference:
@@ -586,11 +586,11 @@ test_config:
 
   phi2/token_classification/pytorch-microsoft/phi-2-single_device-full-inference:
     required_pcc: 0.98
-    status: EXPECTED_PASSING # p150 : https://github.com/tenstorrent/tt-xla/issues/2181 n150 : https://github.com/tenstorrent/tt-xla/issues/2442
+    status: EXPECTED_PASSING # p150 : https://github.com/tenstorrent/tt-xla/issues/2181 n150 : https://github.com/tenstorrent/tt-xla/issues/2433
 
   phi2/token_classification/pytorch-microsoft/phi-2-pytdml-single_device-full-inference:
     required_pcc: 0.98
-    status: EXPECTED_PASSING # p150 : https://github.com/tenstorrent/tt-xla/issues/2181 n150 : https://github.com/tenstorrent/tt-xla/issues/2442
+    status: EXPECTED_PASSING # p150 : https://github.com/tenstorrent/tt-xla/issues/2181 n150 : https://github.com/tenstorrent/tt-xla/issues/2433
 
   phi2/sequence_classification/pytorch-microsoft/phi-2-single_device-full-inference:
     status: EXPECTED_PASSING
@@ -947,7 +947,8 @@ test_config:
       p150:
         required_pcc: 0.97  # https://github.com/tenstorrent/tt-torch/issues/1192
       n150:
-        required_pcc: 0.98  # https://github.com/tenstorrent/tt-xla/issues/2433
+        status: KNOWN_FAILURE_XFAIL
+        reason: "Comparison result 0 failed: PCC comparison failed. Calculated: pcc=0.9755669236183167. Required: pcc=0.98. - https://github.com/tenstorrent/tt-xla/issues/2433"
 
   llama/causal_lm/pytorch-llama_3_2_1b-single_device-full-inference:
     status: EXPECTED_PASSING
@@ -2032,6 +2033,8 @@ test_config:
     reason: "Out of Memory: Not enough space to allocate 65536000 B L1 buffer across 64 banks, where each bank needs to store 1024000 B, but bank size is only 1364704 B, but bank size is only 1366016 B - https://github.com/tenstorrent/tt-xla/issues/1709"
     arch_overrides:
       p150:
+        status: NOT_SUPPORTED_SKIP
+        bringup_status: FAILED_RUNTIME
         reason: "Buffer must be allocated on device - https://github.com/tenstorrent/tt-xla/issues/2439"
 
   bevformer/pytorch-bevformerv2-r50-t1-single_device-full-inference:
@@ -2039,6 +2042,8 @@ test_config:
     reason: "Out of Memory: Not enough space to allocate 65536000 B L1 buffer across 64 banks, where each bank needs to store 1024000 B, but bank size is only 1364704 B, but bank size is only 1366016 B - https://github.com/tenstorrent/tt-xla/issues/1709"
     arch_overrides:
       p150:
+        status: NOT_SUPPORTED_SKIP
+        bringup_status: FAILED_RUNTIME
         reason: "Buffer must be allocated on device - https://github.com/tenstorrent/tt-xla/issues/2439"
 
   bevformer/pytorch-bevformerv2-r50-t2-single_device-full-inference:
@@ -2046,6 +2051,8 @@ test_config:
     reason: "Out of Memory: Not enough space to allocate 65536000 B L1 buffer across 64 banks, where each bank needs to store 1024000 B, but bank size is only 1364704 B, but bank size is only 1366016 B - https://github.com/tenstorrent/tt-xla/issues/1709"
     arch_overrides:
       p150:
+        status: NOT_SUPPORTED_SKIP
+        bringup_status: FAILED_RUNTIME
         reason: "Buffer must be allocated on device - https://github.com/tenstorrent/tt-xla/issues/2439"
 
   bevformer/pytorch-bevformerv2-r50-t8-single_device-full-inference:
@@ -2053,6 +2060,8 @@ test_config:
     reason: "Out of Memory: Not enough space to allocate 65536000 B L1 buffer across 64 banks, where each bank needs to store 1024000 B, but bank size is only 1364704 B, but bank size is only 1366016 B - https://github.com/tenstorrent/tt-xla/issues/1709"
     arch_overrides:
       p150:
+        status: NOT_SUPPORTED_SKIP
+        bringup_status: FAILED_RUNTIME
         reason: "Buffer must be allocated on device - https://github.com/tenstorrent/tt-xla/issues/2439"
 
   ssr/pytorch-single_device-full-inference:
@@ -2293,8 +2302,9 @@ test_config:
     reason: "failed to legalize operation 'ttir.gather' - https://github.com/tenstorrent/tt-xla/issues/318"
 
   ssdlite320_mobilenetv3/pytorch-ssdlite320_mobilenet_v3_large-single_device-full-inference:
-    status: KNOWN_FAILURE_XFAIL
-    reason: "RuntimeError: 'nms_kernel' not implemented for 'BFloat16' - https://github.com/tenstorrent/tt-xla/issues/1816"
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_FE_COMPILATION
+    reason: "Can't convert shape rank  - https://github.com/tenstorrent/tt-xla/issues/2456"
 
   retinanet/pytorch-retinanet_resnet50_fpn_v2-single_device-full-inference:
     status: KNOWN_FAILURE_XFAIL

--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -13,6 +13,7 @@ test_config:
   falcon/pytorch-tiiuae/Falcon3-10B-Base-tensor_parallel-full-inference:
     supported_archs: [n300-llmbox]
     status: EXPECTED_PASSING
+    required_pcc: 0.98 # https://github.com/tenstorrent/tt-xla/issues/2435
 
   falcon/pytorch-tiiuae/Falcon3-Mamba-7B-Base-tensor_parallel-full-inference:
     supported_archs: [n300-llmbox]


### PR DESCRIPTION
### Ticket
[Nightly](https://github.com/tenstorrent/tt-xla/actions/runs/19948408541/attempts/1)

### Problem description
Some of the tests are failing in nightly. They are xfailed or skipped according to the failures

### What's changed
Changes are made to the below models
* Bevformer vairants are skipped
* qwen_2_5 variant is xfailed
* sd_moblite model is skipped
* falcon tensor parallel model's pcc is lowered

