### PR TITLE
Uplift third_party/tt-mlir to 7486d8889de293f2f83d8a9e713e1b1387b8079d 2026-01-16

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -5,7 +5,7 @@
 option(USE_CUSTOM_TT_MLIR_VERSION "Flag to use TT_MLIR_VERSION set by the user" OFF)
 
 if (NOT DEFINED TT_MLIR_VERSION OR NOT USE_CUSTOM_TT_MLIR_VERSION)
-    set(TT_MLIR_VERSION "cb33dc71f08c218deee35bdf69443b17bab848b7")
+    set(TT_MLIR_VERSION "7486d8889de293f2f83d8a9e713e1b1387b8079d")
 endif()
 
 set(PROTOBUF_VERSION "v21.12") # same version as tt-metal uses


### PR DESCRIPTION
This PR uplifts the third_party/tt-mlir to the 7486d8889de293f2f83d8a9e713e1b1387b8079d