### PR TITLE
Add test case and infra for supporting priority to sharding

### DIFF
--- a/tests/filecheck/sharding_conflict_priority.ttir.mlir
+++ b/tests/filecheck/sharding_conflict_priority.ttir.mlir
@@ -1,0 +1,3 @@
+//CHECK: "ttir.all_gather"
+//CHECK: "ttir.gather"
+//CHECK: "ttir.all_to_all"


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/2463#issuecomment-3665964705

### Problem description
When sharding conflict is anticipating, there is no way for user to choose which dimension should be propagated, and let the Shardy make decision.

### What's changed
It introduces user defined sharding priority when it expect to be conflicted.
It already supports from torch-xla and tt-mlir.

### Checklist
- [ ] New/Existing tests provide coverage for changes
