### PR TITLE
Switch from tt-forge to tt-xla benchmark on nightly

### DIFF
--- a/.github/workflows/call-release-tests.yml
+++ b/.github/workflows/call-release-tests.yml
@@ -22,26 +22,24 @@ jobs:
       project-filter: tt-xla
 
   perf-benchmark-n150:
-    uses: tenstorrent/tt-forge/.github/workflows/perf-benchmark.yml@main
+    uses: ./.github/workflows/manual-benchmark.yml
     secrets: inherit
     with:
-      docker-image: ${{ inputs.release_docker_image }}
-      ref: main
-      project: tt-xla
+      docker_image: ${{ inputs.release_docker_image }}
+      runs-on-filter: n150
       sh-runner: false
       skip-device-perf: false
-      runs-on-filter: n150
+      use_docker_wheel: true
 
   perf-benchmark-llmbox:
-    uses: tenstorrent/tt-forge/.github/workflows/perf-benchmark.yml@main
+    uses: ./.github/workflows/manual-benchmark.yml
     secrets: inherit
     with:
-      docker-image: ${{ inputs.release_docker_image }}
-      ref: main
-      project: tt-xla
+      docker_image: ${{ inputs.release_docker_image }}
+      runs-on-filter: n300-llmbox
       sh-runner: false
       skip-device-perf: false
-      runs-on-filter: llmbox
+      use_docker_wheel: true
 
   demo-tests:
     uses: tenstorrent/tt-forge/.github/workflows/demo-tests.yml@main

--- a/.github/workflows/manual-benchmark.yml
+++ b/.github/workflows/manual-benchmark.yml
@@ -1,6 +1,47 @@
 name: Performance Benchmark
 
 on:
+  workflow_call:
+    inputs:
+      mlir_override:
+        description: 'Git SHA of commit in tenstorrent/tt-mlir'
+        required: false
+        type: string
+      docker_image:
+        description: 'Docker image to use'
+        required: false
+        type: string
+        default: 'ghcr.io/tenstorrent/tt-xla-slim:nightly-latest'
+      test_filter:
+        description: "Filter tests based on the name property. One or more strings which are contained (case insensitive) in the name (e.g. 'resn' or 'resn,mni,yol')"
+        required: false
+        type: string
+      runs-on-filter:
+        description: "Architecture you want to run the tests on (All, n150, p150, n300-llmbox)"
+        required: false
+        type: string
+        default: n150
+      skip-device-perf:
+        description: "Skip device performance measurement"
+        required: false
+        type: boolean
+        default: true
+      perf_regression_check:
+        description: "Enable perf metrics regression testing"
+        required: false
+        type: boolean
+        default: false
+      use_docker_wheel:
+        description: "Use wheel from docker"
+        required: false
+        type: boolean
+        default: false
+      sh-runner:
+        description: "Run on shared runner"
+        required: false
+        type: boolean
+        default: true
+
   workflow_dispatch:
     inputs:
       mlir_override:


### PR DESCRIPTION
Recently, performance benchmark was migrated from tt-forge to tt-xla https://github.com/tenstorrent/tt-xla/commit/e02d36ee52cb75b92b7712a925462ecb890869d0

We should trigger tt-xla benchmark on tt-xla nightly instead of tt-forge benchmark that will soon be deprecated.

### Checks
- [x] [Test whole benchmark with temporary manual dispatch](https://github.com/tenstorrent/tt-xla/actions/runs/22183270515)