### PR TITLE
Enable PCC check in llama3.1_70b and gpt-oss-20b (test_models.py / test_llms.py)

### DIFF
--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -850,8 +850,7 @@ def test_llama_3_1_70b_tp(output_file, num_layers, request):
         output_file,
         num_layers=num_layers,
         request=request,
-        required_pcc=-1.0,
-    )  # https://github.com/tenstorrent/tt-xla/issues/2976
+    )
 
 
 # Use 1x8 shard specs for gpt-oss-20b until https://github.com/tenstorrent/tt-xla/issues/3490 is resolved.

--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -35,7 +35,7 @@ test_config:
   gpt_oss/pytorch-20B-tensor_parallel-inference:
     supported_archs: [n300-llmbox]
     status: EXPECTED_PASSING
-    assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/3490
+    required_pcc: 0.98
 
   gpt_oss/pytorch-120B-tensor_parallel-inference:
     supported_archs: [galaxy-wh-6u]
@@ -159,7 +159,6 @@ test_config:
     supported_archs: [galaxy-wh-6u]
     status: EXPECTED_PASSING
     markers: [nightly] # Not red model, but high priority.
-    assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/2976
 
   llama/causal_lm/pytorch-3.1_70B_Instruct-tensor_parallel-inference:
     supported_archs: [n300-llmbox]


### PR DESCRIPTION
### Ticket
#2976 #3490

### Problem description
- Low PCC in models with 2D shard spec, needed "fp32 reduce scatter accumulation by default" to re-enable PCC which just landed today

### What's changed
 - Enable PCC check in llama3.1_70b and gpt-oss-20b in test_models / perf-benchmark
 - llama70b gets 0.99+ PCC, gpt-oss-20b gets 0.985 PCC, gpt-oss-120b gets 0.91 so need to keep PCC disabled
 - But gpt-oss-20b hangs in perf benchmark with 2D mesh shape, so couldn't revert change from #3485 fully

### Checklist
- [x] test_models.py tests passing : https://github.com/tenstorrent/tt-xla/actions/runs/22550876361
- [x] test_llms.py tests passing: https://github.com/tenstorrent/tt-xla/actions/runs/22550900145
