### PR TITLE
Add missing workflow permissions

### DIFF
--- a/.github/workflows/manual-update-durations.yml
+++ b/.github/workflows/manual-update-durations.yml
@@ -8,39 +8,103 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  id-token: write
+  packages: write
+  checks: write
 
 jobs:
-  find-tag:
+  update_test_durations:
     runs-on: ubuntu-latest
-    outputs:
-      tag_name: ${{ steps.find.outputs.tag_name }}
     steps:
-      - name: Find latest nightly release tag
-        id: find
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          # ref: main
+      - uses: actions/setup-python@v6
+      - name: Process test durations from latest workflows
+        id: get-test-durations
         env:
-          GH_TOKEN: ${{ secrets.TT_FORGE_RELEASER }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
-          gh api rate_limit
-          TAG=$(gh release list -R tenstorrent/tt-xla --limit 20 --json tagName \
-            | jq -r '[.[] | select(.tagName | test("^[0-9]+\\.[0-9]+\\.[0-9]+\\.dev[0-9]+$"))] | .[0].tagName')
-          echo "tag_name=$TAG" >> $GITHUB_OUTPUT
+          repo="tenstorrent/tt-xla"
 
-  update-release-notes-tt-xla:
-    needs: find-tag
-    uses: ./.github/workflows/manual-update-release-notes.yml
-    secrets: inherit
-    with:
-      tag_name: ${{ needs.find-tag.outputs.tag_name }}
-      is_nightly: true
-      target_repo: tenstorrent/tt-xla
+          get_test_results_from_wf() {
+            local wf_name="$1"
+            local conclusions="$2"
+            local num=5
 
-  update-release-notes-tt-forge:
-    needs: find-tag
-    uses: ./.github/workflows/manual-update-release-notes.yml
-    secrets: inherit
-    with:
-      tag_name: ${{ needs.find-tag.outputs.tag_name }}
-      is_nightly: true
-      target_repo: tenstorrent/tt-forge
+            # get json of the last $num workflow runs
+            gh run list --workflow $wf_name -R $repo -b main -L $num --status completed --json attempt,conclusion,databaseId >runs.json
+
+            counter=0
+            while true; do
+              # Check the status of 'conclusion'
+              conclusion=$(jq -r ".[$counter].conclusion" runs.json)
+
+              if echo "$conclusions" | grep -q -w "$conclusion"; then
+                break
+              else
+                ((++counter))
+
+                # Exit if the counter reaches $num
+                if [ $counter -ge $num ]; then
+                  echo "ERROR: Did not found good workflow within last $num. Exiting."
+                  exit 1
+                fi
+              fi
+            done
+            curr_wf_id=$(jq -r ".[$counter].databaseId" runs.json)
+            curr_wf_att=$(jq -r ".[$counter].attempt" runs.json)
+            echo "curr_$3_wf_link=\"https://github.com/$repo/actions/runs/$curr_wf_id/attempts/$curr_wf_att\"" >> "$GITHUB_OUTPUT"
+            rm -f runs.json
+
+            gh run download $curr_wf_id --pattern "test-reports-*" -R $repo -D ${{runner.temp}}/reports
+          }
+
+          # get test results from the last nightly that was success or failure
+          get_test_results_from_wf "schedule-nightly.yml" "success,failure" "nightly"
+
+          # get test results from the last successful push
+          get_test_results_from_wf "push-main.yml" "success" "push"
+
+          # get test results from the last weekly that was success or failure
+          get_test_results_from_wf "schedule-weekly.yml" "success,failure" "weekly"
+
+          # get test results from the last weekly training that was success or failure
+          get_test_results_from_wf "schedule-weekly-training.yml" "success,failure" "weekly-training"
+
+          python .github/scripts/get_test_duration_from_junit_xmls.py ${{runner.temp}}/reports .test_durations
+          echo "" >> .test_durations
+          echo "----- NEW DURATIONS"
+          cat .test_durations
+
+          echo "TODAY=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        id: create-pr
+        with:
+          branch: test-durations-update
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
+          base: main
+          commit-message: "Update test durations based on latest workflows ${{ steps.get-test-durations.outputs.TODAY }}"
+          title: "Update test durations based on latest workflows ${{ steps.get-test-durations.outputs.TODAY }}"
+          body: "This PR updates test durations based on latest nightly (${{ steps.get-test-durations.outputs.curr_nightly_wf_link }}), latest weekly (${{ steps.get-test-durations.outputs.curr_weekly_wf_link }}), latest weekly training (${{ steps.get-test-durations.outputs.curr_weekly_training_wf_link }}) and latest push (${{ steps.get-test-durations.outputs.curr_push_wf_link }})"
+          labels: tooling
+          delete-branch: true
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Enable Pull Request Automerge
+        if: ${{ steps.create-pr.outputs.pull-request-number }}
+        run: gh pr merge --squash --auto "${{ steps.create-pr.outputs.pull-request-number }}"
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      - name: Generate Summary
+        run: |
+          echo "## Test duration report" >> $GITHUB_STEP_SUMMARY
+          echo "Used [Nightly](${{ steps.get-test-durations.outputs.curr_nightly_wf_link }})" >> $GITHUB_STEP_SUMMARY
+          echo "And [Push](${{ steps.get-test-durations.outputs.curr_push_wf_link }})" >> $GITHUB_STEP_SUMMARY
+          echo "And [Weekly](${{ steps.get-test-durations.outputs.curr_weekly_wf_link }})" >> $GITHUB_STEP_SUMMARY
+          echo "And [Weekly Training](${{ steps.get-test-durations.outputs.curr_weekly_training_wf_link }})" >> $GITHUB_STEP_SUMMARY
+          echo "Generated test durations in [Pull Request](${{ steps.create-pr.outputs.pull-request-url }})" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
### Ticket
/

### Problem description
Workflow `schedule-nightly-update-release-notes` calls `manual-update-release-notes.yml` but it is missing `contents:write` and `id-token: write` permissions which the callee requires.

### What's changed
Add missing permissions.

### Checklist
- [ ] New/Existing tests provide coverage for changes
