### PR TITLE
Add missing supported_arch n300-llmbox to 8 skipped TP tests 

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -151,41 +151,49 @@ test_config:
   # Models that need work....
 
   llama/causal_lm/pytorch-llama_3_1_405b-tensor_parallel-inference:
+    supported_archs: [n300-llmbox]
     status: NOT_SUPPORTED_SKIP
     reason: "Needs bringup on galaxy"
     bringup_status: FAILED_RUNTIME
 
   llama/causal_lm/pytorch-llama_3_1_70b-tensor_parallel-inference:
+    supported_archs: [n300-llmbox]
     status: NOT_SUPPORTED_SKIP
     reason: "Needs bringup on galaxy"
     bringup_status: FAILED_RUNTIME
 
   llama/causal_lm/pytorch-llama_3_1_70b_instruct-tensor_parallel-inference:
+    supported_archs: [n300-llmbox]
     status: NOT_SUPPORTED_SKIP
     reason: "Needs bringup on galaxy"
     bringup_status: FAILED_RUNTIME
 
   llama/causal_lm/pytorch-llama_3_3_70b_instruct-tensor_parallel-inference:
+    supported_archs: [n300-llmbox]
     status: NOT_SUPPORTED_SKIP
     reason: "Needs bringup on galaxy"
     bringup_status: FAILED_RUNTIME
 
   phi4/causal_lm/pytorch-microsoft/phi-4-tensor_parallel-inference:
+    supported_archs: [n300-llmbox]
     status: NOT_SUPPORTED_SKIP
     reason: "Needs bringup on n300-llmbox 14B param"
     bringup_status: FAILED_RUNTIME
 
   qwen_2/causal_lm/pytorch-qwq_32b-tensor_parallel-inference:
+    supported_archs: [n300-llmbox]
     status: NOT_SUPPORTED_SKIP
     reason: "Needs bringup on n300-llmbox"
     bringup_status: FAILED_RUNTIME
 
   qwen_2_5/causal_lm/pytorch-72b_instruct-tensor_parallel-inference:
+    supported_archs: [n300-llmbox]
     status: NOT_SUPPORTED_SKIP
     reason: "Needs bringup on galaxy"
     bringup_status: FAILED_RUNTIME
 
   qwen_3/causal_lm/pytorch-30b_a3b-tensor_parallel-inference:
+    supported_archs: [n300-llmbox]
     status: NOT_SUPPORTED_SKIP
     reason: "Needs bringup on n300-llmbox"
     bringup_status: FAILED_RUNTIME


### PR DESCRIPTION
### Ticket
Follow up to #2751

### Problem description
- Some skipped tests (too big for n300-llmbox) were accidentally running on n150/p150 

### What's changed
- Add missing supported_arch n300-llmbox to 8 skipped TP tests

### Checklist
- [x] Visual check, obvious fix
