### PR TITLE
Add test configs for missed out vision models and remove assert_pcc=False from the autoencoder conv variant, as it now achieves PCC=1.0

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -228,6 +228,9 @@ test_config:
     required_pcc: 0.98  # AssertionError: PCC comparison failed. Calculated: pcc=0.9871042966842651. Required: pcc=0.99. Exposed by removal of consteval on host: https://github.com/tenstorrent/tt-xla/issues/1242
     status: EXPECTED_PASSING
 
+  densenet/pytorch-densenet121_xray-single_device-inference:
+    status: KNOWN_FAILURE_XFAIL
+
   distilbert/question_answering/pytorch-distilbert-base-cased-distilled-squad-single_device-inference:
     status: EXPECTED_PASSING
 
@@ -433,6 +436,9 @@ test_config:
     status: EXPECTED_PASSING
 
   resnext/pytorch-resnext50_32x4d_osmr-single_device-inference:
+    status: EXPECTED_PASSING
+
+  resnext/pytorch-resnext101_64x4d-single_device-inference:
     status: EXPECTED_PASSING
 
   segformer/pytorch-mit_b0-single_device-inference:
@@ -1446,7 +1452,6 @@ test_config:
     status: EXPECTED_PASSING
 
   autoencoder/pytorch-conv-single_device-inference:
-    assert_pcc: false
     status: EXPECTED_PASSING
 
   phi3/phi_3_5/pytorch-mini_instruct-single_device-inference:
@@ -2401,6 +2406,9 @@ test_config:
     status: EXPECTED_PASSING
 
   arnold/pytorch-vizdoom_2017_track2_rnn-single_device-inference:
+    status: EXPECTED_PASSING
+
+  arnold/pytorch-health_gathering_ff-single_device-inference:
     status: EXPECTED_PASSING
 
   petr/pytorch-vovnet_gridmask_p4_800x320-single_device-inference:


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-xla/issues/2765
- fixes https://github.com/tenstorrent/tt-xla/issues/2393

### Problem description

- There are few models which are present in `tt-forge-models` , but inference test configs are not yet added in `tt-xla`.
  - Densenet121_xray
  - Resnext101_64x4d
  - Arnold-health_gathering_ff
- Autoencoder conv variant having PCC=1 on current main. So remove `assert_pcc=false` from it's config

### What's changed

- Added inference test config for missed out vision models & removed `assert_pcc=false` from autoencoder's conv variant config

### Checklist
- [x] Verified the changes through local testing

### Logs

- [jan8_arnold_health_gathering_ff.log](https://github.com/user-attachments/files/24494312/jan8_arnold_health_gathering_ff.log)
- [jan8_auto_encoder_conv.log](https://github.com/user-attachments/files/24494313/jan8_auto_encoder_conv.log)
- [jan8_densenet_xray.log](https://github.com/user-attachments/files/24494316/jan8_densenet_xray.log)
- [jan8_resnext101_64x4d.log](https://github.com/user-attachments/files/24494319/jan8_resnext101_64x4d.log)

