### PR TITLE
Disable p150-experimental and n150 llm accuracy tests

### DIFF
--- a/.github/workflows/manual-benchmark.yml
+++ b/.github/workflows/manual-benchmark.yml
@@ -171,9 +171,9 @@ jobs:
           ${{ inputs.sh-runner && '--sh-runner' || '' }})
 
         matrix=$(echo $result | jq -r -c '.matrix')
-        matrix_n150=$(echo $result | jq -r -c '.matrix | map(select(."runs-on" | contains("n150") and (contains("llmbox") | not)))')
-        matrix_p150=$(echo $result | jq -r -c '.matrix | map(select(."runs-on" | contains("p150")))')
-        matrix_llmbox=$(echo $result | jq -r -c '.matrix | map(select(."runs-on" | contains("llmbox")))')
+        matrix_n150=$(echo $result | jq -r -c '.matrix | map(select((."runs-on" | contains("n150") and (contains("llmbox") | not)) and (.["accuracy-testing"] != true)))')
+        matrix_p150=$(echo $result | jq -r -c '.matrix | map(select((."runs-on" | contains("p150")) and (.["accuracy-testing"] != true)))')
+        matrix_llmbox=$(echo $result | jq -r -c '.matrix | map(select((."runs-on" | contains("llmbox")) and (.["accuracy-testing"] != true)))')
         matrix_galaxy=$(echo $result | jq -r -c '.matrix | map(select(."runs-on" | contains("galaxy")))')
 
         matrix_n150_skip="false"

--- a/.github/workflows/schedule-benchmark-experimental.yml
+++ b/.github/workflows/schedule-benchmark-experimental.yml
@@ -48,7 +48,7 @@ jobs:
           "tt-xla")
 
         matrix=$(echo $result | jq -r -c '.matrix')
-        matrix_p150=$(echo $result | jq -r -c '.matrix | map(select(."runs-on" | contains("p150")))')
+        matrix_p150=$(echo $result | jq -r -c '.matrix | map(select((."runs-on" | contains("p150")) and (.["accuracy-testing"] != true)))')
 
         matrix_p150_skip="false"
 


### PR DESCRIPTION
This PR filters out accuracy rests from p150 experimental and n150 nightly.

Recently added accuracy (top1/top5) tests were not properly filtered #3461
They were executing in:
- n150 nightly
- n150 experimental nightly
- p150 experimental nightly

We want them only in n150 experimental nightly.