### PR TITLE
Added test for racy FlatbufferLoadedExecutableInstance::execute calls

### DIFF
--- a/tests/torch/graphs/test_tensor_persistence.py
+++ b/tests/torch/graphs/test_tensor_persistence.py
@@ -602,6 +602,51 @@ def create_device_mesh(mesh_shape) -> Mesh:
 @pytest.mark.nightly
 @pytest.mark.llmbox
 @pytest.mark.skip(
+    reason=failed_runtime("https://github.com/tenstorrent/tt-xla/issues/4073")
+)
+def test_concurrent_sharded_buffer_instance_transfer():
+    """
+    Test scenario: Sharded input A participates in some graph, and is concurrently copied to host
+    by multiple framework threads.
+
+    This tests for race conditions in the copyToHost thread instance mutex management.
+    """
+
+    class Identity(torch.nn.Module):
+        def forward(self, A):
+            return A + 0
+
+    xr.set_device_type("TT")
+    setup_spmd()
+
+    device = torch_xla.device()
+    mesh = create_device_mesh((1, torch_xla.device_count()))
+
+    input = torch.randn(32, 32, dtype=torch.float32).to(device)
+    xs.mark_sharding(input, mesh, (None, "model"))
+
+    prog = Identity()
+    res = run_model_on_device(prog, [input])
+
+    # Create multiple threads that all copies result object
+    def copy_to_host():
+        for _ in range(1024):
+            res.cpu()
+
+    threads = []
+    num_threads = 10
+    for _ in range(num_threads):
+        thread_a = threading.Thread(target=copy_to_host)
+        threads.append(thread_a)
+        thread_a.start()
+
+    for thread in threads:
+        thread.join()
+
+
+@pytest.mark.nightly
+@pytest.mark.llmbox
+@pytest.mark.skip(
     reason=failed_runtime("Segfault: https://github.com/tenstorrent/tt-xla/issues/3280")
 )
 def test_shared_input_across_mesh_reshape():


### PR DESCRIPTION
This test is part of multiple (concurrent) buffer instance transfer tests. It differs from the other ones with sharded input tensor.

We can see all kinds of different assertions being hit (from python to metal).

Take a look https://github.com/tenstorrent/tt-xla/issues/4073 for details.
