### PR TITLE
Update the inference test config of OLM-OCR variants and Vocoder-SpeechT5

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -2573,7 +2573,6 @@ test_config:
 
   vocoder_speecht5/pytorch-hifigan-single_device-inference:
     status: EXPECTED_PASSING
-    assert_pcc: false # PCC < 0.1, tracking issue https://github.com/tenstorrent/tt-xla/issues/3064
 
   ssd512/object_detection/pytorch-ssd512-single_device-inference:
     status: EXPECTED_PASSING
@@ -2623,25 +2622,21 @@ test_config:
         status: EXPECTED_PASSING
 
   olm_ocr/image_text_generation/pytorch-olmOCR-7B-0225-preview-single_device-inference:
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "Hangs (https://github.com/tenstorrent/tt-xla/issues/3478)"
-    #Was xfailed previously, reason: "Out of Memory: Not enough space to allocate 681836544 B DRAM buffer across 12 banks, where each bank needs to store 56819712 B, but bank size is 1071821792 B (allocated: 972700384 B, free: 99121408 B, largest free block: 55576928 B) - https://github.com/tenstorrent/tt-xla/issues/3388"
+    supported_archs: ["p150"]
+    status: KNOWN_FAILURE_XFAIL
+    reason: "Statically allocated circular buffers on core range [(x=0,y=0) - (x=12,y=9)] grow to 1745920 B which is beyond max L1 size of 1572864 B"
 
   olm_ocr/image_text_generation/pytorch-olmOCR-7B-0725-single_device-inference:
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "Hangs (https://github.com/tenstorrent/tt-xla/issues/3478)"
-    #Was xfailed previously, reason: "Out of Memory: Not enough space to allocate 681836544 B DRAM buffer across 12 banks, where each bank needs to store 56819712 B, but bank size is 1071821792 B (allocated: 972700384 B, free: 99121408 B, largest free block: 55576928 B) - https://github.com/tenstorrent/tt-xla/issues/3388"
+    supported_archs: ["p150"]
+    status: KNOWN_FAILURE_XFAIL
+    reason: "Statically allocated circular buffers on core range [(x=0,y=0) - (x=12,y=9)] grow to 1745920 B which is beyond max L1 size of 1572864 B"
 
   olm_ocr/image_text_generation/pytorch-olmOCR-7B-0825-single_device-inference:
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "Hangs (https://github.com/tenstorrent/tt-xla/issues/3478)"
-    #Was xfailed previously, reason: "Out of Memory: Not enough space to allocate 681836544 B DRAM buffer across 12 banks, where each bank needs to store 56819712 B, but bank size is 1071821792 B (allocated: 972700384 B, free: 99121408 B, largest free block: 55576928 B) - https://github.com/tenstorrent/tt-xla/issues/3388"
+    supported_archs: ["p150"]
+    status: KNOWN_FAILURE_XFAIL
+    reason: "Statically allocated circular buffers on core range [(x=0,y=0) - (x=12,y=9)] grow to 1745920 B which is beyond max L1 size of 1572864 B"
 
   olm_ocr/image_text_generation/pytorch-olmOCR-2-7B-1025-single_device-inference:
-    status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_RUNTIME
-    reason: "Hangs (https://github.com/tenstorrent/tt-xla/issues/3478)"
-    #Was xfailed previously, reason: "Out of Memory: Not enough space to allocate 681836544 B DRAM buffer across 12 banks, where each bank needs to store 56819712 B, but bank size is 1071821792 B (allocated: 972700384 B, free: 99121408 B, largest free block: 55576928 B) - https://github.com/tenstorrent/tt-xla/issues/3388"
+    supported_archs: ["p150"]
+    status: KNOWN_FAILURE_XFAIL
+    reason: "Statically allocated circular buffers on core range [(x=0,y=0) - (x=12,y=9)] grow to 1745920 B which is beyond max L1 size of 1572864 B"


### PR DESCRIPTION
### Ticket

- closes https://github.com/tenstorrent/tt-xla/issues/3064
- https://github.com/tenstorrent/tt-xla/issues/3388

### Problem description

- From the logs attached [here](https://github.com/tenstorrent/tt-forge-models/pull/445), It's clear that all OLM-OCR variants' size is >8B.
- This variants cannot fit or run on N150, they should be removed from the N150 inference test configs instead of being skipped.
- The vocoder_speecht5 model initially failed due to a PCC drop. The required [tt-metal fix](https://github.com/tenstorrent/tt-metal/pull/38002) is now tracked in tt-xla. 
- On the current main branch, the model is passing with PCC > 0.99.

### What's changed

- Removed OLM-OCR variants from N150 inference test configs.
- Added supported_archs: ["p150"] to restrict these models to P150 only
- Updated the current status in the configs for the impacted variants.
- Updated the vocoder_speecht5 status to EXPECTED_PASSING.

### Checklist
- [x]  Verified the changes locally for N150 cases
- [x]  Verified via Run Test Single for P150 cases

### Logs

- [vocoder_N150.log](https://github.com/user-attachments/files/25677063/mar2_vocoder_n150.log)
- [vocoder_OLM_OCR_P150](https://github.com/tenstorrent/tt-xla/actions/runs/22564607323)
 
