### PR TITLE
Fix trigger for the update release notes workflow

### DIFF
--- a/.github/workflows/schedule-nightly-update-release-notes.yml
+++ b/.github/workflows/schedule-nightly-update-release-notes.yml
@@ -2,7 +2,7 @@ name: Nightly Update Release Notes
 
 on:
   workflow_run:
-    workflows: ["schedule-nightly"]
+    workflows: ["On nightly"]
     types: [completed]
     branches: [main]
 


### PR DESCRIPTION
### Ticket
/

### Problem description
Github's `workflow_run` workflow trigger requires a workflow **name**, not workflow **filename** to be defined.

### What's changed
Define the name of the "On nigthly" workflow in `Nigthly Update Release Notes` workflow.

### Checklist
- [ ] New/Existing tests provide coverage for changes
