### PR TITLE
Add inspect changes to check all green

### DIFF
--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -125,6 +125,7 @@ jobs:
     if: always()
     needs:
       - pre-commit
+      - inspect-changes
       - build-image
       - build-ttxla
       - build-ttxla-debug


### PR DESCRIPTION
### Ticket
/

### Problem description
Inspect changes job in the "On PR" workflow is not defined in `check-all-green`'s needs blocks.
This means that if `inspect-changes` fails rest of the "On PR" will be skipped and `check-all-green` will succeed.

### What's changed
Add `inspect-changes` to `check-all-green`'s needs block.

### Checklist
- [ ] New/Existing tests provide coverage for changes
