### PR TITLE
Add gpt-oss-20b to llm benchmark with batch size = 16 

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -207,6 +207,12 @@
         "runs-on": "llmbox"
       },
       {
+        "name": "gpt_oss_20b_tp",
+        "pyreq": "datasets loguru pytest requests accelerate torch==2.9.0 tqdm transformers==4.57.1",
+        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp",
+        "runs-on": "llmbox"
+      },
+      {
         "name": "microsoft_phi-1",
         "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==4.57.1",
         "pytest": "tests/benchmark/test_llms.py::test_phi1"

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -67,6 +67,7 @@ def test_llm(
         experimental_enable_permute_matmul_fusion: Enable permute matmul fusion optimization
         read_logits_fn: Function to extract logits from model output
         required_pcc: Required PCC threshold
+        num_layers: Number of layers to override
     """
     model_loader = create_model_loader(
         ModelLoaderModule, num_layers=num_layers, variant=variant
@@ -93,6 +94,7 @@ def test_llm(
     enable_weight_bfp8_conversion={enable_weight_bfp8_conversion}
     experimental_enable_permute_matmul_fusion={experimental_enable_permute_matmul_fusion}
     required_pcc={required_pcc}
+    num_layers={num_layers}
     ttnn_perf_metrics_output_file={ttnn_perf_metrics_output_file}
     """
     )
@@ -185,8 +187,6 @@ def test_llm_tp(
         output_file=output_file,
         mesh_config_fn=mesh_config_fn,
         shard_spec_fn=shard_spec_fn,
-        batch_size=32,
-        input_sequence_length=128,
         arch=arch,
         num_layers=num_layers,
         request=request,
@@ -841,3 +841,21 @@ def test_llama_3_1_70b_tp(output_file, num_layers, request):
         request=request,
         required_pcc=-1.0,
     )  # https://github.com/tenstorrent/tt-xla/issues/2976
+
+
+def test_gpt_oss_20b_tp(output_file, num_layers, request):
+    from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
+        ModelLoader,
+        ModelVariant,
+    )
+
+    variant = ModelVariant.GPT_OSS_20B
+    test_llm_tp(
+        ModelLoader,
+        variant,
+        output_file,
+        num_layers=num_layers,
+        request=request,
+        batch_size=16,  # https://github.com/tenstorrent/tt-xla/issues/3251
+        optimization_level=0,  # https://github.com/tenstorrent/tt-mlir/issues/6949
+    )


### PR DESCRIPTION
### Ticket
None

### Problem description
Add gpt-oss-20b to benchmark

### What's changed
Several notes about gpt-oss-20b:
- Does not work with optimizer enabled due to the following errors:
    - https://github.com/tenstorrent/tt-mlir/issues/6840 [FIXED]
    - https://github.com/tenstorrent/tt-mlir/issues/6949 [OPEN]
- Encountered a runtime hang that could be overcome by either 
    - changing the input prompt to "Explain quantum mechanics." 
    - reducing the batch size
    - I went about by changing the batch size, and left a comment which includes reference to https://github.com/tenstorrent/tt-xla/issues/3251

### Checklist
- [X] https://github.com/tenstorrent/tt-xla/actions/runs/21948333500/job/63392825380
