### PR TITLE
Add a new optimized decode flow for DSA and decode tests

### DIFF
--- a/tests/torch/models/deepseek_v3_2_exp/modified_model.py
+++ b/tests/torch/models/deepseek_v3_2_exp/modified_model.py
@@ -786,7 +786,6 @@ class MLA(nn.Module):
         self.register_buffer("prepopulated_topk_indices", None, persistent=False)
         self.dequant_wkv_b = None
 
-
     def forward(
         self,
         x: torch.Tensor,
@@ -868,15 +867,21 @@ class MLA(nn.Module):
             )
 
             if use_optimized_decode_flow:
-                x = self.modified_decode_flow(x, q_nope, q_pe, bsz, end_pos, qr, start_pos, freqs_cis, mask, wkv_b)
+                x = self.modified_decode_flow(
+                    x, q_nope, q_pe, bsz, end_pos, qr, start_pos, freqs_cis, mask, wkv_b
+                )
             else:
-                x = self.original_decode_flow(x, q_nope, q_pe, bsz, end_pos, qr, start_pos, freqs_cis, mask, wkv_b)
+                x = self.original_decode_flow(
+                    x, q_nope, q_pe, bsz, end_pos, qr, start_pos, freqs_cis, mask, wkv_b
+                )
             # Expand from latent
             x = torch.einsum("bshc,hdc->bshd", x, wkv_b[:, -self.v_head_dim :])
         x = self.wo(x.flatten(2))
         return x
 
-    def original_decode_flow(self, x, q_nope, q_pe, bsz, end_pos, qr, start_pos, freqs_cis, mask, wkv_b):
+    def original_decode_flow(
+        self, x, q_nope, q_pe, bsz, end_pos, qr, start_pos, freqs_cis, mask, wkv_b
+    ):
         """
         Original decode flow of the MLA forward pass as presented in Deepseek's original
         implementation.
@@ -904,7 +909,9 @@ class MLA(nn.Module):
         x = torch.einsum("bsht,btc->bshc", scores, self.kv_cache[:bsz, :end_pos])
         return x
 
-    def modified_decode_flow(self, x, q_nope, q_pe, bsz, end_pos, qr, start_pos, freqs_cis, mask, wkv_b):
+    def modified_decode_flow(
+        self, x, q_nope, q_pe, bsz, end_pos, qr, start_pos, freqs_cis, mask, wkv_b
+    ):
         """
         More optimal decode flow for the MLA forward pass.
 
@@ -915,16 +922,26 @@ class MLA(nn.Module):
             if self.prepopulated_topk_indices is not None:
                 topk_indices = self.prepopulated_topk_indices
             else:
-                topk_indices = self.indexer(x, qr, start_pos, freqs_cis, mask) # (bsz, 1, topk)
-            gather_idx = topk_indices.squeeze(1) # (bsz, topk)
-            batch_idx = torch.arange(gather_idx.size(0)).view(-1, 1) # (bsz, 1)
+                topk_indices = self.indexer(
+                    x, qr, start_pos, freqs_cis, mask
+                )  # (bsz, 1, topk)
+            gather_idx = topk_indices.squeeze(1)  # (bsz, topk)
+            batch_idx = torch.arange(gather_idx.size(0)).view(-1, 1)  # (bsz, 1)
 
-            orig_kv_cache = self.kv_cache[:bsz, :end_pos] # (bsz, seq_len, kv_lora_rank)
-            orig_pe_cache = self.pe_cache[:bsz, :end_pos] # (bsz, seq_len, qk_rope_head_dim)
+            orig_kv_cache = self.kv_cache[
+                :bsz, :end_pos
+            ]  # (bsz, seq_len, kv_lora_rank)
+            orig_pe_cache = self.pe_cache[
+                :bsz, :end_pos
+            ]  # (bsz, seq_len, qk_rope_head_dim)
 
             # Extract only the indices specified by batch_idx and gather_idx
-            kv_for_attention = orig_kv_cache[batch_idx, gather_idx] # (bsz, topk, kv_lora_rank)
-            pe_for_attention = orig_pe_cache[batch_idx, gather_idx] # (bsz, topk, qk_rope_head_dim)
+            kv_for_attention = orig_kv_cache[
+                batch_idx, gather_idx
+            ]  # (bsz, topk, kv_lora_rank)
+            pe_for_attention = orig_pe_cache[
+                batch_idx, gather_idx
+            ]  # (bsz, topk, qk_rope_head_dim)
         else:
             kv_for_attention = self.kv_cache[:bsz, :end_pos]
             pe_for_attention = self.pe_cache[:bsz, :end_pos]
@@ -936,6 +953,7 @@ class MLA(nn.Module):
         scores = scores.softmax(dim=-1)
         x = torch.einsum("bsht,btc->bshc", scores, kv_for_attention)
         return x
+
 
 class MLP(nn.Module):
     """

--- a/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_2_exp.py
+++ b/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_2_exp.py
@@ -6,14 +6,15 @@ import pytest
 import torch
 import torch_xla
 import torch_xla.runtime as xr
+from benchmark.utils import compute_pcc
 from infra import Framework, run_graph_test
 from infra.evaluators import ComparisonConfig, PccConfig
 from modified_model import ModelArgs
 from modified_model import Transformer as ModifiedTransformer
+from torch import nn
 from torch_xla.distributed.spmd import Mesh
 
 from tests.utils import failed_ttmlir_compilation
-from benchmark.utils import compute_pcc
 
 # This model is modified from the original deepseek_v3_2_exp model.py to:
 # 1. Use scipy.linalg.hadamard instead of fast_hadamard_transform
@@ -95,7 +96,11 @@ def test_deepseek_complex_rotary_emb():
 def test_deepseek_attention_prefill(batch_size, seq_len):
     xr.set_device_type("TT")
     args = ModelArgs(
-        n_layers=1, q_lora_rank=3072, max_batch_size=batch_size, max_seq_len=seq_len * 2, index_topk=16
+        n_layers=1,
+        q_lora_rank=3072,
+        max_batch_size=batch_size,
+        max_seq_len=seq_len * 2,
+        index_topk=16,
     )
 
     model = ModifiedTransformer(args)
@@ -108,13 +113,16 @@ def test_deepseek_attention_prefill(batch_size, seq_len):
 
     # Create a (batch_size, seq_len, index_topk) tensor of valid indices.
     # Each entry along the last axis contains values from 0 to seq_len-1, in random order per batch/position.
-    topk_indices = torch.stack([
-        torch.stack([
-            torch.randperm(seq_len)[:args.index_topk]
-            for _ in range(seq_len)
-        ]).unsqueeze(1)
-        for _ in range(batch_size)
-    ]).squeeze(2)  # shape: (batch_size, seq_len, index_topk)
+    topk_indices = torch.stack(
+        [
+            torch.stack(
+                [torch.randperm(seq_len)[: args.index_topk] for _ in range(seq_len)]
+            ).unsqueeze(1)
+            for _ in range(batch_size)
+        ]
+    ).squeeze(
+        2
+    )  # shape: (batch_size, seq_len, index_topk)
 
     attention.prepopulated_topk_indices = topk_indices
 
@@ -163,6 +171,126 @@ def test_deepseek_attention_prefill(batch_size, seq_len):
             0,  # start_pos
             freqs_cis,
             attention_mask,
+        ],
+        framework=Framework.TORCH,
+        mesh=mesh,
+        shard_spec_fn=get_shard_spec,
+        comparison_config=comparison_config,
+    )
+
+
+@pytest.mark.llmbox
+@pytest.mark.parametrize("batch_size", [1, 4, 32, 64])
+@pytest.mark.parametrize("prefill_seq_len", [32, 128, 512, 2048])
+def test_deepseek_attention_decode(batch_size, prefill_seq_len, request):
+    _XFAIL_CONFIGS = {
+        (128, 32),
+        (128, 64),
+        (512, 32),
+        (512, 64),
+        (2048, 4),
+        (2048, 32),
+        (2048, 64),
+    }
+    if (prefill_seq_len, batch_size) in _XFAIL_CONFIGS:
+        request.applymarker(
+            pytest.mark.xfail(
+                reason="Low PCC due to ttir.gather lowering bug - https://github.com/tenstorrent/tt-xla/issues/3726"
+            )
+        )
+
+    xr.set_device_type("TT")
+
+    # Decode-specific parameters
+    decode_seq_len = 1  # Generate one token at a time
+    start_pos = prefill_seq_len  # Start position for the new token
+
+    args = ModelArgs(
+        n_layers=1,
+        q_lora_rank=3072,
+        max_batch_size=batch_size,
+        max_seq_len=prefill_seq_len * 2,
+        index_topk=prefill_seq_len // 2,
+    )
+
+    model = ModifiedTransformer(args)
+    model = model.to(torch.bfloat16)
+    attention = model.layers[0].attn
+
+    # Create decode input: single token only
+    hidden_states = torch.randn(
+        (batch_size, decode_seq_len, args.dim), dtype=torch.bfloat16
+    )
+
+    # Pre-populate caches with random data to simulate previous prefill phase
+    attention.kv_cache[:batch_size, :start_pos] = torch.randn(
+        batch_size, start_pos, args.kv_lora_rank, dtype=torch.bfloat16
+    )
+    attention.pe_cache[:batch_size, :start_pos] = torch.randn(
+        batch_size, start_pos, args.qk_rope_head_dim, dtype=torch.bfloat16
+    )
+    attention.indexer.k_cache[:batch_size, :start_pos] = torch.randn(
+        batch_size, start_pos, args.index_head_dim, dtype=torch.bfloat16
+    )
+
+    # Prepopulating topk_indices instead of running the indexer, since we have no
+    # guarantee that the topk indices returned by it will be the same across CPU and
+    # TT devices. Also, the indexer is already separately tested.
+    attention.prepopulated_topk_indices = torch.stack(
+        [torch.randperm(prefill_seq_len)[: args.index_topk] for _ in range(batch_size)]
+    ).unsqueeze(
+        1
+    )  # (batch_size, 1, index_topk)
+
+    # Get rotary embeddings for the current position
+    freqs_cis = model.freqs_cis[start_pos : start_pos + decode_seq_len]
+
+    num_devices = xr.global_runtime_device_count()
+    mesh_shape = (2, 4)
+    device_ids = np.array(range(num_devices))
+    mesh = Mesh(device_ids, mesh_shape, ("batch", "model"))
+
+    def get_shard_spec(attention, args, kwargs):
+        mesh_batch_axis_size = mesh.shape()["batch"]
+        # Conditionally shard weights that involve batch axis
+        batch_axis = "batch" if batch_size >= mesh_batch_axis_size else None
+
+        shard_specs = {}
+
+        # Input tensors
+        shard_specs[args[0]] = (None, None, batch_axis)  # hidden_states (batch, 1, dim)
+
+        # Weight tensors
+        shard_specs[attention.wq_b.weight] = ("model", None)
+        shard_specs[attention.wkv_b.weight] = ("model", None)
+        shard_specs[attention.wo.weight] = (batch_axis, "model")
+        shard_specs[attention.wq_a.weight] = (None, batch_axis)
+        shard_specs[attention.wkv_a.weight] = (None, batch_axis)
+
+        # Cache tensors
+        shard_specs[attention.kv_cache] = (batch_axis, None, None)
+        shard_specs[attention.pe_cache] = (batch_axis, None, None)
+
+        # Indexer sharding (if present)
+        shard_specs[attention.indexer.wq_b.weight] = ("model", None)
+        shard_specs[attention.indexer.wk.weight] = (None, batch_axis)
+        shard_specs[attention.indexer.weights_proj.weight] = ("model", batch_axis)
+        shard_specs[attention.indexer.k_cache] = (batch_axis, None, None)
+
+        return shard_specs
+
+    comparison_config = ComparisonConfig(
+        pcc=PccConfig(enabled=True, required_pcc=0.99),
+    )
+
+    run_graph_test(
+        attention,
+        [
+            hidden_states,
+            start_pos,
+            freqs_cis,
+            None,  # attention_mask - triggers decode path
+            True,  # use_optimized_decode_flow
         ],
         framework=Framework.TORCH,
         mesh=mesh,
@@ -260,7 +388,7 @@ def test_deepseek_indexer(batch_size, seq_len):
 def test_dsa_optimized_decode_flow_compared_to_original(batch_size, prefill_seq_len):
     """
     This test compares the optimized decode flow with the original reference flow provided
-    by Deepseek. It is run only on CPU.  
+    by Deepseek. It is run only on CPU.
     """
     decode_seq_len = 1  # Generate one token at a time
     start_pos = prefill_seq_len  # Start position for the new token
@@ -270,7 +398,7 @@ def test_dsa_optimized_decode_flow_compared_to_original(batch_size, prefill_seq_
         q_lora_rank=3072,
         max_batch_size=batch_size,
         max_seq_len=prefill_seq_len * 2,
-        index_topk=16
+        index_topk=16,
     )
 
     modified_model = ModifiedTransformer(args)
@@ -292,10 +420,11 @@ def test_dsa_optimized_decode_flow_compared_to_original(batch_size, prefill_seq_
         batch_size, start_pos, args.index_head_dim, dtype=torch.bfloat16
     )
     end_pos = start_pos + decode_seq_len
-    topk_indices = torch.stack([
-        torch.randperm(end_pos)[:args.index_topk]
-        for _ in range(batch_size)
-    ]).unsqueeze(1)  # (batch_size, 1, index_topk)
+    topk_indices = torch.stack(
+        [torch.randperm(end_pos)[: args.index_topk] for _ in range(batch_size)]
+    ).unsqueeze(
+        1
+    )  # (batch_size, 1, index_topk)
 
     attention.prepopulated_topk_indices = topk_indices
     attention.kv_cache[:batch_size, :start_pos] = kv_cache


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/3102

### Problem description
The default implementation of DSA's decode flow performed the full attention calculation using the entire KV and PE caches instead of using just the selected Top K indices.

### What's changed
- Modified the decode flow to perform the attention calculation using only the selected top K indices of the caches.
- Added a test for the decode flow.

### Checklist
- [x] New/Existing tests provide coverage for changes
