### PR TITLE
Setting gemma model to xfail

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -2679,7 +2679,8 @@ test_config:
     status: EXCLUDE_MODEL # Too large for single chip, run as tensor_parallel instead. Huge weights, need more diskspace.
 
   gemma/text_extraction_and_translation/pytorch-Translategemma_4B_IT-single_device-inference:
-    status: EXPECTED_PASSING
+    status: KNOWN_FAILURE_XFAIL
+    reason: "Dynamic shapes from get_placeholder_mask cause ValueError in _xla_warm_up_cache - https://github.com/tenstorrent/tt-xla/issues/3854"
 
   gemma3/causal_lm/pytorch-270M_Instruct-single_device-inference:
     status: EXPECTED_PASSING


### PR DESCRIPTION
Setting `gemma/text_extraction_and_translation/pytorch-Translategemma_4B_IT-single_device-inference` to xfail, as it never passed