### PR TITLE
Add installation instruction for libnsl-dev

### DIFF
--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -142,6 +142,7 @@ Install from source if you are a developer who wants to develop for TT-XLA.
    sudo apt install libnuma-dev
    sudo apt install libhwloc-dev
    sudo apt install libboost-all-dev
+   sudo apt install libnsl-dev
    ```
 
 #### Step 2: Building the TT-MLIR Toolchain


### PR DESCRIPTION
### Problem description
`libnsl-dev` is required with ubuntu 24.04 as found by @acolicTT 

### What's changed
Add to `Getting Started` Docs. 

