### PR TITLE
[vLLM Plugin] Fix /v1/responses API test timeout and logprobs (#3061)

### DIFF
--- a/tests/integrations/vllm_plugin/generative/test_responses_api.py
+++ b/tests/integrations/vllm_plugin/generative/test_responses_api.py
@@ -316,6 +316,7 @@ def test_responses_api_top_logprobs(vllm_server):
         "max_output_tokens": 5,
         "temperature": 0.0,
         "top_logprobs": 3,
+        "include": ["message.output_text.logprobs"],
     }
 
     response = requests.post(url, json=data, timeout=REQUEST_TIMEOUT)
@@ -332,7 +333,7 @@ def test_responses_api_top_logprobs(vllm_server):
         if item.get("type") == "message":
             for content in item.get("content", []):
                 if content.get("type") == "output_text":
-                    logprobs = content.get("logprobs", [])
+                    logprobs = content.get("logprobs") or []
                     assert len(logprobs) > 0, "Expected logprobs in output_text content"
                     for entry in logprobs:
                         assert "token" in entry, "Logprob entry should have 'token'"


### PR DESCRIPTION
## Ticket
Follow-up to #3061

## Summary
Fix two issues with the `/v1/responses` API integration tests added in #3585.

## What's changed
- `tests/integrations/vllm_plugin/generative/test_responses_api.py`:
  - Increase server startup timeout from 300s to 600s. CI runners take close to 300s for model download + TT device compilation, causing flaky timeouts.
  - Fix `test_responses_api_top_logprobs`: add `"include": ["message.output_text.logprobs"]` to opt in to logprob output per the OpenAI Responses API spec, and handle explicit `None` logprobs values.

## Checklist
- [x] Tests pass locally
- [x] Tests pass on CI: https://github.com/tenstorrent/tt-xla/actions/runs/22774740325/job/66066997323