### PR TITLE
Revert "[Benchmark] Use argmax for LLM sampling (#4037)"

### DIFF
--- a/tests/benchmark/llm_utils/decode_utils.py
+++ b/tests/benchmark/llm_utils/decode_utils.py
@@ -19,6 +19,30 @@ import tracy
 from transformers.cache_utils import StaticCache
 
 
+def _fast_argmax(last_logits: torch.Tensor) -> torch.Tensor:
+    """Alternative argmax implementation that avoids slow single-core ttnn.argmax.
+
+      1. ``max`` reduction to find the row-wise maximum value  (ttnn.max)
+      2. element-wise ``eq`` to build a boolean mask of matching positions
+      3. multiply mask by a position vector (iota) and ``max``-reduce to
+         recover the index of the (last) matching position
+
+    Args:
+        last_logits: ``[batch, vocab_size]`` logits for the last position.
+
+    Returns:
+        ``[batch, 1]`` token IDs (the argmax indices).
+    """
+    B, V = last_logits.shape
+    row_max = last_logits.max(dim=-1, keepdim=True).values
+    mask = last_logits == row_max
+    positions = torch.arange(1, V + 1, device=last_logits.device, dtype=torch.float32)
+    masked_positions = mask.to(torch.float32) * positions.unsqueeze(0)
+    next_token_ids = (masked_positions.max(dim=-1).values - 1.0).to(torch.int64)
+
+    return next_token_ids.unsqueeze(-1)
+
+
 class LLMSamplingWrapper(torch.nn.Module):
     """Wraps an LLM to perform sampling (token selection, cache positionupdate) on device.
 
@@ -52,7 +76,7 @@ class LLMSamplingWrapper(torch.nn.Module):
             use_cache=use_cache,
         )
         logits = self.read_logits_fn(output)
-        next_token_ids = logits[:, -1].argmax(dim=-1, keepdim=True)
+        next_token_ids = _fast_argmax(logits[:, -1])
         next_cache_position = cache_position[-1:] + 1
         if self.return_logits:
             return next_token_ids, next_cache_position, logits


### PR DESCRIPTION
This reverts commit 4bde69d5d4cd53c7d3e7e50b2af4e1482339c06e.

llama_3_1_70b_tp [fails on LLMBOX](https://github.com/tenstorrent/tt-xla/actions/runs/23825530884/job/69447587067) with:

`TT_FATAL: Out of Memory: Not enough space to allocate 262668288 B DRAM buffer across 12 banks, where each bank needs to store 21889024 B, but bank size is 1071821792 B (allocated: 959582496 B, free: 112239296 B, largest free block: 11624224 B)`

### Checklist
- [x] [llama_3_1_70b_tp on LLMBOX](https://github.com/tenstorrent/tt-xla/actions/runs/23851055613)
