### PR TITLE
Uplift PJRT C API header from v0.68 to v0.88

### DIFF
--- a/pjrt_implementation/src/stubs.inc
+++ b/pjrt_implementation/src/stubs.inc
@@ -128,3 +128,17 @@
   _STUB(PJRT_AsyncHostToDeviceTransferManager_BufferSize);
   _STUB(PJRT_AsyncHostToDeviceTransferManager_SetBufferError);
   _STUB(PJRT_AsyncHostToDeviceTransferManager_AddMetadata);
+  _STUB(PJRT_AsyncHostToDeviceTransferManager_TransferLiteral);
+  _STUB(PJRT_AsyncTrackingEvent_Destroy);
+  _STUB(PJRT_Buffer_CopyRawToHostFuture);
+  _STUB(PJRT_Buffer_DonateWithControlDependency);
+  _STUB(PJRT_Client_CreateAliasBuffer);
+  _STUB(PJRT_Client_CreateErrorBuffer);
+  _STUB(PJRT_Client_CreateUninitializedBuffer);
+  _STUB(PJRT_Client_FulfillAliasBuffer);
+  _STUB(PJRT_Client_UpdateGlobalProcessInfo);
+  _STUB(PJRT_Device_CreateAsyncTrackingEvent);
+  _STUB(PJRT_Device_PoisonExecution);
+  _STUB(PJRT_Executable_GetCompileOptions);
+  _STUB(PJRT_LoadedExecutable_GetDeviceAssignment);
+  _STUB(PJRT_TopologyDescription_Deserialize);


### PR DESCRIPTION
## Description

This PR uplifts the PJRT C API header from the upstream [OpenXLA repository](https://github.com/openxla/xla).

- **Version change:** `v0.68` -> `v0.88`
- **Source file:** https://github.com/openxla/xla/blob/main/xla/pjrt/c/pjrt_c_api.h

## Checklist

- [ ] Review the changes in `pjrt_c_api.h` and ensure backward compatibility with the tt-xla implementation.
- [ ] Review the changes in `stubs.inc` and discuss with the team whether a new feature should be flagged as useful for implementation.
- [ ] Manually run the `.github/workflows/schedule-nightly.yml` workflow to schedule an extended test set run.
- [x] Run PJRT unit tests (scheduled automatically upon PR creation).