### PR TITLE
[vLLM plugin] Use default model loader instead of TPU loader

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/vllm_distributed_utils.py
+++ b/integrations/vllm_plugin/vllm_tt/vllm_distributed_utils.py
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: Portions (c) 2026 Tenstorrent AI ULC
 
 from collections import OrderedDict
-from typing import List
+from typing import List, Optional
 
 import torch
 import torch.nn as nn
@@ -11,7 +11,12 @@ import torch.nn.functional as F
 import torch_xla.distributed.spmd as xs
 from torch.nn.parameter import Parameter
 from tt_torch.sharding import sharding_constraint_hook
-from vllm.model_executor.layers.linear import MergedColumnParallelLinear
+from vllm.model_executor.layers.linear import (
+    ColumnParallelLinear,
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
+    RowParallelLinear,
+)
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
@@ -107,20 +112,141 @@ class XlaMergedColumnParallelLinear(nn.Module):
         return merged_proj, output_bias
 
 
+class XlaQKVParallelLinear(nn.Module):
+
+    def __init__(self, qkv_linear: nn.Module, mesh: "xs.Mesh"):
+        super().__init__()
+        assert isinstance(qkv_linear, QKVParallelLinear)
+        self.skip_bias_add = qkv_linear.skip_bias_add
+        self.return_bias = qkv_linear.return_bias
+        assert qkv_linear.tp_size == 1, "TP > 1 is only supported under SPMD."
+
+        self.q_weight: Parameter
+        self.k_weight: Parameter
+        self.v_weight: Parameter
+        self.q_bias: Optional[Parameter]
+        self.k_bias: Optional[Parameter]
+        self.v_bias: Optional[Parameter]
+        self._load_weights_from_qkv_linear(qkv_linear)
+        self._shard_weight(mesh)
+
+    def _shard_weight(self, mesh: "xs.Mesh"):
+        self.q_weight = Parameter(self.q_weight.to("xla"), requires_grad=False)
+        self.k_weight = Parameter(self.k_weight.to("xla"), requires_grad=False)
+        self.v_weight = Parameter(self.v_weight.to("xla"), requires_grad=False)
+        xs.mark_sharding(self.q_weight, mesh, ("x", None))
+        xs.mark_sharding(self.k_weight, mesh, ("x", None))
+        xs.mark_sharding(self.v_weight, mesh, ("x", None))
+        if self.q_bias is not None:
+            assert (
+                self.k_bias is not None and self.v_bias is not None
+            ), "QKVParallelLinear should have q, k, and v biases together."
+            self.q_bias = Parameter(self.q_bias.to("xla"), requires_grad=False)
+            xs.mark_sharding(self.q_bias, mesh, ("x",))
+            self.k_bias = Parameter(self.k_bias.to("xla"), requires_grad=False)
+            xs.mark_sharding(self.k_bias, mesh, ("x",))
+            self.v_bias = Parameter(self.v_bias.to("xla"), requires_grad=False)
+            xs.mark_sharding(self.v_bias, mesh, ("x",))
+
+    def _load_weights_from_qkv_linear(self, qkv_linear: nn.Module):
+        q_proj_size, k_proj_size, _ = qkv_linear.output_sizes
+        # The weight of qkv linear is a concatenation of q, k, and v weights
+        # along the output dimension.
+        qkv_weight = qkv_linear.weight.data.cpu()
+        q_weight = Parameter(qkv_weight[:q_proj_size], requires_grad=False)
+        k_weight = Parameter(
+            qkv_weight[q_proj_size : q_proj_size + k_proj_size], requires_grad=False
+        )
+        v_weight = Parameter(
+            qkv_weight[q_proj_size + k_proj_size :], requires_grad=False
+        )
+        self.register_parameter("q_weight", q_weight)
+        self.register_parameter("k_weight", k_weight)
+        self.register_parameter("v_weight", v_weight)
+
+        if qkv_linear.bias is not None:
+            q_bias = Parameter(qkv_linear.bias[:q_proj_size], requires_grad=False)
+            k_bias = Parameter(
+                qkv_linear.bias[q_proj_size : q_proj_size + k_proj_size],
+                requires_grad=False,
+            )
+            v_bias = Parameter(
+                qkv_linear.bias[q_proj_size + k_proj_size :], requires_grad=False
+            )
+            self.register_parameter("q_bias", q_bias)
+            self.register_parameter("k_bias", k_bias)
+            self.register_parameter("v_bias", v_bias)
+        else:
+            self.register_parameter("q_bias", None)
+            self.register_parameter("k_bias", None)
+            self.register_parameter("v_bias", None)
+
+    def forward(self, input):
+        # Same forward functionality as QKVParallelLinear, but doing qkv porj
+        # separately.
+        q_bias = self.q_bias if not self.skip_bias_add else None
+        k_bias = self.k_bias if not self.skip_bias_add else None
+        v_bias = self.v_bias if not self.skip_bias_add else None
+        q_proj = F.linear(input, self.q_weight, q_bias)
+        k_proj = F.linear(input, self.k_weight, k_bias)
+        v_proj = F.linear(input, self.v_weight, v_bias)
+        # The q/k/v projections will be split outside of the QKVParallelLinear.
+        # Because we are replacing XlaQKVParallelLinear with the
+        # QKVParallelLinear, we need to concatenate q, k, and v projections to
+        # match the output shape of the QKVParallelLinear implementation even if
+        # it seems to be redundant.
+        # The concat and the following split will be noop, and should be
+        # optimized away by the compiler.
+        qkv_proj = torch.cat([q_proj, k_proj, v_proj], dim=-1)
+        output_bias = (
+            torch.cat([q_bias, k_bias, v_bias], dim=-1) if self.skip_bias_add else None
+        )
+        if not self.return_bias:
+            return qkv_proj
+        return qkv_proj, output_bias
+
+
 def partition_merged_column_parallel_linear(
     layer: torch.nn.Module, mesh: xs.Mesh
 ) -> torch.nn.Module:
     assert isinstance(layer, MergedColumnParallelLinear)
     xla_layer = XlaMergedColumnParallelLinear(layer, mesh)
-    logger.info("Applied parallel sharding to %s", layer)
+    logger.debug("Applied parallel sharding to %s", layer)
     return xla_layer
+
+
+def partition_qkv_parallel_linear(
+    layer: torch.nn.Module, mesh: xs.Mesh
+) -> torch.nn.Module:
+    assert isinstance(layer, QKVParallelLinear)
+    xla_layer = XlaQKVParallelLinear(layer, mesh)
+    logger.debug("Applied parallel sharding to %s", layer)
+    return xla_layer
+
+
+def partition_column_parallel_linear(
+    layer: torch.nn.Module, mesh: xs.Mesh
+) -> torch.nn.Module:
+    assert isinstance(layer, ColumnParallelLinear)
+    xs.mark_sharding(layer.weight, mesh, ("x", None))
+    logger.debug("Applied parallel sharding to %s", layer)
+    return layer
+
+
+def partition_row_parallel_linear(
+    layer: torch.nn.Module, mesh: xs.Mesh
+) -> torch.nn.Module:
+    assert isinstance(layer, RowParallelLinear)
+    xs.mark_sharding(layer.weight, mesh, (None, "x"))
+    logger.debug("Applied parallel sharding to %s", layer)
+    return layer
 
 
 def partition_parallel_lm_head(
     layer: torch.nn.Module, mesh: xs.Mesh
 ) -> torch.nn.Module:
     assert isinstance(layer, ParallelLMHead)
-    logger.info("Applied parallel sharding to %s", layer)
+    logger.debug("Applied parallel sharding to %s", layer)
     xs.mark_sharding(layer.weight, mesh, ("x", None))
     return layer
 
@@ -129,7 +255,7 @@ def partition_vocab_parallel_embedding(
     layer: torch.nn.Module, mesh: xs.Mesh
 ) -> torch.nn.Module:
     assert isinstance(layer, VocabParallelEmbedding)
-    logger.info("Applied parallel sharding to %s", layer)
+    logger.debug("Applied parallel sharding to %s", layer)
     xs.mark_sharding(layer.weight, mesh, (None, "x"))
     # Apply sharding constraint to the output of the layer.
     hook_forward = sharding_constraint_hook(layer, mesh, (None, None, None))
@@ -140,6 +266,9 @@ def partition_vocab_parallel_embedding(
 MODULE_TYPE_TO_WRAPPING_FUNC = OrderedDict(
     [
         ("MergedColumnParallelLinear", partition_merged_column_parallel_linear),
+        ("QKVParallelLinear", partition_qkv_parallel_linear),
+        ("ColumnParallelLinear", partition_column_parallel_linear),
+        ("RowParallelLinear", partition_row_parallel_linear),
         ("ParallelLMHead", partition_parallel_lm_head),
         ("VocabParallelEmbedding", partition_vocab_parallel_embedding),
     ]
@@ -160,6 +289,7 @@ def shard_model(model: torch.nn.Module, mesh: "xs.Mesh") -> None:
         model: torch.nn.Module to process
         mesh: An XLA SPMD mesh object used for sharding
     """
+    logger.info("Applying parallel sharding to the model...")
 
     def _process_module(module, name=None, parent=None):
         for module_type, wrapping_func in MODULE_TYPE_TO_WRAPPING_FUNC.items():


### PR DESCRIPTION
### Ticket
closes #3167 

### Problem description
vLLM plugin uses TPU model loader which is removed in v0.14.0. Moreover, TPU model loader only shard weights for 1D device mesh.

### What's changed
- Replace TPU-specific model loader with default vLLM loader
- Apply model weight sharding within the vLLM plugin

### Checklist
- [x] New/Existing tests provide coverage for changes
