### PR TITLE
Add automatic PyTorch model size calculation and recording to Superset tags

### DIFF
--- a/tests/infra/testers/single_chip/model/torch_model_tester.py
+++ b/tests/infra/testers/single_chip/model/torch_model_tester.py
@@ -60,6 +60,9 @@ class TorchModelTester(ModelTester):
     _get_forward_method_args(self) -> Sequence[Any] # Optional, has default behaviour.
     _get_forward_method_kwargs(self) -> Mapping[str, Any] # Optional, has default behaviour.
     ```
+
+    Attributes:
+        _model_size: Stores the model size in number of parameters
     """
 
     def __init__(
@@ -73,6 +76,7 @@ class TorchModelTester(ModelTester):
 
         self._input_activations: Dict | Sequence[Any] = None
         self._parallelism = parallelism
+        self._model_size = None
 
         super().__init__(
             comparison_config,
@@ -92,6 +96,7 @@ class TorchModelTester(ModelTester):
     def _configure_model(self) -> None:
         self._device_runner.set_training_mode(self._run_mode == RunMode.TRAINING)
         super()._configure_model()
+        self._calculate_model_size()
 
     # @override
     def _configure_model_for_inference(self) -> None:
@@ -102,6 +107,15 @@ class TorchModelTester(ModelTester):
     def _configure_model_for_training(self) -> None:
         assert isinstance(self._model, torch.nn.Module)
         self._model.train()
+
+    def _calculate_model_size(self) -> None:
+        """Calculate and store the total number of parameters in the model."""
+        if isinstance(self._model, torch.nn.Module):
+            self._model_size = sum(p.numel() for p in self._model.parameters())
+            logger.debug(f"Model size: {self._model_size / 1e9}B")
+        else:
+            logger.debug("Model is not a torch.nn.Module, skipping size calculation")
+            self._model_size = None
 
     # @override
     def _cache_model_inputs(self) -> None:

--- a/tests/runner/test_models.py
+++ b/tests/runner/test_models.py
@@ -182,6 +182,10 @@ def _run_model_test_impl(
             raise
         finally:
             comparison_config = tester._comparison_config if tester else None
+            model_size = None
+            if framework == Framework.TORCH and tester is not None:
+                model_size = getattr(tester, "_model_size", None)
+
             # If we mark tests with xfail at collection time, then this isn't hit.
             # Always record properties and handle skip/xfail cases uniformly
             record_model_test_properties(
@@ -195,6 +199,7 @@ def _run_model_test_impl(
                 test_passed=succeeded,
                 comparison_results=list(comparison_result) if comparison_result else [],
                 comparison_config=comparison_config,
+                model_size=model_size,
             )
 
             # prints perf benchmark results to console

--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -512,6 +512,7 @@ def record_model_test_properties(
     test_passed: bool = False,
     comparison_results: list = None,
     comparison_config=None,
+    model_size: int = None,
 ):
     """
     Record standard runtime properties for model tests and optionally control flow.
@@ -610,6 +611,10 @@ def record_model_test_properties(
         "parallelism": str(parallelism),
         "arch": arch,
     }
+
+    # Add model size (in billions of parameters) to tags if available
+    if model_size is not None:
+        tags["model_size_billions"] = model_size / 1e9
 
     # Add execution_pass if available
     execution_pass = getattr(test_metadata, "execution_pass", None)


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-xla/issues/2782

### Problem description

- Several models encounter OOM and L1 errors. Before slicing a model to identify a problematic operator, it's better to first know the model size and verify whether it can fit on a single chip.
- To support this, a feature that calculates the size of each model and records it as part of the superset tags group is needed.

### What's changed

- Implemented automatic model size calculation and recording for all PyTorch models. Model sizes are now:
  - Calculated automatically using `sum(p.numel() for p in self._model.parameters())`
  - Stored in Superset tags as `model_size_billions`

### Checklist
- [x] verified the changes through local testing for some models

#### Reports

- [bevdepth_size_report.xml](https://github.com/user-attachments/files/24524535/bevdepth_size_report.xml)
- [deepseek_ocr_size_report.xml](https://github.com/user-attachments/files/24524537/deepseek_ocr_size_report.xml)
- [yolov6_model_size_report.xml](https://github.com/user-attachments/files/24524539/yolov6_model_size_report.xml)
