### PR TITLE
Fix ttrt install error message

### DIFF
--- a/.github/workflows/call-perf-test.yml
+++ b/.github/workflows/call-perf-test.yml
@@ -295,7 +295,7 @@ jobs:
           | jq -r '.workflow_runs[0].id')
 
         if [[ -z "$RUN_ID" || "$RUN_ID" == "null" ]]; then
-          echo "The tt-mlir commit doesn't contain a ttrt wheel artifact. Run an artifact building workflow on the commit (e.g. 'On PR')."
+          echo "The tt-mlir commit doesn't contain a ttrt wheel artifact. Run the "On push" workflow on the commit in tt-mlir."
           exit 1
         fi
 


### PR DESCRIPTION
### Ticket
/

### Problem description
Error thrown when ttrt artifact is missing refers to the wrong workflow as an example.

### What's changed
Tell users to explicitly run the "On push" workflow on tt-mlir on the commit if artifacts are missing.

### Checklist
- [ ] New/Existing tests provide coverage for changes
