### PR TITLE
Updated the configuration files for the Qwen 3 models.

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -66,7 +66,7 @@ test_config:
   qwen_3/causal_lm/pytorch-0_6B-tensor_parallel-inference:
     supported_archs: [n300-llmbox]
     status: EXPECTED_PASSING
-    assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/2550
+    assert_pcc: True
 
   qwen_3/causal_lm/pytorch-14B-tensor_parallel-inference:
     supported_archs: [n300-llmbox]
@@ -75,7 +75,7 @@ test_config:
   qwen_3/causal_lm/pytorch-1_7B-tensor_parallel-inference:
     supported_archs: [n300-llmbox]
     status: EXPECTED_PASSING
-    assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/2550
+    assert_pcc: True
 
   qwen_3/causal_lm/pytorch-32B-tensor_parallel-inference:
     supported_archs: [n300-llmbox]


### PR DESCRIPTION
### Ticket
[2550](https://github.com/tenstorrent/tt-xla/issues/2550#issuecomment-3963830402) 

### Problem description
Re-run the following models on the latest main branch. If they pass on the latest main, update the configuration files accordingly.
 ```
qwen_3/causal_lm/pytorch-0_6B-tensor_parallel-inference
 qwen_3/causal_lm/pytorch-1_7B-tensor_parallel-inference
```
### What's changed
Since the model is passing in the latest nightly with a PCC of 0.99, set assert_pcc to True.

```
test_all_models_torch[qwen_3/causal_lm/pytorch-0_6B-tensor_parallel-inference]                                                              language    red         n300-llmbox  PASSED                     PASSING       0.9990221728369094      0.99       PCC_DIS  tensor_parallel  123.669   ENABLE_PCC_099

test_all_models_torch[qwen_3/causal_lm/pytorch-1_7B-tensor_parallel-inference]                                                              language    red         n300-llmbox  PASSED                     PASSING       0.9982115452251618      0.99       PCC_DIS  tensor_parallel  105.462   ENABLE_PCC_099

```
FMD, I ran these models in [CI](https://github.com/tenstorrent/tt-xla/actions/runs/22432900613), and both of them are passing successfully.
### Checklist
- [ ] New/Existing tests provide coverage for changes
