### PR TITLE
Training test fix

### DIFF
--- a/tests/runner/test_config/torch/test_config_training_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_training_single_device.yaml
@@ -53,7 +53,7 @@ test_config:
     bringup_status: FAILED_FE_COMPILATION
     reason: "Node arity mismatch; expected 339, but got 338"
   llama/causal_lm/pytorch-3.2_1B-single_device-training:
-    status: EXPECTED_PASSING
+    status: KNOWN_FAILURE_XFAIL
     markers: [large, notimeout]
   llama/causal_lm/pytorch-3.2_1B_Instruct-single_device-training:
     status: KNOWN_FAILURE_XFAIL


### PR DESCRIPTION
One training test was left as `EXCPECTED PASSING` by mistake, so fixing that.