### PR TITLE
Fixing serialization of torch op tests

### DIFF
--- a/tests/infra/testers/single_chip/op/op_tester.py
+++ b/tests/infra/testers/single_chip/op/op_tester.py
@@ -153,6 +153,7 @@ class OpTester(BaseTester):
             compiler_options = self._compiler_config.to_jax_compiler_options()
         elif self._framework == Framework.TORCH:
             compiler_options = self._compiler_config.to_torch_compile_options()
+            self._compile_for_tt_device(workload)
         else:
             compiler_options = None
 

--- a/tests/torch/ops/test_add.py
+++ b/tests/torch/ops/test_add.py
@@ -51,12 +51,12 @@ def test_add(x_shape: tuple, y_shape: tuple, format: str, request):
         compiler_config=compiler_config,
         framework=Framework.TORCH,
     )
-    # if request.config.getoption("--serialize", default=False):
-    #     serialize_op_with_random_inputs(
-    #         add,
-    #         [x_shape, y_shape],
-    #         test_name=request.node.name,
-    #         dtype=dtype,
-    #         compiler_config=compiler_config,
-    #         framework=Framework.TORCH,
-    #     )
+    if request.config.getoption("--serialize", default=False):
+        serialize_op_with_random_inputs(
+            add,
+            [x_shape, y_shape],
+            test_name=request.node.name,
+            dtype=dtype,
+            compiler_config=compiler_config,
+            framework=Framework.TORCH,
+        )


### PR DESCRIPTION
The `--serialize` options was not working for torch ops, since it was missing compilaiton on tt device, necessary to create the needed cache for this. Fixing this issue.