### PR TITLE
Uplift third_party/tt-mlir to aef48b01b8dd14ddfe046a88760fc2a84093e3a5 2026-01-27

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -5,7 +5,7 @@
 option(USE_CUSTOM_TT_MLIR_VERSION "Flag to use TT_MLIR_VERSION set by the user" OFF)
 
 if (NOT DEFINED TT_MLIR_VERSION OR NOT USE_CUSTOM_TT_MLIR_VERSION)
-    set(TT_MLIR_VERSION "8ebaa974be46f0405b008bd2ae5efb7befead660")
+    set(TT_MLIR_VERSION "aef48b01b8dd14ddfe046a88760fc2a84093e3a5")
 endif()
 
 set(PROTOBUF_VERSION "v21.12") # same version as tt-metal uses


### PR DESCRIPTION
This PR uplifts the third_party/tt-mlir to the aef48b01b8dd14ddfe046a88760fc2a84093e3a5