### PR TITLE
Update status of CenterNet ResNet variants and OpenPose v2 in inference test configs

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -92,7 +92,6 @@ test_config:
     markers: ["extended"]
 
   openpose/v2/pytorch-single_device-inference:
-    assert_pcc: false
     status: EXPECTED_PASSING
 
   albert/masked_lm/pytorch-xxlarge_v2-single_device-inference:
@@ -1975,12 +1974,11 @@ test_config:
     reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.04067724570631981. Required: pcc=0.99. - https://github.com/tenstorrent/tt-xla/issues/1505"
 
   centernet/pytorch-resnet18_coco-single_device-inference:
-    status: KNOWN_FAILURE_XFAIL
-    reason: "RuntimeError: deformable_im2col not implemented for 'BFloat16' - https://github.com/tenstorrent/tt-xla/issues/1563"
+    status: EXPECTED_PASSING
 
   centernet/pytorch-resnet101_coco-single_device-inference:
-    status: KNOWN_FAILURE_XFAIL
-    reason: "RuntimeError: deformable_im2col not implemented for 'BFloat16' - https://github.com/tenstorrent/tt-xla/issues/1563"
+    required_pcc: 0.98 # https://github.com/tenstorrent/tt-xla/issues/3043
+    status: EXPECTED_PASSING
 
   centernet/pytorch-dla1x_coco-single_device-inference:
     status: EXPECTED_PASSING


### PR DESCRIPTION
### Ticket

- closes https://github.com/tenstorrent/tt-xla/issues/3043
- closes https://github.com/tenstorrent/tt-xla/issues/2938

### Problem description

- After this [PR](https://github.com/tenstorrent/tt-forge-models/pull/446)'s change, Openposev2 passing with PCC>0.99 on current main
- In centernet, Resnet18 variant having PCC>0.99 & Resnet101 had PCC slightly lower than 0.99([#3043](https://github.com/tenstorrent/tt-xla/issues/3043))
- I'm unable to reproduce the PCC drop present in Resnet101 variant with sanity.
- Experiments and results on root cause analysis are attached in ticket.
- As, Resnet101 variant still achieve PCC value greater than 0.95, pcc threshold can be lowered 
- For complete context on lowering pcc threshold, pls checkout [this](https://github.com/tenstorrent/tt-xla/pull/2818#discussion_r2687257587) discussion

### What's changed

- Reduced the pcc thershold for Centernet's Resnet101 variant & updated the status in inference test configs for CenterNet ResNet18 & openposev2

### Checklist
- [x] Verified the changes through Run Test single ([N150](https://github.com/tenstorrent/tt-xla/actions/runs/21661014075) & [P150](https://github.com/tenstorrent/tt-xla/actions/runs/21661033333))
