### PR TITLE
[pjrt] Fixed race conditions with buffer copy to host

### DIFF
--- a/pjrt_implementation/inc/api/buffer_instance.h
+++ b/pjrt_implementation/inc/api/buffer_instance.h
@@ -194,15 +194,6 @@ private:
     return uid.fetch_add(1, std::memory_order_relaxed);
   }
 
-  // Waits on a current copy to host thread to finish.
-  void joinCopyThread() {
-    const std::lock_guard<std::mutex> copy_lock(m_copy_to_host_thread_mutex);
-    if (m_copy_to_host_thread) {
-      m_copy_to_host_thread->join();
-      m_copy_to_host_thread.reset();
-    }
-  }
-
   // Unique identifier for this buffer instance.
   const uint64_t m_uid;
 
@@ -248,7 +239,7 @@ private:
   std::mutex m_data_deleted_mutex;
 
   // Thread for copying data to host.
-  std::unique_ptr<std::thread> m_copy_to_host_thread;
+  std::thread m_copy_to_host_thread;
 
   // Mutex guarding thread spawning for copying data to host.
   // Prevents multiple threads from concurrently copying into the same

--- a/pjrt_implementation/src/api/buffer_instance.cc
+++ b/pjrt_implementation/src/api/buffer_instance.cc
@@ -142,7 +142,11 @@ void BufferInstance::deleteData() {
     return;
   }
 
-  joinCopyThread();
+  {
+    const std::lock_guard<std::mutex> copy_lock(m_copy_to_host_thread_mutex);
+    if (m_copy_to_host_thread.joinable())
+      m_copy_to_host_thread.join();
+  }
 
   m_data_deleted = true;
   if (m_done_with_host_buffer_event) {
@@ -330,21 +334,18 @@ tt_pjrt_status BufferInstance::copyToHost(void *host_buffer,
   auto rt_data_type =
       tt::pjrt::data_type_utils::convertPJRTToRuntimeDataType(m_data_type);
 
+  std::unique_ptr<EventInstance> event = EventInstance::createInstance();
+
   // TODO(acolic): Copying in a separate thread is left to match previous
   // behavior. Check whether it is needed: it does not make much sense to
   // create new thread for each shard, because tensors are moved once from
-  // device when onHost is called on a first shard; on the other hand, there is
-  // no sense to create new thread for memcpy because framework would wait on a
-  // copy anyway, right? Also, creating std::thread for memcpy might be overhead
-  // with performance loss. We must measure.
-  // Also, std::thread (as all objects from std::) has a value semantic, so it
-  // does not make any sense to create std::thread as a unique_ptr.
-  joinCopyThread();
+  // device when onHost is called on a first shard. Also, creating std::thread
+  // for memcpy might be overhead with performance loss. We should measure.
+  const std::lock_guard<std::mutex> copy_lock(m_copy_to_host_thread_mutex);
+  if (m_copy_to_host_thread.joinable())
+    m_copy_to_host_thread.join();
 
-  std::unique_ptr<EventInstance> event = EventInstance::createInstance();
-
-  m_copy_to_host_thread = std::make_unique<std::thread>([=, this,
-                                                         e = event.get()] {
+  m_copy_to_host_thread = std::thread([=, this, e = event.get()] {
     try {
       ZoneScopedN("CopyToHostThread");
       const std::lock_guard<std::mutex> lock(s_copy_to_host_internal_mutex);

--- a/tests/torch/graphs/test_tensor_persistence.py
+++ b/tests/torch/graphs/test_tensor_persistence.py
@@ -523,18 +523,17 @@ def test_concurrent_buffer_instance_transfer():
 
     result = run_model_on_device(program_a, [input_a_cpu])
 
-    # Create multiple threads that all print the same result concurrently
-    def print_result(thread_id):
-        print(f"Thread {thread_id}: {result}")
-        # time.sleep(0.1)  # Small delay to increase chance of concurrent access
-        print(f"Thread {thread_id}: Shape = {result.shape}")
+    # Create multiple threads that all copies result object
+    def copy_to_host():
+        for _ in range(1024):
+            result.cpu()
 
     threads = []
     num_threads = 10
 
     # Start multiple threads
-    for i in range(num_threads):
-        thread = threading.Thread(target=print_result, args=(i,))
+    for _ in range(num_threads):
+        thread = threading.Thread(target=copy_to_host)
         threads.append(thread)
         thread.start()
 
@@ -566,14 +565,16 @@ def test_concurrent_multi_buffer_instance_transfer():
 
     res_a, res_b = run_model_on_device(program_ab, [input_a_cpu, input_b_cpu])
 
-    def print_result(thread_id, _result):
-        print(f"Result from thread_id {thread_id} = {_result}")
+    # Create multiple threads that all copies result object
+    def copy_to_host(_result):
+        for _ in range(1024):
+            _result.cpu()
 
     threads = []
     num_threads = 10
-    for i in range(num_threads):
-        thread_a = threading.Thread(target=print_result, args=(i, res_a))
-        thread_b = threading.Thread(target=print_result, args=(i, res_b))
+    for _ in range(num_threads):
+        thread_a = threading.Thread(target=copy_to_host, args=(res_a,))
+        thread_b = threading.Thread(target=copy_to_host, args=(res_b,))
 
         threads.append(thread_a)
         threads.append(thread_b)


### PR DESCRIPTION
Extended lock scope for copy thread creation in BufferInstance::copyToHost. This was causing different kinds of race conditions.

Also, improved concurrent buffer transfer tests.
Also, switched std::thread to value semantic.
