### PR TITLE
Fixing pcc checks when the outputs of the tests is only one number

### DIFF
--- a/tests/infra/comparators/comparator.py
+++ b/tests/infra/comparators/comparator.py
@@ -210,10 +210,9 @@ class Comparator(ABC):
         """
         raise NotImplementedError("Subclasses must implement this method")
 
-    @staticmethod
     @abstractmethod
     def _compare_pcc(
-        device_output: PyTree, golden_output: PyTree, pcc_config: PccConfig
+        self, device_output: PyTree, golden_output: PyTree, pcc_config: PccConfig
     ) -> float:
         """
         Compares PCC metric between device and golden output.
@@ -234,8 +233,7 @@ class Comparator(ABC):
         """
         raise NotImplementedError("Subclasses must implement this method")
 
-    @staticmethod
     @abstractmethod
-    def _is_single_element(tensor: Tensor) -> bool:
+    def _is_single_element(self, tensor: Tensor) -> bool:
         """Returns True if the tensor has only a single element."""
         raise NotImplementedError("Subclasses must implement this method")


### PR DESCRIPTION
We had issues in testing infra when we have a failing tests which outputs only one number, as it produced pcc of NaN (since there is no pcc for one number), fixing that in our test infra, so we don't compare pcc if there is only one element.