### PR TITLE
ShuffleNetV2 bringup (torchvision, 4 variants)

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -436,6 +436,26 @@ test_config:
   segformer/pytorch-Mit_B5-single_device-inference:
     status: EXPECTED_PASSING
 
+  shufflenetv2/pytorch-x0_5-single_device-inference:
+    status: KNOWN_FAILURE_XFAIL
+    bringup_status: FAILED_RUNTIME
+    reason: "conv2d_DRAM: buffer size must be divisible by new page size"
+
+  shufflenetv2/pytorch-x1_0-single_device-inference:
+    status: KNOWN_FAILURE_XFAIL
+    bringup_status: FAILED_RUNTIME
+    reason: "conv2d_DRAM: buffer size must be divisible by new page size"
+
+  shufflenetv2/pytorch-x1_5-single_device-inference:
+    status: KNOWN_FAILURE_XFAIL
+    bringup_status: FAILED_RUNTIME
+    reason: "conv2d_DRAM: buffer size must be divisible by new page size"
+
+  shufflenetv2/pytorch-x2_0-single_device-inference:
+    status: KNOWN_FAILURE_XFAIL
+    bringup_status: FAILED_RUNTIME
+    reason: "conv2d_DRAM: buffer size must be divisible by new page size"
+
   squeezebert/pytorch-Mnli-single_device-inference:
     status: EXPECTED_PASSING
 


### PR DESCRIPTION
## Summary

- Add `shufflenetv2` PyTorch loader in `tt_forge_models` (torchvision, all 4 width variants: x0.5, x1.0, x1.5, x2.0)
- Add 4 test config entries as `KNOWN_FAILURE_XFAIL` / `bringup_status: FAILED_RUNTIME`

## Results

| Variant | CPU (bfloat16) | TT result |
|---|---|---|
| x0_5 | PASS | FAILED_RUNTIME |
| x1_0 | PASS | FAILED_RUNTIME |
| x1_5 | PASS | FAILED_RUNTIME |
| x2_0 | PASS | FAILED_RUNTIME |

**Failure:** `TT_FATAL: buffer size must be divisible by new page size` in `conv2d_DRAM` (`buffer.cpp:502`). All variants hit the same assertion during TT runtime execution. Likely caused by a depthwise or grouped conv with a channel count that doesn't satisfy TT-Metal's page alignment requirement.

## Test plan

- [ ] `pytest -svv "tests/runner/test_models.py::test_all_models_torch[shufflenetv2/pytorch-x1_0-single_device-inference]"` → xfail
- [ ] `python tests/runner/validate_test_config.py` → passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)