### PR TITLE
Improve benchmarks PCC computation

### DIFF
--- a/tests/benchmark/benchmarks/encoder_benchmark.py
+++ b/tests/benchmark/benchmarks/encoder_benchmark.py
@@ -259,7 +259,10 @@ def benchmark_encoder_torch_xla(
     )
 
     # Evaluate PCC
-    pcc_value = compute_pcc(predictions[0], golden_output, required_pcc=required_pcc)
+    pcc_value = compute_pcc(predictions[0], golden_output)
+    assert (
+        pcc_value >= required_pcc
+    ), f"PCC comparison failed. PCC={pcc_value:.6f}, Required={required_pcc}"
     print(f"PCC verification passed with PCC={pcc_value:.6f}")
     evaluation_score = pcc_value
 

--- a/tests/benchmark/benchmarks/llm_benchmark.py
+++ b/tests/benchmark/benchmarks/llm_benchmark.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Built-in modules
+import copy
 import os
 import socket
 import sys
@@ -322,19 +323,10 @@ def benchmark_llm_torch_xla(
     if max_output_tokens is None:
         max_output_tokens = max_cache_len - input_args["input_ids"].shape[1]
 
-    # Get CPU result (skip in accuracy testing mode - not needed with ground truth)
+    # Keep CPU model copy for post-benchmark teacher-forced PCC calculation
+    cpu_model = None
     if not accuracy_testing:
-        cpu_logits, _ = generate_and_benchmark(
-            model,
-            input_args,
-            torch.device("cpu"),
-            1,
-            read_logits_fn=read_logits_fn,
-            tokenizer=tokenizer,
-            verbose=False,
-        )
-        # Only one output makes sense to compare.
-        cpu_logits = cpu_logits[0]
+        cpu_model = copy.deepcopy(model)
 
     # Transfer model and inputs to device
     input_args = construct_inputs(
@@ -442,6 +434,42 @@ def benchmark_llm_torch_xla(
             logits[:, -1].argmax(dim=-1)[0].item() for logits in output_logits
         ]
 
+    # Teacher-forced CPU golden generation for PCC (runs after device benchmark)
+    cpu_logits = None
+    if not accuracy_testing:
+        # Extract device-predicted token IDs from benchmark output
+        device_token_ids = torch.tensor(
+            [logits[:, -1].argmax(dim=-1)[0].item() for logits in output_logits]
+        )
+
+        # Construct fresh CPU inputs for teacher-forced golden generation
+        cpu_input_args = construct_inputs(
+            tokenizer,
+            cpu_model.config,
+            batch_size,
+            max_cache_len,
+            input_prompt=custom_input_prompt,
+        )
+
+        # Run CPU teacher-forced generation using device tokens as ground truth
+        print(
+            "\nRunning CPU golden generation "
+            f"(teacher-forced, {max_output_tokens} steps)..."
+        )
+        cpu_logits, _ = generate_and_benchmark(
+            cpu_model,
+            cpu_input_args,
+            torch.device("cpu"),
+            max_output_tokens,
+            read_logits_fn=read_logits_fn,
+            tokenizer=tokenizer,
+            verbose=False,
+            ground_truth_tokens=device_token_ids,
+        )
+
+        # Free CPU model memory
+        del cpu_model
+
     ttft_ns = iteration_times[0]
     ttft_ms = ttft_ns / 1e6
 
@@ -518,9 +546,27 @@ def benchmark_llm_torch_xla(
             ]
         )
     else:
-        # Check PCC
-        pcc_value = compute_pcc(
-            output_logits[0][0], cpu_logits[0], required_pcc=required_pcc
+        # Per-step PCC comparison (teacher-forced across all decode steps)
+        print(
+            f"\nComputing per-step PCC "
+            f"({len(output_logits)} decode steps, teacher-forced)..."
+        )
+        min_pcc = 1.0
+        min_pcc_step = 0
+        for step_idx in range(len(output_logits)):
+            step_pcc = compute_pcc(output_logits[step_idx][0], cpu_logits[step_idx][0])
+            if step_pcc < min_pcc:
+                min_pcc = step_pcc
+                min_pcc_step = step_idx
+            assert step_pcc >= required_pcc, (
+                f"PCC comparison failed at decode step {step_idx}. "
+                f"PCC={step_pcc:.6f}, Required={required_pcc}"
+            )
+        pcc_value = min_pcc
+        print(
+            f"PCC check: All {len(output_logits)} decode steps passed. "
+            f"Min PCC={min_pcc:.6f} (step {min_pcc_step}), "
+            f"Required={required_pcc}"
         )
         print("PCC verification passed with PCC={:.6f}".format(pcc_value))
 

--- a/tests/benchmark/benchmarks/vision_benchmark.py
+++ b/tests/benchmark/benchmarks/vision_benchmark.py
@@ -234,7 +234,10 @@ def benchmark_vision_torch_xla(
     )
 
     # Evaluate PCC
-    pcc_value = compute_pcc(predictions[0], golden_output, required_pcc=required_pcc)
+    pcc_value = compute_pcc(predictions[0], golden_output)
+    assert (
+        pcc_value >= required_pcc
+    ), f"PCC comparison failed. PCC={pcc_value:.6f}, Required={required_pcc}"
     print(f"PCC verification passed with PCC={pcc_value:.6f}")
 
     result = create_benchmark_result(

--- a/tests/benchmark/resnet_jax_benchmark.py
+++ b/tests/benchmark/resnet_jax_benchmark.py
@@ -215,7 +215,10 @@ def benchmark_resnet_jax(
     # Convert JAX arrays to PyTorch tensors for PCC comparison
     golden_tensor = torch.from_numpy(np.asarray(golden_output))
     prediction_tensor = torch.from_numpy(np.asarray(predictions[0]))
-    pcc_value = compute_pcc(golden_tensor, prediction_tensor, required_pcc=required_pcc)
+    pcc_value = compute_pcc(golden_tensor, prediction_tensor)
+    assert (
+        pcc_value >= required_pcc
+    ), f"PCC comparison failed. PCC={pcc_value:.6f}, Required={required_pcc}"
     print(f"PCC verification passed with PCC={pcc_value:.6f}")
 
     result = create_benchmark_result(

--- a/tests/benchmark/utils.py
+++ b/tests/benchmark/utils.py
@@ -8,7 +8,6 @@ import os
 import re
 import secrets
 import socket
-from collections.abc import Sequence
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
@@ -204,8 +203,22 @@ def aggregate_ttnn_perf_metrics(ttnn_perf_metrics_output_file, results):
             results["config"]["ttnn_num_graphs"] = num_graphs_with_metrics
 
 
-def _compute_pcc_single(golden_flat: torch.Tensor, device_flat: torch.Tensor) -> float:
-    """Helper to compute PCC between two flattened tensors."""
+def compute_pcc(golden_output: torch.Tensor, device_output: torch.Tensor) -> float:
+    """Compute Pearson Correlation Coefficient between two tensors.
+
+    Args:
+        golden_output: Golden reference tensor
+        device_output: Device output tensor
+
+    Returns:
+        PCC value in [-1, 1].
+
+    Raises:
+        ValueError: If denominator is zero and tensors are not close.
+    """
+    golden_flat = golden_output.to(torch.float32).flatten()
+    device_flat = device_output.to(torch.float32).flatten()
+
     golden_centered = golden_flat - golden_flat.mean()
     device_centered = device_flat - device_flat.mean()
     denom = golden_centered.norm() * device_centered.norm()
@@ -213,85 +226,13 @@ def _compute_pcc_single(golden_flat: torch.Tensor, device_flat: torch.Tensor) ->
     if denom == 0:
         if torch.allclose(golden_flat, device_flat, rtol=1e-2, atol=1e-2):
             return 1.0
-        raise AssertionError(
+        raise ValueError(
             "PCC computation failed: denominator is zero but tensors are not close"
         )
 
     pcc = ((golden_centered @ device_centered) / denom).item()
     # Clamp to [-1, 1] to handle floating-point precision errors
     return max(-1.0, min(1.0, pcc))
-
-
-def compute_pcc(golden_output, device_output, required_pcc: float = 0.99) -> float:
-    """
-    Compute Pearson Correlation Coefficient between golden and device output.
-
-    Supports single tensors or collections of tensors (e.g., multi-scale outputs).
-    For collections, computes PCC for each element individually, then computes the overall
-    PCC by concatenating all tensors into a single flattened tensor before comparison.
-
-    Args:
-        golden_output: Golden output tensor or collection of tensors
-        device_output: Device output tensor or collection of tensors
-        required_pcc: Minimum required PCC threshold
-
-    Returns:
-        Overall PCC value (computed across all concatenated tensor elements).
-
-    Raises:
-        AssertionError: If computed PCC is below required_pcc threshold
-    """
-    # Normalize inputs to iterables for uniform processing
-    is_collection = isinstance(golden_output, Sequence) and not isinstance(
-        golden_output, torch.Tensor
-    )
-    golden_iter = golden_output if is_collection else (golden_output,)
-    device_iter = device_output if is_collection else (device_output,)
-
-    assert len(golden_iter) == len(device_iter), (
-        f"Output length mismatch: golden has {len(golden_iter)} elements, "
-        f"device has {len(device_iter)} elements"
-    )
-
-    # Compute PCC per scale
-    scale_pccs = []
-    for i, (golden, device) in enumerate(zip(golden_iter, device_iter)):
-        golden_flat = golden.to(torch.float32).flatten()
-        device_flat = device.to(torch.float32).flatten()
-        scale_pcc = _compute_pcc_single(golden_flat, device_flat)
-        scale_pccs.append(scale_pcc)
-
-        if is_collection:
-            print(f"  Scale {i} (shape {golden.shape}): PCC={scale_pcc:.6f}")
-
-    # Compute overall PCC
-    golden_all = torch.cat([g.to(torch.float32).flatten() for g in golden_iter])
-    device_all = torch.cat([d.to(torch.float32).flatten() for d in device_iter])
-    pcc_value = _compute_pcc_single(golden_all, device_all)
-
-    # Print results
-    if is_collection:
-        print(
-            f"PCC check: Computing PCC for {len(golden_iter)} output tensors (multi-scale)"
-        )
-        print(
-            f"PCC check: Overall PCC={pcc_value:.6f}, Min scale PCC={min(scale_pccs):.6f}, Required PCC={required_pcc}"
-        )
-    else:
-        print(f"PCC check: Calculated PCC={pcc_value:.6f}, Required PCC={required_pcc}")
-
-    # Validate
-    if is_collection:
-        assert pcc_value >= required_pcc, (
-            f"PCC comparison failed. Overall PCC={pcc_value:.6f}, "
-            f"Min scale PCC={min(scale_pccs):.6f}. Required: pcc={required_pcc}"
-        )
-    else:
-        assert (
-            pcc_value >= required_pcc
-        ), f"PCC comparison failed. Calculated: pcc={pcc_value:.6f}. Required: pcc={required_pcc}"
-
-    return pcc_value
 
 
 def get_benchmark_metadata() -> Dict[str, str]:


### PR DESCRIPTION
### Problem description
In Performance benchmark PCC for LLMs is calculated based on the first decode token. 
We should check it for every decode token.

### What's changed
LLM PCC for all decode tokens is checked by doing:
- Generate all decode logits during benchmark run
- Generate CPU golden logits with teacher-forcing using benchmark decode tokens as ground truth
- Calculate PCC for every decode output, assert on first failure

### Checklist
- [x] [Single Vision and Encoder test](https://github.com/tenstorrent/tt-xla/actions/runs/23061879362)
- [ ] [n150 LLMs](https://github.com/tenstorrent/tt-xla/actions/runs/23594173334)
- [ ] [n300 LLMs](https://github.com/tenstorrent/tt-xla/actions/runs/23594191213)
- [ ] [galaxy LLMs](https://github.com/tenstorrent/tt-xla/actions/runs/23609387522)