### PR TITLE
Adding codeowners to the `examples` folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,9 @@
 # CI
 /.github/ @vmilosevic @kmabeeTT @nsumrakTT @vvukomanTT
 
+# Examples
+/examples/ @mrakitaTT @ajakovljevicTT @AleksKnezevic @jameszianxuTT @kmabeeTT @ndrakulicTT @sdjukicTT @sgligorijevicTT @vzeljkovicTT @acicovicTT
+
 # Tests
 /tests/ @mrakitaTT @ajakovljevicTT @AleksKnezevic @jameszianxuTT @kmabeeTT @ndrakulicTT @sdjukicTT @sgligorijevicTT @vzeljkovicTT @acicovicTT
 /tests/infra/utilities/failing_reasons/ @mrakitaTT @ajakovljevicTT @AleksKnezevic @jameszianxuTT @kmabeeTT @ndrakulicTT @sdjukicTT @sgligorijevicTT @vzeljkovicTT @vbrkicTT @vobojevicTT @kmilanovicTT @nvukobratTT @dgolubovicTT @acicovicTT


### PR DESCRIPTION
Adding codeowners for the `examples` folder, as they previously did not have one. Copied from codeowners for `/tests/`