### PR TITLE
Add purging of pyarrow extensions

### DIFF
--- a/tests/runner/requirements.py
+++ b/tests/runner/requirements.py
@@ -346,6 +346,7 @@ class RequirementsManager:
         for key in list(sys.modules.keys()):
             top_level = key.split(".")[0].lower().replace("-", "_")
             if top_level in affected_normalized:
+                self._unregister_arrow_ext_types(sys.modules[key])
                 purged.append(key)
                 del sys.modules[key]
 
@@ -355,6 +356,29 @@ class RequirementsManager:
             )
 
         importlib.invalidate_caches()
+
+    @staticmethod
+    def _unregister_arrow_ext_types(module) -> None:
+        """Unregister any pyarrow extension types defined in *module*.
+
+        pyarrow's C-level type registry survives sys.modules purges.
+        Without this, re-importing the module would re-register its types
+        and raise ArrowKeyError.
+        """
+        pa = sys.modules.get("pyarrow")
+        if pa is None:
+            return
+        for attr in vars(module).values():
+            if (
+                isinstance(attr, type)
+                and issubclass(attr, pa.ExtensionType)
+                and attr is not pa.ExtensionType
+            ):
+                name = f"{attr.__module__}.{attr.__qualname__}"
+                try:
+                    pa.unregister_extension_type(name)
+                except (pa.lib.ArrowKeyError, KeyError):
+                    pass
 
     @staticmethod
     def _pip(args: Tuple[str, ...]) -> None:


### PR DESCRIPTION
When running multiple model tests in the same pytest process, the test infrastructure swaps package versions between tests by purging modules from `sys.modules`. The problem is that datasets registers extension types in pyarrow's C-level registry when it's first imported, and that registry lives outside of Python's module system, so purging datasets from sys.modules doesn't clean it up. When the next test re-imports datasets, it tries to register the same types again and crashes with an ArrowKeyError. Now, before removing a module from sys.modules, we now scan it for any `pyarrow` extension types and unregister them first, so the next import can start clean.