### PR TITLE
Update config for Whisper base and medium variant

### DIFF
--- a/tests/runner/test_config/jax/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/jax/test_config_inference_single_device.yaml
@@ -541,14 +541,15 @@ test_config:
     bringup_status: FAILED_TTMLIR_COMPILATION
 
   whisper/audio_classification/jax-base-single_device-inference:
-    status: NOT_SUPPORTED_SKIP
-    reason: "Segfault - https://github.com/tenstorrent/tt-xla/issues/546"
-    bringup_status: FAILED_FE_COMPILATION
+    status: EXPECTED_PASSING
+    reason: "PCC comparison failed. Calculated: pcc=0.668. Required: pcc=0.99"
+    bringup_status: INCORRECT_RESULT
 
   whisper/audio_classification/jax-medium-single_device-inference:
-    status: NOT_SUPPORTED_SKIP
-    reason: "Segfault - https://github.com/tenstorrent/tt-xla/issues/546"
-    bringup_status: FAILED_FE_COMPILATION
+    assert_pcc: false
+    status: EXPECTED_PASSING
+    reason: "PCC comparison failed. Calculated: pcc=0.734. Required: pcc=0.99"
+    bringup_status: INCORRECT_RESULT
 
   whisper/audio_classification/jax-large_v3-single_device-inference:
     status: EXPECTED_PASSING


### PR DESCRIPTION
After transferring Whisper to use EasyDel as the model implementation
([commit
3a9d868](https://github.com/tenstorrent/tt-forge-models/commit/3a9d868b058711da3cc711c3fc75048863b847c8)),
base and medium variant are passing with bad pcc.