### PR TITLE
Disable fp32_dest_acc when using optimizer

### DIFF
--- a/pjrt_implementation/src/api/module_builder/module_builder.cc
+++ b/pjrt_implementation/src/api/module_builder/module_builder.cc
@@ -925,6 +925,11 @@ tt_pjrt_status ModuleBuilder::convertFromTTIRToTTNN(
     options.computeCfgMathFidelity = math_fidelity;
   }
 
+  // By default, we disable fp32 dest accumulation for optimization level > 0.
+  if (compile_options.optimization_level > 0) {
+    options.computeCfgFp32DestAccEn = false;
+  }
+
   if (compile_options.fp32_dest_acc_en.has_value()) {
     options.computeCfgFp32DestAccEn = compile_options.fp32_dest_acc_en.value();
   }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-forge/issues/870)

### Problem description
Llama 8b and ministral 8b are currently failing due to [this issue](https://github.com/tenstorrent/tt-mlir/issues/6920). This happens only when `fp32_dest_acc` is enabled, which is by default.

### What's changed
Setting `computeCfgFp32DestAccEn` false whenever optimizer is enabled (level > 0).

### Checklist
- [ ] [Perf Benchmark](https://github.com/tenstorrent/tt-xla/actions/runs/21759483873)
