### PR TITLE
[CI] Fail inspector disable machine inspect and uplift

### DIFF
--- a/.github/workflows/workflow-run-fail-inspect.yml
+++ b/.github/workflows/workflow-run-fail-inspect.yml
@@ -356,11 +356,11 @@ jobs:
             echo "IRD_LF_CACHE=${{ vars.IRD_LF_CACHE }}" >> $GITHUB_ENV
           fi
 
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
-        with:
-          create-symlink: true
-          key: "release-build"
+      # - name: ccache
+      #   uses: hendrikmuhs/ccache-action@v1.2
+      #   with:
+      #     create-symlink: true
+      #     key: "release-build"
 
       - name: Bisect
         shell: bash


### PR DESCRIPTION
### Ticket
slack

### Problem description
Make fail inspector faster and more useful

### What's changed
Disabled machine inspect feature so it runs bisect for each nightly run
Disabled entering uplifts to speedup results

### Note
This is quick change to incrementally make failure inspector more useful.
Further changes will be introduced day by day 

### Checklist
- [ ] New/Existing tests provide coverage for changes
