### PR TITLE
Update test config for Olmo3 model

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -198,12 +198,12 @@ test_config:
 
   olmo3/causal_lm/pytorch-3_32b_think-tensor_parallel-inference:
     supported_archs: [n300-llmbox]
-    assert_pcc: false # PCC comparison failed. Calculated: pcc=0.3691241923630818. Required: pcc=0.99
+    assert_pcc: True
     status: EXPECTED_PASSING
 
   olmo3/causal_lm/pytorch-3_1125_32b-tensor_parallel-inference:
     supported_archs: [n300-llmbox]
-    assert_pcc: false # PCC comparison failed. Calculated: pcc=0.701951301689392. Required: pcc=0.99
+    assert_pcc: True
     status: EXPECTED_PASSING
 
   mistral/pytorch-mistral_small_3.1_24b_instruct_2503-tensor_parallel-inference:


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Debug the PCC drop in Olmo3 tensor-parallel variants.


### What's changed
In the latest nightly build, the Olmo3 tensor-parallel variants are now passing
```
test_all_models_torch[olmo3/causal_lm/pytorch-3_32b_think-tensor_parallel-inference]                                                        language    red         n300-llmbox   PASSED                     PASSING       0.9913272517823382       0.99       PCC_DIS  tensor_parallel  382.846   N/A           
test_all_models_torch[olmo3/causal_lm/pytorch-3_1125_32b-tensor_parallel-inference]                                                         language    red         n300-llmbox   PASSED                     PASSING       0.9993768450966148       0.99       PCC_DIS  tensor_parallel  381.196   ENABLE_PCC_099
      
```

Cross-checked with the [CI run](https://github.com/tenstorrent/tt-xla/actions/runs/22563791345): both tensor-parallel variants are passing.

Updated the configuration files and set assert_pcc to True.

### Checklist
- [ ] New/Existing tests provide coverage for changes
