### PR TITLE
Adding compile option for dram space-saving optimization pass

### DIFF
--- a/pjrt_implementation/inc/api/compile_options.h
+++ b/pjrt_implementation/inc/api/compile_options.h
@@ -96,6 +96,9 @@ struct CompileOptions {
   // some models until https://github.com/tenstorrent/tt-mlir/pull/6198 lands.
   bool experimental_enable_permute_matmul_fusion = true;
 
+  // Enable DRAM space saving optimization pass (TTNNMemoryManagement).
+  bool experimental_enable_dram_space_saving_optimization = false;
+
   // Enable collection of TTNN performance metrics during execution.
   bool ttnn_perf_metrics_enabled = false;
 

--- a/pjrt_implementation/src/api/compile_options.cc
+++ b/pjrt_implementation/src/api/compile_options.cc
@@ -55,6 +55,10 @@ CompileOptions CompileOptions::parse(
       internal::parseBoolOption(compile_options,
                                 "codegen_try_recover_structure")
           .value_or(options.codegen_try_recover_structure);
+  options.experimental_enable_dram_space_saving_optimization =
+      internal::parseBoolOption(
+          compile_options, "experimental-enable-dram-space-saving-optimization")
+          .value_or(options.experimental_enable_dram_space_saving_optimization);
   options.ttnn_perf_metrics_enabled =
       internal::parseBoolOption(compile_options, "ttnn_perf_metrics_enabled")
           .value_or(false);

--- a/pjrt_implementation/src/api/module_builder/module_builder.cc
+++ b/pjrt_implementation/src/api/module_builder/module_builder.cc
@@ -1026,6 +1026,8 @@ tt_pjrt_status ModuleBuilder::convertFromTTIRToTTNN(
   options.systemDescPath = system_descriptor_path.data();
   options.enableConstEval = compile_options.enable_const_eval;
   options.enableCPUHoistedConstEval = compile_options.enable_const_eval_on_cpu;
+  options.dramSpaceSavingOptimizationEnabled =
+      compile_options.experimental_enable_dram_space_saving_optimization;
   options.ttnnPerfMetricsEnabled = compile_options.ttnn_perf_metrics_enabled;
 
   // Auto-number performance metrics output file if enabled


### PR DESCRIPTION
### What's changed
Adding compile option for enabling `createTTNNMemoryManagement` pass in `tt-mlir`.

