### PR TITLE
Add option for controlling CPU-hoisted const-eval

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -34,6 +34,12 @@ class TTConfig:
     # will essentially end up storing the entire model on device once per graph. This can easily lead to OOM errors.
     # There is an issue tracking this in tt-mlir: https://github.com/tenstorrent/tt-mlir/issues/3888
     enable_const_eval: bool = True
+
+    # Enables hoisting const-eval subgraphs to CPU module. When enabled, const-eval
+    # operations are hoisted to be executed on the CPU instead of being executed
+    # on the device.
+    enable_const_eval_on_cpu: bool = False
+
     min_context_len: int = 128
     batch_size: int = 1
     enable_precompile_all: bool = True
@@ -57,6 +63,7 @@ class TTConfig:
     def get_pjrt_compile_config(self) -> dict:
         return {
             "enable_const_eval": self.enable_const_eval,
+            "enable_const_eval_on_cpu": self.enable_const_eval_on_cpu,
             "optimization_level": self.optimization_level,
             "experimental_enable_weight_bfp8_conversion": self.experimental_enable_weight_bfp8_conversion,
         }

--- a/pjrt_implementation/inc/api/compile_options.h
+++ b/pjrt_implementation/inc/api/compile_options.h
@@ -90,6 +90,13 @@ struct CompileOptions {
   // https://github.com/tenstorrent/tt-mlir/issues/3888
   bool enable_const_eval = true;
 
+  // Enables hoisting const-eval subgraphs to CPU module.
+  //
+  // When enabled, const-eval operations are hoisted to be executed on the CPU
+  // instead of being executed on the device. CPU execution uses 32-bit
+  // precision for all operations, which can improve accuracy for some models.
+  bool enable_const_eval_on_cpu = false;
+
   // Enables transpose + matmul and transpose + linear ops fusion.
   // This controls fusing of transpose + matmul and transpose + linear ops.
   // When disabled, transpose is kept as a separate op which can be constevaled,

--- a/pjrt_implementation/src/api/compile_options.cc
+++ b/pjrt_implementation/src/api/compile_options.cc
@@ -48,6 +48,9 @@ CompileOptions CompileOptions::parse(
   options.enable_const_eval =
       internal::parseBoolOption(compile_options, "enable_const_eval")
           .value_or(true);
+  options.enable_const_eval_on_cpu =
+      internal::parseBoolOption(compile_options, "enable_const_eval_on_cpu")
+          .value_or(false);
   options.experimental_enable_permute_matmul_fusion =
       internal::parseBoolOption(compile_options,
                                 "experimental_enable_permute_matmul_fusion")

--- a/pjrt_implementation/src/api/module_builder/module_builder.cc
+++ b/pjrt_implementation/src/api/module_builder/module_builder.cc
@@ -936,6 +936,7 @@ tt_pjrt_status ModuleBuilder::convertFromTTIRToTTNN(
   options.enableTrace = compile_options.enable_trace;
   options.systemDescPath = system_descriptor_path.data();
   options.enableConstEval = compile_options.enable_const_eval;
+  options.enableCPUHoistedConstEval = compile_options.enable_const_eval_on_cpu;
   options.ttnnPerfMetricsEnabled = compile_options.ttnn_perf_metrics_enabled;
 
   // Auto-number performance metrics output file if enabled

--- a/tests/infra/testers/compiler_config.py
+++ b/tests/infra/testers/compiler_config.py
@@ -63,6 +63,11 @@ class CompilerConfig:
     # some models until https://github.com/tenstorrent/tt-mlir/pull/6198 lands.
     experimental_enable_permute_matmul_fusion: bool = True
 
+    # Enables hoisting const-eval subgraphs to CPU module. When enabled, const-eval
+    # operations are hoisted to be executed on the CPU instead of being executed
+    # on the device.
+    enable_const_eval_on_cpu: bool = False
+
     # Enables trace hoisting for TTNN pipeline.
     enable_trace: bool = False
 
@@ -103,6 +108,9 @@ class CompilerConfig:
 
         if not self.experimental_enable_permute_matmul_fusion:
             options["experimental_enable_permute_matmul_fusion"] = "false"
+
+        if self.enable_const_eval_on_cpu:
+            options["enable_const_eval_on_cpu"] = "true"
 
         if self.enable_trace:
             options["enable_trace"] = "true"


### PR DESCRIPTION
### Ticket
[#6009](https://github.com/tenstorrent/tt-mlir/issues/6009)

### Problem description
With [this PR](https://github.com/tenstorrent/tt-mlir/pull/6633), CPU-hoisted const-eval will be enabled by default in TT-MLIR. Before the PR lands, we need to introduce a compiler option for enabling/disabling CPU-hoisted const-eval, in case some tests/models regress.

### What's changed
- Introduced `enable_const_eval_on_cpu` compiler option, which maps to `enableCPUHoistedConstEval` TT-MLIR option

### Checklist
- [x] New/Existing tests provide coverage for changes
