### PR TITLE
Copy over metadata info when replacing layernorm module

### DIFF
--- a/python_package/tt_torch/composite_ops.py
+++ b/python_package/tt_torch/composite_ops.py
@@ -178,6 +178,9 @@ def replace_layer_norm_module(
         new_node = gm.graph.call_function(
             composite_layer_norm, args=(input_tensor,), kwargs=kwargs
         )
+        # Copy metadata from original node to preserve stack_trace and nn_module_stack
+        # This ensures layer_norm maintains proper source location in MLIR output
+        new_node.meta = node.meta.copy()
 
     node.replace_all_uses_with(new_node)
     gm.graph.erase_node(node)


### PR DESCRIPTION
### Ticket
N/A

### Problem description
When replacing layernorm module in `composite_ops.py`, metadata isn't copied over to the new node. This loses all the important info, like original naming, stack traces, etc.

### What's changed
Set original metadata onto new node.

### Checklist
- [ ] New/Existing tests provide coverage for changes
