### PR TITLE
Enable llmbox perf tests to run on civ2 runners

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -96,127 +96,127 @@
         "name": "falcon3_7b_tp",
         "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b_tp",
-        "runs-on": "llmbox"
+        "runs-on": "n300-llmbox"
       },
       {
         "name": "falcon3_10b_tp",
         "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_10b_tp",
-        "runs-on": "llmbox"
+        "runs-on": "n300-llmbox"
       },
       {
         "name": "llama_3_1_8b_instruct_tp",
         "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b_instruct_tp",
-        "runs-on": "llmbox"
+        "runs-on": "n300-llmbox"
       },
       {
         "name": "mistral_7b_tp",
         "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
         "pytest": "tests/benchmark/test_llms.py::test_mistral_7b_tp",
-        "runs-on": "llmbox"
+        "runs-on": "n300-llmbox"
       },
       {
         "name": "ministral_8b_tp",
         "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
         "pytest": "tests/benchmark/test_llms.py::test_ministral_8b_tp",
-        "runs-on": "llmbox"
+        "runs-on": "n300-llmbox"
       },
       {
         "name": "mistral_nemo_instruct_2407_tp",
         "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
         "pytest": "tests/benchmark/test_llms.py::test_mistral_nemo_instruct_2407_tp",
-        "runs-on": "llmbox"
+        "runs-on": "n300-llmbox"
       },
       {
         "name": "mistral_small_24b_instruct_2501_tp",
         "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
         "pytest": "tests/benchmark/test_llms.py::test_mistral_small_24b_instruct_2501_tp",
-        "runs-on": "llmbox"
+        "runs-on": "n300-llmbox"
       },
       {
         "name": "qwen_2_5_14b_instruct_tp",
         "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_14b_instruct_tp",
-        "runs-on": "llmbox"
+        "runs-on": "n300-llmbox"
       },
       {
         "name": "qwen_2_5_32b_instruct_tp",
         "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_32b_instruct_tp",
-        "runs-on": "llmbox"
+        "runs-on": "n300-llmbox"
       },
       {
         "name": "qwen_2_5_coder_32b_instruct_tp",
         "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_coder_32b_instruct_tp",
-        "runs-on": "llmbox"
+        "runs-on": "n300-llmbox"
       },
       {
         "name": "qwen_3_0_6b_tp",
         "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_0_6b_tp",
-        "runs-on": "llmbox"
+        "runs-on": "n300-llmbox"
       },
       {
         "name": "qwen_3_1_7b_tp",
         "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_1_7b_tp",
-        "runs-on": "llmbox"
+        "runs-on": "n300-llmbox"
       },
       {
         "name": "qwen_3_8b_tp",
         "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_8b_tp",
-        "runs-on": "llmbox"
+        "runs-on": "n300-llmbox"
       },
       {
         "name": "qwen_3_14b_tp",
         "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_14b_tp",
-        "runs-on": "llmbox"
+        "runs-on": "n300-llmbox"
       },
       {
         "name": "qwen_3_32b_tp",
         "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_32b_tp",
-        "runs-on": "llmbox"
+        "runs-on": "n300-llmbox"
       },
       {
         "name": "llama_3_8b_instruct_tp",
         "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_8b_instruct_tp",
-        "runs-on": "llmbox"
+        "runs-on": "n300-llmbox"
       },
       {
         "name": "llama_3_1_8b_tp",
         "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b_tp",
-        "runs-on": "llmbox"
+        "runs-on": "n300-llmbox"
       },
       {
         "name": "llama_3_8b_tp",
         "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_8b_tp",
-        "runs-on": "llmbox"
+        "runs-on": "n300-llmbox"
       },
       {
         "name": "test_llama_3_1_70b_tp",
         "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp",
-        "runs-on": "llmbox"
+        "runs-on": "n300-llmbox"
       },
       {
         "name": "gpt_oss_20b_tp",
         "pyreq": "datasets loguru pytest requests accelerate torch==2.9.0 tqdm transformers==4.57.1",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp",
-        "runs-on": "llmbox"
+        "runs-on": "n300-llmbox"
       },
       {
         "name": "gpt_oss_20b_tp_batch_size_1",
         "pyreq": "datasets loguru pytest requests accelerate torch==2.9.0 tqdm transformers==4.57.1",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_batch_size_1",
-        "runs-on": "llmbox"
+        "runs-on": "n300-llmbox"
       },
       {
         "name": "microsoft_phi-1",


### PR DESCRIPTION
### Ticket
/

### Problem description
There was a bug where llmbox perf tests didn't run on CIv2 (shared) runners.
We generated the label `tt-ubuntu-2204-llmbox-stable` and the required label for shared runners is `tt-ubuntu-2204-n300-llmbox-stable`.

### What's changed
Change the label for tests from "llmbox" to "n300-llmbox"

### Checklist
- An example run with the new changes validating that llmbox perf tests now work on CIv2 runners -> [here](https://github.com/tenstorrent/tt-xla/actions/runs/22660153274)
