### PR TITLE
Fix pip install in the release docker

### DIFF
--- a/.github/Dockerfile.release
+++ b/.github/Dockerfile.release
@@ -23,7 +23,7 @@ RUN apt-get update && \
 
 # Install python
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3.12 python3.12-dev python3.12-venv python3-pip && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3.12 python3.12-dev python3.12-venv python3-pip
 
 COPY *.whl /tmp/
 RUN python3.12 -m venv /opt/venv && \


### PR DESCRIPTION
### Ticket
/

### Problem description
Build of the relase docker images is failing to install a python dependency.

### What's changed
Install the wheels into their venv.

### Checklist
- [x] Passing release docker build [here](https://github.com/tenstorrent/tt-xla/actions/runs/24024218229)
