### PR TITLE
Update test config for phi2 model.

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -582,21 +582,18 @@ test_config:
     status: EXPECTED_PASSING
 
   phi2/token_classification/pytorch-Phi_2-single_device-inference:
-    assert_pcc: false # PCC: 0.8971 - https://github.com/tenstorrent/tt-xla/actions/runs/21091184273
-    status: EXPECTED_PASSING
     arch_overrides:
       p150:
-        required_pcc: 0.975 # p150 : https://github.com/tenstorrent/tt-xla/issues/2181
+        status: EXPECTED_PASSING
       n150:
-        assert_pcc: false # n150 : https://github.com/tenstorrent/tt-xla/issues/2433, large decrese with change torch==2.9.0
+        status: EXPECTED_PASSING
 
   phi2/token_classification/pytorch-Phi_2_Pytdml-single_device-inference:
-    status: EXPECTED_PASSING
     arch_overrides:
       p150:
-        required_pcc: 0.975 # p150 : https://github.com/tenstorrent/tt-xla/issues/2181
+        status: EXPECTED_PASSING
       n150:
-        assert_pcc: false # n150 : https://github.com/tenstorrent/tt-xla/issues/2433, large decrese with change torch==2.9.0
+        status: EXPECTED_PASSING
 
   phi2/sequence_classification/pytorch-Phi_2-single_device-inference:
     status: EXPECTED_PASSING


### PR DESCRIPTION
### Ticket
#2181 #2433

### Problem description
Re-Run the model in the latest main, and verfiy the results,

### What's changed
In the latest main branch, the model passes with the PCC values shown below on different machines, so the config file has been updated accordingly.

phi2/token_classification/pytorch-Phi_2-single_device-inference:
n150: 0.9901187770219674
p150: 0.9961960288821478

phi2/token_classification/pytorch-Phi_2_Pytdml-single_device-inference
n150: 0.9901187770219674
p150: 0.9961960288821478

I have attached the logs for reference:
[phi2_n150.log](https://github.com/user-attachments/files/25765809/phi2_n150.log)
[phi2_p150.log](https://github.com/user-attachments/files/25765811/phi2_p150.log)
[phi2_pytdml_n150.log](https://github.com/user-attachments/files/25765819/phi2_pytdml_n150.log)
[phi2_pytdml_p150.log](https://github.com/user-attachments/files/25765820/phi2_pytdml_p150.log)


### Checklist
- [ ] New/Existing tests provide coverage for changes
