### PR TITLE
Adding alchemist artifact on all CI runs

### DIFF
--- a/.github/workflows/manual-test-single.yml
+++ b/.github/workflows/manual-test-single.yml
@@ -108,3 +108,4 @@ jobs:
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       wheel_release_artifact_name: ${{ needs.build-ttxla.outputs.wheel_artifact_name }}
       wheel_release_vllm_tt_artifact_name: ${{ needs.build-ttxla.outputs.wheel_release_vllm_tt_artifact_name }}
+      alchemist_artifact_name: ${{ needs.build-ttxla.outputs.alchemist_artifact_name }}

--- a/.github/workflows/manual-test.yml
+++ b/.github/workflows/manual-test.yml
@@ -68,3 +68,4 @@ jobs:
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       wheel_release_artifact_name: ${{ needs.build-ttxla.outputs.wheel_artifact_name }}
       wheel_release_vllm_tt_artifact_name: ${{ needs.build-ttxla.outputs.wheel_release_vllm_tt_artifact_name }}
+      alchemist_artifact_name: ${{ needs.build-ttxla.outputs.alchemist_artifact_name }}

--- a/.github/workflows/schedule-nightly-experimental.yml
+++ b/.github/workflows/schedule-nightly-experimental.yml
@@ -32,6 +32,7 @@ jobs:
       docker_image: ${{ needs.build-image.outputs.docker-image }}
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       wheel_release_artifact_name: ${{ needs.build-ttxla.outputs.wheel_artifact_name }}
+      alchemist_artifact_name: ${{ needs.build-ttxla.outputs.alchemist_artifact_name }}
       include_passed: true
 
   fail-notify:

--- a/.github/workflows/schedule-weekly-training.yml
+++ b/.github/workflows/schedule-weekly-training.yml
@@ -31,6 +31,7 @@ jobs:
       docker_image: ${{ needs.build-image.outputs.docker-image }}
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       wheel_release_artifact_name: ${{ needs.build-ttxla.outputs.wheel_artifact_name }}
+      alchemist_artifact_name: ${{ needs.build-ttxla.outputs.alchemist_artifact_name }}
 
   fail-notify:
     if: always()

--- a/.github/workflows/schedule-weekly.yml
+++ b/.github/workflows/schedule-weekly.yml
@@ -32,6 +32,7 @@ jobs:
       docker_image: ${{ needs.build-image.outputs.docker-image }}
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       wheel_release_artifact_name: ${{ needs.build-ttxla.outputs.wheel_artifact_name }}
+      alchemist_artifact_name: ${{ needs.build-ttxla.outputs.alchemist_artifact_name }}
 
   test_forge_models_xfail:
     uses: ./.github/workflows/call-test.yml
@@ -42,6 +43,7 @@ jobs:
       docker_image: ${{ needs.build-image.outputs.docker-image }}
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       wheel_release_artifact_name: ${{ needs.build-ttxla.outputs.wheel_artifact_name }}
+      alchemist_artifact_name: ${{ needs.build-ttxla.outputs.alchemist_artifact_name }}
 
   fail-notify:
     if: always()


### PR DESCRIPTION
Some of the manual CI runs were failing due to missing alchemist .so and other files needed for the examples tests.

Fixes https://github.com/tenstorrent/tt-xla/issues/3017