### PR TITLE
Modify GPT-OSS TP benchmark test to sparse MoE

### DIFF
--- a/python_package/tt_torch/sparse_mlp.py
+++ b/python_package/tt_torch/sparse_mlp.py
@@ -308,7 +308,8 @@ class A2aSparseMLP(nn.Module):
         # Maps each expert to its owning device. When cluster_axis=0, the dispatch
         # kernel derives the target row from the device_id in the mapping.
         mapping = build_expert_mapping(num_experts, num_devices)
-        self.register_buffer("expert_mapping", mapping)
+        device = next(self.experts.parameters()).device
+        self.register_buffer("expert_mapping", mapping.to(device))
 
     def forward(self, hidden_states):
         batch_size, seq_len, hidden_size = hidden_states.shape
@@ -355,12 +356,22 @@ class A2aSparseMLP(nn.Module):
         M = 32
 
         # 4. Determine which dimension to split by M
-        # Prefer seq_len; fall back to BD; assert if neither works
+        # Prefer seq_len; fall back to BD; pad seq_len if neither works
         split_seq = seq_len % M == 0 and seq_len >= M
         split_bd = BD % M == 0 and BD >= M
-        assert (
-            split_seq or split_bd
-        ), f"Neither seq_len ({seq_len}) nor BD ({BD}) is divisible by M={M}"
+
+        seq_len_original = seq_len
+        pad_seq = 0
+        if not split_seq and not split_bd:
+            seq_len_padded = ((seq_len + M - 1) // M) * M
+            pad_seq = seq_len_padded - seq_len
+            # dispatched: [1, BD, S, H] → pad S dim
+            dispatched = F.pad(dispatched, (0, 0, 0, pad_seq))
+            # metadata: [1, BD, S, K] → pad S dim
+            metadata = F.pad(metadata, (0, 0, 0, pad_seq))
+            seq_len = seq_len_padded
+            split_seq = True
+
         if split_seq:
             dim_a, dim_b = BD, seq_len // M
         else:
@@ -445,7 +456,9 @@ class A2aSparseMLP(nn.Module):
             # Build topk_tensor [1, BD, S, E] — fold D into batch dim so the
             # kernel sees BD tokens and produces BD*S/M reduced entries.
             topk_3d = router_logits  # [B, S, E] raw logits for remap kernel
-            topk_repeated = topk_3d.repeat(D, 1, 1)  # [BD, S, E]
+            topk_repeated = topk_3d.repeat(D, 1, 1)  # [BD, S_original, E]
+            if pad_seq > 0:
+                topk_repeated = F.pad(topk_repeated, (0, 0, 0, pad_seq))
             topk_tensor = topk_repeated.unsqueeze(0)  # [1, BD, S, E]
 
             # metadata already [1, BD, S, K] — pass as-is
@@ -642,8 +655,16 @@ class A2aSparseMLP(nn.Module):
                 down_out = down_out.permute(3, 0, 2, 1, 4).contiguous()
                 down_out = down_out.view(E, BD, seq_len, hidden_size)
 
-        # Combine: gather expert outputs back along cluster_axis
+        # Remove seq padding before combine
         decode_mode = dim_b == 1 and not split_seq
+        if pad_seq > 0:
+            # down_out: [E, BD, S, H] — slice S dim back to original
+            down_out = down_out.narrow(2, 0, seq_len_original)
+            # metadata: [1, BD, S, K] — slice S dim back to original
+            metadata = metadata.narrow(2, 0, seq_len_original)
+            seq_len = seq_len_original
+
+        # Combine: gather expert outputs back along cluster_axis
         combined = torch.ops.tt.all_to_all_combine(
             down_out,
             metadata,

--- a/tests/benchmark/benchmarks/llm_benchmark.py
+++ b/tests/benchmark/benchmarks/llm_benchmark.py
@@ -22,6 +22,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer, PreTrainedTokenize
 from transformers.cache_utils import StaticCache
 from transformers.modeling_outputs import CausalLMOutputWithPast
 from tt_torch.sharding import sharding_constraint_hook
+from tt_torch.sparse_mlp import enable_sparse_mlp
 from utils import (
     build_xla_export_name,
     compute_pcc,
@@ -210,6 +211,7 @@ def benchmark_llm_torch_xla(
     model_name_for_accuracy: str = None,
     hf_model_name_for_accuracy: str = None,
     max_output_tokens=None,
+    inject_custom_moe: bool = False,
 ):
     """
     Benchmark an LLM (Large Language Model) using PyTorch and torch-xla.
@@ -353,6 +355,8 @@ def benchmark_llm_torch_xla(
     if is_multichip:
         shard_specs = shard_spec_fn(model_loader, model)
         mesh = get_mesh(model_loader, mesh_config_fn)
+        if inject_custom_moe:
+            enable_sparse_mlp(model, mesh.mesh_shape, cluster_axis=0)
         if shard_specs is not None:
             for tensor, shard_spec in shard_specs.items():
                 xs.mark_sharding(tensor, mesh, shard_spec)

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -57,6 +57,7 @@ def test_llm(
     request=None,
     accuracy_testing: bool = False,
     max_output_tokens=None,
+    inject_custom_moe: bool = False,
 ):
     """Test LLM model with the given variant and optional configuration overrides.
 
@@ -76,6 +77,7 @@ def test_llm(
         required_pcc: Required PCC threshold
         num_layers: Number of layers to override
         accuracy_testing: Enable token accuracy testing with reference data
+        inject_custom_moe: Whether to inject custom MoE logic for models that support it (e.g. GPT-OSS)
     """
     # Set default batch size if None
     if batch_size is None:
@@ -146,6 +148,7 @@ def test_llm(
         model_name_for_accuracy=model_name_for_accuracy,
         hf_model_name_for_accuracy=hf_model_name,
         max_output_tokens=max_output_tokens,
+        inject_custom_moe=inject_custom_moe,
     )
 
     if output_file:
@@ -1089,24 +1092,32 @@ def test_llama_3_1_70b_tp(output_file, num_layers, request, max_output_tokens):
     )
 
 
-# Use 1x8 shard specs for gpt-oss-20b until https://github.com/tenstorrent/tt-xla/issues/3490 is resolved.
 def _gpt_oss_20b_mesh_config_fn(model_loader, num_devices):
-    return (1, num_devices), ("batch", "model")
+    return (2, num_devices // 2), ("batch", "model")
 
 
 def _gpt_oss_20b_shard_spec_fn(model_loader, model):
     shard_specs = {}
+    shard_specs[model.model.embed_tokens.weight] = (None, "batch")
+    shard_specs[model.model.norm.weight] = ("batch",)
+    shard_specs[model.lm_head.weight] = ("model", "batch")
     for layer in model.model.layers:
-        shard_specs[layer.self_attn.q_proj.weight] = ("model", None)
-        shard_specs[layer.self_attn.k_proj.weight] = ("model", None)
-        shard_specs[layer.self_attn.v_proj.weight] = ("model", None)
-        shard_specs[layer.self_attn.o_proj.weight] = (None, "model")
+        shard_specs[layer.self_attn.q_proj.weight] = ("model", "batch")
+        shard_specs[layer.self_attn.q_proj.bias] = ("model",)
+        shard_specs[layer.self_attn.k_proj.weight] = ("model", "batch")
+        shard_specs[layer.self_attn.k_proj.bias] = ("model",)
+        shard_specs[layer.self_attn.v_proj.weight] = ("model", "batch")
+        shard_specs[layer.self_attn.v_proj.bias] = ("model",)
+        shard_specs[layer.self_attn.o_proj.weight] = ("batch", "model")
+        shard_specs[layer.self_attn.o_proj.bias] = ("batch",)
         shard_specs[layer.self_attn.sinks] = (None,)
-        shard_specs[layer.mlp.router.weight] = (None, None)
-        shard_specs[layer.mlp.experts.gate_up_proj] = ("model", None, None)
-        shard_specs[layer.mlp.experts.gate_up_proj_bias] = ("model", None)
-        shard_specs[layer.mlp.experts.down_proj] = ("model", None, None)
-        shard_specs[layer.mlp.experts.down_proj_bias] = ("model", None)
+        shard_specs[layer.mlp.router.weight] = (None, "batch")
+        shard_specs[layer.mlp.experts.gate_up_proj] = (("batch", "model"), None, None)
+        shard_specs[layer.mlp.experts.gate_up_proj_bias] = (("batch", "model"), None)
+        shard_specs[layer.mlp.experts.down_proj] = (("batch", "model"), None, None)
+        shard_specs[layer.mlp.experts.down_proj_bias] = (("batch", "model"), None)
+        shard_specs[layer.input_layernorm.weight] = ("batch",)
+        shard_specs[layer.post_attention_layernorm.weight] = ("batch",)
     return shard_specs
 
 
@@ -1127,6 +1138,7 @@ def test_gpt_oss_20b_tp(output_file, num_layers, request, max_output_tokens):
         mesh_config_fn=_gpt_oss_20b_mesh_config_fn,
         shard_spec_fn=_gpt_oss_20b_shard_spec_fn,
         optimization_level=0,  # https://github.com/tenstorrent/tt-mlir/issues/6949
+        inject_custom_moe=True,  # Enable custom MoE logic for GPT-OSS sparse MoE variant
     )
 
 
@@ -1150,6 +1162,7 @@ def test_gpt_oss_20b_tp_batch_size_1(
         shard_spec_fn=_gpt_oss_20b_shard_spec_fn,
         batch_size=1,
         optimization_level=0,  # https://github.com/tenstorrent/tt-mlir/issues/6949
+        inject_custom_moe=True,  # Enable custom MoE logic for GPT-OSS sparse MoE variant
     )
 
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/3486

### Problem description
We need to run gpt oss benchmark with sparse moe

### What's changed
 - Inject custom MoE logic for GPT-OSS sparse MoE variant into benchmark test
 - Pass option to ttnn workaround for concat, reshape hang.

### Checklist
- [ ] New/Existing tests provide coverage for changes
