### PR TITLE
[pjrt] Fixed racy checks for deleted executable instance

### DIFF
--- a/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
@@ -172,10 +172,6 @@ FlatbufferLoadedExecutableInstance::getSharedExecutableImage() const {
 }
 
 void FlatbufferLoadedExecutableInstance::releaseResources() {
-  if (m_deleted) {
-    return;
-  }
-
   std::lock_guard<std::mutex> deleted_lock(m_deleted_mutex);
   if (m_deleted) {
     return;

--- a/pjrt_implementation/src/api/loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/loaded_executable_instance.cc
@@ -72,10 +72,6 @@ bool LoadedExecutableInstance::isDeleted() {
 }
 
 void LoadedExecutableInstance::releaseResources() {
-  if (m_deleted) {
-    return;
-  }
-
   std::lock_guard<std::mutex> deleted_lock(m_deleted_mutex);
   if (m_deleted) {
     return;

--- a/pjrt_implementation/src/api/so_loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/so_loaded_executable_instance.cc
@@ -63,10 +63,6 @@ SOLoadedExecutableInstance::getSharedExecutableImage() const {
 }
 
 void SOLoadedExecutableInstance::releaseResources() {
-  if (m_deleted) {
-    return;
-  }
-
   std::lock_guard<std::mutex> deleted_lock(m_deleted_mutex);
   if (m_deleted) {
     return;


### PR DESCRIPTION
All checks of m_deleted in LoadedExecutableInstance, FlatbufferLoadedExecutableInstance and SOLoadedExecutableInstance were done outside of scoped lock.

Removed racy checks.
