### PR TITLE
Skipping a training test in CI

### DIFF
--- a/tests/runner/test_config/torch/test_config_training_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_training_tensor_parallel.yaml
@@ -63,7 +63,9 @@ test_config:
 
   qwen_2_5/causal_lm/pytorch-7B_Instruct-tensor_parallel-training:
     supported_archs: [n300-llmbox]
-    status: KNOWN_FAILURE_XFAIL
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_RUNTIME
+    reason: "Buffer must be allocated on device! - https://github.com/tenstorrent/tt-xla/issues/3627"
     # reason: "PCC mismatch"
 
   qwen_2_5/causal_lm/pytorch-Math_7B-tensor_parallel-training:


### PR DESCRIPTION
Skipping one training test that was already xfailed, as it shows a known issue: https://github.com/tenstorrent/tt-xla/issues/3627