### PR TITLE
Uplift third_party/tt-mlir to 45744e4229df260a3bde11b2208fda36e27676a2 2026-01-21

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -5,7 +5,7 @@
 option(USE_CUSTOM_TT_MLIR_VERSION "Flag to use TT_MLIR_VERSION set by the user" OFF)
 
 if (NOT DEFINED TT_MLIR_VERSION OR NOT USE_CUSTOM_TT_MLIR_VERSION)
-    set(TT_MLIR_VERSION "4ee1b7aef867d535d4fe18d4c3f2aaf2fad99592")
+    set(TT_MLIR_VERSION "45744e4229df260a3bde11b2208fda36e27676a2")
 endif()
 
 set(PROTOBUF_VERSION "v21.12") # same version as tt-metal uses


### PR DESCRIPTION
This PR uplifts the third_party/tt-mlir to the 45744e4229df260a3bde11b2208fda36e27676a2