### PR TITLE
Set tensor retain on output buffer instance constructor

### DIFF
--- a/pjrt_implementation/src/api/buffer_instance.cc
+++ b/pjrt_implementation/src/api/buffer_instance.cc
@@ -96,6 +96,10 @@ BufferInstance::BufferInstance(
   if (m_host_runtime_tensor.has_value()) {
     tt::runtime::setTensorRetain(*m_host_runtime_tensor, /*retain=*/true);
   }
+
+  if (m_prepared_runtime_tensor.has_value()) {
+    tt::runtime::setTensorRetain(*m_prepared_runtime_tensor, /*retain=*/true);
+  }
 }
 
 BufferInstance::~BufferInstance() { deleteData(); }

--- a/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
@@ -91,17 +91,6 @@ FlatbufferLoadedExecutableInstance::prepareInputTensor(
            "shape %s",
            arg_index, arg_buffers[0]->toShapeStr().c_str());
 
-    // This prepared tensor may be from a previous graph output aliased to
-    // input, so
-    //  we should set its retention flag to true.
-    if (tt::runtime::getTensorRetain(*prepared_tensor) == false) {
-      DLOG_F(LOG_DEBUG,
-             "Prepared tensor for argument index %zu with shape %s had "
-             "retain=false; setting "
-             "to true to avoid deallocation during execution.",
-             arg_index, arg_buffers[0]->toShapeStr().c_str());
-    }
-    tt::runtime::setTensorRetain(*prepared_tensor, /*retain=*/true);
     return *prepared_tensor;
   }
 


### PR DESCRIPTION

### Ticket
Partial resolution to #2383, as alternative to worse solution in #2389 

### Problem description
Previously in #1657, output BufferInstances had tensor retain set lazily at execution if output is reused as input. This is not necessary, and introduces a duplicate complexity in the loadedExecutableInstance classes that should really belong in BufferInstance implementation.

### What's changed
In the case where a bufferInstance is constructed with an live device tensor, set retain=True inside the constructor rather than lazily doing so at execution time.

### Checklist
- [x] New/Existing tests provide coverage for changes
