### PR TITLE
Executable image assert changes for complex dtype wrt data shape

### DIFF
--- a/pjrt_implementation/src/api/executable_image.cc
+++ b/pjrt_implementation/src/api/executable_image.cc
@@ -218,8 +218,16 @@ FlatbufferExecutableImage::FlatbufferExecutableImage(
   int output_dims_so_far = 0;
   for (size_t output_index = 0; output_index < getNumOutputs();
        ++output_index) {
-    assert(getOutputDimensions()[output_index] ==
-               output_specs[output_index].shape &&
+    // Complex types are lowered by the TT-MLIR compiler to float tensors with
+    // a trailing dimension of 2 (interleaved real/imag pairs), so the
+    // flatbuffer shape will have one extra trailing dimension compared to the
+    // MLIR module shape.
+    std::vector<std::uint32_t> expected_shape =
+        getOutputDimensions()[output_index];
+    if (data_type_utils::isComplexPJRTType(getOutputTypes()[output_index])) {
+      expected_shape.push_back(2);
+    }
+    assert(expected_shape == output_specs[output_index].shape &&
            "Output shape from flatbuffer binary does not match the one "
            "collected from the MLIR module");
 


### PR DESCRIPTION
### Ticket
None

### Problem description
When using `-DCMAKE_BUILD_TYPE=Debug` test_complex.py fails due to `ERR| TT_FATAL: Output shape from flatbuffer binary does not match the one collected from the MLIR module: output_index=0` This is also unblocking progress on https://github.com/tenstorrent/tt-xla/pull/3874.

### What's changed
Added output shape modifications when dtype is complex.