### PR TITLE
Add GLM attention graph tests

### DIFF
--- a/tests/torch/graphs/test_attention.py
+++ b/tests/torch/graphs/test_attention.py
@@ -2466,7 +2466,7 @@ def test_gpt_oss_attention_decode(variant, variant_config, arch):
 
 @pytest.mark.nightly
 @pytest.mark.llmbox
-@pytest.mark.parametrize("seq_len", [1032])
+@pytest.mark.parametrize("seq_len", [1024])
 @pytest.mark.parametrize(
     "variant,variant_config",
     get_available_variants("glm").items(),


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/3619

### Problem description
We want to add GLM attention tests.

### What's changed
Added tests for GLM attention prefill, attention decode and attention following the format of existing attention tests. Differences for GLM are:
- prefill doesn't fit on a single device and so it's only run on an llmbox
- attention_bias=True, so the shard spec includes q/k/v_proj.bias entries
- GLM uses partial rotary embeddings (`partial_rotary_factor=0.5`), so `cos_sin` size uses `rope_dim = head_dim × partial_rotary_factor` rather than `head_dim`

### Checklist
- [x] New/Existing tests provide coverage for changes
