### PR TITLE
Disabling groupnorm composite

### DIFF
--- a/python_package/tt_torch/composite_ops.py
+++ b/python_package/tt_torch/composite_ops.py
@@ -291,8 +291,10 @@ replacements = {
     torch.rms_norm: composite_rms_norm,
     torch.nn.functional.rms_norm: composite_rms_norm,
     torch.nn.functional.layer_norm: composite_layer_norm,
-    torch.nn.functional.group_norm: composite_group_norm,
+    # TODO: uncomment once https://github.com/tenstorrent/tt-metal/issues/40916 is fixed
+    # torch.nn.functional.group_norm: composite_group_norm,
     # module replacements
     torch.nn.LayerNorm: replace_layer_norm_module,
-    torch.nn.GroupNorm: replace_group_norm_module,
+    # TODO: uncomment once https://github.com/tenstorrent/tt-metal/issues/40916 is fixed
+    # torch.nn.GroupNorm: replace_group_norm_module,
 }

--- a/tests/torch/ops/test_composite_ops.py
+++ b/tests/torch/ops/test_composite_ops.py
@@ -290,116 +290,118 @@ def test_composite_layer_norm(use_weight, use_bias, batch_size, seq_len, embeddi
         )
 
 
-@pytest.mark.single_device
-@pytest.mark.parametrize("affine", [True, False])
-@pytest.mark.parametrize(
-    "batch_size, num_channels, height, width, num_groups",
-    [(1, 32, 8, 8, 8), (1, 64, 16, 16, 16), (1, 128, 32, 32, 32)],
-)
-def test_patched_group_norm_module(
-    affine, batch_size, num_channels, height, width, num_groups
-):
-    class GroupNormModel(torch.nn.Module):
-        def __init__(self, num_groups, num_channels):
-            super().__init__()
-            self.gn = nn.GroupNorm(num_groups, num_channels, affine=affine)
+# TODO: uncomment once https://github.com/tenstorrent/tt-metal/issues/40916 is fixed
+# @pytest.mark.single_device
+# @pytest.mark.parametrize("affine", [True, False])
+# @pytest.mark.parametrize(
+#     "batch_size, num_channels, height, width, num_groups",
+#     [(1, 32, 8, 8, 8), (1, 64, 16, 16, 16), (1, 128, 32, 32, 32)],
+# )
+# def test_patched_group_norm_module(
+#     affine, batch_size, num_channels, height, width, num_groups
+# ):
+#     class GroupNormModel(torch.nn.Module):
+#         def __init__(self, num_groups, num_channels):
+#             super().__init__()
+#             self.gn = nn.GroupNorm(num_groups, num_channels, affine=affine)
 
-        def forward(self, x):
-            return self.gn(x)
+#         def forward(self, x):
+#             return self.gn(x)
 
-    options = {"tt_enable_composite_ops": True}
+#     options = {"tt_enable_composite_ops": True}
 
-    input_tensor = torch.randn(
-        batch_size, num_channels, height, width, dtype=torch.bfloat16
-    )
+#     input_tensor = torch.randn(
+#         batch_size, num_channels, height, width, dtype=torch.bfloat16
+#     )
 
-    model = GroupNormModel(num_groups, num_channels)
+#     model = GroupNormModel(num_groups, num_channels)
 
-    run_graph_test(
-        model,
-        [input_tensor],
-        comparison_config=ComparisonConfig(),
-        framework=Framework.TORCH,
-        torch_options=options,
-    )
+#     run_graph_test(
+#         model,
+#         [input_tensor],
+#         comparison_config=ComparisonConfig(),
+#         framework=Framework.TORCH,
+#         torch_options=options,
+#     )
+
+# TODO: uncomment once https://github.com/tenstorrent/tt-metal/issues/40916 is fixed
+# @pytest.mark.single_device
+# @pytest.mark.parametrize(
+#     "use_weight, use_bias", [(True, True), (True, False), (False, False)]
+# )
+# @pytest.mark.parametrize(
+#     "batch_size, num_channels, height, width, num_groups",
+#     [(1, 32, 8, 8, 8), (1, 64, 16, 16, 16), (1, 128, 32, 32, 32)],
+# )
+# def test_patched_group_norm_functional(
+#     use_weight, use_bias, batch_size, num_channels, height, width, num_groups
+# ):
+
+#     class GroupNormModel(torch.nn.Module):
+#         def __init__(self, num_groups):
+#             super().__init__()
+#             self.num_groups = num_groups
+
+#         def forward(self, x, weight=None, bias=None):
+#             return F.group_norm(x, self.num_groups, weight, bias, eps=1e-5)
+
+#     options = {"tt_enable_composite_ops": True}
+
+#     input_tensor = torch.randn(
+#         batch_size, num_channels, height, width, dtype=torch.bfloat16
+#     )
+#     weight = torch.randn(num_channels, dtype=torch.bfloat16) if use_weight else None
+#     bias = torch.randn(num_channels, dtype=torch.bfloat16) if use_bias else None
+
+#     model = GroupNormModel(num_groups)
+
+#     run_graph_test(
+#         model,
+#         [input_tensor, weight, bias],
+#         comparison_config=ComparisonConfig(),
+#         framework=Framework.TORCH,
+#         torch_options=options,
+#     )
 
 
-@pytest.mark.single_device
-@pytest.mark.parametrize(
-    "use_weight, use_bias", [(True, True), (True, False), (False, False)]
-)
-@pytest.mark.parametrize(
-    "batch_size, num_channels, height, width, num_groups",
-    [(1, 32, 8, 8, 8), (1, 64, 16, 16, 16), (1, 128, 32, 32, 32)],
-)
-def test_patched_group_norm_functional(
-    use_weight, use_bias, batch_size, num_channels, height, width, num_groups
-):
+# TODO: uncomment once https://github.com/tenstorrent/tt-metal/issues/40916 is fixed
+# @pytest.mark.single_device
+# @pytest.mark.parametrize(
+#     "use_weight, use_bias", [(True, True), (True, False), (False, False)]
+# )
+# @pytest.mark.parametrize(
+#     "batch_size, num_channels, height, width, num_groups",
+#     [(1, 32, 8, 8, 8), (1, 64, 16, 16, 16), (1, 128, 32, 32, 32)],
+# )
+# def test_composite_group_norm(
+#     use_weight, use_bias, batch_size, num_channels, height, width, num_groups
+# ):
 
-    class GroupNormModel(torch.nn.Module):
-        def __init__(self, num_groups):
-            super().__init__()
-            self.num_groups = num_groups
+#     class GroupNormModel(torch.nn.Module):
+#         def __init__(self, num_groups):
+#             super().__init__()
+#             self.num_groups = num_groups
 
-        def forward(self, x, weight=None, bias=None):
-            return F.group_norm(x, self.num_groups, weight, bias, eps=1e-5)
+#         def forward(self, x, weight=None, bias=None):
+#             return composite_group_norm(x, self.num_groups, weight, bias, eps=1e-5)
 
-    options = {"tt_enable_composite_ops": True}
+#     options = {"tt_enable_composite_ops": False}
 
-    input_tensor = torch.randn(
-        batch_size, num_channels, height, width, dtype=torch.bfloat16
-    )
-    weight = torch.randn(num_channels, dtype=torch.bfloat16) if use_weight else None
-    bias = torch.randn(num_channels, dtype=torch.bfloat16) if use_bias else None
+#     input_tensor = torch.randn(
+#         batch_size, num_channels, height, width, dtype=torch.bfloat16
+#     )
+#     weight = torch.randn(num_channels, dtype=torch.bfloat16) if use_weight else None
+#     bias = torch.randn(num_channels, dtype=torch.bfloat16) if use_bias else None
 
-    model = GroupNormModel(num_groups)
+#     model = GroupNormModel(num_groups)
 
-    run_graph_test(
-        model,
-        [input_tensor, weight, bias],
-        comparison_config=ComparisonConfig(),
-        framework=Framework.TORCH,
-        torch_options=options,
-    )
-
-
-@pytest.mark.single_device
-@pytest.mark.parametrize(
-    "use_weight, use_bias", [(True, True), (True, False), (False, False)]
-)
-@pytest.mark.parametrize(
-    "batch_size, num_channels, height, width, num_groups",
-    [(1, 32, 8, 8, 8), (1, 64, 16, 16, 16), (1, 128, 32, 32, 32)],
-)
-def test_composite_group_norm(
-    use_weight, use_bias, batch_size, num_channels, height, width, num_groups
-):
-
-    class GroupNormModel(torch.nn.Module):
-        def __init__(self, num_groups):
-            super().__init__()
-            self.num_groups = num_groups
-
-        def forward(self, x, weight=None, bias=None):
-            return composite_group_norm(x, self.num_groups, weight, bias, eps=1e-5)
-
-    options = {"tt_enable_composite_ops": False}
-
-    input_tensor = torch.randn(
-        batch_size, num_channels, height, width, dtype=torch.bfloat16
-    )
-    weight = torch.randn(num_channels, dtype=torch.bfloat16) if use_weight else None
-    bias = torch.randn(num_channels, dtype=torch.bfloat16) if use_bias else None
-
-    model = GroupNormModel(num_groups)
-
-    # Disable inplace buffers for inductor compilation
-    # so that we can compare the results with the golden model.
-    with torch._inductor.config.patch({"inplace_buffers": False}):
-        run_graph_test(
-            model,
-            [input_tensor, weight, bias],
-            comparison_config=ComparisonConfig(),
-            framework=Framework.TORCH,
-            torch_options=options,
-        )
+#     # Disable inplace buffers for inductor compilation
+#     # so that we can compare the results with the golden model.
+#     with torch._inductor.config.patch({"inplace_buffers": False}):
+#         run_graph_test(
+#             model,
+#             [input_tensor, weight, bias],
+#             comparison_config=ComparisonConfig(),
+#             framework=Framework.TORCH,
+#             torch_options=options,
+#         )


### PR DESCRIPTION
### Problem description
Introducing group norm composite op in [this PR](https://github.com/tenstorrent/tt-xla/commit/91d3e3b49d93b4221ecbbf1ba57d1a0d40679720) causes [problem](https://github.com/tenstorrent/tt-metal/issues/40916) with important video gen and image gen models  (Z-image, Stable Diffusion, Mochi).
### What's changed
Disabling group norm composite op and all tests regarding it until [the problem](https://github.com/tenstorrent/tt-metal/issues/40916) is resolved.

