### PR TITLE
Update the inference test config of passing models on N150,P150

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -1221,9 +1221,7 @@ test_config:
     status: EXPECTED_PASSING
 
   stable_diffusion_unet/pytorch-Base-single_device-inference:
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "Hangs - https://github.com/tenstorrent/tt-xla/issues/2565"
+    status: EXPECTED_PASSING
 
   unet_for_conditional_generation/pytorch-Base-single_device-inference:
     status: EXPECTED_PASSING
@@ -1273,14 +1271,10 @@ test_config:
     status: EXPECTED_PASSING
 
   nbeats/pytorch-seasonality_basis-single_device-inference:
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_FE_COMPILATION
-    reason: "Url for dataset is not reachable - https://github.com/tenstorrent/tt-xla/issues/2507"
+    status: EXPECTED_PASSING
 
   nbeats/pytorch-trend_basis-single_device-inference:
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_FE_COMPILATION
-    reason: "Url for dataset is not reachable - https://github.com/tenstorrent/tt-xla/issues/2507"
+    status: EXPECTED_PASSING
 
   gpt2/pytorch-Default-single_device-inference:
     status: EXPECTED_PASSING


### PR DESCRIPTION
### Ticket

- closes https://github.com/tenstorrent/tt-xla/issues/2565
- closes https://github.com/tenstorrent/tt-xla/issues/2507

### Problem description

- The following test cases are currently passing on N150 and P150 on the latest main branch. However, their inference test configs have not yet been updated accordingly.

```
tests/runner/test_models.py::test_all_models_torch[stable_diffusion_unet/pytorch-Base-single_device-inference]
tests/runner/test_models.py::test_all_models_torch[nbeats/pytorch-seasonality_basis-single_device-inference]
tests/runner/test_models.py::test_all_models_torch[nbeats/pytorch-trend_basis-single_device-inference]
```

### What's changed

- Updated the STATUS of the above test cases to EXPECTED_PASSING in single device inference test config.

### Checklist

- [x] Verified the changes locally for N150 cases
- [x] Verified via Run Test Single for P150 cases

### Logs

- [N150.zip](https://github.com/user-attachments/files/25604410/n150.zip)
- [P150](https://github.com/tenstorrent/tt-xla/actions/runs/22486435727)

