### PR TITLE
Fix vllm tests for manylinux build

### DIFF
--- a/.github/workflows/call-build.yml
+++ b/.github/workflows/call-build.yml
@@ -20,6 +20,10 @@ on:
             default: release
             type: string
             required: false
+        force_rebuild:
+            description: 'Force rebuild even if artifact exists'
+            type: boolean
+            required: false
     outputs:
         wheel_artifact_name:
             description: 'Name of the wheel artifact'
@@ -56,7 +60,8 @@ jobs:
           # - Not a pull request event
           # - Not a merge commit (has exactly 1 parent)
           # - No MLIR override specified
-          if [[ "${{ github.event_name }}" != "pull_request" && \
+          if [[ "${{ inputs.force_rebuild }}" != "true" && \
+                "${{ github.event_name }}" != "pull_request" && \
                 $(git cat-file -p HEAD | grep -c "^parent ") -eq 1 && \
                 "${{ inputs.mlir_override }}" == "" ]]; then
             artifact_suffix="-$(git rev-parse --short HEAD)"

--- a/.github/workflows/manual-test.yml
+++ b/.github/workflows/manual-test.yml
@@ -63,6 +63,7 @@ jobs:
     with:
       docker_image: ${{ needs.build-image.outputs.docker-image }}
       mlir_override: ${{ inputs.mlir_override }}
+      force_rebuild: ${{ inputs.manylinux_build }} # Force rebuild for non-manylinux build when manylinux_build is true, to ensure the artifact is available for testing.
 
   build-manylinux-ttxla:
     if: inputs.manylinux_build


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/3140 https://github.com/tenstorrent/tt-xla/issues/3547

### Problem description
With manylinux build vllm tests are failing

### What's changed
The problem is in workflow that needs manylinux wheel, tt_vllm, and alchemist lib in the same run_id.
Added force_rebuild option to build workflow so if manylinux wheel is built it rebuilds all of the required components.

### Checklist
- [x] New/Existing tests provide coverage for changes
- Vllm tests: https://github.com/tenstorrent/tt-xla/actions/runs/22665606069
