### PR TITLE
Update gpt_oss variant names

### DIFF
--- a/tests/torch/graphs/test_attention.py
+++ b/tests/torch/graphs/test_attention.py
@@ -122,7 +122,7 @@ AVAILABLE_VARIANT_MAP = {
         "ministral_3b_instruct",
         "ministral_8b_instruct",
     ],
-    "gpt_oss": ["gpt_oss_20b", "gpt_oss_120b"],
+    "gpt_oss": ["20B", "120B"],
 }
 
 

--- a/tests/torch/graphs/test_mlp.py
+++ b/tests/torch/graphs/test_mlp.py
@@ -114,7 +114,7 @@ AVAILABLE_VARIANT_MAP = {
         "tiiuae/Falcon3-Mamba-7B-Base",
         "tiiuae/falcon-7b-instruct",
     ],
-    "gpt_oss": ["gpt_oss_20b", "gpt_oss_120b"],
+    "gpt_oss": ["20B", "120B"],
 }
 
 


### PR DESCRIPTION
### Ticket
None

### Problem description
Somebody updated gpt oss variant names but didn't update unit tests that use it: https://github.com/tenstorrent/tt-forge-models/commit/18d662b8a737ec406681e3f9abc29984f5bbf75f These unit tests aren't being run at the moment.

### What's changed
Updated gpt_oss_20b -> 20B gpt_oss_120b -> 120B
