### PR TITLE
Move run_torch_multi_host from basic-test.json to model-test-push.json for onPush/onPR CI Runs to solve inspect-changes gap

### DIFF
--- a/.github/workflows/test-matrix-presets/basic-test.json
+++ b/.github/workflows/test-matrix-presets/basic-test.json
@@ -9,7 +9,6 @@
   { "runs-on": "n300-llmbox",        "name": "run_jax_4_devices",     "dir": "./tests/jax/multi_chip/llmbox/4_devices", "test-mark": "push", "shared-runners": "true" },
   { "runs-on": "n300-llmbox",        "name": "run_jax_8_devices",     "dir": "./tests/jax/multi_chip/llmbox/8_devices", "test-mark": "push", "shared-runners": "true" },
   { "runs-on": "n300-llmbox",        "name": "run_torch_multi_chip",  "dir": "./tests/torch",                           "test-mark": "push and llmbox", "shared-runners": "true" },
-  { "runs-on": "n300-llmbox",        "name": "run_torch_multi_host",  "dir": "./tests/torch/multi_host",                "test-mark": "push and multi_host_cluster", "shared-runners": "true" },
   { "runs-on": "n150",               "name": "run_vllm_n150_tests",   "dir": "./tests/integrations/vllm_plugin",        "test-mark": "push and single_device", "shared-runners": "true" },
   { "runs-on": "n300",               "name": "run_vllm_n300_tests",   "dir": "./tests/integrations/vllm_plugin",        "test-mark": "push and data_parallel", "shared-runners": "true" },
   { "runs-on": "n300",               "name": "run_vllm_n300_tests",   "dir": "./tests/integrations/vllm_plugin",        "test-mark": "push and tensor_parallel and dual_chip", "shared-runners": "true" },

--- a/.github/workflows/test-matrix-presets/model-test-push.json
+++ b/.github/workflows/test-matrix-presets/model-test-push.json
@@ -1,8 +1,9 @@
 [
-  { "runs-on": "n150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "n150 and expected_passing and push" },
-  { "runs-on": "p150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "p150 and expected_passing and push" },
-  { "runs-on": "n150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "n150 and expected_passing and push" },
-  { "runs-on": "p150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "p150 and expected_passing and push" },
-  { "runs-on": "n150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "n150 and expected_passing and push and large" },
-  { "runs-on": "p150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "p150 and expected_passing and push and large" }
+  { "runs-on": "n150",          "name": "run_forge_models",      "dir": "./tests/runner/test_models.py::test_all_models_torch",      "test-mark": "n150 and expected_passing and push" },
+  { "runs-on": "p150",          "name": "run_forge_models",      "dir": "./tests/runner/test_models.py::test_all_models_torch",      "test-mark": "p150 and expected_passing and push" },
+  { "runs-on": "n150",          "name": "run_forge_models",      "dir": "./tests/runner/test_models.py::test_all_models_jax",        "test-mark": "n150 and expected_passing and push and not large" },
+  { "runs-on": "p150",          "name": "run_forge_models",      "dir": "./tests/runner/test_models.py::test_all_models_jax",        "test-mark": "p150 and expected_passing and push" },
+  { "runs-on": "n150",          "name": "run_forge_models",      "dir": "./tests/runner/test_models.py::test_all_models_jax",        "test-mark": "n150 and expected_passing and push and large" },
+  { "runs-on": "p150",          "name": "run_forge_models",      "dir": "./tests/runner/test_models.py::test_all_models_jax",        "test-mark": "p150 and expected_passing and push and large" },
+  { "runs-on": "n300-llmbox",   "name": "run_torch_multi_host",  "dir": "./tests/torch/multi_host",                                  "test-mark": "push and multi_host_cluster", "shared-runners": "true" }
 ]


### PR DESCRIPTION
### Ticket
None

### Problem description
- The tests/torch/multi_host folder contains llmbox/test_multihost.py which calls `pytest tests/runner/test_models.py` but was run via `basic-test.yml` and not `model-test-push.json` which caused the optimization in `.github/actions/inspect-changes/action.yml` that looks to see if PR contains "only changes to tests/runner/" and if so runs `model-test-push.json` (thinking that this json file is the only one using `tests/runner/test_models.py`. 
- This means that changes made to tests/runner/ files could break tests/torch/multi_host tests and unfortunately this is what happened today (and change had to be reverted via https://github.com/tenstorrent/tt-xla/pull/2777)
- If folks were in the habit of scheduling `Run Test / manual_test.yml` runs against `basic-test.yml` thinking it mimicked onPR, well they were wrong (was missing full models) and will now be missing multi_host test, so in very near future will add an option to run `basic-test.json and model-test-push.json` combined.

### What's changed
- Simply move the test matrix line for `tests/torch/multi_host` targeting n300-llmbox from basic-test.json to model-test-push.json for onPush/onPR CI Runs so that optimization continues to work
- Whitespace changes  for column alignment.

### Checklist
- [x] Tested updated model-test-push.json here: https://github.com/tenstorrent/tt-xla/actions/runs/20830502322
