### PR TITLE
[pjrt] New assertions

### DIFF
--- a/pjrt_implementation/inc/api/tensor.h
+++ b/pjrt_implementation/inc/api/tensor.h
@@ -19,6 +19,9 @@
 // tt-mlir includes
 #include "tt/runtime/runtime.h"
 
+// tt-xla includes
+#include "utils/assert.h"
+
 namespace tt::pjrt {
 
 class BufferInstance;
@@ -158,8 +161,9 @@ public:
   void reset(std::shared_ptr<PjrtTensor> tensor = nullptr,
              BufferInstance *shard = nullptr) noexcept {
 
-    assert(!!tensor == !!shard && "Both must be nullptr or have a value.");
-    assert(!tensor || tensor->has_shard(shard));
+    TT_FATAL(!!tensor == !!shard, "Both must be nullptr or have a value.");
+    TT_FATAL(!tensor || tensor->has_shard(shard),
+             "Tensor does not have the given shard");
 
     if (m_shard != nullptr)
       get()->remove_shard(m_shard);
@@ -177,22 +181,22 @@ public:
   }
 
   const PjrtTensor *operator->() const noexcept {
-    assert(m_tensor && "Accessing non-existing PJRT tensor");
+    TT_FATAL(m_tensor, "Accessing non-existing PJRT tensor");
     return m_tensor.operator->();
   }
 
   PjrtTensor *operator->() noexcept {
-    assert(m_tensor && "Accessing non-existing PJRT tensor");
+    TT_FATAL(m_tensor, "Accessing non-existing PJRT tensor");
     return m_tensor.operator->();
   }
 
   const PjrtTensor &operator*() const noexcept {
-    assert(m_tensor && "Accessing non-existing PJRT tensor");
+    TT_FATAL(m_tensor, "Accessing non-existing PJRT tensor");
     return *m_tensor;
   };
 
   PjrtTensor &operator*() noexcept {
-    assert(m_tensor && "Accessing non-existing PJRT tensor");
+    TT_FATAL(m_tensor, "Accessing non-existing PJRT tensor");
     return *m_tensor;
   };
 

--- a/pjrt_implementation/inc/utils/assert.h
+++ b/pjrt_implementation/inc/utils/assert.h
@@ -1,0 +1,204 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//  Summary:
+//
+//  TT_ASSERT -> debug build only assert. Throws exception with condition,
+//  location and backtrace.
+//
+//  TT_FATAL -> always asserts. Throws exception with condition, location and
+//  backtrace.
+//
+//  TT_THROW -> always throws exception with condition, location and backtrace.
+//
+//  Environment variables:
+//  TT_XLA_DISABLE_BACKTRACE -> disables backtrace.
+//  TT_XLA_ASSERT_ABORT -> forces abort instead of throw.
+//
+//  This header is taken from tt-metal repo and slightly modified (we use
+//  std::format instead of fmt lib and logging is done via loguru).
+
+#ifndef TT_XLA_PJRT_IMPLEMENTATION_INC_UTILS_ASSERT_H_
+#define TT_XLA_PJRT_IMPLEMENTATION_INC_UTILS_ASSERT_H_
+
+// c++ standard library includes
+#include <cxxabi.h>
+#include <execinfo.h>
+#include <format>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string>
+#include <vector>
+
+// tt-xla includes
+#include "logging.h"
+
+namespace tt::assert {
+
+namespace detail {
+static std::string demangle(const char *str);
+}
+
+// @brief Get the current call stack
+// @param[out] bt Save Call Stack
+// @param[in] size Maximum number of return layers
+// @param[in] skip Skip the number of layers at the top of the stack
+// NOLINTBEGIN(cppcoreguidelines-no-malloc)
+inline std::vector<std::string> backtrace(int size = 64, int skip = 1) {
+  std::vector<std::string> bt;
+  bt.reserve(size - skip);
+  void **array = (void **)malloc((sizeof(void *) * size));
+  size_t s = ::backtrace(array, size);
+  char **strings = backtrace_symbols(array, s);
+  if (strings == nullptr) {
+    std::cout << "backtrace_symbols error." << std::endl;
+    free(array); // NOLINT(bugprone-multi-level-implicit-pointer-conversion)
+    return bt;
+  }
+  for (size_t i = skip; i < s; ++i) {
+    bt.push_back(detail::demangle(strings[i]));
+  }
+  free(strings); // NOLINT(bugprone-multi-level-implicit-pointer-conversion)
+  free(array);   // NOLINT(bugprone-multi-level-implicit-pointer-conversion)
+
+  return bt;
+}
+// NOLINTEND(cppcoreguidelines-no-malloc)
+
+// @brief String to get current stack information
+// @param[in] size Maximum number of stacks
+// @param[in] skip Skip the number of layers at the top of the stack
+// @param[in] prefix Output before stack information
+inline std::string backtrace_to_string(int size = 64, int skip = 2,
+                                       const std::string &prefix = "") {
+  std::vector<std::string> bt = backtrace(size, skip);
+  std::stringstream ss;
+  for (const auto &line : bt) {
+    ss << prefix << line << '\n';
+  }
+  return ss.str();
+}
+
+namespace detail {
+// NOLINTBEGIN(cppcoreguidelines-no-malloc)
+static std::string demangle(const char *str) {
+  size_t size = 0;
+  int status = 0;
+  std::string rt(256, '\0');
+  if (1 == sscanf(str, "%*[^(]%*[^_]%255[^)+]", rt.data())) {
+    char *v = abi::__cxa_demangle(rt.data(), nullptr, &size, &status);
+    if (v) {
+      std::string result(v);
+      free(v);
+      return result;
+    }
+  }
+  return str;
+}
+// NOLINTEND(cppcoreguidelines-no-malloc)
+
+template <typename... Args>
+[[noreturn]] void
+tt_throw_impl(const char *file, int line, const char *assert_type,
+              const char *condition_str, const Args &...args) {
+  if (std::getenv("TT_XLA_ASSERT_ABORT")) {
+    if constexpr (sizeof...(args) > 0) {
+      LOG_F(ERROR, "%s: %s", assert_type, std::format(args...).c_str());
+    }
+    abort();
+  }
+
+  std::stringstream trace_message_ss = {};
+  trace_message_ss << assert_type << " @ " << file << ":" << line << ": "
+                   << condition_str << std::endl;
+  if constexpr (sizeof...(args) > 0) {
+    trace_message_ss << "info:" << std::endl;
+    trace_message_ss << std::format(args...) << std::endl;
+    LOG_F(ERROR, "%s: %s", assert_type, std::format(args...).c_str());
+  }
+
+  static const bool disable_backtrace =
+      std::getenv("TT_XLA_DISABLE_BACKTRACE") != nullptr;
+  if (!disable_backtrace) {
+    trace_message_ss << "backtrace:\n";
+    trace_message_ss << tt::assert::backtrace_to_string(100, 3, " --- ");
+  }
+  trace_message_ss << std::flush;
+  throw std::runtime_error(trace_message_ss.str());
+}
+
+[[noreturn]] inline void tt_throw(char const *file, int line,
+                                  char const *assert_type,
+                                  char const *condition_str) {
+  tt_throw_impl(file, line, assert_type, condition_str);
+}
+
+template <typename... Args>
+[[noreturn]] void tt_throw(const char *file, int line, const char *assert_type,
+                           const char *condition_str,
+                           std::format_string<const Args &...> fmt,
+                           const Args &...args) {
+  tt_throw_impl(file, line, assert_type, condition_str, fmt, args...);
+}
+
+inline void tt_assert(char const *file, int line, char const *assert_type,
+                      bool condition, char const *condition_str) {
+  if (not condition) {
+    tt_throw(file, line, assert_type, condition_str);
+  }
+}
+
+template <typename... Args>
+inline void tt_assert(char const *file, int line, char const *assert_type,
+                      bool condition, char const *condition_str,
+                      std::format_string<Args const &...> fmt,
+                      Args const &...args) {
+  if (not condition) {
+    tt_throw(file, line, assert_type, condition_str, fmt, args...);
+  }
+}
+} // namespace detail
+} // namespace tt::assert
+
+// Adding do while around TT_ASSERT to allow flexible usage of the macro. More
+// details can be found in Stack Overflow post:
+// https://stackoverflow.com/questions/55933541/else-without-previous-if-error-when-defining-macro-with-arguments/55933720#55933720
+#ifdef DEBUG
+#ifndef TT_ASSERT
+#define TT_ASSERT(condition, ...)                                              \
+  do {                                                                         \
+    if (not(condition)) [[unlikely]]                                           \
+      tt::assert::detail::tt_assert(__FILE__, __LINE__, "TT_ASSERT",           \
+                                    (condition), #condition, ##__VA_ARGS__);   \
+  } while (0) // NOLINT(cppcoreguidelines-macro-usage)
+#endif
+#else
+#define TT_ASSERT(condition, ...)                                              \
+  do {                                                                         \
+    (void)(condition);                                                         \
+  } while (0) // this was done to avoid the compiler flagging unused variables
+              // when building Release
+#endif
+
+#ifndef TT_THROW
+#define TT_THROW(...)                                                          \
+  tt::assert::detail::tt_throw(__FILE__, __LINE__, "TT_THROW",                 \
+                               "tt::exception", ##__VA_ARGS__)
+#endif
+
+#ifndef TT_FATAL
+#define TT_FATAL(condition, message, ...)                                      \
+  do {                                                                         \
+    if (not(condition)) [[unlikely]] {                                         \
+      tt::assert::detail::tt_throw(__FILE__, __LINE__, "TT_FATAL", #condition, \
+                                   message, ##__VA_ARGS__);                    \
+      __builtin_unreachable();                                                 \
+    }                                                                          \
+  } while (0) // NOLINT(cppcoreguidelines-macro-usage)
+#endif
+
+#endif // TT_XLA_PJRT_IMPLEMENTATION_INC_UTILS_ASSERT_H_

--- a/pjrt_implementation/src/api/buffer_instance.cc
+++ b/pjrt_implementation/src/api/buffer_instance.cc
@@ -35,6 +35,7 @@
 #include "api/device_instance.h"
 #include "api/error_instance.h"
 #include "api/memory_instance.h"
+#include "utils/assert.h"
 #include "utils/data_type_utils.h"
 #include "utils/logging.h"
 #include "utils/status.h"
@@ -155,8 +156,8 @@ void BufferInstance::deleteData() {
 
     // TODO(mrakita): Revert.
     // https://github.com/openxla/xla/issues/25172
-    assert(m_done_with_host_buffer_event->isIndestructible() &&
-           "Expected done_with_host_buffer_event to be indestructible");
+    TT_FATAL(m_done_with_host_buffer_event->isIndestructible(),
+             "Expected done_with_host_buffer_event to be indestructible");
     delete m_done_with_host_buffer_event;
   }
 }
@@ -168,7 +169,11 @@ void BufferInstance::copyFromHost(
     size_t num_byte_strides, PJRT_HostBufferSemantics host_buffer_semantics,
     EventInstance **out_done_with_host_buffer_event) {
 
-  assert(data_type == m_data_type && "m_data_type and data_type do not match");
+  TT_FATAL(
+      data_type == m_data_type,
+      "m_data_type and data_type do not match: m_data_type={}, data_type={}",
+      data_type_utils::getPJRTBufferTypeString(m_data_type),
+      data_type_utils::getPJRTBufferTypeString(data_type));
 
   m_pjrt_tensor.reset();
 
@@ -247,7 +252,7 @@ void BufferInstance::copyFromHost(
 
 void BufferInstance::copyFromBuffer(BufferInstance *src_buffer) {
   DLOG_F(LOG_DEBUG, "BufferInstance::copyFromBuffer");
-  assert(src_buffer->getPjrtTensor() && "Source buffer has no data.");
+  TT_FATAL(src_buffer->getPjrtTensor(), "Source buffer has no data.");
 
   ::tt::target::DataType runtime_data_type =
       tt::pjrt::data_type_utils::convertPJRTToRuntimeDataType(
@@ -280,8 +285,7 @@ BufferInstance::calculateShape(const std::int64_t *dims, size_t num_dims,
     // tensors.
     if (data_type_utils::isComplexPJRTType(data_type)) {
       // Throw error if complex tensor num_dims == 0.
-      throw std::runtime_error(
-          "Complex tensor with num_dims == 0 is not supported.");
+      TT_THROW("Complex tensor with num_dims == 0 is not supported.");
     }
     return {1};
   }
@@ -309,7 +313,10 @@ std::vector<std::uint32_t> BufferInstance::calculateStrides(
     return {1};
   }
 
-  assert(num_byte_strides == 0 || num_byte_strides == num_dims);
+  TT_FATAL(num_byte_strides == 0 || num_byte_strides == num_dims,
+           "num_byte_strides must be 0 or equal to num_dims: "
+           "num_byte_strides={}, num_dims={}",
+           num_byte_strides, num_dims);
 
   std::vector<std::uint32_t> strides;
   for (size_t i = 0; i < num_dims; ++i) {
@@ -329,7 +336,7 @@ tt_pjrt_status BufferInstance::copyToHost(void *host_buffer,
                                           size_t host_buffer_size,
                                           EventInstance **out_copy_done_event) {
   ZoneScoped;
-  assert(m_pjrt_tensor && "Copy from buffer without an associated tensor.");
+  TT_FATAL(m_pjrt_tensor, "Copy from buffer without an associated tensor.");
 
   auto rt_data_type =
       tt::pjrt::data_type_utils::convertPJRTToRuntimeDataType(m_data_type);
@@ -352,8 +359,11 @@ tt_pjrt_status BufferInstance::copyToHost(void *host_buffer,
 
       m_pjrt_tensor->move_to_host();
 
-      assert(logicalTensorSize() <= host_buffer_size &&
-             "Host buffer is too small.");
+      TT_FATAL(logicalTensorSize() <= host_buffer_size,
+               "Host buffer is too small: logical_tensor_size={}, "
+               "host_buffer_size={}",
+               logicalTensorSize(), host_buffer_size);
+
       tt::runtime::memcpy(host_buffer, m_pjrt_tensor->runtime_tensor(),
                           rt_data_type);
 
@@ -372,7 +382,7 @@ tt_pjrt_status BufferInstance::copyToHost(void *host_buffer,
 }
 
 void BufferInstance::markAsDataReady() {
-  assert(!m_data_ready);
+  TT_FATAL(!m_data_ready, "Data is already ready");
 
   std::lock_guard<std::mutex> ready_lock(m_data_ready_mutex);
 

--- a/pjrt_implementation/src/api/client_instance.cc
+++ b/pjrt_implementation/src/api/client_instance.cc
@@ -32,6 +32,7 @@
 #include "api/memory_instance.h"
 #include "api/module_builder/module_builder.h"
 #include "api/tensor_pool.h"
+#include "utils/assert.h"
 #include "utils/logging.h"
 #include "utils/utils.h"
 
@@ -660,7 +661,7 @@ PJRT_Error *onClientCreate(PJRT_Client_Create_Args *args) {
 
   ClientInstance *client_instance =
       GlobalClientInstanceSingleton::getClientInstance();
-  assert(client_instance != nullptr);
+  TT_FATAL(client_instance != nullptr, "Client instance is null");
   args->client = reinterpret_cast<PJRT_Client *>(client_instance);
 
   return nullptr;
@@ -673,7 +674,8 @@ PJRT_Error *onClientDestroy(PJRT_Client_Destroy_Args *args) {
   ClientInstance *client_instance = ClientInstance::unwrap(args->client);
   ClientInstance *global_client_instance =
       GlobalClientInstanceSingleton::getClientInstance();
-  assert(client_instance == global_client_instance);
+  TT_FATAL(client_instance == global_client_instance,
+           "Client instance doesn't match global client instance");
   GlobalClientInstanceSingleton::destroyClient();
   return nullptr;
 }

--- a/pjrt_implementation/src/api/event_instance.cc
+++ b/pjrt_implementation/src/api/event_instance.cc
@@ -19,6 +19,7 @@
 
 // tt-xla includes
 #include "api/error_instance.h"
+#include "utils/assert.h"
 #include "utils/logging.h"
 
 namespace tt::pjrt {
@@ -181,8 +182,8 @@ PJRT_Error *onEventError(PJRT_Event_Error_Args *args) {
     // PJRT docs state that PJRT_Event_Error should only be called if
     // PJRT_Event_IsReady returns true. XLA PJRT implementation aborts if this
     // check is not true.
-    throw std::runtime_error("PJRT_Event_Error should only be called if "
-                             "PJRT_Event_IsReady returns true");
+    TT_THROW("PJRT_Event_Error should only be called if "
+             "PJRT_Event_IsReady returns true");
   }
 
   return event_instance->getErrorFromStatus();

--- a/pjrt_implementation/src/api/executable_image.cc
+++ b/pjrt_implementation/src/api/executable_image.cc
@@ -11,7 +11,6 @@
 #include "api/executable_image.h"
 
 // c++ standard library includes
-#include <cassert>
 #include <functional>
 #include <memory>
 #include <sstream>
@@ -22,6 +21,7 @@
 #include "api/loaded_executable_instance.h"
 #include "api/memory_instance.h"
 #include "api/so_loaded_executable_instance.h"
+#include "utils/assert.h"
 #include "utils/data_type_utils.h"
 
 namespace tt::pjrt {
@@ -177,8 +177,14 @@ ExecutableImage::ExecutableImage(
       m_output_memory_kinds_sizes(std::move(output_memory_kinds_sizes)),
       m_compile_options(std::move(compile_options)) {
 
-  assert(m_num_inputs == m_input_sharding.size());
-  assert(m_num_outputs == m_output_sharding.size());
+  TT_FATAL(m_num_inputs == m_input_sharding.size(),
+           "Number of inputs doesn't match input sharding size: "
+           "m_num_inputs={}, m_input_sharding.size()={}",
+           m_num_inputs, m_input_sharding.size());
+  TT_FATAL(m_num_outputs == m_output_sharding.size(),
+           "Number of outputs doesn't match output sharding size: "
+           "m_num_outputs={}, m_output_sharding.size()={}",
+           m_num_outputs, m_output_sharding.size());
 }
 
 FlatbufferExecutableImage::FlatbufferExecutableImage(
@@ -209,11 +215,18 @@ FlatbufferExecutableImage::FlatbufferExecutableImage(
           std::move(optimized_mlir_code), std::move(compile_options)) {
   // Assuming only one program per flatbuffer for now.
   std::uint32_t program_index = 0;
-  assert(this->getNumInputs() ==
-         m_flatbuffer_binary.getProgramInputs(program_index).size());
+  TT_FATAL(this->getNumInputs() ==
+               m_flatbuffer_binary.getProgramInputs(program_index).size(),
+           "Number of inputs doesn't match flatbuffer program inputs size: "
+           "getNumInputs()={}, getProgramInputs().size()={}",
+           this->getNumInputs(),
+           m_flatbuffer_binary.getProgramInputs(program_index).size());
   std::vector<tt::runtime::TensorDesc> output_specs =
       m_flatbuffer_binary.getProgramOutputs(program_index);
-  assert(this->getNumOutputs() == output_specs.size());
+  TT_FATAL(this->getNumOutputs() == output_specs.size(),
+           "Number of outputs doesn't match output specs size: "
+           "getNumOutputs()={}, output_specs.size()={}",
+           this->getNumOutputs(), output_specs.size());
 
   int output_dims_so_far = 0;
   for (size_t output_index = 0; output_index < getNumOutputs();
@@ -227,22 +240,32 @@ FlatbufferExecutableImage::FlatbufferExecutableImage(
     if (data_type_utils::isComplexPJRTType(getOutputTypes()[output_index])) {
       expected_shape.push_back(2);
     }
-    assert(expected_shape == output_specs[output_index].shape &&
-           "Output shape from flatbuffer binary does not match the one "
-           "collected from the MLIR module");
 
-    assert(getOutputRanks()[output_index] ==
-               getOutputDimensions()[output_index].size() &&
-           "Output rank from flatbuffer binary does not match the one "
-           "collected from the MLIR module");
+    TT_FATAL(expected_shape == output_specs[output_index].shape,
+             "Output shape from flatbuffer binary does not match the one "
+             "collected from the MLIR module: output_index={}",
+             output_index);
+
+    TT_FATAL(getOutputRanks()[output_index] ==
+                 getOutputDimensions()[output_index].size(),
+             "Output rank from flatbuffer binary does not match the one "
+             "collected from the MLIR module: output_index={}, "
+             "getOutputRanks()[output_index]={}, "
+             "getOutputDimensions()[output_index].size()={}",
+             output_index, getOutputRanks()[output_index],
+             getOutputDimensions()[output_index].size());
 
     for (auto dim_index = 0;
          dim_index < getOutputDimensions()[output_index].size(); dim_index++) {
-      assert(getOutputDimensionsFlat()[output_dims_so_far + dim_index] ==
-                 static_cast<std::int64_t>(
-                     getOutputDimensions()[output_index][dim_index]) &&
-             "Output flat dimension from flatbuffer binary does not match the "
-             "one collected from the MLIR module");
+      TT_FATAL(getOutputDimensionsFlat()[output_dims_so_far + dim_index] ==
+                   static_cast<std::int64_t>(
+                       getOutputDimensions()[output_index][dim_index]),
+               "Output flat dimension from flatbuffer binary does not match "
+               "the one collected from the MLIR module: output_index={}, "
+               "dim_index={}, flat_dim={}, mlir_dim={}",
+               output_index, dim_index,
+               getOutputDimensionsFlat()[output_dims_so_far + dim_index],
+               getOutputDimensions()[output_index][dim_index]);
     }
 
     output_dims_so_far += getOutputDimensions()[output_index].size();
@@ -281,21 +304,28 @@ SOExecutableImage::SOExecutableImage(
 
 const std::vector<std::uint32_t> &
 ExecutableImage::getOutputShape(size_t output_index) const {
-  assert(output_index < m_output_dimensions.size() &&
-         "Output index out of range");
+  TT_FATAL(output_index < m_output_dimensions.size(),
+           "Output index out of range: output_index={}, "
+           "m_output_dimensions.size()={}",
+           output_index, m_output_dimensions.size());
   return m_output_dimensions[output_index];
 }
 
 const mlir::tt::sharding_utils::MeshSharding &
 ExecutableImage::getInputSharding(size_t input_index) const {
-  assert(input_index < m_input_sharding.size() && "Input index out of range");
+  TT_FATAL(input_index < m_input_sharding.size(),
+           "Input index out of range: input_index={}, "
+           "m_input_sharding.size()={}",
+           input_index, m_input_sharding.size());
   return m_input_sharding[input_index];
 }
 
 const mlir::tt::sharding_utils::MeshSharding &
 ExecutableImage::getOutputSharding(size_t output_index) const {
-  assert(output_index < m_output_sharding.size() &&
-         "Output index out of range");
+  TT_FATAL(output_index < m_output_sharding.size(),
+           "Output index out of range: output_index={}, "
+           "m_output_sharding.size()={}",
+           output_index, m_output_sharding.size());
   return m_output_sharding[output_index];
 }
 

--- a/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
@@ -5,9 +5,6 @@
 
 #include "api/flatbuffer_loaded_executable_instance.h"
 
-// c++ standard library includes
-#include <cassert>
-
 // tracy includes
 #include "tracy/Tracy.hpp"
 
@@ -23,6 +20,7 @@
 #include "api/event_instance.h"
 #include "api/executable_image.h"
 #include "api/tensor.h"
+#include "utils/assert.h"
 #include "utils/logging.h"
 #include "utils/utils.h"
 
@@ -151,12 +149,16 @@ FlatbufferLoadedExecutableInstance::getOutputShape(size_t output_index) {
   }
   llvm::SmallVector<int64_t> output_sharding_shard_shape =
       outputSharding.getShardShape();
-  assert(output_sharding_shard_shape.size() == outputShape.size() &&
-         "Output sharding shape doesn't match the output shape");
+  TT_FATAL(output_sharding_shard_shape.size() == outputShape.size(),
+           "Output sharding shape doesn't match the output shape: "
+           "output_sharding_shard_shape.size()={}, outputShape.size()={}",
+           output_sharding_shard_shape.size(), outputShape.size());
 
   for (size_t i = 0; i < outputShape.size(); ++i) {
-    assert(outputShape[i] % output_sharding_shard_shape[i] == 0 &&
-           "Output shape is not divisible by the sharding shape");
+    TT_FATAL(outputShape[i] % output_sharding_shard_shape[i] == 0,
+             "Output shape is not divisible by the sharding shape: "
+             "dim={}, outputShape[dim]={}, output_sharding_shard_shape[dim]={}",
+             i, outputShape[i], output_sharding_shard_shape[i]);
     outputShape[i] /= output_sharding_shard_shape[i];
   }
 

--- a/pjrt_implementation/src/api/loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/loaded_executable_instance.cc
@@ -12,7 +12,6 @@
 #include "tt/runtime/types.h"
 
 // c++ standard library includes
-#include <cassert>
 #include <filesystem>
 #include <mutex>
 #include <numeric>
@@ -35,6 +34,7 @@
 #include "api/error_instance.h"
 #include "api/executable_image.h"
 #include "api/executable_instance.h"
+#include "utils/assert.h"
 #include "utils/logging.h"
 
 namespace tt::pjrt {
@@ -90,8 +90,8 @@ void LoadedExecutableInstance::dumpInputs(
     const std::vector<tt::runtime::Tensor> &input_tensors) {
   DLOG_F(LOG_DEBUG, "LoadedExecutableInstance::dumpInputs");
 
-  assert(m_executable_image->getCompileOptions().export_path.has_value() &&
-         "Export path must be set when dumping inputs");
+  TT_FATAL(m_executable_image->getCompileOptions().export_path.has_value(),
+           "Export path must be set when dumping inputs");
 
   std::filesystem::path dump_dir =
       std::filesystem::path(
@@ -163,7 +163,8 @@ std::unordered_set<int> LoadedExecutableInstance::getDeviceIds(
   // TODO: Now we will run only on the first one, but this should be somehow
   // explicit. Maybe use `execute_device` from the args?
   if (device_ids.size() == 0) {
-    assert(!m_addressable_devices.empty());
+    TT_FATAL(!m_addressable_devices.empty(),
+             "No addressable devices available");
     device_ids.emplace(m_addressable_devices.front()->getGlobalDeviceId());
   }
 
@@ -228,7 +229,9 @@ LoadedExecutableInstance::fillStrategyMapFromSharding(
     }
   } else if (meshType == mlir::tt::ttcore::MeshShardType::Devices) {
     llvm::SmallVector<int64_t> mesh_shape_data = meshSharding.getMeshShape();
-    assert(mesh_shape_data.size() <= 2 && mesh_shape_data.size() >= 1);
+    TT_FATAL(mesh_shape_data.size() <= 2 && mesh_shape_data.size() >= 1,
+             "Mesh shape data size must be 1 or 2: mesh_shape_data.size()={}",
+             mesh_shape_data.size());
     if (mesh_shape_data.size() == 1) {
       strategy["strategy"] = "shard";
       strategy["shard_dim"] = std::to_string(mesh_shape_data[0]);

--- a/pjrt_implementation/src/api/memory_instance.cc
+++ b/pjrt_implementation/src/api/memory_instance.cc
@@ -11,13 +11,13 @@
 #include "api/memory_instance.h"
 
 // c++ standard library includes
-#include <cassert>
 #include <cstring>
 
 // tracy includes
 #include "tracy/Tracy.hpp"
 
 // tt-xla includes
+#include "utils/assert.h"
 #include "utils/logging.h"
 
 namespace tt::pjrt {
@@ -66,9 +66,10 @@ DeviceInstance *MemoryInstance::getDevice() {
     return nullptr;
   }
 
-  assert(m_addressable_by_devices.size() == 1 &&
-         "MemoryInstance::getDevice: Device memory should have exactly one "
-         "device.");
+  TT_FATAL(m_addressable_by_devices.size() == 1,
+           "MemoryInstance::getDevice: Device memory should have exactly one "
+           "device: m_addressable_by_devices.size()={}",
+           m_addressable_by_devices.size());
 
   return m_addressable_by_devices[0];
 }

--- a/pjrt_implementation/src/api/module_builder/frontend_passes/shlo_clean_for_xla_ingestion.cc
+++ b/pjrt_implementation/src/api/module_builder/frontend_passes/shlo_clean_for_xla_ingestion.cc
@@ -6,7 +6,6 @@
 #include "api/module_builder/frontend_passes/shlo_clean_for_xla_ingestion.h"
 
 // c++ standard library includes
-#include <cassert>
 #include <cstdint>
 #include <optional>
 
@@ -34,6 +33,7 @@
 #include "stablehlo/dialect/StablehloOps.h"
 
 // tt-xla includes
+#include "utils/assert.h"
 #include "utils/logging.h"
 
 namespace tt::pjrt::module_builder::frontend_passes {
@@ -155,7 +155,10 @@ getOrderedAxisRefs(TensorShardingAttr sdySharding, MeshAttr mesh) {
 // https://github.com/openxla/xla/blob/9ae3d6dab2c10c8195c8d9862f475904c7cdca91/xla/hlo/ir/tile_assignment.cc#L58
 void canonicalizeIotaDims(mlir::SmallVector<int64_t> &reshapeDims,
                           mlir::SmallVector<int64_t> &transposePerm) {
-  assert(reshapeDims.size() == transposePerm.size());
+  TT_FATAL(reshapeDims.size() == transposePerm.size(),
+           "Reshape dims and transpose perm must have the same size: "
+           "reshapeDims.size()={}, transposePerm.size()={}",
+           reshapeDims.size(), transposePerm.size());
   if (reshapeDims.size() < 1) {
     return;
   }
@@ -182,7 +185,10 @@ void canonicalizeIotaDims(mlir::SmallVector<int64_t> &reshapeDims,
         if (new_perm_dim >= 0) {
           transposePerm[new_idx] = new_perm_dim;
           ++new_idx;
-          assert(new_idx <= new_ndims);
+          TT_FATAL(new_idx <= new_ndims,
+                   "New index exceeds new number of dimensions: "
+                   "new_idx={}, new_ndims={}",
+                   new_idx, new_ndims);
         }
       }
       transposePerm.truncate(new_ndims);
@@ -339,7 +345,7 @@ void simplifyMainFuncOp(mlir::func::FuncOp funcOp) {
 
       // Create zero attribute - getZeroAttr should handle all types
       auto zeroAttr = builder.getZeroAttr(elementType);
-      assert(zeroAttr && "Failed to create zero attribute for element type");
+      TT_FATAL(zeroAttr, "Failed to create zero attribute for element type");
 
       // Create dense attribute for tensor using splat
       auto denseAttr = mlir::DenseElementsAttr::get(tensorType, zeroAttr);
@@ -349,7 +355,7 @@ void simplifyMainFuncOp(mlir::func::FuncOp funcOp) {
           funcOp.getLoc(), denseAttr);
       returnValues.push_back(constantOp.getResult());
     } else {
-      assert(false && "Found non-tensor type in return type of mainFuncOp");
+      TT_THROW("Found non-tensor type in return type of mainFuncOp");
     }
   }
 
@@ -388,7 +394,9 @@ cleanForXlaIngestion(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module) {
   // (non-shardy path), we still need to strip sdy.mesh ops and TT dialect
   // attributes so XLA can parse the cleaned module.
   if (manualComputationOps.size() == 1) {
-    assert(meshOps.size() == 1 && "Expected exactly one sdy.mesh op in module");
+    TT_FATAL(meshOps.size() == 1,
+             "Expected exactly one sdy.mesh op in module: meshOps.size()={}",
+             meshOps.size());
     auto meshOp = meshOps.front();
 
     auto manualComputationOp = manualComputationOps.front();

--- a/pjrt_implementation/src/api/module_builder/frontend_passes/shlo_input_role_propagation.cc
+++ b/pjrt_implementation/src/api/module_builder/frontend_passes/shlo_input_role_propagation.cc
@@ -5,9 +5,6 @@
 
 #include "api/module_builder/frontend_passes/shlo_input_role_propagation.h"
 
-// c++ standard library includes
-#include <cassert>
-
 // llvm includes
 #include "llvm/ADT/StringRef.h"
 
@@ -27,6 +24,7 @@
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 
 // tt-xla includes
+#include "utils/assert.h"
 #include "utils/logging.h"
 #include "utils/status.h"
 
@@ -191,13 +189,10 @@ struct PopulateArgumentAttrsFromTTMark final
       return mlir::failure();
     }
 
-    assert(
-        op.getNumOperands() == 1 &&
-        std::string("Expected one operand to " + c_mark_argument_function_name)
-            .c_str());
-    assert(op.getNumResults() == 1 && std::string("Expected one result to " +
-                                                  c_mark_argument_function_name)
-                                          .c_str());
+    TT_FATAL(op.getNumOperands() == 1, "Expected one operand to {}, got {}",
+             c_mark_argument_function_name, op.getNumOperands());
+    TT_FATAL(op.getNumResults() == 1, "Expected one result to {}, got {}",
+             c_mark_argument_function_name, op.getNumResults());
 
     // Torch XLA allows us to populate a frontend_attributes dictionary to
     // custom call ops. This dictionary is used to populate the argument type
@@ -255,7 +250,7 @@ struct PopulateArgumentAttrsFromTTMark final
 
       // Assert that the input is a block argument to a function
       auto funcOp = mlir::dyn_cast<mlir::func::FuncOp>(parentOp);
-      assert(funcOp && "Expected function as parent of block argument");
+      TT_FATAL(funcOp, "Expected function as parent of block argument");
 
       // Set argument type for this argument
       funcOp.setArgAttr(argIndex, mlir::tt::ttcore::ArgumentTypeAttr::name,
@@ -282,7 +277,7 @@ private:
       blockArgs.push_back(blockArg);
     } else {
       auto definingOp = value.getDefiningOp();
-      assert(definingOp && "This value does not have a defining operation, nor "
+      TT_FATAL(definingOp, "This value does not have a defining operation, nor "
                            "is it a block argument.");
       for (mlir::Value operand : definingOp->getOperands()) {
         blockArgs.append(getBlockArguments(operand));

--- a/pjrt_implementation/src/api/module_builder/module_builder.cc
+++ b/pjrt_implementation/src/api/module_builder/module_builder.cc
@@ -8,7 +8,6 @@
 // c++ standard library includes
 #include <algorithm>
 #include <atomic>
-#include <cassert>
 #include <chrono>
 #include <cstdlib>
 #include <filesystem>
@@ -74,6 +73,7 @@
 #include "api/module_builder/frontend_passes/shlo_clean_for_xla_ingestion.h"
 #include "api/module_builder/frontend_passes/shlo_input_role_propagation.h"
 #include "api/module_builder/frontend_passes/shlo_set_proper_sdy_mesh_attribute.h"
+#include "utils/assert.h"
 #include "utils/data_type_utils.h"
 #include "utils/logging.h"
 
@@ -670,8 +670,9 @@ tt_pjrt_status ModuleBuilder::collectNumArguments(
       std::vector<std::uint32_t> output_shape;
 
       for (int64_t dim : shape) {
-        assert(dim != mlir::ShapedType::kDynamic &&
-               "Dynamic dimensions not supported");
+        TT_FATAL(dim != mlir::ShapedType::kDynamic,
+                 "Dynamic dimensions not supported: result_index={}",
+                 result_index);
         output_shape.push_back(static_cast<std::uint32_t>(dim));
       }
 
@@ -682,7 +683,9 @@ tt_pjrt_status ModuleBuilder::collectNumArguments(
         result.output_dimensions_flat.push_back(static_cast<std::int64_t>(dim));
       }
     } else {
-      assert(false && "Expected ranked tensor type for function result");
+      TT_THROW(
+          "Expected ranked tensor type for function result: result_index={}",
+          result_index);
     }
   }
   return tt_pjrt_status::kSuccess;
@@ -1388,8 +1391,8 @@ ModuleBuilder::buildModuleForTTNNCodegen(
 tt_pjrt_status
 ModuleBuilder::performCodegen(std::string_view ttnn_mlir,
                               const CompileOptions &compile_options) {
-  assert(compile_options.export_path.has_value() &&
-         "export_path compile option is not set.");
+  TT_FATAL(compile_options.export_path.has_value(),
+           "export_path compile option is not set.");
 
   if (!m_tt_alchemist_handler.isInitialized()) {
     LOG_F(ERROR, "tt-alchemist library or functions not available");
@@ -1445,7 +1448,7 @@ ModuleBuilder::performCodegen(std::string_view ttnn_mlir,
         instance, input_file.c_str(), folder.c_str(), is_local,
         pipeline_options.c_str());
   } else {
-    assert(false && "Unsupported backend when doing codegen");
+    TT_THROW("Unsupported backend when doing codegen");
   }
 
   if (!result) {

--- a/pjrt_implementation/src/api/serialized_executable_instance.cc
+++ b/pjrt_implementation/src/api/serialized_executable_instance.cc
@@ -17,6 +17,7 @@
 #include "api/buffer_instance.h"
 #include "api/error_instance.h"
 #include "api/module_builder/module_builder.h"
+#include "utils/assert.h"
 
 namespace tt::pjrt {
 
@@ -58,7 +59,8 @@ SerializedExecutableInstance::SerializedExecutableInstance(
   data_ptr = writeRaw(data_ptr, flatbuffer_data.data(), flatbuffer_data.size());
 
   // assert that we wrote the correct number of bytes
-  assert(data_ptr == m_payload.data() + m_payload.size());
+  TT_FATAL(data_ptr == m_payload.data() + m_payload.size(),
+           "Written bytes don't match payload size");
 }
 
 } // namespace tt::pjrt

--- a/pjrt_implementation/src/api/tensor.cc
+++ b/pjrt_implementation/src/api/tensor.cc
@@ -27,6 +27,7 @@
 // tt-xla includes
 #include "api/buffer_instance.h"
 #include "api/tensor_pool.h"
+#include "utils/assert.h"
 #include "utils/logging.h"
 
 namespace tt::pjrt {
@@ -115,7 +116,10 @@ void PjrtTensor::move_to_host() noexcept {
   std::vector<tt::runtime::Tensor> tensors =
       tt::runtime::toHost(m_runtime_tensor, /*untilize=*/true);
 
-  assert(tensors.size() == m_shards.size() || tensors.size() == 1);
+  TT_FATAL(tensors.size() == m_shards.size() || tensors.size() == 1,
+           "Unexpected number of tensors after move to host: "
+           "tensors.size()={}, m_shards.size()={}",
+           tensors.size(), m_shards.size());
   m_runtime_tensor = std::move(tensors[0]);
 
   for (std::size_t i = 1; i < m_shards.size(); ++i) {
@@ -147,7 +151,7 @@ bool PjrtTensor::have_same_tensor(const std::vector<BufferInstance *> &shards) {
 PjrtTensor &
 PjrtTensor::from_shards(const std::vector<BufferInstance *> &shards) {
 
-  assert(have_same_tensor(shards));
+  TT_FATAL(have_same_tensor(shards), "All shards must share the same tensor");
   return *shards.front()->getPjrtTensor();
 }
 
@@ -166,7 +170,8 @@ uint64_t PjrtTensor::next_uid() {
 void PjrtTensor::remove_shard(const BufferInstance *shard) noexcept {
 
   auto it = std::find(m_shards.begin(), m_shards.end(), shard);
-  assert(it != m_shards.end() && *it != nullptr);
+  TT_FATAL(it != m_shards.end() && *it != nullptr,
+           "Shard not found or already removed");
   *it = nullptr;
 }
 

--- a/pjrt_implementation/src/api/tensor_pool.cc
+++ b/pjrt_implementation/src/api/tensor_pool.cc
@@ -17,6 +17,7 @@
 
 // tt-xla includes
 #include "api/buffer_instance.h"
+#include "utils/assert.h"
 #include "utils/logging.h"
 
 // tracy includes
@@ -58,7 +59,7 @@ bool contains(PjrtTensor *tensor) { return get().contains(tensor); }
 // Inserts tensor into tensor pool.
 void PjrtTensorPool::insert(PjrtTensor *tensor) {
 
-  assert(!contains(tensor));
+  TT_FATAL(!contains(tensor), "Tensor already exists in the pool");
 
   const std::scoped_lock lock{m_mtx};
   m_tensors.insert(tensor);
@@ -67,7 +68,7 @@ void PjrtTensorPool::insert(PjrtTensor *tensor) {
 // Erases tensor from tensor pool.
 void PjrtTensorPool::erase(PjrtTensor *tensor) {
 
-  assert(contains(tensor));
+  TT_FATAL(contains(tensor), "Tensor not found in the pool");
 
   const std::scoped_lock lock{m_mtx};
   m_tensors.erase(tensor);

--- a/pjrt_implementation/src/utils/data_type_utils.cc
+++ b/pjrt_implementation/src/utils/data_type_utils.cc
@@ -4,11 +4,11 @@
 
 #include "utils/data_type_utils.h"
 
-// c++ standard library includes
-#include <stdexcept>
-
 // llvm mlir includes
 #include "mlir/IR/BuiltinTypes.h"
+
+// tt-xla includes
+#include "utils/assert.h"
 
 namespace tt::pjrt::data_type_utils {
 
@@ -83,7 +83,7 @@ convertRuntimeToPJRTDataType(tt::target::DataType runtime_data_type) {
   case tt::target::DataType::BFloat16:
     return PJRT_Buffer_Type_BF16;
   default:
-    throw std::runtime_error("Unsupported runtime data type");
+    TT_THROW("Unsupported runtime data type");
   }
 }
 
@@ -123,9 +123,8 @@ convertPJRTToRuntimeDataType(PJRT_Buffer_Type pjrt_data_type) {
   case PJRT_Buffer_Type_C128:
     return tt::target::DataType::Float64;
   default:
-    throw std::runtime_error(std::string("PJRT data type: ") +
-                             getPJRTBufferTypeString(pjrt_data_type) +
-                             " does not have runtime data type equivalent");
+    TT_THROW("PJRT data type: {} does not have runtime data type equivalent",
+             getPJRTBufferTypeString(pjrt_data_type));
   }
 }
 
@@ -147,7 +146,7 @@ PJRT_Buffer_Type convertMLIRToPJRTDataType(mlir::Type type) {
         return PJRT_Buffer_Type_C128;
       }
     }
-    throw std::runtime_error("Unsupported complex element type");
+    TT_THROW("Unsupported complex element type");
   }
 
   if (mlir::FloatType floatType =
@@ -161,7 +160,7 @@ PJRT_Buffer_Type convertMLIRToPJRTDataType(mlir::Type type) {
     } else if (floatType.isBF16()) {
       return PJRT_Buffer_Type_BF16;
     } else {
-      throw std::runtime_error("Unsupported float type");
+      TT_THROW("Unsupported float type");
     }
   } else if (mlir::IntegerType intType =
                  mlir::dyn_cast<mlir::IntegerType>(type)) {
@@ -177,7 +176,7 @@ PJRT_Buffer_Type convertMLIRToPJRTDataType(mlir::Type type) {
       } else if (intType.getWidth() == 1 && intType.isSignless()) {
         return PJRT_Buffer_Type_PRED; // 1 bit integer is a bool in mlir
       } else {
-        throw std::runtime_error("Unsupported signed integer type");
+        TT_THROW("Unsupported signed integer type");
       }
     } else {
       if (intType.getWidth() == 64) {
@@ -191,12 +190,12 @@ PJRT_Buffer_Type convertMLIRToPJRTDataType(mlir::Type type) {
       } else if (intType.getWidth() == 1) {
         return PJRT_Buffer_Type_PRED; // 1 bit integer is a bool in mlir
       } else {
-        throw std::runtime_error("Unsupported unsigned integer type");
+        TT_THROW("Unsupported unsigned integer type");
       }
     }
   }
 
-  throw std::runtime_error("Unsupported data type");
+  TT_THROW("Unsupported data type");
 }
 
 bool isComplexPJRTType(PJRT_Buffer_Type type) {


### PR DESCRIPTION
Added new assertions (pjrt_implementation/inc/utils/assert.h)

This header is copied from tt-metal repo and slightly modified (we are using std::format instread of fmt lib and loguru instead of spdlog).

It provides new assertion features:

- TT_ASSERT -> debug build only assert. Throws exception with condition, location and backtrace.

- TT_FATAL -> always asserts. Throws exception with condition, location and backtrace.

- TT_THROW -> always throws exception with condition, location and backtrace.

Environment variables:
- TT_XLA_DISABLE_BACKTRACE -> disables backtrace.
- TT_XLA_ASSERT_ABORT -> forces abort instead of throw.

All casserts are converted to TT_FATAL asserts with some additional info and all throws are replaced with TT_THROW.
