### PR TITLE
Use torch from url

### DIFF
--- a/python_package/requirements.txt
+++ b/python_package/requirements.txt
@@ -2,6 +2,6 @@
 jax==0.7.1
 jaxlib==0.7.1
 requests
-torch==2.9.0+cpu
+torch@https://download.pytorch.org/whl/cpu/torch-2.9.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl
 loguru
 torch-xla@https://pypi.eng.aws.tenstorrent.com/torch-xla/torch_xla-2.9.0%2Bgit061c1e7-cp311-cp311-linux_x86_64.whl


### PR DESCRIPTION
### Problem description
We must use url in wheel dependencies to install torch from pytorch index
