### PR TITLE
[Benchmark] Add fabric config for ttrt perf

### DIFF
--- a/.github/workflows/call-perf-test.yml
+++ b/.github/workflows/call-perf-test.yml
@@ -352,7 +352,11 @@ jobs:
         cp ./modules/*.ttnn flatbuffers/ 2>/dev/null
 
         echo "Run ttrt perf"
-        ttrt perf flatbuffers --ignore-version
+        if [[ "${{ matrix.build.runs-on }}" == "galaxy-wh-6u" ]]; then
+          ttrt perf flatbuffers --ignore-version --fabric-config fabric_1d_ring
+        else
+          ttrt perf flatbuffers --ignore-version
+        fi
 
         echo "Write device perf to report"
         python3 ./tests/benchmark/scripts/device_perf.py ttrt-artifacts ${{ steps.strings.outputs.perf_report_json_file }}


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/3876)

### Problem description
Device Perf is currently failing on Galaxy CI because ring ccl ops need ring fabric config which was not set.

### What's changed
Set fabric config to `fabric_1d_ring` for tests run on `galaxy-wh-6u`.

### Checklist
- [x] [perf benchmark](https://github.com/tenstorrent/tt-xla/actions/runs/23589741096/job/68693336782) passes for llama, gpt oss has unrelated pcc issue.
