### PR TITLE
Maintain: weekly update for Mar 16–Mar 20

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_data_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_data_parallel.yaml
@@ -65,9 +65,7 @@ test_config:
 
   albert/token_classification/pytorch-Xlarge_v1-data_parallel-inference:
     supported_archs: [n300]
-    assert_pcc: false
     status: EXPECTED_PASSING
-    reason: "PCC comparison failed. Calculated: pcc=0.9775277376174927. Required: pcc=0.98. - https://github.com/tenstorrent/tt-xla/issues/1844"
 
   mnist/image_classification/pytorch-Cnn_Dropout-data_parallel-inference:
     supported_archs: [n300]
@@ -111,9 +109,7 @@ test_config:
 
   squeezebert/pytorch-Mnli-data_parallel-inference:
     supported_archs: [n300]
-    status: KNOWN_FAILURE_XFAIL  # Affected by change in torch=xla wheel - issue is: https://github.com/tenstorrent/tt-xla/issues/1750
-    reason: "error: 'stablehlo.reshape' op requires compatible element types for all operands and results  - https://github.com/tenstorrent/tt-xla/issues/1750"
-    bringup_status: FAILED_FE_COMPILATION
+    status: EXPECTED_PASSING
 
   swin/image_classification/pytorch-v2_T-data_parallel-inference:
     supported_archs: [n300]
@@ -187,9 +183,7 @@ test_config:
 
   albert/token_classification/pytorch-Xxlarge_v1-data_parallel-inference:
     supported_archs: [n300]
-    assert_pcc: false
     status: EXPECTED_PASSING
-    reason: "PCC comparison failed. Calculated: pcc=0.9593995213508606. Required: pcc=0.99. - https://github.com/tenstorrent/tt-xla/issues/1789"
 
   vgg/pytorch-13-data_parallel-inference:
     supported_archs: [n300]
@@ -275,7 +269,6 @@ test_config:
   albert/masked_lm/pytorch-Xxlarge_v2-data_parallel-inference:
     supported_archs: [n300]
     status: EXPECTED_PASSING
-    required_pcc: 0.98
 
   vgg/pytorch-16-data_parallel-inference:
     supported_archs: [n300]
@@ -654,9 +647,7 @@ test_config:
 
   albert/token_classification/pytorch-Xlarge_v2-data_parallel-inference:
     supported_archs: [n300]
-    assert_pcc: false
     status: EXPECTED_PASSING
-    reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.8890893459320068. Required: pcc=0.99."
 
   regnet/pytorch-Y_080-data_parallel-inference:
     supported_archs: [n300]
@@ -1083,7 +1074,6 @@ test_config:
 
   mamba/pytorch-370M_HF-data_parallel-inference:
     supported_archs: [n300]
-    assert_pcc: false # -0.0327 WH / 0.3821 BH as of Nov 5 2025 right after an uplift which contained newer LLVM https://github.com/tenstorrent/tt-xla/issues/2000
     status: EXPECTED_PASSING
 
   codegen/pytorch-350M_Mono-data_parallel-inference:

--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -63,10 +63,6 @@ test_config:
 
   bloom/pytorch-single_device-inference:
     status: EXPECTED_PASSING
-    arch_overrides:
-      n150:
-        assert_pcc: false
-        reason: "PCC comparison failed. Calculated: pcc=0.9799284338951111. Required: pcc=0.98. - https://github.com/tenstorrent/tt-xla/issues/1828"
 
   xglm/pytorch-564M-single_device-inference:
     status: EXPECTED_PASSING
@@ -92,9 +88,6 @@ test_config:
 
   albert/masked_lm/pytorch-Large_v2-single_device-inference:
     status: EXPECTED_PASSING
-    arch_overrides:
-      n150:
-        required_pcc: 0.98
 
   yolov3/pytorch-Base-single_device-inference:
     required_pcc: 0.97  # AssertionError: PCC comparison failed. Calculated: pcc=0.9725883603096008. Required: pcc=0.98. Exposed by removal of consteval on host: https://github.com/tenstorrent/tt-xla/issues/1242
@@ -685,11 +678,6 @@ test_config:
 
   albert/token_classification/pytorch-Xxlarge_v1-single_device-inference:
     status: EXPECTED_PASSING
-    arch_overrides:
-      n150:
-        required_pcc: 0.98 # tt-torch has this at 0.99
-      p150:
-        required_pcc: 0.97 # tt-torch has this at 0.99
 
   albert/masked_lm/pytorch-Base_v1-single_device-inference:
     status: EXPECTED_PASSING
@@ -698,7 +686,6 @@ test_config:
     status: EXPECTED_PASSING
 
   albert/masked_lm/pytorch-Xlarge_v1-single_device-inference:
-    required_pcc: 0.98 # https://github.com/tenstorrent/tt-xla/issues/2944
     status: EXPECTED_PASSING
 
   albert/masked_lm/pytorch-Xxlarge_v1-single_device-inference:
@@ -738,7 +725,6 @@ test_config:
     status: EXPECTED_PASSING
 
   albert/token_classification/pytorch-Large_v2-single_device-inference:
-    required_pcc: 0.975
     status: EXPECTED_PASSING
 
   albert/token_classification/pytorch-Xlarge_v1-single_device-inference:
@@ -755,9 +741,7 @@ test_config:
     status: EXPECTED_PASSING
 
   albert/token_classification/pytorch-Xxlarge_v2-single_device-inference:
-    assert_pcc: false
     status: EXPECTED_PASSING
-    reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.958276593048647. Required: pcc=0.99"
 
   opt/causal_lm/pytorch-1.3b-single_device-inference:
     status: EXPECTED_PASSING
@@ -1809,9 +1793,7 @@ test_config:
   qwen_2_5_coder/pytorch-7B_Instruct-single_device-inference:
     arch_overrides:
       p150:
-        assert_pcc: false
         status: EXPECTED_PASSING
-        reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.964358925819397. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/1474"
       n150:
         status: NOT_SUPPORTED_SKIP
         reason: "Too large for single chip"


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/1844
https://github.com/tenstorrent/tt-xla/issues/1750
https://github.com/tenstorrent/tt-xla/issues/1789
https://github.com/tenstorrent/tt-xla/issues/2000
https://github.com/tenstorrent/tt-xla/issues/1828
https://github.com/tenstorrent/tt-xla/issues/2944
https://github.com/tenstorrent/tt-xla/issues/1474

### Problem description
maintain: weekly update for Mar 16–Mar 20
ci run: https://github.com/tenstorrent/tt-xla/actions/runs/23375485557

### What's changed
```
test_all_models_torch[albert/masked_lm/pytorch-Large_v2-single_device-inference]                                                           language    generality  bfloat16       n150         PASSED                     PASSING       0.9970659574946      0.98       PCC_EN   single_device    84.848   RAISE_PCC_099 
test_all_models_torch[albert/masked_lm/pytorch-Large_v2-single_device-inference]                                                           language    generality  bfloat16       p150         PASSED                     PASSING       0.9947081063819383   0.99       PCC_EN   single_device    54.338   N/A           

test_all_models_torch[albert/masked_lm/pytorch-Xlarge_v1-single_device-inference]                                                          language    generality  bfloat16       n150         PASSED                     PASSING       0.9980844421175042   0.98       PCC_EN   single_device    81.059   RAISE_PCC_099 
test_all_models_torch[albert/masked_lm/pytorch-Xlarge_v1-single_device-inference]                                                          language    generality  bfloat16       p150         PASSED                     PASSING       0.9978040585222574   0.98       PCC_EN   single_device    58.767   RAISE_PCC_099 


test_all_models_torch[albert/masked_lm/pytorch-Xxlarge_v2-data_parallel-inference]                                                         language    generality  bfloat16       n300         PASSED                     PASSING       0.9959917510450549   0.98       PCC_EN   data_parallel    154.815  RAISE_PCC_099 

test_all_models_torch[albert/token_classification/pytorch-Large_v2-single_device-inference]                                                language    generality  bfloat16       n150         PASSED                     PASSING       0.9902382579859578   0.975      PCC_EN   single_device    66.767   RAISE_PCC     
test_all_models_torch[albert/token_classification/pytorch-Large_v2-single_device-inference]                                                language    generality  bfloat16       p150         PASSED                     PASSING       0.9900999372584159   0.975      PCC_EN   single_device    54.899   RAISE_PCC     

test_all_models_torch[albert/token_classification/pytorch-Xlarge_v1-data_parallel-inference]                                               language    generality  bfloat16       n300         PASSED                     PASSING       0.9994361071918757   0.99       PCC_DIS  data_parallel    83.057   ENABLE_PCC_099

test_all_models_torch[albert/token_classification/pytorch-Xlarge_v2-data_parallel-inference]                                               language    generality  bfloat16       n300         PASSED                     PASSING       0.9947194626777948   0.99       PCC_DIS  data_parallel    100.949  ENABLE_PCC_099
test_all_models_torch[albert/token_classification/pytorch-Xxlarge_v1-data_parallel-inference]                                              language    generality  bfloat16       n300         PASSED                     PASSING       0.9968798627494171   0.99       PCC_DIS  data_parallel    80.326   ENABLE_PCC_099

test_all_models_torch[albert/token_classification/pytorch-Xxlarge_v1-single_device-inference]                                              language    generality  bfloat16       n150         PASSED                     PASSING       0.996879862749417    0.98       PCC_EN   single_device    72.721   RAISE_PCC_099 

test_all_models_torch[albert/token_classification/pytorch-Xxlarge_v2-single_device-inference]                                              language    generality  bfloat16       n150         PASSED                     PASSING       0.9940914201748421   0.99       PCC_DIS  single_device    56.115   ENABLE_PCC_099
test_all_models_torch[albert/token_classification/pytorch-Xxlarge_v2-single_device-inference]                                              language    generality  bfloat16       p150         PASSED                     PASSING       0.9925475293447128   0.99       PCC_DIS  single_device    42.371   N/A           

test_all_models_torch[bloom/pytorch-single_device-inference]                                                                               language    generality  bfloat16       n150         PASSED                     PASSING       0.9986005498932201   0.99       PCC_DIS  single_device    118.531  ENABLE_PCC_099


test_all_models_torch[mamba/pytorch-370M_HF-data_parallel-inference]                                                                       language    generality  bfloat16       n300         PASSED                     PASSING       0.9999434038543378   0.99       PCC_DIS  data_parallel    373.325  ENABLE_PCC_099


test_all_models_torch[qwen_2_5_coder/pytorch-7B_Instruct-single_device-inference]                                                          language    generality  bfloat16       n150         FAILED_RUNTIME             SKIP          N/A                  N/A        N/A      single_device    0.973    N/A           
test_all_models_torch[qwen_2_5_coder/pytorch-7B_Instruct-single_device-inference]                                                          language    generality  bfloat16       p150         PASSED                     PASSING       0.9981961482221446   0.99       PCC_DIS  single_device    169.931  ENABLE_PCC_099

test_all_models_torch[squeezebert/pytorch-Mnli-data_parallel-inference]                                                                    language    generality  bfloat16       n300         PASSED                     XFAIL         1.0                  0.99       PCC_EN   data_parallel    88.291   RM_XFAIL   
```   


### Checklist
- [ ] New/Existing tests provide coverage for changes
