### PR TITLE
Remove scalar-to-1D normalization in PJRT buffer shape calculation

### DIFF
--- a/pjrt_implementation/src/api/buffer_instance.cc
+++ b/pjrt_implementation/src/api/buffer_instance.cc
@@ -276,14 +276,9 @@ void BufferInstance::copyFromBuffer(BufferInstance *src_buffer) {
 std::vector<std::uint32_t>
 BufferInstance::calculateShape(const std::int64_t *dims, size_t num_dims,
                                PJRT_Buffer_Type data_type) {
-  if (num_dims == 0) {
-    // Our compiler and runtime don't support scalars so we convert them to 1D
-    // tensors.
-    if (data_type_utils::isComplexPJRTType(data_type)) {
-      // Throw error if complex tensor num_dims == 0.
-      TT_THROW("Complex tensor with num_dims == 0 is not supported.");
-    }
-    return {1};
+  if (data_type_utils::isComplexPJRTType(data_type) && num_dims == 0) {
+    // Throw error if complex tensor num_dims == 0.
+    TT_THROW("Complex tensor with num_dims == 0 is not supported.");
   }
 
   std::vector<std::uint32_t> shape;
@@ -303,11 +298,6 @@ BufferInstance::calculateShape(const std::int64_t *dims, size_t num_dims,
 std::vector<std::uint32_t> BufferInstance::calculateStrides(
     size_t num_dims, const std::int64_t *byte_strides, size_t num_byte_strides,
     std::uint32_t element_size) {
-  if (num_dims == 0) {
-    // Our compiler and runtime don't support scalars so we convert them to 1D
-    // tensors.
-    return {1};
-  }
 
   TT_FATAL(num_byte_strides == 0 || num_byte_strides == num_dims,
            "num_byte_strides must be 0 or equal to num_dims: "


### PR DESCRIPTION
### Ticket
Closes #3929

### Problem description
When using SPMD with a mesh, trace enabled, and unsharded (replicated) scalar inputs, the runtime crashes with:
```
TT_FATAL: Host tensor has different shape
host=Shape([1]) device=Shape([])
```
The root cause was in BufferInstance::calculateShape / calculateStrides, which unconditionally normalized any rank-0 (scalar) tensor to shape [1] / strides [1] at the PJRT boundary:
```cpp
if (num_dims == 0) {
    // Our compiler and runtime don't support scalars so we convert them to 1D tensors.
    return {1};
}
```
The compiler, however, has since gained support for scalar shapes and correctly generates #ttnn.shape<> (rank-0) for scalar inputs. When trace is used, the compiler emits ttnn.empty with shape = #ttnn.shape<> to allocate the device-side capture buffer. At runtime, write_tensor then receives a host tensor with shape [1] (from the PJRT normalization) against the [] device buffer — causing a shape mismatch and fatal error.

This bug manifests in models like GPT-OSS-20B that pass unsharded scalar inputs (e.g. a scale or cache_position scalar) alongside sharded weights on a multi-device mesh with trace enabled.

### What's changed
- Removed the num_dims == 0 → return {1} early-out from BufferInstance::calculateShape. Scalars now return an empty shape vector {}, consistent with the rank-0 representation the compiler already produces.
- Removed the num_dims == 0 → return {1} early-out from BufferInstance::calculateStrides. Scalars now return an empty strides vector {}.
- The complex-dtype rank-0 guard is preserved — complex scalars remain unsupported and still throw.

### Verification
Started models-test passing job, currently in progress:
-[ ] https://github.com/tenstorrent/tt-xla/actions/runs/23896702666/

### Checklist
- [x] New/Existing tests provide coverage for changes
