### PR TITLE
SDXL: Adding option to select 1024x1024 resolution

### DIFF
--- a/examples/pytorch/sdxl-pipeline.py
+++ b/examples/pytorch/sdxl-pipeline.py
@@ -381,7 +381,9 @@ if __name__ == "__main__":
         {"optimization_level": args.optimization_level}
     )
     if args.resolution == 1024:
-        print("Note: 1024x1024 resolution currently only works on p100 and p150 TT devices.")
+        print(
+            "Note: 1024x1024 resolution currently only works on p100 and p150 TT devices."
+        )
 
     config = SDXLConfig(
         width=args.resolution,


### PR DESCRIPTION
## Description

With this tt-mlir PR https://github.com/tenstorrent/tt-mlir/pull/6569, Stable Diffusion XL can be successfully run with resolution 1024x1024 (UNet only on device).

## Performance
Unet execution time (device): 66.6s 
Total time (with rest on cpu): 83.9s