### PR TITLE
Uplift PJRT C API header from v0.90 to v0.97

### DIFF
--- a/pjrt_implementation/src/stubs.inc
+++ b/pjrt_implementation/src/stubs.inc
@@ -174,3 +174,6 @@
   _STUB(PJRT_AsyncHostToDeviceTransferManager_SetBufferError);
   _STUB(PJRT_AsyncHostToDeviceTransferManager_AddMetadata);
   _STUB(PJRT_AsyncHostToDeviceTransferManager_TransferLiteral);
+  _STUB(PJRT_Client_Load);
+  _STUB(PJRT_Device_GetAttributes);
+  _STUB(PJRT_LoadedExecutable_AddressableDeviceLogicalIds);

--- a/third_party/pjrt_c_api/xla/pjrt/c/pjrt_c_api.h
+++ b/third_party/pjrt_c_api/xla/pjrt/c/pjrt_c_api.h
@@ -80,6 +80,10 @@ typedef enum {
   PJRT_Extension_Type_TpuTopology,
   PJRT_Extension_Type_TpuExecutable,
   PJRT_Extension_Type_Megascale,
+  PJRT_Extension_Type_Shardings,
+  PJRT_Extension_Type_AbiVersion,
+  PJRT_Extension_Type_Collectives,
+  PJRT_Extension_Type_MultiSlice,
 } PJRT_Extension_Type;
 
 // PJRT_Extension_Base contains a type and a pointer to next
@@ -114,7 +118,7 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_Extension_Base, next);
 // Changes include:
 // * Adding a new field to the PJRT_Api or argument structs
 // * Renaming a method or argument (doesn't affect ABI)
-#define PJRT_API_MINOR 90
+#define PJRT_API_MINOR 97
 
 // The plugin should set the major_version and minor_version of
 // PJRT_Api.pjrt_api_version to be the `PJRT_API_MAJOR` and `PJRT_API_MINOR` in
@@ -714,6 +718,21 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_Client_Compile_Args, executable);
 // `options`.
 typedef PJRT_Error *PJRT_Client_Compile(PJRT_Client_Compile_Args *args);
 
+struct PJRT_Client_Load_Args {
+  size_t struct_size;
+  PJRT_Extension_Base *extension_start;
+  PJRT_Client *client;
+  PJRT_Executable *executable;
+  // Serialized CompileOptionsProto.
+  const char *compile_options;
+  size_t compile_options_size;
+  PJRT_LoadedExecutable *loaded_executable; // out
+};
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_Client_Load_Args, loaded_executable);
+
+// Loads a PJRT_Executable.
+typedef PJRT_Error *PJRT_Client_Load(PJRT_Client_Load_Args *args);
+
 struct PJRT_Client_DefaultDeviceAssignment_Args {
   size_t struct_size;
   PJRT_Extension_Base *extension_start;
@@ -916,6 +935,10 @@ typedef enum {
 
   // 4-bit MX floating-point format.
   PJRT_Buffer_Type_F4E2M1FN,
+
+  // 1-bit integer types
+  PJRT_Buffer_Type_S1,
+  PJRT_Buffer_Type_U1,
 } PJRT_Buffer_Type;
 
 typedef enum {
@@ -1339,7 +1362,6 @@ typedef PJRT_Error *
 PJRT_DeviceDescription_ToString(PJRT_DeviceDescription_ToString_Args *args);
 
 // --------------------------------- Devices -----------------------------------
-
 struct PJRT_Device_GetDescription_Args {
   size_t struct_size;
   PJRT_Extension_Base *extension_start;
@@ -1474,6 +1496,23 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_Device_PoisonExecution_Args, poisoned);
 // not finished yet, i.e. makes its output buffers error.
 typedef PJRT_Error *
 PJRT_Device_PoisonExecution(PJRT_Device_PoisonExecution_Args *args);
+
+typedef struct PJRT_Device_Attributes PJRT_Device_Attributes;
+
+struct PJRT_Device_GetAttributes_Args {
+  size_t struct_size;
+  PJRT_Extension_Base *extension_start;
+  PJRT_Device *device;
+  const PJRT_NamedValue *attributes;                                     // out
+  size_t num_attributes;                                                 // out
+  PJRT_Device_Attributes *device_attributes;                             // out
+  void (*attributes_deleter)(PJRT_Device_Attributes *device_attributes); // out
+};
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_Device_GetAttributes_Args, attributes_deleter);
+
+// Returns an array of device attributes.
+typedef PJRT_Error *
+PJRT_Device_GetAttributes(PJRT_Device_GetAttributes_Args *args);
 
 // --------------------------- AsyncTrackingEvent ------------------------------
 
@@ -1715,6 +1754,11 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_Executable_NumPartitions_Args, num_partitions);
 typedef PJRT_Error *
 PJRT_Executable_NumPartitions(PJRT_Executable_NumPartitions_Args *args);
 
+typedef struct PJRT_LogicalDeviceIds {
+  int replica;
+  int partition;
+} PJRT_LogicalDeviceIds;
+
 struct PJRT_LoadedExecutable_AddressableDevices_Args {
   size_t struct_size;
   PJRT_Extension_Base *extension_start;
@@ -1728,6 +1772,21 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_LoadedExecutable_AddressableDevices_Args,
 // Returns a list of devices this executable will run on.
 typedef PJRT_Error *PJRT_LoadedExecutable_AddressableDevices(
     PJRT_LoadedExecutable_AddressableDevices_Args *args);
+
+struct PJRT_LoadedExecutable_AddressableDeviceLogicalIds_Args {
+  size_t struct_size;
+  PJRT_Extension_Base *extension_start;
+  PJRT_LoadedExecutable *executable;
+  PJRT_LogicalDeviceIds *addressable_device_logical_ids; // out
+  size_t num_addressable_device_logical_ids;             // out
+};
+PJRT_DEFINE_STRUCT_TRAITS(
+    PJRT_LoadedExecutable_AddressableDeviceLogicalIds_Args,
+    num_addressable_device_logical_ids);
+
+// Returns a list of logical device ids this executable will run on.
+typedef PJRT_Error *PJRT_LoadedExecutable_AddressableDeviceLogicalIds(
+    PJRT_LoadedExecutable_AddressableDeviceLogicalIds_Args *args);
 
 struct PJRT_Executable_OptimizedProgram_Args {
   size_t struct_size;
@@ -1835,6 +1894,8 @@ struct PJRT_RecvCallbackInfo {
 };
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_RecvCallbackInfo, recv_callback);
 
+typedef struct PJRT_MultiSlice_Config PJRT_MultiSlice_Config;
+
 struct PJRT_ExecuteOptions {
   size_t struct_size;
   PJRT_Extension_Base *extension_start;
@@ -1883,8 +1944,9 @@ struct PJRT_ExecuteOptions {
   size_t num_tasks;
   int *task_ids;
   int64_t *incarnation_ids;
+  PJRT_MultiSlice_Config *multi_slice_config;
 };
-PJRT_DEFINE_STRUCT_TRAITS(PJRT_ExecuteOptions, incarnation_ids);
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_ExecuteOptions, multi_slice_config);
 
 struct PJRT_LoadedExecutable_Execute_Args {
   size_t struct_size;
@@ -2921,9 +2983,16 @@ typedef struct PJRT_Api {
   _PJRT_API_STRUCT_FIELD(PJRT_Buffer_DonateWithControlDependency);
   _PJRT_API_STRUCT_FIELD(PJRT_Event_Create);
   _PJRT_API_STRUCT_FIELD(PJRT_Event_Set);
+  _PJRT_API_STRUCT_FIELD(PJRT_Device_GetAttributes);
+
+  _PJRT_API_STRUCT_FIELD(PJRT_Client_Load);
+  _PJRT_API_STRUCT_FIELD(PJRT_LoadedExecutable_AddressableDeviceLogicalIds);
 } PJRT_Api;
 
-enum { PJRT_Api_STRUCT_SIZE = PJRT_STRUCT_SIZE(PJRT_Api, PJRT_Event_Set) };
+enum {
+  PJRT_Api_STRUCT_SIZE = PJRT_STRUCT_SIZE(
+      PJRT_Api, PJRT_LoadedExecutable_AddressableDeviceLogicalIds)
+};
 
 #undef _PJRT_API_STRUCT_FIELD
 


### PR DESCRIPTION
## Description

This PR uplifts the PJRT C API header from the upstream [OpenXLA repository](https://github.com/openxla/xla).

- **Version change:** `v0.90` -> `v0.97`
- **Source file:** https://github.com/openxla/xla/blob/main/xla/pjrt/c/pjrt_c_api.h

## Checklist

- [ ] Review the changes in `pjrt_c_api.h` and ensure backward compatibility with the tt-xla implementation.
- [ ] Review the changes in `stubs.inc` and discuss with the team whether a new feature should be flagged as useful for implementation.
- [ ] Manually run the `.github/workflows/schedule-nightly.yml` workflow to schedule an extended test set run.
- [x] Run PJRT unit tests (scheduled automatically upon PR creation).