### PR TITLE
Add code-reviewer skill specialized for tt-xla

### DIFF
--- a/.claude/skills/code-reviewer/SKILL.md
+++ b/.claude/skills/code-reviewer/SKILL.md
@@ -9,43 +9,12 @@ Specialized code review toolkit for the tt-xla project: a PJRT-based backend tha
 
 ## Languages & Stack
 
-**Languages:** C++17, Python 3.12
+**Languages:** C++20, Python 3.12
 **Build:** CMake + Ninja, Python setuptools (wheel packaging)
 **Formatting:** `clang-format` (C++, style from `.clang-format`), `black` + `isort` (Python)
 **Testing:** pytest with custom markers
 **Logging:** loguru (C++), Python stdlib logging
 **CI:** pre-commit hooks (black, clang-format, SPDX copyright, trailing whitespace, isort)
-
-## Review Focus Areas
-
-### C++ (pjrt_implementation/)
-
-1. **Memory safety** — All owned objects must use `std::unique_ptr`. Raw pointers are only for borrowed references. No manual `delete`.
-2. **Error handling** — Functions return `tt_pjrt_status`. All errors must be logged with `LOG_F(ERROR, ...)`. Use `ErrorInstance::makeError()` for error propagation.
-3. **Thread safety** — Shared mutable state must be protected by `std::mutex` with `std::lock_guard`. Check for data races on static members.
-4. **PJRT API contract** — `bindApi()` function pointers must match the PJRT C API signatures exactly. `unwrap()`/`reinterpret_cast` patterns must preserve type safety.
-5. **Logging discipline** — Public API entry points should have `DLOG_F(LOG_DEBUG, "FunctionName")`. Errors go through `LOG_F(ERROR, ...)`.
-6. **Move semantics** — Large objects (vectors, strings) passed by rvalue reference or std::move. No unnecessary copies.
-7. **Namespace** — All code in `namespace tt::pjrt`. Internal helpers in `namespace internal`.
-8. **Headers** — Include guards (`#ifndef TT_XLA_...`), grouped includes (stdlib → PJRT API → tt-mlir → tt-xla), forward declarations to reduce coupling.
-9. **SPDX license** — Every file must have the SPDX copyright header.
-
-### Python (python_package/, tests/, examples/)
-
-1. **Type hints** — Public functions should have type annotations.
-2. **Test markers** — Every test must have pipeline markers (`@pytest.mark.push` and/or `@pytest.mark.nightly`) and `@pytest.mark.record_test_properties(category=...)`.
-3. **Test properties** — Op tests need `jax_op_name`/`torch_op_name`/`shlo_op_name`. Model tests need `model_name`, `model_group`, `run_mode`, `bringup_status`, etc.
-4. **Hardware markers** — Tests must declare device requirements: `@pytest.mark.single_device`, `@pytest.mark.dual_chip`, or `@pytest.mark.galaxy`.
-5. **Import order** — stdlib → third-party → local, enforced by `isort` with `profile=black`.
-6. **Formatting** — `black` enforced. No manual style overrides.
-7. **Plugin registration** — JAX uses `xb.register_plugin("tt", ...)`. PyTorch uses backend module import for registration. Changes here must be tested end-to-end.
-
-### CMake (CMakeLists.txt)
-
-1. **Target dependencies** — New source files must be added to the correct CMake target (TTPJRTApi, TTPJRTUtils, TTPJRTBindings).
-2. **Include directories** — Use PRIVATE for internal headers, PUBLIC for API-facing headers.
-3. **No RTTI** — `-fno-rtti` is set project-wide. Code must not use `dynamic_cast` or `typeid`.
-4. **PIC** — Position-independent code (`-fPIC`) is required for the shared library.
 
 ## How It Works
 
@@ -57,6 +26,8 @@ When invoked via `/code-reviewer`, Claude Code loads this file and the reference
 
 ## Reference Documentation
 
-- `references/code_review_checklist.md` — Step-by-step review checklist
+All review focus areas, coding standards, and antipatterns are documented in the reference files below. Refer to these as the single source of truth during reviews:
+
+- `references/code_review_checklist.md` — Step-by-step review checklist (C++, Python, CMake, general)
 - `references/coding_standards.md` — Project coding standards for C++ and Python
-- `references/common_antipatterns.md` — Antipatterns specific to tt-xla
+- `references/common_antipatterns.md` — Antipatterns specific to tt-xla with wrong/right examples

--- a/.claude/skills/code-reviewer/references/code_review_checklist.md
+++ b/.claude/skills/code-reviewer/references/code_review_checklist.md
@@ -14,7 +14,7 @@
 - [ ] Functions return `tt_pjrt_status` (not exceptions, not bool)
 - [ ] All error paths logged with `LOG_F(ERROR, ...)`
 - [ ] `tt_pjrt_status_is_ok(status)` checked before proceeding
-- [ ] `ErrorInstance::makeError()` used for error propagation to PJRT layer
+- [ ] `ErrorInstance::makeError()` used for error creation to propagate to PJRT client
 - [ ] No silent error swallowing — every failure is either handled or propagated
 
 ### Thread Safety

--- a/.claude/skills/code-reviewer/references/coding_standards.md
+++ b/.claude/skills/code-reviewer/references/coding_standards.md
@@ -1,11 +1,11 @@
 # Coding Standards — tt-xla
 
-## C++17 Standards
+## C++20 Standards
 
 ### Naming Conventions
 - **Classes**: PascalCase — `BufferInstance`, `ClientInstance`, `ErrorInstance`
 - **Methods**: camelCase — `createInstance()`, `bindApi()`, `copyToHost()`
-- **Member variables**: snake_case with trailing underscore or prefixed — `data_type_`, `num_dims_`
+- **Member variables**: snake_case with `m_` prefix — `m_data_type`, `m_num_dims`
 - **Static members**: `s_` prefix — `s_copy_to_host_internal_mutex`
 - **Constants / Enums**: PascalCase enum class with camelCase values — `enum class tt_pjrt_status { kSuccess, kInvalidArgument }`
 - **Namespaces**: lowercase — `tt::pjrt`, `tt::pjrt::internal`
@@ -15,7 +15,7 @@
 
 **Header files (`.h`)**:
 ```cpp
-// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef TT_XLA_PJRT_IMPLEMENTATION_INC_API_EXAMPLE_H_
@@ -43,7 +43,10 @@ namespace tt::pjrt {
 
 class Example {
 public:
+    // Factory method
     static std::unique_ptr<Example> createInstance(/* params */);
+
+    // Destructor
     ~Example();
 
     // Public API
@@ -56,15 +59,14 @@ public:
     static Example *unwrap(PJRT_Example *ptr) {
         return reinterpret_cast<Example *>(ptr);
     }
+
+    // Wrap to opaque pointer
     operator PJRT_Example *() {
         return reinterpret_cast<PJRT_Example *>(this);
     }
 
 private:
     Example(/* params */);
-
-    // Private make_unique enabler
-    struct make_unique_enabler;
 };
 
 } // namespace tt::pjrt
@@ -74,7 +76,7 @@ private:
 
 **Source files (`.cc`)**:
 ```cpp
-// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 // SPDX-License-Identifier: Apache-2.0
 
 #include "pjrt_implementation/inc/api/example.h"
@@ -83,13 +85,13 @@ private:
 
 namespace tt::pjrt {
 
-// Private enabler for std::make_unique with private constructor
-struct Example::make_unique_enabler : public Example {
-    make_unique_enabler(/* params */) : Example(/* params */) {}
-};
-
 std::unique_ptr<Example> Example::createInstance(/* params */) {
-    return std::make_unique<make_unique_enabler>(/* params */);
+    return std::unique_ptr<Example>(new Example(/* params */));
+}
+
+tt_pjrt_status Example::doWork() {
+    // Implementation
+    return tt_pjrt_status::kSuccess;
 }
 
 } // namespace tt::pjrt
@@ -99,7 +101,7 @@ std::unique_ptr<Example> Example::createInstance(/* params */) {
 1. **Owned objects**: Always `std::unique_ptr<T>`. Use `std::make_unique<T>(...)`.
 2. **Shared ownership** (rare): `std::shared_ptr<T>` only when multiple owners are unavoidable.
 3. **Borrowed references**: Raw pointer `T*` — caller retains ownership.
-4. **Factory pattern**: `static std::unique_ptr<T> createInstance(...)` with private constructor + `make_unique_enabler` struct.
+4. **Factory pattern**: `static std::unique_ptr<T> createInstance(...)` with private constructor.
 5. **No manual delete**: If you write `delete`, refactor to use smart pointers.
 
 ### Error Handling Rules
@@ -175,7 +177,7 @@ def test_example():
 ### SPDX Header
 Every Python file:
 ```python
-# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
 ```

--- a/.claude/skills/code-reviewer/references/common_antipatterns.md
+++ b/.claude/skills/code-reviewer/references/common_antipatterns.md
@@ -13,7 +13,7 @@ delete buffer;  // Leak if exception or early return
 
 **Right:**
 ```cpp
-auto buffer = BufferInstance::createInstance(data_type, dims, num_dims, device, memory);
+std::unique_ptr<BufferInstance> buffer = BufferInstance::createInstance(data_type, dims, num_dims, device, memory);
 // Automatically cleaned up when unique_ptr goes out of scope
 ```
 
@@ -230,7 +230,7 @@ import jax
 
 **Right:**
 ```python
-# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
Installed the code-reviewer Claude skill and customized it for the tt-xla project: C++17/Python focus, PJRT API patterns, project-specific coding standards, review checklist, and common antipatterns. Removed generic placeholder scripts that had no real functionality.