### PR TITLE
Update Phi-2 model test configuration based on nightly results

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -566,8 +566,6 @@ test_config:
 
   phi2/causal_lm/pytorch-Phi_2-single_device-inference:
     status: EXPECTED_PASSING
-    required_pcc: 0.98
-    assert_pcc: false # ComputeConfig math_fidelity/fp32_dest_acc_en - https://github.com/tenstorrent/tt-xla/issues/2861
 
   phi2/causal_lm/pytorch-Phi_2_Pytdml-single_device-inference:
     status: EXPECTED_PASSING


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/2861

### Problem description
In the latest nightly runs, the models achieved a PCC of 0.99.

`test_all_models_torch[phi2/causal_lm/pytorch-Phi_2-single_device-inference]                                                                 language    red         bfloat16       n150         PASSED                     PASSING       0.9960198704454557     0.98       PCC_DIS  single_device    127.540   ENABLE_PCC,RAISE_PCC_099
`

### What's changed
Edited the test configuration file for the Phi-2 model.

### Checklist
- [ ] New/Existing tests provide coverage for changes
