### PR TITLE
[vLLM plugin] Minor fixes for batch-1 input preparation

### DIFF
--- a/tests/integrations/vllm_plugin/pooling/test_qwen3_embedding.py
+++ b/tests/integrations/vllm_plugin/pooling/test_qwen3_embedding.py
@@ -24,7 +24,8 @@ import vllm
         ),
     ],
 )
-def test_embed_qwen3(model_name: str, baseline_path: str):
+@pytest.mark.parametrize("min_context_len", [32, 64])
+def test_embed_qwen3(model_name: str, baseline_path: str, min_context_len: int):
     """
     Test the Qwen3-Embedding models embedding outputs for correctness
     under different batching and padding scenarios.
@@ -66,6 +67,9 @@ def test_embed_qwen3(model_name: str, baseline_path: str):
         "disable_sliding_window": True,
         "max_num_batched_tokens": 64,
         "max_num_seqs": 2,
+        "additional_config": {
+            "min_context_len": min_context_len,
+        },
     }
     model = vllm.LLM(**llm_args)
 


### PR DESCRIPTION
### Ticket
closes #2520 

### Problem description
vLLM engine crashes if `sum of(seq_len)` > `padded input length` during attention mask creation for `{batch_size=1, max_num_reqs>1}` configuration.

### What's changed
- Zero out both input_ids and positions for padded regions.
- Use number of request to slice seq_len

### Checklist
- [X] New/Existing tests provide coverage for changes
