### PR TITLE
Update gpt oss attention tests

### DIFF
--- a/tests/torch/graphs/test_attention.py
+++ b/tests/torch/graphs/test_attention.py
@@ -2319,7 +2319,7 @@ def test_eager_batched_attention():
     output = model(hidden_states).to("cpu")
 
 
-@pytest.mark.push
+@pytest.mark.nighly
 @pytest.mark.parametrize(
     "variant,variant_config",
     get_available_variants("gpt_oss").items(),
@@ -2377,7 +2377,7 @@ def test_gpt_oss_attention_prefill(variant, variant_config, arch):
     )
 
 
-@pytest.mark.push
+@pytest.mark.nightly
 @pytest.mark.parametrize(
     "variant,variant_config",
     get_available_variants("gpt_oss").items(),


### PR DESCRIPTION
### Ticket
None

### Problem description
gpt-oss attention tests were not being sharded even when run on llmbox. Furthermore, the structure of the test was inconsistent with how other tests were written.

### What's changed
Added decode and prefill tests to gpt-oss which use 2x4 mesh when running on llmbox. 
