### PR TITLE
e2e perf file naming bug fix

### DIFF
--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -581,8 +581,10 @@ def create_benchmark_result(
         os.makedirs(output_dir, exist_ok=True)
         # add model name and perf id (Job ID from CI) to the filename
         # Sanitize model name to avoid path separator issues
-        safe_model_name = full_model_name.replace("/", "_")
-        output_path = output_dir + f"/report_perf_{safe_model_name}_{perf_id}.json"
+        safe_model_name = full_model_name.replace("/", "_").replace("\\", "_")
+        output_path = os.path.join(
+            output_dir, f"report_perf_{safe_model_name}_{perf_id}.json"
+        )
         with open(output_path, "w") as file:
             json.dump(benchmark_results, file, indent=2)
             print(f"Benchmark results saved to {output_path}")


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/2578

### Problem description
The `create_benchmark_result` function was failing with a FileNotFoundError when generating benchmark reports for models with names containing forward slashes (e.g., google/gemma-2-9b-it).
The forward slash in the model name was being interpreted as a directory separator in the output file path, causing the OS to look for a non-existent subdirectory.

### What's changed
- Sanitized the full_model_name by replacing path separator characters with underscores before using it in the output filename
- Used os.path.join() for path construction instead of string concatenation

### Checklist
- [ ] New/Existing tests provide coverage for changes
