### PR TITLE
[Composite OPs] Add SDPA composite op and tests

### DIFF
--- a/python_package/tt_torch/backend/passes.py
+++ b/python_package/tt_torch/backend/passes.py
@@ -151,7 +151,10 @@ def handle_composite_ops(gm: torch.fx.GraphModule) -> None:
     """
     for node in list(gm.graph.nodes):  # snapshot to allow mid-loop erasure
         if node.op == "call_function":
-            if node.target in composite_ops.replacements:
+            if (
+                node.target in composite_ops.replacements
+                and composite_ops.can_apply_composite(node)
+            ):
                 replacement = composite_ops.replacements[node.target]
                 if isinstance(replacement, dict):
                     _replace_multi_output_op(gm, node, replacement)

--- a/python_package/tt_torch/composite_ops.py
+++ b/python_package/tt_torch/composite_ops.py
@@ -246,12 +246,6 @@ def composite_scaled_dot_product_attention(
     if scale is not None:
         attr["scale"] = scale
 
-    if dropout_p > 0:
-        logger.warning(
-            "Dropout is not supported for composite scaled_dot_product_attention, setting dropout_p to 0"
-        )
-        dropout_p = 0
-
     builder = StableHLOCompositeBuilder(
         name="tenstorrent.scaled_dot_product_attention", attr=attr
     )
@@ -394,9 +388,19 @@ def replace_group_norm_module(
 def _check_sdpa_constraints(node: torch.fx.Node) -> bool:
     """
     Check that SDPA inputs are bfloat16, the only dtype our composite supports.
-    If not, skip the composite and use the native implementation.
+    Also, check for dropout_p > 0, which is not supported in composite SDPA.
+    If either of these conditions are met, skip the composite and use the native implementation.
     """
-    # Check all positional args and tensor kwargs (e.g. attn_mask)
+    # Dropout is not supported in composite SDPA
+    dropout_p = node.kwargs.get("dropout_p", 0.0)
+    if dropout_p is not None and dropout_p > 0:
+        logger.debug(
+            "composite scaled_dot_product_attention does not support dropout = {dropout_p}, "
+            "skipping composite and using native implementation."
+        )
+        return False
+
+    # Check all inputs are bfloat16
     tensor_args = list(node.args) + [
         v for v in node.kwargs.values() if isinstance(v, torch.fx.Node)
     ]

--- a/python_package/tt_torch/composite_ops.py
+++ b/python_package/tt_torch/composite_ops.py
@@ -7,6 +7,7 @@ from typing import List, Optional, Union
 import torch
 from torch import Tensor
 from torch_xla.experimental.mark_pattern_utils import StableHLOCompositeBuilder
+from ttxla_tools.logging import logger
 
 """
 From XLA documentation: '(Composite operation) Encapsulates an operation made up (composed) of
@@ -244,6 +245,12 @@ def composite_scaled_dot_product_attention(
     attr = {"is_causal": is_causal}
     if scale is not None:
         attr["scale"] = scale
+
+    if dropout_p > 0:
+        logger.warning(
+            "Dropout is not supported for composite scaled_dot_product_attention, setting dropout_p to 0"
+        )
+        dropout_p = 0
 
     builder = StableHLOCompositeBuilder(
         name="tenstorrent.scaled_dot_product_attention", attr=attr

--- a/python_package/tt_torch/composite_ops.py
+++ b/python_package/tt_torch/composite_ops.py
@@ -227,6 +227,48 @@ def composite_topk_indices(
     return indices
 
 
+def composite_scaled_dot_product_attention(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    attn_mask: Optional[Tensor] = None,
+    dropout_p: float = 0.0,
+    is_causal: bool = False,
+    scale: Optional[float] = None,
+    enable_gqa: bool = False,
+) -> Tensor:
+    """
+    Creates composite scaled_dot_product_attention operation for torch xla
+    """
+
+    attr = {"is_causal": is_causal}
+    if scale is not None:
+        attr["scale"] = scale
+
+    builder = StableHLOCompositeBuilder(
+        name="tenstorrent.scaled_dot_product_attention", attr=attr
+    )
+
+    if attn_mask is not None:
+        query, key, value, attn_mask = builder.mark_inputs(query, key, value, attn_mask)
+    else:
+        query, key, value = builder.mark_inputs(query, key, value)
+
+    output = torch.nn.functional.scaled_dot_product_attention(
+        query,
+        key,
+        value,
+        attn_mask=attn_mask,
+        dropout_p=dropout_p,
+        is_causal=is_causal,
+        scale=scale,
+        enable_gqa=enable_gqa,
+    )
+    output = builder.mark_outputs(output)
+
+    return output
+
+
 ################# module replacements #################
 
 
@@ -356,6 +398,7 @@ replacements = {
     torch.rms_norm: composite_rms_norm,
     torch.nn.functional.rms_norm: composite_rms_norm,
     torch.nn.functional.layer_norm: composite_layer_norm,
+    torch.nn.functional.scaled_dot_product_attention: composite_scaled_dot_product_attention,
     # TODO: uncomment once https://github.com/tenstorrent/tt-metal/issues/40916 is fixed
     # torch.nn.functional.group_norm: composite_group_norm,
     torch.topk: {

--- a/python_package/tt_torch/composite_ops.py
+++ b/python_package/tt_torch/composite_ops.py
@@ -388,6 +388,48 @@ def replace_group_norm_module(
     gm.graph.erase_node(node)
 
 
+################# composite constraint checks #################
+
+
+def _check_sdpa_constraints(node: torch.fx.Node) -> bool:
+    """
+    Check that SDPA inputs are bfloat16, the only dtype our composite supports.
+    If not, skip the composite and use the native implementation.
+    """
+    # Check all positional args and tensor kwargs (e.g. attn_mask)
+    tensor_args = list(node.args) + [
+        v for v in node.kwargs.values() if isinstance(v, torch.fx.Node)
+    ]
+    for arg in tensor_args:
+        if hasattr(arg, "meta"):
+            val = arg.meta.get("example_value", None)
+            if val is not None and val.dtype != torch.bfloat16:
+                logger.debug(
+                    "composite scaled_dot_product_attention only supports bfloat16 inputs, "
+                    "skipping composite and using native implementation."
+                )
+                return False
+
+    return True
+
+
+def can_apply_composite(node: torch.fx.Node) -> bool:
+    """
+    Check whether a composite replacement should be applied for the given node.
+    Returns True if the replacement is valid, False if it should be skipped.
+    """
+    return constraints.get(node.target, lambda _: True)(node)
+
+
+"""
+Dictionary holding constraints for composite replacements.
+Maps torch API calls to constraint functions.
+"""
+constraints = {
+    torch.nn.functional.scaled_dot_product_attention: _check_sdpa_constraints,
+}
+
+
 """
 Dictionary holding replacement composite functions for torch functions and modules.
 Maps torch API calls and module types to composite implementations.

--- a/tests/torch/graphs/fusion_patterns/test_sdpa.py
+++ b/tests/torch/graphs/fusion_patterns/test_sdpa.py
@@ -56,5 +56,3 @@ def test_composite_sdpa(request):
         framework=Framework.TORCH,
         request=request,
     )
-
-

--- a/tests/torch/graphs/fusion_patterns/test_sdpa.py
+++ b/tests/torch/graphs/fusion_patterns/test_sdpa.py
@@ -38,3 +38,23 @@ def test_sdpa(request):
         compiler_config=CompilerConfig(optimization_level=1),
         request=request,
     )
+
+
+@pytest.mark.extended
+@pytest.mark.nightly
+@pytest.mark.single_device
+@pytest.mark.record_test_properties(category=Category.GRAPH_TEST)
+@pytest.mark.filecheck(["sdpa.ttnn.mlir"])
+def test_composite_sdpa(request):
+    def sdpa(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+        return torch.nn.functional.scaled_dot_product_attention(q, k, v, is_causal=True)
+
+    run_graph_test_with_random_inputs(
+        sdpa,
+        [(1, 8, 32, 64), (1, 8, 32, 64), (1, 8, 32, 64)],
+        dtype=torch.bfloat16,
+        framework=Framework.TORCH,
+        request=request,
+    )
+
+

--- a/tests/torch/graphs/test_attention.py
+++ b/tests/torch/graphs/test_attention.py
@@ -309,14 +309,14 @@ def test_llama_attention_decode(variant, variant_config, arch):
     )
     cos_sin = torch.rand(batch_size, seq_len, config.head_dim, dtype=torch.bfloat16)
     position_embeddings = (cos_sin, cos_sin)
-    # Additive causal mask: 0 for attend, -inf for mask out
-    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
-    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
-    attention_mask.masked_fill_(
-        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
-    )
+    max_cache_len = 32
 
-    max_cache_len = 16
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, kv_seq_len]
+    # With static cache, kv_seq_len is max_cache_len
+    attention_mask = torch.zeros(
+        batch_size, 1, seq_len, max_cache_len, dtype=torch.bfloat16
+    )
     static_cache: StaticCache = StaticCache(
         config=config,
         max_batch_size=batch_size,
@@ -762,14 +762,14 @@ def test_qwen3_attention_decode(variant, variant_config, arch):
     )
     cos_sin = torch.rand(batch_size, seq_len, config.head_dim, dtype=torch.bfloat16)
     position_embeddings = (cos_sin, cos_sin)
-    # Additive causal mask: 0 for attend, -inf for mask out
-    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
-    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
-    attention_mask.masked_fill_(
-        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
-    )
+    max_cache_len = 32
 
-    max_cache_len = 16
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, kv_seq_len]
+    # With static cache, kv_seq_len is max_cache_len
+    attention_mask = torch.zeros(
+        batch_size, 1, seq_len, max_cache_len, dtype=torch.bfloat16
+    )
     static_cache: StaticCache = StaticCache(
         config=config,
         max_batch_size=batch_size,
@@ -1445,14 +1445,14 @@ def test_qwen2_5_attention_decode(variant, variant_config, arch):
     head_dim = config.hidden_size // config.num_attention_heads
     cos_sin = torch.rand(batch_size, seq_len, head_dim, dtype=torch.bfloat16)
     position_embeddings = (cos_sin, cos_sin)
-    # Additive causal mask: 0 for attend, -inf for mask out
-    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
-    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
-    attention_mask.masked_fill_(
-        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
-    )
+    max_cache_len = 32
 
-    max_cache_len = 16
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, kv_seq_len]
+    # With static cache, kv_seq_len is max_cache_len
+    attention_mask = torch.zeros(
+        batch_size, 1, seq_len, max_cache_len, dtype=torch.bfloat16
+    )
     static_cache: StaticCache = StaticCache(
         config=config,
         max_batch_size=batch_size,
@@ -1859,14 +1859,14 @@ def test_gemma_attention_decode(variant, variant_config, arch):
     )
     cos_sin = torch.rand(batch_size, seq_len, config.head_dim, dtype=torch.bfloat16)
     position_embeddings = (cos_sin, cos_sin)
-    # Additive causal mask: 0 for attend, -inf for mask out
-    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
-    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
-    attention_mask.masked_fill_(
-        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
-    )
+    max_cache_len = 32
 
-    max_cache_len = 16
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, kv_seq_len]
+    # With static cache, kv_seq_len is max_cache_len
+    attention_mask = torch.zeros(
+        batch_size, 1, seq_len, max_cache_len, dtype=torch.bfloat16
+    )
     static_cache: StaticCache = StaticCache(
         config=config,
         max_batch_size=batch_size,
@@ -2160,14 +2160,14 @@ def test_mistral_attention_decode(variant, variant_config, arch):
     head_dim = config.hidden_size // config.num_attention_heads
     cos_sin = torch.rand(batch_size, seq_len, head_dim, dtype=torch.bfloat16)
     position_embeddings = (cos_sin, cos_sin)
-    # Additive causal mask: 0 for attend, -inf for mask out
-    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
-    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
-    attention_mask.masked_fill_(
-        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
-    )
+    max_cache_len = 32
 
-    max_cache_len = 16
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, kv_seq_len]
+    # With static cache, kv_seq_len is max_cache_len
+    attention_mask = torch.zeros(
+        batch_size, 1, seq_len, max_cache_len, dtype=torch.bfloat16
+    )
     static_cache: StaticCache = StaticCache(
         config=config,
         max_batch_size=batch_size,
@@ -2547,14 +2547,14 @@ def test_gpt_oss_attention_decode(variant, variant_config, arch):
 
     cos_sin = torch.rand(batch_size, seq_len, 32, dtype=torch.bfloat16)
     position_embeddings = (cos_sin, cos_sin)
-    # Additive causal mask: 0 for attend, -inf for mask out
-    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
-    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
-    attention_mask.masked_fill_(
-        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
-    )
+    max_cache_len = 32
 
-    max_cache_len = 16
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, kv_seq_len]
+    # With static cache, kv_seq_len is max_cache_len
+    attention_mask = torch.zeros(
+        batch_size, 1, seq_len, max_cache_len, dtype=torch.bfloat16
+    )
     static_cache: StaticCache = StaticCache(
         config=config,
         max_batch_size=batch_size,
@@ -2671,14 +2671,14 @@ def test_glm_4_attention_decode(variant, variant_config, arch):
     )
     cos_sin = torch.rand(batch_size, seq_len, rope_dim, dtype=torch.bfloat16)
     position_embeddings = (cos_sin, cos_sin)
-    # Additive causal mask: 0 for attend, -inf for mask out
-    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
-    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
-    attention_mask.masked_fill_(
-        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
-    )
+    max_cache_len = 32
 
-    max_cache_len = 16
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, kv_seq_len]
+    # With static cache, kv_seq_len is max_cache_len
+    attention_mask = torch.zeros(
+        batch_size, 1, seq_len, max_cache_len, dtype=torch.bfloat16
+    )
     static_cache: StaticCache = StaticCache(
         config=config,
         max_batch_size=batch_size,

--- a/tests/torch/graphs/test_attention.py
+++ b/tests/torch/graphs/test_attention.py
@@ -222,7 +222,12 @@ def test_llama_attention_prefill(seq_len, variant, variant_config, arch):
     )
     cos_sin = torch.rand(batch_size, seq_len, config.head_dim, dtype=torch.bfloat16)
     position_embeddings = (cos_sin, cos_sin)
-    attention_mask = torch.rand(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
+    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    attention_mask.masked_fill_(
+        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
+    )
 
     past_key_states = None
 
@@ -304,7 +309,12 @@ def test_llama_attention_decode(variant, variant_config, arch):
     )
     cos_sin = torch.rand(batch_size, seq_len, config.head_dim, dtype=torch.bfloat16)
     position_embeddings = (cos_sin, cos_sin)
-    attention_mask = torch.rand(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
+    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    attention_mask.masked_fill_(
+        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
+    )
 
     max_cache_len = 16
     static_cache: StaticCache = StaticCache(
@@ -497,7 +507,12 @@ def test_llama_attention(variant, variant_config, seq_len, arch):
         (batch_size, num_key_value_heads, seq_len, head_dim), dtype=torch.bfloat16
     )
 
-    attention_mask = torch.rand(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
+    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    attention_mask.masked_fill_(
+        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
+    )
 
     run_graph_test(
         sdpa,
@@ -596,7 +611,12 @@ def test_qwen3_attention_prefill(seq_len, variant, variant_config, arch):
     )
     cos_sin = torch.rand(batch_size, seq_len, config.head_dim, dtype=torch.bfloat16)
     position_embeddings = (cos_sin, cos_sin)
-    attention_mask = torch.rand(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
+    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    attention_mask.masked_fill_(
+        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
+    )
 
     past_key_states = None
 
@@ -629,7 +649,12 @@ def test_qwen3_attention_prefill_push(seq_len, variant, arch):
     )
     cos_sin = torch.rand(batch_size, seq_len, config.head_dim, dtype=torch.bfloat16)
     position_embeddings = (cos_sin, cos_sin)
-    attention_mask = torch.rand(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
+    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    attention_mask.masked_fill_(
+        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
+    )
 
     past_key_states = None
 
@@ -737,7 +762,12 @@ def test_qwen3_attention_decode(variant, variant_config, arch):
     )
     cos_sin = torch.rand(batch_size, seq_len, config.head_dim, dtype=torch.bfloat16)
     position_embeddings = (cos_sin, cos_sin)
-    attention_mask = torch.rand(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
+    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    attention_mask.masked_fill_(
+        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
+    )
 
     max_cache_len = 16
     static_cache: StaticCache = StaticCache(
@@ -946,7 +976,12 @@ def test_qwen3_attention(variant, variant_config, seq_len, arch):
         (batch_size, num_key_value_heads, seq_len, head_dim), dtype=torch.bfloat16
     )
 
-    attention_mask = torch.rand(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
+    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    attention_mask.masked_fill_(
+        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
+    )
 
     dropout = 0.0
     scaling = attention.scaling
@@ -1218,7 +1253,12 @@ def test_qwen2_5_attention_prefill(seq_len, variant, variant_config, arch):
     head_dim = config.hidden_size // config.num_attention_heads
     cos_sin = torch.rand(batch_size, seq_len, head_dim, dtype=torch.bfloat16)
     position_embeddings = (cos_sin, cos_sin)
-    attention_mask = torch.rand(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
+    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    attention_mask.masked_fill_(
+        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
+    )
 
     past_key_states = None
 
@@ -1305,7 +1345,12 @@ def test_qwen2_5_attention_prefill_push(seq_len, variant, arch):
     head_dim = config.hidden_size // config.num_attention_heads
     cos_sin = torch.rand(batch_size, seq_len, head_dim, dtype=torch.bfloat16)
     position_embeddings = (cos_sin, cos_sin)
-    attention_mask = torch.rand(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
+    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    attention_mask.masked_fill_(
+        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
+    )
 
     past_key_states = None
 
@@ -1400,7 +1445,12 @@ def test_qwen2_5_attention_decode(variant, variant_config, arch):
     head_dim = config.hidden_size // config.num_attention_heads
     cos_sin = torch.rand(batch_size, seq_len, head_dim, dtype=torch.bfloat16)
     position_embeddings = (cos_sin, cos_sin)
-    attention_mask = torch.rand(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
+    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    attention_mask.masked_fill_(
+        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
+    )
 
     max_cache_len = 16
     static_cache: StaticCache = StaticCache(
@@ -1549,7 +1599,12 @@ def test_qwen2_5_attention(variant, variant_config, seq_len, arch):
         (batch_size, num_key_value_heads, seq_len, head_dim), dtype=torch.bfloat16
     )
 
-    attention_mask = torch.rand(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
+    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    attention_mask.masked_fill_(
+        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
+    )
 
     dropout = 0.0
     scaling = attention.scaling
@@ -1649,7 +1704,12 @@ def test_gemma_attention_prefill(seq_len, variant, variant_config, arch):
     )
     cos_sin = torch.rand(batch_size, seq_len, config.head_dim, dtype=torch.bfloat16)
     position_embeddings = (cos_sin, cos_sin)
-    attention_mask = torch.rand(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
+    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    attention_mask.masked_fill_(
+        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
+    )
 
     past_key_states = None
 
@@ -1685,7 +1745,12 @@ def test_gemma_attention_prefill_push(seq_len, variant, arch):
     )
     cos_sin = torch.rand(batch_size, seq_len, config.head_dim, dtype=torch.bfloat16)
     position_embeddings = (cos_sin, cos_sin)
-    attention_mask = torch.rand(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
+    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    attention_mask.masked_fill_(
+        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
+    )
 
     past_key_states = None
 
@@ -1794,7 +1859,12 @@ def test_gemma_attention_decode(variant, variant_config, arch):
     )
     cos_sin = torch.rand(batch_size, seq_len, config.head_dim, dtype=torch.bfloat16)
     position_embeddings = (cos_sin, cos_sin)
-    attention_mask = torch.rand(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
+    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    attention_mask.masked_fill_(
+        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
+    )
 
     max_cache_len = 16
     static_cache: StaticCache = StaticCache(
@@ -1922,7 +1992,12 @@ def test_gemma_attention(variant, variant_config, seq_len, arch):
         (batch_size, num_key_value_heads, seq_len, head_dim), dtype=torch.bfloat16
     )
 
-    attention_mask = torch.rand(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
+    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    attention_mask.masked_fill_(
+        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
+    )
 
     run_graph_test(
         sdpa,
@@ -1968,7 +2043,12 @@ def test_mistral_attention_prefill(seq_len, variant, variant_config, arch):
     head_dim = config.hidden_size // config.num_attention_heads
     cos_sin = torch.rand(batch_size, seq_len, head_dim, dtype=torch.bfloat16)
     position_embeddings = (cos_sin, cos_sin)
-    attention_mask = torch.rand(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
+    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    attention_mask.masked_fill_(
+        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
+    )
 
     past_key_states = None
 
@@ -2020,7 +2100,12 @@ def test_mistral_attention_prefill_push(seq_len, variant, arch):
     head_dim = config.hidden_size // config.num_attention_heads
     cos_sin = torch.rand(batch_size, seq_len, head_dim, dtype=torch.bfloat16)
     position_embeddings = (cos_sin, cos_sin)
-    attention_mask = torch.rand(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
+    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    attention_mask.masked_fill_(
+        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
+    )
 
     past_key_states = None
 
@@ -2075,7 +2160,12 @@ def test_mistral_attention_decode(variant, variant_config, arch):
     head_dim = config.hidden_size // config.num_attention_heads
     cos_sin = torch.rand(batch_size, seq_len, head_dim, dtype=torch.bfloat16)
     position_embeddings = (cos_sin, cos_sin)
-    attention_mask = torch.rand(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
+    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    attention_mask.masked_fill_(
+        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
+    )
 
     max_cache_len = 16
     static_cache: StaticCache = StaticCache(
@@ -2183,7 +2273,12 @@ def test_mistral_attention(variant, variant_config, seq_len, arch):
         (batch_size, num_key_value_heads, seq_len, head_dim), dtype=torch.bfloat16
     )
 
-    attention_mask = torch.rand(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
+    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    attention_mask.masked_fill_(
+        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
+    )
 
     dropout = 0.0
     scaling = attention.scaling
@@ -2384,7 +2479,12 @@ def test_gpt_oss_attention_prefill(variant, variant_config, arch):
 
     cos_sin = torch.rand(batch_size, seq_len, 32, dtype=torch.bfloat16)
     position_embeddings = (cos_sin, cos_sin)
-    attention_mask = torch.rand(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
+    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    attention_mask.masked_fill_(
+        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
+    )
 
     past_key_states = None
 
@@ -2447,7 +2547,12 @@ def test_gpt_oss_attention_decode(variant, variant_config, arch):
 
     cos_sin = torch.rand(batch_size, seq_len, 32, dtype=torch.bfloat16)
     position_embeddings = (cos_sin, cos_sin)
-    attention_mask = torch.rand(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
+    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    attention_mask.masked_fill_(
+        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
+    )
 
     max_cache_len = 16
     static_cache: StaticCache = StaticCache(
@@ -2504,7 +2609,12 @@ def test_glm_4_attention_prefill(seq_len, variant, variant_config):
     )
     cos_sin = torch.rand(batch_size, seq_len, rope_dim, dtype=torch.bfloat16)
     position_embeddings = (cos_sin, cos_sin)
-    attention_mask = torch.rand(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
+    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    attention_mask.masked_fill_(
+        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
+    )
 
     past_key_states = None
 
@@ -2561,7 +2671,12 @@ def test_glm_4_attention_decode(variant, variant_config, arch):
     )
     cos_sin = torch.rand(batch_size, seq_len, rope_dim, dtype=torch.bfloat16)
     position_embeddings = (cos_sin, cos_sin)
-    attention_mask = torch.rand(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
+    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    attention_mask.masked_fill_(
+        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
+    )
 
     max_cache_len = 16
     static_cache: StaticCache = StaticCache(
@@ -2688,7 +2803,12 @@ def test_glm_4_attention(seq_len, variant, variant_config, arch):
     value_states = torch.randn(
         (batch_size, num_key_value_heads, seq_len, head_dim), dtype=torch.bfloat16
     )
-    attention_mask = torch.rand(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
+    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    attention_mask.masked_fill_(
+        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
+    )
 
     run_graph_test(
         sdpa,

--- a/tests/torch/graphs/test_decoder_layer.py
+++ b/tests/torch/graphs/test_decoder_layer.py
@@ -182,7 +182,12 @@ def test_llama_decoder_layer(seq_len, variant, variant_config, arch):
     )
     cos_sin = torch.rand(batch_size, seq_len, config.head_dim, dtype=torch.bfloat16)
     position_embeddings = (cos_sin, cos_sin)
-    attention_mask = torch.rand(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
+    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    attention_mask.masked_fill_(
+        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
+    )
 
     past_key_states = None
 
@@ -267,7 +272,12 @@ def test_qwen3_decoder_layer(seq_len, variant, variant_config, arch):
     )
     cos_sin = torch.rand(batch_size, seq_len, config.head_dim, dtype=torch.bfloat16)
     position_embeddings = (cos_sin, cos_sin)
-    attention_mask = torch.rand(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
+    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    attention_mask.masked_fill_(
+        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
+    )
 
     past_key_states = None
 
@@ -394,7 +404,12 @@ def test_gemma_decoder_layer(seq_len, variant, variant_config, arch):
     )
     cos_sin = torch.rand(batch_size, seq_len, config.head_dim, dtype=torch.bfloat16)
     position_embeddings = (cos_sin, cos_sin)
-    attention_mask = torch.rand(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
+    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    attention_mask.masked_fill_(
+        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
+    )
     past_key_states = None
 
     # For Gemma2, we need to provide position_ids and cache_position
@@ -490,7 +505,12 @@ def test_mistral_decoder_layer(seq_len, variant, variant_config, arch):
     head_dim = config.hidden_size // config.num_attention_heads
     cos_sin = torch.rand(batch_size, seq_len, head_dim, dtype=torch.bfloat16)
     position_embeddings = (cos_sin, cos_sin)
-    attention_mask = torch.rand(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
+    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    attention_mask.masked_fill_(
+        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
+    )
 
     past_key_states = None
 
@@ -579,7 +599,12 @@ def test_qwen2_5_decoder_layer(seq_len, variant, variant_config, arch):
     head_dim = config.hidden_size // config.num_attention_heads
     cos_sin = torch.rand(batch_size, seq_len, head_dim, dtype=torch.bfloat16)
     position_embeddings = (cos_sin, cos_sin)
-    attention_mask = torch.rand(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
+    attention_mask = torch.zeros(batch_size, 1, seq_len, seq_len, dtype=torch.bfloat16)
+    attention_mask.masked_fill_(
+        ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
+    )
 
     past_key_states = None
 

--- a/tests/torch/models/kimi_k2/test_kimi_k2.py
+++ b/tests/torch/models/kimi_k2/test_kimi_k2.py
@@ -84,8 +84,13 @@ def test_kimi_k2_attention_prefill():
     hidden_states = torch.randn(
         (batch_size, seq_len, config.hidden_size), dtype=torch.bfloat16
     )
-    attention_mask = torch.rand(
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
+    attention_mask = torch.zeros(
         batch_size, 1, seq_len, max_cache_len, dtype=torch.bfloat16
+    )
+    attention_mask.masked_fill_(
+        ~torch.ones(seq_len, max_cache_len).bool().tril(), float("-inf")
     )
 
     num_devices = xr.global_runtime_device_count()
@@ -157,8 +162,13 @@ def test_kimi_k2_attention_decode():
     hidden_states = torch.randn(
         (batch_size, seq_len, config.hidden_size), dtype=torch.bfloat16
     )
-    attention_mask = torch.rand(
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
+    attention_mask = torch.zeros(
         batch_size, 1, seq_len, max_cache_len, dtype=torch.bfloat16
+    )
+    attention_mask.masked_fill_(
+        ~torch.ones(seq_len, max_cache_len).bool().tril(), float("-inf")
     )
 
     num_devices = xr.global_runtime_device_count()
@@ -240,8 +250,13 @@ def test_kimi_k2_layer():
     hidden_states = torch.randn(
         (batch_size, seq_len, config.hidden_size), dtype=torch.bfloat16
     )
-    attention_mask = torch.rand(
+    # Additive causal mask: 0 for attend, -inf for mask out
+    # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
+    attention_mask = torch.zeros(
         batch_size, 1, seq_len, max_cache_len, dtype=torch.bfloat16
+    )
+    attention_mask.masked_fill_(
+        ~torch.ones(seq_len, max_cache_len).bool().tril(), float("-inf")
     )
     cache_positions = torch.randint(0, max_cache_len, (seq_len,), dtype=torch.long)
     num_devices = xr.global_runtime_device_count()

--- a/tests/torch/ops/test_composite_ops.py
+++ b/tests/torch/ops/test_composite_ops.py
@@ -678,9 +678,6 @@ def test_patched_sdpa(
     model = SDPAModel(is_causal)
     inputs = [query, key, value, attn_mask] if use_attn_mask else [query, key, value]
 
-    print(model(query, key, value))
-    print(attn_mask)
-
     run_graph_test(
         model,
         inputs,

--- a/tests/torch/ops/test_composite_ops.py
+++ b/tests/torch/ops/test_composite_ops.py
@@ -19,6 +19,7 @@ from tt_torch.composite_ops import (
     composite_group_norm,
     composite_layer_norm,
     composite_rms_norm,
+    composite_scaled_dot_product_attention,
     composite_topk,
     composite_topk_indices,
     composite_topk_values,
@@ -573,3 +574,117 @@ def test_patched_topk_both(input_shape, k):
 #             framework=Framework.TORCH,
 #             torch_options=options,
 #         )
+
+
+@pytest.mark.nightly
+@pytest.mark.single_device
+@pytest.mark.parametrize("is_causal", [True, False])
+@pytest.mark.parametrize("use_attn_mask", [True, False])
+@pytest.mark.parametrize(
+    "batch_size, num_heads, seq_len, head_dim",
+    [(1, 1, 32, 32), (1, 8, 64, 64), (2, 4, 128, 64)],
+)
+def test_composite_sdpa(
+    is_causal, use_attn_mask, batch_size, num_heads, seq_len, head_dim
+):
+    # is_causal and attn_mask cannot both be set
+    if is_causal and use_attn_mask:
+        pytest.skip("is_causal and attn_mask cannot both be set")
+
+    class SDPAModel(torch.nn.Module):
+        def __init__(self, is_causal):
+            super().__init__()
+            self.is_causal = is_causal
+
+        def forward(self, query, key, value, attn_mask=None):
+            return composite_scaled_dot_product_attention(
+                query, key, value, attn_mask=attn_mask, is_causal=self.is_causal
+            )
+
+    options = {"tt_enable_composite_ops": False}
+
+    query = torch.randn(batch_size, num_heads, seq_len, head_dim, dtype=torch.bfloat16)
+    key = torch.randn(batch_size, num_heads, seq_len, head_dim, dtype=torch.bfloat16)
+    value = torch.randn(batch_size, num_heads, seq_len, head_dim, dtype=torch.bfloat16)
+
+    if use_attn_mask:
+        # Additive causal mask: 0 for attend, -inf for mask out
+        # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
+        attn_mask = torch.zeros(
+            batch_size, num_heads, seq_len, seq_len, dtype=torch.bfloat16
+        )
+        attn_mask.masked_fill_(
+            ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
+        )
+    else:
+        attn_mask = None
+
+    model = SDPAModel(is_causal)
+    inputs = [query, key, value, attn_mask] if use_attn_mask else [query, key, value]
+
+    with torch._inductor.config.patch({"inplace_buffers": False}):
+        run_graph_test(
+            model,
+            inputs,
+            comparison_config=ComparisonConfig(),
+            framework=Framework.TORCH,
+            torch_options=options,
+        )
+
+
+@pytest.mark.nightly
+@pytest.mark.single_device
+@pytest.mark.parametrize("is_causal", [True, False])
+@pytest.mark.parametrize("use_attn_mask", [True, False])
+@pytest.mark.parametrize(
+    "batch_size, num_heads, seq_len, head_dim",
+    [(1, 1, 32, 32), (1, 8, 64, 64), (2, 4, 128, 64)],
+)
+def test_patched_sdpa(
+    is_causal, use_attn_mask, batch_size, num_heads, seq_len, head_dim
+):
+    # is_causal and attn_mask cannot both be set
+    if is_causal and use_attn_mask:
+        pytest.skip("is_causal and attn_mask cannot both be set")
+
+    class SDPAModel(torch.nn.Module):
+        def __init__(self, is_causal):
+            super().__init__()
+            self.is_causal = is_causal
+
+        def forward(self, query, key, value, attn_mask=None):
+            return F.scaled_dot_product_attention(
+                query, key, value, attn_mask=attn_mask, is_causal=self.is_causal
+            )
+
+    options = {"tt_enable_composite_ops": True}
+
+    query = torch.randn(batch_size, num_heads, seq_len, head_dim, dtype=torch.bfloat16)
+    key = torch.randn(batch_size, num_heads, seq_len, head_dim, dtype=torch.bfloat16)
+    value = torch.randn(batch_size, num_heads, seq_len, head_dim, dtype=torch.bfloat16)
+
+    if use_attn_mask:
+        # Additive causal mask: 0 for attend, -inf for mask out
+        # TTIR requires 4D mask: [batch, heads, seq_len, seq_len]
+        attn_mask = torch.zeros(
+            batch_size, num_heads, seq_len, seq_len, dtype=torch.bfloat16
+        )
+        attn_mask.masked_fill_(
+            ~torch.ones(seq_len, seq_len).bool().tril(), float("-inf")
+        )
+    else:
+        attn_mask = None
+
+    model = SDPAModel(is_causal)
+    inputs = [query, key, value, attn_mask] if use_attn_mask else [query, key, value]
+
+    print(model(query, key, value))
+    print(attn_mask)
+
+    run_graph_test(
+        model,
+        inputs,
+        comparison_config=ComparisonConfig(),
+        framework=Framework.TORCH,
+        torch_options=options,
+    )


### PR DESCRIPTION
This is the initial push to model `SDPA` trough frontend, which means some features are not supported, primarily modeling of the `attention_sink` that is supported in MLIR ([issue](https://github.com/tenstorrent/tt-xla/issues/4030)) and `dropout_p` which is not modeled (in ttir) for now.

### What's changed

- Added `composite_scaled_dot_product_attention` wrapping for `F.scaled_dot_product_attention`                                                                                                     
- Log a debug for `dropout_p != 0` since dropout is not modeled in TT-MLIR for this op, and fallback to native impl.      
- Added tests
- Added a generic constraint-checking mechanism (`can_apply_composite` in `composite_ops.py`) that `handle_composite_ops` calls before replacing an FX node target with its composite equivalent. This is needed because sdpa kernel in metal currently supports only `bf16` and lower formats, and to account for user wanting to use `fp32`. This can also be used for new composites in the future, and is similar to `match_pattern` functionality in fusing.
- Replaced `torch.rand(...)` attention masks with proper additive causal masks (`0` for attend, `-inf` for mask out) across all attention tests in `test_attention.py`.

### Checklist
- [x] Wait for mlir uplift of https://github.com/tenstorrent/tt-mlir/pull/7728
- [x] Wait for torch_xla uplift of https://github.com/tenstorrent/tt-xla/pull/4033
- [x] Run on-pr with mlir and torch_xla uplift https://github.com/tenstorrent/tt-xla/actions/runs/23874716442
