### PR TITLE
Add PCC enable/threshold guidance to junit xml tags for model tests used downstream

### DIFF
--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -268,7 +268,24 @@ def _to_marshal_safe(value):
 def _derive_guidance_from_pcc(comparison_result, comparison_config) -> list[str]:
     """
     Derive guidance tags from PCC metrics and thresholds.
-    Guidance encodes suggestions such as enabling PCC or raising thresholds.
+
+    These tags are intended for visual aid today and may be used by future
+    automation to promote/demote tests (tighten/enable thresholds) in nightly CI.
+
+    Meanings:
+    - ENABLE_PCC: PCC check is currently disabled, but measured pcc is safely above
+      the current threshold + buffer → enable PCC at the current required threshold.
+    - ENABLE_PCC_099: Same as ENABLE_PCC, but when the current threshold is already
+      in the 0.99 regime (>= 0.99). Useful to call out the stricter default explicitly.
+    - RAISE_PCC: Current threshold < 0.99 and measured pcc exceeds the next
+      centesimal step (e.g., 0.97 → 0.98) by a small buffer → suggest raising to
+      that next step.
+    - RAISE_PCC_099: Current threshold < 0.99 and measured pcc exceeds 0.99 by a
+      small buffer → suggest raising directly to 0.99 (ie. the usual default).
+
+    Notes:
+    - A small buffer (PCC_BUFFER) is applied to avoid suggestions when values are
+      within noise of the boundary (e.g., 0.992 is too close to 0.99 to raise).
     """
     # Small buffer to avoid enabling/tightening thresholds when near boundary,
     # ie. 0.992 is too close to 0.99 to raise the threshold.


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/2484

### Problem description
- It is currently difficult to visually spot tests that can have pcc check enabled or pcc threshold raised
- Was locally having this logic to detect in scripts processing pcc from artifacts, but it is better to compute it at the source

### What's changed
 - Add logic to compute guidance tags for two specific cases (enabling pcc check, and raising pcc threshold) that can be prioritized for automatic updates.  It can be read from summarize_junit_xmls.py to start, next which is being added via https://github.com/tenstorrent/tt-xla/pull/2475, and soon will be the basis of automatic test promotion script/flow.

### Checklist
- [x] Tested locally in handful of cases, will include results in PR comments.
