### PR TITLE
Remove some LLMBOX llms from benchmark CI

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -111,12 +111,6 @@
         "runs-on": "n300-llmbox"
       },
       {
-        "name": "mistral_7b_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
-        "pytest": "tests/benchmark/test_llms.py::test_mistral_7b_tp",
-        "runs-on": "n300-llmbox"
-      },
-      {
         "name": "ministral_8b_tp",
         "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
         "pytest": "tests/benchmark/test_llms.py::test_ministral_8b_tp",
@@ -141,27 +135,9 @@
         "runs-on": "n300-llmbox"
       },
       {
-        "name": "qwen_2_5_32b_instruct_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_32b_instruct_tp",
-        "runs-on": "n300-llmbox"
-      },
-      {
         "name": "qwen_2_5_coder_32b_instruct_tp",
         "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_coder_32b_instruct_tp",
-        "runs-on": "n300-llmbox"
-      },
-      {
-        "name": "qwen_3_0_6b_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_3_0_6b_tp",
-        "runs-on": "n300-llmbox"
-      },
-      {
-        "name": "qwen_3_1_7b_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_3_1_7b_tp",
         "runs-on": "n300-llmbox"
       },
       {
@@ -180,24 +156,6 @@
         "name": "qwen_3_32b_tp",
         "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_32b_tp",
-        "runs-on": "n300-llmbox"
-      },
-      {
-        "name": "llama_3_8b_instruct_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
-        "pytest": "tests/benchmark/test_llms.py::test_llama_3_8b_instruct_tp",
-        "runs-on": "n300-llmbox"
-      },
-      {
-        "name": "llama_3_1_8b_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
-        "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b_tp",
-        "runs-on": "n300-llmbox"
-      },
-      {
-        "name": "llama_3_8b_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
-        "pytest": "tests/benchmark/test_llms.py::test_llama_3_8b_tp",
         "runs-on": "n300-llmbox"
       },
       {


### PR DESCRIPTION
Removed some redundant LLMBOX llms from CI benchmarks.

### Checklist
- [x] [Filtering done correctly](https://github.com/tenstorrent/tt-xla/actions/runs/23066113798)