### PR TITLE
Update test config for Denseunet_3d model

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -2442,8 +2442,8 @@ test_config:
     status: EXPECTED_PASSING
 
   dense_unet_3d/pytorch-Base-single_device-inference:
-    status: NOT_SUPPORTED_SKIP
-    reason: "RuntimeError: torch._dynamo.exc.TorchRuntimeError: Dynamo failed to run FX node with fake tensors: call_module L__self___maxpool1(*(FakeTensor(..., device='xla:0', size=(1, 96, 16, 128, 128), dtype=torch.bfloat16),), https://github.com/tenstorrent/tt-xla/issues/2567"
+    status: KNOWN_FAILURE_XFAIL
+    reason: "error: failed to legalize operation 'stablehlo.reduce_window' - https://github.com/tenstorrent/tt-mlir/issues/7240"
 
   openvla_oft/pytorch-Finetuned_Libero_10-single_device-inference:
     supported_archs: ["p150"]


### PR DESCRIPTION

### Problem description
- The model is currently failing during the legalization operation for reduce_window (see details in [this issue](https://github.com/tenstorrent/tt-mlir/issues/7240)).

- The issue currently referenced in the config has already been resolved ([tt-xla#2567](https://github.com/tenstorrent/tt-xla/issues/2567)).

### What's changed
- Updated test config for Denseunet_3d model

### Checklist
- [x] New/Existing tests provide coverage for changes


### Logs
- [denseunet_3d_failure.log](https://github.com/user-attachments/files/25674199/denseunet_3d_failure.log)
