### PR TITLE
Add e2e perf benchmarking for op tests

### DIFF
--- a/tests/infra/testers/single_chip/op/op_tester.py
+++ b/tests/infra/testers/single_chip/op/op_tester.py
@@ -38,8 +38,8 @@ class OpTester(BaseTester):
             compiler_config = CompilerConfig()
         self._compiler_config = compiler_config
         self._torch_options = torch_options if torch_options is not None else {}
-        self._disable_perf_measurement = (
-            os.environ.get("DISABLE_PERF_MEASUREMENT", "0") == "1"
+        self._enable_perf_measurement = (
+            os.environ.get("ENABLE_OP_TEST_PERF_MEASUREMENT", "0") == "1"
         )
         self._perf_measurements: list[dict[str, float]] = []
         super().__init__(comparison_config, framework)
@@ -58,7 +58,7 @@ class OpTester(BaseTester):
 
         self._comparator.compare(tt_res, cpu_res)
 
-        if not self._disable_perf_measurement:
+        if self._enable_perf_measurement:
             self._test_e2e_perf(tt_workload)
 
     def _test_e2e_perf(self, workload: Workload) -> None:


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/1051

### Problem description
We would like to add e2e perf benchmarking for op tests.

### What's changed
The method `_test_e2e_perf()` for `OpTester` is implemented. It runs a given op test a few times to warm up the device, then run N times to gather perf data. The data is then displayed in stdout.

### Checklist
- [ ] New/Existing tests provide coverage for changes
