### PR TITLE
Implemented PJRT tensor class.

### DIFF
--- a/pjrt_implementation/inc/api/flatbuffer_loaded_executable_instance.h
+++ b/pjrt_implementation/inc/api/flatbuffer_loaded_executable_instance.h
@@ -56,18 +56,13 @@ private:
                      tt::runtime::Device device, size_t num_devices,
                      std::uint32_t program_index, size_t arg_index) override;
 
-  // Converts input tensor to desired layout. This might move it on device.
-  tt::runtime::Tensor
-  convertTensorLayout(tt::runtime::Tensor input_tensor,
-                      std::uint32_t program_index, size_t arg_index,
-                      const tt::runtime::Device &runtime_device);
-
   // Fills the output lists of the PJRT API with the outputs of tt runtime
   // execution. Creates BufferInstances with device tensors instead of
   // transferring them to host.
   void fillPJRTOutputLists(
       const std::vector<tt::runtime::Tensor> &output_tensors,
-      size_t num_devices, PJRT_Buffer **const *output_lists,
+      const tt::runtime::Device &device, size_t num_devices,
+      PJRT_Buffer **const *output_lists,
       const std::vector<PJRT_Buffer_Type> &expected_output_data_types);
 
   // Returns the shape of the output on the specified index.

--- a/pjrt_implementation/inc/api/so_loaded_executable_instance.h
+++ b/pjrt_implementation/inc/api/so_loaded_executable_instance.h
@@ -58,17 +58,6 @@ private:
                      tt::runtime::Device device, size_t num_devices,
                      std::uint32_t program_index, size_t arg_index) override;
 
-  // Converts input tensor to desired layout. This might move it on device.
-  // For SO path, we don't have layout information as we don't have a
-  // flatbuffer. HACK: we just return the input tensor (host tensor) without any
-  // layout conversion in cases we can't reuse the prepared tensor. This works
-  // because codegen code forces layouts (and therefore can basically accept
-  // anything).
-  tt::runtime::Tensor
-  convertTensorLayout(tt::runtime::Tensor input_tensor,
-                      std::uint32_t program_index, size_t arg_index,
-                      const tt::runtime::Device &runtime_device);
-
   // Create default-initialized output buffers for SO execution
   void createDefaultOutputBuffers(PJRT_Buffer **const *output_lists,
                                   size_t num_devices);


### PR DESCRIPTION
Since PJRT does not operate on tensors but on BufferInstances (where each BufferInstance represent single tensor shard), pjrt tensor abstraction is implemented in order to simplify tensors usage.

This abstraction gives us control over host and device tensors and hides complexity behind simple APIs.

In future, we will add support for retrieving shards from device/host tensors which is needed for multi device features.