### PR TITLE
Fixing cpp codegen issue with no try-recover-structure available

### DIFF
--- a/pjrt_implementation/src/api/module_builder/module_builder.cc
+++ b/pjrt_implementation/src/api/module_builder/module_builder.cc
@@ -1310,14 +1310,11 @@ ModuleBuilder::performCodegen(std::string_view ttnn_mlir,
   // Alchemist specific options are passed here.
   // Other options are ingested during TTIR->TTNN conversion.
   std::string should_load = compile_options.export_tensors ? "true" : "false";
-  std::string try_recover_structure =
-      compile_options.codegen_try_recover_structure ? "true" : "false";
+
   std::string pipeline_options = "load-input-tensors-from-disk=" + should_load +
                                  " "
-                                 "tensor-load-directory='./tensors'" +
-                                 " "
-                                 "try-recover-structure=" +
-                                 try_recover_structure;
+                                 "tensor-load-directory='./tensors'";
+
   bool result;
 
   if (compile_options.backend == BackendRuntime::TTNNCodegenCpp) {
@@ -1329,6 +1326,9 @@ ModuleBuilder::performCodegen(std::string_view ttnn_mlir,
     // standalone is currently marked as unsupported, and setting it only
     // results in copying of one extra blank file. As per offline discussion
     // with mlir-core, we should set local to true for Python.
+    std::string try_recover_structure =
+        compile_options.codegen_try_recover_structure ? "true" : "false";
+    pipeline_options += " try-recover-structure=" + try_recover_structure;
     is_local = true;
     result = m_tt_alchemist_handler.generatePythonFunc()(
         instance, input_file.c_str(), folder.c_str(), is_local,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/3059

### Problem description
A customer reported an issue that they can't produce cpp code:
```
(venv) root@tt-devel:/workspace/tt-xla/ESPCN-PyTorch# python custom_module_cpp.py
Using PJRT plugin directory: /workspace/tt-xla/venv/lib/python3.11/site-packages/pjrt_plugin_tt

[custom_module_cpp.py](https://github.com/user-attachments/files/25008852/custom_module_cpp.py)

Using TT-Metal from wheel package: /workspace/tt-xla/venv/lib/python3.11/site-packages/pjrt_plugin_tt/tt-metal
WARNING: TT plugin is setting XLA_STABLEHLO_COMPILE to 1. This is required for TT PJRT plugin to work correctly.
2026-02-02 11:04:55.613540: W torch_xla/csrc/runtime/profiler.cpp:88] Profiler API not found for PJRT plugin
: no such option try-recover-structure
Failed to add pipeline with options: load-input-tensors-from-disk=true tensor-load-directory='./tensors' try-recover-structure=false
```

### What's changed
Currently try-recover-structure option isn't supported for CPP codegen. Removed that option from a cpp pipeline in PJRT implementation, until we support this option properly in cpp path as well.

### Checklist
- [ ] New/Existing tests provide coverage for changes
