### PR TITLE
Add KV cache dtype conversion option

### DIFF
--- a/pjrt_implementation/inc/api/compile_options.h
+++ b/pjrt_implementation/inc/api/compile_options.h
@@ -37,6 +37,9 @@ struct CompileOptions {
   // Valid values: "bfp_bf8", "bfp_bf4". Empty string disables.
   std::string experimental_weight_dtype = "";
 
+  // Enables experimental KV cache dtype override.
+  std::optional<std::string> experimental_kv_cache_dtype = std::nullopt;
+
   // Override math fidelity for all ttnn operations exposing compute kernel
   // config. Valid values: "lofi", "hifi2", "hifi3", "hifi4", "ttnn_default".
   // "ttnn_default" - means that we don't override math_fidelity in comiler,

--- a/pjrt_implementation/src/api/compile_options.cc
+++ b/pjrt_implementation/src/api/compile_options.cc
@@ -21,6 +21,8 @@ CompileOptions CompileOptions::parse(
   options.experimental_weight_dtype =
       internal::parseStringOption(compile_options, "experimental_weight_dtype")
           .value_or(options.experimental_weight_dtype);
+  options.experimental_kv_cache_dtype = internal::parseStringOption(
+      compile_options, "experimental-kv-cache-dtype");
   options.math_fidelity =
       internal::parseStringOption(compile_options, "math_fidelity");
 

--- a/pjrt_implementation/src/api/module_builder/module_builder.cc
+++ b/pjrt_implementation/src/api/module_builder/module_builder.cc
@@ -60,6 +60,7 @@
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
 #include "ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
+#include "ttmlir/Dialect/TTNN/Utils/BFPDtypeParser.h"
 #include "ttmlir/RegisterAll.h"
 #include "ttmlir/Target/Python/PythonEmitter.h"
 #include "ttmlir/Target/TTNN/TTNNToFlatbuffer.h"
@@ -993,11 +994,11 @@ tt_pjrt_status ModuleBuilder::convertFromTTIRToTTNN(
   }
 
   options.optimizationLevel = compile_options.optimization_level;
-  // Map user-facing dtype names to WeightDtype enum values.
+  // Map user-facing dtype names to BFPDtype enum values.
   if (compile_options.experimental_weight_dtype == "bfp_bf8") {
-    options.experimentalWeightDtype = mlir::tt::ttnn::WeightDtype::BFP_BFloat8;
+    options.experimentalWeightDtype = mlir::tt::ttnn::BFPDtype::BFP_BFloat8;
   } else if (compile_options.experimental_weight_dtype == "bfp_bf4") {
-    options.experimentalWeightDtype = mlir::tt::ttnn::WeightDtype::BFP_BFloat4;
+    options.experimentalWeightDtype = mlir::tt::ttnn::BFPDtype::BFP_BFloat4;
   } else if (!compile_options.experimental_weight_dtype.empty()) {
     LOG_F(ERROR,
           "Unknown experimental_weight_dtype: '%s'. Valid values: 'bfp_bf8', "
@@ -1025,6 +1026,21 @@ tt_pjrt_status ModuleBuilder::convertFromTTIRToTTNN(
       compile_options.experimental_enable_fusing_conv2d_with_multiply_pattern;
   options.enablePermuteMatmulFusion =
       compile_options.experimental_enable_permute_matmul_fusion;
+
+  if (compile_options.experimental_kv_cache_dtype.has_value()) {
+    const std::string &dtype_str =
+        compile_options.experimental_kv_cache_dtype.value();
+    std::optional<mlir::tt::ttnn::BFPDtype> dtype =
+        mlir::tt::ttnn::symbolizeBFPDtype(dtype_str);
+    if (!dtype.has_value()) {
+      LOG_F(ERROR,
+            "Invalid experimental_kv_cache_dtype value: '%s'. "
+            "Valid values are: none, bfp_bf8, bfp_bf4",
+            dtype_str.c_str());
+      return tt_pjrt_status::kInvalidArgument;
+    }
+    options.experimentalKVCacheDtype = dtype.value();
+  }
   options.enableTrace = compile_options.enable_trace;
   options.systemDescPath = system_descriptor_path.data();
   options.enableConstEval = compile_options.enable_const_eval;

--- a/tests/benchmark/benchmarks/llm_benchmark.py
+++ b/tests/benchmark/benchmarks/llm_benchmark.py
@@ -253,6 +253,7 @@ def benchmark_llm_torch_xla(
     arch,
     required_pcc,
     fp32_dest_acc_en=None,
+    experimental_kv_cache_dtype=None,
     accuracy_testing: bool = False,
     model_name_for_accuracy: str = None,
     hf_model_name_for_accuracy: str = None,
@@ -448,6 +449,8 @@ def benchmark_llm_torch_xla(
     }
     if fp32_dest_acc_en is not None:
         options["fp32_dest_acc_en"] = fp32_dest_acc_en
+    if experimental_kv_cache_dtype is not None:
+        options["experimental-kv-cache-dtype"] = experimental_kv_cache_dtype
 
     torch_xla.set_custom_compile_options(options)
 

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -320,36 +320,6 @@ def test_llama_3_2_3b(
     )
 
 
-def test_llama_3_2_3b_kv_cache(
-    output_file,
-    num_layers,
-    request,
-    accuracy_testing,
-    batch_size,
-    max_output_tokens,
-    decode_only,
-):
-    from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
-        ModelLoader,
-        ModelVariant,
-    )
-
-    variant = ModelVariant.LLAMA_3_2_3B_INSTRUCT
-    test_llm(
-        ModelLoaderModule=ModelLoader,
-        variant=variant,
-        output_file=output_file,
-        optimization_level=1,
-        num_layers=num_layers,
-        request=request,
-        experimental_kv_cache_dtype="bfp_bf8",
-        accuracy_testing=accuracy_testing,
-        batch_size=batch_size,
-        max_output_tokens=max_output_tokens,
-        decode_only=decode_only,
-    )
-
-
 def test_gemma_1_1_2b(
     output_file,
     num_layers,
@@ -1108,37 +1078,6 @@ def test_llama_3_1_8b(
             else DEFAULT_OPTIMIZATION_LEVEL
         ),
         required_pcc=0.90,
-    )
-
-
-def test_llama_3_1_8b_kv_cache(
-    output_file,
-    num_layers,
-    request,
-    accuracy_testing,
-    batch_size,
-    max_output_tokens,
-    decode_only,
-):
-    from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
-        ModelLoader,
-        ModelVariant,
-    )
-
-    variant = ModelVariant.LLAMA_3_1_8B_INSTRUCT
-    test_llm(
-        ModelLoaderModule=ModelLoader,
-        variant=variant,
-        output_file=output_file,
-        optimization_level=1,
-        num_layers=num_layers,
-        request=request,
-        fp32_dest_acc_en=False,
-        experimental_kv_cache_dtype="bfp_bf8",
-        accuracy_testing=accuracy_testing,
-        batch_size=batch_size,
-        max_output_tokens=max_output_tokens,
-        decode_only=decode_only,
     )
 
 

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -53,6 +53,7 @@ def test_llm(
     arch=None,
     required_pcc=DEFAULT_REQUIRED_PCC,
     fp32_dest_acc_en=None,
+    experimental_kv_cache_dtype=None,
     num_layers=None,
     request=None,
     accuracy_testing: bool = False,
@@ -110,6 +111,7 @@ def test_llm(
     task={task}
     experimental_weight_dtype={experimental_weight_dtype}
     experimental_enable_permute_matmul_fusion={experimental_enable_permute_matmul_fusion}
+    experimental_kv_cache_dtype={experimental_kv_cache_dtype}
     required_pcc={required_pcc}
     num_layers={num_layers}
     ttnn_perf_metrics_output_file={ttnn_perf_metrics_output_file}
@@ -147,6 +149,7 @@ def test_llm(
         arch=arch,
         required_pcc=required_pcc,
         fp32_dest_acc_en=fp32_dest_acc_en,
+        experimental_kv_cache_dtype=experimental_kv_cache_dtype,
         accuracy_testing=accuracy_testing,
         model_name_for_accuracy=model_name_for_accuracy,
         hf_model_name_for_accuracy=hf_model_name,
@@ -314,6 +317,36 @@ def test_llama_3_2_3b(
             if optimization_level is not None
             else DEFAULT_OPTIMIZATION_LEVEL
         ),
+    )
+
+
+def test_llama_3_2_3b_kv_cache(
+    output_file,
+    num_layers,
+    request,
+    accuracy_testing,
+    batch_size,
+    max_output_tokens,
+    decode_only,
+):
+    from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
+        ModelLoader,
+        ModelVariant,
+    )
+
+    variant = ModelVariant.LLAMA_3_2_3B_INSTRUCT
+    test_llm(
+        ModelLoaderModule=ModelLoader,
+        variant=variant,
+        output_file=output_file,
+        optimization_level=1,
+        num_layers=num_layers,
+        request=request,
+        experimental_kv_cache_dtype="bfp_bf8",
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
+        max_output_tokens=max_output_tokens,
+        decode_only=decode_only,
     )
 
 
@@ -1075,6 +1108,37 @@ def test_llama_3_1_8b(
             else DEFAULT_OPTIMIZATION_LEVEL
         ),
         required_pcc=0.90,
+    )
+
+
+def test_llama_3_1_8b_kv_cache(
+    output_file,
+    num_layers,
+    request,
+    accuracy_testing,
+    batch_size,
+    max_output_tokens,
+    decode_only,
+):
+    from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
+        ModelLoader,
+        ModelVariant,
+    )
+
+    variant = ModelVariant.LLAMA_3_1_8B_INSTRUCT
+    test_llm(
+        ModelLoaderModule=ModelLoader,
+        variant=variant,
+        output_file=output_file,
+        optimization_level=1,
+        num_layers=num_layers,
+        request=request,
+        fp32_dest_acc_en=False,
+        experimental_kv_cache_dtype="bfp_bf8",
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
+        max_output_tokens=max_output_tokens,
+        decode_only=decode_only,
     )
 
 

--- a/tests/infra/testers/compiler_config.py
+++ b/tests/infra/testers/compiler_config.py
@@ -31,6 +31,9 @@ class CompilerConfig:
     # Valid values: "", "bfp_bf8", "bfp_bf4". Empty string disables.
     experimental_weight_dtype: str = ""
 
+    # Enables experimental KV cache dtype override in MLIR optimizer passes.
+    experimental_kv_cache_dtype: Optional[str] = None
+
     # Override math fidelity for all ttnn operations exposing compute kernel
     # config. Valid values: "lofi", "hifi2", "hifi3", "hifi4", "ttnn_default".
     # "ttnn_default" - means that we don't override math_fidelity in comiler,
@@ -83,6 +86,9 @@ class CompilerConfig:
 
         if self.experimental_weight_dtype:
             options["experimental_weight_dtype"] = self.experimental_weight_dtype
+
+        if self.experimental_kv_cache_dtype is not None:
+            options["experimental-kv-cache-dtype"] = self.experimental_kv_cache_dtype
 
         if self.math_fidelity is not None:
             options["math_fidelity"] = self.math_fidelity


### PR DESCRIPTION
### Problem description                                                                                                                   
                                                                                                                                        
KV cache tensors consume significant device memory. Storing them in lower-precision block floating-point formats (BFP8, BFP4) reduces memory usage and can improve performance. 
                                                                                                                                        
### What's changed                                                                                                                      

  - Added `experimental_kv_cache_dtype` compile option to allow overriding the KV cache tensor dtype
  - Extended `llm_benchmark.py` to accept and pass through target kv cache dtype parameter                          
  - Extended tests/benchmark/test_llms.py with dedicated bfp_bf8 KV cache benchmark tests          

### Comparing accuracy results


| Model | Baseline TOP1 | bfp_bf8 TOP1 | Baseline TOP5 | bfp_bf8 TOP5 |
| ----- | ------------- | ------------ | ------------- | ------------ |
| Llama-3.2-3B-Instruct | 92.19% | 90.62% | 100.00% | 100.00% |
| Llama-3.1-8B-Instruct | 79.69% | 81.25% | 90.62% | 92.19% |
| Mistral-7B-Instruct-v0.3 | 100.00% | 100.00% | 100.00% | 100.00% |
| Phi-1 | 95.31% | 95.31% | 100.00% | 100.00% |
| Phi-1.5 | 93.75% | 96.88% | 100.00% | 100.00% |
| Phi-2 | 93.75% | 93.75% | 100.00% | 100.00% |
| Falcon3-1B-Base | 98.44% | 100.00% | 100.00% | 100.00% |
| Falcon3-3B-Base | 96.88% | 96.88% | 96.88% | 100.00% |
| Falcon3-7B-Base | 98.44% | 98.44% | 100.00% | 100.00% |
| Qwen2.5-1.5B-Instruct | 84.38% | 78.12% | 96.88% | 92.19% |
| Qwen3-4B | 68.75% | 71.88% | 90.62% | 92.19% |
| Ministral-8B-Instruct | 93.75% | 95.31% | 100.00% | 100.00% |
| Qwen2.5-0.5B-Instruct | 96.88% | 90.62% | 100.00% | 98.44% |



### Note

- Adds explicit `experimental_kv_cache_dtype` per test for now, setting it as a default is tracked in 
#4343 
- This PR depends on changes in [tenstorrent/tt-mlir#7859](https://github.com/tenstorrent/tt-mlir/pull/7859)


                                                                                 