### PR TITLE
Bring up Mixtral models in the vLLM plugin.

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -359,9 +359,9 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # Multi-modal data support
         self.mm_registry = MULTIMODAL_REGISTRY
         self.uses_mrope = model_config.uses_mrope
-        # self.supports_mm_inputs = self.mm_registry.supports_multimodal_inputs(
-        #     model_config)
-        self.supports_mm_inputs = False
+        self.supports_mm_inputs = self.mm_registry.supports_multimodal_inputs(
+            model_config
+        )
 
         self._num_slices_per_kv_cache_update_block = (
             _get_num_slices_per_kv_cache_update_block(
@@ -541,7 +541,9 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # For passing scheduler_output between successive
         # execute_model() and sample_tokens() calls.
         self.scheduler_output: SchedulerOutput | None = None
-        self.mm_embed_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None
+        self.mm_embed_inputs: (
+            tuple[list[torch.Tensor], torch.Tensor, torch.Tensor] | None
+        ) = None
 
         # Override number of hidden layers if specified in TTConfig
         self._original_num_layers, self._target_num_layers = (
@@ -1240,7 +1242,8 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             return
 
         # Batch the multi-modal inputs.
-        mm_kwargs = list[MultiModalKwargsItem]()
+        # `group_and_batch_mm_kwargs` expects a list of (modality, item) tuples.
+        mm_kwargs = list[tuple[str, MultiModalKwargsItem]]()
         # List of tuple (mm_hash, pos_info)
         mm_hashes_pos = list[tuple[str, PlaceholderRange]]()
         for req_id, encoder_input_ids in scheduled_encoder_inputs.items():
@@ -1251,7 +1254,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 if mm_feature.data is None:
                     continue
                 mm_hash = mm_feature.identifier
-                mm_kwargs.append(mm_feature.data)
+                mm_kwargs.append((mm_feature.modality, mm_feature.data))
                 mm_hashes_pos.append((mm_hash, mm_feature.mm_position))
 
         # Batch mm inputs as much as we can: if a request in the batch has
@@ -1285,7 +1288,11 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             )
 
             if isinstance(curr_group_outputs, torch.Tensor):
-                encoder_outputs.append(curr_group_outputs)
+                # Shape is (num_items, feature_size, hidden_size). Unbind the
+                # leading item dimension so each cached entry is a single item's
+                # (feature_size, hidden_size) embedding.
+                for output in curr_group_outputs:
+                    encoder_outputs.append(output)
             else:
                 assert isinstance(curr_group_outputs, (list, tuple))
                 for output in curr_group_outputs:
@@ -1296,26 +1303,34 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # assume to only have whole mm items to process. Hence we avoid the
         # intrinsic dynamism that `scatter_mm_placeholders` introduces.
         for (mm_hash, pos_info), output in zip(mm_hashes_pos, encoder_outputs):
-            assert pos_info.is_embed is None, (
-                "Expected all positions to be" " contiguous and embeddings."
-            )
             self.encoder_cache[mm_hash] = output
 
     def _gather_mm_embeddings(
         self,
         scheduler_output: "SchedulerOutput",
-    ) -> tuple[list[torch.Tensor], torch.Tensor]:
-        total_num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
-        padded_total_num_scheduled_tokens = _get_padded_token_len(
-            self.num_tokens_paddings, total_num_scheduled_tokens
+    ) -> tuple[list[torch.Tensor], torch.Tensor, torch.Tensor]:
+        # The mask must match the (max_num_reqs, padded_width) layout of
+        # `self.input_ids` (see `_prepare_inputs`), so that it broadcasts
+        # against the 3D `inputs_embeds` produced by `embed_input_ids` during
+        # the masked_scatter in `_merge_multimodal_embeddings`. The padded
+        # width is derived from the max per-request scheduled tokens, matching
+        # how `_prepare_inputs` sizes `input_ids`.
+        max_num_scheduled_tokens = max(
+            scheduler_output.num_scheduled_tokens[rid]
+            for rid in self.input_batch.req_ids
+        )
+        padded_width = _get_padded_token_len(
+            self.num_tokens_paddings, max_num_scheduled_tokens
         )
 
-        is_mm_embed = self.is_mm_embed_cpu
-        is_mm_embed[:padded_total_num_scheduled_tokens] = False
+        is_mm_embed = torch.zeros(
+            (self.max_num_reqs, padded_width),
+            dtype=torch.bool,
+            device="cpu",
+        )
         mm_embeds = list[torch.Tensor]()
-        req_start_idx = 0
 
-        for req_id in self.input_batch.req_ids:
+        for req_idx, req_id in enumerate(self.input_batch.req_ids):
             num_scheduled_tokens = scheduler_output.num_scheduled_tokens[req_id]
             req_state = self.requests[req_id]
             num_computed_tokens = req_state.num_computed_tokens
@@ -1347,43 +1362,85 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     num_encoder_tokens,
                 )
                 assert start_idx < end_idx
+                # A placeholder range may interleave real text tokens (e.g.
+                # Pixtral's [IMG_BREAK]/[IMG_END]) with image embeddings, so
+                # map the token range to the corresponding embedding range.
+                curr_embeds_start, curr_embeds_end = (
+                    pos_info.get_embeds_indices_in_range(start_idx, end_idx)
+                )
+                # No embeddings in the current range; nothing to gather.
+                if curr_embeds_start == curr_embeds_end:
+                    continue
 
                 mm_hash = mm_feature.identifier
                 encoder_output = self.encoder_cache.get(mm_hash, None)
                 assert encoder_output is not None, f"Encoder cache miss for {mm_hash}."
 
-                assert pos_info.is_embed is None, (
-                    "Expected all positions to" " be contiguous and embeddings."
-                )
+                if (is_embed := pos_info.is_embed) is not None:
+                    is_embed = is_embed[start_idx:end_idx]
+                    mm_embeds_item = encoder_output[curr_embeds_start:curr_embeds_end]
+                else:
+                    mm_embeds_item = encoder_output[start_idx:end_idx]
 
-                req_start_pos = req_start_idx + start_pos - num_computed_tokens
-                is_mm_embed[req_start_pos + start_idx : req_start_pos + end_idx] = True
+                # Column of this request's row where the placeholder begins.
+                # `self.input_ids` stores each request's scheduled tokens
+                # starting at column 0, so the offset is relative to
+                # num_computed_tokens.
+                col_base = start_pos - num_computed_tokens
+                if is_embed is None:
+                    is_mm_embed[req_idx, col_base + start_idx : col_base + end_idx] = (
+                        True
+                    )
+                else:
+                    is_mm_embed[
+                        req_idx, col_base + start_idx : col_base + end_idx
+                    ] |= is_embed
 
-                # Only whole mm items are processed
-                mm_embeds.append(encoder_output)
+                mm_embeds.append(mm_embeds_item)
 
-            req_start_idx += num_scheduled_tokens
+        # Precompute the flat (row-major) positions of the multimodal tokens on
+        # the host. This lets `_get_model_inputs` scatter the encoder
+        # embeddings into `inputs_embeds` with a statically-shaped index tensor
+        # via `index_copy`, instead of vLLM's `masked_scatter_` which lowers to
+        # a data-dependent (dynamic-shaped) op that the Shardy/SPMD
+        # tensor-parallel pass cannot handle. The row-major order of the True
+        # entries matches the concatenation order of `mm_embeds`.
+        mm_indices = is_mm_embed.flatten().nonzero(as_tuple=True)[0].to(self.device)
+        is_mm_embed = is_mm_embed.to(self.device)
 
-        is_mm_embed = is_mm_embed[:padded_total_num_scheduled_tokens].to(self.device)
-
-        return mm_embeds, is_mm_embed
+        return mm_embeds, is_mm_embed, mm_indices
 
     def _get_model_inputs(
         self,
         input_ids: torch.Tensor,
-        mm_embed_inputs: tuple[list[torch.Tensor], torch.Tensor] | None,
+        mm_embed_inputs: tuple[list[torch.Tensor], torch.Tensor, torch.Tensor] | None,
     ):
         if self.supports_mm_inputs:
-            mm_embeds, is_mm_embed = mm_embed_inputs or (None, None)
+            mm_embeds, is_mm_embed, mm_indices = mm_embed_inputs or (
+                None,
+                None,
+                None,
+            )
 
             # NOTE(woosuk): To unify token ids and soft tokens (vision
             # embeddings), we always use embeddings (rather than token ids)
             # as input to the multimodal model, even when the input is text.
+            # Compute the text embeddings only (no multimodal merge here). The
+            # multimodal embeddings are scattered in below with a static
+            # `index_copy` rather than vLLM's `masked_scatter_`, which lowers to
+            # a dynamic-shaped op that the Shardy/SPMD pass rejects.
             inputs_embeds = self.model.embed_input_ids(
                 input_ids,
-                multimodal_embeddings=mm_embeds,
                 is_multimodal=is_mm_embed,
             )
+
+            if mm_embeds:
+                mm_flat = torch.cat(list(mm_embeds)).to(inputs_embeds.dtype)
+                original_shape = inputs_embeds.shape
+                hidden_size = original_shape[-1]
+                inputs_embeds = inputs_embeds.reshape(-1, hidden_size)
+                inputs_embeds = inputs_embeds.index_copy(0, mm_indices, mm_flat)
+                inputs_embeds = inputs_embeds.reshape(original_shape)
 
             return None, inputs_embeds
         else:
@@ -1935,9 +1992,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         mm_budget = self.mm_budget
         assert mm_budget is not None
 
-        max_items_per_seq_by_modality = (
-            mm_budget.max_items_per_batch_by_modality
-        )  # noqa: E501
+        max_items_per_seq_by_modality = mm_budget.mm_max_items_per_batch  # noqa: E501
 
         for mode, max_items_per_seq in max_items_per_seq_by_modality.items():
             logger.info(
@@ -1978,10 +2033,18 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                         mm_mask = torch.tensor([False] * num_tokens)
                         mm_mask[:items_size] = True
                         mm_mask = mm_mask.to(self.device)
+
+                        # Match the runtime path: a list of per-item 2D
+                        # embeddings plus a static index tensor for the scatter
+                        # (the mm tokens occupy the first `items_size` slots).
+                        mm_embeds_list = list(mm_embeds)
+                        mm_indices = torch.arange(
+                            items_size, dtype=torch.int64, device="cpu"
+                        ).to(self.device)
                         # Assign outputs or the graph will be cut short.
                         a, b = self._get_model_inputs(
                             placeholders_ids,
-                            mm_embed_inputs=([mm_embeds], mm_mask),
+                            mm_embed_inputs=(mm_embeds_list, mm_mask, mm_indices),
                         )
                         assert a is None
                         torch_xla.sync(wait=False)
@@ -2664,7 +2727,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     # modality with the max possible input tokens even when
                     # it supports multiple.
                     dummy_modality = mm_budget.get_modality_with_max_tokens()
-                    max_mm_items_per_batch = mm_budget.max_items_per_batch_by_modality[
+                    max_mm_items_per_batch = mm_budget.mm_max_items_per_batch[
                         dummy_modality
                     ]
 
@@ -3260,22 +3323,17 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         """Dummy data for profiling and precompiling multimodal models."""
         assert self.mm_budget is not None
 
-        dummy_decoder_data = self.mm_registry.get_decoder_dummy_data(
-            model_config=self.model_config,
-            seq_len=self.max_num_tokens,
+        dummy_mm_inputs = self.mm_registry.get_dummy_mm_inputs(
+            self.model_config,
             mm_counts={modality: 1},
             cache=self.mm_budget.cache,
         )
-        dummy_mm_data = dummy_decoder_data.multi_modal_data
-
-        # Result in the maximum GPU consumption of the model
-        dummy_mm_item = dummy_mm_data[modality][0]
-        dummy_mm_items = [dummy_mm_item] * max_items_per_batch
+        dummy_mm_item = dummy_mm_inputs["mm_kwargs"][modality][0]
 
         return next(
             grouped_mm_kwargs
             for _, _, grouped_mm_kwargs in group_mm_kwargs_by_modality(
-                dummy_mm_items,
+                [(modality, dummy_mm_item)] * max_items_per_batch,
                 device=self.device,
                 pin_memory=self.pin_memory,
             )

--- a/integrations/vllm_plugin/vllm_tt/pooling_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/pooling_runner.py
@@ -493,8 +493,7 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         self.mm_budget = (
             MultiModalBudget(
-                self.model_config,
-                self.scheduler_config,
+                self.vllm_config,
                 self.mm_registry,
             )
             if self.supports_mm_inputs
@@ -1552,7 +1551,7 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     # modality with the max possible input tokens even when
                     # it supports multiple.
                     dummy_modality = mm_budget.get_modality_with_max_tokens()
-                    max_mm_items_per_batch = mm_budget.max_items_per_batch_by_modality[
+                    max_mm_items_per_batch = mm_budget.mm_max_items_per_batch[
                         dummy_modality
                     ]
 
@@ -1737,26 +1736,19 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         """Dummy data for profiling and precompiling multimodal models."""
         assert self.mm_budget is not None
 
-        dummy_decoder_data = self.mm_registry.get_decoder_dummy_data(
-            model_config=self.model_config,
-            seq_len=self.max_model_len,
+        dummy_mm_inputs = self.mm_registry.get_dummy_mm_inputs(
+            self.model_config,
             mm_counts={modality: 1},
             cache=self.mm_budget.cache,
         )
-        dummy_mm_data = dummy_decoder_data.multi_modal_data
+        dummy_mm_item = dummy_mm_inputs["mm_kwargs"][modality][0]
 
-        # Result in the maximum GPU consumption of the model
-        dummy_mm_item = dummy_mm_data[modality][0]
-        dummy_mm_items = [dummy_mm_item] * max_items_per_batch
-
-        model = cast(SupportsMultiModal, self.model)
         return next(
             grouped_mm_kwargs
             for _, _, grouped_mm_kwargs in group_mm_kwargs_by_modality(
-                dummy_mm_items,
+                [(modality, dummy_mm_item)] * max_items_per_batch,
                 device=self.device,
                 pin_memory=self.pin_memory,
-                merge_by_field_config=model.merge_by_field_config,
             )
         )
 

--- a/integrations/vllm_plugin/vllm_tt/scheduler/ascend_scheduler.py
+++ b/integrations/vllm_plugin/vllm_tt/scheduler/ascend_scheduler.py
@@ -67,6 +67,10 @@ class AscendScheduler(Scheduler):
         token_budget = self.max_num_scheduled_tokens
         # Spec decode-related.
         scheduled_spec_decode_tokens: dict[str, list[int]] = {}
+        # Encoder-related (multimodal). Tracks which encoder inputs need to be
+        # run by the model runner this step and the remaining encoder budget.
+        scheduled_encoder_inputs: dict[str, list[int]] = {}
+        encoder_compute_budget = self.max_num_encoder_input_tokens
 
         # For logging.
         scheduled_timestamp = time.monotonic()
@@ -131,6 +135,8 @@ class AscendScheduler(Scheduler):
 
             num_external_computed_tokens = 0
             load_kv_async = False
+            encoder_inputs_to_schedule: Optional[list[int]] = None
+            new_encoder_compute_budget = encoder_compute_budget
 
             # Get already-cached tokens.
             if request.num_computed_tokens == 0:
@@ -195,6 +201,27 @@ class AscendScheduler(Scheduler):
                 assert num_new_tokens > 0
                 blocks = new_computed_blocks.blocks[0]
 
+                # Schedule encoder inputs (multimodal). This may reduce
+                # num_new_tokens so we only schedule decoder tokens up to the
+                # point where the encoder output is available.
+                if request.has_encoder_inputs:
+                    (
+                        encoder_inputs_to_schedule,
+                        num_new_tokens,
+                        new_encoder_compute_budget,
+                        _external_load_encoder_input,
+                    ) = self._try_schedule_encoder_inputs(
+                        request,
+                        num_computed_tokens,
+                        num_new_tokens,
+                        encoder_compute_budget,
+                    )
+                    if num_new_tokens == 0:
+                        # The encoder budget or encoder cache is exhausted, so
+                        # the request cannot be scheduled this step.
+                        skip_cur_request()
+                        continue
+
             watermark = getattr(self.scheduler_config, "watermark", 0.01)
             if not self._check_watermark_for_prefill(
                 request, num_new_tokens, blocks, watermark
@@ -258,6 +285,16 @@ class AscendScheduler(Scheduler):
             # Count the number of prefix cached tokens.
             if request.num_cached_tokens < 0:
                 request.num_cached_tokens = num_computed_tokens
+
+            # Encoder-related: commit the scheduled encoder inputs and reserve
+            # space for their outputs in the encoder cache.
+            if encoder_inputs_to_schedule:
+                scheduled_encoder_inputs[request.request_id] = (
+                    encoder_inputs_to_schedule
+                )
+                for i in encoder_inputs_to_schedule:
+                    self.encoder_cache_manager.allocate(request, i)
+                encoder_compute_budget = new_encoder_compute_budget
 
         # Put back any skipped requests at the head of the waiting queue
         if step_skipped_waiting:
@@ -414,7 +451,7 @@ class AscendScheduler(Scheduler):
             num_scheduled_tokens=num_scheduled_tokens,
             total_num_scheduled_tokens=total_num_scheduled_tokens,
             scheduled_spec_decode_tokens=scheduled_spec_decode_tokens,
-            scheduled_encoder_inputs={},
+            scheduled_encoder_inputs=scheduled_encoder_inputs,
             num_common_prefix_blocks=num_common_prefix_blocks,
             preempted_req_ids=set(),
             # finished_req_ids is an existing state in the scheduler,

--- a/integrations/vllm_plugin/vllm_tt/vllm_distributed_utils.py
+++ b/integrations/vllm_plugin/vllm_tt/vllm_distributed_utils.py
@@ -10,7 +10,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch_xla.distributed.spmd as xs
 from torch.nn.parameter import Parameter
-from tt_torch.sharding import sharding_constraint_hook
+from tt_torch.sharding import _partition_spec_to_sdy_sharding, sharding_constraint_hook
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
@@ -273,6 +273,15 @@ def partition_row_parallel_linear(
     return layer
 
 
+def partition_linear(layer: torch.nn.Module, mesh: xs.Mesh) -> torch.nn.Module:
+    assert isinstance(layer, nn.Linear)
+    safe_mark_sharding(layer.weight, mesh, (None, "model"))
+    if layer.bias is not None:
+        safe_mark_sharding(layer.bias, mesh, (None,))
+    logger.debug("Applied row-parallel sharding to nn.Linear %s", layer)
+    return layer
+
+
 def partition_parallel_lm_head(
     layer: torch.nn.Module, mesh: xs.Mesh
 ) -> torch.nn.Module:
@@ -287,9 +296,18 @@ def partition_vocab_parallel_embedding(
 ) -> torch.nn.Module:
     assert isinstance(layer, VocabParallelEmbedding)
     safe_mark_sharding(layer.weight, mesh, (None, "model"))
-    # Apply sharding constraint to the output of the layer.
-    hook_forward = sharding_constraint_hook(layer, mesh, (None, None, None))
-    layer.register_forward_hook(hook_forward)
+    # Apply sharding constraint to the output. The output rank matches input
+    # rank + 1: 2D input_ids (batch, seq) → 3D output; 1D input_ids (seq,) →
+    # 2D output (e.g., during mm-encoder precompilation). Pre-compute both
+    # sharding strings to avoid per-call overhead and dispatch dynamically.
+    sdy_sharding_3d = _partition_spec_to_sdy_sharding(mesh, (None, None, None))
+    sdy_sharding_2d = _partition_spec_to_sdy_sharding(mesh, (None, None))
+
+    def rank_aware_hook(mod, input, output):
+        sdy = sdy_sharding_3d if output.dim() == 3 else sdy_sharding_2d
+        return torch.ops.tt.sharding_constraint(output, sdy)
+
+    layer.register_forward_hook(rank_aware_hook)
     logger.debug("Applied parallel sharding to %s", layer)
     return layer
 
@@ -302,6 +320,10 @@ MODULE_TYPE_TO_WRAPPING_FUNC = OrderedDict(
         ("RowParallelLinear", partition_row_parallel_linear),
         ("ParallelLMHead", partition_parallel_lm_head),
         ("VocabParallelEmbedding", partition_vocab_parallel_embedding),
+        # Catch-all for plain nn.Linear layers (e.g. vision encoder projections
+        # that are not wrapped in vLLM's parallel linear types). Must come last
+        # so the more specific vLLM types above always take priority.
+        ("Linear", partition_linear),
     ]
 )
 

--- a/python_package/tt_torch/torch_overrides.py
+++ b/python_package/tt_torch/torch_overrides.py
@@ -37,6 +37,60 @@ def _unflatten_to_shape(
     )
 
 
+def _to_pair(value: int | tuple[int, int] | list[int]) -> tuple[int, int]:
+    return (value, value) if isinstance(value, int) else tuple(value)
+
+
+def _unfold_via_gather(
+    inp: torch.Tensor,
+    kernel_size,
+    dilation=1,
+    padding=0,
+    stride=1,
+) -> torch.Tensor:
+    """Pure-torch reimplementation of ``torch.nn.functional.unfold`` for 4D
+    ``(N, C, H, W)`` inputs.
+
+    The native op lowers to im2col / ``Tensor.unfold`` HLO ops that are not
+    supported on the XLA/TT backend, so we instead build the sliding-window
+    index grids and gather. The output is guaranteed to match
+    ``torch.nn.functional.unfold`` element-for-element (see
+    ``tests/torch/ops/test_unfold.py``), with column ``l = oh * out_W + ow`` and
+    channel-kernel index ``c * kH * kW + kh * kW + kw``.
+    """
+    kH, kW = _to_pair(kernel_size)
+    dH, dW = _to_pair(dilation)
+    pH, pW = _to_pair(padding)
+    sH, sW = _to_pair(stride)
+
+    N, C, H, W = inp.shape
+
+    if pH > 0 or pW > 0:
+        inp = torch.nn.functional.pad(inp, (pW, pW, pH, pH))
+        _, _, H, W = inp.shape
+
+    eff_kH = dH * (kH - 1) + 1
+    eff_kW = dW * (kW - 1) + 1
+    out_H = (H - eff_kH) // sH + 1
+    out_W = (W - eff_kW) // sW + 1
+
+    # Per-output-position kernel offsets: row/col index for every (out, k) pair.
+    ri = (
+        torch.arange(out_H, device=inp.device).view(-1, 1) * sH
+        + torch.arange(kH, device=inp.device).view(1, -1) * dH
+    )
+    ci = (
+        torch.arange(out_W, device=inp.device).view(-1, 1) * sW
+        + torch.arange(kW, device=inp.device).view(1, -1) * dW
+    )
+
+    # Gather rows then cols: (N, C, out_H*kH, out_W*kW)
+    x = inp[:, :, ri.reshape(-1), :][:, :, :, ci.reshape(-1)]
+    x = x.view(N, C, out_H, kH, out_W, kW)
+    x = x.permute(0, 1, 3, 5, 2, 4).contiguous()
+    return x.view(N, C * kH * kW, out_H * out_W)
+
+
 class TorchFunctionOverride(TorchFunctionMode):
     def __torch_function__(self, func, types, args, kwargs=None):
         kwargs = kwargs or {}
@@ -63,6 +117,21 @@ class TorchFunctionOverride(TorchFunctionMode):
                 if len(args) > 2 and args[2] is not None:
                     res = res + args[2]
                 return res
+        if (
+            func is torch.nn.functional.unfold
+            and not torch.compiler.is_compiling()
+            and args
+            and isinstance(args[0], torch.Tensor)
+            and args[0].device.type == "xla"
+        ):
+            kw = kwargs or {}
+            return _unfold_via_gather(
+                args[0],
+                kernel_size=args[1] if len(args) > 1 else kw["kernel_size"],
+                dilation=args[2] if len(args) > 2 else kw.get("dilation", 1),
+                padding=args[3] if len(args) > 3 else kw.get("padding", 0),
+                stride=args[4] if len(args) > 4 else kw.get("stride", 1),
+            )
         return func(*args, **(kwargs or {}))
 
 

--- a/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
@@ -209,3 +209,50 @@ def test_tensor_parallel_generation_gemma4_31b(
     assert_output_coherent(output_text)
 
     check_host_memory(model_name)
+
+
+@pytest.mark.nightly
+@pytest.mark.tensor_parallel
+@pytest.mark.llmbox
+@pytest.mark.parametrize(
+    ["model_name"],
+    [
+        pytest.param("mistralai/Mistral-Small-3.1-24B-Instruct-2503"),
+        pytest.param("mistralai/Mistral-Small-3.2-24B-Instruct-2506"),
+    ],
+)
+def test_tensor_parallel_generation_mistral_small(model_name: str):
+    image_url = "https://static.wikia.nocookie.net/essentialsdocs/images/7/70/Battle.png/revision/latest?cb=20220523172438"
+
+    user_text = "What action do you think I should take in this situation? "
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": user_text},
+                {"type": "image_url", "image_url": {"url": image_url}},
+            ],
+        },
+    ]
+    sampling_params = vllm.SamplingParams(temperature=0.8, top_p=0.95, max_tokens=32)
+
+    llm_args = {
+        "model": model_name,
+        "limit_mm_per_prompt": {"image": 1},
+        "max_num_batched_tokens": 3025,
+        "max_num_seqs": 1,
+        "max_model_len": 512,
+        "gpu_memory_utilization": 0.01,
+        "additional_config": {
+            "min_context_len": 32,
+            "enable_tensor_parallel": True,
+            "experimental_weight_dtype": "bfp_bf8",
+        },
+    }
+    llm = vllm.LLM(**llm_args)
+
+    output_text = llm.chat(messages, sampling_params=sampling_params)[0].outputs[0].text
+    print(f"prompt: {user_text}, output: {output_text}")
+    assert_output_coherent(output_text)
+
+    check_host_memory(model_name)

--- a/tests/torch/ops/test_unfold.py
+++ b/tests/torch/ops/test_unfold.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Functional-equivalence tests for the ``torch.nn.functional.unfold`` override.
+
+The override in ``tt_torch.torch_overrides`` replaces ``F.unfold`` with a
+gather-based im2col (``_unfold_via_gather``) because the native op lowers to
+HLO ops unsupported on the TT backend. These tests close the testing gap called
+out in review by asserting the rewrite is element-for-element identical to
+``torch.nn.functional.unfold`` on CPU across a wide sweep of kernel / stride /
+padding / dilation combinations (including non-square parameters).
+"""
+
+import itertools
+
+import pytest
+import torch
+from tt_torch.torch_overrides import _unfold_via_gather
+
+KERNELS = [1, 2, 3, (2, 3)]
+STRIDES = [1, 2, (1, 2)]
+PADDINGS = [0, 1, (1, 0)]
+DILATIONS = [1, 2, (1, 2)]
+
+
+@pytest.mark.push
+@pytest.mark.single_device
+@pytest.mark.parametrize(
+    "kernel_size, stride, padding, dilation",
+    list(itertools.product(KERNELS, STRIDES, PADDINGS, DILATIONS)),
+)
+@pytest.mark.parametrize("shape", [(2, 3, 16, 14)])
+def test_unfold_matches_native(shape, kernel_size, stride, padding, dilation):
+    torch.manual_seed(0)
+    x = torch.randn(*shape, dtype=torch.float32)
+
+    expected = torch.nn.functional.unfold(
+        x,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        dilation=dilation,
+    )
+    got = _unfold_via_gather(
+        x,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        dilation=dilation,
+    )
+
+    assert got.shape == expected.shape
+    torch.testing.assert_close(got, expected, rtol=0, atol=0)
+
+
+@pytest.mark.push
+@pytest.mark.single_device
+def test_unfold_defaults_match_native():
+    """The override is also exercised through the positional/keyword default
+    path used by callers that only pass ``kernel_size``."""
+    torch.manual_seed(0)
+    x = torch.randn(1, 4, 8, 8, dtype=torch.float32)
+
+    expected = torch.nn.functional.unfold(x, kernel_size=2)
+    got = _unfold_via_gather(x, kernel_size=2)
+
+    torch.testing.assert_close(got, expected, rtol=0, atol=0)


### PR DESCRIPTION
### Ticket
[2620](https://github.com/tenstorrent/tt-xla/issues/2620#issuecomment-3949392101)

### Problem description
BringUp Mistral models in the vLLM plugin.

### What's changed
Added a **torch.nn.functional.unfold** override in python_package/tt_torch/torch_overrides.py (XLA-device only): it replaces the native op — which lowers to im2col / Tensor.unfold HLO ops unsupported on the TT backend — with an equivalent gather-based im2col. Functional equivalence with native F.unfold is verified in tests/torch/ops/test_unfold.py.


Added a new test case in **tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py** to cover two Mistral variants: **mistralai/Mistral-Small-3.2-24B-Instruct-2506** and **mistralai/Mistral-Small-3.1-24B-Instruct-2503.**

Both models are passing successfully. The outputs from both models are as follows:

**mistralai/Mistral-Small-3.2-24B-Instruct-2506:**

`prompt: What action do you think I should take in this situation? , output: [RequestOutput(request_id=0, prompt=None, prompt_token_ids=[1, 3, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 12, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 12, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 12, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 12, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 12, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 12, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 12, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 12, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 12, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 12, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 12, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 12, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 12, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 13, 7493, 5263, 1653, 1636, 3648, 1362, 2715, 4069, 1294, 1593, 8516, 1063, 1032, 4], encoder_prompt=None, encoder_prompt_token_ids=None, prompt_logprobs=None, outputs=[CompletionOutput(index=0, text="In the situation depicted in the image, you have a few options to choose from based on the interface provided. Here's a breakdown of the choices you can make", token_ids=[1785, 1278, 8516, 30394, 1294, 1278, 3937, 1044, 1636, 1736, 1261, 4517, 7791, 1317, 12729, 1562, 4057, 1408, 1278, 8288, 5662, 1046, 9380, 1681, 1261, 44433, 1307, 1278, 24207, 1636, 1710, 3180], routed_experts=None, cumulative_logprob=None, logprobs=None, finish_reason=length, stop_reason=None)], finished=True, metrics=None, lora_request=None, num_cached_tokens=0)]
`



**mistralai/Mistral-Small-3.1-24B-Instruct-2503:**
`prompt: What action do you think I should take in this situation? , output: [RequestOutput(request_id=0, prompt=None, prompt_token_ids=[1, 3, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 12, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 12, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 12, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 12, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 12, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 12, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 12, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 12, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 12, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 12, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 12, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 12, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 12, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 13, 7493, 5263, 1653, 1636, 3648, 1362, 2715, 4069, 1294, 1593, 8516, 1063, 1032, 4], encoder_prompt=None, encoder_prompt_token_ids=None, prompt_logprobs=None, outputs=[CompletionOutput(index=0, text='In this situation, you have several options available as indicated by the buttons at the bottom of the screen: "FIGHT," "BAG," "POK', token_ids=[1785, 1593, 8516, 1044, 1636, 1736, 4631, 7791, 5178, 1435, 10770, 1536, 1278, 26591, 1513, 1278, 9478, 1307, 1278, 7026, 1058, 1429, 10839, 8395, 4225, 1429, 1066, 6970, 4225, 1429, 7836, 1075], routed_experts=None, cumulative_logprob=None, logprobs=None, finish_reason=length, stop_reason=None)], finished=True, metrics=None, lora_request=None, num_cached_tokens=0)]
`

Logs:
[mistralai:Mistral-Small-3.1-24B-Instruct-2503.log](https://github.com/user-attachments/files/28762514/mistralai.Mistral-Small-3.1-24B-Instruct-2503.log)
[mistralai:Mistral-Small-3.2-24B-Instruct-2506.log](https://github.com/user-attachments/files/28762523/mistralai.Mistral-Small-3.2-24B-Instruct-2506.log)

### Checklist
- [ ] New/Existing tests provide coverage for changes
