### PR TITLE
Add sparse_matmul custom op, SparseMLP module for expert computation

### DIFF
--- a/python_package/tt_torch/__init__.py
+++ b/python_package/tt_torch/__init__.py
@@ -17,4 +17,7 @@ from .serialization import (
     parse_compiled_artifacts_from_cache_to_disk,
 )
 from .sharding import sharding_constraint_hook
+
+# Sparse MLP for MoE models
+from .sparse_mlp import SparseMLP, enable_sparse_mlp
 from .tools import mark_module_user_inputs

--- a/python_package/tt_torch/custom_ops.py
+++ b/python_package/tt_torch/custom_ops.py
@@ -826,6 +826,169 @@ def paged_scaled_dot_product_attention_decode_fake(
     return torch.zeros_like(query)
 
 
+@torch.library.custom_op(
+    "tt::sparse_matmul", mutates_args=[], device_types=["xla", "cpu"]
+)
+def sparse_matmul(
+    input_tensor_a: torch.Tensor,
+    input_tensor_b: torch.Tensor,
+    sparsity: torch.Tensor,
+    nnz: int = None,
+    is_input_a_sparse: bool = False,
+    is_input_b_sparse: bool = True,
+) -> torch.Tensor:
+    """
+    Sparse matrix multiplication for MoE (Mixture of Experts) models.
+
+    This operation performs matrix multiplication where computation is skipped
+    for sparse (zero) blocks based on the sparsity tensor.
+
+    Args:
+        input_tensor_a: First input tensor. Shape depends on sparse mode:
+            - is_input_a_sparse=True, is_input_b_sparse=True: [1, E, M, K]
+            - is_input_a_sparse=False, is_input_b_sparse=True: [A, B, M, K]
+            - is_input_a_sparse=True, is_input_b_sparse=False: [A, E, M, K]
+        input_tensor_b: Second input tensor (expert weights). Shape:
+            - [1, E, K, N] for all modes
+        sparsity: Sparsity mask tensor (bfloat16, ROW_MAJOR). Shape depends on mode:
+            - is_input_a_sparse=True, is_input_b_sparse=True: [1, 1, 1, E]
+            - is_input_a_sparse=False, is_input_b_sparse=True: [A, B, 1, E]
+            - is_input_a_sparse=True, is_input_b_sparse=False: [1, 1, A, E]
+        nnz: Number of non-zero elements in sparsity tensor. If None, inferred at runtime.
+        is_input_a_sparse: Whether input_tensor_a is sparse.
+        is_input_b_sparse: Whether input_tensor_b is sparse.
+
+    Returns:
+        Output tensor with sparse results. Shape depends on mode:
+            - is_input_a_sparse=True, is_input_b_sparse=True: [1, E, M, N]
+            - is_input_a_sparse=False, is_input_b_sparse=True: [A, B, 1, E, M, N]
+            - is_input_a_sparse=True, is_input_b_sparse=False: [A, E, M, N]
+    """
+    device = input_tensor_a.device
+
+    if device.type == "xla":
+        frontend_attributes = {
+            "is_input_a_sparse": str(is_input_a_sparse),
+            "is_input_b_sparse": str(is_input_b_sparse),
+        }
+        if nnz is not None:
+            frontend_attributes["nnz"] = str(nnz)
+
+        # Compute output shape based on sparse mode
+        if is_input_a_sparse and is_input_b_sparse:
+            # [1, E, M, K] @ [1, E, K, N] -> [1, E, M, N]
+            output_shape = list(input_tensor_a.shape)
+            output_shape[-1] = input_tensor_b.shape[-1]
+        elif not is_input_a_sparse and is_input_b_sparse:
+            # [A, B, M, K] @ [1, E, K, N] -> [A, B, 1, E, M, N]
+            A, B, M, K = input_tensor_a.shape
+            E = input_tensor_b.shape[1]
+            N = input_tensor_b.shape[-1]
+            output_shape = [A, B, 1, E, M, N]
+        elif is_input_a_sparse and not is_input_b_sparse:
+            # [A, E, M, K] @ [1, E, K, N] -> [A, E, M, N]
+            output_shape = list(input_tensor_a.shape)
+            output_shape[-1] = input_tensor_b.shape[-1]
+        else:
+            raise ValueError(
+                "Invalid sparse mode: both is_input_a_sparse and is_input_b_sparse cannot be False"
+            )
+
+        return stablehlo_custom_call.stablehlo_custom_call(
+            [input_tensor_a, input_tensor_b, sparsity],
+            "tt.sparse_matmul",
+            [output_shape],
+            [input_tensor_a.dtype],
+            frontend_attributes=frontend_attributes,
+        )
+
+    elif device.type == "cpu":
+        # CPU fallback: dense matmul with masking
+        # This is not truly sparse but provides correct results for testing
+        if is_input_a_sparse and is_input_b_sparse:
+            # [1, E, M, K] @ [1, E, K, N] -> [1, E, M, N]
+            # Ensure same dtype for matmul
+            input_b_casted = input_tensor_b.to(input_tensor_a.dtype)
+            output = torch.matmul(input_tensor_a, input_b_casted)
+            # Mask out inactive experts
+            mask = (sparsity > 0).to(input_tensor_a.dtype)
+            # Broadcast mask to output shape
+            while mask.dim() < output.dim():
+                mask = mask.unsqueeze(-1)
+            output = output * mask
+            return output
+
+        elif not is_input_a_sparse and is_input_b_sparse:
+            # [A, B, M, K] @ [1, E, K, N] -> [A, B, 1, E, M, N]
+            A, B, M, K = input_tensor_a.shape
+            E = input_tensor_b.shape[1]
+            N = input_tensor_b.shape[-1]
+
+            # Ensure same dtype for matmul
+            input_b_casted = input_tensor_b.to(input_tensor_a.dtype)
+
+            # Expand input_a for broadcasting: [A, B, 1, 1, M, K]
+            input_a_expanded = input_tensor_a.unsqueeze(2).unsqueeze(3)
+            # Expand input_b for broadcasting: [1, 1, 1, E, K, N]
+            input_b_expanded = input_b_casted.unsqueeze(0)
+
+            # Matmul: [A, B, 1, E, M, N]
+            output = torch.matmul(input_a_expanded, input_b_expanded)
+
+            # Apply sparsity mask [A, B, 1, E] -> [A, B, 1, E, 1, 1]
+            mask = (sparsity > 0).to(input_tensor_a.dtype).unsqueeze(-1).unsqueeze(-1)
+            output = output * mask
+            return output
+
+        elif is_input_a_sparse and not is_input_b_sparse:
+            # [A, E, M, K] @ [1, E, K, N] -> [A, E, M, N]
+            # Ensure same dtype for matmul
+            input_b_casted = input_tensor_b.to(input_tensor_a.dtype)
+            output = torch.matmul(input_tensor_a, input_b_casted)
+            # Apply sparsity mask [1, 1, A, E] -> [A, E, 1, 1]
+            mask = (sparsity > 0).to(input_tensor_a.dtype).permute(2, 3, 0, 1)
+            output = output * mask
+            return output
+
+        else:
+            raise ValueError(
+                "Invalid sparse mode: both is_input_a_sparse and is_input_b_sparse cannot be False"
+            )
+    else:
+        raise ValueError(f"Unsupported device type: {device.type}")
+
+
+@sparse_matmul.register_fake
+def sparse_matmul_fake(
+    input_tensor_a: torch.Tensor,
+    input_tensor_b: torch.Tensor,
+    sparsity: torch.Tensor,
+    nnz: int = None,
+    is_input_a_sparse: bool = False,
+    is_input_b_sparse: bool = True,
+) -> torch.Tensor:
+    """FakeTensor implementation of sparse_matmul for torch dynamo tracing."""
+    if is_input_a_sparse and is_input_b_sparse:
+        output_shape = list(input_tensor_a.shape)
+        output_shape[-1] = input_tensor_b.shape[-1]
+    elif not is_input_a_sparse and is_input_b_sparse:
+        A, B, M, K = input_tensor_a.shape
+        E = input_tensor_b.shape[1]
+        N = input_tensor_b.shape[-1]
+        output_shape = [A, B, 1, E, M, N]
+    elif is_input_a_sparse and not is_input_b_sparse:
+        output_shape = list(input_tensor_a.shape)
+        output_shape[-1] = input_tensor_b.shape[-1]
+    else:
+        raise ValueError(
+            "Invalid sparse mode: both is_input_a_sparse and is_input_b_sparse cannot be False"
+        )
+
+    return torch.zeros(
+        output_shape, dtype=input_tensor_a.dtype, device=input_tensor_a.device
+    )
+
+
 # Allow the torch dynamo to trace our custom operation(s). This will allow
 # the tt custom operation(s) to be represented in a torch.fx.GraphModule.
 for attr in dir(torch.ops.tt):

--- a/python_package/tt_torch/sparse_mlp.py
+++ b/python_package/tt_torch/sparse_mlp.py
@@ -1,0 +1,324 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Sparse MLP module for MoE (Mixture of Experts) models.
+
+This module provides utilities to replace dense MLP layers with sparse MLP
+implementations that use sparse_matmul for efficient expert computation.
+
+Usage:
+    import tt_torch
+    from tt_torch.sparse_mlp import enable_sparse_mlp
+
+    model = load_your_moe_model()
+    model = enable_sparse_mlp(model)  # Replace MLP layers with SparseMLP
+"""
+
+from typing import List, Optional, Type
+
+import torch
+import torch.nn as nn
+from torch.nn import functional as F
+
+
+class SparseMLP(nn.Module):
+    """
+    Sparse MLP implementation that uses sparse_matmul for MoE computation.
+
+    This module wraps an existing MLP and replaces dense expert computation
+    with sparse_matmul operations that skip inactive experts.
+
+    Uses INTERLEAVED gate_up_proj layout directly from original model:
+    - Weights stored as [g0, u0, g1, u1, ...] (interleaved)
+    - Split with [::2]/[1::2] strided slices
+    - TP sharding works because UpdateGlobalToLocalShapes pass handles
+      strided slices where stride == shard_factor
+    """
+
+    def __init__(
+        self,
+        original_mlp,
+        num_experts: int,
+        num_experts_per_tok: int,
+        config: Optional[object] = None,
+    ):
+        super().__init__()
+
+        # Note: We intentionally do NOT store original_mlp to avoid memory duplication.
+        # Only store references to the components we actually need.
+        self.num_experts = num_experts
+        self.num_experts_per_tok = num_experts_per_tok
+
+        # Copy references to original module's components
+        # Keep same structure as original MLP: router + experts
+        self.router = original_mlp.router
+        self.experts = original_mlp.experts  # Keep same structure for sharding
+
+        # Use INTERLEAVED gate_up_proj directly (no conversion needed)
+        # The UpdateGlobalToLocalShapes pass now handles strided slices
+        # where stride == shard_factor, making [::2]/[1::2] TP-compatible.
+        if hasattr(self.experts, "gate_up_proj"):
+            # intermediate_size is half of the last dimension (interleaved)
+            self.intermediate_size = self.experts.gate_up_proj.shape[-1] // 2
+        else:
+            raise ValueError("Expected fused gate_up_proj in experts module")
+
+        # Get hidden_size from config or infer from down_proj shape
+        if config is not None and hasattr(config, "hidden_size"):
+            hidden_size = config.hidden_size
+        else:
+            # Infer from down_proj shape: [E, inter, hidden]
+            hidden_size = self.experts.down_proj.shape[-1]
+
+        # GPT-OSS specific activation parameters
+        self.alpha = getattr(self.experts, "alpha", 1.702)
+        self.limit = getattr(self.experts, "limit", 7.0)
+
+    def forward(self, hidden_states):
+        batch_size, seq_len, hidden_size = hidden_states.shape
+
+        # 1. Router Execution
+        # router_scores: [batch*seq, num_experts] (scattered probabilities)
+        # router_indices: [batch*seq, top_k]
+        router_scores, router_indices = self.router(hidden_states)
+
+        # 2. Create Sparsity Mask [batch, seq, 1, num_experts]
+        sparsity = torch.zeros(
+            batch_size,
+            seq_len,
+            1,
+            self.num_experts,
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+
+        # Reshape indices for scatter: [batch, seq, 1, top_k]
+        topk_indices_unsqueezed = router_indices.view(
+            batch_size, seq_len, 1, self.num_experts_per_tok
+        )
+
+        sparsity.scatter_(
+            dim=-1,
+            index=topk_indices_unsqueezed,
+            src=torch.ones_like(topk_indices_unsqueezed, dtype=hidden_states.dtype),
+        )
+
+        # 3. Reshape Input for sparse_matmul [batch, seq, 1, hidden]
+        hidden_4d = hidden_states.view(batch_size, seq_len, 1, hidden_size)
+
+        # 4. Fused Gate+Up Projection
+        # gate_up_weight: [1, E, hidden, inter*2]
+        gate_up_proj = self.experts.gate_up_proj.unsqueeze(0)
+        gate_up_out = torch.ops.tt.sparse_matmul(
+            hidden_4d,
+            gate_up_proj,
+            sparsity,
+            nnz=0,  # Let runtime calculate
+            is_input_a_sparse=False,
+            is_input_b_sparse=True,
+        )
+
+        # Output: [batch, seq, 1, E, M, inter*2] where M=1
+        # Reshape to [batch, seq, E, inter*2]
+        gate_up_out = gate_up_out.view(
+            batch_size, seq_len, self.num_experts, self.intermediate_size * 2
+        )
+        gate_up_out = gate_up_out + self.experts.gate_up_proj_bias
+
+        # 5. Split & Activation (Interleaved Layout)
+        # Slicing works for TP because stride (2) matches shard_factor
+        gate_out = gate_up_out[..., ::2]  # Even indices
+        up_out = gate_up_out[..., 1::2]  # Odd indices
+
+        gate_out = gate_out.clamp(max=self.limit)
+        up_out = up_out.clamp(-self.limit, self.limit)
+        glu = gate_out * torch.sigmoid(gate_out * self.alpha)
+        activated = (up_out + 1) * glu
+
+        # 6. Down Projection setup
+        # activated: [batch*seq, E, 1, inter]
+        activated_reshaped = activated.view(
+            batch_size * seq_len, self.num_experts, 1, self.intermediate_size
+        )
+
+        # sparsity_down: [1, 1, batch*seq, E]
+        sparsity_down = sparsity.view(1, 1, batch_size * seq_len, self.num_experts)
+
+        # Reshape down_proj for sparse_matmul
+        # down_proj: [1, E, inter, hidden]
+        down_proj = self.experts.down_proj.view(
+            1, self.num_experts, self.intermediate_size, hidden_size
+        )
+
+        # 7. Down Projection (sparse_matmul)
+        # down_weight: [1, E, inter, hidden]
+        # Output: [batch*seq, E, M, hidden] where M=1
+        down_out = torch.ops.tt.sparse_matmul(
+            activated_reshaped,
+            down_proj,
+            sparsity_down,
+            nnz=0,
+            is_input_a_sparse=True,  # Activations are sparse (only TopK are valid)
+            is_input_b_sparse=False,
+        )
+
+        # Squeeze M dimension: [batch*seq, E, 1, hidden] -> [batch*seq, E, hidden]
+        down_out = down_out.squeeze(2)
+        down_out = down_out + self.experts.down_proj_bias
+
+        # 8. Weighted Sum & Final Output
+        # down_out: [BS, E, H]
+        # router_scores: [BS, E] -> [BS, E, 1]
+        # output: [BS, H] (Sum over Experts dim=1)
+        output = (down_out * router_scores.unsqueeze(-1)).sum(dim=1)
+
+        # Reshape back to [batch, seq, hidden]
+        output = output.view(batch_size, seq_len, hidden_size)
+
+        return output, router_scores
+
+
+def _is_moe_mlp(module: nn.Module) -> bool:
+    """Check if a module is an MoE MLP that can be replaced with SparseMLP."""
+    # Check for common MoE MLP patterns
+    module_name = type(module).__name__.lower()
+
+    # Known MoE MLP class names
+    moe_patterns = ["gptossmlp", "mixtralmlp", "qwen2moemlp", "deepseekmlp"]
+
+    if any(pattern in module_name for pattern in moe_patterns):
+        return True
+
+    # Check if module has router and experts attributes (common MoE pattern)
+    has_router = hasattr(module, "router")
+    has_experts = hasattr(module, "experts")
+
+    return has_router and has_experts
+
+
+def _get_moe_config(module: nn.Module) -> Optional[tuple]:
+    """Extract MoE configuration from a module."""
+    try:
+        num_experts = None
+        # Try to get from experts
+        if hasattr(module, "experts"):
+            experts = module.experts
+            num_experts = getattr(experts, "num_experts", None)
+            # Try fused gate_up_proj (expected input format)
+            if num_experts is None and hasattr(experts, "gate_up_proj"):
+                num_experts = experts.gate_up_proj.shape[0]
+
+        # Try to get num_experts_per_tok from router
+        if hasattr(module, "router"):
+            router = module.router
+            num_experts_per_tok = getattr(router, "top_k", None)
+            if num_experts_per_tok is None:
+                num_experts_per_tok = getattr(router, "num_experts_per_tok", 2)
+        else:
+            num_experts_per_tok = 2  # Default
+
+        if num_experts is not None:
+            return (num_experts, num_experts_per_tok)
+    except Exception:
+        pass
+
+    return None
+
+
+def enable_sparse_mlp(
+    model: nn.Module,
+    target_classes: Optional[List[Type]] = None,
+    verbose: bool = False,
+    config: Optional[object] = None,
+) -> nn.Module:
+    """
+    Replace MoE MLP layers in a model with SparseMLP implementations.
+
+    This function traverses the model and replaces compatible MLP layers
+    with SparseMLP, which uses sparse_matmul for efficient expert computation.
+
+    Args:
+        model: The model to transform
+        target_classes: Optional list of specific MLP classes to replace.
+                       If None, auto-detects MoE MLPs.
+        verbose: If True, print information about replaced layers
+        config: Optional model config for extracting MoE parameters
+
+    Returns:
+        The transformed model with SparseMLP layers
+
+    Example:
+        >>> import tt_torch
+        >>> from tt_torch.sparse_mlp import enable_sparse_mlp
+        >>>
+        >>> model = AutoModelForCausalLM.from_pretrained("openai/gpt-oss-20b")
+        >>> model = enable_sparse_mlp(model, verbose=True)
+    """
+    replaced_count = 0
+
+    # Try to get config from model if not provided
+    if config is None:
+        config = getattr(model, "config", None)
+
+    def replace_mlp(parent: nn.Module, name: str, module: nn.Module):
+        nonlocal replaced_count
+
+        # Check if this is a target MLP
+        should_replace = False
+        if target_classes:
+            should_replace = any(isinstance(module, cls) for cls in target_classes)
+        else:
+            should_replace = _is_moe_mlp(module)
+
+        if not should_replace:
+            return False
+
+        # Get MoE configuration from module first, then fall back to config
+        moe_config = _get_moe_config(module)
+        if moe_config is None and config is not None:
+            # Try to get from model config
+            num_experts = getattr(config, "num_local_experts", None)
+            num_experts_per_tok = getattr(config, "num_experts_per_tok", 2)
+            if num_experts is not None:
+                moe_config = (num_experts, num_experts_per_tok)
+
+        if moe_config is None:
+            if verbose:
+                print(f"[SparseMLP] Skipping {name}: could not determine MoE config")
+            return False
+
+        num_experts, num_experts_per_tok = moe_config
+
+        # Create SparseMLP wrapper
+        sparse_mlp = SparseMLP(module, num_experts, num_experts_per_tok, config)
+
+        # Replace the module
+        setattr(parent, name, sparse_mlp)
+        replaced_count += 1
+
+        if verbose:
+            print(
+                f"[SparseMLP] Replaced {name}: {type(module).__name__} -> SparseMLP "
+                f"(experts={num_experts}, top_k={num_experts_per_tok})"
+            )
+
+        return True
+
+    # Traverse and replace
+    for name, module in list(model.named_modules()):
+        if "." in name:
+            # Get parent module
+            parts = name.rsplit(".", 1)
+            parent_name, child_name = parts
+            parent = model.get_submodule(parent_name)
+        else:
+            parent = model
+            child_name = name
+
+        replace_mlp(parent, child_name, module)
+
+    if verbose:
+        print(f"[SparseMLP] Total layers replaced: {replaced_count}")
+
+    return model

--- a/tests/torch/graphs/test_mlp.py
+++ b/tests/torch/graphs/test_mlp.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
-
 from typing import Callable
 
 import numpy as np
@@ -9,6 +8,7 @@ import pytest
 import torch
 import torch_xla
 import torch_xla.runtime as xr
+import tt_torch
 from infra import Framework, run_graph_test
 from infra.evaluators import ComparisonConfig, PccConfig
 from torch_xla.distributed.spmd import Mesh
@@ -469,12 +469,13 @@ def test_falcon_mlp(seq_len, variant, variant_config, arch):
 
 @pytest.mark.nightly
 @parametrize_arch(["single_device", "llmbox"])
+@pytest.mark.parametrize("mlp_type", ["original", "sparse"])
 @pytest.mark.parametrize(
     "variant,variant_config",
     get_available_variants("gpt_oss").items(),
     ids=[str(k) for k in get_available_variants("gpt_oss").keys()],
 )
-def test_gpt_oss_mlp(variant, variant_config, arch):
+def test_gpt_oss_mlp(variant, variant_config, mlp_type, arch):
     xr.set_device_type("TT")
 
     loader = GPTOSSModelLoader(variant=variant, num_layers=1)
@@ -485,6 +486,9 @@ def test_gpt_oss_mlp(variant, variant_config, arch):
     batch_size = inputs["input_ids"].shape[0]  # 1
     seq_len = inputs["input_ids"].shape[1]  # 128 with padding
 
+    if mlp_type == "sparse":
+        tt_torch.sparse_mlp.enable_sparse_mlp(model)
+
     mlp = model.model.layers[0].mlp
 
     hidden_states = torch.randn(
@@ -494,22 +498,31 @@ def test_gpt_oss_mlp(variant, variant_config, arch):
     if arch == "llmbox":
         comparison_config = ComparisonConfig(pcc=PccConfig(required_pcc=0.97))
         num_devices = xr.global_runtime_device_count()
-        mesh_shape = (1, num_devices)
+        mesh_shape = (2, 4)
         device_ids = np.array(range(num_devices))
-        mesh = Mesh(device_ids, mesh_shape, ("batch", "model"))
+        mesh = Mesh(device_ids, mesh_shape, ("model", "batch"))
 
         def get_shard_spec(mlp, args, kwargs):
             shard_specs = {}
+            shard_specs[mlp.router.weight] = (None, "batch")
 
-            # Router weights (not sharded).
-            shard_specs[mlp.router.weight] = (None, None)
-            shard_specs[mlp.router.bias] = (None,)
+            # Both original and sparse use the same reshaped weights now
+            # Sparse: reshaped in-place to [1, E, H, inter*2] and [1, E, inter, H]
+            # Original: [E, H, inter*2] and [E, inter, H]
 
-            # Shard experts across devices.
-            shard_specs[mlp.experts.gate_up_proj] = ("model", None, None)
+            # gate_up_proj: (E, hidden, inter*2) or (1, E, hidden, inter*2) -> EP + hidden TP
+            #   - E: "model" (4-way EP)
+            #   - hidden: "batch" (2-way, K shard -> all-reduce)
+            #   - inter: None (output replicated)
+            shard_specs[mlp.experts.gate_up_proj] = ("model", "batch", None)
             shard_specs[mlp.experts.gate_up_proj_bias] = ("model", None)
-            shard_specs[mlp.experts.down_proj] = ("model", None, None)
-            shard_specs[mlp.experts.down_proj_bias] = ("model", None)
+
+            # down_proj: (E, inter, hidden) or (1, E, inter, hidden) -> EP + hidden TP
+            #   - E: "model" (4-way EP)
+            #   - inter: None (input replicated)
+            #   - hidden: "batch" (2-way, output sharded)
+            shard_specs[mlp.experts.down_proj] = ("model", None, "batch")
+            shard_specs[mlp.experts.down_proj_bias] = ("model", "batch")
 
             return shard_specs
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/3095)

### Problem description
Today we support dense mlp in gpt oss, however to efficient MoE support it needs to be sparse. Now that we have op in tt-metal (`ttnn.sparse_matmul`), we can use it for sparsity.

### What's changed
Introduce sparse_matmul as a custom op (XLA/CPU backends) and SparseMLP, a drop-in replacement for MoE MLP layers that uses sparse_matmul to skip inactive expert computation. Currently tailored to GPT-OSS MLP structure (fused gate_up_proj with interleaved layout, GEGLU activation); future work will generalize this to support other MoE architectures.

### Checklist
- [ ] New/Existing tests provide coverage for changes
