### PR TITLE
Use tt-xla benchmark on uplift PRs

### DIFF
--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -5,7 +5,7 @@ on:
     branches: [ "main" ]
 
 permissions:
-  contents: read
+  contents: write
   packages: write
   checks: write
   pull-requests: write


### PR DESCRIPTION
### Description

After benchmark migration from tt-forge to tt-xla, uplift On PR workflows still use the deprecated tt-forge benchmark.

### What's changed

Switched to tt-xla benchmark on uplift On PR workflow.