### PR TITLE
Add inference test config for Qwen2_5_72b variants in galaxy 

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -185,10 +185,12 @@ test_config:
     bringup_status: FAILED_RUNTIME
 
   qwen_2_5/causal_lm/pytorch-72B_Instruct-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
-    status: NOT_SUPPORTED_SKIP
-    reason: "Needs bringup on galaxy"
-    bringup_status: FAILED_RUNTIME
+    supported_archs: [galaxy-wh-6u]
+    status: EXPECTED_PASSING
+
+  qwen_2_5/causal_lm/pytorch-72B-tensor_parallel-inference:
+    supported_archs: [galaxy-wh-6u]
+    status: EXPECTED_PASSING
 
   qwen_3/causal_lm/pytorch-30B_A3b-tensor_parallel-inference:
     supported_archs: [n300-llmbox]


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/3566#event-23250928107)

### Problem description
Inference test config not yet added for Qwen2_5_72b variants in galaxy machine.

### What's changed

- Based on the results from [Run Test](https://github.com/tenstorrent/tt-xla/actions/runs/22949444062/job/66611426114) added inference test config for qwen2_5_72b variants in galaxy machine.
- Both the models are passing.
 
### Logs
[qwen_2_5_72b_ins.log](https://github.com/user-attachments/files/25900384/qwen_2_5_72b_ins.log)
[qwen_2_5_72b.log](https://github.com/user-attachments/files/25900387/qwen_2_5_72b.log)

### Checklist
- [ ] New/Existing tests provide coverage for changes
