### PR TITLE
Get tt-mlir SHA from pre-installed wheel on docker

### DIFF
--- a/.github/scripts/get_description_field_from_wheel.py
+++ b/.github/scripts/get_description_field_from_wheel.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import importlib.metadata as im
+import re
+import sys
+
+if len(sys.argv) != 3:
+    print(f"Usage: {sys.argv[0]} <package_name> <field_key>", file=sys.stderr)
+    sys.exit(1)
+
+pkg = sys.argv[1]
+field_key = sys.argv[2]
+
+try:
+    md = im.metadata(pkg)
+except im.PackageNotFoundError:
+    print(f"{pkg} not installed", file=sys.stderr)
+    sys.exit(1)
+
+# Try as a metadata field first (Key: Value)
+value = md.get(field_key)
+if not value:
+    # Fallback: search raw metadata text for "field_key=..."
+    text = str(md)
+    pattern = rf"{re.escape(field_key)}=([0-9a-zA-Z_.-]+)"
+    m = re.search(pattern, text)
+    if not m:
+        print(f"{field_key} not found in metadata for {pkg}", file=sys.stderr)
+        sys.exit(1)
+    value = m.group(1)
+
+print(value.strip())

--- a/.github/workflows/call-perf-test.yml
+++ b/.github/workflows/call-perf-test.yml
@@ -268,12 +268,17 @@ jobs:
       if: ${{ !matrix.build.skip-device-perf && !inputs.skip-device-perf }}
       shell: bash
       run: |
-        mlir_sha=$(grep -oP 'set\(TT_MLIR_VERSION "\K[^"]+' third_party/CMakeLists.txt)
-        echo "Found TT_MLIR_VERSION: $mlir_sha"
+        mlir_sha=$(python .github/scripts/get_description_field_from_wheel.py "pjrt-plugin-tt" "tt-mlir-commit")
+        echo "Found tt-mlir-commit: $mlir_sha"
 
         RUN_ID=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
           "https://api.github.com/repos/tenstorrent/tt-mlir/actions/workflows/on-push.yml/runs?head_sha=${mlir_sha}&per_page=1" \
           | jq -r '.workflow_runs[0].id')
+
+        if [[ -z "$RUN_ID" || "$RUN_ID" == "null" ]]; then
+          echo "The tt-mlir commit doesn't contain a ttrt wheel artifact. Run an artifact building workflow on the commit (e.g. 'On PR')."
+          exit 1
+        fi
 
         echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
         echo "mlir_sha=$mlir_sha" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Closes #3377

### Checks
- [x] [Llama-3.2-1B on pre-installed docker wheel](https://github.com/tenstorrent/tt-xla/actions/runs/22179076635)
- [x] [Llama-3.2-1B on fresh wheel](https://github.com/tenstorrent/tt-xla/actions/runs/22179276709)
    [On push](https://github.com/tenstorrent/tt-mlir/actions/runs/22164190625) flow failed in tt-mlir, so there are no artifacts!