### PR TITLE
Fix: handle EncoderDecoderCache in _cache_to_legacy for transformers 5.x

### DIFF
--- a/tests/infra/evaluators/torch_comparison_evaluator.py
+++ b/tests/infra/evaluators/torch_comparison_evaluator.py
@@ -38,6 +38,15 @@ class TorchComparisonEvaluator(ComparisonEvaluator):
         # and any other Cache subclass). Each layer exposes .keys and .values via CacheLayerMixin.
         if hasattr(cache, "layers"):
             return tuple((layer.keys, layer.values) for layer in cache.layers)
+        # Handle EncoderDecoderCache (transformers 5.x): contains self_attention_cache and
+        # cross_attention_cache as separate DynamicCache objects instead of .layers directly.
+        if hasattr(cache, "self_attention_cache") and hasattr(
+            cache, "cross_attention_cache"
+        ):
+            return (
+                TorchComparisonEvaluator._cache_to_legacy(cache.self_attention_cache),
+                TorchComparisonEvaluator._cache_to_legacy(cache.cross_attention_cache),
+            )
         return cache
 
     # @override


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-xla/issues/4143

### Problem description

- Models with encoder-decoder KV caches (e.g. MusicGen) return EncoderDecoderCache in their outputs - [apr7_musicgen_cpu_run.log](https://github.com/user-attachments/files/26537404/apr7_musicgen_cpu_run.log)
- PyTorch's tree_map treats it as a leaf, so it was passed raw into comparison methods causing `TypeError: equal(): argument 'input' must be  Tensor, not EncoderDecoderCache` 

### What's changed

- Added a branch in `_cache_to_legacy` to handle EncoderDecoderCache (transformers 5.x) by recursively converting its self_attention_cache and cross_attention_cache into legacy tensor tuples. 
- Since `_match_data_types` calls `_cache_to_legacy` and runs before all comparison methods, this single fix ensures all comparators (equal, atol, pcc, allclose) receive plain tensors without any per-method changes.
- Post this change model passes with PCC>0.99

### Checklist
- [x] Verify the changes by local run

### Logs

- [apr7_musicgen_small_before_fix.log](https://github.com/user-attachments/files/26537430/apr7_musicgen_small_before_fix.log)
- [apr7_musicgen_small_after_fix.log](https://github.com/user-attachments/files/26537428/apr7_musicgen_small_after_fix.log)



