### PR TITLE
[Benchmark] Disable device perf

### DIFF
--- a/.github/workflows/call-perf-test.yml
+++ b/.github/workflows/call-perf-test.yml
@@ -33,7 +33,7 @@ on:
         description: "Skip device performance measurement"
         required: false
         type: boolean
-        default: false
+        default: true
       perf_regression_check:
         description: "Enable perf metrics regression testing"
         required: false

--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -14,7 +14,7 @@
       "libreq": "libgl1 libglib2.0-0",
       "skip-ttir-dump": false,
       "skip-ttnn-dump": false,
-      "skip-device-perf": false
+      "skip-device-perf": true
     },
     "tests": [
       {

--- a/.github/workflows/schedule-nightly.yml
+++ b/.github/workflows/schedule-nightly.yml
@@ -87,7 +87,7 @@ jobs:
     with:
       docker_image: ${{ needs.build-image.outputs.docker-image-base }}
       sh-runner: false
-      skip-device-perf: false
+      skip-device-perf: true
       perf_regression_check: true
       adv_filter: '[ {"accuracy-testing": false}, {"runs-on": "n150"}, {"runs-on": "n300-llmbox"}, {"runs-on": "galaxy-wh-6u"} ]'
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}


### PR DESCRIPTION
Run device perf job is often failing in benchmark CI.

This PR disables device perf on benchmark CI.
