### PR TITLE
Adding CMakePresets.json for easier debug/release builds

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -18,11 +18,8 @@
           "TT_RUNTIME_DEBUG": "ON",
           "TT_RUNTIME_ENABLE_PERF_TRACE": "ON",
           "TTMLIR_BUILD_TYPE": "Debug",
-          "TTMLIR_ENABLE_RUNTIME": "ON",
-          "TTMLIR_ENABLE_OPMODEL": "ON",
           "TTMLIR_ENABLE_BINDINGS_PYTHON": "ON",
-          "TTMETAL_ENABLE_PYTHON_BINDINGS": "ON",
-          "TTMLIR_ENABLE_STABLEHLO": "ON"
+          "TTMETAL_ENABLE_PYTHON_BINDINGS": "ON"
         },
         "cmakeExecutable": "sea_cmake"
       },
@@ -39,10 +36,8 @@
           "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
           "CMAKE_EXPORT_COMPILE_COMMANDS": "YES",
           "TTMLIR_BUILD_TYPE": "Release",
-          "TTMLIR_ENABLE_RUNTIME": "ON",
           "TTMLIR_ENABLE_BINDINGS_PYTHON": "ON",
-          "TT_RUNTIME_DEBUG": "OFF",
-          "TTMLIR_ENABLE_STABLEHLO": "ON"
+          "TT_RUNTIME_DEBUG": "OFF"
         },
         "cmakeExecutable": "sea_cmake"
       }


### PR DESCRIPTION
After talking to several people working on tt-xla repo, we came to conclusion that most people have their own notes with build commands that they copy paste for debug/release builds. This PR tries addresses this and adds `CMakePresets.json` file.

This file contains premade recipes for debug and release builds of tt-xla which includes most of the flags people like to use. 
This can also speed up onboarding of new people on tt-xla.

### How to use
To get a debug/release build of tt-xla, do
```
cmake --preset [debug|release]
cmake --build build
```
