### PR TITLE
Sync only what's strictly necessary in codegen utility functions

### DIFF
--- a/python_package/tt_torch/codegen.py
+++ b/python_package/tt_torch/codegen.py
@@ -39,7 +39,7 @@ def codegen_py(
     args = [arg.to(device) for arg in args if isinstance(arg, torch.Tensor)]
     kwargs = {k: v.to(device) for k, v in kwargs.items() if isinstance(v, torch.Tensor)}
     output = model(*args, **kwargs)
-    torch_xla.sync(wait=True)
+    torch_xla._XLAC._xla_sync_multi(list(output), [], wait=True)
     return None
 
 
@@ -64,5 +64,5 @@ def codegen_cpp(
     args = [arg.to(device) for arg in args if isinstance(arg, torch.Tensor)]
     kwargs = {k: v.to(device) for k, v in kwargs.items() if isinstance(v, torch.Tensor)}
     output = model(*args, **kwargs)
-    torch_xla.sync(wait=True)
+    torch_xla._XLAC._xla_sync_multi(list(output), [], wait=True)
     return None


### PR DESCRIPTION
### Ticket
Caused problems in #2417 #2434 (does not close), also got offline reports

### Problem description
Calling codegen utility functions could invoke compile-run flow twice, causing the needed code to get overwritten. This happened because of an (indiscriminate) sync in the helper functions.

### What's changed
Only sync on the output of the compiled function. This avoids triggering anything related to gradients, therefore avoiding any extra runs and overwriting.

### Checklist
- [ ] New/Existing tests provide coverage for changes
