### PR TITLE
Tracy build disable -march_native to avoid avx512 instructions being compiled into tracy capture  

### DIFF
--- a/.github/workflows/call-build.yml
+++ b/.github/workflows/call-build.yml
@@ -149,6 +149,10 @@ jobs:
 
       - name: Build the wheel
         shell: bash
+        env:
+          # TODO: Revisit the addition of these env vars https://github.com/tenstorrent/tt-metal/issues/20161
+          TRACY_NO_INVARIANT_CHECK: 1
+          TRACY_NO_ISA_EXTENSIONS: 1
         run: |
             source venv/activate
             cd ${{ steps.strings.outputs.work-dir }}/python_package


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] New/Existing tests provide coverage for changes
