### PR TITLE
Disable dynamic torch model tester _initialize_model path due to dtype override bugs

### DIFF
--- a/tests/runner/testers/torch/dynamic_torch_model_tester.py
+++ b/tests/runner/testers/torch/dynamic_torch_model_tester.py
@@ -68,20 +68,20 @@ class DynamicTorchModelTester(TorchModelTester):
         if test_metadata and getattr(test_metadata, "inject_custom_moe", False):
             self._inject_custom_moe(self._model)
 
-    def _initialize_model(self):
-        """Initialize model and auto-apply per-variant weight dtype overrides."""
-        super()._initialize_model()
-        loader = self.dynamic_loader.loader
-        if hasattr(loader, "get_weight_dtype_config_path"):
-            config_path = loader.get_weight_dtype_config_path()
-            if config_path:
-                from tt_torch.weight_dtype import apply_weight_dtype_overrides
+    # def _initialize_model(self):
+    #     """Initialize model and auto-apply per-variant weight dtype overrides."""
+    #     super()._initialize_model()
+    #     loader = self.dynamic_loader.loader
+    #     if hasattr(loader, "get_weight_dtype_config_path"):
+    #         config_path = loader.get_weight_dtype_config_path()
+    #         if config_path:
+    #             from tt_torch.weight_dtype import apply_weight_dtype_overrides
 
-                applied = apply_weight_dtype_overrides(self._model, config_path)
-                if applied:
-                    logger.info(
-                        f"Applied {len(applied)} weight dtype overrides from {config_path}"
-                    )
+    #             applied = apply_weight_dtype_overrides(self._model, config_path)
+    #             if applied:
+    #                 logger.info(
+    #                     f"Applied {len(applied)} weight dtype overrides from {config_path}"
+    #                 )
 
     # --- TorchModelTester interface implementations ---
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/4068

### Problem
- Dynamic torch model tester broken on some models from #3975 

### What's changed
- Disable get_weight_dtype_config application path for dynamic torch model tester, fallback to parent _initialized_model
- This is a temporary measure until issues from #3975 are fixed, this may have a significant blast radius on nightly which I'd like to avoid 

### Checklist
- [x] New/Existing tests provide coverage for changes
