### PR TITLE
Uplift third_party/tt-mlir to b0184d45b48306a95d971ae3662f38ba0a3db67a 2025-12-25

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -5,7 +5,7 @@
 option(USE_CUSTOM_TT_MLIR_VERSION "Flag to use TT_MLIR_VERSION set by the user" OFF)
 
 if (NOT DEFINED TT_MLIR_VERSION OR NOT USE_CUSTOM_TT_MLIR_VERSION)
-    set(TT_MLIR_VERSION "175c33bd68bde8c7090fbb83a5b93d6763b06083")
+    set(TT_MLIR_VERSION "b0184d45b48306a95d971ae3662f38ba0a3db67a")
 endif()
 
 set(PROTOBUF_VERSION "v21.12") # same version as tt-metal uses


### PR DESCRIPTION
This PR uplifts the third_party/tt-mlir to the b0184d45b48306a95d971ae3662f38ba0a3db67a