### PR TITLE
[tests] Updated mistral test failure reason.

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -216,7 +216,7 @@ test_config:
   mistral/pytorch-mistral_small_3.2_24b_instruct_2506-tensor_parallel-inference:
     supported_archs: [n300-llmbox]
     status: KNOWN_FAILURE_XFAIL
-    reason: "KeyError: c_lifted_tensor_1 - https://github.com/tenstorrent/tt-xla/issues/3221"
+    reason: "Device count mismatch: 2 vs 1: https://github.com/tenstorrent/tt-xla/issues/4078"
 
   solar-10_7B/causal_lm/pytorch-10_7B_Instruct_v1.0-tensor_parallel-inference:
     supported_archs: [n300-llmbox]


### PR DESCRIPTION
Initial bugs were fixed for pytorch-mistral_small_3.2_24b_instruct_2506-tensor_parallel-inference with https://github.com/tenstorrent/tt-xla/issues/3221

Now, we have a new problem: https://github.com/tenstorrent/tt-xla/issues/4078

Updated failure reason for mistral in test config to match new bug.