### PR TITLE
Add support to print the model in the vLLM plugin.

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/worker.py
+++ b/integrations/vllm_plugin/vllm_tt/worker.py
@@ -320,6 +320,11 @@ class TTWorker:
     def get_model(self) -> nn.Module:
         return self.model_runner.get_model()
 
+    def get_model_inspection(self) -> str:
+        from vllm.model_inspection import format_model_inspection
+
+        return format_model_inspection(self.get_model())
+
     def get_supported_tasks(self) -> tuple[SupportedTask, ...]:
         return self.model_runner.get_supported_tasks()
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Add support to print the model in the vLLM plugin.

### What's changed
While running the multimodal model in the vLLM plugin, I encountered the following error:
```
loc("reshape.270"): error: Could not apply propagated tensor shardings to tensor dimensions
error: Could not update shapes based on their tensor sharding attributes
2026-03-26 05:42:53.517 ( 465.453s) [        64741300]      module_builder.cc:839    ERR| Failed to run stablehlo pipeline
```
To debug this, I attempted to print the model for slicing purposes, but encountered the following error
```
    print("llm: ", llm)
venv/lib/python3.12/site-packages/vllm/entrypoints/llm.py:1987: in __repr__
    results = self.llm_engine.collective_rpc("get_model_inspection")
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
venv/lib/python3.12/site-packages/vllm/v1/engine/llm_engine.py:414: in collective_rpc
    return self.engine_core.collective_rpc(method, timeout, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
venv/lib/python3.12/site-packages/vllm/v1/engine/core_client.py:814: in collective_rpc
    return self.call_utility("collective_rpc", method, timeout, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
venv/lib/python3.12/site-packages/vllm/v1/engine/core_client.py:753: in call_utility
    return future.result()
           ^^^^^^^^^^^^^^^
/usr/lib/python3.12/concurrent/futures/_base.py:456: in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
/usr/lib/python3.12/concurrent/futures/_base.py:401: in __get_result
    raise self._exception
E   Exception: Call to collective_rpc method failed: Method 'get_model_inspection' is not implemented
```

I introduced a get_model_inspection function to print the model. Following this fix, the model prints successfully and the function is highly useful for debugging.

logs:
[vllm_error.log](https://github.com/user-attachments/files/26296568/vllm3.log)
[vllm4.log](https://github.com/user-attachments/files/26296570/vllm4.log)


### Checklist
- [ ] New/Existing tests provide coverage for changes
