### PR TITLE
[vLLM Plugin] Add warning: "Sampler not supported currently, using greedy sampling" in model_runner.py

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -1146,6 +1146,12 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     logits, self.mesh, (None, None, None)
                 )
 
+            # Need to remove hack that forces greedy in sample_from_logits. https://github.com/tenstorrent/tt-xla/issues/3026
+            if not tpu_sampling_metadata.all_greedy:
+                logger.warning_once(
+                    "Sampler not supported currently, using greedy sampling. Issue #3026"
+                )
+
             selected_token_ids = self.sample_from_logits_func(
                 logits, tpu_sampling_metadata
             )


### PR DESCRIPTION
### Ticket
#3026

### Problem description
- SamplingParams can be ignored silently and greedy sampling (argmax) always used... not great.

### What's changed
- Add a warning that prints once if this scenario is encountered (non-greedy SamplingParams used, ignored)
- There isn't any usage of sample_from_logits in pooling_runner.py so no place to add this warning there.

### Checklist
- [x] Tested locally, warning appears once
