### PR TITLE
Removed push markers from jax qwen 2.5 coder and onPR workflows that became empty

### DIFF
--- a/.github/workflows/test-matrix-presets/model-test-push.json
+++ b/.github/workflows/test-matrix-presets/model-test-push.json
@@ -3,7 +3,5 @@
   { "runs-on": "p150",          "name": "run_forge_models",      "dir": "./tests/runner/test_models.py::test_all_models_torch",      "test-mark": "p150 and expected_passing and push" },
   { "runs-on": "n150",          "name": "run_forge_models",      "dir": "./tests/runner/test_models.py::test_all_models_jax",        "test-mark": "n150 and expected_passing and push and not large" },
   { "runs-on": "p150",          "name": "run_forge_models",      "dir": "./tests/runner/test_models.py::test_all_models_jax",        "test-mark": "p150 and expected_passing and push" },
-  { "runs-on": "n150",          "name": "run_forge_models",      "dir": "./tests/runner/test_models.py::test_all_models_jax",        "test-mark": "n150 and expected_passing and push and large" },
-  { "runs-on": "p150",          "name": "run_forge_models",      "dir": "./tests/runner/test_models.py::test_all_models_jax",        "test-mark": "p150 and expected_passing and push and large" },
   { "runs-on": "n300-llmbox",   "name": "run_torch_multi_host",  "dir": "./tests/torch/multi_host/llmbox",                           "test-mark": "push and multi_host_cluster", "require": "release", "shared-runners": "true" }
 ]

--- a/tests/runner/test_config/jax/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/jax/test_config_inference_single_device.yaml
@@ -384,11 +384,11 @@ test_config:
 
   qwen_2_5_coder/causal_lm/jax-1.5B-single_device-inference:
     status: EXPECTED_PASSING
-    markers: [large, push]
+    markers: [large]
 
   qwen_2_5_coder/causal_lm/jax-1.5B_Instruct-single_device-inference:
     status: EXPECTED_PASSING
-    markers: [large, push]
+    markers: [large]
 
   qwen_2_5_coder/causal_lm/jax-3B-single_device-inference:
     status: NOT_SUPPORTED_SKIP


### PR DESCRIPTION
### Ticket
Non-deterministic test hangs likely due to OOM issues with a test depending on device like here: https://github.com/tenstorrent/tt-xla/actions/runs/23250136393/job/67594309949?pr=3777#step:17:164. 

### Problem description
This affects all onPR workflows as the cause of error tends not to be due to actual changes, preventing PR tests from being reliable

### What's changed
Push markers removed from the two concerning tests.
Two workflows had to be removed from `model-test-push.json` as those workflows do not have any tests anymore. This is mainly due to the drop in support for JAX models with Transformers 5.x onwards.

### Checklist
- [ ] New/Existing tests provide coverage for changes
