### PR TITLE
[vLLM plugin] Move InputBatch execution to CPU backend

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -327,7 +327,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             max_num_reqs=self.max_num_reqs,
             max_model_len=self.max_model_len,
             max_num_batched_tokens=self.max_num_tokens,
-            device=self.device,
+            device="cpu",
             pin_memory=self.pin_memory,
             vocab_size=self.model_config.get_vocab_size(),
             block_sizes=[self.block_size],
@@ -1756,7 +1756,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 max_num_reqs=self.max_num_reqs,
                 max_model_len=self.max_model_len,
                 max_num_batched_tokens=self.max_num_tokens,
-                device=self.device,
+                device="cpu",
                 pin_memory=self.pin_memory,
                 vocab_size=self.model_config.get_vocab_size(),
                 block_sizes=[


### PR DESCRIPTION
### Ticket
closes #2547 

### Problem description
InputBatch graphs are not sharded and executing them on device leads to crashes under parallel execution. There is no need to execute them on device. 

### What's changed
Move InputBatch execution to CPU backend.