### PR TITLE
Infer device_type from CI inputs

### DIFF
--- a/.github/workflows/call-perf-test.yml
+++ b/.github/workflows/call-perf-test.yml
@@ -413,6 +413,18 @@ jobs:
             --job-id-url "$JOB_ID_URL"
         fi
 
+    - name: Patch device_info.device_type from CI runner
+      if: success() || failure()
+      shell: bash
+      run: |
+        PERF_REPORT_FILE="${{ steps.strings.outputs.perf_report_json_file }}"
+        MACHINE_TYPE="${{ matrix.build.runs-on }}"
+        if [ -f "$PERF_REPORT_FILE" ] && [ -n "$MACHINE_TYPE" ]; then
+          jq --arg mt "$MACHINE_TYPE" '.device_info.device_type = $mt' "$PERF_REPORT_FILE" > "${PERF_REPORT_FILE}.tmp" \
+            && mv "${PERF_REPORT_FILE}.tmp" "$PERF_REPORT_FILE"
+          echo "Patched device_info.device_type to '$MACHINE_TYPE' in $PERF_REPORT_FILE"
+        fi
+
     - name: Upload Perf Report
       uses: actions/upload-artifact@v6
       if: success() || failure()

--- a/.github/workflows/call-perf-test.yml
+++ b/.github/workflows/call-perf-test.yml
@@ -413,12 +413,14 @@ jobs:
             --job-id-url "$JOB_ID_URL"
         fi
 
-    - name: Patch device_info.device_type from CI runner
+    # Patch report fields that can't be properly set in benchmark scripts
+    - name: Patch report fields
       if: success() || failure()
       shell: bash
       run: |
         PERF_REPORT_FILE="${{ steps.strings.outputs.perf_report_json_file }}"
-        MACHINE_TYPE="${{ matrix.build.runs-on }}"
+        # Patch device_info.device_type from CI runner.
+        MACHINE_TYPE="${{ matrix.build.runs-on-original }}"
         if [ -f "$PERF_REPORT_FILE" ] && [ -n "$MACHINE_TYPE" ]; then
           jq --arg mt "$MACHINE_TYPE" '.device_info.device_type = $mt' "$PERF_REPORT_FILE" > "${PERF_REPORT_FILE}.tmp" \
             && mv "${PERF_REPORT_FILE}.tmp" "$PERF_REPORT_FILE"


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/7377

### Problem description
Currently we derive device_type in benchmarks from the number of chips:
https://github.com/tenstorrent/tt-xla/blob/1e5781dc41ca608cc3d8c5f9aeeaea21e0b53706/tests/benchmark/utils.py#L48-L66

which can be faulty.

### What's changed

Added a benchark CI job to infer and overwrite device_type from CI inputs that determine on which machine (device type) model runs.

### Checklist
- [x] [n150 run](https://github.com/tenstorrent/tt-xla/actions/runs/23302157864)
- [x] [p150 run](https://github.com/tenstorrent/tt-xla/actions/runs/23302185379)
- [x] [n300-llmbox run](https://github.com/tenstorrent/tt-xla/actions/runs/23302209077)
- [x] [galaxy run](https://github.com/tenstorrent/tt-xla/actions/runs/23302241115)
