### PR TITLE
Add per-tensor weight dtype overrides

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -4,6 +4,7 @@
 - [Getting Started](./getting_started.md)
     - [Breaking Into the Source With a Debugger](getting_started_debugging.md)
 - [Improving Model Performance](./performance.md)
+    - [Mixed Precision](./mixed_precision.md)
 - [Test Infra](./test_infra.md)
 - [Fusing and Composite Ops](./fusing_and_composite_ops.md)
 - [Model Auto-Discovery Tests](./model_auto_discovery_tests.md)

--- a/docs/src/mixed_precision.md
+++ b/docs/src/mixed_precision.md
@@ -1,0 +1,88 @@
+# Mixed Precision (Per-Tensor Weight Dtype Overrides)
+
+When uniform weight conversion (e.g. `experimental_weight_dtype: "bfp_bf8"`) causes accuracy degradation in specific layers, you can specify dtype overrides on a per-tensor basis. This lets you keep sensitive layers at higher precision (e.g. `bf16`) while converting the rest to a lower format (e.g. `bfp_bf8` or `bfp_bf4`).
+
+> **Note:** Currently only matmul/linear layer weight overrides are propagated and respected. Convolution weights on lower data types are not yet supported through the compiler.
+
+## Method 1: Python dict (recommended)
+
+Build a dict mapping parameter names (or glob patterns) to target dtypes and call `apply_weight_dtype_overrides()`:
+
+```python
+from tt_torch import apply_weight_dtype_overrides
+
+# Override specific weights by name.
+apply_weight_dtype_overrides(model, {
+    "fc2.weight": "bfp_bf8",
+})
+
+# Or use glob patterns to target groups of layers.
+apply_weight_dtype_overrides(model, {
+    "model.layers.*.mlp.gate_proj.weight": "bfp_bf4",
+    "model.layers.*.mlp.up_proj.weight": "bfp_bf4",
+    "model.layers.0.self_attn.q_proj.weight": "bf16",
+})
+
+# A "default" key applies to all weights, with specific overrides taking precedence.
+apply_weight_dtype_overrides(model, {
+    "default": "bfp_bf8",
+    "model.layers.0.self_attn.q_proj.weight": "bf16",
+})
+```
+
+Call this **after** creating the model and **before** `torch.compile`. See `examples/pytorch/mnist_performant.py` for a complete working example that lowers the last linear layer weight to bfp_bf8.
+
+## Method 2: JSON config + CLI
+
+For large models with hundreds of weight parameters, use the `tt-gen-weight-template` CLI to generate a JSON template, then edit it:
+
+```bash
+tt-gen-weight-template --loader third_party/tt_forge_models/llama/causal_lm/pytorch/loader.py
+```
+
+**CLI options:**
+
+| Option | Description |
+|--------|-------------|
+| `--loader` | **(Required)** Path to a model `loader.py` file |
+| `--variant` | Variant enum name (e.g. `LLAMA_3_1_8B`). Defaults to the loader's `DEFAULT_VARIANT` |
+| `--list-variants` | List available variants and exit |
+| `--default-dtype` | Default dtype for all entries: `bfp_bf8` (default), `bfp_bf4`, or `bf16` |
+| `--output-dir` | Override output directory (default: `mixed_precision_configs/` next to the loader) |
+| `--auto-class` | transformers `Auto*` class to use (default: `AutoModelForCausalLM`) |
+
+The output is a JSON file mapping every weight parameter to a dtype string. Edit it to fine-tune per-layer dtypes:
+
+```json
+{
+    "model.layers.*.mlp.gate_proj.weight": "bfp_bf4",
+    "model.layers.*.mlp.up_proj.weight": "bfp_bf4",
+    "model.layers.0.self_attn.q_proj.weight": "bf16"
+}
+```
+
+Then pass the JSON file path to `apply_weight_dtype_overrides()`:
+
+```python
+apply_weight_dtype_overrides(model, "path/to/config.json")
+```
+
+**Auto-discovery for tests and benchmarks:** JSON configs placed in `mixed_precision_configs/` next to the model's `loader.py` are automatically discovered by the model test runner (`tests/runner/test_models.py`) and LLM benchmarks (`tests/benchmark/benchmarks/llm_benchmark.py`).
+
+## In-model annotation
+
+If you control the model code, you can annotate weights directly in the forward pass using `torch.ops.tt.weight_dtype_override`:
+
+```python
+def forward(self, x):
+    w = torch.ops.tt.weight_dtype_override(self.fc.weight, "bfp_bf8")
+    return torch.matmul(x, w)
+```
+
+This is useful for custom models or when you need dtype overrides to interact with other operations (e.g. tensor-parallel sharding). In practice this is rarely needed — the dict and JSON methods above cover most use cases.
+
+## How it works
+
+Overrides are applied transparently via `torch.nn.utils.parametrize` — there is **no need** to edit model forward functions or manually insert custom ops (unless using in-model annotation). The `apply_weight_dtype_overrides()` function registers a parametrization on each matched weight that injects a `torch.ops.tt.weight_dtype_override` call. During compilation, a C++ frontend pass extracts these annotations and propagates them as per-argument attributes for the tt-mlir weight dtype conversion pass.
+
+> **Note:** If `apply_weight_dtype_overrides()` is called multiple times on the same model (e.g. first with a dict, then with a JSON config), the first call has priority for any given weight — already-parametrized weights are not overridden by subsequent calls.

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -19,7 +19,7 @@ This guide covers best practices and techniques for optimizing the performance o
 
 1. **[Optimization Levels](#1-optimization-levels)** - Compiler optimization levels (0, 1, 2) to balance compile and runtime performance
 2. **[Device Warmup](#2-device-warmup)** - Eliminate first-run overhead by performing warmup iterations
-3. **[Data Formats](#3-data-formats)** - Use bfloat16 and bfloat8_b for faster computation and reduced memory usage
+3. **[Data Formats](#3-data-formats)** - Use bfloat16 and bfloat8_b for faster computation and reduced memory usage, including manual mixed precision via per-tensor weight dtype overrides
 4. **[Runtime Trace](#4-runtime-trace)** - Reduce host-device communication overhead by recording and replaying command sequences
 5. **[Batch Size Tuning](#5-batch-size-tuning)** - Find the optimal batch size to maximize throughput for your model
 
@@ -124,14 +124,14 @@ bfloat16 (Brain Floating Point 16-bit) provides:
 
 ### bfloat8_b
 
-Enable bfp8 weight conversion using compile options. The model **MUST** be cast to bfloat16 before compilation.
+Enable bfp_bf8 weight conversion using compile options. The model **MUST** be cast to bfloat16 before compilation.
 ```python
 torch_xla.set_custom_compile_options({
-    "experimental_weight_dtype": "bfp8",  # Cast matmul weights to bfloat8_b
+    "experimental_weight_dtype": "bfp_bf8",  # Cast matmul weights to bfloat8_b
 })
 ```
 
-bfloat8_b (Block Float 8-bit) weight conversion casts matmul weights to bfp8 format, providing faster computation and reduced memory usage.
+bfloat8_b (Block Float 8-bit) weight conversion casts matmul weights to bfp_bf8 format, providing faster computation and reduced memory usage.
 
 #### Notes
 
@@ -140,6 +140,26 @@ bfloat8_b (Block Float 8-bit) weight conversion casts matmul weights to bfp8 for
 - **Automatic conversion:** Weights are automatically converted during compilation
 - **Not always beneficial:** Profile your specific model to verify improvement
 
+### Per-Tensor Weight Dtype Overrides (Manual Mixed Precision)
+
+When uniform weight conversion causes accuracy degradation in specific layers, you can override dtypes on a per-tensor basis. This lets you keep sensitive layers at higher precision (e.g. `bf16`) while converting the rest to a lower format (e.g. `bfp_bf8` or `bfp_bf4`).
+
+Pass a dict mapping parameter names to target dtypes to `apply_weight_dtype_overrides()`:
+
+```python
+from tt_torch import apply_weight_dtype_overrides
+
+# Override specific weights by name (glob patterns supported).
+apply_weight_dtype_overrides(model, {
+    "fc2.weight": "bfp_bf8",
+})
+```
+
+Call this **after** creating the model and **before** `torch.compile`. See `examples/pytorch/mnist_performant.py` for a complete working example.
+
+> **Note:** Currently only matmul/linear layer weight overrides are supported. Convolution weights on lower data types are not yet supported through the compiler.
+
+For more advanced usage including JSON configs, the `tt-gen-weight-template` CLI, and implementation details, see [Mixed Precision](./mixed_precision.md).
 ---
 
 ## 4. Runtime Trace

--- a/examples/pytorch/mnist_performant.py
+++ b/examples/pytorch/mnist_performant.py
@@ -14,6 +14,7 @@ import torch.nn.functional as F
 import torch_xla
 import torch_xla.core.xla_model as xm
 import torch_xla.runtime as xr
+from tt_torch import apply_weight_dtype_overrides
 
 
 class MNISTCNNDropoutModel(torch.nn.Module):
@@ -58,6 +59,10 @@ def mnist_performant():
 
     # Convert weights and ops to bfloat16.
     model = model.to(dtype=torch.bfloat16)
+
+    # Lower the last linear layer weight to bfp_bf8 for faster computation.
+    # Only matmul/linear weights are supported; conv weights are unaffected.
+    apply_weight_dtype_overrides(model, {"fc2.weight": "bfp_bf8"})
 
     # Set relevant compiler options.
     torch_xla.set_custom_compile_options(

--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -66,7 +66,7 @@ class TTConfig:
     # Optimization level for tt-mlir compilation.
     optimization_level: int = 0
 
-    # Target dtype for weight conversion (e.g. "bfp8", "bfp4"). Empty disables.
+    # Target dtype for weight conversion (e.g. "bfp_bf8", "bfp_bf4"). Empty disables.
     experimental_weight_dtype: str = ""
 
     # Perform token sampling on CPU instead of compiling a sampling graph for device

--- a/pjrt_implementation/inc/api/compile_options.h
+++ b/pjrt_implementation/inc/api/compile_options.h
@@ -34,7 +34,7 @@ struct CompileOptions {
   int optimization_level = 0;
 
   // Target dtype for weight conversion in matmul and linear operations.
-  // Valid values: "bfp8", "bfp4". Empty string disables.
+  // Valid values: "bfp_bf8", "bfp_bf4". Empty string disables.
   std::string experimental_weight_dtype = "";
 
   // Override math fidelity for all ttnn operations exposing compute kernel

--- a/pjrt_implementation/src/api/module_builder/frontend_passes/shlo_input_role_propagation.cc
+++ b/pjrt_implementation/src/api/module_builder/frontend_passes/shlo_input_role_propagation.cc
@@ -32,6 +32,9 @@ namespace tt::pjrt::module_builder::frontend_passes {
 
 const std::string c_name_attr_name = "ttir.name";
 const std::string c_mark_argument_function_name = "tt.mark_argument";
+const std::string c_weight_dtype_override_function_name =
+    "tt.weight_dtype_override";
+const std::string c_weight_dtype_attr_name = "ttcore.weight_dtype";
 
 tt_pjrt_status
 annotateArgumentAttributes(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module) {
@@ -166,6 +169,24 @@ bool isTTMarkFunction(const std::string &function_name) {
   return function_name.rfind(c_tt_mark_function_prefix, 0) == 0;
 }
 
+// Traces a value to its root block arguments by walking the use-def chain.
+mlir::SmallVector<mlir::BlockArgument> getBlockArguments(mlir::Value value) {
+  mlir::SmallVector<mlir::BlockArgument> blockArgs;
+  auto blockArg = mlir::dyn_cast<mlir::BlockArgument>(value);
+  if (blockArg) {
+    blockArgs.push_back(blockArg);
+  } else {
+    auto definingOp = value.getDefiningOp();
+    TT_FATAL(definingOp, "This value does not have a defining operation, nor "
+                         "is it a block argument.");
+    for (mlir::Value operand : definingOp->getOperands()) {
+      blockArgs.append(getBlockArguments(operand));
+    }
+  }
+
+  return blockArgs;
+}
+
 // This pattern is used to populate function argument attributes. It looks for
 // calls to `tt.mark_argument` and populates the argument attributes using the
 // attributes of the `tt.mark_argument` call. It then erases the
@@ -266,25 +287,71 @@ struct PopulateArgumentAttrsFromTTMark final
 
     return mlir::success();
   }
+};
 
-private:
-  // Traces a value to its root block arguments.
-  mlir::SmallVector<mlir::BlockArgument>
-  getBlockArguments(mlir::Value value) const {
-    mlir::SmallVector<mlir::BlockArgument> blockArgs;
-    auto blockArg = mlir::dyn_cast<mlir::BlockArgument>(value);
-    if (blockArg) {
-      blockArgs.push_back(blockArg);
-    } else {
-      auto definingOp = value.getDefiningOp();
-      TT_FATAL(definingOp, "This value does not have a defining operation, nor "
-                           "is it a block argument.");
-      for (mlir::Value operand : definingOp->getOperands()) {
-        blockArgs.append(getBlockArguments(operand));
-      }
+// This pattern extracts per-tensor weight dtype annotations from
+// `tt.weight_dtype_override` custom calls and sets them as function argument
+// attributes. The custom call is then replaced with its input value.
+struct PopulateWeightDtypeFromCustomCall final
+    : mlir::OpRewritePattern<mlir::stablehlo::CustomCallOp> {
+  using mlir::OpRewritePattern<mlir::stablehlo::CustomCallOp>::OpRewritePattern;
+
+  PopulateWeightDtypeFromCustomCall(mlir::MLIRContext *context)
+      : mlir::OpRewritePattern<mlir::stablehlo::CustomCallOp>(context) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::stablehlo::CustomCallOp op,
+                  mlir::PatternRewriter &rewriter) const override {
+
+    if (op.getCallTargetName() != c_weight_dtype_override_function_name) {
+      return mlir::failure();
     }
 
-    return blockArgs;
+    TT_FATAL(op.getNumOperands() == 1,
+             "Expected one operand to tt.weight_dtype_override");
+    TT_FATAL(op.getNumResults() == 1,
+             "Expected one result from tt.weight_dtype_override");
+
+    // Extract frontend_attributes from the custom call.
+    mlir::DictionaryAttr frontendAttrs;
+    if (mlir::Attribute frontendAttrs_ =
+            op->getDiscardableAttr("mhlo.frontend_attributes")) {
+      frontendAttrs = mlir::cast<mlir::DictionaryAttr>(frontendAttrs_);
+    } else {
+      return mlir::failure();
+    }
+
+    // Extract the weight dtype string attribute.
+    auto weightDtypeAttr = frontendAttrs.get(c_weight_dtype_attr_name);
+    if (!weightDtypeAttr) {
+      return mlir::failure();
+    }
+
+    mlir::StringAttr weightDtypeStrAttr =
+        mlir::dyn_cast<mlir::StringAttr>(weightDtypeAttr);
+    if (!weightDtypeStrAttr) {
+      return mlir::failure();
+    }
+
+    // Trace the input to its root block arguments and set the weight dtype
+    // attribute on each.
+    mlir::Value input = op.getOperand(0);
+    mlir::SmallVector<mlir::BlockArgument> blockArgs = getBlockArguments(input);
+
+    for (auto blockArg : blockArgs) {
+      auto *parentOp = blockArg.getOwner()->getParentOp();
+      auto argIndex = blockArg.getArgNumber();
+
+      auto funcOp = mlir::dyn_cast<mlir::func::FuncOp>(parentOp);
+      TT_FATAL(funcOp, "Expected function as parent of block argument");
+
+      funcOp.setArgAttr(argIndex, c_weight_dtype_attr_name, weightDtypeStrAttr);
+    }
+
+    // Remove the custom call op and replace it with the input value.
+    rewriter.replaceOp(op, input);
+
+    return mlir::success();
   }
 };
 
@@ -293,6 +360,7 @@ tt_pjrt_status annotateArgumentAttributesFromCustomCall(
   mlir::MLIRContext *context = mlir_module->getContext();
   mlir::RewritePatternSet patterns(context);
   patterns.add<internal::PopulateArgumentAttrsFromTTMark>(context);
+  patterns.add<internal::PopulateWeightDtypeFromCustomCall>(context);
 
   if (failed(mlir::applyPatternsGreedily(mlir_module.get(),
                                          std::move(patterns)))) {

--- a/pjrt_implementation/src/api/module_builder/module_builder.cc
+++ b/pjrt_implementation/src/api/module_builder/module_builder.cc
@@ -994,14 +994,14 @@ tt_pjrt_status ModuleBuilder::convertFromTTIRToTTNN(
 
   options.optimizationLevel = compile_options.optimization_level;
   // Map user-facing dtype names to WeightDtype enum values.
-  if (compile_options.experimental_weight_dtype == "bfp8") {
+  if (compile_options.experimental_weight_dtype == "bfp_bf8") {
     options.experimentalWeightDtype = mlir::tt::ttnn::WeightDtype::BFP_BFloat8;
-  } else if (compile_options.experimental_weight_dtype == "bfp4") {
+  } else if (compile_options.experimental_weight_dtype == "bfp_bf4") {
     options.experimentalWeightDtype = mlir::tt::ttnn::WeightDtype::BFP_BFloat4;
   } else if (!compile_options.experimental_weight_dtype.empty()) {
     LOG_F(ERROR,
-          "Unknown experimental_weight_dtype: '%s'. Valid values: 'bfp8', "
-          "'bfp4'.",
+          "Unknown experimental_weight_dtype: '%s'. Valid values: 'bfp_bf8', "
+          "'bfp_bf4'.",
           compile_options.experimental_weight_dtype.c_str());
     return tt_pjrt_status::kUnimplemented;
   }

--- a/python_package/setup.py
+++ b/python_package/setup.py
@@ -552,6 +552,7 @@ setup(
         "console_scripts": [
             "tt-forge-install = ttxla_tools.install_sfpi:main",
             "tracy = tracy.__main__:main",
+            "tt-gen-weight-template = tt_torch.weight_dtype:main",
         ],
     },
     include_package_data=True,

--- a/python_package/tt_torch/__init__.py
+++ b/python_package/tt_torch/__init__.py
@@ -22,3 +22,8 @@ from .sharding import sharding_constraint_hook
 # Sparse MLP for MoE models
 from .sparse_mlp import A2aSparseMLP, SparseMLP, enable_sparse_mlp
 from .tools import mark_module_user_inputs
+from .weight_dtype import (
+    apply_weight_dtype_overrides,
+    dump_weight_names,
+    remove_weight_dtype_overrides,
+)

--- a/python_package/tt_torch/custom_ops.py
+++ b/python_package/tt_torch/custom_ops.py
@@ -131,6 +131,79 @@ def _(ctx, grad_output):
 
 
 @torch.library.custom_op(
+    "tt::weight_dtype_override", mutates_args=[], device_types=["cpu", "xla"]
+)
+def weight_dtype_override(tensor: torch.Tensor, dtype_str: str) -> torch.Tensor:
+    """
+    Apply a per-tensor weight dtype constraint for tt-mlir's weight dtype conversion pass.
+
+    This function is a custom registered operator accessible as torch.ops.tt.weight_dtype_override.
+    It creates a stablehlo.custom_call @tt.weight_dtype_override op whose frontend_attributes
+    carry the target dtype. The C++ frontend pass lifts this to a function arg attribute, and
+    the tt-mlir weight dtype conversion pass reads it to insert a typecast for this specific weight.
+
+    Args:
+        tensor: The weight tensor to annotate with a target dtype
+        dtype_str: Target dtype string, one of "bfp_bf4", "bfp_bf8", or "bf16"
+
+    Returns:
+        The tensor with weight dtype constraint metadata applied
+    """
+    if tensor.device.type == "cpu":
+        return tensor.clone()
+
+    assert isinstance(
+        dtype_str, str
+    ), f"dtype_str must be a string, received {type(dtype_str)}"
+    assert dtype_str in [
+        "bfp_bf4",
+        "bfp_bf8",
+        "bf16",
+    ], f"dtype_str must be one of 'bfp_bf4', 'bfp_bf8', or 'bf16', received {dtype_str}"
+
+    frontend_attributes = {"ttcore.weight_dtype": dtype_str}
+
+    # stablehlo_custom_call causes issues within XLA for shapes which are 2D or less.
+    # Workaround: reshape the tensor to 3D, then reshape back after the custom call.
+    original_shape = list(tensor.shape)
+    if len(tensor.shape) < 3:
+        extra_dims = [1] * (3 - len(original_shape))
+        tensor = tensor.reshape((*extra_dims, *original_shape))
+
+    result = stablehlo_custom_call.stablehlo_custom_call(
+        [tensor],
+        "tt.weight_dtype_override",
+        [tensor.shape],
+        [tensor.dtype],
+        frontend_attributes=frontend_attributes,
+    )
+
+    if len(original_shape) < 3:
+        result = result.reshape(original_shape)
+
+    return result
+
+
+@weight_dtype_override.register_fake
+def _(tensor: torch.Tensor, dtype_str: str) -> torch.Tensor:
+    """
+    FakeTensor implementation of torch.ops.tt.weight_dtype_override.
+    This must be implemented in order for dynamo to trace the function.
+    """
+    return tensor.clone()
+
+
+@weight_dtype_override.register_autograd
+def _(ctx, grad_output):
+    """
+    Autograd implementation for weight_dtype_override.
+    This op only applies dtype metadata, so gradients pass through unchanged.
+    Returns gradients for: (tensor, dtype_str)
+    """
+    return grad_output, None
+
+
+@torch.library.custom_op(
     "tt::scaled_dot_product_attention", mutates_args=[], device_types=["xla", "cpu"]
 )
 def scaled_dot_product_attention(

--- a/python_package/tt_torch/weight_dtype.py
+++ b/python_package/tt_torch/weight_dtype.py
@@ -1,0 +1,321 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+import warnings
+from fnmatch import fnmatch
+from typing import List, Optional, Tuple, Union
+
+import torch
+from torch.nn.utils import parametrize
+
+
+class WeightDtypeParametrization(torch.nn.Module):
+    """Parametrization that applies weight_dtype_override during module.weight access."""
+
+    def __init__(self, dtype_str: str):
+        super().__init__()
+        self.dtype_str = dtype_str
+
+    def forward(self, weight: torch.Tensor) -> torch.Tensor:
+        return torch.ops.tt.weight_dtype_override(weight, self.dtype_str)
+
+
+def apply_weight_dtype_overrides(
+    model: torch.nn.Module,
+    config: Union[str, dict, os.PathLike],
+) -> List[Tuple[str, str]]:
+    """
+    Apply per-tensor weight dtype overrides to a model using torch.nn.utils.parametrize.
+
+    Each matched parameter gets a parametrization that calls
+    torch.ops.tt.weight_dtype_override on every access, ensuring the custom_call
+    appears in the traced StableHLO graph.
+
+    Args:
+        model: The model to apply overrides to.
+        config: One of:
+            - A dict mapping full parameter paths (with fnmatch glob support) to
+              dtype strings ("bfp_bf4", "bfp_bf8", or "bf16"). An optional "default" key applies
+              to all weight parameters not matched by other keys.
+            - A JSON file path (str or PathLike ending in ".json").
+            - A plain dtype string ("bfp_bf4", "bfp_bf8", or "bf16") to apply to all weights.
+
+    Returns:
+        List of (param_path, dtype_str) tuples for each parameter that was overridden.
+
+    Example:
+        >>> apply_weight_dtype_overrides(model, {
+        ...     "model.layers.*.mlp.fc1.weight": "bfp_bf4",
+        ...     "model.layers.*.mlp.fc2.weight": "bfp_bf4",
+        ... })
+        >>> apply_weight_dtype_overrides(model, "overrides.json")
+        >>> apply_weight_dtype_overrides(model, "bfp_bf8")
+    """
+    overrides = _load_config(config)
+    default_dtype = overrides.pop("default", None)
+
+    modules_by_name = dict(model.named_modules())
+    all_param_names = [name for name, _ in model.named_parameters()]
+
+    applied = []
+
+    # Build a mapping: param_path -> dtype_str
+    resolved = {}
+
+    # First apply default to all weight parameters
+    if default_dtype is not None:
+        for param_name in all_param_names:
+            if param_name.endswith(".weight"):
+                resolved[param_name] = default_dtype
+
+    # Then apply specific overrides (may use globs), overwriting defaults
+    for pattern, dtype_str in overrides.items():
+        matched = False
+        for param_name in all_param_names:
+            if fnmatch(param_name, pattern):
+                resolved[param_name] = dtype_str
+                matched = True
+        if not matched:
+            warnings.warn(
+                f"Weight dtype override pattern '{pattern}' did not match any "
+                f"model parameters. Check that parameter names match the model "
+                f"(e.g. 'model.layers.0...' vs 'layers.0...')."
+            )
+
+    # Register parametrizations
+    for param_path, dtype_str in resolved.items():
+        module_path, param_name = param_path.rsplit(".", 1)
+        module = modules_by_name.get(module_path)
+        if module is None:
+            continue
+        if not isinstance(getattr(module, param_name, None), torch.nn.Parameter):
+            continue
+
+        parametrize.register_parametrization(
+            module, param_name, WeightDtypeParametrization(dtype_str)
+        )
+        applied.append((param_path, dtype_str))
+
+    return applied
+
+
+def remove_weight_dtype_overrides(model: torch.nn.Module) -> int:
+    """
+    Remove only WeightDtypeParametrization instances from a model, preserving
+    any other parametrizations on the same parameters.
+
+    Returns:
+        Number of parametrizations removed.
+    """
+    count = 0
+    for _, module in model.named_modules():
+        if not parametrize.is_parametrized(module):
+            continue
+        for param_name in list(module.parametrizations.keys()):
+            param_list = getattr(module.parametrizations, param_name)
+            to_remove = [
+                i
+                for i, p in enumerate(param_list)
+                if isinstance(p, WeightDtypeParametrization)
+            ]
+            if not to_remove:
+                continue
+            # If ours is the only parametrization, use the standard API
+            if len(to_remove) == len(param_list):
+                parametrize.remove_parametrizations(module, param_name)
+            else:
+                # Remove only our entries, preserving others
+                for i in reversed(to_remove):
+                    del param_list[i]
+            count += len(to_remove)
+    return count
+
+
+def dump_weight_names(
+    model: torch.nn.Module,
+    model_name: str,
+    output_dir: Optional[str] = None,
+    default_dtype: str = "bfp_bf8",
+) -> dict:
+    """
+    Generate a JSON template of all weight parameters in a model.
+
+    Iterates model.named_modules() and collects modules that have a 'weight'
+    parameter. Users can edit the resulting dict/file to set per-layer dtypes,
+    then pass it to apply_weight_dtype_overrides().
+
+    Args:
+        model: The model to inspect.
+        model_name: HuggingFace model name (e.g. "mistralai/Mistral-7B-Instruct-v0.3").
+            The part after '/' is used as the JSON filename.
+        output_dir: Optional directory to write the JSON file to.
+            The filename is derived from model_name automatically.
+        default_dtype: Default dtype string to use for all entries.
+
+    Returns:
+        Dict mapping full parameter paths to the default dtype string.
+    """
+    result = {}
+    for name, module in model.named_modules():
+        if hasattr(module, "weight") and isinstance(module.weight, torch.nn.Parameter):
+            key = f"{name}.weight" if name else "weight"
+            result[key] = default_dtype
+
+    if output_dir is not None:
+        filename = model_name.split("/")[-1] + ".json"
+        output_path = os.path.join(output_dir, filename)
+        os.makedirs(output_dir, exist_ok=True)
+        with open(output_path, "w") as f:
+            json.dump(result, f, indent=2)
+
+    return result
+
+
+def _load_config(config: Union[str, dict, os.PathLike]) -> dict:
+    """Parse config into a dict of {pattern: dtype_str}."""
+    if isinstance(config, dict):
+        return dict(config)
+
+    config_str = str(config)
+
+    # Plain dtype string
+    if config_str in ("bfp_bf4", "bfp_bf8", "bf16"):
+        return {"default": config_str}
+
+    # JSON file path
+    if config_str.endswith(".json") or os.path.isfile(config_str):
+        with open(config_str) as f:
+            return json.load(f)
+
+    raise ValueError(
+        f"config must be a dict, a JSON file path, or a dtype string ('bfp_bf4'/'bfp_bf8'/'bf16'), "
+        f"got: {config!r}"
+    )
+
+
+def _import_loader_module(loader_path: str):
+    """Dynamically import a loader module from a file path.
+
+    Walks up from the file to find the first ancestor directory that is already
+    on sys.path, then computes a dotted module name relative to that root.
+    This lets importlib handle relative imports correctly without hardcoding
+    any directory names.
+    """
+    import importlib
+    import sys
+
+    abs_path = os.path.abspath(loader_path)
+    if not os.path.isfile(abs_path):
+        raise FileNotFoundError(f"Loader file not found: {abs_path}")
+
+    parent = os.path.dirname(abs_path)
+    while parent != os.path.dirname(parent):
+        if parent in sys.path:
+            rel = os.path.relpath(abs_path, parent)
+            module_name = rel.removesuffix(".py").replace(os.sep, ".")
+            return importlib.import_module(module_name)
+        parent = os.path.dirname(parent)
+
+    raise RuntimeError(
+        f"Could not find a sys.path entry that is an ancestor of {abs_path}. "
+        f"Ensure the project virtualenv is activated."
+    )
+
+
+def _resolve_variant(module, variant_name: Optional[str]):
+    """Resolve a variant enum member from the loader module.
+
+    Returns DEFAULT_VARIANT if variant_name is None.
+    """
+    if variant_name is None:
+        return module.ModelLoader.DEFAULT_VARIANT
+
+    variant_enum = module.ModelVariant
+    try:
+        return variant_enum[variant_name]
+    except KeyError:
+        valid = [v.name for v in variant_enum]
+        raise ValueError(f"Unknown variant '{variant_name}'. Valid variants: {valid}")
+
+
+def main():
+    """CLI entry point for generating weight dtype JSON templates."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Generate a JSON template of weight dtype overrides from a model loader."
+    )
+    parser.add_argument(
+        "--loader",
+        required=True,
+        help="Path to a loader.py file (e.g. third_party/tt_forge_models/gpt_oss/pytorch/loader.py)",
+    )
+    parser.add_argument(
+        "--variant",
+        default=None,
+        help="Variant enum name (e.g. GPT_OSS_20B). Defaults to the loader's DEFAULT_VARIANT.",
+    )
+    parser.add_argument(
+        "--list-variants",
+        action="store_true",
+        help="List available variants and exit.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=None,
+        help="Override output directory (default: mixed_precision_configs/ next to loader.py)",
+    )
+    parser.add_argument(
+        "--default-dtype",
+        default="bfp_bf8",
+        choices=["bfp_bf4", "bfp_bf8", "bf16"],
+        help="Default dtype string for all weight entries (default: bfp_bf8)",
+    )
+    parser.add_argument(
+        "--auto-class",
+        default="AutoModelForCausalLM",
+        help="transformers Auto* class to use for loading (default: AutoModelForCausalLM)",
+    )
+    args = parser.parse_args()
+
+    mod = _import_loader_module(args.loader)
+
+    if args.list_variants:
+        default = mod.ModelLoader.DEFAULT_VARIANT
+        for variant, config in mod.ModelLoader._VARIANTS.items():
+            marker = " (default)" if variant == default else ""
+            hf_name = getattr(config, "pretrained_model_name", "N/A")
+            print(f"  {variant.name:40s} {hf_name}{marker}")
+        return
+
+    variant = _resolve_variant(mod, args.variant)
+    config = mod.ModelLoader.get_variant_config(variant)
+    model_name = config.pretrained_model_name
+
+    output_dir = args.output_dir or os.path.join(
+        os.path.dirname(os.path.abspath(args.loader)), "mixed_precision_configs"
+    )
+
+    import transformers
+
+    auto_cls = getattr(transformers, args.auto_class, None)
+    if auto_cls is None:
+        raise ValueError(f"Unknown transformers class: {args.auto_class}")
+
+    print(
+        f"Loading model {model_name} (variant: {variant.name}) with {args.auto_class}..."
+    )
+    model = auto_cls.from_pretrained(model_name, torch_dtype=torch.bfloat16)
+
+    dump_weight_names(model, model_name, output_dir, args.default_dtype)
+
+    filename = model_name.split("/")[-1] + ".json"
+    output_path = os.path.join(output_dir, filename)
+    print(f"Weight dtype template written to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -45,6 +45,10 @@ tests/benchmark/
 ├── llm_utils/               # LLM-specific utilities
 ```
 
+## Mixed Precision
+
+See [MIXED_PRECISION.md](../../docs/src/mixed_precision.md) for detailed instructions on per-tensor weight dtype overrides and manual mixed precision.
+
 ## Profiling
 
 See [PROFILING.md](PROFILING.md) for detailed instructions on device and host profiling with Tracy.

--- a/tests/benchmark/benchmarks/encoder_benchmark.py
+++ b/tests/benchmark/benchmarks/encoder_benchmark.py
@@ -191,7 +191,7 @@ def benchmark_encoder_torch_xla(
             Signature: fn(outputs, model_inputs) -> embeddings.
             This function should extract hidden states and apply the appropriate pooling.
         required_pcc: Minimum PCC threshold for output validation
-        experimental_weight_dtype: Weight dtype for block format conversion ("bfp8", "bfp4", or "" for none)
+        experimental_weight_dtype: Weight dtype for block format conversion ("bfp_bf8", "bfp_bf4", or "" for none)
         experimental_enable_permute_matmul_fusion: Whether to enable permute matmul fusion optimization
 
     Returns:

--- a/tests/benchmark/benchmarks/llm_benchmark.py
+++ b/tests/benchmark/benchmarks/llm_benchmark.py
@@ -18,11 +18,13 @@ import tracy
 import transformers
 from llm_utils import generate_and_benchmark, init_accuracy_testing, init_static_cache
 from llm_utils.decode_utils import LLMSamplingWrapper
+from loguru import logger
 from torch_xla.distributed.spmd import Mesh
 from transformers import AutoModelForCausalLM, AutoTokenizer, PreTrainedTokenizer
 from transformers.cache_utils import StaticCache
 from transformers.modeling_outputs import CausalLMOutputWithPast
 from tt_torch.sharding import sharding_constraint_hook
+from tt_torch.weight_dtype import apply_weight_dtype_overrides
 from utils import (
     build_xla_export_name,
     compute_pcc,
@@ -230,7 +232,7 @@ def benchmark_llm_torch_xla(
         task: Task type
         data_format: Data precision format
         input_sequence_length: Length of input sequence for generation context
-        experimental_weight_dtype: Weight dtype for block format conversion (e.g. "bfp8", "bfp4", or "" for none)
+        experimental_weight_dtype: Weight dtype for block format conversion (e.g. "bfp_bf8", "bfp_bf4", or "" for none)
         experimental_enable_permute_matmul_fusion: Whether to enable permute matmul fusion optimization
         ttnn_perf_metrics_output_file: Path to save TTNN performance metrics
         read_logits_fn: Callback function to extract logits from model output
@@ -391,6 +393,13 @@ def benchmark_llm_torch_xla(
 
     torch_xla.set_custom_compile_options(options)
 
+    # Apply per-tensor weight dtype overrides from model's weight_dtype_configs JSON.
+    weight_dtype_config = model_loader.get_weight_dtype_config_path()
+    if weight_dtype_config:
+        applied = apply_weight_dtype_overrides(model, weight_dtype_config)
+        logger.info(
+            f"Applied {len(applied)} weight dtype overrides from {weight_dtype_config}"
+        )
     # PERFORMANCE BENCHMARK
     # No logits returned to avoid OOM.
     perf_wrapper = LLMSamplingWrapper(model, read_logits_fn, return_logits=False)

--- a/tests/benchmark/benchmarks/vllm_benchmark.py
+++ b/tests/benchmark/benchmarks/vllm_benchmark.py
@@ -240,7 +240,7 @@ def benchmark_vllm(
         program_cache_enabled=True,
         trace_enabled=False,
         experimental_weight_dtype=(
-            "bfp8"
+            "bfp_bf8"
             if config.additional_config.get(
                 "experimental_enable_weight_bfp8_conversion", False
             )

--- a/tests/benchmark/resnet_jax_benchmark.py
+++ b/tests/benchmark/resnet_jax_benchmark.py
@@ -109,7 +109,7 @@ def benchmark_resnet_jax(
         optimization_level: tt-mlir optimization level for compilation
         program_cache_enabled: Whether to enable program cache
         trace_enabled: Whether to enable tracing
-        experimental_weight_dtype: Weight dtype for block format conversion (e.g. "bfp8", "bfp4", or "" for none)
+        experimental_weight_dtype: Weight dtype for block format conversion (e.g. "bfp_bf8", "bfp_bf4", or "" for none)
         required_pcc: Minimum PCC threshold for output validation
 
     Returns:

--- a/tests/benchmark/test_encoders.py
+++ b/tests/benchmark/test_encoders.py
@@ -96,7 +96,7 @@ def test_encoder(
         input_sequence_length: Length of input sentence
         data_format: Data format
         required_pcc: Required PCC threshold
-        experimental_weight_dtype: Weight dtype for block format conversion (e.g. "bfp8", "bfp4", or "" for none)
+        experimental_weight_dtype: Weight dtype for block format conversion (e.g. "bfp_bf8", "bfp_bf4", or "" for none)
         experimental_enable_permute_matmul_fusion: Enable permute matmul fusion
         load_inputs_fn: Optional function to load raw inputs.
             Signature: fn(batch_size) -> List[str]. Defaults to get_default_inputs.

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -25,7 +25,7 @@ DEFAULT_LOOP_COUNT = 1
 DEFAULT_INPUT_SEQUENCE_LENGTH = 128
 DEFAULT_DATA_FORMAT = "bfloat16"
 DEFAULT_TASK = "text-generation"
-DEFAULT_EXPERIMENTAL_WEIGHT_DTYPE = "bfp8"
+DEFAULT_EXPERIMENTAL_WEIGHT_DTYPE = "bfp_bf8"
 DEFAULT_EXPERIMENTAL_ENABLE_PERMUTE_MATMUL_FUSION = False
 DEFAULT_REQUIRED_PCC = 0.95
 
@@ -70,7 +70,7 @@ def test_llm(
         input_sequence_length: Input sequence length
         data_format: Data format
         task: Task type
-        experimental_weight_dtype: Weight dtype for block format conversion (e.g. "bfp8", "bfp4", or "" for none)
+        experimental_weight_dtype: Weight dtype for block format conversion (e.g. "bfp_bf8", "bfp_bf4", or "" for none)
         experimental_enable_permute_matmul_fusion: Enable permute matmul fusion optimization
         read_logits_fn: Function to extract logits from model output
         required_pcc: Required PCC threshold

--- a/tests/infra/testers/compiler_config.py
+++ b/tests/infra/testers/compiler_config.py
@@ -28,7 +28,7 @@ class CompilerConfig:
     optimization_level: int = 0
 
     # Target dtype for weight conversion in matmul and linear operations.
-    # Valid values: "", "bfp8", "bfp4". Empty string disables.
+    # Valid values: "", "bfp_bf8", "bfp_bf4". Empty string disables.
     experimental_weight_dtype: str = ""
 
     # Override math fidelity for all ttnn operations exposing compute kernel

--- a/tests/infra/utilities/utils.py
+++ b/tests/infra/utilities/utils.py
@@ -165,11 +165,11 @@ def create_jax_inference_tester(
         dtype = jnp.float32
     elif format == "bfloat16":
         dtype = jnp.bfloat16
-    elif format == "bfp8":
+    elif format == "bfp_bf8":
         dtype = jnp.bfloat16
         if compiler_config is None:
             compiler_config = CompilerConfig()
-        compiler_config.experimental_weight_dtype = "bfp8"
+        compiler_config.experimental_weight_dtype = "bfp_bf8"
 
     return model_tester_class(
         variant_or_args, compiler_config=compiler_config, dtype_override=dtype, **kwargs
@@ -190,11 +190,11 @@ def create_torch_inference_tester(
         dtype = None
     elif format == "bfloat16":
         dtype = torch.bfloat16
-    elif format == "bfp8":
+    elif format == "bfp_bf8":
         dtype = torch.bfloat16
         if compiler_config is None:
             compiler_config = CompilerConfig()
-        compiler_config.experimental_weight_dtype = "bfp8"
+        compiler_config.experimental_weight_dtype = "bfp_bf8"
 
     return model_tester_class(
         variant_or_args, compiler_config=compiler_config, dtype_override=dtype, **kwargs

--- a/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
@@ -80,7 +80,7 @@ def test_tensor_parallel_generation_llmbox_small(
     [
         pytest.param("Qwen/Qwen3-32B", False, ""),
         pytest.param("Qwen/Qwen2.5-32B", False, ""),
-        pytest.param("meta-llama/Llama-3.1-70B", True, "bfp8"),
+        pytest.param("meta-llama/Llama-3.1-70B", True, "bfp_bf8"),
     ],
 )
 def test_tensor_parallel_generation_llmbox_large(

--- a/tests/integrations/vllm_plugin/pooling/test_single_device.py
+++ b/tests/integrations/vllm_plugin/pooling/test_single_device.py
@@ -135,7 +135,7 @@ def test_embed_qwen3_reduced_dims():
             "Qwen/Qwen3-Embedding-8B",
             "baseline/qwen3_embedding_8B_baseline.pt",
             64,
-            "bfp8",
+            "bfp_bf8",
         ),
     ],
 )

--- a/tests/jax/single_chip/models/mnist/mlp/test_mnist_mlp.py
+++ b/tests/jax/single_chip/models/mnist/mlp/test_mnist_mlp.py
@@ -51,7 +51,7 @@ def create_inference_tester(hidden_sizes: tuple, format: str) -> MNISTMLPTester:
     [
         "float32",
         "bfloat16",
-        "bfp8",
+        "bfp_bf8",
     ],
 )
 def test_mnist_mlp_inference(hidden_sizes: tuple, format: str, request):

--- a/tests/jax/single_chip/models/resnet_v1_5/resnet_18/test_resnet_18.py
+++ b/tests/jax/single_chip/models/resnet_v1_5/resnet_18/test_resnet_18.py
@@ -24,7 +24,7 @@ def create_inference_tester(format: str) -> ResNetTester:
         "float32",
         "bfloat16",
         pytest.param(
-            "bfp8",
+            "bfp_bf8",
             marks=pytest.mark.skip(
                 reason=(
                     "Skip until mixed-precision is supported in MLIR. https://github.com/tenstorrent/tt-mlir/issues/5252"

--- a/tests/runner/test_models.py
+++ b/tests/runner/test_models.py
@@ -96,8 +96,8 @@ def _run_model_test_impl(
             compiler_config = CompilerConfig()
         weights_dtype = None
         if test_metadata.enable_weight_bfp8_conversion:
-            compiler_config.experimental_weight_dtype = "bfp8"
-            weights_dtype = "bfp8"
+            compiler_config.experimental_weight_dtype = "bfp_bf8"
+            weights_dtype = "bfp_bf8"
 
         if ir_dump_path:
             compiler_config.export_path = ir_dump_path

--- a/tests/runner/testers/torch/dynamic_torch_model_tester.py
+++ b/tests/runner/testers/torch/dynamic_torch_model_tester.py
@@ -68,6 +68,21 @@ class DynamicTorchModelTester(TorchModelTester):
         if test_metadata and getattr(test_metadata, "inject_custom_moe", False):
             self._inject_custom_moe(self._model)
 
+    def _initialize_model(self):
+        """Initialize model and auto-apply per-variant weight dtype overrides."""
+        super()._initialize_model()
+        loader = self.dynamic_loader.loader
+        if hasattr(loader, "get_weight_dtype_config_path"):
+            config_path = loader.get_weight_dtype_config_path()
+            if config_path:
+                from tt_torch.weight_dtype import apply_weight_dtype_overrides
+
+                applied = apply_weight_dtype_overrides(self._model, config_path)
+                if applied:
+                    logger.info(
+                        f"Applied {len(applied)} weight dtype overrides from {config_path}"
+                    )
+
     # --- TorchModelTester interface implementations ---
 
     def _get_model(self):

--- a/tests/torch/models/resnet/test_resnet.py
+++ b/tests/torch/models/resnet/test_resnet.py
@@ -76,11 +76,11 @@ def training_tester() -> ResnetTester:
     "format,optimization_level",
     [
         pytest.param(
-            "bfp8",
+            "bfp_bf8",
             1,
         ),
         pytest.param(
-            "bfp8",
+            "bfp_bf8",
             0,
         ),
         pytest.param(

--- a/tests/torch/ops/test_linear.py
+++ b/tests/torch/ops/test_linear.py
@@ -41,7 +41,7 @@ class Linear(torch.nn.Module):
 @pytest.mark.parametrize("in_features", [32, 64])
 @pytest.mark.parametrize("out_features", [32, 64])
 @pytest.mark.parametrize("bias", [False, True])
-@pytest.mark.parametrize("experimental_weight_dtype", ["", "bfp8", "bfp4"])
+@pytest.mark.parametrize("experimental_weight_dtype", ["", "bfp_bf8", "bfp_bf4"])
 def test_linear(
     batch_size,
     in_features,
@@ -55,7 +55,7 @@ def test_linear(
         experimental_weight_dtype=experimental_weight_dtype
     )
     comparison_config = ComparisonConfig()
-    if experimental_weight_dtype == "bfp4":
+    if experimental_weight_dtype == "bfp_bf4":
         comparison_config.pcc = PccConfig(required_pcc=0.98)
 
     run_op_test_with_random_inputs(
@@ -101,6 +101,93 @@ def test_linear_torch_override():
 
     comparator = TorchComparisonEvaluator(ComparisonConfig())
     comparator.evaluate(output, golden)
+
+
+class TensorParallelMLP(torch.nn.Module):
+    """
+    Simple two-layer MLP with per-tensor weight_dtype_override annotations.
+
+    Mimics tensor-parallel LLM MLP pattern:
+      - up_proj: column-parallel (weight sharded on output dim)
+      - down_proj: row-parallel (weight sharded on input dim)
+    """
+
+    def __init__(
+        self,
+        hidden_size,
+        intermediate_size,
+        weight_dtype,
+        dtype=torch.bfloat16,
+    ):
+        super().__init__()
+        self.up_proj = torch.nn.Linear(
+            hidden_size, intermediate_size, bias=False, dtype=dtype
+        )
+        self.down_proj = torch.nn.Linear(
+            intermediate_size, hidden_size, bias=False, dtype=dtype
+        )
+        self.weight_dtype = weight_dtype
+
+    def forward(self, x):
+        up_w = torch.ops.tt.weight_dtype_override(
+            self.up_proj.weight, self.weight_dtype
+        )
+        x = F.linear(x, up_w)
+        x = F.relu(x)
+        down_w = torch.ops.tt.weight_dtype_override(
+            self.down_proj.weight, self.weight_dtype
+        )
+        x = F.linear(x, down_w)
+        return x
+
+
+@pytest.mark.nightly
+@pytest.mark.dual_chip
+@pytest.mark.record_test_properties(category=Category.OP_TEST)
+@pytest.mark.parametrize("weight_dtype", ["bfp_bf8", "bfp_bf4"])
+def test_linear_tensor_parallel_per_tensor_weight_dtype(weight_dtype):
+    """
+    Tensor-parallel MLP with per-tensor weight dtype overrides.
+
+    up_proj weight is column-parallel sharded ("model", None) — each device
+    holds a slice of the output dimension. down_proj weight is row-parallel
+    sharded (None, "model") — each device holds a slice of the input dimension.
+    The matmul + CCL (all-reduce after down_proj) pattern tests that
+    weight_dtype_override annotations survive through tensor-parallel CCL ops.
+    """
+    dtype = torch.bfloat16
+    hidden_size = 64
+    intermediate_size = 128
+
+    mlp = TensorParallelMLP(hidden_size, intermediate_size, weight_dtype, dtype)
+
+    def get_shard_spec(model, args, kwargs):
+        return {
+            model.up_proj.weight: ("model", None),
+            model.down_proj.weight: (None, "model"),
+        }
+
+    num_devices = xr.global_runtime_device_count()
+    mesh_shape = (1, num_devices)
+    device_ids = np.array(range(num_devices))
+    mesh = Mesh(device_ids, mesh_shape, ("batch", "model"))
+
+    batch_size = 1
+    seq_len = 32
+    hidden_states = torch.randn(batch_size, seq_len, hidden_size, dtype=dtype)
+
+    comparison_config = ComparisonConfig()
+    if weight_dtype == "bfp_bf4":
+        comparison_config.pcc = PccConfig(required_pcc=0.98)
+
+    run_op_test(
+        mlp,
+        [hidden_states],
+        comparison_config=comparison_config,
+        framework=Framework.TORCH,
+        mesh=mesh,
+        shard_spec_fn=get_shard_spec,
+    )
 
 
 @pytest.mark.nightly

--- a/tests/torch/ops/test_matmul.py
+++ b/tests/torch/ops/test_matmul.py
@@ -2,9 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import numpy as np
 import pytest
 import torch
-from infra import Framework, run_op_test_with_random_inputs
+import torch_xla.runtime as xr
+from infra import Framework, run_op_test, run_op_test_with_random_inputs
+from torch_xla.distributed.spmd import Mesh
 from utils import Category
 
 from tests.infra.evaluators.evaluation_config import ComparisonConfig, PccConfig
@@ -12,14 +15,18 @@ from tests.infra.testers.compiler_config import CompilerConfig
 
 
 class Matmul(torch.nn.Module):
-    def __init__(self, inner_dim, rhs_outer_dim, dtype=torch.float32):
+    def __init__(
+        self, inner_dim, rhs_outer_dim, weight_dtype="bf16", dtype=torch.bfloat16
+    ):
         super().__init__()
         self.weight = torch.nn.Parameter(
             torch.randn(inner_dim, rhs_outer_dim, dtype=dtype)
         )
+        self.weight_dtype = weight_dtype
 
     def forward(self, x):
-        return torch.matmul(x, self.weight)
+        w = torch.ops.tt.weight_dtype_override(self.weight, self.weight_dtype)
+        return torch.matmul(x, w)
 
 
 @pytest.mark.push
@@ -29,16 +36,13 @@ class Matmul(torch.nn.Module):
 @pytest.mark.parametrize("lhs_outer", [32, 64])
 @pytest.mark.parametrize("rhs_outer", [32, 64])
 @pytest.mark.parametrize("inner", [32, 64])
-@pytest.mark.parametrize("experimental_weight_dtype", ["", "bfp8", "bfp4"])
-def test_matmul_rhs_as_param(lhs_outer, rhs_outer, inner, experimental_weight_dtype):
+@pytest.mark.parametrize("weight_dtype", ["bfp_bf8", "bfp_bf4"])
+def test_matmul_rhs_as_param(lhs_outer, rhs_outer, inner, weight_dtype):
     dtype = torch.bfloat16
-    matmul = Matmul(inner, rhs_outer, dtype=dtype)
-    compiler_config = CompilerConfig(
-        experimental_weight_dtype=experimental_weight_dtype
-    )
+    matmul = Matmul(inner, rhs_outer, weight_dtype=weight_dtype, dtype=dtype)
+    compiler_config = CompilerConfig()
     comparison_config = ComparisonConfig()
-    if experimental_weight_dtype == "bfp4":
-        comparison_config.pcc = PccConfig(required_pcc=0.98)
+    comparison_config.pcc = PccConfig(required_pcc=0.98)
 
     run_op_test_with_random_inputs(
         matmul,
@@ -73,4 +77,54 @@ def test_matmul_mf_fp32_acc(math_fidelity, fp32_dest_acc_en):
         dtype=dtype,
         framework=Framework.TORCH,
         compiler_config=compiler_config,
+    )
+
+
+@pytest.mark.nightly
+@pytest.mark.dual_chip
+@pytest.mark.record_test_properties(category=Category.OP_TEST)
+@pytest.mark.parametrize(
+    "shard_spec",
+    [("model", None), (None, "model")],
+    ids=["shard_dim0", "shard_dim1"],
+)
+@pytest.mark.parametrize("weight_dtype", ["bfp_bf8", "bfp_bf4"])
+def test_matmul_weight_dtype_override_multi_chip(weight_dtype, shard_spec):
+    """
+    Matmul with weight_dtype_override and weight sharded across devices.
+
+    Tests two sharding axes:
+    - shard_dim0: weight sharded on contraction dim — forces all-gather on weight path
+    - shard_dim1: column-parallel, weight sharded on output dim
+
+    Verifies that weight_dtype_override annotations survive through CCL operations.
+    """
+    dtype = torch.bfloat16
+    inner_dim = 64
+    rhs_outer_dim = 64
+    lhs_outer_dim = 32
+
+    matmul = Matmul(inner_dim, rhs_outer_dim, weight_dtype, dtype)
+
+    def get_shard_spec(model, args, kwargs):
+        return {model.weight: shard_spec}
+
+    num_devices = xr.global_runtime_device_count()
+    mesh_shape = (1, num_devices)
+    device_ids = np.array(range(num_devices))
+    mesh = Mesh(device_ids, mesh_shape, ("batch", "model"))
+
+    activation = torch.randn(lhs_outer_dim, inner_dim, dtype=dtype)
+
+    comparison_config = ComparisonConfig()
+    if weight_dtype == "bfp_bf4":
+        comparison_config.pcc = PccConfig(required_pcc=0.98)
+
+    run_op_test(
+        matmul,
+        [activation],
+        comparison_config=comparison_config,
+        framework=Framework.TORCH,
+        mesh=mesh,
+        shard_spec_fn=get_shard_spec,
     )

--- a/tests/torch/test_weight_dtype.py
+++ b/tests/torch/test_weight_dtype.py
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import tempfile
+
+import pytest
+import torch
+import torch.nn as nn
+from torch.nn.utils import parametrize
+from tt_torch.weight_dtype import (
+    WeightDtypeParametrization,
+    apply_weight_dtype_overrides,
+    dump_weight_names,
+    remove_weight_dtype_overrides,
+)
+
+
+class SimpleModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear1 = nn.Linear(16, 32)
+        self.linear2 = nn.Linear(32, 8)
+
+    def forward(self, x):
+        return self.linear2(torch.relu(self.linear1(x)))
+
+
+class NestedModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.model = nn.ModuleDict(
+            {
+                "layers": nn.ModuleList(
+                    [
+                        nn.ModuleDict(
+                            {
+                                "mlp": nn.ModuleDict(
+                                    {
+                                        "fc1": nn.Linear(16, 32),
+                                        "fc2": nn.Linear(32, 16),
+                                    }
+                                ),
+                                "self_attn": nn.ModuleDict(
+                                    {
+                                        "q_proj": nn.Linear(16, 16),
+                                        "k_proj": nn.Linear(16, 16),
+                                    }
+                                ),
+                            }
+                        )
+                        for _ in range(2)
+                    ]
+                )
+            }
+        )
+
+    def forward(self, x):
+        for layer in self.model["layers"]:
+            x = layer["mlp"]["fc2"](torch.relu(layer["mlp"]["fc1"](x)))
+        return x
+
+
+@pytest.mark.push
+class TestWeightDtypeParametrization:
+
+    def test_forward(self):
+        linear = nn.Linear(4, 8)
+        x = torch.randn(2, 4)
+        parametrize.register_parametrization(
+            linear, "weight", WeightDtypeParametrization("bfp_bf4")
+        )
+        out = linear(x)
+        assert out.shape == (2, 8)
+
+
+@pytest.mark.push
+class TestApplyWeightDtypeOverrides:
+    def test_dict_config(self):
+        model = SimpleModel()
+        applied = apply_weight_dtype_overrides(
+            model, {"linear1.weight": "bfp_bf4", "linear2.weight": "bfp_bf8"}
+        )
+        assert len(applied) == 2
+        assert ("linear1.weight", "bfp_bf4") in applied
+        assert ("linear2.weight", "bfp_bf8") in applied
+        assert parametrize.is_parametrized(model.linear1, "weight")
+        assert parametrize.is_parametrized(model.linear2, "weight")
+
+    def test_glob_pattern(self):
+        model = NestedModel()
+        applied = apply_weight_dtype_overrides(
+            model, {"model.layers.*.mlp.*.weight": "bfp_bf4"}
+        )
+        # 2 layers x 2 MLP linears = 4
+        assert len(applied) == 4
+        assert all(dtype == "bfp_bf4" for _, dtype in applied)
+        # Attention layers should NOT be parametrized
+        assert not parametrize.is_parametrized(
+            model.model["layers"][0]["self_attn"]["q_proj"], "weight"
+        )
+
+    def test_default_with_overrides(self):
+        model = SimpleModel()
+        applied = apply_weight_dtype_overrides(
+            model, {"default": "bfp_bf8", "linear1.weight": "bfp_bf4"}
+        )
+        applied_dict = dict(applied)
+        assert applied_dict["linear1.weight"] == "bfp_bf4"
+        assert applied_dict["linear2.weight"] == "bfp_bf8"
+
+    def test_json_file(self):
+        model = SimpleModel()
+        config = {"linear1.weight": "bfp_bf4"}
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(config, f)
+            f.flush()
+            applied = apply_weight_dtype_overrides(model, f.name)
+        assert len(applied) == 1
+        assert ("linear1.weight", "bfp_bf4") in applied
+
+    def test_no_match_applies_nothing(self):
+        model = SimpleModel()
+        applied = apply_weight_dtype_overrides(
+            model, {"nonexistent.layer.weight": "bfp_bf4"}
+        )
+        assert len(applied) == 0
+
+
+@pytest.mark.push
+class TestRemoveWeightDtypeOverrides:
+    def test_remove(self):
+        model = SimpleModel()
+        apply_weight_dtype_overrides(
+            model, {"linear1.weight": "bfp_bf4", "linear2.weight": "bfp_bf8"}
+        )
+        count = remove_weight_dtype_overrides(model)
+        assert count == 2
+        assert not parametrize.is_parametrized(model.linear1)
+        assert not parametrize.is_parametrized(model.linear2)
+
+
+@pytest.mark.push
+class TestDumpWeightNames:
+    def test_simple_model(self):
+        model = SimpleModel()
+        result = dump_weight_names(model)
+        assert "linear1.weight" in result
+        assert "linear2.weight" in result
+        assert len(result) == 2
+        assert all(v == "bfp_bf8" for v in result.values())
+
+    def test_nested_model(self):
+        model = NestedModel()
+        result = dump_weight_names(model, default_dtype="bfp_bf4")
+        # 2 layers x (2 MLP + 2 attn) = 8 weight parameters
+        assert len(result) == 8
+        assert all(v == "bfp_bf4" for v in result.values())
+        assert "model.layers.0.mlp.fc1.weight" in result
+        assert "model.layers.1.self_attn.q_proj.weight" in result


### PR DESCRIPTION
This PR introduces per-tensor weight dtype overriding. We are now able to easily
- create  templated .json per-tensor overrides
- edit them manually
- apply them to the model automatically

### Ticket
Closes #2322. Closes #3659

### Problem description
As part of Mixed Precision effort, we needed per-tensor overrides for weight dtype.

### What's changed
Introduced a `tt::weight_dtype_override` custom op and Python API (`weight_dtype.py`) that enables per-tensor weight dtype control via torch parametrize.

Changes:
- New torch.ops.tt.weight_dtype_override custom op with fake/autograd support
- Added a new C++ frontend pass (`PopulateWeightDtypeFromCustomCall`) that extracts dtype annotations from StableHLO custom calls and propagates them as function argument attributes to be later consumed by tt-mlir.

Python API: 
- dump_weight_names - Generate a JSON template of all weight parameters in a model.
- apply_weight_dtype_overrides - Applies per-tensor weight dtype overrides (passed via .json/dict/string) to a model using torch.nn.utils.parametrize.
- remove_weight_dtype_overrides - Removes  WeightDtypeParametrization instances from a model, preserving any other parametrizations on the same parameters.

- `tt-gen-weight-template` CLI that generates a .JSON config template (using dump_weight_names) used as a starting point for fine-tuning per-tensor weight dtype overrides.
- Rename weight dtype values: bfp8 -> bfp_bf8, bfp4 -> bfp_bf4 across codebase. This aligns with tt-mlir and tt-metal block format notation.
- Auto-apply per-tensor overrides in LLM benchmarks and model test runner
- Multi-chip tests for matmul/linear with weight dtype override + CCL
- Add per-tensor mixed precision documentation to performance guide