### PR TITLE
Uplift PJRT C API header from v0.97 to v0.98

### DIFF
--- a/pjrt_implementation/src/stubs.inc
+++ b/pjrt_implementation/src/stubs.inc
@@ -177,3 +177,4 @@
   _STUB(PJRT_Client_Load);
   _STUB(PJRT_Device_GetAttributes);
   _STUB(PJRT_LoadedExecutable_AddressableDeviceLogicalIds);
+  _STUB(PJRT_Buffer_Bitcast);

--- a/third_party/pjrt_c_api/xla/pjrt/c/pjrt_c_api.h
+++ b/third_party/pjrt_c_api/xla/pjrt/c/pjrt_c_api.h
@@ -118,7 +118,7 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_Extension_Base, next);
 // Changes include:
 // * Adding a new field to the PJRT_Api or argument structs
 // * Renaming a method or argument (doesn't affect ABI)
-#define PJRT_API_MINOR 97
+#define PJRT_API_MINOR 98
 
 // The plugin should set the major_version and minor_version of
 // PJRT_Api.pjrt_api_version to be the `PJRT_API_MAJOR` and `PJRT_API_MINOR` in
@@ -2454,6 +2454,26 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_CopyToMemory_Args, dst_buffer);
 typedef PJRT_Error *
 PJRT_Buffer_CopyToMemory(PJRT_Buffer_CopyToMemory_Args *args);
 
+struct PJRT_Buffer_Bitcast_Args {
+  size_t struct_size;
+  PJRT_Extension_Base *extension_start;
+  PJRT_Buffer *buffer;
+  // The new buffer type.
+  PJRT_Buffer_Type element_type;
+  // The new array dimensions.
+  const int64_t *dims;
+  size_t num_dims;
+  // The new buffer layout. If nullptr, a default layout (not the source
+  // buffer's layout) will be used.
+  PJRT_Buffer_MemoryLayout *device_layout;
+  // The new buffer.
+  PJRT_Buffer *out_buffer; // out
+};
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_Buffer_Bitcast_Args, out_buffer);
+
+// Bitcasts the buffer to a new type, dimensions, and layout.
+typedef PJRT_Error *PJRT_Buffer_Bitcast(PJRT_Buffer_Bitcast_Args *args);
+
 struct PJRT_Buffer_IsOnCpu_Args {
   size_t struct_size;
   PJRT_Extension_Base *extension_start;
@@ -2987,12 +3007,10 @@ typedef struct PJRT_Api {
 
   _PJRT_API_STRUCT_FIELD(PJRT_Client_Load);
   _PJRT_API_STRUCT_FIELD(PJRT_LoadedExecutable_AddressableDeviceLogicalIds);
+  _PJRT_API_STRUCT_FIELD(PJRT_Buffer_Bitcast);
 } PJRT_Api;
 
-enum {
-  PJRT_Api_STRUCT_SIZE = PJRT_STRUCT_SIZE(
-      PJRT_Api, PJRT_LoadedExecutable_AddressableDeviceLogicalIds)
-};
+enum { PJRT_Api_STRUCT_SIZE = PJRT_STRUCT_SIZE(PJRT_Api, PJRT_Buffer_Bitcast) };
 
 #undef _PJRT_API_STRUCT_FIELD
 


### PR DESCRIPTION
## Description

This PR uplifts the PJRT C API header from the upstream [OpenXLA repository](https://github.com/openxla/xla).

- **Version change:** `v0.97` -> `v0.98`
- **Source file:** https://github.com/openxla/xla/blob/main/xla/pjrt/c/pjrt_c_api.h

## Checklist

- [x] Review the changes in `pjrt_c_api.h` and ensure backward compatibility with the tt-xla implementation.
- [x] Review the changes in `stubs.inc` and discuss with the team whether a new feature should be flagged as useful for implementation.
- [ ] Manually run the `.github/workflows/schedule-nightly.yml` workflow to schedule an extended test set run.
- [x] Run PJRT unit tests (scheduled automatically upon PR creation).