### PR TITLE
Adding more runners to data_parallel weekly tests

### DIFF
--- a/.github/workflows/test-matrix-presets/model-test-passing-weekly.json
+++ b/.github/workflows/test-matrix-presets/model-test-passing-weekly.json
@@ -8,6 +8,6 @@
   { "runs-on": "n150", "name": "run_forge_models_jax", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "n150 and training and weekly and expected_passing and not large", "parallel-groups": 1 },
   { "runs-on": "p150", "name": "run_forge_models_jax", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "p150 and training and weekly and expected_passing and not large", "parallel-groups": 1 },
   { "runs-on": "n300-llmbox", "name": "run_forge_models_multichip_torch", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "n300-llmbox and weekly and tensor_parallel and expected_passing and not tp_2x4_mesh", "parallel-groups": 1 },
-  { "runs-on": "n300", "name": "run_forge_models_multichip_torch", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "n300 and weekly and data_parallel and expected_passing", "parallel-groups": 1 },
+  { "runs-on": "n300", "name": "run_forge_models_multichip_torch", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "n300 and weekly and data_parallel and expected_passing", "parallel-groups": 5 },
   { "runs-on": "n300-llmbox", "name": "run_forge_models_multichip_jax", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "n300-llmbox and weekly and tensor_parallel and expected_passing", "parallel-groups": 1 }
 ]


### PR DESCRIPTION
As the current excepted passing weekly tests had only one runner, the workflow was taking a long time. Adding 4 more.