### PR TITLE
Fix update test durations script

### DIFF
--- a/.github/workflows/manual-update-durations.yml
+++ b/.github/workflows/manual-update-durations.yml
@@ -43,7 +43,7 @@ jobs:
               if echo "$conclusions" | grep -q -w "$conclusion"; then
                 break
               else
-                ((counter++))
+                ((++counter))
 
                 # Exit if the counter reaches $num
                 if [ $counter -ge $num ]; then


### PR DESCRIPTION
The workflow script runs with bash -e (GitHub Actions default). When the first run of a workflow (e.g. push-main.yml) doesn't match the expected conclusion, the script executes `((counter++))` with `counter=0`. In bash, post-increment evaluates the expression before incrementing, so ((0)) is falsy and returns exit code 1, which with bash -e silently kills the entire script. The fix replaces `((counter++))` with `((++counter))` (pre-increment), which evaluates to ((1)) and returns exit code 0.

Now produces correct update: 
https://github.com/tenstorrent/tt-xla/actions/workflows/manual-update-durations.yml