### PR TITLE
Add enable_permute_matmul_fusion compile option to compiler config

### DIFF
--- a/pjrt_implementation/inc/api/compile_options.h
+++ b/pjrt_implementation/inc/api/compile_options.h
@@ -82,7 +82,7 @@ struct CompileOptions {
   // When disabled, transpose is kept as a separate op which can be constevaled,
   // potentially improving performance. However, this may cause OOM errors on
   // some models until https://github.com/tenstorrent/tt-mlir/pull/6198 lands.
-  bool enable_permute_matmul_fusion = true;
+  bool experimental_enable_permute_matmul_fusion = true;
 
   // Enable collection of TTNN performance metrics during execution.
   bool ttnn_perf_metrics_enabled = false;

--- a/pjrt_implementation/src/api/compile_options.cc
+++ b/pjrt_implementation/src/api/compile_options.cc
@@ -43,9 +43,10 @@ CompileOptions CompileOptions::parse(
   options.enable_const_eval =
       internal::parseBoolOption(compile_options, "enable_const_eval")
           .value_or(true);
-  options.enable_permute_matmul_fusion =
-      internal::parseBoolOption(compile_options, "enable_permute_matmul_fusion")
-          .value_or(options.enable_permute_matmul_fusion);
+  options.experimental_enable_permute_matmul_fusion =
+      internal::parseBoolOption(compile_options,
+                                "experimental_enable_permute_matmul_fusion")
+          .value_or(options.experimental_enable_permute_matmul_fusion);
   options.ttnn_perf_metrics_enabled =
       internal::parseBoolOption(compile_options, "ttnn_perf_metrics_enabled")
           .value_or(false);

--- a/pjrt_implementation/src/api/module_builder/module_builder.cc
+++ b/pjrt_implementation/src/api/module_builder/module_builder.cc
@@ -829,7 +829,7 @@ tt_pjrt_status ModuleBuilder::convertFromTTIRToTTNN(
   options.enableFusingConv2dWithMultiplyPattern =
       compile_options.experimental_enable_fusing_conv2d_with_multiply_pattern;
   options.enablePermuteMatmulFusion =
-      compile_options.enable_permute_matmul_fusion;
+      compile_options.experimental_enable_permute_matmul_fusion;
   options.enableTrace = compile_options.enable_trace;
   options.systemDescPath = system_descriptor_path.data();
   options.enableConstEval = compile_options.enable_const_eval;

--- a/tests/infra/testers/compiler_config.py
+++ b/tests/infra/testers/compiler_config.py
@@ -48,7 +48,7 @@ class CompilerConfig:
     # When disabled, transpose is kept as a separate op which can be constevaled,
     # potentially improving performance. However, this may cause OOM errors on
     # some models until https://github.com/tenstorrent/tt-mlir/pull/6198 lands.
-    enable_permute_matmul_fusion: bool = True
+    experimental_enable_permute_matmul_fusion: bool = True
 
     # Enables trace hoisting for TTNN pipeline.
     enable_trace: bool = False
@@ -74,8 +74,8 @@ class CompilerConfig:
         if self.experimental_enable_fusing_conv2d_with_multiply_pattern:
             options["experimental_enable_fusing_conv2d_with_multiply_pattern"] = "true"
 
-        if not self.enable_permute_matmul_fusion:
-            options["enable_permute_matmul_fusion"] = "false"
+        if not self.experimental_enable_permute_matmul_fusion:
+            options["experimental_enable_permute_matmul_fusion"] = "false"
 
         if self.enable_trace:
             options["enable_trace"] = "true"


### PR DESCRIPTION
### Problem description
The tt-mlir compiler currently performs a default fusion of `transpose + matmul` and `transpose + linear` operations.
This fusion prevents the transpose operation from being const-evaluated, which hurts performance on LLMs.
We cannot disable this behavior by default (until this [PR](https://github.com/tenstorrent/tt-mlir/pull/6198) and this https://github.com/tenstorrent/tt-mlir/issues/3888 lands in tt-mlir) because some models encounter OOM errors.

### What's changed
- Introduced a temporary `enable_permute_matmul_fusion` flag that allows us to disable the fusion and improve performance.

### Checklist
- [ ] New/Existing tests provide coverage for changes
