### PR TITLE
Don't ignore device perf failures

### DIFF
--- a/.github/workflows/call-perf-test.yml
+++ b/.github/workflows/call-perf-test.yml
@@ -341,13 +341,13 @@ jobs:
 
         echo "Copy binaries"
         mkdir -p flatbuffers
-        cp ./modules/*.ttnn flatbuffers/ 2>/dev/null || echo "No .ttnn files found"
+        cp ./modules/*.ttnn flatbuffers/ 2>/dev/null
 
         echo "Run ttrt perf"
-        ttrt perf flatbuffers --ignore-version || echo "ttrt perf failed, continuing..."
+        ttrt perf flatbuffers --ignore-version
 
         echo "Write device perf to report"
-        python3 ./tests/benchmark/scripts/device_perf.py ttrt-artifacts ${{ steps.strings.outputs.perf_report_json_file }} || echo "device_perf.py failed, continuing..."
+        python3 ./tests/benchmark/scripts/device_perf.py ttrt-artifacts ${{ steps.strings.outputs.perf_report_json_file }}
 
         echo "Copy device perf CSVs"
         mkdir -p ${{ steps.strings.outputs.perf_report_path }}/device_perf


### PR DESCRIPTION
### Ticket
Closes #3603 

### Problem description
Device perf job in benchmark CI was skipping device perf failures.
[Llama3.1 70B galaxy](https://github.com/tenstorrent/tt-xla/actions/runs/22930075253/job/66550691550) was failing `ttrt perf`, but the job was reported as Success.

### What's changed
Disabled skipping device perf failures on benchmark CI.