### PR TITLE
Cleaning presets that are not used or conflicting

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -13,13 +13,8 @@
           "CMAKE_C_COMPILER_LAUNCHER": "ccache",
           "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
           "CMAKE_EXPORT_COMPILE_COMMANDS": "YES",
-          "TTMLIR_ENABLE_EXPLORER": "ON",
-          "TT_METAL_ENABLE_LOGGING": "ON",
           "TT_RUNTIME_DEBUG": "ON",
-          "TT_RUNTIME_ENABLE_PERF_TRACE": "ON",
-          "TTMLIR_BUILD_TYPE": "Debug",
-          "TTMLIR_ENABLE_BINDINGS_PYTHON": "ON",
-          "TTMETAL_ENABLE_PYTHON_BINDINGS": "ON"
+          "TTMLIR_BUILD_TYPE": "Debug"
         },
         "cmakeExecutable": "sea_cmake"
       },
@@ -36,7 +31,6 @@
           "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
           "CMAKE_EXPORT_COMPILE_COMMANDS": "YES",
           "TTMLIR_BUILD_TYPE": "Release",
-          "TTMLIR_ENABLE_BINDINGS_PYTHON": "ON",
           "TT_RUNTIME_DEBUG": "OFF"
         },
         "cmakeExecutable": "sea_cmake"


### PR DESCRIPTION
Some presets from `CMakePresets.json` were not passed down to tt-mlir / tt-metal and therefore useless, so this PR deletes them:`TTMETAL_ENABLE_PYTHON_BINDINGS, TT_RUNTIME_ENABLE_PERF_TRACE, TT_METAL_ENABLE_LOGGING, TTMLIR_ENABLE_EXPLORER`

Additionally, flag `TTMLIR_ENABLE_BINDINGS_PYTHON` included ttrt build in tt-xla repo which has a requirement for torch 2.7 (while tt-xla torch has been upgraded to 2.9) and this causes a conflict in a build: 

```
/localdev/user/tt-xla/venv/lib/python3.11/site-packages/_XLAC.cpython-311-x86_64-linux-gnu.so: undefined symbol: _ZNK3c1010TensorImpl39sym_is_non_overlapping_and_dense_customEv
```

