### PR TITLE
Deepseek attention and MLP tests

### DIFF
--- a/tests/torch/graphs/test_attention.py
+++ b/tests/torch/graphs/test_attention.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import os
-import sys
 from typing import Callable
 
 import numpy as np
@@ -37,12 +35,6 @@ from transformers.models.xlm_roberta.modeling_xlm_roberta import XLMRobertaSelfA
 from tests.torch.models.deepseek_v3_2_exp.modified_model import MLA as DeepseekMLA
 from tests.torch.models.deepseek_v3_2_exp.modified_model import (
     ModelArgs as DeepseekModelArgs,
-)
-from tests.torch.models.kimi_k2.configuration_deepseek import (
-    DeepseekV3Config as KimiK2Config,
-)
-from tests.torch.models.kimi_k2.modeling_deepseek import (
-    DeepseekV3Attention as KimiK2Attention,
 )
 from tests.utils import parametrize_arch
 from third_party.tt_forge_models.bert.masked_lm.pytorch.loader import (
@@ -2503,76 +2495,6 @@ def test_deepseek_attention_module(seq_len, arch):
     run_graph_test(
         attention,
         [hidden_states, start_pos, freqs_cis, mask],
-        framework=Framework.TORCH,
-        comparison_config=comparison_config,
-        mesh=mesh,
-        shard_spec_fn=get_shard_spec,
-    )
-
-
-"""Kimi K2 attention tests"""
-
-
-@pytest.mark.nightly
-@parametrize_arch(["single_device", "llmbox"])
-@pytest.mark.parametrize("seq_len", [1024])
-def test_kimi_k2_attention_module(seq_len, arch):
-    xr.set_device_type("TT")
-
-    model_dir = os.path.join(os.path.dirname(__file__), "../models/kimi_k2")
-    sys.path.append(os.path.abspath(model_dir))
-
-    current_dir = os.path.dirname(__file__)
-    config_path = os.path.join(current_dir, "../models/kimi_k2/config.json")
-
-    config = KimiK2Config.from_json_file(config_path)
-
-    # Override for single layer testing
-    config.num_hidden_layers = 1
-    config.use_cache = False
-
-    attention = KimiK2Attention(config, layer_idx=0).to(torch.bfloat16)
-
-    batch_size = 4
-    hidden_states = torch.randn(
-        (batch_size, seq_len, config.hidden_size), dtype=torch.bfloat16
-    )
-    attention_mask = torch.rand(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
-    position_ids = torch.arange(seq_len).unsqueeze(0)
-
-    past_key_value = None
-
-    # Setup for tensor parallel
-    if arch == "llmbox":
-        num_devices = xr.global_runtime_device_count()
-        mesh_shape = (2, 4)
-        device_ids = np.array(range(num_devices))
-        mesh = Mesh(device_ids, mesh_shape, ("batch", "model"))
-
-        def get_shard_spec(attention, args, kwargs):
-            """Returns shard specifications for the layer's parameters."""
-            shard_specs = {}
-
-            shard_specs[args[0]] = ("model", None, "batch")
-            shard_specs[attention.q_b_proj.weight] = ("model", "batch")
-            shard_specs[attention.kv_b_proj.weight] = ("model", "batch")
-            shard_specs[attention.o_proj.weight] = ("batch", "model")
-
-            # Consume hidden states, TP on batch dimension
-            shard_specs[attention.q_a_proj.weight] = ("model", "batch")
-            shard_specs[attention.kv_a_proj_with_mqa.weight] = ("model", "batch")
-
-            return shard_specs
-
-    else:
-        mesh = None
-        get_shard_spec = None
-
-    comparison_config = ComparisonConfig(pcc=PccConfig(required_pcc=0.99))
-
-    run_graph_test(
-        attention,
-        [hidden_states, attention_mask, position_ids, past_key_value, False, False],
         framework=Framework.TORCH,
         comparison_config=comparison_config,
         mesh=mesh,

--- a/tests/torch/graphs/test_attention.py
+++ b/tests/torch/graphs/test_attention.py
@@ -2521,7 +2521,9 @@ import sys
 model_dir = os.path.join(os.path.dirname(__file__), "../models/kimi_k2")
 sys.path.append(os.path.abspath(model_dir))
 
-from tests.torch.models.kimi_k2.configuration_deepseek import DeepseekV3Config
+from tests.torch.models.kimi_k2.configuration_deepseek import (
+    DeepseekV3Config as KimiK2Config,
+)
 from tests.torch.models.kimi_k2.modeling_deepseek import (
     DeepseekV3Attention as KimiK2Attention,
 )
@@ -2536,7 +2538,7 @@ def test_kimi_k2_attention_module(seq_len, arch):
     current_dir = os.path.dirname(__file__)
     config_path = os.path.join(current_dir, "../models/kimi_k2/config.json")
 
-    config = DeepseekV3Config.from_json_file(config_path)
+    config = KimiK2Config.from_json_file(config_path)
 
     # Override for single layer testing
     config.num_hidden_layers = 1

--- a/tests/torch/graphs/test_attention.py
+++ b/tests/torch/graphs/test_attention.py
@@ -2533,7 +2533,7 @@ def test_kimi_k2_attention_module(seq_len, arch):
 
     attention = KimiK2Attention(config, layer_idx=0).to(torch.bfloat16)
 
-    batch_size = 2
+    batch_size = 4
     hidden_states = torch.randn(
         (batch_size, seq_len, config.hidden_size), dtype=torch.bfloat16
     )
@@ -2545,7 +2545,7 @@ def test_kimi_k2_attention_module(seq_len, arch):
     # Setup for tensor parallel
     if arch == "llmbox":
         num_devices = xr.global_runtime_device_count()
-        mesh_shape = (batch_size, num_devices // batch_size)
+        mesh_shape = (2, 4)
         device_ids = np.array(range(num_devices))
         mesh = Mesh(device_ids, mesh_shape, ("batch", "model"))
 
@@ -2553,14 +2553,14 @@ def test_kimi_k2_attention_module(seq_len, arch):
             """Returns shard specifications for the layer's parameters."""
             shard_specs = {}
 
-            shard_specs[args[0]] = (None, None, "batch")
-            shard_specs[attention.q_b_proj.weight] = ("model", None)
-            shard_specs[attention.kv_b_proj.weight] = ("model", None)
+            shard_specs[args[0]] = ("model", None, "batch")
+            shard_specs[attention.q_b_proj.weight] = ("model", "batch")
+            shard_specs[attention.kv_b_proj.weight] = ("model", "batch")
             shard_specs[attention.o_proj.weight] = ("batch", "model")
 
             # Consume hidden states, TP on batch dimension
-            shard_specs[attention.q_a_proj.weight] = (None, "batch")
-            shard_specs[attention.kv_a_proj_with_mqa.weight] = (None, "batch")
+            shard_specs[attention.q_a_proj.weight] = ("model", "batch")
+            shard_specs[attention.kv_a_proj_with_mqa.weight] = ("model", "batch")
 
             return shard_specs
 

--- a/tests/torch/graphs/test_mlp.py
+++ b/tests/torch/graphs/test_mlp.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import os
-import sys
 from typing import Callable
 
 import numpy as np
@@ -26,11 +24,6 @@ from tests.torch.models.deepseek_v3_2_exp.modified_model import (
     ModelArgs as DeepseekModelArgs,
 )
 from tests.torch.models.deepseek_v3_2_exp.modified_model import MoE as DeepseekMoE
-from tests.torch.models.kimi_k2.configuration_deepseek import (
-    DeepseekV3Config as KimiK2Config,
-)
-from tests.torch.models.kimi_k2.modeling_deepseek import DeepseekV3MLP as KimiK2MLP
-from tests.torch.models.kimi_k2.modeling_deepseek import DeepseekV3MoE as KimiK2MoE
 from tests.utils import parametrize_arch
 from third_party.tt_forge_models.falcon.pytorch.loader import (
     ModelLoader as FalconModelLoader,
@@ -598,85 +591,6 @@ def test_deepseek_mlp(mlp_type, seq_len, arch):
 
             # input sharding
             shard_specs[args[0]] = ("batch", None, "model")
-
-            return shard_specs
-
-    else:
-        mesh = None
-        get_shard_spec = None
-
-    run_graph_test(
-        mlp,
-        [hidden_states],
-        framework=Framework.TORCH,
-        mesh=mesh,
-        shard_spec_fn=get_shard_spec,
-    )
-
-
-"""Kimi K2 MLP tests"""
-
-
-# NOTE: Decoder layer has two MLPs, one with MoE and one without
-@pytest.mark.nightly
-@parametrize_arch(["single_device", "llmbox"])
-@pytest.mark.parametrize("seq_len", [1024])
-@pytest.mark.parametrize(
-    "mlp_type",
-    [
-        "mlp",
-        pytest.param(
-            "moe",
-            marks=pytest.mark.xfail(
-                reason="Torch Dynamo fails at a scalar addition (start_idx + num_tokens) as it treats one of the operands as a NumPy array instead of a Tensor."
-            ),
-        ),
-    ],
-)
-def test_kimi_k2_mlp(mlp_type, seq_len, arch):
-    xr.set_device_type("TT")
-
-    model_dir = os.path.join(os.path.dirname(__file__), "../models/kimi_k2")
-    sys.path.append(os.path.abspath(model_dir))
-
-    current_dir = os.path.dirname(__file__)
-    config_path = os.path.join(current_dir, "../models/kimi_k2/config.json")
-
-    config = KimiK2Config.from_json_file(config_path)
-
-    if mlp_type == "mlp":
-        mlp = KimiK2MLP(config).to(torch.bfloat16)
-    elif mlp_type == "moe":
-        mlp = KimiK2MoE(config).to(torch.bfloat16)
-        mlp.eval()
-        seq_len = 32  # hardcoded for now to test the MoE.Bigger seq_len takes longer.
-
-    batch_size = 4
-    hidden_states = torch.randn(
-        (batch_size, seq_len, config.hidden_size), dtype=torch.bfloat16
-    )
-
-    if arch == "llmbox":
-        num_devices = xr.global_runtime_device_count()
-        mesh_shape = (2, 4)
-        device_ids = np.array(range(num_devices))
-        mesh = Mesh(device_ids, mesh_shape, ("batch", "model"))
-
-        def get_shard_spec(mlp, args, kwargs):
-            shard_specs = {}
-
-            if hasattr(mlp, "experts"):
-                for expert in mlp.experts:
-                    shard_specs[expert.gate_proj.weight] = ("model", "batch")
-                    shard_specs[expert.up_proj.weight] = ("model", "batch")
-                    shard_specs[expert.down_proj.weight] = ("batch", "model")
-            else:
-                shard_specs[mlp.gate_proj.weight] = ("model", "batch")
-                shard_specs[mlp.up_proj.weight] = ("model", "batch")
-                shard_specs[mlp.down_proj.weight] = ("batch", "model")
-
-            # input sharding
-            shard_specs[args[0]] = ("model", None, "batch")
 
             return shard_specs
 

--- a/tests/torch/graphs/test_mlp.py
+++ b/tests/torch/graphs/test_mlp.py
@@ -556,6 +556,7 @@ def test_deepseek_mlp(mlp_type, seq_len, arch):
         mlp = DeepseekMLP(args.dim, args.inter_dim).to(torch.bfloat16)
     elif mlp_type == "moe":
         mlp = DeepseekMoE(args).to(torch.bfloat16)
+        seq_len = 32  # hardcoded for now to test the MoE
 
     batch_size = 2
     hidden_states = torch.randn(batch_size, seq_len, args.dim, dtype=torch.bfloat16)
@@ -625,6 +626,8 @@ def test_kimi_k2_mlp(mlp_type, seq_len, arch):
         mlp = KimiK2MLP(config).to(torch.bfloat16)
     elif mlp_type == "moe":
         mlp = KimiK2MoE(config).to(torch.bfloat16)
+        mlp.eval()
+        seq_len = 32  # hardcoded for now to test the MoE
 
     batch_size = 2
     hidden_states = torch.randn(

--- a/tests/torch/graphs/test_mlp.py
+++ b/tests/torch/graphs/test_mlp.py
@@ -580,6 +580,9 @@ def test_deepseek_mlp(mlp_type, seq_len, arch):
                 shard_specs[mlp.w2.weight] = (None, "model")  # inter_dim, dim
                 shard_specs[mlp.w3.weight] = ("model", None)  # dim, inter_dim
 
+            # input sharding
+            shard_specs[args[0]] = ("batch", None, "model")
+
             return shard_specs
 
     else:
@@ -652,6 +655,9 @@ def test_kimi_k2_mlp(mlp_type, seq_len, arch):
                 shard_specs[mlp.gate_proj.weight] = ("model", None)
                 shard_specs[mlp.up_proj.weight] = ("model", None)
                 shard_specs[mlp.down_proj.weight] = (None, "model")
+
+            # input sharding
+            shard_specs[args[0]] = ("batch", None, "model")
 
             return shard_specs
 

--- a/tests/torch/graphs/test_mlp.py
+++ b/tests/torch/graphs/test_mlp.py
@@ -588,13 +588,13 @@ def test_deepseek_mlp(mlp_type, seq_len, arch):
 
             if hasattr(mlp, "experts"):
                 for expert in mlp.experts:
-                    shard_specs[expert.w1.weight] = ("model", None)  # dim, inter_dim
-                    shard_specs[expert.w2.weight] = (None, "model")  # inter_dim, dim
-                    shard_specs[expert.w3.weight] = ("model", None)  # dim, inter_dim
+                    shard_specs[expert.w1.weight] = ("model", "batch")  # dim, inter_dim
+                    shard_specs[expert.w2.weight] = ("batch", "model")  # inter_dim, dim
+                    shard_specs[expert.w3.weight] = ("model", "batch")  # dim, inter_dim
             else:
-                shard_specs[mlp.w1.weight] = ("model", None)  # dim, inter_dim
-                shard_specs[mlp.w2.weight] = (None, "model")  # inter_dim, dim
-                shard_specs[mlp.w3.weight] = ("model", None)  # dim, inter_dim
+                shard_specs[mlp.w1.weight] = ("model", "batch")  # dim, inter_dim
+                shard_specs[mlp.w2.weight] = ("batch", "model")  # inter_dim, dim
+                shard_specs[mlp.w3.weight] = ("model", "batch")  # dim, inter_dim
 
             # input sharding
             shard_specs[args[0]] = ("batch", None, "model")


### PR DESCRIPTION
### Ticket
[tt-xla #2954](https://github.com/tenstorrent/tt-xla/issues/2954)

### Problem description
As a part of ongoing effort to run Deepseek, attention and MLP tests needed to be added.

### What's changed
Test running the attention module of Deepseek have been added to run on nightly. Deepseek attention tests have been xfailed as they fail on an L1 cache error.

Tests running the MLP of Deepseek have been added to run on nightly.
Test is parametrized on MLP type, as it has regular MLP as well as MoE.
MoE currently xfailed: Deepseek MoE fails due to a ttnn.sort op not accepting float32.

### Checklist
- [ ] New/Existing tests provide coverage for changes
