### PR TITLE
Record input/output shapes for all model tests (Torch + JAX)

### DIFF
--- a/tests/infra/testers/single_chip/model/jax_model_tester.py
+++ b/tests/infra/testers/single_chip/model/jax_model_tester.py
@@ -54,6 +54,7 @@ class JaxModelTester(ModelTester):
     ) -> None:
 
         self._input_activations: Dict | Sequence[Any] = None
+        self._output_activations: Any = None
         self._input_parameters: PyTree = None
         self._has_batch_norm = has_batch_norm
 
@@ -88,6 +89,10 @@ class JaxModelTester(ModelTester):
         """Caches model inputs."""
         self._input_activations = self._get_input_activations()
         self._input_parameters = self._get_input_parameters()
+
+    def _cache_output_activations(self, output: Any) -> None:
+        """Cache forward output for reporting (e.g. input/output size)."""
+        self._output_activations = output
 
     def _get_input_parameters(self) -> PyTree:
         """
@@ -266,6 +271,7 @@ class JaxModelTester(ModelTester):
             args=[training_workload.args, training_workload.kwargs],
         )
         cpu_forward_out, cpu_pullback = self._run_on_cpu(train_fwd_cpu)
+        self._output_activations = cpu_forward_out
 
         # Compile workloads for TT device with vjp of model
         self._compile_for_tt_device(training_workload)

--- a/tests/infra/testers/single_chip/model/model_tester.py
+++ b/tests/infra/testers/single_chip/model/model_tester.py
@@ -157,12 +157,17 @@ class ModelTester(BaseTester, ABC):
         else:
             return self._test_training()
 
+    def _cache_output_activations(self, output) -> None:
+        """Cache forward output for shape reporting. Overridden by subclasses."""
+        pass
+
     def _test_inference(self, request=None) -> Tuple[ComparisonResult, ...] | None:
         """
         Tests the model by running inference on TT device and on CPU and comparing the
         results.
         """
         cpu_res = self._run_on_cpu(self._workload)
+        self._cache_output_activations(cpu_res)
 
         self._compile_for_tt_device(self._workload)
 

--- a/tests/infra/testers/single_chip/model/torch_model_tester.py
+++ b/tests/infra/testers/single_chip/model/torch_model_tester.py
@@ -80,6 +80,7 @@ class TorchModelTester(ModelTester):
     ) -> None:
 
         self._input_activations: Dict | Sequence[Any] = None
+        self._output_activations: Any = None
         self._parallelism = parallelism
         self._model_size = None
 
@@ -189,6 +190,10 @@ class TorchModelTester(ModelTester):
         """
         return output
 
+    def _cache_output_activations(self, output: Any) -> None:
+        """Cache unpacked forward output for reporting (e.g. input/output size)."""
+        self._output_activations = self._unpack_forward_output(output)
+
     def _extract_grads(
         self, model: torch.nn.Module
     ) -> Tuple[Dict[str, torch.Tensor], Set[str]]:
@@ -249,6 +254,7 @@ class TorchModelTester(ModelTester):
         # Run forward on CPU
         cpu_res = self._run_on_cpu(self._workload)
         cpu_res = self._unpack_forward_output(cpu_res)
+        self._output_activations = cpu_res
 
         # Generate random gradient
         random_grad = torch.randn(cpu_res.shape, dtype=cpu_res.dtype)

--- a/tests/runner/test_models.py
+++ b/tests/runner/test_models.py
@@ -32,6 +32,7 @@ from tests.runner.test_utils import (
     create_benchmark_result,
     find_dumped_ir_files,
     get_input_shape_info,
+    get_output_shape_info,
     get_xla_device_arch,
     record_model_test_properties,
     update_test_metadata_for_exception,
@@ -218,6 +219,17 @@ def _run_model_test_impl(
         finally:
             comparison_config = tester._comparison_config if tester else None
             model_size = None
+            input_shape = None
+            output_size = None
+
+            if tester is not None:
+                # Extract input/output shapes for all frameworks
+                _, _, _, input_shape = get_input_shape_info(
+                    getattr(tester, "_input_activations", None)
+                )
+                _, output_size = get_output_shape_info(
+                    getattr(tester, "_output_activations", None)
+                )
             if framework == Framework.TORCH and tester is not None:
                 model_size = getattr(tester, "_model_size", None)
 
@@ -236,6 +248,8 @@ def _run_model_test_impl(
                 comparison_config=comparison_config,
                 model_size=model_size,
                 weights_dtype=weights_dtype,
+                input_shape=input_shape,
+                output_size=output_size,
             )
 
             # prints perf benchmark results to console
@@ -243,10 +257,15 @@ def _run_model_test_impl(
             if framework == Framework.TORCH and run_mode == RunMode.INFERENCE:
                 measurements = getattr(tester, "_perf_measurements", None)
                 model_config = loader.load_config()
-                batch_size, input_sequence_length, input_size = (
+                batch_size, input_sequence_length, input_size, input_shape = (
                     get_input_shape_info(getattr(tester, "_input_activations", None))
                     if tester
-                    else (1, -1, (-1,))
+                    else (1, -1, (-1,), (1, -1))
+                )
+                _, output_size = (
+                    get_output_shape_info(getattr(tester, "_output_activations", None))
+                    if tester
+                    else (1, (-1,))
                 )
                 create_benchmark_result(
                     full_model_name=model_info.name,
@@ -262,8 +281,8 @@ def _run_model_test_impl(
                     device_arch=get_xla_device_arch(),
                     run_mode=str(run_mode),
                     device_name=socket.gethostname(),
-                    batch_size=batch_size,
-                    input_size=input_size,
+                    input_shape=input_shape,
+                    output_size=output_size,
                     num_layers=getattr(model_config, "num_hidden_layers", 0),
                     total_time=(
                         measurements[0].get("total_time", -1)

--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -528,6 +528,8 @@ def record_model_test_properties(
     comparison_config=None,
     model_size: int = None,
     weights_dtype: str = None,
+    input_shape: tuple = None,
+    output_size: tuple = None,
 ):
     """
     Record standard runtime properties for model tests and optionally control flow.
@@ -637,6 +639,14 @@ def record_model_test_properties(
     if model_size is not None:
         tags["model_size_billions"] = model_size / 1e9
 
+    # Add input/output shape information for Superset visualization
+    if input_shape is not None:
+        tags["input_shape"] = str(input_shape)
+        tags["batch_size"] = input_shape[0] if len(input_shape) > 0 else None
+        tags["input_size"] = str(input_shape[1:]) if len(input_shape) > 1 else "()"
+    if output_size is not None:
+        tags["output_size"] = str(output_size)
+
     # Add execution_pass if available
     execution_pass = getattr(test_metadata, "execution_pass", None)
     if execution_pass is not None:
@@ -709,29 +719,32 @@ def get_xla_device_arch():
     return ""
 
 
-def get_input_shape_info(inputs) -> tuple[int, int, tuple]:
-    """Extract batch_size, sequence_length, and input_size from input activations.
+def get_input_shape_info(inputs) -> tuple[int, int, tuple, tuple]:
+    """Extract batch_size, sequence_length, input_size, and input_shape from input activations.
 
     This function uses heuristics to determine shape information:
     - If inputs is a Mapping (dict), it tries to get 'input_ids' if present,
       otherwise uses the first value found (generally the primary input).
     - If inputs is a Sequence (list/tuple), it uses the first element.
-    - It assumes the extracted item is a torch.Tensor.
+    - Supports torch.Tensor, jax.Array, numpy.ndarray, and any array-like with .shape.
 
     Returns:
-        (batch_size, sequence_length, input_size)
-        For LLMs: input_size is (sequence_length,)
-        For image models: input_size is shape[1:] (e.g., (3, 224, 224))
-                         sequence_length will be -1 (not applicable)
+        (batch_size, sequence_length, input_size, input_shape)
+        - input_shape: full tensor shape including batch (e.g. (1, 3, 224, 224))
+        - input_size: shape[1:] (e.g. (3, 224, 224)); for LLMs (sequence_length,)
+        - sequence_length: -1 for image models, shape[1] for LLMs
 
-        Returns default (1, -1, (-1,)) if inputs are None, empty, or don't match expected formats.
+        Returns default (1, -1, (-1,), (1, -1)) if inputs are None, empty, or invalid.
     """
     if inputs is None:
-        return 1, -1, (-1,)
+        return 1, -1, (-1,), (1, -1)
 
-    # Get the first tensor to extract shape
+    # Get the first tensor/array to extract shape
     tensor = None
     if isinstance(inputs, torch.Tensor):
+        tensor = inputs
+    elif hasattr(inputs, "shape"):
+        # Single array (e.g. jax.Array, numpy.ndarray)
         tensor = inputs
     elif isinstance(inputs, collections.abc.Mapping):
         # Get 'input_ids' if present
@@ -744,22 +757,18 @@ def get_input_shape_info(inputs) -> tuple[int, int, tuple]:
         if len(inputs) > 0:
             tensor = inputs[0]
 
-    # Validate we got a tensor with a shape
-    if (
-        tensor is None
-        or not isinstance(tensor, torch.Tensor)
-        or not hasattr(tensor, "shape")
-    ):
-        return 1, -1, (-1,)
+    # Validate we got an array-like with a shape (torch.Tensor, jax.Array, etc.)
+    if tensor is None or not hasattr(tensor, "shape"):
+        return 1, -1, (-1,), (1, -1)
 
-    shape = tensor.shape
+    shape = tuple(tensor.shape)
     batch_size = shape[0] if len(shape) > 0 else 1
 
     if len(shape) >= 2:
         if len(shape) >= 4:
             # Image case [batch, channels, height, width]
             sequence_length = -1  # Not applicable for images
-            input_size = tuple(shape[1:])  # (channels, height, width)
+            input_size = shape[1:]  # (channels, height, width)
         else:
             # 2D or 3D: LLM case [batch, seq_len] or [batch, seq_len, hidden_dim]
             sequence_length = shape[1]
@@ -769,7 +778,47 @@ def get_input_shape_info(inputs) -> tuple[int, int, tuple]:
         sequence_length = -1
         input_size = (-1,)
 
-    return batch_size, sequence_length, input_size
+    input_shape = shape
+    return batch_size, sequence_length, input_size, input_shape
+
+
+def get_output_shape_info(output) -> tuple[int, tuple]:
+    """Extract batch_size and output_size from model output.
+
+    Uses the same heuristics as get_input_shape_info for dict/sequence/tensor.
+    Supports torch.Tensor, jax.Array, numpy.ndarray, and any array-like with .shape.
+
+    For dicts, prefers the 'logits' key (common for transformer models).
+
+    Returns:
+        (batch_size, output_size) where output_size is shape[1:] of the
+        chosen tensor, or (1, (-1,)) if output is None or invalid.
+    """
+    if output is None:
+        return 1, (-1,)
+
+    tensor = None
+    if isinstance(output, torch.Tensor):
+        tensor = output
+    elif isinstance(output, collections.abc.Mapping):
+        if "logits" in output:
+            tensor = output["logits"]
+        elif len(output) > 0:
+            tensor = next(iter(output.values()))
+    elif isinstance(output, collections.abc.Sequence) and not isinstance(output, str):
+        if len(output) > 0:
+            tensor = output[0]
+    elif hasattr(output, "shape"):
+        # Single array (e.g. jax.Array, numpy.ndarray)
+        tensor = output
+
+    if tensor is None or not hasattr(tensor, "shape"):
+        return 1, (-1,)
+
+    shape = tuple(tensor.shape)
+    batch_size = shape[0] if len(shape) > 0 else 1
+    output_size = shape[1:] if len(shape) > 1 else (-1,)
+    return batch_size, output_size
 
 
 def create_measurement(
@@ -807,6 +856,8 @@ def create_benchmark_result(
     device_name: str = "",
     batch_size: int = 1,
     input_size: tuple = (1, 1),
+    input_shape: tuple = None,
+    output_size: tuple = None,
     num_layers: int = 0,
     total_time: float = -1,
     total_samples: int = 0,
@@ -869,15 +920,27 @@ def create_benchmark_result(
         "device_arch": device_arch,
     }
 
+    # Prefer input_shape (includes batch, e.g. (1, 3, 224, 224)); derive
+    # batch_size/input_size from it for backward compatibility.
+    if input_shape is not None:
+        _batch_size = input_shape[0] if len(input_shape) > 0 else 1
+        _input_size = input_shape[1:] if len(input_shape) > 1 else (1, 1)
+    else:
+        _batch_size = batch_size
+        _input_size = input_size
+
     benchmark_results = {
         "model": full_model_name,
         "model_type": model_type,
-        "run_type": f"{'_'.join(full_model_name.split())}_{batch_size}_{'_'.join([str(dim) for dim in input_size])}_{num_layers}",
+        "run_type": f"{'_'.join(full_model_name.split())}_{_batch_size}_{'_'.join([str(dim) for dim in _input_size])}_{num_layers}",
         "config": config,
         "measurements": metric_list,
         "device_info": device_info,
         "num_layers": num_layers,
-        "batch_size": batch_size,
+        "batch_size": _batch_size,
+        "input_size": list(_input_size),
+        "input_shape": list(input_shape) if input_shape is not None else None,
+        "output_size": list(output_size) if output_size is not None else None,
         "precision": data_format,
         "input_sequence_length": input_sequence_length,
         "training": training,


### PR DESCRIPTION
## Summary

- Record **input shapes** and **output sizes** for all model tests (both Torch and JAX) so they appear in Superset dashboards
- Add `get_output_shape_info()` utility to extract output tensor shapes (mirrors existing `get_input_shape_info()`)
- Extend `get_input_shape_info()` to return full `input_shape` tuple (including batch dim) and support JAX arrays / numpy ndarrays in addition to torch tensors
- Pass `input_shape`, `output_size`, and `batch_size` through `record_model_test_properties()` → test property tags, and through `create_benchmark_result()` → benchmark JSON

## What's changed

**`tests/runner/test_utils.py`**
- `get_input_shape_info()` now returns a 4-tuple `(batch_size, seq_len, input_size, input_shape)` and supports any array-like with `.shape` (torch, jax, numpy)
- New `get_output_shape_info()` extracts `(batch_size, output_size)` from model output; prefers `logits` key for transformer dict outputs
- `record_model_test_properties()` accepts `input_shape` / `output_size` and writes them as test tags (`input_shape`, `batch_size`, `input_size`, `output_size`)
- `create_benchmark_result()` accepts `input_shape` / `output_size` and includes them in benchmark JSON; derives `batch_size` and `input_size` from `input_shape` for backward compatibility

**`tests/runner/test_models.py`**
- `_run_model_test_impl()` extracts input/output shapes from the tester after each test run and passes them to both `record_model_test_properties()` and `create_benchmark_result()`

**`tests/infra/testers/single_chip/model/`**
- `model_tester.py`: base class gains `_cache_output_activations()` hook, called after CPU inference
- `torch_model_tester.py`: stores `_output_activations` (unpacked) during inference and training
- `jax_model_tester.py`: stores `_output_activations` during inference and training

## Test plan
- [x] All 13 existing unit tests for shape utilities pass
- [x] 7988 model tests collect successfully with no import errors
- [ ] Verify input_shape / output_size appear in Superset after a nightly run

🤖 Generated with [Claude Code](https://claude.com/claude-code)