### PR TITLE
Remove protobuf compilation

### DIFF
--- a/pjrt_implementation/src/api/CMakeLists.txt
+++ b/pjrt_implementation/src/api/CMakeLists.txt
@@ -11,6 +11,8 @@
 # Static lib containing core PJRT API implementation: handling device/client/buffer/etc.
 # Depends on: TTMLIRCompiler, TTMLIRRuntime, TTPJRTUtils, coverage_config, protobuf::libprotobuf
 
+find_package(Protobuf REQUIRED)
+
 add_library(TTPJRTApi
     "buffer_instance.cc"
     "client_instance.cc"
@@ -35,7 +37,6 @@ add_library(TTPJRTApi
 )
 
 target_include_directories(TTPJRTApi PUBLIC
-    ${Protobuf_INCLUDE_DIRS}
     ${TTMLIR_TOOLCHAIN_DIR}/src/shardy
     ${TTMLIR_TOOLCHAIN_DIR}/src/stablehlo
 )
@@ -44,7 +45,7 @@ target_link_libraries(TTPJRTApi
 PRIVATE
     dl
     coverage_config
-    libprotobuf
+    protobuf::libprotobuf
     TTMLIRCompiler
     TTMLIRRuntime
 PUBLIC

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -8,7 +8,6 @@ if (NOT DEFINED TT_MLIR_VERSION OR NOT USE_CUSTOM_TT_MLIR_VERSION)
     set(TT_MLIR_VERSION "aef48b01b8dd14ddfe046a88760fc2a84093e3a5")
 endif()
 
-set(PROTOBUF_VERSION "v21.12") # same version as tt-metal uses
 set(LOGURU_VERSION "4adaa185883e3c04da25913579c451d3c32cfac1")
 
 if (TOOLCHAIN STREQUAL "ON")
@@ -29,33 +28,6 @@ if (TOOLCHAIN STREQUAL "ON")
 else()
     include(ExternalProject)
     add_subdirectory(pjrt_c_api)
-
-    # ----- protobuf -----
-
-    include(FetchContent)
-
-    FetchContent_Declare(
-        protobuf
-        GIT_REPOSITORY https://github.com/protocolbuffers/protobuf.git
-        GIT_TAG ${PROTOBUF_VERSION}
-        GIT_SHALLOW ON
-    )
-
-    # match options from metal
-    set(protobuf_BUILD_TESTS OFF CACHE BOOL "" FORCE)
-    set(protobuf_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
-    set(CMAKE_POSITION_INDEPENDENT_CODE ON CACHE BOOL "" FORCE)
-    set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
-
-    # Use full compiler paths since it can't find it during build config phase
-    if(CMAKE_C_COMPILER MATCHES "clang-17")
-        set(CMAKE_C_COMPILER "/usr/bin/clang-17" CACHE STRING "" FORCE)
-    endif()
-    if(CMAKE_CXX_COMPILER MATCHES "clang\\+\\+-17")
-        set(CMAKE_CXX_COMPILER "/usr/bin/clang++-17" CACHE STRING "" FORCE)
-    endif()
-
-    FetchContent_MakeAvailable(protobuf)
 
     # ----- tt-mlir -----
 


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-xla/issues/2701

### Problem description
protobuf compilation is no longer needed.

### What's changed
removed protobuf compilation.

### Checklist
- [ ] New/Existing tests provide coverage for changes
