### PR TITLE
[vLLM Plugin] Bypass CI proxy for /v1/responses API tests to fix failures in Nightly on CiV2 (#3637)

### DIFF
--- a/tests/integrations/vllm_plugin/generative/test_responses_api.py
+++ b/tests/integrations/vllm_plugin/generative/test_responses_api.py
@@ -26,6 +26,11 @@ MODEL = "facebook/opt-125m"
 SERVER_STARTUP_TIMEOUT = 600  # seconds (CI can be slow: model download + compilation)
 REQUEST_TIMEOUT = 120  # seconds
 
+# CI shared runners route traffic through a restricted proxy that returns 403
+# for local URLs. Use a session with proxies disabled for all requests.
+_session = requests.Session()
+_session.trust_env = False
+
 # Minimal chat template for models that lack one (e.g. opt-125m).
 CHAT_TEMPLATE = "{% for message in messages %}{{ message['content'] }}{% endfor %}"
 
@@ -115,7 +120,7 @@ def vllm_server():
                     f"Output:\n{log_tail}"
                 )
             try:
-                resp = requests.get(health_url, timeout=5)
+                resp = _session.get(health_url, timeout=5)
                 if resp.status_code == 200:
                     ready = True
                     break
@@ -178,7 +183,7 @@ def test_responses_api_basic(vllm_server, input_value):
         "max_output_tokens": 32,
     }
 
-    response = requests.post(url, json=data, timeout=REQUEST_TIMEOUT)
+    response = _session.post(url, json=data, timeout=REQUEST_TIMEOUT)
     assert (
         response.status_code == 200
     ), f"Expected 200, got {response.status_code}: {response.text}"
@@ -211,7 +216,7 @@ def test_responses_api_streaming(vllm_server):
     }
 
     collected_events = []
-    with requests.post(url, json=data, stream=True, timeout=REQUEST_TIMEOUT) as resp:
+    with _session.post(url, json=data, stream=True, timeout=REQUEST_TIMEOUT) as resp:
         assert (
             resp.status_code == 200
         ), f"Expected 200, got {resp.status_code}: {resp.text}"
@@ -262,10 +267,10 @@ def test_responses_api_deterministic(vllm_server):
         "temperature": 0.0,
     }
 
-    response1 = requests.post(url, json=data, timeout=REQUEST_TIMEOUT)
+    response1 = _session.post(url, json=data, timeout=REQUEST_TIMEOUT)
     assert response1.status_code == 200, f"Request 1 failed: {response1.text}"
 
-    response2 = requests.post(url, json=data, timeout=REQUEST_TIMEOUT)
+    response2 = _session.post(url, json=data, timeout=REQUEST_TIMEOUT)
     assert response2.status_code == 200, f"Request 2 failed: {response2.text}"
 
     text1 = get_output_text(response1.json())
@@ -293,7 +298,7 @@ def test_responses_api_instructions(vllm_server):
         "max_output_tokens": 32,
     }
 
-    response = requests.post(url, json=data, timeout=REQUEST_TIMEOUT)
+    response = _session.post(url, json=data, timeout=REQUEST_TIMEOUT)
     assert (
         response.status_code == 200
     ), f"Expected 200, got {response.status_code}: {response.text}"
@@ -319,7 +324,7 @@ def test_responses_api_top_logprobs(vllm_server):
         "include": ["message.output_text.logprobs"],
     }
 
-    response = requests.post(url, json=data, timeout=REQUEST_TIMEOUT)
+    response = _session.post(url, json=data, timeout=REQUEST_TIMEOUT)
     assert (
         response.status_code == 200
     ), f"Expected 200, got {response.status_code}: {response.text}"


### PR DESCRIPTION
## Summary
Fix /v1/responses API tests failing on CIv2 shared runners with 403 Forbidden. The shared runner containers route HTTP traffic through a restricted proxy that rejects localhost requests to the subprocess vLLM server.

## Ticket
Fixes #3637

## What's changed
- `tests/integrations/vllm_plugin/generative/test_responses_api.py`: Use a `requests.Session` with `trust_env=False` to bypass proxy configuration for all HTTP requests to the local server.

## Checklist
- [x] Tests pass locally
- [x] Tests pass on CIv2 shared runners: https://github.com/tenstorrent/tt-xla/actions/runs/22824750257/job/66203509267
- [x] Tests pass when run alongside others in vllm nightly set of tests on CiV2: https://github.com/tenstorrent/tt-xla/actions/runs/22825194478