### PR TITLE
Temporarily lower PCC in 9 Red LLM models due to ComputeConfig (math_fidelity/fp32_dest_acc_en) defaults change needs debug

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -585,6 +585,7 @@ test_config:
   phi2/causal_lm/pytorch-microsoft/phi-2-single_device-inference:
     status: EXPECTED_PASSING
     required_pcc: 0.98
+    assert_pcc: false # ComputeConfig math_fidelity/fp32_dest_acc_en - https://github.com/tenstorrent/tt-xla/issues/2861
 
   phi2/causal_lm/pytorch-microsoft/phi-2-pytdml-single_device-inference:
     status: EXPECTED_PASSING
@@ -1528,6 +1529,7 @@ test_config:
   gemma/pytorch-google/gemma-1.1-7b-it-single_device-inference:
     supported_archs: ["p150"]
     status: EXPECTED_PASSING
+    assert_pcc: false # ComputeConfig math_fidelity/fp32_dest_acc_en - https://github.com/tenstorrent/tt-xla/issues/2861
 
   stable_diffusion_xl/pytorch-stable-diffusion-xl-base-1.0-single_device-inference:
     status: EXCLUDE_MODEL  # stable_diffusion variants have a hand written test, don't run via test_models.py. TODO(@ppadjinTT): when pipeline becomes supported through test infra, enable this model again.
@@ -1673,6 +1675,7 @@ test_config:
 
   llama/causal_lm/pytorch-llama_3_1_8b_instruct-single_device-inference:
     status: EXPECTED_PASSING
+    assert_pcc: false # ComputeConfig math_fidelity/fp32_dest_acc_en - https://github.com/tenstorrent/tt-xla/issues/2861
     arch_overrides:
       n150:
         status: NOT_SUPPORTED_SKIP
@@ -2553,6 +2556,7 @@ test_config:
   mistral/pytorch-mistral_nemo_instruct_2407-single_device-inference:
     supported_archs: ["p150"] # 12B param model
     status: EXPECTED_PASSING
+    assert_pcc: false # ComputeConfig math_fidelity/fp32_dest_acc_en - https://github.com/tenstorrent/tt-xla/issues/2861
 
   wan/pytorch-wan2.2-ti2v-5b-single_device-inference:
     status: NOT_SUPPORTED_SKIP

--- a/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
@@ -10,10 +10,12 @@
 test_config:
   falcon/pytorch-tiiuae/Falcon3-1B-Base-llm_decode-single_device-inference:
     status: EXPECTED_PASSING
+    assert_pcc: false # ComputeConfig math_fidelity/fp32_dest_acc_en - https://github.com/tenstorrent/tt-xla/issues/2861
 
   falcon/pytorch-tiiuae/Falcon3-3B-Base-llm_decode-single_device-inference:
     required_pcc: 0.985 # Is 0.990 (p150) or 0.989 (n150)
     status: EXPECTED_PASSING
+    assert_pcc: false # ComputeConfig math_fidelity/fp32_dest_acc_en - https://github.com/tenstorrent/tt-xla/issues/2861
 
   falcon/pytorch-tiiuae/Falcon3-7B-Base-llm_decode-single_device-inference:
     supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.
@@ -53,6 +55,7 @@ test_config:
 
   gemma/pytorch-google/gemma-1.1-2b-it-llm_decode-single_device-inference:
     status: EXPECTED_PASSING
+    assert_pcc: false # ComputeConfig math_fidelity/fp32_dest_acc_en - https://github.com/tenstorrent/tt-xla/issues/2861
 
   gemma/pytorch-google/gemma-1.1-7b-it-llm_decode-single_device-inference:
     supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.
@@ -74,6 +77,7 @@ test_config:
   llama/causal_lm/pytorch-llama_3_1_8b_instruct-llm_decode-single_device-inference:
     supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.
     status: EXPECTED_PASSING
+    assert_pcc: false # ComputeConfig math_fidelity/fp32_dest_acc_en - https://github.com/tenstorrent/tt-xla/issues/2861
 
   llama/causal_lm/pytorch-llama_3_1_70b-llm_decode-single_device-inference:
     status: EXCLUDE_MODEL # Too large for single chip, run as tensor_parallel instead.

--- a/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
@@ -38,6 +38,7 @@ test_config:
   gemma/pytorch-google/gemma-1.1-7b-it-llm_decode-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
+    assert_pcc: false # ComputeConfig math_fidelity/fp32_dest_acc_en - https://github.com/tenstorrent/tt-xla/issues/2861
 
   gemma/pytorch-google/gemma-2-9b-it-llm_decode-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]


### PR DESCRIPTION
### Ticket
#2861 

### Problem description
- ComputeConfigs defaults changed in tt-mlir and in local/branch testing PCC drop was seen in few models, then in nightly on jan 16.  
- We considered using ComputeConfig override via #2898 to temporarily restore to previous values (it works) but it was decided against.

### What's changed
- Temporarily lower PCC in 4x test_all_models_torch RED models and 5x newly added test_llms_torch models until debugged and fixed.

### Checklist
- [x] Tested locally, tested affected tests with previous ComputeConfig values to confirm the cause, on branch here: https://github.com/tenstorrent/tt-xla/actions/runs/21153245447
