### PR TITLE
[CI] Make more compact nightly experimental notification

### DIFF
--- a/.github/workflows/schedule-nightly-experimental.yml
+++ b/.github/workflows/schedule-nightly-experimental.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           payload: |
             {
-              "text": "<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}>",
+              "text": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}",
               "result": "${{ needs.fail-notify.outputs.failed == 'true' && 'FAILED' || 'SUCCEEDED' }}",
               "channel": "C08GYB57C8M",
               "unfurl_links": false, "unfurl_media": false


### PR DESCRIPTION
### Ticket
slack

### Problem description
Notification for failed experimental nightly is clunky because  of link preview.

### What's changed
Made it more compact with button link to workflow run.

### Checklist
- [ ] New/Existing tests provide coverage for changes
