### PR TITLE
Add qb2-blackhole support to Nightly CI support + 4x TP tests in onPush/onPR

### DIFF
--- a/.github/workflows/schedule-nightly-qb2.yml
+++ b/.github/workflows/schedule-nightly-qb2.yml
@@ -1,4 +1,4 @@
-name: On nightly
+name: On nightly QB2
 
 on:
   workflow_dispatch:
@@ -22,52 +22,26 @@ jobs:
     with:
       docker_image: ${{ needs.build-image.outputs.docker-image }}
 
-  nightly_tests:
+  # This is a single test job that runs all passing tt-forge-models tests on QB2.
+  test_forge_models_passing_qb2:
     uses: ./.github/workflows/call-test.yml
     secrets: inherit
     needs: [ build-image, build-ttxla ]
-    with:
-      test_suite: basic-test-nightly.json
-      docker_image: ${{ needs.build-image.outputs.docker-image-base }}
-      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
-      wheel_release_artifact_name: ${{ needs.build-ttxla.outputs.wheel_artifact_name }}
-      wheel_release_vllm_tt_artifact_name: ${{ needs.build-ttxla.outputs.wheel_release_vllm_tt_artifact_name }}
-      alchemist_artifact_name: ${{ needs.build-ttxla.outputs.alchemist_artifact_name }}
-
-  test_full_model:
-    uses: ./.github/workflows/call-test.yml
-    secrets: inherit
-    needs: [ build-image, build-ttxla ]
-    # This ensures the job runs regardless of success or failure of `nightly_tests`:
     if: success() || failure()
     with:
-      test_suite: model-test-full.json
-      docker_image: ${{ needs.build-image.outputs.docker-image-base }}
-      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
-      wheel_release_artifact_name: ${{ needs.build-ttxla.outputs.wheel_artifact_name }}
-
-  # This is a single test job that runs all passing tt-forge-models tests.
-  test_forge_models_passing:
-    uses: ./.github/workflows/call-test.yml
-    secrets: inherit
-    needs: [ build-image, build-ttxla ]
-    # This ensures the job runs regardless of success or failure of `nightly_tests`:
-    if: success() || failure()
-    with:
-      test_suite: model-test-passing.json
+      test_suite: model-test-passing-qb2.json
       docker_image: ${{ needs.build-image.outputs.docker-image }}
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       wheel_release_artifact_name: ${{ needs.build-ttxla.outputs.wheel_artifact_name }}
 
-  # This is a single test job that runs all xfailing, skipped or placeholder tt-forge-models tests.
-  test_forge_models_xfail:
+  # This is a single test job that runs all xfailing, skipped or placeholder tt-forge-models tests on QB2.
+  test_forge_models_xfail_qb2:
     uses: ./.github/workflows/call-test.yml
     secrets: inherit
     needs: [ build-image, build-ttxla ]
-    # This ensures the job runs regardless of success or failure of `nightly_tests`:
     if: success() || failure()
     with:
-      test_suite: model-test-xfail.json
+      test_suite: model-test-xfail-qb2.json
       docker_image: ${{ needs.build-image.outputs.docker-image }}
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       wheel_release_artifact_name: ${{ needs.build-ttxla.outputs.wheel_artifact_name }}
@@ -75,10 +49,8 @@ jobs:
   fail-notify:
     if: always()
     needs:
-      - nightly_tests
-      - test_full_model
-      - test_forge_models_passing
-      - test_forge_models_xfail
+      - test_forge_models_passing_qb2
+      - test_forge_models_xfail_qb2
       - build-image
       - build-ttxla
     runs-on: Ubuntu-latest
@@ -107,7 +79,7 @@ jobs:
         with:
           payload: |
             {
-              "text": "Bad bad nightly: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}>",
+              "text": "Bad bad QB2 nightly: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}>",
               "channel": "C08GYB57C8M",
               "unfurl_links": false, "unfurl_media": false
             }
@@ -120,7 +92,7 @@ jobs:
         with:
           payload: |
             {
-              "text": "Good nightly: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}>",
+              "text": "Good QB2 nightly: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}>",
               "channel": "C08GYB57C8M",
               "unfurl_links": false, "unfurl_media": false
             }

--- a/.github/workflows/schedule-nightly.yml
+++ b/.github/workflows/schedule-nightly.yml
@@ -72,6 +72,34 @@ jobs:
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       wheel_release_artifact_name: ${{ needs.build-ttxla.outputs.wheel_artifact_name }}
 
+  # QB2-specific jobs (only run on main branch)
+  # NOTE: QB2 jobs are restricted to main branch as a temporary workaround due to limited CI machines.
+  # This is a single test job that runs all passing tt-forge-models tests on QB2.
+  test_forge_models_passing_qb2:
+    uses: ./.github/workflows/call-test.yml
+    secrets: inherit
+    needs: [ build-image, build-ttxla ]
+    # Only run on main branch and regardless of success or failure of `nightly_tests`:
+    if: (success() || failure()) && github.ref == 'refs/heads/main'
+    with:
+      test_suite: model-test-passing-qb2.json
+      docker_image: ${{ needs.build-image.outputs.docker-image }}
+      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
+      wheel_release_artifact_name: ${{ needs.build-ttxla.outputs.wheel_artifact_name }}
+
+  # This is a single test job that runs all xfailing, skipped or placeholder tt-forge-models tests on QB2.
+  test_forge_models_xfail_qb2:
+    uses: ./.github/workflows/call-test.yml
+    secrets: inherit
+    needs: [ build-image, build-ttxla ]
+    # Only run on main branch and regardless of success or failure of `nightly_tests`:
+    if: (success() || failure()) && github.ref == 'refs/heads/main'
+    with:
+      test_suite: model-test-xfail-qb2.json
+      docker_image: ${{ needs.build-image.outputs.docker-image }}
+      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
+      wheel_release_artifact_name: ${{ needs.build-ttxla.outputs.wheel_artifact_name }}
+
   fail-notify:
     if: always()
     needs:
@@ -79,6 +107,8 @@ jobs:
       - test_full_model
       - test_forge_models_passing
       - test_forge_models_xfail
+      - test_forge_models_passing_qb2
+      - test_forge_models_xfail_qb2
       - build-image
       - build-ttxla
     runs-on: Ubuntu-latest

--- a/.github/workflows/test-matrix-presets/model-test-passing-qb2.json
+++ b/.github/workflows/test-matrix-presets/model-test-passing-qb2.json
@@ -1,0 +1,10 @@
+[
+  { "runs-on": "qb2-blackhole", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "p150 and nightly and expected_passing", "parallel-groups": 3 },
+  { "runs-on": "qb2-blackhole", "name": "run_forge_models_multichip", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "n300-llmbox and nightly and tensor_parallel and expected_passing", "parallel-groups": 4 },
+  { "runs-on": "qb2-blackhole", "name": "run_forge_models_multichip", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "n300 and nightly and data_parallel and expected_passing", "parallel-groups": 1 },
+  { "runs-on": "qb2-blackhole", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "p150 and nightly and expected_passing and not large", "parallel-groups": 1 },
+  { "runs-on": "qb2-blackhole", "name": "run_forge_models_multichip", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "n300-llmbox and nightly and tensor_parallel and expected_passing", "parallel-groups": 1 },
+  { "runs-on": "qb2-blackhole", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "p150 and nightly and expected_passing and large" },
+  { "runs-on": "qb2-blackhole", "name": "run_forge_models_llm_multichip", "dir": "./tests/runner/test_models.py::test_llms_torch", "test-mark": "n300-llmbox and nightly and tensor_parallel and expected_passing", "parallel-groups": 1 },
+  { "runs-on": "qb2-blackhole", "name": "run_forge_models_llm", "dir": "./tests/runner/test_models.py::test_llms_torch", "test-mark": "p150 and nightly and expected_passing and single_device", "parallel-groups": 1 }
+]

--- a/.github/workflows/test-matrix-presets/model-test-push.json
+++ b/.github/workflows/test-matrix-presets/model-test-push.json
@@ -5,5 +5,6 @@
   { "runs-on": "p150",          "name": "run_forge_models",      "dir": "./tests/runner/test_models.py::test_all_models_jax",        "test-mark": "p150 and expected_passing and push" },
   { "runs-on": "n150",          "name": "run_forge_models",      "dir": "./tests/runner/test_models.py::test_all_models_jax",        "test-mark": "n150 and expected_passing and push and large" },
   { "runs-on": "p150",          "name": "run_forge_models",      "dir": "./tests/runner/test_models.py::test_all_models_jax",        "test-mark": "p150 and expected_passing and push and large" },
-  { "runs-on": "n300-llmbox",   "name": "run_torch_multi_host",  "dir": "./tests/torch/multi_host",                                  "test-mark": "push and multi_host_cluster", "shared-runners": "true" }
+  { "runs-on": "n300-llmbox",   "name": "run_torch_multi_host",  "dir": "./tests/torch/multi_host",                                  "test-mark": "push and multi_host_cluster", "shared-runners": "true" },
+  { "runs-on": "qb2-blackhole", "name": "run_forge_models_multichip", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "qb2-blackhole and push and tensor_parallel and expected_passing", "parallel-groups": 1 }
 ]

--- a/.github/workflows/test-matrix-presets/model-test-xfail-qb2.json
+++ b/.github/workflows/test-matrix-presets/model-test-xfail-qb2.json
@@ -1,0 +1,11 @@
+[
+  { "runs-on": "qb2-blackhole", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "qb2-blackhole and nightly and inference and (known_failure_xfail or not_supported_skip) and not large", "parallel-groups": 1 },
+  { "runs-on": "qb2-blackhole", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "qb2-blackhole and nightly and training and (known_failure_xfail or not_supported_skip) and not large", "parallel-groups": 1 },
+  { "runs-on": "qb2-blackhole", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "qb2-blackhole and nightly and inference and (known_failure_xfail or not_supported_skip) and not large", "parallel-groups": 3 },
+  { "runs-on": "qb2-blackhole", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "qb2-blackhole and nightly and training and (known_failure_xfail or not_supported_skip) and not large", "parallel-groups": 5 },
+  { "runs-on": "qb2-blackhole", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "qb2-blackhole and nightly and inference and (known_failure_xfail or not_supported_skip) and large", "parallel-groups": 1 },
+  { "runs-on": "qb2-blackhole", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "qb2-blackhole and nightly and training and (known_failure_xfail or not_supported_skip) and large", "parallel-groups": 1 },
+  { "runs-on": "qb2-blackhole", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "qb2-blackhole and nightly and training and (known_failure_xfail or not_supported_skip) and large", "parallel-groups": 1 },
+  { "runs-on": "qb2-blackhole", "name": "run_forge_models_multichip", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "qb2-blackhole and nightly and tensor_parallel and (known_failure_xfail or not_supported_skip)", "parallel-groups": 1 },
+  { "runs-on": "qb2-blackhole", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_placeholder_models", "test-mark": "placeholder", "parallel-groups": 1 }
+]

--- a/.github/workflows/workflow-run-collect-data.yml
+++ b/.github/workflows/workflow-run-collect-data.yml
@@ -7,6 +7,7 @@ on:
       - "On PR"
       - "On push"
       - "On nightly"
+      - "On nightly QB2"
       - "On weekly"
       - "On weekly training"
       - "Performance Benchmark"

--- a/tests/runner/conftest.py
+++ b/tests/runner/conftest.py
@@ -18,7 +18,7 @@ _collected_nodeids = set()
 _collected_test_functions = set()
 
 # Allowed architecture identifiers for arch_overrides and --arch option
-ALLOWED_ARCHES = {"n150", "p150", "n300", "n300-llmbox"}
+ALLOWED_ARCHES = {"n150", "p150", "n300", "n300-llmbox", "qb2-blackhole"}
 _BRINGUP_STAGE_FILE = "._bringup_stage.txt"
 
 
@@ -185,7 +185,7 @@ def pytest_collection_modifyitems(config, items):
 
         # Define default set of supported archs, which can be optionally overridden in test_config files
         # by a model (ie. n300, n300-llmbox), and are applied as markers for filtering tests on CI.
-        default_archs = ["n150", "p150"]
+        default_archs = ["n150", "p150", "qb2-blackhole"]
         archs_to_mark = getattr(meta, "supported_archs", None) or default_archs
         for arch_marker in archs_to_mark:
             # Prefer the exact string; if it contains a hyphen and pytest disallows it, also add underscore variant

--- a/tests/runner/test_config/jax/test_config_inference_data_parallel.yaml
+++ b/tests/runner/test_config/jax/test_config_inference_data_parallel.yaml
@@ -5,159 +5,159 @@
 test_config:
 
   falcon/jax-tiiuae/Falcon3-1B-Base-data_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
 
   falcon/jax-tiiuae/Falcon3-3B-Base-single_device-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "Not enough space to allocate 37748736 B DRAM buffer across 12 banks, where each bank needs to store 3145728 B, but bank size is 1073741792 B"
     bringup_status: FAILED_RUNTIME
 
   gpt2/causal_lm/jax-base-data_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
     markers: [nightly]
 
   gpt2/causal_lm/jax-large-data_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
 
   gpt2/causal_lm/jax-medium-data_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
 
   gpt2/causal_lm/jax-xl-data_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
     markers: [large]
 
   llama/causal_lm/jax-1B_TINY-data_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
 
   phi1/causal_lm/jax-microsoft/phi-1-data_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
 
   phi1_5/causal_lm/jax-microsoft/phi-1_5-data_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
 
   phi2/causal_lm/jax-microsoft/phi-2-data_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "Not enough space to allocate 16777216 B DRAM buffer across 12 banks, where each bank needs to store 1400832 B, but bank size is 1073741792 B"
     bringup_status: FAILED_RUNTIME
 
   phi2/causal_lm/jax-microsoft/phi-2-pytdml-data_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "Not enough space to allocate 16777216 B DRAM buffer across 12 banks, where each bank needs to store 1400832 B, but bank size is 1073741792 B"
     bringup_status: FAILED_RUNTIME
 
   phi3/causal_lm/jax-microsoft/Phi-3-mini-128k-instruct-data_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "DRAM OOM"
     bringup_status: FAILED_RUNTIME
 
   phi3/causal_lm/jax-microsoft/Phi-3-mini-4k-instruct-data_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "OOM DRAM"
     bringup_status: FAILED_RUNTIME
 
   qwen_2_5/causal_lm/jax-0_5b-data_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
 
   qwen_2_5/causal_lm/jax-0_5b_instruct-data_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
 
   qwen_2_5/causal_lm/jax-1_5b-data_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "Not enough space to allocate 34359738368 B DRAM buffer across 12 banks, where each bank needs to store 2863312896 B, but bank size is 1073741792 B "
     bringup_status: FAILED_RUNTIME
 
   qwen_2_5/causal_lm/jax-1_5b_instruct-data_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
 
   qwen_2_5/causal_lm/jax-3b-data_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "Out of Memory: Not enough space to allocate 2147483648 B DRAM buffer across 12 banks, where each bank needs to store 178958336 B, but bank size is 1073741792 B "
     bringup_status: FAILED_RUNTIME
 
   qwen_2_5/causal_lm/jax-3b_instruct-data_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "Not enough space to allocate 2147483648 B DRAM buffer across 12 banks, where each bank needs to store 178958336 B, but bank size is 1073741792 B "
     bringup_status: FAILED_RUNTIME
 
   qwen_2_5/causal_lm/jax-7b-data_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "Not enough space to allocate 271581184 B DRAM buffer across 12 banks, where each bank needs to store 22636544 B, but bank size is 1073741792 B"
     bringup_status: FAILED_RUNTIME
 
   qwen_2_5/causal_lm/jax-7b_instruct-data_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "Not enough space to allocate 271581184 B DRAM buffer across 12 banks, where each bank needs to store 22636544 B, but bank size is 1073741792 B"
     bringup_status: FAILED_RUNTIME
 
   qwen_2_5_coder/causal_lm/jax-0_5b-data_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
 
   qwen_2_5_coder/causal_lm/jax-1_5b-data_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
 
   qwen_2_5_coder/causal_lm/jax-1_5b_instruct-data_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
 
   qwen_2_5_coder/causal_lm/jax-3b-data_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "DRAM OOM"
     bringup_status: FAILED_RUNTIME
 
   qwen_2_5_coder/causal_lm/jax-3b_instruct-data_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "DRAM OOM"
     bringup_status: FAILED_RUNTIME
 
   qwen_2_5_coder/causal_lm/jax-7b-data_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "DRAM OOM"
     bringup_status: FAILED_RUNTIME
 
   qwen_2_5_coder/causal_lm/jax-7b_instruct-data_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "DRAM OOM"
     bringup_status: FAILED_RUNTIME
 
   qwen_3/causal_lm/jax-0_6b-data_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
 
   qwen_3/causal_lm/jax-1_7b-data_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "DRAM OOM"
     bringup_status: FAILED_RUNTIME
 
   qwen_3/causal_lm/jax-4b-data_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "Not enough space to allocate 10485760 B DRAM buffer across 12 banks, where each bank needs to store 876544 B, but bank size is 1073741792 B"
     bringup_status: FAILED_RUNTIME

--- a/tests/runner/test_config/jax/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/jax/test_config_inference_tensor_parallel.yaml
@@ -9,212 +9,212 @@
 
 test_config:
   alexnet/image_classification/jax-custom_1x2-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
     markers: [nightly]
 
   alexnet/image_classification/jax-custom_1x4-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_RUNTIME
     reason: "Hangs in runtime - https://github.com/tenstorrent/tt-xla/issues/2440"
 
   alexnet/image_classification/jax-custom_1x8-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_RUNTIME
     reason: "Hangs in runtime - https://github.com/tenstorrent/tt-xla/issues/2440"
 
   falcon/jax-tiiuae/Falcon3-1B-Base-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
     assert_pcc: false
     reason: "Severe PCC comparison failed: pcc=0.066 < 0.99 required"
 
   falcon/jax-tiiuae/Falcon3-3B-Base-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "Not enough space to allocate 2147483648 B DRAM buffer across 12 banks, where each bank needs to store 178958336 B, but bank size is 1073741792 B"
     bringup_status: FAILED_RUNTIME
 
   qwen_2_5/causal_lm/jax-0_5b-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "Currently failing - https://github.com/tenstorrent/tt-xla/issues/3001. Severe PCC comparison failed: pcc=-0.011 < 0.99 required"
 
   qwen_2_5/causal_lm/jax-0_5b_instruct-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "Currently failing - https://github.com/tenstorrent/tt-xla/issues/3001. Severe PCC comparison failed: pcc=-0.036 < 0.99 required"
 
   qwen_2_5/causal_lm/jax-1_5b-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "Not enough space to allocate 34359738368 B DRAM buffer across 12 banks, where each bank needs to store 2863312896 B, but bank size is 1073741792 B"
     bringup_status: FAILED_RUNTIME
 
   qwen_2_5/causal_lm/jax-1_5b_instruct-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "Currently failing - https://github.com/tenstorrent/tt-xla/issues/3001. Severe PCC comparison failed: pcc=-0.019 < 0.99 required"
 
   qwen_2_5/causal_lm/jax-3b-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "Currently failing - https://github.com/tenstorrent/tt-xla/issues/3001. Severe PCC comparison failed: pcc=-0.0005 < 0.99 required"
 
   qwen_2_5/causal_lm/jax-3b_instruct-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "Currently failing - https://github.com/tenstorrent/tt-xla/issues/3001. Severe PCC comparison failed: pcc=-0.001 < 0.99 required"
 
   qwen_2_5/causal_lm/jax-7b-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "Not enough space to allocate 135790592 B DRAM buffer across 12 banks, where each bank needs to store 11317248 B, but bank size is 1073741792 B"
     bringup_status: FAILED_RUNTIME
 
   qwen_2_5/causal_lm/jax-7b_instruct-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "Not enough space to allocate 135790592 B DRAM buffer across 12 banks, where each bank needs to store 11317248 B, but bank size is 1073741792 B"
     bringup_status: FAILED_RUNTIME
 
   qwen_2_5_coder/causal_lm/jax-0_5b-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "Currently failing - https://github.com/tenstorrent/tt-xla/issues/3001. Severe PCC comparison failed: pcc=0.0073 < 0.99 required"
 
   qwen_2_5_coder/causal_lm/jax-1_5b-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "Currently failing - https://github.com/tenstorrent/tt-xla/issues/3001. Severe PCC comparison failed: pcc=-0.054 < 0.99 required"
 
   qwen_2_5_coder/causal_lm/jax-1_5b_instruct-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "Currently failing - https://github.com/tenstorrent/tt-xla/issues/3001. Severe PCC comparison failed: pcc=-0.025 < 0.99 required"
 
   qwen_2_5_coder/causal_lm/jax-3b-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "Currently failing - https://github.com/tenstorrent/tt-xla/issues/3001. Severe PCC comparison failed: pcc=0.012 < 0.99 required"
 
   qwen_2_5_coder/causal_lm/jax-3b_instruct-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "Currently failing - https://github.com/tenstorrent/tt-xla/issues/3001. Severe PCC comparison failed: pcc=-0.004 < 0.99 required"
 
   qwen_2_5_coder/causal_lm/jax-7b-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "DRAM OOM"
     bringup_status: FAILED_RUNTIME
 
   qwen_2_5_coder/causal_lm/jax-7b_instruct-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "DRAM OOM"
     bringup_status: FAILED_RUNTIME
 
   qwen_3/causal_lm/jax-0_6b-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
     assert_pcc: false
     reason: "Severe PCC comparison failed: pcc=-0.018 < 0.99 required"
 
   qwen_3/causal_lm/jax-1_7b-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "Not enough space to allocate 3355443200 B DRAM buffer across 12 banks, where each bank needs to store 279621632 B, but bank size is 1073741792 B"
     bringup_status: FAILED_RUNTIME
 
   qwen_3/causal_lm/jax-4b-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "Not enough space to allocate 3355443200 B DRAM buffer across 12 banks, where each bank needs to store 279621632 B, but bank size is 1073741792 B"
     bringup_status: FAILED_RUNTIME
 
   mnist/image_classification/jax-mlp_custom_1x2-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
     markers: [nightly]
 
   mnist/image_classification/jax-mlp_custom_1x4-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
 
   mnist/image_classification/jax-mlp_custom_1x8-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
 
   gpt2/causal_lm/jax-base-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: KNOWN_FAILURE_XFAIL
     reason: "'stablehlo.gather' op slice size out of bounds - https://github.com/tenstorrent/tt-mlir/issues/6653"
     bringup_status: FAILED_TTMLIR_COMPILATION
     markers: [nightly]
 
   gpt2/causal_lm/jax-large-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: KNOWN_FAILURE_XFAIL
     reason: "'stablehlo.gather' op slice size out of bounds - https://github.com/tenstorrent/tt-mlir/issues/6653"
     bringup_status: FAILED_TTMLIR_COMPILATION
 
   gpt2/causal_lm/jax-medium-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: KNOWN_FAILURE_XFAIL
     reason: "'stablehlo.gather' op slice size out of bounds - https://github.com/tenstorrent/tt-mlir/issues/6653"
     bringup_status: FAILED_TTMLIR_COMPILATION
 
   gpt2/causal_lm/jax-xl-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: KNOWN_FAILURE_XFAIL
     reason: "'stablehlo.gather' op slice size out of bounds - https://github.com/tenstorrent/tt-mlir/issues/6653"
     bringup_status: FAILED_TTMLIR_COMPILATION
 
   llama/causal_lm/jax-1B_TINY-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
 
   llama/causal_lm/jax-3b-v2-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
     assert_pcc: false
     reason: "Severe PCC comparison failed: pcc=0.144 < 0.99 required"
 
   phi1/causal_lm/jax-microsoft/phi-1-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
     assert_pcc: false
     reason: "Severe PCC comparison failed: pcc=-0.01 < 0.99 required"
 
   phi1_5/causal_lm/jax-microsoft/phi-1_5-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
     assert_pcc: false
     reason: "Severe PCC comparison failed: pcc=0.006 < 0.99 required"
 
   phi2/causal_lm/jax-microsoft/phi-2-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
     assert_pcc: false
     reason: "Severe PCC comparison failed: pcc=-0.012 < 0.99 required"
 
   phi2/causal_lm/jax-microsoft/phi-2-pytdml-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
     assert_pcc: false
     reason: "Severe PCC comparison failed: pcc=-0.012 < 0.99 required"
 
   phi3/causal_lm/jax-microsoft/Phi-3-mini-128k-instruct-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "Not enough space to allocate 34359738368 B DRAM buffer across 12 banks, where each bank needs to store 2863312896 B, but bank size is 1073741792 B"
     bringup_status: FAILED_RUNTIME
 
   phi3/causal_lm/jax-microsoft/Phi-3-mini-4k-instruct-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "Not enough space to allocate 39845888 B DRAM buffer across 12 banks, where each bank needs to store 3321856 B, but bank size is 1073741792 B"
     bringup_status: FAILED_RUNTIME

--- a/tests/runner/test_config/torch/test_config_inference_data_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_data_parallel.yaml
@@ -4,1239 +4,1247 @@
 
 test_config:
   vit/pytorch-base-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   swin/image_classification/pytorch-swin_t-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   mlp_mixer/pytorch-mixer_s32_224-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   t5/pytorch-t5-small-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   segformer/pytorch-mit_b0-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   albert/masked_lm/pytorch-base_v1-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   albert/token_classification/pytorch-base_v1-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   bert/token_classification/pytorch-dbmdz/bert-large-cased-finetuned-conll03-english-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   deit/pytorch-base_distilled-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   dpr/context_encoder/pytorch-facebook/dpr-ctx_encoder-multiset-base-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   swin/masked_image_modeling/pytorch-microsoft/swinv2-tiny-patch4-window8-256-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   mlp_mixer/pytorch-mixer_b32_224-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   segformer/pytorch-mit_b4-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   beit/pytorch-large-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   albert/masked_lm/pytorch-xlarge_v1-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   albert/token_classification/pytorch-xlarge_v1-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     assert_pcc: false
     status: EXPECTED_PASSING
     reason: "PCC comparison failed. Calculated: pcc=0.9775277376174927. Required: pcc=0.98. - https://github.com/tenstorrent/tt-xla/issues/1844"
 
   mnist/image_classification/pytorch-cnn_dropout-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   mnist/image_classification/pytorch-cnn_nodropout-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   vit/pytorch-large-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   swin/image_classification/pytorch-swin_v2_b-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   segformer/pytorch-mit_b1-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   albert/masked_lm/pytorch-base_v2-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     assert_pcc: false
     status: EXPECTED_PASSING
     reason: "PCC comparison failed. Calculated: pcc=0.978430986404419. Required: pcc=0.99. - https://github.com/tenstorrent/tt-xla/issues/1789"
 
   yolov6/pytorch-yolov6l-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: KNOWN_FAILURE_XFAIL # Failed after experimental compile  https://github.com/tenstorrent/tt-xla/issues/2994
 
   vgg/pytorch-torchvision_vgg16-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   deit/pytorch-small-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   autoencoder/pytorch-linear-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   squeezebert/pytorch-squeezebert-mnli-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: KNOWN_FAILURE_XFAIL  # Affected by change in torch=xla wheel - issue is: https://github.com/tenstorrent/tt-xla/issues/1750
     reason: "error: 'stablehlo.reshape' op requires compatible element types for all operands and results  - https://github.com/tenstorrent/tt-xla/issues/1750"
     bringup_status: FAILED_FE_COMPILATION
 
   swin/image_classification/pytorch-swin_v2_t-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   segformer/pytorch-mit_b3-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   beit/pytorch-base-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   albert/masked_lm/pytorch-large_v2-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
 
   albert/token_classification/pytorch-large_v2-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
 
   vgg/pytorch-torchvision_vgg19-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   fuyu/pytorch-adept/fuyu-8b-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   gpt2/pytorch-gpt2-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   dpr/context_encoder/pytorch-facebook/dpr-ctx_encoder-single-nq-base-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   mlp_mixer/pytorch-mixer_github-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   segformer/pytorch-mit_b5-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   albert/masked_lm/pytorch-xlarge_v2-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   vgg/pytorch-vgg11-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   vgg/pytorch-hf_vgg19-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   bert/masked_lm/pytorch-bert-base-uncased-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   dpr/question_encoder/pytorch-facebook/dpr-question_encoder-multiset-base-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   swin/image_classification/pytorch-microsoft/swin-tiny-patch4-window7-224-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   albert/token_classification/pytorch-xxlarge_v1-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     assert_pcc: false
     status: EXPECTED_PASSING
     reason: "PCC comparison failed. Calculated: pcc=0.9593995213508606. Required: pcc=0.99. - https://github.com/tenstorrent/tt-xla/issues/1789"
 
   vgg/pytorch-vgg13-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   bert/question_answering/pytorch-bert-large-cased-whole-word-masking-finetuned-squad-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   swin/image_classification/pytorch-swin_v2_s-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   mlp_mixer/pytorch-mixer_b16_224_miil-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   segformer/pytorch-mit_b2-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   albert/masked_lm/pytorch-large_v1-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   albert/token_classification/pytorch-large_v1-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   deit/pytorch-tiny-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   swin/image_classification/pytorch-swin_s-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   mlp_mixer/pytorch-mixer_s16_224-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   perceiver/pytorch-deepmind/language-perceiver-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   albert/sequence_classification/pytorch-imdb-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   vgg/pytorch-torchvision_vgg13-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   bert/sequence_classification/pytorch-textattack/bert-base-uncased-SST-2-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   alexnet/pytorch-alexnetb-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   deit/pytorch-base-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
 
   dpr/question_encoder/pytorch-facebook/dpr-question_encoder-single-nq-base-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   swin/image_classification/pytorch-microsoft/swinv2-tiny-patch4-window8-256-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   deepseek/deepseek_coder/pytorch-1_3b_instruct-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   mgp_str_base/pytorch-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   albert/masked_lm/pytorch-xxlarge_v2-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
 
   vgg/pytorch-vgg16-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   vgg/pytorch-torchvision_vgg11-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   bert/question_answering/pytorch-phiyodr/bert-large-finetuned-squad2-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   swin/image_classification/pytorch-swin_b-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   rcnn/pytorch-alexnet-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   mlp_mixer/pytorch-mixer_l32_224-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   albert/question_answering/pytorch-squad2-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   vgg/pytorch-vgg19-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.975  # Decreased after https://github.com/tenstorrent/tt-forge-models/pull/87
 
   bert/sentence_embedding_generation/pytorch-emrecan/bert-base-turkish-cased-mean-nli-stsb-tr-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   alexnet/pytorch-alexnet-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   xception/pytorch-xception65-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
 
   dla/pytorch-dla60-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   dla/pytorch-dla102x-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   regnet/pytorch-regnet_y_040-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   regnet/pytorch-regnet_y_320-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   regnet/pytorch-regnet_x_16gf-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   mobilenetv2/pytorch-google/mobilenet_v2_1.0_224-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.97
 
   t5/pytorch-google/flan-t5-large-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   yolov4/pytorch-base-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
+    arch_overrides:
+      qb2-blackhole:
+        status: KNOWN_FAILURE_XFAIL
+        reason: "Missing s3 bucket mirror on QB2-Blackhole CI - https://github.com/tenstorrent/tt-xla/issues/3171"
 
   xception/pytorch-xception71-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
 
   fpn/pytorch-resnet50_fpn_v2-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   dla/pytorch-dla60x-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   dla/pytorch-dla102x2-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   xception/pytorch-xception71.tf_in1k-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
 
   dla/pytorch-dla60x_c-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   mobilenetv1/pytorch-mobilenet_v1-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   dla/pytorch-dla34-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   mobilenetv1/pytorch-mobilenetv1_100.ra4_e3600_r224_in1k-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.96
 
   wide_resnet/pytorch-wide_resnet101_2.timm-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     assert_pcc: false
     status: EXPECTED_PASSING
     reason: "PCC comparison failed. Calculated: pcc=0.9714103734933311. Required: pcc=0.98."
 
   dla/pytorch-dla34.in1k-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   unet/pytorch-carvana_unet-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   # yolov8/pytorch-yolov8n-data_parallel-inference:
-  #   supported_archs: [n300]
+  #   supported_archs: [n300, qb2-blackhole]
   #   status: EXPECTED_PASSING
 
   roberta/pytorch-cardiffnlp/twitter-roberta-base-sentiment-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   wide_resnet/pytorch-wide_resnet50_2-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
 
   regnet/pytorch-regnet_y_160-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   regnet/pytorch-regnet_y_800mf-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   regnet/pytorch-regnet_x_400mf-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   mobilenetv2/pytorch-google/deeplabv3_mobilenet_v2_1.0_513-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   inception/pytorch-inception_v4-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.96
 
   ssd300_resnet50/pytorch-base-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   hardnet/pytorch-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.97
 
   dla/pytorch-dla46_c-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   unet/pytorch-torchhub_brain_unet-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   # yolov8/pytorch-yolov8x-data_parallel-inference:
-  #   supported_archs: [n300]
+  #   supported_archs: [n300, qb2-blackhole]
   #   status: EXPECTED_PASSING
   #   required_pcc: 0.98
 
   wide_resnet/pytorch-wide_resnet50_2.timm-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     assert_pcc: false
     reason: "PCC comparison failed.  Calculated: pcc=0.97700434923172. Required: pcc=0.98. - https://github.com/tenstorrent/tt-xla/issues/2368"
 
   xception/pytorch-xception41-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   dla/pytorch-dla46x_c-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   dla/pytorch-dla102-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   dla/pytorch-dla169-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     required_pcc: 0.98  # PCC comparison failed with pcc=0.9898209571838379 in n150 and pcc=0.9885705709457397 in p150.
     reason: "AssertionError: Comparison result 0 failed: PCC comparison failed - https://github.com/tenstorrent/tt-xla/issues/2010"
     status: EXPECTED_PASSING
 
   regnet/pytorch-regnet_y_3_2gf-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   regnet/pytorch-regnet_x_8gf-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
 
   hrnet/pytorch-hrnet_w18_small-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   hrnet/pytorch-hrnet_w44-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   yolov6/pytorch-yolov6n-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: KNOWN_FAILURE_XFAIL # Failed after experimental compile  https://github.com/tenstorrent/tt-xla/issues/2994
 
   vgg/pytorch-timm_vgg19_bn-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     assert_pcc: false
     status: EXPECTED_PASSING
     reason: "PCC comparison failed. Calculated: pcc=0.956895405489452. Required: pcc=0.98."
 
   vovnet/pytorch-ese_vovnet19b_dw.ra_in1k-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   ghostnet/pytorch-ghostnet_100-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
 
   efficientnet_lite/pytorch-tf_efficientnet_lite0.in1k-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   monodepth2/pytorch-mono_640x192-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   mobilenetv3/pytorch-mobilenet_v3_small-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.96
 
   resnet/pytorch-resnet50-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
 
   efficientnet/pytorch-efficientnet_b6-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   wide_resnet/pytorch-wide_resnet101_2-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     assert_pcc: false
     status: EXPECTED_PASSING
     reason: "PCC comparison failed. Calculated: pcc=0.9714103734933311. Required: pcc=0.98."
 
   regnet/pytorch-regnet_y_400mf-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   mobilenetv2/pytorch-google/mobilenet_v2_0.35_96-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     assert_pcc: false
     status: EXPECTED_PASSING
     reason: "PCC comparison failed. Calculated: pcc=0.9587556719779968. Required: pcc=0.96 - https://github.com/tenstorrent/tt-xla/issues/2201"
 
   t5/pytorch-google/flan-t5-base-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   hrnet/pytorch-hrnet_w48-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   albert/token_classification/pytorch-base_v2-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   yolov6/pytorch-yolov6s-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: KNOWN_FAILURE_XFAIL # Failed after experimental compile  https://github.com/tenstorrent/tt-xla/issues/2994
 
   vgg/pytorch-torchvision_vgg11_bn-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   vovnet/pytorch-ese_vovnet39b-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     assert_pcc: false
     status: EXPECTED_PASSING
     reason: "PCC comparison failed. Calculated: pcc=0.9872968792915344. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/2201"
 
   ghostnet/pytorch-ghostnet_100.in1k-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
 
   efficientnet_lite/pytorch-tf_efficientnet_lite1.in1k-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
 
   monodepth2/pytorch-mono_no_pt_640x192-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   resnet/pytorch-resnet50_timm-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.97
 
   efficientnet/pytorch-efficientnet_b0-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
 
   efficientnet/pytorch-efficientnet_b7-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   resnext/pytorch-resnext50_32x4d-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   mlp_mixer/pytorch-mixer_l16_224_in21k-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     assert_pcc: false
     status: EXPECTED_PASSING
     reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.9550153017044067. Required: pcc=0.99."
 
   retinanet/pytorch-retinanet_rn50fpn-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     assert_pcc: false
     status: EXPECTED_PASSING
     reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.956940770149231. Required: pcc=0.99."
 
   vovnet/pytorch-vovnet57_th-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/1832
     status: KNOWN_FAILURE_XFAIL
     reason: "Issues with pulling urls - https://github.com/tenstorrent/tt-xla/issues/2390"
 
   yolos/pytorch-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     assert_pcc: false
     status: EXPECTED_PASSING
     reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.968181848526001. Required: pcc=0.99."
 
   vovnet/pytorch-ese_vovnet99b-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     assert_pcc: false
     reason: "PCC comparison failed. Calculated: pcc=0.7919955849647522. Required: pcc=0.98 - https://github.com/tenstorrent/tt-xla/issues/1242"
 
   albert/token_classification/pytorch-xlarge_v2-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     assert_pcc: false
     status: EXPECTED_PASSING
     reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.8890893459320068. Required: pcc=0.99."
 
   regnet/pytorch-regnet_y_080-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   regnet/pytorch-regnet_y_8gf-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   mobilenetv2/pytorch-google/mobilenet_v2_0.75_160-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.96
 
   inception/pytorch-inception_v4.tf_in1k-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.96
 
   t5/pytorch-google/flan-t5-small-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   segformer/semantic_segmentation/pytorch-b0_finetuned_ade_512_512-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   hrnet/pytorch-hrnet_w18_small_v2-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   hrnet/pytorch-hrnet_w64-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
 
   vgg/pytorch-torchvision_vgg13_bn-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
 
   efficientnet_lite/pytorch-tf_efficientnet_lite2.in1k-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
 
   monodepth2/pytorch-stereo_1024x320-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   mobilenetv3/pytorch-mobilenetv3_small_100-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.97
 
   resnet/pytorch-resnet_50_hf-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.96
     bringup_status: INCORRECT_RESULT # Single device required_pcc: 0.98
 
   efficientnet/pytorch-efficientnet_b1-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
 
   efficientnet/pytorch-hf_hub_timm_efficientnet_b0_ra_in1k-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
 
   retinanet/pytorch-retinanet_rn101fpn-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     assert_pcc: false
     status: EXPECTED_PASSING
     reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.9655160903930664. Required: pcc=0.99."
 
   albert/token_classification/pytorch-xxlarge_v2-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     assert_pcc: false
     status: EXPECTED_PASSING
     reason: "Calculated: pcc=0.9272822141647339. Required: pcc=0.99."
 
   regnet/pytorch-regnet_y_120-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   regnet/pytorch-regnet_x_1_6gf-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
 
   mobilenetv2/pytorch-mobilenet_v2-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   t5/pytorch-t5-base-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   segformer/semantic_segmentation/pytorch-b1_finetuned_ade_512_512-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   vgg/pytorch-torchvision_vgg16_bn-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.979
 
   # yolov10/pytorch-yolov10n-data_parallel-inference:
-  #   supported_archs: [n300]
+  #   supported_archs: [n300, qb2-blackhole]
   #   status: EXPECTED_PASSING
 
   efficientnet_lite/pytorch-tf_efficientnet_lite3.in1k-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   monodepth2/pytorch-stereo_640x192-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   monodepth2/pytorch-mono+stereo_1024x320-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   resnet/pytorch-resnet101-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
 
   efficientnet/pytorch-efficientnet_b2-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   efficientnet/pytorch-hf_hub_timm_efficientnetv2_rw_s_ra2_in1k-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   resnext/pytorch-resnext101_32x8d-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   mlp_mixer/pytorch-mixer_b16_224-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     assert_pcc: false
     status: EXPECTED_PASSING
 
   retinanet/pytorch-retinanet_rn152fpn-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     assert_pcc: false
     status: EXPECTED_PASSING
     reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.9571177363395691. Required: pcc=0.99."
 
   autoencoder/pytorch-conv-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     assert_pcc: false
     status: EXPECTED_PASSING
     reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.5767203569412231. Required: pcc=0.99."
 
   regnet/pytorch-regnet_y_16gf-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   regnet/pytorch-regnet_x_32gf-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
 
   mobilenetv2/pytorch-mobilenet_v2_torchvision-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
     bringup_status: INCORRECT_RESULT
     reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.9898824691772461. Required: pcc=0.99 - http://github.com/tenstorrent/tt-xla/issues/1402"
 
   t5/pytorch-t5-large-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   segformer/semantic_segmentation/pytorch-b2_finetuned_ade_512_512-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   hrnet/pytorch-hrnet_w30-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   googlenet/pytorch-googlenet-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   vgg/pytorch-torchvision_vgg19_bn-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     assert_pcc: false
     status: EXPECTED_PASSING
     reason: "PCC comparison failed. Calculated: pcc=0.9619955010531175. Required: pcc=0.98."
 
   # yolov10/pytorch-yolov10x-data_parallel-inference:
-  #   supported_archs: [n300]
+  #   supported_archs: [n300, qb2-blackhole]
   #   status: EXPECTED_PASSING
 
   efficientnet_lite/pytorch-tf_efficientnet_lite4.in1k-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
 
   monodepth2/pytorch-mono+stereo_640x192-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   monodepth2/pytorch-stereo_no_pt_640x192-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   resnet/pytorch-resnet152-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.97
 
   efficientnet/pytorch-efficientnet_b3-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
 
   efficientnet/pytorch-hf_hub_timm_tf_efficientnet_b0_aa_in1k-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   resnext/pytorch-resnext101_32x8d_wsl-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   mlp_mixer/pytorch-mixer_b16_224_in21k-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     assert_pcc: false
     status: EXPECTED_PASSING
 
   retinanet/pytorch-retinanet_rn18fpn-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     assert_pcc: false
     status: EXPECTED_PASSING
     reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.9567028880119324. Required: pcc=0.99."
 
   vovnet/pytorch-vovnet39_th-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/1832
     status: KNOWN_FAILURE_XFAIL
     reason: "Issues with pulling urls - https://github.com/tenstorrent/tt-xla/issues/2390"
 
   centernet/pytorch-hourglass_coco-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     assert_pcc: false
     status: EXPECTED_PASSING
     reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.25450941920280457. Required: pcc=0.99."
+    arch_overrides:
+      qb2-blackhole:
+        status: KNOWN_FAILURE_XFAIL
+        reason: "Missing s3 bucket mirror on QB2-Blackhole CI - https://github.com/tenstorrent/tt-xla/issues/3171"
 
   openpose/v2/pytorch-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     assert_pcc: false
     status: EXPECTED_PASSING
     reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.9093026518821716. Required: pcc=0.99."
 
   retinanet/pytorch-retinanet_rn34fpn-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     assert_pcc: false
     status: EXPECTED_PASSING
     reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.9525967836380005. Required: pcc=0.99."
 
   regnet/pytorch-regnet_y_1_6gf-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   regnet/pytorch-regnet_x_3_2gf-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
 
   mobilenetv2/pytorch-mobilenetv2_100-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   segformer/semantic_segmentation/pytorch-b3_finetuned_ade_512_512-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   hrnet/pytorch-hrnet_w18-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   hrnet/pytorch-hrnet_w32-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   vgg/pytorch-bn_vgg19-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     assert_pcc: false
     status: EXPECTED_PASSING
     reason: "PCC comparison failed. Calculated: pcc=0.9689233920026501. Required: pcc=0.98."
 
   vgg/pytorch-vgg19_bn-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     assert_pcc: false
     status: EXPECTED_PASSING
     reason: "PCC comparison failed. Calculated: pcc=0.9619955010531175. Required: pcc=0.98."
 
   monodepth2/pytorch-mono+stereo_no_pt_640x192-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   resnet/pytorch-resnet18-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   efficientnet/pytorch-efficientnet_b4-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   efficientnet/pytorch-hf_hub_timm_tf_efficientnetv2_s_in21k-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   yolov3/pytorch-base-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.97
 
   distilbert/masked_lm/pytorch-distilbert-base-multilingual-cased-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   efficientnet/pytorch-efficientnet_b5-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   hrnet/pytorch-hrnet_w18.ms_aug_in1k-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   hrnet/pytorch-hrnet_w40-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
 
   mlp_mixer/pytorch-mixer_b16_224_miil_in21k-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/2433
 
   opt/qa/pytorch-facebook/opt-350m-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   monodepth2/pytorch-mono_1024x320-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   yolov6/pytorch-yolov6m-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: KNOWN_FAILURE_XFAIL # Failed after experimental compile  https://github.com/tenstorrent/tt-xla/issues/2994
 
   mobilenetv3/pytorch-mobilenet_v3_large-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
 
   resnet/pytorch-resnet34-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
 
   regnet/pytorch-regnet_y_32gf-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   regnet/pytorch-regnet_x_800mf-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
 
   vovnet/pytorch-ese_vovnet19b_dw-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   efficientnet/pytorch-timm_efficientnet_b0-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
 
   segformer/semantic_segmentation/pytorch-b4_finetuned_ade_512_512-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   vgg/pytorch-bn_vgg19b-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.96
 
   roberta/masked_lm/pytorch-xlm_base-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   codegen/pytorch-Salesforce/codegen-350M-multi-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   distilbert/sequence_classification/pytorch-distilbert-base-uncased-finetuned-sst-2-english-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   codegen/pytorch-Salesforce/codegen-350M-nl-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   opt/qa/pytorch-facebook/opt-125m-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   opt/causal_lm/pytorch-facebook/opt-125m-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   distilbert/token_classification/pytorch-Davlan/distilbert-base-multilingual-cased-ner-hrl-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   mamba/pytorch-mamba-370m-hf-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     assert_pcc: false # -0.0327 WH / 0.3821 BH as of Nov 5 2025 right after an uplift which contained newer LLVM https://github.com/tenstorrent/tt-xla/issues/2000
     status: EXPECTED_PASSING
 
   codegen/pytorch-Salesforce/codegen-350M-mono-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   opt/causal_lm/pytorch-facebook/opt-350m-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   distilbert/masked_lm/pytorch-distilbert-base-cased-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   distilbert/question_answering/pytorch-distilbert-base-cased-distilled-squad-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   mlp_mixer/pytorch-mixer_l16_224-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     assert_pcc: false
     status: EXPECTED_PASSING
     reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.8585371971130371. Required: pcc=0.99."
 
   gpt_neo/causal_lm/pytorch-gpt_neo_125M-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     assert_pcc: false
     status: EXPECTED_PASSING
     reason: "PCC decreased with inputs changes to 0.946 in BH / 0.887 in WH"
 
   mlp_mixer/pytorch-mixer_b16_224.goog_in21k-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     assert_pcc: false
     status: EXPECTED_PASSING
 
   vit/pytorch-vit_b_16-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   stereo/pytorch-medium-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     assert_pcc: false
     status: EXPECTED_PASSING
     reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.3149577673900601. Required: pcc=0.99"
 
   mamba/pytorch-mamba-790m-hf-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     assert_pcc: false # issue - https://github.com/tenstorrent/tt-xla/issues/2607
 
   mobilenetv3/pytorch-mobilenetv3_large_100-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   # yoloworld/pytorch-data_parallel-inference:
-  #   supported_archs: [n300]
+  #   supported_archs: [n300, qb2-blackhole]
   #   status: EXPECTED_PASSING
 
   hrnet/pytorch-hrnetv2_w44_osmr-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.96
 
   resnext/pytorch-resnext26_32x4d_osmr-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   hrnet/pytorch-hrnet_w18_small_v1_osmr-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   hrnet/pytorch-hrnetv2_w48_osmr-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.985
 
   ghostnet/pytorch-ghostnetv2_100.in1k-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   resnext/pytorch-resnext50_32x4d_osmr-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   inception/pytorch-inceptionv4-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.97
 
   hrnet/pytorch-hrnetv2_w18_osmr-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   hrnet/pytorch-hrnet_w18_small_v2_osmr-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   vovnet/pytorch-vovnet27s-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   hrnet/pytorch-hrnetv2_w30_osmr-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
 
   vovnet/pytorch-vovnet39-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     assert_pcc: false
     status: EXPECTED_PASSING
     reason: "PCC comparison failed. Calculated: pcc=0.964539647102356. Required: pcc=0.98 - https://github.com/tenstorrent/tt-xla/issues/2201"
 
   hrnet/pytorch-hrnetv2_w32_osmr-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.985
 
   resnext/pytorch-resnext101_64x4d_osmr-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   hrnet/pytorch-hrnetv2_w40_osmr-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
 
   vovnet/pytorch-vovnet57-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/1832
     status: KNOWN_FAILURE_XFAIL
     reason: "Issues with pulling urls - https://github.com/tenstorrent/tt-xla/issues/2390"
 
   resnext/pytorch-resnext14_32x4d_osmr-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   densenet/pytorch-densenet121-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
 
   densenet/pytorch-densenet161-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     required_pcc: 0.98 # PCC comparison failed. Calculated: pcc=0.9897865056991577. Required: pcc=0.99.
     status: EXPECTED_PASSING
 
   densenet/pytorch-densenet169-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98
 
   densenet/pytorch-densenet201-data_parallel-inference:
-    supported_archs: [n300]
+    supported_archs: [n300, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.98

--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -112,6 +112,10 @@ test_config:
   yolov4/pytorch-base-single_device-inference:
     required_pcc: 0.98  # AssertionError: PCC comparison failed. Calculated: pcc=0.9872550368309021. Required: pcc=0.99. Exposed by removal of consteval on host: https://github.com/tenstorrent/tt-xla/issues/1242
     status: EXPECTED_PASSING
+    arch_overrides:
+      qb2-blackhole:
+        status: KNOWN_FAILURE_XFAIL
+        reason: "Missing s3 bucket mirror on QB2-Blackhole CI - https://github.com/tenstorrent/tt-xla/issues/3171"
 
   t5/pytorch-google/flan-t5-small-single_device-inference:
     status: EXPECTED_PASSING
@@ -133,15 +137,15 @@ test_config:
     status: EXPECTED_PASSING
 
   falcon/pytorch-tiiuae/Falcon3-7B-Base-single_device-inference:
-    supported_archs: ["p150"]
+    supported_archs: ["p150", "qb2-blackhole"]
     status: EXPECTED_PASSING
 
   falcon/pytorch-tiiuae/Falcon3-10B-Base-single_device-inference:
-    supported_archs: ["p150"]
+    supported_archs: ["p150", "qb2-blackhole"]
     status: EXPECTED_PASSING
 
   falcon/pytorch-tiiuae/Falcon3-Mamba-7B-Base-single_device-inference:
-    supported_archs: ["p150"]
+    supported_archs: ["p150", "qb2-blackhole"]
     status: EXPECTED_PASSING
     assert_pcc: false # issue - https://github.com/tenstorrent/tt-xla/issues/2607
 
@@ -331,6 +335,9 @@ test_config:
     status: EXPECTED_PASSING
     arch_overrides:
       p150:
+        status: KNOWN_FAILURE_XFAIL
+        reason: "Statically allocated circular buffers in program 260 clash with L1 buffers on core range [(x=0,y=0) - (x=12,y=9)] - https://github.com/tenstorrent/tt-xla/issues/2368"
+      qb2-blackhole:
         status: KNOWN_FAILURE_XFAIL
         reason: "Statically allocated circular buffers in program 260 clash with L1 buffers on core range [(x=0,y=0) - (x=12,y=9)] - https://github.com/tenstorrent/tt-xla/issues/2368"
 
@@ -556,6 +563,8 @@ test_config:
     arch_overrides:
       p150:
         required_pcc: 0.97 # https://github.com/tenstorrent/tt-xla/issues/2433
+      qb2-blackhole:
+        required_pcc: 0.97 # https://github.com/tenstorrent/tt-xla/issues/2433
 
   mlp_mixer/lucidrains/pytorch-base-single_device-inference:
     status: EXPECTED_PASSING
@@ -598,6 +607,8 @@ test_config:
     arch_overrides:
       p150:
         required_pcc: 0.975 # p150 : https://github.com/tenstorrent/tt-xla/issues/2181
+      qb2-blackhole:
+        required_pcc: 0.975 # p150 : https://github.com/tenstorrent/tt-xla/issues/2181
       n150:
         assert_pcc: false # n150 : https://github.com/tenstorrent/tt-xla/issues/2433, large decrese with change torch==2.9.0
 
@@ -605,6 +616,8 @@ test_config:
     status: EXPECTED_PASSING
     arch_overrides:
       p150:
+        required_pcc: 0.975 # p150 : https://github.com/tenstorrent/tt-xla/issues/2181
+      qb2-blackhole:
         required_pcc: 0.975 # p150 : https://github.com/tenstorrent/tt-xla/issues/2181
       n150:
         assert_pcc: false # n150 : https://github.com/tenstorrent/tt-xla/issues/2433, large decrese with change torch==2.9.0
@@ -640,6 +653,10 @@ test_config:
   yoloworld/pytorch-small_640-single_device-inference:
     status: EXPECTED_PASSING
     required_pcc: 0.98 # https://github.com/tenstorrent/tt-xla/issues/2727
+    arch_overrides:
+      qb2-blackhole:
+        status: KNOWN_FAILURE_XFAIL
+        reason: "Missing s3 bucket mirror on QB2-Blackhole CI - https://github.com/tenstorrent/tt-xla/issues/3171"
 
   yoloworld/pytorch-small_1280-single_device-inference:
     status: EXPECTED_PASSING
@@ -669,6 +686,8 @@ test_config:
     status: EXPECTED_PASSING
     arch_overrides:
       p150:
+        required_pcc: 0.98 # https://github.com/tenstorrent/tt-xla/issues/2433
+      qb2-blackhole:
         required_pcc: 0.98 # https://github.com/tenstorrent/tt-xla/issues/2433
 
   opt/qa/pytorch-facebook/opt-350m-single_device-inference:
@@ -719,6 +738,8 @@ test_config:
       n150:
         required_pcc: 0.98 # tt-torch has this at 0.99
       p150:
+        required_pcc: 0.97 # tt-torch has this at 0.99
+      qb2-blackhole:
         required_pcc: 0.97 # tt-torch has this at 0.99
 
   albert/masked_lm/pytorch-base_v1-single_device-inference:
@@ -997,11 +1018,15 @@ test_config:
         required_pcc: 0.96 # AssertionError: PCC comparison failed. Calculated: pcc=0.9509297013282776. Required: pcc=0.96. Change of torch=xla wheel, issue is: https://github.com/tenstorrent/tt-xla/issues/1750 // tt-torch has this at 0.97
       p150:
         required_pcc: 0.95
+      qb2-blackhole:
+        required_pcc: 0.95
 
   qwen_2_5/causal_lm/pytorch-0_5b-single_device-inference:
     status: EXPECTED_PASSING
     arch_overrides:
       p150:
+        required_pcc: 0.97  # https://github.com/tenstorrent/tt-torch/issues/1192
+      qb2-blackhole:
         required_pcc: 0.97  # https://github.com/tenstorrent/tt-torch/issues/1192
       n150:
         assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/2433
@@ -1217,6 +1242,8 @@ test_config:
     arch_overrides:
       p150:
         assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/2368
+      qb2-blackhole:
+        assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/2368
 
   regnet/pytorch-regnet_x_8gf-single_device-inference:
     status: EXPECTED_PASSING
@@ -1308,6 +1335,10 @@ test_config:
     required_pcc: 0.98
     status: EXPECTED_PASSING
     markers: [push, nightly]
+    arch_overrides:
+      qb2-blackhole:
+        status: KNOWN_FAILURE_XFAIL
+        reason: "Missing s3 bucket mirror on QB2-Blackhole CI - https://github.com/tenstorrent/tt-xla/issues/3171"
 
   yolov9/pytorch-s-single_device-inference:
     required_pcc: 0.98 # https://github.com/tenstorrent/tt-xla/issues/2944
@@ -1328,6 +1359,8 @@ test_config:
     status: EXPECTED_PASSING
     arch_overrides:
       p150:
+        assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/2181
+      qb2-blackhole:
         assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/2181
 
   ghostnet/pytorch-ghostnetv2_100.in1k-single_device-inference:
@@ -1503,6 +1536,10 @@ test_config:
         assert_pcc: false
         status: EXPECTED_PASSING
         reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.9095736145973206. Required: pcc=0.99"
+      qb2-blackhole:
+        assert_pcc: false
+        status: EXPECTED_PASSING
+        reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.9095736145973206. Required: pcc=0.99"
       n150:
         status: NOT_SUPPORTED_SKIP
         reason: "Too large for single chip" # (flux.1-schnell is 12B param model)
@@ -1511,6 +1548,8 @@ test_config:
   flux/pytorch-dev-single_device-inference:
     arch_overrides:
       p150:
+        status: EXPECTED_PASSING
+      qb2-blackhole:
         status: EXPECTED_PASSING
       n150:
         status: NOT_SUPPORTED_SKIP
@@ -1522,7 +1561,7 @@ test_config:
     reason: "TypeError: GLiNER.compile() got an unexpected keyword argument 'backend'"
 
   gemma/pytorch-google/gemma-1.1-7b-it-single_device-inference:
-    supported_archs: ["p150"]
+    supported_archs: ["p150", "qb2-blackhole"]
     status: EXPECTED_PASSING
     assert_pcc: false # ComputeConfig math_fidelity/fp32_dest_acc_en - https://github.com/tenstorrent/tt-xla/issues/2861
 
@@ -1543,7 +1582,7 @@ test_config:
         bringup_status: FAILED_RUNTIME
 
   phi4/causal_lm/pytorch-microsoft/phi-4-single_device-inference:
-    supported_archs: ["p150"] # Run as tensor_parallel for wormhole (14B param model).
+    supported_archs: ["p150", "qb2-blackhole"] # Run as tensor_parallel for wormhole (14B param model).
     status: EXPECTED_PASSING
 
   phi4/seq_cls/pytorch-microsoft/phi-4-single_device-inference:
@@ -1565,6 +1604,9 @@ test_config:
   phi3/phi_3_5_vision/pytorch-instruct-single_device-inference:
     arch_overrides:
       p150:
+        status: KNOWN_FAILURE_XFAIL
+        reason: "Out of Memory: Not enough space to allocate 52428800 B DRAM buffer across 12 banks, where each bank needs to store 4370432 B, but bank size is only 1073741792 B"
+      qb2-blackhole:
         status: KNOWN_FAILURE_XFAIL
         reason: "Out of Memory: Not enough space to allocate 52428800 B DRAM buffer across 12 banks, where each bank needs to store 4370432 B, but bank size is only 1073741792 B"
       n150:
@@ -1596,7 +1638,8 @@ test_config:
     arch_overrides:
       p150:
         status: EXPECTED_PASSING
-
+      qb2-blackhole:
+        status: EXPECTED_PASSING
       n150:
         status: KNOWN_FAILURE_XFAIL
         reason: "RuntimeError: Out of Memory: Not enough space to allocate 49971200 B L1 buffer across 64 banks"
@@ -1652,6 +1695,9 @@ test_config:
         reason: "Too large for single chip"
         bringup_status: FAILED_RUNTIME
       p150:
+        status: EXPECTED_PASSING
+        assert_pcc: false # Calculated: pcc=0.9130426049232483. Change to torch==2.9.0
+      qb2-blackhole:
         status: EXPECTED_PASSING
         assert_pcc: false # Calculated: pcc=0.9130426049232483. Change to torch==2.9.0
 
@@ -1712,6 +1758,9 @@ test_config:
       p150:
         status: EXPECTED_PASSING
         assert_pcc: false # Calculated: pcc=0.9396957755088806. Change to torch==2.9.0
+      qb2-blackhole:
+        status: EXPECTED_PASSING
+        assert_pcc: false # Calculated: pcc=0.9396957755088806. Change to torch==2.9.0
 
   llama/sequence_classification/pytorch-llama_3_1_70b-single_device-inference:
     status: NOT_SUPPORTED_SKIP
@@ -1750,6 +1799,10 @@ test_config:
         assert_pcc: false
         status: EXPECTED_PASSING
         reason: "AssertionError: PCC comparison failed. Calculated: pcc=-1.0000001192092896. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/1472"
+      qb2-blackhole:
+        assert_pcc: false
+        status: EXPECTED_PASSING
+        reason: "AssertionError: PCC comparison failed. Calculated: pcc=-1.0000001192092896. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/1472"
       n150:
         status: NOT_SUPPORTED_SKIP
         reason: "Too large for single chip"
@@ -1766,6 +1819,8 @@ test_config:
   mistral/pytorch-7b-single_device-inference:
     arch_overrides:
       p150:
+        status: EXPECTED_PASSING
+      qb2-blackhole:
         status: EXPECTED_PASSING
       n150:
         status: NOT_SUPPORTED_SKIP
@@ -1784,7 +1839,8 @@ test_config:
     arch_overrides:
       p150:
         status: EXPECTED_PASSING
-
+      qb2-blackhole:
+        status: EXPECTED_PASSING
       n150:
         status: NOT_SUPPORTED_SKIP
         reason: "Too large for single chip"
@@ -1796,18 +1852,26 @@ test_config:
         assert_pcc: false
         status: EXPECTED_PASSING
         reason: "AssertionError: PCC comparison failed. Calculated: pcc=nan. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/1474"
+      qb2-blackhole:
+        assert_pcc: false
+        status: EXPECTED_PASSING
+        reason: "AssertionError: PCC comparison failed. Calculated: pcc=nan. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/1474"
       n150:
         status: NOT_SUPPORTED_SKIP
         reason: "Too large for single chip"
         bringup_status: FAILED_RUNTIME
 
   qwen_2_5/causal_lm/pytorch-14b_instruct-single_device-inference:
-    supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.
+    supported_archs: ["p150", "qb2-blackhole"] # Runs as tensor_parallel for wormhole.
     status: EXPECTED_PASSING
 
   qwen_2_5/causal_lm/pytorch-14b_instruct_1m-single_device-inference:
     arch_overrides:
       p150:
+        assert_pcc: false
+        status: EXPECTED_PASSING
+        reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.7706121206283569. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/1474"
+      qb2-blackhole:
         assert_pcc: false
         status: EXPECTED_PASSING
         reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.7706121206283569. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/1474"
@@ -1825,6 +1889,10 @@ test_config:
         assert_pcc: false
         status: EXPECTED_PASSING
         reason: "AssertionError: PCC comparison failed. Calculated: pcc=nan. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/1474"
+      qb2-blackhole:
+        assert_pcc: false
+        status: EXPECTED_PASSING
+        reason: "AssertionError: PCC comparison failed. Calculated: pcc=nan. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/1474"
       n150:
         status: NOT_SUPPORTED_SKIP
         reason: "Too large for single chip"
@@ -1833,6 +1901,10 @@ test_config:
   qwen_2_5/causal_lm/pytorch-7b_instruct-single_device-inference:
     arch_overrides:
       p150:
+        assert_pcc: false
+        status: EXPECTED_PASSING
+        reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.7253174185752869. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/1474"
+      qb2-blackhole:
         assert_pcc: false
         status: EXPECTED_PASSING
         reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.7253174185752869. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/1474"
@@ -1847,6 +1919,10 @@ test_config:
         assert_pcc: false
         status: EXPECTED_PASSING
         reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.8598132729530334. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/1474"
+      qb2-blackhole:
+        assert_pcc: false
+        status: EXPECTED_PASSING
+        reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.8598132729530334. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/1474"
       n150:
         status: NOT_SUPPORTED_SKIP
         reason: "Too large for single chip"
@@ -1855,6 +1931,10 @@ test_config:
   qwen_2_5/causal_lm/pytorch-math_7b-single_device-inference:
     arch_overrides:
       p150:
+        assert_pcc: false
+        status: EXPECTED_PASSING
+        reason: "AssertionError: PCC comparison failed. Calculated: pcc=nan. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/1474"
+      qb2-blackhole:
         assert_pcc: false
         status: EXPECTED_PASSING
         reason: "AssertionError: PCC comparison failed. Calculated: pcc=nan. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/1474"
@@ -1872,6 +1952,10 @@ test_config:
         assert_pcc: false
         status: EXPECTED_PASSING
         reason: "AssertionError: PCC comparison failed. Calculated: pcc=nan. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/1474"
+      qb2-blackhole:
+        assert_pcc: false
+        status: EXPECTED_PASSING
+        reason: "AssertionError: PCC comparison failed. Calculated: pcc=nan. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/1474"
       n150:
         status: NOT_SUPPORTED_SKIP
         reason: "Too large for single chip"
@@ -1883,13 +1967,17 @@ test_config:
         assert_pcc: false
         status: EXPECTED_PASSING
         reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.964358925819397. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/1474"
+      qb2-blackhole:
+        assert_pcc: false
+        status: EXPECTED_PASSING
+        reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.964358925819397. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/1474"
       n150:
         status: NOT_SUPPORTED_SKIP
         reason: "Too large for single chip"
         bringup_status: FAILED_RUNTIME
 
   qwen_3/causal_lm/pytorch-14b-single_device-inference:
-    supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.
+    supported_archs: ["p150", "qb2-blackhole"] # Runs as tensor_parallel for wormhole.
     status: EXPECTED_PASSING
     required_pcc: 0.98
 
@@ -1924,14 +2012,14 @@ test_config:
     status: EXCLUDE_MODEL # Too large for single chip, run as tensor_parallel instead.
 
   gemma/pytorch-google/gemma-2-9b-it-single_device-inference:
-    supported_archs: ["p150"]
+    supported_archs: ["p150", "qb2-blackhole"]
     status: EXPECTED_PASSING
 
   gemma/pytorch-google/gemma-2-27b-it-single_device-inference:
     status: EXCLUDE_MODEL # Too large for single chip, run as tensor_parallel instead.
 
   falcon/pytorch-tiiuae/falcon-7b-instruct-single_device-inference:
-    supported_archs: ["p150"]
+    supported_archs: ["p150", "qb2-blackhole"]
     assert_pcc: false
     status: EXPECTED_PASSING
     reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.9418849945068359. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/1475"
@@ -1972,6 +2060,10 @@ test_config:
     assert_pcc: false
     status: EXPECTED_PASSING
     reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.04067724570631981. Required: pcc=0.99. - https://github.com/tenstorrent/tt-xla/issues/1505"
+    arch_overrides:
+      qb2-blackhole:
+        status: KNOWN_FAILURE_XFAIL
+        reason: "Missing s3 bucket mirror on QB2-Blackhole CI - https://github.com/tenstorrent/tt-xla/issues/3171"
 
   centernet/pytorch-resnet18_coco-single_device-inference:
     status: EXPECTED_PASSING
@@ -2024,12 +2116,20 @@ test_config:
         status: NOT_SUPPORTED_SKIP
         bringup_status: FAILED_RUNTIME
         reason: "Buffer must be allocated on device - https://github.com/tenstorrent/tt-xla/issues/2439"
+      qb2-blackhole:
+        status: NOT_SUPPORTED_SKIP
+        bringup_status: FAILED_RUNTIME
+        reason: "Buffer must be allocated on device - https://github.com/tenstorrent/tt-xla/issues/2439"
 
   bevformer/pytorch-bevformerv2-r50-t1-single_device-inference:
     status: KNOWN_FAILURE_XFAIL
     reason: "Out of Memory: Not enough space to allocate 65536000 B L1 buffer across 64 banks, where each bank needs to store 1024000 B, but bank size is only 1364704 B, but bank size is only 1366016 B - https://github.com/tenstorrent/tt-xla/issues/1709"
     arch_overrides:
       p150:
+        status: NOT_SUPPORTED_SKIP
+        bringup_status: FAILED_RUNTIME
+        reason: "Buffer must be allocated on device - https://github.com/tenstorrent/tt-xla/issues/2439"
+      qb2-blackhole:
         status: NOT_SUPPORTED_SKIP
         bringup_status: FAILED_RUNTIME
         reason: "Buffer must be allocated on device - https://github.com/tenstorrent/tt-xla/issues/2439"
@@ -2042,12 +2142,20 @@ test_config:
         status: NOT_SUPPORTED_SKIP
         bringup_status: FAILED_RUNTIME
         reason: "Buffer must be allocated on device - https://github.com/tenstorrent/tt-xla/issues/2439"
+      qb2-blackhole:
+        status: NOT_SUPPORTED_SKIP
+        bringup_status: FAILED_RUNTIME
+        reason: "Buffer must be allocated on device - https://github.com/tenstorrent/tt-xla/issues/2439"
 
   bevformer/pytorch-bevformerv2-r50-t8-single_device-inference:
     status: KNOWN_FAILURE_XFAIL
     reason: "Out of Memory: Not enough space to allocate 65536000 B L1 buffer across 64 banks, where each bank needs to store 1024000 B, but bank size is only 1364704 B, but bank size is only 1366016 B - https://github.com/tenstorrent/tt-xla/issues/1709"
     arch_overrides:
       p150:
+        status: NOT_SUPPORTED_SKIP
+        bringup_status: FAILED_RUNTIME
+        reason: "Buffer must be allocated on device - https://github.com/tenstorrent/tt-xla/issues/2439"
+      qb2-blackhole:
         status: NOT_SUPPORTED_SKIP
         bringup_status: FAILED_RUNTIME
         reason: "Buffer must be allocated on device - https://github.com/tenstorrent/tt-xla/issues/2439"
@@ -2200,6 +2308,9 @@ test_config:
   transfuser/pytorch-single_device-inference:
     status: KNOWN_FAILURE_XFAIL
     reason: "Input tensor data type for ttnn.sort must be BFLOAT16 or UINT16, got DataType::FLOAT32 (https://github.com/tenstorrent/tt-xla/issues/3089)"
+    arch_overrides:
+      qb2-blackhole:
+        reason: "Missing s3 bucket mirror on QB2-Blackhole CI - https://github.com/tenstorrent/tt-xla/issues/3171"
 
   issac_groot/pytorch-GR00T_n1.5-3b-single_device-inference:
     status: NOT_SUPPORTED_SKIP
@@ -2343,6 +2454,8 @@ test_config:
         required_pcc: 0.96 # https://github.com/tenstorrent/tt-xla/issues/1472, https://github.com/tenstorrent/tt-mlir/issues/6217
       p150:
         required_pcc: 0.95 # https://github.com/tenstorrent/tt-xla/issues/1472, https://github.com/tenstorrent/tt-mlir/issues/6217
+      qb2-blackhole:
+        required_pcc: 0.95 # https://github.com/tenstorrent/tt-xla/issues/1472, https://github.com/tenstorrent/tt-mlir/issues/6217
 
   maskformer_swin_b/pytorch-swin_base_coco-single_device-inference:
     status: EXPECTED_PASSING
@@ -2375,6 +2488,10 @@ test_config:
 
   ultra_fast_lane_detection/pytorch-tusimple_resnet18-single_device-inference:
     status: EXPECTED_PASSING
+    arch_overrides:
+      qb2-blackhole:
+        status: KNOWN_FAILURE_XFAIL
+        reason: "Missing s3 bucket mirror on QB2-Blackhole CI - https://github.com/tenstorrent/tt-xla/issues/3171"
 
   ultra_fast_lane_detection/pytorch-culane_resnet18-single_device-inference:
     status: EXPECTED_PASSING
@@ -2556,7 +2673,7 @@ test_config:
         reason: "Multi chip is required"
 
   mistral/pytorch-mistral_nemo_instruct_2407-single_device-inference:
-    supported_archs: ["p150"] # 12B param model
+    supported_archs: ["p150", "qb2-blackhole"] # 12B param model
     status: EXPECTED_PASSING
     assert_pcc: false # ComputeConfig math_fidelity/fp32_dest_acc_en - https://github.com/tenstorrent/tt-xla/issues/2861
 
@@ -2607,11 +2724,15 @@ test_config:
     arch_overrides:
       p150:
         required_pcc: 0.98  # Actual PCC: 0.9847531158203227 - https://github.com/tenstorrent/tt-xla/runs/61718495993 TODO: pending investigation
+      qb2-blackhole:
+        required_pcc: 0.98  # Actual PCC: 0.9847531158203227 - https://github.com/tenstorrent/tt-xla/runs/61718495993 TODO: pending investigation
 
   siglip/image_text_similarity/pytorch-base_patch16_512-single_device-inference:
     status: EXPECTED_PASSING
     arch_overrides:
       p150:
+        required_pcc: 0.98  # Actual PCC: 0.9867153999500852 - https://github.com/tenstorrent/tt-xla/runs/61718495993 TODO: pending investigation
+      qb2-blackhole:
         required_pcc: 0.98  # Actual PCC: 0.9867153999500852 - https://github.com/tenstorrent/tt-xla/runs/61718495993 TODO: pending investigation
 
   siglip/image_text_similarity/pytorch-base_patch16_256_multilingual-single_device-inference:
@@ -2624,6 +2745,8 @@ test_config:
         required_pcc: 0.98  # Actual PCC: 0.986684763880969 - https://github.com/tenstorrent/tt-xla/runs/61718821565 TODO: pending investigation
       p150:
         required_pcc: 0.98  # Actual PCC: 0.9873568504978747 - https://github.com/tenstorrent/tt-xla/runs/61718495993 TODO: pending investigation
+      qb2-blackhole:
+        required_pcc: 0.98  # Actual PCC: 0.9873568504978747 - https://github.com/tenstorrent/tt-xla/runs/61718495993 TODO: pending investigation
 
   siglip/image_text_similarity/pytorch-large_patch16_384-single_device-inference:
     status: EXPECTED_PASSING
@@ -2631,6 +2754,8 @@ test_config:
       n150:
         required_pcc: 0.98  # Actual PCC: 0.9893993879478543 - https://github.com/tenstorrent/tt-xla/runs/61718821565 TODO: pending investigation
       p150:
+        assert_pcc: false  # Actual PCC: 0.9799736818706198 - https://github.com/tenstorrent/tt-xla/runs/61718495993 TODO: pending investigation
+      qb2-blackhole:
         assert_pcc: false  # Actual PCC: 0.9799736818706198 - https://github.com/tenstorrent/tt-xla/runs/61718495993 TODO: pending investigation
 
   siglip/image_text_similarity/pytorch-so400m_patch14_224-single_device-inference:
@@ -2640,6 +2765,8 @@ test_config:
         assert_pcc: false  # Actual PCC: 0.9590273983037481 - https://github.com/tenstorrent/tt-xla/runs/61718821565 TODO: pending investigation
       p150:
         assert_pcc: false  # Actual PCC: 0.9558645998697567 - https://github.com/tenstorrent/tt-xla/runs/61718495993 TODO: pending investigation
+      qb2-blackhole:
+        assert_pcc: false  # Actual PCC: 0.9558645998697567 - https://github.com/tenstorrent/tt-xla/runs/61718495993 TODO: pending investigation
 
   siglip/image_text_similarity/pytorch-so400m_patch14_384-single_device-inference:
     status: EXPECTED_PASSING
@@ -2648,6 +2775,8 @@ test_config:
         assert_pcc: false  # Actual PCC: 0.9579560773278014 - https://github.com/tenstorrent/tt-xla/runs/61718821565 TODO: pending investigation
       p150:
         assert_pcc: false  # Actual PCC: 0.9555685660373453 - https://github.com/tenstorrent/tt-xla/runs/61718495993 TODO: pending investigation
+      qb2-blackhole:
+        assert_pcc: false  # Actual PCC: 0.9555685660373453 - https://github.com/tenstorrent/tt-xla/runs/61718495993 TODO: pending investigation
 
   siglip/image_text_similarity/pytorch-so400m_patch16_256_i18n-single_device-inference:
     status: EXPECTED_PASSING
@@ -2655,6 +2784,8 @@ test_config:
       n150:
         assert_pcc: false  # Actual PCC: 0.9693205147128082 - https://github.com/tenstorrent/tt-xla/runs/61718821565 TODO: pending investigation
       p150:
+        assert_pcc: false  # Actual PCC: 0.9661477411303401 - https://github.com/tenstorrent/tt-xla/runs/61718495993 TODO: pending investigation
+      qb2-blackhole:
         assert_pcc: false  # Actual PCC: 0.9661477411303401 - https://github.com/tenstorrent/tt-xla/runs/61718495993 TODO: pending investigation
 
   vocoder_speecht5/pytorch-hifigan-single_device-inference:

--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -5,118 +5,124 @@
 
 test_config:
   falcon/pytorch-tiiuae/Falcon3-7B-Base-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: EXPECTED_PASSING
 
   falcon/pytorch-tiiuae/Falcon3-10B-Base-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: EXPECTED_PASSING
 
   falcon/pytorch-tiiuae/Falcon3-Mamba-7B-Base-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: KNOWN_FAILURE_XFAIL
     reason: " Error: loc('compare.1209'): error: Compare operation is not supported in stablehlo-pipeline for meshes not 1x1 - https://github.com/tenstorrent/tt-mlir/issues/3497"
 
   gemma/pytorch-google/gemma-1.1-7b-it-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: EXPECTED_PASSING
+    arch_overrides:
+      qb2-blackhole:
+        required_pcc: 0.98
 
   gemma/pytorch-google/gemma-2-9b-it-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: EXPECTED_PASSING
     markers: [extended]
 
   gemma/pytorch-google/gemma-2-27b-it-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: NOT_SUPPORTED_SKIP
     reason: "Too large for single chip or even n300-llmbox either, needs debug - https://github.com/tenstorrent/tt-xla/issues/1494"
     bringup_status: FAILED_RUNTIME
 
   gpt_oss/pytorch-gpt_oss_20b-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.96
 
   falcon/pytorch-tiiuae/falcon-7b-instruct-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: EXPECTED_PASSING
 
   llama/causal_lm/pytorch-llama_3_1_8b-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: EXPECTED_PASSING
 
   llama/causal_lm/pytorch-llama_3_1_8b_instruct-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: EXPECTED_PASSING
+    arch_overrides:
+      qb2-blackhole:
+        required_pcc: 0.98
 
   llama/causal_lm/pytorch-llama_3_8b_instruct-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: EXPECTED_PASSING
 
   mistral/pixtral/pytorch-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: EXPECTED_PASSING
     assert_pcc: false
 
   mistral/pytorch-7b_instruct_v03-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: EXPECTED_PASSING
     markers: [extended]
 
   qwen_3/causal_lm/pytorch-0_6b-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: EXPECTED_PASSING
     assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/2550
 
   qwen_3/causal_lm/pytorch-14b-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: EXPECTED_PASSING
 
   qwen_3/causal_lm/pytorch-1_7b-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: EXPECTED_PASSING
     assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/2550
 
   qwen_3/causal_lm/pytorch-32b-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: EXPECTED_PASSING
 
   qwen_3/causal_lm/pytorch-8b-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: EXPECTED_PASSING
 
   qwen_3/embedding/pytorch-embedding_8b-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: EXPECTED_PASSING
     markers: [extended]
 
   mistral/pytorch-ministral_8b_instruct-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: EXPECTED_PASSING
 
   mistral/pytorch-mistral_small_24b_instruct_2501-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: EXPECTED_PASSING
 
   mistral/pytorch-mistral_nemo_instruct_2407-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: EXPECTED_PASSING
 
   mistral/pytorch-mistral_large_instruct_2411-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: NOT_SUPPORTED_SKIP
     reason: "xr.global_runtime_device_count() - Expected 2 eth links from physical chip 4 to physical chip 0 - https://github.com/tenstorrent/tt-xla/issues/1975"
 
   mistral/pytorch-devstral_small_2505-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: EXPECTED_PASSING
 
   mistral/pytorch-magistral_small_2506-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: EXPECTED_PASSING
 
   qwen_2_5/causal_lm/pytorch-7b_instruct-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     # bringup_status: INCORRECT_RESULT
     # assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/1474
     status: NOT_SUPPORTED_SKIP
@@ -124,19 +130,19 @@ test_config:
     reason: "DRAM OOM - recently regressed around Nov 4 - https://github.com/tenstorrent/tt-xla/issues/2150"
 
   qwen_2_5/causal_lm/pytorch-14b_instruct-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: EXPECTED_PASSING
 
   qwen_2_5/causal_lm/pytorch-32b_instruct-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: EXPECTED_PASSING
 
   qwen_2_5_coder/pytorch-32b_instruct-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: EXPECTED_PASSING
 
   qwen_2_5/causal_lm/pytorch-math_7b-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     # bringup_status: INCORRECT_RESULT
     # assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/1474
     status: NOT_SUPPORTED_SKIP
@@ -145,49 +151,49 @@ test_config:
   # Models that need work....
 
   llama/causal_lm/pytorch-llama_3_1_405b-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: NOT_SUPPORTED_SKIP
     reason: "Needs bringup on galaxy"
     bringup_status: FAILED_RUNTIME
 
   llama/causal_lm/pytorch-llama_3_1_70b-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: NOT_SUPPORTED_SKIP
     reason: "Needs bringup on galaxy"
     bringup_status: FAILED_RUNTIME
 
   llama/causal_lm/pytorch-llama_3_1_70b_instruct-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: NOT_SUPPORTED_SKIP
     reason: "Needs bringup on galaxy"
     bringup_status: FAILED_RUNTIME
 
   llama/causal_lm/pytorch-llama_3_3_70b_instruct-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: NOT_SUPPORTED_SKIP
     reason: "Needs bringup on galaxy"
     bringup_status: FAILED_RUNTIME
 
   phi4/causal_lm/pytorch-microsoft/phi-4-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: NOT_SUPPORTED_SKIP
     reason: "Needs bringup on n300-llmbox 14B param"
     bringup_status: FAILED_RUNTIME
 
   qwen_2/causal_lm/pytorch-qwq_32b-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: NOT_SUPPORTED_SKIP
     reason: "Needs bringup on n300-llmbox"
     bringup_status: FAILED_RUNTIME
 
   qwen_2_5/causal_lm/pytorch-72b_instruct-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: NOT_SUPPORTED_SKIP
     reason: "Needs bringup on galaxy"
     bringup_status: FAILED_RUNTIME
 
   qwen_3/causal_lm/pytorch-30b_a3b-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, qb2-blackhole]
     status: NOT_SUPPORTED_SKIP
     reason: "Needs bringup on n300-llmbox"
     bringup_status: FAILED_RUNTIME

--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -39,6 +39,9 @@ test_config:
     supported_archs: [n300-llmbox, qb2-blackhole]
     status: EXPECTED_PASSING
     required_pcc: 0.96
+    arch_overrides:
+      qb2-blackhole:
+        markers: [push]
 
   falcon/pytorch-tiiuae/falcon-7b-instruct-tensor_parallel-inference:
     supported_archs: [n300-llmbox, qb2-blackhole]
@@ -54,6 +57,7 @@ test_config:
     arch_overrides:
       qb2-blackhole:
         required_pcc: 0.98
+        markers: [push]
 
   llama/causal_lm/pytorch-llama_3_8b_instruct-tensor_parallel-inference:
     supported_archs: [n300-llmbox, qb2-blackhole]
@@ -63,6 +67,9 @@ test_config:
     supported_archs: [n300-llmbox, qb2-blackhole]
     status: EXPECTED_PASSING
     assert_pcc: false
+    arch_overrides:
+      qb2-blackhole:
+        markers: [push]
 
   mistral/pytorch-7b_instruct_v03-tensor_parallel-inference:
     supported_archs: [n300-llmbox, qb2-blackhole]
@@ -77,6 +84,9 @@ test_config:
   qwen_3/causal_lm/pytorch-14b-tensor_parallel-inference:
     supported_archs: [n300-llmbox, qb2-blackhole]
     status: EXPECTED_PASSING
+    arch_overrides:
+      qb2-blackhole:
+        markers: [push]
 
   qwen_3/causal_lm/pytorch-1_7b-tensor_parallel-inference:
     supported_archs: [n300-llmbox, qb2-blackhole]

--- a/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
@@ -18,11 +18,11 @@ test_config:
     assert_pcc: false # ComputeConfig math_fidelity/fp32_dest_acc_en - https://github.com/tenstorrent/tt-xla/issues/2861
 
   falcon/pytorch-tiiuae/Falcon3-7B-Base-llm_decode-single_device-inference:
-    supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.
+    supported_archs: ["p150", "qb2-blackhole"] # Runs as tensor_parallel for wormhole.
     status: EXPECTED_PASSING
 
   falcon/pytorch-tiiuae/Falcon3-10B-Base-llm_decode-single_device-inference:
-    supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.
+    supported_archs: ["p150", "qb2-blackhole"] # Runs as tensor_parallel for wormhole.
     required_pcc: 0.98 # Is 0.984(p150)
     status: EXPECTED_PASSING
 
@@ -39,11 +39,11 @@ test_config:
     assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/2845 - original test also has low pcc
 
   qwen_2_5/causal_lm/pytorch-7b_instruct-llm_decode-single_device-inference:
-    supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.
+    supported_archs: ["p150", "qb2-blackhole"] # Runs as tensor_parallel for wormhole.
     status: EXPECTED_PASSING
 
   qwen_2_5/causal_lm/pytorch-14b_instruct-llm_decode-single_device-inference:
-    supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.
+    supported_archs: ["p150", "qb2-blackhole"] # Runs as tensor_parallel for wormhole.
     status: EXPECTED_PASSING
     assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/2845
 
@@ -58,7 +58,7 @@ test_config:
     assert_pcc: false # ComputeConfig math_fidelity/fp32_dest_acc_en - https://github.com/tenstorrent/tt-xla/issues/2861
 
   gemma/pytorch-google/gemma-1.1-7b-it-llm_decode-single_device-inference:
-    supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.
+    supported_archs: ["p150", "qb2-blackhole"] # Runs as tensor_parallel for wormhole.
     status: EXPECTED_PASSING
     assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/2845
 
@@ -67,7 +67,7 @@ test_config:
     assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/2845
 
   gemma/pytorch-google/gemma-2-9b-it-llm_decode-single_device-inference:
-    supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.
+    supported_archs: ["p150", "qb2-blackhole"] # Runs as tensor_parallel for wormhole.
     status: EXPECTED_PASSING
     assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/2845
 
@@ -75,7 +75,7 @@ test_config:
     status: EXCLUDE_MODEL # Too large for single chip, run as tensor_parallel instead.
 
   llama/causal_lm/pytorch-llama_3_1_8b_instruct-llm_decode-single_device-inference:
-    supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.
+    supported_archs: ["p150", "qb2-blackhole"] # Runs as tensor_parallel for wormhole.
     status: EXPECTED_PASSING
     assert_pcc: false # ComputeConfig math_fidelity/fp32_dest_acc_en - https://github.com/tenstorrent/tt-xla/issues/2861
 
@@ -108,12 +108,12 @@ test_config:
     status: EXPECTED_PASSING
 
   qwen_3/causal_lm/pytorch-8b-llm_decode-single_device-inference:
-    supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.
+    supported_archs: ["p150", "qb2-blackhole"] # Runs as tensor_parallel for wormhole.
     status: EXPECTED_PASSING
     assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/2845
 
   qwen_3/causal_lm/pytorch-14b-llm_decode-single_device-inference:
-    supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.
+    supported_archs: ["p150", "qb2-blackhole"] # Runs as tensor_parallel for wormhole.
     status: EXPECTED_PASSING
 
   qwen_3/causal_lm/pytorch-32b-llm_decode-single_device-inference:
@@ -132,6 +132,8 @@ test_config:
     arch_overrides:
       p150:
         status: EXPECTED_PASSING
+      qb2-blackhole:
+        status: EXPECTED_PASSING
       n150:
         status: NOT_SUPPORTED_SKIP
         reason: "Too large for single chip"
@@ -140,29 +142,33 @@ test_config:
     arch_overrides:
       p150:
         status: EXPECTED_PASSING
+      qb2-blackhole:
+        status: EXPECTED_PASSING
       n150:
         status: NOT_SUPPORTED_SKIP
         reason: "Too large for single chip"
 
   qwen_2_5/causal_lm/pytorch-14b_instruct_1m-llm_decode-single_device-inference:
-    supported_archs: ["p150"]
+    supported_archs: ["p150", "qb2-blackhole"]
     status: EXPECTED_PASSING
 
   llama/causal_lm/pytorch-llama_3_8b_instruct-llm_decode-single_device-inference:
-    supported_archs: ["p150"]
+    supported_archs: ["p150", "qb2-blackhole"]
     status: EXPECTED_PASSING
 
   llama/causal_lm/pytorch-llama_3_8b-llm_decode-single_device-inference:
-    supported_archs: ["p150"]
+    supported_archs: ["p150", "qb2-blackhole"]
     status: EXPECTED_PASSING
 
   llama/causal_lm/pytorch-llama_3_1_8b-llm_decode-single_device-inference:
-    supported_archs: ["p150"]
+    supported_archs: ["p150", "qb2-blackhole"]
     status: EXPECTED_PASSING
 
   llama/causal_lm/pytorch-huggyllama_7b-llm_decode-single_device-inference:
     arch_overrides:
       p150:
+        status: EXPECTED_PASSING
+      qb2-blackhole:
         status: EXPECTED_PASSING
       n150:
         status: NOT_SUPPORTED_SKIP
@@ -171,6 +177,8 @@ test_config:
   falcon/pytorch-tiiuae/falcon-7b-instruct-llm_decode-single_device-inference:
     arch_overrides:
       p150:
+        status: EXPECTED_PASSING
+      qb2-blackhole:
         status: EXPECTED_PASSING
       n150:
         status: NOT_SUPPORTED_SKIP

--- a/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
@@ -5,97 +5,97 @@
 
 test_config:
   falcon/pytorch-tiiuae/Falcon3-7B-Base-llm_decode-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
 
   falcon/pytorch-tiiuae/Falcon3-10B-Base-llm_decode-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
     required_pcc: 0.985 # 0.989 (p150)
 
   qwen_2_5/causal_lm/pytorch-7b_instruct-llm_decode-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_RUNTIME
     reason: "DRAM OOM - shard spec issues - https://github.com/tenstorrent/tt-xla/issues/2150"
 
   qwen_2_5/causal_lm/pytorch-14b_instruct-llm_decode-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
 
   qwen_2_5/causal_lm/pytorch-32b_instruct-llm_decode-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_RUNTIME
     reason: "trisc2 compile failure - https://github.com/tenstorrent/tt-xla/issues/2958"
 
   qwen_2_5/causal_lm/pytorch-72b_instruct-llm_decode-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "Needs bringup on galaxy"
     bringup_status: FAILED_RUNTIME
 
   gemma/pytorch-google/gemma-1.1-7b-it-llm_decode-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
     assert_pcc: false # ComputeConfig math_fidelity/fp32_dest_acc_en - https://github.com/tenstorrent/tt-xla/issues/2861
 
   gemma/pytorch-google/gemma-2-9b-it-llm_decode-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
     assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/2845
 
   gemma/pytorch-google/gemma-2-27b-it-llm_decode-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
 
   llama/causal_lm/pytorch-llama_3_1_8b_instruct-llm_decode-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
 
   llama/causal_lm/pytorch-llama_3_1_70b-llm_decode-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "Needs bringup on galaxy"
     bringup_status: FAILED_RUNTIME
 
   llama/causal_lm/pytorch-llama_3_1_70b_instruct-llm_decode-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "Needs bringup on galaxy"
     bringup_status: FAILED_RUNTIME
 
   llama/causal_lm/pytorch-llama_3_1_405b-llm_decode-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "Needs bringup on galaxy"
     bringup_status: FAILED_RUNTIME
 
   llama/causal_lm/pytorch-llama_3_3_70b_instruct-llm_decode-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "Needs bringup on galaxy"
     bringup_status: FAILED_RUNTIME
 
   qwen_3/causal_lm/pytorch-8b-llm_decode-tensor_parallel-inference:
     required_pcc: 0.985 # https://github.com/tenstorrent/tt-xla/issues/2942
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: EXPECTED_PASSING
 
   qwen_3/causal_lm/pytorch-14b-llm_decode-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_RUNTIME
     reason: "trisc2 compile failure - https://github.com/tenstorrent/tt-xla/issues/2958"
 
   qwen_3/causal_lm/pytorch-32b-llm_decode-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_RUNTIME
     reason: "trisc2 compile failure - https://github.com/tenstorrent/tt-xla/issues/2958"
 
   qwen_3/causal_lm/pytorch-30b_a3b-llm_decode-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    supported_archs: ["n300-llmbox", "qb2-blackhole"]
     status: NOT_SUPPORTED_SKIP
     reason: "Needs bringup on n300-llmbox"
     bringup_status: FAILED_RUNTIME


### PR DESCRIPTION
### Ticket
None

### Problem description
- We have our first QuietBox 2 machine in CI this week and need to start qualifying our models in preparation for product launch
- Just a single machine to start without s3-bucket mirror, more machines coming later this month in cloud, so for now we need to limit the usage of this machine by not rolling out QB2 tests in the same frequency as other archs.
- We'd also like to have TP tests in onPush/onPR, was missing until now, use the otherwise-idle during the daytime CI machine for this

### What's changed
 - Add qb2 specific nightly CI jobs via dedicated model-test-passing-qb2.json, model-test-xfail-qb2.json with usage only in new QB2 Nightly on main branch (exclude from official nightly for now).
 - Add qb2-blackhole to ALLOWED_ARCHES and default_archs in conftest.py
 - Add qb2-blackhole to supported_archs in ~420 test config entries
 - Add ~50 explicit qb2-blackhole arch_overrides modelled after p150 to start, refine/improve later.
 - Add qb2-blackhole arch_overrides for 2x lower PCC (0.98) and 8x s3-bucket-missing fails
 - Tag 4x TP tests for QB2 onPush/onPR and upate model-test-push.json (<10 min runtime)

### Checklist
- [x] Initial run of nightly models as stable commit yesterday passing: https://github.com/tenstorrent/tt-xla/actions/runs/21660160320 - will run again closer to when this is released with the actual changes in this PR
- [x] test run of new models on QB2 added to push today, passing: https://github.com/tenstorrent/tt-xla/actions/runs/21697421408
