### PR TITLE
[vLLM plugin] Skip N300-llmbox tensor parallel tests

### DIFF
--- a/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
@@ -36,7 +36,7 @@ def test_tensor_parallel_generation_n300(model_name: str):
 @pytest.mark.tensor_parallel
 @pytest.mark.llmbox
 @pytest.mark.skip(
-    reason="Skipping due to bug in tt-metal SPDA op. Issue: https://github.com/tenstorrent/tt-xla/issues/3465"
+    reason="Skipping due to bug in tt-metal SDPA op. Issue: https://github.com/tenstorrent/tt-xla/issues/3465"
 )
 @pytest.mark.parametrize(
     ["model_name", "enable_const_eval", "experimental_enable_weight_bfp8_conversion"],
@@ -76,7 +76,7 @@ def test_tensor_parallel_generation_llmbox_small(
 @pytest.mark.tensor_parallel
 @pytest.mark.llmbox
 @pytest.mark.skip(
-    reason="Skipping due to bug in tt-metal SPDA op. Issue: https://github.com/tenstorrent/tt-xla/issues/3465"
+    reason="Skipping due to bug in tt-metal SDPA op. Issue: https://github.com/tenstorrent/tt-xla/issues/3465"
 )
 @pytest.mark.parametrize(
     ["model_name", "enable_const_eval", "experimental_enable_weight_bfp8_conversion"],

--- a/tests/integrations/vllm_plugin/sampling/test_sampling_params.py
+++ b/tests/integrations/vllm_plugin/sampling/test_sampling_params.py
@@ -31,7 +31,13 @@ _TARGET_MARKS = {
     "n300": ("vllm_n300", [pytest.mark.tensor_parallel, pytest.mark.dual_chip]),
     "n300_llmbox": (
         "vllm_n300_llmbox",
-        [pytest.mark.tensor_parallel, pytest.mark.llmbox],
+        [
+            pytest.mark.tensor_parallel,
+            pytest.mark.llmbox,
+            pytest.mark.skip(
+                reason="Skipping due to bug in tt-metal SDPA op. Issue: https://github.com/tenstorrent/tt-xla/issues/3465"
+            ),
+        ],
     ),
 }
 
@@ -183,9 +189,6 @@ def test_sampling_param_sweep(llm, prompt, param_name, values):
 
 
 @for_targets(single_device="push", n300="push", n300_llmbox="push")
-@pytest.mark.skip(
-    reason="Skipping due to bug in tt-metal SPDA op. Issue: https://github.com/tenstorrent/tt-xla/issues/3465"
-)
 def test_sampling_has_diversity_when_temp_positive(llm, prompt):
     """Test that n>1 with temperature>0 produces diverse outputs in a single call."""
     params = vllm.SamplingParams(
@@ -204,9 +207,6 @@ def test_sampling_has_diversity_when_temp_positive(llm, prompt):
 
 
 @for_targets(single_device="push", n300="push", n300_llmbox="push")
-@pytest.mark.skip(
-    reason="Skipping due to bug in tt-metal SPDA op. Issue: https://github.com/tenstorrent/tt-xla/issues/3465"
-)
 def test_greedy_determinism(llm, prompt):
     """Verify greedy sampling (temperature=0) is deterministic."""
     params = vllm.SamplingParams(temperature=0.0, max_tokens=20)


### PR DESCRIPTION
### Ticket
#3465 

### Problem description
Tensor parallel tests (on N300-llmbox) are failing for tt-metal uplift due to bug in SDPA op.

### What's changed
Skip tensor parallel tests temporarily.

### Checklist
- [X] Existing tests provide coverage for changes
