### PR TITLE
Bring back galaxy-wh-6u job in nightly pipeline

### DIFF
--- a/.github/workflows/test-matrix-presets/model-test-passing.json
+++ b/.github/workflows/test-matrix-presets/model-test-passing.json
@@ -4,6 +4,7 @@
   { "runs-on": "n150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "n150 and nightly and training and expected_passing", "parallel-groups": 2 },
   { "runs-on": "p150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "p150 and nightly and training and expected_passing", "parallel-groups": 2 },
   { "runs-on": "n300-llmbox", "name": "run_forge_models_multichip", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "n300-llmbox and nightly and tensor_parallel and expected_passing", "parallel-groups": 4 },
+  { "runs-on": "galaxy-wh-6u", "name": "run_forge_models_multichip", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "galaxy-wh-6u and nightly and tensor_parallel and expected_passing", "parallel-groups": 1 },
   { "runs-on": "n300", "name": "run_forge_models_multichip", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "n300 and nightly and data_parallel and expected_passing", "parallel-groups": 1 },
   { "runs-on": "n150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "n150 and nightly and expected_passing and not large", "parallel-groups": 1 },
   { "runs-on": "p150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "p150 and nightly and expected_passing and not large", "parallel-groups": 1 },


### PR DESCRIPTION
### Ticket
#3762 https://github.com/tenstorrent/cloud/issues/5943

### What's changed
- Machine is back working, adding tests back that were removed yesterday

### Checklist
- [x] Running galaxy tests on latest main, passing: https://github.com/tenstorrent/tt-xla/actions/runs/23210693059
