### PR TITLE
[Composite OPs] Refactor tests under composite ops

### DIFF
--- a/tests/torch/ops/test_composite_ops.py
+++ b/tests/torch/ops/test_composite_ops.py
@@ -84,7 +84,7 @@ def test_patched_rms_norm_functional_single_device(
             self.normalized_shape = normalized_shape
 
         def forward(self, x, weight):
-            return torch.nn.functional.rms_norm(x, self.normalized_shape, weight)
+            return torch.nn.functional.rms_norm(x, (self.normalized_shape,), weight)
 
     options = {"tt_enable_composite_ops": True}
 
@@ -116,7 +116,7 @@ def test_patched_rms_norm_functional_batch_parallel(
             self.normalized_shape = normalized_shape
 
         def forward(self, x, weight):
-            return torch.nn.functional.rms_norm(x, self.normalized_shape, weight)
+            return torch.nn.functional.rms_norm(x, (self.normalized_shape,), weight)
 
     options = {"tt_enable_composite_ops": True}
 


### PR DESCRIPTION
### Ticket
No issue

### Problem description
Unify way tests are written inside `test_composite_ops`

### What's changed
Rewrite tests to use `run_graph_test`
