### PR TITLE
Add attention prefill and indexer tests for Deepseek v3.2-exp

### DIFF
--- a/python_package/tt_torch/torch_overrides.py
+++ b/python_package/tt_torch/torch_overrides.py
@@ -7,7 +7,6 @@ from torch.overrides import TorchFunctionMode
 
 class TorchFunctionOverride(TorchFunctionMode):
     def __torch_function__(self, func, types, args, kwargs=None):
-        kwargs = kwargs or {}
         if (
             func.__name__ == "matmul" or func.__name__ == "linear"
         ) and not torch.compiler.is_compiling():
@@ -20,7 +19,7 @@ class TorchFunctionOverride(TorchFunctionMode):
                 if len(args) > 2 and args[2] is not None:
                     res = res + args[2]
                 return res
-        return func(*args, **kwargs)
+        return func(*args, **(kwargs or {}))
 
 
 torch_function_override = TorchFunctionOverride()

--- a/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_2_exp.py
+++ b/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_2_exp.py
@@ -1,25 +1,18 @@
 # SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
-
-import os
-
 import numpy as np
 import pytest
-import scipy.linalg
 import torch
 import torch_xla
 import torch_xla.runtime as xr
 from infra import Framework, run_graph_test
 from infra.evaluators import ComparisonConfig, PccConfig
-from modified_model import Indexer, ModelArgs
+from modified_model import ModelArgs
 from modified_model import Transformer as ModifiedTransformer
-from modified_model import precompute_freqs_cis
 from torch_xla.distributed.spmd import Mesh
 
 from tests.utils import failed_ttmlir_compilation
-
-# from tests.torch.models.kimi_k2.utils import MLACache
 
 # This model is modified from the original deepseek_v3_2_exp model.py to:
 # 1. Use scipy.linalg.hadamard instead of fast_hadamard_transform


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/3102

### Problem description
Add tests for Deepseek v3.2-exp attention prefill and indexer modules.

### What's changed
- Within `modified_model.py`:
    - Added support for bf16 indexing.
    - Correctly initialized weights for all Linear, Gate, and ParallelEmbedding layers.
- Within `test_deepseek_v3_2_exp.py`:
    - Added attention prefill and indexer tests for llmbox with batch_sizes: 1, 4, 32, 64.

### Checklist
- [x] New/Existing tests provide coverage for changes
