### PR TITLE
Update gpt-oss pcc after dequantization changes.

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -37,7 +37,7 @@ test_config:
   gpt_oss/pytorch-gpt_oss_20b-tensor_parallel-inference:
     supported_archs: [n300-llmbox]
     status: EXPECTED_PASSING
-    required_pcc: 0.98
+    required_pcc: 0.96
 
   falcon/pytorch-tiiuae/falcon-7b-instruct-tensor_parallel-inference:
     supported_archs: [n300-llmbox]


### PR DESCRIPTION
### Ticket
None

### Problem description
Under tt-forge-models, gpt-oss dequantization has changed resulting in 0.96 pcc. Currently, it is 0.98. This will cause a failure when tt-forge-models is uplifted.

### Checklist
- [X] https://github.com/tenstorrent/tt-xla/actions/runs/21458311717
