### PR TITLE
Fix the type of `TTMLIR_BUILD_TYPE`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,10 +44,12 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
 
 option(TTMLIR_ENABLE_PERF_TRACE "Enable performance tracing in tt-mlir" OFF)
-option(TTMLIR_BUILD_TYPE "Build type for tt-mlir" Release)
 option(TTMLIR_ENABLE_BINDINGS_PYTHON "Enable Python bindings in tt-mlir" OFF)
 option(TTXLA_ENABLE_EXPLORER "Enable Explorer feature in tt-mlir" OFF)
 option(TTXLA_ENABLE_PJRT_TESTS "Enable PJRT tests" ON)
+
+set(TTMLIR_BUILD_TYPE "Release" CACHE STRING "Build type for tt-mlir")
+set_property(CACHE TTMLIR_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "RelWithDebInfo" "MinSizeRel")
 
 if(TTXLA_ENABLE_EXPLORER)
     set(TTMLIR_ENABLE_PERF_TRACE ON)


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`TTMLIR_BUILD_TYPE` is a cache variable that's used to set `CMAKE_BUILD_TYPE` of `tt-mlir` project. It was erroneously defined as `option`, which means it was treated as a boolean variable, which effectively means if was always treated as `OFF` for standard values (`Release`, `Debug` etc.). This resulted in `tt-mlir` being built in `Release` mode even when `-DTTMLIR_BUILD_TYPE=Debug` is set.
 
### What's changed
Changed the type of the variable to `STRING` with an added property as a helper in GUI/TUI environment.

### Checklist
- [ ] New/Existing tests provide coverage for changes
