### PR TITLE
Remove workaround for retracing

### DIFF
--- a/python_package/tt_torch/backend/backend.py
+++ b/python_package/tt_torch/backend/backend.py
@@ -217,9 +217,7 @@ class XLAExecutor:
             )
 
         full_args = self.params_and_consts + args
-        # Ensure unsharded tensors are marked REPLICATED in SPMD mode so their
-        # sharding spec matches what was recorded at graph capture time. This is a temporary workaround
-        # until a change is made in torch-xla to automatically mark unsharded tensors as REPLICATED at runtime in SPMD mode.
+
         return self.compiled_graph(*full_args)
 
     def __call__(self, *args):


### PR DESCRIPTION
With the PR (https://github.com/tenstorrent/pytorch-xla/commit/757568fa77e12bb2c735e7c44e5c5ae42b2c5ee6) going into our fork of torch_xla, we can now remove the workaround that adds "replicated" marking to all unmarked inputs of a torch graph.

Resolves https://github.com/tenstorrent/tt-xla/issues/3302