### PR TITLE
Set `gpt_oss_20b_tp` benchmarks optimization level to 1

### DIFF
--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -1126,7 +1126,7 @@ def test_gpt_oss_20b_tp(output_file, num_layers, request, max_output_tokens):
         max_output_tokens=max_output_tokens,
         mesh_config_fn=_gpt_oss_20b_mesh_config_fn,
         shard_spec_fn=_gpt_oss_20b_shard_spec_fn,
-        optimization_level=0,  # https://github.com/tenstorrent/tt-mlir/issues/6949
+        optimization_level=1,
     )
 
 
@@ -1149,7 +1149,7 @@ def test_gpt_oss_20b_tp_batch_size_1(
         mesh_config_fn=_gpt_oss_20b_mesh_config_fn,
         shard_spec_fn=_gpt_oss_20b_shard_spec_fn,
         batch_size=1,
-        optimization_level=0,  # https://github.com/tenstorrent/tt-mlir/issues/6949
+        optimization_level=1,
     )
 
 


### PR DESCRIPTION
### Summary
The optimization_level=0 override removed as [tt-mlir#6949](https://github.com/tenstorrent/tt-mlir/issues/6949) has been resolved. Additional issues emerged and were fixed in the meantime:
- https://github.com/tenstorrent/tt-mlir/pull/7325
- https://github.com/tenstorrent/tt-mlir/pull/7445 (solved possibly machine-specific hangs)

Effect on TTNN graphs: sortOp is replaced with topKOp and 48 redundant slice_static ops are eliminated. Soon expect fusing of SDPA to land too.

### CI benchmark run passed
- [x] https://github.com/tenstorrent/tt-xla/actions/runs/23437995463/job/68194535703
  - no perf change on batch_size=32
  - possible small gain on batch_size=1 (5.5 -> 5.8 sps)