### PR TITLE
Fixing some of the weekly CI errors

### DIFF
--- a/.test_durations
+++ b/.test_durations
@@ -2970,7 +2970,7 @@
     "tests/runner/test_models.py::test_all_models_torch[albert/masked_lm/pytorch-base_v2-single_device-inference]": 67.475,
     "tests/runner/test_models.py::test_all_models_torch[phi1_5/token_classification/pytorch-microsoft/phi-1_5-single_device-inference]": 79.562,
     "tests/runner/test_models.py::test_all_models_torch[xglm/pytorch-xglm-1.7B-single_device-inference]": 136.649,
-    "tests/runner/test_models.py::test_all_models_torch[falcon/pytorch-tiiuae/Falcon3-Mamba-7B-Base-tensor_parallel-inference]": 347.227,
+    "tests/runner/test_models.py::test_all_models_torch[falcon/pytorch-tiiuae/Falcon3-Mamba-7B-Base-tensor_parallel-inference]": 10800,
     "tests/runner/test_models.py::test_all_models_torch[qwen_2_5/causal_lm/pytorch-math_7b-tensor_parallel-inference]": 3.241,
     "tests/runner/test_models.py::test_all_models_torch[dla/pytorch-dla169-single_device-inference]": 86.003,
     "tests/jax/multi_chip/llmbox/8_devices/graphs/tensor_parallel/test_dot_psum.py::test_dot_psum[ShardingMode.INPUTS_AND_MODULE-batch_shape0-W1_shape0-B1_shape0-mesh_shape0-axis_names0-True]": 23.511,

--- a/tests/runner/test_config/jax/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/jax/test_config_inference_single_device.yaml
@@ -219,10 +219,10 @@ test_config:
     bringup_status: FAILED_TTMLIR_COMPILATION
 
   mistral/causal_lm/jax-v0_1-single_device-inference:
-    status: KNOWN_FAILURE_XFAIL
-    reason: "Can't load the model for 'mistralai/Mistral-7B-v0.1'."
+    status: NOT_SUPPORTED_SKIP
+    reason: "OOM on host"
     markers: [large]
-    bringup_status: FAILED_FE_COMPILATION
+    bringup_status: FAILED_RUNTIME
 
   mistral/causal_lm/jax-v0_1_tiny-single_device-inference:
     status: EXPECTED_PASSING


### PR DESCRIPTION
Fixing some of the weekly CI errors that we have found, skipping one test that OOMs on host, and raising the duration for another.