### PR TITLE
Uplift third_party/tt-mlir to c38e82afd3fc2ee7a733e65506c960ee42237b99 2026-01-06

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -5,7 +5,7 @@
 option(USE_CUSTOM_TT_MLIR_VERSION "Flag to use TT_MLIR_VERSION set by the user" OFF)
 
 if (NOT DEFINED TT_MLIR_VERSION OR NOT USE_CUSTOM_TT_MLIR_VERSION)
-    set(TT_MLIR_VERSION "74a2616baba80272c77713c6934415fc6e30b8b2")
+    set(TT_MLIR_VERSION "c38e82afd3fc2ee7a733e65506c960ee42237b99")
 endif()
 
 set(PROTOBUF_VERSION "v21.12") # same version as tt-metal uses


### PR DESCRIPTION
This PR uplifts the third_party/tt-mlir to the c38e82afd3fc2ee7a733e65506c960ee42237b99