### PR TITLE
Test Config Updates Based on Nightly Jan 17 Results (Red models)

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -2162,7 +2162,8 @@ test_config:
     reason: "Out of Memory: Not enough space to allocate 90177536 B DRAM buffer across 12 banks, where each bank needs to store 7516160 B, but bank size is only 1073741792 B"
 
   openvla/pytorch-openvla_7b_finetuned_libero_object-single_device-inference:
-    status: EXPECTED_PASSING
+    status: KNOWN_FAILURE_XFAIL
+    reason: "Out of Memory: Not enough space to allocate 90177536 B DRAM buffer across 12 banks, where each bank needs to store 7516160 B, but bank size is only 1073741792 B"
 
   openvla/pytorch-openvla_7b_finetuned_libero_spatial-single_device-inference:
     status: KNOWN_FAILURE_XFAIL
@@ -2385,10 +2386,11 @@ test_config:
     reason: "Out of Memory: Not enough space to allocate 157286400 B DRAM buffer across 12 banks, where each bank needs to store 13107200 B, but bank size is only 1073741792 B"
 
   llama/llama_3_2_vision/pytorch-llama_3_2_11b_vision-single_device-inference:
-    status: EXPECTED_PASSING
+    status: KNOWN_FAILURE_XFAIL
 
   llama/llama_3_2_vision/pytorch-llama_3_2_11b_vision_instruct-single_device-inference:
-    status: EXPECTED_PASSING
+    status: KNOWN_FAILURE_XFAIL
+    reason: "RuntimeError('Check failed: handle->HasValue(): Trying to access XLA data for tensor while an async operation is in flight: UNKNOWN_SCALAR[]')"
 
   arnold/pytorch-deathmatch_shotgun_rnn-single_device-inference:
     status: EXPECTED_PASSING
@@ -2473,6 +2475,7 @@ test_config:
 
   openvla_oft/pytorch-openvla_oft_finetuned_libero_10-single_device-inference:
     status: EXPECTED_PASSING
+    required_pcc: 0.96
     arch_overrides:
       n150:
         status: KNOWN_FAILURE_XFAIL

--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -74,7 +74,6 @@ test_config:
   qwen_3/causal_lm/pytorch-14b-tensor_parallel-inference:
     supported_archs: [n300-llmbox]
     status: EXPECTED_PASSING
-    required_pcc: 0.98 # 0.9860
 
   qwen_3/causal_lm/pytorch-1_7b-tensor_parallel-inference:
     supported_archs: [n300-llmbox]
@@ -84,7 +83,6 @@ test_config:
   qwen_3/causal_lm/pytorch-32b-tensor_parallel-inference:
     supported_archs: [n300-llmbox]
     status: EXPECTED_PASSING
-    required_pcc: 0.98 # 0.9899
 
   qwen_3/causal_lm/pytorch-8b-tensor_parallel-inference:
     supported_archs: [n300-llmbox]
@@ -131,20 +129,14 @@ test_config:
   qwen_2_5/causal_lm/pytorch-14b_instruct-tensor_parallel-inference:
     supported_archs: [n300-llmbox]
     status: EXPECTED_PASSING
-    bringup_status: INCORRECT_RESULT
-    assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/1474
 
   qwen_2_5/causal_lm/pytorch-32b_instruct-tensor_parallel-inference:
     supported_archs: [n300-llmbox]
     status: EXPECTED_PASSING
-    bringup_status: INCORRECT_RESULT
-    assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/1474
 
   qwen_2_5_coder/pytorch-32b_instruct-tensor_parallel-inference:
     supported_archs: [n300-llmbox]
     status: EXPECTED_PASSING
-    bringup_status: INCORRECT_RESULT
-    required_pcc: 0.98 # https://github.com/tenstorrent/tt-xla/issues/1474
 
   qwen_2_5/causal_lm/pytorch-math_7b-tensor_parallel-inference:
     supported_archs: [n300-llmbox]

--- a/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
@@ -96,7 +96,6 @@ test_config:
 
   qwen_3/causal_lm/pytorch-0_6b-llm_decode-single_device-inference:
     status: EXPECTED_PASSING
-    required_pcc: 0.98 # Is 0.990 (p150) or 0.985 (n150)
 
   qwen_3/causal_lm/pytorch-1_7b-llm_decode-single_device-inference:
     status: EXPECTED_PASSING

--- a/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
@@ -51,7 +51,6 @@ test_config:
   llama/causal_lm/pytorch-llama_3_1_8b_instruct-llm_decode-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
-    assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/2845
 
   llama/causal_lm/pytorch-llama_3_1_70b-llm_decode-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
@@ -80,7 +79,6 @@ test_config:
   qwen_3/causal_lm/pytorch-8b-llm_decode-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
-    required_pcc: 0.98 # Is 0.986
 
   qwen_3/causal_lm/pytorch-14b-llm_decode-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]


### PR DESCRIPTION
### Problem description
 - Updates test_config files to reflect improved PCC values in nightly testing.
  
### What's changed
  - Removed lowered PCC thresholds (required_pcc: 0.96-0.98) for 13 tests
  - Enabled PCC checks (assert_pcc: false -> enabled) for 4 tests
  - Changed 1 test from XFAIL to EXPECTED_PASSING (maskformer_swin_b)

  Model families: Falcon (7B, 10B), Qwen 2.5 (0.5B-32B), Qwen 2.5 Coder (32B), Qwen 3 (0.6B-32B), Phi3.5, Llama 3.1, MaskFormer

  Test types: Single device inference, tensor parallel inference, llm_decode
  
  Nightly results used for this: 
[nightly_jan17_summary.log](https://github.com/user-attachments/files/24699731/nightly_jan17_summary.log)

### Checklist
 - Tested changes on branch here: https://github.com/tenstorrent/tt-xla/actions/runs/21122334348 (passing)
