### PR TITLE
[vLLM plugin] Support batch input processing for generative models

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/scheduler/ascend_scheduler.py
+++ b/integrations/vllm_plugin/vllm_tt/scheduler/ascend_scheduler.py
@@ -92,7 +92,6 @@ class AscendScheduler(Scheduler):
 
         # Schedule prefill requests first (unless decode is forced).
         req_index = 0
-        prefill_scheduled = 0
         while self.waiting and token_budget > 0 and self._forced_mode != 0:
             if len(self.running) == self.max_num_running_reqs:
                 break
@@ -271,10 +270,6 @@ class AscendScheduler(Scheduler):
             # Count the number of prefix cached tokens.
             if request.num_cached_tokens < 0:
                 request.num_cached_tokens = num_computed_tokens
-            # TODO(sshon): Handle prefill scheduling for multi user at same request.
-            prefill_scheduled += 1
-            if prefill_scheduled >= 1:
-                break
 
         # Put back any skipped requests at the head of the waiting queue
         if skipped_waiting_requests:


### PR DESCRIPTION
### Ticket
closes #2921 

### Problem description
Model runner process each pre-fill request individually. 

### What's changed
- Ascend_scheduler forwards multiple pre-fill requests together to the model runner.
- _prepare_input creates a 2D input tensor of shape [batch_size, padded_input_len], where each row corresponds to a single request. Each input contains either all pre-fill requests or all decode requests.
- _prepare_input uses num_computed_tokens to correctly identify the next token to process and updates position_ids accordingly.
- Input dim0 is fixed to batch_size. If the model runner receives fewer requests, it pads the inputs to match batch_size, which results in a smaller number of generated graphs.
- The model generates a 3D output tensor (hidden_states); select_hidden_states is updated to select the appropriate hidden states.
- Other warmup functions are updated to generate computation graphs assuming a fixed input dim0 = batch_size.

### Checklist
- [X] Existing tests provide coverage for changes
