### PR TITLE
Change test_gpt_oss_20b_sdpa optimization level to 0 due to regression

### DIFF
--- a/tests/torch/graphs/fusion_patterns/realworld/test_attn.py
+++ b/tests/torch/graphs/fusion_patterns/realworld/test_attn.py
@@ -92,7 +92,9 @@ def test_gpt_oss_20b_sdpa(layer_idx, request):
         attention,
         [hidden_states, (cos, sin), None, None],
         framework=Framework.TORCH,
-        compiler_config=CompilerConfig(optimization_level=1),
+        # Revert optimization level to 1 once tt-mlir issue is fixed:
+        # https://github.com/tenstorrent/tt-mlir/issues/7763
+        compiler_config=CompilerConfig(optimization_level=0),
         comparison_config=comparison_config,
         request=request,
     )


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/7763

### Problem description
There is a tt-mlir commit that will cause `test_gpt_oss_20b_sdpa` to fail with optimization level 0. I am pre-emptively changing optimization level to 0 until the issue is narrowed down and fixed. Otherwise during tt-mlir uplift, this will cause an error.

### What's changed
`test_gpt_oss_20b_sdpa` optimization level = 0.

### Checklist
- [x] `tests/torch/graphs/fusion_patterns/realworld/test_attn.py` with tt-mlir hash [7db2d5b8d35f05c5a3476e5e28420cd58c0ba6c7](https://github.com/tenstorrent/tt-mlir/commit/7db2d5b8d35f05c5a3476e5e28420cd58c0ba6c7): https://github.com/tenstorrent/tt-xla/actions/runs/23913096330
