### PR TITLE
Fix weight dtype overrides breaking model tests

### DIFF
--- a/tests/runner/testers/torch/dynamic_torch_model_tester.py
+++ b/tests/runner/testers/torch/dynamic_torch_model_tester.py
@@ -68,20 +68,42 @@ class DynamicTorchModelTester(TorchModelTester):
         if test_metadata and getattr(test_metadata, "inject_custom_moe", False):
             self._inject_custom_moe(self._model)
 
-    # def _initialize_model(self):
-    #     """Initialize model and auto-apply per-variant weight dtype overrides."""
-    #     super()._initialize_model()
-    #     loader = self.dynamic_loader.loader
-    #     if hasattr(loader, "get_weight_dtype_config_path"):
-    #         config_path = loader.get_weight_dtype_config_path()
-    #         if config_path:
-    #             from tt_torch.weight_dtype import apply_weight_dtype_overrides
+    def _compile_for_tt_device(self, workload, options=None):
+        """Apply per-variant weight dtype overrides before compiling for TT device."""
+        self._apply_weight_dtype_overrides()
+        super()._compile_for_tt_device(workload, options)
+        self._remove_weight_dtype_overrides()
 
-    #             applied = apply_weight_dtype_overrides(self._model, config_path)
-    #             if applied:
-    #                 logger.info(
-    #                     f"Applied {len(applied)} weight dtype overrides from {config_path}"
-    #                 )
+    def _apply_weight_dtype_overrides(self):
+        """Auto-apply per-variant weight dtype overrides if available."""
+        loader = self.dynamic_loader.loader
+        if not hasattr(loader, "get_weight_dtype_config_path"):
+            return
+        try:
+            config_path = loader.get_weight_dtype_config_path()
+        except TypeError:
+            return
+        if config_path:
+            from tt_torch.weight_dtype import apply_weight_dtype_overrides
+
+            applied = apply_weight_dtype_overrides(self._model, config_path)
+            if applied:
+                logger.info(
+                    f"Applied {len(applied)} weight dtype overrides from {config_path}"
+                )
+
+    def _remove_weight_dtype_overrides(self):
+        """Remove weight dtype parametrizations after compilation.
+
+        Parametrizations only need to be present during tracing/compilation to
+        inject stablehlo custom_call metadata. Removing them afterwards prevents
+        conflicts with tie_weights() during subsequent device placement.
+        """
+        from tt_torch.weight_dtype import remove_weight_dtype_overrides
+
+        removed = remove_weight_dtype_overrides(self._model)
+        if removed:
+            logger.info(f"Removed {removed} weight dtype overrides after compilation")
 
     # --- TorchModelTester interface implementations ---
 


### PR DESCRIPTION
### Ticket
Closes #4068 

### Problem description
[PR](https://github.com/tenstorrent/tt-xla/pull/3975) introduced a bug in DynamicTorchModelTester.
[onPR](https://github.com/tenstorrent/tt-xla/actions/runs/23848482271) CI was run run before the tt-forge-models changes landed in tt-xla. Turns out there are failures in main when this got merged and runs alongside the tt-forge-models changes.

 The per-tensor weight dtype overrides (#3975) applied parametrizations during _initialize_model(), which caused two issues:                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                    
  1. inspect.getfile() TypeError — get_weight_dtype_config_path() was called unconditionally during init, but some ModelLoader classes are loaded via torch.package, which makes inspect.getfile() raise TypeError: is a built-in class. Affected: mnist, vit, phi3, falcon, qwen, vgg.                                                                             
  2. tie_weights() TypeError — torch.nn.utils.parametrize replaces nn.Parameter with a plain Tensor accessor. Issue when the device runner later calls tie_weights() (both for CPU golden and TT device runs). Affected: gemma, llama.   

### What's changed
                                                                                                                                                                                                                                                                               
  Moved weight dtype override application from _initialize_model() to bracket _compile_for_tt_device() - apply before compilation (where the StableHLO custom_call metadata gets traced), remove immediately after (since the metadata is already baked into the compiled graph). This avoids conflicts with tie_weights() during device placement. This fixes two issues:
- tie_weights() failing after parametrization replaced nn.Parameters with plain tensors (gemma, llama)
- inspect.getfile() TypeError for package-imported loader classes (mnist, vit, phi3, falcon, qwen, vgg)
