### PR TITLE
Skip vision models exceeding 7B parameters in n150

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -902,6 +902,10 @@ test_config:
   qwen_2_5_vl/pytorch-7b_instruct-single_device-inference:
     status: KNOWN_FAILURE_XFAIL
     reason: "error: failed to legalize operation 'ttir.convolution' - https://github.com/tenstorrent/tt-xla/issues/1662"
+    arch_overrides:
+      n150:
+        status: NOT_SUPPORTED_SKIP
+        reason: "Multi chip is required"
 
   llama/sequence_classification/pytorch-llama_3_2_1b-single_device-inference:
     status: EXPECTED_PASSING
@@ -2155,26 +2159,50 @@ test_config:
   openvla/pytorch-openvla_7b-single_device-inference:
     status: KNOWN_FAILURE_XFAIL
     reason: "Out of Memory: Not enough space to allocate 90177536 B DRAM buffer across 12 banks, where each bank needs to store 7516160 B, but bank size is only 1073741792 B"
+    arch_overrides:
+      n150:
+        status: NOT_SUPPORTED_SKIP
+        reason: "Multi chip is required"
 
   openvla/pytorch-openvla_v01_7b-single_device-inference:
     status: KNOWN_FAILURE_XFAIL
     reason: "Out of Memory: Not enough space to allocate 90177536 B DRAM buffer across 12 banks, where each bank needs to store 7516160 B, but bank size is only 1073741792 B"
+    arch_overrides:
+      n150:
+        status: NOT_SUPPORTED_SKIP
+        reason: "Multi chip is required"
 
   openvla/pytorch-openvla_7b_finetuned_libero_10-single_device-inference:
     status: KNOWN_FAILURE_XFAIL
     reason: "Out of Memory: Not enough space to allocate 90177536 B DRAM buffer across 12 banks, where each bank needs to store 7516160 B, but bank size is only 1073741792 B"
+    arch_overrides:
+      n150:
+        status: NOT_SUPPORTED_SKIP
+        reason: "Multi chip is required"
 
   openvla/pytorch-openvla_7b_finetuned_libero_goal-single_device-inference:
     status: KNOWN_FAILURE_XFAIL
     reason: "Out of Memory: Not enough space to allocate 90177536 B DRAM buffer across 12 banks, where each bank needs to store 7516160 B, but bank size is only 1073741792 B"
+    arch_overrides:
+      n150:
+        status: NOT_SUPPORTED_SKIP
+        reason: "Multi chip is required"
 
   openvla/pytorch-openvla_7b_finetuned_libero_object-single_device-inference:
     status: KNOWN_FAILURE_XFAIL
     reason: "Out of Memory: Not enough space to allocate 90177536 B DRAM buffer across 12 banks, where each bank needs to store 7516160 B, but bank size is only 1073741792 B"
+    arch_overrides:
+      n150:
+        status: NOT_SUPPORTED_SKIP
+        reason: "Multi chip is required"
 
   openvla/pytorch-openvla_7b_finetuned_libero_spatial-single_device-inference:
     status: KNOWN_FAILURE_XFAIL
     reason: "Out of Memory: Not enough space to allocate 90177536 B DRAM buffer across 12 banks, where each bank needs to store 7516160 B, but bank size is only 1073741792 B"
+    arch_overrides:
+      n150:
+        status: NOT_SUPPORTED_SKIP
+        reason: "Multi chip is required"
 
   transfuser/pytorch-single_device-inference:
     assert_pcc: false # PCC is -0.715
@@ -2395,10 +2423,18 @@ test_config:
 
   llama/llama_3_2_vision/pytorch-llama_3_2_11b_vision-single_device-inference:
     status: KNOWN_FAILURE_XFAIL
+    arch_overrides:
+      n150:
+        status: NOT_SUPPORTED_SKIP
+        reason: "Multi chip is required"
 
   llama/llama_3_2_vision/pytorch-llama_3_2_11b_vision_instruct-single_device-inference:
     status: KNOWN_FAILURE_XFAIL
     reason: "RuntimeError('Check failed: handle->HasValue(): Trying to access XLA data for tensor while an async operation is in flight: UNKNOWN_SCALAR[]')"
+    arch_overrides:
+      n150:
+        status: NOT_SUPPORTED_SKIP
+        reason: "Multi chip is required"
 
   arnold/pytorch-deathmatch_shotgun_rnn-single_device-inference:
     status: EXPECTED_PASSING
@@ -2495,32 +2531,32 @@ test_config:
     required_pcc: 0.98
     arch_overrides:
       n150:
-        status: KNOWN_FAILURE_XFAIL
-        reason: "Out of Memory: Not enough space to allocate 90177536 B DRAM buffer across 12 banks, where each bank needs to store 7516160 B, but bank size is only 1073741792 B - https://github.com/tenstorrent/tt-xla/issues/2328"
+        status: NOT_SUPPORTED_SKIP
+        reason: "Multi chip is required"
 
   openvla_oft/pytorch-openvla_oft_finetuned_libero_goal-single_device-inference:
     status: EXPECTED_PASSING
     required_pcc: 0.98
     arch_overrides:
       n150:
-        status: KNOWN_FAILURE_XFAIL
-        reason: "Out of Memory: Not enough space to allocate 90177536 B DRAM buffer across 12 banks, where each bank needs to store 7516160 B, but bank size is only 1073741792 B - https://github.com/tenstorrent/tt-xla/issues/2328"
+        status: NOT_SUPPORTED_SKIP
+        reason: "Multi chip is required"
 
   openvla_oft/pytorch-openvla_oft_finetuned_libero_object-single_device-inference:
     status: EXPECTED_PASSING
     required_pcc: 0.98
     arch_overrides:
       n150:
-        status: KNOWN_FAILURE_XFAIL
-        reason: "Out of Memory: Not enough space to allocate 90177536 B DRAM buffer across 12 banks, where each bank needs to store 7516160 B, but bank size is only 1073741792 B - https://github.com/tenstorrent/tt-xla/issues/2328"
+        status: NOT_SUPPORTED_SKIP
+        reason: "Multi chip is required"
 
   openvla_oft/pytorch-openvla_oft_finetuned_libero_spatial_object_goal_10-single_device-inference:
     status: EXPECTED_PASSING
     required_pcc: 0.97
     arch_overrides:
       n150:
-        status: KNOWN_FAILURE_XFAIL
-        reason: "Out of Memory: Not enough space to allocate 90177536 B DRAM buffer across 12 banks, where each bank needs to store 7516160 B, but bank size is only 1073741792 B - https://github.com/tenstorrent/tt-xla/issues/2328"
+        status: NOT_SUPPORTED_SKIP
+        reason: "Multi chip is required"
 
   mistral/pytorch-mistral_nemo_instruct_2407-single_device-inference:
     supported_archs: ["p150"] # 12B param model


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-xla/issues/2874

### Problem description

- Among the models failing due to OOM, some exceed 7B parameters, which cannot fit on a single N150 chip
  - [Model size chart](https://superset.tenstorrent.com/superset/dashboard/dbaae652-4864-41bf-9934-76d01df7741c/?permalink_key=blkVmeGmVvZ#HEADER-3K-UYEMaJ-n_UJfC4bBf6)
  - [Failure reason (per test overiew) - N150](https://superset.tenstorrent.com/superset/dashboard/p/O7bQ2XDJjAN/)
  - [Failure reason (per test overiew) - P150](https://superset.tenstorrent.com/superset/dashboard/p/dD4YPW6OQNr/)


### What's changed

- Skipped models with more than 7B parameters on N150.
- **Note:** Qwen 2.5 VL-7B has approximately 8.29B parameters, yet it also encounters OOM on P150. This suggests that the OOM issue is not solely due to model size and requires further investigation.

