### PR TITLE
Location line fix for multi-line return statements

### DIFF
--- a/python_package/tt_torch/backend/metadata_propagation.py
+++ b/python_package/tt_torch/backend/metadata_propagation.py
@@ -149,11 +149,12 @@ def _find_enclosing_function(
                     self.found_name = None
 
                 def visit_FunctionDef(self, node):
-                    if hasattr(node, "body") and node.lineno <= self.line <= (
+                    end_line = getattr(node, "end_lineno", None) or (
                         max(getattr(x, "lineno", node.lineno) for x in node.body)
                         if node.body
                         else node.lineno
-                    ):
+                    )
+                    if hasattr(node, "body") and node.lineno <= self.line <= end_line:
                         # Recursively visit all children to find more specific (inner) functions.
                         # This includes functions nested directly AND methods inside nested classes.
                         self.generic_visit(node)


### PR DESCRIPTION
The AST-based enclosing function finder in metadata_propagation.py incorrectly calculates function boundaries by using only the start line numbers of direct body children (max(x.lineno for x in node.body)). This fails for multi-line expressions, where the actual end of a statement extends beyond its start line, causing the line to not be recognized as inside the function. The fix uses Python's end_lineno AST attribute to accurately determine function boundaries, which resolves the mismatch between "simple" and "ast" modes in _find_enclosing_function. 