### PR TITLE
[vLLM plugin] Enable SamplingParams seed support (#3365)

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -262,14 +262,7 @@ class TTPlatform(Platform):
         params: ParamsType,
         processed_inputs: ProcessorInputs,
     ) -> None:
-        """Raises if this request is unsupported on this platform"""
-        from vllm.sampling_params import SamplingParams, SamplingType
-
-        if (
-            isinstance(params, SamplingParams)
-            and params.sampling_type == SamplingType.RANDOM_SEED
-        ):
-            raise ValueError("Torch XLA does not support per-request seed.")
+        pass
 
     @classmethod
     @torch.compile(backend="tt")

--- a/tests/integrations/vllm_plugin/sampling/test_sampling_params.py
+++ b/tests/integrations/vllm_plugin/sampling/test_sampling_params.py
@@ -342,13 +342,10 @@ def test_output_length_controls(llm, prompt):
     ), f"short ({results[0][3]} tokens) should be <= medium ({results[1][3]} tokens)"
 
 
-@pytest.mark.skip(
-    reason="seed not yet supported in TT sampler — https://github.com/tenstorrent/tt-xla/issues/3365"
-)
 @for_targets(single_device="nightly", n300="nightly", n300_llmbox="nightly")
 def test_seed(llm, prompt):
     """Test that same seed produces same output, different seeds diverge."""
-    base = {"temperature": 0.8, "top_p": 0.9, "max_tokens": 16}
+    base = {"temperature": 1.5, "top_p": 0.9, "max_tokens": 32}
     outputs_same = []
     for i in range(2):
         params = vllm.SamplingParams(seed=42, **base)

--- a/tests/integrations/vllm_plugin/sampling/test_seed_correctness.py
+++ b/tests/integrations/vllm_plugin/sampling/test_seed_correctness.py
@@ -1,0 +1,155 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Correctness tests for seed / q_samples pre-sampling logic.
+
+Pure CPU tests — no TT hardware, no torch_xla, no compilation needed.
+Validates that:
+  - random_sample() uses q_samples when provided (not on-device noise)
+  - same seed -> same Generator -> same noise -> same token
+  - mixed batch: seeded rows deterministic, un-seeded rows use global RNG
+  - q_samples=None falls through to the original exponential_ path
+"""
+
+import pytest
+import torch
+from vllm_tt.sampler import Sampler
+
+# Tests do not need silicon runner, but CI only runs on silicon runners.
+pytestmark = pytest.mark.single_device
+
+_VOCAB = 1000  # small vocab keeps CPU tests fast
+
+
+def _build_q_samples(batch_size, vocab_size, generators=None):
+    """Reproduce the q_samples construction from metadata.py on CPU."""
+    q = torch.empty(batch_size, vocab_size, dtype=torch.float32)
+    q.exponential_()
+    if generators:
+        for idx, gen in generators.items():
+            q[idx].exponential_(generator=gen)
+    return q
+
+
+@pytest.mark.push
+def test_seed_random_sample_uses_q_samples():
+    """random_sample() with q_samples must use the provided noise, not generate new.
+
+    Constructs known probs and known q, then verifies the output matches
+    the manual (probs / q).argmax() — proving the q_samples branch is taken.
+    """
+    sampler = Sampler()
+    torch.manual_seed(0)
+    probs = torch.softmax(torch.randn(1, _VOCAB), dim=-1)
+
+    gen = torch.Generator(device="cpu")
+    gen.manual_seed(42)
+    q = torch.empty(1, _VOCAB, dtype=torch.float32)
+    q.exponential_(generator=gen)
+
+    expected = probs.clone().div_(q.clone()).argmax(dim=-1).view(-1)
+    actual = sampler.random_sample(probs.clone(), generators={}, q_samples=q.clone())
+
+    assert (
+        actual.item() == expected.item()
+    ), f"random_sample must use q_samples: expected {expected.item()}, got {actual.item()}"
+
+
+@pytest.mark.push
+def test_seed_q_samples_determinism():
+    """Same seed -> same Generator -> same exponential noise -> same token."""
+    sampler = Sampler()
+    torch.manual_seed(0)
+    logits = torch.randn(1, _VOCAB, dtype=torch.float32)
+    probs = torch.softmax(logits, dim=-1)
+
+    tokens = []
+    for _ in range(3):
+        gen = torch.Generator(device="cpu")
+        gen.manual_seed(42)
+        q = torch.empty(1, _VOCAB, dtype=torch.float32)
+        q.exponential_(generator=gen)
+        tok = sampler.random_sample(probs.clone(), generators={}, q_samples=q)
+        tokens.append(tok.item())
+
+    assert (
+        tokens[0] == tokens[1] == tokens[2]
+    ), f"Same seed must produce identical tokens across runs: {tokens}"
+
+    # Different seed should produce different noise (and very likely a different token).
+    gen_diff = torch.Generator(device="cpu")
+    gen_diff.manual_seed(999)
+    q_diff = torch.empty(1, _VOCAB, dtype=torch.float32)
+    q_diff.exponential_(generator=gen_diff)
+    tok_diff = sampler.random_sample(probs.clone(), generators={}, q_samples=q_diff)
+
+    # With vocab=1000 and different noise, collision is very unlikely.
+    assert tok_diff.item() != tokens[0], (
+        f"Different seed should (almost certainly) produce a different token: "
+        f"seed=42 -> {tokens[0]}, seed=999 -> {tok_diff.item()}"
+    )
+
+
+@pytest.mark.push
+def test_seed_mixed_batch_q_samples():
+    """Mixed batch: seeded rows are deterministic, un-seeded rows use global RNG.
+
+    Simulates the metadata.py construction: batch of 4 requests where
+    rows 1 and 3 have per-request seeds, rows 0 and 2 use global RNG.
+    The seeded rows must be identical across two independent constructions.
+    """
+    sampler = Sampler()
+    batch_size = 4
+    torch.manual_seed(0)
+    logits = torch.randn(batch_size, _VOCAB, dtype=torch.float32)
+    probs = torch.softmax(logits, dim=-1)
+
+    seeded_indices = {1: 42, 3: 123}
+
+    results = []
+    for _ in range(2):
+        generators = {}
+        for idx, seed in seeded_indices.items():
+            g = torch.Generator(device="cpu")
+            g.manual_seed(seed)
+            generators[idx] = g
+        q = _build_q_samples(batch_size, _VOCAB, generators)
+        tokens = sampler.random_sample(probs.clone(), generators={}, q_samples=q)
+        results.append(tokens.tolist())
+
+    # Seeded rows must be identical across runs.
+    for idx in seeded_indices:
+        assert results[0][idx] == results[1][idx], (
+            f"Seeded row {idx} (seed={seeded_indices[idx]}) must be deterministic: "
+            f"run1={results[0][idx]}, run2={results[1][idx]}"
+        )
+
+    # Un-seeded rows use global RNG so they'll differ across runs
+    # (since we don't reset torch.manual_seed between runs).
+    # We can't assert inequality reliably, but we can assert the tokens are valid.
+    for run in results:
+        for tok in run:
+            assert 0 <= tok < _VOCAB, f"Token {tok} out of range"
+
+
+@pytest.mark.push
+def test_seed_q_samples_none_falls_through():
+    """When q_samples is None, random_sample generates noise on-device (existing path).
+
+    Two calls without q_samples should produce different tokens (with high
+    probability) because the on-device exponential_ draws from the global RNG.
+    """
+    sampler = Sampler()
+    torch.manual_seed(0)
+    logits = torch.randn(1, _VOCAB, dtype=torch.float32)
+    probs = torch.softmax(logits, dim=-1)
+
+    # q_samples=None triggers the original on-device exponential path.
+    tok1 = sampler.random_sample(probs.clone(), generators={}, q_samples=None)
+    tok2 = sampler.random_sample(probs.clone(), generators={}, q_samples=None)
+
+    # With vocab=1000 and independent RNG draws, collision is very unlikely.
+    assert tok1.item() != tok2.item(), (
+        f"Without q_samples, successive calls should produce different tokens "
+        f"(global RNG): got {tok1.item()} both times"
+    )


### PR DESCRIPTION
### Ticket
#3365

### Problem description
`SamplingParams(seed=N)` was silently rejected at the platform level — `validate_request()` raised `ValueError` for `RANDOM_SEED`, and the generator was hardcoded to `None` at request creation. Two calls with the same seed produced different outputs.

### What's changed
- **`platform.py`**: Remove `RANDOM_SEED` rejection guard.
- **`model_runner.py`**: Create CPU `torch.Generator` from `SamplingParams.seed` at request creation (matching the GPU model runner path). Add `no_generators` to the greedy fast-path check. Remove stale GPU-specific generator rewind code (CPU generators don't support `get_offset`/`set_offset`).
- **`metadata.py`**: Build `q_samples` exponential noise tensor on CPU in `from_input_batch()` using per-request generators, transfer to XLA device. Add `no_generators` and `q_samples` fields.
- **`sampler.py`**: When `q_samples` is provided, use it directly in `random_sample()` instead of generating noise on-device.
- **`test_seed_correctness.py`** (new): 4 CPU-only unit tests for q_samples logic.
- **`test_sampling_params_synthetic.py`**: On-device determinism and mixed-batch tests at production vocab sizes.
- **`test_sampling_params.py`**: Enable E2E `test_seed` (was skipped).

### Checklist
- [x] New tests (CPU-only, synthetic, e2e) passing locally for single_device
- [x] Tests run in VLLM Nightly passing: https://github.com/tenstorrent/tt-xla/actions/runs/22551275489
