### PR TITLE
Expand prefill testing to support various meshes and multichip strategies

### DIFF
--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -276,7 +276,7 @@ jobs:
         # NOTE: Torch tests must be run in separate processes to avoid current issues with test isolation
         # See issue: https://github.com/tenstorrent/tt-xla/issues/795
         PYTEST_FORKED=""
-        for n in run_torch run_large_jax_models run_forge_models run_forge_models_llm run_forge_models_llm_multichip run_forge_models_torch run_jax_training run_large_jax_training extended_models run_large_torch_models; do
+        for n in run_torch run_large_jax_models run_forge_models run_forge_models_llm run_forge_models_torch run_jax_training run_large_jax_training extended_models run_large_torch_models; do
           if [[ "${{ matrix.build.name }}" == "$n" ]]; then
             PYTEST_FORKED="--forked"; break
           fi

--- a/tests/infra/evaluators/comparison_evaluator.py
+++ b/tests/infra/evaluators/comparison_evaluator.py
@@ -50,11 +50,11 @@ class ComparisonEvaluator(Evaluator):
         _comparison_result.atol = self._compare_atol(
             device_output, golden_output, self._comparison_config.atol
         )
-        _comparison_result.pcc = self._compare_pcc_masked(
+        _comparison_result.pcc = self._compare_pcc(
             device_output,
             golden_output,
             self._comparison_config.pcc,
-            pcc_mask,
+            pcc_mask=pcc_mask,
         )
         _comparison_result.allclose = self._compare_allclose(
             device_output, golden_output, self._comparison_config.allclose
@@ -176,25 +176,17 @@ class ComparisonEvaluator(Evaluator):
         """
         raise NotImplementedError("Subclasses must implement this method")
 
-    def _compare_pcc_masked(
-        self,
-        device_output: PyTree,
-        golden_output: PyTree,
-        pcc_config: PccConfig,
-        pcc_mask: Tensor | None = None,
-    ) -> float:
-        """Optional PCC mask hook; default behavior ignores the mask."""
-        return self._compare_pcc(device_output, golden_output, pcc_config)
-
     @abstractmethod
     def _compare_pcc(
         self,
         device_output: PyTree,
         golden_output: PyTree,
         pcc_config: PccConfig,
+        pcc_mask: Tensor | None = None,
     ) -> float:
         """
-        Compares PCC metric between device and golden output.
+        Compares PCC metric between device and golden output, with optional
+        masking for padded tokens.
         Returns the calculated PCC value.
         """
         raise NotImplementedError("Subclasses must implement this method")

--- a/tests/infra/evaluators/comparison_evaluator.py
+++ b/tests/infra/evaluators/comparison_evaluator.py
@@ -21,7 +21,9 @@ class ComparisonEvaluator(Evaluator):
         """Initialize the comparison evaluator with comparison configuration."""
         self._comparison_config = comparison_config
 
-    def evaluate(self, device_out: Tensor, golden_out: Tensor) -> ComparisonResult:
+    def evaluate(
+        self, device_out: Tensor, golden_out: Tensor, *, pcc_mask: Tensor | None = None
+    ) -> ComparisonResult:
         """
         Compares device output with golden output based on ComparisonConfig provided
         during creation.
@@ -48,8 +50,11 @@ class ComparisonEvaluator(Evaluator):
         _comparison_result.atol = self._compare_atol(
             device_output, golden_output, self._comparison_config.atol
         )
-        _comparison_result.pcc = self._compare_pcc(
-            device_output, golden_output, self._comparison_config.pcc
+        _comparison_result.pcc = self._compare_pcc_masked(
+            device_output,
+            golden_output,
+            self._comparison_config.pcc,
+            pcc_mask,
         )
         _comparison_result.allclose = self._compare_allclose(
             device_output, golden_output, self._comparison_config.allclose
@@ -171,9 +176,22 @@ class ComparisonEvaluator(Evaluator):
         """
         raise NotImplementedError("Subclasses must implement this method")
 
+    def _compare_pcc_masked(
+        self,
+        device_output: PyTree,
+        golden_output: PyTree,
+        pcc_config: PccConfig,
+        pcc_mask: Tensor | None = None,
+    ) -> float:
+        """Optional PCC mask hook; default behavior ignores the mask."""
+        return self._compare_pcc(device_output, golden_output, pcc_config)
+
     @abstractmethod
     def _compare_pcc(
-        self, device_output: PyTree, golden_output: PyTree, pcc_config: PccConfig
+        self,
+        device_output: PyTree,
+        golden_output: PyTree,
+        pcc_config: PccConfig,
     ) -> float:
         """
         Compares PCC metric between device and golden output.

--- a/tests/infra/evaluators/jax_comparison_evaluator.py
+++ b/tests/infra/evaluators/jax_comparison_evaluator.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
+
 import jax
 import jax.numpy as jnp
 from infra.runners import run_on_cpu
@@ -61,8 +63,17 @@ class JaxComparisonEvaluator(ComparisonEvaluator):
     # @override
     @run_on_cpu(Framework.JAX)
     def _compare_pcc(
-        self, device_output: PyTree, golden_output: PyTree, pcc_config: PccConfig
+        self,
+        device_output: PyTree,
+        golden_output: PyTree,
+        pcc_config: PccConfig,
+        pcc_mask: PyTree | None = None,
     ) -> float:
+        if pcc_mask is not None:
+            warnings.warn(
+                "pcc_mask was provided to JaxComparisonEvaluator but will be ignored.",
+            )
+
         def compute_pcc(x: jax.Array, y: jax.Array):
             # PCC formula can be ill conditioned. If inputs are allclose, fudge the result to 1.0.
             # Done per tensor to avoid cases where some pairs in a pytree are not allclose and others enter the ill-conditioned region.

--- a/tests/infra/evaluators/jax_comparison_evaluator.py
+++ b/tests/infra/evaluators/jax_comparison_evaluator.py
@@ -69,6 +69,8 @@ class JaxComparisonEvaluator(ComparisonEvaluator):
         pcc_config: PccConfig,
         pcc_mask: PyTree | None = None,
     ) -> float:
+
+        # TODO: Once https://github.com/tenstorrent/tt-xla/issues/3641 is fixed, add support for pcc_mask, as done in TorchComparisonEvaluator.
         if pcc_mask is not None:
             warnings.warn(
                 "pcc_mask was provided to JaxComparisonEvaluator but will be ignored.",

--- a/tests/infra/evaluators/torch_comparison_evaluator.py
+++ b/tests/infra/evaluators/torch_comparison_evaluator.py
@@ -15,20 +15,6 @@ from .evaluation_config import AllcloseConfig, AtolConfig, PccConfig
 class TorchComparisonEvaluator(ComparisonEvaluator):
     """ComparisonEvaluator for Torch tensors/pytrees."""
 
-    def _compare_pcc_masked(
-        self,
-        device_output: PyTree,
-        golden_output: PyTree,
-        pcc_config: PccConfig,
-        pcc_mask: torch.Tensor | None = None,
-    ) -> float:
-        return self._compare_pcc(
-            device_output,
-            golden_output,
-            pcc_config,
-            pcc_mask=pcc_mask,
-        )
-
     # @override
     def _is_single_element(self, tensor: PyTree) -> bool:
         """Returns True if the tensor has only a single element."""
@@ -128,6 +114,9 @@ class TorchComparisonEvaluator(ComparisonEvaluator):
             if pcc_mask is None:
                 return x, y
 
+            assert (
+                pcc_mask.ndim == 2
+            ), f"Expected pcc_mask to have shape [batch, seq], got {tuple(pcc_mask.shape)}"
             batch_size, seq_len = pcc_mask.shape
 
             if x.dim() < 2 or y.dim() < 2:
@@ -144,19 +133,19 @@ class TorchComparisonEvaluator(ComparisonEvaluator):
                 and x.shape[1] == seq_len
                 and y.shape[1] == seq_len
             ):
-                pass
+                x_seq_first, y_seq_first = x, y
             elif (
                 x.dim() == 4
                 and y.dim() == 4
                 and x.shape[2] == seq_len
                 and y.shape[2] == seq_len
             ):
-                x = x.movedim(2, 1)
-                y = y.movedim(2, 1)
+                x_seq_first = x.movedim(2, 1)
+                y_seq_first = y.movedim(2, 1)
             else:
                 return x, y
 
-            x, y = x[pcc_mask], y[pcc_mask]
+            x, y = x_seq_first[pcc_mask], y_seq_first[pcc_mask]
             return x, y
 
         def compute_pcc(x: torch.Tensor, y: torch.Tensor):

--- a/tests/infra/evaluators/torch_comparison_evaluator.py
+++ b/tests/infra/evaluators/torch_comparison_evaluator.py
@@ -124,26 +124,22 @@ class TorchComparisonEvaluator(ComparisonEvaluator):
             if x.shape[0] != batch_size or y.shape[0] != batch_size:
                 return x, y
 
-            # Keep masking deterministic and simple for known LLM outputs:
-            # - rank-3 tensors (e.g. logits [B, S, V]) -> sequence dim is 1
-            # - rank-4 tensors (e.g. KV [B, H, S, D]) -> sequence dim is 2
-            if (
-                x.dim() == 3
-                and y.dim() == 3
-                and x.shape[1] == seq_len
-                and y.shape[1] == seq_len
-            ):
-                x_seq_first, y_seq_first = x, y
-            elif (
-                x.dim() == 4
-                and y.dim() == 4
-                and x.shape[2] == seq_len
-                and y.shape[2] == seq_len
-            ):
-                x_seq_first = x.movedim(2, 1)
-                y_seq_first = y.movedim(2, 1)
-            else:
-                return x, y
+            # Known LLM outputs:
+            # - rank-3 tensors (e.g. logits [B, S, V]) -> sequence dim is -2
+            # - rank-4 tensors (e.g. KV [B, H, S, D]) -> sequence dim is -2
+            assert (
+                x.shape == y.shape
+            ), f"pcc_mask requires matching shapes, got {x.shape} vs {y.shape}"
+            assert x.dim() in (
+                3,
+                4,
+            ), f"pcc_mask only supports rank-3 (logits) or rank-4 (KV) tensors, got rank {x.dim()} with shape {x.shape}"
+            assert (
+                x.shape[-2] == seq_len
+            ), f"dim -2 should be seq_len ({seq_len}), got {x.shape[-2]} in shape {x.shape}"
+
+            x_seq_first = x.movedim(-2, 1)
+            y_seq_first = y.movedim(-2, 1)
 
             x, y = x_seq_first[pcc_mask], y_seq_first[pcc_mask]
             return x, y

--- a/tests/infra/evaluators/torch_comparison_evaluator.py
+++ b/tests/infra/evaluators/torch_comparison_evaluator.py
@@ -15,6 +15,20 @@ from .evaluation_config import AllcloseConfig, AtolConfig, PccConfig
 class TorchComparisonEvaluator(ComparisonEvaluator):
     """ComparisonEvaluator for Torch tensors/pytrees."""
 
+    def _compare_pcc_masked(
+        self,
+        device_output: PyTree,
+        golden_output: PyTree,
+        pcc_config: PccConfig,
+        pcc_mask: torch.Tensor | None = None,
+    ) -> float:
+        return self._compare_pcc(
+            device_output,
+            golden_output,
+            pcc_config,
+            pcc_mask=pcc_mask,
+        )
+
     # @override
     def _is_single_element(self, tensor: PyTree) -> bool:
         """Returns True if the tensor has only a single element."""
@@ -104,11 +118,51 @@ class TorchComparisonEvaluator(ComparisonEvaluator):
     # @override
     @run_on_cpu(Framework.TORCH)
     def _compare_pcc(
-        self, device_output: PyTree, golden_output: PyTree, pcc_config: PccConfig
+        self,
+        device_output: PyTree,
+        golden_output: PyTree,
+        pcc_config: PccConfig,
+        pcc_mask: torch.Tensor | None = None,
     ) -> float:
+        def apply_real_token_mask(x: torch.Tensor, y: torch.Tensor):
+            if pcc_mask is None:
+                return x, y
+
+            batch_size, seq_len = pcc_mask.shape
+
+            if x.dim() < 2 or y.dim() < 2:
+                return x, y
+            if x.shape[0] != batch_size or y.shape[0] != batch_size:
+                return x, y
+
+            # Keep masking deterministic and simple for known LLM outputs:
+            # - rank-3 tensors (e.g. logits [B, S, V]) -> sequence dim is 1
+            # - rank-4 tensors (e.g. KV [B, H, S, D]) -> sequence dim is 2
+            if (
+                x.dim() == 3
+                and y.dim() == 3
+                and x.shape[1] == seq_len
+                and y.shape[1] == seq_len
+            ):
+                pass
+            elif (
+                x.dim() == 4
+                and y.dim() == 4
+                and x.shape[2] == seq_len
+                and y.shape[2] == seq_len
+            ):
+                x = x.movedim(2, 1)
+                y = y.movedim(2, 1)
+            else:
+                return x, y
+
+            x, y = x[pcc_mask], y[pcc_mask]
+            return x, y
+
         def compute_pcc(x: torch.Tensor, y: torch.Tensor):
             if x is None and y is None:
                 return None
+            x, y = apply_real_token_mask(x, y)
             # PCC formula can be ill conditioned. If inputs are allclose, fudge the result to 1.0.
             # Done per tensor to avoid cases where some pairs in a pytree are not allclose and others enter the ill-conditioned region.
             if TorchComparisonEvaluator._compare_allclose(x, y, pcc_config.allclose):

--- a/tests/runner/test_config/constants.py
+++ b/tests/runner/test_config/constants.py
@@ -51,7 +51,15 @@ FRAMEWORKS = ("torch", "jax", "torch_llm")
 
 # Parallelism values for test ID cross-product
 PARALLELISMS_STANDARD = ("single_device", "data_parallel", "tensor_parallel")
-PARALLELISMS_LLM = ("single_device", "tensor_parallel")
+PARALLELISMS_LLM = (
+    "single_device",
+    "tensor_parallel",
+    "megatron_mesh_1x8-no_dp-tensor_parallel",
+    "fsdp_mesh_2x4-no_dp-tensor_parallel",
+    "fsdp_mesh_2x4-dp-tensor_parallel",
+    "megatron_mesh_2x4-no_dp-tensor_parallel",
+    "megatron_mesh_2x4-dp-tensor_parallel",
+)
 
 # Run modes
 RUN_MODES_STANDARD = ("inference", "training")

--- a/tests/runner/test_config/constants.py
+++ b/tests/runner/test_config/constants.py
@@ -70,7 +70,7 @@ LLM_PHASES = {"load_inputs_decode": "llm_decode", "load_inputs_prefill": "llm_pr
 
 # LLM parametrization values (mirrors test_models.py)
 LLM_SEQUENCE_LENGTHS = (128, 1024, 2048, 4096, 8192)
-LLM_BATCH_SIZES = (1, 2)
+LLM_BATCH_SIZES = (1, 32)
 
 # Models excluded from PyTorch discovery (matches dynamic_loader.py)
 TORCH_EXCLUDED_MODEL_DIRS = {"suryaocr"}

--- a/tests/runner/test_config/constants.py
+++ b/tests/runner/test_config/constants.py
@@ -54,12 +54,12 @@ PARALLELISMS_STANDARD = ("single_device", "data_parallel", "tensor_parallel")
 PARALLELISMS_LLM = (
     "single_device",
     "tensor_parallel",
-    "megatron_mesh_1x8-no_dp-tensor_parallel",
-    "fsdp_mesh_2x4-no_dp-tensor_parallel",
-    "fsdp_mesh_2x4-dp-tensor_parallel",
-    "megatron_mesh_2x4-no_dp-tensor_parallel",
-    "megatron_mesh_2x4-dp-tensor_parallel",
+    "megatron-no_dp-tensor_parallel",
+    "fsdp-no_dp-tensor_parallel",
+    "fsdp-dp-tensor_parallel",
+    "megatron-dp-tensor_parallel",
 )
+LLM_MESH_SHAPES = ("mesh_default", "mesh_1x8", "mesh_2x4")
 
 # Run modes
 RUN_MODES_STANDARD = ("inference", "training")

--- a/tests/runner/test_config/constants.py
+++ b/tests/runner/test_config/constants.py
@@ -70,7 +70,7 @@ LLM_PHASES = {"load_inputs_decode": "llm_decode", "load_inputs_prefill": "llm_pr
 
 # LLM parametrization values (mirrors test_models.py)
 LLM_SEQUENCE_LENGTHS = (128, 1024, 2048, 4096, 8192)
-LLM_BATCH_SIZES = (1, 32)
+LLM_BATCH_SIZES = (1, 4)
 
 # Models excluded from PyTorch discovery (matches dynamic_loader.py)
 TORCH_EXCLUDED_MODEL_DIRS = {"suryaocr"}

--- a/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
@@ -196,56 +196,56 @@ test_config:
       - matmul_with_activation_silu.ttnn.mlir
       - softmax.ttnn.mlir # SDPA fusion is not enabled without the optimizer, so we only check for softmax
 
-  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_128-batch_32-single_device-mesh_default-inference:
-    supported_archs: ["n150"]
+  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_128-batch_4-single_device-mesh_default-inference:
+    supported_archs: ["n150", "p150"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_1024-batch_1-single_device-mesh_default-inference:
-    supported_archs: ["n150"]
+    supported_archs: ["n150", "p150"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
 
-  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_1024-batch_32-single_device-mesh_default-inference:
-    supported_archs: ["n150"]
+  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_1024-batch_4-single_device-mesh_default-inference:
+    supported_archs: ["n150", "p150"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_2048-batch_1-single_device-mesh_default-inference:
-    supported_archs: ["n150"]
+    supported_archs: ["n150", "p150"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
 
-  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_2048-batch_32-single_device-mesh_default-inference:
-    supported_archs: ["n150"]
+  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_2048-batch_4-single_device-mesh_default-inference:
+    supported_archs: ["n150", "p150"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_4096-batch_1-single_device-mesh_default-inference:
-    supported_archs: ["n150"]
+    supported_archs: ["n150", "p150"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
 
-  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_4096-batch_32-single_device-mesh_default-inference:
-    supported_archs: ["n150"]
+  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_4096-batch_4-single_device-mesh_default-inference:
+    supported_archs: ["n150", "p150"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_8192-batch_1-single_device-mesh_default-inference:
-    supported_archs: ["n150"]
+    supported_archs: ["n150", "p150"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
 
-  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_8192-batch_32-single_device-mesh_default-inference:
-    supported_archs: ["n150"]
+  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_8192-batch_4-single_device-mesh_default-inference:
+    supported_archs: ["n150", "p150"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]

--- a/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
@@ -18,11 +18,11 @@ test_config:
     reason: "Hang - https://github.com/tenstorrent/tt-xla/issues/3838"
     bringup_status: FAILED_RUNTIME
 
-  falcon/pytorch-3_7B_Base-llm_decode-seq_1-batch_1-single_device-inference:
+  falcon/pytorch-3_7B_Base-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.
     status: EXPECTED_PASSING
 
-  falcon/pytorch-3_10B_Base-llm_decode-seq_1-batch_1-single_device-inference:
+  falcon/pytorch-3_10B_Base-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.
     status: EXPECTED_PASSING
 
@@ -41,18 +41,18 @@ test_config:
     reason: "Hang - https://github.com/tenstorrent/tt-xla/issues/3838"
     bringup_status: FAILED_RUNTIME
 
-  qwen_2_5/causal_lm/pytorch-7B_Instruct-llm_decode-seq_1-batch_1-single_device-inference:
+  qwen_2_5/causal_lm/pytorch-7B_Instruct-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.
     status: EXPECTED_PASSING
 
-  qwen_2_5/causal_lm/pytorch-14B_Instruct-llm_decode-seq_1-batch_1-single_device-inference:
+  qwen_2_5/causal_lm/pytorch-14B_Instruct-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.
     status: EXPECTED_PASSING
 
-  qwen_2_5/causal_lm/pytorch-32B_Instruct-llm_decode-seq_1-batch_1-single_device-inference:
+  qwen_2_5/causal_lm/pytorch-32B_Instruct-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     status: EXCLUDE_MODEL # Too large for single chip, run as tensor_parallel instead.
 
-  qwen_2_5/causal_lm/pytorch-72B_Instruct-llm_decode-seq_1-batch_1-single_device-inference:
+  qwen_2_5/causal_lm/pytorch-72B_Instruct-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     status: EXCLUDE_MODEL # Too large for single chip, run as tensor_parallel instead.
 
   gemma/pytorch-1.1_2B_IT-llm_decode-seq_1-batch_1-single_device-inference:
@@ -60,43 +60,43 @@ test_config:
     reason: "Hangs - https://github.com/tenstorrent/tt-xla/issues/4004"
     bringup_status: FAILED_RUNTIME
 
-  gemma/pytorch-1.1_7B_IT-llm_decode-seq_1-batch_1-single_device-inference:
+  gemma/pytorch-1.1_7B_IT-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.
     status: NOT_SUPPORTED_SKIP
     reason: "Hang - https://github.com/tenstorrent/tt-xla/issues/4094"
     bringup_status: FAILED_RUNTIME
 
-  gemma/pytorch-2_2B_IT-llm_decode-seq_1-batch_1-single_device-inference:
+  gemma/pytorch-2_2B_IT-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     status: EXPECTED_PASSING
 
-  gemma/pytorch-2_9B_IT-llm_decode-seq_1-batch_1-single_device-inference:
+  gemma/pytorch-2_9B_IT-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.
     status: EXPECTED_PASSING
 
-  gemma/pytorch-2_27B_IT-llm_decode-seq_1-batch_1-single_device-inference:
+  gemma/pytorch-2_27B_IT-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     status: EXCLUDE_MODEL # Too large for single chip, run as tensor_parallel instead.
 
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_decode-seq_1-batch_1-single_device-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.
     status: EXPECTED_PASSING
 
-  llama/causal_lm/pytorch-3.1_70B-llm_decode-seq_1-batch_1-single_device-inference:
+  llama/causal_lm/pytorch-3.1_70B-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     status: EXCLUDE_MODEL # Too large for single chip, run as tensor_parallel instead.
 
-  llama/causal_lm/pytorch-3.1_70B_Instruct-llm_decode-seq_1-batch_1-single_device-inference:
+  llama/causal_lm/pytorch-3.1_70B_Instruct-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     status: EXCLUDE_MODEL # Too large for single chip, run as tensor_parallel instead.
 
-  llama/causal_lm/pytorch-3.1_405B-llm_decode-seq_1-batch_1-single_device-inference:
+  llama/causal_lm/pytorch-3.1_405B-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     status: EXCLUDE_MODEL # Too large for single chip, run as tensor_parallel instead.
 
-  llama/causal_lm/pytorch-3.2_1B_Instruct-llm_decode-seq_1-batch_1-single_device-inference:
+  llama/causal_lm/pytorch-3.2_1B_Instruct-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     status: EXPECTED_PASSING
     assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/2845
 
-  llama/causal_lm/pytorch-3.2_3B_Instruct-llm_decode-seq_1-batch_1-single_device-inference:
+  llama/causal_lm/pytorch-3.2_3B_Instruct-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     status: EXPECTED_PASSING
 
-  llama/causal_lm/pytorch-3.3_70B_Instruct-llm_decode-seq_1-batch_1-single_device-inference:
+  llama/causal_lm/pytorch-3.3_70B_Instruct-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     status: EXCLUDE_MODEL # Too large for single chip, run as tensor_parallel instead.
 
   qwen_3/causal_lm/pytorch-0_6B-llm_decode-seq_1-batch_1-single_device-inference:
@@ -114,29 +114,29 @@ test_config:
     reason: "Hang - https://github.com/tenstorrent/tt-xla/issues/3838"
     bringup_status: FAILED_RUNTIME
 
-  qwen_3/causal_lm/pytorch-8B-llm_decode-seq_1-batch_1-single_device-inference:
+  qwen_3/causal_lm/pytorch-8B-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.
     status: EXPECTED_PASSING
 
-  qwen_3/causal_lm/pytorch-14B-llm_decode-seq_1-batch_1-single_device-inference:
+  qwen_3/causal_lm/pytorch-14B-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.
     status: EXPECTED_PASSING
 
-  qwen_3/causal_lm/pytorch-32B-llm_decode-seq_1-batch_1-single_device-inference:
+  qwen_3/causal_lm/pytorch-32B-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     status: EXCLUDE_MODEL # Too large for single chip, run as tensor_parallel instead.
 
-  qwen_3/causal_lm/pytorch-30B_A3b-llm_decode-seq_1-batch_1-single_device-inference:
+  qwen_3/causal_lm/pytorch-30B_A3b-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     status: EXCLUDE_MODEL # Too large for single chip, run as tensor_parallel instead.
 
-  llama/causal_lm/pytorch-3.2_3B-llm_decode-seq_1-batch_1-single_device-inference:
+  llama/causal_lm/pytorch-3.2_3B-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     status: EXPECTED_PASSING
     assert_pcc: false
     required_pcc: 0.97
 
-  llama/causal_lm/pytorch-Tinyllama_v1.1-llm_decode-seq_1-batch_1-single_device-inference:
+  llama/causal_lm/pytorch-Tinyllama_v1.1-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     status: EXPECTED_PASSING
 
-  qwen_2_5/causal_lm/pytorch-7B-llm_decode-seq_1-batch_1-single_device-inference:
+  qwen_2_5/causal_lm/pytorch-7B-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     arch_overrides:
       p150:
         status: EXPECTED_PASSING
@@ -144,7 +144,7 @@ test_config:
         status: NOT_SUPPORTED_SKIP
         reason: "Too large for single chip"
 
-  qwen_2_5/causal_lm/pytorch-7B_Instruct_1M-llm_decode-seq_1-batch_1-single_device-inference:
+  qwen_2_5/causal_lm/pytorch-7B_Instruct_1M-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     arch_overrides:
       p150:
         status: EXPECTED_PASSING
@@ -152,23 +152,23 @@ test_config:
         status: NOT_SUPPORTED_SKIP
         reason: "Too large for single chip"
 
-  qwen_2_5/causal_lm/pytorch-14B_Instruct_1M-llm_decode-seq_1-batch_1-single_device-inference:
+  qwen_2_5/causal_lm/pytorch-14B_Instruct_1M-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     supported_archs: ["p150"]
     status: EXPECTED_PASSING
 
-  llama/causal_lm/pytorch-3.0_8B_Instruct-llm_decode-seq_1-batch_1-single_device-inference:
+  llama/causal_lm/pytorch-3.0_8B_Instruct-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     supported_archs: ["p150"]
     status: EXPECTED_PASSING
 
-  llama/causal_lm/pytorch-3.0_8B-llm_decode-seq_1-batch_1-single_device-inference:
+  llama/causal_lm/pytorch-3.0_8B-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     supported_archs: ["p150"]
     status: EXPECTED_PASSING
 
-  llama/causal_lm/pytorch-3.1_8B-llm_decode-seq_1-batch_1-single_device-inference:
+  llama/causal_lm/pytorch-3.1_8B-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     supported_archs: ["p150"]
     status: EXPECTED_PASSING
 
-  llama/causal_lm/pytorch-Huggyllama_7B-llm_decode-seq_1-batch_1-single_device-inference:
+  llama/causal_lm/pytorch-Huggyllama_7B-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     arch_overrides:
       p150:
         status: EXPECTED_PASSING
@@ -176,7 +176,7 @@ test_config:
         status: NOT_SUPPORTED_SKIP
         reason: "Too large for single chip"
 
-  falcon/pytorch-7B_Instruct-llm_decode-seq_1-batch_1-single_device-inference:
+  falcon/pytorch-7B_Instruct-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     arch_overrides:
       p150:
         status: EXPECTED_PASSING
@@ -185,7 +185,7 @@ test_config:
         reason: "Too large for single chip"
 
   # Llama 3.2 1B Prefill tests with different seq_len and batch_size
-  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_128-batch_1-single_device-inference:
+  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_128-batch_1-single_device-mesh_default-inference:
     status: EXPECTED_PASSING
     markers: [nightly]
     filechecks:
@@ -195,27 +195,29 @@ test_config:
       - matmul_with_activation_silu.ttnn.mlir
       - softmax.ttnn.mlir # SDPA fusion is not enabled without the optimizer, so we only check for softmax
 
-  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_128-batch_2-single_device-inference:
+  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_128-batch_2-single_device-mesh_default-inference:
     status: EXPECTED_PASSING
     markers: [nightly]
 
-  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_1024-batch_1-single_device-inference:
+  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_1024-batch_1-single_device-mesh_default-inference:
     status: EXPECTED_PASSING
     markers: [nightly]
 
-  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_1024-batch_2-single_device-inference:
+  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_1024-batch_2-single_device-mesh_default-inference:
     status: EXPECTED_PASSING
     markers: [nightly]
 
-  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_2048-batch_1-single_device-inference:
+  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_2048-batch_1-single_device-mesh_default-inference:
+    required_pcc: 0.98 # Is 0.986 for n150 and p150
     status: EXPECTED_PASSING
     markers: [nightly]
 
-  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_2048-batch_2-single_device-inference:
+  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_2048-batch_2-single_device-mesh_default-inference:
+    required_pcc: 0.98 # Is 0.984 for n150 and p150
     status: EXPECTED_PASSING
     markers: [nightly, large]
 
-  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_4096-batch_1-single_device-inference:
+  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_4096-batch_1-single_device-mesh_default-inference:
     arch_overrides:
       n150:
         status: NOT_SUPPORTED_SKIP
@@ -225,7 +227,7 @@ test_config:
         status: EXPECTED_PASSING
         markers: [nightly]
 
-  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_4096-batch_2-single_device-inference:
+  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_4096-batch_2-single_device-mesh_default-inference:
     arch_overrides:
       n150:
         status: NOT_SUPPORTED_SKIP
@@ -235,12 +237,12 @@ test_config:
         status: EXPECTED_PASSING
         markers: [nightly]
 
-  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_8192-batch_1-single_device-inference:
+  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_8192-batch_1-single_device-mesh_default-inference:
     status: NOT_SUPPORTED_SKIP
     reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
     markers: [nightly]
 
-  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_8192-batch_2-single_device-inference:
+  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_8192-batch_2-single_device-mesh_default-inference:
     status: NOT_SUPPORTED_SKIP
     reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
     markers: [nightly]

--- a/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
@@ -186,6 +186,7 @@ test_config:
 
   # Llama 3.2 1B Prefill tests with different seq_len and batch_size
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_128-batch_1-single_device-mesh_default-inference:
+    required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
     filechecks:
@@ -196,24 +197,27 @@ test_config:
       - softmax.ttnn.mlir # SDPA fusion is not enabled without the optimizer, so we only check for softmax
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_128-batch_32-single_device-mesh_default-inference:
+    required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_1024-batch_1-single_device-mesh_default-inference:
+    required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_1024-batch_32-single_device-mesh_default-inference:
+    required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_2048-batch_1-single_device-mesh_default-inference:
-    required_pcc: 0.98 # Is 0.986 for n150 and p150
+    required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_2048-batch_32-single_device-mesh_default-inference:
-    required_pcc: 0.98 # Is 0.984 for n150 and p150
+    required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly, large]
 
@@ -224,6 +228,7 @@ test_config:
         reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
 
       p150:
+        required_pcc: 0.99
         status: EXPECTED_PASSING
         markers: [nightly]
 
@@ -234,6 +239,7 @@ test_config:
         reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
         markers: [nightly]
       p150:
+        required_pcc: 0.99
         status: EXPECTED_PASSING
         markers: [nightly]
 

--- a/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
@@ -8,12 +8,12 @@
 #   - bringup_status (if present): BringupStatus names (e.g., FAILED_TTMLIR_COMPILATION) or values (e.g., failed_ttmlir_compilation)
 
 test_config:
-  falcon/pytorch-3_1B_Base-llm_decode-seq_1-batch_1-single_device-inference:
+  falcon/pytorch-3_1B_Base-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     status: NOT_SUPPORTED_SKIP
     reason: "Hang - https://github.com/tenstorrent/tt-xla/issues/3838"
     bringup_status: FAILED_RUNTIME
 
-  falcon/pytorch-3_3B_Base-llm_decode-seq_1-batch_1-single_device-inference:
+  falcon/pytorch-3_3B_Base-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     status: NOT_SUPPORTED_SKIP
     reason: "Hang - https://github.com/tenstorrent/tt-xla/issues/3838"
     bringup_status: FAILED_RUNTIME
@@ -26,17 +26,17 @@ test_config:
     supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.
     status: EXPECTED_PASSING
 
-  qwen_2_5/causal_lm/pytorch-0.5B_Instruct-llm_decode-seq_1-batch_1-single_device-inference:
+  qwen_2_5/causal_lm/pytorch-0.5B_Instruct-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     status: NOT_SUPPORTED_SKIP
     reason: "Hang - https://github.com/tenstorrent/tt-xla/issues/3838"
     bringup_status: FAILED_RUNTIME
 
-  qwen_2_5/causal_lm/pytorch-1.5B_Instruct-llm_decode-seq_1-batch_1-single_device-inference:
+  qwen_2_5/causal_lm/pytorch-1.5B_Instruct-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     status: NOT_SUPPORTED_SKIP
     reason: "Hang - https://github.com/tenstorrent/tt-xla/issues/3838"
     bringup_status: FAILED_RUNTIME
 
-  qwen_2_5/causal_lm/pytorch-3B_Instruct-llm_decode-seq_1-batch_1-single_device-inference:
+  qwen_2_5/causal_lm/pytorch-3B_Instruct-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     status: NOT_SUPPORTED_SKIP
     reason: "Hang - https://github.com/tenstorrent/tt-xla/issues/3838"
     bringup_status: FAILED_RUNTIME
@@ -55,7 +55,7 @@ test_config:
   qwen_2_5/causal_lm/pytorch-72B_Instruct-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     status: EXCLUDE_MODEL # Too large for single chip, run as tensor_parallel instead.
 
-  gemma/pytorch-1.1_2B_IT-llm_decode-seq_1-batch_1-single_device-inference:
+  gemma/pytorch-1.1_2B_IT-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     status: NOT_SUPPORTED_SKIP
     reason: "Hangs - https://github.com/tenstorrent/tt-xla/issues/4004"
     bringup_status: FAILED_RUNTIME
@@ -99,17 +99,17 @@ test_config:
   llama/causal_lm/pytorch-3.3_70B_Instruct-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     status: EXCLUDE_MODEL # Too large for single chip, run as tensor_parallel instead.
 
-  qwen_3/causal_lm/pytorch-0_6B-llm_decode-seq_1-batch_1-single_device-inference:
+  qwen_3/causal_lm/pytorch-0_6B-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     status: NOT_SUPPORTED_SKIP
     reason: "Hang - https://github.com/tenstorrent/tt-xla/issues/4094"
     bringup_status: FAILED_RUNTIME
 
-  qwen_3/causal_lm/pytorch-1_7B-llm_decode-seq_1-batch_1-single_device-inference:
+  qwen_3/causal_lm/pytorch-1_7B-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     status: NOT_SUPPORTED_SKIP
     reason: "Hang - https://github.com/tenstorrent/tt-xla/issues/4125"
     bringup_status: FAILED_RUNTIME
 
-  qwen_3/causal_lm/pytorch-4B-llm_decode-seq_1-batch_1-single_device-inference:
+  qwen_3/causal_lm/pytorch-4B-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     status: NOT_SUPPORTED_SKIP
     reason: "Hang - https://github.com/tenstorrent/tt-xla/issues/3838"
     bringup_status: FAILED_RUNTIME
@@ -219,36 +219,24 @@ test_config:
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_2048-batch_32-single_device-mesh_default-inference:
     required_pcc: 0.99
     status: EXPECTED_PASSING
-    markers: [nightly, large]
+    markers: [nightly]
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_4096-batch_1-single_device-mesh_default-inference:
-    arch_overrides:
-      n150:
-        status: NOT_SUPPORTED_SKIP
-        reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
-
-      p150:
-        required_pcc: 0.99
-        status: EXPECTED_PASSING
-        markers: [nightly]
+    required_pcc: 0.99
+    status: EXPECTED_PASSING
+    markers: [nightly]
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_4096-batch_32-single_device-mesh_default-inference:
-    arch_overrides:
-      n150:
-        status: NOT_SUPPORTED_SKIP
-        reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
-        markers: [nightly]
-      p150:
-        required_pcc: 0.99
-        status: EXPECTED_PASSING
-        markers: [nightly]
+    required_pcc: 0.99
+    status: EXPECTED_PASSING
+    markers: [nightly]
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_8192-batch_1-single_device-mesh_default-inference:
-    status: NOT_SUPPORTED_SKIP
-    reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
+    required_pcc: 0.99
+    status: EXPECTED_PASSING
     markers: [nightly]
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_8192-batch_32-single_device-mesh_default-inference:
-    status: NOT_SUPPORTED_SKIP
-    reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
+    required_pcc: 0.99
+    status: EXPECTED_PASSING
     markers: [nightly]

--- a/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
@@ -223,29 +223,46 @@ test_config:
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_2048-batch_4-single_device-mesh_default-inference:
     supported_archs: ["n150", "p150"]
     required_pcc: 0.99
-    status: EXPECTED_PASSING
     markers: [nightly]
+    arch_overrides:
+      p150:
+        status: EXPECTED_PASSING
+      n150:
+        status: NOT_SUPPORTED_SKIP
+        reason: "DRAM OOM"
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_4096-batch_1-single_device-mesh_default-inference:
     supported_archs: ["n150", "p150"]
     required_pcc: 0.99
-    status: EXPECTED_PASSING
     markers: [nightly]
+    arch_overrides:
+      p150:
+        status: EXPECTED_PASSING
+      n150:
+        status: NOT_SUPPORTED_SKIP
+        reason: "DRAM OOM"
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_4096-batch_4-single_device-mesh_default-inference:
     supported_archs: ["n150", "p150"]
     required_pcc: 0.99
-    status: EXPECTED_PASSING
+    status: NOT_SUPPORTED_SKIP
+    reason: "DRAM OOM"
     markers: [nightly]
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_8192-batch_1-single_device-mesh_default-inference:
     supported_archs: ["n150", "p150"]
     required_pcc: 0.99
-    status: EXPECTED_PASSING
     markers: [nightly]
+    arch_overrides:
+      p150:
+        status: EXPECTED_PASSING
+      n150:
+        status: NOT_SUPPORTED_SKIP
+        reason: "DRAM OOM"
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_8192-batch_4-single_device-mesh_default-inference:
     supported_archs: ["n150", "p150"]
     required_pcc: 0.99
-    status: EXPECTED_PASSING
+    status: NOT_SUPPORTED_SKIP
+    reason: "DRAM OOM"
     markers: [nightly]

--- a/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
@@ -197,55 +197,55 @@ test_config:
       - softmax.ttnn.mlir # SDPA fusion is not enabled without the optimizer, so we only check for softmax
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_128-batch_32-single_device-mesh_default-inference:
-    supported_archs: ["p150"]
+    supported_archs: ["n150"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_1024-batch_1-single_device-mesh_default-inference:
-    supported_archs: ["p150"]
+    supported_archs: ["n150"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_1024-batch_32-single_device-mesh_default-inference:
-    supported_archs: ["p150"]
+    supported_archs: ["n150"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_2048-batch_1-single_device-mesh_default-inference:
-    supported_archs: ["p150"]
+    supported_archs: ["n150"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_2048-batch_32-single_device-mesh_default-inference:
-    supported_archs: ["p150"]
+    supported_archs: ["n150"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_4096-batch_1-single_device-mesh_default-inference:
-    supported_archs: ["p150"]
+    supported_archs: ["n150"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_4096-batch_32-single_device-mesh_default-inference:
-    supported_archs: ["p150"]
+    supported_archs: ["n150"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_8192-batch_1-single_device-mesh_default-inference:
-    supported_archs: ["p150"]
+    supported_archs: ["n150"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_8192-batch_32-single_device-mesh_default-inference:
-    supported_archs: ["p150"]
+    supported_archs: ["n150"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]

--- a/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
@@ -197,46 +197,55 @@ test_config:
       - softmax.ttnn.mlir # SDPA fusion is not enabled without the optimizer, so we only check for softmax
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_128-batch_32-single_device-mesh_default-inference:
+    supported_archs: ["p150"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_1024-batch_1-single_device-mesh_default-inference:
+    supported_archs: ["p150"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_1024-batch_32-single_device-mesh_default-inference:
+    supported_archs: ["p150"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_2048-batch_1-single_device-mesh_default-inference:
+    supported_archs: ["p150"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_2048-batch_32-single_device-mesh_default-inference:
+    supported_archs: ["p150"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_4096-batch_1-single_device-mesh_default-inference:
+    supported_archs: ["p150"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_4096-batch_32-single_device-mesh_default-inference:
+    supported_archs: ["p150"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_8192-batch_1-single_device-mesh_default-inference:
+    supported_archs: ["p150"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
 
   llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_8192-batch_32-single_device-mesh_default-inference:
+    supported_archs: ["p150"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]

--- a/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
@@ -195,7 +195,7 @@ test_config:
       - matmul_with_activation_silu.ttnn.mlir
       - softmax.ttnn.mlir # SDPA fusion is not enabled without the optimizer, so we only check for softmax
 
-  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_128-batch_2-single_device-mesh_default-inference:
+  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_128-batch_32-single_device-mesh_default-inference:
     status: EXPECTED_PASSING
     markers: [nightly]
 
@@ -203,7 +203,7 @@ test_config:
     status: EXPECTED_PASSING
     markers: [nightly]
 
-  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_1024-batch_2-single_device-mesh_default-inference:
+  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_1024-batch_32-single_device-mesh_default-inference:
     status: EXPECTED_PASSING
     markers: [nightly]
 
@@ -212,7 +212,7 @@ test_config:
     status: EXPECTED_PASSING
     markers: [nightly]
 
-  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_2048-batch_2-single_device-mesh_default-inference:
+  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_2048-batch_32-single_device-mesh_default-inference:
     required_pcc: 0.98 # Is 0.984 for n150 and p150
     status: EXPECTED_PASSING
     markers: [nightly, large]
@@ -227,7 +227,7 @@ test_config:
         status: EXPECTED_PASSING
         markers: [nightly]
 
-  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_4096-batch_2-single_device-mesh_default-inference:
+  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_4096-batch_32-single_device-mesh_default-inference:
     arch_overrides:
       n150:
         status: NOT_SUPPORTED_SKIP
@@ -242,7 +242,7 @@ test_config:
     reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
     markers: [nightly]
 
-  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_8192-batch_2-single_device-mesh_default-inference:
+  llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_8192-batch_32-single_device-mesh_default-inference:
     status: NOT_SUPPORTED_SKIP
     reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
     markers: [nightly]

--- a/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
@@ -92,7 +92,8 @@ test_config:
   # Llama 3.1 8B Instruct — Prefill tensor-parallel tests
   # Constraints:
   #  - Keep only one strategy for 1x8 (Megatron).
-  #  - DP only for mesh 2x4 with batch >= data dim (=2), so batch_2 only.
+  #  - batch_X means batch-per-device. For DP, global batch is X * mesh_data_dim.
+  #  - DP is used only with mesh 2x4.
   #  - Cover all prefill sequence lengths through 8192.
   # ============================================================================
 

--- a/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
@@ -54,6 +54,7 @@ test_config:
 
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_decode-seq_1-batch_1-tensor_parallel-mesh_default-inference:
     supported_archs: ["n300-llmbox"]
+    required_pcc: 0.99
     status: EXPECTED_PASSING
 
 <<<<<<< HEAD
@@ -129,14 +130,17 @@ test_config:
   # --- Megatron, mesh 1x8, no DP ---
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
+    required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_32-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
+    required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
+    required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_32-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
@@ -166,6 +170,7 @@ test_config:
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_RUNTIME
     reason: "DRAM OOM"
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
@@ -177,6 +182,7 @@ test_config:
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_32-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_RUNTIME
     reason: "DRAM OOM"
     markers: [nightly]
 
@@ -226,16 +232,19 @@ test_config:
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_RUNTIME
     reason: "DRAM OOM"
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_RUNTIME
     reason: "DRAM OOM"
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_32-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_RUNTIME
     reason: "DRAM OOM"
     markers: [nightly]
 
@@ -285,26 +294,31 @@ test_config:
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_RUNTIME
     reason: "DRAM OOM"
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_RUNTIME
     reason: "DRAM OOM"
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_32-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_RUNTIME
     reason: "DRAM OOM"
     markers: [nightly]
 
   # --- Megatron, mesh 2x4, no DP ---
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
+    required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_32-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
+    required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
@@ -321,38 +335,46 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
+    required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_32-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
+    required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
+    required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_RUNTIME
     reason: "DRAM OOM"
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
+    required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_32-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_RUNTIME
     reason: "DRAM OOM"
     markers: [nightly]
 
   # --- Megatron, mesh 2x4, DP (batch must be >= data dim 2) ---
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
+    required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_32-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
+    required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference:
@@ -388,15 +410,18 @@ test_config:
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_RUNTIME
     reason: "DRAM OOM"
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_RUNTIME
     reason: "DRAM OOM"
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_32-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_RUNTIME
     reason: "DRAM OOM"
     markers: [nightly]

--- a/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
@@ -128,225 +128,275 @@ test_config:
 
   # --- Megatron, mesh 1x8, no DP ---
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+    supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+    supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+    supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.94 # Is 0.941
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.95 # Is 0.950
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.86 # Is 0.863
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.81 # Is 0.818
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.81 # Is 0.817
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.74 # Is 0.747
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+    supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
     reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
     markers: [nightly]
 
   # --- FSDP, mesh 2x4, no DP ---
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.92 # Is 0.928
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.92 # Is 0.928
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.92 # Is 0.924
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.87 # Is 0.875
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.92 # Is 0.920
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.75 # Is 0.758
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.81 # Is 0.818
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.80 # Is 0.802
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
     reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
     reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
     markers: [nightly]
 
   # --- FSDP, mesh 2x4, DP (batch must be >= data dim 2) ---
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.92 # Is 0.928
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.93 # Is 0.933
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.87 # Is 0.876
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.89 # Is 0.896
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.75 # Is 0.758
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.77 # Is 0.779
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.80 # Is 0.801
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
     reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
     reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
     reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
     markers: [nightly]
 
   # --- Megatron, mesh 2x4, no DP ---
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.93 # Is 0.938
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.96 # Is 0.965
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
 
   # --- Megatron, mesh 2x4, DP (batch must be >= data dim 2) ---
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-megatron-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.93 # Is 0.938
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-megatron-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.96 # Is 0.965
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.86 # Is 0.861
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-megatron-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.87 # Is 0.879
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.81 # Is 0.817
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-megatron-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
     reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
     reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-megatron-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
     reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
     markers: [nightly]

--- a/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
@@ -95,210 +95,260 @@ test_config:
 
   # --- Megatron, mesh 1x8, no DP ---
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
 
   # --- FSDP, mesh 2x4, no DP ---
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
 
   # --- FSDP, mesh 2x4, DP (batch must be >= data dim 2) ---
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
 
   # --- Megatron, mesh 2x4, no DP ---
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
 
   # --- Megatron, mesh 2x4, DP (batch must be >= data dim 2) ---
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-megatron-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-megatron-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-megatron-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-megatron-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-megatron-dp-tensor_parallel-mesh_2x4-inference:
+    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]

--- a/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
@@ -90,11 +90,7 @@ test_config:
 
   # ============================================================================
   # Llama 3.1 8B Instruct — Prefill tensor-parallel tests
-  # Constraints:
-  #  - Keep only one strategy for 1x8 (Megatron).
-  #  - batch_X means batch-per-device. For DP, global batch is X * mesh_data_dim.
-  #  - DP is used only with mesh 2x4.
-  #  - Cover all prefill sequence lengths through 8192.
+  #  - batch_X means per-device batch size.
   # ============================================================================
 
   # --- Megatron, mesh 1x8, no DP ---

--- a/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
@@ -165,9 +165,8 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.81 # Is 0.817
-    status: EXPECTED_PASSING
-    assert_pcc: false
+    status: NOT_SUPPORTED_SKIP
+    reason: "DRAM OOM"
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
@@ -178,7 +177,7 @@ test_config:
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_32-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
-    reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
+    reason: "DRAM OOM"
     markers: [nightly]
 
   # --- FSDP, mesh 2x4, no DP ---
@@ -226,19 +225,18 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.80 # Is 0.802
-    status: EXPECTED_PASSING
-    assert_pcc: false
+    status: NOT_SUPPORTED_SKIP
+    reason: "DRAM OOM"
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
-    reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
+    reason: "DRAM OOM"
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_32-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
-    reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
+    reason: "DRAM OOM"
     markers: [nightly]
 
   # --- FSDP, mesh 2x4, DP (batch must be >= data dim 2) ---
@@ -287,17 +285,17 @@ test_config:
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
-    reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
+    reason: "DRAM OOM"
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
-    reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
+    reason: "DRAM OOM"
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_32-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
-    reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
+    reason: "DRAM OOM"
     markers: [nightly]
 
   # --- Megatron, mesh 2x4, no DP ---
@@ -335,7 +333,8 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    status: EXPECTED_PASSING
+    status: NOT_SUPPORTED_SKIP
+    reason: "DRAM OOM"
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
@@ -343,7 +342,8 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_32-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    status: EXPECTED_PASSING
+    status: NOT_SUPPORTED_SKIP
+    reason: "DRAM OOM"
     markers: [nightly]
 
   # --- Megatron, mesh 2x4, DP (batch must be >= data dim 2) ---
@@ -388,15 +388,15 @@ test_config:
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
-    reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
+    reason: "DRAM OOM"
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
-    reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
+    reason: "DRAM OOM"
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_32-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
-    reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
+    reason: "DRAM OOM"
     markers: [nightly]

--- a/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
@@ -99,7 +99,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_32-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -109,7 +109,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_32-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -119,7 +119,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_32-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -129,7 +129,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -139,7 +139,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_32-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -151,7 +151,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_32-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -161,7 +161,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_32-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -171,7 +171,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_32-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -181,7 +181,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -191,7 +191,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_32-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -203,7 +203,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_32-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -213,7 +213,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_32-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -223,7 +223,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_32-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -233,7 +233,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -243,7 +243,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_32-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -255,7 +255,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_32-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -265,7 +265,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_32-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -275,7 +275,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_32-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -285,7 +285,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -295,7 +295,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_32-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -307,7 +307,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-megatron-dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_32-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -317,7 +317,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-megatron-dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_32-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -327,7 +327,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-megatron-dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_32-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -337,7 +337,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-megatron-dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -347,7 +347,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-megatron-dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_32-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING

--- a/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
@@ -87,3 +87,147 @@ test_config:
     status: NOT_SUPPORTED_SKIP
     reason: "Needs bringup on n300-llmbox"
     bringup_status: FAILED_RUNTIME
+
+  # ============================================================================
+  # Llama 3.1 8B Instruct — Prefill tensor-parallel tests
+  # Combinations of sharding strategy (fsdp/megatron), mesh (1x8/2x4), and
+  # data-parallelism (no_dp/dp).
+  # ============================================================================
+
+  # --- FSDP, mesh 1x8, no DP ---
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-fsdp-mesh_1x8-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-fsdp-mesh_1x8-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-fsdp-mesh_1x8-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-fsdp-mesh_1x8-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+
+  # --- FSDP, mesh 2x4, no DP ---
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-fsdp-mesh_2x4-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-fsdp-mesh_2x4-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-fsdp-mesh_2x4-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-fsdp-mesh_2x4-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+
+  # --- FSDP, mesh 2x4, DP ---
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-fsdp-mesh_2x4-dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-fsdp-mesh_2x4-dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-fsdp-mesh_2x4-dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-fsdp-mesh_2x4-dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+
+  # --- FSDP, mesh 1x8, DP (trivial: data axis = 1) ---
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-fsdp-mesh_1x8-dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+
+  # --- Megatron, mesh 1x8, no DP ---
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-megatron-mesh_1x8-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-megatron-mesh_1x8-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-megatron-mesh_1x8-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-megatron-mesh_1x8-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+
+  # --- Megatron, mesh 2x4, no DP ---
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-megatron-mesh_2x4-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-megatron-mesh_2x4-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-megatron-mesh_2x4-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-megatron-mesh_2x4-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+
+  # --- Megatron, mesh 2x4, DP ---
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-megatron-mesh_2x4-dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-megatron-mesh_2x4-dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-megatron-mesh_2x4-dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-megatron-mesh_2x4-dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+
+  # --- Megatron, mesh 1x8, DP (trivial: data axis = 1) ---
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-megatron-mesh_1x8-dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]

--- a/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
@@ -95,210 +95,225 @@ test_config:
 
   # --- Megatron, mesh 1x8, no DP ---
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-megatron_mesh_1x8-no_dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-megatron_mesh_1x8-no_dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-megatron_mesh_1x8-no_dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-megatron_mesh_1x8-no_dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    required_pcc: 0.94 # Is 0.941
     status: EXPECTED_PASSING
+    assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-megatron_mesh_1x8-no_dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    required_pcc: 0.95 # Is 0.950
     status: EXPECTED_PASSING
+    assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-megatron_mesh_1x8-no_dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    required_pcc: 0.86 # Is 0.863
     status: EXPECTED_PASSING
+    assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron_mesh_1x8-no_dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    required_pcc: 0.81 # Is 0.818
     status: EXPECTED_PASSING
+    assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-megatron_mesh_1x8-no_dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    required_pcc: 0.81 # Is 0.817
     status: EXPECTED_PASSING
+    assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron_mesh_1x8-no_dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    required_pcc: 0.74 # Is 0.747
     status: EXPECTED_PASSING
+    assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-megatron_mesh_1x8-no_dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
-    status: EXPECTED_PASSING
+    status: NOT_SUPPORTED_SKIP
+    reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
     markers: [nightly]
 
   # --- FSDP, mesh 2x4, no DP ---
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-fsdp_mesh_2x4-no_dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    required_pcc: 0.92 # Is 0.928
     status: EXPECTED_PASSING
+    assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-fsdp_mesh_2x4-no_dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    required_pcc: 0.92 # Is 0.928
     status: EXPECTED_PASSING
+    assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-fsdp_mesh_2x4-no_dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    required_pcc: 0.92 # Is 0.924
     status: EXPECTED_PASSING
+    assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-fsdp_mesh_2x4-no_dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    required_pcc: 0.87 # Is 0.875
     status: EXPECTED_PASSING
+    assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-fsdp_mesh_2x4-no_dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    required_pcc: 0.92 # Is 0.920
     status: EXPECTED_PASSING
+    assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-fsdp_mesh_2x4-no_dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    required_pcc: 0.75 # Is 0.758
     status: EXPECTED_PASSING
+    assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-fsdp_mesh_2x4-no_dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    required_pcc: 0.81 # Is 0.818
     status: EXPECTED_PASSING
+    assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-fsdp_mesh_2x4-no_dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    required_pcc: 0.80 # Is 0.802
     status: EXPECTED_PASSING
+    assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-fsdp_mesh_2x4-no_dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
-    status: EXPECTED_PASSING
+    status: NOT_SUPPORTED_SKIP
+    reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-fsdp_mesh_2x4-no_dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
-    status: EXPECTED_PASSING
+    status: NOT_SUPPORTED_SKIP
+    reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
     markers: [nightly]
 
   # --- FSDP, mesh 2x4, DP (batch must be >= data dim 2) ---
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-fsdp_mesh_2x4-dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    required_pcc: 0.92 # Is 0.928
     status: EXPECTED_PASSING
+    assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-fsdp_mesh_2x4-dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    required_pcc: 0.93 # Is 0.933
     status: EXPECTED_PASSING
+    assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-fsdp_mesh_2x4-dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    required_pcc: 0.87 # Is 0.876
     status: EXPECTED_PASSING
+    assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-fsdp_mesh_2x4-dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    required_pcc: 0.89 # Is 0.896
     status: EXPECTED_PASSING
+    assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-fsdp_mesh_2x4-dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    required_pcc: 0.75 # Is 0.758
     status: EXPECTED_PASSING
+    assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-fsdp_mesh_2x4-dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    required_pcc: 0.77 # Is 0.779
     status: EXPECTED_PASSING
+    assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-fsdp_mesh_2x4-dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    required_pcc: 0.80 # Is 0.801
     status: EXPECTED_PASSING
+    assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-fsdp_mesh_2x4-dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
-    status: EXPECTED_PASSING
+    status: NOT_SUPPORTED_SKIP
+    reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-fsdp_mesh_2x4-dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
-    status: EXPECTED_PASSING
+    status: NOT_SUPPORTED_SKIP
+    reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-fsdp_mesh_2x4-dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
-    status: EXPECTED_PASSING
+    status: NOT_SUPPORTED_SKIP
+    reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
     markers: [nightly]
 
   # --- Megatron, mesh 2x4, no DP ---
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-megatron_mesh_2x4-no_dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-megatron_mesh_2x4-no_dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-megatron_mesh_2x4-no_dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    required_pcc: 0.93 # Is 0.938
     status: EXPECTED_PASSING
+    assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-megatron_mesh_2x4-no_dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    required_pcc: 0.96 # Is 0.965
     status: EXPECTED_PASSING
+    assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-megatron_mesh_2x4-no_dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-megatron_mesh_2x4-no_dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron_mesh_2x4-no_dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-megatron_mesh_2x4-no_dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron_mesh_2x4-no_dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-megatron_mesh_2x4-no_dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
 
   # --- Megatron, mesh 2x4, DP (batch must be >= data dim 2) ---
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-megatron_mesh_2x4-dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-megatron_mesh_2x4-dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-megatron_mesh_2x4-dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    required_pcc: 0.93 # Is 0.938
     status: EXPECTED_PASSING
+    assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-megatron_mesh_2x4-dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    required_pcc: 0.96 # Is 0.965
     status: EXPECTED_PASSING
+    assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-megatron_mesh_2x4-dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    required_pcc: 0.86 # Is 0.861
     status: EXPECTED_PASSING
+    assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-megatron_mesh_2x4-dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    required_pcc: 0.87 # Is 0.879
     status: EXPECTED_PASSING
+    assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron_mesh_2x4-dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
+    required_pcc: 0.81 # Is 0.817
     status: EXPECTED_PASSING
+    assert_pcc: false
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-megatron_mesh_2x4-dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
-    status: EXPECTED_PASSING
+    status: NOT_SUPPORTED_SKIP
+    reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron_mesh_2x4-dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
-    status: EXPECTED_PASSING
+    status: NOT_SUPPORTED_SKIP
+    reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-megatron_mesh_2x4-dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
-    status: EXPECTED_PASSING
+    status: NOT_SUPPORTED_SKIP
+    reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
     markers: [nightly]

--- a/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
@@ -4,50 +4,59 @@
 
 
 test_config:
-  falcon/pytorch-3_7B_Base-llm_decode-seq_1-batch_1-tensor_parallel-inference:
+  falcon/pytorch-3_7B_Base-llm_decode-seq_1-batch_1-tensor_parallel-mesh_default-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
 
-  falcon/pytorch-3_10B_Base-llm_decode-seq_1-batch_1-tensor_parallel-inference:
+  falcon/pytorch-3_10B_Base-llm_decode-seq_1-batch_1-tensor_parallel-mesh_default-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
 
-  qwen_2_5/causal_lm/pytorch-7B_Instruct-llm_decode-seq_1-batch_1-tensor_parallel-inference:
+  qwen_2_5/causal_lm/pytorch-7B_Instruct-llm_decode-seq_1-batch_1-tensor_parallel-mesh_default-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     assert_pcc: false
     required_pcc: 0.98
 
-  qwen_2_5/causal_lm/pytorch-14B_Instruct-llm_decode-seq_1-batch_1-tensor_parallel-inference:
+  qwen_2_5/causal_lm/pytorch-14B_Instruct-llm_decode-seq_1-batch_1-tensor_parallel-mesh_default-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
 
-  qwen_2_5/causal_lm/pytorch-32B_Instruct-llm_decode-seq_1-batch_1-tensor_parallel-inference:
+  qwen_2_5/causal_lm/pytorch-32B_Instruct-llm_decode-seq_1-batch_1-tensor_parallel-mesh_default-inference:
     supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_RUNTIME
     reason: "trisc2 compile failure - https://github.com/tenstorrent/tt-xla/issues/2958"
 
+<<<<<<< HEAD
   qwen_2_5/causal_lm/pytorch-72B_Instruct-llm_decode-seq_1-batch_1-tensor_parallel-inference:
     supported_archs: ["galaxy-wh-6u"]
     status: EXPECTED_PASSING
+=======
+  qwen_2_5/causal_lm/pytorch-72B_Instruct-llm_decode-seq_1-batch_1-tensor_parallel-mesh_default-inference:
+    supported_archs: ["n300-llmbox"]
+    status: NOT_SUPPORTED_SKIP
+    reason: "Needs bringup on galaxy"
+    bringup_status: FAILED_RUNTIME
+>>>>>>> 8ba24b9a5 (Separate mesh_shape and sharding_config fully.)
 
-  gemma/pytorch-1.1_7B_IT-llm_decode-seq_1-batch_1-tensor_parallel-inference:
+  gemma/pytorch-1.1_7B_IT-llm_decode-seq_1-batch_1-tensor_parallel-mesh_default-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
 
-  gemma/pytorch-2_9B_IT-llm_decode-seq_1-batch_1-tensor_parallel-inference:
+  gemma/pytorch-2_9B_IT-llm_decode-seq_1-batch_1-tensor_parallel-mesh_default-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
 
-  gemma/pytorch-2_27B_IT-llm_decode-seq_1-batch_1-tensor_parallel-inference:
+  gemma/pytorch-2_27B_IT-llm_decode-seq_1-batch_1-tensor_parallel-mesh_default-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
 
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_decode-seq_1-batch_1-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_decode-seq_1-batch_1-tensor_parallel-mesh_default-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
 
+<<<<<<< HEAD
   llama/causal_lm/pytorch-3.1_70B-llm_decode-seq_1-batch_1-tensor_parallel-inference:
     supported_archs: ["galaxy-wh-6u"]
     status: EXPECTED_PASSING
@@ -55,34 +64,58 @@ test_config:
   llama/causal_lm/pytorch-3.1_70B_Instruct-llm_decode-seq_1-batch_1-tensor_parallel-inference:
     supported_archs: ["galaxy-wh-6u"]
     status: EXPECTED_PASSING
-
-  llama/causal_lm/pytorch-3.1_405B-llm_decode-seq_1-batch_1-tensor_parallel-inference:
+=======
+  llama/causal_lm/pytorch-3.1_70B-llm_decode-seq_1-batch_1-tensor_parallel-mesh_default-inference:
     supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
     reason: "Needs bringup on galaxy"
     bringup_status: FAILED_RUNTIME
 
+  llama/causal_lm/pytorch-3.1_70B_Instruct-llm_decode-seq_1-batch_1-tensor_parallel-mesh_default-inference:
+    supported_archs: ["n300-llmbox"]
+    status: NOT_SUPPORTED_SKIP
+    reason: "Needs bringup on galaxy"
+    bringup_status: FAILED_RUNTIME
+>>>>>>> 8ba24b9a5 (Separate mesh_shape and sharding_config fully.)
+
+  llama/causal_lm/pytorch-3.1_405B-llm_decode-seq_1-batch_1-tensor_parallel-mesh_default-inference:
+    supported_archs: ["n300-llmbox"]
+    status: NOT_SUPPORTED_SKIP
+    reason: "Needs bringup on galaxy"
+    bringup_status: FAILED_RUNTIME
+
+<<<<<<< HEAD
   llama/causal_lm/pytorch-3.3_70B_Instruct-llm_decode-seq_1-batch_1-tensor_parallel-inference:
     supported_archs: ["galaxy-wh-6u"]
     status: EXPECTED_PASSING
 
   qwen_3/causal_lm/pytorch-8B-llm_decode-seq_1-batch_1-tensor_parallel-inference:
+=======
+  llama/causal_lm/pytorch-3.3_70B_Instruct-llm_decode-seq_1-batch_1-tensor_parallel-mesh_default-inference:
+    supported_archs: ["n300-llmbox"]
+    status: NOT_SUPPORTED_SKIP
+    reason: "Needs bringup on galaxy"
+    bringup_status: FAILED_RUNTIME
+
+  qwen_3/causal_lm/pytorch-8B-llm_decode-seq_1-batch_1-tensor_parallel-mesh_default-inference:
+    required_pcc: 0.985 # https://github.com/tenstorrent/tt-xla/issues/2942
+>>>>>>> 8ba24b9a5 (Separate mesh_shape and sharding_config fully.)
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
 
-  qwen_3/causal_lm/pytorch-14B-llm_decode-seq_1-batch_1-tensor_parallel-inference:
+  qwen_3/causal_lm/pytorch-14B-llm_decode-seq_1-batch_1-tensor_parallel-mesh_default-inference:
     supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_RUNTIME
     reason: "trisc2 compile failure - https://github.com/tenstorrent/tt-xla/issues/2958"
 
-  qwen_3/causal_lm/pytorch-32B-llm_decode-seq_1-batch_1-tensor_parallel-inference:
+  qwen_3/causal_lm/pytorch-32B-llm_decode-seq_1-batch_1-tensor_parallel-mesh_default-inference:
     supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_RUNTIME
     reason: "trisc2 compile failure - https://github.com/tenstorrent/tt-xla/issues/2958"
 
-  qwen_3/causal_lm/pytorch-30B_A3b-llm_decode-seq_1-batch_1-tensor_parallel-inference:
+  qwen_3/causal_lm/pytorch-30B_A3b-llm_decode-seq_1-batch_1-tensor_parallel-mesh_default-inference:
     supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
     reason: "Needs bringup on n300-llmbox"
@@ -94,226 +127,226 @@ test_config:
   # ============================================================================
 
   # --- Megatron, mesh 1x8, no DP ---
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-megatron_mesh_1x8-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-megatron_mesh_1x8-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-megatron_mesh_1x8-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-megatron_mesh_1x8-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     required_pcc: 0.94 # Is 0.941
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-megatron_mesh_1x8-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     required_pcc: 0.95 # Is 0.950
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-megatron_mesh_1x8-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     required_pcc: 0.86 # Is 0.863
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron_mesh_1x8-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     required_pcc: 0.81 # Is 0.818
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-megatron_mesh_1x8-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     required_pcc: 0.81 # Is 0.817
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron_mesh_1x8-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     required_pcc: 0.74 # Is 0.747
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-megatron_mesh_1x8-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     status: NOT_SUPPORTED_SKIP
     reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
     markers: [nightly]
 
   # --- FSDP, mesh 2x4, no DP ---
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-fsdp_mesh_2x4-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     required_pcc: 0.92 # Is 0.928
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-fsdp_mesh_2x4-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     required_pcc: 0.92 # Is 0.928
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-fsdp_mesh_2x4-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     required_pcc: 0.92 # Is 0.924
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-fsdp_mesh_2x4-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     required_pcc: 0.87 # Is 0.875
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-fsdp_mesh_2x4-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     required_pcc: 0.92 # Is 0.920
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-fsdp_mesh_2x4-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     required_pcc: 0.75 # Is 0.758
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-fsdp_mesh_2x4-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     required_pcc: 0.81 # Is 0.818
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-fsdp_mesh_2x4-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     required_pcc: 0.80 # Is 0.802
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-fsdp_mesh_2x4-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     status: NOT_SUPPORTED_SKIP
     reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-fsdp_mesh_2x4-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     status: NOT_SUPPORTED_SKIP
     reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
     markers: [nightly]
 
   # --- FSDP, mesh 2x4, DP (batch must be >= data dim 2) ---
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-fsdp_mesh_2x4-dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     required_pcc: 0.92 # Is 0.928
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-fsdp_mesh_2x4-dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     required_pcc: 0.93 # Is 0.933
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-fsdp_mesh_2x4-dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     required_pcc: 0.87 # Is 0.876
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-fsdp_mesh_2x4-dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     required_pcc: 0.89 # Is 0.896
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-fsdp_mesh_2x4-dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     required_pcc: 0.75 # Is 0.758
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-fsdp_mesh_2x4-dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     required_pcc: 0.77 # Is 0.779
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-fsdp_mesh_2x4-dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     required_pcc: 0.80 # Is 0.801
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-fsdp_mesh_2x4-dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     status: NOT_SUPPORTED_SKIP
     reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-fsdp_mesh_2x4-dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     status: NOT_SUPPORTED_SKIP
     reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-fsdp_mesh_2x4-dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     status: NOT_SUPPORTED_SKIP
     reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
     markers: [nightly]
 
   # --- Megatron, mesh 2x4, no DP ---
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-megatron_mesh_2x4-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-megatron_mesh_2x4-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-megatron_mesh_2x4-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     required_pcc: 0.93 # Is 0.938
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-megatron_mesh_2x4-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     required_pcc: 0.96 # Is 0.965
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-megatron_mesh_2x4-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-megatron_mesh_2x4-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron_mesh_2x4-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-megatron_mesh_2x4-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron_mesh_2x4-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-megatron_mesh_2x4-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     status: EXPECTED_PASSING
     markers: [nightly]
 
   # --- Megatron, mesh 2x4, DP (batch must be >= data dim 2) ---
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-megatron_mesh_2x4-dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference:
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-megatron_mesh_2x4-dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-megatron-dp-tensor_parallel-mesh_2x4-inference:
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-megatron_mesh_2x4-dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference:
     required_pcc: 0.93 # Is 0.938
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-megatron_mesh_2x4-dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-megatron-dp-tensor_parallel-mesh_2x4-inference:
     required_pcc: 0.96 # Is 0.965
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-megatron_mesh_2x4-dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference:
     required_pcc: 0.86 # Is 0.861
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-megatron_mesh_2x4-dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-megatron-dp-tensor_parallel-mesh_2x4-inference:
     required_pcc: 0.87 # Is 0.879
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron_mesh_2x4-dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference:
     required_pcc: 0.81 # Is 0.817
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-megatron_mesh_2x4-dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-megatron-dp-tensor_parallel-mesh_2x4-inference:
     status: NOT_SUPPORTED_SKIP
     reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron_mesh_2x4-dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference:
     status: NOT_SUPPORTED_SKIP
     reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-megatron_mesh_2x4-dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-megatron-dp-tensor_parallel-mesh_2x4-inference:
     status: NOT_SUPPORTED_SKIP
     reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
     markers: [nightly]

--- a/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
@@ -207,9 +207,9 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_32-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
-    status: EXPECTED_PASSING
-
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_RUNTIME
+    reason: "DRAM OOM - https://github.com/tenstorrent/tt-mlir/issues/6877"
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
@@ -219,9 +219,9 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_32-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
-    status: EXPECTED_PASSING
-
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_RUNTIME
+    reason: "DRAM OOM - https://github.com/tenstorrent/tt-mlir/issues/6877"
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
@@ -269,9 +269,9 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_32-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
-    status: EXPECTED_PASSING
-
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_RUNTIME
+    reason: "DRAM OOM - https://github.com/tenstorrent/tt-mlir/issues/6877"
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
@@ -281,9 +281,9 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_32-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
-    status: EXPECTED_PASSING
-
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_RUNTIME
+    reason: "DRAM OOM - https://github.com/tenstorrent/tt-mlir/issues/6877"
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
@@ -329,9 +329,9 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_32-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
-    status: EXPECTED_PASSING
-
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_RUNTIME
+    reason: "DRAM OOM - https://github.com/tenstorrent/tt-mlir/issues/6877"
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
@@ -340,8 +340,9 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_32-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
-    status: EXPECTED_PASSING
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_RUNTIME
+    reason: "DRAM OOM - https://github.com/tenstorrent/tt-mlir/issues/6877"
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
@@ -385,9 +386,9 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_32-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
-    status: EXPECTED_PASSING
-
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_RUNTIME
+    reason: "DRAM OOM - https://github.com/tenstorrent/tt-mlir/issues/6877"
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
@@ -397,9 +398,9 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_32-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
-    status: EXPECTED_PASSING
-
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_RUNTIME
+    reason: "DRAM OOM - https://github.com/tenstorrent/tt-mlir/issues/6877"
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]

--- a/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
@@ -141,27 +141,27 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_32-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.94 # Is 0.941
+    required_pcc: 0.99
     status: EXPECTED_PASSING
-    assert_pcc: false
+
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.95 # Is 0.950
+    required_pcc: 0.99
     status: EXPECTED_PASSING
-    assert_pcc: false
+
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_32-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.86 # Is 0.863
+    required_pcc: 0.99
     status: EXPECTED_PASSING
-    assert_pcc: false
+
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.81 # Is 0.818
+    required_pcc: 0.99
     status: EXPECTED_PASSING
-    assert_pcc: false
+
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
@@ -170,9 +170,9 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.74 # Is 0.747
+    required_pcc: 0.99
     status: EXPECTED_PASSING
-    assert_pcc: false
+
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_32-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
@@ -183,45 +183,45 @@ test_config:
   # --- FSDP, mesh 2x4, no DP ---
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.92 # Is 0.928
+    required_pcc: 0.99
     status: EXPECTED_PASSING
-    assert_pcc: false
+
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_32-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.92 # Is 0.928
+    required_pcc: 0.99
     status: EXPECTED_PASSING
-    assert_pcc: false
+
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.92 # Is 0.924
+    required_pcc: 0.99
     status: EXPECTED_PASSING
-    assert_pcc: false
+
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_32-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.87 # Is 0.875
+    required_pcc: 0.99
     status: EXPECTED_PASSING
-    assert_pcc: false
+
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.92 # Is 0.920
+    required_pcc: 0.99
     status: EXPECTED_PASSING
-    assert_pcc: false
+
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_32-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.75 # Is 0.758
+    required_pcc: 0.99
     status: EXPECTED_PASSING
-    assert_pcc: false
+
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.81 # Is 0.818
+    required_pcc: 0.99
     status: EXPECTED_PASSING
-    assert_pcc: false
+
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
@@ -242,45 +242,45 @@ test_config:
   # --- FSDP, mesh 2x4, DP (batch must be >= data dim 2) ---
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.92 # Is 0.928
+    required_pcc: 0.99
     status: EXPECTED_PASSING
-    assert_pcc: false
+
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_32-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.93 # Is 0.933
+    required_pcc: 0.99
     status: EXPECTED_PASSING
-    assert_pcc: false
+
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.87 # Is 0.876
+    required_pcc: 0.99
     status: EXPECTED_PASSING
-    assert_pcc: false
+
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_32-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.89 # Is 0.896
+    required_pcc: 0.99
     status: EXPECTED_PASSING
-    assert_pcc: false
+
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.75 # Is 0.758
+    required_pcc: 0.99
     status: EXPECTED_PASSING
-    assert_pcc: false
+
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_32-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.77 # Is 0.779
+    required_pcc: 0.99
     status: EXPECTED_PASSING
-    assert_pcc: false
+
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.80 # Is 0.801
+    required_pcc: 0.99
     status: EXPECTED_PASSING
-    assert_pcc: false
+
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
@@ -309,15 +309,15 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.93 # Is 0.938
+    required_pcc: 0.99
     status: EXPECTED_PASSING
-    assert_pcc: false
+
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_32-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.96 # Is 0.965
+    required_pcc: 0.99
     status: EXPECTED_PASSING
-    assert_pcc: false
+
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
@@ -357,33 +357,33 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.93 # Is 0.938
+    required_pcc: 0.99
     status: EXPECTED_PASSING
-    assert_pcc: false
+
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_32-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.96 # Is 0.965
+    required_pcc: 0.99
     status: EXPECTED_PASSING
-    assert_pcc: false
+
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.86 # Is 0.861
+    required_pcc: 0.99
     status: EXPECTED_PASSING
-    assert_pcc: false
+
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_32-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.87 # Is 0.879
+    required_pcc: 0.99
     status: EXPECTED_PASSING
-    assert_pcc: false
+
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.81 # Is 0.817
+    required_pcc: 0.99
     status: EXPECTED_PASSING
-    assert_pcc: false
+
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]

--- a/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
@@ -99,7 +99,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_32-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_4-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -109,7 +109,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_32-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_4-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -119,7 +119,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_32-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_4-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -129,7 +129,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_4-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -139,7 +139,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_32-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_4-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -151,7 +151,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_32-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_4-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -161,7 +161,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_32-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_4-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -171,7 +171,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_32-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_4-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -181,7 +181,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_4-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -191,7 +191,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_32-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_4-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -203,7 +203,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_32-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_4-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -213,7 +213,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_32-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_4-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -223,7 +223,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_32-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_4-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -233,7 +233,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_4-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -243,7 +243,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_32-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_4-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -255,7 +255,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_32-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_4-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -265,7 +265,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_32-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_4-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -275,7 +275,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_32-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_4-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -285,7 +285,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_4-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -295,7 +295,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_32-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_4-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -307,7 +307,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_32-megatron-dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_4-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -317,7 +317,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_32-megatron-dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_4-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -327,7 +327,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_32-megatron-dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_4-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -337,7 +337,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-megatron-dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_4-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
@@ -347,7 +347,7 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_32-megatron-dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_4-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING

--- a/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
@@ -90,144 +90,178 @@ test_config:
 
   # ============================================================================
   # Llama 3.1 8B Instruct — Prefill tensor-parallel tests
-  # Combinations of sharding strategy (fsdp/megatron), mesh (1x8/2x4), and
-  # data-parallelism (no_dp/dp).
+  # Constraints:
+  #  - Keep only one strategy for 1x8 (FSDP).
+  #  - DP only for mesh 2x4 with batch >= data dim (=2), so batch_2 only.
+  #  - Cover all prefill sequence lengths through 8192.
   # ============================================================================
 
   # --- FSDP, mesh 1x8, no DP ---
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-fsdp-mesh_1x8-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-fsdp_mesh_1x8-no_dp-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
-
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-fsdp-mesh_1x8-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-fsdp_mesh_1x8-no_dp-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
-
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-fsdp-mesh_1x8-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-fsdp_mesh_1x8-no_dp-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
-
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-fsdp-mesh_1x8-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-fsdp_mesh_1x8-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-fsdp_mesh_1x8-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-fsdp_mesh_1x8-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-fsdp_mesh_1x8-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-fsdp_mesh_1x8-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-fsdp_mesh_1x8-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-fsdp_mesh_1x8-no_dp-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
 
   # --- FSDP, mesh 2x4, no DP ---
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-fsdp-mesh_2x4-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-fsdp_mesh_2x4-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-fsdp_mesh_2x4-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-fsdp_mesh_2x4-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-fsdp_mesh_2x4-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-fsdp_mesh_2x4-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-fsdp_mesh_2x4-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-fsdp_mesh_2x4-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-fsdp_mesh_2x4-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-fsdp_mesh_2x4-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-fsdp_mesh_2x4-no_dp-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
 
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-fsdp-mesh_2x4-no_dp-tensor_parallel-inference:
+  # --- FSDP, mesh 2x4, DP (batch must be >= data dim 2) ---
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-fsdp_mesh_2x4-dp-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
-
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-fsdp-mesh_2x4-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-fsdp_mesh_2x4-dp-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
-
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-fsdp-mesh_2x4-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-fsdp_mesh_2x4-dp-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
-
-  # --- FSDP, mesh 2x4, DP ---
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-fsdp-mesh_2x4-dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-fsdp_mesh_2x4-dp-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
-
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-fsdp-mesh_2x4-dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
-    status: EXPECTED_PASSING
-    markers: [nightly]
-
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-fsdp-mesh_2x4-dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
-    status: EXPECTED_PASSING
-    markers: [nightly]
-
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-fsdp-mesh_2x4-dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
-    status: EXPECTED_PASSING
-    markers: [nightly]
-
-  # --- FSDP, mesh 1x8, DP (trivial: data axis = 1) ---
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-fsdp-mesh_1x8-dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
-    status: EXPECTED_PASSING
-    markers: [nightly]
-
-  # --- Megatron, mesh 1x8, no DP ---
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-megatron-mesh_1x8-no_dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
-    status: EXPECTED_PASSING
-    markers: [nightly]
-
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-megatron-mesh_1x8-no_dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
-    status: EXPECTED_PASSING
-    markers: [nightly]
-
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-megatron-mesh_1x8-no_dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
-    status: EXPECTED_PASSING
-    markers: [nightly]
-
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-megatron-mesh_1x8-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-fsdp_mesh_2x4-dp-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
 
   # --- Megatron, mesh 2x4, no DP ---
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-megatron-mesh_2x4-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-megatron_mesh_2x4-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-megatron_mesh_2x4-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-megatron_mesh_2x4-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-megatron_mesh_2x4-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-megatron_mesh_2x4-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-megatron_mesh_2x4-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron_mesh_2x4-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-megatron_mesh_2x4-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron_mesh_2x4-no_dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-megatron_mesh_2x4-no_dp-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
 
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-megatron-mesh_2x4-no_dp-tensor_parallel-inference:
+  # --- Megatron, mesh 2x4, DP (batch must be >= data dim 2) ---
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-megatron_mesh_2x4-dp-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
-
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-megatron-mesh_2x4-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-megatron_mesh_2x4-dp-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
-
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-megatron-mesh_2x4-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-megatron_mesh_2x4-dp-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
-
-  # --- Megatron, mesh 2x4, DP ---
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-megatron-mesh_2x4-dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-megatron_mesh_2x4-dp-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
-
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-megatron-mesh_2x4-dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
-    status: EXPECTED_PASSING
-    markers: [nightly]
-
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-megatron-mesh_2x4-dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
-    status: EXPECTED_PASSING
-    markers: [nightly]
-
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-megatron-mesh_2x4-dp-tensor_parallel-inference:
-    supported_archs: ["n300-llmbox"]
-    status: EXPECTED_PASSING
-    markers: [nightly]
-
-  # --- Megatron, mesh 1x8, DP (trivial: data axis = 1) ---
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-megatron-mesh_1x8-dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-megatron_mesh_2x4-dp-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]

--- a/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
@@ -145,9 +145,9 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_32-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
-    status: EXPECTED_PASSING
-
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_RUNTIME
+    reason: "DRAM OOM - https://github.com/tenstorrent/tt-mlir/issues/6877"
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
@@ -157,15 +157,15 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_32-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
-    status: EXPECTED_PASSING
-
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_RUNTIME
+    reason: "DRAM OOM - https://github.com/tenstorrent/tt-mlir/issues/6877"
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
-    status: EXPECTED_PASSING
-
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_RUNTIME
+    reason: "DRAM OOM - https://github.com/tenstorrent/tt-mlir/issues/6877"
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
@@ -175,9 +175,9 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
+    required_pcc: 0.91
     status: EXPECTED_PASSING
-
+    assert_pcc: false # pcc=0.9103
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_32-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
@@ -225,9 +225,9 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
+    required_pcc: 0.96
     status: EXPECTED_PASSING
-
+    assert_pcc: false # pcc=0.9612
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
@@ -287,9 +287,9 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
+    required_pcc: 0.95
     status: EXPECTED_PASSING
-
+    assert_pcc: false # pcc=0.9595
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
@@ -346,8 +346,9 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
+    required_pcc: 0.96
     status: EXPECTED_PASSING
+    assert_pcc: false # pcc=0.9613
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
@@ -357,8 +358,9 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
-    status: EXPECTED_PASSING
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_RUNTIME
+    reason: "DRAM OOM - https://github.com/tenstorrent/tt-mlir/issues/6877"
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_32-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
@@ -404,9 +406,9 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
+    required_pcc: 0.96
     status: EXPECTED_PASSING
-
+    assert_pcc: false # pcc=0.9600
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]

--- a/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
@@ -93,58 +93,6 @@ test_config:
   #  - batch_X means per-device batch size.
   # ============================================================================
 
-  # --- Megatron, mesh 1x8, no DP ---
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
-    supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
-    status: EXPECTED_PASSING
-    markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_4-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
-    supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
-    status: EXPECTED_PASSING
-    markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
-    supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
-    status: EXPECTED_PASSING
-    markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_4-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
-    supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
-    status: EXPECTED_PASSING
-    markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
-    supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
-    status: EXPECTED_PASSING
-    markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_4-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
-    supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
-    status: EXPECTED_PASSING
-    markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
-    supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
-    status: EXPECTED_PASSING
-    markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_4-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
-    supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
-    status: EXPECTED_PASSING
-    markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
-    supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
-    status: EXPECTED_PASSING
-    markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_4-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
-    supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
-    status: EXPECTED_PASSING
-    markers: [nightly]
-
   # --- FSDP, mesh 2x4, no DP ---
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
@@ -178,23 +126,26 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
+    required_pcc: 0.95
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_4-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
-    status: EXPECTED_PASSING
+    status: NOT_SUPPORTED_SKIP
+    reason: "DRAM OOM"
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
-    status: EXPECTED_PASSING
+    status: NOT_SUPPORTED_SKIP
+    reason: "DRAM OOM"
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_4-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
-    status: EXPECTED_PASSING
+    status: NOT_SUPPORTED_SKIP
+    reason: "DRAM OOM"
     markers: [nightly]
 
   # --- FSDP, mesh 2x4, DP (batch must be >= data dim 2) ---
@@ -228,25 +179,16 @@ test_config:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
-    status: EXPECTED_PASSING
-    markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_4-fsdp-dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
-    status: EXPECTED_PASSING
-    markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
+    required_pcc: 0.90
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_4-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
-    status: EXPECTED_PASSING
+    status: NOT_SUPPORTED_SKIP
+    reason: "DRAM OOM"
     markers: [nightly]
 
   # --- Megatron, mesh 2x4, no DP ---
@@ -282,23 +224,25 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
+    required_pcc: 0.95
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_4-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
-    status: EXPECTED_PASSING
+    status: NOT_SUPPORTED_SKIP
+    reason: "DRAM OOM"
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
+    required_pcc: 0.90
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_4-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
-    status: EXPECTED_PASSING
+    status: NOT_SUPPORTED_SKIP
+    reason: "DRAM OOM"
     markers: [nightly]
 
   # --- Megatron, mesh 2x4, DP (batch must be >= data dim 2) ---
@@ -330,25 +274,23 @@ test_config:
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_4-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
-    status: EXPECTED_PASSING
+    status: NOT_SUPPORTED_SKIP
+    reason: "DRAM OOM"
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
+    required_pcc: 0.95
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_4-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
-    status: EXPECTED_PASSING
-    markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
-    status: EXPECTED_PASSING
+    status: NOT_SUPPORTED_SKIP
+    reason: "DRAM OOM"
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_4-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
-    status: EXPECTED_PASSING
+    status: NOT_SUPPORTED_SKIP
+    reason: "DRAM OOM"
     markers: [nightly]

--- a/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
@@ -131,7 +131,7 @@ test_config:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_32-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
@@ -139,7 +139,7 @@ test_config:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_32-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.94 # Is 0.941
     status: EXPECTED_PASSING
@@ -151,7 +151,7 @@ test_config:
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_32-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.86 # Is 0.863
     status: EXPECTED_PASSING
@@ -163,7 +163,7 @@ test_config:
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.81 # Is 0.817
     status: EXPECTED_PASSING
@@ -175,7 +175,7 @@ test_config:
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_32-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
     reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
@@ -188,7 +188,7 @@ test_config:
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_32-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.92 # Is 0.928
     status: EXPECTED_PASSING
@@ -200,7 +200,7 @@ test_config:
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_32-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.87 # Is 0.875
     status: EXPECTED_PASSING
@@ -212,7 +212,7 @@ test_config:
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_32-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.75 # Is 0.758
     status: EXPECTED_PASSING
@@ -224,7 +224,7 @@ test_config:
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.80 # Is 0.802
     status: EXPECTED_PASSING
@@ -235,7 +235,7 @@ test_config:
     status: NOT_SUPPORTED_SKIP
     reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_32-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
     reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
@@ -248,7 +248,7 @@ test_config:
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_32-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.93 # Is 0.933
     status: EXPECTED_PASSING
@@ -260,7 +260,7 @@ test_config:
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_32-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.89 # Is 0.896
     status: EXPECTED_PASSING
@@ -272,7 +272,7 @@ test_config:
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_32-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.77 # Is 0.779
     status: EXPECTED_PASSING
@@ -284,7 +284,7 @@ test_config:
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
     reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
@@ -294,7 +294,7 @@ test_config:
     status: NOT_SUPPORTED_SKIP
     reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_32-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
     reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
@@ -305,7 +305,7 @@ test_config:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_32-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
@@ -315,7 +315,7 @@ test_config:
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_32-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.96 # Is 0.965
     status: EXPECTED_PASSING
@@ -325,7 +325,7 @@ test_config:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_32-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
@@ -333,7 +333,7 @@ test_config:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
@@ -341,7 +341,7 @@ test_config:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_32-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
@@ -351,7 +351,7 @@ test_config:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-megatron-dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_32-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
@@ -361,7 +361,7 @@ test_config:
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-megatron-dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_32-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.96 # Is 0.965
     status: EXPECTED_PASSING
@@ -373,7 +373,7 @@ test_config:
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-megatron-dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_32-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     required_pcc: 0.87 # Is 0.879
     status: EXPECTED_PASSING
@@ -385,7 +385,7 @@ test_config:
     status: EXPECTED_PASSING
     assert_pcc: false
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-megatron-dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
     reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
@@ -395,7 +395,7 @@ test_config:
     status: NOT_SUPPORTED_SKIP
     reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-megatron-dp-tensor_parallel-mesh_2x4-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_32-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox"]
     status: NOT_SUPPORTED_SKIP
     reason: "Out of memory" # See https://github.com/tenstorrent/tt-mlir/issues/6877

--- a/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
@@ -91,49 +91,49 @@ test_config:
   # ============================================================================
   # Llama 3.1 8B Instruct — Prefill tensor-parallel tests
   # Constraints:
-  #  - Keep only one strategy for 1x8 (FSDP).
+  #  - Keep only one strategy for 1x8 (Megatron).
   #  - DP only for mesh 2x4 with batch >= data dim (=2), so batch_2 only.
   #  - Cover all prefill sequence lengths through 8192.
   # ============================================================================
 
-  # --- FSDP, mesh 1x8, no DP ---
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-fsdp_mesh_1x8-no_dp-tensor_parallel-inference:
+  # --- Megatron, mesh 1x8, no DP ---
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-megatron_mesh_1x8-no_dp-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-fsdp_mesh_1x8-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-megatron_mesh_1x8-no_dp-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-fsdp_mesh_1x8-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-megatron_mesh_1x8-no_dp-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-fsdp_mesh_1x8-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-megatron_mesh_1x8-no_dp-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-fsdp_mesh_1x8-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-megatron_mesh_1x8-no_dp-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-fsdp_mesh_1x8-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-megatron_mesh_1x8-no_dp-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-fsdp_mesh_1x8-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron_mesh_1x8-no_dp-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-fsdp_mesh_1x8-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-megatron_mesh_1x8-no_dp-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-fsdp_mesh_1x8-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron_mesh_1x8-no_dp-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-fsdp_mesh_1x8-no_dp-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-megatron_mesh_1x8-no_dp-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
@@ -181,7 +181,15 @@ test_config:
     markers: [nightly]
 
   # --- FSDP, mesh 2x4, DP (batch must be >= data dim 2) ---
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-fsdp_mesh_2x4-dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-fsdp_mesh_2x4-dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-fsdp_mesh_2x4-dp-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
@@ -189,11 +197,23 @@ test_config:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-fsdp_mesh_2x4-dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-fsdp_mesh_2x4-dp-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-fsdp_mesh_2x4-dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-fsdp_mesh_2x4-dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-fsdp_mesh_2x4-dp-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
@@ -245,7 +265,15 @@ test_config:
     markers: [nightly]
 
   # --- Megatron, mesh 2x4, DP (batch must be >= data dim 2) ---
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-megatron_mesh_2x4-dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-megatron_mesh_2x4-dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-megatron_mesh_2x4-dp-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
@@ -253,11 +281,23 @@ test_config:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-megatron_mesh_2x4-dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-megatron_mesh_2x4-dp-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron_mesh_2x4-dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-megatron_mesh_2x4-dp-tensor_parallel-inference:
+    supported_archs: ["n300-llmbox"]
+    status: EXPECTED_PASSING
+    markers: [nightly]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron_mesh_2x4-dp-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
     markers: [nightly]

--- a/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
@@ -28,17 +28,9 @@ test_config:
     bringup_status: FAILED_RUNTIME
     reason: "trisc2 compile failure - https://github.com/tenstorrent/tt-xla/issues/2958"
 
-<<<<<<< HEAD
-  qwen_2_5/causal_lm/pytorch-72B_Instruct-llm_decode-seq_1-batch_1-tensor_parallel-inference:
+  qwen_2_5/causal_lm/pytorch-72B_Instruct-llm_decode-seq_1-batch_1-tensor_parallel-mesh_default-inference:
     supported_archs: ["galaxy-wh-6u"]
     status: EXPECTED_PASSING
-=======
-  qwen_2_5/causal_lm/pytorch-72B_Instruct-llm_decode-seq_1-batch_1-tensor_parallel-mesh_default-inference:
-    supported_archs: ["n300-llmbox"]
-    status: NOT_SUPPORTED_SKIP
-    reason: "Needs bringup on galaxy"
-    bringup_status: FAILED_RUNTIME
->>>>>>> 8ba24b9a5 (Separate mesh_shape and sharding_config fully.)
 
   gemma/pytorch-1.1_7B_IT-llm_decode-seq_1-batch_1-tensor_parallel-mesh_default-inference:
     supported_archs: ["n300-llmbox"]
@@ -54,30 +46,15 @@ test_config:
 
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_decode-seq_1-batch_1-tensor_parallel-mesh_default-inference:
     supported_archs: ["n300-llmbox"]
-    required_pcc: 0.99
     status: EXPECTED_PASSING
 
-<<<<<<< HEAD
-  llama/causal_lm/pytorch-3.1_70B-llm_decode-seq_1-batch_1-tensor_parallel-inference:
-    supported_archs: ["galaxy-wh-6u"]
-    status: EXPECTED_PASSING
-
-  llama/causal_lm/pytorch-3.1_70B_Instruct-llm_decode-seq_1-batch_1-tensor_parallel-inference:
-    supported_archs: ["galaxy-wh-6u"]
-    status: EXPECTED_PASSING
-=======
   llama/causal_lm/pytorch-3.1_70B-llm_decode-seq_1-batch_1-tensor_parallel-mesh_default-inference:
-    supported_archs: ["n300-llmbox"]
-    status: NOT_SUPPORTED_SKIP
-    reason: "Needs bringup on galaxy"
-    bringup_status: FAILED_RUNTIME
+    supported_archs: ["galaxy-wh-6u"]
+    status: EXPECTED_PASSING
 
   llama/causal_lm/pytorch-3.1_70B_Instruct-llm_decode-seq_1-batch_1-tensor_parallel-mesh_default-inference:
-    supported_archs: ["n300-llmbox"]
-    status: NOT_SUPPORTED_SKIP
-    reason: "Needs bringup on galaxy"
-    bringup_status: FAILED_RUNTIME
->>>>>>> 8ba24b9a5 (Separate mesh_shape and sharding_config fully.)
+    supported_archs: ["galaxy-wh-6u"]
+    status: EXPECTED_PASSING
 
   llama/causal_lm/pytorch-3.1_405B-llm_decode-seq_1-batch_1-tensor_parallel-mesh_default-inference:
     supported_archs: ["n300-llmbox"]
@@ -85,22 +62,11 @@ test_config:
     reason: "Needs bringup on galaxy"
     bringup_status: FAILED_RUNTIME
 
-<<<<<<< HEAD
-  llama/causal_lm/pytorch-3.3_70B_Instruct-llm_decode-seq_1-batch_1-tensor_parallel-inference:
+  llama/causal_lm/pytorch-3.3_70B_Instruct-llm_decode-seq_1-batch_1-tensor_parallel-mesh_default-inference:
     supported_archs: ["galaxy-wh-6u"]
     status: EXPECTED_PASSING
 
-  qwen_3/causal_lm/pytorch-8B-llm_decode-seq_1-batch_1-tensor_parallel-inference:
-=======
-  llama/causal_lm/pytorch-3.3_70B_Instruct-llm_decode-seq_1-batch_1-tensor_parallel-mesh_default-inference:
-    supported_archs: ["n300-llmbox"]
-    status: NOT_SUPPORTED_SKIP
-    reason: "Needs bringup on galaxy"
-    bringup_status: FAILED_RUNTIME
-
   qwen_3/causal_lm/pytorch-8B-llm_decode-seq_1-batch_1-tensor_parallel-mesh_default-inference:
-    required_pcc: 0.985 # https://github.com/tenstorrent/tt-xla/issues/2942
->>>>>>> 8ba24b9a5 (Separate mesh_shape and sharding_config fully.)
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
 
@@ -129,302 +95,210 @@ test_config:
 
   # --- Megatron, mesh 1x8, no DP ---
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
-    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_32-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
-    supported_archs: ["n300-llmbox"]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
-    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_32-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
-    supported_archs: ["n300-llmbox"]
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "DRAM OOM - https://github.com/tenstorrent/tt-mlir/issues/6877"
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+    required_pcc: 0.99
+    status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
-    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
-
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_32-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
-    supported_archs: ["n300-llmbox"]
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "DRAM OOM - https://github.com/tenstorrent/tt-mlir/issues/6877"
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+    required_pcc: 0.99
+    status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
-    supported_archs: ["n300-llmbox"]
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "DRAM OOM - https://github.com/tenstorrent/tt-mlir/issues/6877"
+    required_pcc: 0.99
+    status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
-    supported_archs: ["n300-llmbox"]
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "DRAM OOM"
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+    required_pcc: 0.99
+    status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
-    supported_archs: ["n300-llmbox"]
-    required_pcc: 0.91
+    required_pcc: 0.99
     status: EXPECTED_PASSING
-    assert_pcc: false # pcc=0.9103
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_32-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
-    supported_archs: ["n300-llmbox"]
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "DRAM OOM"
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-megatron-no_dp-tensor_parallel-mesh_1x8-inference:
+    required_pcc: 0.99
+    status: EXPECTED_PASSING
     markers: [nightly]
 
   # --- FSDP, mesh 2x4, no DP ---
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
-
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_32-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     required_pcc: 0.99
     status: EXPECTED_PASSING
-
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
-
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_32-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "DRAM OOM - https://github.com/tenstorrent/tt-mlir/issues/6877"
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+    required_pcc: 0.99
+    status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
-
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_32-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "DRAM OOM - https://github.com/tenstorrent/tt-mlir/issues/6877"
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+    required_pcc: 0.99
+    status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
-    required_pcc: 0.96
+    required_pcc: 0.99
     status: EXPECTED_PASSING
-    assert_pcc: false # pcc=0.9612
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "DRAM OOM"
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+    required_pcc: 0.99
+    status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "DRAM OOM"
+    required_pcc: 0.99
+    status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_32-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "DRAM OOM"
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
+    required_pcc: 0.99
+    status: EXPECTED_PASSING
     markers: [nightly]
 
   # --- FSDP, mesh 2x4, DP (batch must be >= data dim 2) ---
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
-
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_32-fsdp-dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     required_pcc: 0.99
     status: EXPECTED_PASSING
-
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
-
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_32-fsdp-dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "DRAM OOM - https://github.com/tenstorrent/tt-mlir/issues/6877"
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+    required_pcc: 0.99
+    status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
-
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_32-fsdp-dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "DRAM OOM - https://github.com/tenstorrent/tt-mlir/issues/6877"
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+    required_pcc: 0.99
+    status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
-    required_pcc: 0.95
+    required_pcc: 0.99
     status: EXPECTED_PASSING
-    assert_pcc: false # pcc=0.9595
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-fsdp-dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "DRAM OOM"
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+    required_pcc: 0.99
+    status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "DRAM OOM"
+    required_pcc: 0.99
+    status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_32-fsdp-dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "DRAM OOM"
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-fsdp-dp-tensor_parallel-mesh_2x4-inference:
+    required_pcc: 0.99
+    status: EXPECTED_PASSING
     markers: [nightly]
 
   # --- Megatron, mesh 2x4, no DP ---
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_32-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
-
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_32-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "DRAM OOM - https://github.com/tenstorrent/tt-mlir/issues/6877"
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+    required_pcc: 0.99
+    status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_32-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "DRAM OOM - https://github.com/tenstorrent/tt-mlir/issues/6877"
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+    required_pcc: 0.99
+    status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
-    required_pcc: 0.96
+    required_pcc: 0.99
     status: EXPECTED_PASSING
-    assert_pcc: false # pcc=0.9613
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "DRAM OOM"
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+    required_pcc: 0.99
+    status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "DRAM OOM - https://github.com/tenstorrent/tt-mlir/issues/6877"
+    required_pcc: 0.99
+    status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_32-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "DRAM OOM"
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
+    required_pcc: 0.99
+    status: EXPECTED_PASSING
     markers: [nightly]
 
   # --- Megatron, mesh 2x4, DP (batch must be >= data dim 2) ---
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_32-megatron-dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_128-batch_2-megatron-dp-tensor_parallel-mesh_2x4-inference:
     required_pcc: 0.99
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
-
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_32-megatron-dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "DRAM OOM - https://github.com/tenstorrent/tt-mlir/issues/6877"
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_1024-batch_2-megatron-dp-tensor_parallel-mesh_2x4-inference:
+    required_pcc: 0.99
+    status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
     required_pcc: 0.99
     status: EXPECTED_PASSING
-
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_32-megatron-dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "DRAM OOM - https://github.com/tenstorrent/tt-mlir/issues/6877"
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_2048-batch_2-megatron-dp-tensor_parallel-mesh_2x4-inference:
+    required_pcc: 0.99
+    status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
-    required_pcc: 0.96
+    required_pcc: 0.99
     status: EXPECTED_PASSING
-    assert_pcc: false # pcc=0.9600
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_32-megatron-dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "DRAM OOM"
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_2-megatron-dp-tensor_parallel-mesh_2x4-inference:
+    required_pcc: 0.99
+    status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "DRAM OOM"
+    required_pcc: 0.99
+    status: EXPECTED_PASSING
     markers: [nightly]
-  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_32-megatron-dp-tensor_parallel-mesh_2x4-inference:
-    supported_archs: ["n300-llmbox"]
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "DRAM OOM"
+  llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_2-megatron-dp-tensor_parallel-mesh_2x4-inference:
+    required_pcc: 0.99
+    status: EXPECTED_PASSING
     markers: [nightly]

--- a/tests/runner/test_models.py
+++ b/tests/runner/test_models.py
@@ -493,7 +493,7 @@ def test_llms_torch(
         # Decode tests don't parametrize on sequence length (default is seq_len = 1).
         if sequence_length is not None:
             pytest.skip("Decode tests do not support sequence_length parameterization")
-        # Decode tests for now run only batch_size = 1.
+        # Decode tests for now run only batch_per_device = 1.
         if batch_per_device != 1:
             pytest.skip("Decode tests currently only support batch_size=1")
         # Decode uses only the backward-compatible default sharding configs.
@@ -531,15 +531,6 @@ def test_llms_torch(
             pytest.skip(
                 "Prefill TP for strategy-aware loaders uses explicit sharding configs"
             )
-        # Combined TP + input sharding: batch_size must cover the DP axis so each
-        # device processes different data (no replication).
-        if sharding_config.shard_inputs and mesh_shape:
-            dp_size = mesh_shape[0]
-            if batch_size < dp_size:
-                pytest.skip(
-                    f"Input sharding requires batch_size >= dp axis size ({dp_size}), "
-                    f"got batch_size={batch_size}"
-                )
         request.node.add_marker(pytest.mark.llm_prefill)
     else:
         # Decode and default phase semantics are unchanged (batch already global).

--- a/tests/runner/test_models.py
+++ b/tests/runner/test_models.py
@@ -386,9 +386,9 @@ def _generate_sequence_length_id(sequence_length):
     return f"seq_{sequence_length}" if sequence_length is not None else "seq_1"
 
 
-def _generate_batch_size_id(batch_per_device):
-    """Generate test ID component for batch-per-device."""
-    return f"batch_{batch_per_device}"
+def _generate_batch_size_id(batch_size):
+    """Generate test ID component for batch_size."""
+    return f"batch_{batch_size}"
 
 
 def _supports_strategy_shard_spec(model_loader_cls) -> bool:
@@ -459,7 +459,7 @@ def _supports_strategy_shard_spec(model_loader_cls) -> bool:
         ),
     ],
 )
-@pytest.mark.parametrize("batch_per_device", [1, 2], ids=_generate_batch_size_id)
+@pytest.mark.parametrize("batch_size", [1, 2], ids=_generate_batch_size_id)
 @pytest.mark.parametrize(
     "sequence_length",
     [None, 128, 1024, 2048, 4096, 8192],
@@ -473,7 +473,7 @@ def _supports_strategy_shard_spec(model_loader_cls) -> bool:
 def test_llms_torch(
     test_entry_and_phase,
     sequence_length,
-    batch_per_device,
+    batch_size,
     sharding_config,
     mesh_shape,
     run_mode,
@@ -493,8 +493,7 @@ def test_llms_torch(
         # Decode tests don't parametrize on sequence length (default is seq_len = 1).
         if sequence_length is not None:
             pytest.skip("Decode tests do not support sequence_length parameterization")
-        # Decode tests for now run only batch_per_device = 1.
-        if batch_per_device != 1:
+        if batch_size != 1:
             pytest.skip("Decode tests currently only support batch_size=1")
         # Decode uses only the backward-compatible default sharding configs.
         if sharding_config.shard_strategy is not None:
@@ -502,13 +501,12 @@ def test_llms_torch(
         request.node.add_marker(pytest.mark.llm_decode)
 
     if run_phase == RunPhase.LLM_PREFILL:
-        # Batch parameterization is per-device.
-        # Convert to global batch only when inputs are data-sharded (dp).
+        # NOTE: batch_size in test_llms_torch is interpreted as per-device batch size.
         mesh_data_dim = mesh_shape[0] if mesh_shape else 1
         if sharding_config.shard_inputs:
-            batch_size = batch_per_device * mesh_data_dim
+            effective_batch_size = batch_size * mesh_data_dim
         else:
-            batch_size = batch_per_device
+            effective_batch_size = batch_size
 
         # Sequence length should be specified for prefill tests.
         if sequence_length is None:
@@ -533,10 +531,9 @@ def test_llms_torch(
             )
         request.node.add_marker(pytest.mark.llm_prefill)
     else:
-        # Decode and default phase semantics are unchanged (batch already global).
-        batch_size = batch_per_device
+        effective_batch_size = batch_size
 
-    test_metadata.batch_size = batch_size
+    test_metadata.batch_size = effective_batch_size
     test_metadata.seq_len = sequence_length
 
     # Propagate sharding configuration into test_metadata for downstream consumers

--- a/tests/runner/test_models.py
+++ b/tests/runner/test_models.py
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
-import os
 import inspect
+import os
 import shutil
 import socket
 import subprocess
@@ -429,8 +429,8 @@ def _supports_strategy_shard_spec(model_loader_cls) -> bool:
         ),
         pytest.param(
             ShardingConfigs.MEGATRON,
-            (1, 8),
-            id="megatron_mesh_1x8-no_dp-tensor_parallel",
+            (2, 4),
+            id="megatron_mesh_2x4-no_dp-tensor_parallel",
             marks=pytest.mark.tensor_parallel,
         ),
         pytest.param(
@@ -447,8 +447,8 @@ def _supports_strategy_shard_spec(model_loader_cls) -> bool:
         ),
         pytest.param(
             ShardingConfigs.MEGATRON,
-            (2, 4),
-            id="megatron_mesh_2x4-no_dp-tensor_parallel",
+            (1, 8),
+            id="megatron_mesh_1x8-no_dp-tensor_parallel",
             marks=pytest.mark.tensor_parallel,
         ),
         pytest.param(

--- a/tests/runner/test_models.py
+++ b/tests/runner/test_models.py
@@ -492,7 +492,7 @@ def _validate_llm_sharding_mesh_combination(sharding_config, mesh_shape):
         ),
     ],
 )
-@pytest.mark.parametrize("batch_size", [1, 32], ids=_generate_batch_size_id)
+@pytest.mark.parametrize("batch_size", [1, 4], ids=_generate_batch_size_id)
 @pytest.mark.parametrize(
     "sequence_length",
     [None, 128, 1024, 2048, 4096, 8192],

--- a/tests/runner/test_models.py
+++ b/tests/runner/test_models.py
@@ -391,6 +391,13 @@ def _generate_batch_size_id(batch_size):
     return f"batch_{batch_size}"
 
 
+def _generate_mesh_shape_id(mesh_shape):
+    """Generate test ID component for mesh shape."""
+    if mesh_shape is None:
+        return "mesh_default"
+    return f"mesh_{mesh_shape[0]}x{mesh_shape[1]}"
+
+
 def _supports_strategy_shard_spec(model_loader_cls) -> bool:
     """Return True if loader.load_shard_spec supports strategy/batch_axis kwargs."""
     if not hasattr(model_loader_cls, "load_shard_spec"):
@@ -403,6 +410,30 @@ def _supports_strategy_shard_spec(model_loader_cls) -> bool:
     return "strategy" in params and "batch_axis" in params
 
 
+def _validate_llm_combo(sharding_config, mesh_shape):
+    """Return skip reason for invalid sharding/mesh combinations."""
+    strategy = sharding_config.shard_strategy
+    shard_inputs = sharding_config.shard_inputs
+
+    if strategy is None:
+        if mesh_shape is not None:
+            return "Default single/tensor parallel config uses mesh_default only"
+        return None
+
+    if mesh_shape is None:
+        return "Explicit sharding strategy requires mesh_shape"
+
+    if mesh_shape == (1, 8):
+        if strategy != "megatron" or shard_inputs:
+            return "Redundant on mesh_1x8: keep only megatron no-DP"
+        return None
+
+    if mesh_shape != (2, 4):
+        return "Unsupported mesh_shape for explicit sharding strategy"
+
+    return None
+
+
 @pytest.mark.model_test
 @pytest.mark.no_auto_properties
 @pytest.mark.llm
@@ -413,48 +444,41 @@ def _supports_strategy_shard_spec(model_loader_cls) -> bool:
     ],
 )
 @pytest.mark.parametrize(
-    "sharding_config,mesh_shape",
+    "mesh_shape",
+    [None, (1, 8), (2, 4)],
+    ids=_generate_mesh_shape_id,
+)
+@pytest.mark.parametrize(
+    "sharding_config",
     [
         pytest.param(
             ShardingConfigs.SINGLE_DEVICE,
-            None,
             id="single_device",
             marks=pytest.mark.single_device,
         ),
         pytest.param(
             ShardingConfigs.TENSOR_PARALLEL,
-            None,
             id="tensor_parallel",
             marks=pytest.mark.tensor_parallel,
         ),
         pytest.param(
             ShardingConfigs.MEGATRON,
-            (2, 4),
-            id="megatron_mesh_2x4-no_dp-tensor_parallel",
+            id="megatron-no_dp-tensor_parallel",
             marks=pytest.mark.tensor_parallel,
         ),
         pytest.param(
             ShardingConfigs.FSDP,
-            (2, 4),
-            id="fsdp_mesh_2x4-no_dp-tensor_parallel",
+            id="fsdp-no_dp-tensor_parallel",
             marks=pytest.mark.tensor_parallel,
         ),
         pytest.param(
             ShardingConfigs.FSDP_DP,
-            (2, 4),
-            id="fsdp_mesh_2x4-dp-tensor_parallel",
-            marks=pytest.mark.tensor_parallel,
-        ),
-        pytest.param(
-            ShardingConfigs.MEGATRON,
-            (1, 8),
-            id="megatron_mesh_1x8-no_dp-tensor_parallel",
+            id="fsdp-dp-tensor_parallel",
             marks=pytest.mark.tensor_parallel,
         ),
         pytest.param(
             ShardingConfigs.MEGATRON_DP,
-            (2, 4),
-            id="megatron_mesh_2x4-dp-tensor_parallel",
+            id="megatron-dp-tensor_parallel",
             marks=pytest.mark.tensor_parallel,
         ),
     ],
@@ -488,6 +512,10 @@ def test_llms_torch(
     _, model_loader_cls = test_entry.variant_info
     supports_strategy_shard_spec = _supports_strategy_shard_spec(model_loader_cls)
     parallelism = sharding_config.parallelism
+
+    invalid_combo_reason = _validate_llm_combo(sharding_config, mesh_shape)
+    if invalid_combo_reason is not None:
+        pytest.skip(invalid_combo_reason)
 
     if run_phase == RunPhase.LLM_DECODE:
         # Decode tests don't parametrize on sequence length (default is seq_len = 1).

--- a/tests/runner/test_models.py
+++ b/tests/runner/test_models.py
@@ -413,28 +413,50 @@ def _supports_strategy_shard_spec(model_loader_cls) -> bool:
     ],
 )
 @pytest.mark.parametrize(
-    "sharding_config",
+    "sharding_config,mesh_shape",
     [
-        pytest.param(ShardingConfigs.SINGLE_DEVICE, id="single_device",
-                     marks=pytest.mark.single_device),
-        pytest.param(ShardingConfigs.TENSOR_PARALLEL, id="tensor_parallel",
-                     marks=pytest.mark.tensor_parallel),
-        pytest.param(ShardingConfigs.FSDP_1x8, id="fsdp-mesh_1x8-no_dp-tensor_parallel",
-                     marks=pytest.mark.tensor_parallel),
-        pytest.param(ShardingConfigs.FSDP_1x8_DP, id="fsdp-mesh_1x8-dp-tensor_parallel",
-                     marks=pytest.mark.tensor_parallel),
-        pytest.param(ShardingConfigs.FSDP_2x4, id="fsdp-mesh_2x4-no_dp-tensor_parallel",
-                     marks=pytest.mark.tensor_parallel),
-        pytest.param(ShardingConfigs.FSDP_2x4_DP, id="fsdp-mesh_2x4-dp-tensor_parallel",
-                     marks=pytest.mark.tensor_parallel),
-        pytest.param(ShardingConfigs.MEGATRON_1x8, id="megatron-mesh_1x8-no_dp-tensor_parallel",
-                     marks=pytest.mark.tensor_parallel),
-        pytest.param(ShardingConfigs.MEGATRON_1x8_DP, id="megatron-mesh_1x8-dp-tensor_parallel",
-                     marks=pytest.mark.tensor_parallel),
-        pytest.param(ShardingConfigs.MEGATRON_2x4, id="megatron-mesh_2x4-no_dp-tensor_parallel",
-                     marks=pytest.mark.tensor_parallel),
-        pytest.param(ShardingConfigs.MEGATRON_2x4_DP, id="megatron-mesh_2x4-dp-tensor_parallel",
-                     marks=pytest.mark.tensor_parallel),
+        pytest.param(
+            ShardingConfigs.SINGLE_DEVICE,
+            None,
+            id="single_device",
+            marks=pytest.mark.single_device,
+        ),
+        pytest.param(
+            ShardingConfigs.TENSOR_PARALLEL,
+            None,
+            id="tensor_parallel",
+            marks=pytest.mark.tensor_parallel,
+        ),
+        pytest.param(
+            ShardingConfigs.FSDP,
+            (1, 8),
+            id="fsdp_mesh_1x8-no_dp-tensor_parallel",
+            marks=pytest.mark.tensor_parallel,
+        ),
+        pytest.param(
+            ShardingConfigs.FSDP,
+            (2, 4),
+            id="fsdp_mesh_2x4-no_dp-tensor_parallel",
+            marks=pytest.mark.tensor_parallel,
+        ),
+        pytest.param(
+            ShardingConfigs.FSDP_DP,
+            (2, 4),
+            id="fsdp_mesh_2x4-dp-tensor_parallel",
+            marks=pytest.mark.tensor_parallel,
+        ),
+        pytest.param(
+            ShardingConfigs.MEGATRON,
+            (2, 4),
+            id="megatron_mesh_2x4-no_dp-tensor_parallel",
+            marks=pytest.mark.tensor_parallel,
+        ),
+        pytest.param(
+            ShardingConfigs.MEGATRON_DP,
+            (2, 4),
+            id="megatron_mesh_2x4-dp-tensor_parallel",
+            marks=pytest.mark.tensor_parallel,
+        ),
     ],
 )
 @pytest.mark.parametrize("batch_size", [1, 2], ids=_generate_batch_size_id)
@@ -453,6 +475,7 @@ def test_llms_torch(
     sequence_length,
     batch_size,
     sharding_config,
+    mesh_shape,
     run_mode,
     record_property,
     test_metadata,
@@ -502,8 +525,8 @@ def test_llms_torch(
             )
         # Combined TP + input sharding: batch_size must cover the DP axis so each
         # device processes different data (no replication).
-        if sharding_config.shard_inputs and sharding_config.mesh_shape:
-            dp_size = sharding_config.mesh_shape[0]
+        if sharding_config.shard_inputs and mesh_shape:
+            dp_size = mesh_shape[0]
             if batch_size < dp_size:
                 pytest.skip(
                     f"Input sharding requires batch_size >= dp axis size ({dp_size}), "
@@ -517,7 +540,7 @@ def test_llms_torch(
     # Propagate sharding configuration into test_metadata for downstream consumers
     if sharding_config.shard_strategy is not None:
         test_metadata.sharding_strategy = sharding_config.shard_strategy
-        test_metadata.mesh_shape = sharding_config.mesh_shape
+        test_metadata.mesh_shape = mesh_shape
         test_metadata.shard_inputs = sharding_config.shard_inputs
 
     _run_model_test_impl(

--- a/tests/runner/test_models.py
+++ b/tests/runner/test_models.py
@@ -30,6 +30,7 @@ from tests.runner.test_utils import (
     ModelTestStatus,
     RunPhase,
     ShardingConfigs,
+    ShardingStrategy,
     create_benchmark_result,
     find_dumped_ir_files,
     get_input_shape_info,
@@ -410,8 +411,8 @@ def _supports_strategy_shard_spec(model_loader_cls) -> bool:
     return "strategy" in params and "batch_axis" in params
 
 
-def _validate_llm_combo(sharding_config, mesh_shape):
-    """Return skip reason for invalid sharding/mesh combinations."""
+def _validate_llm_sharding_mesh_combination(sharding_config, mesh_shape):
+    """Return skip reason for invalid LLM sharding strategy/mesh combinations."""
     strategy = sharding_config.shard_strategy
     shard_inputs = sharding_config.shard_inputs
 
@@ -424,12 +425,20 @@ def _validate_llm_combo(sharding_config, mesh_shape):
         return "Explicit sharding strategy requires mesh_shape"
 
     if mesh_shape == (1, 8):
-        if strategy != "megatron" or shard_inputs:
-            return "Redundant on mesh_1x8: keep only megatron no-DP"
+        if strategy != ShardingStrategy.MEGATRON or shard_inputs:
+            return (
+                "For mesh_1x8, only megatron-no_dp is kept because fsdp-no_dp is "
+                "effectively equivalent here (non-model mesh dimension is size 1). "
+                "Use strategy=megatron with shard_inputs=False, or switch to mesh_2x4 "
+                "if you want distinct fsdp behavior."
+            )
         return None
 
     if mesh_shape != (2, 4):
-        return "Unsupported mesh_shape for explicit sharding strategy"
+        return (
+            f"Unsupported mesh_shape={mesh_shape} for explicit sharding strategy. "
+            "Supported explicit strategy mesh shapes: mesh_1x8 and mesh_2x4."
+        )
 
     return None
 
@@ -483,7 +492,7 @@ def _validate_llm_combo(sharding_config, mesh_shape):
         ),
     ],
 )
-@pytest.mark.parametrize("batch_size", [1, 2], ids=_generate_batch_size_id)
+@pytest.mark.parametrize("batch_size", [1, 32], ids=_generate_batch_size_id)
 @pytest.mark.parametrize(
     "sequence_length",
     [None, 128, 1024, 2048, 4096, 8192],
@@ -513,7 +522,9 @@ def test_llms_torch(
     supports_strategy_shard_spec = _supports_strategy_shard_spec(model_loader_cls)
     parallelism = sharding_config.parallelism
 
-    invalid_combo_reason = _validate_llm_combo(sharding_config, mesh_shape)
+    invalid_combo_reason = _validate_llm_sharding_mesh_combination(
+        sharding_config, mesh_shape
+    )
     if invalid_combo_reason is not None:
         pytest.skip(invalid_combo_reason)
 

--- a/tests/runner/test_models.py
+++ b/tests/runner/test_models.py
@@ -386,9 +386,9 @@ def _generate_sequence_length_id(sequence_length):
     return f"seq_{sequence_length}" if sequence_length is not None else "seq_1"
 
 
-def _generate_batch_size_id(batch_size):
-    """Generate test ID component for batch_size."""
-    return f"batch_{batch_size}"
+def _generate_batch_size_id(batch_per_device):
+    """Generate test ID component for batch-per-device."""
+    return f"batch_{batch_per_device}"
 
 
 def _supports_strategy_shard_spec(model_loader_cls) -> bool:
@@ -428,9 +428,9 @@ def _supports_strategy_shard_spec(model_loader_cls) -> bool:
             marks=pytest.mark.tensor_parallel,
         ),
         pytest.param(
-            ShardingConfigs.FSDP,
+            ShardingConfigs.MEGATRON,
             (1, 8),
-            id="fsdp_mesh_1x8-no_dp-tensor_parallel",
+            id="megatron_mesh_1x8-no_dp-tensor_parallel",
             marks=pytest.mark.tensor_parallel,
         ),
         pytest.param(
@@ -459,7 +459,7 @@ def _supports_strategy_shard_spec(model_loader_cls) -> bool:
         ),
     ],
 )
-@pytest.mark.parametrize("batch_size", [1, 2], ids=_generate_batch_size_id)
+@pytest.mark.parametrize("batch_per_device", [1, 2], ids=_generate_batch_size_id)
 @pytest.mark.parametrize(
     "sequence_length",
     [None, 128, 1024, 2048, 4096, 8192],
@@ -473,7 +473,7 @@ def _supports_strategy_shard_spec(model_loader_cls) -> bool:
 def test_llms_torch(
     test_entry_and_phase,
     sequence_length,
-    batch_size,
+    batch_per_device,
     sharding_config,
     mesh_shape,
     run_mode,
@@ -494,7 +494,7 @@ def test_llms_torch(
         if sequence_length is not None:
             pytest.skip("Decode tests do not support sequence_length parameterization")
         # Decode tests for now run only batch_size = 1.
-        if batch_size != 1:
+        if batch_per_device != 1:
             pytest.skip("Decode tests currently only support batch_size=1")
         # Decode uses only the backward-compatible default sharding configs.
         if sharding_config.shard_strategy is not None:
@@ -502,6 +502,14 @@ def test_llms_torch(
         request.node.add_marker(pytest.mark.llm_decode)
 
     if run_phase == RunPhase.LLM_PREFILL:
+        # Batch parameterization is per-device.
+        # Convert to global batch only when inputs are data-sharded (dp).
+        mesh_data_dim = mesh_shape[0] if mesh_shape else 1
+        if sharding_config.shard_inputs:
+            batch_size = batch_per_device * mesh_data_dim
+        else:
+            batch_size = batch_per_device
+
         # Sequence length should be specified for prefill tests.
         if sequence_length is None:
             pytest.skip("Sequence length must be specified for prefill tests")
@@ -533,6 +541,9 @@ def test_llms_torch(
                     f"got batch_size={batch_size}"
                 )
         request.node.add_marker(pytest.mark.llm_prefill)
+    else:
+        # Decode and default phase semantics are unchanged (batch already global).
+        batch_size = batch_per_device
 
     test_metadata.batch_size = batch_size
     test_metadata.seq_len = sequence_length

--- a/tests/runner/test_models.py
+++ b/tests/runner/test_models.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import os
+import inspect
 import shutil
 import socket
 import subprocess
@@ -28,6 +29,7 @@ from tests.runner.test_utils import (
     ModelTestConfig,
     ModelTestStatus,
     RunPhase,
+    ShardingConfigs,
     create_benchmark_result,
     find_dumped_ir_files,
     get_input_shape_info,
@@ -389,6 +391,18 @@ def _generate_batch_size_id(batch_size):
     return f"batch_{batch_size}"
 
 
+def _supports_strategy_shard_spec(model_loader_cls) -> bool:
+    """Return True if loader.load_shard_spec supports strategy/batch_axis kwargs."""
+    if not hasattr(model_loader_cls, "load_shard_spec"):
+        return False
+    try:
+        signature = inspect.signature(model_loader_cls.load_shard_spec)
+    except (TypeError, ValueError):
+        return False
+    params = signature.parameters
+    return "strategy" in params and "batch_axis" in params
+
+
 @pytest.mark.model_test
 @pytest.mark.no_auto_properties
 @pytest.mark.llm
@@ -399,18 +413,28 @@ def _generate_batch_size_id(batch_size):
     ],
 )
 @pytest.mark.parametrize(
-    "parallelism",
+    "sharding_config",
     [
-        pytest.param(
-            Parallelism.SINGLE_DEVICE,
-            id="single_device",
-            marks=pytest.mark.single_device,
-        ),
-        pytest.param(
-            Parallelism.TENSOR_PARALLEL,
-            id="tensor_parallel",
-            marks=pytest.mark.tensor_parallel,
-        ),
+        pytest.param(ShardingConfigs.SINGLE_DEVICE, id="single_device",
+                     marks=pytest.mark.single_device),
+        pytest.param(ShardingConfigs.TENSOR_PARALLEL, id="tensor_parallel",
+                     marks=pytest.mark.tensor_parallel),
+        pytest.param(ShardingConfigs.FSDP_1x8, id="fsdp-mesh_1x8-no_dp-tensor_parallel",
+                     marks=pytest.mark.tensor_parallel),
+        pytest.param(ShardingConfigs.FSDP_1x8_DP, id="fsdp-mesh_1x8-dp-tensor_parallel",
+                     marks=pytest.mark.tensor_parallel),
+        pytest.param(ShardingConfigs.FSDP_2x4, id="fsdp-mesh_2x4-no_dp-tensor_parallel",
+                     marks=pytest.mark.tensor_parallel),
+        pytest.param(ShardingConfigs.FSDP_2x4_DP, id="fsdp-mesh_2x4-dp-tensor_parallel",
+                     marks=pytest.mark.tensor_parallel),
+        pytest.param(ShardingConfigs.MEGATRON_1x8, id="megatron-mesh_1x8-no_dp-tensor_parallel",
+                     marks=pytest.mark.tensor_parallel),
+        pytest.param(ShardingConfigs.MEGATRON_1x8_DP, id="megatron-mesh_1x8-dp-tensor_parallel",
+                     marks=pytest.mark.tensor_parallel),
+        pytest.param(ShardingConfigs.MEGATRON_2x4, id="megatron-mesh_2x4-no_dp-tensor_parallel",
+                     marks=pytest.mark.tensor_parallel),
+        pytest.param(ShardingConfigs.MEGATRON_2x4_DP, id="megatron-mesh_2x4-dp-tensor_parallel",
+                     marks=pytest.mark.tensor_parallel),
     ],
 )
 @pytest.mark.parametrize("batch_size", [1, 2], ids=_generate_batch_size_id)
@@ -428,8 +452,8 @@ def test_llms_torch(
     test_entry_and_phase,
     sequence_length,
     batch_size,
+    sharding_config,
     run_mode,
-    parallelism,
     record_property,
     test_metadata,
     request,
@@ -438,6 +462,9 @@ def test_llms_torch(
 ):
     """PyTorch LLM model test (decode/prefill phases) - delegates to shared implementation."""
     test_entry, run_phase = test_entry_and_phase
+    _, model_loader_cls = test_entry.variant_info
+    supports_strategy_shard_spec = _supports_strategy_shard_spec(model_loader_cls)
+    parallelism = sharding_config.parallelism
 
     if run_phase == RunPhase.LLM_DECODE:
         # Decode tests don't parametrize on sequence length (default is seq_len = 1).
@@ -446,16 +473,52 @@ def test_llms_torch(
         # Decode tests for now run only batch_size = 1.
         if batch_size != 1:
             pytest.skip("Decode tests currently only support batch_size=1")
+        # Decode uses only the backward-compatible default sharding configs.
+        if sharding_config.shard_strategy is not None:
+            pytest.skip("Decode tests use default sharding config only")
         request.node.add_marker(pytest.mark.llm_decode)
 
     if run_phase == RunPhase.LLM_PREFILL:
         # Sequence length should be specified for prefill tests.
         if sequence_length is None:
             pytest.skip("Sequence length must be specified for prefill tests")
+        # Explicit strategy configs are supported only for loaders that accept
+        # strategy/batch_axis kwargs in load_shard_spec.
+        if (
+            parallelism == Parallelism.TENSOR_PARALLEL
+            and sharding_config.shard_strategy is not None
+            and not supports_strategy_shard_spec
+        ):
+            pytest.skip("Loader does not support explicit sharding strategy config")
+        # For loaders that support strategy kwarg (e.g. Llama), avoid redundant
+        # default TP prefill and rely on explicit strategy configs.
+        if (
+            parallelism == Parallelism.TENSOR_PARALLEL
+            and sharding_config.shard_strategy is None
+            and supports_strategy_shard_spec
+        ):
+            pytest.skip(
+                "Prefill TP for strategy-aware loaders uses explicit sharding configs"
+            )
+        # Combined TP + input sharding: batch_size must cover the DP axis so each
+        # device processes different data (no replication).
+        if sharding_config.shard_inputs and sharding_config.mesh_shape:
+            dp_size = sharding_config.mesh_shape[0]
+            if batch_size < dp_size:
+                pytest.skip(
+                    f"Input sharding requires batch_size >= dp axis size ({dp_size}), "
+                    f"got batch_size={batch_size}"
+                )
         request.node.add_marker(pytest.mark.llm_prefill)
 
     test_metadata.batch_size = batch_size
     test_metadata.seq_len = sequence_length
+
+    # Propagate sharding configuration into test_metadata for downstream consumers
+    if sharding_config.shard_strategy is not None:
+        test_metadata.sharding_strategy = sharding_config.shard_strategy
+        test_metadata.mesh_shape = sharding_config.mesh_shape
+        test_metadata.shard_inputs = sharding_config.shard_inputs
 
     _run_model_test_impl(
         test_entry=test_entry,

--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -186,7 +186,9 @@ class ModelTestConfig:
         # Sharding configuration for TP prefill tests (set from parametrization, not YAML)
         self.sharding_strategy = None  # "fsdp" or "megatron"
         self.mesh_shape = None  # e.g. (1, 8), (2, 4)
-        self.shard_inputs = False  # whether to shard inputs across the batch/data mesh axis
+        self.shard_inputs = (
+            False  # whether to shard inputs across the batch/data mesh axis
+        )
 
         # Arguments to skip_full_eval_test() for skipping tests
         self.reason = self._resolve("reason", default=None)

--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -13,7 +13,7 @@ import os
 import sys
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional
 
 import numpy as np
 import pytest
@@ -61,18 +61,16 @@ class RunPhase(Enum):
 class ShardingConfig:
     """Configuration for multi-chip sharding in LLM tests.
 
-    Bundles mesh_shape, shard_strategy, and shard_inputs into a single
-    test parameter.  Used only by test_llms_torch to expand tested sharding
+    Bundles shard_strategy and shard_inputs into a single
+    test parameter. Used only by test_llms_torch to expand tested sharding
     combinations without changing the Parallelism enum or shared code paths.
 
     Attributes:
-        mesh_shape: Device mesh shape, e.g. (1,8) or (2,4). None = use loader default.
         shard_strategy: "fsdp" (both axes) or "megatron" (model axis only). None = loader default.
         shard_inputs: Whether to shard inputs across the batch/data axis of the mesh.
         parallelism: Parallelism enum value for dispatch and backward-compat reporting.
     """
 
-    mesh_shape: Optional[Tuple[int, int]]
     shard_strategy: Optional[str]
     shard_inputs: bool
     parallelism: Parallelism
@@ -85,21 +83,17 @@ class ShardingConfigs:
     existing (loader-driven) code path — preserving current behavior and test IDs.
     """
 
-    # --- Backward-compatible defaults (None fields → existing code paths) ---
-    SINGLE_DEVICE = ShardingConfig(None, None, False, Parallelism.SINGLE_DEVICE)
-    TENSOR_PARALLEL = ShardingConfig(None, None, False, Parallelism.TENSOR_PARALLEL)
+    # --- Backward-compatible defaults (None strategy → existing code paths) ---
+    SINGLE_DEVICE = ShardingConfig(None, False, Parallelism.SINGLE_DEVICE)
+    TENSOR_PARALLEL = ShardingConfig(None, False, Parallelism.TENSOR_PARALLEL)
 
-    # --- FSDP-like sharding (weights sharded on both "batch" and "model" axes) ---
-    FSDP_1x8 = ShardingConfig((1, 8), "fsdp", False, Parallelism.TENSOR_PARALLEL)
-    FSDP_1x8_DP = ShardingConfig((1, 8), "fsdp", True, Parallelism.TENSOR_PARALLEL)
-    FSDP_2x4 = ShardingConfig((2, 4), "fsdp", False, Parallelism.TENSOR_PARALLEL)
-    FSDP_2x4_DP = ShardingConfig((2, 4), "fsdp", True, Parallelism.TENSOR_PARALLEL)
+    # --- Explicit TP strategies (mesh shape is parametrized separately) ---
+    FSDP = ShardingConfig("fsdp", False, Parallelism.TENSOR_PARALLEL)
+    FSDP_DP = ShardingConfig("fsdp", True, Parallelism.TENSOR_PARALLEL)
 
     # --- Megatron sharding (weights sharded on "model" axis only) ---
-    MEGATRON_1x8 = ShardingConfig((1, 8), "megatron", False, Parallelism.TENSOR_PARALLEL)
-    MEGATRON_1x8_DP = ShardingConfig((1, 8), "megatron", True, Parallelism.TENSOR_PARALLEL)
-    MEGATRON_2x4 = ShardingConfig((2, 4), "megatron", False, Parallelism.TENSOR_PARALLEL)
-    MEGATRON_2x4_DP = ShardingConfig((2, 4), "megatron", True, Parallelism.TENSOR_PARALLEL)
+    MEGATRON = ShardingConfig("megatron", False, Parallelism.TENSOR_PARALLEL)
+    MEGATRON_DP = ShardingConfig("megatron", True, Parallelism.TENSOR_PARALLEL)
 
 
 def fix_venv_isolation():

--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -57,6 +57,14 @@ class RunPhase(Enum):
         return self.value
 
 
+class ShardingStrategy(Enum):
+    FSDP = "fsdp"
+    MEGATRON = "megatron"
+
+    def __str__(self) -> str:
+        return self.value
+
+
 @dataclass(frozen=True)
 class ShardingConfig:
     """Configuration for multi-chip sharding in LLM tests.
@@ -66,12 +74,12 @@ class ShardingConfig:
     combinations without changing the Parallelism enum or shared code paths.
 
     Attributes:
-        shard_strategy: "fsdp" (both axes) or "megatron" (model axis only). None = loader default.
+        shard_strategy: FSDP (both axes) or MEGATRON (model axis only). None = loader default.
         shard_inputs: Whether to shard inputs across the batch/data axis of the mesh.
         parallelism: Parallelism enum value for dispatch and backward-compat reporting.
     """
 
-    shard_strategy: Optional[str]
+    shard_strategy: Optional[ShardingStrategy]
     shard_inputs: bool
     parallelism: Parallelism
 
@@ -88,43 +96,16 @@ class ShardingConfigs:
     TENSOR_PARALLEL = ShardingConfig(None, False, Parallelism.TENSOR_PARALLEL)
 
     # --- Explicit TP strategies (mesh shape is parametrized separately) ---
-    FSDP = ShardingConfig("fsdp", False, Parallelism.TENSOR_PARALLEL)
-    FSDP_DP = ShardingConfig("fsdp", True, Parallelism.TENSOR_PARALLEL)
+    FSDP = ShardingConfig(ShardingStrategy.FSDP, False, Parallelism.TENSOR_PARALLEL)
+    FSDP_DP = ShardingConfig(ShardingStrategy.FSDP, True, Parallelism.TENSOR_PARALLEL)
 
     # --- Megatron sharding (weights sharded on "model" axis only) ---
-    MEGATRON = ShardingConfig("megatron", False, Parallelism.TENSOR_PARALLEL)
-    MEGATRON_DP = ShardingConfig("megatron", True, Parallelism.TENSOR_PARALLEL)
-
-
-def fix_venv_isolation():
-    """
-    Fix venv isolation issue: ensure venv packages take precedence over system packages.
-
-    This function adjusts the Python path to prioritize virtual environment packages
-    over system packages, preventing package conflicts and ensuring proper isolation
-    during test execution.
-    """
-    venv_site = os.path.join(
-        os.path.dirname(os.path.dirname(__file__)),
-        "..",
-        "venv",
-        "lib",
-        "python3.11",
-        "site-packages",
+    MEGATRON = ShardingConfig(
+        ShardingStrategy.MEGATRON, False, Parallelism.TENSOR_PARALLEL
     )
-    if os.path.exists(venv_site) and venv_site not in sys.path:
-        sys.path.insert(0, os.path.abspath(venv_site))
-
-    # Remove system packages from path to ensure proper isolation
-    sys.path = [
-        p
-        for p in sys.path
-        if "/usr/local/lib/python3.11/dist-packages" not in p
-        or p == "/usr/local/lib/python3.11/dist-packages"
-    ]
-    # Re-add at the end as fallback
-    if "/usr/local/lib/python3.11/dist-packages" not in sys.path:
-        sys.path.append("/usr/local/lib/python3.11/dist-packages")
+    MEGATRON_DP = ShardingConfig(
+        ShardingStrategy.MEGATRON, True, Parallelism.TENSOR_PARALLEL
+    )
 
 
 def find_dumped_ir_files(artifacts_dir: str) -> List[str]:
@@ -184,7 +165,7 @@ class ModelTestConfig:
         self.seq_len = self._resolve("seq_len", default=None)
 
         # Sharding configuration for TP prefill tests (set from parametrization, not YAML)
-        self.sharding_strategy = None  # "fsdp" or "megatron"
+        self.sharding_strategy: ShardingStrategy | None = None
         self.mesh_shape = None  # e.g. (1, 8), (2, 4)
         self.shard_inputs = (
             False  # whether to shard inputs across the batch/data mesh axis

--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -13,7 +13,7 @@ import os
 import sys
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Tuple
 
 import numpy as np
 import pytest
@@ -55,6 +55,82 @@ class RunPhase(Enum):
 
     def __str__(self) -> str:
         return self.value
+
+
+@dataclass(frozen=True)
+class ShardingConfig:
+    """Configuration for multi-chip sharding in LLM tests.
+
+    Bundles mesh_shape, shard_strategy, and shard_inputs into a single
+    test parameter.  Used only by test_llms_torch to expand tested sharding
+    combinations without changing the Parallelism enum or shared code paths.
+
+    Attributes:
+        mesh_shape: Device mesh shape, e.g. (1,8) or (2,4). None = use loader default.
+        shard_strategy: "fsdp" (both axes) or "megatron" (model axis only). None = loader default.
+        shard_inputs: Whether to shard inputs across the batch/data axis of the mesh.
+        parallelism: Parallelism enum value for dispatch and backward-compat reporting.
+    """
+
+    mesh_shape: Optional[Tuple[int, int]]
+    shard_strategy: Optional[str]
+    shard_inputs: bool
+    parallelism: Parallelism
+
+
+class ShardingConfigs:
+    """Pre-defined sharding configurations for test_llms_torch parametrization.
+
+    TENSOR_PARALLEL has all-None fields so the tester falls through to the
+    existing (loader-driven) code path — preserving current behavior and test IDs.
+    """
+
+    # --- Backward-compatible defaults (None fields → existing code paths) ---
+    SINGLE_DEVICE = ShardingConfig(None, None, False, Parallelism.SINGLE_DEVICE)
+    TENSOR_PARALLEL = ShardingConfig(None, None, False, Parallelism.TENSOR_PARALLEL)
+
+    # --- FSDP-like sharding (weights sharded on both "batch" and "model" axes) ---
+    FSDP_1x8 = ShardingConfig((1, 8), "fsdp", False, Parallelism.TENSOR_PARALLEL)
+    FSDP_1x8_DP = ShardingConfig((1, 8), "fsdp", True, Parallelism.TENSOR_PARALLEL)
+    FSDP_2x4 = ShardingConfig((2, 4), "fsdp", False, Parallelism.TENSOR_PARALLEL)
+    FSDP_2x4_DP = ShardingConfig((2, 4), "fsdp", True, Parallelism.TENSOR_PARALLEL)
+
+    # --- Megatron sharding (weights sharded on "model" axis only) ---
+    MEGATRON_1x8 = ShardingConfig((1, 8), "megatron", False, Parallelism.TENSOR_PARALLEL)
+    MEGATRON_1x8_DP = ShardingConfig((1, 8), "megatron", True, Parallelism.TENSOR_PARALLEL)
+    MEGATRON_2x4 = ShardingConfig((2, 4), "megatron", False, Parallelism.TENSOR_PARALLEL)
+    MEGATRON_2x4_DP = ShardingConfig((2, 4), "megatron", True, Parallelism.TENSOR_PARALLEL)
+
+
+def fix_venv_isolation():
+    """
+    Fix venv isolation issue: ensure venv packages take precedence over system packages.
+
+    This function adjusts the Python path to prioritize virtual environment packages
+    over system packages, preventing package conflicts and ensuring proper isolation
+    during test execution.
+    """
+    venv_site = os.path.join(
+        os.path.dirname(os.path.dirname(__file__)),
+        "..",
+        "venv",
+        "lib",
+        "python3.11",
+        "site-packages",
+    )
+    if os.path.exists(venv_site) and venv_site not in sys.path:
+        sys.path.insert(0, os.path.abspath(venv_site))
+
+    # Remove system packages from path to ensure proper isolation
+    sys.path = [
+        p
+        for p in sys.path
+        if "/usr/local/lib/python3.11/dist-packages" not in p
+        or p == "/usr/local/lib/python3.11/dist-packages"
+    ]
+    # Re-add at the end as fallback
+    if "/usr/local/lib/python3.11/dist-packages" not in sys.path:
+        sys.path.append("/usr/local/lib/python3.11/dist-packages")
 
 
 def find_dumped_ir_files(artifacts_dir: str) -> List[str]:
@@ -112,6 +188,11 @@ class ModelTestConfig:
         # Misc arguments used in test
         self.batch_size = self._resolve("batch_size", default=None)
         self.seq_len = self._resolve("seq_len", default=None)
+
+        # Sharding configuration for TP prefill tests (set from parametrization, not YAML)
+        self.sharding_strategy = None  # "fsdp" or "megatron"
+        self.mesh_shape = None  # e.g. (1, 8), (2, 4)
+        self.shard_inputs = False  # whether to shard inputs across the batch/data mesh axis
 
         # Arguments to skip_full_eval_test() for skipping tests
         self.reason = self._resolve("reason", default=None)

--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -81,7 +81,7 @@ class ShardingConfig:
 
     shard_strategy: Optional[ShardingStrategy]
     shard_inputs: bool
-    parallelism: Parallelism
+    parallelism: Parallelism  # Parallelism here is used for backward-compatibility.
 
 
 class ShardingConfigs:

--- a/tests/runner/testers/torch/dynamic_torch_model_tester.py
+++ b/tests/runner/testers/torch/dynamic_torch_model_tester.py
@@ -201,7 +201,7 @@ class DynamicTorchModelTester(TorchModelTester):
         batch_axis = "data" if shard_inputs else "batch"
         if supports_strategy_kwargs:
             weight_fn = lambda model: self.dynamic_loader.loader.load_shard_spec(
-                model, strategy=strategy, batch_axis=batch_axis
+                model, strategy=str(strategy), batch_axis=batch_axis
             )
         else:
             # Backward-compat fallback: ignore explicit strategy if loader does
@@ -252,6 +252,26 @@ class DynamicTorchModelTester(TorchModelTester):
         if mesh_shape and mesh_names:
             return get_mesh(mesh_shape, mesh_names)
         return None
+
+    def _get_prefill_pcc_mask(self):
+        """Return boolean token mask for LLM prefill PCC filtering."""
+        if self.run_phase != RunPhase.LLM_PREFILL:
+            return None
+        if not isinstance(self._input_activations, collections.abc.Mapping):
+            return None
+
+        attention_mask = self._input_activations.get("attention_mask")
+        if not isinstance(attention_mask, torch.Tensor):
+            return None
+        return attention_mask.to(dtype=torch.bool)
+
+    def _compare(self, device_out, golden_out):
+        """Compare outputs, masking padded prefill tokens for PCC only."""
+        return self._evaluator.evaluate(
+            device_out,
+            golden_out,
+            pcc_mask=self._get_prefill_pcc_mask(),
+        )
 
     def _unpack_forward_output(self, output: Any) -> torch.Tensor:
         """

--- a/tests/runner/testers/torch/dynamic_torch_model_tester.py
+++ b/tests/runner/testers/torch/dynamic_torch_model_tester.py
@@ -188,6 +188,8 @@ class DynamicTorchModelTester(TorchModelTester):
 
         supports_strategy_kwargs = False
         try:
+            # TODO(umales): Remove inspect check, once we migrate to custom loader class for
+            # Focus models.
             signature = inspect.signature(self.dynamic_loader.loader.load_shard_spec)
             params = signature.parameters
             supports_strategy_kwargs = "strategy" in params and "batch_axis" in params
@@ -242,6 +244,7 @@ class DynamicTorchModelTester(TorchModelTester):
             # Explicit mesh from test metadata, e.g. (1, 8) or (2, 4)
             mesh_shape = self._test_metadata.mesh_shape
             shard_inputs = getattr(self._test_metadata, "shard_inputs", False)
+            # TODO(umales): Remove this once https://github.com/tenstorrent/tt-xla/issues/3397 is fixed
             if shard_inputs:
                 mesh_names = ("data", "model")
             else:

--- a/tests/runner/testers/torch/dynamic_torch_model_tester.py
+++ b/tests/runner/testers/torch/dynamic_torch_model_tester.py
@@ -257,8 +257,6 @@ class DynamicTorchModelTester(TorchModelTester):
         """Return boolean token mask for LLM prefill PCC filtering."""
         if self.run_phase != RunPhase.LLM_PREFILL:
             return None
-        if not isinstance(self._input_activations, collections.abc.Mapping):
-            return None
 
         attention_mask = self._input_activations.get("attention_mask")
         if not isinstance(attention_mask, torch.Tensor):

--- a/tests/runner/testers/torch/dynamic_torch_model_tester.py
+++ b/tests/runner/testers/torch/dynamic_torch_model_tester.py
@@ -5,6 +5,7 @@
 """Dynamic Torch model tester implementation."""
 
 import collections
+import inspect
 from typing import Any
 
 import torch
@@ -158,16 +159,74 @@ class DynamicTorchModelTester(TorchModelTester):
     def _get_shard_specs_function(self):
         """Get shard specs function from the dynamic loader if available.
 
+        Handles standard TP, DP, and combined TP+DP with FSDP/megatron strategies.
+
         Returns:
             Shard spec function if loader supports it, None otherwise
         """
         if self.parallelism == Parallelism.DATA_PARALLEL:
             return self.dynamic_loader.load_shard_spec_data_parallel
-        else:
+
+        strategy = (
+            getattr(self._test_metadata, "sharding_strategy", None)
+            if self._test_metadata
+            else None
+        )
+        shard_inputs = (
+            getattr(self._test_metadata, "shard_inputs", False)
+            if self._test_metadata
+            else False
+        )
+
+        # No explicit strategy → default TP behavior from the loader
+        if strategy is None:
             return self.dynamic_loader.get_shard_spec_function()
+
+        loader_shard_spec_fn = self.dynamic_loader.get_shard_spec_function()
+        if loader_shard_spec_fn is None:
+            return None
+
+        supports_strategy_kwargs = False
+        try:
+            signature = inspect.signature(self.dynamic_loader.loader.load_shard_spec)
+            params = signature.parameters
+            supports_strategy_kwargs = "strategy" in params and "batch_axis" in params
+        except (TypeError, ValueError):
+            supports_strategy_kwargs = False
+
+        # Build the weight shard spec function.
+        # When shard_inputs is on, the mesh uses ("data", "model") axes, so FSDP
+        # specs must use "data" instead of "batch" — handled by batch_axis arg.
+        # (Megatron ignores batch_axis — its non-model axis is always None.)
+        batch_axis = "data" if shard_inputs else "batch"
+        if supports_strategy_kwargs:
+            weight_fn = lambda model: self.dynamic_loader.loader.load_shard_spec(
+                model, strategy=strategy, batch_axis=batch_axis
+            )
+        else:
+            # Backward-compat fallback: ignore explicit strategy if loader does
+            # not support strategy kwargs.
+            weight_fn = loader_shard_spec_fn
+
+        if shard_inputs:
+            # Combined TP + input sharding: shard weights AND inputs.
+            # The device runner dispatches to the 3-arg form (model, args, kwargs).
+            dp_loader = self.dynamic_loader
+
+            def combined_shard_spec(model, args, kwargs):
+                weight_specs = weight_fn(model) or {}
+                dp_specs = dp_loader.load_shard_spec_data_parallel(args, kwargs)
+                weight_specs.update(dp_specs)
+                return weight_specs
+
+            return combined_shard_spec
+
+        return weight_fn
 
     def _get_mesh(self):
         """Get mesh configuration from the dynamic loader if available.
+
+        Supports explicit mesh_shape / shard_inputs from test_metadata.
 
         Returns:
             Mesh object if loader supports mesh configuration, None otherwise
@@ -176,8 +235,17 @@ class DynamicTorchModelTester(TorchModelTester):
             return None
 
         num_devices = xr.global_runtime_device_count()
+
         if self.parallelism == Parallelism.DATA_PARALLEL:
             mesh_shape, mesh_names = (1, num_devices), ("model", "data")
+        elif self._test_metadata and getattr(self._test_metadata, "mesh_shape", None):
+            # Explicit mesh from test metadata, e.g. (1, 8) or (2, 4)
+            mesh_shape = self._test_metadata.mesh_shape
+            shard_inputs = getattr(self._test_metadata, "shard_inputs", False)
+            if shard_inputs:
+                mesh_names = ("data", "model")
+            else:
+                mesh_names = ("batch", "model")
         else:
             mesh_shape, mesh_names = self.dynamic_loader.get_mesh_config(num_devices)
 

--- a/tests/runner/validate_test_config.py
+++ b/tests/runner/validate_test_config.py
@@ -31,6 +31,7 @@ from tests.runner.test_config.constants import (
     ALLOWED_FIELDS,
     FRAMEWORKS,
     LLM_BATCH_SIZES,
+    LLM_MESH_SHAPES,
     LLM_PHASES,
     LLM_SEQUENCE_LENGTHS,
     PARALLELISMS_LLM,
@@ -436,24 +437,27 @@ class TestConfigValidator:
                 for run_mode in RUN_MODES_STANDARD:
                     ids.add(f"{base}-{parallelism}-{run_mode}")
 
-        # test_llms_torch: {base}-{phase}-seq_{X}-batch_{Y}-{parallelism}-{run_mode}
+        # test_llms_torch:
+        # {base}-{phase}-seq_{X}-batch_{Y}-{parallelism}-{mesh_shape}-{run_mode}
         # Decode: only seq_1-batch_1 (test_models.py:436-441)
         # Prefill: seq_{128..8192} x batch_{1,2} (test_models.py:444-448)
         for rel_path, variant, phase in llm_models:
             base = f"{rel_path}-{variant}" if variant else rel_path
             for parallelism in PARALLELISMS_LLM:
-                for run_mode in RUN_MODES_LLM:
-                    if phase == "llm_decode":
-                        ids.add(
-                            f"{base}-{phase}-seq_1-batch_1" f"-{parallelism}-{run_mode}"
-                        )
-                    else:
-                        for seq in LLM_SEQUENCE_LENGTHS:
-                            for batch in LLM_BATCH_SIZES:
-                                ids.add(
-                                    f"{base}-{phase}-seq_{seq}-batch_{batch}"
-                                    f"-{parallelism}-{run_mode}"
-                                )
+                for mesh_shape in LLM_MESH_SHAPES:
+                    for run_mode in RUN_MODES_LLM:
+                        if phase == "llm_decode":
+                            ids.add(
+                                f"{base}-{phase}-seq_1-batch_1"
+                                f"-{parallelism}-{mesh_shape}-{run_mode}"
+                            )
+                        else:
+                            for seq in LLM_SEQUENCE_LENGTHS:
+                                for batch in LLM_BATCH_SIZES:
+                                    ids.add(
+                                        f"{base}-{phase}-seq_{seq}-batch_{batch}"
+                                        f"-{parallelism}-{mesh_shape}-{run_mode}"
+                                    )
 
         return ids
 

--- a/tests/runner/validate_test_config.py
+++ b/tests/runner/validate_test_config.py
@@ -13,6 +13,7 @@ Usage:
 
 import ast
 import difflib
+import itertools
 import os
 import sys
 from dataclasses import dataclass, field
@@ -443,21 +444,22 @@ class TestConfigValidator:
         # Prefill: seq_{128..8192} x batch_{1,2} (test_models.py:444-448)
         for rel_path, variant, phase in llm_models:
             base = f"{rel_path}-{variant}" if variant else rel_path
-            for parallelism in PARALLELISMS_LLM:
-                for mesh_shape in LLM_MESH_SHAPES:
-                    for run_mode in RUN_MODES_LLM:
-                        if phase == "llm_decode":
-                            ids.add(
-                                f"{base}-{phase}-seq_1-batch_1"
-                                f"-{parallelism}-{mesh_shape}-{run_mode}"
-                            )
-                        else:
-                            for seq in LLM_SEQUENCE_LENGTHS:
-                                for batch in LLM_BATCH_SIZES:
-                                    ids.add(
-                                        f"{base}-{phase}-seq_{seq}-batch_{batch}"
-                                        f"-{parallelism}-{mesh_shape}-{run_mode}"
-                                    )
+            for parallelism, mesh_shape, run_mode in itertools.product(
+                PARALLELISMS_LLM, LLM_MESH_SHAPES, RUN_MODES_LLM
+            ):
+                if phase == "llm_decode":
+                    ids.add(
+                        f"{base}-{phase}-seq_1-batch_1"
+                        f"-{parallelism}-{mesh_shape}-{run_mode}"
+                    )
+                else:
+                    for seq, batch in itertools.product(
+                        LLM_SEQUENCE_LENGTHS, LLM_BATCH_SIZES
+                    ):
+                        ids.add(
+                            f"{base}-{phase}-seq_{seq}-batch_{batch}"
+                            f"-{parallelism}-{mesh_shape}-{run_mode}"
+                        )
 
         return ids
 


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-xla/issues/3230, https://github.com/tenstorrent/tt-xla/issues/3019, https://github.com/tenstorrent/tt-xla/issues/3018

### Problem description
More details in linked issues and in [relevant doc](https://docs.google.com/document/d/1nmFd002Ycv8wadpyOs1ZMMkV6zV6v0pWCl-LZsap1J8/edit?tab=t.0). 

### What's changed
Added ```sharding_config``` and ```mesh_shape``` parameters in pytest. This was driven by backward compatibility and support for flexibility when adding new machines (thereby new meshes) to CI.
The ```dynamic_torch_model_tester``` shards the model accordingly, if model loader has support for (sharding) ```strategy``` kwarg. Additional logic is applied for axis renaming, following this [issue](https://github.com/tenstorrent/tt-xla/issues/3397).

### Checklist
- [x] New/Existing tests provide coverage for changes
