### PR TITLE
[CI] Route large LLM torch tests to shared runners on n150/p150

### DIFF
--- a/.github/workflows/test-matrix-presets/model-test-passing.json
+++ b/.github/workflows/test-matrix-presets/model-test-passing.json
@@ -13,6 +13,8 @@
   { "runs-on": "n150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "n150 and nightly and expected_passing and large", "shared-runners": "true" },
   { "runs-on": "p150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "p150 and nightly and expected_passing and large", "shared-runners": "true" },
   { "runs-on": "n300-llmbox", "name": "run_forge_models_llm_multichip", "dir": "./tests/runner/test_models.py::test_llms_torch", "test-mark": "n300-llmbox and nightly and tensor_parallel and expected_passing", "parallel-groups": 1 },
-  { "runs-on": "n150", "name": "run_forge_models_llm", "dir": "./tests/runner/test_models.py::test_llms_torch", "test-mark": "n150 and nightly and expected_passing and single_device", "parallel-groups": 1 },
-  { "runs-on": "p150", "name": "run_forge_models_llm", "dir": "./tests/runner/test_models.py::test_llms_torch", "test-mark": "p150 and nightly and expected_passing and single_device", "parallel-groups": 1 }
+  { "runs-on": "n150", "name": "run_forge_models_llm", "dir": "./tests/runner/test_models.py::test_llms_torch", "test-mark": "n150 and nightly and expected_passing and single_device and large", "parallel-groups": 1, "shared-runners": "true" },
+  { "runs-on": "n150", "name": "run_forge_models_llm", "dir": "./tests/runner/test_models.py::test_llms_torch", "test-mark": "n150 and nightly and expected_passing and single_device and not large", "parallel-groups": 1 },
+  { "runs-on": "p150", "name": "run_forge_models_llm", "dir": "./tests/runner/test_models.py::test_llms_torch", "test-mark": "p150 and nightly and expected_passing and single_device and large", "parallel-groups": 1, "shared-runners": "true" },
+  { "runs-on": "p150", "name": "run_forge_models_llm", "dir": "./tests/runner/test_models.py::test_llms_torch", "test-mark": "p150 and nightly and expected_passing and single_device and not large", "parallel-groups": 1 }
 ]


### PR DESCRIPTION
Route `large`-marked single-device LLM tests to shared (civ2) runners on n150/p150. Fixes OOM kills (signal 9) for tests that exceed host RAM memory.