### PR TITLE
Update test config for Phi4 model.

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -174,9 +174,7 @@ test_config:
 
   phi4/causal_lm/pytorch-Phi_4-tensor_parallel-inference:
     supported_archs: [n300-llmbox]
-    status: NOT_SUPPORTED_SKIP
-    reason: "Needs bringup on n300-llmbox 14B param"
-    bringup_status: FAILED_RUNTIME
+    status: EXPECTED_PASSING
 
   qwen_2/causal_lm/pytorch-Qwq_32B-tensor_parallel-inference:
     supported_archs: [n300-llmbox]


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Resolve the runtime errors encountered when running the Phi-4 model with tensor parallelism.

### What's changed
Initially, while running the model with tensor parallelism, the following runtime error was encountered:
```
_ test_all_models_torch[phi4/causal_lm/pytorch-Phi_4-tensor_parallel-inference] _
tests/runner/test_models.py:288: in test_all_models_torch
    _run_model_test_impl(
tests/runner/test_models.py:111: in _run_model_test_impl
    tester = DynamicTorchModelTester(
tests/runner/testers/torch/dynamic_torch_model_tester.py:59: in __init__
    super().__init__(
tests/infra/testers/single_chip/model/torch_model_tester.py:86: in __init__
    super().__init__(
tests/infra/testers/single_chip/model/model_tester.py:61: in __init__
    self._initialize_components()
tests/infra/testers/single_chip/model/model_tester.py:68: in _initialize_components
    self._initialize_workload()
tests/infra/testers/single_chip/model/torch_model_tester.py:154: in _initialize_workload
    self._workload.mesh and len(self._workload.mesh.device_ids) > 1
E   AssertionError: Tensor parallel requires multi-chip mesh

```
fix pr: https://github.com/tenstorrent/tt-forge-models/pull/508
After that fix, the model is passing with a PCC of 0.9996130444915992.
The logs are attached for reference:
[phi4:causal_lm:pytorch-Phi_4-tensor_parallel-inference.log](https://github.com/user-attachments/files/25706233/phi4.causal_lm.pytorch-Phi_4-tensor_parallel-inference.log)


### Checklist
- [ ] New/Existing tests provide coverage for changes
