### PR TITLE
Set TORCH_HOME for persisting torch hub files

### DIFF
--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -286,6 +286,7 @@ jobs:
       timeout-minutes: ${{ fromJson(steps.collect-tests.outputs.timeout-minutes) }}
       env:
         HF_HOME: /mnt/dockercache/huggingface
+        TORCH_HOME: /mnt/dockercache/torchhub
         GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         HF_TOKEN: ${{ secrets.HF_TOKEN }}
         ENABLE_BRINGUP_STAGE_LOGGING: 1


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-forge/issues/727

### Problem description
Torch hub files not getting cached.

### What's changed
Set TORCH_HOME for persisting torch hub files

### Checklist
- [ ] New/Existing tests provide coverage for changes
