### PR TITLE
Re-enable Qwen models

### DIFF
--- a/tests/runner/test_config/jax/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/jax/test_config_inference_single_device.yaml
@@ -369,9 +369,7 @@ test_config:
     bringup_status: FAILED_RUNTIME
 
   qwen_2_5/causal_lm/jax-1.5B_Instruct-single_device-inference:
-    status: NOT_SUPPORTED_SKIP
-    reason: "Host OOM due to cpu hoisting - https://github.com/tenstorrent/tt-xla/issues/3901"
-    bringup_status: FAILED_RUNTIME
+    status: EXPECTED_PASSING
 
   qwen_2_5/causal_lm/jax-3B-single_device-inference:
     status: NOT_SUPPORTED_SKIP
@@ -398,15 +396,11 @@ test_config:
     markers: [large]
 
   qwen_2_5_coder/causal_lm/jax-1.5B-single_device-inference:
-    status: NOT_SUPPORTED_SKIP
-    reason: "Host OOM due to cpu hoisting - https://github.com/tenstorrent/tt-xla/issues/3901"
-    bringup_status: FAILED_RUNTIME
+    status: EXPECTED_PASSING
     markers: [large]
 
   qwen_2_5_coder/causal_lm/jax-1.5B_Instruct-single_device-inference:
-    status: NOT_SUPPORTED_SKIP
-    reason: "Host OOM due to cpu hoisting - https://github.com/tenstorrent/tt-xla/issues/3901"
-    bringup_status: FAILED_RUNTIME
+    status: EXPECTED_PASSING
     markers: [large]
 
   qwen_2_5_coder/causal_lm/jax-3B-single_device-inference:
@@ -430,9 +424,7 @@ test_config:
     bringup_status: FAILED_RUNTIME
 
   qwen_3/causal_lm/jax-0_6B-single_device-inference:
-    status: NOT_SUPPORTED_SKIP
-    reason: "Host OOM due to cpu hoisting - https://github.com/tenstorrent/tt-xla/issues/3901"
-    bringup_status: FAILED_RUNTIME
+    status: EXPECTED_PASSING
 
   qwen_3/causal_lm/jax-1_7B-single_device-inference:
     status: NOT_SUPPORTED_SKIP


### PR DESCRIPTION
### Ticket
#3901

### Problem description
With the recent uplift of relevant PRs in tt-mlir, the host OOM issues affecting Qwen models have been resolved. 

The host RAM overhead for CPU-hoisted constant evaluation has been optimized and now represents a negligible fraction of total usage.

CI validation run for the enabled tests: [✅  passed](https://github.com/tenstorrent/tt-xla/actions/runs/23795597984)

### Checklist
- [x] New/Existing tests provide coverage for changes
