### PR TITLE
[vLLM plugin] Skip Qwen3-Embedding-0.6B test for batch_size=2

### DIFF
--- a/tests/integrations/vllm_plugin/pooling/test_batched_inference.py
+++ b/tests/integrations/vllm_plugin/pooling/test_batched_inference.py
@@ -50,6 +50,10 @@ def test_batched_inference(
 
     - Baseline embeddings are computed using vLLM on CPU backend.
     """
+    if model_name == "Qwen/Qwen3-Embedding-0.6B" and batch_size == 2:
+        pytest.skip(
+            "Skipping due to non-deterministic failure in CI. Issue: https://github.com/tenstorrent/tt-xla/issues/3094"
+        )
 
     path = os.path.join(os.path.dirname(__file__), baseline_path)
     loaded_data = torch.load(path)


### PR DESCRIPTION
### Ticket
#3094

### Problem description
Qwen3-Embedding-0.6B model is failing randomly in CI for batch_size=2 due to seg fault.

### What's changed
Disable the test temporarily