### PR TITLE
[FX Fusing] Turn off by default

### DIFF
--- a/python_package/tt_torch/backend/backend.py
+++ b/python_package/tt_torch/backend/backend.py
@@ -35,7 +35,7 @@ def torch_pass_pipeline(
 
     # Run fusion passes to detect and fuse multi-op patterns
     # This runs before composite_ops to allow fused patterns to be wrapped as composites
-    enable_fusion_passes = options is None or options.get(
+    enable_fusion_passes = options is not None and options.get(
         "tt_enable_fusion_passes", False
     )
     if enable_fusion_passes:


### PR DESCRIPTION
### Ticket
#2846

### Problem description
- Many TP n300-llmbox red models hitting "TT_THROW: Statically allocated circular buffers on core range [(x=0,y=0) - (x=0,y=0)] grow to 1511680 B which is beyond max L1 size of 1499136 B (assert.hpp:104)" in latest nightly, bisected to #2786 changes pretty quickly, needs debug.

### What's changed
Turn off `fx fusing` by default until stable for multichip
