### PR TITLE
Add Claude skill for analyzing nightly workflow

### DIFF
--- a/.claude/skills/analyze-nightly/SKILL.md
+++ b/.claude/skills/analyze-nightly/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: analyze-nightly
+description: Analyze and summarize failures from a GitHub Actions workflow
+disable-model-invocation: true
+allowed-tools: Bash(gh run view *), Bash(gh run list *), Bash(gh pr view *), Read, Glob, Grep, Bash(tee *), Read(/tmp/**), Bash(gh api *), Bash(wc *), Bash(jq *)
+context: fork
+argument-hint: [run-id]
+model: opus
+---
+
+Create a summary of test/job failures, loosely grouped by type of failure:
+
+**Note**: "Test" refers broadly to any test run, (perf) benchmark run,
+tt-xla project demo run, and tt-xla project example run.
+
+1. Tests/jobs are run in the GitHub Actions workflow with run-id $0.
+2. GitHub repo associated with the workflow is github.com/tenstorrent/tt-xla.
+3. Analyze the workflow file .github/workflows/schedule-nightly.yml to build
+   context around which jobs are run as part of the workflow. Jobs mostly use
+   other workflow .yml files, so if you need details of each job, analyze those
+   files. Some .yml files may be in another repository, namely
+   github.com/tenstorrent/tt-forge.
+4. For the run with run-id $0, fetch all job-ids by using the appropriate
+   `gh {subcommand}` call. Since the command for fetching job-ids is non-obvious
+   here is a command that return all job URLs:
+   `gh run view $0 --json jobs --jq '.jobs[].url'`. Each URL has the following
+   format:
+   https://github.com/tenstorrent/tt-xla/actions/runs/{run-id}/job/{job-id}.
+5. Fetch job details by using the appropriate `gh api` call. For the rest of
+   these instructions, focus only on the jobs that failed. Disregard others,
+   and whenever a job is mentioned in the following instructions, note that
+   instructions only apply for those filtered failed jobs. Always disregard
+   successful, canceled, and skipped jobs.
+6. For each job, identify which steps of the jobs have failed. If multiple steps
+   have failed, focus on the first one, assuming the first one is the one that
+   cause subsequent steps to fail as well. Fetch logs for the failed step.
+7. Analyze each fetched log, analyze the text in search of error messages,
+   failure messages, timeout messages etc. Keywords to look for are error,
+   assert, assertion, failed, failure, fatal, timeout, timed out, and similar
+   (case insensitive). There may be others as well, do not rely only on
+   these keywords.
+8. Job steps (and therefore their logs) that are responsible for running tests
+    are actually responsible for running multiple tests, so also
+    analyze the text for test beginning markers so you can associate the error
+    message with the name of the tests. Tests are either simple pytest-invoked
+    scripts or AI model tests invoked by tests/runner/test_models.py script.
+    Each test may run on different hardware architectures, so it is possible for
+    the test to fail in multiple jobs with the same root cause.
+9. Summarize which tests/steps failed, loosely grouped by root cause for failure.
+    If no steps were run because one of the required setup steps failed before the
+    step responsible for running tests had a chance to run, then include the
+    step failure in the summary instead of test failure. The generated output
+    must be a text bullet list, where a top level bullet is a verbatim failure
+    message or similar (e.g. timeout), and the sub-bullets must be a list of
+    tests and/or job steps that failed with the given message.
+
+Always respect these additional constraints:
+
+- Never ask for, and never run any `gh {subcommand}` calls that may modify the
+  state of the GitHub repository (for example issue creation/deletion,
+  PR closing, branch manipulation etc.), especially `gh api` calls.
+  Always use only read-only calls.

--- a/.claude/skills/analyze-nightly/SKILL.md
+++ b/.claude/skills/analyze-nightly/SKILL.md
@@ -1,62 +1,110 @@
 ---
 name: analyze-nightly
-description: Analyze and summarize failures from a GitHub Actions workflow
+description: Analyze a GitHub Actions run and summarize failures
 disable-model-invocation: true
-allowed-tools: Bash(gh run view *), Bash(gh run list *), Bash(gh pr view *), Read, Glob, Grep, Bash(tee *), Read(/tmp/**), Bash(gh api *), Bash(wc *), Bash(jq *)
+allowed-tools: Read, Read(/tmp/**), Glob, Grep, Bash(git clone *), Bash(gh run view *), Bash(gh run list *), Bash(gh run download *), Bash(gh pr view *), Bash(tee *), Bash(gh api *), Bash(gh api * > /tmp/**), Bash(wc -l /tmp/**), Bash(jq *), Bash(mkdir -p /tmp/**), Bash(rm -rf /tmp/**), Bash(for *)
 context: fork
-argument-hint: [run-id]
+argument-hint: run-id
 model: opus
 ---
 
-Create a summary of test/job failures, loosely grouped by type of failure:
+Create a summary of test failures or job failures, grouped by ownership area:
+- Ownership area: PJRT unit tests.
+    - PJRT tests are rooted under various directories in pjrt_implementation/.
+- Ownership area: vLLM integration and multi-host execution.
+    - vLLM integration tests are rooted in tests/integrations/vllm_plugin/.
+    - vLLM integration is rooted in integrations/vllm_tt/.
+    - Multi-host execution PyTorch tests are rooted in tests/torch/multi_host/.
+- Ownership area: Performance benchmarks.
+    - Performance benchmarks are rooted in tests/benchmark/.
+- Ownership area: Examples.
+    - Examples are rooted under examples/.
+- Ownership area: PyTorch and JAX single-chip and multi-chip tests.
+    - This is a catch-all category for tests rooted under tests/.
+Important note: "test" refers broadly to any test run, performance benchmark
+run, tt-xla project demo run, or tt-xla project example run.
 
-**Note**: "Test" refers broadly to any test run, (perf) benchmark run,
-tt-xla project demo run, and tt-xla project example run.
+Analyze the run with run-id $0 and create a summary of test failures:
+- Tests/jobs are run in the GitHub Actions workflow with run-id $0.
+- GitHub repo associated with the workflow is github.com/tenstorrent/tt-xla.
+- Read the workflow file .github/workflows/schedule-nightly.yml to build
+  context around which jobs are executed in the workflow. Jobs mostly invoke
+  other workflow *.yml files; read other worklow *.yml files that are
+  referenced from .github/workflows/schedule-nightly.yml. Some .yml files
+  may be in another repository, namely github.com/tenstorrent/tt-forge. To
+  access files in other repositories, use git to clone them to /tmp/.
+- For the run with run-id $0 fetch all job-ids by using the `gh` CLI tool.
+  Run `gh run view $0 --json jobs --jq '.jobs[].url'` to fetch all job URLs,
+  which have the following format, from which you can extract {job-id}:
+  https://github.com/tenstorrent/tt-xla/actions/runs/{run-id}/job/{job-id}
+- Fetch details for every job by using the `gh api` subcommand. Discard any job
+  that was successfully completed, canceled, skipped, or is still in progress.
+  Focus only on jobs that failed!
+- For each failed job, identify which step(s) failed. If multiple steps failed,
+  focus on the first one, assuming the first one is the one that cause
+  subsequent step failures. Fetch and read raw logs for the failed step by
+  using the `gh` CLI tool. Analyze the logs in search for error messages,
+  failure messages, timeout messages, or any other text indicating a root cause
+  for the failure of that step of the job. Keywords to look for are error,
+  assert, assertion, failed, throw, failure, fatal, timeout, timed out, HTTP
+  error codes from 400 and 500 range, Linux exit codes corresponding to signals
+  processes can receive, etc. Don't limit yourself to only these keywords, there
+  may be others that indicate a root cause, there are just the most common ones.
+- Strategies for how to improve log crawling: (a) Always use case insensitive
+  pattern matching for specific words or phrases. (b) If the logs are truncated
+  or too large, download them to /tmp/ in a temporary directory. Ensure that
+  this temporary directory is deleted after you complete executing all your
+  other tasks. (c) If a log exceeds 5000 lines, first try to use Grep to search
+  for keywords rather than reading the full log. Only if you fail to identify
+  a root cause with Grep, read the whole log. (d) if you identify a root cause,
+  searching backward through the log will in most cases yield a line of text
+  identifying the specific test that failed.
+- Job steps (and therefore their logs) that are responsible for running tests
+  are always running multiple tests, not just one. Tests are in most cases
+  either a pytest command specifying a parametrized test, or model tests invoked
+  by the tests/runner/test_models.py script with the model name as the parameter
+  in brackets. The same test may run on different hardware architectures, but
+  never in the same job, so it is possible for the same test to fail in multiple
+  jobs with the same root cause.
+- Gather information relevant to the failure: name of the test and/or model
+  that failed (or job step name that failed if previous is not applicable),
+  root cause, hardware architecture (if applicable). If the same test fails with
+  the same root cause on multiple architectures, list it once with all affected
+  architectures in the {arch-list}.
+- Summarize which tests or job steps have failed. If a job step failed because
+  a test failed, present it as a test failure. If a job step failed before any
+  test is run, present it as a job failure unrelated to test execution. Group
+  all failures by ownership area. If an ownership area has no failures, do not
+  emit any text for that area in the output.
 
-1. Tests/jobs are run in the GitHub Actions workflow with run-id $0.
-2. GitHub repo associated with the workflow is github.com/tenstorrent/tt-xla.
-3. Analyze the workflow file .github/workflows/schedule-nightly.yml to build
-   context around which jobs are run as part of the workflow. Jobs mostly use
-   other workflow .yml files, so if you need details of each job, analyze those
-   files. Some .yml files may be in another repository, namely
-   github.com/tenstorrent/tt-forge.
-4. For the run with run-id $0, fetch all job-ids by using the appropriate
-   `gh {subcommand}` call. Since the command for fetching job-ids is non-obvious
-   here is a command that return all job URLs:
-   `gh run view $0 --json jobs --jq '.jobs[].url'`. Each URL has the following
-   format:
-   https://github.com/tenstorrent/tt-xla/actions/runs/{run-id}/job/{job-id}.
-5. Fetch job details by using the appropriate `gh api` call. For the rest of
-   these instructions, focus only on the jobs that failed. Disregard others,
-   and whenever a job is mentioned in the following instructions, note that
-   instructions only apply for those filtered failed jobs. Always disregard
-   successful, canceled, and skipped jobs.
-6. For each job, identify which steps of the jobs have failed. If multiple steps
-   have failed, focus on the first one, assuming the first one is the one that
-   cause subsequent steps to fail as well. Fetch logs for the failed step.
-7. Analyze each fetched log, analyze the text in search of error messages,
-   failure messages, timeout messages etc. Keywords to look for are error,
-   assert, assertion, failed, failure, fatal, timeout, timed out, and similar
-   (case insensitive). There may be others as well, do not rely only on
-   these keywords.
-8. Job steps (and therefore their logs) that are responsible for running tests
-    are actually responsible for running multiple tests, so also
-    analyze the text for test beginning markers so you can associate the error
-    message with the name of the tests. Tests are either simple pytest-invoked
-    scripts or AI model tests invoked by tests/runner/test_models.py script.
-    Each test may run on different hardware architectures, so it is possible for
-    the test to fail in multiple jobs with the same root cause.
-9. Summarize which tests/steps failed, loosely grouped by root cause for failure.
-    If no steps were run because one of the required setup steps failed before the
-    step responsible for running tests had a chance to run, then include the
-    step failure in the summary instead of test failure. The generated output
-    must be a text bullet list, where a top level bullet is a verbatim failure
-    message or similar (e.g. timeout), and the sub-bullets must be a list of
-    tests and/or job steps that failed with the given message.
+Output format that you need to follow (raw Markdown text):
+```
+# {ownership-area-name}
+
+## {root-cause-1}
+- {test-or-step-name} ({arch-list}) -> [job-link]({url})
+- {test-or-step-name} ({arch-list}) -> [job-link]({url})
+
+## {root-cause-2}
+- {test-or-step-name} ({arch-list}) -> [job-link]({url})
+- {test-or-step-name} ({arch-list}) -> [job-link]({url})
+
+# {ownership-area-name}
+
+## {root-cause-1}
+- {test-or-step-name} ({arch-list}) -> [job-link]({url})
+- {test-or-step-name} ({arch-list}) -> [job-link]({url})
+
+## {root-cause-2}
+- {test-or-step-name} ({arch-list}) -> [job-link]({url})
+- {test-or-step-name} ({arch-list}) -> [job-link]({url})
+```
 
 Always respect these additional constraints:
-
-- Never ask for, and never run any `gh {subcommand}` calls that may modify the
-  state of the GitHub repository (for example issue creation/deletion,
-  PR closing, branch manipulation etc.), especially `gh api` calls.
-  Always use only read-only calls.
+- Never ask for, and never run any `gh {subcommand}` commands that may modify
+  the state of the GitHub repository (for example issue creation/deletion,
+  PR closing, branch manipulation etc.), especially when using the `gh api`
+  subcommand. Always use only read-only calls!
+- Never execute multiple commands separated by a semi-colon!
+- Always use for loops in bash for executing commands for different job-ids!
+  Never execute the same command separately for multiple job-ids!

--- a/.claude/skills/analyze-nightly/SKILL.md
+++ b/.claude/skills/analyze-nightly/SKILL.md
@@ -19,6 +19,7 @@ Create a summary of test failures or job failures, grouped by ownership area:
     - Performance benchmarks are rooted in tests/benchmark/.
 - Ownership area: Examples.
     - Examples are rooted under examples/.
+    - Test which runs examples is in tests/examples/test_examples.py.
 - Ownership area: PyTorch and JAX single-chip and multi-chip tests.
     - This is a catch-all category for tests rooted under tests/.
 Important note: "test" refers broadly to any test run, performance benchmark
@@ -32,7 +33,9 @@ Analyze the run with run-id $0 and create a summary of test failures:
   other workflow *.yml files; read other worklow *.yml files that are
   referenced from .github/workflows/schedule-nightly.yml. Some .yml files
   may be in another repository, namely github.com/tenstorrent/tt-forge. To
-  access files in other repositories, use git to clone them to /tmp/.
+  access files in other repositories, use git to clone them to /tmp/. Ensure
+  that these cloned files are deleted after you complete executing all your
+  other tasks.
 - For the run with run-id $0 fetch all job-ids by using the `gh` CLI tool.
   Run `gh run view $0 --json jobs --jq '.jobs[].url'` to fetch all job URLs,
   which have the following format, from which you can extract {job-id}:
@@ -49,7 +52,7 @@ Analyze the run with run-id $0 and create a summary of test failures:
   assert, assertion, failed, throw, failure, fatal, timeout, timed out, HTTP
   error codes from 400 and 500 range, Linux exit codes corresponding to signals
   processes can receive, etc. Don't limit yourself to only these keywords, there
-  may be others that indicate a root cause, there are just the most common ones.
+  may be others that indicate a root cause, these are just the most common ones.
 - Strategies for how to improve log crawling: (a) Always use case insensitive
   pattern matching for specific words or phrases. (b) If the logs are truncated
   or too large, download them to /tmp/ in a temporary directory. Ensure that


### PR DESCRIPTION
Skill analyzes the nightly tests GitHub Action, grouped by various areas of ownership. Consistent results across several different skill runs for the same run-id, however the permission system for different tools is super-flaky/broken so it may ask for some explicit permissions; mitigated somewhat by instructing it to always use for loops for multiple jobs... We might be able to use hooks like described in https://code.claude.com/docs/en/permissions#tool-specific-permission-rules or sandboxing https://code.claude.com/docs/en/sandboxing to fix this kind of problem.