### PR TITLE
Add extra index to ttrt wheel install

### DIFF
--- a/.github/workflows/call-perf-test.yml
+++ b/.github/workflows/call-perf-test.yml
@@ -136,7 +136,7 @@ jobs:
           --name ${{ inputs.wheel_artifact_name }}
 
         echo "=== Installing wheel ==="
-        uv pip install wheels/*.whl
+        pip install wheels/*.whl
 
     - name: Install system dependencies
       shell: bash
@@ -147,8 +147,8 @@ jobs:
     - name: Install Python dependencies
       shell: bash
       run: |
-        uv pip install ${{ matrix.build.pyreq }}
-        uv pip install torchvision==0.24.0+cpu --index-url https://download.pytorch.org/whl/cpu
+        pip install ${{ matrix.build.pyreq }}
+        pip install torchvision==0.24.0+cpu --index-url https://download.pytorch.org/whl/cpu
 
     - name: Create perf report directory
       run: mkdir -p ${{ steps.strings.outputs.perf_report_path }}
@@ -314,16 +314,16 @@ jobs:
         python3.12 -m venv ttrt-venv
         source ttrt-venv/bin/activate
         apt-get install -y -qq --no-install-recommends libtbb12 libcapstone4
-        uv pip install ttrt-whl-tracy/ttrt*.whl --upgrade --extra-index-url https://download.pytorch.org/whl/cpu
-        uv pip install torch==2.3.0 --index-url https://download.pytorch.org/whl/cpu
-        uv pip install pandas==2.3.3
+        pip install ttrt-whl-tracy/ttrt*.whl --upgrade --extra-index-url https://download.pytorch.org/whl/cpu
+        pip install torch==2.3.0 --index-url https://download.pytorch.org/whl/cpu
+        pip install pandas==2.3.3
 
     - name: Run Device Perf
       if: ${{ !matrix.build.skip-device-perf && !inputs.skip-device-perf && matrix.build.runs-on != 'p150' }}
       shell: bash
       run: |
         source ttrt-venv/bin/activate
-        uv pip install pandas==2.3.3
+        pip install pandas==2.3.3
 
         echo "Save artifacts"
         ttrt query --save-artifacts


### PR DESCRIPTION
### Ticket
#3509

### Problem description
Due to changes made to ttrt in this [PR](https://github.com/tenstorrent/tt-mlir/pull/7206), `pip install ttrt.whl` no longer works without previously installing it's `requirements.txt` file or adding the extra index to the pip install command.

### What's changed
Added `--extra-index-url https://download.pytorch.org/whl/cpu` to the wheel install command.

Important: this PR is **not** the adequate way to deal with this issue, this should be fixed in ttrt (tt-mlir). 
When the [issue](https://github.com/tenstorrent/tt-mlir/issues/7291) there is resolved, this workaround can be removed.

### Checklist
- [ ] New/Existing tests provide coverage for changes
