### PR TITLE
[tools] Add Claude Code plugin templates and developer workflow docs

### DIFF
--- a/.claude/commit-template.md
+++ b/.claude/commit-template.md
@@ -1,0 +1,90 @@
+# tt-xla Commit Message Template
+
+## Format
+
+```
+[Area] Short imperative description (#PR)
+```
+
+The `(#PR)` suffix is added automatically by GitHub on merge — omit it when writing manually.
+
+---
+
+## Area Prefix Table
+
+Choose the **one** prefix that best matches the primary area touched. If no single area dominates, use the bare-verb style (no prefix).
+
+| Prefix | Use when changes are primarily in… |
+|---|---|
+| `[vLLM plugin]` | `integrations/vllm_plugin/`, `tests/integrations/vllm_plugin/` |
+| `[vLLM]` | vLLM-related but not plugin-specific (e.g. sampling, logprobs) |
+| `[CI]` | `.github/workflows/`, `.github/actions/`, `.github/scripts/` |
+| `[Test Infra]` | `tests/infra/`, `tests/runner/`, `pytest.ini`, `.test_durations` |
+| `[pjrt]` | `pjrt_implementation/` |
+| `[FX fusing]` | `python_package/tt_torch/` fusion passes |
+| `[test]` | New/updated test files only (no source changes) |
+| `[build]` | `CMakeLists.txt`, `CMakePresets.json`, `python_package/` build config |
+| `[python-package]` | `python_package/` (non-build: deps, packaging) |
+| `[tools]` | `scripts/` |
+
+---
+
+## Bare-Verb Style (no prefix)
+
+Use for general changes that span areas or don't fit a prefix:
+
+```
+Add <thing>
+Fix <thing>
+Update <thing>
+Enable <thing>
+Remove <thing>
+Disable <thing>
+Uplift third_party/<name> to <hash> <date>
+```
+
+---
+
+## Rules
+
+1. **Title ≤ 72 characters**
+2. **Imperative, sentence-case** — e.g. "Add support for sparse moe", not "Added" or "adding"
+3. **No trailing period**
+4. **No conventional-commit prefixes** (`feat:`, `fix:`, `chore:` etc.) — this repo does NOT use that convention
+5. **SPDX copyright header** required on all new source files: `// SPDX-License-Identifier: Apache-2.0`
+
+---
+
+## Path-to-Prefix Lookup
+
+| Changed path starts with… | Prefix |
+|---|---|
+| `.github/` | `[CI]` |
+| `tests/integrations/vllm_plugin/` | `[vLLM plugin]` |
+| `integrations/vllm_plugin/` | `[vLLM plugin]` |
+| `tests/infra/` or `tests/runner/` | `[Test Infra]` |
+| `tests/` (other) | `[test]` |
+| `pjrt_implementation/` | `[pjrt]` |
+| `python_package/tt_torch/` (fusion) | `[FX fusing]` |
+| `python_package/` | `[build]` or `[python-package]` |
+| `scripts/` | `[tools]` |
+| `third_party/` (submodule bump) | bare `Uplift third_party/…` |
+
+---
+
+## Examples (from recent history)
+
+```
+[vLLM] Implement prompt_logprobs support
+[CI] revert upgrade of checkout
+[Test Infra] prevent ReferenceError during test teardown cleanup
+[FX fusing] Expand rms_norm pattern for gpt_oss
+[vLLM plugin] Implement allowed_token_ids and min_tokens sampler-level enforcement
+[pjrt] PJRT_Buffer_ToHostBuffer size query fix
+[build] local dev build fixes
+[test] conv3d + mochi decoder tests improvement
+Add support for sparse moe
+Fix nightly
+Enable dtype in CI runs log summary
+Uplift third_party/tt_forge_models to 78e977e 2026-03-11
+```

--- a/.claude/install-plugin.sh
+++ b/.claude/install-plugin.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Installs the tt-xla-dev Claude Code plugin to ~/.claude/plugins/tt-xla-dev/
+# Run from the repo root: bash .claude/install-plugin.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_SRC="$SCRIPT_DIR/plugins/tt-xla-dev"
+PLUGIN_DEST="$HOME/.claude/plugins/tt-xla-dev"
+
+echo "Installing tt-xla-dev plugin..."
+echo "  src:  $PLUGIN_SRC"
+echo "  dest: $PLUGIN_DEST"
+
+mkdir -p "$PLUGIN_DEST"
+cp -r "$PLUGIN_SRC/." "$PLUGIN_DEST/"
+
+echo "Done. Plugin installed at $PLUGIN_DEST"
+echo "Restart Claude Code to activate the plugin."
+echo ""
+echo "Available commands:"
+echo "  /tt-xla-dev:local-review        Review staged changes before creating a PR"
+echo "  /tt-xla-dev:ci-review [PR#]     Summarize CI status for a PR"
+echo "  /tt-xla-dev:create-pr [area]    Create a PR with proper template and reviewers"

--- a/.claude/plugins/tt-xla-dev/.claude-plugin/plugin.json
+++ b/.claude/plugins/tt-xla-dev/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "tt-xla-dev",
+  "description": "Commit message templates, local PR review, CI review, and PR creation for the tt-xla repository",
+  "author": {
+    "name": "ctr-sraguram",
+    "email": ""
+  }
+}

--- a/.claude/plugins/tt-xla-dev/commands/ci-review.md
+++ b/.claude/plugins/tt-xla-dev/commands/ci-review.md
@@ -1,0 +1,108 @@
+---
+allowed-tools: Bash(gh pr:*), Bash(gh run:*), Bash(gh api:*), Bash(git branch:*), Bash(git log:*)
+description: Query and summarize GitHub CI results for a tt-xla PR — shows job status, failure logs, and merge readiness
+argument-hint: "[pr-number] (default: current branch's open PR)"
+---
+
+## tt-xla CI Review
+
+You are summarizing the GitHub CI status for a tt-xla pull request.
+
+### Step 1 — Resolve the PR
+
+If a PR number was given as `$ARGUMENTS`, use it directly.
+
+Otherwise, resolve from the current branch:
+```bash
+gh pr view --json number,title,state,headRefName,url
+```
+
+If no open PR exists for the current branch, report that and stop.
+
+---
+
+### Step 2 — Fetch Check Status
+
+```bash
+gh pr checks <PR_NUMBER> --json name,state,conclusion,startedAt,completedAt,detailsUrl
+```
+
+Also get the overall PR status:
+```bash
+gh pr view <PR_NUMBER> --json mergeable,mergeStateStatus,reviewDecision,statusCheckRollup
+```
+
+---
+
+### Step 3 — Categorize by Known tt-xla CI Jobs
+
+The tt-xla `pr-main.yml` workflow defines these jobs. Map each check result to its category:
+
+| Job name pattern | Category | Blocking? |
+|---|---|---|
+| `pre-commit` | Lint gate | Yes |
+| `inspect-changes` | Change detection | No |
+| `build-ttxla` / `build-ttxla-debug` | Build | Yes |
+| `test` / `basic-test` | Push test suite | Yes |
+| `test_forge_models_push` | Model tests | Yes |
+| `build-docs` | Documentation build | No |
+| `check-all-green` | Merge sentinel | Yes |
+
+---
+
+### Step 4 — For Each Failing Job, Fetch Log Tail
+
+```bash
+# Get the run ID from the detailsUrl or:
+gh run list --branch <branch> --json databaseId,name,status,conclusion | head -5
+
+# Fetch failed job logs
+gh run view <RUN_ID> --log-failed 2>&1 | tail -150
+```
+
+For each failure, identify:
+- The specific error message / stack trace
+- Which file or test caused the failure
+- The likely root cause (CMake error, test assertion, lint violation, etc.)
+
+---
+
+### Step 5 — Output Structured Summary
+
+```
+## CI Review: PR #<N> — <title>
+
+**Branch:** <branch>  **URL:** <url>
+
+### Overall: PASS / FAIL / IN PROGRESS / WAITING
+
+| Job | Status | Duration | Notes |
+|-----|--------|----------|-------|
+| pre-commit | PASS | 1m23s | |
+| build-ttxla | FAIL | 8m12s | CMake error |
+| test | IN PROGRESS | — | |
+| check-all-green | FAIL | — | blocked by build-ttxla |
+
+### Failing Jobs
+
+#### <job-name>
+**Status:** FAIL  **Run:** <url>
+
+```
+<log excerpt — last 30-50 lines of failure>
+```
+
+**Likely cause:** <brief diagnosis>
+**Suggested fix:** <concrete next step>
+
+---
+
+### Merge Readiness
+
+- Required checks green: yes / no
+- `check-all-green`: PASS / FAIL / pending
+- Review decision: APPROVED / REVIEW_REQUIRED / CHANGES_REQUESTED
+- Mergeable: yes / no / CONFLICTING
+
+**Verdict:** READY TO MERGE / BLOCKED (reasons)
+```

--- a/.claude/plugins/tt-xla-dev/commands/create-pr.md
+++ b/.claude/plugins/tt-xla-dev/commands/create-pr.md
@@ -1,0 +1,171 @@
+---
+allowed-tools: Bash(git diff:*), Bash(git log:*), Bash(git branch:*), Bash(git push:*), Bash(git status:*), Bash(gh pr:*), Bash(gh label:*), Bash(gh api:*), Read, Grep
+description: Create a tt-xla PR with proper title, body template, CODEOWNERS-derived reviewers, and labels
+argument-hint: "[area-prefix] (optional: e.g. 'vLLM', 'CI', 'pjrt' — auto-detected if omitted)"
+---
+
+## tt-xla PR Creation
+
+You are creating a GitHub pull request for the tt-xla repository. Work through each step carefully.
+
+### Step 1 — Pre-flight Checks
+
+Verify we are NOT on `main`:
+```bash
+git branch --show-current
+```
+If on `main`, stop and ask the user to switch to a feature branch.
+
+Check for uncommitted changes:
+```bash
+git status --short
+```
+Warn if there are unstaged changes that might be missing from the PR.
+
+Show the commits that will be in the PR:
+```bash
+git log main..HEAD --oneline
+```
+If there are no commits ahead of main, stop — nothing to PR.
+
+---
+
+### Step 2 — Detect Area and Generate PR Title
+
+Read the changed paths:
+```bash
+git diff main...HEAD --name-only
+```
+
+If `$ARGUMENTS` provides an area prefix (e.g. "vLLM", "CI"), use it directly.
+Otherwise, auto-detect using the path lookup table from `.claude/commit-template.md`:
+
+| Path pattern | Prefix |
+|---|---|
+| `tests/integrations/vllm_plugin/` or `integrations/vllm_plugin/` | `[vLLM plugin]` |
+| `.github/` | `[CI]` |
+| `tests/infra/` or `tests/runner/` or `pytest.ini` | `[Test Infra]` |
+| `pjrt_implementation/` | `[pjrt]` |
+| `python_package/tt_torch/` (fusion) | `[FX fusing]` |
+| `python_package/` or `CMakeLists.txt` | `[build]` |
+| `scripts/` | `[tools]` |
+| `tests/` (other) | `[test]` |
+| Multiple areas or no clear match | no prefix, bare verb |
+
+Read the commit log to understand the change:
+```bash
+git log main..HEAD --format='%s%n%b' | head -40
+```
+
+Generate a PR title following the convention from `.claude/commit-template.md`:
+- Format: `[Area] Short imperative description`
+- ≤ 72 characters, sentence-case, no trailing period
+- No `feat:` / `fix:` prefixes
+
+**Present the proposed title to the user and ask for confirmation before proceeding.**
+
+---
+
+### Step 3 — Generate PR Body
+
+Read the PR body template from `.claude/pr-body-template.md`.
+
+Auto-fill the sections:
+
+**Ticket:** Leave as placeholder `<!-- ... -->` unless the user mentioned an issue number.
+
+**Problem description:** Summarize *why* this change is needed, inferred from commit messages and diff.
+
+**What's changed:** Pull from `git log main..HEAD --format='%s%n%b'` and the diff summary:
+```bash
+git diff main...HEAD --stat
+```
+
+**Testing:** Based on changed paths, suggest the relevant test command:
+- Changes in `pjrt_implementation/` or `python_package/tt_jax/` → `pytest -v tests/jax/single_chip`
+- Changes in `python_package/tt_torch/` or `tests/torch/` → `pytest -v tests/torch -m single_device`
+- Changes in `tests/integrations/vllm_plugin/` → suggest vLLM integration tests
+- CI / build changes → `pre-commit run --all-files`
+
+**Checklist:** Pre-tick based on what you can verify:
+- SPDX headers: `git diff main...HEAD --name-only --diff-filter=A | xargs grep -L 'SPDX-License-Identifier' 2>/dev/null`
+- Tests present: check if changed source files have corresponding test files
+
+---
+
+### Step 4 — Determine Reviewers from CODEOWNERS
+
+Read CODEOWNERS:
+```bash
+cat .github/CODEOWNERS
+```
+
+For each changed path, find the matching CODEOWNERS entry (most specific match wins).
+Collect all owner handles, deduplicate, strip the `@` prefix.
+
+Always include at least one of the global owners: `mrakitaTT`, `nvukobratTT`, `AleksKnezevic`.
+
+Build the `--reviewer` list (max 15 reviewers for GitHub).
+
+---
+
+### Step 5 — Determine Labels
+
+Map the detected area prefix to a GitHub label:
+
+| Area | Label |
+|---|---|
+| `[CI]` | `ci` |
+| `[vLLM plugin]` or `[vLLM]` | `vllm` |
+| `[pjrt]` | `pjrt` |
+| `[test]` or `[Test Infra]` | `testing` |
+| `[build]` | `build` |
+| `[FX fusing]` | `fx-fusing` |
+| `Uplift third_party/tt-mlir` | `uplift-mlir` |
+| `Uplift third_party/tt_forge_models` | `uplift-forge-models` |
+
+Check that the label exists on the repo:
+```bash
+gh label list --json name | python3 -c "import sys,json; labels=[l['name'] for l in json.load(sys.stdin)]; print('\n'.join(labels))"
+```
+
+If a needed label does not exist, create it:
+```bash
+gh label create <label> --color "0075ca" --description "<description>"
+```
+
+---
+
+### Step 6 — Push and Create PR
+
+If the branch has not been pushed yet:
+```bash
+git push -u origin $(git branch --show-current)
+```
+
+Create the PR:
+```bash
+gh pr create \
+  --title "<generated title>" \
+  --body "$(cat <<'EOF'
+<generated body>
+EOF
+)" \
+  --reviewer <reviewer1>,<reviewer2>,... \
+  --label <label> \
+  --base main
+```
+
+---
+
+### Step 7 — Post-Creation
+
+After the PR is created:
+1. Print the PR URL.
+2. Run a quick CI status check (wait ~15 seconds for workflows to trigger):
+   ```bash
+   sleep 15 && gh pr checks <PR_NUMBER>
+   ```
+3. Report which CI jobs have started.
+
+Remind the user they can run `/tt-xla-dev:ci-review <PR_NUMBER>` at any time for a full CI summary.

--- a/.claude/plugins/tt-xla-dev/commands/create-pr.md
+++ b/.claude/plugins/tt-xla-dev/commands/create-pr.md
@@ -1,12 +1,12 @@
 ---
-allowed-tools: Bash(git diff:*), Bash(git log:*), Bash(git branch:*), Bash(git push:*), Bash(git status:*), Bash(gh pr:*), Bash(gh label:*), Bash(gh api:*), Read, Grep
-description: Create a tt-xla PR with proper title, body template, CODEOWNERS-derived reviewers, and labels
+allowed-tools: Bash(git diff:*), Bash(git log:*), Bash(git branch:*), Bash(git push:*), Bash(git status:*), Bash(gh pr:*), Bash(gh issue:*), Bash(gh label:*), Bash(gh api:*), Read, Grep
+description: Create a tt-xla GitHub issue + PR with proper title, body template, CODEOWNERS-derived reviewers, and labels
 argument-hint: "[area-prefix] (optional: e.g. 'vLLM', 'CI', 'pjrt' — auto-detected if omitted)"
 ---
 
 ## tt-xla PR Creation
 
-You are creating a GitHub pull request for the tt-xla repository. Work through each step carefully.
+You are creating a GitHub issue and pull request for the tt-xla repository. Work through each step carefully.
 
 ### Step 1 — Pre-flight Checks
 
@@ -30,7 +30,47 @@ If there are no commits ahead of main, stop — nothing to PR.
 
 ---
 
-### Step 2 — Detect Area and Generate PR Title
+### Step 2 — Create GitHub Issue
+
+Before creating the PR, create a GitHub issue to document the problem and provide a ticket link.
+
+Ask the user: "Do you have an existing GitHub issue to link? (enter number or URL, or press Enter to create one now)"
+
+**If creating a new issue:**
+
+Build the issue body from the commit log and diff:
+```bash
+git log main..HEAD --format='%s%n%b' | head -40
+git diff main...HEAD --stat
+```
+
+Create the issue:
+```bash
+gh issue create \
+  --title "<same title as the PR, without the [Area] prefix if it reads naturally>" \
+  --body "$(cat <<'EOF'
+## Problem
+<!-- Why is this change needed? What is broken or missing? -->
+<summarize from commit messages and diff>
+
+## Proposed Solution
+<!-- What approach does this PR take? -->
+<summarize from diff>
+
+## Files Changed
+<git diff --stat output>
+EOF
+)" \
+  --repo tenstorrent/tt-xla
+```
+
+Save the returned issue URL/number — it will be linked in the PR body as the Ticket.
+
+**If the user provides an existing issue number:** use it directly (format: `https://github.com/tenstorrent/tt-xla/issues/<N>`).
+
+---
+
+### Step 3 — Detect Area and Generate PR Title
 
 Read the changed paths:
 ```bash
@@ -66,13 +106,13 @@ Generate a PR title following the convention from `.claude/commit-template.md`:
 
 ---
 
-### Step 3 — Generate PR Body
+### Step 4 — Generate PR Body
 
 Read the PR body template from `.claude/pr-body-template.md`.
 
 Auto-fill the sections:
 
-**Ticket:** Leave as placeholder `<!-- ... -->` unless the user mentioned an issue number.
+**Ticket:** Use the issue URL from Step 2 (e.g. `https://github.com/tenstorrent/tt-xla/issues/4047`).
 
 **Problem description:** Summarize *why* this change is needed, inferred from commit messages and diff.
 
@@ -93,7 +133,7 @@ git diff main...HEAD --stat
 
 ---
 
-### Step 4 — Determine Reviewers from CODEOWNERS
+### Step 5 — Determine Reviewers from CODEOWNERS
 
 Read CODEOWNERS:
 ```bash
@@ -109,7 +149,7 @@ Build the `--reviewer` list (max 15 reviewers for GitHub).
 
 ---
 
-### Step 5 — Determine Labels
+### Step 6 — Determine Labels
 
 Map the detected area prefix to a GitHub label:
 
@@ -136,7 +176,7 @@ gh label create <label> --color "0075ca" --description "<description>"
 
 ---
 
-### Step 6 — Push and Create PR
+### Step 7 — Push and Create PR
 
 If the branch has not been pushed yet:
 ```bash
@@ -158,7 +198,7 @@ EOF
 
 ---
 
-### Step 7 — Post-Creation
+### Step 8 — Post-Creation
 
 After the PR is created:
 1. Print the PR URL.

--- a/.claude/plugins/tt-xla-dev/commands/local-review.md
+++ b/.claude/plugins/tt-xla-dev/commands/local-review.md
@@ -1,0 +1,162 @@
+---
+allowed-tools: Bash(git diff:*), Bash(git log:*), Bash(git status:*), Bash(git stash:*), Bash(pre-commit:*), Bash(black:*), Bash(python3:*), Bash(grep:*), Bash(find:*), Read, Glob, Grep
+description: Review staged/branch changes before creating a PR — lint, diff analysis, test gap detection, and pre-filled PR checklist
+argument-hint: "[--branch <base-branch>] (default: compares staged changes; with --branch compares HEAD vs base)"
+---
+
+## tt-xla Local PR Review
+
+You are performing a pre-PR review of changes in the tt-xla repository. Work through the five phases below in order, reporting findings as you go.
+
+### Setup
+
+Determine review scope:
+- If the argument `--branch <base>` was given: compare `git diff <base>...HEAD`
+- Otherwise: compare staged changes via `git diff --staged`
+
+Run:
+```bash
+git diff --staged --stat
+# or if --branch was given:
+git diff <base>...HEAD --stat
+```
+
+Also get the list of changed files:
+```bash
+git diff --staged --name-only
+# or
+git diff <base>...HEAD --name-only
+```
+
+---
+
+### Phase 1 — Lint Gate
+
+Run pre-commit on changed files:
+```bash
+pre-commit run --files $(git diff --staged --name-only | tr '\n' ' ')
+```
+
+If `pre-commit` is not available, fall back to:
+```bash
+# Python files
+black --check $(git diff --staged --name-only | grep '\.py$' | tr '\n' ' ')
+python3 -m isort --check-only $(git diff --staged --name-only | grep '\.py$' | tr '\n' ' ')
+
+# C++ files
+for f in $(git diff --staged --name-only | grep -E '\.(cpp|h|hpp)$'); do
+  clang-format --dry-run -Werror "$f" 2>&1 && echo "OK: $f" || echo "FAIL: $f"
+done
+```
+
+Check SPDX headers on newly added files:
+```bash
+git diff --staged --name-only --diff-filter=A | grep -E '\.(cpp|h|hpp|py)$' | while read f; do
+  grep -q 'SPDX-License-Identifier: Apache-2.0' "$f" || echo "MISSING SPDX: $f"
+done
+```
+
+Report: PASS / FAIL with specific violations.
+
+---
+
+### Phase 2 — Diff Analysis
+
+Read the full diff:
+```bash
+git diff --staged
+# or git diff <base>...HEAD
+```
+
+For each changed file, note:
+- **What changed**: brief functional summary (not just "lines added")
+- **Risk flags** (highlight these):
+  - File touches multiple CODEOWNERS areas (will need more reviewers)
+  - TODO / FIXME / HACK / print statement / debug code added
+  - Large function added (>50 lines) with no corresponding test change
+  - Public API change (function signature, exported symbol) with no doc update
+
+Parse `.github/CODEOWNERS` to identify which owner groups are affected by the changed paths:
+```bash
+cat .github/CODEOWNERS
+```
+
+Report which CODEOWNERS areas are touched and which owners will be auto-requested.
+
+---
+
+### Phase 3 — Test Coverage Check
+
+For each changed **source** file (`.cpp`, `.h`, `.py` in non-test directories), check whether a corresponding test exists:
+
+| Source path | Expected test location |
+|---|---|
+| `pjrt_implementation/src/` | `tests/jax/` or `tests/torch/` |
+| `python_package/tt_torch/` | `tests/torch/` |
+| `python_package/tt_jax/` | `tests/jax/` |
+| `integrations/vllm_plugin/` | `tests/integrations/vllm_plugin/` |
+
+```bash
+# Example: find test files that reference the changed module
+git diff --staged --name-only | grep -v '^tests/' | while read src; do
+  base=$(basename "$src" | sed 's/\.[^.]*$//')
+  found=$(find tests/ -name "*${base}*" -o -name "test_${base}*" 2>/dev/null | head -3)
+  echo "Source: $src -> Tests: ${found:-NONE FOUND}"
+done
+```
+
+Report any source files with no identifiable test coverage.
+
+---
+
+### Phase 4 — Commit Message Check
+
+Check the staged commits (or branch commits) for convention compliance:
+```bash
+git log --oneline -10
+# or for branch: git log <base>..HEAD --oneline
+```
+
+For each commit title:
+- Verify `[Area]` prefix is from the known list (see `.claude/commit-template.md`) OR uses bare-verb style
+- Verify title ≤ 72 characters
+- Verify no `feat:` / `fix:` / `chore:` prefixes
+- Verify imperative form
+
+Report any violations.
+
+---
+
+### Phase 5 — Pre-PR Checklist Output
+
+Produce a filled-in checklist based on findings from Phases 1-4. Use the template from `.claude/pr-body-template.md` and pre-tick items that passed.
+
+```
+## Pre-PR Review Summary
+
+### Lint
+- [x/] pre-commit / black / clang-format: PASS or FAIL (details)
+- [x/] SPDX headers: all present / MISSING on: <files>
+
+### Diff Analysis
+- Changed areas: <list>
+- CODEOWNERS affected: <owners>
+- Risk flags: <none / list>
+
+### Test Coverage
+- Source files with tests: <n>/<total>
+- Gaps: <list or "none">
+
+### Commit Messages
+- All commits follow convention: yes / no (violations: <list>)
+
+### Suggested PR Checklist
+- [x] New/existing tests provide coverage for changes
+- [ ] pre-commit run --all-files passes
+- [x] SPDX headers present on new files
+- [ ] CLAUDE.md updated if needed
+- [x] CODEOWNERS will auto-assign: <owners>
+
+### Verdict
+READY FOR PR / NEEDS FIXES (list blocking issues)
+```

--- a/.claude/plugins/tt-xla-dev/hooks/hooks.json
+++ b/.claude/plugins/tt-xla-dev/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "description": "tt-xla-dev plugin hooks — validates commit messages after git commit calls",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/validate-commit.py",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/plugins/tt-xla-dev/hooks/validate-commit.py
+++ b/.claude/plugins/tt-xla-dev/hooks/validate-commit.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+tt-xla commit message validator.
+Fires on every PostToolUse Bash event. Only acts on git commit calls.
+Outputs a JSON systemMessage if the commit message violates tt-xla conventions.
+"""
+
+import json
+import re
+import sys
+
+KNOWN_PREFIXES = {
+    "[vLLM plugin]",
+    "[vLLM Plugin]",
+    "[vLLM]",
+    "[CI]",
+    "[Test Infra]",
+    "[pjrt]",
+    "[FX fusing]",
+    "[test]",
+    "[build]",
+    "[python-package]",
+    "[tools]",
+}
+
+WRONG_PREFIXES = re.compile(r"^(feat|fix|chore|docs|style|refactor|test|perf|ci|build)(\(.+\))?:", re.IGNORECASE)
+
+PAST_TENSE = re.compile(r"^(Added|Fixed|Updated|Removed|Enabled|Disabled|Changed|Implemented|Improved|Moved|Renamed|Refactored)\s", re.IGNORECASE)
+
+GERUND = re.compile(r"^(Adding|Fixing|Updating|Removing|Enabling|Disabling|Changing|Implementing|Improving)\s", re.IGNORECASE)
+
+
+def extract_commit_message(command: str) -> str | None:
+    """Extract the -m argument from a git commit command string."""
+    # Match: git commit -m "..." or git commit -m '...'
+    patterns = [
+        r'git\s+commit\b.*?-m\s+"((?:[^"\\]|\\.)*)"',
+        r"git\s+commit\b.*?-m\s+'((?:[^'\\]|\\.)*)'",
+        # heredoc via $() — can't reliably extract, skip
+    ]
+    for pat in patterns:
+        m = re.search(pat, command, re.DOTALL)
+        if m:
+            return m.group(1)
+    return None
+
+
+def validate(title: str) -> list[str]:
+    violations = []
+
+    # Check conventional commit prefix
+    if WRONG_PREFIXES.match(title):
+        violations.append(
+            f"uses conventional-commit prefix ('{title.split(':')[0]}:') — "
+            "tt-xla uses '[Area] Description' style, not 'feat:'/'fix:' etc."
+        )
+
+    # Check bracket prefix validity
+    if title.startswith("["):
+        bracket_end = title.find("]")
+        if bracket_end != -1:
+            prefix = title[: bracket_end + 1]
+            # Case-insensitive match against known prefixes
+            normalized = {p.lower(): p for p in KNOWN_PREFIXES}
+            if prefix.lower() not in normalized:
+                violations.append(
+                    f"unknown area prefix '{prefix}' — "
+                    f"valid prefixes: {', '.join(sorted(KNOWN_PREFIXES))}"
+                )
+
+    # Check length
+    first_line = title.split("\n")[0]
+    if len(first_line) > 72:
+        violations.append(
+            f"title is {len(first_line)} characters (max 72): '{first_line[:50]}...'"
+        )
+
+    # Check past tense
+    body = title.lstrip("[")
+    if "]" in body:
+        body = body[body.index("]") + 1:].lstrip()
+    if PAST_TENSE.match(body):
+        violations.append(
+            "title uses past tense — use imperative form (e.g. 'Add' not 'Added')"
+        )
+
+    # Check gerund
+    if GERUND.match(body):
+        violations.append(
+            "title uses gerund form — use imperative form (e.g. 'Add' not 'Adding')"
+        )
+
+    # Check trailing period
+    if first_line.endswith("."):
+        violations.append("title ends with a period — omit it")
+
+    return violations
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+
+    tool_name = payload.get("tool_name", "")
+    if tool_name != "Bash":
+        sys.exit(0)
+
+    tool_input = payload.get("tool_input", {})
+    command = tool_input.get("command", "")
+
+    if "git commit" not in command:
+        sys.exit(0)
+
+    msg = extract_commit_message(command)
+    if not msg:
+        # Can't extract message (heredoc etc.) — skip silently
+        sys.exit(0)
+
+    title = msg.strip().split("\n")[0]
+    violations = validate(title)
+
+    if violations:
+        violation_list = "\n".join(f"  • {v}" for v in violations)
+        output = {
+            "systemMessage": (
+                f"tt-xla commit message warning for: '{title}'\n"
+                f"Violations:\n{violation_list}\n\n"
+                f"Convention: [Area] Short imperative description (≤72 chars, no feat:/fix: prefixes)\n"
+                f"See .claude/commit-template.md for the full reference."
+            )
+        }
+        print(json.dumps(output))
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/plugins/tt-xla-dev/hooks/validate-commit.py
+++ b/.claude/plugins/tt-xla-dev/hooks/validate-commit.py
@@ -1,12 +1,17 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
 """
-tt-xla commit message validator.
+tt-xla commit message validator + PR description printer.
 Fires on every PostToolUse Bash event. Only acts on git commit calls.
-Outputs a JSON systemMessage if the commit message violates tt-xla conventions.
+- On violations: outputs a JSON systemMessage with the issues.
+- On success: outputs a JSON systemMessage with a draft PR description.
 """
 
 import json
 import re
+import subprocess
 import sys
 
 KNOWN_PREFIXES = {
@@ -23,11 +28,19 @@ KNOWN_PREFIXES = {
     "[tools]",
 }
 
-WRONG_PREFIXES = re.compile(r"^(feat|fix|chore|docs|style|refactor|test|perf|ci|build)(\(.+\))?:", re.IGNORECASE)
+WRONG_PREFIXES = re.compile(
+    r"^(feat|fix|chore|docs|style|refactor|test|perf|ci|build)(\(.+\))?:", re.IGNORECASE
+)
 
-PAST_TENSE = re.compile(r"^(Added|Fixed|Updated|Removed|Enabled|Disabled|Changed|Implemented|Improved|Moved|Renamed|Refactored)\s", re.IGNORECASE)
+PAST_TENSE = re.compile(
+    r"^(Added|Fixed|Updated|Removed|Enabled|Disabled|Changed|Implemented|Improved|Moved|Renamed|Refactored)\s",
+    re.IGNORECASE,
+)
 
-GERUND = re.compile(r"^(Adding|Fixing|Updating|Removing|Enabling|Disabling|Changing|Implementing|Improving)\s", re.IGNORECASE)
+GERUND = re.compile(
+    r"^(Adding|Fixing|Updating|Removing|Enabling|Disabling|Changing|Implementing|Improving)\s",
+    re.IGNORECASE,
+)
 
 
 def extract_commit_message(command: str) -> str | None:
@@ -78,7 +91,7 @@ def validate(title: str) -> list[str]:
     # Check past tense
     body = title.lstrip("[")
     if "]" in body:
-        body = body[body.index("]") + 1:].lstrip()
+        body = body[body.index("]") + 1 :].lstrip()
     if PAST_TENSE.match(body):
         violations.append(
             "title uses past tense — use imperative form (e.g. 'Add' not 'Added')"
@@ -97,6 +110,60 @@ def validate(title: str) -> list[str]:
     return violations
 
 
+def git(*args) -> str:
+    """Run a git command and return stdout, or empty string on error."""
+    try:
+        return (
+            subprocess.check_output(["git"] + list(args), stderr=subprocess.DEVNULL)
+            .decode()
+            .strip()
+        )
+    except subprocess.CalledProcessError:
+        return ""
+
+
+def build_pr_description(commit_title: str) -> str:
+    """Build a draft PR description from current branch state."""
+    branch = git("branch", "--show-current")
+    log = git("log", "main..HEAD", "--format=%s")
+    diff_stat = git("diff", "main...HEAD", "--stat")
+
+    # Infer ticket placeholder — real issue URL filled in by user
+    ticket = "<!-- Link to GitHub Issue -->"
+
+    # Problem description: infer from commit title
+    # Strip [Area] prefix for readability
+    problem_title = re.sub(r"^\[.+?\]\s*", "", commit_title)
+
+    pr_description = f"""### Ticket
+{ticket}
+
+### Problem description
+{problem_title}
+
+### What's changed
+{log if log else commit_title}
+
+```
+{diff_stat if diff_stat else "No diff against main yet"}
+```
+
+### Checklist
+- [ ] New/Existing tests provide coverage for changes"""
+
+    lines = [
+        f"Commit successful on branch: {branch}" if branch else "Commit successful.",
+        "",
+        "Draft PR description:",
+        "─" * 60,
+        pr_description,
+        "─" * 60,
+        "",
+        "Run /tt-xla-dev:create-pr to open a PR with full body, reviewers, and labels.",
+    ]
+    return "\n".join(lines)
+
+
 def main():
     try:
         payload = json.load(sys.stdin)
@@ -113,9 +180,14 @@ def main():
     if "git commit" not in command:
         sys.exit(0)
 
+    # Only act on successful commits
+    tool_response = payload.get("tool_response", {})
+    exit_code = tool_response.get("exit_code", 0)
+    if exit_code != 0:
+        sys.exit(0)
+
     msg = extract_commit_message(command)
     if not msg:
-        # Can't extract message (heredoc etc.) — skip silently
         sys.exit(0)
 
     title = msg.strip().split("\n")[0]
@@ -131,6 +203,10 @@ def main():
                 f"See .claude/commit-template.md for the full reference."
             )
         }
+        print(json.dumps(output))
+    else:
+        # Commit is clean — print draft PR description
+        output = {"systemMessage": build_pr_description(title)}
         print(json.dumps(output))
 
     sys.exit(0)

--- a/.claude/plugins/tt-xla-dev/skills/commit-message/SKILL.md
+++ b/.claude/plugins/tt-xla-dev/skills/commit-message/SKILL.md
@@ -95,7 +95,7 @@ Remind the user if any new file is missing this header.
 ## Anti-patterns to Avoid
 
 - `feat: add something` — wrong convention
-- `fix(pjrt): something` — wrong convention  
+- `fix(pjrt): something` — wrong convention
 - `Added support for X` — past tense, wrong
 - `Adding support for X` — gerund, wrong
 - `Update stuff` — too vague

--- a/.claude/plugins/tt-xla-dev/skills/commit-message/SKILL.md
+++ b/.claude/plugins/tt-xla-dev/skills/commit-message/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: commit-message
+description: >
+  This skill should be used when the user asks to "write a commit message",
+  "create a commit", "what commit message should I use", "what prefix should I use",
+  "format a commit", "stage and commit", "commit this change", "commit these changes",
+  or when Claude is about to run a git commit command in the tt-xla repository.
+  Also applies when the user asks "what is the commit convention" or "how should I format commits".
+version: 1.0.0
+---
+
+# tt-xla Commit Message Skill
+
+This skill enforces the tt-xla commit message convention whenever Claude writes or suggests a commit message.
+
+## Convention: `[Area] Short imperative description`
+
+The full reference is in the repo at `.claude/commit-template.md`. Key rules:
+
+1. **Title ≤ 72 characters**, imperative, sentence-case, no trailing period
+2. **No `feat:` / `fix:` / `chore:` prefixes** — this repo does NOT use conventional commits
+3. **`[Area]` bracket prefix** when the change is clearly in one area; bare verb otherwise
+4. **`(#PR)` is added by GitHub on merge** — omit it when writing manually
+
+## Step-by-Step: How to Generate the Commit Message
+
+### Step 1 — Identify changed paths
+
+Run:
+```bash
+git diff --staged --name-only
+```
+If nothing is staged, run `git diff --name-only HEAD` instead.
+
+### Step 2 — Map paths to prefix
+
+Use this lookup table (first match wins, most specific path first):
+
+| If ANY changed path starts with… | Use prefix |
+|---|---|
+| `tests/integrations/vllm_plugin/` or `integrations/vllm_plugin/` | `[vLLM plugin]` |
+| `.github/` | `[CI]` |
+| `tests/infra/` or `tests/runner/` or `pytest.ini` | `[Test Infra]` |
+| `pjrt_implementation/` | `[pjrt]` |
+| `python_package/tt_torch/` (fusion-related file names) | `[FX fusing]` |
+| `python_package/` or `CMakeLists.txt` or `CMakePresets.json` | `[build]` |
+| `scripts/` | `[tools]` |
+| `tests/` (other) | `[test]` |
+| `third_party/` (submodule bump commit) | bare `Uplift third_party/<name> to <hash> <date>` |
+
+**If changes span multiple areas**, use no prefix — use a bare imperative verb instead.
+
+### Step 3 — Read the diff to understand the change
+
+Run:
+```bash
+git diff --staged
+```
+Read what was actually changed. The commit title must describe *what changed and why*, not just *which files*.
+
+### Step 4 — Draft the title
+
+Structure: `[Prefix] <Verb> <what> [for/in/to <context>]`
+
+Examples:
+- `[vLLM] Implement prompt_logprobs support`
+- `[CI] revert upgrade of checkout`
+- `[Test Infra] prevent ReferenceError during test teardown cleanup`
+- `[FX fusing] Expand rms_norm pattern for gpt_oss`
+- `[pjrt] PJRT_Buffer_ToHostBuffer size query fix`
+- `[build] local dev build fixes`
+- `[test] conv3d + mochi decoder tests improvement`
+- `Add support for sparse moe`
+- `Fix nightly`
+- `Enable dtype in CI runs log summary`
+- `Uplift third_party/tt_forge_models to 78e977e 2026-03-11`
+
+### Step 5 — Add optional body (for non-trivial changes)
+
+If the change is non-trivial (> ~50 lines changed, or the title alone doesn't capture why), add a blank line then 1-3 body lines:
+- Wrap at 72 characters
+- Explain *why*, not *what* (the diff shows what)
+- Reference the issue/ticket if one exists
+
+### Step 6 — Check for SPDX headers on new files
+
+If new source files (`.cpp`, `.h`, `.py`) were added, verify they contain:
+```
+// SPDX-License-Identifier: Apache-2.0
+```
+(Python files use `# SPDX-License-Identifier: Apache-2.0`)
+
+Remind the user if any new file is missing this header.
+
+## Anti-patterns to Avoid
+
+- `feat: add something` — wrong convention
+- `fix(pjrt): something` — wrong convention  
+- `Added support for X` — past tense, wrong
+- `Adding support for X` — gerund, wrong
+- `Update stuff` — too vague
+- Title > 72 characters — too long, shorten it

--- a/.claude/pr-body-template.md
+++ b/.claude/pr-body-template.md
@@ -1,0 +1,53 @@
+# tt-xla PR Body Template
+
+Use this template when creating PRs. Fill in each section; remove sections that are not applicable.
+
+---
+
+```markdown
+### Ticket
+<!-- Link to GitHub Issue, Linear ticket, or "N/A" -->
+
+### Problem description
+<!-- What is broken or missing? Provide context for *why* this change is needed. -->
+
+### What's changed
+<!-- Approach used. Summary of changes and their impact.
+     For multi-commit PRs, list what each logical group of commits does. -->
+
+### Testing
+<!-- How was this tested? Be specific about which test suites were run and on what hardware. -->
+
+#### Test commands run
+```bash
+# e.g.
+pytest -v tests/jax/single_chip
+pytest -v tests/torch -m single_device
+pre-commit run --all-files
+```
+
+#### Checklist
+- [ ] New/existing tests provide coverage for changes
+- [ ] `pre-commit run --all-files` passes (black, clang-format, isort, SPDX header check)
+- [ ] SPDX copyright header added to all new source files (`// SPDX-License-Identifier: Apache-2.0`)
+- [ ] CLAUDE.md updated if architecture, commands, or dev workflow changed
+- [ ] Relevant CODEOWNERS areas notified (auto-assigned by GitHub)
+- [ ] No debug prints, TODOs, or temporary hacks left in
+```
+
+---
+
+## CODEOWNERS Quick Reference
+
+| Path | Owners |
+|---|---|
+| `/.github/` | @vmilosevic @kmabeeTT @nsumrakTT @vvukomanTT |
+| `/pjrt_implementation/` | @mrakitaTT @pilkicTT @nvukobratTT @acolicTT @ajakovljevicTT |
+| `/tests/integrations/vllm_plugin/` | @AleksKnezevic @kmabeeTT @mmanzoorTT @ljovanovicTT |
+| `/integrations/vllm_plugin/` | @AleksKnezevic @kmabeeTT @mmanzoorTT @ljovanovicTT |
+| `/python_package/tt_torch/` | @nvukobratTT @dgolubovicTT @jameszianxuTT @AleksKnezevic |
+| `/python_package/tt_jax/` | @mrakitaTT @ajakovljevicTT @sdjukicTT @sgligorijevicTT |
+| `/tests/` | @mrakitaTT @ajakovljevicTT @AleksKnezevic @kmabeeTT |
+| `/third_party/` | @mrakitaTT @pilkicTT @nvukobratTT @acolicTT |
+| `/scripts/` | @rpavlovicTT @odjuricicTT @AleksKnezevic @mrakitaTT |
+| `*` (global) | @mrakitaTT @nvukobratTT @AleksKnezevic |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,3 +128,28 @@ Use `@pytest.mark.record_test_properties()` to tag tests with:
 ### Python Requirements
 - jax==0.7.1, jaxlib==0.7.1, torch==2.7.0
 - torch-xla (custom build from Tenstorrent PyPI)
+
+## Claude Code Developer Tools
+
+A `tt-xla-dev` plugin provides automated commit/PR workflows. Install it at `~/.claude/plugins/tt-xla-dev/`.
+
+### Slash Commands
+
+| Command | Purpose |
+|---|---|
+| `/tt-xla-dev:local-review` | Review staged changes before creating a PR (lint, diff analysis, test gaps, checklist) |
+| `/tt-xla-dev:ci-review [PR#]` | Fetch and summarize GitHub CI status for a PR |
+| `/tt-xla-dev:create-pr [area]` | Create a PR with proper title, body, reviewers, and labels |
+
+### Commit Message Convention
+
+The `commit-message` skill auto-activates whenever Claude writes a commit. Format:
+
+```
+[Area] Short imperative description
+```
+
+Valid area prefixes: `[vLLM plugin]`, `[vLLM]`, `[CI]`, `[Test Infra]`, `[pjrt]`, `[FX fusing]`, `[test]`, `[build]`, `[tools]`
+
+Full reference: `.claude/commit-template.md`
+PR body template: `.claude/pr-body-template.md`


### PR DESCRIPTION
### Ticket

[Issue Link](  https://github.com/tenstorrent/tt-xla/issues/4047)

### Problem description

  The tt-xla repo has no standardized tooling for commit message conventions, pre-PR review, or PR
  creation. Contributors use inconsistent commit formats, there's no structured checklist before
  opening a PR, and picking reviewers/labels from CODEOWNERS requires manual cross-referencing
  every time.

### What's changed
Added a tt-xla-dev Claude Code plugin under .claude/ that automates the developer PR workflow:

  - Commit message skill — auto-invoked by Claude when writing commits; enforces the repo's [Area]
  Short imperative description convention with a path-to-prefix lookup table built from repo
  history. A validate-commit.py PostToolUse hook warns on violations (past tense, wrong prefix,
  length > 72 chars, feat:/fix: prefixes)
  - /tt-xla-dev:local-review — 5-phase pre-PR review: pre-commit lint, SPDX header check on new
  files, diff analysis (flags multi-CODEOWNER touches, TODOs, large additions without tests), test
  gap detection, and a pre-filled PR checklist
  - /tt-xla-dev:ci-review [PR#] — fetches and summarizes GitHub CI status per known tt-xla job
  (pre-commit, build-ttxla, test, test_forge_models_push, check-all-green), extracts failure logs,
  gives merge readiness verdict
  - /tt-xla-dev:create-pr [area] — creates a PR with auto-generated title, filled body template,
  CODEOWNERS-derived reviewers, and correct labels
  - CLAUDE.md — updated with a developer tools section documenting the commands and commit
  convention

  **Install after merging with: bash .claude/install-plugin.sh**

