### PR TITLE
Schedule uplift of tt-mlir for 03:00 UTC every day

### DIFF
--- a/.github/workflows/schedule-uplift.yml
+++ b/.github/workflows/schedule-uplift.yml
@@ -5,7 +5,7 @@ name: Nighty Uplift
 
 on:
   schedule:
-    - cron: '0 6 * * *'  # Runs at 06:00 UTC every day
+    - cron: '0 3 * * *'  # Runs at 03:00 UTC every day
   workflow_dispatch:  # Manual trigger
     inputs:
       force-overwrite:


### PR DESCRIPTION
Moves tt-mlir uplift workflow to run at 03:00 UTC every day. Nigthly, which is a much lighter workload now, runs at 00:00 UTC.