### PR TITLE
Updated the test configuration files based on weekly CI runs.

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -9,18 +9,12 @@
 
 test_config:
   gpt_neo/causal_lm/pytorch-125M-single_device-inference:
-    # required_pcc: 0.98,
-    # PCC decreased with inputs changes to 0.946 in BH / 0.887 in WH
-    assert_pcc: false
     status: EXPECTED_PASSING
-    reason: "PCC decreased with inputs changes to 0.946 in BH / 0.887 in WH"
 
   gpt_neo/causal_lm/pytorch-1_3B-single_device-inference:
-    required_pcc: 0.98 # https://github.com/tenstorrent/tt-mlir/issues/6461
     status: EXPECTED_PASSING
 
   gpt_neo/causal_lm/pytorch-2_7B-single_device-inference:
-    assert_pcc: false  # 0.749 on BH / 0.76 on WH
     status: EXPECTED_PASSING
 
   vovnet/pytorch-27s-single_device-inference:
@@ -87,7 +81,6 @@ test_config:
 
   mamba/pytorch-790M_HF-single_device-inference:
     status: EXPECTED_PASSING
-    assert_pcc: false # issue - https://github.com/tenstorrent/tt-xla/issues/2607
     markers: ["extended"]
 
   openpose/v2/pytorch-single_device-inference:
@@ -149,7 +142,6 @@ test_config:
 #    reason: "TypeError: AutoShape.forward() takes from 2 to 5 positional arguments but 7 were given - https://github.com/tenstorrent/tt-forge-models/issues/136"
 
   albert/masked_lm/pytorch-Base_v2-single_device-inference:
-    required_pcc: 0.97 # https://github.com/tenstorrent/tt-mlir/issues/6461
     status: EXPECTED_PASSING
 
   albert/masked_lm/pytorch-Xlarge_v2-single_device-inference:
@@ -364,11 +356,9 @@ test_config:
     status: EXPECTED_PASSING
 
   mamba/pytorch-1.4b_HF-single_device-inference:
-    assert_pcc: false # -0.0130 WH / -0.0888 BH as of Nov 5 2025 right after an uplift which contained newer LLVM https://github.com/tenstorrent/tt-xla/issues/2000
     status: EXPECTED_PASSING
 
   mamba/pytorch-370M_HF-single_device-inference:
-    assert_pcc: false # -0.0327 WH / 0.3821 BH as of Nov 5 2025 right after an uplift which contained newer LLVM https://github.com/tenstorrent/tt-xla/issues/2000
     status: EXPECTED_PASSING
 
   mgp_str_base/pytorch-single_device-inference:
@@ -536,7 +526,6 @@ test_config:
 
   mamba/pytorch-2.8b_HF-single_device-inference:
     status: EXPECTED_PASSING
-    assert_pcc: false # issue - https://github.com/tenstorrent/tt-xla/issues/2607
 
   deit/pytorch-Base-single_device-inference:
     status: EXPECTED_PASSING
@@ -577,7 +566,6 @@ test_config:
     assert_pcc: false # ComputeConfig math_fidelity/fp32_dest_acc_en - https://github.com/tenstorrent/tt-xla/issues/2861
 
   phi2/causal_lm/pytorch-Phi_2_Pytdml-single_device-inference:
-    assert_pcc: false # PCC: 0.9345 - https://github.com/tenstorrent/tt-xla/actions/runs/21091184273
     status: EXPECTED_PASSING
 
   phi2/token_classification/pytorch-Phi_2-single_device-inference:
@@ -758,7 +746,6 @@ test_config:
 
   albert/token_classification/pytorch-Xlarge_v1-single_device-inference:
     status: EXPECTED_PASSING
-    required_pcc: 0.98
 
   perceiverio_vision/pytorch-Vision_Perceiver_Fourier-single_device-inference:
     status: KNOWN_FAILURE_XFAIL
@@ -776,9 +763,7 @@ test_config:
     reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.958276593048647. Required: pcc=0.99"
 
   opt/causal_lm/pytorch-1.3b-single_device-inference:
-    assert_pcc: false
     status: EXPECTED_PASSING
-    reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.9574284831613491. Required: pcc=0.99"
 
   perceiverio_vision/pytorch-Vision_Perceiver_Learned-single_device-inference:
     status: KNOWN_FAILURE_XFAIL
@@ -883,10 +868,8 @@ test_config:
 
   qwen_1_5/causal_lm/pytorch-0.5B-single_device-inference:
     status: EXPECTED_PASSING
-    assert_pcc: false # AssertionError: Calculated: pcc=0.9186094999313354. Required: pcc=0.99. Change to torch==2.9.0, issue
 
   qwen_1_5/causal_lm/pytorch-0_5B_Chat-single_device-inference:
-    required_pcc: 0.97
     status: EXPECTED_PASSING
 
   qwen_2_5_vl/pytorch-72B_Instruct-single_device-inference:
@@ -922,7 +905,6 @@ test_config:
     status: EXPECTED_PASSING
 
   qwen_2_5_coder/pytorch-3B-single_device-inference:
-    assert_pcc: false
     status: EXPECTED_PASSING
 
   qwen_3/causal_lm/pytorch-0_6B-single_device-inference:
@@ -937,7 +919,6 @@ test_config:
     status: EXPECTED_PASSING
 
   qwen_2_5_coder/pytorch-3B_Instruct-single_device-inference:
-    assert_pcc: false
     status: EXPECTED_PASSING
 
   qwen_2_5_coder/pytorch-1.5B-single_device-inference:
@@ -1467,7 +1448,6 @@ test_config:
   #   status: EXPECTED_PASSING
 
   gemma/pytorch-2B-single_device-inference:
-    assert_pcc: false
     status: EXPECTED_PASSING
 
   autoencoder/pytorch-conv-single_device-inference:
@@ -1550,11 +1530,9 @@ test_config:
     markers: [push]
 
   phi3/token_cls/pytorch-Mini_128K_Instruct-single_device-inference:
-    required_pcc: 0.98
     status: EXPECTED_PASSING
 
   phi3/token_cls/pytorch-Mini_4K_Instruct-single_device-inference:
-    required_pcc: 0.97 # https://github.com/tenstorrent/tt-xla/issues/2944
     status: EXPECTED_PASSING
 
   phi3/seq_cls/pytorch-Mini_128K_Instruct-single_device-inference:


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/6461
https://github.com/tenstorrent/tt-xla/issues/2607
https://github.com/tenstorrent/tt-xla/issues/2000
https://github.com/tenstorrent/tt-xla/issues/2607
https://github.com/tenstorrent/tt-xla/issues/2944

### Problem description
Since these models achieved a PCC of 0.99 in the [latest Weekly CI runs](https://github.com/tenstorrent/tt-xla/actions/runs/22795337660), the config file is being updated.


### What's changed
```
test_all_models_torch[gemma/pytorch-2B-single_device-inference]                                                                            language    generality  n150         PASSED                     PASSING       0.9989945575877228   0.99       PCC_DIS  single_device    103.297  ENABLE_PCC_099
test_all_models_torch[gemma/pytorch-2B-single_device-inference]                                                                            language    generality  p150         PASSED                     PASSING       0.999321788990909    0.99       PCC_DIS  single_device    71.969   ENABLE_PCC_099

test_all_models_torch[albert/token_classification/pytorch-Xlarge_v1-single_device-inference]                                               language    generality  n150         PASSED                     PASSING       0.9988702698442546   0.98       PCC_EN   single_device    66.909   RAISE_PCC_099 
test_all_models_torch[albert/token_classification/pytorch-Xlarge_v1-single_device-inference]                                               language    generality  p150         PASSED                     PASSING       0.9988932657528128   0.98       PCC_EN   single_device    35.596   RAISE_PCC_099 

test_all_models_torch[albert/masked_lm/pytorch-Base_v2-single_device-inference]                                                            language    generality  n150         PASSED                     PASSING       0.997944405834615    0.97       PCC_EN   single_device    59.490   RAISE_PCC_099 
test_all_models_torch[albert/masked_lm/pytorch-Base_v2-single_device-inference]                                                            language    generality  p150         PASSED                     PASSING       0.9981560660128801   0.97       PCC_EN   single_device    44.122   RAISE_PCC_099 

test_all_models_torch[gpt_neo/causal_lm/pytorch-125M-single_device-inference]                                                              language    generality  n150         PASSED                     PASSING       0.9948517058630354   0.99       PCC_DIS  single_device    68.363   ENABLE_PCC_099
test_all_models_torch[gpt_neo/causal_lm/pytorch-125M-single_device-inference]                                                              language    generality  p150         PASSED                     PASSING       0.9957667764196411   0.99       PCC_DIS  single_device    57.724   ENABLE_PCC_099
test_all_models_torch[gpt_neo/causal_lm/pytorch-1_3B-single_device-inference]                                                              language    generality  n150         PASSED                     PASSING       0.9982151476927175   0.98       PCC_EN   single_device    103.338  RAISE_PCC_099 
test_all_models_torch[gpt_neo/causal_lm/pytorch-1_3B-single_device-inference]                                                              language    generality  p150         PASSED                     PASSING       0.9978441412152297   0.98       PCC_EN   single_device    91.787   RAISE_PCC_099 
test_all_models_torch[gpt_neo/causal_lm/pytorch-2_7B-single_device-inference]                                                              language    generality  n150         PASSED                     PASSING       0.995607723226833    0.99       PCC_DIS  single_device    179.052  ENABLE_PCC_099
test_all_models_torch[gpt_neo/causal_lm/pytorch-2_7B-single_device-inference]                                                              language    generality  p150         PASSED                     PASSING       0.9959663674101786   0.99       PCC_DIS  single_device    149.800  ENABLE_PCC_099

test_all_models_torch[mamba/pytorch-1.4b_HF-single_device-inference]                                                                       language    generality  n150         PASSED                     PASSING       0.9995349962170248   0.99       PCC_DIS  single_device    424.861  ENABLE_PCC_099
test_all_models_torch[mamba/pytorch-1.4b_HF-single_device-inference]                                                                       language    generality  p150         PASSED                     PASSING       0.999335671854287    0.99       PCC_DIS  single_device    273.336  ENABLE_PCC_099
test_all_models_torch[mamba/pytorch-2.8b_HF-single_device-inference]                                                                       language    generality  n150         PASSED                     PASSING       0.9994954567020254   0.99       PCC_DIS  single_device    836.661  ENABLE_PCC_099
test_all_models_torch[mamba/pytorch-2.8b_HF-single_device-inference]                                                                       language    generality  p150         PASSED                     PASSING       0.999692970158336    0.99       PCC_DIS  single_device    497.696  ENABLE_PCC_099
test_all_models_torch[mamba/pytorch-370M_HF-single_device-inference]                                                                       language    generality  n150         PASSED                     PASSING       0.9999516301479012   0.99       PCC_DIS  single_device    287.820  ENABLE_PCC_099
test_all_models_torch[mamba/pytorch-370M_HF-single_device-inference]                                                                       language    generality  p150         PASSED                     PASSING       0.999984462984458    0.99       PCC_DIS  single_device    201.578  ENABLE_PCC_099
test_all_models_torch[mamba/pytorch-790M_HF-single_device-inference]                                                                       language    generality  n150         PASSED                     PASSING       0.9978273871260293   0.99       PCC_DIS  single_device    366.521  ENABLE_PCC_099
test_all_models_torch[mamba/pytorch-790M_HF-single_device-inference]                                                                       language    generality  p150         PASSED                     PASSING       0.9961266858896014   0.99       PCC_DIS  single_device    241.329  ENABLE_PCC_099

test_all_models_torch[opt/causal_lm/pytorch-1.3b-single_device-inference]                                                                  language    generality  n150         PASSED                     PASSING       0.9959809874867499   0.99       PCC_DIS  single_device    108.153  ENABLE_PCC_099
test_all_models_torch[opt/causal_lm/pytorch-1.3b-single_device-inference]                                                                  language    generality  p150         PASSED                     PASSING       0.999471090054262    0.99       PCC_DIS  single_device    73.634   ENABLE_PCC_099

test_all_models_torch[phi2/causal_lm/pytorch-Phi_2_Pytdml-single_device-inference]                                                         language    generality  n150         PASSED                     PASSING       0.996019870445456    0.99       PCC_DIS  single_device    147.546  ENABLE_PCC_099
test_all_models_torch[phi2/causal_lm/pytorch-Phi_2_Pytdml-single_device-inference]                                                         language    generality  p150         PASSED                     PASSING       0.9958342396246354   0.99       PCC_DIS  single_device    104.803  ENABLE_PCC_099

test_all_models_torch[phi3/token_cls/pytorch-Mini_128K_Instruct-single_device-inference]                                                   language    generality  n150         PASSED                     PASSING       0.9981430530160372   0.98       PCC_EN   single_device    120.192  RAISE_PCC_099 
test_all_models_torch[phi3/token_cls/pytorch-Mini_128K_Instruct-single_device-inference]                                                   language    generality  p150         PASSED                     PASSING       0.9981496722313126   0.98       PCC_EN   single_device    110.266  RAISE_PCC_099 
test_all_models_torch[phi3/token_cls/pytorch-Mini_4K_Instruct-single_device-inference]                                                     language    generality  n150         PASSED                     PASSING       0.9946293457640243   0.97       PCC_EN   single_device    124.520  RAISE_PCC_099 
test_all_models_torch[phi3/token_cls/pytorch-Mini_4K_Instruct-single_device-inference]                                                     language    generality  p150         PASSED                     PASSING       0.997979560148218    0.97       PCC_EN   single_device    91.481   RAISE_PCC_099 

test_all_models_torch[qwen_1_5/causal_lm/pytorch-0.5B-single_device-inference]                                                             language    generality  n150         PASSED                     PASSING       0.9987332025636749   0.99       PCC_DIS  single_device    135.858  ENABLE_PCC_099
test_all_models_torch[qwen_1_5/causal_lm/pytorch-0.5B-single_device-inference]                                                             language    generality  p150         PASSED                     PASSING       0.9988076726175299   0.99       PCC_DIS  single_device    65.535   ENABLE_PCC_099
test_all_models_torch[qwen_1_5/causal_lm/pytorch-0_5B_Chat-single_device-inference]                                                        language    generality  n150         PASSED                     PASSING       0.9988374573611163   0.97       PCC_EN   single_device    78.355   RAISE_PCC_099 
test_all_models_torch[qwen_1_5/causal_lm/pytorch-0_5B_Chat-single_device-inference]                                                        language    generality  p150         PASSED                     PASSING       0.9997887005511514   0.97       PCC_EN   single_device    70.948   RAISE_PCC_099 

test_all_models_torch[qwen_2_5_coder/pytorch-3B-single_device-inference]                                                                   language    generality  n150         PASSED                     PASSING       0.9961538915381787   0.99       PCC_DIS  single_device    153.786  ENABLE_PCC_099
test_all_models_torch[qwen_2_5_coder/pytorch-3B-single_device-inference]                                                                   language    generality  p150         PASSED                     PASSING       0.9969537176481589   0.99       PCC_DIS  single_device    126.056  ENABLE_PCC_099
test_all_models_torch[qwen_2_5_coder/pytorch-3B_Instruct-single_device-inference]                                                          language    generality  n150         PASSED                     PASSING       0.9986399729583897   0.99       PCC_DIS  single_device    156.077  ENABLE_PCC_099
test_all_models_torch[qwen_2_5_coder/pytorch-3B_Instruct-single_device-inference]                                                          language    generality  p150         PASSED                     PASSING       0.9985206806090102   0.99       PCC_DIS  single_device    120.449  ENABLE_PCC_099
```


### Checklist
- [ ] New/Existing tests provide coverage for changes
