### PR TITLE
[Torch-XLA test] Remove Tan Op from list of xfail ops

### DIFF
--- a/tests/torch/test_torch_xla_basic.py
+++ b/tests/torch/test_torch_xla_basic.py
@@ -177,7 +177,6 @@ eager_failing_unary_ops = {
     torch.logit,
     torch.rsqrt,
     torch.sqrt,
-    torch.tan,
 }
 
 # Create eager version with xfail markers for failing ops


### PR DESCRIPTION
This change will be required with next tt-mlir uplift

### Ticket
closes #3467 

### Problem description
TanOp is marked as xfail due to PCC issue; the issue is fixed in tt-metal 

### What's changed
Remove Tan Op from list of xfail ops

### Checklist
- [X] Existing tests provide coverage for changes
