### PR TITLE
Always add config fields in perf report

### DIFF
--- a/.github/workflows/call-perf-test.yml
+++ b/.github/workflows/call-perf-test.yml
@@ -360,6 +360,7 @@ jobs:
         if-no-files-found: warn
 
     - name: Add config fields to perf report
+      if: success() || failure()
       shell: bash
       run: |
         PERF_REPORT_FILE="${{ steps.strings.outputs.perf_report_json_file }}"


### PR DESCRIPTION
Closes #3396 

This PR enables always adding config fields to perf report, so if a later job fails e.g. device perf, results from earlier jobs will be added (TTIR, TTNN, ...).