### PR TITLE
Add mpi shared object file to path

### DIFF
--- a/.github/Dockerfile.release
+++ b/.github/Dockerfile.release
@@ -41,6 +41,10 @@ RUN apt-get update && \
     apt install -y "./mpi.deb" && \
     rm -f "mpi.deb"
 
+ARG OMPI_TAG=v5.0.7
+ARG OMPI_PREFIX=/opt/openmpi-${OMPI_TAG}-ulfm
+ENV LD_LIBRARY_PATH=${OMPI_PREFIX}/lib:$LD_LIBRARY_PATH
+
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/
 


### PR DESCRIPTION
### Ticket
/

### Problem description
With the new ubuntu wheel changes tt-xla ubuntu release wheel can't find the libmpi.so.

### What's changed
Added libmpi.so to the LD_LIBRARY_PATH so the pjrt_plugin_tt.so can find it.

### Checklist
- [ ] New/Existing tests provide coverage for changes
