### PR TITLE
Fix trigger for extended model tests on uplift PR

### DIFF
--- a/.github/actions/inspect-changes/action.yml
+++ b/.github/actions/inspect-changes/action.yml
@@ -99,7 +99,13 @@ runs:
           # Detect TT-MLIR dependency updates in PRs.
           if echo "$CHANGED_FILES" | grep -q "^third_party/CMakeLists.txt$"; then
             TT_MLIR_DIFF=$(gh pr diff ${{ github.event.pull_request.number }} --repo ${{ github.repository }} || true)
-            if echo "$TT_MLIR_DIFF" | grep -qE '^[+-][[:space:]]*set\(TT_MLIR_VERSION'; then
+
+            CMAKE_FILE_DIFF=$(
+              echo "$TT_MLIR_DIFF" |
+              sed -n '/^diff --git a\/third_party\/CMakeLists\.txt/,/^diff --git /p'
+            )
+
+            if echo "$CMAKE_FILE_DIFF" | grep -qE '^[+-][[:space:]]*set\(TT_MLIR_VERSION'; then
               echo "Detected TT_MLIR_VERSION change in PR diff."
               tt_mlir_version_changed=true
             fi


### PR DESCRIPTION
### Ticket
/

### Problem description
Test suite `test_models_on_uplift` doesn't get triggered on tt-mlir uplift PRs.

### What's changed
Fix the `gh pr diff` command by removing the file specifier which doesn't actually work.
Refactor logic to: get the entire PR diff -> get the diff for third_party/CMakeLists.txt -> get the tt-mlir version change.

### Checklist
- [ ] New/Existing tests provide coverage for changes
