### PR TITLE
Uplift PJRT C API header from 0.68 to 0.88

### DIFF
--- a/third_party/pjrt_c_api/xla/pjrt/c/pjrt_c_api.h
+++ b/third_party/pjrt_c_api/xla/pjrt/c/pjrt_c_api.h
@@ -1,11 +1,3 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
-//
-// SPDX-License-Identifier: Apache-2.0
-//
-// This file incorporates work covered by the following copyright and permission
-// notice: SPDX-FileCopyrightText: Copyright 2022 The OpenXLA Authors
-// SPDX-License-Identifier: Apache-2.0
-
 /* Copyright 2022 The OpenXLA Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,6 +16,7 @@ limitations under the License.
 #ifndef XLA_PJRT_C_PJRT_C_API_H_
 #define XLA_PJRT_C_PJRT_C_API_H_
 
+#include <assert.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -31,14 +24,27 @@ limitations under the License.
 // Read more on C API ABI versioning and compatibility here:
 // https://docs.google.com/document/d/1TKB5NyGtdzrpgw5mpyFjVAhJjpSNdF31T6pjPl_UT2o/edit?usp=sharing
 
-#define PJRT_STRUCT_SIZE(struct_type, last_field)                              \
-  offsetof(struct_type, last_field) + sizeof(((struct_type *)0)->last_field)
+#define PJRT_STRUCT_SIZE(struct_type, last_field) \
+  offsetof(struct_type, last_field) + sizeof(((struct_type*)0)->last_field)
+
+#ifdef __cplusplus
+#define PJRT_CHECK_STRUCT_SIZE(sname, last_field)                       \
+  static_assert(                                                        \
+      sizeof(struct sname) ==                                           \
+          ((PJRT_STRUCT_SIZE(sname, last_field) + alignof(sname) - 1) / \
+           alignof(sname)) *                                            \
+              alignof(sname),                                           \
+      "Failed to update last_field");
+#else
+#define PJRT_CHECK_STRUCT_SIZE(sname, last_field)
+#endif
 
 // Must update PJRT_DEFINE_STRUCT_TRAITS with the new `last_field` after
 // adding a new member to a struct.
-#define PJRT_DEFINE_STRUCT_TRAITS(sname, last_field)                           \
-  typedef struct sname sname;                                                  \
-  enum { sname##_STRUCT_SIZE = PJRT_STRUCT_SIZE(sname, last_field) }
+#define PJRT_DEFINE_STRUCT_TRAITS(sname, last_field)                  \
+  typedef struct sname sname;                                         \
+  enum { sname##_STRUCT_SIZE = PJRT_STRUCT_SIZE(sname, last_field) }; \
+  PJRT_CHECK_STRUCT_SIZE(sname, last_field)
 
 #ifdef __cplusplus
 extern "C" {
@@ -55,7 +61,15 @@ typedef enum {
   PJRT_Extension_Type_FFI,
   PJRT_Extension_Type_MemoryDescriptions,
   PJRT_Extension_Type_Triton,
-  PJRT_Extension_Type_RawBuffer, // Experimental.
+  PJRT_Extension_Type_RawBuffer,     // Experimental.
+  PJRT_Extension_Type_PhaseCompile,  // Experimental.
+  PJRT_Extension_Type_Example,
+  PJRT_Extension_Type_Unknown,
+  PJRT_Extension_Type_CrossHostTransfers,
+  PJRT_Extension_Type_ExecutableMetadata,
+  PJRT_Extension_Type_Callback,
+  PJRT_Extension_Type_HostAllocator,  // Experimental.
+  PJRT_Extension_Type_TpuTopology,
 } PJRT_Extension_Type;
 
 // PJRT_Extension_Base contains a type and a pointer to next
@@ -64,7 +78,7 @@ typedef enum {
 typedef struct PJRT_Extension_Base {
   size_t struct_size;
   PJRT_Extension_Type type;
-  struct PJRT_Extension_Base *next;
+  struct PJRT_Extension_Base* next;
 } PJRT_Extension_Base;
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Extension_Base, next);
 
@@ -90,16 +104,16 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_Extension_Base, next);
 // Changes include:
 // * Adding a new field to the PJRT_Api or argument structs
 // * Renaming a method or argument (doesn't affect ABI)
-#define PJRT_API_MINOR 68
+#define PJRT_API_MINOR 88
 
 // The plugin should set the major_version and minor_version of
 // PJRT_Api.pjrt_api_version to be the `PJRT_API_MAJOR` and `PJRT_API_MINOR` in
 // this header that the implementation was compiled with.
 struct PJRT_Api_Version {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  int major_version; // out
-  int minor_version; // out
+  PJRT_Extension_Base* extension_start;
+  int major_version;  // out
+  int minor_version;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Api_Version, minor_version);
 
@@ -114,30 +128,31 @@ typedef struct PJRT_Error PJRT_Error;
 
 struct PJRT_Error_Destroy_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Error *error;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Error* error;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Error_Destroy_Args, error);
 
 // Frees `error`. `error` can be nullptr.
-typedef void PJRT_Error_Destroy(PJRT_Error_Destroy_Args *args);
+typedef void PJRT_Error_Destroy(PJRT_Error_Destroy_Args* args);
 
 struct PJRT_Error_Message_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  const PJRT_Error *error;
+  PJRT_Extension_Base* extension_start;
+  const PJRT_Error* error;
   // Has the lifetime of `error`.
-  const char *message; // out
-  size_t message_size; // out
+  const char* message;  // out
+  size_t message_size;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Error_Message_Args, message_size);
 
 // Gets the human-readable reason for `error`. `message` has the lifetime of
 // `error`.
-typedef void PJRT_Error_Message(PJRT_Error_Message_Args *args);
+typedef void PJRT_Error_Message(PJRT_Error_Message_Args* args);
 
 // Codes are based on https://abseil.io/docs/cpp/guides/status-codes
 typedef enum {
+  PJRT_Error_Code_OK = 0,
   PJRT_Error_Code_CANCELLED = 1,
   PJRT_Error_Code_UNKNOWN = 2,
   PJRT_Error_Code_INVALID_ARGUMENT = 3,
@@ -158,21 +173,21 @@ typedef enum {
 
 struct PJRT_Error_GetCode_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  const PJRT_Error *error;
-  PJRT_Error_Code code; // out
+  PJRT_Extension_Base* extension_start;
+  const PJRT_Error* error;
+  PJRT_Error_Code code;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Error_GetCode_Args, code);
 
-typedef PJRT_Error *PJRT_Error_GetCode(PJRT_Error_GetCode_Args *args);
+typedef PJRT_Error* PJRT_Error_GetCode(PJRT_Error_GetCode_Args* args);
 
 // Function for PJRT implementation to pass to callback functions provided by
 // caller so the callback can create a PJRT_Error* on error (to return to the
 // implementation). `message` is only required to live for the
 // PJRT_CallbackError call, i.e. the PJRT_CallbackError implementation must copy
 // `message` into the PJRT_Error.
-typedef PJRT_Error *(*PJRT_CallbackError)(PJRT_Error_Code code,
-                                          const char *message,
+typedef PJRT_Error* (*PJRT_CallbackError)(PJRT_Error_Code code,
+                                          const char* message,
                                           size_t message_size);
 
 // ---------------------------- Named Values -----------------------------------
@@ -188,14 +203,14 @@ typedef enum {
 // Named value for key-value pairs.
 struct PJRT_NamedValue {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  const char *name;
+  PJRT_Extension_Base* extension_start;
+  const char* name;
   size_t name_size;
   PJRT_NamedValue_Type type;
   union {
-    const char *string_value;
+    const char* string_value;
     int64_t int64_value;
-    const int64_t *int64_array_value;
+    const int64_t* int64_array_value;
     float float_value;
     bool bool_value;
   };
@@ -209,26 +224,26 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_NamedValue, value_size);
 
 struct PJRT_Plugin_Initialize_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
+  PJRT_Extension_Base* extension_start;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Plugin_Initialize_Args, extension_start);
 
 // One-time plugin setup. Must be called before any other functions are called.
-typedef PJRT_Error *PJRT_Plugin_Initialize(PJRT_Plugin_Initialize_Args *args);
+typedef PJRT_Error* PJRT_Plugin_Initialize(PJRT_Plugin_Initialize_Args* args);
 
 struct PJRT_Plugin_Attributes_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
+  PJRT_Extension_Base* extension_start;
   // Returned attributes have the lifetime of the process.
-  const PJRT_NamedValue *attributes; // out
-  size_t num_attributes;             // out
+  const PJRT_NamedValue* attributes;  // out
+  size_t num_attributes;              // out
 };
-PJRT_DEFINE_STRUCT_TRAITS(PJRT_Plugin_Attributes_Args, attributes);
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_Plugin_Attributes_Args, num_attributes);
 
 // Returns an array of plugin attributes which are key-value pairs. Common keys
 // include `xla_version`, `stablehlo_current_version`, and
 // `stablehlo_minimum_version`.
-typedef PJRT_Error *PJRT_Plugin_Attributes(PJRT_Plugin_Attributes_Args *args);
+typedef PJRT_Error* PJRT_Plugin_Attributes(PJRT_Plugin_Attributes_Args* args);
 
 // ---------------------------------- Events -----------------------------------
 
@@ -242,30 +257,30 @@ typedef struct PJRT_Event PJRT_Event;
 
 struct PJRT_Event_Destroy_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Event *event;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Event* event;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Event_Destroy_Args, event);
 
 // Frees `event`. `event` can be `nullptr`.
-typedef PJRT_Error *PJRT_Event_Destroy(PJRT_Event_Destroy_Args *args);
+typedef PJRT_Error* PJRT_Event_Destroy(PJRT_Event_Destroy_Args* args);
 
 struct PJRT_Event_IsReady_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Event *event;
-  bool is_ready; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_Event* event;
+  bool is_ready;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Event_IsReady_Args, is_ready);
 
 // Returns true if this PJRT_Event has completed, including if an error has
 // occurred.
-typedef PJRT_Error *PJRT_Event_IsReady(PJRT_Event_IsReady_Args *args);
+typedef PJRT_Error* PJRT_Event_IsReady(PJRT_Event_IsReady_Args* args);
 
 struct PJRT_Event_Error_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Event *event;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Event* event;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Event_Error_Args, event);
 
@@ -278,40 +293,40 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_Event_Error_Args, event);
 // `PJRT_Event_Error`. However, each of these `PJRT_Error *` pointers are
 // independent of `PJRT_Error *`s returned by other function calls, so they must
 // each be freed separately using `PJRT_Error_Destroy`.
-typedef PJRT_Error *PJRT_Event_Error(PJRT_Event_Error_Args *args);
+typedef PJRT_Error* PJRT_Event_Error(PJRT_Event_Error_Args* args);
 
 struct PJRT_Event_Await_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Event *event;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Event* event;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Event_Await_Args, event);
 
 // Blocks the calling thread until `event` is ready, then returns the error
 // status (with `nullptr` indicating no error). The returned status should be
 // freed with `PJRT_Error_Destroy`.
-typedef PJRT_Error *PJRT_Event_Await(PJRT_Event_Await_Args *args);
+typedef PJRT_Error* PJRT_Event_Await(PJRT_Event_Await_Args* args);
 
 // A callback to be performed once an event is ready. It will be called on the
 // event's error state and a pointer to an object of the caller's choice.
 // Ownership of `error` is passed to the callback. The callback must destroy
 // `error` via `PJRT_Error_Destroy`. The caller retains ownership of `user_arg`.
-typedef void (*PJRT_Event_OnReadyCallback)(PJRT_Error *error, void *user_arg);
+typedef void (*PJRT_Event_OnReadyCallback)(PJRT_Error* error, void* user_arg);
 
 struct PJRT_Event_OnReady_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Event *event;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Event* event;
   PJRT_Event_OnReadyCallback callback;
   // `user_arg` allows `callback` to be called with arbitrary arguments (e.g.
   // via pointers in a struct cast to void*).
-  void *user_arg;
+  void* user_arg;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Event_OnReady_Args, user_arg);
 
 // Registers `callback` to be called once `event` is ready, with `event`'s
 // error status and a pointer to an object of the caller's choice as arguments.
-typedef PJRT_Error *PJRT_Event_OnReady(PJRT_Event_OnReady_Args *args);
+typedef PJRT_Error* PJRT_Event_OnReady(PJRT_Event_OnReady_Args* args);
 
 // ---------------------------------- Client -----------------------------------
 
@@ -324,31 +339,33 @@ typedef struct PJRT_TopologyDescription PJRT_TopologyDescription;
 typedef struct PJRT_Executable PJRT_Executable;
 typedef struct PJRT_LoadedExecutable PJRT_LoadedExecutable;
 typedef struct PJRT_Buffer PJRT_Buffer;
+typedef struct PJRT_FulfillAliasBufferCallback PJRT_FulfillAliasBufferCallback;
 typedef struct PJRT_AsyncHostToDeviceTransferManager
     PJRT_AsyncHostToDeviceTransferManager;
+typedef struct PJRT_PhaseCompiler PJRT_PhaseCompiler;
 
 // The caller of PJRT_Client_Create can optionally provide a key-value store
-// accessible across nodes and/or processes. KV store access may be necessary to
-// create some multi-node/multi-process clients. The caller can provide the two
-// callbacks below to access the key-value store.
+// accessible across nodes and/or processes. KV store access may be necessary
+// to create some multi-node/multi-process clients. The caller can provide the
+// two callbacks below to access the key-value store.
 
 // A callback to delete the value returned by PJRT_KeyValueGetCallback.
-typedef void (*PJRT_KeyValueGetCallback_ValueDeleter)(char *value);
+typedef void (*PJRT_KeyValueGetCallback_ValueDeleter)(char* value);
 
 struct PJRT_KeyValueGetCallback_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  const char *key;
+  PJRT_Extension_Base* extension_start;
+  const char* key;
   size_t key_size;
   int timeout_in_ms;
-  PJRT_CallbackError *callback_error;
-  void *user_arg;
-  char *value;       // out
-  size_t value_size; // out
+  PJRT_CallbackError* callback_error;
+  void* user_arg;
+  char* value;        // out
+  size_t value_size;  // out
   // The caller needs to set a PJRT_KeyValueGetCallback_ValueDeleter to delete
   // the value returned by PJRT_KeyValueGetCallback. The implementation is
   // responsible for copying `value` and then calling value_deleter_callback.
-  PJRT_KeyValueGetCallback_ValueDeleter value_deleter_callback; // out
+  PJRT_KeyValueGetCallback_ValueDeleter value_deleter_callback;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_KeyValueGetCallback_Args,
                           value_deleter_callback);
@@ -358,27 +375,27 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_KeyValueGetCallback_Args,
 // key collisions between different users of key-value store (i.e. between
 // different plugins, but not between different nodes in one plugin). (3)
 // Blocking.
-typedef PJRT_Error *(*PJRT_KeyValueGetCallback)(
-    PJRT_KeyValueGetCallback_Args *args);
+typedef PJRT_Error* (*PJRT_KeyValueGetCallback)(
+    PJRT_KeyValueGetCallback_Args* args);
 
 // Same as KeyValueGet, but returns `NotFoundError` immediately if the key is
 // not found.
-typedef void (*PJRT_KeyValueTryGetCallback_ValueDeleter)(char *value);
+typedef void (*PJRT_KeyValueTryGetCallback_ValueDeleter)(char* value);
 
 struct PJRT_KeyValueTryGetCallback_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  const char *key;
+  PJRT_Extension_Base* extension_start;
+  const char* key;
   size_t key_size;
-  PJRT_CallbackError *callback_error;
-  void *user_arg;
-  char *value;       // out
-  size_t value_size; // out
+  PJRT_CallbackError* callback_error;
+  void* user_arg;
+  char* value;        // out
+  size_t value_size;  // out
   // The caller needs to set a PJRT_KeyValueTryGetCallback_ValueDeleter to
   // delete the value returned by PJRT_KeyValueTryGetCallback. The
   // implementation is responsible for copying `value` and then calling
   // value_deleter_callback.
-  PJRT_KeyValueTryGetCallback_ValueDeleter value_deleter_callback; // out
+  PJRT_KeyValueTryGetCallback_ValueDeleter value_deleter_callback;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_KeyValueTryGetCallback_Args,
                           value_deleter_callback);
@@ -387,20 +404,20 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_KeyValueTryGetCallback_Args,
 // (2) The caller that provides the two callbacks is responsible for avoiding
 // key collisions between different users of key-value store (i.e. between
 // different plugins, but not between different nodes in one plugin).
-typedef PJRT_Error *(*PJRT_KeyValueTryGetCallback)(
-    PJRT_KeyValueTryGetCallback_Args *args);
+typedef PJRT_Error* (*PJRT_KeyValueTryGetCallback)(
+    PJRT_KeyValueTryGetCallback_Args* args);
 
 struct PJRT_KeyValuePutCallback_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  const char *key;
+  PJRT_Extension_Base* extension_start;
+  const char* key;
   size_t key_size;
   // Only needs to stay alive for the duration of the PJRT_KeyValuePutCallback
   // call.
-  const char *value;
+  const char* value;
   size_t value_size;
-  PJRT_CallbackError *callback_error;
-  void *user_arg;
+  PJRT_CallbackError* callback_error;
+  void* user_arg;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_KeyValuePutCallback_Args, user_arg);
 
@@ -408,126 +425,126 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_KeyValuePutCallback_Args, user_arg);
 // (2) The caller that provides the two callbacks is responsible for avoiding
 // key collisions between different users of key-value store (i.e. between
 // different plugins, but not between different nodes in one plugin).
-typedef PJRT_Error *(*PJRT_KeyValuePutCallback)(
-    PJRT_KeyValuePutCallback_Args *args);
+typedef PJRT_Error* (*PJRT_KeyValuePutCallback)(
+    PJRT_KeyValuePutCallback_Args* args);
 
 struct PJRT_Client_Create_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
+  PJRT_Extension_Base* extension_start;
   // Extra platform-specific options to create a client.
-  const PJRT_NamedValue *create_options;
+  const PJRT_NamedValue* create_options;
   size_t num_options;
   // Key-value get/put callback provided by the caller of PJRT_Client_Create.
   // PJRT client can use these callbacks to share information between
   // processes/nodes.
   PJRT_KeyValueGetCallback kv_get_callback;
   // Will be passed to `kv_get_callback` as `user_arg` argument.
-  void *kv_get_user_arg;
+  void* kv_get_user_arg;
   PJRT_KeyValuePutCallback kv_put_callback;
   // Will be passed to `kv_put_callback` as `user_arg` argument.
-  void *kv_put_user_arg;
+  void* kv_put_user_arg;
 
-  PJRT_Client *client; // out
+  PJRT_Client* client;  // out
 
   // Key-value try-get callback provided by the caller of PJRT_Client_Create.
   // Same as key-value get callback, but returns `NotFoundError` immediately if
   // the key is not found.
   PJRT_KeyValueTryGetCallback kv_try_get_callback;
   // Will be passed to `kv_try_get_callback` as `user_arg` argument.
-  void *kv_try_get_user_arg;
+  void* kv_try_get_user_arg;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Client_Create_Args, kv_try_get_user_arg);
 
 // Creates and initializes a new PJRT_Client and returns in `client`.
-typedef PJRT_Error *PJRT_Client_Create(PJRT_Client_Create_Args *args);
+typedef PJRT_Error* PJRT_Client_Create(PJRT_Client_Create_Args* args);
 
 struct PJRT_Client_Destroy_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Client *client;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Client* client;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Client_Destroy_Args, client);
 
 // Shuts down and frees `client`. `client` can be nullptr.
-typedef PJRT_Error *PJRT_Client_Destroy(PJRT_Client_Destroy_Args *args);
+typedef PJRT_Error* PJRT_Client_Destroy(PJRT_Client_Destroy_Args* args);
 
 struct PJRT_Client_PlatformName_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Client *client;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Client* client;
   // `platform_name` has the same lifetime as `client`. It is owned by `client`.
-  const char *platform_name; // out
-  size_t platform_name_size; // out
+  const char* platform_name;  // out
+  size_t platform_name_size;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Client_PlatformName_Args, platform_name_size);
 
 // Returns a string that identifies the platform (e.g. "cpu", "gpu", "tpu").
-typedef PJRT_Error *
-PJRT_Client_PlatformName(PJRT_Client_PlatformName_Args *args);
+typedef PJRT_Error* PJRT_Client_PlatformName(
+    PJRT_Client_PlatformName_Args* args);
 
 struct PJRT_Client_ProcessIndex_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Client *client;
-  int process_index; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_Client* client;
+  int process_index;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Client_ProcessIndex_Args, process_index);
 
 // Return the process index of this client. Always 0 in single-process
 // settings.
-typedef PJRT_Error *
-PJRT_Client_ProcessIndex(PJRT_Client_ProcessIndex_Args *args);
+typedef PJRT_Error* PJRT_Client_ProcessIndex(
+    PJRT_Client_ProcessIndex_Args* args);
 
 struct PJRT_Client_PlatformVersion_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Client *client;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Client* client;
   // `platform_version` has the same lifetime as `client`. It's owned by
   // `client`.
-  const char *platform_version; // out
-  size_t platform_version_size; // out
+  const char* platform_version;  // out
+  size_t platform_version_size;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Client_PlatformVersion_Args,
                           platform_version_size);
 
 // Returns a string containing human-readable, platform-specific version info
 // (e.g. the CUDA version on GPU or libtpu version on Cloud TPU).
-typedef PJRT_Error *
-PJRT_Client_PlatformVersion(PJRT_Client_PlatformVersion_Args *args);
+typedef PJRT_Error* PJRT_Client_PlatformVersion(
+    PJRT_Client_PlatformVersion_Args* args);
 
 struct PJRT_Client_TopologyDescription_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Client *client;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Client* client;
   // Is owned by and has the same lifetime as `client`.
-  PJRT_TopologyDescription *topology; // out
+  PJRT_TopologyDescription* topology;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Client_TopologyDescription_Args, topology);
 
 // Returns the topology description of the runtime topology. The returned
 // topology is owned by the client and should not be deleted by the caller.
-typedef PJRT_Error *
-PJRT_Client_TopologyDescription(PJRT_Client_TopologyDescription_Args *args);
+typedef PJRT_Error* PJRT_Client_TopologyDescription(
+    PJRT_Client_TopologyDescription_Args* args);
 
 struct PJRT_Client_Devices_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Client *client;
-  PJRT_Device *const *devices; // out
-  size_t num_devices;          // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_Client* client;
+  PJRT_Device* const* devices;  // out
+  size_t num_devices;           // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Client_Devices_Args, num_devices);
 
 // Returns a list of all devices visible to the runtime, including addressable
 // and non-addressable devices.
-typedef PJRT_Error *PJRT_Client_Devices(PJRT_Client_Devices_Args *args);
+typedef PJRT_Error* PJRT_Client_Devices(PJRT_Client_Devices_Args* args);
 
 struct PJRT_Client_AddressableDevices_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Client *client;
-  PJRT_Device *const *addressable_devices; // out
-  size_t num_addressable_devices;          // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_Client* client;
+  PJRT_Device* const* addressable_devices;  // out
+  size_t num_addressable_devices;           // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Client_AddressableDevices_Args,
                           num_addressable_devices);
@@ -535,47 +552,87 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_Client_AddressableDevices_Args,
 // Returns a list of devices that are addressable from the client.
 // Addressable devices are those that the client can issue commands to.
 // All devices are addressable in a single-process environment.
-typedef PJRT_Error *
-PJRT_Client_AddressableDevices(PJRT_Client_AddressableDevices_Args *args);
+typedef PJRT_Error* PJRT_Client_AddressableDevices(
+    PJRT_Client_AddressableDevices_Args* args);
 
 struct PJRT_Client_LookupDevice_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Client *client;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Client* client;
   int id;
   // `device` has the same lifetime as `client`. It is owned by `client`.
-  PJRT_Device *device; // out
+  PJRT_Device* device;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Client_LookupDevice_Args, device);
 
 // Returns a PJRT_Device* with the specified ID as returned by
 // PJRT_DeviceDescription_Id.
-typedef PJRT_Error *
-PJRT_Client_LookupDevice(PJRT_Client_LookupDevice_Args *args);
+typedef PJRT_Error* PJRT_Client_LookupDevice(
+    PJRT_Client_LookupDevice_Args* args);
 
 struct PJRT_Client_LookupAddressableDevice_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Client *client;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Client* client;
   int local_hardware_id;
   // `addressable_device` has the same lifetime as `client`. It is owned by
   // `client`.
-  PJRT_Device *addressable_device; // out
+  PJRT_Device* addressable_device;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Client_LookupAddressableDevice_Args,
                           addressable_device);
 
 // Returns an addressable PJRT_Device* with the specified ID as returned by
 // PJRT_DeviceDescription_LocalHardwareId.
-typedef PJRT_Error *PJRT_Client_LookupAddressableDevice(
-    PJRT_Client_LookupAddressableDevice_Args *args);
+typedef PJRT_Error* PJRT_Client_LookupAddressableDevice(
+    PJRT_Client_LookupAddressableDevice_Args* args);
+
+typedef enum {
+  PJRT_ProcessState_kUnspecified = 0,
+  PJRT_ProcessState_kUninitialized = 1,
+  PJRT_ProcessState_kDisconnected = 2,
+  PJRT_ProcessState_kConnected = 3,
+  PJRT_ProcessState_kError = 4,
+} PJRT_ProcessState;
+
+// TODO: mwhittaker - Add the remaining fields from
+// tensorflow::CoordinatedTaskStateInfo.
+struct PJRT_ProcessInfo {
+  size_t struct_size;
+  int task_id;
+  uint64_t incarnation_id;
+  PJRT_ProcessState state;
+  int error_code;
+  const char* error_message;
+  size_t error_message_size;
+};
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_ProcessInfo, error_message_size);
+
+struct PJRT_Client_UpdateGlobalProcessInfo_Args {
+  size_t struct_size;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Client* client;
+  PJRT_ProcessInfo* process_infos;
+  size_t num_process_infos;
+};
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_Client_UpdateGlobalProcessInfo_Args,
+                          num_process_infos);
+
+// Updates the PjRt client with information about all global processes.
+//
+// Recall that a distributed program may consist of multiple PjRt clients
+// spanning multiple machines. These clients perform collective operations, like
+// AllGather, to execute a distributed program. UpdateGlobalProcessInfo updates
+// a PjRt client with information about all processes.
+typedef PJRT_Error* PJRT_Client_UpdateGlobalProcessInfo(
+    PJRT_Client_UpdateGlobalProcessInfo_Args* args);
 
 struct PJRT_Client_AddressableMemories_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Client *client;
-  PJRT_Memory *const *addressable_memories; // out
-  size_t num_addressable_memories;          // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_Client* client;
+  PJRT_Memory* const* addressable_memories;  // out
+  size_t num_addressable_memories;           // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Client_AddressableMemories_Args,
                           num_addressable_memories);
@@ -583,50 +640,49 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_Client_AddressableMemories_Args,
 // Returns a list of memories that are addressable from the client. Addressable
 // memories are those that the client can directly transfer data to and from.
 // All memories are addressable in a single-process environment.
-typedef PJRT_Error *
-PJRT_Client_AddressableMemories(PJRT_Client_AddressableMemories_Args *args);
+typedef PJRT_Error* PJRT_Client_AddressableMemories(
+    PJRT_Client_AddressableMemories_Args* args);
 
 struct PJRT_Program {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
+  PJRT_Extension_Base* extension_start;
   // Serialized code in the specified format below.
   // String is owned by the caller.
-  char *code; // in/out depending on usage
+  char* code;  // in/out depending on usage
   size_t code_size;
   // Supported formats are:
   // "hlo": code string takes serialized HloModuleProto.
   // "hlo_with_config": code string takes serialized HloModuleProtoWithConfig.
   // "mlir": code string takes MLIR module bytecode (or string).
   // Ownership of `format` varies across API functions.
-  const char *format;
+  const char* format;
   size_t format_size;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Program, format_size);
 
 struct PJRT_Client_Compile_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Client *client;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Client* client;
   // Only needs to stay alive for the duration of the Compile call.
   // `program->format` and `program->format_size` are owned by the caller.
-  const PJRT_Program *program;
+  const PJRT_Program* program;
   // TODO(b/240560013): consider putting some of option fields in priv.
-  // Serialized CompileOptionsProto
-  // (https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/pjrt/compile_options.proto)
-  const char *compile_options;
+  // Serialized CompileOptionsProto.
+  const char* compile_options;
   size_t compile_options_size;
-  PJRT_LoadedExecutable *executable; // out
+  PJRT_LoadedExecutable* executable;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Client_Compile_Args, executable);
 
 // Compiles a program in specified format (such as MLIR or HLO) with given
 // `options`.
-typedef PJRT_Error *PJRT_Client_Compile(PJRT_Client_Compile_Args *args);
+typedef PJRT_Error* PJRT_Client_Compile(PJRT_Client_Compile_Args* args);
 
 struct PJRT_Client_DefaultDeviceAssignment_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Client *client;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Client* client;
   int num_replicas;
   int num_partitions;
   // Must be greater than or equal to `num_replicas * num_partitions`
@@ -634,136 +690,136 @@ struct PJRT_Client_DefaultDeviceAssignment_Args {
   // Points to an array of size `default_assignment_size`.
   // This API writes `num_replicas * num_partitions` ints within that buffer.
   // The caller retains ownership of this memory.
-  int *default_assignment; // pointer to array in; values written as out
+  int* default_assignment;  // pointer to array in; values written as out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Client_DefaultDeviceAssignment_Args,
                           default_assignment);
 
-typedef PJRT_Error *PJRT_Client_DefaultDeviceAssignment(
-    PJRT_Client_DefaultDeviceAssignment_Args *args);
+typedef PJRT_Error* PJRT_Client_DefaultDeviceAssignment(
+    PJRT_Client_DefaultDeviceAssignment_Args* args);
 
 struct PJRT_Client_DmaMap_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Client *client;
-  void *data;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Client* client;
+  void* data;
   size_t size;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Client_DmaMap_Args, size);
 
-typedef PJRT_Error *PJRT_Client_DmaMap(PJRT_Client_DmaMap_Args *args);
+typedef PJRT_Error* PJRT_Client_DmaMap(PJRT_Client_DmaMap_Args* args);
 
 struct PJRT_Client_DmaUnmap_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Client *client;
-  void *data;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Client* client;
+  void* data;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Client_DmaUnmap_Args, data);
 
-typedef PJRT_Error *PJRT_Client_DmaUnmap(PJRT_Client_DmaUnmap_Args *args);
+typedef PJRT_Error* PJRT_Client_DmaUnmap(PJRT_Client_DmaUnmap_Args* args);
 
 struct PJRT_AsyncHostToDeviceTransferManager_Destroy_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_AsyncHostToDeviceTransferManager *transfer_manager;
+  PJRT_Extension_Base* extension_start;
+  PJRT_AsyncHostToDeviceTransferManager* transfer_manager;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_AsyncHostToDeviceTransferManager_Destroy_Args,
                           transfer_manager);
 
 // Frees `transfer_manager`. `transfer_manager` can be nullptr.
-typedef PJRT_Error *PJRT_AsyncHostToDeviceTransferManager_Destroy(
-    PJRT_AsyncHostToDeviceTransferManager_Destroy_Args *args);
+typedef PJRT_Error* PJRT_AsyncHostToDeviceTransferManager_Destroy(
+    PJRT_AsyncHostToDeviceTransferManager_Destroy_Args* args);
 
 struct PJRT_AsyncHostToDeviceTransferManager_TransferData_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_AsyncHostToDeviceTransferManager *transfer_manager;
+  PJRT_Extension_Base* extension_start;
+  PJRT_AsyncHostToDeviceTransferManager* transfer_manager;
   int buffer_index;
-  const void *data;
+  const void* data;
   int64_t offset;
   int64_t transfer_size;
   bool is_last_transfer;
-  PJRT_Event *done_with_h2d_transfer; // out
+  PJRT_Event* done_with_h2d_transfer;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(
     PJRT_AsyncHostToDeviceTransferManager_TransferData_Args,
     done_with_h2d_transfer);
-typedef PJRT_Error *PJRT_AsyncHostToDeviceTransferManager_TransferData(
-    PJRT_AsyncHostToDeviceTransferManager_TransferData_Args *args);
+typedef PJRT_Error* PJRT_AsyncHostToDeviceTransferManager_TransferData(
+    PJRT_AsyncHostToDeviceTransferManager_TransferData_Args* args);
 
 struct PJRT_AsyncHostToDeviceTransferManager_RetrieveBuffer_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_AsyncHostToDeviceTransferManager *transfer_manager;
+  PJRT_Extension_Base* extension_start;
+  PJRT_AsyncHostToDeviceTransferManager* transfer_manager;
   int buffer_index;
-  PJRT_Buffer *buffer_out; // out
+  PJRT_Buffer* buffer_out;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(
     PJRT_AsyncHostToDeviceTransferManager_RetrieveBuffer_Args, buffer_out);
-typedef PJRT_Error *PJRT_AsyncHostToDeviceTransferManager_RetrieveBuffer(
-    PJRT_AsyncHostToDeviceTransferManager_RetrieveBuffer_Args *args);
+typedef PJRT_Error* PJRT_AsyncHostToDeviceTransferManager_RetrieveBuffer(
+    PJRT_AsyncHostToDeviceTransferManager_RetrieveBuffer_Args* args);
 
 struct PJRT_AsyncHostToDeviceTransferManager_Device_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_AsyncHostToDeviceTransferManager *transfer_manager;
-  PJRT_Device *device_out; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_AsyncHostToDeviceTransferManager* transfer_manager;
+  PJRT_Device* device_out;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_AsyncHostToDeviceTransferManager_Device_Args,
                           device_out);
-typedef PJRT_Error *PJRT_AsyncHostToDeviceTransferManager_Device(
-    PJRT_AsyncHostToDeviceTransferManager_Device_Args *args);
+typedef PJRT_Error* PJRT_AsyncHostToDeviceTransferManager_Device(
+    PJRT_AsyncHostToDeviceTransferManager_Device_Args* args);
 
 struct PJRT_AsyncHostToDeviceTransferManager_BufferCount_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_AsyncHostToDeviceTransferManager *transfer_manager;
-  size_t buffer_count; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_AsyncHostToDeviceTransferManager* transfer_manager;
+  size_t buffer_count;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(
     PJRT_AsyncHostToDeviceTransferManager_BufferCount_Args, buffer_count);
-typedef PJRT_Error *PJRT_AsyncHostToDeviceTransferManager_BufferCount(
-    PJRT_AsyncHostToDeviceTransferManager_BufferCount_Args *args);
+typedef PJRT_Error* PJRT_AsyncHostToDeviceTransferManager_BufferCount(
+    PJRT_AsyncHostToDeviceTransferManager_BufferCount_Args* args);
 
 struct PJRT_AsyncHostToDeviceTransferManager_BufferSize_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_AsyncHostToDeviceTransferManager *transfer_manager;
+  PJRT_Extension_Base* extension_start;
+  PJRT_AsyncHostToDeviceTransferManager* transfer_manager;
   int buffer_index;
-  size_t buffer_size; // out
+  size_t buffer_size;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_AsyncHostToDeviceTransferManager_BufferSize_Args,
                           buffer_size);
-typedef PJRT_Error *PJRT_AsyncHostToDeviceTransferManager_BufferSize(
-    PJRT_AsyncHostToDeviceTransferManager_BufferSize_Args *args);
+typedef PJRT_Error* PJRT_AsyncHostToDeviceTransferManager_BufferSize(
+    PJRT_AsyncHostToDeviceTransferManager_BufferSize_Args* args);
 
 struct PJRT_AsyncHostToDeviceTransferManager_SetBufferError_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_AsyncHostToDeviceTransferManager *transfer_manager;
+  PJRT_Extension_Base* extension_start;
+  PJRT_AsyncHostToDeviceTransferManager* transfer_manager;
   int buffer_index;
   PJRT_Error_Code error_code;
-  const char *error_message;
+  const char* error_message;
   size_t error_message_size;
 };
 PJRT_DEFINE_STRUCT_TRAITS(
     PJRT_AsyncHostToDeviceTransferManager_SetBufferError_Args,
     error_message_size);
-typedef PJRT_Error *PJRT_AsyncHostToDeviceTransferManager_SetBufferError(
-    PJRT_AsyncHostToDeviceTransferManager_SetBufferError_Args *args);
+typedef PJRT_Error* PJRT_AsyncHostToDeviceTransferManager_SetBufferError(
+    PJRT_AsyncHostToDeviceTransferManager_SetBufferError_Args* args);
 
 struct PJRT_AsyncHostToDeviceTransferManager_AddMetadata_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_AsyncHostToDeviceTransferManager *transfer_manager;
-  const PJRT_NamedValue *transfer_metadata;
+  PJRT_Extension_Base* extension_start;
+  PJRT_AsyncHostToDeviceTransferManager* transfer_manager;
+  const PJRT_NamedValue* transfer_metadata;
   size_t num_metadata;
 };
 PJRT_DEFINE_STRUCT_TRAITS(
     PJRT_AsyncHostToDeviceTransferManager_AddMetadata_Args, num_metadata);
-typedef PJRT_Error *PJRT_AsyncHostToDeviceTransferManager_AddMetadata(
-    PJRT_AsyncHostToDeviceTransferManager_AddMetadata_Args *args);
+typedef PJRT_Error* PJRT_AsyncHostToDeviceTransferManager_AddMetadata(
+    PJRT_AsyncHostToDeviceTransferManager_AddMetadata_Args* args);
 
 typedef enum {
   // Invalid primitive type to serve as default.
@@ -869,30 +925,30 @@ typedef enum {
 
 struct PJRT_Buffer_MemoryLayout_Tiled {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
+  PJRT_Extension_Base* extension_start;
   // A map from physical dimension numbers to logical dimension numbers.
   // The first element is the most minor physical dimension (fastest varying
   // index) and the last the most major (slowest varying index). The contents of
   // the vector are the indices of the *logical* dimensions in the shape. Must
   // be the same size as the number of dimensions of the buffer.
-  const int64_t *minor_to_major;
+  const int64_t* minor_to_major;
   size_t minor_to_major_size;
   // A concatenated list of tile dimensions.
-  const int64_t *tile_dims;
+  const int64_t* tile_dims;
   // The list of tile dimension sizes. The size of this list is `num_tiles`.
-  const size_t *tile_dim_sizes;
+  const size_t* tile_dim_sizes;
   size_t num_tiles;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_MemoryLayout_Tiled, num_tiles);
 
 struct PJRT_Buffer_MemoryLayout_Strides {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
+  PJRT_Extension_Base* extension_start;
   // Number of bytes to traverse per dimension. Must be the same size as
   // the number of dimensions of the data. Caution: `byte_strides` are allowed
   // to be negative, in which case data may need to point to the interior of
   // the buffer, not necessarily its start.
-  const int64_t *byte_strides;
+  const int64_t* byte_strides;
   size_t num_byte_strides;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_MemoryLayout_Strides, num_byte_strides);
@@ -902,7 +958,7 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_MemoryLayout_Strides, num_byte_strides);
 // strides.
 struct PJRT_Buffer_MemoryLayout {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
+  PJRT_Extension_Base* extension_start;
   union {
     PJRT_Buffer_MemoryLayout_Tiled tiled;
     PJRT_Buffer_MemoryLayout_Strides strides;
@@ -911,16 +967,136 @@ struct PJRT_Buffer_MemoryLayout {
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_MemoryLayout, type);
 
+struct PJRT_AsyncHostToDeviceTransferManager_TransferLiteral_Args {
+  size_t struct_size;
+  PJRT_Extension_Base* extension_start;
+
+  PJRT_AsyncHostToDeviceTransferManager* transfer_manager;
+  int buffer_index;
+  const void* data;
+
+  // Shape fields.
+  const int64_t* shape_dims;
+  size_t shape_num_dims;
+  PJRT_Buffer_Type shape_element_type;
+  PJRT_Buffer_MemoryLayout* shape_layout;
+
+  PJRT_Event* done_with_h2d_transfer;  // out
+};
+PJRT_DEFINE_STRUCT_TRAITS(
+    PJRT_AsyncHostToDeviceTransferManager_TransferLiteral_Args,
+    done_with_h2d_transfer);
+
+// Asynchronously copies a host literal to a buffer managed by a transfer
+// manager.
+typedef PJRT_Error* PJRT_AsyncHostToDeviceTransferManager_TransferLiteral(
+    PJRT_AsyncHostToDeviceTransferManager_TransferLiteral_Args* args);
+
+struct PJRT_Client_CreateUninitializedBuffer_Args {
+  size_t struct_size;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Client* client;
+
+  // Shape fields.
+  const int64_t* shape_dims;
+  size_t shape_num_dims;
+  PJRT_Buffer_Type shape_element_type;
+  PJRT_Buffer_MemoryLayout* shape_layout;
+
+  // Device to copy host data to.
+  PJRT_Device* device;
+
+  // If nullptr, host data will be copied to `device`, otherwise we copy data to
+  // `memory`.
+  PJRT_Memory* memory;
+
+  // Output device buffer. The caller is responsible for calling
+  // PJRT_Buffer_Destroy.
+  PJRT_Buffer* buffer;  // out
+};
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_Client_CreateUninitializedBuffer_Args, buffer);
+
+typedef PJRT_Error* PJRT_Client_CreateUninitializedBuffer(
+    PJRT_Client_CreateUninitializedBuffer_Args* args);
+
+struct PJRT_Client_CreateErrorBuffer_Args {
+  size_t struct_size;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Client* client;
+
+  // Status fields.
+  PJRT_Error_Code error_code;
+  const char* error_message;
+  size_t error_message_size;
+
+  // Shape fields.
+  const int64_t* shape_dims;
+  size_t shape_num_dims;
+  PJRT_Buffer_Type shape_element_type;
+  PJRT_Buffer_MemoryLayout* shape_layout;
+
+  // Destination memory space for the error buffer.
+  PJRT_Memory* memory;
+
+  // Output device buffer. The caller is responsible for calling
+  // PJRT_Buffer_Destroy.
+  PJRT_Buffer* buffer;  // out
+};
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_Client_CreateErrorBuffer_Args, buffer);
+
+typedef PJRT_Error* PJRT_Client_CreateErrorBuffer(
+    PJRT_Client_CreateErrorBuffer_Args* args);
+
+struct PJRT_Client_CreateAliasBuffer_Args {
+  size_t struct_size;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Client* client;
+
+  // Destination memory space for the buffer alias.
+  PJRT_Memory* memory;
+
+  // Shape fields.
+  const int64_t* shape_dims;
+  size_t shape_num_dims;
+  PJRT_Buffer_Type shape_element_type;
+  PJRT_Buffer_MemoryLayout* shape_layout;
+
+  PJRT_Buffer* alias_buffer;                                 // out
+  PJRT_FulfillAliasBufferCallback* fulfill_alias_buffer_cb;  // out
+};
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_Client_CreateAliasBuffer_Args,
+                          fulfill_alias_buffer_cb);
+
+typedef PJRT_Error* PJRT_Client_CreateAliasBuffer(
+    PJRT_Client_CreateAliasBuffer_Args* args);
+
+struct PJRT_Client_FulfillAliasBuffer_Args {
+  size_t struct_size;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Client* client;
+
+  PJRT_Buffer* buffer;                                       // in
+  PJRT_Error_Code status_code;                               // in
+  const char* error_message;                                 // in
+  size_t error_message_size;                                 // in
+  PJRT_FulfillAliasBufferCallback* fulfill_alias_buffer_cb;  // in
+};
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_Client_FulfillAliasBuffer_Args,
+                          fulfill_alias_buffer_cb);
+
+typedef PJRT_Error* PJRT_Client_FulfillAliasBuffer(
+    PJRT_Client_FulfillAliasBuffer_Args* args);
+
 struct PJRT_Client_BufferFromHostBuffer_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Client *client;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Client* client;
   // Pointer to the host buffer
-  const void *data;
+  const void* data;
   // The type of the `data`, and the type of the resulting output `buffer`
   PJRT_Buffer_Type type;
   // The array dimensions of `data`.
-  const int64_t *dims;
+  const int64_t* dims;
   size_t num_dims;
 
   // Number of bytes to traverse per dimension of the input data. Must be the
@@ -928,58 +1104,58 @@ struct PJRT_Client_BufferFromHostBuffer_Args {
   // dense layout with dimensions in major-to-minor order
   // Caution: `byte_strides` are allowed to be negative, in which case `data`
   // may need to point to the interior of the buffer, not necessarily its start.
-  const int64_t *byte_strides;
+  const int64_t* byte_strides;
   size_t num_byte_strides;
 
   PJRT_HostBufferSemantics host_buffer_semantics;
 
   // Device to copy host data to.
-  PJRT_Device *device;
+  PJRT_Device* device;
 
   // If nullptr, host data will be copied to `device`, otherwise we copy data to
   // `memory`.
-  PJRT_Memory *memory;
+  PJRT_Memory* memory;
 
   // The caller is responsible to keep the data (tiled or strides) in the
   // device_layout alive during the call. If nullptr, the device layout is
   // assumed to be a dense layout with dimensions in major-to-minor order.
-  PJRT_Buffer_MemoryLayout *device_layout;
+  PJRT_Buffer_MemoryLayout* device_layout;
 
   // Event indicating when it's safe to free `data`. The caller is responsible
   // for calling PJRT_Event_Destroy.
-  PJRT_Event *done_with_host_buffer; // out
+  PJRT_Event* done_with_host_buffer;  // out
 
   // Output device buffer. The caller is responsible for calling
   // PJRT_Buffer_Destroy.
-  PJRT_Buffer *buffer; // out
+  PJRT_Buffer* buffer;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Client_BufferFromHostBuffer_Args, buffer);
 
 // Asynchronously copies a buffer stored on host to device memory.
-typedef PJRT_Error *
-PJRT_Client_BufferFromHostBuffer(PJRT_Client_BufferFromHostBuffer_Args *args);
+typedef PJRT_Error* PJRT_Client_BufferFromHostBuffer(
+    PJRT_Client_BufferFromHostBuffer_Args* args);
 
 struct PJRT_Client_CreateViewOfDeviceBuffer_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Client *client;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Client* client;
   // A pointer to a non-owned device buffer. A PJRT_Buffer that is a non-owned
   // view of this device buffer will be created.
-  void *device_buffer_ptr;
-  const int64_t *dims;
+  void* device_buffer_ptr;
+  const int64_t* dims;
   size_t num_dims;
   PJRT_Buffer_Type element_type;
-  PJRT_Buffer_MemoryLayout *layout;
+  PJRT_Buffer_MemoryLayout* layout;
   // The device that `device_buffer_ptr` is on. The argument is ignored if
   // `memory` is provided.
   // DEPRECATED: Use `memory` instead.
-  PJRT_Device *device;
+  PJRT_Device* device;
   // A callback to be performed when the PJRT_Buffer is done with the on-device
   // buffer. This callback is optional and can be a nullptr.
-  void (*on_delete_callback)(void *device_buffer_ptr, void *user_arg);
+  void (*on_delete_callback)(void* device_buffer_ptr, void* user_arg);
   // `on_delete_callback_arg` will be passed to `on_delete_callback` as
   // `user_arg` argument.
-  void *on_delete_callback_arg;
+  void* on_delete_callback_arg;
   // A platform-specific stream handle that should contain the work or events
   // needed to materialize the on-device buffer. It is optional and can be
   // casted from a nullptr. PJRT_Client_CreateViewOfDeviceBuffer_Args will
@@ -987,9 +1163,9 @@ struct PJRT_Client_CreateViewOfDeviceBuffer_Args {
   // ready to use. This is intended to support dlpack on GPU and is not expected
   // to be supported on all hardware platforms.
   intptr_t stream;
-  PJRT_Buffer *buffer; // out
+  PJRT_Buffer* buffer;  // out
   // The memory space that `device_buffer_ptr` is in.
-  PJRT_Memory *memory;
+  PJRT_Memory* memory;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Client_CreateViewOfDeviceBuffer_Args, memory);
 
@@ -997,13 +1173,13 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_Client_CreateViewOfDeviceBuffer_Args, memory);
 // (typically allocated by another library). The buffer may be mutated,
 // for example, if the buffer is donated to an Execute operation. This method is
 // not required on all hardware platforms.
-typedef PJRT_Error *PJRT_Client_CreateViewOfDeviceBuffer(
-    PJRT_Client_CreateViewOfDeviceBuffer_Args *args);
+typedef PJRT_Error* PJRT_Client_CreateViewOfDeviceBuffer(
+    PJRT_Client_CreateViewOfDeviceBuffer_Args* args);
 
 struct PJRT_ShapeSpec {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  const int64_t *dims;
+  PJRT_Extension_Base* extension_start;
+  const int64_t* dims;
   size_t num_dims;
   PJRT_Buffer_Type element_type;
 };
@@ -1011,19 +1187,19 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_ShapeSpec, element_type);
 
 struct PJRT_Client_CreateBuffersForAsyncHostToDevice_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Client *client;
-  PJRT_ShapeSpec *shape_specs;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Client* client;
+  PJRT_ShapeSpec* shape_specs;
   size_t num_shape_specs;
-  PJRT_Buffer_MemoryLayout **device_layouts; // optional
+  PJRT_Buffer_MemoryLayout** device_layouts;  // optional
   size_t num_device_layouts;
-  PJRT_Memory *memory;
-  PJRT_AsyncHostToDeviceTransferManager *transfer_manager; // out
+  PJRT_Memory* memory;
+  PJRT_AsyncHostToDeviceTransferManager* transfer_manager;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Client_CreateBuffersForAsyncHostToDevice_Args,
                           transfer_manager);
-typedef PJRT_Error *PJRT_Client_CreateBuffersForAsyncHostToDevice(
-    PJRT_Client_CreateBuffersForAsyncHostToDevice_Args *args);
+typedef PJRT_Error* PJRT_Client_CreateBuffersForAsyncHostToDevice(
+    PJRT_Client_CreateBuffersForAsyncHostToDevice_Args* args);
 
 // -------------------------- Device Descriptions ------------------------------
 
@@ -1036,23 +1212,23 @@ typedef PJRT_Error *PJRT_Client_CreateBuffersForAsyncHostToDevice(
 
 struct PJRT_DeviceDescription_Id_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_DeviceDescription *device_description;
-  int id; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_DeviceDescription* device_description;
+  int id;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_DeviceDescription_Id_Args, id);
 
 // The ID of this device. IDs are unique among devices of this type
 // (e.g. CPUs, GPUs). On multi-host platforms, this will be unique across all
 // hosts' devices.
-typedef PJRT_Error *
-PJRT_DeviceDescription_Id(PJRT_DeviceDescription_Id_Args *args);
+typedef PJRT_Error* PJRT_DeviceDescription_Id(
+    PJRT_DeviceDescription_Id_Args* args);
 
 struct PJRT_DeviceDescription_ProcessIndex_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_DeviceDescription *device_description;
-  int process_index; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_DeviceDescription* device_description;
+  int process_index;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_DeviceDescription_ProcessIndex_Args,
                           process_index);
@@ -1062,258 +1238,309 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_DeviceDescription_ProcessIndex_Args,
 // multi-process setting, where each client can see devices from all
 // processes, but only a subset of them are addressable and have the same
 // process_index as the client.
-typedef PJRT_Error *PJRT_DeviceDescription_ProcessIndex(
-    PJRT_DeviceDescription_ProcessIndex_Args *args);
+typedef PJRT_Error* PJRT_DeviceDescription_ProcessIndex(
+    PJRT_DeviceDescription_ProcessIndex_Args* args);
 
 struct PJRT_DeviceDescription_Attributes_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_DeviceDescription *device_description;
-  size_t num_attributes;             // out
-  const PJRT_NamedValue *attributes; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_DeviceDescription* device_description;
+  size_t num_attributes;              // out
+  const PJRT_NamedValue* attributes;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_DeviceDescription_Attributes_Args, attributes);
 
 // Returns an array of device specific attributes with attribute name, value
 // and value type.
-typedef PJRT_Error *
-PJRT_DeviceDescription_Attributes(PJRT_DeviceDescription_Attributes_Args *args);
+typedef PJRT_Error* PJRT_DeviceDescription_Attributes(
+    PJRT_DeviceDescription_Attributes_Args* args);
 
 struct PJRT_DeviceDescription_Kind_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_DeviceDescription *device_description;
+  PJRT_Extension_Base* extension_start;
+  PJRT_DeviceDescription* device_description;
   // `device_kind` string is owned by `device` and has same lifetime as
   // `device`.
-  const char *device_kind; // out
-  size_t device_kind_size; // out
+  const char* device_kind;  // out
+  size_t device_kind_size;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_DeviceDescription_Kind_Args, device_kind_size);
 
 // A vendor-dependent string that uniquely identifies the kind of device,
 // e.g., "Tesla V100-SXM2-16GB".
-typedef PJRT_Error *
-PJRT_DeviceDescription_Kind(PJRT_DeviceDescription_Kind_Args *args);
+typedef PJRT_Error* PJRT_DeviceDescription_Kind(
+    PJRT_DeviceDescription_Kind_Args* args);
 
 struct PJRT_DeviceDescription_DebugString_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_DeviceDescription *device_description;
-  const char *debug_string; // out
-  size_t debug_string_size; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_DeviceDescription* device_description;
+  const char* debug_string;  // out
+  size_t debug_string_size;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_DeviceDescription_DebugString_Args,
                           debug_string_size);
 
 // Debug string suitable for logging when errors occur. Should be verbose
 // enough to describe the current device unambiguously.
-typedef PJRT_Error *PJRT_DeviceDescription_DebugString(
-    PJRT_DeviceDescription_DebugString_Args *args);
+typedef PJRT_Error* PJRT_DeviceDescription_DebugString(
+    PJRT_DeviceDescription_DebugString_Args* args);
 
 struct PJRT_DeviceDescription_ToString_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_DeviceDescription *device_description;
-  const char *to_string; // out
-  size_t to_string_size; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_DeviceDescription* device_description;
+  const char* to_string;  // out
+  size_t to_string_size;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_DeviceDescription_ToString_Args, to_string_size);
 
 // Debug string suitable for reading by end users, should be reasonably terse,
 // for example: "CpuDevice(id=0)".
-typedef PJRT_Error *
-PJRT_DeviceDescription_ToString(PJRT_DeviceDescription_ToString_Args *args);
+typedef PJRT_Error* PJRT_DeviceDescription_ToString(
+    PJRT_DeviceDescription_ToString_Args* args);
 
 // --------------------------------- Devices -----------------------------------
 
 struct PJRT_Device_GetDescription_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Device *device;
-  PJRT_DeviceDescription *device_description; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_Device* device;
+  PJRT_DeviceDescription* device_description;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Device_GetDescription_Args, device_description);
 
 // Fetch the DeviceDescription associated with this device.
-typedef PJRT_Error *
-PJRT_Device_GetDescription(PJRT_Device_GetDescription_Args *args);
+typedef PJRT_Error* PJRT_Device_GetDescription(
+    PJRT_Device_GetDescription_Args* args);
 
 struct PJRT_Device_IsAddressable_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Device *device;
-  bool is_addressable; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_Device* device;
+  bool is_addressable;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Device_IsAddressable_Args, is_addressable);
 
 // Whether client can issue command to this device.
-typedef PJRT_Error *
-PJRT_Device_IsAddressable(PJRT_Device_IsAddressable_Args *args);
+typedef PJRT_Error* PJRT_Device_IsAddressable(
+    PJRT_Device_IsAddressable_Args* args);
 
 struct PJRT_Device_LocalHardwareId_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Device *device;
-  int local_hardware_id; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_Device* device;
+  int local_hardware_id;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Device_LocalHardwareId_Args, local_hardware_id);
 
 // Opaque hardware ID, e.g., the CUDA device number. In general, not guaranteed
 // to be dense, and -1 if undefined.
-typedef PJRT_Error *
-PJRT_Device_LocalHardwareId(PJRT_Device_LocalHardwareId_Args *args);
+typedef PJRT_Error* PJRT_Device_LocalHardwareId(
+    PJRT_Device_LocalHardwareId_Args* args);
 
 struct PJRT_Device_AddressableMemories_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Device *device;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Device* device;
   // Has the lifetime of `device`.
-  PJRT_Memory *const *memories; // out
-  size_t num_memories;          // out
+  PJRT_Memory* const* memories;  // out
+  size_t num_memories;           // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Device_AddressableMemories_Args, num_memories);
 
 // Returns the memories that a device can address.
-typedef PJRT_Error *
-PJRT_Device_AddressableMemories(PJRT_Device_AddressableMemories_Args *args);
+typedef PJRT_Error* PJRT_Device_AddressableMemories(
+    PJRT_Device_AddressableMemories_Args* args);
 
 struct PJRT_Device_DefaultMemory_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Device *device;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Device* device;
   // `memory` has the same lifetime as `device`.
-  PJRT_Memory *memory; // out
+  PJRT_Memory* memory;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Device_DefaultMemory_Args, memory);
 
 // Returns the default memory of a device, i.e. which memory data processed by
 // this device should be stored in by default.
-typedef PJRT_Error *
-PJRT_Device_DefaultMemory(PJRT_Device_DefaultMemory_Args *args);
+typedef PJRT_Error* PJRT_Device_DefaultMemory(
+    PJRT_Device_DefaultMemory_Args* args);
 
 struct PJRT_Device_MemoryStats_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Device *device;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Device* device;
 
   // Number of bytes in use.
-  int64_t bytes_in_use; // out
+  int64_t bytes_in_use;  // out
 
   // The peak bytes in use.
-  int64_t peak_bytes_in_use;     // out
-  bool peak_bytes_in_use_is_set; // out
+  int64_t peak_bytes_in_use;      // out
+  bool peak_bytes_in_use_is_set;  // out
   // Number of allocations.
-  int64_t num_allocs;     // out
-  bool num_allocs_is_set; // out
+  int64_t num_allocs;      // out
+  bool num_allocs_is_set;  // out
   // The largest single allocation seen.
-  int64_t largest_alloc_size;     // out
-  bool largest_alloc_size_is_set; // out
+  int64_t largest_alloc_size;      // out
+  bool largest_alloc_size_is_set;  // out
   // The upper limit of user-allocatable device memory in bytes.
-  int64_t bytes_limit;     // out
-  bool bytes_limit_is_set; // out
+  int64_t bytes_limit;      // out
+  bool bytes_limit_is_set;  // out
 
   // Number of bytes reserved.
-  int64_t bytes_reserved;     // out
-  bool bytes_reserved_is_set; // out
+  int64_t bytes_reserved;      // out
+  bool bytes_reserved_is_set;  // out
   // The peak number of bytes reserved.
-  int64_t peak_bytes_reserved;     // out
-  bool peak_bytes_reserved_is_set; // out
+  int64_t peak_bytes_reserved;      // out
+  bool peak_bytes_reserved_is_set;  // out
   // The upper limit on the number bytes of reservable memory.
-  int64_t bytes_reservable_limit;     // out
-  bool bytes_reservable_limit_is_set; // out
+  int64_t bytes_reservable_limit;      // out
+  bool bytes_reservable_limit_is_set;  // out
 
   // Largest free block size in bytes.
-  int64_t largest_free_block_bytes;     // out
-  bool largest_free_block_bytes_is_set; // out
+  int64_t largest_free_block_bytes;      // out
+  bool largest_free_block_bytes_is_set;  // out
 
   // Number of bytes of memory held by the allocator.  This may be higher than
   // bytes_in_use if the allocator holds a pool of memory (e.g. BFCAllocator).
-  int64_t pool_bytes;          // out
-  bool pool_bytes_is_set;      // out
-  int64_t peak_pool_bytes;     // out
-  bool peak_pool_bytes_is_set; // out
+  int64_t pool_bytes;           // out
+  bool pool_bytes_is_set;       // out
+  int64_t peak_pool_bytes;      // out
+  bool peak_pool_bytes_is_set;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Device_MemoryStats_Args, peak_pool_bytes_is_set);
 
 // Device memory/allocator statistics. All returned stats except `bytes_in_use`
 // are optional and may not be returned by all platforms. Implementations may
 // also return PJRT_Error_Code_UNIMPLEMENTED. Intended for diagnostic purposes.
-typedef PJRT_Error *PJRT_Device_MemoryStats(PJRT_Device_MemoryStats_Args *args);
+typedef PJRT_Error* PJRT_Device_MemoryStats(PJRT_Device_MemoryStats_Args* args);
+
+struct PJRT_Device_PoisonExecution_Args {
+  size_t struct_size;
+  PJRT_Extension_Base* extension_start;
+
+  PJRT_Device* device;
+  int32_t launch_id;
+
+  // Status fields.
+  PJRT_Error_Code error_code;
+  const char* error_message;
+  size_t error_message_size;
+
+  bool poisoned;  // out
+};
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_Device_PoisonExecution_Args, poisoned);
+
+// Poisons the earliest execution on this device with given launch_id if it's
+// not finished yet, i.e. makes its output buffers error.
+typedef PJRT_Error* PJRT_Device_PoisonExecution(
+    PJRT_Device_PoisonExecution_Args* args);
+
+// --------------------------- AsyncTrackingEvent ------------------------------
+
+typedef struct PJRT_AsyncTrackingEvent PJRT_AsyncTrackingEvent;
+
+struct PJRT_Device_CreateAsyncTrackingEvent_Args {
+  size_t struct_size;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Device* device;
+  const char* description;
+  size_t description_size;
+  PJRT_AsyncTrackingEvent* event;  // out
+};
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_Device_CreateAsyncTrackingEvent_Args, event);
+
+// Creates an async tracking event. The caller is responsible for destroying the
+// event.
+typedef PJRT_Error* PJRT_Device_CreateAsyncTrackingEvent(
+    PJRT_Device_CreateAsyncTrackingEvent_Args* args);
+
+struct PJRT_AsyncTrackingEvent_Destroy_Args {
+  size_t struct_size;
+  PJRT_Extension_Base* extension_start;
+  PJRT_AsyncTrackingEvent* event;
+};
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_AsyncTrackingEvent_Destroy_Args, event);
+
+// Destroys the async tracking event.
+typedef PJRT_Error* PJRT_AsyncTrackingEvent_Destroy(
+    PJRT_AsyncTrackingEvent_Destroy_Args* args);
 
 //-------------------------------- Memory --------------------------------------
 
 struct PJRT_Memory_Id_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Memory *memory;
-  int id; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_Memory* memory;
+  int id;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Memory_Id_Args, id);
 
 // The ID of this memory. IDs are unique among memories of this type.
-typedef PJRT_Error *PJRT_Memory_Id(PJRT_Memory_Id_Args *args);
+typedef PJRT_Error* PJRT_Memory_Id(PJRT_Memory_Id_Args* args);
 
 struct PJRT_Memory_Kind_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Memory *memory;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Memory* memory;
   // `memory_kind` has same lifetime as `memory`.
-  const char *kind; // out
-  size_t kind_size; // out
+  const char* kind;  // out
+  size_t kind_size;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Memory_Kind_Args, kind_size);
 
 // A platform-dependent string that uniquely identifies the kind of the memory.
-typedef PJRT_Error *PJRT_Memory_Kind(PJRT_Memory_Kind_Args *args);
+typedef PJRT_Error* PJRT_Memory_Kind(PJRT_Memory_Kind_Args* args);
 
 struct PJRT_Memory_Kind_Id_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Memory *memory;
-  int kind_id; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_Memory* memory;
+  int kind_id;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Memory_Kind_Id_Args, kind_id);
 
 // A platform-dependent ID that uniquely identifies the kind of the memory.
-typedef PJRT_Error *PJRT_Memory_Kind_Id(PJRT_Memory_Kind_Id_Args *args);
+typedef PJRT_Error* PJRT_Memory_Kind_Id(PJRT_Memory_Kind_Id_Args* args);
 
 struct PJRT_Memory_DebugString_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Memory *memory;
-  const char *debug_string; // out
-  size_t debug_string_size; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_Memory* memory;
+  const char* debug_string;  // out
+  size_t debug_string_size;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Memory_DebugString_Args, debug_string_size);
 
 // Debug string suitable for logging when errors occur. Should be verbose
 // enough to describe the current memory unambiguously.
-typedef PJRT_Error *PJRT_Memory_DebugString(PJRT_Memory_DebugString_Args *args);
+typedef PJRT_Error* PJRT_Memory_DebugString(PJRT_Memory_DebugString_Args* args);
 
 struct PJRT_Memory_ToString_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Memory *memory;
-  const char *to_string; // out
-  size_t to_string_size; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_Memory* memory;
+  const char* to_string;  // out
+  size_t to_string_size;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Memory_ToString_Args, to_string_size);
 
 // Debug string suitable for reading by end users, should be reasonably terse.
-typedef PJRT_Error *PJRT_Memory_ToString(PJRT_Memory_ToString_Args *args);
+typedef PJRT_Error* PJRT_Memory_ToString(PJRT_Memory_ToString_Args* args);
 
 struct PJRT_Memory_AddressableByDevices_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Memory *memory;
-  PJRT_Device *const *devices; // out
-  size_t num_devices;          // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_Memory* memory;
+  PJRT_Device* const* devices;  // out
+  size_t num_devices;           // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Memory_AddressableByDevices_Args, num_devices);
 
 // Returns the devices that can address this memory.
-typedef PJRT_Error *
-PJRT_Memory_AddressableByDevices(PJRT_Memory_AddressableByDevices_Args *args);
+typedef PJRT_Error* PJRT_Memory_AddressableByDevices(
+    PJRT_Memory_AddressableByDevices_Args* args);
 
 // ------------------------------- Execute Context -----------------------------
 
@@ -1325,121 +1552,150 @@ typedef struct PJRT_ExecuteContext PJRT_ExecuteContext;
 
 struct PJRT_ExecuteContext_Create_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_ExecuteContext *context; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_ExecuteContext* context;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_ExecuteContext_Create_Args, context);
 
 // Creates an execute context.
-typedef PJRT_Error *
-PJRT_ExecuteContext_Create(PJRT_ExecuteContext_Create_Args *args);
+typedef PJRT_Error* PJRT_ExecuteContext_Create(
+    PJRT_ExecuteContext_Create_Args* args);
 
 struct PJRT_ExecuteContext_Destroy_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_ExecuteContext *context;
+  PJRT_Extension_Base* extension_start;
+  PJRT_ExecuteContext* context;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_ExecuteContext_Destroy_Args, context);
 
 // Frees an execute context. `context` can be nullptr.
-typedef PJRT_Error *
-PJRT_ExecuteContext_Destroy(PJRT_ExecuteContext_Destroy_Args *args);
+typedef PJRT_Error* PJRT_ExecuteContext_Destroy(
+    PJRT_ExecuteContext_Destroy_Args* args);
 
 // ------------------------------- Executables ---------------------------------
 
 struct PJRT_Executable_Destroy_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Executable *executable;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Executable* executable;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Executable_Destroy_Args, executable);
 
 // Frees `executable`. `executable` can be nullptr.
-typedef PJRT_Error *PJRT_Executable_Destroy(PJRT_Executable_Destroy_Args *args);
+typedef PJRT_Error* PJRT_Executable_Destroy(PJRT_Executable_Destroy_Args* args);
 
 struct PJRT_LoadedExecutable_Destroy_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_LoadedExecutable *executable;
+  PJRT_Extension_Base* extension_start;
+  PJRT_LoadedExecutable* executable;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_LoadedExecutable_Destroy_Args, executable);
 
 // Frees `executable` and deletes the underlying runtime object as if
 // `PJRT_LoadedExecutable_Delete` were called. `executable` can be nullptr.
-typedef PJRT_Error *
-PJRT_LoadedExecutable_Destroy(PJRT_LoadedExecutable_Destroy_Args *args);
+typedef PJRT_Error* PJRT_LoadedExecutable_Destroy(
+    PJRT_LoadedExecutable_Destroy_Args* args);
 
 struct PJRT_LoadedExecutable_GetExecutable_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_LoadedExecutable *loaded_executable;
-  PJRT_Executable *executable; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_LoadedExecutable* loaded_executable;
+  PJRT_Executable* executable;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_LoadedExecutable_GetExecutable_Args, executable);
 
 // Constructs a PJRT_Executable from a PJRT_LoadedExecutable. The returned
 // executable should be freed by the caller with PJRT_Executable_Destroy.
-typedef PJRT_Error *PJRT_LoadedExecutable_GetExecutable(
-    PJRT_LoadedExecutable_GetExecutable_Args *args);
+typedef PJRT_Error* PJRT_LoadedExecutable_GetExecutable(
+    PJRT_LoadedExecutable_GetExecutable_Args* args);
+
+typedef struct PJRT_DeviceAssignmentSerialized PJRT_DeviceAssignmentSerialized;
+
+struct PJRT_LoadedExecutable_GetDeviceAssignment_Args {
+  size_t struct_size;
+  PJRT_Extension_Base* extension_start;
+  PJRT_LoadedExecutable* executable;
+
+  // Lives only as long as serialized_device_assignment
+  const char* serialized_bytes;  // out
+  size_t serialized_bytes_size;  // out
+
+  PJRT_DeviceAssignmentSerialized*
+      serialized_device_assignment;  // backs serialized_bytes.
+  // cleanup fn must be called to free the backing memory for serialized_bytes.
+  // Should only be called once on serialized_device_assignment.
+  void (*serialized_device_assignment_deleter)(
+      PJRT_DeviceAssignmentSerialized* da);  // out
+};
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_LoadedExecutable_GetDeviceAssignment_Args,
+                          serialized_device_assignment_deleter);
+
+// Retrieves the serialized DeviceAssignmentProto for a given
+// PJRT_LoadedExecutable. The implementation allocates the serialized data,
+// which is valid as long as `serialized_device_assignment` is alive. The
+// caller must call `serialized_device_assignment_deleter` to free the
+// backing memory.
+typedef PJRT_Error* PJRT_LoadedExecutable_GetDeviceAssignment(
+    PJRT_LoadedExecutable_GetDeviceAssignment_Args* args);
 
 struct PJRT_Executable_Name_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Executable *executable;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Executable* executable;
   // `executable_name` has the same lifetime as `executable`. It is owned by
   // `executable`.
-  const char *executable_name; // out
-  size_t executable_name_size; // out
+  const char* executable_name;  // out
+  size_t executable_name_size;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Executable_Name_Args, executable_name_size);
 
 // Returns a string that identifies the executable.
-typedef PJRT_Error *PJRT_Executable_Name(PJRT_Executable_Name_Args *args);
+typedef PJRT_Error* PJRT_Executable_Name(PJRT_Executable_Name_Args* args);
 
 // TODO(b/269178731): Revisit whether num_replicas is needed.
 struct PJRT_Executable_NumReplicas_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Executable *executable;
-  size_t num_replicas; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_Executable* executable;
+  size_t num_replicas;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Executable_NumReplicas_Args, num_replicas);
 
 // Returns the number of replicas of the executable.
-typedef PJRT_Error *
-PJRT_Executable_NumReplicas(PJRT_Executable_NumReplicas_Args *args);
+typedef PJRT_Error* PJRT_Executable_NumReplicas(
+    PJRT_Executable_NumReplicas_Args* args);
 
 struct PJRT_Executable_NumPartitions_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Executable *executable;
-  size_t num_partitions; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_Executable* executable;
+  size_t num_partitions;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Executable_NumPartitions_Args, num_partitions);
 
 // Returns the number of partitions of the executable.
-typedef PJRT_Error *
-PJRT_Executable_NumPartitions(PJRT_Executable_NumPartitions_Args *args);
+typedef PJRT_Error* PJRT_Executable_NumPartitions(
+    PJRT_Executable_NumPartitions_Args* args);
 
 struct PJRT_LoadedExecutable_AddressableDevices_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_LoadedExecutable *executable;
-  PJRT_Device *const *addressable_devices; // out
-  size_t num_addressable_devices;          // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_LoadedExecutable* executable;
+  PJRT_Device* const* addressable_devices;  // out
+  size_t num_addressable_devices;           // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_LoadedExecutable_AddressableDevices_Args,
                           num_addressable_devices);
 
 // Returns a list of devices this executable will run on.
-typedef PJRT_Error *PJRT_LoadedExecutable_AddressableDevices(
-    PJRT_LoadedExecutable_AddressableDevices_Args *args);
+typedef PJRT_Error* PJRT_LoadedExecutable_AddressableDevices(
+    PJRT_LoadedExecutable_AddressableDevices_Args* args);
 
 struct PJRT_Executable_OptimizedProgram_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Executable *executable;
-  PJRT_Program *program; // out, but read below
+  PJRT_Extension_Base* extension_start;
+  PJRT_Executable* executable;
+  PJRT_Program* program;  // out, but read below
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Executable_OptimizedProgram_Args, program);
 
@@ -1466,13 +1722,13 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_Executable_OptimizedProgram_Args, program);
 // least `code_size` bytes. Before the second call, callers should set
 // `program->code = code_buff`. The second call will then write the serialized
 // program to `code_buff`.
-typedef PJRT_Error *
-PJRT_Executable_OptimizedProgram(PJRT_Executable_OptimizedProgram_Args *args);
+typedef PJRT_Error* PJRT_Executable_OptimizedProgram(
+    PJRT_Executable_OptimizedProgram_Args* args);
 
 struct PJRT_LoadedExecutable_Delete_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_LoadedExecutable *executable;
+  PJRT_Extension_Base* extension_start;
+  PJRT_LoadedExecutable* executable;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_LoadedExecutable_Delete_Args, executable);
 
@@ -1481,27 +1737,27 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_LoadedExecutable_Delete_Args, executable);
 // `executable` can only be used with PJRT_LoadedExecutable_IsDeleted and
 // PJRT_LoadedExecutable_Destroy after calling this method. The internal runtime
 // executable will be freed after the last execution completes.
-typedef PJRT_Error *
-PJRT_LoadedExecutable_Delete(PJRT_LoadedExecutable_Delete_Args *args);
+typedef PJRT_Error* PJRT_LoadedExecutable_Delete(
+    PJRT_LoadedExecutable_Delete_Args* args);
 
 struct PJRT_LoadedExecutable_IsDeleted_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_LoadedExecutable *executable;
-  bool is_deleted; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_LoadedExecutable* executable;
+  bool is_deleted;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_LoadedExecutable_IsDeleted_Args, is_deleted);
 
 // True if and only if PJRT_LoadedExecutable_Delete has previously been called.
-typedef PJRT_Error *
-PJRT_LoadedExecutable_IsDeleted(PJRT_LoadedExecutable_IsDeleted_Args *args);
+typedef PJRT_Error* PJRT_LoadedExecutable_IsDeleted(
+    PJRT_LoadedExecutable_IsDeleted_Args* args);
 
 typedef struct PJRT_Chunk {
-  void *data;
+  void* data;
   size_t size;
-  void (*deleter)(void *data, void *deleter_arg);
+  void (*deleter)(void* data, void* deleter_arg);
   // `deleter_arg` will be passed to `deleter` as `deleter_arg` argument.
-  void *deleter_arg;
+  void* deleter_arg;
 } PJRT_Chunk;
 
 // TODO(b/263390934) implement C API that calls `AddChunk` and other
@@ -1514,20 +1770,20 @@ struct PJRT_TransferMetadata;
 // Otherwise, returns nullptr. The callback must call
 // `chunk->deleter(chunk->data, chunk->deleter_arg)` when it's finished with
 // `chunk`.
-typedef PJRT_Error *(*PJRT_SendCallback)(PJRT_Chunk *chunk,
-                                         PJRT_CallbackError *callback_error,
+typedef PJRT_Error* (*PJRT_SendCallback)(PJRT_Chunk* chunk,
+                                         PJRT_CallbackError* callback_error,
                                          size_t total_size_in_bytes, bool done,
-                                         void *user_arg);
+                                         void* user_arg);
 // The callback takes the ownership of the stream object. The callback must call
 // `PJRT_CopyToDeviceStream_Destroy` when it is done with the stream.
-typedef void (*PJRT_RecvCallback)(PJRT_CopyToDeviceStream *stream,
-                                  void *user_arg);
+typedef void (*PJRT_RecvCallback)(PJRT_CopyToDeviceStream* stream,
+                                  void* user_arg);
 
 struct PJRT_SendCallbackInfo {
   // Used to associate this callback with the correct send op.
   int64_t channel_id;
   // Will be passed to `send_callback` as `user_arg` argument.
-  void *user_arg;
+  void* user_arg;
   PJRT_SendCallback send_callback;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_SendCallbackInfo, send_callback);
@@ -1536,14 +1792,14 @@ struct PJRT_RecvCallbackInfo {
   // Used to associate this callback with the correct recv op.
   int64_t channel_id;
   // Will be passed to `recv_callback` as `user_arg` argument.
-  void *user_arg;
+  void* user_arg;
   PJRT_RecvCallback recv_callback;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_RecvCallbackInfo, recv_callback);
 
 struct PJRT_ExecuteOptions {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
+  PJRT_Extension_Base* extension_start;
   // Callbacks for when send/recv ops are executed. The outer lists correspond
   // to each device returned by `PJRT_Executable_AddressableDevices` for
   // `executable` (i.e. they will have length `num_devices`). Each inner list
@@ -1551,8 +1807,8 @@ struct PJRT_ExecuteOptions {
   // doesn't matter as the channel IDs are used instead. The callbacks can be
   // stateful and the user code is responsible for managing state. The callback
   // functions must outlive the execution (but not the info structs or lists).
-  PJRT_SendCallbackInfo **send_callbacks;
-  PJRT_RecvCallbackInfo **recv_callbacks;
+  PJRT_SendCallbackInfo** send_callbacks;
+  PJRT_RecvCallbackInfo** recv_callbacks;
   size_t num_send_ops;
   size_t num_recv_ops;
   // If non-zero, identifies this execution as part of a potentially
@@ -1568,20 +1824,38 @@ struct PJRT_ExecuteOptions {
   // indices, a higher-level PJRT caller can instruct PJRT client not to donate
   // specific input buffers. The caller needs to make sure to keep it alive
   // during the call.
-  const int64_t *non_donatable_input_indices;
+  const int64_t* non_donatable_input_indices;
   size_t num_non_donatable_input_indices;
-  PJRT_ExecuteContext *context;
+  PJRT_ExecuteContext* context;
+  // The `call_location` field is used to pass down call site location
+  // information from higher-level frameworks like JAX and PyTorch to the PJRT
+  // plugin. This field stores the source location (e.g., file:line) of the
+  // Python code that triggered the execution of this compiled program. This
+  // differs from the source location metadata stored in `OpMetadata`, which
+  // refers to the origin of individual operations within the HLO module.
+  // The plugin can use `call_location` for debugging and error reporting,
+  // allowing users to pinpoint which program execution led to an issue.
+  // The `call_location` pointer is owned by the caller and must point to a
+  // null-terminated string. It is only valid for the duration of the C API
+  // call. The plugin must copy the string if it needs to be stored.
+  const char* call_location;
+
+  // The incarnation id for every task. For every 0 <= i < num_tasks,
+  // task task_ids[i] has incarnation incarnation_ids[i].
+  size_t num_tasks;
+  int* task_ids;
+  int64_t* incarnation_ids;
 };
-PJRT_DEFINE_STRUCT_TRAITS(PJRT_ExecuteOptions, context);
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_ExecuteOptions, incarnation_ids);
 
 struct PJRT_LoadedExecutable_Execute_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_LoadedExecutable *executable;
+  PJRT_Extension_Base* extension_start;
+  PJRT_LoadedExecutable* executable;
   // Only needs to stay alive for the duration of the Execute call.
-  PJRT_ExecuteOptions *options;
+  PJRT_ExecuteOptions* options;
   // Execution input of size [`num_devices`, `num_args`].
-  PJRT_Buffer *const *const *argument_lists;
+  PJRT_Buffer* const* const* argument_lists;
   size_t num_devices;
   size_t num_args;
   // Execution output of size [`num_devices`, num_outputs`], where `num_outputs`
@@ -1589,14 +1863,14 @@ struct PJRT_LoadedExecutable_Execute_Args {
   // outer (`PJRT_Buffer***`) and inner lists (`PJRT_Buffer**`) must be
   // allocated and deallocated by the caller. PJRT_Buffer_Destroy must be called
   // on the output PJRT_Buffer*.
-  PJRT_Buffer **const *output_lists; // in/out
+  PJRT_Buffer** const* output_lists;  // in/out
   // If `device_complete_events` isn't nullptr, `device_complete_events` needs
   // to be the same length as `output_lists` (i.e. of length `num_devices`), and
   // each `PJRT_Event` will become ready once the corresponding device execution
   // is complete. If Execute returns an error, then `device_complete_events`
   // will not be populated. The caller is responsible for calling
   // PJRT_Event_Destroy on the returned PJRT_Event*s.
-  PJRT_Event **device_complete_events; // in/out
+  PJRT_Event** device_complete_events;  // in/out
   // The device to execute on. If nullptr, will execute on the device(s)
   // specified at compile time. If set, must be an addressable device, and
   // `num_devices` should be 1 with `argument_lists` only containing arguments
@@ -1605,45 +1879,45 @@ struct PJRT_LoadedExecutable_Execute_Args {
   // make sure the executable is launched on all participating devices specified
   // at compile time. Setting this field may not be supported on all platforms
   // or executables.
-  PJRT_Device *execute_device;
+  PJRT_Device* execute_device;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_LoadedExecutable_Execute_Args, execute_device);
 
 // Executes on devices addressable by the client.
-typedef PJRT_Error *
-PJRT_LoadedExecutable_Execute(PJRT_LoadedExecutable_Execute_Args *args);
+typedef PJRT_Error* PJRT_LoadedExecutable_Execute(
+    PJRT_LoadedExecutable_Execute_Args* args);
 
 struct PJRT_Executable_NumOutputs_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Executable *executable;
-  size_t num_outputs; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_Executable* executable;
+  size_t num_outputs;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Executable_NumOutputs_Args, num_outputs);
 
 // Gets the number of outputs per device produced by `executable`.
-typedef PJRT_Error *
-PJRT_Executable_NumOutputs(PJRT_Executable_NumOutputs_Args *args);
+typedef PJRT_Error* PJRT_Executable_NumOutputs(
+    PJRT_Executable_NumOutputs_Args* args);
 
 struct PJRT_Executable_SizeOfGeneratedCodeInBytes_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Executable *executable;
-  int64_t size_in_bytes; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_Executable* executable;
+  int64_t size_in_bytes;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Executable_SizeOfGeneratedCodeInBytes_Args,
-                          size_in_bytes); // last field in the struct
+                          size_in_bytes);  // last field in the struct
 
-typedef PJRT_Error *PJRT_Executable_SizeOfGeneratedCodeInBytes(
-    PJRT_Executable_SizeOfGeneratedCodeInBytes_Args *args);
+typedef PJRT_Error* PJRT_Executable_SizeOfGeneratedCodeInBytes(
+    PJRT_Executable_SizeOfGeneratedCodeInBytes_Args* args);
 
 struct PJRT_Executable_Fingerprint_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Executable *executable;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Executable* executable;
   // Has the lifetime of `executable`
-  const char *executable_fingerprint; // out
-  size_t executable_fingerprint_size; // out
+  const char* executable_fingerprint;  // out
+  size_t executable_fingerprint_size;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Executable_Fingerprint_Args,
                           executable_fingerprint_size);
@@ -1652,17 +1926,17 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_Executable_Fingerprint_Args,
 // compiling with identical inputs (same program, compile options, compiler
 // version, etc.) should have the same fingerprint. May not be implemented by
 // all platforms.
-typedef PJRT_Error *
-PJRT_Executable_Fingerprint(PJRT_Executable_Fingerprint_Args *args);
+typedef PJRT_Error* PJRT_Executable_Fingerprint(
+    PJRT_Executable_Fingerprint_Args* args);
 
 struct PJRT_Executable_GetCostAnalysis_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Executable *executable;
-  size_t num_properties; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_Executable* executable;
+  size_t num_properties;  // out
   // `properties` and any embedded data are owned by and have the same lifetime
   // as `executable`.
-  const PJRT_NamedValue *properties; // out
+  const PJRT_NamedValue* properties;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Executable_GetCostAnalysis_Args, properties);
 
@@ -1670,136 +1944,169 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_Executable_GetCostAnalysis_Args, properties);
 // different properties; for example, some platforms may return the number of
 // operations, or memory size of the input/output of the executable, based on
 // program analysis.
-typedef PJRT_Error *
-PJRT_Executable_GetCostAnalysis(PJRT_Executable_GetCostAnalysis_Args *args);
+typedef PJRT_Error* PJRT_Executable_GetCostAnalysis(
+    PJRT_Executable_GetCostAnalysis_Args* args);
 
 struct PJRT_Executable_GetCompiledMemoryStats_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Executable *executable;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Executable* executable;
 
   // Mirrors xla::CompiledMemoryStats.
   // Device default memory (e.g., HBM for GPU/TPU) usage stats.
-  int64_t generated_code_size_in_bytes; // out
-  int64_t argument_size_in_bytes;       // out
-  int64_t output_size_in_bytes;         // out
+  int64_t generated_code_size_in_bytes;  // out
+  int64_t argument_size_in_bytes;        // out
+  int64_t output_size_in_bytes;          // out
   // How much argument is reused for output.
-  int64_t alias_size_in_bytes; // out
-  int64_t temp_size_in_bytes;  // out
+  int64_t alias_size_in_bytes;  // out
+  int64_t temp_size_in_bytes;   // out
 
   // Host memory usage stats.
-  int64_t host_generated_code_size_in_bytes; // out
-  int64_t host_argument_size_in_bytes;       // out
-  int64_t host_output_size_in_bytes;         // out
-  int64_t host_alias_size_in_bytes;          // out
-  int64_t host_temp_size_in_bytes;           // out
+  int64_t host_generated_code_size_in_bytes;  // out
+  int64_t host_argument_size_in_bytes;        // out
+  int64_t host_output_size_in_bytes;          // out
+  int64_t host_alias_size_in_bytes;           // out
+  int64_t host_temp_size_in_bytes;            // out
+
+  // Device memory stats, from xla::CompiledMemoryStats.
+  int64_t peak_memory_in_bytes;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Executable_GetCompiledMemoryStats_Args,
-                          host_temp_size_in_bytes);
+                          peak_memory_in_bytes);
 
 // Return memory stats that allow callers to estimate memory usage when running
 // this executable. The memory stats could contain usage info from different
 // memory spaces, like default memory (e.g., HBM for GPU/TPU) and host memory.
-typedef PJRT_Error *PJRT_Executable_GetCompiledMemoryStats(
-    PJRT_Executable_GetCompiledMemoryStats_Args *args);
+typedef PJRT_Error* PJRT_Executable_GetCompiledMemoryStats(
+    PJRT_Executable_GetCompiledMemoryStats_Args* args);
 
 struct PJRT_Executable_OutputElementTypes_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Executable *executable;
-  PJRT_Buffer_Type *output_types; // out
-  size_t num_output_types;        // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_Executable* executable;
+  PJRT_Buffer_Type* output_types;  // out
+  size_t num_output_types;         // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Executable_OutputElementTypes_Args,
                           num_output_types);
 
 // Returns a list of element types for outputs.
-typedef PJRT_Error *PJRT_Executable_OutputElementTypes(
-    PJRT_Executable_OutputElementTypes_Args *args);
+typedef PJRT_Error* PJRT_Executable_OutputElementTypes(
+    PJRT_Executable_OutputElementTypes_Args* args);
 
 struct PJRT_Executable_OutputDimensions_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Executable *executable;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Executable* executable;
   size_t num_outputs;
   // Has length: sum of all elements in the list `dim_sizes`.
-  const int64_t *dims; // out
+  const int64_t* dims;  // out
   // Has length `num_outputs`.
-  const size_t *dim_sizes; // out
+  const size_t* dim_sizes;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Executable_OutputDimensions_Args, dim_sizes);
 
 // Returns a list of dimensions for outputs. Each output has an array shape,
 // which is represented by a list of dimensions. The array shapes of all outputs
 // are concatenated into a single list of dimensions.
-typedef PJRT_Error *
-PJRT_Executable_OutputDimensions(PJRT_Executable_OutputDimensions_Args *args);
+typedef PJRT_Error* PJRT_Executable_OutputDimensions(
+    PJRT_Executable_OutputDimensions_Args* args);
 
 struct PJRT_Executable_OutputMemoryKinds_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Executable *executable;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Executable* executable;
   size_t num_outputs;
   // Has length `num_outputs`.
-  const char *const *memory_kinds; // out
+  const char* const* memory_kinds;  // out
   // Has length `num_outputs`.
-  const size_t *memory_kind_sizes; // out
+  const size_t* memory_kind_sizes;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Executable_OutputMemoryKinds_Args,
                           memory_kind_sizes);
 
 // Returns a list of memory kind strings for outputs.
-typedef PJRT_Error *
-PJRT_Executable_OutputMemoryKinds(PJRT_Executable_OutputMemoryKinds_Args *args);
+typedef PJRT_Error* PJRT_Executable_OutputMemoryKinds(
+    PJRT_Executable_OutputMemoryKinds_Args* args);
 
 typedef struct PJRT_SerializedExecutable PJRT_SerializedExecutable;
 
+typedef struct PJRT_SerializedCompileOptions PJRT_SerializedCompileOptions;
+
 struct PJRT_Executable_Serialize_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  const PJRT_Executable *executable;
+  PJRT_Extension_Base* extension_start;
+  const PJRT_Executable* executable;
 
   // Lives only as long as serialized_executable
-  const char *serialized_bytes; // out
-  size_t serialized_bytes_size; // out
+  const char* serialized_bytes;  // out
+  size_t serialized_bytes_size;  // out
 
-  PJRT_SerializedExecutable *serialized_executable; // backs serialized_bytes.
+  PJRT_SerializedExecutable* serialized_executable;  // backs serialized_bytes.
   // cleanup fn must be called to free the backing memory for serialized_bytes.
   // Should only be called once on serialized_executable.
-  void (*serialized_executable_deleter)(PJRT_SerializedExecutable *exec); // out
+  void (*serialized_executable_deleter)(
+      PJRT_SerializedExecutable* exec);  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Executable_Serialize_Args,
                           serialized_executable_deleter);
 
 // Returns a platform-specific serialization of `executable`. The serialization
 // is not guaranteed to be stable over time.
-typedef PJRT_Error *
-PJRT_Executable_Serialize(PJRT_Executable_Serialize_Args *args);
+typedef PJRT_Error* PJRT_Executable_Serialize(
+    PJRT_Executable_Serialize_Args* args);
+
+struct PJRT_Executable_GetCompileOptions_Args {
+  size_t struct_size;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Executable* executable;
+
+  // Lives only as long as serialized_compile_options
+  const char* serialized_bytes;  // out
+  size_t serialized_bytes_size;  // out
+
+  PJRT_SerializedCompileOptions*
+      serialized_compile_options;  // backs serialized_bytes.
+  // cleanup fn must be called to free the backing memory for serialized_bytes.
+  // Should only be called once on serialized_compile_options.
+  void (*serialized_compile_options_deleter)(
+      PJRT_SerializedCompileOptions* options);  // out
+};
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_Executable_GetCompileOptions_Args,
+                          serialized_compile_options_deleter);
+
+// Returns the CompileOptions that were used to compile this executable.
+typedef PJRT_Error* PJRT_Executable_GetCompileOptions(
+    PJRT_Executable_GetCompileOptions_Args* args);
 
 struct PJRT_Executable_DeserializeAndLoad_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Client *client;
-  const char *serialized_executable;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Client* client;
+  const char* serialized_executable;
   size_t serialized_executable_size;
-  PJRT_LoadedExecutable *loaded_executable; // out
+  PJRT_LoadedExecutable* loaded_executable;  // out
+  // Serialized CompileOptionsProto or null (to use the options
+  // from the serialized executable).
+  const char* overridden_serialized_compile_options;
+  size_t overridden_serialized_compile_options_size;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Executable_DeserializeAndLoad_Args,
-                          loaded_executable);
+                          overridden_serialized_compile_options_size);
 
 // Deserializes an executable serialized by `PJRT_Executable_Serialize`.
 // `serialized_executable` must have been produced by the same platform and
 // library version as this one.
-typedef PJRT_Error *PJRT_Executable_DeserializeAndLoad(
-    PJRT_Executable_DeserializeAndLoad_Args *args);
+typedef PJRT_Error* PJRT_Executable_DeserializeAndLoad(
+    PJRT_Executable_DeserializeAndLoad_Args* args);
 
 struct PJRT_LoadedExecutable_Fingerprint_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_LoadedExecutable *executable;
+  PJRT_Extension_Base* extension_start;
+  PJRT_LoadedExecutable* executable;
   // Has the lifetime of `executable`
-  const char *executable_fingerprint; // out
-  size_t executable_fingerprint_size; // out
+  const char* executable_fingerprint;  // out
+  size_t executable_fingerprint_size;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_LoadedExecutable_Fingerprint_Args,
                           executable_fingerprint_size);
@@ -1808,53 +2115,53 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_LoadedExecutable_Fingerprint_Args,
 // Two executables that were produced by compiling with identical inputs (same
 // program, compile options, compiler version, etc.) should have the same
 // fingerprint. May not be implemented by all platforms.
-typedef PJRT_Error *
-PJRT_LoadedExecutable_Fingerprint(PJRT_LoadedExecutable_Fingerprint_Args *args);
+typedef PJRT_Error* PJRT_LoadedExecutable_Fingerprint(
+    PJRT_LoadedExecutable_Fingerprint_Args* args);
 
 // ---------------------------------- Buffers ----------------------------------
 
 struct PJRT_Buffer_Destroy_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Buffer *buffer;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Buffer* buffer;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_Destroy_Args, buffer);
 
 // Deletes the underlying runtime objects as if 'PJRT_Buffer_Delete' were
 // called and frees `buffer`. `buffer` can be nullptr.
-typedef PJRT_Error *PJRT_Buffer_Destroy(PJRT_Buffer_Destroy_Args *args);
+typedef PJRT_Error* PJRT_Buffer_Destroy(PJRT_Buffer_Destroy_Args* args);
 
 struct PJRT_Buffer_ElementType_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Buffer *buffer;
-  PJRT_Buffer_Type type; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_Buffer* buffer;
+  PJRT_Buffer_Type type;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_ElementType_Args, type);
 
 // Returns the type of the array elements of a buffer.
-typedef PJRT_Error *PJRT_Buffer_ElementType(PJRT_Buffer_ElementType_Args *args);
+typedef PJRT_Error* PJRT_Buffer_ElementType(PJRT_Buffer_ElementType_Args* args);
 
 struct PJRT_Buffer_Dimensions_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Buffer *buffer;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Buffer* buffer;
   // Has the lifetime of `buffer` and length `num_dims`.
-  const int64_t *dims; // out
-  size_t num_dims;     // out
+  const int64_t* dims;  // out
+  size_t num_dims;      // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_Dimensions_Args, num_dims);
 
 // Returns the array shape of `buffer`, i.e. the size of each dimension.
-typedef PJRT_Error *PJRT_Buffer_Dimensions(PJRT_Buffer_Dimensions_Args *args);
+typedef PJRT_Error* PJRT_Buffer_Dimensions(PJRT_Buffer_Dimensions_Args* args);
 
 struct PJRT_Buffer_UnpaddedDimensions_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Buffer *buffer;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Buffer* buffer;
   // Has the lifetime of `buffer` and length `num_dims`.
-  const int64_t *unpadded_dims; // out
-  size_t num_dims;              // out
+  const int64_t* unpadded_dims;  // out
+  size_t num_dims;               // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_UnpaddedDimensions_Args, num_dims);
 
@@ -1865,16 +2172,16 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_UnpaddedDimensions_Args, num_dims);
 // PJRT_Buffer_Dimensions. ("Dynamic" dimensions are those whose length is
 // only known at runtime, vs. "static" dimensions whose size is fixed at compile
 // time.)
-typedef PJRT_Error *
-PJRT_Buffer_UnpaddedDimensions(PJRT_Buffer_UnpaddedDimensions_Args *args);
+typedef PJRT_Error* PJRT_Buffer_UnpaddedDimensions(
+    PJRT_Buffer_UnpaddedDimensions_Args* args);
 
 struct PJRT_Buffer_DynamicDimensionIndices_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Buffer *buffer;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Buffer* buffer;
   // Has the lifetime of `buffer` and length `num_dynamic_dims`.
-  const size_t *dynamic_dim_indices; // out
-  size_t num_dynamic_dims;           // out
+  const size_t* dynamic_dim_indices;  // out
+  size_t num_dynamic_dims;            // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_DynamicDimensionIndices_Args,
                           num_dynamic_dims);
@@ -1883,67 +2190,67 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_DynamicDimensionIndices_Args,
 // dimensions are static. ("Dynamic" dimensions are those whose length is
 // only known at runtime, vs. "static" dimensions whose size is fixed at compile
 // time.)
-typedef PJRT_Error *PJRT_Buffer_DynamicDimensionIndices(
-    PJRT_Buffer_DynamicDimensionIndices_Args *args);
+typedef PJRT_Error* PJRT_Buffer_DynamicDimensionIndices(
+    PJRT_Buffer_DynamicDimensionIndices_Args* args);
 
 struct PJRT_Buffer_GetMemoryLayout_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Buffer *buffer;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Buffer* buffer;
   // Layout data is owned by and has the lifetime of `buffer`.
-  PJRT_Buffer_MemoryLayout layout; // out
+  PJRT_Buffer_MemoryLayout layout;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_GetMemoryLayout_Args, layout);
 
 // DEPRECATED. Please use layout extension instead.
 // https://github.com/openxla/xla/blob/main/xla/pjrt/c/pjrt_c_api_layouts_extension.h
 // Returns the memory layout of the data in this buffer.
-typedef PJRT_Error *
-PJRT_Buffer_GetMemoryLayout(PJRT_Buffer_GetMemoryLayout_Args *args);
+typedef PJRT_Error* PJRT_Buffer_GetMemoryLayout(
+    PJRT_Buffer_GetMemoryLayout_Args* args);
 
 struct PJRT_Buffer_ToHostBuffer_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Buffer *src;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Buffer* src;
 
   // The caller can specify an optional host layout. If nullptr, the layout of
   // the src buffer will be used. The caller is responsible to keep the data
   // (tiled or strides) in the host_layout alive during the call.
-  PJRT_Buffer_MemoryLayout *host_layout;
+  PJRT_Buffer_MemoryLayout* host_layout;
   // `dst` can be nullptr to query required size which will be set into
   // `dst_size`.
-  void *dst; // in/out
+  void* dst;  // in/out
   // Size of `dst` in bytes. If `dst` is nullptr, then `dst_size` is set to the
   // size needed. Otherwise, `dst_size` must be greater than or equal to the
   // needed size.
-  size_t dst_size; // in/out
+  size_t dst_size;  // in/out
 
   // Event that signals when the copy has completed.
-  PJRT_Event *event; // out
+  PJRT_Event* event;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_ToHostBuffer_Args, event);
 
 // Asynchronously copies the buffer's value into a preallocated host buffer.
-typedef PJRT_Error *
-PJRT_Buffer_ToHostBuffer(PJRT_Buffer_ToHostBuffer_Args *args);
+typedef PJRT_Error* PJRT_Buffer_ToHostBuffer(
+    PJRT_Buffer_ToHostBuffer_Args* args);
 
 struct PJRT_Buffer_OnDeviceSizeInBytes_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Buffer *buffer;
-  size_t on_device_size_in_bytes; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_Buffer* buffer;
+  size_t on_device_size_in_bytes;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_OnDeviceSizeInBytes_Args,
                           on_device_size_in_bytes);
 
 // Gets the number of bytes of the buffer storage on the device
-typedef PJRT_Error *
-PJRT_Buffer_OnDeviceSizeInBytes(PJRT_Buffer_OnDeviceSizeInBytes_Args *args);
+typedef PJRT_Error* PJRT_Buffer_OnDeviceSizeInBytes(
+    PJRT_Buffer_OnDeviceSizeInBytes_Args* args);
 
 struct PJRT_Buffer_Delete_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Buffer *buffer;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Buffer* buffer;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_Delete_Args, buffer);
 
@@ -1952,102 +2259,139 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_Delete_Args, buffer);
 // PJRT_Buffer_IsDeleted and PJRT_Buffer_Destroy after calling this method. The
 // device memory will be freed when all async operations using the buffer have
 // completed, according to the allocation semantics of the underlying platform.
-typedef PJRT_Error *PJRT_Buffer_Delete(PJRT_Buffer_Delete_Args *args);
+typedef PJRT_Error* PJRT_Buffer_Delete(PJRT_Buffer_Delete_Args* args);
 
 struct PJRT_Buffer_IsDeleted_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Buffer *buffer;
-  bool is_deleted; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_Buffer* buffer;
+  bool is_deleted;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_IsDeleted_Args, is_deleted);
 
 // True if and only if PJRT_Buffer_Delete has previously been called.
-typedef PJRT_Error *PJRT_Buffer_IsDeleted(PJRT_Buffer_IsDeleted_Args *args);
+typedef PJRT_Error* PJRT_Buffer_IsDeleted(PJRT_Buffer_IsDeleted_Args* args);
 
 struct PJRT_Buffer_CopyRawToHost_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Buffer *buffer;
-  void *dst;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Buffer* buffer;
+  void* dst;
   int64_t offset;
   int64_t transfer_size;
-  PJRT_Event *event; // out
+  PJRT_Event* event;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_CopyRawToHost_Args, event);
 
-typedef PJRT_Error *
-PJRT_Buffer_CopyRawToHost(PJRT_Buffer_CopyRawToHost_Args *args);
+typedef PJRT_Error* PJRT_Buffer_CopyRawToHost(
+    PJRT_Buffer_CopyRawToHost_Args* args);
+
+struct PJRT_Buffer_CopyRawToHostFuture_Callback_Args {
+  size_t struct_size;
+
+  // callback_data should be set to the one returned by
+  // PJRT_Buffer_CopyRawToHostFuture.
+  void* callback_data;
+
+  PJRT_Error_Code error_code;
+  // error_message and error_message_size are only valid if error_code is not
+  // PJRT_ERROR_CODE_OK.
+  const char* error_message;
+  size_t error_message_size;
+  // dst is only valid if error_code is PJRT_ERROR_CODE_OK.
+  void* dst;
+};
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_CopyRawToHostFuture_Callback_Args, dst);
+
+struct PJRT_Buffer_CopyRawToHostFuture_Args {
+  size_t struct_size;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Buffer* buffer;
+  int64_t offset;
+  int64_t transfer_size;
+  PJRT_Event* event;  // out
+  // callback_data should be sent to the future_ready, when dst is ready.
+  void* callback_data;  // out
+  void (*future_ready_callback)(
+      PJRT_Buffer_CopyRawToHostFuture_Callback_Args* args);  // out
+};
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_CopyRawToHostFuture_Args,
+                          future_ready_callback);
+
+// Similar to PJRT_Buffer_CopyRawToHost, but the transfer will not happen until
+// `future_ready_callback` is invoked.
+typedef PJRT_Error* PJRT_Buffer_CopyRawToHostFuture(
+    PJRT_Buffer_CopyRawToHostFuture_Args* args);
 
 struct PJRT_Buffer_CopyToDevice_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Buffer *buffer;
-  PJRT_Device *dst_device;
-  PJRT_Buffer *dst_buffer; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_Buffer* buffer;
+  PJRT_Device* dst_device;
+  PJRT_Buffer* dst_buffer;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_CopyToDevice_Args, dst_buffer);
 
 // Copies the buffer to device `dst_device` within the same client. Caller is
 // responsible for freeing returned `dst_buffer` with PJRT_Buffer_Destroy.
 // Returns an error if the buffer is already on `dst_device`.
-typedef PJRT_Error *
-PJRT_Buffer_CopyToDevice(PJRT_Buffer_CopyToDevice_Args *args);
+typedef PJRT_Error* PJRT_Buffer_CopyToDevice(
+    PJRT_Buffer_CopyToDevice_Args* args);
 
 struct PJRT_Buffer_CopyToMemory_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Buffer *buffer;
-  PJRT_Memory *dst_memory;
-  PJRT_Buffer *dst_buffer; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_Buffer* buffer;
+  PJRT_Memory* dst_memory;
+  PJRT_Buffer* dst_buffer;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_CopyToMemory_Args, dst_buffer);
 
 // Copies the buffer to memory `dst_memory` within the same client. Caller is
 // responsible for freeing returned `dst_buffer` with PJRT_Buffer_Destroy.
 // Returns an error if the buffer is already on `dst_memory`.
-typedef PJRT_Error *
-PJRT_Buffer_CopyToMemory(PJRT_Buffer_CopyToMemory_Args *args);
+typedef PJRT_Error* PJRT_Buffer_CopyToMemory(
+    PJRT_Buffer_CopyToMemory_Args* args);
 
 struct PJRT_Buffer_IsOnCpu_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Buffer *buffer;
-  bool is_on_cpu; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_Buffer* buffer;
+  bool is_on_cpu;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_IsOnCpu_Args, is_on_cpu);
 
 // Whether this buffer is on CPU and thus allows for certain optimizations.
-typedef PJRT_Error *PJRT_Buffer_IsOnCpu(PJRT_Buffer_IsOnCpu_Args *args);
+typedef PJRT_Error* PJRT_Buffer_IsOnCpu(PJRT_Buffer_IsOnCpu_Args* args);
 
 struct PJRT_Buffer_Device_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Buffer *buffer;
-  PJRT_Device *device; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_Buffer* buffer;
+  PJRT_Device* device;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_Device_Args, device);
 
 // Returns this buffer's storage device.
-typedef PJRT_Error *PJRT_Buffer_Device(PJRT_Buffer_Device_Args *args);
+typedef PJRT_Error* PJRT_Buffer_Device(PJRT_Buffer_Device_Args* args);
 
 struct PJRT_Buffer_Memory_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Buffer *buffer;
-  PJRT_Memory *memory; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_Buffer* buffer;
+  PJRT_Memory* memory;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_Memory_Args, memory);
 
 // Returns this buffer's storage memory.
-typedef PJRT_Error *PJRT_Buffer_Memory(PJRT_Buffer_Memory_Args *args);
+typedef PJRT_Error* PJRT_Buffer_Memory(PJRT_Buffer_Memory_Args* args);
 
 struct PJRT_Buffer_ReadyEvent_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Buffer *buffer;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Buffer* buffer;
   // The caller is responsible for calling PJRT_Event_Destroy on `event`.
-  PJRT_Event *event; // out
+  PJRT_Event* event;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_ReadyEvent_Args, event);
 
@@ -2060,25 +2404,25 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_ReadyEvent_Args, event);
 // immediately indicate an error. However, if PJRT_Buffer_ReadyEvent() is
 // called on the buffer before PJRT_Buffer_Delete() is, the returned event will
 // not transition to an error state after PJRT_Buffer_Delete() is called.
-typedef PJRT_Error *PJRT_Buffer_ReadyEvent(PJRT_Buffer_ReadyEvent_Args *args);
+typedef PJRT_Error* PJRT_Buffer_ReadyEvent(PJRT_Buffer_ReadyEvent_Args* args);
 
 struct PJRT_Buffer_UnsafePointer_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Buffer *buffer;
-  uintptr_t buffer_pointer; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_Buffer* buffer;
+  uintptr_t buffer_pointer;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_UnsafePointer_Args, buffer_pointer);
 
 // Returns platform-dependent address for the given buffer that is often but
 // not guaranteed to be the physical/device address.
-typedef PJRT_Error *
-PJRT_Buffer_UnsafePointer(PJRT_Buffer_UnsafePointer_Args *args);
+typedef PJRT_Error* PJRT_Buffer_UnsafePointer(
+    PJRT_Buffer_UnsafePointer_Args* args);
 
 struct PJRT_Buffer_IncreaseExternalReferenceCount_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Buffer *buffer;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Buffer* buffer;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_IncreaseExternalReferenceCount_Args,
                           buffer);
@@ -2088,13 +2432,13 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_IncreaseExternalReferenceCount_Args,
 // dlpack) and should not be deleted or moved by the PJRT implementation (e.g.
 // for memory compaction). TODO(b/295230663): document more API contract
 // details, e.g. does this block, can the buffer be modified in-place.
-typedef PJRT_Error *PJRT_Buffer_IncreaseExternalReferenceCount(
-    PJRT_Buffer_IncreaseExternalReferenceCount_Args *args);
+typedef PJRT_Error* PJRT_Buffer_IncreaseExternalReferenceCount(
+    PJRT_Buffer_IncreaseExternalReferenceCount_Args* args);
 
 struct PJRT_Buffer_DecreaseExternalReferenceCount_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Buffer *buffer;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Buffer* buffer;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_DecreaseExternalReferenceCount_Args,
                           buffer);
@@ -2102,14 +2446,14 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_DecreaseExternalReferenceCount_Args,
 // Decrements the reference count for the buffer. Returns an error if the
 // reference count is zero (i.e. PJRT_Buffer_IncreaseExternalReferenceCount is
 // not called beforehand).
-typedef PJRT_Error *PJRT_Buffer_DecreaseExternalReferenceCount(
-    PJRT_Buffer_DecreaseExternalReferenceCount_Args *args);
+typedef PJRT_Error* PJRT_Buffer_DecreaseExternalReferenceCount(
+    PJRT_Buffer_DecreaseExternalReferenceCount_Args* args);
 
 struct PJRT_Buffer_OpaqueDeviceMemoryDataPointer_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_Buffer *buffer;
-  void *device_memory_ptr; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_Buffer* buffer;
+  void* device_memory_ptr;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_OpaqueDeviceMemoryDataPointer_Args,
                           device_memory_ptr);
@@ -2117,29 +2461,56 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_OpaqueDeviceMemoryDataPointer_Args,
 // Returns the opaque device memory data pointer of the buffer. The returned
 // data pointer may become invalid at any point unless the external reference
 // count is greater than 0 via PJRT_Buffer_IncreaseExternalReferenceCount.
-typedef PJRT_Error *PJRT_Buffer_OpaqueDeviceMemoryDataPointer(
-    PJRT_Buffer_OpaqueDeviceMemoryDataPointer_Args *args);
+typedef PJRT_Error* PJRT_Buffer_OpaqueDeviceMemoryDataPointer(
+    PJRT_Buffer_OpaqueDeviceMemoryDataPointer_Args* args);
+
+struct PJRT_Buffer_DonateWithControlDependency_Callback_Args {
+  size_t struct_size;
+  void* callback_data;
+  PJRT_Error_Code error_code;
+  const char* error_message;
+  size_t error_message_size;
+};
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_DonateWithControlDependency_Callback_Args,
+                          error_message_size);
+
+struct PJRT_Buffer_DonateWithControlDependency_Args {
+  size_t struct_size;
+  PJRT_Extension_Base* extension_start;
+  PJRT_Buffer* buffer;
+
+  void* callback_data;  // out
+  void (*dependency_ready_callback)(
+      PJRT_Buffer_DonateWithControlDependency_Callback_Args* args);  // out
+
+  PJRT_Buffer* out_buffer;  // out
+};
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_DonateWithControlDependency_Args,
+                          out_buffer);
+
+typedef PJRT_Error* PJRT_Buffer_DonateWithControlDependency(
+    PJRT_Buffer_DonateWithControlDependency_Args* args);
 
 // ---------------------------- CopyToDeviceStream -----------------------------
 
 struct PJRT_CopyToDeviceStream_Destroy_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_CopyToDeviceStream *stream;
+  PJRT_Extension_Base* extension_start;
+  PJRT_CopyToDeviceStream* stream;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_CopyToDeviceStream_Destroy_Args, stream);
 
 // Frees `stream`. `stream` can be nullptr.
-typedef PJRT_Error *
-PJRT_CopyToDeviceStream_Destroy(PJRT_CopyToDeviceStream_Destroy_Args *args);
+typedef PJRT_Error* PJRT_CopyToDeviceStream_Destroy(
+    PJRT_CopyToDeviceStream_Destroy_Args* args);
 
 struct PJRT_CopyToDeviceStream_AddChunk_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_CopyToDeviceStream *stream;
+  PJRT_Extension_Base* extension_start;
+  PJRT_CopyToDeviceStream* stream;
   // Takes ownership of `chunk` (i.e. implementation will call chunk.deleter).
-  PJRT_Chunk *chunk;
-  PJRT_Event *transfer_complete; // out
+  PJRT_Chunk* chunk;
+  PJRT_Event* transfer_complete;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_CopyToDeviceStream_AddChunk_Args,
                           transfer_complete);
@@ -2151,119 +2522,119 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_CopyToDeviceStream_AddChunk_Args,
 // The returned event will indicate an error if the chunk's size causes the
 // amount of transferred data to exceed the total bytes, if the stream is
 // already complete, or if the chunk is not a multiple of the granule size.
-typedef PJRT_Error *
-PJRT_CopyToDeviceStream_AddChunk(PJRT_CopyToDeviceStream_AddChunk_Args *args);
+typedef PJRT_Error* PJRT_CopyToDeviceStream_AddChunk(
+    PJRT_CopyToDeviceStream_AddChunk_Args* args);
 
 struct PJRT_CopyToDeviceStream_TotalBytes_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_CopyToDeviceStream *stream;
-  int64_t total_bytes; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_CopyToDeviceStream* stream;
+  int64_t total_bytes;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_CopyToDeviceStream_TotalBytes_Args, total_bytes);
 
 // Returns the total amount of data the stream expects to be transferred.
-typedef PJRT_Error *PJRT_CopyToDeviceStream_TotalBytes(
-    PJRT_CopyToDeviceStream_TotalBytes_Args *args);
+typedef PJRT_Error* PJRT_CopyToDeviceStream_TotalBytes(
+    PJRT_CopyToDeviceStream_TotalBytes_Args* args);
 
 struct PJRT_CopyToDeviceStream_GranuleSize_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_CopyToDeviceStream *stream;
-  int64_t granule_size_in_bytes; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_CopyToDeviceStream* stream;
+  int64_t granule_size_in_bytes;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_CopyToDeviceStream_GranuleSize_Args,
                           granule_size_in_bytes);
 
 // Returns the granule size in bytes. The size of the chunk added to this stream
 // must be a multiple of this number.
-typedef PJRT_Error *PJRT_CopyToDeviceStream_GranuleSize(
-    PJRT_CopyToDeviceStream_GranuleSize_Args *args);
+typedef PJRT_Error* PJRT_CopyToDeviceStream_GranuleSize(
+    PJRT_CopyToDeviceStream_GranuleSize_Args* args);
 
 struct PJRT_CopyToDeviceStream_CurrentBytes_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_CopyToDeviceStream *stream;
-  int64_t current_bytes; // out
+  PJRT_Extension_Base* extension_start;
+  PJRT_CopyToDeviceStream* stream;
+  int64_t current_bytes;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_CopyToDeviceStream_CurrentBytes_Args,
                           current_bytes);
 
 // Returns the amount of data the stream currently has either transferred or has
 // buffered to transfer.
-typedef PJRT_Error *PJRT_CopyToDeviceStream_CurrentBytes(
-    PJRT_CopyToDeviceStream_CurrentBytes_Args *args);
+typedef PJRT_Error* PJRT_CopyToDeviceStream_CurrentBytes(
+    PJRT_CopyToDeviceStream_CurrentBytes_Args* args);
 
 // ------------------------------ Device Topology ------------------------------
 
 struct PJRT_TopologyDescription_Create_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  const char *topology_name;
+  PJRT_Extension_Base* extension_start;
+  const char* topology_name;
   size_t topology_name_size;
   // Extra platform-specific options to create a client.
-  const PJRT_NamedValue *create_options;
+  const PJRT_NamedValue* create_options;
   size_t num_options;
-  PJRT_TopologyDescription *topology; // out
+  PJRT_TopologyDescription* topology;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_TopologyDescription_Create_Args, topology);
 
 // Creates and initializes a new PJRT_TopologyDescription and returns in
 // `topology`.
-typedef PJRT_Error *
-PJRT_TopologyDescription_Create(PJRT_TopologyDescription_Create_Args *args);
+typedef PJRT_Error* PJRT_TopologyDescription_Create(
+    PJRT_TopologyDescription_Create_Args* args);
 
 struct PJRT_TopologyDescription_Destroy_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_TopologyDescription *topology;
+  PJRT_Extension_Base* extension_start;
+  PJRT_TopologyDescription* topology;
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_TopologyDescription_Destroy_Args, topology);
 
 // Frees `topology`. `topology` can be nullptr.
-typedef PJRT_Error *
-PJRT_TopologyDescription_Destroy(PJRT_TopologyDescription_Destroy_Args *args);
+typedef PJRT_Error* PJRT_TopologyDescription_Destroy(
+    PJRT_TopologyDescription_Destroy_Args* args);
 
 struct PJRT_TopologyDescription_PlatformVersion_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_TopologyDescription *topology;
+  PJRT_Extension_Base* extension_start;
+  PJRT_TopologyDescription* topology;
   // `platform_version` has the same lifetime as `topology`. It's owned by
   // `topology`.
-  const char *platform_version; // out
-  size_t platform_version_size; // out
+  const char* platform_version;  // out
+  size_t platform_version_size;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_TopologyDescription_PlatformVersion_Args,
                           platform_version_size);
 
 // Returns a string containing human-readable, platform-specific version info
 // (e.g. the CUDA version on GPU or libtpu version on Cloud TPU).
-typedef PJRT_Error *PJRT_TopologyDescription_PlatformVersion(
-    PJRT_TopologyDescription_PlatformVersion_Args *args);
+typedef PJRT_Error* PJRT_TopologyDescription_PlatformVersion(
+    PJRT_TopologyDescription_PlatformVersion_Args* args);
 
 struct PJRT_TopologyDescription_PlatformName_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  const PJRT_TopologyDescription *topology;
+  PJRT_Extension_Base* extension_start;
+  const PJRT_TopologyDescription* topology;
   // `platform_name` has the same lifetime as `topology`. It is owned by
   // `topology`.
-  const char *platform_name; // out
-  size_t platform_name_size; // out
+  const char* platform_name;  // out
+  size_t platform_name_size;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_TopologyDescription_PlatformName_Args,
                           platform_name_size);
 
 // Returns a string that identifies the platform (e.g. "cpu", "gpu", "tpu").
-typedef PJRT_Error *PJRT_TopologyDescription_PlatformName(
-    PJRT_TopologyDescription_PlatformName_Args *args);
+typedef PJRT_Error* PJRT_TopologyDescription_PlatformName(
+    PJRT_TopologyDescription_PlatformName_Args* args);
 
 struct PJRT_TopologyDescription_GetDeviceDescriptions_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  const PJRT_TopologyDescription *topology;
+  PJRT_Extension_Base* extension_start;
+  const PJRT_TopologyDescription* topology;
   // Has the same lifetime as topology.
-  PJRT_DeviceDescription *const *descriptions; // out
-  size_t num_descriptions;                     // out
+  PJRT_DeviceDescription* const* descriptions;  // out
+  size_t num_descriptions;                      // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_TopologyDescription_GetDeviceDescriptions_Args,
                           num_descriptions);
@@ -2271,80 +2642,92 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_TopologyDescription_GetDeviceDescriptions_Args,
 // Returns descriptions for all devices in this topology. The device
 // descriptions can be returned in any order, but will be in the same order
 // across calls within a process.
-typedef PJRT_Error *PJRT_TopologyDescription_GetDeviceDescriptions(
-    PJRT_TopologyDescription_GetDeviceDescriptions_Args *args);
+typedef PJRT_Error* PJRT_TopologyDescription_GetDeviceDescriptions(
+    PJRT_TopologyDescription_GetDeviceDescriptions_Args* args);
 
 typedef struct PJRT_SerializedTopology PJRT_SerializedTopology;
 
 struct PJRT_TopologyDescription_Serialize_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_TopologyDescription *topology;
+  PJRT_Extension_Base* extension_start;
+  PJRT_TopologyDescription* topology;
 
   // Lives only as long as serialized_topology.
-  const char *serialized_bytes; // out
-  size_t serialized_bytes_size; // out
+  const char* serialized_bytes;  // out
+  size_t serialized_bytes_size;  // out
 
-  PJRT_SerializedTopology *serialized_topology; // out
+  PJRT_SerializedTopology* serialized_topology;  // out
   // Must be called exactly once to free the backing memory for
   // serialized_bytes.
   void (*serialized_topology_deleter)(
-      PJRT_SerializedTopology *serialized_topology); // out
+      PJRT_SerializedTopology* serialized_topology);  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_TopologyDescription_Serialize_Args,
                           serialized_topology_deleter);
 
 // Serializes the TopologyDescription to a string for use in cache keys.
-typedef PJRT_Error *PJRT_TopologyDescription_Serialize(
-    PJRT_TopologyDescription_Serialize_Args *args);
+typedef PJRT_Error* PJRT_TopologyDescription_Serialize(
+    PJRT_TopologyDescription_Serialize_Args* args);
+
+struct PJRT_TopologyDescription_Deserialize_Args {
+  size_t struct_size;
+  PJRT_Extension_Base* extension_start;
+  const char* serialized_topology;
+  size_t serialized_topology_size;
+
+  PJRT_TopologyDescription* topology;  // out
+};
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_TopologyDescription_Deserialize_Args, topology);
+
+typedef PJRT_Error* PJRT_TopologyDescription_Deserialize(
+    PJRT_TopologyDescription_Deserialize_Args* args);
 
 struct PJRT_TopologyDescription_Attributes_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  PJRT_TopologyDescription *topology;
+  PJRT_Extension_Base* extension_start;
+  PJRT_TopologyDescription* topology;
 
   // Only lives as long as topology.
-  const PJRT_NamedValue *attributes; // out
-  size_t num_attributes;             // out
+  const PJRT_NamedValue* attributes;  // out
+  size_t num_attributes;              // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_TopologyDescription_Attributes_Args,
                           num_attributes);
 
 // Returns platform-specific topology attributes.
-typedef PJRT_Error *PJRT_TopologyDescription_Attributes(
-    PJRT_TopologyDescription_Attributes_Args *args);
+typedef PJRT_Error* PJRT_TopologyDescription_Attributes(
+    PJRT_TopologyDescription_Attributes_Args* args);
 
 struct PJRT_Compile_Args {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
-  const PJRT_TopologyDescription *topology;
+  PJRT_Extension_Base* extension_start;
+  const PJRT_TopologyDescription* topology;
   // Only needs to stay alive for the duration of the Compile call.
   // `program->format` and `program->format_size` are owned by the caller.
-  const PJRT_Program *program;
+  const PJRT_Program* program;
   // TODO(b/240560013): consider putting some of option fields in priv.
-  // Serialized CompileOptionsProto
-  // (https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/pjrt/compile_options.proto)
-  const char *compile_options;
+  // Serialized CompileOptionsProto.
+  const char* compile_options;
   size_t compile_options_size;
   // Optionally provided for performance-guided optimizations.
-  PJRT_Client *client;
-  PJRT_Executable *executable; // out
+  PJRT_Client* client;
+  PJRT_Executable* executable;  // out
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Compile_Args, executable);
 
 // Compiles a program in specified format (such as MLIR or HLO) with given
 // `options`. The returned executable must be loaded by a compatible
 // PJRT_Client before execution.
-typedef PJRT_Error *PJRT_Compile(PJRT_Compile_Args *args);
+typedef PJRT_Error* PJRT_Compile(PJRT_Compile_Args* args);
 
 // -------------------------------- API access ---------------------------------
 
-#define _PJRT_API_STRUCT_FIELD(fn_type) fn_type *fn_type
+#define _PJRT_API_STRUCT_FIELD(fn_type) fn_type* fn_type
 
 // Please modify PJRT_Api_STRUCT_SIZE if the last field of PJRT_Api is changed.
 typedef struct PJRT_Api {
   size_t struct_size;
-  PJRT_Extension_Base *extension_start;
+  PJRT_Extension_Base* extension_start;
 
   PJRT_Api_Version pjrt_api_version;
 
@@ -2482,10 +2865,26 @@ typedef struct PJRT_Api {
   _PJRT_API_STRUCT_FIELD(PJRT_AsyncHostToDeviceTransferManager_AddMetadata);
   _PJRT_API_STRUCT_FIELD(PJRT_Client_DmaMap);
   _PJRT_API_STRUCT_FIELD(PJRT_Client_DmaUnmap);
+
+  _PJRT_API_STRUCT_FIELD(PJRT_Client_CreateUninitializedBuffer);
+  _PJRT_API_STRUCT_FIELD(PJRT_Client_UpdateGlobalProcessInfo);
+  _PJRT_API_STRUCT_FIELD(PJRT_TopologyDescription_Deserialize);
+  _PJRT_API_STRUCT_FIELD(PJRT_Client_CreateAliasBuffer);
+  _PJRT_API_STRUCT_FIELD(PJRT_Client_FulfillAliasBuffer);
+  _PJRT_API_STRUCT_FIELD(PJRT_LoadedExecutable_GetDeviceAssignment);
+  _PJRT_API_STRUCT_FIELD(PJRT_Client_CreateErrorBuffer);
+  _PJRT_API_STRUCT_FIELD(PJRT_AsyncHostToDeviceTransferManager_TransferLiteral);
+  _PJRT_API_STRUCT_FIELD(PJRT_Buffer_CopyRawToHostFuture);
+  _PJRT_API_STRUCT_FIELD(PJRT_Device_PoisonExecution);
+  _PJRT_API_STRUCT_FIELD(PJRT_Device_CreateAsyncTrackingEvent);
+  _PJRT_API_STRUCT_FIELD(PJRT_AsyncTrackingEvent_Destroy);
+  _PJRT_API_STRUCT_FIELD(PJRT_Executable_GetCompileOptions);
+  _PJRT_API_STRUCT_FIELD(PJRT_Buffer_DonateWithControlDependency);
 } PJRT_Api;
 
 enum {
-  PJRT_Api_STRUCT_SIZE = PJRT_STRUCT_SIZE(PJRT_Api, PJRT_Client_DmaUnmap)
+  PJRT_Api_STRUCT_SIZE =
+      PJRT_STRUCT_SIZE(PJRT_Api, PJRT_Buffer_DonateWithControlDependency)
 };
 
 #undef _PJRT_API_STRUCT_FIELD
@@ -2494,4 +2893,4 @@ enum {
 }
 #endif
 
-#endif // XLA_PJRT_C_PJRT_C_API_H_
+#endif  // XLA_PJRT_C_PJRT_C_API_H_


### PR DESCRIPTION
This PR uplifts the PJRT C API header file from the upstream [OpenXLA repository](https://github.com/openxla/xla).

**Version change:** `0.68` -> `0.88`

**Source file:** https://github.com/openxla/xla/blob/main/xla/pjrt/c/pjrt_c_api.h

Please review the changes and ensure compatibility with the current implementation.