### PR TITLE
Avoid unnecessary mesh reshaping in SPMD mode

### DIFF
--- a/pjrt_implementation/inc/api/module_builder/frontend_passes/shlo_set_proper_sdy_mesh_attribute.h
+++ b/pjrt_implementation/inc/api/module_builder/frontend_passes/shlo_set_proper_sdy_mesh_attribute.h
@@ -19,7 +19,9 @@ namespace tt::pjrt::module_builder::frontend_passes {
 // the same inputs/weights. This function detects that case and rewrites the
 // mesh to [1, num_devices] so fully replicated graphs execute as intended.
 tt_pjrt_status setProperSdyMeshAttributeInSpmdMode(
-    mlir::OwningOpRef<mlir::ModuleOp> &mlir_module);
+    mlir::OwningOpRef<mlir::ModuleOp> &mlir_module,
+    const std::optional<std::vector<uint32_t>> &current_mesh_shape =
+        std::nullopt);
 
 namespace internal {
 // Checks whether the graph is in SPMD mode.

--- a/pjrt_implementation/inc/api/module_builder/module_builder.h
+++ b/pjrt_implementation/inc/api/module_builder/module_builder.h
@@ -184,11 +184,13 @@ private:
   collectResultPresharded(const mlir::OwningOpRef<mlir::ModuleOp> &module);
 
   // Runs compiler StableHLO pipeline on the MLIR module.
-  tt_pjrt_status
-  runCompilerStableHLOPipeline(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module,
-                               const std::vector<int64_t> &result_presharded,
-                               const std::optional<std::string> &export_path,
-                               const std::string &model_name = "");
+  tt_pjrt_status runCompilerStableHLOPipeline(
+      mlir::OwningOpRef<mlir::ModuleOp> &mlir_module,
+      const std::vector<int64_t> &result_presharded,
+      const std::optional<std::string> &export_path,
+      const std::string &model_name = "",
+      const std::optional<std::vector<uint32_t>> &current_mesh_shape =
+          std::nullopt);
 
   // Converts StableHLO module to TTIR module.
   tt_pjrt_status

--- a/pjrt_implementation/src/api/module_builder/frontend_passes/shlo_set_proper_sdy_mesh_attribute.cc
+++ b/pjrt_implementation/src/api/module_builder/frontend_passes/shlo_set_proper_sdy_mesh_attribute.cc
@@ -19,7 +19,8 @@
 
 namespace tt::pjrt::module_builder::frontend_passes {
 tt_pjrt_status setProperSdyMeshAttributeInSpmdMode(
-    mlir::OwningOpRef<mlir::ModuleOp> &mlir_module) {
+    mlir::OwningOpRef<mlir::ModuleOp> &mlir_module,
+    const std::optional<std::vector<uint32_t>> &current_mesh_shape) {
   if (!internal::isSpmdMode(mlir_module)) {
     return tt_pjrt_status::kSuccess;
   }
@@ -34,19 +35,36 @@ tt_pjrt_status setProperSdyMeshAttributeInSpmdMode(
         // This axis already has a non-trivial size; leave the mesh as-is.
         return tt_pjrt_status::kSuccess;
       }
-      if (i == mesh_attr.getAxes().size() - 1) {
-        // We use the last axis to encode the mesh shape (e.g., [1,
-        // num_devices]).
-        new_axes.push_back(mlir::sdy::MeshAxisAttr::get(
-            ctx, axis.getName(), tt::runtime::getNumAvailableDevices()));
-      } else {
-        new_axes.push_back(axis);
-      }
     }
 
-    DLOG_F(LOG_DEBUG,
-           "SPMD-enabled mesh has trivial size [1, 1], reshaping to [1, %ld]",
-           tt::runtime::getNumAvailableDevices());
+    // If a mesh is already open and number of axes of opened mesh matches with
+    // the mesh op in the current graph, reuse its shape to avoid closing and
+    // reopening. Otherwise, fall back to a 1xN mesh.
+    if (current_mesh_shape.has_value() &&
+        current_mesh_shape->size() == mesh_attr.getAxes().size()) {
+      for (auto [i, axis] : llvm::enumerate(mesh_attr.getAxes())) {
+        new_axes.push_back(mlir::sdy::MeshAxisAttr::get(
+            ctx, axis.getName(), (*current_mesh_shape)[i]));
+      }
+      DLOG_F(LOG_DEBUG,
+             "SPMD-enabled mesh has trivial size [1, 1], reusing already "
+             "opened mesh shape");
+    } else {
+      for (auto [i, axis] : llvm::enumerate(mesh_attr.getAxes())) {
+        if (i == mesh_attr.getAxes().size() - 1) {
+          // We use the last axis to encode the mesh shape (e.g., [1,
+          // num_devices]).
+          new_axes.push_back(mlir::sdy::MeshAxisAttr::get(
+              ctx, axis.getName(), tt::runtime::getNumAvailableDevices()));
+        } else {
+          new_axes.push_back(axis);
+        }
+      }
+      DLOG_F(LOG_DEBUG,
+             "SPMD-enabled mesh has trivial size [1, 1], reshaping to [1, "
+             "%ld]",
+             tt::runtime::getNumAvailableDevices());
+    }
 
     // Replace the mesh on the op with the updated axes.
     shardy_op->setMeshAttr(mlir::sdy::MeshAttr::get(ctx, new_axes));

--- a/pjrt_implementation/src/api/module_builder/module_builder.cc
+++ b/pjrt_implementation/src/api/module_builder/module_builder.cc
@@ -305,9 +305,15 @@ ModuleBuilder::buildModule(
 
   std::vector<int64_t> result_presharded = collectResultPresharded(mlir_module);
 
-  status = runCompilerStableHLOPipeline(mlir_module, result_presharded,
-                                        compile_options.export_path,
-                                        compile_options.export_model_name);
+  const std::optional<tt::runtime::Device> &parent_mesh =
+      client_instance->parentMesh();
+  std::optional<std::vector<uint32_t>> current_mesh_shape =
+      parent_mesh ? std::make_optional(tt::runtime::getMeshShape(*parent_mesh))
+                  : std::nullopt;
+
+  status = runCompilerStableHLOPipeline(
+      mlir_module, result_presharded, compile_options.export_path,
+      compile_options.export_model_name, current_mesh_shape);
   if (!tt_pjrt_status_is_ok(status)) {
     return {status, nullptr};
   }
@@ -372,6 +378,14 @@ ModuleBuilder::buildModule(
                                  ttnn_mlir);
   if (!tt_pjrt_status_is_ok(status)) {
     return {status, nullptr};
+  }
+
+  // tt-xla creates 1D mesh by default, so if compiler determines a different
+  // mesh shape, we need to update the mesh in the client instance to match the
+  // compiler determined mesh shape.
+  if (current_mesh_shape.has_value() &&
+      current_mesh_shape.value() != mesh_shape) {
+    client_instance->getOrCreateMeshDevice(mesh_shape);
   }
 
   // TODO(mrakita): Use the VHLO module name from the module builder, if it has
@@ -807,7 +821,8 @@ tt_pjrt_status ModuleBuilder::runCompilerStableHLOPipeline(
     mlir::OwningOpRef<mlir::ModuleOp> &mlir_module,
     const std::vector<int64_t> &result_presharded,
     const std::optional<std::string> &export_path,
-    const std::string &model_name) {
+    const std::string &model_name,
+    const std::optional<std::vector<uint32_t>> &current_mesh_shape) {
   mlir::PassManager stablehlo_pipeline_pm(mlir_module.get()->getName(),
                                           mlir::PassManager::Nesting::Implicit);
   mlir::tt::stablehlo::StableHLOPipelineOptions stablehlo_pipeline_options;
@@ -825,10 +840,13 @@ tt_pjrt_status ModuleBuilder::runCompilerStableHLOPipeline(
   printModule(mlir_module, export_path, "shlo_compiler", model_name);
 
   if (!tt_pjrt_status_is_ok(
-          frontend_passes::setProperSdyMeshAttributeInSpmdMode(mlir_module))) {
+          frontend_passes::setProperSdyMeshAttributeInSpmdMode(
+              mlir_module, current_mesh_shape))) {
     LOG_F(ERROR, "Failed to set proper sdy.mesh attribute in SPMD mode");
     return tt_pjrt_status::kInternal;
   }
+
+  printModule(mlir_module, export_path, "shlo_set_mesh_attr", model_name);
 
   return tt_pjrt_status::kSuccess;
 }


### PR DESCRIPTION
### Ticket
closes #3744 

### Problem description
If a device-mesh is already opened as 2D mesh, we reshape it to 1xN unnecessarily on fully replicated graphs.

### What's changed
This optimization avoid closing and reopening mesh connections by reusing the current mesh shape when available and possible.
This change improves performance by eliminating unnecessary mesh teardown/setup cycles while maintaining the same functional behavior for SPMD graph execution.
