### PR TITLE
Extend accuracy testing to all TP LLM benchmarks on llmbox and galaxy

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -427,6 +427,120 @@
         "accuracy-testing": true
       },
       {
+        "name": "falcon3_7b_tp_accuracy",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
+        "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b_tp",
+        "runs-on": "n300-llmbox",
+        "accuracy-testing": true
+      },
+      {
+        "name": "falcon3_10b_tp_accuracy",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
+        "pytest": "tests/benchmark/test_llms.py::test_falcon3_10b_tp",
+        "runs-on": "n300-llmbox",
+        "accuracy-testing": true
+      },
+      {
+        "name": "llama_3_1_8b_instruct_tp_accuracy",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
+        "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b_instruct_tp",
+        "runs-on": "n300-llmbox",
+        "accuracy-testing": true,
+        "batch-size": 16
+      },
+      {
+        "name": "ministral_8b_tp_accuracy",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
+        "pytest": "tests/benchmark/test_llms.py::test_ministral_8b_tp",
+        "runs-on": "n300-llmbox",
+        "accuracy-testing": true
+      },
+      {
+        "name": "mistral_nemo_instruct_2407_tp_accuracy",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
+        "pytest": "tests/benchmark/test_llms.py::test_mistral_nemo_instruct_2407_tp",
+        "runs-on": "n300-llmbox",
+        "accuracy-testing": true
+      },
+      {
+        "name": "mistral_small_24b_instruct_2501_tp_accuracy",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
+        "pytest": "tests/benchmark/test_llms.py::test_mistral_small_24b_instruct_2501_tp",
+        "runs-on": "n300-llmbox",
+        "accuracy-testing": true
+      },
+      {
+        "name": "qwen_2_5_14b_instruct_tp_accuracy",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
+        "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_14b_instruct_tp",
+        "runs-on": "n300-llmbox",
+        "accuracy-testing": true
+      },
+      {
+        "name": "qwen_2_5_coder_32b_instruct_tp_accuracy",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
+        "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_coder_32b_instruct_tp",
+        "runs-on": "n300-llmbox",
+        "accuracy-testing": true
+      },
+      {
+        "name": "qwen_3_8b_tp_accuracy",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
+        "pytest": "tests/benchmark/test_llms.py::test_qwen_3_8b_tp",
+        "runs-on": "n300-llmbox",
+        "accuracy-testing": true
+      },
+      {
+        "name": "qwen_3_14b_tp_accuracy",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
+        "pytest": "tests/benchmark/test_llms.py::test_qwen_3_14b_tp",
+        "runs-on": "n300-llmbox",
+        "accuracy-testing": true
+      },
+      {
+        "name": "qwen_3_32b_tp_accuracy",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
+        "pytest": "tests/benchmark/test_llms.py::test_qwen_3_32b_tp",
+        "runs-on": "n300-llmbox",
+        "accuracy-testing": true
+      },
+      {
+        "name": "llama_3_1_70b_tp_accuracy",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
+        "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp",
+        "runs-on": "n300-llmbox",
+        "accuracy-testing": true,
+        "batch-size": 16
+      },
+      {
+        "name": "gpt_oss_20b_tp_accuracy",
+        "pyreq": "datasets loguru pytest requests accelerate torch==2.9.0 tqdm transformers==4.57.1",
+        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp",
+        "runs-on": "n300-llmbox",
+        "accuracy-testing": true
+      },
+      {
+        "name": "llama_3_1_70b_tp_galaxy_accuracy",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
+        "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp_galaxy",
+        "runs-on": "galaxy-wh-6u",
+        "accuracy-testing": true
+      },
+      {
+        "name": "gpt_oss_20b_tp_galaxy_accuracy",
+        "pyreq": "datasets loguru pytest requests accelerate torch==2.9.0 tqdm transformers==4.57.1",
+        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_galaxy_batch_size_64",
+        "runs-on": "galaxy-wh-6u",
+        "accuracy-testing": true
+      },
+      {
+        "name": "gpt_oss_120b_tp_galaxy_accuracy",
+        "pyreq": "datasets loguru pytest requests accelerate torch==2.9.0 tqdm transformers==4.57.1",
+        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_120b_tp_galaxy_batch_size_64",
+        "runs-on": "galaxy-wh-6u",
+        "accuracy-testing": true
+      },
+      {
         "name": "vllm_llama_3_2_3b",
         "pyreq": "loguru pytest torch==2.9.1 transformers==4.57.6 vllm==0.16.0",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[llama-3.2-3b]",

--- a/.github/workflows/schedule-benchmark-experimental.yml
+++ b/.github/workflows/schedule-benchmark-experimental.yml
@@ -44,10 +44,30 @@ jobs:
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
       sh-runner: true
 
+  run-llmbox-accuracy-benchmarks:
+    needs: [build-image, build-ttxla]
+    secrets: inherit
+    uses: ./.github/workflows/call-filtered-perf-tests.yml
+    with:
+      adv_filter: '[ {"runs-on": "n300-llmbox", "accuracy-testing": true} ]'
+      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
+      artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
+
+  run-galaxy-accuracy-benchmarks:
+    needs: [build-image, build-ttxla]
+    secrets: inherit
+    uses: ./.github/workflows/call-filtered-perf-tests.yml
+    with:
+      adv_filter: '[ {"runs-on": "galaxy-wh-6u", "accuracy-testing": true} ]'
+      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
+      artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
+
   fail-notify:
     needs:
       - run-p150-perf-benchmarks
       - run-n150-accuracy-benchmarks
+      - run-llmbox-accuracy-benchmarks
+      - run-galaxy-accuracy-benchmarks
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -760,7 +760,9 @@ def test_llama_3_1_8b(
     )
 
 
-def test_falcon3_7b_tp(output_file, num_layers, request, max_output_tokens):
+def test_falcon3_7b_tp(
+    output_file, num_layers, request, accuracy_testing, batch_size, max_output_tokens
+):
     from third_party.tt_forge_models.falcon.pytorch.loader import (
         ModelLoader,
         ModelVariant,
@@ -773,11 +775,15 @@ def test_falcon3_7b_tp(output_file, num_layers, request, max_output_tokens):
         output_file,
         num_layers=num_layers,
         request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
         max_output_tokens=max_output_tokens,
     )
 
 
-def test_falcon3_10b_tp(output_file, num_layers, request, max_output_tokens):
+def test_falcon3_10b_tp(
+    output_file, num_layers, request, accuracy_testing, batch_size, max_output_tokens
+):
     from third_party.tt_forge_models.falcon.pytorch.loader import (
         ModelLoader,
         ModelVariant,
@@ -790,11 +796,15 @@ def test_falcon3_10b_tp(output_file, num_layers, request, max_output_tokens):
         output_file,
         num_layers=num_layers,
         request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
         max_output_tokens=max_output_tokens,
     )
 
 
-def test_llama_3_1_8b_instruct_tp(output_file, num_layers, request, max_output_tokens):
+def test_llama_3_1_8b_instruct_tp(
+    output_file, num_layers, request, accuracy_testing, batch_size, max_output_tokens
+):
     from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
         ModelLoader,
         ModelVariant,
@@ -807,11 +817,15 @@ def test_llama_3_1_8b_instruct_tp(output_file, num_layers, request, max_output_t
         output_file,
         num_layers=num_layers,
         request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
         max_output_tokens=max_output_tokens,
     )
 
 
-def test_mistral_7b_tp(output_file, num_layers, request, max_output_tokens):
+def test_mistral_7b_tp(
+    output_file, num_layers, request, accuracy_testing, batch_size, max_output_tokens
+):
     from third_party.tt_forge_models.mistral.pytorch.loader import (
         ModelLoader,
         ModelVariant,
@@ -824,11 +838,15 @@ def test_mistral_7b_tp(output_file, num_layers, request, max_output_tokens):
         output_file,
         num_layers=num_layers,
         request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
         max_output_tokens=max_output_tokens,
     )
 
 
-def test_ministral_8b_tp(output_file, num_layers, request, max_output_tokens):
+def test_ministral_8b_tp(
+    output_file, num_layers, request, accuracy_testing, batch_size, max_output_tokens
+):
     from third_party.tt_forge_models.mistral.pytorch.loader import (
         ModelLoader,
         ModelVariant,
@@ -841,12 +859,14 @@ def test_ministral_8b_tp(output_file, num_layers, request, max_output_tokens):
         output_file,
         num_layers=num_layers,
         request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
         max_output_tokens=max_output_tokens,
     )
 
 
 def test_mistral_nemo_instruct_2407_tp(
-    output_file, num_layers, request, max_output_tokens
+    output_file, num_layers, request, accuracy_testing, batch_size, max_output_tokens
 ):
     from third_party.tt_forge_models.mistral.pytorch.loader import (
         ModelLoader,
@@ -860,12 +880,14 @@ def test_mistral_nemo_instruct_2407_tp(
         output_file,
         num_layers=num_layers,
         request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
         max_output_tokens=max_output_tokens,
     )
 
 
 def test_mistral_small_24b_instruct_2501_tp(
-    output_file, num_layers, request, max_output_tokens
+    output_file, num_layers, request, accuracy_testing, batch_size, max_output_tokens
 ):
     from third_party.tt_forge_models.mistral.pytorch.loader import (
         ModelLoader,
@@ -879,11 +901,15 @@ def test_mistral_small_24b_instruct_2501_tp(
         output_file,
         num_layers=num_layers,
         request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
         max_output_tokens=max_output_tokens,
     )
 
 
-def test_qwen_2_5_14b_instruct_tp(output_file, num_layers, request, max_output_tokens):
+def test_qwen_2_5_14b_instruct_tp(
+    output_file, num_layers, request, accuracy_testing, batch_size, max_output_tokens
+):
     from third_party.tt_forge_models.qwen_2_5.causal_lm.pytorch.loader import (
         ModelLoader,
         ModelVariant,
@@ -896,11 +922,15 @@ def test_qwen_2_5_14b_instruct_tp(output_file, num_layers, request, max_output_t
         output_file,
         num_layers=num_layers,
         request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
         max_output_tokens=max_output_tokens,
     )
 
 
-def test_qwen_2_5_32b_instruct_tp(output_file, num_layers, request, max_output_tokens):
+def test_qwen_2_5_32b_instruct_tp(
+    output_file, num_layers, request, accuracy_testing, batch_size, max_output_tokens
+):
     from third_party.tt_forge_models.qwen_2_5.causal_lm.pytorch.loader import (
         ModelLoader,
         ModelVariant,
@@ -913,12 +943,14 @@ def test_qwen_2_5_32b_instruct_tp(output_file, num_layers, request, max_output_t
         output_file,
         num_layers=num_layers,
         request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
         max_output_tokens=max_output_tokens,
     )
 
 
 def test_qwen_2_5_coder_32b_instruct_tp(
-    output_file, num_layers, request, max_output_tokens
+    output_file, num_layers, request, accuracy_testing, batch_size, max_output_tokens
 ):
     from third_party.tt_forge_models.qwen_2_5_coder.pytorch.loader import (
         ModelLoader,
@@ -932,11 +964,15 @@ def test_qwen_2_5_coder_32b_instruct_tp(
         output_file,
         num_layers=num_layers,
         request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
         max_output_tokens=max_output_tokens,
     )
 
 
-def test_qwen_3_0_6b_tp(output_file, num_layers, request, max_output_tokens):
+def test_qwen_3_0_6b_tp(
+    output_file, num_layers, request, accuracy_testing, batch_size, max_output_tokens
+):
     from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import (
         ModelLoader,
         ModelVariant,
@@ -949,11 +985,15 @@ def test_qwen_3_0_6b_tp(output_file, num_layers, request, max_output_tokens):
         output_file,
         num_layers=num_layers,
         request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
         max_output_tokens=max_output_tokens,
     )
 
 
-def test_qwen_3_1_7b_tp(output_file, num_layers, request, max_output_tokens):
+def test_qwen_3_1_7b_tp(
+    output_file, num_layers, request, accuracy_testing, batch_size, max_output_tokens
+):
     from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import (
         ModelLoader,
         ModelVariant,
@@ -966,11 +1006,15 @@ def test_qwen_3_1_7b_tp(output_file, num_layers, request, max_output_tokens):
         output_file,
         num_layers=num_layers,
         request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
         max_output_tokens=max_output_tokens,
     )
 
 
-def test_qwen_3_8b_tp(output_file, num_layers, request, max_output_tokens):
+def test_qwen_3_8b_tp(
+    output_file, num_layers, request, accuracy_testing, batch_size, max_output_tokens
+):
     from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import (
         ModelLoader,
         ModelVariant,
@@ -983,11 +1027,15 @@ def test_qwen_3_8b_tp(output_file, num_layers, request, max_output_tokens):
         output_file,
         num_layers=num_layers,
         request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
         max_output_tokens=max_output_tokens,
     )
 
 
-def test_qwen_3_14b_tp(output_file, num_layers, request, max_output_tokens):
+def test_qwen_3_14b_tp(
+    output_file, num_layers, request, accuracy_testing, batch_size, max_output_tokens
+):
     from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import (
         ModelLoader,
         ModelVariant,
@@ -1000,11 +1048,15 @@ def test_qwen_3_14b_tp(output_file, num_layers, request, max_output_tokens):
         output_file,
         num_layers=num_layers,
         request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
         max_output_tokens=max_output_tokens,
     )
 
 
-def test_qwen_3_32b_tp(output_file, num_layers, request, max_output_tokens):
+def test_qwen_3_32b_tp(
+    output_file, num_layers, request, accuracy_testing, batch_size, max_output_tokens
+):
     from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import (
         ModelLoader,
         ModelVariant,
@@ -1017,11 +1069,15 @@ def test_qwen_3_32b_tp(output_file, num_layers, request, max_output_tokens):
         output_file,
         num_layers=num_layers,
         request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
         max_output_tokens=max_output_tokens,
     )
 
 
-def test_llama_3_8b_instruct_tp(output_file, num_layers, request, max_output_tokens):
+def test_llama_3_8b_instruct_tp(
+    output_file, num_layers, request, accuracy_testing, batch_size, max_output_tokens
+):
     from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
         ModelLoader,
         ModelVariant,
@@ -1034,11 +1090,15 @@ def test_llama_3_8b_instruct_tp(output_file, num_layers, request, max_output_tok
         output_file,
         num_layers=num_layers,
         request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
         max_output_tokens=max_output_tokens,
     )
 
 
-def test_llama_3_1_8b_tp(output_file, num_layers, request, max_output_tokens):
+def test_llama_3_1_8b_tp(
+    output_file, num_layers, request, accuracy_testing, batch_size, max_output_tokens
+):
     from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
         ModelLoader,
         ModelVariant,
@@ -1051,11 +1111,15 @@ def test_llama_3_1_8b_tp(output_file, num_layers, request, max_output_tokens):
         output_file,
         num_layers=num_layers,
         request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
         max_output_tokens=max_output_tokens,
     )
 
 
-def test_llama_3_8b_tp(output_file, num_layers, request, max_output_tokens):
+def test_llama_3_8b_tp(
+    output_file, num_layers, request, accuracy_testing, batch_size, max_output_tokens
+):
     from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
         ModelLoader,
         ModelVariant,
@@ -1068,11 +1132,15 @@ def test_llama_3_8b_tp(output_file, num_layers, request, max_output_tokens):
         output_file,
         num_layers=num_layers,
         request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
         max_output_tokens=max_output_tokens,
     )
 
 
-def test_llama_3_1_70b_tp(output_file, num_layers, request, max_output_tokens):
+def test_llama_3_1_70b_tp(
+    output_file, num_layers, request, accuracy_testing, batch_size, max_output_tokens
+):
     from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
         ModelLoader,
         ModelVariant,
@@ -1085,6 +1153,8 @@ def test_llama_3_1_70b_tp(output_file, num_layers, request, max_output_tokens):
         output_file,
         num_layers=num_layers,
         request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
         max_output_tokens=max_output_tokens,
     )
 
@@ -1110,27 +1180,8 @@ def _gpt_oss_20b_shard_spec_fn(model_loader, model):
     return shard_specs
 
 
-def test_gpt_oss_20b_tp(output_file, num_layers, request, max_output_tokens):
-    from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
-        ModelLoader,
-        ModelVariant,
-    )
-
-    variant = ModelVariant.GPT_OSS_20B
-    test_llm_tp(
-        ModelLoader,
-        variant,
-        output_file,
-        num_layers=num_layers,
-        request=request,
-        max_output_tokens=max_output_tokens,
-        mesh_config_fn=_gpt_oss_20b_mesh_config_fn,
-        shard_spec_fn=_gpt_oss_20b_shard_spec_fn,
-    )
-
-
-def test_gpt_oss_20b_tp_batch_size_1(
-    output_file, num_layers, request, max_output_tokens
+def test_gpt_oss_20b_tp(
+    output_file, num_layers, request, accuracy_testing, batch_size, max_output_tokens
 ):
     from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
         ModelLoader,
@@ -1144,14 +1195,40 @@ def test_gpt_oss_20b_tp_batch_size_1(
         output_file,
         num_layers=num_layers,
         request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         mesh_config_fn=_gpt_oss_20b_mesh_config_fn,
         shard_spec_fn=_gpt_oss_20b_shard_spec_fn,
-        batch_size=1,
     )
 
 
-def test_llama_3_1_70b_tp_galaxy(output_file, num_layers, request):
+def test_gpt_oss_20b_tp_batch_size_1(
+    output_file, num_layers, request, accuracy_testing, batch_size, max_output_tokens
+):
+    from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
+        ModelLoader,
+        ModelVariant,
+    )
+
+    variant = ModelVariant.GPT_OSS_20B
+    test_llm_tp(
+        ModelLoader,
+        variant,
+        output_file,
+        num_layers=num_layers,
+        request=request,
+        accuracy_testing=accuracy_testing,
+        max_output_tokens=max_output_tokens,
+        mesh_config_fn=_gpt_oss_20b_mesh_config_fn,
+        shard_spec_fn=_gpt_oss_20b_shard_spec_fn,
+        batch_size=batch_size if batch_size is not None else 1,
+    )
+
+
+def test_llama_3_1_70b_tp_galaxy(
+    output_file, num_layers, request, accuracy_testing, batch_size, max_output_tokens
+):
     from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
         ModelLoader,
         ModelVariant,
@@ -1164,12 +1241,15 @@ def test_llama_3_1_70b_tp_galaxy(output_file, num_layers, request):
         output_file,
         num_layers=num_layers,
         request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
+        max_output_tokens=max_output_tokens,
         arch="wormhole_galaxy",
     )
 
 
 def test_gpt_oss_20b_tp_galaxy_batch_size_64(
-    output_file, num_layers, request, max_output_tokens
+    output_file, num_layers, request, accuracy_testing, batch_size, max_output_tokens
 ):
     from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
         ModelLoader,
@@ -1183,15 +1263,18 @@ def test_gpt_oss_20b_tp_galaxy_batch_size_64(
         output_file,
         num_layers=num_layers,
         request=request,
+        accuracy_testing=accuracy_testing,
         max_output_tokens=max_output_tokens,
-        batch_size=64,  # 128 fails to compile - https://github.com/tenstorrent/tt-xla/issues/3907
+        batch_size=(
+            batch_size if batch_size is not None else 64
+        ),  # 128 fails to compile - https://github.com/tenstorrent/tt-xla/issues/3907
         arch="wormhole_galaxy",
         optimization_level=1,
     )
 
 
 def test_gpt_oss_120b_tp_galaxy_batch_size_64(
-    output_file, num_layers, request, max_output_tokens
+    output_file, num_layers, request, accuracy_testing, batch_size, max_output_tokens
 ):
     from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
         ModelLoader,
@@ -1205,8 +1288,11 @@ def test_gpt_oss_120b_tp_galaxy_batch_size_64(
         output_file,
         num_layers=num_layers,
         request=request,
+        accuracy_testing=accuracy_testing,
         max_output_tokens=max_output_tokens,
-        batch_size=64,  # 128 fails to compile - https://github.com/tenstorrent/tt-xla/issues/3907
+        batch_size=(
+            batch_size if batch_size is not None else 64
+        ),  # 128 fails to compile - https://github.com/tenstorrent/tt-xla/issues/3907
         arch="wormhole_galaxy",
         optimization_level=1,
     )


### PR DESCRIPTION
### Ticket
Closes #3657

### Problem description
We needed support for Accuracy testing of bigger models, the same way we supported n150 models in [PR](https://github.com/tenstorrent/tt-xla/pull/3461).

### What's changed
Add accuracy_testing and batch_size fixture params to all TP test functions in test_llms.py, add 16 accuracy matrix entries (13 for n300-llmbox, 3 for galaxy-wh-6u), and add corresponding CI jobs in the experimental benchmark workflow.