### PR TITLE
Add debug-pcc Claude Code skill

### DIFF
--- a/.claude/skills/debug-pcc/SKILL.md
+++ b/.claude/skills/debug-pcc/SKILL.md
@@ -1,0 +1,315 @@
+---
+name: debug-pcc
+description: >
+  Debug PCC (Pearson Correlation Coefficient) failures in tt-xla performance benchmarks.
+  Use this skill whenever a benchmark test reports a PCC drop or assertion failure,
+  when the user mentions PCC issues, numerical divergence, precision problems with
+  optimized models, or wants to find which TTNN op breaks accuracy. Also trigger when
+  the user mentions instrument_codegen, vanillify, or codegen PCC comparison.
+  Covers the full workflow: generating codegen Python, running the instrumentation
+  tool to compare vanilla vs optimized intermediate tensors, identifying the first
+  bad op, and creating an isolated reproduction test.
+---
+
+# Debug PCC Issues in TT-XLA Benchmarks
+
+This skill walks through debugging PCC (Pearson Correlation Coefficient) failures
+in tt-xla benchmark tests. PCC measures how closely device outputs match CPU
+golden outputs. When the tt-mlir compiler applies optimizations (level 1 or 2),
+it may move tensors from DRAM to L1 memory, change memory layouts, or fuse
+operations -- any of which can introduce numerical divergence.
+
+## When to use this
+
+- A benchmark test fails its PCC assertion (e.g. expected >= 0.97, got 0.91)
+- PCC regressed after a tt-mlir or tt-metal update
+- A new model has low PCC only at optimization_level > 0
+- You need to isolate which specific TTNN operation causes precision loss
+
+## High-level workflow
+
+1. **Reproduce the PCC failure** with the normal benchmark
+2. **Generate codegen Python** by switching the benchmark backend to `codegen_py`
+3. **Run `instrument_codegen.py auto`** to compare vanilla vs optimized per-op
+4. **Identify the first bad op** from the comparison summary
+5. **Create an isolated reproduction** for the offending op
+
+---
+
+## Step 1: Reproduce the PCC failure
+
+Run the failing benchmark to confirm the issue and capture the PCC value:
+
+```bash
+source venv/activate
+pytest -svv tests/benchmark/test_vision.py::test_swin
+```
+
+Look for output like:
+```
+AssertionError: PCC 0.9134 is below required threshold 0.97
+```
+
+Note the model name, optimization level, and reported PCC.
+
+The benchmark test files live in `tests/benchmark/`:
+- `test_vision.py` -- vision models (resnet50, swin, efficientnet, unet, etc.)
+- `test_llms.py` -- language models (llama, gemma, qwen, ministral, etc.)
+- `test_encoders.py` -- encoder models
+
+Each test calls a benchmark function in `tests/benchmark/benchmarks/` which sets
+compile options via `torch_xla.set_custom_compile_options(options)`.
+
+### Speeding things up with fewer layers
+
+For LLM models, you can reduce the number of transformer layers to speed up both
+reproduction and codegen. The benchmark harness supports `--num-layers`:
+
+```bash
+pytest -svv tests/benchmark/test_llms.py::test_ministral_8b --num-layers 2
+```
+
+This compiles only 2 layers instead of the full model, which is much faster and
+often sufficient to reproduce the PCC issue since the same optimization decisions
+apply to every layer. Start small (1-2 layers) and increase only if the PCC
+failure doesn't reproduce.
+
+Vision models (test_vision.py) do not currently support `--num-layers` -- they
+always compile the full model. For large vision models, the codegen step may take
+longer but there's no shortcut available.
+
+## Step 2: Generate codegen Python
+
+To get a standalone TTNN Python script we can instrument, modify the benchmark's
+compile options to emit Python code instead of a flatbuffer binary.
+
+Find the options dict in the relevant benchmark file. For vision models it's in
+`tests/benchmark/benchmarks/vision_benchmark.py` around line 151:
+
+```python
+options = {
+    "optimization_level": optimization_level,
+    "export_path": MODULE_EXPORT_PATH,
+    "export_model_name": export_model_name,
+    ...
+}
+```
+
+Add these two keys to switch to codegen mode:
+
+```python
+options = {
+    "optimization_level": optimization_level,
+    "export_path": MODULE_EXPORT_PATH,
+    "export_model_name": export_model_name,
+    ...
+    "backend": "codegen_py",        # emit Python instead of flatbuffer
+    "export_tensors": True,          # serialize input tensors as .tensorbin
+}
+```
+
+For LLM benchmarks, the options dict is in `tests/benchmark/benchmarks/llm_benchmark.py`.
+
+Then run the benchmark again (with `--num-layers` for LLMs if desired). It will
+compile the model and write generated files instead of executing on device:
+
+```bash
+# Vision
+pytest -svv tests/benchmark/test_vision.py::test_swin
+
+# LLM (use fewer layers for faster iteration)
+pytest -svv tests/benchmark/test_llms.py::test_ministral_8b --num-layers 2
+```
+
+After this completes, the generated code appears under `modules/`:
+```
+modules/
+  main.py              -- generated TTNN Python code (the optimized version)
+  utils.py             -- codegen runtime utilities (DeviceGetter, tensor loading)
+  tensors/             -- serialized input/weight tensors as .tensorbin files
+  irs/                 -- intermediate representations (SHLO, TTIR, TTNN MLIR)
+```
+
+The `main.py` file contains direct `ttnn.*` API calls that mirror exactly what
+the compiler would execute. The optimization level affects memory configs
+(L1 vs DRAM), matmul program configs, and operation fusion in this generated code.
+
+**Important:** After generating, revert the backend change so the benchmark runs
+normally again. The codegen step only needs to happen once per investigation.
+
+## Step 3: Run instrument_codegen.py
+
+The `instrument_codegen.py` script (at `scripts/instrument_codegen.py`) compares
+intermediate tensor outputs between a "vanilla" baseline and the optimized version
+to pinpoint which operation introduces numerical divergence.
+
+### What "vanillify" means
+
+The script creates a vanilla baseline by:
+- Converting ALL `ttnn.MemoryConfig(...)` to DRAM interleaved (removing L1/sharded configs)
+- Replacing matmul `program_config` with `None` (letting TTNN auto-select kernels)
+- Extracting `fused_activation` from program configs and moving it to the `activation=` kwarg
+- Preserving sharded configs only where hardware requires it (e.g. `paged_update_cache` inputs)
+
+This vanilla version has the same graph structure but uses the safest memory
+configuration. If the vanilla version produces correct results but the optimized
+version doesn't, the divergence is caused by the optimizer's memory/layout decisions.
+
+### The `auto` command (recommended)
+
+```bash
+python scripts/instrument_codegen.py auto modules/main.py
+```
+
+This runs three steps automatically:
+1. Creates `modules/main_vanilla.py` (DRAM interleaved baseline)
+2. Runs vanilla version, monkey-patches every TTNN compute op to save intermediate
+   tensors as `.tensorbin` files in `golden_tensors/`
+3. Runs the optimized `main.py` with the same monkey-patching, but instead of
+   saving, compares each op's output against the golden tensor via PCC
+
+The monkey-patching intercepts ~35 TTNN ops (matmul, linear, add, softmax,
+rms_norm, to_memory_config, etc.) plus namespaced ops like
+`ttnn.transformer.scaled_dot_product_attention`.
+
+### Reading the output
+
+The compare phase prints per-op PCC scores:
+
+```
+  [matmul_0]            PCC=0.999998 OK
+  [add_0]               PCC=0.999999 OK
+  [to_memory_config_3]  PCC=0.912345 BAD <<<
+  [matmul_1]            PCC=0.891234 BAD <<<
+```
+
+The summary at the end shows:
+```
+SUMMARY
+======================================================================
+Total ops compared: 147
+  OK   (PCC >= 0.99): 89
+  WARN (0.95-0.99):   12
+  BAD  (PCC < 0.95):  46
+
+First bad op: to_memory_config_3
+^ This is likely where the optimizer introduces the error.
+```
+
+The **first bad op** is the key finding. Everything downstream of it will also
+show degraded PCC because the error cascades through the computation graph.
+
+### Step-by-step alternative
+
+If `auto` has issues (e.g. device reset between runs fails), run each step
+separately:
+
+```bash
+# 1. Create vanilla version
+python scripts/instrument_codegen.py vanillify modules/main.py
+
+# 2. Run vanilla and dump golden tensors
+python scripts/instrument_codegen.py dump modules/main_vanilla.py --tensor-dir golden_tensors
+
+# 3. Compare optimized against golden
+python scripts/instrument_codegen.py compare modules/main.py --tensor-dir golden_tensors
+```
+
+### Prerequisites
+
+- `TT_MLIR_HOME` environment variable must be set (set by `source venv/activate`)
+- The tt-xla virtual environment must be activated
+- Generated `modules/main.py` and `modules/tensors/` must exist from Step 2
+
+## Step 4: Identify the offending op
+
+Once you have the first bad op (e.g. `to_memory_config_3`), open `modules/main.py`
+and find that operation. The generated code is sequential, so you can count
+occurrences of the op to find the exact line.
+
+Common culprits:
+- **`to_memory_config`** -- resharding from DRAM to L1 or between shard specs
+  can introduce precision loss depending on the padding/alignment
+- **`matmul` with specific `program_config`** -- certain matmul kernel configs
+  at L1 can lose precision vs DRAM-based auto-selected kernels
+- **`linear`** -- same as matmul (linear is matmul + bias under the hood)
+- **`softmax`/`rms_norm`/`layer_norm`** -- reduction ops can be sensitive to
+  memory layout changes
+
+Look at the memory_config and program_config arguments of the failing op in
+`main.py` vs what the vanilla version uses. The difference reveals what the
+optimizer changed that broke precision.
+
+## Step 5: Create an isolated reproduction
+
+Extract the failing op and its inputs into a standalone test script. The goal is
+a minimal reproducer that a tt-mlir or tt-metal developer can run independently.
+
+Example structure for a matmul PCC issue:
+
+```python
+import ttnn
+import torch
+
+device = ttnn.open_device(0)
+
+# Load or create input tensors matching the shapes from main.py
+a = ttnn.from_torch(torch.randn(1, 1, 256, 512, dtype=torch.bfloat16),
+                     layout=ttnn.TILE_LAYOUT, device=device)
+b = ttnn.from_torch(torch.randn(1, 1, 512, 1024, dtype=torch.bfloat16),
+                     layout=ttnn.TILE_LAYOUT, device=device)
+
+# Run with DRAM interleaved (golden)
+dram_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+result_golden = ttnn.matmul(a, b, memory_config=dram_config)
+
+# Run with the optimizer's config (the one that breaks PCC)
+l1_config = ttnn.MemoryConfig(
+    ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+    ttnn.BufferType.L1,
+    ttnn.ShardSpec(...)  # copy from main.py
+)
+result_opt = ttnn.matmul(a, b, memory_config=l1_config,
+                          program_config=...)  # copy from main.py
+
+# Compare
+golden_torch = ttnn.to_torch(ttnn.from_device(result_golden))
+opt_torch = ttnn.to_torch(ttnn.from_device(result_opt))
+pcc = torch.corrcoef(torch.stack([golden_torch.flatten(), opt_torch.flatten()]))[0, 1]
+print(f"PCC: {pcc:.6f}")
+
+ttnn.close_device(device)
+```
+
+For real tensors, you can load the `.tensorbin` files from `modules/tensors/`
+or `golden_tensors/` using `ttnn.load_tensor()`.
+
+## PCC thresholds reference
+
+| Threshold | Classification | Meaning |
+|-----------|---------------|---------|
+| >= 0.99   | OK            | Numerically equivalent within expected floating-point tolerance |
+| 0.95-0.99 | WARN          | Minor divergence, may or may not be a problem depending on model |
+| < 0.95    | BAD           | Significant divergence, likely a real optimization bug |
+
+Default required PCC by model type (from benchmark tests):
+- Vision models: 0.97
+- LLMs: 0.95
+- Encoders: 0.97
+- Some models override lower (e.g. ResNet50, Swin at 0.90)
+
+## Tips
+
+- **Use `--num-layers` for LLMs** to drastically reduce iteration time. A 1-2
+  layer model compiles and runs in seconds vs minutes for the full model, and
+  the same optimizer decisions apply to every layer.
+- If the first bad op is a `to_memory_config`, the issue is likely in the shard
+  spec or memory layout chosen by the optimizer, not in the compute op itself.
+- If multiple unrelated ops go bad simultaneously, the issue might be in a shared
+  input tensor that got corrupted by an earlier resharding.
+- For LLM models with tensor parallelism, make sure the codegen is run on the
+  same chip configuration as the benchmark.
+- The `modules/irs/` directory contains MLIR at various stages (SHLO, TTIR, TTNN).
+  The TTNN MLIR shows the compiler's final decisions before code emission.
+- You can edit `main.py` directly to test hypotheses -- e.g. change one op's
+  memory_config back to DRAM interleaved and re-run to confirm it fixes PCC.

--- a/.claude/skills/debug-pcc/scripts/instrument_codegen.py
+++ b/.claude/skills/debug-pcc/scripts/instrument_codegen.py
@@ -1,0 +1,749 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Codegen Instrumentation Tool
+
+Compares intermediate tensor outputs between a "vanilla" (DRAM interleaved)
+and an optimized version of generated TTNN Python code to pinpoint which
+operation introduces numerical divergence.
+
+USAGE:
+------
+
+1. All-in-one (recommended):
+
+   python scripts/instrument_codegen.py auto modules/main.py
+
+   This will:
+   a) Create a vanilla version (all DRAM interleaved, no program configs)
+   b) Run the vanilla version and dump golden tensors
+   c) Run the optimized version and compare against golden tensors
+
+2. Step-by-step:
+
+   # Create vanilla baseline
+   python scripts/instrument_codegen.py vanillify modules/main.py
+
+   # Run vanilla and dump golden intermediate tensors
+   python scripts/instrument_codegen.py dump modules/main_vanilla.py \\
+       --tensor-dir golden_tensors
+
+   # Run optimized and compare each op against golden
+   python scripts/instrument_codegen.py compare modules/main.py \\
+       --tensor-dir golden_tensors
+
+WHAT VANILLIFY DOES:
+--------------------
+
+Transforms the optimizer's output into a safe baseline by:
+  - Converting ALL memory_config arguments to DRAM interleaved
+  - Replacing matmul program_config with None (auto kernel selection)
+  - Preserving sharded memory configs for ops with hardware constraints
+    (e.g. inputs to paged_update_cache must remain sharded)
+  - Keeping to_memory_config calls as DRAM-to-DRAM no-ops to preserve
+    tensor lifetime semantics (important when a source tensor feeds
+    multiple consumers)
+
+PREREQUISITES:
+--------------
+
+  - TT_MLIR_HOME environment variable must be set
+  - The tt-xla virtual environment must be activated (source venv/activate)
+  - A generated main.py with input tensors must exist. To produce them,
+    include the following keys in the compile options dict passed to
+    ``torch_xla.set_custom_compile_options()``:
+
+      "backend": "codegen_py"      — emit standalone Python instead of flatbuffer
+      "export_tensors": True       — serialise model inputs as .tensorbin files
+
+    These are added alongside the other compile options (optimization_level,
+    export_path, etc.) already present in the benchmark harness. See
+    ``tests/benchmark/benchmarks/llm_benchmark.py`` for the full options dict.
+
+    After running the model, the codegen backend produces:
+
+      modules/main.py              — generated TTNN Python code
+      modules/utils.py             — codegen runtime utilities
+      modules/tensors/*.tensorbin  — serialised input tensors
+"""
+
+import argparse
+import importlib.util
+import os
+import re
+import sys
+from pathlib import Path
+
+import torch
+
+# Sentinel value used to replace all MemoryConfig(...) expressions.
+DRAM_INTERLEAVED = (
+    "ttnn.MemoryConfig("
+    "ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM, None)"
+)
+
+# TTNN ops to intercept for PCC comparison.
+# Includes data movement ops (to_memory_config, to_layout) to catch
+# resharding-induced corruption.
+COMPUTE_OPS = {
+    "abs",
+    "add",
+    "concat",
+    "cos",
+    "div",
+    "embedding",
+    "exp",
+    "gelu",
+    "layer_norm",
+    "linear",
+    "matmul",
+    "max",
+    "mean",
+    "min",
+    "multiply",
+    "neg",
+    "pad",
+    "permute",
+    "reciprocal",
+    "relu",
+    "repeat",
+    "reshape",
+    "rms_norm",
+    "rsqrt",
+    "sigmoid",
+    "silu",
+    "slice",
+    "sin",
+    "softmax",
+    "sqrt",
+    "subtract",
+    "sum",
+    "tanh",
+    "to_layout",
+    "to_memory_config",
+    "typecast",
+    "where",
+}
+
+# Namespaced TTNN ops to intercept (dot-separated path under ttnn).
+NAMESPACED_COMPUTE_OPS = {
+    "experimental.rotary_embedding",
+    "transformer.concatenate_heads",
+    "transformer.scaled_dot_product_attention",
+    "transformer.scaled_dot_product_attention_decode",
+    "transformer.split_query_key_value_and_split_heads",
+}
+
+# PCC thresholds for classification.
+PCC_OK_THRESHOLD = 0.99
+PCC_BAD_THRESHOLD = 0.95
+
+
+# ---------------------------------------------------------------------------
+# Vanillify helpers
+# ---------------------------------------------------------------------------
+
+
+def find_matching_paren(text, start):
+    """Return the index of the closing paren matching the open paren at *start*.
+
+    Uses a simple depth counter. Returns -1 if no match is found.
+    """
+    depth = 0
+    i = start
+    while i < len(text):
+        if text[i] == "(":
+            depth += 1
+        elif text[i] == ")":
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return -1
+
+
+def _replace_nested_expression(source, needle, replacement):
+    """Replace every occurrence of *needle*(...) in *source* with *replacement*.
+
+    Handles arbitrarily nested parentheses inside the expression.
+    """
+    result_parts = []
+    i = 0
+    while i < len(source):
+        idx = source.find(needle, i)
+        if idx == -1:
+            result_parts.append(source[i:])
+            break
+        result_parts.append(source[i:idx])
+        open_paren = idx + len(needle) - 1
+        close_paren = find_matching_paren(source, open_paren)
+        if close_paren == -1:
+            # Malformed — keep as-is and advance past the needle.
+            result_parts.append(source[idx : idx + len(needle)])
+            i = idx + len(needle)
+        else:
+            result_parts.append(replacement)
+            i = close_paren + 1
+    return "".join(result_parts)
+
+
+def replace_all_memconfigs(source):
+    """Replace every ``ttnn.MemoryConfig(...)`` with DRAM interleaved."""
+    return _replace_nested_expression(source, "ttnn.MemoryConfig(", DRAM_INTERLEAVED)
+
+
+def replace_matmul_program_configs(source):
+    """Replace ``program_config=ttnn.MatmulMultiCore...(...)`` with ``None``.
+
+    If the program config contains a non-None ``fused_activation``, it is
+    extracted and moved to the matmul's ``activation=`` kwarg so that the
+    fused op is not silently dropped.
+    """
+    needle = "program_config=ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig("
+    result_parts = []
+    i = 0
+    while i < len(source):
+        idx = source.find(needle, i)
+        if idx == -1:
+            result_parts.append(source[i:])
+            break
+        result_parts.append(source[i:idx])
+        open_paren = idx + len(needle) - 1
+        close_paren = find_matching_paren(source, open_paren)
+        if close_paren == -1:
+            result_parts.append(source[idx : idx + len(needle)])
+            i = idx + len(needle)
+            continue
+
+        # Extract the full program_config expression to check for fused_activation
+        pc_text = source[idx : close_paren + 1]
+
+        # Look for fused_activation that is not None.  The value may contain
+        # nested parentheses (e.g. ttnn.UnaryWithParam(ttnn.UnaryOpType.GELU))
+        # so we extract it using balanced-paren matching instead of a simple
+        # regex character class.
+        activation_str = None
+        fa_needle = "fused_activation=ttnn."
+        fa_idx = pc_text.find(fa_needle)
+        if fa_idx != -1:
+            # Find the opening paren of the activation value
+            fa_start = fa_idx + len("fused_activation=")
+            fa_open = pc_text.find("(", fa_start)
+            if fa_open != -1:
+                fa_close = find_matching_paren(pc_text, fa_open)
+                if fa_close != -1:
+                    fa_expr = pc_text[fa_start : fa_close + 1]
+                    # Extract the op name (e.g. GELU, SILU, RELU) and convert
+                    # to the lowercase string form that activation= expects.
+                    op_match = re.search(
+                        r"UnaryOpType\.(\w+)", fa_expr
+                    )
+                    if op_match:
+                        activation_str = f'"{op_match.group(1).lower()}"'
+
+        result_parts.append("program_config=None")
+        i = close_paren + 1
+
+        # If there was a non-None fused_activation, patch the activation= kwarg
+        # that follows the program_config in the same matmul call.
+        if activation_str:
+            act_needle = "activation=None"
+            act_idx = source.find(act_needle, i)
+            if act_idx != -1 and act_idx - i < 200:  # must be nearby
+                result_parts.append(source[i:act_idx])
+                result_parts.append(f"activation={activation_str}")
+                i = act_idx + len(act_needle)
+
+    return "".join(result_parts)
+
+
+def restore_paged_cache_inputs(original, vanillified):
+    """Restore original memory configs for ops that feed ``paged_update_cache``.
+
+    ``paged_update_cache`` requires its input tensor (the second positional
+    argument) to be sharded — this is a hardware constraint, not an optimizer
+    decision. This function identifies the variable names passed as that
+    argument and restores their assignment statements from the original source
+    so the sharded memory config is preserved.
+    """
+    vars_to_restore = set()
+    for m in re.finditer(
+        r"paged_update_cache\(\s*\n\s*\S+,\s*\n\s*(\w+),", vanillified
+    ):
+        vars_to_restore.add(m.group(1))
+
+    if not vars_to_restore:
+        return vanillified
+
+    result = vanillified
+    for var_name in vars_to_restore:
+        pattern = re.compile(
+            rf"^(    {re.escape(var_name)} = ttnn\.\w+\()",
+            re.MULTILINE,
+        )
+        orig_match = pattern.search(original)
+        van_match = pattern.search(result)
+        if orig_match and van_match:
+            orig_end = find_matching_paren(original, orig_match.end() - 1)
+            van_end = find_matching_paren(result, van_match.end() - 1)
+            if orig_end != -1 and van_end != -1:
+                orig_stmt = original[orig_match.start() : orig_end + 1]
+                result = result[: van_match.start()] + orig_stmt + result[van_end + 1 :]
+
+    return result
+
+
+def vanillify(source):
+    """Transform optimized codegen into a vanilla DRAM-interleaved baseline.
+
+    The resulting code has the same graph structure as the optimized version
+    but uses only DRAM interleaved memory configs and lets TTNN auto-select
+    matmul program configs.
+    """
+    result = replace_all_memconfigs(source)
+    result = replace_matmul_program_configs(result)
+    result = restore_paged_cache_inputs(source, result)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# PCC computation
+# ---------------------------------------------------------------------------
+
+
+def compute_pcc(tensor_a, tensor_b):
+    """Compute Pearson Correlation Coefficient between two flat tensors.
+
+    Returns ``nan`` for size mismatches or scalar tensors, ``1.0`` for
+    identical constant tensors, and ``0.0`` when only one tensor is constant.
+    """
+    a = tensor_a.float().flatten()
+    b = tensor_b.float().flatten()
+
+    if a.numel() != b.numel():
+        return float("nan")
+    if a.numel() <= 1:
+        return float("nan") if a.numel() == 0 else 1.0
+
+    a_mean, b_mean = a.mean(), b.mean()
+    a_std, b_std = a.std(), b.std()
+    if a_std == 0 and b_std == 0:
+        return 1.0
+    if a_std == 0 or b_std == 0:
+        return 0.0
+
+    a_centered = a - a_mean
+    b_centered = b - b_mean
+    pcc = (a_centered * b_centered).sum() / (
+        torch.sqrt((a_centered**2).sum()) * torch.sqrt((b_centered**2).sum())
+    )
+    return pcc.item()
+
+
+# ---------------------------------------------------------------------------
+# Tensor tracking
+# ---------------------------------------------------------------------------
+
+
+class TensorTracker:
+    """Records or compares intermediate tensors produced by TTNN ops.
+
+    In *dump* mode, saves each intercepted tensor to ``tensor_dir`` as a
+    ``.tensorbin`` file (TTNN's native FlatBuffer serialisation format).
+
+    In *compare* mode, loads the corresponding golden tensor from
+    ``tensor_dir`` and reports the PCC for each op.
+    """
+
+    def __init__(self, mode, tensor_dir):
+        self.mode = mode
+        self.tensor_dir = Path(tensor_dir).resolve()
+        self.op_counter = {}
+        self.results = []
+        self.first_bad_op = None
+
+        if mode == "dump":
+            self.tensor_dir.mkdir(parents=True, exist_ok=True)
+
+    def _next_op_id(self, op_name):
+        """Return a unique identifier like ``matmul_0``, ``matmul_1``, etc."""
+        count = self.op_counter.get(op_name, 0)
+        self.op_counter[op_name] = count + 1
+        return f"{op_name}_{count}"
+
+    def _tensor_path(self, op_id):
+        return self.tensor_dir / f"{op_id}.tensorbin"
+
+    def track(self, op_name, result_tensor):
+        """Save or compare a single op result."""
+        import ttnn
+
+        op_id = self._next_op_id(op_name)
+
+        try:
+            host_tensor = ttnn.from_device(result_tensor)
+        except Exception as e:
+            print(f"  [{op_id}] WARNING: could not read back from device: {e}")
+            self.results.append((op_id, None))
+            return
+
+        if self.mode == "dump":
+            ttnn.dump_tensor(str(self._tensor_path(op_id)), host_tensor)
+            print(
+                f"  [{op_id}] saved "
+                f"shape={list(host_tensor.shape)} dtype={host_tensor.dtype}"
+            )
+            self.results.append((op_id, None))
+
+        elif self.mode == "compare":
+            golden_path = self._tensor_path(op_id)
+            if not golden_path.exists():
+                print(f"  [{op_id}] WARNING: no golden tensor found, skipping")
+                self.results.append((op_id, None))
+                return
+
+            golden = ttnn.load_tensor(str(golden_path))
+            pcc = compute_pcc(ttnn.to_torch(host_tensor), ttnn.to_torch(golden))
+
+            if pcc >= PCC_OK_THRESHOLD:
+                status = "OK"
+            elif pcc < PCC_BAD_THRESHOLD:
+                status = "BAD"
+            else:
+                status = "WARN"
+
+            marker = " <<<" if status == "BAD" else ""
+            print(f"  [{op_id}] PCC={pcc:.6f} {status}{marker}")
+            self.results.append((op_id, pcc))
+
+            if status == "BAD" and self.first_bad_op is None:
+                self.first_bad_op = op_id
+
+    def print_summary(self):
+        """Print a human-readable summary of all tracked ops."""
+        print("\n" + "=" * 70)
+        print("SUMMARY")
+        print("=" * 70)
+
+        if self.mode == "dump":
+            print(f"Saved {len(self.results)} tensors to {self.tensor_dir}")
+            return
+
+        scored = [(op_id, pcc) for op_id, pcc in self.results if pcc is not None]
+        bad = [(op_id, pcc) for op_id, pcc in scored if pcc < PCC_BAD_THRESHOLD]
+        warn = [
+            (op_id, pcc)
+            for op_id, pcc in scored
+            if PCC_BAD_THRESHOLD <= pcc < PCC_OK_THRESHOLD
+        ]
+        ok = [(op_id, pcc) for op_id, pcc in scored if pcc >= PCC_OK_THRESHOLD]
+
+        print(f"Total ops compared: {len(scored)}")
+        print(f"  OK   (PCC >= {PCC_OK_THRESHOLD}): {len(ok)}")
+        print(f"  WARN ({PCC_BAD_THRESHOLD}-{PCC_OK_THRESHOLD}):   {len(warn)}")
+        print(f"  BAD  (PCC < {PCC_BAD_THRESHOLD}):  {len(bad)}")
+
+        if self.first_bad_op:
+            print(f"\nFirst bad op: {self.first_bad_op}")
+            print("^ This is likely where the optimizer introduces the error.")
+
+        if bad:
+            print("\nAll bad ops:")
+            for op_id, pcc in bad:
+                print(f"  {op_id}: PCC={pcc:.6f}")
+
+
+# ---------------------------------------------------------------------------
+# Runtime helpers
+# ---------------------------------------------------------------------------
+
+
+def _ensure_ttnn_env():
+    """Set up ``TT_METAL_RUNTIME_ROOT`` and ``sys.path`` for TTNN imports.
+
+    Mirrors the environment setup performed by the ``modules/run`` shell
+    script so that the instrumentation script can be invoked from any
+    working directory.
+    """
+    tt_mlir_home = os.environ.get("TT_MLIR_HOME")
+    if not tt_mlir_home:
+        print("ERROR: TT_MLIR_HOME environment variable is not set.")
+        sys.exit(1)
+
+    tt_metal_root = os.environ.get("TT_METAL_RUNTIME_ROOT")
+    if not tt_metal_root:
+        tt_metal_root = os.path.join(
+            tt_mlir_home, "third_party", "tt-metal", "src", "tt-metal"
+        )
+        os.environ["TT_METAL_RUNTIME_ROOT"] = tt_metal_root
+        print(f"TT_METAL_RUNTIME_ROOT set to {tt_metal_root}")
+
+    for subdir in ("ttnn", "tools"):
+        p = os.path.join(tt_metal_root, subdir)
+        if p not in sys.path:
+            sys.path.insert(0, p)
+
+
+_original_ttnn_ops = {}
+
+
+def _wrap_ttnn_ops(tracker):
+    """Monkey-patch TTNN compute ops to route results through *tracker*.
+
+    Saves original functions so that :func:`_unwrap_ttnn_ops` can restore them
+    between runs (avoids double-wrapping in ``auto`` mode).
+    """
+    import ttnn
+
+    # Restore originals first to avoid double-wrapping on repeated calls.
+    _unwrap_ttnn_ops()
+
+    def make_wrapper(original_fn, op_name):
+        def wrapper(*args, **kwargs):
+            result = original_fn(*args, **kwargs)
+            if isinstance(result, ttnn.Tensor):
+                tracker.track(op_name, result)
+            return result
+
+        return wrapper
+
+    wrapped = []
+
+    for op_name in COMPUTE_OPS:
+        original = getattr(ttnn, op_name, None)
+        if original is not None and callable(original):
+            _original_ttnn_ops[("ttnn", op_name)] = original
+            setattr(ttnn, op_name, make_wrapper(original, op_name))
+            wrapped.append(op_name)
+
+    for op_name in NAMESPACED_COMPUTE_OPS:
+        parts = op_name.split(".")
+        module = ttnn
+        for part in parts[:-1]:
+            module = getattr(module, part, None)
+            if module is None:
+                break
+        if module is None:
+            continue
+        attr_name = parts[-1]
+        original = getattr(module, attr_name, None)
+        if original is not None and callable(original):
+            mod_key = "ttnn." + ".".join(parts[:-1])
+            _original_ttnn_ops[(mod_key, attr_name)] = (module, original)
+            setattr(module, attr_name, make_wrapper(original, op_name))
+            wrapped.append(op_name)
+
+    print(f"Wrapped {len(wrapped)} TTNN ops: {', '.join(sorted(wrapped))}")
+
+
+def _unwrap_ttnn_ops():
+    """Restore original TTNN ops, undoing any monkey-patching."""
+    import ttnn
+
+    for key, value in _original_ttnn_ops.items():
+        mod_path, attr_name = key
+        if mod_path == "ttnn":
+            setattr(ttnn, attr_name, value)
+        else:
+            module, original_fn = value
+            setattr(module, attr_name, original_fn)
+    _original_ttnn_ops.clear()
+
+
+def run_codegen_main(main_py_path, tracker):
+    """Load and execute a generated ``main.py`` with instrumented TTNN ops.
+
+    The function:
+      1. Sets up TTNN environment variables and ``sys.path``
+      2. Monkey-patches TTNN ops to intercept results via *tracker*
+      3. Changes the working directory to the script's parent (generated code
+         uses relative paths like ``./tensors/arg0.tensorbin``)
+      4. Imports and calls ``main()`` from the generated module
+      5. Prints the PCC comparison summary
+    """
+    _ensure_ttnn_env()
+
+    main_py_path = Path(main_py_path).resolve()
+    main_dir = main_py_path.parent
+
+    if str(main_dir) not in sys.path:
+        sys.path.insert(0, str(main_dir))
+
+    _wrap_ttnn_ops(tracker)
+
+    original_cwd = os.getcwd()
+    os.chdir(main_dir)
+
+    try:
+        spec = importlib.util.spec_from_file_location("codegen_main", str(main_py_path))
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        print("\nRunning generated code...")
+        module.main()
+    finally:
+        os.chdir(original_cwd)
+
+    tracker.print_summary()
+
+
+# ---------------------------------------------------------------------------
+# Subcommands
+# ---------------------------------------------------------------------------
+
+
+def cmd_vanillify(args):
+    """Create a vanilla DRAM-interleaved version of optimized ``main.py``."""
+    source = Path(args.main_py).read_text()
+    vanilla = vanillify(source)
+    output = args.output or str(Path(args.main_py).parent / "main_vanilla.py")
+    Path(output).write_text(vanilla)
+    print(f"Vanilla version written to: {output}")
+
+
+def cmd_dump(args):
+    """Run generated code and save intermediate tensors as golden references."""
+    tracker = TensorTracker("dump", args.tensor_dir)
+    run_codegen_main(args.main_py, tracker)
+
+
+def cmd_compare(args):
+    """Run generated code and compare intermediate tensors against golden."""
+    if not Path(args.tensor_dir).exists():
+        print(f"ERROR: Golden tensor directory '{args.tensor_dir}' not found.")
+        print("Run the 'dump' subcommand first to create golden tensors.")
+        sys.exit(1)
+    tracker = TensorTracker("compare", args.tensor_dir)
+    run_codegen_main(args.main_py, tracker)
+
+
+def cmd_auto(args):
+    """All-in-one: vanillify, dump golden tensors, compare optimized."""
+    main_py = Path(args.main_py).resolve()
+    main_dir = main_py.parent
+    tensor_dir = Path(args.tensor_dir)
+
+    # Step 1 — Create vanilla version
+    print("=" * 70)
+    print("STEP 1: Creating vanilla version (DRAM interleaved, no program configs)")
+    print("=" * 70)
+    source = main_py.read_text()
+    vanilla = vanillify(source)
+    vanilla_path = main_dir / "main_vanilla.py"
+    vanilla_path.write_text(vanilla)
+    print(f"Written to: {vanilla_path}\n")
+
+    # Step 2 — Run vanilla and dump golden tensors
+    print("=" * 70)
+    print("STEP 2: Running vanilla version — dumping golden tensors")
+    print("=" * 70)
+    tracker_dump = TensorTracker("dump", tensor_dir)
+    run_codegen_main(str(vanilla_path), tracker_dump)
+
+    # Reset device between runs
+    print("\n\nClosing device for second run...")
+    import ttnn
+
+    try:
+        import utils as codegen_utils
+
+        if codegen_utils.DeviceGetter._instance is not None:
+            ttnn.close_mesh_device(codegen_utils.DeviceGetter._instance)
+            codegen_utils.DeviceGetter._instance = None
+            codegen_utils.DeviceGetter._mesh_shape = None
+    except Exception as e:
+        print(f"WARNING: Could not close device cleanly: {e}")
+
+    # Clear the cached codegen module so the second run starts fresh.
+    for mod_name in list(sys.modules.keys()):
+        if mod_name == "codegen_main":
+            del sys.modules[mod_name]
+
+    # Step 3 — Run optimized version and compare
+    print("\n" + "=" * 70)
+    print("STEP 3: Running optimized version — comparing against golden")
+    print("=" * 70)
+    tracker_compare = TensorTracker("compare", tensor_dir)
+    run_codegen_main(str(main_py), tracker_compare)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Instrument generated TTNN Python code to compare intermediate "
+            "tensors between a vanilla (DRAM interleaved) baseline and an "
+            "optimized version, pinpointing where PCC diverges."
+        ),
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # -- vanillify ----------------------------------------------------------
+    p_van = subparsers.add_parser(
+        "vanillify",
+        help="Create vanilla baseline (DRAM interleaved, no program configs)",
+    )
+    p_van.add_argument("main_py", help="Path to the generated main.py")
+    p_van.add_argument(
+        "-o",
+        "--output",
+        help="Output path (default: main_vanilla.py alongside input)",
+    )
+
+    # -- dump ---------------------------------------------------------------
+    p_dump = subparsers.add_parser(
+        "dump",
+        help="Run generated code and save intermediate tensors",
+    )
+    p_dump.add_argument("main_py", help="Path to generated main.py")
+    p_dump.add_argument(
+        "--tensor-dir",
+        default="golden_tensors",
+        help="Output directory for tensors (default: golden_tensors)",
+    )
+
+    # -- compare ------------------------------------------------------------
+    p_cmp = subparsers.add_parser(
+        "compare",
+        help="Run generated code and compare against golden tensors",
+    )
+    p_cmp.add_argument("main_py", help="Path to generated main.py")
+    p_cmp.add_argument(
+        "--tensor-dir",
+        default="golden_tensors",
+        help="Golden tensor directory (default: golden_tensors)",
+    )
+
+    # -- auto ---------------------------------------------------------------
+    p_auto = subparsers.add_parser(
+        "auto",
+        help="All-in-one: vanillify, dump golden, compare optimized",
+    )
+    p_auto.add_argument("main_py", help="Path to the optimized generated main.py")
+    p_auto.add_argument(
+        "--tensor-dir",
+        default="golden_tensors",
+        help="Directory for golden tensors (default: golden_tensors)",
+    )
+
+    args = parser.parse_args()
+
+    commands = {
+        "vanillify": cmd_vanillify,
+        "dump": cmd_dump,
+        "compare": cmd_compare,
+        "auto": cmd_auto,
+    }
+    commands[args.command](args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds a Claude Code skill (`debug-pcc`) for debugging PCC failures in tt-xla benchmarks
- Includes `instrument_codegen.py` script that compares per-op intermediate tensors between a vanilla (DRAM interleaved) baseline and the optimized version to pinpoint which TTNN op introduces numerical divergence
- Covers the full workflow: generating codegen Python, vanillifying, dumping golden tensors, and comparing

## Test plan
- [x] Used this skill to debug Swin PCC regression (0.829 vs required 0.90) — successfully identified `ttnn.embedding` with L1 output on non-tile-aligned dims as the root cause
- [x] Verified skill triggers correctly when user mentions PCC issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)