### PR TITLE
Use integer type in gather op test

### DIFF
--- a/tests/jax/single_chip/ops/test_gather.py
+++ b/tests/jax/single_chip/ops/test_gather.py
@@ -65,5 +65,5 @@ def test_gather(data_shape, indices_shape, offset_dims, start_index_map, slice_s
         input_shapes=[data_shape, indices_shape],
         minval=0,
         maxval=jnp.min(indexing_dim_sizes),
-        dtype=jnp.int32
+        dtype=jnp.int32,
     )


### PR DESCRIPTION
### Ticket

https://github.com/tenstorrent/tt-mlir/issues/6217

### Problem description

In the gather op test, PCC comparison fails due to a loss in precision during float <-> int conversion.

### What's changed

This test now initializes input tensors with integers.

### Checklist

- [x] New/Existing tests provide coverage for changes
