### PR TITLE
Demote new "Function name mismatch" error to warning in metadata_propagation.py, fixes 32 tests

### DIFF
--- a/python_package/tt_torch/backend/metadata_propagation.py
+++ b/python_package/tt_torch/backend/metadata_propagation.py
@@ -225,9 +225,13 @@ def _extract_source_and_module_hierarchy_info(
     # If the function names don't match, raise an error
     if func_name != found_func_name:
         DBG_LOC and print(f"  function name mismatch: {func_name}, {found_func_name}")
-        raise ValueError(
-            f"Function name mismatch between stack_trace and found_func_name modes\nstack_trace: {func_name}\nfound_func_name: {found_func_name}\nfound_func_name_ast: {found_func_name_ast}"
+        logger.warning(
+            "Function name mismatch between stack_trace and found_func_name modes\n"
+            f"stack_trace: {func_name}\n"
+            f"found_func_name: {found_func_name}\n"
+            f"found_func_name_ast: {found_func_name_ast}"
         )
+        return EmitLoc.make_unknown()
 
     # If the function paths don't match, raise an error
     if func_path != func_path_ast:


### PR DESCRIPTION
### Ticket
#2518 

### Problem description
- A new error was added in metadata_propagation.py today which fires for 32 models in nightly, found today by folks running tests on branch to prepare to merge some large changes (transformers uplift) we want to get in

### What's changed
- As quick workaround to restore passing nightly, demote the new error to a warning, like warnings nearby in code
- Leaving issue opened for author to look at in more detail tomorrow after offline chat

### Checklist
- [x] Tested locally for few tests, back to passing as expected
