### PR TITLE
Show deprecated logger level warning only if new env variable is not set

### DIFF
--- a/pjrt_implementation/src/utils/logging.cc
+++ b/pjrt_implementation/src/utils/logging.cc
@@ -22,7 +22,7 @@ void initializeLogging() {
 
   const char *loguru_verbosity = std::getenv("TTXLA_LOGGER_LEVEL");
   const char *deprecated_loguru_verbosity = std::getenv("LOGGER_LEVEL");
-  if (deprecated_loguru_verbosity) {
+  if (deprecated_loguru_verbosity && !loguru_verbosity) {
     DLOG_F(WARNING,
            "Environment variable LOGGER_LEVEL is deprecated. Please use "
            "TTXLA_LOGGER_LEVEL instead. Logging will be disabled.");


### PR DESCRIPTION
### Problem description
If both old and new logging env variables are set then logger is disabled due to old/deprecated env variable.

### What's changed
Enable logging if new env variable is set and ignore the deprecated env variable.
