### PR TITLE
Skip Long Running Training Test

### DIFF
--- a/tests/runner/test_config/torch/test_config_training_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_training_single_device.yaml
@@ -990,7 +990,9 @@ test_config:
   segformer/pytorch-mit_b1-single_device-full-training:
     status: KNOWN_FAILURE_XFAIL
   segformer/pytorch-mit_b2-single_device-full-training:
-    status: KNOWN_FAILURE_XFAIL
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_RUNTIME
+    reason: "RuntimeError: Test Hangs (Runs for 3 hours)"
   segformer/pytorch-mit_b3-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_RUNTIME


### PR DESCRIPTION
### Ticket
N/A

### Problem description
We have a test that is running for 3 hours for a single forward + backward pass. This is from the family of segformers where we already skipped tests, so we need to fix this. Link to the job: https://github.com/tenstorrent/tt-xla/actions/runs/20391513033/job/58601367371

### What's changed
Skipping the test for now until we figure out what the problem with the model is.