### PR TITLE
Re-enable N300-llmbox tensor parallel tests for VLLM

### DIFF
--- a/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
@@ -35,9 +35,6 @@ def test_tensor_parallel_generation_n300(model_name: str):
 @pytest.mark.push
 @pytest.mark.tensor_parallel
 @pytest.mark.llmbox
-@pytest.mark.skip(
-    reason="Skipping due to bug in tt-metal SDPA op. Issue: https://github.com/tenstorrent/tt-xla/issues/3465"
-)
 @pytest.mark.parametrize(
     ["model_name", "enable_const_eval", "experimental_enable_weight_bfp8_conversion"],
     [
@@ -75,9 +72,6 @@ def test_tensor_parallel_generation_llmbox_small(
 @pytest.mark.nightly
 @pytest.mark.tensor_parallel
 @pytest.mark.llmbox
-@pytest.mark.skip(
-    reason="Skipping due to bug in tt-metal SDPA op. Issue: https://github.com/tenstorrent/tt-xla/issues/3465"
-)
 @pytest.mark.parametrize(
     ["model_name", "enable_const_eval", "experimental_enable_weight_bfp8_conversion"],
     [

--- a/tests/integrations/vllm_plugin/sampling/test_sampling_params.py
+++ b/tests/integrations/vllm_plugin/sampling/test_sampling_params.py
@@ -31,13 +31,7 @@ _TARGET_MARKS = {
     "n300": ("vllm_n300", [pytest.mark.tensor_parallel, pytest.mark.dual_chip]),
     "n300_llmbox": (
         "vllm_n300_llmbox",
-        [
-            pytest.mark.tensor_parallel,
-            pytest.mark.llmbox,
-            pytest.mark.skip(
-                reason="Skipping due to bug in tt-metal SDPA op. Issue: https://github.com/tenstorrent/tt-xla/issues/3465"
-            ),
-        ],
+        [pytest.mark.tensor_parallel, pytest.mark.llmbox],
     ),
 }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/3465

### Problem description
 - Issue w/ SDPA op that needed these tests to be skipped on Feb 26 is now resolved in tt-mlir main and about to land in tt-xla

### What's changed
 - Revert 491dad301823 change that marked tests for skip

### Checklist
- [x] Tested affected tests w/ tt-mlir uplift locally (passing) and on CI: https://github.com/tenstorrent/tt-xla/actions/runs/22647234232
