### PR TITLE
Update test config for Arcee model.

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -2598,8 +2598,12 @@ test_config:
     reason: "RuntimeError('Check failed: handle->HasValue(): Trying to access XLA data for tensor with ID 645 while an async operation is in flight: UNKNOWN_SCALAR[]') - https://github.com/tenstorrent/tt-xla/issues/3184"
 
   arcee/text_generation/pytorch-arcee_Spark-single_device-inference:
-    status: KNOWN_FAILURE_XFAIL
-    reason: "Out of Memory: Not enough space to allocate 135790592 B DRAM buffer across 12 banks, where each bank needs to store 11317248 B, but bank size is 1073741792 B (allocated: 1055220960 B, free: 18520832 B, largest free block: 9253856 B) - https://github.com/tenstorrent/tt-xla/issues/3183"
+    arch_overrides:
+      n150:
+        status: KNOWN_FAILURE_XFAIL
+        reason: "Out of Memory: Not enough space to allocate 135790592 B DRAM buffer across 12 banks, where each bank needs to store 11317248 B, but bank size is 1073741792 B (allocated: 1055220960 B, free: 18520832 B, largest free block: 9253856 B) - https://github.com/tenstorrent/tt-xla/issues/3183"
+      p150:
+        status: EXPECTED_PASSING
 
   olmo3/causal_lm/pytorch-3_7b_think-single_device-inference:
     arch_overrides:


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Update test config for Arcee model.

### What's changed
Here are the latest nightly CI runs for the Arcee model:
```
test_all_models_torch[arcee/text_generation/pytorch-arcee_Spark-single_device-inference]                                                    language    red         n150          FAILED_RUNTIME             XFAIL         N/A                    0.99       PCC_EN   single_device    108.503   N/A          
test_all_models_torch[arcee/text_generation/pytorch-arcee_Spark-single_device-inference]                                                    language    red         p150          PASSED                     XFAIL         0.9951972680633119     0.99       PCC_EN   single_device    136.517   RM_XFAIL     
```

The model was running into an out-of-memory error on the n150 machine, whereas it passes on the p150 machine with a 0.99 PCC. I’ve updated the config file by adding the arch_overrides to address this.

### Checklist
- [ ] New/Existing tests provide coverage for changes
