### PR TITLE
Fix MNIST imports in pytorch examples

### DIFF
--- a/examples/pytorch/compiler_options.py
+++ b/examples/pytorch/compiler_options.py
@@ -11,7 +11,7 @@ import torch_xla
 import torch_xla.core.xla_model as xm
 import torch_xla.runtime as xr
 
-from tests.torch.models.mnist.cnn.dropout.model_implementation import (
+from third_party.tt_forge_models.mnist.image_classification.pytorch.loader import (
     MNISTCNNDropoutModel,
 )
 

--- a/examples/pytorch/explicit_argument_type_annotation_mnist.py
+++ b/examples/pytorch/explicit_argument_type_annotation_mnist.py
@@ -7,7 +7,7 @@ import torch_xla.core.xla_model as xm
 import torch_xla.runtime as xr
 import tt_torch
 
-from tests.torch.models.mnist.cnn.dropout.model_implementation import (
+from third_party.tt_forge_models.mnist.image_classification.pytorch.loader import (
     MNISTCNNDropoutModel,
 )
 

--- a/examples/pytorch/mnist.py
+++ b/examples/pytorch/mnist.py
@@ -6,7 +6,7 @@ import torch
 import torch_xla.core.xla_model as xm
 import torch_xla.runtime as xr
 
-from tests.torch.models.mnist.cnn.dropout.model_implementation import (
+from third_party.tt_forge_models.mnist.image_classification.pytorch.loader import (
     MNISTCNNDropoutModel,
 )
 


### PR DESCRIPTION
### Problem description
Several pytorch examples have broken imports because of changes with how third party models are referenced in `tt-xla`.

### What's changed
Import paths are modified to have the accurate path.

The examples are verified to now run properly.
