### PR TITLE
Updated the Mistral 32B variants in the tensor parallel yaml file

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -201,3 +201,13 @@ test_config:
     supported_archs: [n300-llmbox]
     assert_pcc: false # PCC comparison failed. Calculated: pcc=0.701951301689392. Required: pcc=0.99
     status: EXPECTED_PASSING
+
+  mistral/pytorch-mistral_small_3.1_24b_instruct_2503-tensor_parallel-inference:
+    supported_archs: [n300-llmbox]
+    assert_pcc: false # PCC comparison failed. Calculated: pcc=0.9757716745992953. Required: pcc=0.99
+    status: EXPECTED_PASSING
+
+  mistral/pytorch-mistral_small_3.2_24b_instruct_2506-tensor_parallel-inference:
+    supported_archs: [n300-llmbox]
+    status: KNOWN_FAILURE_XFAIL
+    reason: "KeyError: c_lifted_tensor_1 - https://github.com/tenstorrent/tt-xla/issues/3221"


### PR DESCRIPTION
### Ticket
[2620](https://github.com/tenstorrent/tt-xla/issues/2620)

### Problem description
Added support for the Mistral 32B variants in the tensor parallel YAML file.

### What's changed

- mistral/pytorch-mistral_small_3.1_24b_instruct_2503-tensor_parallel-inference: Failing with low pcc

- mistral/pytorch-mistral_small_3.2_24b_instruct_2506-tensor_parallel-inference: Runtime error(KeyError: c_lifted_tensor_1)

I have attached the log files for reference:
[mistral/pytorch-mistral_small_3.1_24b_instruct_2503-tensor_parallel-inference.log](https://github.com/user-attachments/files/25551026/mistral.log)
[mistral/pytorch-mistral_small_3.2_24b_instruct_2506-tensor_parallel-inference.log](https://github.com/user-attachments/files/25551045/mistral_2506.log)





### Checklist
- [ ] New/Existing tests provide coverage for changes
