### PR TITLE
Replace empty sharding annotations with `{replicated}`

### DIFF
--- a/python_package/tt_torch/backend/backend.py
+++ b/python_package/tt_torch/backend/backend.py
@@ -198,7 +198,8 @@ class XLAExecutor:
 
         full_args = self.params_and_consts + args
         # Ensure unsharded tensors are marked REPLICATED in SPMD mode so their
-        # sharding spec matches what was recorded at graph capture time.
+        # sharding spec matches what was recorded at graph capture time. This is a temporary workaround
+        # until a change is made in torch-xla to automatically mark unsharded tensors as REPLICATED at runtime in SPMD mode.
         _mark_unsharded_args_replicated(full_args)
         return self.compiled_graph(*full_args)
 


### PR DESCRIPTION
### Ticket
Fixes #3302

### Problem description
Multichip models were being retraced every step, incurring python interpreter overhead. 

Low level detail is that apparently tensors would enter with blank sharding annotations and the dispatch code would store those as having `{replicated}` annotations, which would then differ under a simple equals comparison, causing a retrace.

### What's changed
Tensors with no sharding annotations are explicitly annotated as `{replicated}` before being sent to the dispatch code, removing the dispatch. Note that this assume unannotated tensors are replicated, but that should be a relatively reasonable assumptions.

To be honest this is a bit of a hack.

### Checklist
- [ ] New/Existing tests provide coverage for changes
