### PR TITLE
Enable dtype in CI runs log summary

### DIFF
--- a/.github/scripts/summarize_junit_xmls.py
+++ b/.github/scripts/summarize_junit_xmls.py
@@ -186,6 +186,7 @@ def get_columns() -> List[str]:
         "specific_test_case",
         "model_type",
         "group",
+        "weights_dtype",
         "arch",
         "bringup_status",
         "model_status",
@@ -241,6 +242,9 @@ def iter_test_records(tree: ET.ElementTree) -> Iterator[Dict]:
         # Get model_status from model_test_status field in tags (optional)
         model_test_status = record.get("model_test_status")
         record["model_status"] = normalize_model_test_status(model_test_status)
+
+        # Data type / weights_dtype: support both tag keys (e.g. "weights_dtype": "bfloat16")
+        record["weights_dtype"] = record.get("weights_dtype") or ""
 
         yield record
 

--- a/tests/runner/test_models.py
+++ b/tests/runner/test_models.py
@@ -94,9 +94,10 @@ def _run_model_test_impl(
 
         if compiler_config is None:
             compiler_config = CompilerConfig()
-
+        weights_dtype = None
         if test_metadata.enable_weight_bfp8_conversion:
             compiler_config.experimental_enable_weight_bfp8_conversion = True
+            weights_dtype = "bfp8"
 
         if ir_dump_path:
             compiler_config.export_path = ir_dump_path
@@ -200,6 +201,7 @@ def _run_model_test_impl(
                 comparison_results=list(comparison_result) if comparison_result else [],
                 comparison_config=comparison_config,
                 model_size=model_size,
+                weights_dtype=weights_dtype,
             )
 
             # prints perf benchmark results to console
@@ -616,7 +618,7 @@ def test_placeholder_models(model_name, record_property, request):
 
     model_info = DummyModelInfo(model_name_lc)
     test_metadata = ModelTestConfig(data=model_test_config_data, arch=None)
-
+    weights_dtype = None
     record_model_test_properties(
         record_property,
         request,
@@ -624,4 +626,5 @@ def test_placeholder_models(model_name, record_property, request):
         test_metadata=test_metadata,
         run_mode=RunMode.INFERENCE,
         parallelism=Parallelism.SINGLE_DEVICE,
+        weights_dtype=weights_dtype,
     )

--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -493,6 +493,7 @@ def record_model_test_properties(
     comparison_results: list = None,
     comparison_config=None,
     model_size: int = None,
+    weights_dtype: str = None,
 ):
     """
     Record standard runtime properties for model tests and optionally control flow.
@@ -595,6 +596,7 @@ def record_model_test_properties(
         "arch": arch,
         "seq_len": getattr(test_metadata, "seq_len", None),
         "batch_size": getattr(test_metadata, "batch_size", None),
+        "weights_dtype": weights_dtype if weights_dtype is not None else "bfloat16",
     }
 
     # Add model size (in billions of parameters) to tags if available


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Enable dtype in CI runs log summary

### What's changed
Initially, the CI runs summary did not include a data_type column. This was not an issue when runs were executed with only one data type (bfloat16). However, in the latest main, I noticed that with enable_weight_bfp8_conversion: true, the model can now run in bfp8 data type. This could cause confusion about which data type the model is using.

To address this, I have added a new data_type column in the CI log summary, which reflects the data type of each model run based on the configuration files.

Below is the ci log summary:
```
specific_test_case                                                                                                                          model_type  group       arch          bringup_status             model_status  pcc                    pcc_thres  pcc_en   parallelism      time      guidance                
N/A                                                                                                                                         unknown     red         N/A           N/A                        N/A           N/A                    N/A        N/A      N/A              216.713   N/A                     
test_all_models_jax[alexnet/image_classification/jax-Custom_1x2-tensor_parallel-inference]                                                  vision      generality  n300-llmbox   PASSED                     PASSING       1.0                    0.99       PCC_EN   tensor_parallel  80.169    N/A                     
test_all_models_jax[bert/masked_lm/jax-Base-single_device-inference]                                                                        language    generality  n150          PASSED                     PASSING       0.9996176423520953     0.99       PCC_EN   single_device    49.223    N/A                     
test_all_models_jax[bert/masked_lm/jax-Base-single_device-inference]                                                                        language    generality  p150          PASSED                     PASSING       0.9995732367714768     0.99       PCC_EN   single_device    38.542    N/A          
```           
After my change:
A new column is added in the log summary data_type.
updated the config files to run QWEN-2.5-0.5B and QWEN-3.0-6B with bfloat16(default) weights, and QWEN-3.1-7B with bfp8 weights by enabling the enable_weight_bfp8_conversion: true parameter.
```
specific_test_case                                                                       model_type  group  data_type  arch  bringup_status  model_status  pcc                 pcc_thres  pcc_en  parallelism    time     guidance
test_all_models_torch[qwen_2_5/causal_lm/pytorch-0.5B_Instruct-single_device-inference]  language    red    bfloat16   n150  PASSED          PASSING       0.9942524177514536  0.99       PCC_EN  single_device  149.049  N/A     
test_all_models_torch[qwen_3/causal_lm/pytorch-0_6B-single_device-inference]             language    red    bfloat16   n150  PASSED          PASSING       0.9990071968735074  0.99       PCC_EN  single_device  179.329  N/A     
test_all_models_torch[qwen_3/causal_lm/pytorch-1_7B-single_device-inference]             language    red    bfp8       n150  PASSED          PASSING       0.9982919495485162  0.99       PCC_EN  single_device  136.334  N/A     
```
### Checklist
- [ ] New/Existing tests provide coverage for changes
