### PR TITLE
Return configs as tests xfail regularly now

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -2504,9 +2504,8 @@ test_config:
     required_pcc: 0.96
     arch_overrides:
       n150:
-        status: NOT_SUPPORTED_SKIP
-        bringup_status: FAILED_FE_COMPILATION
-        reason: "Segmentation fault: https://github.com/tenstorrent/tt-xla/issues/3178"
+        status: KNOWN_FAILURE_XFAIL
+        reason: "Out of Memory: Not enough space to allocate 90177536 B DRAM buffer across 12 banks, where each bank needs to store 7516160 B, but bank size is only 1073741792 B - https://github.com/tenstorrent/tt-xla/issues/2328"
 
   openvla_oft/pytorch-Finetuned_Libero_Spatial-single_device-inference:
     status: EXPECTED_PASSING
@@ -2577,9 +2576,8 @@ test_config:
     status: EXPECTED_PASSING
     arch_overrides:
       n150:
-        status: NOT_SUPPORTED_SKIP
-        bringup_status: FAILED_FE_COMPILATION
-        reason: "Segmentation fault: https://github.com/tenstorrent/tt-xla/issues/3178"
+        status: KNOWN_FAILURE_XFAIL
+        reason: "Out of Memory: Not enough space to allocate 100663296 B DRAM buffer across 12 banks, where each bank needs to store 8388608 B, but bank size is 1073741792 B"
 
   siglip/image_text_similarity/pytorch-Base_Patch16_224-single_device-inference:
     status: EXPECTED_PASSING

--- a/tests/torch/models/resnet/test_resnet.py
+++ b/tests/torch/models/resnet/test_resnet.py
@@ -85,14 +85,9 @@ def training_tester() -> ResnetTester:
         pytest.param(
             "bfp8",
             0,
-            marks=[
-                pytest.mark.skip(
-                    reason="Never finishes execution. Tracking issue: https://github.com/tenstorrent/tt-xla/issues/3163"
-                ),
-                pytest.mark.record_test_properties(
-                    bringup_status=BringupStatus.FAILED_TTMLIR_COMPILATION,
-                ),
-            ],
+            marks=pytest.mark.xfail(
+                reason="ttnn.batch_norm not supported for bfp8 https://github.com/tenstorrent/tt-xla/issues/3163"
+            ),
         ),
         pytest.param(
             "bfloat16",


### PR DESCRIPTION
Mark skipped tests as xfailed, as they regularly fail on main as before