### PR TITLE
Update configs based on nightly

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -2257,7 +2257,7 @@ test_config:
     required_pcc: 0.98
 
   owl_vit/pytorch-Base_Patch32-single_device-inference:
-    required_pcc: 0.98  # PCC dropped to 0.9837 on n150 0.9836 on p150 - https://github.com/tenstorrent/tt-xla/issues/3182
+    required_pcc: 0.975  # PCC dropped to 0.9837 on n150 0.9836 on p150 - https://github.com/tenstorrent/tt-xla/issues/3182
     status: EXPECTED_PASSING
 
   # yolov12/pytorch-yolo12n-single_device-inference:

--- a/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
@@ -9,10 +9,14 @@
 
 test_config:
   falcon/pytorch-3_1B_Base-llm_decode-seq_1-batch_1-single_device-inference:
-    status: EXPECTED_PASSING
+    status: NOT_SUPPORTED_SKIP
+    reason: "Hang - https://github.com/tenstorrent/tt-xla/issues/3838"
+    bringup_status: FAILED_RUNTIME
 
   falcon/pytorch-3_3B_Base-llm_decode-seq_1-batch_1-single_device-inference:
-    status: EXPECTED_PASSING
+    status: NOT_SUPPORTED_SKIP
+    reason: "Hang - https://github.com/tenstorrent/tt-xla/issues/3838"
+    bringup_status: FAILED_RUNTIME
 
   falcon/pytorch-3_7B_Base-llm_decode-seq_1-batch_1-single_device-inference:
     supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.
@@ -23,19 +27,19 @@ test_config:
     status: EXPECTED_PASSING
 
   qwen_2_5/causal_lm/pytorch-0.5B_Instruct-llm_decode-seq_1-batch_1-single_device-inference:
-    status: EXPECTED_PASSING
+    status: NOT_SUPPORTED_SKIP
+    reason: "Hang - https://github.com/tenstorrent/tt-xla/issues/3838"
+    bringup_status: FAILED_RUNTIME
 
   qwen_2_5/causal_lm/pytorch-1.5B_Instruct-llm_decode-seq_1-batch_1-single_device-inference:
-    arch_overrides:
-      n150:
-        status: EXPECTED_PASSING
-        required_pcc: 0.98
-        assert_pcc: false
-      p150:
-        status: EXPECTED_PASSING
+    status: NOT_SUPPORTED_SKIP
+    reason: "Hang - https://github.com/tenstorrent/tt-xla/issues/3838"
+    bringup_status: FAILED_RUNTIME
 
   qwen_2_5/causal_lm/pytorch-3B_Instruct-llm_decode-seq_1-batch_1-single_device-inference:
-    status: EXPECTED_PASSING
+    status: NOT_SUPPORTED_SKIP
+    reason: "Hang - https://github.com/tenstorrent/tt-xla/issues/3838"
+    bringup_status: FAILED_RUNTIME
 
   qwen_2_5/causal_lm/pytorch-7B_Instruct-llm_decode-seq_1-batch_1-single_device-inference:
     supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.
@@ -106,7 +110,9 @@ test_config:
     bringup_status: FAILED_RUNTIME
 
   qwen_3/causal_lm/pytorch-4B-llm_decode-seq_1-batch_1-single_device-inference:
-    status: EXPECTED_PASSING
+    status: NOT_SUPPORTED_SKIP
+    reason: "Hang - https://github.com/tenstorrent/tt-xla/issues/3838"
+    bringup_status: FAILED_RUNTIME
 
   qwen_3/causal_lm/pytorch-8B-llm_decode-seq_1-batch_1-single_device-inference:
     supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.

--- a/tests/torch/models/whisper/test_whisper.py
+++ b/tests/torch/models/whisper/test_whisper.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from infra import RunMode
+from infra import ComparisonConfig, RunMode
 from utils import BringupStatus, Category, failed_ttmlir_compilation
 
 from third_party.tt_forge_models.whisper.pytorch import ModelLoader, ModelVariant
@@ -18,6 +18,11 @@ from .tester import WhisperTester
 
 _FAILING_VARIANTS = [
     ModelVariant.WHISPER_LARGE,
+]
+
+_NO_ASSERT_PCC_VARIANTS = [
+    ModelVariant.WHISPER_LARGE_V3,
+    ModelVariant.WHISPER_LARGE_V3_TURBO,
 ]
 
 
@@ -69,7 +74,10 @@ def inference_tester(request) -> WhisperTester:
     """Fixture that returns a WhisperTester configured for each model variant."""
     variant, bringup_status = request.param
     request.node.bringup_status = bringup_status
-    return WhisperTester(variant)
+    comparison_config = ComparisonConfig()
+    if variant in _NO_ASSERT_PCC_VARIANTS:
+        comparison_config.pcc.disable()
+    return WhisperTester(variant, comparison_config=comparison_config)
 
 
 # ----- Tests -----

--- a/tests/torch/models/whisper/test_whisper.py
+++ b/tests/torch/models/whisper/test_whisper.py
@@ -75,7 +75,6 @@ def inference_tester(request) -> WhisperTester:
 # ----- Tests -----
 
 
-@pytest.mark.nightly
 @pytest.mark.single_device
 @pytest.mark.large
 def test_torch_whisper_inference(inference_tester: WhisperTester):

--- a/tests/torch/ops/test_composite_ops.py
+++ b/tests/torch/ops/test_composite_ops.py
@@ -109,6 +109,9 @@ def test_patched_rms_norm_functional_single_device(
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail(
+    reason="To be investigated - https://github.com/tenstorrent/tt-xla/issues/4138"
+)
 @pytest.mark.dual_chip
 @pytest.mark.parametrize("use_weight", [True, False])
 @pytest.mark.parametrize(


### PR DESCRIPTION
Based on nightly run https://github.com/tenstorrent/tt-xla/actions/runs/24110796064:
- skipping tests that hang because of same root cause https://github.com/tenstorrent/tt-xla/issues/3838
- lowering PCC on owl_vit while investigation is ongoing
- removing nightly marker from test_torch_whisper_inference because was picked up by two groups on nightly
