### PR TITLE
Reverting the change for try catching torch_xla sync

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -496,6 +496,7 @@ def clear_torchxla_computation_cache():
             "This is expected if the test throws an exception, https://github.com/tenstorrent/tt-xla/issues/2814"
         )
 
+
 class TeeCaptureResult:
     """Result object mimicking pytest's CaptureResult."""
 


### PR DESCRIPTION
### Ticket


### Problem description
PR #2896 introduced more issues then it solved, so reverting the change

### What's changed
Reverting the change for try catching torch_xla sync from #2896. Now only catching `xr.clear_computation_cache` which will solve the original problems in training runs.

Nightly: https://github.com/tenstorrent/tt-xla/actions/runs/21191748570

### Checklist
- [ ] New/Existing tests provide coverage for changes
