### PR TITLE
Op by op script

### DIFF
--- a/tests/op_by_op/conftest.py
+++ b/tests/op_by_op/conftest.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
+
+
 def pytest_addoption(parser):
     """Add custom command line options for pytest."""
     parser.addoption(

--- a/tests/op_by_op/op_by_op_test.py
+++ b/tests/op_by_op/op_by_op_test.py
@@ -1,9 +1,9 @@
-# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Op-by-op test that processes StableHLO IR files from a folder.
+Op-by-op test that processes IR files from a folder.
 
 This test allows the user to:
 1. Process all .mlir files from a specified folder
@@ -42,7 +42,7 @@ Command Line Arguments:
     --blacklist: Comma-separated list of ops to skip (ignored if whitelist is set)
 
 Note:
-    - Each file should contain a MLIR module in StableHLO dialect
+    - Each file should contain a MLIR module in StableHLO/TTIR/TTNN dialect
 """
 
 from pathlib import Path


### PR DESCRIPTION
### Ticket
(https://github.com/tenstorrent/tt-xla/issues/1002)

### Problem description
We want to take multiple SHLO IR graphs, take unique ops from them and test them individually.

### What's changed
Added a script that:
- looks for appropriate SHLO IR files in a folder and processes them
- takes a module from a file and extracts ops from it
- removes duplicates across different modules
- wraps each op in its own module, compiles and runs it

### Checklist
- tested with a few model graphs, will test on red models next
- feedback is appreciated, open issues and assign me if there are bugs
