### PR TITLE
[vLLM plugin] Add support for BFP8 weight conversion option

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -51,10 +51,14 @@ class TTConfig:
     # Optimization level for tt-mlir compilation.
     optimization_level: int = 0
 
+    # Enables experimental BFP8 weight conversion in tt-mlir.
+    experimental_enable_weight_bfp8_conversion: bool = False
+
     def get_pjrt_compile_config(self) -> dict:
         return {
             "enable_const_eval": self.enable_const_eval,
             "optimization_level": self.optimization_level,
+            "experimental_enable_weight_bfp8_conversion": self.experimental_enable_weight_bfp8_conversion,
         }
 
 

--- a/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
@@ -7,11 +7,9 @@ import vllm
 
 @pytest.mark.push
 @pytest.mark.tensor_parallel
-@pytest.mark.llmbox
-@pytest.mark.parametrize(
-    "model_name", ["Qwen/Qwen3-32B", "Qwen/Qwen2.5-32B", "meta-llama/Llama-3.2-3B"]
-)
-def test_qwen3_32b_generation(model_name: str):
+@pytest.mark.dual_chip
+@pytest.mark.parametrize("model_name", ["meta-llama/Llama-3.2-3B"])
+def test_tensor_parallel_generation_n300(model_name: str):
     prompts = [
         "I like taking walks in the",
     ]
@@ -26,6 +24,45 @@ def test_qwen3_32b_generation(model_name: str):
             "enable_const_eval": False,
             "min_context_len": 32,
             "enable_tensor_parallel": True,
+        },
+    }
+    llm = vllm.LLM(**llm_args)
+
+    output_text = llm.generate(prompts, sampling_params)[0].outputs[0].text
+    print(f"prompt: {prompts[0]}, output: {output_text}")
+
+
+@pytest.mark.push
+@pytest.mark.tensor_parallel
+@pytest.mark.llmbox
+@pytest.mark.parametrize(
+    ["model_name", "enable_const_eval", "experimental_enable_weight_bfp8_conversion"],
+    [
+        pytest.param("Qwen/Qwen3-32B", False, False),
+        pytest.param("Qwen/Qwen2.5-32B", False, False),
+        pytest.param("meta-llama/Llama-3.1-70B", True, True),
+    ],
+)
+def test_tensor_parallel_generation_llmbox(
+    model_name: str,
+    enable_const_eval: bool,
+    experimental_enable_weight_bfp8_conversion: bool,
+):
+    prompts = [
+        "I like taking walks in the",
+    ]
+    sampling_params = vllm.SamplingParams(temperature=0.8, top_p=0.95, max_tokens=32)
+    llm_args = {
+        "model": model_name,
+        "max_num_batched_tokens": 32,
+        "max_num_seqs": 1,
+        "max_model_len": 32,
+        "gpu_memory_utilization": 0.002,
+        "additional_config": {
+            "enable_const_eval": enable_const_eval,
+            "min_context_len": 32,
+            "enable_tensor_parallel": True,
+            "experimental_enable_weight_bfp8_conversion": experimental_enable_weight_bfp8_conversion,
         },
     }
     llm = vllm.LLM(**llm_args)


### PR DESCRIPTION
### Ticket
closes #2905 

### Problem description
Experimental BFP8 weight conversion flag is helpful to run large models on TT device.

### What's changed
- Add experimental BFP8 weight conversion in vLLM plugin (disabled by default).
- Add test for meta-llama/Llama-3.1-70B and enable BFP8 weight conversion. 
- meta-llama/Llama-3.2-3B test is moved from llmbox to N300

### Checklist
- [X] New/Existing tests provide coverage for changes
