### PR TITLE
[CI] Fix docker build to n/a mlir sha

### DIFF
--- a/.github/build-docker-images.sh
+++ b/.github/build-docker-images.sh
@@ -30,13 +30,14 @@ else
     exit 1
 fi
 
-if [ "$CHECK_ONLY" = false ]; then
-    echo "Ensure tt-mlir docker images with tag: $MLIR_DOCKER_TAG exist"
-    if ! ./.github/build-docker-images.sh ci --check-only; then
+echo "Ensure tt-mlir docker images with tag: $MLIR_DOCKER_TAG exist"
+if ! ./.github/build-docker-images.sh ci --check-only; then
+    if [ "$CHECK_ONLY" = false ]; then
         echo -e "\033[31mDocker image does not exist.\033[0m"
         echo -e "\033[31mYou should build tt-mlir docker image for sha $tt_mlir_sha first, and then rerun the tt-xla workflow.\033[0m"
         exit 9
     fi
+    echo -e "\033[31mtt-mlir docker image does not exist (check-only mode)\033[0m"
 fi
 
 cd $cwd


### PR DESCRIPTION
### Ticket
slack

### Problem description
If mlir sha is set to commit in mlir where docker is changed and never built, docker build fails.

### What's changed
Print the right error message if build is not possible.

### Checklist
- [ ] New/Existing tests provide coverage for changes
