### PR TITLE
Enable batch_size=32 for gpt-oss-20b benchmark test

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -213,6 +213,12 @@
         "runs-on": "llmbox"
       },
       {
+        "name": "gpt_oss_20b_tp_batch_size_1",
+        "pyreq": "datasets loguru pytest requests accelerate torch==2.9.0 tqdm transformers==4.57.1",
+        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_batch_size_1",
+        "runs-on": "llmbox"
+      },
+      {
         "name": "microsoft_phi-1",
         "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==4.57.1",
         "pytest": "tests/benchmark/test_llms.py::test_phi1"

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -865,3 +865,21 @@ def test_gpt_oss_20b_tp(output_file, num_layers, request):
         request=request,
         optimization_level=0,  # https://github.com/tenstorrent/tt-mlir/issues/6949
     )
+
+
+def test_gpt_oss_20b_tp_batch_size_1(output_file, num_layers, request):
+    from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
+        ModelLoader,
+        ModelVariant,
+    )
+
+    variant = ModelVariant.GPT_OSS_20B
+    test_llm_tp(
+        ModelLoader,
+        variant,
+        output_file,
+        num_layers=num_layers,
+        request=request,
+        batch_size=1,
+        optimization_level=0,  # https://github.com/tenstorrent/tt-mlir/issues/6949
+    )


### PR DESCRIPTION
### Ticket
#3251 
[#7128](https://github.com/tenstorrent/tt-mlir/issues/7128)

### Problem description
Reshape operation hang is a known issue in tt-metal: https://github.com/tenstorrent/tt-metal/issues/29830 
Recently, a tt-mlir change significantly changed the produced gpt-oss graph: https://github.com/tenstorrent/tt-mlir/commit/56081a1a0a181659da0342014ea905a86f201d02 
Not encountering the hang with batch_size 32 with the new graph. Will debug the reshape hang more if we encounter again.

### What's changed
Removed batch size=16. Added additional test for batch_size=1. 

### Checklist
- [x] Benchmark run with gpt-oss: https://github.com/tenstorrent/tt-xla/actions/runs/22409723493
