### PR TITLE
SDXL Adding default optimization level to 1

### DIFF
--- a/examples/pytorch/sdxl-pipeline.py
+++ b/examples/pytorch/sdxl-pipeline.py
@@ -323,7 +323,9 @@ if __name__ == "__main__":
 
     xr.set_device_type("TT")
 
-    torch_xla.set_custom_compile_options({"optimization_level": args.optimization_level})
+    torch_xla.set_custom_compile_options(
+        {"optimization_level": args.optimization_level}
+    )
     # only 512x512 is supported for now
     config = SDXLConfig(width=512, height=512, device="cpu")
     pipeline = SDXLPipeline(config=config)


### PR DESCRIPTION
### Problem description
With this PR in tt-mlir https://github.com/tenstorrent/tt-mlir/pull/6138, enabling optimizer for SDXL pipeline now works. Therefore, I'm adding a command line argument, and enabling it by default.

### Performance gains

E2E warm inference time:
**Before**: 113.0s
**After**: 59.9s

### Next steps
1. Adding SDXL UNet to the perf tests to avoid manual measurements, currently working on this with @odjuricicTT @rpavlovicTT 
2. Placing text encoders on device while optimizer is active, currently failing 

