### PR TITLE
Add n300 tensor-parallel JAX model tests for models that cannot run on llmbox

### DIFF
--- a/.github/workflows/test-matrix-presets/model-test-passing.json
+++ b/.github/workflows/test-matrix-presets/model-test-passing.json
@@ -6,6 +6,7 @@
   { "runs-on": "n150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "n150 and nightly and expected_passing and not large", "parallel-groups": 1 },
   { "runs-on": "p150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "p150 and nightly and expected_passing and not large", "parallel-groups": 1 },
   { "runs-on": "n300-llmbox", "name": "run_forge_models_multichip", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "n300-llmbox and nightly and tensor_parallel and expected_passing", "parallel-groups": 1 },
+  { "runs-on": "n300", "name": "run_forge_models_multichip", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "n300 and nightly and tensor_parallel and expected_passing", "parallel-groups": 1 },
   { "runs-on": "n150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "n150 and nightly and expected_passing and large", "shared-runners": "true" },
   { "runs-on": "p150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "p150 and nightly and expected_passing and large", "shared-runners": "true" },
   { "runs-on": "n300-llmbox", "name": "run_forge_models_llm_multichip", "dir": "./tests/runner/test_models.py::test_llms_torch", "test-mark": "n300-llmbox and nightly and tensor_parallel and expected_passing", "parallel-groups": 1 },


### PR DESCRIPTION
Similar to PyTorch, JAX needs to run some tests solo on n300 in tensor-parallel mode.

  ### Changes
  - Added n300 test configuration for JAX models with tensor_parallel marker
  - These models cannot currently be executed on n300-llmbox, so they run solo on n300 instead


  **Qwen 2.5 Models (EXPECTED_PASSING):**
  1. `qwen_2_5/causal_lm/jax-0_5b-tensor_parallel-inference`
  2. `qwen_2_5/causal_lm/jax-0_5b_instruct-tensor_parallel-inference`
  3. `qwen_2_5/causal_lm/jax-1_5b_instruct-tensor_parallel-inference`
  4. `qwen_2_5/causal_lm/jax-3b-tensor_parallel-inference`
  5. `qwen_2_5/causal_lm/jax-3b_instruct-tensor_parallel-inference`

  **Qwen 2.5 Coder Models (EXPECTED_PASSING):**
  6. `qwen_2_5_coder/causal_lm/jax-0_5b-tensor_parallel-inference`
  7. `qwen_2_5_coder/causal_lm/jax-1_5b-tensor_parallel-inference`
  8. `qwen_2_5_coder/causal_lm/jax-1_5b_instruct-tensor_parallel-inference`
  9. `qwen_2_5_coder/causal_lm/jax-3b-tensor_parallel-inference`
  10. `qwen_2_5_coder/causal_lm/jax-3b_instruct-tensor_parallel-inference`