### PR TITLE
Torch accelerator fix

### DIFF
--- a/tests/infra/testers/single_chip/model/torch_model_tester.py
+++ b/tests/infra/testers/single_chip/model/torch_model_tester.py
@@ -36,7 +36,7 @@ def _mask_jax_accelerator():
         try:
             acc = torch.accelerator.current_accelerator()
             # current_accelerator() returns device(type='jax'), need to check .type
-            if acc.type == "jax":
+            if acc and acc.type == "jax":
                 return False
         except RuntimeError:
             pass


### PR DESCRIPTION
A set of tests in issue (https://github.com/tenstorrent/tt-xla/issues/2653) were failing due to `torch.accelerator` not being registered, therefore `acc` in test infra having NoneType. This PR fixes that.