### PR TITLE
Add inference test config for olm_ocr model

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -2692,3 +2692,19 @@ test_config:
         reason: "Out of Memory: Not enough space to allocate 52428800 B L1 buffer across 64 banks, where each bank needs to store 819200 B, but bank size is only 1331936 B"
       p150:
         status: EXPECTED_PASSING
+
+  olm_ocr/image_text_generation/pytorch-olmOCR-7B-0225-preview-single_device-inference:
+    status: KNOWN_FAILURE_XFAIL
+    reason: "Out of Memory: Not enough space to allocate 681836544 B DRAM buffer across 12 banks, where each bank needs to store 56819712 B, but bank size is 1071821792 B (allocated: 972700384 B, free: 99121408 B, largest free block: 55576928 B) - https://github.com/tenstorrent/tt-xla/issues/3388"
+
+  olm_ocr/image_text_generation/pytorch-olmOCR-7B-0725-single_device-inference:
+    status: KNOWN_FAILURE_XFAIL
+    reason: "Out of Memory: Not enough space to allocate 681836544 B DRAM buffer across 12 banks, where each bank needs to store 56819712 B, but bank size is 1071821792 B (allocated: 972700384 B, free: 99121408 B, largest free block: 55576928 B) - https://github.com/tenstorrent/tt-xla/issues/3388"
+
+  olm_ocr/image_text_generation/pytorch-olmOCR-7B-0825-single_device-inference:
+    status: KNOWN_FAILURE_XFAIL
+    reason: "Out of Memory: Not enough space to allocate 681836544 B DRAM buffer across 12 banks, where each bank needs to store 56819712 B, but bank size is 1071821792 B (allocated: 972700384 B, free: 99121408 B, largest free block: 55576928 B) - https://github.com/tenstorrent/tt-xla/issues/3388"
+
+  olm_ocr/image_text_generation/pytorch-olmOCR-2-7B-1025-single_device-inference:
+    status: KNOWN_FAILURE_XFAIL
+    reason: "Out of Memory: Not enough space to allocate 681836544 B DRAM buffer across 12 banks, where each bank needs to store 56819712 B, but bank size is 1071821792 B (allocated: 972700384 B, free: 99121408 B, largest free block: 55576928 B) - https://github.com/tenstorrent/tt-xla/issues/3388"


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/3388

### Problem description

- Inference test config not yet added for olm_ocr model

### What's changed

Added inference test config for Olm ocr model

### Logs
[olm_ocr_7b_0225.log](https://github.com/user-attachments/files/25445670/olm_ocr.log)
[olm_ocr_7b_0725.log](https://github.com/user-attachments/files/25510966/olm_ocr_7b_0725.log)
[olm_ocr_7b_0825.log](https://github.com/user-attachments/files/25510969/olm_ocr_7b_0825.log)
[olm_ocr_2_7b_1025.log](https://github.com/user-attachments/files/25510973/olm_ocr_2_7b_1025.log)
