### PR TITLE
Enable gpt_oss 20B tensor parallel inference on WH galaxy

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -31,7 +31,7 @@ test_config:
     status: EXPECTED_PASSING
 
   gpt_oss/pytorch-20B-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, galaxy-wh-6u]
     status: EXPECTED_PASSING
     required_pcc: 0.98
 


### PR DESCRIPTION
### Ticket
None

### Problem description
- We should run gpt-oss-20b on galaxy too for extra coverage, got a request for this today from @vladimirjovanovicTT 

### What's changed
- Tag gpt-oss-20b to run on galaxy-wh-6u

### Checklist
- [x] Verify it's collected locally, run alongside existing galaxy tests on CI here: https://github.com/tenstorrent/tt-xla/actions/runs/22682073185
