### PR TITLE
Add cache positions to attention tests

### DIFF
--- a/tests/torch/graphs/test_attention.py
+++ b/tests/torch/graphs/test_attention.py
@@ -304,7 +304,7 @@ def test_llama_attention_decode(variant, variant_config, arch):
     )
     past_key_states = static_cache
 
-    cache_positions = torch.randint(0, max_cache_len, (batch_size,), dtype=torch.long)
+    cache_positions = torch.randint(0, max_cache_len, (seq_len,), dtype=torch.long)
 
     run_graph_test(
         attention,
@@ -737,7 +737,7 @@ def test_qwen3_attention_decode(variant, variant_config, arch):
     )
     past_key_states = static_cache
 
-    cache_positions = torch.randint(0, max_cache_len, (batch_size,), dtype=torch.long)
+    cache_positions = torch.randint(0, max_cache_len, (seq_len,), dtype=torch.long)
 
     run_graph_test(
         attention,
@@ -1400,7 +1400,7 @@ def test_qwen2_5_attention_decode(variant, variant_config, arch):
     )
     past_key_states = static_cache
 
-    cache_positions = torch.randint(0, max_cache_len, (batch_size,), dtype=torch.long)
+    cache_positions = torch.randint(0, max_cache_len, (seq_len,), dtype=torch.long)
 
     run_graph_test(
         attention,
@@ -1794,7 +1794,7 @@ def test_gemma_attention_decode(variant, variant_config, arch):
     )
     past_key_states = static_cache
 
-    cache_positions = torch.randint(0, max_cache_len, (batch_size,), dtype=torch.long)
+    cache_positions = torch.randint(0, max_cache_len, (seq_len,), dtype=torch.long)
 
     run_graph_test(
         attention,
@@ -2075,7 +2075,7 @@ def test_mistral_attention_decode(variant, variant_config, arch):
     )
     past_key_states = static_cache
 
-    cache_positions = torch.randint(0, max_cache_len, (batch_size,), dtype=torch.long)
+    cache_positions = torch.randint(0, max_cache_len, (seq_len,), dtype=torch.long)
 
     if arch == "llmbox":
         num_devices = xr.global_runtime_device_count()


### PR DESCRIPTION
### Ticket
Addresses 1/2 of #3165 

### Problem description
Attention tests failed on nightly after experimental compile was added. I rootcaused this to a constant getting embedded into the graph instead of an input argument coming in, causing a conversion pattern to fail in MLIR. This is because cache positions weren't being passed into the test and instead getting defaulted.

### What's changed
This change both papers over the lack of generality of a conversion pattern in MLIR **and makes the test more representative of how models would be used in the wild**

Conversion will be fixed too, at a later date.

### Checklist
- [X] New/Existing tests provide coverage for changes
