### PR TITLE
Update the inference test configs of transfuser, panoptic segmentation variants and detr

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -2208,7 +2208,7 @@ test_config:
 
   transfuser/pytorch-single_device-inference:
     status: KNOWN_FAILURE_XFAIL
-    reason: "Input tensor data type for ttnn.sort must be BFLOAT16 or UINT16, got DataType::FLOAT32 (https://github.com/tenstorrent/tt-xla/issues/3089)"
+    reason: "error: Shardy propagation doesn't support tuples: 'tuple<tensor<3x3xf32>, tensor<3xf32>>' (https://github.com/tenstorrent/tt-xla/issues/3257)"
 
   issac_groot/pytorch-GR00T_n1.5-3b-single_device-inference:
     status: NOT_SUPPORTED_SKIP
@@ -2268,15 +2268,15 @@ test_config:
 
   panoptic_segmentation/pytorch-resnet101_3x_coco-single_device-inference:
     status: KNOWN_FAILURE_XFAIL
-    reason: "torch._inductor.exc.InductorError: DynamicOutputShapeException: aten.repeat_interleave.Tensor, issue link: https://github.com/tenstorrent/tt-xla/issues/2310"
+    reason: "Can't convert shape rank (https://github.com/tenstorrent/tt-xla/issues/3258)"
 
   panoptic_segmentation/pytorch-resnet50_1x_coco-single_device-inference:
     status: KNOWN_FAILURE_XFAIL
-    reason: "torch._inductor.exc.InductorError: DynamicOutputShapeException: aten.repeat_interleave.Tensor, issue link: https://github.com/tenstorrent/tt-xla/issues/2310"
+    reason: "Can't convert shape rank (https://github.com/tenstorrent/tt-xla/issues/3258)"
 
   panoptic_segmentation/pytorch-resnet50_3x_coco-single_device-inference:
     status: KNOWN_FAILURE_XFAIL
-    reason: "torch._inductor.exc.InductorError: DynamicOutputShapeException: aten.repeat_interleave.Tensor, issue link: https://github.com/tenstorrent/tt-xla/issues/2310"
+    reason: "Can't convert shape rank (https://github.com/tenstorrent/tt-xla/issues/3258)"
 
   sam/pytorch-facebook/sam-vit-huge-single_device-inference:
     status: NOT_SUPPORTED_SKIP
@@ -2292,9 +2292,7 @@ test_config:
     status: EXPECTED_PASSING
 
   detr/object_detection/pytorch-resnet_50-single_device-inference:
-    assert_pcc: false
     status: EXPECTED_PASSING
-    reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.9024592638015747. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/1776"
 
   sentencizer/pytorch-xlm-roberta-base-single_device-inference:
     status: KNOWN_FAILURE_XFAIL


### PR DESCRIPTION
### Ticket

- closes https://github.com/tenstorrent/tt-xla/issues/2826
- closes https://github.com/tenstorrent/tt-xla/issues/3196
- closes https://github.com/tenstorrent/tt-xla/issues/3202
- https://github.com/tenstorrent/tt-xla/issues/3089

### Problem description

- `detr/object_detection/pytorch-resnet_50-single_device-inference` passing with PCC>0.99 on current main. So status need to be updated
- update the current failure in reason for transfuser & panoptic segmentation variants

### What's changed

- Removed `assert_pcc=false` from detr obj det variant's config
- updated the current failure in reason for transfuser & panoptic segmentation variants

### Checklist
- [x] verified the changes through local testing 

### Logs

- [logs.zip](https://github.com/user-attachments/files/25228714/logs.zip)

