### PR TITLE
Kimi K2 attention and MLP tests

### DIFF
--- a/tests/torch/graphs/test_attention.py
+++ b/tests/torch/graphs/test_attention.py
@@ -2521,7 +2521,9 @@ import sys
 model_dir = os.path.join(os.path.dirname(__file__), "../models/kimi_k2")
 sys.path.append(os.path.abspath(model_dir))
 
-from tests.torch.models.kimi_k2.configuration_deepseek import DeepseekV3Config
+from tests.torch.models.kimi_k2.configuration_deepseek import (
+    DeepseekV3Config as KimiK2Config,
+)
 from tests.torch.models.kimi_k2.modeling_deepseek import (
     DeepseekV3Attention as KimiK2Attention,
 )
@@ -2536,7 +2538,7 @@ def test_kimi_k2_attention_module(seq_len, arch):
     current_dir = os.path.dirname(__file__)
     config_path = os.path.join(current_dir, "../models/kimi_k2/config.json")
 
-    config = DeepseekV3Config.from_json_file(config_path)
+    config = KimiK2Config.from_json_file(config_path)
 
     # Override for single layer testing
     config.num_hidden_layers = 1

--- a/tests/torch/graphs/test_mlp.py
+++ b/tests/torch/graphs/test_mlp.py
@@ -572,14 +572,14 @@ def test_kimi_k2_mlp(mlp_type, seq_len, arch):
         mlp.eval()
         seq_len = 32  # hardcoded for now to test the MoE.Bigger seq_len takes longer.
 
-    batch_size = 2
+    batch_size = 4
     hidden_states = torch.randn(
         (batch_size, seq_len, config.hidden_size), dtype=torch.bfloat16
     )
 
     if arch == "llmbox":
         num_devices = xr.global_runtime_device_count()
-        mesh_shape = (batch_size, num_devices // batch_size)
+        mesh_shape = (2, 4)
         device_ids = np.array(range(num_devices))
         mesh = Mesh(device_ids, mesh_shape, ("batch", "model"))
 
@@ -597,7 +597,7 @@ def test_kimi_k2_mlp(mlp_type, seq_len, arch):
                 shard_specs[mlp.down_proj.weight] = ("batch", "model")
 
             # input sharding
-            shard_specs[args[0]] = ("batch", None, "model")
+            shard_specs[args[0]] = ("model", None, "batch")
 
             return shard_specs
 

--- a/tests/torch/graphs/test_mlp.py
+++ b/tests/torch/graphs/test_mlp.py
@@ -556,6 +556,7 @@ def test_deepseek_mlp(mlp_type, seq_len, arch):
         mlp = DeepseekMLP(args.dim, args.inter_dim).to(torch.bfloat16)
     elif mlp_type == "moe":
         mlp = DeepseekMoE(args).to(torch.bfloat16)
+        seq_len = 32  # hardcoded for now to test the MoE
 
     batch_size = 2
     hidden_states = torch.randn(batch_size, seq_len, args.dim, dtype=torch.bfloat16)
@@ -625,6 +626,8 @@ def test_kimi_k2_mlp(mlp_type, seq_len, arch):
         mlp = KimiK2MLP(config).to(torch.bfloat16)
     elif mlp_type == "moe":
         mlp = KimiK2MoE(config).to(torch.bfloat16)
+        mlp.eval()
+        seq_len = 32  # hardcoded for now to test the MoE
 
     batch_size = 2
     hidden_states = torch.randn(

--- a/tests/torch/graphs/test_mlp.py
+++ b/tests/torch/graphs/test_mlp.py
@@ -21,11 +21,6 @@ from transformers.models.mistral.modeling_mistral import MistralMLP
 from transformers.models.qwen2.modeling_qwen2 import Qwen2MLP
 from transformers.models.qwen3.modeling_qwen3 import Qwen3MLP
 
-from tests.torch.models.deepseek_v3_2_exp.modified_model import MLP as DeepseekMLP
-from tests.torch.models.deepseek_v3_2_exp.modified_model import (
-    ModelArgs as DeepseekModelArgs,
-)
-from tests.torch.models.deepseek_v3_2_exp.modified_model import MoE as DeepseekMoE
 from tests.torch.models.kimi_k2.configuration_deepseek import (
     DeepseekV3Config as KimiK2Config,
 )
@@ -540,80 +535,6 @@ def test_gpt_oss_mlp(variant, variant_config, arch):
     )
 
 
-"""Deepseek MLP test"""
-
-
-# NOTE: Deepseek Decoder layer has two MLPs, one with MoE and one without
-@pytest.mark.nightly
-@parametrize_arch(["single_device", "llmbox"])
-@pytest.mark.parametrize("seq_len", [1024])
-@pytest.mark.parametrize(
-    "mlp_type",
-    [
-        "mlp",
-        pytest.param(
-            "moe",
-            marks=pytest.mark.xfail(
-                reason="Fails on ttnn.sort as it doesnt support fp32 input types."
-            ),
-        ),
-    ],
-)
-def test_deepseek_mlp(mlp_type, seq_len, arch):
-    xr.set_device_type("TT")
-
-    # Create model args with a single layer for testing
-    args = DeepseekModelArgs(
-        n_layers=1,
-        q_lora_rank=3072,
-    )
-
-    if mlp_type == "mlp":
-        mlp = DeepseekMLP(args.dim, args.inter_dim).to(torch.bfloat16)
-    elif mlp_type == "moe":
-        mlp = DeepseekMoE(args).to(torch.bfloat16)
-        seq_len = 32  # hardcoded for now to test the MoE. Bigger seq_len takes longer.
-
-    batch_size = 2
-    hidden_states = torch.randn(batch_size, seq_len, args.dim, dtype=torch.bfloat16)
-
-    if arch == "llmbox":
-        num_devices = xr.global_runtime_device_count()
-        mesh_shape = (batch_size, num_devices // batch_size)
-        device_ids = np.array(range(num_devices))
-        mesh = Mesh(device_ids, mesh_shape, ("batch", "model"))
-
-        def get_shard_spec(mlp, args, kwargs):
-            shard_specs = {}
-
-            if hasattr(mlp, "experts"):
-                for expert in mlp.experts:
-                    shard_specs[expert.w1.weight] = ("model", "batch")  # dim, inter_dim
-                    shard_specs[expert.w2.weight] = ("batch", "model")  # inter_dim, dim
-                    shard_specs[expert.w3.weight] = ("model", "batch")  # dim, inter_dim
-            else:
-                shard_specs[mlp.w1.weight] = ("model", "batch")  # dim, inter_dim
-                shard_specs[mlp.w2.weight] = ("batch", "model")  # inter_dim, dim
-                shard_specs[mlp.w3.weight] = ("model", "batch")  # dim, inter_dim
-
-            # input sharding
-            shard_specs[args[0]] = ("batch", None, "model")
-
-            return shard_specs
-
-    else:
-        mesh = None
-        get_shard_spec = None
-
-    run_graph_test(
-        mlp,
-        [hidden_states],
-        framework=Framework.TORCH,
-        mesh=mesh,
-        shard_spec_fn=get_shard_spec,
-    )
-
-
 """Kimi K2 MLP tests"""
 
 
@@ -667,13 +588,13 @@ def test_kimi_k2_mlp(mlp_type, seq_len, arch):
 
             if hasattr(mlp, "experts"):
                 for expert in mlp.experts:
-                    shard_specs[expert.gate_proj.weight] = ("model", None)
-                    shard_specs[expert.up_proj.weight] = ("model", None)
-                    shard_specs[expert.down_proj.weight] = (None, "model")
+                    shard_specs[expert.gate_proj.weight] = ("model", "batch")
+                    shard_specs[expert.up_proj.weight] = ("model", "batch")
+                    shard_specs[expert.down_proj.weight] = ("batch", "model")
             else:
-                shard_specs[mlp.gate_proj.weight] = ("model", None)
-                shard_specs[mlp.up_proj.weight] = ("model", None)
-                shard_specs[mlp.down_proj.weight] = (None, "model")
+                shard_specs[mlp.gate_proj.weight] = ("model", "batch")
+                shard_specs[mlp.up_proj.weight] = ("model", "batch")
+                shard_specs[mlp.down_proj.weight] = ("batch", "model")
 
             # input sharding
             shard_specs[args[0]] = ("batch", None, "model")

--- a/tests/torch/graphs/test_mlp.py
+++ b/tests/torch/graphs/test_mlp.py
@@ -580,6 +580,9 @@ def test_deepseek_mlp(mlp_type, seq_len, arch):
                 shard_specs[mlp.w2.weight] = (None, "model")  # inter_dim, dim
                 shard_specs[mlp.w3.weight] = ("model", None)  # dim, inter_dim
 
+            # input sharding
+            shard_specs[args[0]] = ("batch", None, "model")
+
             return shard_specs
 
     else:
@@ -652,6 +655,9 @@ def test_kimi_k2_mlp(mlp_type, seq_len, arch):
                 shard_specs[mlp.gate_proj.weight] = ("model", None)
                 shard_specs[mlp.up_proj.weight] = ("model", None)
                 shard_specs[mlp.down_proj.weight] = (None, "model")
+
+            # input sharding
+            shard_specs[args[0]] = ("batch", None, "model")
 
             return shard_specs
 

--- a/tests/torch/graphs/test_mlp.py
+++ b/tests/torch/graphs/test_mlp.py
@@ -588,13 +588,13 @@ def test_deepseek_mlp(mlp_type, seq_len, arch):
 
             if hasattr(mlp, "experts"):
                 for expert in mlp.experts:
-                    shard_specs[expert.w1.weight] = ("model", None)  # dim, inter_dim
-                    shard_specs[expert.w2.weight] = (None, "model")  # inter_dim, dim
-                    shard_specs[expert.w3.weight] = ("model", None)  # dim, inter_dim
+                    shard_specs[expert.w1.weight] = ("model", "batch")  # dim, inter_dim
+                    shard_specs[expert.w2.weight] = ("batch", "model")  # inter_dim, dim
+                    shard_specs[expert.w3.weight] = ("model", "batch")  # dim, inter_dim
             else:
-                shard_specs[mlp.w1.weight] = ("model", None)  # dim, inter_dim
-                shard_specs[mlp.w2.weight] = (None, "model")  # inter_dim, dim
-                shard_specs[mlp.w3.weight] = ("model", None)  # dim, inter_dim
+                shard_specs[mlp.w1.weight] = ("model", "batch")  # dim, inter_dim
+                shard_specs[mlp.w2.weight] = ("batch", "model")  # inter_dim, dim
+                shard_specs[mlp.w3.weight] = ("model", "batch")  # dim, inter_dim
 
             # input sharding
             shard_specs[args[0]] = ("batch", None, "model")


### PR DESCRIPTION
### Ticket
[tt-xla #2954](https://github.com/tenstorrent/tt-xla/issues/2954)

### Problem description
As a part of ongoing effort to run Kimi K2, attention and MLP tests needed to be added.

### What's changed
Test running the attention module of Kimi K2 have been added to run on nightly.

Tests running the MLP of Kimi K2 have been added to run on nightly.
MLP tests are parametrized on MLP type, as it has regular MLP as well as MoE.
MoE is currently xfailed: fails due to a Dynamo compilation error.

### Checklist
- [ ] New/Existing tests provide coverage for changes
