### PR TITLE
Update config files

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -2261,7 +2261,9 @@ test_config:
         required_pcc: 0.95 # https://github.com/tenstorrent/tt-xla/issues/1472, https://github.com/tenstorrent/tt-mlir/issues/6217
 
   maskformer_swin_b/pytorch-Swin_Base_Coco-single_device-inference:
-    status: EXPECTED_PASSING
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_FE_COMPILATION
+    reason: "Test hangs, investigation is ongoing: https://github.com/tenstorrent/tt-xla/issues/3838"
 
   maskformer_swin_b/pytorch-Swin_Base_Ade-single_device-inference:
     status: EXPECTED_PASSING

--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -33,7 +33,7 @@ test_config:
   gpt_oss/pytorch-20B-tensor_parallel-inference:
     supported_archs: [n300-llmbox, galaxy-wh-6u]
     status: EXPECTED_PASSING
-    required_pcc: 0.98
+    required_pcc: 0.975
     inject_custom_moe: true
 
   gpt_oss/pytorch-120B-tensor_parallel-inference:

--- a/tests/runner/test_config/torch/test_config_training_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_training_tensor_parallel.yaml
@@ -6,8 +6,9 @@
 test_config:
   falcon/pytorch-3_7B_Base-tensor_parallel-training:
     supported_archs: [n300-llmbox]
-    status: KNOWN_FAILURE_XFAIL
-    # reason: "DRAM OOM"
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_RUNTIME
+    reason: "Fatal Python error: Aborted: https://github.com/tenstorrent/tt-xla/issues/3627"
 
   falcon/pytorch-7B_Instruct-tensor_parallel-training:
     supported_archs: [n300-llmbox]


### PR DESCRIPTION
Update test configs for tests:

- gpt_oss/pytorch-20B-tensor_parallel-inference
```
PCC comparison failed. Calculated: pcc=0.9797330843468324. Required: pcc=0.98.
```
- maskformer_swin_b/pytorch-Swin_Base_Coco-single_device-inference
```
Error: The action 'Run tests' has timed out after 240 minutes.
```
- falcon/pytorch-3_7B_Base-tensor_parallel-training
```
TT_FATAL: Buffer must be allocated on device! (assert.hpp:104)
terminate called after throwing an instance of 'std::runtime_error'
Fatal Python error: Aborted
```