### PR TITLE
Static model info fallback writing in case of segfault

### DIFF
--- a/tests/runner/conftest.py
+++ b/tests/runner/conftest.py
@@ -10,9 +10,18 @@ from tests.runner.test_config.constants import ALLOWED_ARCHES
 from tests.runner.test_config.jax import test_config as jax_test_config
 from tests.runner.test_config.torch import test_config as torch_test_config
 from tests.runner.test_config.torch_llm import test_config as torch_llm_test_config
-from tests.runner.test_utils import ModelTestConfig, ModelTestStatus
+from tests.runner.test_utils import (
+    ModelTestConfig,
+    ModelTestStatus,
+    RunPhase,
+    to_marshal_safe,
+)
+from tests.utils import BringupStatus, Category
 
 _BRINGUP_STAGE_FILE = "._bringup_stage.txt"
+
+# Maps nodeid -> item, populated during collection for crash-report fallback.
+_item_by_nodeid: dict = {}
 
 
 def _get_model_group_from_item(item):
@@ -183,3 +192,90 @@ def pytest_collection_modifyitems(config, items):
     if deselected:
         config.hook.pytest_deselected(items=deselected)
         items[:] = [i for i in items if i not in deselected]
+
+    # Build nodeid->item mapping for crash-report fallback (see pytest_runtest_logreport).
+    for item in items:
+        _item_by_nodeid[item.nodeid] = item
+
+
+@pytest.hookimpl(hookwrapper=True, trylast=True)
+def pytest_runtest_logreport(report):
+    """Inject static model properties into crash reports missing tags (forked process died)."""
+
+    # Only process failed crash reports (when="???") (this is produced by pytest-forked)
+    # normal failures are handled by record_model_test_properties.
+    if report.when != "???" or report.passed:
+        yield
+        return
+
+    if any(key == "tags" for key, _ in report.user_properties):
+        yield
+        return
+
+    item = _item_by_nodeid.get(report.nodeid)
+    if item is None or not hasattr(item, "callspec") or not hasattr(item, "_test_meta"):
+        yield
+        return
+
+    meta = item._test_meta
+    params = item.callspec.params
+
+    # Resolve test_entry (regular: "test_entry"; LLM: "test_entry_and_phase")
+    test_entry = params.get("test_entry")
+    run_phase = RunPhase.DEFAULT
+    if test_entry is None:
+        test_entry_and_phase = params.get("test_entry_and_phase")
+        if test_entry_and_phase is not None:
+            test_entry, run_phase = test_entry_and_phase
+
+    if test_entry is None:
+        yield
+        return
+
+    variant, ModelLoader = test_entry.variant_info
+    model_info = ModelLoader.get_model_info(variant=variant)
+
+    run_mode = params.get("run_mode")
+    parallelism = params.get("parallelism")
+    weights_dtype = (
+        "bfp8" if getattr(meta, "enable_weight_bfp8_conversion", False) else "bfloat16"
+    )
+
+    tags = {
+        "test_name": str(item.originalname),
+        "specific_test_case": str(item.name),
+        "category": str(Category.MODEL_TEST),
+        "model_name": str(model_info.name),
+        "model_info": model_info.to_report_dict(),
+        "run_mode": str(run_mode) if run_mode is not None else None,
+        "run_phase": str(run_phase),
+        "parallelism": str(parallelism) if parallelism is not None else None,
+        "bringup_status": str(BringupStatus.UNKNOWN),
+        "model_test_status": str(meta.status),
+        "arch": getattr(meta, "arch", None),
+        "seq_len": getattr(meta, "seq_len", None),
+        "batch_size": getattr(meta, "batch_size", None),
+        "weights_dtype": weights_dtype,
+        "failing_reason": {
+            "name": None,
+            "description": None,
+            "component": None,
+            "summary": None,
+        },
+        "guidance": [],
+    }
+
+    report.user_properties.append(("tags", to_marshal_safe(tags)))
+    report.user_properties.append(("owner", "tt-xla"))
+    if hasattr(model_info, "group") and model_info.group is not None:
+        report.user_properties.append(("group", str(model_info.group)))
+
+    # pytest-junitxml writes user_properties only when finalize() is
+    # called, which happens on teardown reports. Crash reports (when="???")
+    # never produce a teardown, so finalize() is never triggered.
+    # Re-classifying as "teardown" causes junitxml to call finalize(report)
+    # and write our properties. The crash message in longrepr is preserved.
+    # Verified against pytest 9.0.2 and pytest-forked 1.6.0.
+    report.when = "teardown"
+
+    yield

--- a/tests/runner/test_models.py
+++ b/tests/runner/test_models.py
@@ -80,13 +80,13 @@ def _run_model_test_impl(
     loader_path = test_entry.path
     variant, ModelLoader = test_entry.variant_info
 
+    # Get the model loader and model info from desired model, variant.
+    loader = ModelLoader(variant=variant)
+    model_info = ModelLoader.get_model_info(variant=variant)
+    print(f"Running {request.node.nodeid} - {model_info.name}", flush=True)
+
     # Ensure per-model requirements are installed, and roll back after the test
     with RequirementsManager.for_loader(loader_path, framework=str(framework)):
-
-        # Get the model loader and model info from desired model, variant.
-        loader = ModelLoader(variant=variant)
-        model_info = ModelLoader.get_model_info(variant=variant)
-        print(f"Running {request.node.nodeid} - {model_info.name}", flush=True)
 
         ir_dump_path = ""
         # Dump all collected IRs if --dump-irs option is enabled

--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -300,7 +300,7 @@ def update_test_metadata_for_exception(
 # ruamel returns ScalarFloat/ScalarString types (subclasses of float/str).
 # pytest-forked uses Python's marshal, which rejects non-builtin subclasses inside the
 # test report's user_properties, causing ValueError: unmarshallable object.
-def _to_marshal_safe(value):
+def to_marshal_safe(value):
     """Recursively convert values to marshal-safe builtin types for pytest-forked."""
     # None stays None
     if value is None:
@@ -327,9 +327,9 @@ def _to_marshal_safe(value):
 
     # Collections
     if isinstance(value, dict):
-        return {str(k): _to_marshal_safe(v) for k, v in value.items()}
+        return {str(k): to_marshal_safe(v) for k, v in value.items()}
     if isinstance(value, (list, tuple)):
-        return [_to_marshal_safe(v) for v in value]
+        return [to_marshal_safe(v) for v in value]
 
     # Fallback to string to avoid unmarshallable objects
     return str(value)
@@ -676,10 +676,10 @@ def record_model_test_properties(
     # If we have an explanatory reason, include it as a top-level property too for DB visibility
     # which is especially useful for passing tests (used to just from xkip/xfail reason)
     if reason:
-        record_property("error_message", _to_marshal_safe(reason))
+        record_property("error_message", to_marshal_safe(reason))
 
     # Write properties
-    record_property("tags", _to_marshal_safe(tags))
+    record_property("tags", to_marshal_safe(tags))
     record_property("owner", "tt-xla")
     if hasattr(model_info, "group") and model_info.group is not None:
         record_property("group", str(model_info.group))


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
  When model tests run with `--forked`, each test executes in a subprocess. If that subprocess crashes (segfault, abort hang, os._exit()) before the test body completes, pytest-forked generates a crash report with `when="???"` and empty user_properties. This means the junitxml output for crashed tests contains no `tags`(model_name, bringup_status,...) - making them invisible in result dashboards and impossible to triage.

The root cause is a two-part gap:                                                                                                                                                                                                                                                                                                                          
1. record_model_test_properties() never runs because the subprocess dies first, so report.user_properties stays empty.
2. Even if properties were injected onto the crash report, junitxml's finalize() — which transfers user_properties into XML <properties> — is only called for when="teardown" reports. A when="???" crash report never reaches that branch.

### What's changed

Crash-report fallback hook in conftest.py: 
A new pytest_runtest_logreport hookwrapper intercepts crash reports (when="???") and reconstructs model metadata from collection-time data. 
During pytest_collection_modifyitems, a nodeid -> item mapping is built so the parent process can look up the original test item. 

The hook builds the full tags dict (model name, run mode, parallelism, arch, ...), appends it to report.user_properties, and re-classifies report.when from "???" to "teardown" so that junitxml's finalize() writes the properties to XML.

  ModelLoader init moved outside RequirementsManager in test_models.py: ModelLoader() and get_model_info() are now called before entering the RequirementsManager context manager. This ensures these calls are safe to invoke from the parent process (in the conftest hook) without requiring per-model pip dependencies to be installed.

### Checklist
- [ ] To check the PR I have inserted by hand `os._exit(1)` into test to check it crashing, here are three files
1. normal execution of the test with `--forked` [test_output_normal.xml](https://github.com/user-attachments/files/26555021/test_output_normal.xml)
2. same as above but with inserted `os._exit(1)` in the middle of the test [test_output_crash.xml](https://github.com/user-attachments/files/26555022/test_output_crash.xml)
3. same as above but with changes from this PR [test_output_crash_fix.xml](https://github.com/user-attachments/files/26555023/test_output_crash_fix.xml)


