### PR TITLE
Add failing-reason mappings for TorchXLA Error code 13 and UnboundLocalError

### DIFF
--- a/tests/infra/utilities/failing_reasons/checks_xla.py
+++ b/tests/infra/utilities/failing_reasons/checks_xla.py
@@ -234,6 +234,20 @@ class FailingReasons(Enum):
         ],
     )
 
+    UNBOUND_LOCAL_ERROR = FailingReason(
+        description="UnboundLocalError: cannot access local variable",
+        checks=[
+            # E   UnboundLocalError: cannot access local variable '<name>' where it is not associated with a value
+            ExceptionCheck(
+                class_name="UnboundLocalError",
+                message=[
+                    M.contains("cannot access local variable"),
+                    M.contains("not associated with a value"),
+                ],
+            ),
+        ],
+    )
+
     # Torch split_with_sizes shape mismatch on dimension
     SPLIT_WITH_SIZES_MISMATCH = FailingReason(
         description="RuntimeError: split_with_sizes expects split_sizes to sum exactly to <size>",
@@ -523,6 +537,56 @@ class FailingReasons(Enum):
                     M.any(
                         M.last_line(M.contains("tt_torch/backend/backend.py:")),
                         M.last_line(M.contains("torch_xla/torch_xla.py:")),
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    ERROR_CODE_13_XLA_WARM_UP_CACHE = FailingReason(
+        description="Error code 13 in xla_warm_up_cache call",
+        checks=[
+            # torch_xla/_dynamo/dynamo_bridge.py:483: in extract_graph_helper
+            #     torch_xla._XLAC._xla_warm_up_cache(args_and_out_tensor_only, [])
+            # E   ValueError: Error code: 13
+            ExceptionCheck(
+                class_name="ValueError",
+                message=[
+                    M.contains("Error code: 13"),
+                ],
+                error_log=[
+                    M.any(
+                        M.contains("_xla_warm_up_cache("),
+                        M.contains("torch_xla._XLAC._xla_warm_up_cache"),
+                    ),
+                    M.contains("torch_xla/_dynamo/dynamo_bridge.py"),
+                ],
+            ),
+        ],
+    )
+
+    ERROR_CODE_13_XLA_STEP_MARKER = FailingReason(
+        description="Error code 13 in xla_step_marker call",
+        checks=[
+            # venv/lib/python3.12/site-packages/torch_xla/_dynamo/dynamo_bridge.py:826: in extract_compiled_graph_helper
+            #     torch_xla.sync(reset_scope=False)
+            # venv/lib/python3.12/site-packages/torch_xla/torch_xla.py:87: in sync
+            #     torch_xla._XLAC._xla_step_marker(
+            # E   ValueError: Error code: 13
+            ExceptionCheck(
+                class_name="ValueError",
+                message=[
+                    M.contains("Error code: 13"),
+                ],
+                error_log=[
+                    M.any(
+                        M.contains("_xla_step_marker("),
+                        M.contains("torch_xla._XLAC._xla_step_marker"),
+                    ),
+                    M.contains("torch_xla/torch_xla.py"),
+                    M.any(
+                        M.contains("torch_xla.sync("),
+                        M.contains("torch_xla/torch_xla.py:"),
                     ),
                 ],
             ),


### PR DESCRIPTION
### Ticket
Fixes #3472 

### Problem description
To add entries for new errors in checks_xla and ensure models are not being detected as unclassified errors.

### What's changed

- The update introduces two new error classifications to better detect Torch XLA runtime failures with Error code: 13. The first, ERROR_CODE_13_XLA_WARM_UP_CACHE, targets failures occurring during torch_xla._XLAC._xla_warm_up_cache(...), typically surfaced in torch_xla/_dynamo/dynamo_bridge.py. It matches when the exception is a ValueError, the message contains "Error code: 13", and the traceback includes _xla_warm_up_cache. This rule intentionally does not require the component to be identified as XLA, ensuring detection even when the component heuristic misses XLA-related traces.

- The second classification, ERROR_CODE_13_XLA_STEP_MARKER, captures similar ValueError: Error code: 13 failures that happen during synchronization when torch_xla.sync(...) invokes torch_xla._XLAC._xla_step_marker(...). It matches when the traceback includes _xla_step_marker, references torch_xla/torch_xla.py, and indicates the call originated from torch_xla.sync(...). Together, these additions improve the system’s ability to precisely categorize XLA runtime errors occurring during cache warm-up and step synchronization phases.

- A third addition introduces a new failure classification for UnboundLocalError, enabling the system to detect cases where a local variable is accessed before being assigned. This rule matches when the exception type is UnboundLocalError and the error message contains both "cannot access local variable" and "not associated with a value", allowing such Python runtime errors to be consistently grouped into a dedicated failure bucket for clearer reporting and analysis.

### Logs
[ssdlite320.log](https://github.com/user-attachments/files/25768581/ssdlite320.log)
[bevformer_v2_r50_t1.log](https://github.com/user-attachments/files/25786438/bevformer_v2_r50_t1.log)
