### PR TITLE
Add Weekly Training to Manual Update Durations Workflow

### DIFF
--- a/tests/runner/test_config/torch/test_config_training_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_training_single_device.yaml
@@ -990,9 +990,7 @@ test_config:
   segformer/pytorch-mit_b1-single_device-full-training:
     status: KNOWN_FAILURE_XFAIL
   segformer/pytorch-mit_b2-single_device-full-training:
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "RuntimeError: Test Hangs (Runs for 3 hours)"
+    status: KNOWN_FAILURE_XFAIL
   segformer/pytorch-mit_b3-single_device-full-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_RUNTIME


### PR DESCRIPTION
### Ticket
N/A

### Problem description
While refactoring tests in https://github.com/tenstorrent/tt-xla/pull/2540 we did not add capability to run manual update durations for weekly training.

### What's changed
This PR adds weekly training to `manual-update-duraitons` workflow and fixes some small issues in comments.

### Checklist
- [ ] New/Existing tests provide coverage for changes
