### PR TITLE
Fix transformers version for llama_3_1_70b_tp_galaxy benchmark

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -166,7 +166,7 @@
       },
       {
         "name": "llama_3_1_70b_tp_galaxy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp_galaxy",
         "runs-on": "galaxy-wh-6u"
       },


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/3869

### Problem description
The revert of the transformers v5.2.0 uplift (#3824) missed updating the `llama_3_1_70b_tp_galaxy` entry in `perf-bench-matrix.json`, leaving it pinned to `transformers==5.2.0` instead of `4.57.1`. This causes the nightly benchmark to fail.

### What's changed
Pin `transformers==4.57.1` for the `llama_3_1_70b_tp_galaxy` benchmark entry in `perf-bench-matrix.json`.

CI run: https://github.com/tenstorrent/tt-xla/actions/runs/23446364748

### Checklist
- [x] New/Existing tests provide coverage for changes