### PR TITLE
Temporarily remove galaxy-wh-6u perf benchmark test

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -165,12 +165,6 @@
         "runs-on": "n300-llmbox"
       },
       {
-        "name": "llama_3_1_70b_tp_galaxy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
-        "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp_galaxy",
-        "runs-on": "galaxy-wh-6u"
-      },
-      {
         "name": "gpt_oss_20b_tp",
         "pyreq": "datasets loguru pytest requests accelerate torch==2.9.0 tqdm transformers==4.57.1",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp",


### PR DESCRIPTION
## Issue

https://github.com/tenstorrent/tt-xla/issues/3762

## Summary
- Temporarily disable the `llama_3_1_70b_tp_galaxy` performance benchmark test from `perf-bench-matrix.json`
- The `galaxy-wh-6u` machine is currently unavailable; this change will be reverted once the machine is back online