### PR TITLE
Add repeat to expand decomposition 

### DIFF
--- a/python_package/tt_torch/backend/decompositions.py
+++ b/python_package/tt_torch/backend/decompositions.py
@@ -277,6 +277,33 @@ def dot(input: torch.Tensor, tensor: torch.Tensor):
         return NotImplemented
 
 
+def repeat(self, repeats):
+    # This is a specific decomposition to handle the case where we are repeating the leading dimension only.
+    # i.e. (128, 2880) -> (4096, 2880) when repeats is (32, 1)
+    # Instead of repeat, we can use unsqueeze + expand + flatten.
+    # This prevents "stablehlo.concatenate" and uses "stablehlo.broadcast_in_dim" instead.
+
+    # Check if we are repeating the leading dimension only
+    if (
+        len(repeats) == self.dim()
+        and repeats[0] > 1
+        and all(r == 1 for r in repeats[1:])
+    ):
+
+        # Create the broadcast path:
+        # (128, 2880) -> unsqueeze(0) -> (1, 128, 2880)
+        # (1, 128, 2880) -> expand(32, 128, 2880) -> (32, 128, 2880)
+        # (32, 128, 2880) -> flatten(0, 1) -> (4096, 2880)
+
+        expand_shape = [repeats[0]] + [-1] * self.dim()
+
+        return self.unsqueeze(0).expand(expand_shape).flatten(0, 1)
+
+    # This decomposition is targeting gpt-oss's MOE implementation.
+    # It might not be necessary for other models, so the decomposition is not generalistic.
+    return NotImplemented
+
+
 # TODO: DO we ever need this?
 def _get_default_decomposition_ops() -> DecompositionOpsList:
     aten = torch.ops.aten
@@ -336,6 +363,7 @@ def _get_custom_decompositions() -> DecompositionTable:
         aten.split_with_sizes.default: split_with_sizes,
         aten.masked_fill.Tensor: masked_fill_tensor,
         torch.ops.prims.squeeze.default: squeeze,
+        aten.repeat.default: repeat,
     }
 
 

--- a/tests/torch/ops/test_expand.py
+++ b/tests/torch/ops/test_expand.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+import torch
+from infra import Framework, run_op_test, run_op_test_with_random_inputs
+from infra.comparators.torch_comparator import TorchComparator
+from utils import Category
+
+from tests.infra.comparators.comparison_config import ComparisonConfig
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.single_device
+@pytest.mark.record_test_properties(category=Category.OP_TEST)
+@pytest.mark.parametrize(
+    "input_shape,expand_sizes",
+    [
+        # 1D tensor expansion
+        ((1,), (10,)),
+        ((5,), (-1,)),
+        # 2D expansion - expanding singleton dimensions
+        ((1, 5), (10, 5)),
+        ((5, 1), (5, 10)),
+        ((1, 1), (10, 10)),
+        # Using -1 to keep dimension unchanged
+        ((3, 1), (-1, 4)),
+        ((1, 5), (10, -1)),
+        # 3D tensor expansion
+        ((1, 4, 5), (3, 4, 5)),
+        ((3, 1, 5), (3, 4, 5)),
+        ((3, 4, 1), (3, 4, 5)),
+        ((1, 1, 5), (3, 4, 5)),
+        ((1, 4, 1), (3, 4, 5)),
+        ((3, 1, 1), (3, 4, 5)),
+        ((1, 1, 1), (3, 4, 5)),
+        # Using -1 to keep dimension unchanged
+        ((4, 1, 8), (4, 5, -1)),
+        ((1, 1, 1), (-1, 10, 20)),
+        # 4D tensor expansion
+        ((1, 3, 1, 1), (8, 3, 32, 32)),
+        ((1, 1, 224, 224), (16, 3, 224, 224)),
+        ((2, 1, 4, 1), (2, 5, 4, 10)),
+        # Dimension addition (expanding to more dimensions)
+        ((3, 4), (2, 3, 4)),
+        ((5,), (3, 5)),
+        ((2, 3), (4, 5, 2, 3)),
+        ((1, 1), (2, 3, 1, 1)),
+        # Large expansions
+        ((1, 10), (100, 10)),
+        ((1, 1), (100, 100)),
+        ((1, 5, 1), (50, 5, 20)),
+        # No expansion (identity cases)
+        ((5, 10), (5, 10)),
+        ((3, 4, 5), (3, 4, 5)),
+        # Edge cases with size 1
+        ((1,), (1,)),  # Single element, no expansion
+        ((1, 1, 1, 1), (1, 1, 1, 1)),  # All singleton, no expansion
+        # Complex -1 patterns
+        ((1, 5, 1, 10), (-1, -1, 20, -1)),  # Multiple -1 with expansion
+        ((1, 1, 7), (3, 4, -1)),  # -1 on non-singleton dimension
+    ],
+)
+def test_expand_parameterized(input_shape, expand_sizes):
+    """Test expand operation with various input shapes and expansion sizes"""
+
+    class Expand(torch.nn.Module):
+        def __init__(self, expand_sizes):
+            super().__init__()
+            self.expand_sizes = expand_sizes
+
+        def forward(self, x):
+            return x.expand(*self.expand_sizes)
+
+    expand = Expand(expand_sizes)
+
+    run_op_test_with_random_inputs(
+        expand, [input_shape], dtype=torch.bfloat16, framework=Framework.TORCH
+    )
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.single_device
+@pytest.mark.record_test_properties(category=Category.OP_TEST)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])
+def test_expand_different_dtypes(dtype):
+    """Test expand operation with different data types"""
+
+    class Expand(torch.nn.Module):
+        def forward(self, x):
+            return x.expand(10, 20)
+
+    expand = Expand()
+
+    run_op_test_with_random_inputs(
+        expand, [(1, 20)], dtype=dtype, framework=Framework.TORCH
+    )
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.single_device
+@pytest.mark.record_test_properties(category=Category.OP_TEST)
+def test_expand_gpt_oss_mlp():
+    class Expand(torch.nn.Module):
+        def forward(self, x):
+            return x.unsqueeze(0).expand(32, -1, -1).flatten(0, 1)
+
+    expand = Expand()
+
+    run_op_test_with_random_inputs(
+        expand, [(128, 2880)], dtype=torch.bfloat16, framework=Framework.TORCH
+    )

--- a/tests/torch/ops/test_repeat.py
+++ b/tests/torch/ops/test_repeat.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+import torch
+from infra import Framework, run_op_test, run_op_test_with_random_inputs
+from infra.comparators.torch_comparator import TorchComparator
+from utils import Category
+
+from tests.infra.comparators.comparison_config import ComparisonConfig
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.single_device
+@pytest.mark.record_test_properties(category=Category.OP_TEST)
+@pytest.mark.parametrize(
+    "input_shape,repeat_dims",
+    [
+        # 1D tensor tests
+        ((10,), (3,)),
+        ((100,), (1,)),
+        ((50,), (5,)),
+        # 2D tensor tests - repeat along different dimensions
+        ((32, 64), (1, 1)),  # No repeat (identity)
+        ((32, 64), (2, 1)),  # Repeat rows only
+        ((32, 64), (1, 3)),  # Repeat columns only
+        ((32, 64), (2, 3)),  # Repeat both dimensions
+        ((1, 100), (10, 1)),  # Single row repeated
+        ((100, 1), (1, 10)),  # Single column repeated
+        # 3D tensor tests
+        ((4, 8, 16), (1, 1, 1)),  # No repeat
+        ((4, 8, 16), (2, 1, 1)),  # Repeat first dimension
+        ((4, 8, 16), (1, 2, 1)),  # Repeat middle dimension
+        ((4, 8, 16), (1, 1, 2)),  # Repeat last dimension
+        ((4, 8, 16), (2, 2, 2)),  # Repeat all dimensions
+        ((2, 3, 4), (3, 2, 1)),  # Mixed repeats
+        # 4D tensor tests
+        ((2, 3, 4, 5), (1, 1, 1, 1)),  # No repeat
+        ((2, 3, 4, 5), (2, 1, 1, 1)),  # Repeat batch dimension
+        ((2, 3, 4, 5), (1, 2, 3, 4)),  # Different repeats per dimension
+        # Edge cases
+        ((1,), (100,)),  # Single element repeated many times
+        ((1, 1), (10, 10)),  # Single element in 2D
+        ((100, 100), (1, 1)),  # Large tensor, no repeat
+        # Broadcasting-like patterns
+        (
+            (128, 2880),
+            (32, 1),
+        ),  # GPT-OSS MOE - should be decomposed into unsqueeze + expand + flatten
+        ((5, 1), (1, 10)),  # Expand along second dimension
+        ((1, 5), (10, 1)),  # Expand along first dimension
+    ],
+)
+def test_repeat_parameterized(input_shape, repeat_dims):
+    class Repeat(torch.nn.Module):
+        def __init__(self, repeat_dims):
+            super().__init__()
+            self.repeat_dims = repeat_dims
+
+        def forward(self, x):
+            return x.repeat(*self.repeat_dims)
+
+    repeat = Repeat(repeat_dims)
+
+    run_op_test_with_random_inputs(
+        repeat, [input_shape], dtype=torch.bfloat16, framework=Framework.TORCH
+    )
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.single_device
+@pytest.mark.record_test_properties(category=Category.OP_TEST)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])
+def test_repeat_different_dtypes(dtype):
+    """Test repeat operation with different data types"""
+
+    class Repeat(torch.nn.Module):
+        def forward(self, x):
+            return x.repeat(2, 3)
+
+    repeat = Repeat()
+
+    run_op_test_with_random_inputs(
+        repeat, [(16, 32)], dtype=dtype, framework=Framework.TORCH
+    )
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.single_device
+@pytest.mark.record_test_properties(category=Category.OP_TEST)
+def test_repeat_dimension_expansion():
+    """Test repeating with more dimensions than input (adds new dimensions)"""
+
+    class Repeat(torch.nn.Module):
+        def forward(self, x):
+            return x.repeat(4, 2, 1)
+
+    repeat = Repeat()
+
+    run_op_test_with_random_inputs(
+        repeat, [(10, 20)], dtype=torch.bfloat16, framework=Framework.TORCH
+    )


### PR DESCRIPTION
### Ticket
#2601 

### Problem description
When running gpt-oss mlp expert sharded, `stablehlo.concatenate` is not being properly sharded in `InsertExplicitReshardsPass` ([ref](https://github.com/openxla/shardy/issues/945)) The `stablehlo.concatenate` op can be replaced with `stablehlo.broadcast_in_dim` which would be sharded accurately automatically. To achieve `stablehlo.broadcast_in_dim`, the following [line](https://github.com/huggingface/transformers/blob/main/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L129) in `modeling_gpt_oss.py`
```
hidden_states = hidden_states.repeat(self.num_experts, 1)
```
needs to be replaced with
```
hidden_states = hidden_states.unsqueeze(0).expand(num_experts, -1, -1).flatten(0, 1)
```

### What's changed
Added a repeat to expand decomposition which works only under these circumstances:
- repeat is not adding any new dimension, so len(repeats) == dim(self)
- only the first dimension is being repeated, i.e. `x.repeat(32, 1)` or `x.repeat(32, 1, 1)`
There are other circumstances when a repeat can be expressed as an expand, however decided to limit the coverage for this decomposition to a limited subset of cases that cover GPT-OSS-MLP.

With this decomposition:
- a trailing dimension of 1 will be added (hidden_states.unsqueeze(0))
- the leading dimension is expanded, whereas the other dimensions remain unchanged (hidden_states.unsqueeze(0).expand(num_experts, -1, -1))
- the first two dimensions are flattened which results in the accurate output shape (hidden_states.unsqueeze(0).expand(num_experts, -1, -1).flatten(0, 1))

Following gpt-oss example, the hidden shape is (128, 2880). With the decomposition, instead of repeating dim 0 32 times, we do the following: (128, 2880) -> (1, 128, 2880) -> (32, 128, 2880) -> (4096, 2880) 

### Checklist
- [X] Added `tests/torch/ops/test_repeat.py` and `tests/torch/ops/test_expand.py` 