### PR TITLE
Enable torch compile in training tests

### DIFF
--- a/tests/infra/testers/single_chip/model/torch_model_tester.py
+++ b/tests/infra/testers/single_chip/model/torch_model_tester.py
@@ -238,9 +238,7 @@ class TorchModelTester(ModelTester):
         self._workload.model.zero_grad()
 
         # Run forward on TT
-        compile_options = {
-            "tt_experimental_compile": False
-        }
+        compile_options = {"tt_experimental_compile": False}
         self._compile_for_tt_device(self._workload, compile_options)
         tt_res = self._run_on_tt_device(self._workload)
         tt_res = self._unpack_forward_output(tt_res)


### PR DESCRIPTION
### Ticket
N/A

### What's changed
Given that `torch.compile` is unblocked for backward (https://github.com/tenstorrent/tt-xla/issues/1391), we should use it in tests.

