### PR TITLE
Update inference test configs of carvana_unet_480x640, mlp_mixer_L16_224_In21k, ssdlite320_mobilenetv3, ssd300_vgg16

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -478,11 +478,7 @@ test_config:
     status: EXPECTED_PASSING
 
   unet/pytorch-carvana_unet_480x640-single_device-inference:
-    status: KNOWN_FAILURE_XFAIL
-    reason: "Out of Memory: Not enough space to allocate 2537856 B L1_SMALL buffer across 72 banks, where each bank needs to store 35248 B, but bank size is only 65536 B"
-    arch_overrides:
-      p150:
-        status: EXPECTED_PASSING
+    status: EXPECTED_PASSING
 
   vgg/pytorch-Torchvision_Vgg11_Bn-single_device-inference:
     status: EXPECTED_PASSING
@@ -571,7 +567,7 @@ test_config:
 
   mlp_mixer/pytorch-Mixer_L16_224_In21k-single_device-inference:
     status: EXPECTED_PASSING
-    assert_pcc: false
+    required_pcc: 0.98 # https://github.com/tenstorrent/tt-xla/issues/3318
 
   mlp_mixer/pytorch-Mixer_B16_224.goog_In21k-single_device-inference:
     status: EXPECTED_PASSING
@@ -2315,9 +2311,8 @@ test_config:
     reason: "failed to legalize operation 'ttir.gather' - https://github.com/tenstorrent/tt-xla/issues/318"
 
   ssdlite320_mobilenetv3/pytorch-Ssdlite320_Mobilenet_v3_Large-single_device-inference:
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_FE_COMPILATION
-    reason: "Can't convert shape rank  - https://github.com/tenstorrent/tt-xla/issues/2456"
+    status: KNOWN_FAILURE_XFAIL
+    reason: "error: 'ttir.arange' op Invalid range: start=0, end=0, step=1 - https://github.com/tenstorrent/tt-xla/issues/3380"
 
   retinanet/pytorch-ResNet50_Backbone_with_FPN_V2-single_device-inference:
     status: NOT_SUPPORTED_SKIP
@@ -2325,9 +2320,8 @@ test_config:
     bringup_status: FAILED_RUNTIME
 
   ssd300_vgg16/pytorch-Default-single_device-inference:
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "Can't convert shape rank - https://github.com/tenstorrent/tt-xla/issues/2456"
+    status: KNOWN_FAILURE_XFAIL
+    reason: "Can't convert shape rank - https://github.com/tenstorrent/tt-xla/issues/3379"
 
   gemma/codegemma/pytorch-2B-single_device-inference:
     assert_pcc: false # https://github.com/tenstorrent/tt-mlir/issues/6461


### PR DESCRIPTION
### Ticket

- closes https://github.com/tenstorrent/tt-xla/issues/3318

### Problem description

- The configs for carvana_unet_480x640, ssdlite320_mobilenetv3, and ssd300_vgg16 need to be updated based on the latest results.
- I'm unable to replicate the PCC drop in mlp_mixer_L16_224_In21k with sanity
- All the experiments and results on root cause analysis are attached in ticket
- Since the model’s PCC is consistently > 0.95, the PCC threshold can be safely reduced. 
- For complete context on reducing threshold pls checkout this [comment](https://github.com/tenstorrent/tt-xla/pull/2818#discussion_r2687257587)

### What's changed

- carvana_unet_480x640 is now passing with PCC=1.0 on the current main. So updated the config accordingly.
- Removed ssdlite320_mobilenetv3 and ssd300_vgg16 from the skipped list and updated their configs based on the latest failures.
- Reduced the PCC threshold for mlp_mixer_L16_224_In21k.


### Checklist
- [x] verified the changes through local testing

### Logs

- [results.zip](https://github.com/user-attachments/files/25414956/results.zip)
