### PR TITLE
[python-package] fix wrapping logic

### DIFF
--- a/.github/workflows/call-test-tools.yml
+++ b/.github/workflows/call-test-tools.yml
@@ -88,22 +88,22 @@ jobs:
 
           echo "=== Testing ttnn package ==="
           python << 'EOF'
+          import torch
           import ttnn
           print('✓ ttnn imported successfully')
 
-          # Test core modules
-          assert hasattr(ttnn, 'CONFIG'), 'CONFIG not found'
-          print('✓ CONFIG found')
+          # Open device and run a real tensor addition
+          with ttnn.manage_device(device_id=0) as device:
+              a = torch.rand((32, 32), dtype=torch.bfloat16)
+              b = torch.rand((32, 32), dtype=torch.bfloat16)
 
-          import ttnn.operations
-          print('✓ Operations module accessible')
+              tt_a = ttnn.from_torch(a, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+              tt_b = ttnn.from_torch(b, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
 
-          import ttnn.device
-          print('✓ Device module accessible')
+              tt_c = ttnn.add(tt_a, tt_b)
+              result = ttnn.to_torch(tt_c)
 
-          # Test C++ extension
-          import ttnn._ttnn
-          print('✓ C++ extension loaded')
+              print(f'a + b =\n{result}')
 
           # Test tracy-ttnn integration
           import tracy


### PR DESCRIPTION
The module wrapping logic, which is used for packaging `tracy` and`ttnn`, did not cover the case when a module is dynamically adding attributes, via `setattr()`, which is the case for lots of top-level attributes of `ttnn` (e.g. `ttnn.from_torch`, `ttnn.add`).

Fixing by copying the dynamically added attributes manually to the wrapper module.

`ttnn` test in CI is improved by running an actual operation with ttnn tensors instead of just verifying existence of a couple of top-level attributes.