### PR TITLE
[CI] Fix ird docker

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -10,6 +10,10 @@ COPY --chown=root:root --chmod=777 .github/docker_install.sh /tmp/script.sh
 RUN pkg_install() { apt-get update && apt-get install -y "$@"; } && export -f pkg_install && /tmp/script.sh ubuntu && \
     rm /tmp/script.sh
 
+ARG OMPI_TAG=v5.0.7
+ARG OMPI_PREFIX=/opt/openmpi-${OMPI_TAG}-ulfm
+ENV LD_LIBRARY_PATH=${OMPI_PREFIX}/lib:$LD_LIBRARY_PATH
+
 FROM ghcr.io/tenstorrent/tt-mlir/tt-mlir-ci-ubuntu-22-04:${MLIR_TAG} as ci
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
### Ticket
slack

### Problem description
Manual build produce errors such as:
```
usr/bin/ld: tt-xla/third_party/tt-mlir/install/lib/libtt_metal.so: undefined reference to `MPIX_Comm_shrink'
/usr/bin/ld: tt-xla/third_party/tt-mlir/install/lib/libtt_metal.so: undefined reference to `MPIX_Comm_revoke'
```

### What's changed
Add mpi-ulfm lib to ld_library_path on both IRD and base docker images.

### Checklist
- [ ] New/Existing tests provide coverage for changes
