### PR TITLE
Update pcc requirements for models

### DIFF
--- a/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
@@ -23,9 +23,8 @@ test_config:
 
   falcon/pytorch-tiiuae/Falcon3-10B-Base-llm_decode-single_device-inference:
     supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.
-    required_pcc: 0.985 # Is 0.990 (p150)
+    required_pcc: 0.98 # Is 0.984(p150)
     status: EXPECTED_PASSING
-    assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/3000
 
   qwen_2_5/causal_lm/pytorch-0_5b_instruct-llm_decode-single_device-inference:
     status: EXPECTED_PASSING
@@ -42,7 +41,6 @@ test_config:
   qwen_2_5/causal_lm/pytorch-7b_instruct-llm_decode-single_device-inference:
     supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.
     status: EXPECTED_PASSING
-    assert_pcc: false #https://github.com/tenstorrent/tt-xla/issues/3000
 
   qwen_2_5/causal_lm/pytorch-14b_instruct-llm_decode-single_device-inference:
     supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.

--- a/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
@@ -11,7 +11,7 @@ test_config:
   falcon/pytorch-tiiuae/Falcon3-10B-Base-llm_decode-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
-    required_pcc: 0.977 # https://github.com/tenstorrent/tt-xla/issues/3000
+    required_pcc: 0.985 # 0.989 (p150)
 
   qwen_2_5/causal_lm/pytorch-7b_instruct-llm_decode-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]


### PR DESCRIPTION
### Ticket
fixes: #3000

After offline discussion, It was decided to update these models:

```
tests/runner/test_models.py::test_llms_torch[falcon/pytorch-tiiuae/Falcon3-10B-Base-llm_decode-single_device-inference]
tests/runner/test_models.py::test_llms_torch[qwen_2_5/causal_lm/pytorch-7b_instruct-llm_decode-single_device-inference]
tests/runner/test_models.py::test_llms_torch[falcon/pytorch-tiiuae/Falcon3-10B-Base-llm_decode-tensor_parallel-inference]
```

Issue regarding `torch_fx` fusing was fixed.
