### PR TITLE
Enable mochi test

### DIFF
--- a/tests/torch/models/mochi/test_mochi_vae.py
+++ b/tests/torch/models/mochi/test_mochi_vae.py
@@ -23,7 +23,6 @@ _DRAM_OOM_SKIP_REASON = (
         pytest.param(
             ModelVariant.MOCHI,
             marks=[
-                pytest.mark.skip(reason=_DRAM_OOM_SKIP_REASON),
                 pytest.mark.record_test_properties(
                     category=Category.MODEL_TEST,
                     model_info=ModelLoader.get_model_info(ModelVariant.MOCHI),


### PR DESCRIPTION
Enabling just one mochi test out of two until we fix device memory release after each pytest.