### PR TITLE
Skip pi_0 on n150

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -758,24 +758,14 @@ test_config:
     reason: "Can't convert shape rank (https://github.com/tenstorrent/tt-xla/issues/3392)"
 
   pi_0/pytorch-lerobot_pi0_libero_base-single_device-inference:
-    assert_pcc: false
-    status: EXPECTED_PASSING
-    reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.7923736013936152. Required: pcc=0.99."
-    arch_overrides:
-      p150:
-        status: NOT_SUPPORTED_SKIP
-        reason: "Hangs - https://github.com/tenstorrent/tt-xla/issues/3922"
-        bringup_status: FAILED_RUNTIME
+    status: NOT_SUPPORTED_SKIP
+    reason: "Hangs - https://github.com/tenstorrent/tt-xla/issues/3922"
+    bringup_status: FAILED_RUNTIME
 
   pi_0/pytorch-pi0_base-single_device-inference:
-    assert_pcc: false
-    status: EXPECTED_PASSING
-    reason: "AssertionError:PCC comparison failed. Calculated: pcc=0.9835311599617622. Required: pcc=0.99."
-    arch_overrides:
-      p150:
-        status: NOT_SUPPORTED_SKIP
-        reason: "Hangs - https://github.com/tenstorrent/tt-xla/issues/3922"
-        bringup_status: FAILED_RUNTIME
+    status: NOT_SUPPORTED_SKIP
+    reason: "Hangs - https://github.com/tenstorrent/tt-xla/issues/3922"
+    bringup_status: FAILED_RUNTIME
 
   opt/qa/pytorch-1.3b-single_device-inference:
     assert_pcc: false


### PR DESCRIPTION
`pi_0` models also hang on n150, so skipping them