### PR TITLE
Skip stablehlo dump and device perf for vllm models

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -419,8 +419,10 @@
         "pyreq": "loguru pytest torch==2.9.1 transformers==4.57.6 vllm==0.16.0",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[llama-3.2-3b]",
         "vllm": true,
+        "skip-stablehlo-dump": true,
         "skip-ttir-dump": true,
         "skip-ttnn-dump": true,
+        "skip-device-perf": true,
         "runs-on": "n150"
       },
       {
@@ -428,8 +430,10 @@
         "pyreq": "loguru pytest torch==2.9.1 transformers==4.57.6 vllm==0.16.0",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[llama-3.2-3b-batch32]",
         "vllm": true,
+        "skip-stablehlo-dump": true,
         "skip-ttir-dump": true,
         "skip-ttnn-dump": true,
+        "skip-device-perf": true,
         "runs-on": "n150"
       }
     ]


### PR DESCRIPTION
### Ticket
Closes #3870 

### Problem description
vllm models don't produce IR artifacts.

### What's changed
Skipped IR dump and Device perf job for vllm models in benchmark.

### Checklist
- [x] [vllm run](https://github.com/tenstorrent/tt-xla/actions/runs/23438294724)
