### PR TITLE
Remove Qwen2.5-VL-72B from N150 and P150, and MiniCPM-o-2_6 (8B) from N150 inference test configs

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -170,6 +170,7 @@ test_config:
     status: EXPECTED_PASSING
 
   minicpm_o_2_6/pytorch-Default-single_device-inference:
+    supported_archs: ["p150"]
     status: NOT_SUPPORTED_SKIP
     reason: "MiniCPM model has a larger test execution time, hence skipping it for now."
 
@@ -874,11 +875,6 @@ test_config:
 
   qwen_1_5/causal_lm/pytorch-0_5B_Chat-single_device-inference:
     status: EXPECTED_PASSING
-
-  qwen_2_5_vl/pytorch-72B_Instruct-single_device-inference:
-    status: NOT_SUPPORTED_SKIP
-    reason: "Too large for single chip"
-    bringup_status: FAILED_RUNTIME
 
   qwen_2_5_vl/pytorch-3B_Instruct-single_device-inference:
     status: KNOWN_FAILURE_XFAIL


### PR DESCRIPTION
### Ticket

- closes https://github.com/tenstorrent/tt-xla/issues/2292

### Problem description

- Qwen2.5-VL-72B and MiniCPM-o-2_6 (8B) are currently being skipped on N150 and P150
- Since Qwen2.5-VL-72B cannot fit or run on N150/P150, it should be removed from the N150 and P150 inference test configs.
- Similarly, MiniCPM-o-2_6 (8B) should be removed from the N150 inference test configs instead of being skipped.

### What's changed

- Removed Qwen2.5-VL-72B from N150 and P150 inference test configs.
- Removed MiniCPM-o-2_6 (8B) from N150 inference test configs.
