### PR TITLE
Add support for sparse moe

### DIFF
--- a/python_package/tt_torch/__init__.py
+++ b/python_package/tt_torch/__init__.py
@@ -18,4 +18,7 @@ from .serialization import (
     parse_compiled_artifacts_from_cache_to_disk,
 )
 from .sharding import sharding_constraint_hook
+
+# Sparse MLP for MoE models
+from .sparse_mlp import A2aSparseMLP, SparseMLP, enable_sparse_mlp
 from .tools import mark_module_user_inputs

--- a/python_package/tt_torch/custom_ops.py
+++ b/python_package/tt_torch/custom_ops.py
@@ -817,6 +817,489 @@ def paged_scaled_dot_product_attention_decode_fake(
     return torch.zeros_like(query)
 
 
+@torch.library.custom_op(
+    "tt::sparse_matmul", mutates_args=[], device_types=["xla", "cpu"]
+)
+def sparse_matmul(
+    input_tensor_a: torch.Tensor,
+    input_tensor_b: torch.Tensor,
+    sparsity: torch.Tensor,
+    nnz: int = None,
+    is_input_a_sparse: bool = False,
+    is_input_b_sparse: bool = True,
+) -> torch.Tensor:
+    """
+    Sparse matrix multiplication for MoE (Mixture of Experts) models.
+
+    This operation performs matrix multiplication where computation is skipped
+    for sparse (zero) blocks based on the sparsity tensor.
+
+    Args:
+        input_tensor_a: First input tensor. Shape depends on sparse mode:
+            - is_input_a_sparse=True, is_input_b_sparse=True: [1, E, M, K]
+            - is_input_a_sparse=False, is_input_b_sparse=True: [A, B, M, K]
+            - is_input_a_sparse=True, is_input_b_sparse=False: [A, E, M, K]
+        input_tensor_b: Second input tensor (expert weights). Shape:
+            - [1, E, K, N] for all modes
+        sparsity: Sparsity mask tensor (bfloat16, ROW_MAJOR). Shape depends on mode:
+            - is_input_a_sparse=True, is_input_b_sparse=True: [1, 1, 1, E]
+            - is_input_a_sparse=False, is_input_b_sparse=True: [A, B, 1, E]
+            - is_input_a_sparse=True, is_input_b_sparse=False: [1, 1, A, E]
+        nnz: Number of non-zero elements in sparsity tensor. If None, inferred at runtime.
+        is_input_a_sparse: Whether input_tensor_a is sparse.
+        is_input_b_sparse: Whether input_tensor_b is sparse.
+
+    Returns:
+        Output tensor with sparse results. Shape depends on mode:
+            - is_input_a_sparse=True, is_input_b_sparse=True: [1, E, M, N]
+            - is_input_a_sparse=False, is_input_b_sparse=True: [A, B, 1, E, M, N]
+            - is_input_a_sparse=True, is_input_b_sparse=False: [A, E, M, N]
+    """
+    device = input_tensor_a.device
+
+    if device.type == "xla":
+        frontend_attributes = {
+            "is_input_a_sparse": str(is_input_a_sparse),
+            "is_input_b_sparse": str(is_input_b_sparse),
+        }
+        if nnz is not None:
+            frontend_attributes["nnz"] = str(nnz)
+
+        # Compute output shape based on sparse mode
+        if is_input_a_sparse and is_input_b_sparse:
+            # [1, E, M, K] @ [1, E, K, N] -> [1, E, M, N]
+            output_shape = list(input_tensor_a.shape)
+            output_shape[-1] = input_tensor_b.shape[-1]
+        elif not is_input_a_sparse and is_input_b_sparse:
+            # [A, B, M, K] @ [1, E, K, N] -> [A, B, 1, E, M, N]
+            A, B, M, K = input_tensor_a.shape
+            E = input_tensor_b.shape[1]
+            N = input_tensor_b.shape[-1]
+            output_shape = [A, B, 1, E, M, N]
+        elif is_input_a_sparse and not is_input_b_sparse:
+            # [A, E, M, K] @ [1, E, K, N] -> [A, E, M, N]
+            output_shape = list(input_tensor_a.shape)
+            output_shape[-1] = input_tensor_b.shape[-1]
+        else:
+            raise ValueError(
+                "Invalid sparse mode: both is_input_a_sparse and is_input_b_sparse cannot be False"
+            )
+
+        return stablehlo_custom_call.stablehlo_custom_call(
+            [input_tensor_a, input_tensor_b, sparsity],
+            "tt.sparse_matmul",
+            [output_shape],
+            [input_tensor_a.dtype],
+            frontend_attributes=frontend_attributes,
+        )
+
+    elif device.type == "cpu":
+        # CPU fallback: loop over experts to avoid broadcasting weights
+        # across large batch dimensions (can exceed 1TB for D=8, E=32).
+        input_b_casted = input_tensor_b.to(input_tensor_a.dtype)
+
+        if is_input_a_sparse and is_input_b_sparse:
+            # [1, E, M, K] @ [1, E, K, N] -> [1, E, M, N]
+            E = input_tensor_b.shape[1]
+            N = input_tensor_b.shape[-1]
+            M = input_tensor_a.shape[2]
+            output = torch.zeros(1, E, M, N, dtype=input_tensor_a.dtype, device=device)
+            for e in range(E):
+                if sparsity[0, 0, 0, e] > 0:
+                    output[0, e] = torch.matmul(
+                        input_tensor_a[0, e], input_b_casted[0, e]
+                    )
+            return output
+
+        elif not is_input_a_sparse and is_input_b_sparse:
+            # [A, B, M, K] @ [1, E, K, N] -> [A, B, 1, E, M, N]
+            A, B, M, K = input_tensor_a.shape
+            E = input_tensor_b.shape[1]
+            N = input_tensor_b.shape[-1]
+            output = torch.zeros(
+                A, B, 1, E, M, N, dtype=input_tensor_a.dtype, device=device
+            )
+            for e in range(E):
+                mask_e = sparsity[:, :, 0, e]  # [A, B]
+                if mask_e.any():
+                    # [A, B, M, K] @ [K, N] -> [A, B, M, N]
+                    out_e = torch.matmul(input_tensor_a, input_b_casted[0, e])
+                    output[:, :, 0, e, :, :] = out_e * mask_e.unsqueeze(-1).unsqueeze(
+                        -1
+                    )
+            return output
+
+        elif is_input_a_sparse and not is_input_b_sparse:
+            # [A, E, M, K] @ [1, E, K, N] -> [A, E, M, N]
+            A = input_tensor_a.shape[0]
+            E = input_tensor_b.shape[1]
+            M = input_tensor_a.shape[2]
+            N = input_tensor_b.shape[-1]
+            output = torch.zeros(A, E, M, N, dtype=input_tensor_a.dtype, device=device)
+            for e in range(E):
+                mask_e = sparsity[0, 0, :, e]  # [A]
+                if mask_e.any():
+                    # [A, M, K] @ [K, N] -> [A, M, N]
+                    out_e = torch.matmul(input_tensor_a[:, e], input_b_casted[0, e])
+                    output[:, e] = out_e * mask_e.unsqueeze(-1).unsqueeze(-1)
+            return output
+
+        else:
+            raise ValueError(
+                "Invalid sparse mode: both is_input_a_sparse and is_input_b_sparse cannot be False"
+            )
+    else:
+        raise ValueError(f"Unsupported device type: {device.type}")
+
+
+@sparse_matmul.register_fake
+def sparse_matmul_fake(
+    input_tensor_a: torch.Tensor,
+    input_tensor_b: torch.Tensor,
+    sparsity: torch.Tensor,
+    nnz: int = None,
+    is_input_a_sparse: bool = False,
+    is_input_b_sparse: bool = True,
+) -> torch.Tensor:
+    """FakeTensor implementation of sparse_matmul for torch dynamo tracing."""
+    if is_input_a_sparse and is_input_b_sparse:
+        output_shape = list(input_tensor_a.shape)
+        output_shape[-1] = input_tensor_b.shape[-1]
+    elif not is_input_a_sparse and is_input_b_sparse:
+        A, B, M, K = input_tensor_a.shape
+        E = input_tensor_b.shape[1]
+        N = input_tensor_b.shape[-1]
+        output_shape = [A, B, 1, E, M, N]
+    elif is_input_a_sparse and not is_input_b_sparse:
+        output_shape = list(input_tensor_a.shape)
+        output_shape[-1] = input_tensor_b.shape[-1]
+    else:
+        raise ValueError(
+            "Invalid sparse mode: both is_input_a_sparse and is_input_b_sparse cannot be False"
+        )
+
+    return torch.zeros(
+        output_shape, dtype=input_tensor_a.dtype, device=input_tensor_a.device
+    )
+
+
+@torch.library.custom_op(
+    "tt::all_to_all_dispatch", mutates_args=[], device_types=["xla", "cpu"]
+)
+def all_to_all_dispatch(
+    input_tensor: torch.Tensor,
+    expert_indices: torch.Tensor,
+    expert_mapping: torch.Tensor,
+    num_devices: int = 1,
+    cluster_axis: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Dispatch tokens to devices holding their selected experts.
+
+    Selectively routes tokens based on expert_indices and expert_mapping,
+    sending each token only to devices that hold its selected experts.
+
+    Args:
+        input_tensor: Input tokens [B, 1, S, H], bfloat16
+        expert_indices: Selected expert IDs per token [B, 1, S, K], int64
+        expert_mapping: One-hot expert-to-device mapping [1, 1, E, D], int64
+        num_devices: Number of devices along dispatch axis (D)
+        cluster_axis: Mesh axis to dispatch along (0=rows, 1=cols)
+
+    Returns:
+        dispatched_tokens: [1, B*D, S, H] sparsely populated tokens
+        expert_metadata: [1, B*D, S, K] all-gathered expert indices
+    """
+    device = input_tensor.device
+    B, _, S, H = input_tensor.shape
+    K = expert_indices.shape[-1]
+
+    if device.type == "xla":
+        BD = B * num_devices
+        output_shapes = [[1, BD, S, H], [1, BD, S, K]]
+        output_dtypes = [input_tensor.dtype, expert_indices.dtype]
+
+        frontend_attributes = {
+            "num_devices": str(num_devices),
+            "cluster_axis": str(cluster_axis),
+        }
+
+        return stablehlo_custom_call.stablehlo_custom_call(
+            [input_tensor, expert_indices, expert_mapping],
+            "tt.all_to_all_dispatch",
+            output_shapes,
+            output_dtypes,
+            frontend_attributes=frontend_attributes,
+        )
+
+    elif device.type == "cpu":
+        # CPU fallback: simulate dispatch by repeating tokens D times.
+        # Shape must match fake kernel: [1, B*D, S, H] and [1, B*D, S, K].
+        # On real hardware, dispatch selectively routes tokens; on CPU we
+        # replicate so that downstream sparse_matmul sees all tokens.
+        x = input_tensor.permute(1, 0, 2, 3)  # [1, B, S, H]
+        m = expert_indices.permute(1, 0, 2, 3)  # [1, B, S, K]
+        if num_devices > 1:
+            x = x.repeat(1, num_devices, 1, 1)  # [1, B*D, S, H]
+            m = m.repeat(1, num_devices, 1, 1)  # [1, B*D, S, K]
+        return x.clone(), m.clone()
+
+    else:
+        raise ValueError(f"Unsupported device type: {device.type}")
+
+
+@all_to_all_dispatch.register_fake
+def all_to_all_dispatch_fake(
+    input_tensor: torch.Tensor,
+    expert_indices: torch.Tensor,
+    expert_mapping: torch.Tensor,
+    num_devices: int = 1,
+    cluster_axis: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    B, _, S, H = input_tensor.shape
+    K = expert_indices.shape[-1]
+    BD = B * num_devices
+
+    dispatched = torch.zeros(
+        [1, BD, S, H], dtype=input_tensor.dtype, device=input_tensor.device
+    )
+    metadata = torch.zeros(
+        [1, BD, S, K], dtype=expert_indices.dtype, device=expert_indices.device
+    )
+    return dispatched, metadata
+
+
+@torch.library.custom_op(
+    "tt::all_to_all_combine", mutates_args=[], device_types=["xla", "cpu"]
+)
+def all_to_all_combine(
+    input_tensor: torch.Tensor,
+    expert_metadata: torch.Tensor,
+    expert_mapping: torch.Tensor,
+    num_devices: int = 1,
+    cluster_axis: int = 0,
+    num_experts_per_tok: int = 2,
+    output_shard_dim: int = 1,
+) -> torch.Tensor:
+    """
+    Combine expert outputs back to original token positions.
+
+    Inverse of dispatch: gathers expert computation results from all devices
+    and restores tokens to their original device and order.
+
+    Args:
+        input_tensor: Expert outputs, bfloat16. Shape depends on output_shard_dim:
+            - output_shard_dim=1: [E_local, B*D, S, H] (default)
+            - output_shard_dim=2: [E_local, S, B*D, H] (decode-optimized, avoids tile waste on S=1)
+        expert_metadata: Routing metadata from dispatch [1, B*D, S, K], int64
+        expert_mapping: One-hot expert-to-device mapping [1, 1, E, D], int64
+        num_devices: Number of devices along dispatch axis (D)
+        cluster_axis: Mesh axis to combine along (0=rows, 1=cols)
+        num_experts_per_tok: Number of selected experts per token (K)
+        output_shard_dim: Dimension index for the BD shard dimension (1 or 2).
+            Use 2 for decode to place BD on dim -2 and avoid tile padding on S=1.
+
+    Returns:
+        combined: Shape depends on output_shard_dim:
+            - output_shard_dim=1: [K, B, S, H]
+            - output_shard_dim=2: [K, S, B, H]
+    """
+    device = input_tensor.device
+    K = num_experts_per_tok
+
+    if output_shard_dim == 1:
+        E_local, BD, S, H = input_tensor.shape
+    elif output_shard_dim == 2:
+        E_local, S, BD, H = input_tensor.shape
+    else:
+        raise ValueError(f"output_shard_dim must be 1 or 2, got {output_shard_dim}")
+
+    B = BD // num_devices
+
+    if device.type == "xla":
+        if output_shard_dim == 1:
+            output_shape = [K, B, S, H]
+        else:
+            output_shape = [K, S, B, H]
+
+        frontend_attributes = {
+            "num_devices": str(num_devices),
+            "cluster_axis": str(cluster_axis),
+            "num_experts_per_tok": str(K),
+            "output_shard_dim": str(output_shard_dim),
+        }
+
+        return stablehlo_custom_call.stablehlo_custom_call(
+            [input_tensor, expert_metadata, expert_mapping],
+            "tt.all_to_all_combine",
+            [output_shape],
+            [input_tensor.dtype],
+            frontend_attributes=frontend_attributes,
+        )
+
+    elif device.type == "cpu":
+        # CPU fallback: dispatch repeats tokens D times, so BD = B * D.
+        # Combine reverses this by taking only the first B entries (all
+        # D copies are identical on CPU since dispatch just replicates).
+        B_local = BD // num_devices
+        metadata_indices = expert_metadata[0]  # [BD, S, K]
+
+        if output_shard_dim == 1:
+            combined = torch.zeros(
+                K, B_local, S, H, dtype=input_tensor.dtype, device=device
+            )
+            for b in range(B_local):
+                for s in range(S):
+                    for k in range(K):
+                        expert_id = metadata_indices[b, s, k].item()
+                        if 0 <= expert_id < E_local:
+                            combined[k, b, s, :] = input_tensor[expert_id, b, s, :]
+        else:
+            combined = torch.zeros(
+                K, S, B_local, H, dtype=input_tensor.dtype, device=device
+            )
+            for b in range(B_local):
+                for s in range(S):
+                    for k in range(K):
+                        expert_id = metadata_indices[b, s, k].item()
+                        if 0 <= expert_id < E_local:
+                            combined[k, s, b, :] = input_tensor[expert_id, s, b, :]
+
+        return combined
+
+    else:
+        raise ValueError(f"Unsupported device type: {device.type}")
+
+
+@all_to_all_combine.register_fake
+def all_to_all_combine_fake(
+    input_tensor: torch.Tensor,
+    expert_metadata: torch.Tensor,
+    expert_mapping: torch.Tensor,
+    num_devices: int = 1,
+    cluster_axis: int = 0,
+    num_experts_per_tok: int = 2,
+    output_shard_dim: int = 1,
+) -> torch.Tensor:
+    K = num_experts_per_tok
+
+    if output_shard_dim == 1:
+        _, BD, S, H = input_tensor.shape
+        B = BD // num_devices
+        return torch.zeros(
+            [K, B, S, H], dtype=input_tensor.dtype, device=input_tensor.device
+        )
+    else:
+        _, S, BD, H = input_tensor.shape
+        B = BD // num_devices
+        return torch.zeros(
+            [K, S, B, H], dtype=input_tensor.dtype, device=input_tensor.device
+        )
+
+
+@torch.library.custom_op(
+    "tt::moe_expert_token_remap", mutates_args=[], device_types=["xla", "cpu"]
+)
+def moe_expert_token_remap(
+    topk_tensor: torch.Tensor,
+    expert_mapping: torch.Tensor,
+    expert_metadata: torch.Tensor,
+    reduction_size: int = 16,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Convert global expert routing to local device expert mapping and sparsity.
+
+    Remaps global expert indices from dispatch metadata to local per-device
+    expert indices and creates a sparsity pattern for efficient sparse_matmul.
+
+    The batch dimension B should include all dispatch groups (B = BD = batch *
+    dispatch_devices) so the kernel processes all tokens and produces correctly
+    sized outputs without needing post-hoc tiling.
+
+    Args:
+        topk_tensor: Routing scores [1, B, S, E], bfloat16
+        expert_mapping: Expert-to-device mapping [1, 1, E, D], int64
+        expert_metadata: Expert indices from dispatch [1, B, S, K], int64
+        reduction_size: Group size for sparsity reduction (default 16)
+
+    Returns:
+        mapping: Expert routing weights [1, B, S, E], bfloat16 (compound-sharded to E_local on device)
+        reduced: Sparsity pattern [1, 1, ceil(B*S/reduction_size), E], bfloat16 (compound-sharded to E_local on device)
+    """
+    import math
+
+    device = topk_tensor.device
+    D, B, S, E = topk_tensor.shape
+    K = expert_metadata.shape[-1]
+    num_devices = expert_mapping.shape[-1]
+    E_local = E // num_devices
+
+    reduced_seq = math.ceil(B * S / reduction_size)
+
+    if device.type == "xla":
+        output_shapes = [
+            [1, B, S, E],
+            [1, 1, reduced_seq, E],
+        ]
+        output_dtypes = [topk_tensor.dtype, topk_tensor.dtype]
+
+        frontend_attributes = {
+            "reduction_size": str(reduction_size),
+        }
+
+        return stablehlo_custom_call.stablehlo_custom_call(
+            [topk_tensor, expert_mapping, expert_metadata],
+            "tt.moe_expert_token_remap",
+            output_shapes,
+            output_dtypes,
+            frontend_attributes=frontend_attributes,
+        )
+
+    # CPU fallback: uses global E shape (compiler shards to E_local on device)
+    # Populate ALL experts so downstream sparse_matmul produces valid output
+    # for every device (not just device 0).
+    mapping = torch.zeros(1, B, S, E, dtype=topk_tensor.dtype, device=device)
+    reduced = torch.zeros(1, 1, reduced_seq, E, dtype=topk_tensor.dtype, device=device)
+
+    for d in range(D):
+        for b in range(B):
+            for s in range(S):
+                for k in range(K):
+                    global_expert = expert_metadata[d, b, s, k].item()
+                    mapping[0, b, s, global_expert] = topk_tensor[
+                        d, b, s, global_expert
+                    ]
+                    chunk_idx = (b * S + s) // reduction_size
+                    if chunk_idx < reduced_seq:
+                        reduced[0, 0, chunk_idx, global_expert] = 1.0
+
+    return mapping, reduced
+
+
+@moe_expert_token_remap.register_fake
+def moe_expert_token_remap_fake(
+    topk_tensor: torch.Tensor,
+    expert_mapping: torch.Tensor,
+    expert_metadata: torch.Tensor,
+    reduction_size: int = 16,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    import math
+
+    D, B, S, E = topk_tensor.shape
+    num_devices = expert_mapping.shape[-1]
+    reduced_seq = math.ceil(B * S / reduction_size)
+
+    mapping = torch.zeros(
+        [1, B, S, E], dtype=topk_tensor.dtype, device=topk_tensor.device
+    )
+    reduced = torch.zeros(
+        [1, 1, reduced_seq, E],
+        dtype=topk_tensor.dtype,
+        device=topk_tensor.device,
+    )
+    return mapping, reduced
+
+
 # Allow the torch dynamo to trace our custom operation(s). This will allow
 # the tt custom operation(s) to be represented in a torch.fx.GraphModule.
 for attr in dir(torch.ops.tt):

--- a/python_package/tt_torch/sharding.py
+++ b/python_package/tt_torch/sharding.py
@@ -19,7 +19,7 @@ import torch
 _MESH_IDX_PREFIX = "mesh_idx_"
 
 
-def _partition_spec_to_sdy_sharding(mesh, partition_spec) -> str:
+def _partition_spec_to_sdy_sharding(mesh, partition_spec, unreduced=None) -> str:
     """
     Convert a partition_spec to an sdy.sharding string.
 
@@ -32,6 +32,9 @@ def _partition_spec_to_sdy_sharding(mesh, partition_spec) -> str:
         partition_spec = ("batch", None, None)
         mesh.axis_names = ("batch", "model")
         → '#sdy.sharding_per_value<[<@mesh, [{"mesh_idx_0"}, {}, {}]>]>'
+
+        With unreduced=["model"]:
+        → '#sdy.sharding_per_value<[<@mesh, [{"mesh_idx_0"}, {}, {}], unreduced={"mesh_idx_1"}>]>'
     """
     dim_shardings = []
     for axis in partition_spec:
@@ -50,13 +53,45 @@ def _partition_spec_to_sdy_sharding(mesh, partition_spec) -> str:
         elif isinstance(axis, int):
             if mesh.mesh_shape[axis] > 1:
                 dim_shardings.append(f'{{"{_MESH_IDX_PREFIX}{axis}"}}')
+            dim_shardings.append(f'{{"{_MESH_IDX_PREFIX}{axis}"}}')
+        elif isinstance(axis, (list, tuple)):
+            # Compound sharding: ("model", "batch") → single dim sharded on both axes
+            axis_refs = []
+            for ax_name in axis:
+                if isinstance(ax_name, str):
+                    try:
+                        axis_idx = mesh.axis_names.index(ax_name)
+                        axis_refs.append(f'"{_MESH_IDX_PREFIX}{axis_idx}"')
+                    except ValueError:
+                        pass
+                elif isinstance(ax_name, int):
+                    axis_refs.append(f'"{_MESH_IDX_PREFIX}{ax_name}"')
+            if axis_refs:
+                dim_shardings.append("{" + ", ".join(axis_refs) + "}")
             else:
                 dim_shardings.append("{}")
         else:
             dim_shardings.append("{}")
 
     dims_str = ", ".join(dim_shardings)
-    return f"#sdy.sharding_per_value<[<@mesh, [{dims_str}]>]>"
+
+    # Build unreduced axes string if specified
+    unreduced_str = ""
+    if unreduced:
+        unreduced_refs = []
+        for ax in unreduced:
+            if isinstance(ax, str):
+                try:
+                    axis_idx = mesh.axis_names.index(ax)
+                    unreduced_refs.append(f'"{_MESH_IDX_PREFIX}{axis_idx}"')
+                except ValueError:
+                    pass
+            elif isinstance(ax, int):
+                unreduced_refs.append(f'"{_MESH_IDX_PREFIX}{ax}"')
+        if unreduced_refs:
+            unreduced_str = f", unreduced={{{', '.join(unreduced_refs)}}}"
+
+    return f"#sdy.sharding_per_value<[<@mesh, [{dims_str}]{unreduced_str}>]>"
 
 
 def sharding_constraint_hook(module, mesh, partition_spec):
@@ -108,7 +143,7 @@ def sharding_constraint_hook(module, mesh, partition_spec):
     return hook
 
 
-def sharding_constraint_tensor(input, mesh, partition_spec):
+def sharding_constraint_tensor(input, mesh, partition_spec, unreduced=None):
     """
     Apply a sharding constraint to a tensor.
 
@@ -120,6 +155,9 @@ def sharding_constraint_tensor(input, mesh, partition_spec):
         mesh: The mesh object describing device topology
         partition_spec: A tuple specifying how each dimension should be sharded.
             Use axis names (e.g., "batch", "model") or None for replicated dimensions.
+        unreduced: Optional list of axis names/indices that have partial sums.
+            Shardy will insert all-reduce on these axes when the tensor is consumed
+            by an op that requires full values.
 
     Returns:
         torch.Tensor: The tensor with the sharding constraint applied
@@ -133,6 +171,9 @@ def sharding_constraint_tensor(input, mesh, partition_spec):
         >>> from tt_torch import sharding_constraint_tensor
         >>> mesh = Mesh(device_ids, mesh_shape, ("batch", "model"))
         >>> updated_tensor = sharding_constraint_tensor(input_tensor, mesh, (None, None, None))
+
+        Mark tensor as having partial sums on "model" axis:
+        >>> partial_tensor = sharding_constraint_tensor(tensor, mesh, (None, None, None), unreduced=["model"])
     """
     if not isinstance(input, torch.Tensor):
         raise TypeError(f"Expected torch.Tensor, got {type(input).__name__}")
@@ -146,7 +187,7 @@ def sharding_constraint_tensor(input, mesh, partition_spec):
     if not hasattr(mesh, "axis_names"):
         raise ValueError("mesh must have 'axis_names' attribute")
 
-    # Convert to sdy.sharding string at hook creation time
-    sdy_sharding = _partition_spec_to_sdy_sharding(mesh, partition_spec)
+    # Convert to sdy.sharding string
+    sdy_sharding = _partition_spec_to_sdy_sharding(mesh, partition_spec, unreduced)
 
     return torch.ops.tt.sharding_constraint(input, sdy_sharding)

--- a/python_package/tt_torch/sparse_mlp.py
+++ b/python_package/tt_torch/sparse_mlp.py
@@ -1,0 +1,1166 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Sparse MLP module for MoE (Mixture of Experts) models.
+
+This module provides utilities to replace dense MLP layers with sparse MLP
+implementations that use sparse_matmul for efficient expert computation.
+
+Usage:
+    import tt_torch
+    from tt_torch.sparse_mlp import enable_sparse_mlp
+
+    model = load_your_moe_model()
+    model = enable_sparse_mlp(model)  # Replace MLP layers with SparseMLP
+"""
+
+from typing import Any, Dict, List, Optional, Type
+
+import torch
+import torch.nn as nn
+from torch.nn import functional as F
+
+# Activation types for A2aSparseMLP
+ACTIVATION_GPT_OSS = "gpt_oss"  # clamp, sigmoid, alpha, glu
+ACTIVATION_DEEPSEEK = "deepseek"  # SiLU (swish) for gate * up
+
+
+class SparseMLP(nn.Module):
+    """
+    Sparse MLP implementation that uses sparse_matmul for MoE computation.
+
+    This module wraps an existing MLP and replaces dense expert computation
+    with sparse_matmul operations that skip inactive experts.
+
+    Uses INTERLEAVED gate_up_proj layout directly from original model:
+    - Weights stored as [g0, u0, g1, u1, ...] (interleaved)
+    - Split with [::2]/[1::2] strided slices
+    - TP sharding works because UpdateGlobalToLocalShapes pass handles
+      strided slices where stride == shard_factor
+    """
+
+    def __init__(
+        self,
+        original_mlp,
+        num_experts: int,
+        num_experts_per_tok: int,
+        config: Optional[object] = None,
+    ):
+        super().__init__()
+
+        # Note: We intentionally do NOT store original_mlp to avoid memory duplication.
+        # Only store references to the components we actually need.
+        self.num_experts = num_experts
+        self.num_experts_per_tok = num_experts_per_tok
+
+        # Copy references to original module's components
+        # Keep same structure as original MLP: router + experts
+        self.router = original_mlp.router
+        self.experts = original_mlp.experts  # Keep same structure for sharding
+
+        # Use INTERLEAVED gate_up_proj directly (no conversion needed)
+        # The UpdateGlobalToLocalShapes pass now handles strided slices
+        # where stride == shard_factor, making [::2]/[1::2] TP-compatible.
+        if hasattr(self.experts, "gate_up_proj"):
+            # intermediate_size is half of the last dimension (interleaved)
+            self.intermediate_size = self.experts.gate_up_proj.shape[-1] // 2
+        else:
+            raise ValueError("Expected fused gate_up_proj in experts module")
+
+        # Get hidden_size from config or infer from down_proj shape
+        if config is not None and hasattr(config, "hidden_size"):
+            hidden_size = config.hidden_size
+        else:
+            # Infer from down_proj shape: [E, inter, hidden]
+            hidden_size = self.experts.down_proj.shape[-1]
+
+        # GPT-OSS specific activation parameters
+        self.alpha = getattr(self.experts, "alpha", 1.702)
+        self.limit = getattr(self.experts, "limit", 7.0)
+
+    def forward(self, hidden_states):
+        batch_size, seq_len, hidden_size = hidden_states.shape
+
+        # 1. Router Execution
+        # router_scores: [batch*seq, num_experts] (scattered probabilities)
+        # router_indices: [batch*seq, top_k]
+        router_scores, router_indices = self.router(hidden_states)
+
+        # 2. Create Sparsity Mask [batch, seq, 1, num_experts]
+        sparsity = torch.zeros(
+            batch_size,
+            seq_len,
+            1,
+            self.num_experts,
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+
+        # Reshape indices for scatter: [batch, seq, 1, top_k]
+        topk_indices_unsqueezed = router_indices.view(
+            batch_size, seq_len, 1, self.num_experts_per_tok
+        )
+
+        sparsity.scatter_(
+            dim=-1,
+            index=topk_indices_unsqueezed,
+            src=torch.ones_like(topk_indices_unsqueezed, dtype=hidden_states.dtype),
+        )
+
+        # 3. Reshape Input for sparse_matmul [batch, seq, 1, hidden]
+        hidden_4d = hidden_states.view(batch_size, seq_len, 1, hidden_size)
+
+        # 4. Fused Gate+Up Projection
+        # gate_up_weight: [1, E, hidden, inter*2]
+        gate_up_proj = self.experts.gate_up_proj.unsqueeze(0)
+        gate_up_out = torch.ops.tt.sparse_matmul(
+            hidden_4d,
+            gate_up_proj,
+            sparsity,
+            nnz=0,  # Let runtime calculate
+            is_input_a_sparse=False,
+            is_input_b_sparse=True,
+        )
+
+        # Output: [batch, seq, 1, E, M, inter*2] where M=1
+        # Reshape to [batch, seq, E, inter*2]
+        gate_up_out = gate_up_out.view(
+            batch_size, seq_len, self.num_experts, self.intermediate_size * 2
+        )
+        gate_up_out = gate_up_out + self.experts.gate_up_proj_bias
+
+        # 5. Split & Activation (Interleaved Layout)
+        # Slicing works for TP because stride (2) matches shard_factor
+        gate_out = gate_up_out[..., ::2]  # Even indices
+        up_out = gate_up_out[..., 1::2]  # Odd indices
+
+        gate_out = gate_out.clamp(max=self.limit)
+        up_out = up_out.clamp(-self.limit, self.limit)
+        glu = gate_out * torch.sigmoid(gate_out * self.alpha)
+        activated = (up_out + 1) * glu
+
+        # 6. Down Projection setup
+        # activated: [batch*seq, E, 1, inter]
+        activated_reshaped = activated.view(
+            batch_size * seq_len, self.num_experts, 1, self.intermediate_size
+        )
+
+        # sparsity_down: [1, 1, batch*seq, E]
+        sparsity_down = sparsity.view(1, 1, batch_size * seq_len, self.num_experts)
+
+        # Reshape down_proj for sparse_matmul
+        # down_proj: [1, E, inter, hidden]
+        down_proj = self.experts.down_proj.view(
+            1, self.num_experts, self.intermediate_size, hidden_size
+        )
+
+        # 7. Down Projection (sparse_matmul)
+        # down_weight: [1, E, inter, hidden]
+        # Output: [batch*seq, E, M, hidden] where M=1
+        down_out = torch.ops.tt.sparse_matmul(
+            activated_reshaped,
+            down_proj,
+            sparsity_down,
+            nnz=0,
+            is_input_a_sparse=True,  # Activations are sparse (only TopK are valid)
+            is_input_b_sparse=False,
+        )
+
+        # Squeeze M dimension: [batch*seq, E, 1, hidden] -> [batch*seq, E, hidden]
+        down_out = down_out.squeeze(2)
+        down_out = down_out + self.experts.down_proj_bias
+
+        # 8. Weighted Sum & Final Output
+        # down_out: [BS, E, H]
+        # router_scores: [BS, E] -> [BS, E, 1]
+        # output: [BS, H] (Sum over Experts dim=1)
+        output = (down_out * router_scores.unsqueeze(-1)).sum(dim=1)
+
+        # Reshape back to [batch, seq, hidden]
+        output = output.view(batch_size, seq_len, hidden_size)
+
+        return output, router_scores
+
+
+def build_expert_mapping(num_experts, num_devices, mesh_shape=None):
+    """
+    Build one-hot expert-to-device mapping tensor.
+
+    Creates a [1, 1, E, D] tensor where mapping[0, 0, i, d] = 1 means
+    expert i resides on device d.
+
+    For 1D meshes (mesh_shape=None), experts are sequentially distributed:
+    experts 0..E/D-1 on device 0, E/D..2*E/D-1 on device 1, etc.
+
+    For 2D meshes, accounts for GSPMD compound sharding ("axis_0", "axis_1")
+    where axis_0 is the inner (fast-varying) dimension:
+    expert e -> mesh position (e % rows, e // rows) -> device (e % rows) * cols + (e // rows).
+
+    Args:
+        num_experts: Total number of experts (E)
+        num_devices: Number of devices along dispatch axis (D)
+        mesh_shape: Optional (rows, cols) tuple for 2D compound sharding
+
+    Returns:
+        Tensor of shape [1, 1, E, D] with one-hot encoding
+    """
+    assert (
+        num_experts % num_devices == 0
+    ), f"num_experts ({num_experts}) must be divisible by num_devices ({num_devices})"
+    mapping = torch.zeros(1, 1, num_experts, num_devices, dtype=torch.int64)
+    experts_per_device = num_experts // num_devices
+    for i in range(num_experts):
+        if mesh_shape is not None:
+            rows, cols = mesh_shape
+            device_id = (i % rows) * cols + (i // rows)
+        else:
+            device_id = i // experts_per_device
+        mapping[0, 0, i, device_id] = 1
+    return mapping
+
+
+class A2aSparseMLP(nn.Module):
+    """
+    Sparse MLP with all-to-all dispatch/combine for multi-device expert parallelism.
+
+    Wraps sparse_matmul expert computation with all_to_all_dispatch (before) and
+    all_to_all_combine (after) to selectively route tokens to devices holding
+    their selected experts.
+
+    Expert distribution follows the DeepSeek v3 pattern:
+    - Experts are compound-sharded across both mesh dims (each device has unique experts)
+    - Dispatch/combine operate along cluster_axis only (typically axis 0)
+    - BD = B * dispatch_devices (devices along cluster_axis)
+    - After combine, reduce-scatter along the other axis aggregates expert results
+      from different column devices (handled by the sharding framework via shard_specs)
+
+    On single device (num_devices=1), dispatch/combine are no-ops and this
+    produces identical results to SparseMLP.
+    """
+
+    def __init__(
+        self,
+        original_mlp,
+        num_experts: int,
+        num_experts_per_tok: int,
+        num_devices: int = 1,
+        cluster_axis: int = 0,
+        config: Optional[object] = None,
+        activation_type: str = ACTIVATION_GPT_OSS,
+        dispatch_devices: Optional[int] = None,
+    ):
+        super().__init__()
+
+        self.num_experts = num_experts
+        self.num_experts_per_tok = num_experts_per_tok
+        self.cluster_axis = cluster_axis
+        self.activation_type = activation_type
+
+        # num_devices: total mesh devices (for expert_mapping D dimension)
+        # dispatch_devices: devices along cluster_axis (for BD = B * dispatch_devices)
+        # When dispatch_devices is None, defaults to num_devices (single-axis or flat mesh)
+        self.num_devices = num_devices
+        self.dispatch_devices = (
+            dispatch_devices if dispatch_devices is not None else num_devices
+        )
+        # When True, uses fused moe_expert_token_remap kernel for sparsity
+        # and runs the entire sparse_matmul pathway with E_local (experts per device).
+        self.use_fused_remap = True
+        # When True, uses dense torch.matmul instead of sparse_matmul.
+        # Skips remap (no sparsity mask needed). Demo-style approach.
+        self.use_dense_matmul = False
+
+        # Copy references to original module's components
+        self.router = original_mlp.router
+        self.experts = original_mlp.experts
+
+        if hasattr(self.experts, "gate_up_proj"):
+            self.intermediate_size = self.experts.gate_up_proj.shape[-1] // 2
+        else:
+            raise ValueError("Expected fused gate_up_proj in experts module")
+
+        if config is not None and hasattr(config, "hidden_size"):
+            hidden_size = config.hidden_size
+        else:
+            hidden_size = self.experts.down_proj.shape[-1]
+
+        # GPT-OSS specific activation parameters (used when activation_type=gpt_oss)
+        self.alpha = getattr(self.experts, "alpha", 1.702)
+        self.limit = getattr(self.experts, "limit", 7.0)
+
+        # Expert-to-device mapping [1, 1, E, D] where D = num_devices (total)
+        # Maps each expert to its owning device. When cluster_axis=0, the dispatch
+        # kernel derives the target row from the device_id in the mapping.
+        mapping = build_expert_mapping(num_experts, num_devices)
+        self.register_buffer("expert_mapping", mapping)
+
+    def forward(self, hidden_states):
+        batch_size, seq_len, hidden_size = hidden_states.shape
+        K = self.num_experts_per_tok
+
+        # 1. Router
+        router_scores, router_indices = self.router(hidden_states)
+        # router_scores: [B*S, E], router_indices: [B*S, K]
+
+        # 2. Reshape for dispatch: tt-metal expects [B, 1, S, H] format
+        x = hidden_states.view(batch_size, 1, seq_len, hidden_size)
+        expert_indices = router_indices.view(batch_size, 1, seq_len, K)
+
+        # 3. Dispatch: route tokens to devices along cluster_axis
+        # BD = B * dispatch_devices (devices along the dispatch axis)
+        effective_dispatch = self.dispatch_devices
+        dispatched, metadata = torch.ops.tt.all_to_all_dispatch(
+            x,
+            expert_indices,
+            self.expert_mapping,
+            num_devices=effective_dispatch,
+            cluster_axis=self.cluster_axis,
+        )
+        # dispatched: [1, B*dispatch_devices, S, H]
+        # metadata:   [1, B*dispatch_devices, S, K]
+
+        BD = dispatched.shape[1]  # B * dispatch_devices
+        M = 32
+
+        # 4. Determine which dimension to split by M
+        # Prefer seq_len; fall back to BD; assert if neither works
+        split_seq = seq_len % M == 0 and seq_len >= M
+        split_bd = BD % M == 0 and BD >= M
+        assert (
+            split_seq or split_bd
+        ), f"Neither seq_len ({seq_len}) nor BD ({BD}) is divisible by M={M}"
+        if split_seq:
+            dim_a, dim_b = BD, seq_len // M
+        else:
+            dim_a, dim_b = BD // M, seq_len
+
+        # 5. Expert computation
+        E = self.num_experts
+
+        if getattr(self, "use_dense_matmul", False):
+            # ===== Dense matmul path (demo-style) =====
+            # No remap/sparsity needed. Dispatch already routed tokens to
+            # the right devices; dense matmul computes ALL E_local experts.
+            # Compiler compound-shards E→E_local on device.
+            gate_up_proj = self.experts.gate_up_proj.unsqueeze(0)  # [1, E, H, inter*2]
+            down_proj = self.experts.down_proj.view(
+                1, E, self.intermediate_size, -1
+            )  # [1, E, inter, H]
+            gate_up_bias = self.experts.gate_up_proj_bias
+            down_bias = self.experts.down_proj_bias
+
+            # Reshape dispatched for matmul
+            if split_seq:
+                hidden_4d = dispatched.view(BD, seq_len // M, M, hidden_size)
+            elif dim_b == 1:
+                hidden_4d = dispatched.view(BD // M, 1, M, hidden_size)
+            else:
+                hidden_4d = dispatched.view(BD // M, M, seq_len, hidden_size)
+                hidden_4d = hidden_4d.permute(0, 2, 1, 3)
+
+            # Gate+Up: [dim_a, dim_b, 1, M, H] @ [1, E, H, inter*2]
+            #        → [dim_a, dim_b, E, M, inter*2]
+            hidden_5d = hidden_4d.unsqueeze(2)
+            gate_up_out = torch.matmul(hidden_5d, gate_up_proj)
+            gate_up_out = gate_up_out.permute(
+                0, 1, 3, 2, 4
+            )  # [dim_a, dim_b, M, E, inter*2]
+            gate_up_out = gate_up_out + gate_up_bias
+
+            # Activation
+            # We can un-interleave these experts in init and save the overhead of strided slicing on device.
+            # Issue : https://github.com/tenstorrent/tt-xla/issues/3668
+            gate_out = gate_up_out[..., ::2]
+            up_out = gate_up_out[..., 1::2]
+            if self.activation_type == ACTIVATION_DEEPSEEK:
+                activated = F.silu(gate_out) * up_out
+            else:
+                gate_out = gate_out.clamp(max=self.limit)
+                up_out = up_out.clamp(-self.limit, self.limit)
+                glu = gate_out * torch.sigmoid(gate_out * self.alpha)
+                activated = (up_out + 1) * glu
+
+            # Down: [dim_a*dim_b, E, M, inter] @ [1, E, inter, H]
+            #      → [dim_a*dim_b, E, M, H]
+            activated_reshaped = (
+                activated.permute(0, 1, 3, 2, 4)
+                .contiguous()
+                .view(dim_a * dim_b, E, M, self.intermediate_size)
+            )
+            down_out = torch.matmul(activated_reshaped, down_proj)
+
+            # Reshape for combine: [E, BD, S, H]
+            down_out = down_out.view(dim_a, dim_b, E, M, hidden_size)
+            down_out = down_out.permute(0, 1, 3, 2, 4)  # [dim_a, dim_b, M, E, H]
+            down_out = down_out + down_bias
+            if split_seq:
+                down_out = down_out.permute(3, 0, 1, 2, 4).contiguous()
+                down_out = down_out.view(E, BD, seq_len, hidden_size)
+            elif dim_b == 1:
+                down_out = down_out.squeeze(1)
+                down_out = down_out.permute(2, 0, 1, 3).contiguous()
+                down_out = down_out.view(E, BD, hidden_size).unsqueeze(1)
+            else:
+                down_out = down_out.permute(3, 0, 2, 1, 4).contiguous()
+                down_out = down_out.view(E, BD, seq_len, hidden_size)
+
+        elif self.use_fused_remap:
+            # ===== Fused moe_expert_token_remap path =====
+            # Output uses global E shape; compiler compound-shards E→E_local on device.
+            # Weights [E, H, inter*2] → [1, E, H, inter*2] similarly sharded.
+            D = effective_dispatch
+
+            # Build topk_tensor [1, BD, S, E] — fold D into batch dim so the
+            # kernel sees BD tokens and produces BD*S/M reduced entries.
+            topk_3d = router_scores.view(batch_size, seq_len, E)
+            topk_repeated = topk_3d.repeat(D, 1, 1)  # [BD, S, E]
+            topk_tensor = topk_repeated.unsqueeze(0)  # [1, BD, S, E]
+
+            # metadata already [1, BD, S, K] — pass as-is
+            remap_mapping, sparsity_remap = torch.ops.tt.moe_expert_token_remap(
+                topk_tensor,
+                self.expert_mapping,
+                metadata,
+                reduction_size=M,
+            )
+            # remap_mapping: [1, BD, S, E_local] — routing weights for local experts
+            # sparsity_remap: [1, 1, ceil(BD*S/M), E] (global E shape)
+            sparsity = sparsity_remap.view(dim_a, dim_b, 1, E)
+
+            # Weights: [E, H, inter*2] → [1, E, H, inter*2] (compiler shards E→E_local)
+            gate_up_proj = self.experts.gate_up_proj.unsqueeze(0)
+            down_proj = self.experts.down_proj.view(1, E, self.intermediate_size, -1)
+            gate_up_bias = self.experts.gate_up_proj_bias
+            down_bias = self.experts.down_proj_bias
+
+            # Reshape dispatched for sparse_matmul
+            if split_seq:
+                hidden_4d = dispatched.view(BD, seq_len // M, M, hidden_size)
+            elif dim_b == 1:
+                hidden_4d = dispatched.view(BD // M, 1, M, hidden_size)
+            else:
+                hidden_4d = dispatched.view(BD // M, M, seq_len, hidden_size)
+                hidden_4d = hidden_4d.permute(0, 2, 1, 3)
+
+            # Gate+Up sparse_matmul with E_local sparsity
+            gate_up_out = torch.ops.tt.sparse_matmul(
+                hidden_4d,
+                gate_up_proj,
+                sparsity,
+                nnz=0,
+                is_input_a_sparse=False,
+                is_input_b_sparse=True,
+            )
+            gate_up_out = gate_up_out.squeeze(2)  # [dim_a, dim_b, E_local, M, inter*2]
+            gate_up_out = gate_up_out.permute(
+                0, 1, 3, 2, 4
+            )  # [dim_a, dim_b, M, E_local, inter*2]
+            gate_up_out = gate_up_out + gate_up_bias
+
+            # Activation
+            gate_out = gate_up_out[..., ::2]
+            up_out = gate_up_out[..., 1::2]
+            if self.activation_type == ACTIVATION_DEEPSEEK:
+                activated = F.silu(gate_out) * up_out
+            else:
+                gate_out = gate_out.clamp(max=self.limit)
+                up_out = up_out.clamp(-self.limit, self.limit)
+                glu = gate_out * torch.sigmoid(gate_out * self.alpha)
+                activated = (up_out + 1) * glu
+
+            # Down sparse_matmul (sparsity already expanded to E)
+            activated_reshaped = (
+                activated.permute(0, 1, 3, 2, 4)
+                .contiguous()
+                .view(dim_a * dim_b, E, M, self.intermediate_size)
+            )
+            sparsity_down = sparsity.view(1, 1, dim_a * dim_b, E)
+            down_out = torch.ops.tt.sparse_matmul(
+                activated_reshaped,
+                down_proj,
+                sparsity_down,
+                nnz=0,
+                is_input_a_sparse=True,
+                is_input_b_sparse=False,
+            )
+
+            # Reshape for combine: [E, BD, S, H]
+            down_out = down_out.view(dim_a, dim_b, E, M, hidden_size)
+            down_out = down_out.permute(0, 1, 3, 2, 4)  # [dim_a, dim_b, M, E, H]
+            down_out = down_out + down_bias
+            if split_seq:
+                down_out = down_out.permute(3, 0, 1, 2, 4).contiguous()
+                down_out = down_out.view(E, BD, seq_len, hidden_size)
+            elif dim_b == 1:
+                down_out = down_out.squeeze(1)
+                down_out = down_out.permute(2, 0, 1, 3).contiguous()
+                down_out = down_out.view(E, BD, hidden_size).unsqueeze(1)
+            else:
+                down_out = down_out.permute(3, 0, 2, 1, 4).contiguous()
+                down_out = down_out.view(E, BD, seq_len, hidden_size)
+
+        else:
+            # ===== Manual sparsity construction path (E_total throughout) =====
+            if split_seq:
+                metadata_full = metadata[0].view(BD, seq_len // M, M, K)
+                metadata_flat = metadata_full.reshape(BD, (seq_len // M) * M, K)
+                sparsity_flat = torch.zeros(
+                    BD,
+                    (seq_len // M) * M,
+                    1,
+                    E,
+                    dtype=hidden_states.dtype,
+                    device=hidden_states.device,
+                )
+                sparsity_flat.scatter_(
+                    dim=-1,
+                    index=metadata_flat.unsqueeze(2),
+                    src=torch.ones_like(
+                        metadata_flat.unsqueeze(2), dtype=hidden_states.dtype
+                    ),
+                )
+                sparsity = (
+                    sparsity_flat.view(BD, seq_len // M, M, E).sum(dim=2).clamp(max=1.0)
+                )
+                sparsity = sparsity.unsqueeze(2)
+            else:
+                metadata_full = metadata[0].view(BD // M, M, seq_len, K)
+                metadata_flat = metadata_full.reshape((BD // M) * M, seq_len, K)
+                sparsity_flat = torch.zeros(
+                    (BD // M) * M,
+                    seq_len,
+                    1,
+                    E,
+                    dtype=hidden_states.dtype,
+                    device=hidden_states.device,
+                )
+                sparsity_flat.scatter_(
+                    dim=-1,
+                    index=metadata_flat.unsqueeze(2),
+                    src=torch.ones_like(
+                        metadata_flat.unsqueeze(2), dtype=hidden_states.dtype
+                    ),
+                )
+                sparsity = (
+                    sparsity_flat.view(BD // M, M, seq_len, E).sum(dim=1).clamp(max=1.0)
+                )
+                sparsity = sparsity.unsqueeze(2)
+
+            gate_up_proj = self.experts.gate_up_proj.unsqueeze(0)
+            down_proj = self.experts.down_proj.view(1, E, self.intermediate_size, -1)
+            gate_up_bias = self.experts.gate_up_proj_bias
+            down_bias = self.experts.down_proj_bias
+
+            if split_seq:
+                hidden_4d = dispatched.view(BD, seq_len // M, M, hidden_size)
+            elif dim_b == 1:
+                hidden_4d = dispatched.view(BD // M, 1, M, hidden_size)
+            else:
+                hidden_4d = dispatched.view(BD // M, M, seq_len, hidden_size)
+                hidden_4d = hidden_4d.permute(0, 2, 1, 3)
+
+            gate_up_out = torch.ops.tt.sparse_matmul(
+                hidden_4d,
+                gate_up_proj,
+                sparsity,
+                nnz=0,
+                is_input_a_sparse=False,
+                is_input_b_sparse=True,
+            )
+            gate_up_out = gate_up_out.squeeze(2)
+            gate_up_out = gate_up_out.permute(0, 1, 3, 2, 4)
+            gate_up_out = gate_up_out + gate_up_bias
+
+            gate_out = gate_up_out[..., ::2]
+            up_out = gate_up_out[..., 1::2]
+            if self.activation_type == ACTIVATION_DEEPSEEK:
+                activated = F.silu(gate_out) * up_out
+            else:
+                gate_out = gate_out.clamp(max=self.limit)
+                up_out = up_out.clamp(-self.limit, self.limit)
+                glu = gate_out * torch.sigmoid(gate_out * self.alpha)
+                activated = (up_out + 1) * glu
+
+            activated_reshaped = (
+                activated.permute(0, 1, 3, 2, 4)
+                .contiguous()
+                .view(dim_a * dim_b, E, M, self.intermediate_size)
+            )
+            sparsity_down = sparsity.view(1, 1, dim_a * dim_b, E)
+            down_out = torch.ops.tt.sparse_matmul(
+                activated_reshaped,
+                down_proj,
+                sparsity_down,
+                nnz=0,
+                is_input_a_sparse=True,
+                is_input_b_sparse=False,
+            )
+
+            down_out = down_out.view(dim_a, dim_b, E, M, hidden_size)
+            down_out = down_out.permute(0, 1, 3, 2, 4)
+            down_out = down_out + down_bias
+            if split_seq:
+                down_out = down_out.permute(3, 0, 1, 2, 4).contiguous()
+                down_out = down_out.view(E, BD, seq_len, hidden_size)
+            elif dim_b == 1:
+                down_out = down_out.squeeze(1)
+                down_out = down_out.permute(2, 0, 1, 3).contiguous()
+                down_out = down_out.view(E, BD, hidden_size).unsqueeze(1)
+            else:
+                down_out = down_out.permute(3, 0, 2, 1, 4).contiguous()
+                down_out = down_out.view(E, BD, seq_len, hidden_size)
+
+        # Combine: gather expert outputs back along cluster_axis
+        decode_mode = dim_b == 1 and not split_seq
+        combined = torch.ops.tt.all_to_all_combine(
+            down_out,
+            metadata,
+            self.expert_mapping,
+            num_devices=effective_dispatch,
+            cluster_axis=self.cluster_axis,
+            num_experts_per_tok=K,
+            output_shard_dim=2 if decode_mode else 1,
+        )
+
+        # Weighted sum
+        # Workaround: avoid torch.gather (TTNN scatter-based lowering has issues
+        # for large seq_len). Instead, use einsum with one-hot mask.
+        E = self.num_experts
+        # Build one-hot: [B*S, K, E] where one_hot[n, k, e] = 1 if indices[n,k] == e
+        expert_range = torch.arange(E, device=router_scores.device)  # [E]
+        one_hot = (router_indices.unsqueeze(-1) == expert_range).to(
+            router_scores.dtype
+        )  # [B*S, K, E]
+        topk_weights = torch.einsum("nke,ne->nk", one_hot, router_scores)  # [B*S, K]
+        if seq_len == 1:
+            topk_weights = topk_weights.view(batch_size, K)
+            topk_weights = topk_weights.permute(1, 0).unsqueeze(-1)  # [K, B, 1]
+            output = (combined.squeeze(1) * topk_weights).sum(dim=0)  # [B, H]
+            output = output.unsqueeze(1)  # [B, 1, H]
+        else:
+            topk_weights = topk_weights.view(batch_size, seq_len, K)
+            topk_weights = topk_weights.permute(2, 0, 1).unsqueeze(-1)  # [K, B, S, 1]
+            output = (combined * topk_weights).sum(dim=0)  # [B, S, H]
+
+        return output.to(hidden_states.dtype), router_scores
+
+
+class A2aSparseStackedMlp(nn.Module):
+    """
+    Sparse MLP with all-to-all dispatch/combine for multi-device expert parallelism.
+
+    Same as A2aSparseMLP but pre-deinterleaves gate_up_proj weights and biases
+    in __init__ so the forward pass uses contiguous splits ([:inter] / [inter:])
+    instead of strided slices ([::2] / [1::2]).
+    """
+
+    def __init__(
+        self,
+        original_mlp,
+        num_experts: int,
+        num_experts_per_tok: int,
+        num_devices: int = 1,
+        cluster_axis: int = -1,
+        config: Optional[object] = None,
+    ):
+        super().__init__()
+
+        self.num_experts = num_experts
+        self.num_experts_per_tok = num_experts_per_tok
+        self.num_devices = num_devices
+        self.cluster_axis = cluster_axis
+
+        # Copy references to original module's components
+        self.router = original_mlp.router
+        orig_experts = original_mlp.experts
+
+        if hasattr(orig_experts, "gate_up_proj"):
+            self.intermediate_size = orig_experts.gate_up_proj.shape[-1] // 2
+        else:
+            raise ValueError("Expected fused gate_up_proj in experts module")
+
+        if config is not None and hasattr(config, "hidden_size"):
+            hidden_size = config.hidden_size
+        else:
+            hidden_size = orig_experts.down_proj.shape[-1]
+
+        # GPT-OSS specific activation parameters
+        self.alpha = getattr(orig_experts, "alpha", 1.702)
+        self.limit = getattr(orig_experts, "limit", 7.0)
+
+        # New experts container — preserves layer.mlp.experts.* path for shard_specs
+        # (shard_specs is built after replacement)
+        self.experts = nn.Module()
+
+        # De-interleave gate_up_proj: [g0, u0, g1, u1, ...] -> [g0, g1, ..., u0, u1, ...]
+        # Pre-reshape to [1, E, H, inter*2] for sparse_matmul (no unsqueeze in forward)
+        orig_w = orig_experts.gate_up_proj
+        gate_w = orig_w[..., ::2].contiguous()
+        up_w = orig_w[..., 1::2].contiguous()
+        self.experts.gate_up_proj = nn.Parameter(
+            torch.cat([gate_w, up_w], dim=-1).unsqueeze(0)
+        )
+
+        orig_b = orig_experts.gate_up_proj_bias
+        gate_b = orig_b[..., ::2].contiguous()
+        up_b = orig_b[..., 1::2].contiguous()
+        self.experts.gate_up_proj_bias = nn.Parameter(torch.cat([gate_b, up_b], dim=-1))
+
+        # Down proj / bias — pre-reshape to [1, E, inter, H] for sparse_matmul
+        self.experts.down_proj = nn.Parameter(
+            orig_experts.down_proj.data.view(
+                1, num_experts, self.intermediate_size, hidden_size
+            )
+        )
+        self.experts.down_proj_bias = orig_experts.down_proj_bias
+
+        # Expert-to-device mapping [1, 1, E, D]
+        mapping = build_expert_mapping(num_experts, num_devices)
+        self.register_buffer("expert_mapping", mapping)
+
+    def forward(self, hidden_states):
+        batch_size, seq_len, hidden_size = hidden_states.shape
+        K = self.num_experts_per_tok
+
+        # 1. Router
+        router_scores, router_indices = self.router(hidden_states)
+
+        # 2. Reshape for dispatch: tt-metal expects [B, 1, S, H] format
+        x = hidden_states.view(batch_size, 1, seq_len, hidden_size)
+        expert_indices = router_indices.view(batch_size, 1, seq_len, K)
+
+        # 3. Dispatch: route tokens to devices with selected experts
+        dispatched, metadata = torch.ops.tt.all_to_all_dispatch(
+            x,
+            expert_indices,
+            self.expert_mapping,
+            num_devices=self.num_devices,
+            cluster_axis=self.cluster_axis,
+        )
+        # dispatched: [1, B*D, S, H]
+        # metadata:   [1, B*D, S, K]
+
+        BD = dispatched.shape[1]
+
+        # 4. Build sparsity mask from metadata
+        metadata_indices = metadata.view(BD, seq_len, 1, K)  # [BD, S, 1, K]
+        sparsity = torch.zeros(
+            BD,
+            seq_len,
+            1,
+            self.num_experts,
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+        sparsity.scatter_(
+            dim=-1,
+            index=metadata_indices,
+            src=torch.ones_like(metadata_indices, dtype=hidden_states.dtype),
+        )
+
+        # 5. Gate+Up projection (stacked layout)
+        hidden_4d = dispatched.view(BD, seq_len, 1, hidden_size)
+        gate_up_out = torch.ops.tt.sparse_matmul(
+            hidden_4d,
+            self.experts.gate_up_proj,
+            sparsity,
+            nnz=0,
+            is_input_a_sparse=False,
+            is_input_b_sparse=True,
+        )
+        gate_up_out = gate_up_out.view(
+            BD, seq_len, self.num_experts, self.intermediate_size * 2
+        )
+        gate_up_out = gate_up_out + self.experts.gate_up_proj_bias
+
+        # 6. Split & Activation (contiguous stacked layout)
+        gate_up_out = gate_up_out.clamp(max=self.limit)
+        gate_out = gate_up_out[..., : self.intermediate_size]
+        up_out = gate_up_out[..., self.intermediate_size :]
+
+        # gate_out = gate_out.clamp(max=self.limit)
+        up_out = up_out.clamp(min=-self.limit)
+        glu = gate_out * torch.sigmoid(gate_out * self.alpha)
+        activated = (up_out + 1) * glu
+
+        # 7. Down projection
+        activated_reshaped = activated.view(
+            BD * seq_len, self.num_experts, 1, self.intermediate_size
+        )
+        sparsity_down = sparsity.view(1, 1, BD * seq_len, self.num_experts)
+
+        down_out = torch.ops.tt.sparse_matmul(
+            activated_reshaped,
+            self.experts.down_proj,
+            sparsity_down,
+            nnz=0,
+            is_input_a_sparse=True,
+            is_input_b_sparse=False,
+        )
+        down_out = down_out.squeeze(2)
+        down_out = down_out + self.experts.down_proj_bias
+
+        # 8. Reshape for combine: [E, BD, S, H]
+        down_out = down_out.view(BD, seq_len, self.num_experts, hidden_size)
+        down_out = down_out.permute(2, 0, 1, 3)
+
+        # 9. Combine: gather expert outputs back to original positions
+        combined = torch.ops.tt.all_to_all_combine(
+            down_out,
+            metadata,
+            self.expert_mapping,
+            num_devices=self.num_devices,
+            cluster_axis=self.cluster_axis,
+            num_experts_per_tok=K,
+        )
+        # combined: [K, B, S, H]
+
+        # 10. Weighted sum
+        topk_weights = torch.gather(router_scores, dim=-1, index=router_indices)
+        topk_weights = topk_weights.view(batch_size, seq_len, K)
+        topk_weights = topk_weights.permute(2, 0, 1).unsqueeze(-1)
+
+        output = (combined * topk_weights).sum(dim=0)
+        output = output.view(batch_size, seq_len, hidden_size)
+
+        return output, router_scores
+
+
+class DeepseekV3MoEToA2AAdapter(nn.Module):
+    """
+    Adapter that converts DeepseekV3MoE to A2aSparseMLP-compatible interface.
+
+    DeepseekV3MoE has:
+    - gate (MoEGate): returns (topk_idx, topk_weight)
+    - experts: ModuleList of DeepseekV3MLP with gate_proj, up_proj, down_proj (separate)
+
+    A2aSparseMLP expects:
+    - router: returns (scores, indices)
+    - experts: gate_up_proj [E, H, inter*2], down_proj [E, inter, H], biases
+    """
+
+    class RouterAdapter(nn.Module):
+        """Wraps MoEGate to return (scores, indices) for A2aSparseMLP."""
+
+        def __init__(self, gate: nn.Module, n_experts: int):
+            super().__init__()
+            self.gate = gate
+            self.n_experts = n_experts
+
+        def forward(self, hidden_states):
+            topk_idx, topk_weight = self.gate(hidden_states)
+            bsz_seq = topk_idx.shape[0]
+            # Build sparse scores so gather(scores, indices) gives topk_weight
+            scores = torch.zeros(
+                bsz_seq,
+                self.n_experts,
+                dtype=topk_weight.dtype,
+                device=topk_weight.device,
+            )
+            scores.scatter_(1, topk_idx, topk_weight)
+            return scores, topk_idx
+
+    class StackedExperts(nn.Module):
+        """Stacks DeepseekV3MLP experts into gate_up_proj, down_proj format."""
+
+        def __init__(self, expert_list):
+            super().__init__()
+            experts_list = [e for e in expert_list if e is not None]
+            if not experts_list:
+                experts_list = list(expert_list)
+            first = experts_list[0]
+            hidden_size = first.gate_proj.in_features
+            inter = first.gate_proj.out_features
+
+            gate_up_list = []
+            down_list = []
+            for exp in experts_list:
+                # gate_proj.weight [inter, H], up_proj.weight [inter, H] -> interleave [H, inter*2]
+                gate_up = torch.empty(
+                    hidden_size,
+                    inter * 2,
+                    dtype=exp.gate_proj.weight.dtype,
+                    device=exp.gate_proj.weight.device,
+                )
+                gate_up[:, 0::2] = exp.gate_proj.weight.T
+                gate_up[:, 1::2] = exp.up_proj.weight.T
+                gate_up_list.append(gate_up)
+                down_list.append(exp.down_proj.weight.T)
+
+            num_experts = len(gate_up_list)
+            gate_up_proj = torch.stack(gate_up_list, dim=0)
+            down_proj = torch.stack(down_list, dim=0)
+            self.gate_up_proj = nn.Parameter(gate_up_proj)
+            self.down_proj = nn.Parameter(down_proj)
+            self.gate_up_proj_bias = nn.Parameter(
+                torch.zeros(
+                    num_experts,
+                    inter * 2,
+                    dtype=gate_up_proj.dtype,
+                    device=gate_up_proj.device,
+                )
+            )
+            self.down_proj_bias = nn.Parameter(
+                torch.zeros(
+                    num_experts,
+                    hidden_size,
+                    dtype=down_proj.dtype,
+                    device=down_proj.device,
+                )
+            )
+
+    def __init__(self, moe_module):
+        super().__init__()
+        self.router = self.RouterAdapter(
+            moe_module.gate, moe_module.gate.n_routed_experts
+        )
+        experts_list = [e for e in moe_module.experts if e is not None]
+        if not experts_list:
+            experts_list = list(moe_module.experts)
+        if len(experts_list) != moe_module.gate.n_routed_experts:
+            raise ValueError(
+                "DeepseekV3MoEToA2AAdapter requires ep_size=1 (all experts on one process). "
+                f"Got {len(experts_list)} experts, expected {moe_module.gate.n_routed_experts}."
+            )
+        self.experts = self.StackedExperts(experts_list)
+
+
+class A2aSparseMLPWithSharedExperts(nn.Module):
+    """Wraps A2aSparseMLP and adds shared_experts output; returns single tensor for layer compatibility."""
+
+    def __init__(
+        self, a2a_mlp: A2aSparseMLP, shared_experts: Optional[nn.Module] = None
+    ):
+        super().__init__()
+        self.mlp = a2a_mlp
+        self.shared_experts = shared_experts
+
+    def forward(self, hidden_states):
+        out, _ = self.mlp(hidden_states)
+        if self.shared_experts is not None:
+            out = out + self.shared_experts(hidden_states)
+        return out
+
+
+def create_a2a_from_deepseek_v3_moe(
+    moe_module,
+    config,
+    num_devices: int = 8,
+    cluster_axis: int = 0,
+    dispatch_devices: Optional[int] = None,
+) -> A2aSparseMLPWithSharedExperts:
+    """
+    Create A2aSparseMLP from DeepseekV3MoE.
+
+    Args:
+        moe_module: DeepseekV3MoE instance
+        config: Model config (DeepseekV3Config)
+        num_devices: Total mesh devices (for expert_mapping D dimension)
+        cluster_axis: Mesh axis for dispatch/combine (0=rows, 1=cols)
+        dispatch_devices: Devices along cluster_axis (for BD = B * dispatch_devices).
+            Defaults to num_devices when None (single-axis dispatch).
+    """
+    adapter = DeepseekV3MoEToA2AAdapter(moe_module)
+    a2a_mlp = A2aSparseMLP(
+        adapter,
+        num_experts=config.n_routed_experts,
+        num_experts_per_tok=config.num_experts_per_tok,
+        num_devices=num_devices,
+        cluster_axis=cluster_axis,
+        config=config,
+        activation_type=ACTIVATION_DEEPSEEK,
+        dispatch_devices=dispatch_devices,
+    )
+    shared_experts = getattr(moe_module, "shared_experts", None)
+    return A2aSparseMLPWithSharedExperts(a2a_mlp, shared_experts)
+
+
+def _is_moe_mlp(module: nn.Module) -> bool:
+    """Check if a module is an MoE MLP that can be replaced with SparseMLP."""
+    # Check for common MoE MLP patterns
+    module_name = type(module).__name__.lower()
+
+    # Known MoE MLP class names
+    moe_patterns = ["gptossmlp", "mixtralmlp", "qwen2moemlp", "deepseekmlp", "deepseek"]
+
+    if any(pattern in module_name for pattern in moe_patterns):
+        return True
+
+    # Check if module has router and experts attributes (common MoE pattern)
+    has_router = hasattr(module, "router")
+    has_experts = hasattr(module, "experts")
+
+    return has_router and has_experts
+
+
+def _get_moe_config(module: nn.Module) -> Optional[tuple]:
+    """Extract MoE configuration from a module."""
+    try:
+        num_experts = None
+        # Try to get from experts
+        if hasattr(module, "experts"):
+            experts = module.experts
+            num_experts = getattr(experts, "num_experts", None)
+            # Try fused gate_up_proj (expected input format)
+            if num_experts is None and hasattr(experts, "gate_up_proj"):
+                num_experts = experts.gate_up_proj.shape[0]
+
+        # Try to get num_experts_per_tok from router
+        if hasattr(module, "router"):
+            router = module.router
+            num_experts_per_tok = getattr(router, "top_k", None)
+            if num_experts_per_tok is None:
+                num_experts_per_tok = getattr(router, "num_experts_per_tok", 2)
+        else:
+            num_experts_per_tok = 2  # Default
+
+        if num_experts is not None:
+            return (num_experts, num_experts_per_tok)
+    except Exception:
+        pass
+
+    return None
+
+
+def enable_sparse_mlp(
+    model: nn.Module,
+    mesh: tuple,
+    cluster_axis: int = 0,
+    target_classes: Optional[List[Type]] = None,
+    verbose: bool = False,
+    config: Optional[object] = None,
+) -> nn.Module:
+    """
+    Replace MoE MLP layers in a model with A2aSparseMLP implementations.
+    """
+    replaced_count = 0
+
+    if config is None:
+        config = getattr(model, "config", None)
+
+    num_devices = mesh[0] * mesh[1]
+    dispatch_devices = mesh[cluster_axis]
+
+    def replace_mlp(parent: nn.Module, name: str, module: nn.Module):
+        nonlocal replaced_count
+
+        should_replace = False
+        if target_classes:
+            should_replace = any(isinstance(module, cls) for cls in target_classes)
+        else:
+            should_replace = _is_moe_mlp(module)
+
+        if not should_replace:
+            return False
+
+        module_type_name = type(module).__name__.lower()
+
+        if (
+            "deepseek" in module_type_name
+            and hasattr(module, "gate")
+            and hasattr(module, "experts")
+        ):
+            sparse_mlp = create_a2a_from_deepseek_v3_moe(
+                moe_module=module,
+                config=config,
+                num_devices=num_devices,
+                cluster_axis=cluster_axis,
+                dispatch_devices=dispatch_devices,
+            )
+            setattr(parent, name, sparse_mlp)
+            replaced_count += 1
+            if verbose:
+                print(
+                    f"[SparseMLP] Replaced {name}: {type(module).__name__} -> DeepseekV3MoEToA2AAdapter"
+                )
+            return True
+
+        moe_config = _get_moe_config(module)
+        if moe_config is None and config is not None:
+            num_experts = getattr(config, "num_local_experts", None)
+            num_experts_per_tok = getattr(config, "num_experts_per_tok", 2)
+            if num_experts is not None:
+                moe_config = (num_experts, num_experts_per_tok)
+
+        if moe_config is None:
+            if verbose:
+                print(f"[SparseMLP] Skipping {name}: could not determine MoE config")
+            return False
+
+        num_experts, num_experts_per_tok = moe_config
+
+        sparse_mlp = A2aSparseMLP(
+            module,
+            num_experts=num_experts,
+            num_experts_per_tok=num_experts_per_tok,
+            num_devices=num_devices,
+            cluster_axis=cluster_axis,
+            config=config,
+            dispatch_devices=dispatch_devices,
+        )
+
+        setattr(parent, name, sparse_mlp)
+        replaced_count += 1
+
+        if verbose:
+            print(
+                f"[SparseMLP] Replaced {name}: {type(module).__name__} -> A2aSparseMLP "
+                f"(experts={num_experts}, num_devices={num_devices})"
+            )
+        return True
+
+    # Traverse and replace. Track replaced prefixes to skip their children.
+    replaced_prefixes = set()
+    for name, module in list(model.named_modules()):
+        # Skip children of already-replaced modules
+        if any(name.startswith(p + ".") or name == p for p in replaced_prefixes):
+            continue
+
+        if "." in name:
+            parts = name.rsplit(".", 1)
+            parent_name, child_name = parts
+            try:
+                parent = model.get_submodule(parent_name)
+            except AttributeError:
+                continue
+        else:
+            parent = model
+            child_name = name
+
+        if replace_mlp(parent, child_name, module):
+            replaced_prefixes.add(name)
+
+    if verbose:
+        print(f"[SparseMLP] Total layers replaced: {replaced_count}")
+
+    return model
+
+
+def get_moe_shard_specs(
+    model: nn.Module, original_spec_fn, mesh_names: tuple
+) -> Dict[str, Any]:
+    shard_specs = original_spec_fn(model)
+    for layer in model.model.layers:
+        if isinstance(layer.mlp, A2aSparseMLP):
+            # Full expert weights are needed on all devices for the sparse matmuls, so shard with None (replicated) for E dimension.
+            shard_specs[layer.mlp.experts.gate_up_proj] = (
+                (mesh_names[0], mesh_names[1]),
+                None,
+                None,
+            )
+            shard_specs[layer.mlp.experts.gate_up_proj_bias] = (
+                (mesh_names[0], mesh_names[1]),
+                None,
+            )
+            shard_specs[layer.mlp.experts.down_proj] = (
+                (mesh_names[0], mesh_names[1]),
+                None,
+                None,
+            )
+            shard_specs[layer.mlp.experts.down_proj_bias] = (
+                (mesh_names[0], mesh_names[1]),
+                None,
+            )
+
+    return shard_specs

--- a/tests/runner/test_config/constants.py
+++ b/tests/runner/test_config/constants.py
@@ -32,6 +32,8 @@ ALLOWED_FIELDS = {
     "filechecks",
     # Compiler config options
     "enable_weight_bfp8_conversion",
+    # Whether to inject a custom MoE implementation in the test (using the sparse_mlp.py in tt_torch).
+    "inject_custom_moe",
 }
 
 # Single source of truth for the placeholders YAML filename

--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -34,10 +34,12 @@ test_config:
     supported_archs: [n300-llmbox, galaxy-wh-6u]
     status: EXPECTED_PASSING
     required_pcc: 0.98
+    inject_custom_moe: true
 
   gpt_oss/pytorch-120B-tensor_parallel-inference:
     supported_archs: [galaxy-wh-6u]
     status: EXPECTED_PASSING
+    inject_custom_moe: true
     assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/3490
 
   falcon/pytorch-7B_Instruct-tensor_parallel-inference:

--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -130,6 +130,9 @@ class ModelTestConfig:
             "enable_weight_bfp8_conversion", default=False
         )
 
+        # Whether to inject a custom MoE implementation in the test (using the sparse_mlp.py in tt_torch).
+        self.inject_custom_moe = self._resolve("inject_custom_moe", default=False)
+
     def _resolve(self, key, default=None):
         overrides = self.data.get("arch_overrides", {})
         if self.arch in overrides and key in overrides[self.arch]:

--- a/tests/runner/testers/torch/dynamic_torch_model_tester.py
+++ b/tests/runner/testers/torch/dynamic_torch_model_tester.py
@@ -13,6 +13,8 @@ from infra.evaluators import ComparisonConfig
 from infra.testers.compiler_config import CompilerConfig
 from infra.testers.single_chip.model import RunMode, TorchModelTester
 from infra.utilities.torch_multichip_utils import get_mesh
+from loguru import logger
+from tt_torch.sparse_mlp import enable_sparse_mlp, get_moe_shard_specs
 
 from tests.runner.test_utils import RunPhase
 from tests.runner.utils import TorchDynamicLoader
@@ -62,6 +64,9 @@ class DynamicTorchModelTester(TorchModelTester):
             run_mode=run_mode,
             parallelism=self.parallelism,
         )
+
+        if test_metadata and getattr(test_metadata, "inject_custom_moe", False):
+            self._inject_custom_moe(self._model)
 
     # --- TorchModelTester interface implementations ---
 
@@ -149,3 +154,20 @@ class DynamicTorchModelTester(TorchModelTester):
         Calls the unpack_forward_output method of the dynamic loader.
         """
         return self.dynamic_loader.unpack_forward_output(output)
+
+    def _inject_custom_moe(self, model):
+        """Injects a custom MoE implementation into the model if specified in test metadata."""
+        logger.info(
+            "Custom MoE injection enabled for this test - using sparse_mlp.py implementation in tt_torch"
+        )
+        mesh_info = self._workload.mesh.shape()
+        mesh_shape = tuple(mesh_info.values())
+        mesh_names = tuple(mesh_info.keys())
+        enable_sparse_mlp(model, mesh=mesh_shape)
+        shard_spec_fn = self._workload.shard_spec_fn
+        if shard_spec_fn:
+
+            def combined_shard_spec_fn(model, _fn=shard_spec_fn, _names=mesh_names):
+                return get_moe_shard_specs(model, _fn, _names)
+
+            self._workload.shard_spec_fn = combined_shard_spec_fn

--- a/tests/torch/graphs/test_mlp.py
+++ b/tests/torch/graphs/test_mlp.py
@@ -18,6 +18,7 @@ from transformers.models.llama.modeling_llama import LlamaMLP
 from transformers.models.mistral.modeling_mistral import MistralMLP
 from transformers.models.qwen2.modeling_qwen2 import Qwen2MLP
 from transformers.models.qwen3.modeling_qwen3 import Qwen3MLP
+from tt_torch.sparse_mlp import A2aSparseMLP, enable_sparse_mlp
 
 from tests.utils import parametrize_arch
 from third_party.tt_forge_models.falcon.pytorch.loader import (
@@ -473,14 +474,20 @@ def test_falcon_mlp(seq_len, variant, variant_config, arch):
 
 
 @pytest.mark.nightly
+@pytest.mark.parametrize("mlp_type", ["standard", "sparse"])
 @parametrize_arch(["single_device", "llmbox"])
 @pytest.mark.parametrize(
     "variant,variant_config",
     get_available_variants("gpt_oss").items(),
     ids=[str(k) for k in get_available_variants("gpt_oss").keys()],
 )
-@pytest.mark.filecheck(["matmul_with_activation_silu.ttnn.mlir"])
-def test_gpt_oss_mlp(variant, variant_config, arch):
+def test_gpt_oss_mlp(variant, variant_config, arch, mlp_type, request):
+    if mlp_type == "sparse" and arch != "llmbox":
+        pytest.skip("Sparse MLP test only supported on multi-device (llmbox) arch")
+    if mlp_type != "sparse":
+        request.node.add_marker(
+            pytest.mark.filecheck(["matmul_with_activation_silu.ttnn.mlir"])
+        )
     xr.set_device_type("TT")
 
     loader = GPTOSSModelLoader(variant=variant, num_layers=1)
@@ -502,6 +509,8 @@ def test_gpt_oss_mlp(variant, variant_config, arch):
         mesh_shape = (2, num_devices // 2)
         device_ids = np.array(range(num_devices))
         mesh = Mesh(device_ids, mesh_shape, ("batch", "model"))
+        if mlp_type == "sparse":
+            mlp = enable_sparse_mlp(mlp, mesh=mesh_shape, cluster_axis=0)
 
         def get_shard_spec(mlp, args, kwargs):
             shard_specs = {}
@@ -511,10 +520,16 @@ def test_gpt_oss_mlp(variant, variant_config, arch):
             shard_specs[mlp.router.bias] = (None,)
 
             # Shard experts across devices.
-            shard_specs[mlp.experts.gate_up_proj] = ("model", "batch", None)
-            shard_specs[mlp.experts.gate_up_proj_bias] = ("model", None)
-            shard_specs[mlp.experts.down_proj] = ("model", None, "batch")
-            shard_specs[mlp.experts.down_proj_bias] = ("model", "batch")
+            if mlp_type == "standard":
+                shard_specs[mlp.experts.gate_up_proj] = ("model", "batch", None)
+                shard_specs[mlp.experts.gate_up_proj_bias] = ("model", None)
+                shard_specs[mlp.experts.down_proj] = ("model", None, "batch")
+                shard_specs[mlp.experts.down_proj_bias] = ("model", "batch")
+            elif mlp_type == "sparse":
+                shard_specs[mlp.experts.gate_up_proj] = (("batch", "model"), None, None)
+                shard_specs[mlp.experts.gate_up_proj_bias] = (("batch", "model"), None)
+                shard_specs[mlp.experts.down_proj] = (("batch", "model"), None, None)
+                shard_specs[mlp.experts.down_proj_bias] = (("batch", "model"), None)
 
             return shard_specs
 
@@ -529,3 +544,57 @@ def test_gpt_oss_mlp(variant, variant_config, arch):
         mesh=mesh,
         shard_spec_fn=get_shard_spec,
     )
+
+
+@pytest.mark.nightly
+def test_a2a_sparse_mlp_cpu_parity():
+    """Verify A2aSparseMLP produces the same results as the original MLP on CPU.
+
+    Tests with num_devices=1 (no E0/E1 reshape) and num_devices>1 (E0/E1 reshape active).
+    On CPU, dispatch/combine are no-ops regardless of num_devices, so outputs should match.
+    PCC checks internally because we don't have support for cpu vs cpu comparison in our current test infra.
+    """
+    loader = GPTOSSModelLoader(num_layers=1)
+    model = loader.load_model()
+    config = loader.load_config()
+    inputs = loader.load_inputs()
+
+    batch_size = inputs["input_ids"].shape[0]
+    seq_len = inputs["input_ids"].shape[1]
+
+    original_mlp = model.model.layers[0].mlp
+
+    hidden_states = torch.randn(
+        (batch_size, seq_len, config.hidden_size), dtype=torch.bfloat16
+    )
+
+    # Run original BEFORE creating A2aSparseMLP (init reshapes shared experts)
+    with torch.no_grad():
+        original_out, original_scores = original_mlp(hidden_states)
+
+    a2a_mlp = A2aSparseMLP(
+        original_mlp,
+        num_experts=config.num_local_experts,
+        num_experts_per_tok=config.num_experts_per_tok,
+        num_devices=8,
+        dispatch_devices=2,
+        cluster_axis=0,
+        config=config,
+    )
+
+    with torch.no_grad():
+        a2a_out, a2a_scores = a2a_mlp(hidden_states)
+
+    def compute_pcc(x, y):
+        x_flat, y_flat = x.flatten().float(), y.flatten().float()
+        vx, vy = x_flat - x_flat.mean(), y_flat - y_flat.mean()
+        denom = vx.norm() * vy.norm()
+        if denom == 0:
+            return 1.0 if torch.allclose(x_flat, y_flat) else 0.0
+        return float((vx @ vy) / denom)
+
+    pcc_out = compute_pcc(original_out, a2a_out)
+    pcc_scores = compute_pcc(original_scores, a2a_scores)
+
+    assert pcc_out > 0.99, f"Output PCC too low: {pcc_out:.6f}"
+    assert pcc_scores > 0.99, f"Router scores PCC too low: {pcc_scores:.6f}"

--- a/tests/torch/multi_host/llmbox/test_multihost.py
+++ b/tests/torch/multi_host/llmbox/test_multihost.py
@@ -39,7 +39,12 @@ def get_distributed_worker_path():
     "model_variant",
     [
         "llama/causal_lm/pytorch-3.1_8B-tensor_parallel-inference",
-        "gpt_oss/pytorch-20B-tensor_parallel-inference",
+        pytest.param(
+            "gpt_oss/pytorch-20B-tensor_parallel-inference",
+            marks=pytest.mark.skip(
+                reason="Reduce scatter op hang issue on model - tracked by issue https://github.com/tenstorrent/tt-xla/issues/3650"
+            ),
+        ),
     ],
 )
 def test_multihost_models(model_variant):


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/3096
https://github.com/tenstorrent/tt-xla/issues/3095
https://github.com/tenstorrent/tt-xla/issues/3486

### Problem description
We have no support for sparse MoE.

### What's changed
- Add sparse_mlp.py with SparseMLP, A2aSparseMLP, and DeepseekV3 (kimi k2) adapter
- Register custom ops: sparse_matmul, all_to_all_dispatch/combine, moe_expert_token_remap
- Extend sharding.py with compound sharding and unreduced axis support
- Add inject_custom_moe config flag to dynamically replace MoE layers in tester
- Enable for gpt_oss 20B/120B tensor parallel tests

### Checklist
- [ ] New/Existing tests provide coverage for changes
