### PR TITLE
[FX fusing] Add composite wrap pattern matching

### DIFF
--- a/python_package/tt_torch/fusion_passes/__init__.py
+++ b/python_package/tt_torch/fusion_passes/__init__.py
@@ -2,10 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from .providers import FusionProvider
-from .utils import apply_fusion_pattern
+from .providers import CompositeWrapProvider, FusionProvider, PatternProvider
+from .utils import create_composite_wrap_replacement
 
 __all__ = [
+    "PatternProvider",
     "FusionProvider",
-    "apply_fusion_pattern",
+    "CompositeWrapProvider",
+    "create_composite_wrap_replacement",
 ]

--- a/python_package/tt_torch/fusion_passes/utils.py
+++ b/python_package/tt_torch/fusion_passes/utils.py
@@ -2,43 +2,56 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from dataclasses import dataclass
+import inspect
 from typing import Callable
 
+import torch
 from torch.fx import GraphModule
-from torch.fx.subgraph_rewriter import replace_pattern
+from torch_xla.experimental.mark_pattern_utils import StableHLOCompositeBuilder
 
 
-@dataclass
-class FusionPattern:
-    """
-    Represents a fusion pattern for subgraph matching and replacement.
+def create_composite_wrap_replacement(
+    pattern_fn: Callable,
+    composite_name: str,
+    attr: dict | None = None,
+    example_inputs: tuple | None = None,
+) -> GraphModule:
+    """Creates a traced replacement GraphModule that wraps pattern in composite.
 
-    Attributes:
-        name: Unique identifier for the pattern
-        pattern: Function defining the subgraph pattern to match
-        replacement: Function defining the replacement subgraph
-    """
+    This function generates a replacement that:
+    1. Marks the inputs with StableHLOCompositeBuilder
+    2. Executes the original pattern function
+    3. Marks the outputs with StableHLOCompositeBuilder
 
-    name: str
-    pattern: Callable
-    replacement: Callable
-
-
-def apply_fusion_pattern(gm: GraphModule, fusion_pattern: FusionPattern) -> int:
-    """
-    Apply a single fusion pattern to a GraphModule.
+    The replacement is traced using make_fx to produce a GraphModule that
+    can be used with torch.fx.subgraph_rewriter.replace_pattern.
 
     Args:
-        gm: The GraphModule to transform
-        fusion_pattern: The fusion pattern to apply
+        pattern_fn: The pattern function to wrap
+        composite_name: Name for the StableHLO composite (e.g., 'tenstorrent.op, must match the name in tt-mlir')
+        attr: Optional attributes dict for the composite (e.g., {'normalized_shape': (1, 32, 32)})
+        example_inputs: Tuple of example tensors for tracing. If None, creates
+            dummy tensors based on the pattern signature (shape [1, 32, 32]).
 
     Returns:
-        Number of replacements made
+        A traced GraphModule that wraps pattern_fn in composite markers
     """
-    replaced = replace_pattern(
-        gm,
-        fusion_pattern.pattern,
-        fusion_pattern.replacement,
-    )
-    return len(replaced)
+    from torch.fx.experimental.proxy_tensor import make_fx
+
+    sig = inspect.signature(pattern_fn)
+    param_count = len(sig.parameters)
+
+    def replacement(*args):
+        builder = StableHLOCompositeBuilder(name=composite_name, attr=attr)
+        marked_args = builder.mark_inputs(*args)
+        # Handle single arg case (mark_inputs returns single tensor, not tuple)
+        if param_count == 1:
+            marked_args = (marked_args,)
+        result = pattern_fn(*marked_args)
+        return builder.mark_outputs(result)
+
+    # Create dummy inputs if not provided
+    if example_inputs is None:
+        example_inputs = tuple(torch.randn(1, 32, 32) for _ in range(param_count))
+
+    return make_fx(replacement)(*example_inputs)

--- a/tests/torch/ops/test_fusion_ops.py
+++ b/tests/torch/ops/test_fusion_ops.py
@@ -7,7 +7,7 @@ import torch
 from infra.utilities.types import Framework
 from torch._dynamo import register_backend
 from transformers.models.llama.modeling_llama import LlamaRMSNorm
-from tt_torch.backend.passes import run_fusion_passes
+from tt_torch.backend.passes import run_fusion_pass
 
 from tests.infra.comparators.comparison_config import ComparisonConfig
 from tests.infra.testers.single_chip.graph.graph_tester import run_graph_test
@@ -41,7 +41,7 @@ def capture_graph_backend(gm, example_inputs, options=None):
         gm, fused_op_fn
     ), f"{fused_op_fn} should not be in graph before fusion"
 
-    gm = run_fusion_passes(gm)
+    gm = run_fusion_pass(gm)
 
     assert has_op_in_graph(
         gm, fused_op_fn


### PR DESCRIPTION
### Ticket
Extends #2786

### Problem description
After implementing the fusion pass in #2786, we needed a way to pattern match multi-op sequences and wrap them in `StableHLO` composites without replacing the underlying operations. This is useful for patterns like `RoPE` where we want to preserve the original operations inside a composite marker and we dont have `torch` op equivalent .

### Summary
  - Added `PatternProvider` base class that unifies `FusionProvider` and the new `CompositeWrapProvider`
  - Added `CompositeWrapProvider` for wrapping matched patterns into `StableHLO` composites
  - Auto-generate replacement functions (no need to duplicate pattern code)
  - Added `run_composite_wrap_pass()` alongside `run_fusion_pass()` with shared logic via `run_pattern_replacement_pass()`

### What's changed
  - `tt_torch/fusion_passes/providers.py` - Refactored to introduce `PatternProvider` base class, `FusionProvider` now extends it, added `CompositeWrapProvider`
  - `tt_torch/fusion_passes/utils.py` - Removed `FusionPattern` and `apply_fusion_pattern()` and added `create_composite_wrap_replacement()`
  - `tt_torch/backend/passes.py` - Added `run_pattern_replacement_pass()` shared function, `run_fusion_pass()`, and `run_composite_wrap_pass()`
  - `tt_torch/backend/backend.py` - Updated pipeline to call both passes separately with new option flags

### Adding new patterns

``` python
  class RoPECompositeWrapProvider(CompositeWrapProvider):
      """Add to providers.py - auto-registers via __init_subclass__."""

      @property
      def name(self) -> str:
          return "rope_composite_wrap"

      @property
      def composite_name(self) -> str:
          return "tenstorrent.rope"

      @staticmethod
      def pattern(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
          x1, x2 = x.chunk(2, dim=-1)
          rotated = torch.cat((-x2, x1), dim=-1)
          return x.mul(cos).add(rotated.mul(sin))

      # No replacement() needed - auto-generated!
```

### Architecture

```
  PatternProvider (ABC)
  ├── name (abstract)
  ├── pattern() (abstract)
  ├── get_replacement() (abstract) ← polymorphic
  └── replace_pattern(gm) → int (shared implementation)

  FusionProvider(PatternProvider)
  ├── replacement() (user-defined)
  └── get_replacement() → returns self.replacement

  CompositeWrapProvider(PatternProvider)
  ├── composite_name (e.g., 'tenstorrent.rope')
  ├── composite_attr (optional)
  └── get_replacement() → auto-generates from pattern()
```
