### PR TITLE
Revert "Remove galaxy-wh-6u job from nightly pipeline (#3741)"

### DIFF
--- a/.github/workflows/test-matrix-presets/model-test-passing.json
+++ b/.github/workflows/test-matrix-presets/model-test-passing.json
@@ -4,6 +4,7 @@
   { "runs-on": "n150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "n150 and nightly and training and expected_passing", "parallel-groups": 2 },
   { "runs-on": "p150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "p150 and nightly and training and expected_passing", "parallel-groups": 2 },
   { "runs-on": "n300-llmbox", "name": "run_forge_models_multichip", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "n300-llmbox and nightly and tensor_parallel and expected_passing", "parallel-groups": 4 },
+  { "runs-on": "galaxy-wh-6u", "name": "run_forge_models_multichip", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "galaxy-wh-6u and nightly and tensor_parallel and expected_passing", "parallel-groups": 1 },
   { "runs-on": "n300", "name": "run_forge_models_multichip", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "n300 and nightly and data_parallel and expected_passing", "parallel-groups": 1 },
   { "runs-on": "n150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "n150 and nightly and expected_passing and not large", "parallel-groups": 1 },
   { "runs-on": "p150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "p150 and nightly and expected_passing and not large", "parallel-groups": 1 },


### PR DESCRIPTION
This reverts commit e461f3d8c4151298723e1d6a187f61b7a8eaea39.

### Ticket
None

### Problem description
g07glx05 is back online: https://github.com/tenstorrent/cloud/issues/5943

### What's changed
Add galaxy to nightly pipeline
