### PR TITLE
Fixed ifdefs in header files

### DIFF
--- a/pjrt_implementation/inc/api/buffer_instance.h
+++ b/pjrt_implementation/inc/api/buffer_instance.h
@@ -8,6 +8,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // https://llvm.org/LICENSE.txt
 
+#ifndef TT_XLA_PJRT_IMPLEMENTATION_INC_API_BUFFER_INSTANCE_H_
+#define TT_XLA_PJRT_IMPLEMENTATION_INC_API_BUFFER_INSTANCE_H_
+
 // c++ standard library includes
 #include <atomic>
 #include <memory>
@@ -27,9 +30,6 @@
 #include "api/event_instance.h"
 #include "api/tensor.h"
 #include "utils/status.h"
-
-#ifndef TT_XLA_PJRT_IMPLEMENTATION_INC_API_BUFFER_INSTANCE_H_
-#define TT_XLA_PJRT_IMPLEMENTATION_INC_API_BUFFER_INSTANCE_H_
 
 namespace tt::pjrt {
 

--- a/pjrt_implementation/inc/api/client_instance.h
+++ b/pjrt_implementation/inc/api/client_instance.h
@@ -8,6 +8,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // https://llvm.org/LICENSE.txt
 
+#ifndef TT_XLA_PJRT_IMPLEMENTATION_INC_API_CLIENT_INSTANCE_H_
+#define TT_XLA_PJRT_IMPLEMENTATION_INC_API_CLIENT_INSTANCE_H_
+
 #include "xla/pjrt/c/pjrt_c_api.h"
 
 // c++ standard library includes
@@ -23,9 +26,6 @@
 #include "api/loaded_executable_instance.h"
 #include "api/memory_instance.h"
 #include "utils/status.h"
-
-#ifndef TT_XLA_PJRT_IMPLEMENTATION_INC_API_CLIENT_INSTANCE_H_
-#define TT_XLA_PJRT_IMPLEMENTATION_INC_API_CLIENT_INSTANCE_H_
 
 namespace tt::pjrt {
 

--- a/pjrt_implementation/inc/api/device_description.h
+++ b/pjrt_implementation/inc/api/device_description.h
@@ -8,6 +8,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // https://llvm.org/LICENSE.txt
 
+#ifndef TT_XLA_PJRT_IMPLEMENTATION_INC_API_DEVICE_DESCRIPTION_H_
+#define TT_XLA_PJRT_IMPLEMENTATION_INC_API_DEVICE_DESCRIPTION_H_
+
 // c++ standard library includes
 #include <string>
 
@@ -16,9 +19,6 @@
 
 // tt-mlir includes
 #include "ttmlir/Target/Common/types_generated.h"
-
-#ifndef TT_XLA_PJRT_IMPLEMENTATION_INC_API_DEVICE_DESCRIPTION_H_
-#define TT_XLA_PJRT_IMPLEMENTATION_INC_API_DEVICE_DESCRIPTION_H_
 
 namespace tt::pjrt {
 

--- a/pjrt_implementation/inc/api/device_instance.h
+++ b/pjrt_implementation/inc/api/device_instance.h
@@ -8,6 +8,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // https://llvm.org/LICENSE.txt
 
+#ifndef TT_XLA_PJRT_IMPLEMENTATION_INC_API_DEVICE_INSTANCE_H_
+#define TT_XLA_PJRT_IMPLEMENTATION_INC_API_DEVICE_INSTANCE_H_
+
 // c++ standard library includes
 #include <memory>
 
@@ -16,9 +19,6 @@
 
 // tt-xla includes
 #include "api/device_description.h"
-
-#ifndef TT_XLA_PJRT_IMPLEMENTATION_INC_API_DEVICE_INSTANCE_H_
-#define TT_XLA_PJRT_IMPLEMENTATION_INC_API_DEVICE_INSTANCE_H_
 
 namespace tt::pjrt {
 

--- a/pjrt_implementation/inc/api/error_instance.h
+++ b/pjrt_implementation/inc/api/error_instance.h
@@ -8,6 +8,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // https://llvm.org/LICENSE.txt
 
+#ifndef TT_XLA_PJRT_IMPLEMENTATION_INC_API_ERROR_INSTANCE_H_
+#define TT_XLA_PJRT_IMPLEMENTATION_INC_API_ERROR_INSTANCE_H_
+
 // c++ standard library includes
 #include <memory>
 #include <string>
@@ -17,9 +20,6 @@
 
 // tt-xla includes
 #include "utils/status.h"
-
-#ifndef TT_XLA_PJRT_IMPLEMENTATION_INC_API_ERROR_INSTANCE_H_
-#define TT_XLA_PJRT_IMPLEMENTATION_INC_API_ERROR_INSTANCE_H_
 
 namespace tt::pjrt {
 

--- a/pjrt_implementation/inc/api/event_instance.h
+++ b/pjrt_implementation/inc/api/event_instance.h
@@ -8,6 +8,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // https://llvm.org/LICENSE.txt
 
+#ifndef TT_XLA_PJRT_IMPLEMENTATION_INC_API_EVENT_INSTANCE_H_
+#define TT_XLA_PJRT_IMPLEMENTATION_INC_API_EVENT_INSTANCE_H_
+
 // c++ standard library includes
 #include <condition_variable>
 #include <memory>
@@ -20,9 +23,6 @@
 
 // tt-xla includes
 #include "utils/status.h"
-
-#ifndef TT_XLA_PJRT_IMPLEMENTATION_INC_API_EVENT_INSTANCE_H_
-#define TT_XLA_PJRT_IMPLEMENTATION_INC_API_EVENT_INSTANCE_H_
 
 namespace tt::pjrt {
 

--- a/pjrt_implementation/inc/api/executable_image.h
+++ b/pjrt_implementation/inc/api/executable_image.h
@@ -8,6 +8,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // https://llvm.org/LICENSE.txt
 
+#ifndef TT_XLA_PJRT_IMPLEMENTATION_INC_API_EXECUTABLE_IMAGE_H_
+#define TT_XLA_PJRT_IMPLEMENTATION_INC_API_EXECUTABLE_IMAGE_H_
+
 // c++ standard library includes
 #include <cstddef>
 #include <memory>
@@ -21,9 +24,6 @@
 #define TTMLIR_ENABLE_STABLEHLO 1
 #include "tt/runtime/types.h"
 #include "ttmlir/Dialect/StableHLO/Utils/ShardingUtils.h"
-
-#ifndef TT_XLA_PJRT_IMPLEMENTATION_INC_API_EXECUTABLE_IMAGE_H_
-#define TT_XLA_PJRT_IMPLEMENTATION_INC_API_EXECUTABLE_IMAGE_H_
 
 // tt-xla includes
 #include "api/compile_options.h"

--- a/pjrt_implementation/inc/api/executable_instance.h
+++ b/pjrt_implementation/inc/api/executable_instance.h
@@ -8,6 +8,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // https://llvm.org/LICENSE.txt
 
+#ifndef TT_XLA_PJRT_IMPLEMENTATION_INC_API_EXECUTABLE_INSTANCE_H_
+#define TT_XLA_PJRT_IMPLEMENTATION_INC_API_EXECUTABLE_INSTANCE_H_
+
 // c++ standard library includes
 #include <memory>
 
@@ -16,9 +19,6 @@
 
 // tt-xla includes
 #include "api/executable_image.h"
-
-#ifndef TT_XLA_PJRT_IMPLEMENTATION_INC_API_EXECUTABLE_INSTANCE_H_
-#define TT_XLA_PJRT_IMPLEMENTATION_INC_API_EXECUTABLE_INSTANCE_H_
 
 namespace tt::pjrt {
 

--- a/pjrt_implementation/inc/api/memory_instance.h
+++ b/pjrt_implementation/inc/api/memory_instance.h
@@ -8,6 +8,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // https://llvm.org/LICENSE.txt
 
+#ifndef TT_XLA_PJRT_IMPLEMENTATION_INC_API_MEMORY_INSTANCE_H_
+#define TT_XLA_PJRT_IMPLEMENTATION_INC_API_MEMORY_INSTANCE_H_
+
 // c++ standard library includes
 #include <memory>
 #include <string>
@@ -15,9 +18,6 @@
 
 // PJRT C API includes
 #include "xla/pjrt/c/pjrt_c_api.h"
-
-#ifndef TT_XLA_PJRT_IMPLEMENTATION_INC_API_MEMORY_INSTANCE_H_
-#define TT_XLA_PJRT_IMPLEMENTATION_INC_API_MEMORY_INSTANCE_H_
 
 namespace tt::pjrt {
 

--- a/pjrt_implementation/inc/api/serialized_executable_instance.h
+++ b/pjrt_implementation/inc/api/serialized_executable_instance.h
@@ -8,6 +8,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // https://llvm.org/LICENSE.txt
 
+#ifndef TT_XLA_PJRT_IMPLEMENTATION_INC_API_SERIALIZED_EXECUTABLE_INSTANCE_H_
+#define TT_XLA_PJRT_IMPLEMENTATION_INC_API_SERIALIZED_EXECUTABLE_INSTANCE_H_
+
 // c++ standard library includes
 #include <cstddef>
 
@@ -21,9 +24,6 @@
 #include "api/device_instance.h"
 #include "api/executable_instance.h"
 #include "utils/status.h"
-
-#ifndef TT_XLA_PJRT_IMPLEMENTATION_INC_API_SERIALIZED_EXECUTABLE_INSTANCE_H_
-#define TT_XLA_PJRT_IMPLEMENTATION_INC_API_SERIALIZED_EXECUTABLE_INSTANCE_H_
 
 namespace tt::pjrt {
 

--- a/pjrt_implementation/inc/api/tensor.h
+++ b/pjrt_implementation/inc/api/tensor.h
@@ -8,6 +8,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // https://llvm.org/LICENSE.txt
 
+#ifndef TT_XLA_PJRT_IMPLEMENTATION_INC_API_TENSOR_H_
+#define TT_XLA_PJRT_IMPLEMENTATION_INC_API_TENSOR_H_
+
 // c++ standard library includes
 #include <memory>
 #include <string>
@@ -15,9 +18,6 @@
 
 // tt-mlir includes
 #include "tt/runtime/runtime.h"
-
-#ifndef TT_XLA_PJRT_IMPLEMENTATION_INC_API_TENSOR_H_
-#define TT_XLA_PJRT_IMPLEMENTATION_INC_API_TENSOR_H_
 
 namespace tt::pjrt {
 

--- a/pjrt_implementation/inc/api/tensor_pool.h
+++ b/pjrt_implementation/inc/api/tensor_pool.h
@@ -8,14 +8,14 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // https://llvm.org/LICENSE.txt
 
+#ifndef TT_XLA_PJRT_IMPLEMENTATION_INC_API_TENSOR_POOL_H_
+#define TT_XLA_PJRT_IMPLEMENTATION_INC_API_TENSOR_POOL_H_
+
 #include "tensor.h"
 
 // c++ standard library includes
 #include <mutex>
 #include <unordered_set>
-
-#ifndef TT_XLA_PJRT_IMPLEMENTATION_INC_API_TENSOR_POOL_H_
-#define TT_XLA_PJRT_IMPLEMENTATION_INC_API_TENSOR_POOL_H_
 
 namespace tt::pjrt {
 

--- a/pjrt_implementation/inc/api_bindings.h
+++ b/pjrt_implementation/inc/api_bindings.h
@@ -8,11 +8,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // https://llvm.org/LICENSE.txt
 
-// PJRT C API includes
-#include "xla/pjrt/c/pjrt_c_api.h"
-
 #ifndef TT_XLA_PJRT_IMPLEMENTATION_INC_API_BINDINGS_H_
 #define TT_XLA_PJRT_IMPLEMENTATION_INC_API_BINDINGS_H_
+
+// PJRT C API includes
+#include "xla/pjrt/c/pjrt_c_api.h"
 
 namespace tt::pjrt {
 

--- a/pjrt_implementation/inc/utils/data_type_utils.h
+++ b/pjrt_implementation/inc/utils/data_type_utils.h
@@ -2,6 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#ifndef TT_XLA_PJRT_IMPLEMENTATION_INC_UTILS_DATA_TYPE_UTILS_H_
+#define TT_XLA_PJRT_IMPLEMENTATION_INC_UTILS_DATA_TYPE_UTILS_H_
+
 // llvm mlir includes
 #include "mlir/IR/Types.h"
 
@@ -10,9 +13,6 @@
 
 // tt-mlir includes
 #include "tt/runtime/types.h"
-
-#ifndef TT_XLA_PJRT_IMPLEMENTATION_INC_UTILS_DATA_TYPE_UTILS_H_
-#define TT_XLA_PJRT_IMPLEMENTATION_INC_UTILS_DATA_TYPE_UTILS_H_
 
 namespace tt::pjrt::data_type_utils {
 

--- a/pjrt_implementation/inc/utils/logging.h
+++ b/pjrt_implementation/inc/utils/logging.h
@@ -8,15 +8,15 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // https://llvm.org/LICENSE.txt
 
+#ifndef TT_XLA_PJRT_IMPLEMENTATION_INC_UTILS_LOGGING_H_
+#define TT_XLA_PJRT_IMPLEMENTATION_INC_UTILS_LOGGING_H_
+
 // Loguru doesn't have debug named verbosity and the next verbosity after INFO
 // is called `Verbosity_1`, so defining this to avoid doing `DLOG_F(1, ...)`.
 #define LOG_DEBUG 1
 #define LOG_VERBOSE 2
 
 #include <loguru/loguru.hpp>
-
-#ifndef TT_XLA_PJRT_IMPLEMENTATION_INC_UTILS_LOGGING_H_
-#define TT_XLA_PJRT_IMPLEMENTATION_INC_UTILS_LOGGING_H_
 
 namespace tt::pjrt {
 void initializeLogging();

--- a/pjrt_implementation/src/api/unit_tests/inc/unit_test_utils.h
+++ b/pjrt_implementation/src/api/unit_tests/inc/unit_test_utils.h
@@ -8,6 +8,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // https://llvm.org/LICENSE.txt
 
+#ifndef TT_XLA_PJRT_IMPLEMENTATION_SRC_API_UNIT_TESTS_INC_UNIT_TEST_UTILS_H_
+#define TT_XLA_PJRT_IMPLEMENTATION_SRC_API_UNIT_TESTS_INC_UNIT_TEST_UTILS_H_
+
 // C++ standard library headers
 #include <vector>
 
@@ -18,9 +21,6 @@
 #include "api/client_instance.h"
 #include "api/device_instance.h"
 #include "api/memory_instance.h"
-
-#ifndef TT_XLA_PJRT_IMPLEMENTATION_SRC_API_UNIT_TESTS_INC_UNIT_TEST_UTILS_H_
-#define TT_XLA_PJRT_IMPLEMENTATION_SRC_API_UNIT_TESTS_INC_UNIT_TEST_UTILS_H_
 
 namespace tt::pjrt::tests {
 


### PR DESCRIPTION
For most header files, we were first including all dependencies before checking whether header is already included.

With this change, we should stop torturing preprocessor.
