### PR TITLE
Add force-overwrite manual dispatch protection to nightly uplift

### DIFF
--- a/.github/workflows/schedule-uplift.yml
+++ b/.github/workflows/schedule-uplift.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:  # Manual trigger
     inputs:
       force-overwrite:
-        description: 'Proceed even if an existing uplift PR with multiple commits exists'
+        description: 'Proceed to force overwrite existing uplift branch PR if one exists.'
         type: boolean
         default: false
 


### PR DESCRIPTION
### Ticket
None 

### Problem description
Nightly uplift workflow has no protection against overwriting other's work in a live uplift branch. 

### What's changed
Disallow manual dispatch of uplift to overwrite an existing uplift PR, unless force-overwrite checkbox is set.

### Checklist
- [x] Example aborted run: https://github.com/tenstorrent/tt-xla/actions/runs/20042448083/job/57479772984