### PR TITLE
Further splitting torch onPR tests

### DIFF
--- a/.github/workflows/test-matrix-presets/basic-test.json
+++ b/.github/workflows/test-matrix-presets/basic-test.json
@@ -1,6 +1,6 @@
 [
   { "runs-on": "wormhole_b0",        "name": "run_jax",               "dir": "./tests/jax/single_chip",                 "test-mark": "push and not large", "parallel-groups": 2 },
-  { "runs-on": "n150",               "name": "run_torch",             "dir": "./tests/torch",                           "test-mark": "push and single_device", "parallel-groups": 3, "shared-runners": "true" },
+  { "runs-on": "n150",               "name": "run_torch",             "dir": "./tests/torch",                           "test-mark": "push and single_device", "parallel-groups": 5, "shared-runners": "true" },
   { "runs-on": "wormhole_b0",        "name": "run_meta_infra_tests",  "dir": "./tests/infra_tests/single_chip",         "test-mark": "push" },
   { "runs-on": "p150",               "name": "run_jax",               "dir": "./tests/jax/single_chip",                 "test-mark": "push and not large", "parallel-groups": 2 },
   { "runs-on": "p150",               "name": "run_torch",             "dir": "./tests/torch",                           "test-mark": "push and single_device", "parallel-groups": 3  },


### PR DESCRIPTION
It seems that torch onPR tests take a longer time. Increasing the number of parallel runners from 3 to 5 to speed it up.