### PR TITLE
[pjrt] log error messages in release build

### DIFF
--- a/pjrt_implementation/inc/utils/utils.h
+++ b/pjrt_implementation/inc/utils/utils.h
@@ -59,9 +59,9 @@ invoke_noexcept(Fn &&fn, Args &&...args) noexcept {
           std::invoke(std::forward<Fn>(fn), std::forward<Args>(args)...)};
     }
   } catch (const std::exception &ex) {
-    DLOG_F(ERROR, "Exception:\n{%s}\n", ex.what());
+    LOG_F(ERROR, "Exception:\n{%s}\n", ex.what());
   } catch (...) {
-    DLOG_F(ERROR, "Unknown exception.");
+    LOG_F(ERROR, "Unknown exception.");
   }
 
   return std::nullopt;

--- a/pjrt_implementation/src/api/buffer_instance.cc
+++ b/pjrt_implementation/src/api/buffer_instance.cc
@@ -332,7 +332,7 @@ tt_pjrt_status BufferInstance::copyToHost(void *host_buffer,
       e->markAsReady(tt_pjrt_status::kSuccess);
 
     } catch (const std::exception &error) {
-      DLOG_F(ERROR, "Copy to host buffer failed with error: %s", error.what());
+      LOG_F(ERROR, "Copy to host buffer failed with error: %s", error.what());
       e->markAsReady(tt_pjrt_status::kInternal);
     }
   });
@@ -362,7 +362,7 @@ tt_pjrt_status BufferInstance::copyToDeviceMemory(DeviceInstance *dst_device,
   // PJRT API specification requires returning error in case of copying to same
   // device/memory space.
   if (getMemory() == dst_memory || getDevice() == dst_device) {
-    DLOG_F(ERROR, "Cannot copy buffer to the same memory or device");
+    LOG_F(ERROR, "Cannot copy buffer to the same memory or device");
     return tt_pjrt_status::kInvalidArgument;
   }
 
@@ -380,7 +380,7 @@ tt_pjrt_status BufferInstance::copyToDeviceMemory(DeviceInstance *dst_device,
 
 tt_pjrt_status BufferInstance::createDataReadyEvent(EventInstance **out_event) {
   if (m_data_ready_event) {
-    DLOG_F(ERROR, "Buffer marked as data ready multiple times");
+    LOG_F(ERROR, "Buffer marked as data ready multiple times");
     return tt_pjrt_status::kInternal;
   }
 
@@ -523,7 +523,7 @@ PJRT_Error *onBufferCopyToMemory(PJRT_Buffer_CopyToMemory_Args *args) {
   // Copying into to host memory is undefined, since it's not clear
   // when we should use it, since PJRT_Buffer_ToHostBuffer is used for this.
   if (dst_memory->isHostMemory()) {
-    DLOG_F(ERROR, "Copying buffer to host memory is not supported");
+    LOG_F(ERROR, "Copying buffer to host memory is not supported");
     return *ErrorInstance::makeError(tt_pjrt_status::kUnimplemented).release();
   }
 

--- a/pjrt_implementation/src/api/client_instance.cc
+++ b/pjrt_implementation/src/api/client_instance.cc
@@ -41,12 +41,11 @@ static std::string getRankBindingPath(const std::string &metal_home) {
 
   const char *rank_binding = std::getenv("TT_DISTRIBUTED_RANK_BINDING");
   if (!rank_binding) {
-    DLOG_F(ERROR,
-           "TT_DISTRIBUTED_RANK_BINDING environment variable is not set");
+    LOG_F(ERROR, "TT_DISTRIBUTED_RANK_BINDING environment variable is not set");
     return "";
   }
   if (rank_binding_paths.find(rank_binding) == rank_binding_paths.end()) {
-    DLOG_F(ERROR, "Invalid rank binding: %s", rank_binding);
+    LOG_F(ERROR, "Invalid rank binding: %s", rank_binding);
     return "";
   }
 
@@ -54,8 +53,8 @@ static std::string getRankBindingPath(const std::string &metal_home) {
       std::filesystem::path(metal_home) / rank_binding_paths.at(rank_binding);
 
   if (std::filesystem::exists(rank_binding_path) == false) {
-    DLOG_F(ERROR, "Rank binding file does not exist at path: %s",
-           rank_binding_path.c_str());
+    LOG_F(ERROR, "Rank binding file does not exist at path: %s",
+          rank_binding_path.c_str());
     return "";
   }
 
@@ -66,13 +65,13 @@ static std::string getDistributedWorkerPath() {
   const char *distributed_worker_path =
       std::getenv("TT_DISTRIBUTED_WORKER_PATH");
   if (!distributed_worker_path) {
-    DLOG_F(ERROR, "TT_DISTRIBUTED_WORKER_PATH environment variable is not set");
+    LOG_F(ERROR, "TT_DISTRIBUTED_WORKER_PATH environment variable is not set");
     return "";
   }
 
   if (std::filesystem::exists(distributed_worker_path) == false) {
-    DLOG_F(ERROR, "Distributed worker file does not exist at path: %s",
-           distributed_worker_path);
+    LOG_F(ERROR, "Distributed worker file does not exist at path: %s",
+          distributed_worker_path);
     return "";
   }
 
@@ -82,7 +81,7 @@ static std::string getDistributedWorkerPath() {
 static tt_pjrt_status launchDistributedRuntime() {
   const char *metal_home = std::getenv("TT_METAL_RUNTIME_ROOT");
   if (!metal_home) {
-    DLOG_F(ERROR, "TT_METAL_RUNTIME_ROOT environment variable is not set");
+    LOG_F(ERROR, "TT_METAL_RUNTIME_ROOT environment variable is not set");
     return tt_pjrt_status::kInternal;
   }
   tt::runtime::setMetalHome(metal_home);
@@ -131,7 +130,7 @@ static tt_pjrt_status setMemoryLogLevel() {
   } else if (memory_log_level_str == "any" || memory_log_level_str == "all") {
     log_level = tt::runtime::MemoryLogLevel::ANY;
   } else {
-    DLOG_F(ERROR, "Invalid memory logging level: %s", memory_log_level_env);
+    LOG_F(ERROR, "Invalid memory logging level: %s", memory_log_level_env);
     return tt_pjrt_status::kInternal;
   }
 
@@ -251,9 +250,9 @@ tt_pjrt_status ClientInstance::populateDevices() {
 
   m_system_descriptor.store(m_cached_system_descriptor_path.data());
   if (std::filesystem::exists(m_cached_system_descriptor_path) == false) {
-    DLOG_F(ERROR,
-           "Failed to store the system descriptor to the disk using path: %s",
-           m_cached_system_descriptor_path.c_str());
+    LOG_F(ERROR,
+          "Failed to store the system descriptor to the disk using path: %s",
+          m_cached_system_descriptor_path.c_str());
     return tt_pjrt_status::kInternal;
   }
 
@@ -284,7 +283,7 @@ tt_pjrt_status ClientInstance::populateDevices() {
   }
 
   if (m_addressable_devices_raw.empty()) {
-    DLOG_F(ERROR, "Found no addressable devices in the system");
+    LOG_F(ERROR, "Found no addressable devices in the system");
     return tt_pjrt_status::kInternal;
   }
 
@@ -345,7 +344,7 @@ tt_pjrt_status ClientInstance::compileMlirProgram(
           device_id < static_cast<int64_t>(m_addressable_devices_raw.size())) {
         addressable_devices.push_back(m_addressable_devices_raw[device_id]);
       } else {
-        DLOG_F(ERROR, "Invalid device ID %ld in DeviceAssignment", device_id);
+        LOG_F(ERROR, "Invalid device ID %ld in DeviceAssignment", device_id);
         return tt_pjrt_status::kInvalidArgument;
       }
     }
@@ -522,7 +521,7 @@ PJRT_Error *onClientCreate(PJRT_Client_Create_Args *args) {
   PJRT_Error *error = GlobalClientInstanceSingleton::initClient();
 
   if (error) {
-    DLOG_F(ERROR, "Failed to initialize PJRT client instance");
+    LOG_F(ERROR, "Failed to initialize PJRT client instance");
     return error;
   }
 
@@ -612,7 +611,7 @@ PJRT_Error *onClientLookupDevice(PJRT_Client_LookupDevice_Args *args) {
     }
   }
 
-  DLOG_F(ERROR, "Client device lookup failed for device with ID: %d", args->id);
+  LOG_F(ERROR, "Client device lookup failed for device with ID: %d", args->id);
 
   return *ErrorInstance::makeError(tt_pjrt_status::kInvalidArgument).release();
 }
@@ -630,9 +629,9 @@ PJRT_Error *onClientLookupAddressableDevice(
     }
   }
 
-  DLOG_F(ERROR,
-         "Client addressable device lookup failed for device with local ID: %d",
-         args->local_hardware_id);
+  LOG_F(ERROR,
+        "Client addressable device lookup failed for device with local ID: %d",
+        args->local_hardware_id);
 
   return *ErrorInstance::makeError(tt_pjrt_status::kInvalidArgument).release();
 }
@@ -669,10 +668,10 @@ PJRT_Error *onClientCompile(PJRT_Client_Compile_Args *args) {
   std::string_view program_format(args->program->format,
                                   args->program->format_size);
   if (program_format != module_builder::c_mlir_format_name) {
-    DLOG_F(ERROR,
-           "Program code format \"%s\" is not supported, only MLIR format is "
-           "currently supported",
-           args->program->format);
+    LOG_F(ERROR,
+          "Program code format \"%s\" is not supported, only MLIR format is "
+          "currently supported",
+          args->program->format);
     return *ErrorInstance::makeError(tt_pjrt_status::kUnimplemented).release();
   }
 
@@ -706,13 +705,13 @@ onBufferFromHostBuffer(PJRT_Client_BufferFromHostBuffer_Args *args) {
 
   if (args->device_layout &&
       args->device_layout->type != PJRT_Buffer_MemoryLayout_Type_Strides) {
-    DLOG_F(ERROR,
-           "Copying from host is supported only with strided memory layout");
+    LOG_F(ERROR,
+          "Copying from host is supported only with strided memory layout");
     return *ErrorInstance::makeError(tt_pjrt_status::kUnimplemented).release();
   }
 
   if (args->num_byte_strides != 0 && args->num_byte_strides != args->num_dims) {
-    DLOG_F(ERROR, "Invalid `num_byte_strides` argument");
+    LOG_F(ERROR, "Invalid `num_byte_strides` argument");
     return *ErrorInstance::makeError(tt_pjrt_status::kInvalidArgument)
                 .release();
   }
@@ -724,8 +723,8 @@ onBufferFromHostBuffer(PJRT_Client_BufferFromHostBuffer_Args *args) {
   // otherwise we copy data to `memory`."
   if (memory_instance) {
     if (device_instance && device_instance != memory_instance->getDevice()) {
-      DLOG_F(ERROR, "Device set in `device` arg is different from the memory "
-                    "space device set in `memory` arg");
+      LOG_F(ERROR, "Device set in `device` arg is different from the memory "
+                   "space device set in `memory` arg");
       return *ErrorInstance::makeError(tt_pjrt_status::kInvalidArgument)
                   .release();
     }
@@ -735,18 +734,18 @@ onBufferFromHostBuffer(PJRT_Client_BufferFromHostBuffer_Args *args) {
   }
 
   if (!memory_instance) {
-    DLOG_F(ERROR, "Memory space is not set either in `memory` arg nor in "
-                  "device from `device` arg");
+    LOG_F(ERROR, "Memory space is not set either in `memory` arg nor in "
+                 "device from `device` arg");
     return *ErrorInstance::makeError(tt_pjrt_status::kInvalidArgument)
                 .release();
   }
   if (memory_instance->isHostMemory()) {
-    DLOG_F(ERROR, "We only support creating buffers on device memory");
+    LOG_F(ERROR, "We only support creating buffers on device memory");
     return *ErrorInstance::makeError(tt_pjrt_status::kUnimplemented).release();
   }
   if (!device_instance) {
-    DLOG_F(ERROR, "Device is not set either in `device` arg nor in device from "
-                  "`memory` arg");
+    LOG_F(ERROR, "Device is not set either in `device` arg nor in device from "
+                 "`memory` arg");
     return *ErrorInstance::makeError(tt_pjrt_status::kInvalidArgument)
                 .release();
   }

--- a/pjrt_implementation/src/api/compile_options_parser.cc
+++ b/pjrt_implementation/src/api/compile_options_parser.cc
@@ -50,7 +50,7 @@ bool CompileOptionsParser::parseCompileOptionsProto(
       compile_options_size);
 
   if (!unknown_fields.MergeFromCodedStream(&cis)) {
-    DLOG_F(ERROR, "Failed to parse compile options protobuf data");
+    LOG_F(ERROR, "Failed to parse compile options protobuf data");
     return false;
   }
 
@@ -209,8 +209,8 @@ tt_pjrt_status CompileOptionsParser::extractCustomProtobufFields(
 
     google::protobuf::UnknownFieldSet map_entry_fields;
     if (!map_entry_fields.MergeFromCodedStream(&cis)) {
-      DLOG_F(ERROR, "Failed to parse the map entry fields from the custom "
-                    "compile options protobuf data");
+      LOG_F(ERROR, "Failed to parse the map entry fields from the custom "
+                   "compile options protobuf data");
       return tt_pjrt_status::kInternal;
     }
 
@@ -237,8 +237,8 @@ tt_pjrt_status CompileOptionsParser::extractCustomProtobufFields(
 
         google::protobuf::UnknownFieldSet value_fields;
         if (!value_fields.MergeFromCodedStream(&override_stream)) {
-          DLOG_F(ERROR, "Failed to parse the map entry field value from the "
-                        "custom compile options protobuf data");
+          LOG_F(ERROR, "Failed to parse the map entry field value from the "
+                       "custom compile options protobuf data");
           return tt_pjrt_status::kInternal;
         }
 
@@ -280,8 +280,8 @@ tt_pjrt_status CompileOptionsParser::extractCustomProtobufFields(
           break;
         }
         default: {
-          DLOG_F(ERROR, "Unknown field number in OptionOverrideProto: %d",
-                 value_field.number());
+          LOG_F(ERROR, "Unknown field number in OptionOverrideProto: %d",
+                value_field.number());
           return tt_pjrt_status::kInternal;
         }
         }

--- a/pjrt_implementation/src/api/executable_instance.cc
+++ b/pjrt_implementation/src/api/executable_instance.cc
@@ -127,10 +127,10 @@ onExecutableOptimizedProgram(PJRT_Executable_OptimizedProgram_Args *args) {
     program->code_size = code_size;
   } else {
     if (program->code_size < code_size) {
-      DLOG_F(ERROR,
-             "Not enough space allocated for optimized program: expected %zu "
-             "bytes, allocated %zu bytes",
-             code_size, program->code_size);
+      LOG_F(ERROR,
+            "Not enough space allocated for optimized program: expected %zu "
+            "bytes, allocated %zu bytes",
+            code_size, program->code_size);
       return *ErrorInstance::makeError(tt_pjrt_status::kInvalidArgument)
                   .release();
     }

--- a/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
@@ -69,7 +69,7 @@ FlatbufferLoadedExecutableInstance::prepareInputTensor(
           m_executable_image->getInputSharding(arg_index), num_devices);
 
   if (mlir::failed(strategy)) {
-    DLOG_F(ERROR, "Failed to fill strategy map from sharding");
+    LOG_F(ERROR, "Failed to fill strategy map from sharding");
     return std::nullopt;
   }
 
@@ -189,14 +189,14 @@ tt_pjrt_status FlatbufferLoadedExecutableInstance::execute(
   LOG_BRINGUP_STAGE("RUNTIME_EXECUTION_START");
 
   if (args->num_devices != m_executable_image->getNumDevicesToUtilize()) {
-    DLOG_F(ERROR, "Device count mismatch: %zu vs %zu", args->num_devices,
-           m_executable_image->getNumDevicesToUtilize());
+    LOG_F(ERROR, "Device count mismatch: %zu vs %zu", args->num_devices,
+          m_executable_image->getNumDevicesToUtilize());
     return tt_pjrt_status::kInternal;
   }
 
   if (args->num_args != m_executable_image->getNumInputs()) {
-    DLOG_F(ERROR, "Argument count mismatch: %zu vs %zu", args->num_args,
-           m_executable_image->getNumInputs());
+    LOG_F(ERROR, "Argument count mismatch: %zu vs %zu", args->num_args,
+          m_executable_image->getNumInputs());
     return tt_pjrt_status::kInternal;
   }
 
@@ -240,10 +240,10 @@ tt_pjrt_status FlatbufferLoadedExecutableInstance::execute(
   std::vector<tt::runtime::Tensor> &output_tensors = *r;
 
   if (output_tensors.size() != m_executable_image->getNumOutputs()) {
-    DLOG_F(ERROR,
-           "Runtime produced different number of output tensors (%zu) than the "
-           "compiler estimated number of outputs (%zu)",
-           output_tensors.size(), m_executable_image->getNumOutputs());
+    LOG_F(ERROR,
+          "Runtime produced different number of output tensors (%zu) than the "
+          "compiler estimated number of outputs (%zu)",
+          output_tensors.size(), m_executable_image->getNumOutputs());
     return tt_pjrt_status::kInternal;
   }
 

--- a/pjrt_implementation/src/api/loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/loaded_executable_instance.cc
@@ -114,10 +114,10 @@ LoadedExecutableInstance::getOrCreateMeshDevice(
                       std::multiplies<std::uint32_t>{}));
 
   if (device_ids.size() != mesh_shape_num_devices) {
-    DLOG_F(ERROR,
-           "Input buffers are placed on a different number of devices (%zu) "
-           "than in the mesh shape estimated by the compiler (%zu)",
-           device_ids.size(), mesh_shape_num_devices);
+    LOG_F(ERROR,
+          "Input buffers are placed on a different number of devices (%zu) "
+          "than in the mesh shape estimated by the compiler (%zu)",
+          device_ids.size(), mesh_shape_num_devices);
     return std::nullopt;
   }
 
@@ -125,8 +125,8 @@ LoadedExecutableInstance::getOrCreateMeshDevice(
   if (device_instance &&
       !(device_ids.size() == 1 &&
         *device_ids.begin() == device_instance->getGlobalDeviceId())) {
-    DLOG_F(ERROR, "Input buffers are placed on a different device than the one "
-                  "specified in the execute_device argument");
+    LOG_F(ERROR, "Input buffers are placed on a different device than the one "
+                 "specified in the execute_device argument");
     return std::nullopt;
   }
 
@@ -191,13 +191,13 @@ tt_pjrt_status LoadedExecutableInstance::getInputRuntimeTensors(
     // Safety check to ensure no input tensor can be accidentally
     //  deallocated during execution, as it may be reused in a future graph.
     if (!tt::runtime::getTensorRetain(*prepared_tensor)) {
-      DLOG_F(ERROR, "Prepared input tensor should have retain=true or it may "
-                    "be deallocated during execution.");
+      LOG_F(ERROR, "Prepared input tensor should have retain=true or it may "
+                   "be deallocated during execution.");
       return tt_pjrt_status::kInternal;
     }
     if (!tt::runtime::isTensorAllocated(*prepared_tensor)) {
-      DLOG_F(ERROR, "Prepared input tensor is not allocated on device. This "
-                    "means it was deallocated by a previous operation.");
+      LOG_F(ERROR, "Prepared input tensor is not allocated on device. This "
+                   "means it was deallocated by a previous operation.");
       return tt_pjrt_status::kInternal;
     }
   }

--- a/pjrt_implementation/src/api/module_builder/frontend_passes/shlo_input_role_propagation.cc
+++ b/pjrt_implementation/src/api/module_builder/frontend_passes/shlo_input_role_propagation.cc
@@ -301,7 +301,7 @@ tt_pjrt_status annotateArgumentAttributesFromCustomCall(
 
   if (failed(mlir::applyPatternsGreedily(mlir_module.get(),
                                          std::move(patterns)))) {
-    DLOG_F(ERROR, "Failed to uplift mark parameters custom call");
+    LOG_F(ERROR, "Failed to uplift mark parameters custom call");
     return tt_pjrt_status::kInternal;
   }
 

--- a/pjrt_implementation/src/api/module_builder/module_builder.cc
+++ b/pjrt_implementation/src/api/module_builder/module_builder.cc
@@ -378,7 +378,7 @@ ModuleBuilder::buildModule(
         std::move(optimized_mlir_code), std::move(compile_options));
   }
 
-  DLOG_F(ERROR, "Unsupported backend option");
+  LOG_F(ERROR, "Unsupported backend option");
   return {tt_pjrt_status::kInvalidArgument, nullptr};
 }
 
@@ -392,7 +392,7 @@ ModuleBuilder::createVHLOModule(const std::string_view &mlir_code,
       mlir::ParserConfig{m_context.get(), /*verifyAfterParse=*/true});
 
   if (!vhlo_module) {
-    DLOG_F(ERROR, "Failed to create VHLO module from the input program code");
+    LOG_F(ERROR, "Failed to create VHLO module from the input program code");
     return tt_pjrt_status::kInternal;
   }
 
@@ -412,7 +412,7 @@ tt_pjrt_status ModuleBuilder::convertFromVHLOToSHLO(
   enableVerboseIRPrinting(vhlo_to_shlo_pm);
 
   if (mlir::failed(vhlo_to_shlo_pm.run(mlir_module.get()))) {
-    DLOG_F(ERROR, "Failed to convert from VHLO to SHLO module");
+    LOG_F(ERROR, "Failed to convert from VHLO to SHLO module");
     return tt_pjrt_status::kInternal;
   }
 
@@ -469,7 +469,7 @@ tt_pjrt_status ModuleBuilder::collectInputShardingsGSPMD(
   mlir::LogicalResult result =
       createShardingsFromGSPMD(gspmd_attributes, input_shardings);
   if (result.failed()) {
-    DLOG_F(ERROR, "Failed to create input shardings from GSPMD attributes");
+    LOG_F(ERROR, "Failed to create input shardings from GSPMD attributes");
     return tt_pjrt_status::kInternal;
   }
 
@@ -502,7 +502,7 @@ ModuleBuilder::collectInputShardingsShardy(
   mlir::LogicalResult result = createShardingsFromShardy(
       shardy_attributes, shardy_mesh, input_shardings);
   if (result.failed()) {
-    DLOG_F(ERROR, "Failed to create input shardings from Shardy attributes");
+    LOG_F(ERROR, "Failed to create input shardings from Shardy attributes");
     return std::nullopt;
   }
   return input_shardings;
@@ -533,7 +533,7 @@ tt_pjrt_status ModuleBuilder::collectOutputShardingsGSPMD(
   mlir::LogicalResult result =
       createShardingsFromGSPMD(gspmd_attributes, output_shardings);
   if (result.failed()) {
-    DLOG_F(ERROR, "Failed to create output shardings from GSPMD attributes");
+    LOG_F(ERROR, "Failed to create output shardings from GSPMD attributes");
     return tt_pjrt_status::kInternal;
   }
   return tt_pjrt_status::kSuccess;
@@ -569,9 +569,9 @@ ModuleBuilder::collectOutputShardingsShardy(
     }
 
     if (manual_computation_ops.size() != 1) {
-      DLOG_F(ERROR,
-             "Expected exactly zero or one manual computation op, found: %zu",
-             manual_computation_ops.size());
+      LOG_F(ERROR,
+            "Expected exactly zero or one manual computation op, found: %zu",
+            manual_computation_ops.size());
       return std::nullopt;
     }
     mlir::sdy::ManualComputationOp manual_op = manual_computation_ops[0];
@@ -586,7 +586,7 @@ ModuleBuilder::collectOutputShardingsShardy(
   mlir::LogicalResult result = createShardingsFromShardy(
       shardy_attributes, shardy_mesh, output_shardings);
   if (result.failed()) {
-    DLOG_F(ERROR, "Failed to create output shardings from Shardy attributes");
+    LOG_F(ERROR, "Failed to create output shardings from Shardy attributes");
     return std::nullopt;
   }
   return output_shardings;
@@ -616,8 +616,8 @@ tt_pjrt_status ModuleBuilder::collectNumArguments(
 
   std::vector<mlir::func::FuncOp> publicFuncOps = getPublicFuncOps(module);
   if (publicFuncOps.size() != 1) {
-    DLOG_F(ERROR, "Expected exactly one public function, found: %zu",
-           publicFuncOps.size());
+    LOG_F(ERROR, "Expected exactly one public function, found: %zu",
+          publicFuncOps.size());
     return tt_pjrt_status::kInternal;
   }
 
@@ -691,7 +691,7 @@ mlir::LogicalResult ModuleBuilder::createShardingsFromGSPMD(
           default_mesh_sharding_result =
               mlir::tt::gspmd_utils::GSPMDMeshSharding::generateDefault();
       if (default_mesh_sharding_result.takeError()) {
-        DLOG_F(ERROR, "Failed to generate default mesh sharding");
+        LOG_F(ERROR, "Failed to generate default mesh sharding");
         return llvm::LogicalResult::failure();
       }
       shardings.push_back(*default_mesh_sharding_result);
@@ -705,7 +705,7 @@ mlir::LogicalResult ModuleBuilder::createShardingsFromGSPMD(
                 mlir::tt::ttcore::ShardStatus::Unsharded,
                 mlir::tt::ttcore::MeshShardDirection::FullToShard);
     if (mesh_sharding_result.takeError()) {
-      DLOG_F(ERROR, "Failed to convert sharding attribute to mesh sharding");
+      LOG_F(ERROR, "Failed to convert sharding attribute to mesh sharding");
       return llvm::LogicalResult::failure();
     }
 
@@ -728,7 +728,7 @@ mlir::LogicalResult ModuleBuilder::createShardingsFromShardy(
           default_mesh_sharding_result =
               mlir::tt::shardy_utils::ShardyMeshSharding::generateDefault();
       if (llvm::Error e = default_mesh_sharding_result.takeError()) {
-        DLOG_F(ERROR, "Failed to generate default mesh sharding");
+        LOG_F(ERROR, "Failed to generate default mesh sharding");
         return llvm::LogicalResult::failure();
       }
       shardings.push_back(*default_mesh_sharding_result);
@@ -742,7 +742,7 @@ mlir::LogicalResult ModuleBuilder::createShardingsFromShardy(
                 mlir::tt::ttcore::ShardStatus::Unsharded,
                 mlir::tt::ttcore::MeshShardDirection::FullToShard);
     if (llvm::Error e = mesh_sharding_result.takeError()) {
-      DLOG_F(ERROR, "Failed to convert sharding attribute to mesh sharding");
+      LOG_F(ERROR, "Failed to convert sharding attribute to mesh sharding");
       return llvm::LogicalResult::failure();
     }
 
@@ -765,7 +765,7 @@ tt_pjrt_status ModuleBuilder::runCompilerStableHLOPipeline(
   enableVerboseIRPrinting(stablehlo_pipeline_pm);
 
   if (mlir::failed(stablehlo_pipeline_pm.run(mlir_module.get()))) {
-    DLOG_F(ERROR, "Failed to run stablehlo pipeline");
+    LOG_F(ERROR, "Failed to run stablehlo pipeline");
     return tt_pjrt_status::kInternal;
   }
 
@@ -773,7 +773,7 @@ tt_pjrt_status ModuleBuilder::runCompilerStableHLOPipeline(
 
   if (!tt_pjrt_status_is_ok(
           frontend_passes::setProperSdyMeshAttributeInSpmdMode(mlir_module))) {
-    DLOG_F(ERROR, "Failed to set proper sdy.mesh attribute in SPMD mode");
+    LOG_F(ERROR, "Failed to set proper sdy.mesh attribute in SPMD mode");
     return tt_pjrt_status::kInternal;
   }
 
@@ -797,7 +797,7 @@ tt_pjrt_status ModuleBuilder::convertFromSHLOToTTIR(
   enableVerboseIRPrinting(shlo_to_ttir_pm);
 
   if (mlir::failed(shlo_to_ttir_pm.run(mlir_module.get()))) {
-    DLOG_F(ERROR, "Failed to convert from SHLO to TTIR module");
+    LOG_F(ERROR, "Failed to convert from SHLO to TTIR module");
     return tt_pjrt_status::kInternal;
   }
 
@@ -914,7 +914,7 @@ tt_pjrt_status ModuleBuilder::convertFromTTIRToTTNN(
   if (tt::runtime::getCurrentHostRuntime() ==
           tt::runtime::HostRuntime::Distributed &&
       compile_options.optimization_level > 0) {
-    DLOG_F(ERROR, "Optimizer passes are not supported in distributed runtime");
+    LOG_F(ERROR, "Optimizer passes are not supported in distributed runtime");
     return tt_pjrt_status::kInternal;
   }
 
@@ -980,9 +980,9 @@ tt_pjrt_status ModuleBuilder::convertFromTTIRToTTNN(
   }
 
   if (devices_mesh_shape.size() != 2) {
-    DLOG_F(ERROR,
-           "Invalid mesh shape size: %zu. Shape must have two dimensions!",
-           devices_mesh_shape.size());
+    LOG_F(ERROR,
+          "Invalid mesh shape size: %zu. Shape must have two dimensions!",
+          devices_mesh_shape.size());
     return tt_pjrt_status::kInternal;
   }
 
@@ -1009,7 +1009,7 @@ tt_pjrt_status ModuleBuilder::convertFromTTIRToTTNN(
   client_instance->closeOptimizerSubmesh();
 
   if (mlir::failed(mlir_result)) {
-    DLOG_F(ERROR, "Failed to convert from TTIR to TTNN module");
+    LOG_F(ERROR, "Failed to convert from TTIR to TTNN module");
     return tt_pjrt_status::kInternal;
   }
 
@@ -1042,7 +1042,7 @@ tt_pjrt_status ModuleBuilder::verifyCreatedFlatbufferBinary(
     const std::vector<mlir::tt::sharding_utils::MeshSharding>
         &output_shardings) {
   if (flatbuffer_binary.handle == nullptr) {
-    DLOG_F(ERROR, "Failed to generate flatbuffer binary");
+    LOG_F(ERROR, "Failed to generate flatbuffer binary");
     return tt_pjrt_status::kInternal;
   }
 
@@ -1054,18 +1054,18 @@ tt_pjrt_status ModuleBuilder::verifyCreatedFlatbufferBinary(
   size_t num_outputs = output_specs.size();
 
   if (num_inputs != input_shardings.size()) {
-    DLOG_F(ERROR,
-           "Created flatbuffer binary contains different number of inputs %zu"
-           "than expected from the m_input_shardings %zu",
-           num_inputs, input_shardings.size());
+    LOG_F(ERROR,
+          "Created flatbuffer binary contains different number of inputs %zu"
+          "than expected from the m_input_shardings %zu",
+          num_inputs, input_shardings.size());
     return tt_pjrt_status::kInternal;
   }
 
   if (num_outputs != output_shardings.size()) {
-    DLOG_F(ERROR,
-           "Created flatbuffer binary contains different number of outputs %zu "
-           "than expected from the m_output_shardings %zu",
-           num_outputs, output_shardings.size());
+    LOG_F(ERROR,
+          "Created flatbuffer binary contains different number of outputs %zu "
+          "than expected from the m_output_shardings %zu",
+          num_outputs, output_shardings.size());
     return tt_pjrt_status::kInternal;
   }
 
@@ -1093,18 +1093,18 @@ tt_pjrt_status ModuleBuilder::checkOutputShardingShapes(
         output_specs[output_index].shape;
 
     if (shard_shape.size() != output_shape.size()) {
-      DLOG_F(ERROR,
-             "Output sharding shape (%zu) doesn't match the output shape (%zu)",
-             shard_shape.size(), output_shape.size());
+      LOG_F(ERROR,
+            "Output sharding shape (%zu) doesn't match the output shape (%zu)",
+            shard_shape.size(), output_shape.size());
 
       return tt_pjrt_status::kInternal;
     }
 
     for (size_t shard_dim = 0; shard_dim < shard_shape.size(); ++shard_dim) {
       if (output_shape[shard_dim] % shard_shape[shard_dim] != 0) {
-        DLOG_F(ERROR,
-               "Output shape (%u) is not divisible by the sharding shape (%zu)",
-               output_shape[shard_dim], shard_shape[shard_dim]);
+        LOG_F(ERROR,
+              "Output shape (%u) is not divisible by the sharding shape (%zu)",
+              output_shape[shard_dim], shard_shape[shard_dim]);
 
         return tt_pjrt_status::kInternal;
       }
@@ -1296,7 +1296,7 @@ ModuleBuilder::performCodegen(std::string_view ttnn_mlir,
          "export_path compile option is not set.");
 
   if (!m_tt_alchemist_handler.isInitialized()) {
-    DLOG_F(ERROR, "tt-alchemist library or functions not available");
+    LOG_F(ERROR, "tt-alchemist library or functions not available");
     return tt_pjrt_status::kInternal;
   }
 
@@ -1309,7 +1309,7 @@ ModuleBuilder::performCodegen(std::string_view ttnn_mlir,
 
   void *instance = m_tt_alchemist_handler.getInstanceFunc()();
   if (!instance) {
-    DLOG_F(ERROR, "Failed to get tt-alchemist instance");
+    LOG_F(ERROR, "Failed to get tt-alchemist instance");
     return tt_pjrt_status::kInternal;
   }
 
@@ -1350,7 +1350,7 @@ ModuleBuilder::performCodegen(std::string_view ttnn_mlir,
   }
 
   if (!result) {
-    DLOG_F(ERROR, "tt-alchemist generatePython failed");
+    LOG_F(ERROR, "tt-alchemist generatePython failed");
     return tt_pjrt_status::kInternal;
   }
 

--- a/pjrt_implementation/src/api/so_loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/so_loaded_executable_instance.cc
@@ -80,14 +80,14 @@ SOLoadedExecutableInstance::execute(PJRT_LoadedExecutable_Execute_Args *args) {
   DLOG_F(LOG_DEBUG, "SOLoadedExecutableInstance::Execute");
 
   if (args->num_devices != m_executable_image->getNumDevicesToUtilize()) {
-    DLOG_F(ERROR, "Device count mismatch: %zu vs %zu", args->num_devices,
-           m_executable_image->getNumDevicesToUtilize());
+    LOG_F(ERROR, "Device count mismatch: %zu vs %zu", args->num_devices,
+          m_executable_image->getNumDevicesToUtilize());
     return tt_pjrt_status::kInternal;
   }
 
   if (args->num_args != m_executable_image->getNumInputs()) {
-    DLOG_F(ERROR, "Argument count mismatch: %zu vs %zu", args->num_args,
-           m_executable_image->getNumInputs());
+    LOG_F(ERROR, "Argument count mismatch: %zu vs %zu", args->num_args,
+          m_executable_image->getNumInputs());
     return tt_pjrt_status::kInternal;
   }
 
@@ -193,7 +193,7 @@ SOLoadedExecutableInstance::prepareInputTensor(
           m_executable_image->getInputSharding(arg_index), num_devices);
 
   if (mlir::failed(strategy)) {
-    DLOG_F(ERROR, "Failed to fill strategy map from sharding");
+    LOG_F(ERROR, "Failed to fill strategy map from sharding");
     return std::nullopt;
   }
 


### PR DESCRIPTION
Error messages were being logged with `DLOG_F` which is a no-op in `Release` builds. Changing it to `LOG_F` so that we can see what is failing on `Release` builds.