### PR TITLE
Fix panoptic segmentation empty tensor host-copy crash

### DIFF
--- a/pjrt_implementation/src/api/buffer_instance.cc
+++ b/pjrt_implementation/src/api/buffer_instance.cc
@@ -328,6 +328,16 @@ tt_pjrt_status BufferInstance::copyToHost(void *host_buffer,
   joinCopyThread();
 
   std::unique_ptr<EventInstance> event = EventInstance::createInstance();
+  const size_t logical_tensor_size = logicalTensorSize();
+
+  // Empty tensors have nothing to copy. Skip memcpy to avoid null-pointer
+  // failures for zero-sized buffers.
+  if (logical_tensor_size == 0) {
+    EventInstance::markAsReadyAndCallback(event.get(),
+                                          tt_pjrt_status::kSuccess);
+    *out_copy_done_event = event.release();
+    return tt_pjrt_status::kSuccess;
+  }
 
   m_copy_to_host_thread = std::make_unique<std::thread>([=, e = event.get()] {
     try {
@@ -336,7 +346,7 @@ tt_pjrt_status BufferInstance::copyToHost(void *host_buffer,
 
       m_pjrt_tensor->move_to_host();
 
-      assert(logicalTensorSize() <= host_buffer_size &&
+      assert(logical_tensor_size <= host_buffer_size &&
              "Host buffer is too small.");
       tt::runtime::memcpy(host_buffer, m_pjrt_tensor->runtime_tensor(),
                           rt_data_type);

--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -2189,15 +2189,15 @@ test_config:
 
   panoptic_segmentation/pytorch-ResNet101_Backbone_3x_COCO-single_device-inference:
     status: NOT_SUPPORTED_SKIP
-    reason: "Copy to host buffer failed with error: Buffer pointers must not be null (https://github.com/tenstorrent/tt-xla/issues/3722)"
+    reason: "Fatal Python error: Floating-point exception (https://github.com/tenstorrent/tt-xla/issues/3775)"
 
   panoptic_segmentation/pytorch-ResNet50_Backbone_1x_COCO-single_device-inference:
     status: NOT_SUPPORTED_SKIP
-    reason: "Copy to host buffer failed with error: Buffer pointers must not be null (https://github.com/tenstorrent/tt-xla/issues/3722)"
+    reason: "Fatal Python error: Floating-point exception (https://github.com/tenstorrent/tt-xla/issues/3775)"
 
   panoptic_segmentation/pytorch-ResNet50_Backbone_3x_COCO-single_device-inference:
     status: NOT_SUPPORTED_SKIP
-    reason: "Copy to host buffer failed with error: Buffer pointers must not be null (https://github.com/tenstorrent/tt-xla/issues/3722)"
+    reason: "Fatal Python error: Floating-point exception (https://github.com/tenstorrent/tt-xla/issues/3775)"
 
   sam/pytorch-Vit_Huge-single_device-inference:
     status: EXPECTED_PASSING

--- a/tests/torch/ops/test_emtpy.py
+++ b/tests/torch/ops/test_emtpy.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Minimal torch.empty empty-tensor host-transfer repro."""
+
+import pytest
+import torch
+import torch_xla.core.xla_model as xm
+import torch_xla.runtime as xr
+from utils import Category
+
+
+@pytest.mark.nightly
+@pytest.mark.single_device
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    torch_op_name="torch.empty",
+)
+def test_empty():
+    class Empty(torch.nn.Module):
+        def forward(self, x):
+            return torch.empty((0,), device=x.device, dtype=torch.int64)
+
+    xr.set_device_type("TT")
+
+    model = torch.compile(Empty(), backend="tt")
+    device = xm.xla_device()
+    model = model.to(device)
+    input_tensor = torch.tensor(0, dtype=torch.int64).to(device)
+
+    with torch.no_grad():
+        output = model(input_tensor)
+
+    host_output = output.to("cpu")


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-xla/issues/3722

### Problem description

- Panoptic segmentation model variants were crashing with the following error when an empty tensor was copied from device to host:
 
```
buffer_instance.cc:344    ERR| Copy to host buffer failed with error: Buffer pointers must not be null
```

- The failure is triggered by an [arange(0)](https://github.com/tenstorrent/tt-forge-models/blob/a106f38f40e8a79b50a75890d2bd29e97127fbf2/panoptic_segmentation/pytorch/src/model.py#L2248) which produces an empty tensor.
- During host transfer, the old runtime path still attempted to copy that empty tensor.
- Since zero-sized tensors may have null data pointers, the old host-copy path crashed instead of recognizing that there are 0 bytes to copy.


### What's changed

- Added a zero-sized tensor guard in the PJRT host-copy path.
- If the logical tensor size is 0, the runtime now skips memcpy and returns success immediately.
- In other words, empty tensor host transfer is treated as a successful no-data-movement case.

### Checklist
- [x] Verified with sanity repro and model rerun that the original empty-tensor host-copy crash is resolved

### Logs

- Before Fix
  - Sanity run - [mar19_empty_before_fix.log](https://github.com/user-attachments/files/26108934/mar19_empty_before_fix.log)
  - Model run - https://github.com/tenstorrent/tt-xla/actions/runs/23207659937/job/67450944996

- After Fix
  - Sanity run - [mar19_empty_after_fix.log](https://github.com/user-attachments/files/26108937/mar19_empty_after_fix.log)
  - Model run - https://github.com/tenstorrent/tt-xla/actions/runs/23207465323/job/67452019417
