### PR TITLE
Adding more descriptive model naming to `test_models.py`

### DIFF
--- a/tests/infra/testers/compiler_config.py
+++ b/tests/infra/testers/compiler_config.py
@@ -69,6 +69,9 @@ class CompilerConfig:
     # Enables IR dumping to a specified path.
     export_path: str = ""
 
+    # When set, exported IRs are named: <stage>_<model_name>_g<N>_<timestamp>.mlir
+    export_model_name: str = ""
+
     # Enables "try to recover structure" option for TTNN IR. Tries to match the
     # structure of the original graph. This generates a more readable solution,
     # useful when generating code.
@@ -109,6 +112,9 @@ class CompilerConfig:
 
         if self.export_path != "":
             options["export_path"] = self.export_path
+
+        if self.export_model_name:
+            options["export_model_name"] = self.export_model_name
 
         if self.codegen_try_recover_structure:
             options["codegen_try_recover_structure"] = "true"

--- a/tests/runner/test_models.py
+++ b/tests/runner/test_models.py
@@ -97,7 +97,10 @@ def _run_model_test_impl(
             ir_dump_path = os.path.join(PROJECT_ROOT, "collected_irs", model_info.name)
 
         if compiler_config is None and ir_dump_path:
-            compiler_config = CompilerConfig(export_path=ir_dump_path)
+            compiler_config = CompilerConfig(
+                export_path=ir_dump_path,
+                export_model_name=model_info.name,
+            )
 
         succeeded = False
         comparison_result = None


### PR DESCRIPTION
Based on the PR here: https://github.com/tenstorrent/tt-xla/pull/2677, adding the support for more descriptive dumped module naming in `test_models.py`, via `--dump-irs` flag.