### PR TITLE
[pjrt] add tracy zones

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,8 @@ if(TTXLA_ENABLE_EXPLORER)
     set(TTMLIR_ENABLE_BINDINGS_PYTHON ON)
 endif()
 
+option(TTXLA_TRACY_ZONES "Enable PJRT tracy zones" OFF)
+
 # ----- coverage_config -----
 
 add_library(coverage_config INTERFACE)

--- a/pjrt_implementation/src/CMakeLists.txt
+++ b/pjrt_implementation/src/CMakeLists.txt
@@ -7,11 +7,8 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # https://llvm.org/LICENSE.txt
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 add_subdirectory(api)
 add_subdirectory(utils)
-
-include(ExternalProject)
 
 # ----- TTPJRTBindings -----
 # Static lib that implements api bindings logic.

--- a/pjrt_implementation/src/api/CMakeLists.txt
+++ b/pjrt_implementation/src/api/CMakeLists.txt
@@ -38,9 +38,19 @@ add_library(TTPJRTApi
     "tensor_pool.cc"
 )
 
-target_include_directories(TTPJRTApi PUBLIC
+target_include_directories(TTPJRTApi
+PRIVATE
+    # Includes used in .cpp files.
+
+    # Used for tracy zones in PJRT.
+    ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/src/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/third_party/tracy/public
+PUBLIC
+    # Includes used in public headers.
+    ${PROJECT_SOURCE_DIR}/pjrt_implementation/inc
     ${TTMLIR_TOOLCHAIN_DIR}/src/shardy
     ${TTMLIR_TOOLCHAIN_DIR}/src/stablehlo
+    ${TTMLIR_TOOLCHAIN_DIR}/include
+    ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/install/include
 )
 
 target_link_libraries(TTPJRTApi
@@ -53,6 +63,14 @@ PRIVATE
 PUBLIC
     TTPJRTUtils
 )
+
+# Enable Tracy profiling if requested
+if(TTXLA_TRACY_ZONES)
+    # Define TRACY_ENABLE to enable Tracy zones in the code - this is used in `tracy` headers.
+    target_compile_definitions(TTPJRTApi PUBLIC TRACY_ENABLE)
+    target_link_libraries(TTPJRTApi PUBLIC tracy)
+    message(STATUS "PJRT tracy zones enabled")
+endif()
 
 target_link_directories(TTPJRTApi PUBLIC
     ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/install/lib

--- a/pjrt_implementation/src/api/client_instance.cc
+++ b/pjrt_implementation/src/api/client_instance.cc
@@ -16,6 +16,9 @@
 #include <map>
 #include <optional>
 
+// tracy includes
+#include "tracy/Tracy.hpp"
+
 // tt-mlir includes
 #include "tt/runtime/runtime.h"
 #include "tt/runtime/types.h"
@@ -573,6 +576,7 @@ tt::runtime::Device ClientInstance::getOrCreateOptimizerSubmesh(
 namespace internal {
 
 PJRT_Error *onClientCreate(PJRT_Client_Create_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "ClientInstance::PJRT_Client_Create");
 
   // We currently don't utilize any of the PJRT Client create options.
@@ -597,6 +601,7 @@ PJRT_Error *onClientCreate(PJRT_Client_Create_Args *args) {
 }
 
 PJRT_Error *onClientDestroy(PJRT_Client_Destroy_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "ClientInstance::PJRT_Client_Destroy");
 
   ClientInstance *client_instance = ClientInstance::unwrap(args->client);
@@ -608,6 +613,7 @@ PJRT_Error *onClientDestroy(PJRT_Client_Destroy_Args *args) {
 }
 
 PJRT_Error *onClientPlatformName(PJRT_Client_PlatformName_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "ClientInstance::PJRT_Client_PlatformName");
 
   ClientInstance *client = ClientInstance::unwrap(args->client);
@@ -619,6 +625,7 @@ PJRT_Error *onClientPlatformName(PJRT_Client_PlatformName_Args *args) {
 }
 
 PJRT_Error *onClientProcessIndex(PJRT_Client_ProcessIndex_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "ClientInstance::PJRT_Client_ProcessIndex");
 
   args->process_index = ClientInstance::unwrap(args->client)->getProcessIndex();
@@ -627,6 +634,7 @@ PJRT_Error *onClientProcessIndex(PJRT_Client_ProcessIndex_Args *args) {
 }
 
 PJRT_Error *onClientPlatformVersion(PJRT_Client_PlatformVersion_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "ClientInstance::PJRT_Client_PlatformVersion");
 
   ClientInstance *client = ClientInstance::unwrap(args->client);
@@ -638,6 +646,7 @@ PJRT_Error *onClientPlatformVersion(PJRT_Client_PlatformVersion_Args *args) {
 }
 
 PJRT_Error *onClientDevices(PJRT_Client_Devices_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "ClientInstance::PJRT_Client_Devices");
 
   const std::vector<DeviceInstance *> &devices_raw =
@@ -651,6 +660,7 @@ PJRT_Error *onClientDevices(PJRT_Client_Devices_Args *args) {
 
 PJRT_Error *
 onClientAddressableDevices(PJRT_Client_AddressableDevices_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "ClientInstance::PJRT_Client_AddressableDevices");
 
   const std::vector<DeviceInstance *> &addressable_devices_raw =
@@ -664,6 +674,7 @@ onClientAddressableDevices(PJRT_Client_AddressableDevices_Args *args) {
 }
 
 PJRT_Error *onClientLookupDevice(PJRT_Client_LookupDevice_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "ClientInstance::PJRT_Client_LookupDevice");
 
   ClientInstance *client_instance = ClientInstance::unwrap(args->client);
@@ -681,6 +692,7 @@ PJRT_Error *onClientLookupDevice(PJRT_Client_LookupDevice_Args *args) {
 
 PJRT_Error *onClientLookupAddressableDevice(
     PJRT_Client_LookupAddressableDevice_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "ClientInstance::PJRT_Client_LookupAddressableDevice");
 
   ClientInstance *client_instance = ClientInstance::unwrap(args->client);
@@ -701,6 +713,7 @@ PJRT_Error *onClientLookupAddressableDevice(
 
 PJRT_Error *
 onClientAddressableMemories(PJRT_Client_AddressableMemories_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "ClientInstance::PJRT_Client_AddressableMemories");
 
   ClientInstance *client_instance = ClientInstance::unwrap(args->client);
@@ -714,6 +727,7 @@ onClientAddressableMemories(PJRT_Client_AddressableMemories_Args *args) {
 }
 
 PJRT_Error *onClientCompile(PJRT_Client_Compile_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "ClientInstance::PJRT_Client_Compile");
 
   // Parse compile options and extract both custom options and replica device
@@ -750,6 +764,7 @@ PJRT_Error *onClientCompile(PJRT_Client_Compile_Args *args) {
 
 PJRT_Error *onClientDefaultDeviceAssignment(
     PJRT_Client_DefaultDeviceAssignment_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "ClientInstance::PJRT_Client_DefaultDeviceAssignment");
 
   // TODO(mrakita): Revisit this implementation.
@@ -763,6 +778,7 @@ PJRT_Error *onClientDefaultDeviceAssignment(
 // Constructing buffer instance for the first time.
 PJRT_Error *
 onBufferFromHostBuffer(PJRT_Client_BufferFromHostBuffer_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "ClientInstance::PJRT_Client_BufferFromHostBuffer");
   ClientInstance *client_instance = ClientInstance::unwrap(args->client);
 

--- a/pjrt_implementation/src/api/device_description.cc
+++ b/pjrt_implementation/src/api/device_description.cc
@@ -13,6 +13,9 @@
 // c++ standard library includes
 #include <sstream>
 
+// tracy includes
+#include "tracy/Tracy.hpp"
+
 // tt-xla includes
 #include "utils/logging.h"
 
@@ -60,6 +63,7 @@ void DeviceDescription::bindApi(PJRT_Api *api) {
 namespace internal {
 
 PJRT_Error *onDeviceDescriptionId(PJRT_DeviceDescription_Id_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "DeviceDescription::PJRT_DeviceDescription_Id");
 
   args->id = DeviceDescription::unwrap(args->device_description)->getDeviceId();
@@ -69,6 +73,7 @@ PJRT_Error *onDeviceDescriptionId(PJRT_DeviceDescription_Id_Args *args) {
 
 PJRT_Error *onDeviceDescriptionProcessIndex(
     PJRT_DeviceDescription_ProcessIndex_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "DeviceDescription::PJRT_DeviceDescription_ProcessIndex");
 
   args->process_index =
@@ -79,6 +84,7 @@ PJRT_Error *onDeviceDescriptionProcessIndex(
 
 PJRT_Error *
 onDeviceDescriptionAttributes(PJRT_DeviceDescription_Attributes_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "DeviceDescription::PJRT_DeviceDescription_Attributes");
 
   const auto &attributes =
@@ -91,6 +97,7 @@ onDeviceDescriptionAttributes(PJRT_DeviceDescription_Attributes_Args *args) {
 }
 
 PJRT_Error *onDeviceDescriptionKind(PJRT_DeviceDescription_Kind_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "DeviceDescription::PJRT_DeviceDescription_Kind");
 
   const std::string &device_kind =
@@ -104,6 +111,7 @@ PJRT_Error *onDeviceDescriptionKind(PJRT_DeviceDescription_Kind_Args *args) {
 
 PJRT_Error *
 onDeviceDescriptionDebugString(PJRT_DeviceDescription_DebugString_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "DeviceDescription::PJRT_DeviceDescription_DebugString");
 
   const std::string &debug_str =
@@ -117,6 +125,7 @@ onDeviceDescriptionDebugString(PJRT_DeviceDescription_DebugString_Args *args) {
 
 PJRT_Error *
 onDeviceDescriptionToString(PJRT_DeviceDescription_ToString_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "DeviceDescription::PJRT_DeviceDescription_ToString");
 
   const std::string &description_str =

--- a/pjrt_implementation/src/api/device_instance.cc
+++ b/pjrt_implementation/src/api/device_instance.cc
@@ -10,6 +10,9 @@
 
 #include "api/device_instance.h"
 
+// tracy includes
+#include "tracy/Tracy.hpp"
+
 // tt-xla includes
 #include "api/memory_instance.h"
 #include "utils/logging.h"
@@ -41,6 +44,7 @@ void DeviceInstance::bindApi(PJRT_Api *api) {
 namespace internal {
 
 PJRT_Error *onDeviceGetDescription(PJRT_Device_GetDescription_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "DeviceInstance::PJRT_Device_GetDescription");
 
   args->device_description =
@@ -50,6 +54,7 @@ PJRT_Error *onDeviceGetDescription(PJRT_Device_GetDescription_Args *args) {
 }
 
 PJRT_Error *onDeviceIsAddressable(PJRT_Device_IsAddressable_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "DeviceInstance::PJRT_Device_IsAddressable");
 
   args->is_addressable = DeviceInstance::unwrap(args->device)->isAddressable();
@@ -58,6 +63,7 @@ PJRT_Error *onDeviceIsAddressable(PJRT_Device_IsAddressable_Args *args) {
 }
 
 PJRT_Error *onDeviceLocalHardwareId(PJRT_Device_LocalHardwareId_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "DeviceInstance::PJRT_Device_LocalHardwareId");
 
   args->local_hardware_id =
@@ -68,6 +74,7 @@ PJRT_Error *onDeviceLocalHardwareId(PJRT_Device_LocalHardwareId_Args *args) {
 
 PJRT_Error *
 onDeviceAddressableMemories(PJRT_Device_AddressableMemories_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "DeviceInstance::PJRT_Device_AddressableMemories");
 
   DeviceInstance *device = DeviceInstance::unwrap(args->device);
@@ -79,6 +86,7 @@ onDeviceAddressableMemories(PJRT_Device_AddressableMemories_Args *args) {
 };
 
 PJRT_Error *onDeviceDefaultMemory(PJRT_Device_DefaultMemory_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "DeviceInstance::PJRT_Device_DefaultMemory");
 
   args->memory = *(DeviceInstance::unwrap(args->device)->getDefaultMemory());

--- a/pjrt_implementation/src/api/event_instance.cc
+++ b/pjrt_implementation/src/api/event_instance.cc
@@ -13,6 +13,9 @@
 // c++ standard library includes
 #include <stdexcept>
 
+// tracy includes
+#include "tracy/Tracy.hpp"
+
 // tt-xla includes
 #include "api/error_instance.h"
 #include "utils/logging.h"
@@ -169,6 +172,7 @@ void EventInstance::onReady(PJRT_Event_OnReadyCallback callback_function,
 namespace internal {
 
 PJRT_Error *onEventDestroy(PJRT_Event_Destroy_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "EventInstance::PJRT_Event_Destroy");
 
   EventInstance *event_instance = EventInstance::unwrap(args->event);
@@ -188,6 +192,7 @@ PJRT_Error *onEventDestroy(PJRT_Event_Destroy_Args *args) {
 }
 
 PJRT_Error *onEventIsReady(PJRT_Event_IsReady_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "EventInstance::PJRT_Event_IsReady");
 
   args->is_ready = EventInstance::unwrap(args->event)->isReady();
@@ -196,6 +201,7 @@ PJRT_Error *onEventIsReady(PJRT_Event_IsReady_Args *args) {
 }
 
 PJRT_Error *onEventError(PJRT_Event_Error_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "EventInstance::PJRT_Event_Error");
 
   EventInstance *event_instance = EventInstance::unwrap(args->event);
@@ -211,6 +217,7 @@ PJRT_Error *onEventError(PJRT_Event_Error_Args *args) {
 }
 
 PJRT_Error *onEventAwait(PJRT_Event_Await_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "EventInstance::PJRT_Event_Await");
 
   EventInstance *event_instance = EventInstance::unwrap(args->event);
@@ -220,6 +227,7 @@ PJRT_Error *onEventAwait(PJRT_Event_Await_Args *args) {
 }
 
 PJRT_Error *onEventOnReady(PJRT_Event_OnReady_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "EventInstance::PJRT_Event_OnReady");
 
   EventInstance *event_instance = EventInstance::unwrap(args->event);

--- a/pjrt_implementation/src/api/executable_instance.cc
+++ b/pjrt_implementation/src/api/executable_instance.cc
@@ -14,6 +14,9 @@
 #include <cstring>
 #include <string>
 
+// tracy includes
+#include "tracy/Tracy.hpp"
+
 // tt-xla includes
 #include "api/client_instance.h"
 #include "api/error_instance.h"
@@ -57,6 +60,7 @@ void ExecutableInstance::bindApi(PJRT_Api *api) {
 namespace internal {
 
 PJRT_Error *onExecutableDestroy(PJRT_Executable_Destroy_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "ExecutableInstance::PJRT_Executable_Destroy");
 
   delete ExecutableInstance::unwrap(args->executable);
@@ -65,6 +69,7 @@ PJRT_Error *onExecutableDestroy(PJRT_Executable_Destroy_Args *args) {
 }
 
 PJRT_Error *onExecutableName(PJRT_Executable_Name_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "ExecutableInstance::PJRT_Executable_Name");
 
   ExecutableInstance *executable_instance =
@@ -79,6 +84,7 @@ PJRT_Error *onExecutableName(PJRT_Executable_Name_Args *args) {
 }
 
 PJRT_Error *onExecutableNumReplicas(PJRT_Executable_NumReplicas_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "ExecutableInstance::PJRT_Executable_NumReplicas");
 
   ExecutableInstance *executable_instance =
@@ -92,6 +98,7 @@ PJRT_Error *onExecutableNumReplicas(PJRT_Executable_NumReplicas_Args *args) {
 
 PJRT_Error *
 onExecutableNumPartitions(PJRT_Executable_NumPartitions_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "ExecutableInstance::PJRT_Executable_NumPartitions");
 
   ExecutableInstance *executable_instance =
@@ -105,6 +112,7 @@ onExecutableNumPartitions(PJRT_Executable_NumPartitions_Args *args) {
 
 PJRT_Error *
 onExecutableOptimizedProgram(PJRT_Executable_OptimizedProgram_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "ExecutableInstance::PJRT_Executable_OptimizedProgram");
 
   ExecutableInstance *executable_instance =
@@ -142,6 +150,7 @@ onExecutableOptimizedProgram(PJRT_Executable_OptimizedProgram_Args *args) {
 }
 
 PJRT_Error *onExecutableNumOutputs(PJRT_Executable_NumOutputs_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "ExecutableInstance::PJRT_Executable_NumOutputs");
 
   ExecutableInstance *executable_instance =
@@ -155,6 +164,7 @@ PJRT_Error *onExecutableNumOutputs(PJRT_Executable_NumOutputs_Args *args) {
 
 PJRT_Error *onExecutableSizeOfGeneratedCodeInBytes(
     PJRT_Executable_SizeOfGeneratedCodeInBytes_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG,
          "ExecutableInstance::PJRT_Executable_SizeOfGeneratedCodeInBytes");
 
@@ -168,6 +178,7 @@ PJRT_Error *onExecutableSizeOfGeneratedCodeInBytes(
 }
 
 PJRT_Error *onExecutableFingerprint(PJRT_Executable_Fingerprint_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "ExecutableInstance::PJRT_Executable_Fingerprint");
 
   const ExecutableInstance *executable_instance =
@@ -184,6 +195,7 @@ PJRT_Error *onExecutableFingerprint(PJRT_Executable_Fingerprint_Args *args) {
 
 PJRT_Error *
 onExecutableOutputElementTypes(PJRT_Executable_OutputElementTypes_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "ExecutableInstance::PJRT_Executable_OutputElementTypes");
 
   ExecutableInstance *executable_instance =
@@ -199,6 +211,7 @@ onExecutableOutputElementTypes(PJRT_Executable_OutputElementTypes_Args *args) {
 
 PJRT_Error *
 onExecutableOutputDimensions(PJRT_Executable_OutputDimensions_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "ExecutableInstance::PJRT_Executable_OutputDimensions");
 
   ExecutableInstance *executable_instance =
@@ -220,6 +233,7 @@ onExecutableOutputDimensions(PJRT_Executable_OutputDimensions_Args *args) {
 
 PJRT_Error *
 onExecutableOutputMemoryKinds(PJRT_Executable_OutputMemoryKinds_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "ExecutableImage::PJRT_Executable_OutputMemoryKinds");
 
   ExecutableInstance *executable_instance =
@@ -236,6 +250,7 @@ onExecutableOutputMemoryKinds(PJRT_Executable_OutputMemoryKinds_Args *args) {
 };
 
 PJRT_Error *onExecutableSerialize(PJRT_Executable_Serialize_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "ExecutableInstance::PJRT_Executable_Serialize");
 
   const ExecutableInstance *executable_instance =

--- a/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
@@ -8,6 +8,9 @@
 // c++ standard library includes
 #include <cassert>
 
+// tracy includes
+#include "tracy/Tracy.hpp"
+
 // tt-mlir includes
 #define TTMLIR_ENABLE_STABLEHLO 1
 #include "tt/runtime/types.h"
@@ -57,6 +60,7 @@ FlatbufferLoadedExecutableInstance::prepareInputTensor(
     const std::vector<BufferInstance *> &arg_buffers,
     tt::runtime::Device runtime_device, size_t num_devices,
     std::uint32_t program_index, size_t arg_index) {
+  ZoneScoped;
 
   FlatbufferExecutableImage *executable_image =
       static_cast<FlatbufferExecutableImage *>(m_executable_image.get());
@@ -85,6 +89,7 @@ void FlatbufferLoadedExecutableInstance::fillPJRTOutputLists(
     const std::vector<tt::runtime::Tensor> &output_tensors, size_t num_devices,
     PJRT_Buffer **const *output_lists,
     const std::vector<PJRT_Buffer_Type> &expected_output_data_types) {
+  ZoneScoped;
   size_t n_prog_output_tensors = output_tensors.size();
 
   // Iterate over the available tensors and devices, filling in the PJRT Buffer
@@ -185,6 +190,7 @@ void FlatbufferLoadedExecutableInstance::releaseResources() {
 // TODO(mrakita): Make this method work in asynchronous fashion.
 tt_pjrt_status FlatbufferLoadedExecutableInstance::execute(
     PJRT_LoadedExecutable_Execute_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "FlatbufferLoadedExecutableInstance::Execute");
   LOG_BRINGUP_STAGE("RUNTIME_EXECUTION_START");
 

--- a/pjrt_implementation/src/api/loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/loaded_executable_instance.cc
@@ -19,6 +19,9 @@
 #include <optional>
 #include <unordered_set>
 
+// tracy includes
+#include "tracy/Tracy.hpp"
+
 // tt-mlir includes
 #define TTMLIR_ENABLE_STABLEHLO 1
 #include "tt/runtime/runtime.h"
@@ -243,6 +246,7 @@ namespace internal {
 
 PJRT_Error *
 onLoadedExecutableDestroy(PJRT_LoadedExecutable_Destroy_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "LoadedExecutableInstance::PJRT_LoadedExecutable_Destroy");
 
   delete LoadedExecutableInstance::unwrap(args->executable);
@@ -252,6 +256,7 @@ onLoadedExecutableDestroy(PJRT_LoadedExecutable_Destroy_Args *args) {
 
 PJRT_Error *onLoadedExecutableGetExecutable(
     PJRT_LoadedExecutable_GetExecutable_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG,
          "LoadedExecutableInstance::PJRT_LoadedExecutable_GetExecutable");
 
@@ -271,6 +276,7 @@ PJRT_Error *onLoadedExecutableGetExecutable(
 
 PJRT_Error *onLoadedExecutableAddressableDevices(
     PJRT_LoadedExecutable_AddressableDevices_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG,
          "LoadedExecutableInstance::PJRT_LoadedExecutable_AddressableDevices");
 
@@ -288,6 +294,7 @@ PJRT_Error *onLoadedExecutableAddressableDevices(
 }
 
 PJRT_Error *onLoadedExecutableDelete(PJRT_LoadedExecutable_Delete_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "LoadedExecutableInstance::PJRT_LoadedExecutable_Delete");
 
   LoadedExecutableInstance::unwrap(args->executable)->releaseResources();
@@ -297,6 +304,7 @@ PJRT_Error *onLoadedExecutableDelete(PJRT_LoadedExecutable_Delete_Args *args) {
 
 PJRT_Error *
 onLoadedExecutableIsDeleted(PJRT_LoadedExecutable_IsDeleted_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG,
          "LoadedExecutableInstance::PJRT_LoadedExecutable_IsDeleted");
 
@@ -308,6 +316,7 @@ onLoadedExecutableIsDeleted(PJRT_LoadedExecutable_IsDeleted_Args *args) {
 
 PJRT_Error *
 onLoadedExecutableExecute(PJRT_LoadedExecutable_Execute_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "LoadedExecutableInstance::PJRT_LoadedExecutable_Execute");
 
   tt_pjrt_status status =

--- a/pjrt_implementation/src/api/memory_instance.cc
+++ b/pjrt_implementation/src/api/memory_instance.cc
@@ -14,6 +14,9 @@
 #include <cassert>
 #include <cstring>
 
+// tracy includes
+#include "tracy/Tracy.hpp"
+
 // tt-xla includes
 #include "utils/logging.h"
 
@@ -73,6 +76,7 @@ DeviceInstance *MemoryInstance::getDevice() {
 namespace internal {
 
 PJRT_Error *onMemoryId(PJRT_Memory_Id_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "MemoryInstance::PJRT_Memory_Id");
 
   args->id = MemoryInstance::unwrap(args->memory)->getId();
@@ -81,6 +85,7 @@ PJRT_Error *onMemoryId(PJRT_Memory_Id_Args *args) {
 }
 
 PJRT_Error *onMemoryKind(PJRT_Memory_Kind_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "MemoryInstance::PJRT_Memory_Kind");
 
   MemoryInstance *memory_instance = MemoryInstance::unwrap(args->memory);
@@ -91,6 +96,7 @@ PJRT_Error *onMemoryKind(PJRT_Memory_Kind_Args *args) {
 }
 
 PJRT_Error *onMemoryKindId(PJRT_Memory_Kind_Id_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "MemoryInstance::PJRT_Memory_Kind_Id");
 
   MemoryInstance *memory_instance = MemoryInstance::unwrap(args->memory);
@@ -100,6 +106,7 @@ PJRT_Error *onMemoryKindId(PJRT_Memory_Kind_Id_Args *args) {
 }
 
 PJRT_Error *onMemoryDebugString(PJRT_Memory_DebugString_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "MemoryInstance::PJRT_Memory_DebugString");
 
   MemoryInstance *memory_instance = MemoryInstance::unwrap(args->memory);
@@ -110,6 +117,7 @@ PJRT_Error *onMemoryDebugString(PJRT_Memory_DebugString_Args *args) {
 }
 
 PJRT_Error *onMemoryToString(PJRT_Memory_ToString_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "MemoryInstance::PJRT_Memory_ToString");
 
   MemoryInstance *memory_instance = MemoryInstance::unwrap(args->memory);
@@ -121,6 +129,7 @@ PJRT_Error *onMemoryToString(PJRT_Memory_ToString_Args *args) {
 
 PJRT_Error *
 onMemoryAddressableByDevices(PJRT_Memory_AddressableByDevices_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "MemoryInstance::PJRT_Memory_AddressableByDevices");
 
   const MemoryInstance *memory_instance = MemoryInstance::unwrap(args->memory);

--- a/pjrt_implementation/src/api/plugin_attributes.cc
+++ b/pjrt_implementation/src/api/plugin_attributes.cc
@@ -4,6 +4,9 @@
 
 #include "api/plugin_attributes.h"
 
+// tracy includes
+#include "tracy/Tracy.hpp"
+
 // tt-xla includes
 #include "utils/logging.h"
 
@@ -57,12 +60,14 @@ void PluginAttributes::bindApi(PJRT_Api *api) {
 namespace internal {
 
 PJRT_Error *onPluginInitialize(PJRT_Plugin_Initialize_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "PluginAttributes::PJRT_Plugin_Initialize");
 
   return nullptr;
 }
 
 PJRT_Error *onPluginAttributes(PJRT_Plugin_Attributes_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "PluginAttributes::PJRT_Plugin_Attributes");
 
   const std::vector<PJRT_NamedValue> &attrs = PluginAttributes::getAttributes();

--- a/pjrt_implementation/src/api/so_loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/so_loaded_executable_instance.cc
@@ -10,6 +10,9 @@
 #include <mutex>
 #include <numeric>
 
+// tracy includes
+#include "tracy/Tracy.hpp"
+
 // tt-mlir includes
 #include "tt/runtime/runtime.h"
 #include "tt/runtime/types.h"
@@ -77,6 +80,7 @@ void SOLoadedExecutableInstance::releaseResources() {
 
 tt_pjrt_status
 SOLoadedExecutableInstance::execute(PJRT_LoadedExecutable_Execute_Args *args) {
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "SOLoadedExecutableInstance::Execute");
 
   if (args->num_devices != m_executable_image->getNumDevicesToUtilize()) {
@@ -142,6 +146,7 @@ SOLoadedExecutableInstance::execute(PJRT_LoadedExecutable_Execute_Args *args) {
 
 void SOLoadedExecutableInstance::createDefaultOutputBuffers(
     PJRT_Buffer **const *output_lists, size_t num_devices) {
+  ZoneScoped;
   size_t num_outputs = m_executable_image->getNumOutputs();
 
   for (size_t device_index = 0; device_index < num_devices; ++device_index) {
@@ -187,6 +192,7 @@ SOLoadedExecutableInstance::prepareInputTensor(
     const std::vector<BufferInstance *> &arg_buffers,
     tt::runtime::Device runtime_device, size_t num_devices,
     std::uint32_t program_index, size_t arg_index) {
+  ZoneScoped;
 
   mlir::FailureOr<std::unordered_map<std::string, std::string>> strategy =
       fillStrategyMapFromSharding(

--- a/pjrt_implementation/src/api/tensor.cc
+++ b/pjrt_implementation/src/api/tensor.cc
@@ -17,6 +17,9 @@
 #include <utility>
 #include <vector>
 
+// tracy includes
+#include "tracy/Tracy.hpp"
+
 // tt-mlir includes
 #include "tt/runtime/runtime.h"
 #include "tt/runtime/types.h"
@@ -108,7 +111,7 @@ void PjrtTensor::ensure_layout(const tt::runtime::Device &device,
 // Additional note: for checking whether shard is nullptr, see comment in
 // remove_shard().
 void PjrtTensor::move_to_host() noexcept {
-
+  ZoneScoped;
   std::vector<tt::runtime::Tensor> tensors =
       tt::runtime::toHost(m_runtime_tensor, /*untilize=*/true);
 

--- a/pjrt_implementation/src/api/tensor_pool.cc
+++ b/pjrt_implementation/src/api/tensor_pool.cc
@@ -19,6 +19,9 @@
 #include "api/buffer_instance.h"
 #include "utils/logging.h"
 
+// tracy includes
+#include "tracy/Tracy.hpp"
+
 namespace tt::pjrt {
 
 namespace TensorPool {
@@ -85,7 +88,7 @@ void PjrtTensorPool::clear() {
 //
 // Note: this function is not thread safe.
 void PjrtTensorPool::move_tensors_to_host() {
-
+  ZoneScoped;
   DLOG_F(LOG_DEBUG, "Moving tensors to host.");
 
   std::vector<PjrtTensor *> tensors{m_tensors.begin(), m_tensors.end()};

--- a/pjrt_implementation/src/utils/CMakeLists.txt
+++ b/pjrt_implementation/src/utils/CMakeLists.txt
@@ -16,12 +16,16 @@ add_library(TTPJRTUtils
     "logging.cc"
 )
 
-target_include_directories(TTPJRTUtils PUBLIC
+target_include_directories(TTPJRTUtils
+PRIVATE
+    # Includes used in .cpp files.
     ${PROJECT_SOURCE_DIR}/pjrt_implementation/inc
-    ${PROJECT_SOURCE_DIR}/third_party/loguru/src/loguru-install/include/
-    ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/install/include
-    ${PROJECT_SOURCE_DIR}/third_party/pjrt_c_api
     ${TTMLIR_TOOLCHAIN_DIR}/include
+    ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/install/include
+PUBLIC
+    # Includes used in public headers.
+    ${PROJECT_SOURCE_DIR}/third_party/loguru/src/loguru-install/include
+    ${PROJECT_SOURCE_DIR}/third_party/pjrt_c_api
 )
 
 add_dependencies(TTPJRTUtils


### PR DESCRIPTION
Tracy zones are added when compiled with `TTXLA_TRACY_ZONES=ON`.

All PJRT APIs are covered for now (except for error instance related stuff), we can iterate on this if we notice that we are getting too much noise; at this moment that doesn't seem to be the case.

Additionally, some expensive threads/methods are instrumented as well.

Cmake changes are to enable including needed `tracy` files. We will see if it makes sense to install those in `tt-mlir` installation, so that we can pick them up from there, but for now we take them from the `tt-metal` path.

The way we set up include dirs is refactored, so that each lib defines its own include dirs and propagates them via `PUBLIC` if needed.

Closes #3295