### PR TITLE
Update xpassing tests in nightly from xfail to pass

### DIFF
--- a/tests/jax/multi_chip/llmbox/8_devices/ops/data_parallel/batch_sharded/test_pmean.py
+++ b/tests/jax/multi_chip/llmbox/8_devices/ops/data_parallel/batch_sharded/test_pmean.py
@@ -33,11 +33,16 @@ from utils import failed_fe_compilation
     "sharding_mode",
     [
         ShardingMode.INPUTS_AND_MODULE,
-        ShardingMode.MODULE,
+        pytest.param(
+            ShardingMode.MODULE,
+            marks=pytest.mark.xfail(
+                reason=failed_fe_compilation(
+                    "jax.lax.pmean not outputting the correct values "
+                    "https://github.com/tenstorrent/tt-mlir/issues/3645"
+                )
+            ),
+        ),
     ],
-)
-@pytest.mark.xfail(
-    reason="jax.lax.pmean not outputting the correct values https://github.com/tenstorrent/tt-mlir/issues/3645"
 )
 def test_pmean(
     use_shardy: bool,

--- a/tests/jax/multi_chip/n300/graphs/tensor_parallel/test_dot_psum.py
+++ b/tests/jax/multi_chip/n300/graphs/tensor_parallel/test_dot_psum.py
@@ -34,11 +34,6 @@ from utils import failed_fe_compilation, incorrect_result
     [
         pytest.param(
             ShardingMode.INPUTS_AND_MODULE,
-            marks=pytest.mark.xfail(
-                reason=incorrect_result(
-                    "PCC comparison failed. Calculated: pcc=0.6282761096954346. (https://github.com/tenstorrent/tt-xla/issues/1161)"
-                )
-            ),
         ),
         pytest.param(
             ShardingMode.MODULE,

--- a/tests/jax/multi_chip/n300/graphs/tensor_parallel/test_dot_psum_scatter.py
+++ b/tests/jax/multi_chip/n300/graphs/tensor_parallel/test_dot_psum_scatter.py
@@ -30,11 +30,6 @@ from utils import failed_fe_compilation, incorrect_result
     [
         pytest.param(
             ShardingMode.INPUTS_AND_MODULE,
-            marks=pytest.mark.xfail(
-                reason=incorrect_result(
-                    "PCC comparison failed. Calculated: pcc=0.6282761096954346. (https://github.com/tenstorrent/tt-xla/issues/1161)"
-                )
-            ),
         ),
         pytest.param(
             ShardingMode.MODULE,

--- a/tests/jax/multi_chip/n300/ops/data_parallel/batch_sharded/test_pmean.py
+++ b/tests/jax/multi_chip/n300/ops/data_parallel/batch_sharded/test_pmean.py
@@ -32,11 +32,16 @@ from utils import failed_fe_compilation
     "sharding_mode",
     [
         ShardingMode.INPUTS_AND_MODULE,
-        ShardingMode.MODULE,
+        pytest.param(
+            ShardingMode.MODULE,
+            marks=pytest.mark.xfail(
+                reason=failed_fe_compilation(
+                    "jax.lax.pmean not outputting the correct values"
+                    "https://github.com/tenstorrent/tt-mlir/issues/3645"
+                )
+            ),
+        ),
     ],
-)
-@pytest.mark.xfail(
-    reason="jax.lax.pmean not outputting the correct values https://github.com/tenstorrent/tt-mlir/issues/3645"
 )
 def test_pmean(
     use_shardy: bool,

--- a/tests/jax/single_chip/ops/test_reduce.py
+++ b/tests/jax/single_chip/ops/test_reduce.py
@@ -63,12 +63,6 @@ def test_reduce_max(x_shape: tuple, comparison_config: ComparisonConfig):
     shlo_op_name="stablehlo.reduce{AND}",
 )
 @pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)], ids=lambda val: f"{val}")
-@pytest.mark.xfail(
-    reason=failed_runtime(
-        "i1 (boolean) output type mismatch on TTNN backend"
-        "https://github.com/tenstorrent/tt-xla/issues/668"
-    )
-)
 def test_reduce_and(x_shape: tuple, comparison_config: ComparisonConfig):
     def reduce_and(x: jax.Array) -> jax.Array:
         x_bool = x > 0.5
@@ -87,12 +81,6 @@ def test_reduce_and(x_shape: tuple, comparison_config: ComparisonConfig):
     shlo_op_name="stablehlo.reduce{OR}",
 )
 @pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)], ids=lambda val: f"{val}")
-@pytest.mark.xfail(
-    reason=failed_runtime(
-        "i1 (boolean) output type mismatch on TTNN backend"
-        "https://github.com/tenstorrent/tt-xla/issues/668"
-    )
-)
 def test_reduce_or(x_shape: tuple, comparison_config: ComparisonConfig):
     def reduce_or(x: jax.Array) -> jax.Array:
         x_bool = x > 0.5
@@ -111,12 +99,6 @@ def test_reduce_or(x_shape: tuple, comparison_config: ComparisonConfig):
     shlo_op_name="stablehlo.reduce{MULTIPLY}",
 )
 @pytest.mark.parametrize("x_shape", [(32, 32), (64, 64)], ids=lambda val: f"{val}")
-@pytest.mark.xfail(
-    reason=failed_runtime(
-        "'ttnn.prod' op TTNN only supports Reduce(prod) along all dimensions for bfloat16 datatype"
-        "https://github.com/tenstorrent/tt-xla/issues/669"
-    )
-)
 def test_reduce_multiply(x_shape: tuple, comparison_config: ComparisonConfig):
     def reduce_multiply(x: jax.Array) -> jax.Array:
         return jnp.prod(x, axis=None)

--- a/tests/torch/models/bge_m3/test_bge_m3_custom_encode.py
+++ b/tests/torch/models/bge_m3/test_bge_m3_custom_encode.py
@@ -195,12 +195,7 @@ def bge_m3_encode():
     category=Category.MODEL_TEST,
     model_info=MODEL_INFO,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.INCORRECT_RESULT,
-)
-@pytest.mark.xfail(
-    reason=incorrect_result(
-        "Comparison result 0 failed: PCC comparison failed. Calculated: pcc=0.941021203994751. Required: pcc=0.97"
-    )
+    bringup_status=BringupStatus.PASSED,
 )
 def test_bge_m3_custom_encode():
     """Run BGE-M3 encode on TT device and validate PCC outputs are finite and bounded."""

--- a/tests/torch/models/resnet/test_resnet.py
+++ b/tests/torch/models/resnet/test_resnet.py
@@ -96,17 +96,11 @@ def training_tester() -> ResnetTester:
         pytest.param(
             "bfloat16",
             0,
-            marks=pytest.mark.xfail(
-                reason="PCC comparison < 0.99 (observed ~0.982-0.984)"
-            ),
         ),
         pytest.param("float32", 1),
         pytest.param(
             "float32",
             0,
-            marks=pytest.mark.xfail(
-                reason="PCC comparison < 0.99 (observed ~0.9875). Small, mentioned here anyways: https://github.com/tenstorrent/tt-xla/issues/1673"
-            ),
         ),
     ],
     ids=[
@@ -131,13 +125,7 @@ def test_torch_resnet_inference(format: str, optimization_level: int):
     model_name=MODEL_NAME,
     model_group=ModelGroup.GENERALITY,
     run_mode=RunMode.INFERENCE,
-    bringup_status=BringupStatus.INCORRECT_RESULT,
-)
-@pytest.mark.xfail(
-    reason=incorrect_result(
-        "PCC comparison failed. Calculated: pcc=nan. Required: pcc=0.99 "
-        "https://github.com/tenstorrent/tt-xla/issues/1384"
-    )
+    bringup_status=BringupStatus.PASSED,
 )
 def test_torch_resnet_inference_trace(trace_tester: ResnetTester):
     trace_tester.test()

--- a/tests/torch/models/whisper/test_whisper.py
+++ b/tests/torch/models/whisper/test_whisper.py
@@ -18,8 +18,6 @@ from .tester import WhisperTester
 
 _FAILING_VARIANTS = [
     ModelVariant.WHISPER_LARGE,
-    ModelVariant.WHISPER_LARGE_V3,
-    ModelVariant.WHISPER_LARGE_V3_TURBO,
 ]
 
 
@@ -31,24 +29,14 @@ def _variant_param(v):
     model_info = ModelLoader.get_model_info(v)
 
     if v in _FAILING_VARIANTS:
-        if v == ModelVariant.WHISPER_LARGE:
-            bringup_status = BringupStatus.FAILED_TTMLIR_COMPILATION
-            marks.append(
-                pytest.mark.xfail(
-                    reason=failed_ttmlir_compilation(
-                        "RuntimeError: Not enough space to allocate 6710886400 B DRAM buffer across 12 banks - https://github.com/tenstorrent/tt-xla/issues/1886"
-                    )
+        bringup_status = BringupStatus.FAILED_TTMLIR_COMPILATION
+        marks.append(
+            pytest.mark.xfail(
+                reason=failed_ttmlir_compilation(
+                    "RuntimeError: Not enough space to allocate 6710886400 B DRAM buffer across 12 banks - https://github.com/tenstorrent/tt-xla/issues/1886"
                 )
             )
-        else:
-            bringup_status = BringupStatus.FAILED_TTMLIR_COMPILATION
-            marks.append(
-                pytest.mark.xfail(
-                    reason=failed_ttmlir_compilation(
-                        "Statically allocated circular buffers in program 142 clash with L1 buffers on core range [(x=0,y=0) - (x=7,y=7)] - https://github.com/tenstorrent/tt-xla/issues/2380"
-                    )
-                )
-            )
+        )
     else:
         bringup_status = BringupStatus.PASSED
 

--- a/tests/torch/ops/test_eltwise_binary_ops.py
+++ b/tests/torch/ops/test_eltwise_binary_ops.py
@@ -132,9 +132,6 @@ def test_bitwise_right_shift():
 @pytest.mark.nightly
 @pytest.mark.single_device
 @pytest.mark.record_test_properties(category=Category.OP_TEST)
-@pytest.mark.xfail(
-    reason="PCC comparison failed. Calculated: pcc=nan. Required: pcc=0.99. https://github.com/tenstorrent/tt-xla/issues/379"
-)
 def test_div():
     class Div(torch.nn.Module):
         def forward(self, x, y):
@@ -147,9 +144,6 @@ def test_div():
 @pytest.mark.nightly
 @pytest.mark.single_device
 @pytest.mark.record_test_properties(category=Category.OP_TEST)
-@pytest.mark.xfail(
-    reason="PCC comparison failed. Calculated: pcc=nan. Required: pcc=0.99. https://github.com/tenstorrent/tt-xla/issues/379"
-)
 def test_divide():
     class Divide(torch.nn.Module):
         def forward(self, x, y):
@@ -291,9 +285,6 @@ def test_subtract():
 @pytest.mark.nightly
 @pytest.mark.single_device
 @pytest.mark.record_test_properties(category=Category.OP_TEST)
-@pytest.mark.xfail(
-    reason="PCC comparison failed. Calculated: pcc=nan. Required: pcc=0.99. https://github.com/tenstorrent/tt-xla/issues/379"
-)
 def test_true_divide():
     class TrueDivide(torch.nn.Module):
         def forward(self, x, y):

--- a/tests/torch/ops/test_eltwise_unary_ops.py
+++ b/tests/torch/ops/test_eltwise_unary_ops.py
@@ -353,9 +353,6 @@ def test_log():
 @pytest.mark.nightly
 @pytest.mark.single_device
 @pytest.mark.record_test_properties(category=Category.OP_TEST)
-@pytest.mark.xfail(
-    reason="PCC comparison failed. Calculated: pcc=nan. Required: pcc=0.99. https://github.com/tenstorrent/tt-xla/issues/2466"
-)
 def test_log10():
     class Log10(torch.nn.Module):
         def forward(self, x):
@@ -380,9 +377,6 @@ def test_log1p():
 @pytest.mark.nightly
 @pytest.mark.single_device
 @pytest.mark.record_test_properties(category=Category.OP_TEST)
-@pytest.mark.xfail(
-    reason="PCC comparison failed. Calculated: pcc=nan. Required: pcc=0.99. https://github.com/tenstorrent/tt-xla/issues/2466"
-)
 def test_log2():
     class Log2(torch.nn.Module):
         def forward(self, x):


### PR DESCRIPTION
### Ticket
Ref [Nightly](https://github.com/tenstorrent/tt-xla/actions/runs/21154942267/attempts/2) on 20 Jan 2026

### Problem description
Some of the models and ops are xpassing in latest nightly . They can be promoted to passing status from xfail

### What's changed
* removed xfail markers from tests and models which are passing


### Checklist
- [x] New/Existing tests provide coverage for changes
tested some files in local and also in CI

Full models in CI : https://github.com/tenstorrent/tt-xla/actions/runs/21161604131
n300 tests in CI : https://github.com/tenstorrent/tt-xla/actions/runs/21161652995
ops in CI : https://github.com/tenstorrent/tt-xla/actions/runs/21162049487/job/60858524328


