### PR TITLE
Fix training timings for nightly CI

### DIFF
--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -274,7 +274,7 @@ jobs:
         cat collected_tests.txt
 
         # Check if any collected tests have notimeout marker
-        NOTIMEOUT_COUNT=$(python -m pytest --collect-only -q --disable-warnings -m notimeout $(cat collected_tests.txt | tr '\n' ' ') 2>/dev/null | grep -c "::" || echo "0")
+        NOTIMEOUT_COUNT=$(python -m pytest --collect-only -q --disable-warnings -m notimeout $(grep "::" collected_tests.txt | tr '\n' ' ') 2>/dev/null | grep -c "::" || echo "0")
         if [[ "$NOTIMEOUT_COUNT" -gt 0 ]]; then
           echo "Found $NOTIMEOUT_COUNT tests with notimeout marker, using default timeout of 240 minutes"
           ESTIMATED_DURATION=240

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,7 @@
 markers =
     push: marks tests as push, to be executed on PR pipeline
     nightly: marks tests as nightly, to be executed on nightly pipeline
+    notimeout: marks tests that should use a default (240min) timeout instead of calculated duration
     model_test: marks test as model test, to be executed in a separate job in nightly tests
     large: marks model tests as large, to be executed in a separate runner with more resources
     # ModelTestStatus

--- a/tests/runner/test_config/torch/test_config_training_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_training_single_device.yaml
@@ -53,7 +53,7 @@ test_config:
     markers: [notimeout]
   llama/causal_lm/pytorch-llama_3_2_1b_instruct-single_device-training:
     status: KNOWN_FAILURE_XFAIL
-    markers: [notimeout]
+    markers: [large, notimeout]
   qwen_2_5_coder/pytorch-0_5b-single_device-training:
     status: KNOWN_FAILURE_XFAIL
     markers: [notimeout]


### PR DESCRIPTION
There was an issue in gathering the `notimeout` marker in nightly CI, so fixing that.