### PR TITLE
PJRT Complex dtype support and complex tests

### DIFF
--- a/pjrt_implementation/inc/api/buffer_instance.h
+++ b/pjrt_implementation/inc/api/buffer_instance.h
@@ -179,7 +179,8 @@ private:
 
   // Calculates required tensor shape.
   static std::vector<std::uint32_t> calculateShape(const std::int64_t *dims,
-                                                   size_t num_dims);
+                                                   size_t num_dims,
+                                                   PJRT_Buffer_Type data_type);
 
   // Calculates required tensor strides.
   static std::vector<std::uint32_t>

--- a/pjrt_implementation/inc/utils/data_type_utils.h
+++ b/pjrt_implementation/inc/utils/data_type_utils.h
@@ -32,6 +32,12 @@ convertPJRTToRuntimeDataType(PJRT_Buffer_Type pjrt_data_type);
 // Returns the PJRT_Buffer_Type enum corresponding to the given MLIR type.
 PJRT_Buffer_Type convertMLIRToPJRTDataType(mlir::Type type);
 
+// Returns true if the given PJRT buffer type is a complex type (C64 or C128).
+// Complex tensors are stored internally as float tensors with a trailing
+// dimension of 2 (interleaved real/imag), since the runtime has no complex
+// type support.
+bool isComplexPJRTType(PJRT_Buffer_Type type);
+
 } // namespace tt::pjrt::data_type_utils
 
 #endif // TT_XLA_PJRT_IMPLEMENTATION_INC_UTILS_DATA_TYPE_UTILS_H_

--- a/pjrt_implementation/src/api/buffer_instance.cc
+++ b/pjrt_implementation/src/api/buffer_instance.cc
@@ -172,7 +172,8 @@ void BufferInstance::copyFromHost(
       tt::pjrt::data_type_utils::convertPJRTToRuntimeDataType(m_data_type);
   std::uint32_t element_size =
       tt::runtime::utils::dataTypeElementSize(runtime_data_type);
-  std::vector<std::uint32_t> shape = calculateShape(dims, num_dims);
+  std::vector<std::uint32_t> shape =
+      calculateShape(dims, num_dims, m_data_type);
   std::vector<std::uint32_t> strides =
       calculateStrides(num_dims, byte_strides, num_byte_strides, element_size);
 
@@ -251,7 +252,8 @@ void BufferInstance::copyFromBuffer(BufferInstance *src_buffer) {
   std::uint32_t element_size =
       tt::runtime::utils::dataTypeElementSize(runtime_data_type);
   std::vector<std::uint32_t> shape = calculateShape(
-      src_buffer->getDimensionsRaw(), src_buffer->getNumberOfDimensions());
+      src_buffer->getDimensionsRaw(), src_buffer->getNumberOfDimensions(),
+      src_buffer->getDataType());
   std::vector<std::uint32_t> strides = calculateStrides(
       src_buffer->getNumberOfDimensions(), nullptr, 0, element_size);
 
@@ -267,7 +269,8 @@ void BufferInstance::copyFromBuffer(BufferInstance *src_buffer) {
 }
 
 std::vector<std::uint32_t>
-BufferInstance::calculateShape(const std::int64_t *dims, size_t num_dims) {
+BufferInstance::calculateShape(const std::int64_t *dims, size_t num_dims,
+                               PJRT_Buffer_Type data_type) {
   if (num_dims == 0) {
     // Our compiler and runtime don't support scalars so we convert them to 1D
     // tensors.
@@ -277,6 +280,12 @@ BufferInstance::calculateShape(const std::int64_t *dims, size_t num_dims) {
   std::vector<std::uint32_t> shape;
   for (size_t i = 0; i < num_dims; ++i) {
     shape.push_back(dims[i]);
+  }
+
+  // Complex tensors have no runtime equivalent dtype, so they are stored as
+  // float tensors with a trailing dimension of 2 for interleaved real/imag.
+  if (data_type_utils::isComplexPJRTType(data_type)) {
+    shape.push_back(2);
   }
 
   return shape;

--- a/pjrt_implementation/src/api/buffer_instance.cc
+++ b/pjrt_implementation/src/api/buffer_instance.cc
@@ -274,6 +274,11 @@ BufferInstance::calculateShape(const std::int64_t *dims, size_t num_dims,
   if (num_dims == 0) {
     // Our compiler and runtime don't support scalars so we convert them to 1D
     // tensors.
+    if (data_type_utils::isComplexPJRTType(data_type)) {
+      // Throw error if complex tensor num_dims == 0.
+      throw std::runtime_error(
+          "Complex tensor with num_dims == 0 is not supported.");
+    }
     return {1};
   }
 

--- a/pjrt_implementation/src/utils/data_type_utils.cc
+++ b/pjrt_implementation/src/utils/data_type_utils.cc
@@ -116,6 +116,12 @@ convertPJRTToRuntimeDataType(PJRT_Buffer_Type pjrt_data_type) {
     return tt::target::DataType::UInt64;
   case PJRT_Buffer_Type_PRED:
     return tt::target::DataType::Bool;
+  // Complex types have no runtime equivalent. They are stored as float tensors
+  // with a trailing dimension of 2 (interleaved real/imag pairs).
+  case PJRT_Buffer_Type_C64:
+    return tt::target::DataType::Float32;
+  case PJRT_Buffer_Type_C128:
+    return tt::target::DataType::Float64;
   default:
     throw std::runtime_error(std::string("PJRT data type: ") +
                              getPJRTBufferTypeString(pjrt_data_type) +
@@ -128,6 +134,20 @@ PJRT_Buffer_Type convertMLIRToPJRTDataType(mlir::Type type) {
   if (mlir::RankedTensorType tensorType =
           mlir::dyn_cast<mlir::RankedTensorType>(type)) {
     return convertMLIRToPJRTDataType(tensorType.getElementType());
+  }
+
+  if (mlir::ComplexType complexType =
+          mlir::dyn_cast_or_null<mlir::ComplexType>(type)) {
+    mlir::Type elementType = complexType.getElementType();
+    if (mlir::FloatType floatType =
+            mlir::dyn_cast<mlir::FloatType>(elementType)) {
+      if (floatType.isF32()) {
+        return PJRT_Buffer_Type_C64;
+      } else if (floatType.isF64()) {
+        return PJRT_Buffer_Type_C128;
+      }
+    }
+    throw std::runtime_error("Unsupported complex element type");
   }
 
   if (mlir::FloatType floatType =
@@ -177,6 +197,10 @@ PJRT_Buffer_Type convertMLIRToPJRTDataType(mlir::Type type) {
   }
 
   throw std::runtime_error("Unsupported data type");
+}
+
+bool isComplexPJRTType(PJRT_Buffer_Type type) {
+  return type == PJRT_Buffer_Type_C64 || type == PJRT_Buffer_Type_C128;
 }
 
 } // namespace tt::pjrt::data_type_utils

--- a/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_2_exp.py
+++ b/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_2_exp.py
@@ -54,11 +54,6 @@ def test_deepseek_modified_transformer_single_layer():
         output.to("cpu")
 
 
-@pytest.mark.xfail(
-    reason=failed_ttmlir_compilation(
-        "error: failed to legalize operation 'stablehlo.constant'"
-    )
-)
 def test_deepseek_complex_rotary_emb():
     xr.set_device_type("TT")
 
@@ -77,21 +72,20 @@ def test_deepseek_complex_rotary_emb():
             y = torch.cat([y[..., 0::2], y[..., 1::2]], dim=-1)
         return y.to(dtype)
 
-    compiled_apply_rotary_emb = torch.compile(apply_rotary_emb, backend="tt")
-
     batch_size = 2
     seq_len = 16
     dim = 64
     n_heads = 4
     head_dim = dim // n_heads
 
-    x = torch.randn(
-        batch_size, seq_len, n_heads, head_dim, device="xla", dtype=torch.bfloat16
-    )
-    freqs_cis = torch.randn(seq_len, head_dim // 2, device="xla", dtype=torch.complex64)
+    x = torch.randn(batch_size, seq_len, n_heads, head_dim, dtype=torch.bfloat16)
+    freqs_cis = torch.randn(seq_len, head_dim // 2, dtype=torch.complex64)
 
-    y = compiled_apply_rotary_emb(x, freqs_cis, interleaved=True)
-    assert y.shape == x.shape
+    run_graph_test(
+        apply_rotary_emb,
+        [x, freqs_cis],
+        framework=Framework.TORCH,
+    )
 
 
 @pytest.mark.llmbox

--- a/tests/torch/ops/test_complex.py
+++ b/tests/torch/ops/test_complex.py
@@ -1,0 +1,169 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from infra import Framework, run_op_test, run_op_test_with_random_inputs
+from utils import Category
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.single_device
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    torch_op_name="torch.view_as_complex",
+)
+@pytest.mark.parametrize(
+    "shape",
+    [(32, 32), (64, 64)],
+    ids=lambda val: f"{val}",
+)
+def test_complex(shape: tuple, request):
+    class Complex(torch.nn.Module):
+        def forward(self, real: torch.Tensor, imag: torch.Tensor) -> torch.Tensor:
+            return torch.view_as_complex(torch.stack([real, imag], dim=-1))
+
+    run_op_test_with_random_inputs(
+        Complex(),
+        input_shapes=[shape, shape],
+        framework=Framework.TORCH,
+        request=request,
+    )
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.single_device
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    torch_op_name="torch.view_as_real",
+)
+@pytest.mark.parametrize(
+    "shape",
+    [(32, 32), (64, 64)],
+    ids=lambda val: f"{val}",
+)
+def test_view_as_real(shape: tuple, request):
+    class ViewAsReal(torch.nn.Module):
+        def forward(self, real: torch.Tensor, imag: torch.Tensor) -> torch.Tensor:
+            z = torch.view_as_complex(torch.stack([real, imag], dim=-1))
+            return torch.view_as_real(z)
+
+    run_op_test_with_random_inputs(
+        ViewAsReal(),
+        input_shapes=[shape, shape],
+        framework=Framework.TORCH,
+        request=request,
+    )
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.single_device
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    torch_op_name="torch.real",
+)
+@pytest.mark.parametrize(
+    "shape",
+    [(32, 32), (64, 64)],
+    ids=lambda val: f"{val}",
+)
+def test_real(shape: tuple, request):
+    class Real(torch.nn.Module):
+        def forward(self, real: torch.Tensor, imag: torch.Tensor) -> torch.Tensor:
+            z = torch.view_as_complex(torch.stack([real, imag], dim=-1))
+            return torch.real(z)
+
+    run_op_test_with_random_inputs(
+        Real(),
+        input_shapes=[shape, shape],
+        framework=Framework.TORCH,
+        request=request,
+    )
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.single_device
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    torch_op_name="torch.imag",
+)
+@pytest.mark.parametrize(
+    "shape",
+    [(32, 32), (64, 64)],
+    ids=lambda val: f"{val}",
+)
+def test_imag(shape: tuple, request):
+    class Imag(torch.nn.Module):
+        def forward(self, real: torch.Tensor, imag: torch.Tensor) -> torch.Tensor:
+            z = torch.view_as_complex(torch.stack([real, imag], dim=-1))
+            return torch.imag(z)
+
+    run_op_test_with_random_inputs(
+        Imag(),
+        input_shapes=[shape, shape],
+        framework=Framework.TORCH,
+        request=request,
+    )
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.single_device
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    torch_op_name="torch.view_as_complex+torch.real+torch.imag",
+)
+@pytest.mark.parametrize(
+    "shape",
+    [(32, 32), (64, 64)],
+    ids=lambda val: f"{val}",
+)
+def test_complex_real_imag_combined(shape: tuple, request):
+    """Constructs a complex tensor, extracts real and imaginary parts, then
+    reconstructs it via view_as_complex to verify round-trip correctness."""
+
+    class ComplexRealImagCombined(torch.nn.Module):
+        def forward(self, real: torch.Tensor, imag: torch.Tensor) -> torch.Tensor:
+            z = torch.view_as_complex(torch.stack([real, imag], dim=-1))
+            r = torch.real(z)
+            i = torch.imag(z)
+            return torch.view_as_complex(torch.stack([r, i], dim=-1))
+
+    run_op_test_with_random_inputs(
+        ComplexRealImagCombined(),
+        input_shapes=[shape, shape],
+        framework=Framework.TORCH,
+        request=request,
+    )
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.single_device
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST, torch_op_name="torch.mul"
+)
+@pytest.mark.parametrize(
+    "shape",
+    [(32, 32)],
+    ids=lambda val: f"{val}",
+)
+def test_complex_mul(shape: tuple, request):
+    class ComplexMul(torch.nn.Module):
+        def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            return x * y
+
+    run_op_test(
+        ComplexMul(),
+        [
+            torch.randn(shape, dtype=torch.complex64),
+            torch.randn(shape, dtype=torch.complex64),
+        ],
+        framework=Framework.TORCH,
+        request=request,
+    )

--- a/tests/torch/ops/test_complex.py
+++ b/tests/torch/ops/test_complex.py
@@ -176,6 +176,40 @@ def test_complex_real_imag_combined(shape: tuple, dtype: torch.dtype, request):
 @pytest.mark.nightly
 @pytest.mark.single_device
 @pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    torch_op_name="torch.view_as_complex+torch.real+torch.imag",
+)
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.float32, torch.float64],
+    ids=["float32", "float64"],
+)
+def test_complex_real_imag_combined_scalar(dtype: torch.dtype, request):
+    """Scalar variant: constructs a complex scalar, extracts real/imag parts,
+    then reconstructs it via view_as_complex to verify round-trip correctness."""
+
+    class ComplexRealImagCombined(torch.nn.Module):
+        def forward(self, real: torch.Tensor, imag: torch.Tensor) -> torch.Tensor:
+            z = torch.view_as_complex(torch.stack([real, imag], dim=-1))
+            r = torch.real(z)
+            i = torch.imag(z)
+            return torch.view_as_complex(torch.stack([r, i], dim=-1))
+
+    run_op_test(
+        ComplexRealImagCombined(),
+        [
+            torch.tensor(1.5, dtype=dtype),
+            torch.tensor(2.5, dtype=dtype),
+        ],
+        framework=Framework.TORCH,
+        request=request,
+    )
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.single_device
+@pytest.mark.record_test_properties(
     category=Category.OP_TEST, torch_op_name="torch.mul"
 )
 @pytest.mark.parametrize(

--- a/tests/torch/ops/test_complex.py
+++ b/tests/torch/ops/test_complex.py
@@ -20,7 +20,12 @@ from utils import Category
     [(32, 32), (64, 64)],
     ids=lambda val: f"{val}",
 )
-def test_complex(shape: tuple, request):
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.float32, torch.float64],
+    ids=["float32", "float64"],
+)
+def test_complex(shape: tuple, dtype: torch.dtype, request):
     class Complex(torch.nn.Module):
         def forward(self, real: torch.Tensor, imag: torch.Tensor) -> torch.Tensor:
             return torch.view_as_complex(torch.stack([real, imag], dim=-1))
@@ -28,6 +33,7 @@ def test_complex(shape: tuple, request):
     run_op_test_with_random_inputs(
         Complex(),
         input_shapes=[shape, shape],
+        dtype=dtype,
         framework=Framework.TORCH,
         request=request,
     )
@@ -45,7 +51,12 @@ def test_complex(shape: tuple, request):
     [(32, 32), (64, 64)],
     ids=lambda val: f"{val}",
 )
-def test_view_as_real(shape: tuple, request):
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.float32, torch.float64],
+    ids=["float32", "float64"],
+)
+def test_view_as_real(shape: tuple, dtype: torch.dtype, request):
     class ViewAsReal(torch.nn.Module):
         def forward(self, real: torch.Tensor, imag: torch.Tensor) -> torch.Tensor:
             z = torch.view_as_complex(torch.stack([real, imag], dim=-1))
@@ -54,6 +65,7 @@ def test_view_as_real(shape: tuple, request):
     run_op_test_with_random_inputs(
         ViewAsReal(),
         input_shapes=[shape, shape],
+        dtype=dtype,
         framework=Framework.TORCH,
         request=request,
     )
@@ -71,7 +83,12 @@ def test_view_as_real(shape: tuple, request):
     [(32, 32), (64, 64)],
     ids=lambda val: f"{val}",
 )
-def test_real(shape: tuple, request):
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.float32, torch.float64],
+    ids=["float32", "float64"],
+)
+def test_real(shape: tuple, dtype: torch.dtype, request):
     class Real(torch.nn.Module):
         def forward(self, real: torch.Tensor, imag: torch.Tensor) -> torch.Tensor:
             z = torch.view_as_complex(torch.stack([real, imag], dim=-1))
@@ -80,6 +97,7 @@ def test_real(shape: tuple, request):
     run_op_test_with_random_inputs(
         Real(),
         input_shapes=[shape, shape],
+        dtype=dtype,
         framework=Framework.TORCH,
         request=request,
     )
@@ -97,7 +115,12 @@ def test_real(shape: tuple, request):
     [(32, 32), (64, 64)],
     ids=lambda val: f"{val}",
 )
-def test_imag(shape: tuple, request):
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.float32, torch.float64],
+    ids=["float32", "float64"],
+)
+def test_imag(shape: tuple, dtype: torch.dtype, request):
     class Imag(torch.nn.Module):
         def forward(self, real: torch.Tensor, imag: torch.Tensor) -> torch.Tensor:
             z = torch.view_as_complex(torch.stack([real, imag], dim=-1))
@@ -106,6 +129,7 @@ def test_imag(shape: tuple, request):
     run_op_test_with_random_inputs(
         Imag(),
         input_shapes=[shape, shape],
+        dtype=dtype,
         framework=Framework.TORCH,
         request=request,
     )
@@ -123,7 +147,12 @@ def test_imag(shape: tuple, request):
     [(32, 32), (64, 64)],
     ids=lambda val: f"{val}",
 )
-def test_complex_real_imag_combined(shape: tuple, request):
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.float32, torch.float64],
+    ids=["float32", "float64"],
+)
+def test_complex_real_imag_combined(shape: tuple, dtype: torch.dtype, request):
     """Constructs a complex tensor, extracts real and imaginary parts, then
     reconstructs it via view_as_complex to verify round-trip correctness."""
 
@@ -137,6 +166,7 @@ def test_complex_real_imag_combined(shape: tuple, request):
     run_op_test_with_random_inputs(
         ComplexRealImagCombined(),
         input_shapes=[shape, shape],
+        dtype=dtype,
         framework=Framework.TORCH,
         request=request,
     )
@@ -153,7 +183,12 @@ def test_complex_real_imag_combined(shape: tuple, request):
     [(32, 32)],
     ids=lambda val: f"{val}",
 )
-def test_complex_mul(shape: tuple, request):
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.complex64, torch.complex128],
+    ids=["complex64", "complex128"],
+)
+def test_complex_mul(shape: tuple, dtype: torch.dtype, request):
     class ComplexMul(torch.nn.Module):
         def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
             return x * y
@@ -161,8 +196,8 @@ def test_complex_mul(shape: tuple, request):
     run_op_test(
         ComplexMul(),
         [
-            torch.randn(shape, dtype=torch.complex64),
-            torch.randn(shape, dtype=torch.complex64),
+            torch.randn(shape, dtype=dtype),
+            torch.randn(shape, dtype=dtype),
         ],
         framework=Framework.TORCH,
         request=request,


### PR DESCRIPTION
### Ticket
#3060 

### Problem description
Currently, we do not have pjrt complex dtype support for tt device. Complex dtype is interleaved: [re0, im0, re1, im1, ...] 
We know this from the following PJRT dtype definition https://github.com/openxla/xla/blob/main/xla/pjrt/c/pjrt_c_api.h:
```
  // Paired F32 (real, imag), as in std::complex<float>.
  PJRT_Buffer_Type_C64,
  // Paired F64 (real, imag), as in std::complex<double>.
  PJRT_Buffer_Type_C128,
```
We need a way to represent complex dtype in tt-mlir and map that.

### What's changed
In tt-mlir, complex dtype is unpacked by adding a trailing dimension of 2. This corresponds 1:1 with interleaved nature. Last dim represent real (0) and imaginary (1), respectively.

I.e. tensor<1x3xcomplex<f32>> --> tensor<1x3x2xf32>

Therefore, added support for complex dtype and this conversion.

Added test for complex ops. 

### Checklist
- [x] tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_2_exp.py::test_deepseek_complex_rotary_emb - https://github.com/tenstorrent/tt-xla/actions/runs/23299919559
