### PR TITLE
Update test configuration for LLaMA model

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -162,16 +162,22 @@ test_config:
         assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/3591
 
   llama/causal_lm/pytorch-3.1_70B_Instruct-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
-    status: NOT_SUPPORTED_SKIP
-    reason: "Needs bringup on galaxy"
-    bringup_status: FAILED_RUNTIME
+    arch_overrides:
+      n300-llmbox:
+        status: EXPECTED_PASSING
+        enable_weight_bfp8_conversion: true
+        assert_pcc: false  # https://github.com/tenstorrent/tt-xla/issues/3591
+      galaxy-wh-6u:
+        status: EXPECTED_PASSING
+        required_pcc: 0.98
 
   llama/causal_lm/pytorch-3.3_70B_Instruct-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
-    status: NOT_SUPPORTED_SKIP
-    reason: "Needs bringup on galaxy"
-    bringup_status: FAILED_RUNTIME
+    arch_overrides:
+      n300-llmbox:
+        enable_weight_bfp8_conversion: true
+        assert_pcc: false  # https://github.com/tenstorrent/tt-xla/issues/3591
+      galaxy-wh-6u:
+        status: EXPECTED_PASSING
 
   phi4/causal_lm/pytorch-Phi_4-tensor_parallel-inference:
     supported_archs: [n300-llmbox]


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/3733

### Problem description
Bring up LLaMA variants on Galaxy machine

### What's changed
```
Model: llama/causal_lm/pytorch-3.1_70B_Instruct-tensor_parallel-inference
galaxy machine:
weights_type: bfloat16
pcc: 0.9896286503133871
ci run: https://github.com/tenstorrent/tt-xla/actions/runs/23228330298/job/67516796102

n300-llmbox:
weights_type: bfp8
pcc: 0.9129025914704121
ci run: https://github.com/tenstorrent/tt-xla/actions/runs/23228568586/job/67517489257

```

```
Model: llama/causal_lm/pytorch-3.3_70B_Instruct-tensor_parallel-inference
galaxy machine:
weights_type: bfloat16
pcc: 0.99
ci run: https://github.com/tenstorrent/tt-xla/actions/runs/23228370379/job/67519182550

n300-llmbox:
weights_type: bfp8
pcc: 0.9221148698246782
ci run: https://github.com/tenstorrent/tt-xla/actions/runs/23228568586/job/67517489235


```
### Checklist
- [ ] New/Existing tests provide coverage for changes
