### PR TITLE
[pjrt] Fixed racy data deleted check

### DIFF
--- a/pjrt_implementation/src/api/buffer_instance.cc
+++ b/pjrt_implementation/src/api/buffer_instance.cc
@@ -134,10 +134,6 @@ bool BufferInstance::isDataDeleted() {
 }
 
 void BufferInstance::deleteData() {
-  if (m_data_deleted) {
-    return;
-  }
-
   std::lock_guard<std::mutex> deleted_lock(m_data_deleted_mutex);
   if (m_data_deleted) {
     return;


### PR DESCRIPTION
We were checking BufferInstance::m_data_deleted outside of mutex.
Removed racy check.
