### PR TITLE
Weekly maintenance updates - Apr 4

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -280,7 +280,6 @@ test_config:
     status: EXPECTED_PASSING
 
   dpr/reader/pytorch-Reader_Single_Nq_Base-single_device-inference:
-    required_pcc: 0.97 # https://github.com/tenstorrent/tt-xla/issues/2944
     status: EXPECTED_PASSING
 
   dpr/reader/pytorch-Reader_Multiset_Base-single_device-inference:
@@ -768,9 +767,7 @@ test_config:
     bringup_status: FAILED_RUNTIME
 
   opt/qa/pytorch-1.3b-single_device-inference:
-    assert_pcc: false
     status: EXPECTED_PASSING
-    reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.9410670165223607. Required: pcc=0.99"
 
   # yolov8/pytorch-yolov8n-single_device-inference:
   #   status: EXPECTED_PASSING
@@ -785,9 +782,7 @@ test_config:
     bringup_status: FAILED_RUNTIME
 
   albert/token_classification/pytorch-Xlarge_v2-single_device-inference:
-    assert_pcc: false
     status: EXPECTED_PASSING
-    reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.872334097539835. Required: pcc=0.99"
 
   t5/pytorch-Base-single_device-inference:
     status: EXPECTED_PASSING


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/2944

### Problem description
Weekly maintenance updates - Apr 4
CI RUN: https://github.com/tenstorrent/tt-xla/actions/runs/23975014491

### What's changed
Since the following models are passing in the latest weekly run, I have updated the configuration files accordingly.

```
test_all_models_torch[albert/token_classification/pytorch-Xlarge_v2-single_device-inference]                                               language    generality  bfloat16       n150         PASSED                     PASSING       0.9971384176224953     0.99       PCC_DIS  single_device    61.991    ENABLE_PCC_099
test_all_models_torch[albert/token_classification/pytorch-Xlarge_v2-single_device-inference]                                               language    generality  bfloat16       p150         PASSED                     PASSING       0.990778532838673      0.99       PCC_DIS  single_device    33.372    N/A           

test_all_models_torch[dpr/reader/pytorch-Reader_Single_Nq_Base-single_device-inference]                                                    language    generality  bfloat16       n150         PASSED                     PASSING       0.9992073530815127     0.97       PCC_EN   single_device    51.697    RAISE_PCC_099 
test_all_models_torch[dpr/reader/pytorch-Reader_Single_Nq_Base-single_device-inference]                                                    language    generality  bfloat16       p150         PASSED                     PASSING       0.9988455911510888     0.97       PCC_EN   single_device    30.426    RAISE_PCC_099 


test_all_models_torch[opt/qa/pytorch-1.3b-single_device-inference]                                                                         language    generality  bfloat16       n150         PASSED                     PASSING       0.995238375416081      0.99       PCC_DIS  single_device    82.709    ENABLE_PCC_099
test_all_models_torch[opt/qa/pytorch-1.3b-single_device-inference]                                                                         language    generality  bfloat16       p150         PASSED                     PASSING       0.9977945198353201     0.99       PCC_DIS  single_device    59.952    ENABLE_PCC_099

```

### Checklist
- [ ] New/Existing tests provide coverage for changes
