### PR TITLE
Update OLMo3 model in test_config files

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -192,3 +192,11 @@ test_config:
     status: NOT_SUPPORTED_SKIP
     reason: "Needs bringup on n300-llmbox"
     bringup_status: FAILED_RUNTIME
+
+  olmo3/causal_lm/pytorch-3_32b_think-tensor_parallel-inference:
+    supported_archs: [n300-llmbox]
+    status: EXPECTED_PASSING
+
+  olmo3/causal_lm/pytorch-3_1125_32b-tensor_parallel-inference:
+    supported_archs: [n300-llmbox]
+    status: EXPECTED_PASSING


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Add inference test config for OLMO3 variants

### What's changed
Initially, I was facing a ValueError: bad optional access.
fix pr: https://github.com/tenstorrent/tt-forge-models/pull/483. 

In tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml, I have added all 32B variants related to the Olmo3 model

| model_vareint | pcc |
|--------|--------|
| allenai/Olmo-3-1125-32B | 0.999842419511947 |
| allenai/Olmo-3-32B-Think | 0.9909116597742709 |

### Checklist
- [ ] New/Existing tests provide coverage for changes
