### PR TITLE
[Benchmarking] add option to overwrite optimization level

### DIFF
--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -187,7 +187,6 @@ def test_llm_tp(
     else:
         optimization_level = DEFAULT_TP_OPTIMIZATION_LEVEL
 
-
     test_llm(
         ModelLoaderModule=ModelLoaderModule,
         variant=variant,


### PR DESCRIPTION
### Ticket
#3304

### Problem description
A change was committed so that tp tests use default tp optimization level. This disables optimization level overwrites for tp tests: https://github.com/tenstorrent/tt-xla/commit/557a4b9491474d61d2719c1776a65967f872cca3
Causes gpt oss 20b benchmarking script to fail: https://github.com/tenstorrent/tt-xla/actions/runs/21993732844/job/63550857033 
```
FAILED tests/benchmark/test_llms.py::test_gpt_oss_20b_tp - TypeError: test_llms.test_llm() got multiple values for keyword argument 'optimization_level'
```

### What's changed
Read optimization level from kwargs and overwrite default tp optimization level if it is being passed. 

### Checklist
- [X] Successful llmbox benchmark run: https://github.com/tenstorrent/tt-xla/actions/runs/22096129881
