### PR TITLE
PointPillars BEV_INPUT bringup: EXPECTED_PASSING

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -2045,6 +2045,9 @@ test_config:
     status: KNOWN_FAILURE_XFAIL
     reason: "error: failed to legalize operation 'ttir.gather' that was explicitly marked illegal' - https://github.com/tenstorrent/tt-xla/issues/1884"
 
+  pointpillars/pytorch-pointpillars_bev-single_device-inference:
+    status: EXPECTED_PASSING
+
   sam/pytorch-Vit_Base-single_device-inference:
     status: EXPECTED_PASSING
 


### PR DESCRIPTION
## Summary

Brings up PointPillars 3D LiDAR detection model to `EXPECTED_PASSING` via a new `BEV_INPUT` variant that moves the problematic pillar scatter to CPU.

## Problem

The existing `pointpillars` variant fails with:
```
error: failed to legalize operation 'ttir.gather' that was explicitly marked illegal
— https://github.com/tenstorrent/tt-xla/issues/1884
```
Root cause: `canvas[cur_coors_flat] = cur_features` in `PillarEncoder.forward()` compiles to a StableHLO gather that tt-mlir cannot legalize.

## Solution

New `pointpillars_bev` variant:
- CPU preprocessing: voxelization → PillarEncoder (Conv1d + BN + scatter) → BEV map `(1, 64, 496, 432)`
- TT: backbone (3× stride-2 Conv2d blocks) + neck (FPN) + detection head — all standard 2D conv ops
- Input is fully static-shape — no dynamic dims, no gather

## Results

| Variant | Status | Notes |
|---|---|---|
| `pointpillars` | `KNOWN_FAILURE_XFAIL` | ttir.gather #1884 |
| `pointpillars_bev` | **`EXPECTED_PASSING`** | PCC ≥ 0.99 ✓ |

## Test plan

- [x] `pytest --runxfail tests/runner/test_models.py::test_all_models_torch[pointpillars/pytorch-pointpillars_bev-single_device-inference]` → PASSED
- [x] `python tests/runner/validate_test_config.py` → PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)