### PR TITLE
[vLLM] Add large-batch non-greedy sampling regression tests (#3610)

### DIFF
--- a/tests/integrations/vllm_plugin/sampling/test_sampling_params_synthetic.py
+++ b/tests/integrations/vllm_plugin/sampling/test_sampling_params_synthetic.py
@@ -800,3 +800,32 @@ def test_prompt_logprobs_known_target(device):
             f"row {i}: dominant token logprob {lp[i, 0].item():.4f} "
             f"should be close to 0"
         )
+
+
+# ---------------------------------------------------------------------------
+# Large batch size tests
+# ---------------------------------------------------------------------------
+
+# Use Llama-3-8B vocab as the representative production shape.
+_LARGE_BATCH_VOCAB = 128256
+
+_NON_GREEDY_LARGE_BATCH_SIZES = [
+    pytest.param(8, id="batch8"),
+    pytest.param(16, id="batch16"),
+    pytest.param(32, id="batch32"),
+]
+
+
+@pytest.mark.push
+@pytest.mark.single_device
+@pytest.mark.parametrize("batch_size", _NON_GREEDY_LARGE_BATCH_SIZES)
+def test_non_greedy_large_batch(device, batch_size):
+    """Non-greedy stochastic sampling at batch sizes 8, 16, 32."""
+    logits_cpu = torch.randn(batch_size, _LARGE_BATCH_VOCAB, dtype=torch.float32)
+
+    compiled_fn = torch.compile(run_sampler, backend="tt", dynamic=False)
+    metadata_dev = make_metadata(batch_size=batch_size, device=device)
+    actual = compiled_fn(logits_cpu.to(device), metadata_dev).cpu()
+
+    assert actual.shape == (batch_size, 1)
+    assert_valid_tokens(actual, _LARGE_BATCH_VOCAB, context=f"batch_size={batch_size}")


### PR DESCRIPTION
### Ticket
#3610

### Problem description
- Non-greedy sampling OOMed at batch ≥ 16: `ttnn.moreh_cumsum` required rank-4 input, triggering a reshape to `[batch, vocab, 1, 1]` whose tile layout allocated one 32×32 tile per scalar element — 8.4 GB for batch=16.
- Fixed upstream in tt-mlir#7483, which replaces `moreh_cumsum` with native `ttnn::cumsum` that accepts 2D input directly.

### What's changed
- `tests/integrations/vllm_plugin/sampling/test_sampling_params_synthetic.py`: Add `test_non_greedy_large_batch` parametrized over batch sizes 8, 16, 32 at Llama-3-8B vocab size (128256). Tests the stochastic sampler's sort/softmax/cumsum path without loading a model.  Tests fail without tt-mlir fix, pass with tt-mlir fix.

### Checklist
- [x] New tests added