### PR TITLE
Fix race condition in PjrtTensorPool insert/erase

### DIFF
--- a/pjrt_implementation/src/api/tensor_pool.cc
+++ b/pjrt_implementation/src/api/tensor_pool.cc
@@ -59,18 +59,16 @@ bool contains(PjrtTensor *tensor) { return get().contains(tensor); }
 // Inserts tensor into tensor pool.
 void PjrtTensorPool::insert(PjrtTensor *tensor) {
 
-  TT_FATAL(!contains(tensor), "Tensor already exists in the pool");
-
   const std::scoped_lock lock{m_mtx};
+  TT_FATAL(!m_tensors.contains(tensor), "Tensor already exists in the pool");
   m_tensors.insert(tensor);
 }
 
 // Erases tensor from tensor pool.
 void PjrtTensorPool::erase(PjrtTensor *tensor) {
 
-  TT_FATAL(contains(tensor), "Tensor not found in the pool");
-
   const std::scoped_lock lock{m_mtx};
+  TT_FATAL(m_tensors.contains(tensor), "Tensor not found in the pool");
   m_tensors.erase(tensor);
 }
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Previously, contains() acquired and released the lock separately from the actual insert/erase, allowing two threads to pass the check concurrently and then fail or double-mutate the pool.

### What's changed
Move TT_FATAL assertions inside the scoped_lock in insert() and erase(). 


### Checklist
- [ ] New/Existing tests provide coverage for changes
