### PR TITLE
Set default for triggering perf benchmark tests

### DIFF
--- a/.github/workflows/manual-benchmark.yml
+++ b/.github/workflows/manual-benchmark.yml
@@ -23,6 +23,12 @@ on:
         description: "Run on shared runner"
         required: false
         type: boolean
+        default: true
+      skip-device-perf:
+        description: "Skip device performance measurement"
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   packages: write
@@ -72,3 +78,4 @@ jobs:
         ref: ${{ needs.set-inputs.outputs.ref }}
         test-filter: ${{ inputs.test_filter }}
         sh-runner: ${{ inputs.sh-runner }}
+        skip-device-perf: ${{ inputs.skip-device-perf }}


### PR DESCRIPTION
### Ticket
tenstorrent/tt-forge#810

### Problem description
Change defaults for performance benchmark workflow triggering to reduce CI machine usage.

### What's changed
Set default values for `sh-runner` and `skip-device-perf` so that people trigger them only if they need them.
No functionality was lost, only different defaults were set.

### Checklist
- [ ] New/Existing tests provide coverage for changes
