### PR TITLE
Enable StaticCache checking in TorchComparator

### DIFF
--- a/tests/infra/evaluators/torch_comparison_evaluator.py
+++ b/tests/infra/evaluators/torch_comparison_evaluator.py
@@ -26,23 +26,19 @@ class TorchComparisonEvaluator(ComparisonEvaluator):
             leaf.numel() == 1 for leaf in leaves if isinstance(leaf, torch.Tensor)
         )
 
-    # LLM decode tests may include transformers StaticCache objects in outputs (e.g., past_key_values).
-    # These are not torch.Tensors, so we detect them and treat matching StaticCache leaves as equal.
-    # TODO https://github.com/tenstorrent/tt-xla/issues/2743: Enable checking for allclose, pcc, atol, equal.
     @staticmethod
-    def _is_static_cache(x: object) -> bool:
-        # Avoid importing transformers at module import time.
-        try:
-            from transformers.cache_utils import StaticCache  # type: ignore
-
-            return isinstance(x, StaticCache)
-        except Exception:
-            return False
-
-    @staticmethod
-    def _both_static_cache(x: object, y: object) -> bool:
-        is_sc = TorchComparisonEvaluator._is_static_cache
-        return is_sc(x) and is_sc(y)
+    def _cache_to_legacy(cache: Cache) -> tuple:
+        """
+        Convert a Cache (DynamicCache, StaticCache, etc.) to legacy tuple of
+        (key, value) tensors per layer for comparison.
+        """
+        if hasattr(cache, "to_legacy_cache"):
+            return cache.to_legacy_cache()
+        # Fallback for StaticCache and any Cache with .layers that do not
+        # implement to_legacy_cache (e.g. StaticCache with StaticLayer).
+        if hasattr(cache, "layers"):
+            return tuple((layer.keys, layer.values) for layer in cache.layers)
+        return cache
 
     # @override
     @staticmethod
@@ -54,12 +50,11 @@ class TorchComparisonEvaluator(ComparisonEvaluator):
             return tensor
 
         def convert_and_match(tensor):
-            if isinstance(tensor, Cache) and hasattr(tensor, "to_legacy_cache"):
-                # New transformers library has changed the Cache classes
-                # to contain and arrays of CacheLayers instead of an array of
-                # torch.tensors, we need to extract the torch tensors from CacheLayers
-                # before comparing values in the comparator.
-                tensor = tensor.to_legacy_cache()
+            if isinstance(tensor, Cache):
+                # New transformers library uses Cache classes (DynamicCache, StaticCache)
+                # with CacheLayers/StaticLayers instead of raw tensors. Convert to legacy
+                # (keys, values) tuple per layer so the comparator can compare tensors.
+                tensor = TorchComparisonEvaluator._cache_to_legacy(tensor)
             if isinstance(tensor, torch.Tensor) and tensor.dtype != torch.float64:
                 tensor = tensor.to(torch.float64)
             return tree_map(match, tensor)
@@ -71,9 +66,7 @@ class TorchComparisonEvaluator(ComparisonEvaluator):
     @run_on_cpu(Framework.TORCH)
     def _compare_equal(device_output: PyTree, golden_output: PyTree) -> bool:
         def _equal_leaf(x, y):
-            if TorchComparisonEvaluator._both_static_cache(x, y) or (
-                x is None and y is None
-            ):
+            if x is None and y is None:
                 return True
             return torch.equal(x, y)
 
@@ -87,10 +80,9 @@ class TorchComparisonEvaluator(ComparisonEvaluator):
     def _compare_atol(
         device_output: PyTree, golden_output: PyTree, atol_config: AtolConfig
     ) -> float:
+
         def _atol_leaf(x, y):
-            if TorchComparisonEvaluator._both_static_cache(x, y) or (
-                x is None and y is None
-            ):
+            if x is None and y is None:
                 return torch.tensor(0.0)
             return torch.max(torch.abs(x - y))
 
@@ -106,8 +98,6 @@ class TorchComparisonEvaluator(ComparisonEvaluator):
         self, device_output: PyTree, golden_output: PyTree, pcc_config: PccConfig
     ) -> float:
         def compute_pcc(x: torch.Tensor, y: torch.Tensor):
-            if TorchComparisonEvaluator._both_static_cache(x, y):
-                return torch.tensor(1.0)
             if x is None and y is None:
                 return None
             # PCC formula can be ill conditioned. If inputs are allclose, fudge the result to 1.0.
@@ -140,9 +130,7 @@ class TorchComparisonEvaluator(ComparisonEvaluator):
         allclose_config: AllcloseConfig,
     ) -> bool:
         def _allclose_leaf(x, y):
-            if TorchComparisonEvaluator._both_static_cache(x, y) or (
-                x is None and y is None
-            ):
+            if x is None and y is None:
                 return True
             return torch.allclose(
                 x, y, rtol=allclose_config.rtol, atol=allclose_config.atol


### PR DESCRIPTION
### Ticket
[2743](https://github.com/tenstorrent/tt-xla/issues/2743)

### Problem description
```
pytest -svv tests/runner/test_models.py::test_llms_decode_torch[falcon/pytorch-tiiuae/Falcon3-1B-Base-single_device-inference]

<snip>

tests/infra/comparators/torch_comparator.py:34: in _compare_equal
    passed = tree_map(lambda x, y: torch.equal(x, y), device_output, golden_output)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/local/lib/python3.11/dist-packages/torch/utils/_pytree.py:1145: in tree_map
    return treespec.unflatten(map(func, *flat_args))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/local/lib/python3.11/dist-packages/torch/utils/_pytree.py:982: in unflatten
    leaves = list(leaves)
             ^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

x = <transformers.cache_utils.StaticCache object at 0x7b5e3a74bf90>
y = <transformers.cache_utils.StaticCache object at 0x7b5e3a74bf90>

>   passed = tree_map(lambda x, y: torch.equal(x, y), device_output, golden_output)
                                   ^^^^^^^^^^^^^^^^^
E   TypeError: equal(): argument 'input' (position 1) must be Tensor, not StaticCache

tests/infra/comparators/torch_comparator.py:34: TypeError

```
### What's changed
In the Torch comparison evaluator, the [convert_and_match](https://github.com/tenstorrent/tt-xla/blob/main/tests/infra/evaluators/torch_comparison_evaluator.py#L56) function first normalizes past_key_values into the legacy format—a tuple of (key, value) tensors per layer—before performing the comparison.

Previously, only cache objects implementing to_legacy_cache() were converted, while StaticCache (and any cache exposing only .layers) remained unconverted and therefore wasn’t compared as tensors. This update introduces a fallback mechanism that converts StaticCache instances to the same legacy tensor format, ensuring they are properly included in tensor-based comparisons.

**DynamicCache** (DynamicLayer) continues to be converted via **to_legacy_cache**.
**StaticCache** (StaticLayer) is now also converted via the .**layers** fallback.
Comparison (atol, pcc, allclose, etc.) runs on the same legacy (keys, values) tensor structure for both cache types.

Reverted the changes made by Kyle in this [commit](https://github.com/tenstorrent/tt-xla/pull/2742).

### Checklist
- [ ] New/Existing tests provide coverage for changes
