### PR TITLE
Remove galaxy-wh-6u job from nightly pipeline

### DIFF
--- a/.github/workflows/test-matrix-presets/model-test-passing.json
+++ b/.github/workflows/test-matrix-presets/model-test-passing.json
@@ -2,7 +2,6 @@
   { "runs-on": "n150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "n150 and nightly and expected_passing", "parallel-groups": 3 },
   { "runs-on": "p150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "p150 and nightly and expected_passing", "parallel-groups": 3 },
   { "runs-on": "n300-llmbox", "name": "run_forge_models_multichip", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "n300-llmbox and nightly and tensor_parallel and expected_passing", "parallel-groups": 4 },
-  { "runs-on": "galaxy-wh-6u", "name": "run_forge_models_multichip", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "galaxy-wh-6u and nightly and tensor_parallel and expected_passing", "parallel-groups": 1 },
   { "runs-on": "n300", "name": "run_forge_models_multichip", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "n300 and nightly and data_parallel and expected_passing", "parallel-groups": 1 },
   { "runs-on": "n150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "n150 and nightly and expected_passing and not large", "parallel-groups": 1 },
   { "runs-on": "p150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "p150 and nightly and expected_passing and not large", "parallel-groups": 1 },


### PR DESCRIPTION
## Issue

https://github.com/tenstorrent/tt-xla/issues/3762

## Summary
- Temporarily removes the `galaxy-wh-6u and nightly and tensor_parallel and expected_passing` test matrix entry from `model-test-passing.json`, which eliminates the corresponding `test_forge_models_passing` job in the nightly pipeline.
- This is a temporary removal until the galaxy machine becomes available again.