### PR TITLE
Update test config file for Squeezebert model

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -452,8 +452,7 @@ test_config:
     status: EXPECTED_PASSING
 
   squeezebert/pytorch-Mnli-single_device-inference:
-    status: KNOWN_FAILURE_XFAIL  # Affected by change in torch=xla wheel - issue is: https://github.com/tenstorrent/tt-xla/issues/1750
-    reason: "error: 'stablehlo.reshape' op requires compatible element types for all operands and results  - https://github.com/tenstorrent/tt-xla/issues/1750"
+    status: EXPECTED_PASSING
 
   swin/image_classification/pytorch-T-single_device-inference:
     status: EXPECTED_PASSING


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/1750

### Problem description
Re-Run the model in the latest main, and verfiy the results,


### What's changed
In the latest main branch, the model achieves a PCC of 1.0. This has also been verified in the weekly CI runs.
CI run results

```
test_all_models_torch[squeezebert/pytorch-Mnli-single_device-inference]                                                                    language    generality  n150         PASSED                     XFAIL         1.0                    0.99       PCC_EN   single_device    77.506    RM_XFAIL      
test_all_models_torch[squeezebert/pytorch-Mnli-single_device-inference]                                                                    language    generality  p150         PASSED                     XFAIL         1.0                    0.99       PCC_EN   single_device    47.088    RM_XFAIL      
```

In the latest main run results:
p150: (passed=True, error_message=None, pcc=1.0, atol=0.0078125, allclose=True, equal=False)
n150: (passed=True, error_message=None, pcc=1.0, atol=0.00390625, allclose=True, equal=False)

I have attached the logs for reference:
n150- [squeezebert:pytorch-Mnli-single_device-inference.log](https://github.com/user-attachments/files/25763666/squeezebert.pytorch-Mnli-single_device-inference.log)
p150- [p150_squeebert.log](https://github.com/user-attachments/files/25765462/p150_squeebert.log)


### Checklist
- [ ] New/Existing tests provide coverage for changes
