### PR TITLE
Add option to use pre-installed docker wheel in benchmarks

### DIFF
--- a/.github/workflows/call-perf-test.yml
+++ b/.github/workflows/call-perf-test.yml
@@ -13,12 +13,19 @@ on:
         type: string
       artifact_run_id:
         description: "Run ID to download wheel artifact from"
-        required: true
+        required: false
         type: string
+        default: ''
       wheel_artifact_name:
         description: "Name of the wheel artifact"
-        required: true
+        required: false
         type: string
+        default: ''
+      use_docker_wheel:
+        description: "Use wheel from docker instead of building a new one"
+        required: false
+        type: boolean
+        default: false
       skip-device-perf:
         description: "Skip device performance measurement"
         required: false
@@ -119,6 +126,7 @@ jobs:
         fi
 
     - name: Download and install wheel
+      if: ${{ !inputs.use_docker_wheel }}
       shell: bash
       run: |
         echo "=== Downloading wheel ==="

--- a/.github/workflows/manual-benchmark.yml
+++ b/.github/workflows/manual-benchmark.yml
@@ -36,6 +36,11 @@ on:
         required: false
         type: boolean
         default: false
+      use_docker_wheel:
+        description: "Use wheel from docker"
+        required: false
+        type: boolean
+        default: false
       sh-runner:
         description: "Run on shared runner"
         required: false
@@ -51,6 +56,7 @@ permissions:
 
 jobs:
   docker-build:
+    if: ${{ !inputs.use_docker_wheel }}
     uses: ./.github/workflows/call-build-docker.yml
     secrets: inherit
     with:
@@ -58,6 +64,7 @@ jobs:
 
   build:
     needs: docker-build
+    if: ${{ !inputs.use_docker_wheel }}
     uses: ./.github/workflows/call-build.yml
     secrets: inherit
     with:
@@ -137,7 +144,7 @@ jobs:
 
   run-n150-perf-benchmarks:
     needs: [filter-tests, build]
-    if: ${{ needs.filter-tests.outputs.matrix_n150_skip == 'false' }}
+    if: ${{ !cancelled() && needs.filter-tests.result == 'success' && (needs.build.result == 'success' || needs.build.result == 'skipped') && needs.filter-tests.outputs.matrix_n150_skip == 'false' }}
     secrets: inherit
     uses: ./.github/workflows/call-perf-test.yml
     with:
@@ -145,13 +152,14 @@ jobs:
       docker_image: ${{ inputs.docker_image }}
       artifact_run_id: ${{ needs.build.outputs.artifacts_run_id }}
       wheel_artifact_name: ${{ needs.build.outputs.wheel_artifact_name }}
+      use_docker_wheel: ${{ inputs.use_docker_wheel || false }}
       skip-device-perf: ${{ inputs.skip-device-perf || false }}
       perf_regression_check: ${{ inputs.perf_regression_check || false }}
       sh-runner: ${{ inputs.sh-runner || false }}
 
   run-p150-perf-benchmarks:
     needs: [filter-tests, build]
-    if: ${{ needs.filter-tests.outputs.matrix_p150_skip == 'false' }}
+    if: ${{ !cancelled() && needs.filter-tests.result == 'success' && (needs.build.result == 'success' || needs.build.result == 'skipped') && needs.filter-tests.outputs.matrix_p150_skip == 'false' }}
     secrets: inherit
     uses: ./.github/workflows/call-perf-test.yml
     with:
@@ -159,13 +167,14 @@ jobs:
       docker_image: ${{ inputs.docker_image }}
       artifact_run_id: ${{ needs.build.outputs.artifacts_run_id }}
       wheel_artifact_name: ${{ needs.build.outputs.wheel_artifact_name }}
+      use_docker_wheel: ${{ inputs.use_docker_wheel || false }}
       skip-device-perf: ${{ inputs.skip-device-perf || false }}
       perf_regression_check: ${{ inputs.perf_regression_check || false }}
       sh-runner: ${{ inputs.sh-runner || false }}
 
   run-llmbox-perf-benchmarks:
     needs: [filter-tests, build]
-    if: ${{ needs.filter-tests.outputs.matrix_llmbox_skip == 'false' }}
+    if: ${{ !cancelled() && needs.filter-tests.result == 'success' && (needs.build.result == 'success' || needs.build.result == 'skipped') && needs.filter-tests.outputs.matrix_llmbox_skip == 'false' }}
     secrets: inherit
     uses: ./.github/workflows/call-perf-test.yml
     with:
@@ -173,6 +182,7 @@ jobs:
       docker_image: ${{ inputs.docker_image }}
       artifact_run_id: ${{ needs.build.outputs.artifacts_run_id }}
       wheel_artifact_name: ${{ needs.build.outputs.wheel_artifact_name }}
+      use_docker_wheel: ${{ inputs.use_docker_wheel || false }}
       skip-device-perf: ${{ inputs.skip-device-perf || false }}
       perf_regression_check: ${{ inputs.perf_regression_check || false }}
       sh-runner: ${{ inputs.sh-runner || false }}


### PR DESCRIPTION
Currently in Performance benchmark, wheel from latest commit is installed.
This PR adds the option "Use wheel from docker" to use pre-installed wheel on specified docker.

### Checklist
- [x] [Run](https://github.com/tenstorrent/tt-xla/actions/runs/21984052306) with "Use wheel from docker" checked (use wheel from docker)
- [x] [Run](https://github.com/tenstorrent/tt-xla/actions/runs/21984075300) with "Use wheel from docker" not checked (build wheel from latest commit)
- [x] [Run](https://github.com/tenstorrent/tt-xla/actions/runs/21984068340) with MLIR SHA override
