### PR TITLE
Add galaxy-wh-6u vLLM support with Mistral-Large model test

### DIFF
--- a/.github/workflows/test-matrix-presets/basic-test-nightly.json
+++ b/.github/workflows/test-matrix-presets/basic-test-nightly.json
@@ -13,5 +13,6 @@
   {"runs-on": "p150",                "name": "run_vllm_p150_tests",    "dir": "./tests/integrations/vllm_plugin",         "test-mark": "nightly and single_device",               "shared-runners": "true", "extra-wheel": "vllm"},
   {"runs-on": "n300",                "name": "run_vllm_n300_tests",    "dir": "./tests/integrations/vllm_plugin",         "test-mark": "nightly and data_parallel",               "shared-runners": "true", "extra-wheel": "vllm"},
   {"runs-on": "n300",                "name": "run_vllm_n300_tests",    "dir": "./tests/integrations/vllm_plugin",         "test-mark": "nightly and tensor_parallel and dual_chip", "shared-runners": "true", "extra-wheel": "vllm"},
-  { "runs-on": "galaxy-wh-6u",       "name": "run_torch_galaxy",       "dir": "./tests/torch",                            "test-mark": "nightly and galaxy" }
+  { "runs-on": "galaxy-wh-6u",       "name": "run_torch_galaxy",       "dir": "./tests/torch",                            "test-mark": "nightly and galaxy" },
+  { "runs-on": "galaxy-wh-6u",        "name": "run_vllm_galaxy_wh_6u_tests", "dir": "./tests/integrations/vllm_plugin", "test-mark": "nightly and tensor_parallel and galaxy_wh_6u", "extra-wheel": "vllm" }
 ]

--- a/.github/workflows/test-matrix-presets/vllm-model-tests-nightly.json
+++ b/.github/workflows/test-matrix-presets/vllm-model-tests-nightly.json
@@ -3,5 +3,6 @@
     {"runs-on": "p150", "name": "run_vllm_p150_tests", "dir": "./tests/integrations/vllm_plugin", "test-mark": "nightly and single_device", "shared-runners": "true", "extra-wheel": "vllm"},
     {"runs-on": "n300", "name": "run_vllm_n300_tests", "dir": "./tests/integrations/vllm_plugin", "test-mark": "nightly and data_parallel", "shared-runners": "true", "extra-wheel": "vllm"},
     {"runs-on": "n300", "name": "run_vllm_n300_tests", "dir": "./tests/integrations/vllm_plugin", "test-mark": "nightly and tensor_parallel and dual_chip", "shared-runners": "true", "extra-wheel": "vllm"},
-    {"runs-on": "n300-llmbox", "name": "run_vllm_llmbox_tests", "dir": "./tests/integrations/vllm_plugin", "test-mark": "nightly and tensor_parallel and llmbox", "shared-runners": "true", "extra-wheel": "vllm"}
+    {"runs-on": "n300-llmbox", "name": "run_vllm_llmbox_tests", "dir": "./tests/integrations/vllm_plugin", "test-mark": "nightly and tensor_parallel and llmbox", "shared-runners": "true", "extra-wheel": "vllm"},
+    { "runs-on": "galaxy-wh-6u",        "name": "run_vllm_galaxy_wh_6u_tests", "dir": "./tests/integrations/vllm_plugin", "test-mark": "nightly and tensor_parallel and galaxy_wh_6u", "extra-wheel": "vllm" }
 ]

--- a/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
@@ -121,3 +121,42 @@ def test_tensor_parallel_generation_llmbox_large(
     assert_output_coherent(output_text)
 
     check_host_memory(model_name)
+
+
+@pytest.mark.nightly
+@pytest.mark.tensor_parallel
+@pytest.mark.galaxy_wh_6u
+@pytest.mark.parametrize(
+    ["model_name", "enable_const_eval", "experimental_weight_dtype", "use_2d_mesh"],
+    [pytest.param("mistralai/Mistral-Large-Instruct-2411", True, "bfp_bf8", True)],
+)
+def test_tensor_parallel_generation_galaxy_wh_6u_large(
+    model_name: str,
+    enable_const_eval: bool,
+    experimental_weight_dtype: str,
+    use_2d_mesh: bool,
+):
+    inputs = ["How many days ago was Mistral founded?"]
+
+    sampling_params = vllm.SamplingParams(temperature=0.8, top_p=0.95, max_tokens=16)
+    llm_args = {
+        "model": model_name,
+        "max_num_batched_tokens": 32,
+        "max_num_seqs": 1,
+        "max_model_len": 32,
+        "gpu_memory_utilization": 0.02,
+        "additional_config": {
+            "enable_const_eval": enable_const_eval,
+            "min_context_len": 64,
+            "enable_tensor_parallel": True,
+            "experimental_weight_dtype": experimental_weight_dtype,
+            "use_2d_mesh": use_2d_mesh,
+        },
+    }
+    llm = vllm.LLM(**llm_args)
+
+    output_text = llm.generate(inputs, sampling_params)[0].outputs[0].text
+    print("output: ", output_text)
+    assert_output_coherent(output_text)
+
+    check_host_memory(model_name)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/3734

### Problem description
Add support for running the **mistralai/Mistral-Large-Instruct-2411** model with vLLM in the galaxy-wh-6u setup.

### What's changed
ci run: https://github.com/tenstorrent/tt-xla/actions/runs/25413774714/job/74540896688
question: How many days ago was Mistral founded?
vllm output:  Mistural was founded 47 days ago.
### Checklist
- [ ] New/Existing tests provide coverage for changes
