### PR TITLE
Re-enable densenet/pytorch-121_Xray single device inference test

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -216,7 +216,7 @@ test_config:
     status: EXPECTED_PASSING
 
   densenet/pytorch-121_Xray-single_device-inference:
-    status: KNOWN_FAILURE_XFAIL
+    status: EXPECTED_PASSING
 
   distilbert/question_answering/pytorch-Base_Cased_Distilled_Squad-single_device-inference:
     status: EXPECTED_PASSING


### PR DESCRIPTION
## Summary
  - Re-enable the `densenet/pytorch-121_Xray` single device inference test by changing its status from `KNOWN_FAILURE_XFAIL` to `EXPECTED_PASSING`.

  ## Test plan
  - [x] Verify the `densenet/pytorch-121_Xray-single_device-inference` test passes.