### PR TITLE
Nightly maintenance on mar18

### DIFF
--- a/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
@@ -24,7 +24,6 @@ test_config:
 
   qwen_2_5/causal_lm/pytorch-0.5B_Instruct-llm_decode-seq_1-batch_1-single_device-inference:
     status: EXPECTED_PASSING
-    assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/2845
 
   qwen_2_5/causal_lm/pytorch-1.5B_Instruct-llm_decode-seq_1-batch_1-single_device-inference:
     status: EXPECTED_PASSING
@@ -52,21 +51,17 @@ test_config:
 
   gemma/pytorch-1.1_2B_IT-llm_decode-seq_1-batch_1-single_device-inference:
     status: EXPECTED_PASSING
-    assert_pcc: false # ComputeConfig math_fidelity/fp32_dest_acc_en - https://github.com/tenstorrent/tt-xla/issues/2861
 
   gemma/pytorch-1.1_7B_IT-llm_decode-seq_1-batch_1-single_device-inference:
     supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.
     status: EXPECTED_PASSING
-    assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/2845
 
   gemma/pytorch-2_2B_IT-llm_decode-seq_1-batch_1-single_device-inference:
     status: EXPECTED_PASSING
-    assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/2845
 
   gemma/pytorch-2_9B_IT-llm_decode-seq_1-batch_1-single_device-inference:
     supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.
     status: EXPECTED_PASSING
-    assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/2845
 
   gemma/pytorch-2_27B_IT-llm_decode-seq_1-batch_1-single_device-inference:
     status: EXCLUDE_MODEL # Too large for single chip, run as tensor_parallel instead.
@@ -74,7 +69,6 @@ test_config:
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_decode-seq_1-batch_1-single_device-inference:
     supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.
     status: EXPECTED_PASSING
-    assert_pcc: false # ComputeConfig math_fidelity/fp32_dest_acc_en - https://github.com/tenstorrent/tt-xla/issues/2861
 
   llama/causal_lm/pytorch-3.1_70B-llm_decode-seq_1-batch_1-single_device-inference:
     status: EXCLUDE_MODEL # Too large for single chip, run as tensor_parallel instead.

--- a/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
@@ -37,12 +37,10 @@ test_config:
   gemma/pytorch-1.1_7B_IT-llm_decode-seq_1-batch_1-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
-    assert_pcc: false # ComputeConfig math_fidelity/fp32_dest_acc_en - https://github.com/tenstorrent/tt-xla/issues/2861
 
   gemma/pytorch-2_9B_IT-llm_decode-seq_1-batch_1-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]
     status: EXPECTED_PASSING
-    assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/2845
 
   gemma/pytorch-2_27B_IT-llm_decode-seq_1-batch_1-tensor_parallel-inference:
     supported_archs: ["n300-llmbox"]


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/2845
https://github.com/tenstorrent/tt-xla/issues/2861


### Problem description
Nightly maintenance on mar18
ci run: https://github.com/tenstorrent/tt-xla/actions/runs/23273415455

### What's changed
Since the models are being updated nightly, the configuration files have been updated accordingly.

```
test_llms_torch[gemma/pytorch-1.1_2B_IT-llm_decode-seq_1-batch_1-single_device-inference]                                                   language    red         bfloat16       n150         PASSED                     PASSING       0.9991055975580894     0.99       PCC_DIS  single_device    124.591   ENABLE_PCC_099
test_llms_torch[gemma/pytorch-1.1_2B_IT-llm_decode-seq_1-batch_1-single_device-inference]                                                   language    red         bfloat16       p150         PASSED                     PASSING       0.9988833499828352     0.99       PCC_DIS  single_device    81.129    ENABLE_PCC_099
test_llms_torch[gemma/pytorch-1.1_7B_IT-llm_decode-seq_1-batch_1-single_device-inference]                                                   language    red         bfloat16       p150         PASSED                     PASSING       0.9960663492101999     0.99       PCC_DIS  single_device    166.606   ENABLE_PCC_099
test_llms_torch[gemma/pytorch-1.1_7B_IT-llm_decode-seq_1-batch_1-tensor_parallel-inference]                                                 language    red         bfloat16       n300-llmbox  PASSED                     PASSING       0.995976188053565      0.99       PCC_DIS  tensor_parallel  132.266   ENABLE_PCC_099
test_llms_torch[gemma/pytorch-2_2B_IT-llm_decode-seq_1-batch_1-single_device-inference]                                                     language    red         bfloat16       n150         PASSED                     PASSING       0.9996250554512018     0.99       PCC_DIS  single_device    424.492   ENABLE_PCC_099
test_llms_torch[gemma/pytorch-2_2B_IT-llm_decode-seq_1-batch_1-single_device-inference]                                                     language    red         bfloat16       p150         PASSED                     PASSING       0.9995759205976643     0.99       PCC_DIS  single_device    307.823   ENABLE_PCC_099
test_llms_torch[gemma/pytorch-2_9B_IT-llm_decode-seq_1-batch_1-single_device-inference]                                                     language    red         bfloat16       p150         PASSED                     PASSING       0.9996054346590143     0.99       PCC_DIS  single_device    642.496   ENABLE_PCC_099
test_llms_torch[gemma/pytorch-2_9B_IT-llm_decode-seq_1-batch_1-tensor_parallel-inference]                                                   language    red         bfloat16       n300-llmbox  PASSED                     PASSING       0.9998034528218451     0.99       PCC_DIS  tensor_parallel  569.653   ENABLE_PCC_099
test_llms_torch[llama/causal_lm/pytorch-3.1_8B_Instruct-llm_decode-seq_1-batch_1-single_device-inference]                                   language    priority    bfloat16       p150         PASSED                     PASSING       0.9953364563099275     0.99       PCC_DIS  single_device    147.107   ENABLE_PCC_099         
test_llms_torch[qwen_2_5/causal_lm/pytorch-0.5B_Instruct-llm_decode-seq_1-batch_1-single_device-inference]                                  language    red         bfloat16       n150         PASSED                     PASSING       0.9945968771010741     0.99       PCC_DIS  single_device    103.614   ENABLE_PCC_099
test_llms_torch[qwen_2_5/causal_lm/pytorch-0.5B_Instruct-llm_decode-seq_1-batch_1-single_device-inference]                                  language    red         bfloat16       p150         PASSED                     PASSING       0.9941320362401144     0.99       PCC_DIS  single_device    57.369    ENABLE_PCC_099

```
### Checklist
- [ ] New/Existing tests provide coverage for changes
