### PR TITLE
Unskip test_shared_input_across_mesh_reshape

### DIFF
--- a/tests/torch/graphs/test_tensor_persistence.py
+++ b/tests/torch/graphs/test_tensor_persistence.py
@@ -646,9 +646,6 @@ def test_concurrent_sharded_buffer_instance_transfer():
 
 @pytest.mark.nightly
 @pytest.mark.llmbox
-@pytest.mark.skip(
-    reason=failed_runtime("Segfault: https://github.com/tenstorrent/tt-xla/issues/3280")
-)
 def test_shared_input_across_mesh_reshape():
     """
     Test scenario: Run 2 models back to back, one on 2x4 mesh and a 1x8 mesh,


### PR DESCRIPTION
The `test_shared_input_across_mesh_reshape` test is now passing again, so removing the skip marker.