### PR TITLE
updating yolov7 with latest results

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -1039,28 +1039,22 @@ test_config:
     status: EXPECTED_PASSING
 
   yolov7/pytorch-yolov7x-single_device-inference:
-    status: KNOWN_FAILURE_XFAIL
-    reason: "Function path mismatch for /usr/local/lib/python3.11/dist-packages/torch/_tensor.py:39 between simple and ast modes - https://github.com/tenstorrent/tt-xla/issues/2525"
-    bringup_status: FAILED_FE_COMPILATION
+    status: EXPECTED_PASSING
 
   yolov7/pytorch-yolov7-single_device-inference:
     status: EXPECTED_PASSING
 
   yolov7/pytorch-yolov7-w6-single_device-inference:
-    status: KNOWN_FAILURE_XFAIL
-    reason: "error: 'ttnn.max_pool2d' op Kernel height 13 is greater than input height 10. This ttnn.max_pool2d configuration is invalid - https://github.com/tenstorrent/tt-xla/issues/2007"
+    status: EXPECTED_PASSING
 
   yolov7/pytorch-yolov7-e6-single_device-inference:
-    status: KNOWN_FAILURE_XFAIL
-    reason: "error: 'ttnn.max_pool2d' op Kernel height 13 is greater than input height 10. This ttnn.max_pool2d configuration is invalid - https://github.com/tenstorrent/tt-xla/issues/2007"
+    status: EXPECTED_PASSING
 
   yolov7/pytorch-yolov7-d6-single_device-inference:
-    status: KNOWN_FAILURE_XFAIL
-    reason: "error: 'ttnn.max_pool2d' op Kernel height 13 is greater than input height 10. This ttnn.max_pool2d configuration is invalid - https://github.com/tenstorrent/tt-xla/issues/2007"
+    status: EXPECTED_PASSING
 
   yolov7/pytorch-yolov7-e6e-single_device-inference:
-    status: KNOWN_FAILURE_XFAIL
-    reason: "error: 'ttnn.max_pool2d' op Kernel height 13 is greater than input height 10. This ttnn.max_pool2d configuration is invalid - https://github.com/tenstorrent/tt-xla/issues/2007"
+    status: EXPECTED_PASSING
 
   yolox/pytorch-yolox_nano-single_device-inference:
     status: EXPECTED_PASSING


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-xla/issues/2871

### Problem description
All the yolov7 models are passing in latest main so marking them as "Expected passing"

### What's changed
changed the status yolov7 models 

### Checklist
- [x] New/Existing tests provide coverage for changes

I have attached the logs for your reference:
[test_yolov7_d6.log](https://github.com/user-attachments/files/24936724/test_yolov7_d6.log)
[test_yolov7_default.log](https://github.com/user-attachments/files/24936725/test_yolov7_default.log)
[test_yolov7_e6.log](https://github.com/user-attachments/files/24936726/test_yolov7_e6.log)
[test_yolov7_e6e.log](https://github.com/user-attachments/files/24936728/test_yolov7_e6e.log)
[test_yolov7_w6.log](https://github.com/user-attachments/files/24936729/test_yolov7_w6.log)
[test_yolov7.log](https://github.com/user-attachments/files/24936730/test_yolov7.log)
[test_yolov7x.log](https://github.com/user-attachments/files/24936731/test_yolov7x.log)
