### PR TITLE
Dynamically capture failing reason for unclassified cases

### DIFF
--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -32,6 +32,19 @@ from third_party.tt_forge_models.config import Parallelism
 BRINGUP_STAGE_FILE = "._bringup_stage.txt"
 
 
+class ResolvedFailingReason:
+    def __init__(self, name: str, description: str, component=None, summary=None):
+        self.name = name
+        self.summary = summary
+
+        class Value:
+            def __init__(self, description, component):
+                self.description = description
+                self.component_checker_description = component
+
+        self.value = Value(description, component)
+
+
 # Optional hint that selects a non-default execution/input-loading phase.
 # Today this is only used to distinguish LLM prefill vs decode; in the future it may
 # be extended to other model families (e.g., vision) if they need phase-specific inputs.
@@ -261,7 +274,22 @@ def update_test_metadata_for_exception(
     runtime_reason = detailed_error if detailed_error else message
 
     setattr(test_metadata, "runtime_reason", runtime_reason)
-    setattr(test_metadata, "failing_reason", exception_reason.failing_reasons)
+
+    if (
+        exception_reason.failing_reasons is not None
+        and exception_reason.failing_reasons.name != "UNCLASSIFIED"
+    ):
+        setattr(test_metadata, "failing_reason", exception_reason.failing_reasons)
+    else:
+        failing_reason_obj = ResolvedFailingReason(
+            name=type(exc).__name__,
+            description=runtime_reason,
+            component=None,
+            summary=exception_reason.summary,
+        )
+
+        setattr(test_metadata, "failing_reason", failing_reason_obj)
+
     setattr(test_metadata, "failing_reason_summary", exception_reason.summary)
 
 


### PR DESCRIPTION
### Ticket
Fixes #3694 

### Problem description
Dynamically capture failing reasons for all unclassified cases while all the previously added failing reason checks remain the same.

### What's changed

-  checks_xla.py is a static classifier, it tries to match an exception to a known FailingReasons enum entry. When nothing matches, it falls back to: FailingReasons.UNCLASSIFIED with description "Unclassified error"
That fallback is safe, but it’s not useful every new failure which means the Superset lose the real failure text. So instead of adding new failure reasons, brought in a feature to dynamically capture failing reason.

- Updated exception metadata handling in update_test_metadata_for_exception to improve failing reason quality for unclassified errors.

- Introduced a fallback path when the classifier returns UNCLASSIFIED or no failing reason and instead of propagating UNCLASSIFIED field, a ResolvedFailingReason has been constructed by using available exception details.

- For unclassified cases, the runtime_reason is now explicitly mapped into the failing reason description.

- The fallback reason uses Exception type  as the name, Extracted runtime_reason as the description and Existing summary from the classifier

- Preserved existing behavior for classified exceptions — no changes when a meaningful failing reason is returned.

### Logs
[bev_v2_reason.log](https://github.com/user-attachments/files/26014719/bev_v2_reason_updates.log)
