### PR TITLE
Fix canonicalizeIotaDims assert to <= to match upstream

### DIFF
--- a/pjrt_implementation/src/api/module_builder/frontend_passes/shlo_clean_for_xla_ingestion.cc
+++ b/pjrt_implementation/src/api/module_builder/frontend_passes/shlo_clean_for_xla_ingestion.cc
@@ -182,7 +182,7 @@ void canonicalizeIotaDims(mlir::SmallVector<int64_t> &reshapeDims,
         if (new_perm_dim >= 0) {
           transposePerm[new_idx] = new_perm_dim;
           ++new_idx;
-          assert(new_idx < new_ndims);
+          assert(new_idx <= new_ndims);
         }
       }
       transposePerm.truncate(new_ndims);


### PR DESCRIPTION
### Ticket
None

### Problem description
Failures in main `Assertion new_idx < new_ndims' failed.` due to incorrect comparison.

### What's changed
Change < to <=, according to [upstream reference](https://github.com/openxla/xla/blob/9ae3d6dab2c10c8195c8d9862f475904c7cdca91/xla/hlo/ir/tile_assignment.cc#L87) which uses DCHECK_LE (not LT).

Note - This causes many of the tests we run in CI to fail, but only when executed locally. However, it is not caught in CI because we use a release build in CI and these asserts get turned into a no-op. So, this bug is only encountered if running multichip tests with a debug build locally. 

### Checklist
- [x] New/Existing tests provide coverage for changes
