### PR TITLE
Fix KV cache bleed: logits_indices overflow and prefix cache block overwrite 

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/attention.py
+++ b/integrations/vllm_plugin/vllm_tt/attention.py
@@ -173,6 +173,9 @@ class TTMetadata:
     attn_mask: torch.Tensor
     page_table: torch.Tensor
     is_causal: bool
+    # Block offset for prefix caching: skip this many blocks in page_table
+    # when filling the cache during prefill (prefix blocks are already filled).
+    prefill_block_offset: int
 
     def __init__(
         self,
@@ -180,11 +183,13 @@ class TTMetadata:
         attn_mask: torch.Tensor | None = None,
         page_table: torch.Tensor | None = None,
         is_causal: bool = True,
+        prefill_block_offset: int = 0,
     ):
         self.cache_position = cache_position
         self.attn_mask = attn_mask
         self.page_table = page_table
         self.is_causal = is_causal
+        self.prefill_block_offset = prefill_block_offset
 
 
 class TTAttentionBackendImpl(AttentionImpl):
@@ -470,11 +475,20 @@ class TTAttentionBackendImpl(AttentionImpl):
             key_for_update = inputs.key.transpose(1, 2)
             value_for_update = inputs.value.transpose(1, 2)
 
+            # With prefix caching, some blocks are already filled from the
+            # cached prefix. Offset the page_table to skip those blocks so
+            # paged_fill_cache only writes to the new (non-prefix) blocks.
+            fill_page_table = attn_metadata.page_table
+            if attn_metadata.prefill_block_offset > 0:
+                fill_page_table = attn_metadata.page_table[
+                    :, attn_metadata.prefill_block_offset :
+                ]
+
             for batch_idx in range(inputs.users):
                 k_cache = torch.ops.tt.paged_fill_cache(
                     k_cache,
                     key_for_update[batch_idx : batch_idx + 1],
-                    attn_metadata.page_table,
+                    fill_page_table,
                     batch_idx=torch.tensor(
                         [batch_idx], dtype=torch.int32, device=k_cache.device
                     ),
@@ -482,7 +496,7 @@ class TTAttentionBackendImpl(AttentionImpl):
                 v_cache = torch.ops.tt.paged_fill_cache(
                     v_cache,
                     value_for_update[batch_idx : batch_idx + 1],
-                    attn_metadata.page_table,
+                    fill_page_table,
                     batch_idx=torch.tensor(
                         [batch_idx], dtype=torch.int32, device=v_cache.device
                     ),

--- a/integrations/vllm_plugin/vllm_tt/attention.py
+++ b/integrations/vllm_plugin/vllm_tt/attention.py
@@ -173,9 +173,9 @@ class TTMetadata:
     attn_mask: torch.Tensor
     page_table: torch.Tensor
     is_causal: bool
-    # Block offset for prefix caching: skip this many blocks in page_table
-    # when filling the cache during prefill (prefix blocks are already filled).
-    prefill_block_offset: int
+    # Page table with prefix blocks rolled to the end for paged_fill_cache.
+    # Computed outside the compiled graph to avoid shape-change recompilation.
+    fill_page_table: torch.Tensor
 
     def __init__(
         self,
@@ -183,13 +183,15 @@ class TTMetadata:
         attn_mask: torch.Tensor | None = None,
         page_table: torch.Tensor | None = None,
         is_causal: bool = True,
-        prefill_block_offset: int = 0,
+        fill_page_table: torch.Tensor | None = None,
     ):
         self.cache_position = cache_position
         self.attn_mask = attn_mask
         self.page_table = page_table
         self.is_causal = is_causal
-        self.prefill_block_offset = prefill_block_offset
+        self.fill_page_table = (
+            fill_page_table if fill_page_table is not None else page_table
+        )
 
 
 class TTAttentionBackendImpl(AttentionImpl):
@@ -475,14 +477,7 @@ class TTAttentionBackendImpl(AttentionImpl):
             key_for_update = inputs.key.transpose(1, 2)
             value_for_update = inputs.value.transpose(1, 2)
 
-            # With prefix caching, some blocks are already filled from the
-            # cached prefix. Offset the page_table to skip those blocks so
-            # paged_fill_cache only writes to the new (non-prefix) blocks.
-            fill_page_table = attn_metadata.page_table
-            if attn_metadata.prefill_block_offset > 0:
-                fill_page_table = attn_metadata.page_table[
-                    :, attn_metadata.prefill_block_offset :
-                ]
+            fill_page_table = attn_metadata.fill_page_table
 
             for batch_idx in range(inputs.users):
                 k_cache = torch.ops.tt.paged_fill_cache(

--- a/integrations/vllm_plugin/vllm_tt/attention.py
+++ b/integrations/vllm_plugin/vllm_tt/attention.py
@@ -477,13 +477,11 @@ class TTAttentionBackendImpl(AttentionImpl):
             key_for_update = inputs.key.transpose(1, 2)
             value_for_update = inputs.value.transpose(1, 2)
 
-            fill_page_table = attn_metadata.fill_page_table
-
             for batch_idx in range(inputs.users):
                 k_cache = torch.ops.tt.paged_fill_cache(
                     k_cache,
                     key_for_update[batch_idx : batch_idx + 1],
-                    fill_page_table,
+                    attn_metadata.fill_page_table,
                     batch_idx=torch.tensor(
                         [batch_idx], dtype=torch.int32, device=k_cache.device
                     ),
@@ -491,7 +489,7 @@ class TTAttentionBackendImpl(AttentionImpl):
                 v_cache = torch.ops.tt.paged_fill_cache(
                     v_cache,
                     value_for_update[batch_idx : batch_idx + 1],
-                    fill_page_table,
+                    attn_metadata.fill_page_table,
                     batch_idx=torch.tensor(
                         [batch_idx], dtype=torch.int32, device=v_cache.device
                     ),

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -637,7 +637,6 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 output_token_ids=[],
                 lora_request=new_req_data.lora_request,
             )
-
             if sampling_params and sampling_params.prompt_logprobs is not None:
                 self.num_prompt_logprobs[req_id] = (
                     self.input_batch.vocab_size
@@ -1042,18 +1041,34 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
             self.set_active_loras(self.input_batch, padded_num_scheduled_tokens_per_req)
 
+        # With prefix caching, some blocks are already filled. Use the
+        # minimum num_computed_tokens across the batch to determine how many
+        # leading page_table blocks to skip during paged_fill_cache. Using
+        # min is safe: all requests in a prefill batch share the same prefix
+        # (the scheduler groups by prefix), so min == max in practice.
+        prefill_block_offset = 0
+        if num_reqs > 0:
+            min_computed = int(
+                np.min(self.input_batch.num_computed_tokens_cpu[:num_reqs])
+            )
+            prefill_block_offset = min_computed // self.block_size
+
         attn_metadata = TTMetadata(
             page_table=page_table,
             cache_position=cache_position,
             is_causal=True,
             attn_mask=None,
+            prefill_block_offset=prefill_block_offset,
         )
         # NOTE(woosuk): Due to chunked prefills, there can be at most 1 partial
         # request in the batch. While we should not sample any token from this
         # partial request, we do so for simplicity. We will ignore the sampled
         # token from the partial request.
-        # Indices at which we sample (positions of last token in the sequence).
-        logits_indices = self.query_start_loc_cpu[1 : self.max_num_reqs + 1] - 1
+        # Per-user last-token index within each padded slot.
+        logits_indices = torch.zeros(self.max_num_reqs, dtype=torch.int32)
+        logits_indices[: len(num_scheduled_tokens_per_req)] = (
+            torch.from_numpy(num_scheduled_tokens_per_req).to(torch.int32) - 1
+        )
         logits_indices = logits_indices.to(self.device)
 
         if self.lora_config is not None:

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -637,6 +637,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 output_token_ids=[],
                 lora_request=new_req_data.lora_request,
             )
+
             if sampling_params and sampling_params.prompt_logprobs is not None:
                 self.num_prompt_logprobs[req_id] = (
                     self.input_batch.vocab_size
@@ -1038,11 +1039,20 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 np.min(self.input_batch.num_computed_tokens_cpu[:num_reqs])
             )
             prefill_block_offset = min_computed // self.block_size
-        fill_page_table = torch.roll(page_table, shifts=-prefill_block_offset, dims=1)
+        if prefill_block_offset > 0:
+            fill_page_table = torch.roll(
+                page_table, shifts=-prefill_block_offset, dims=1
+            )
+        else:
+            fill_page_table = page_table
 
         cache_position = cache_position.to(self.device)
         page_table = page_table.to(self.device)
-        fill_page_table = fill_page_table.to(self.device)
+        fill_page_table = (
+            fill_page_table.to(self.device)
+            if fill_page_table is not page_table
+            else page_table
+        )
 
         if self.lora_config is not None:
             # We need to respect padding when activating LoRA adapters
@@ -1069,7 +1079,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # Per-user last-token index within each padded slot.
         logits_indices = torch.zeros(self.max_num_reqs, dtype=torch.int32)
         logits_indices[: len(num_scheduled_tokens_per_req)] = (
-            torch.from_numpy(num_scheduled_tokens_per_req).to(torch.int32) - 1
+            torch.from_numpy(num_scheduled_tokens_per_req) - 1
         )
         logits_indices = logits_indices.to(self.device)
 

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -1028,21 +1028,23 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             cache_position[1:] = -1
             page_table[1:, :] = 0
 
-        # With prefix caching, some blocks are already filled. Roll the
-        # page_table so prefix blocks move to the end and paged_fill_cache
-        # writes to non-prefix blocks first. The roll is done HERE (outside
-        # the compiled graph) so the tensor shape stays constant and doesn't
-        # trigger torch.compile recompilation.
-        prefill_block_offset = 0
-        if num_reqs > 0:
-            min_computed = int(
-                np.min(self.input_batch.num_computed_tokens_cpu[:num_reqs])
-            )
-            prefill_block_offset = min_computed // self.block_size
-        if prefill_block_offset > 0:
-            fill_page_table = torch.roll(
-                page_table, shifts=-prefill_block_offset, dims=1
-            )
+        # With prefix caching, some blocks are already filled. Roll each
+        # user's page_table row so paged_fill_cache writes to suffix blocks
+        # instead of overwriting shared prefix blocks. Each user may have a
+        # different prefix length, so we roll per-row. Done outside the
+        # compiled graph to avoid shape-change recompilation.
+        offsets = (
+            self.input_batch.num_computed_tokens_cpu[:num_reqs] // self.block_size
+            if num_reqs > 0
+            else np.array([], dtype=np.int64)
+        )
+        if np.any(offsets > 0):
+            fill_page_table = page_table.clone()
+            for i in range(num_reqs):
+                if offsets[i] > 0:
+                    fill_page_table[i] = torch.roll(
+                        page_table[i], shifts=-int(offsets[i])
+                    )
         else:
             fill_page_table = page_table
 

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -1027,8 +1027,22 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             cache_position[1:] = -1
             page_table[1:, :] = 0
 
+        # With prefix caching, some blocks are already filled. Roll the
+        # page_table so prefix blocks move to the end and paged_fill_cache
+        # writes to non-prefix blocks first. The roll is done HERE (outside
+        # the compiled graph) so the tensor shape stays constant and doesn't
+        # trigger torch.compile recompilation.
+        prefill_block_offset = 0
+        if num_reqs > 0:
+            min_computed = int(
+                np.min(self.input_batch.num_computed_tokens_cpu[:num_reqs])
+            )
+            prefill_block_offset = min_computed // self.block_size
+        fill_page_table = torch.roll(page_table, shifts=-prefill_block_offset, dims=1)
+
         cache_position = cache_position.to(self.device)
         page_table = page_table.to(self.device)
+        fill_page_table = fill_page_table.to(self.device)
 
         if self.lora_config is not None:
             # We need to respect padding when activating LoRA adapters
@@ -1041,24 +1055,12 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
             self.set_active_loras(self.input_batch, padded_num_scheduled_tokens_per_req)
 
-        # With prefix caching, some blocks are already filled. Use the
-        # minimum num_computed_tokens across the batch to determine how many
-        # leading page_table blocks to skip during paged_fill_cache. Using
-        # min is safe: all requests in a prefill batch share the same prefix
-        # (the scheduler groups by prefix), so min == max in practice.
-        prefill_block_offset = 0
-        if num_reqs > 0:
-            min_computed = int(
-                np.min(self.input_batch.num_computed_tokens_cpu[:num_reqs])
-            )
-            prefill_block_offset = min_computed // self.block_size
-
         attn_metadata = TTMetadata(
             page_table=page_table,
             cache_position=cache_position,
             is_causal=True,
             attn_mask=None,
-            prefill_block_offset=prefill_block_offset,
+            fill_page_table=fill_page_table,
         )
         # NOTE(woosuk): Due to chunked prefills, there can be at most 1 partial
         # request in the batch. While we should not sample any token from this

--- a/integrations/vllm_plugin/vllm_tt/pooling_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/pooling_runner.py
@@ -1085,9 +1085,11 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         padded_num_reqs = _get_padded_num_reqs_with_upper_limit(
             num_reqs, self.max_num_reqs
         )
-        # Indices at which we sample (positions of last token in the sequence).
-        # Padded to avoid recompiling when `num_reqs` varies.
-        logits_indices = self.query_start_loc_cpu[1 : padded_num_reqs + 1] - 1
+        # Per-user last-token index within each padded slot.
+        logits_indices = torch.zeros(padded_num_reqs, dtype=torch.int32)
+        logits_indices[: len(num_scheduled_tokens_per_req)] = (
+            torch.from_numpy(num_scheduled_tokens_per_req).to(torch.int32) - 1
+        )
         logits_indices = logits_indices.to(self.device)
 
         if self.lora_config is not None:

--- a/integrations/vllm_plugin/vllm_tt/pooling_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/pooling_runner.py
@@ -1088,7 +1088,7 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # Per-user last-token index within each padded slot.
         logits_indices = torch.zeros(padded_num_reqs, dtype=torch.int32)
         logits_indices[: len(num_scheduled_tokens_per_req)] = (
-            torch.from_numpy(num_scheduled_tokens_per_req).to(torch.int32) - 1
+            torch.from_numpy(num_scheduled_tokens_per_req) - 1
         )
         logits_indices = logits_indices.to(self.device)
 

--- a/tests/integrations/vllm_plugin/generative/test_kv_cache_bleed.py
+++ b/tests/integrations/vllm_plugin/generative/test_kv_cache_bleed.py
@@ -1,0 +1,232 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Regression test for KV cache bleed (#3899).
+
+Two bugs caused cross-user response contamination:
+
+1. logits_indices overflow (batched prefill): cumulative offsets overflow past
+   each user's padded slot, reading from the wrong user's hidden states.
+
+2. Prefix cache block overwrite (staggered prefill): paged_fill_cache writes
+   suffix KV data to shared prefix blocks, corrupting cached data for
+   concurrent requests.
+
+Starts a vLLM server with TinyLlama-1.1B-Chat, sends concurrent and staggered
+requests with distinct topics, and checks for cross-topic keyword contamination.
+"""
+
+import concurrent.futures
+import json
+import os
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+
+import pytest
+import requests as http_requests
+
+MODEL = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
+SERVER_STARTUP_TIMEOUT = 600
+REQUEST_TIMEOUT = 300
+
+TOPICS = [
+    ("Explain how penguins survive in Antarctica.", "penguin"),
+    ("Describe how a submarine navigates underwater using sonar.", "submarine"),
+    ("Tell me about how dinosaurs went extinct millions of years ago.", "dinosaur"),
+    ("Explain the process of making chocolate from cacao beans.", "chocolate"),
+]
+
+SYSTEM_MSG = (
+    "You are a helpful assistant. Always stay on topic. "
+    "Only discuss what the user asks about. "
+    "Do not mention unrelated subjects."
+)
+
+# Shared prefix (system message) must span at least one cache block (16 tokens)
+# to trigger the prefix caching bug.
+CHAT_TEMPLATE = (
+    "{% for message in messages %}"
+    "{% if message['role'] == 'system' %}System: {{ message['content'] }}\n{% endif %}"
+    "{% if message['role'] == 'user' %}User: {{ message['content'] }}\nAssistant: {% endif %}"
+    "{% endfor %}"
+)
+
+_session = http_requests.Session()
+_session.trust_env = False
+
+
+def _find_free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def _read_tail(path, chars=2000):
+    try:
+        with open(path) as f:
+            return f.read()[-chars:]
+    except OSError:
+        return "<could not read log>"
+
+
+def _send_request(url, prompt, idx, max_tokens=32):
+    """Send a chat completion and return (idx, response_text)."""
+    resp = _session.post(
+        f"{url}/v1/chat/completions",
+        json={
+            "model": MODEL,
+            "messages": [
+                {"role": "system", "content": SYSTEM_MSG},
+                {"role": "user", "content": prompt},
+            ],
+            "max_tokens": max_tokens,
+            "temperature": 0.0,
+        },
+        timeout=REQUEST_TIMEOUT,
+    )
+    resp.raise_for_status()
+    return idx, resp.json()["choices"][0]["message"]["content"]
+
+
+def _check_bleed(texts, label):
+    """Print responses and return failure messages for cross-topic contamination."""
+    keywords = [kw for _, kw in TOPICS]
+    failures = []
+    for i, text in enumerate(texts):
+        text_lower = text.lower()
+        foreign = [kw for j, kw in enumerate(keywords) if j != i and kw in text_lower]
+        status = f"BLEED {foreign}" if foreign else "ok"
+        print(f"  {label} user {i} ({keywords[i]}): [{status}] {text[:80]}")
+        if foreign:
+            failures.append(
+                f"{label} user {i} ({keywords[i]}): "
+                f"foreign {foreign} in: {text[:80]}"
+            )
+    return failures
+
+
+def _send_round(url, stagger_delay=0, max_tokens=32):
+    """Send one round of requests. If stagger_delay > 0, stagger submissions."""
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(TOPICS)) as pool:
+        futures = []
+        for i, (prompt, _) in enumerate(TOPICS):
+            futures.append(pool.submit(_send_request, url, prompt, i, max_tokens))
+            if stagger_delay > 0:
+                time.sleep(stagger_delay)
+        texts = [""] * len(TOPICS)
+        for f in concurrent.futures.as_completed(futures):
+            idx, text = f.result()
+            texts[idx] = text
+    return texts
+
+
+@pytest.fixture(scope="module")
+def vllm_server():
+    """Start a vLLM server with prefix caching enabled."""
+    port = _find_free_port()
+    base_url = f"http://localhost:{port}"
+
+    template_fd, template_path = tempfile.mkstemp(suffix=".jinja")
+    os.write(template_fd, CHAT_TEMPLATE.encode())
+    os.close(template_fd)
+
+    log_fd, log_path = tempfile.mkstemp(suffix=".log", prefix="vllm_bleed_test_")
+    log_file = os.fdopen(log_fd, "w")
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "vllm.entrypoints.openai.api_server",
+        "--model",
+        MODEL,
+        "--port",
+        str(port),
+        "--max-model-len",
+        "192",
+        "--max-num-batched-tokens",
+        "768",
+        "--max-num-seqs",
+        "4",
+        "--gpu-memory-utilization",
+        "0.001",
+        "--enforce-eager",
+        "--chat-template",
+        template_path,
+        "--additional-config",
+        json.dumps({"enable_const_eval": False, "min_context_len": 32}),
+    ]
+
+    proc = None
+    try:
+        proc = subprocess.Popen(cmd, stdout=log_file, stderr=subprocess.STDOUT)
+
+        deadline = time.time() + SERVER_STARTUP_TIMEOUT
+        ready = False
+        while time.time() < deadline:
+            if proc.poll() is not None:
+                pytest.fail(
+                    f"Server exited ({proc.returncode}).\n{_read_tail(log_path)}"
+                )
+            try:
+                if _session.get(f"{base_url}/health", timeout=5).status_code == 200:
+                    ready = True
+                    break
+            except http_requests.ConnectionError:
+                pass
+            time.sleep(2)
+
+        if not ready:
+            proc.send_signal(signal.SIGTERM)
+            proc.wait(timeout=10)
+            pytest.fail(f"Server not ready in {SERVER_STARTUP_TIMEOUT}s")
+
+        yield base_url
+
+        proc.send_signal(signal.SIGTERM)
+        try:
+            proc.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+    finally:
+        if proc and proc.poll() is None:
+            proc.kill()
+            proc.wait()
+        log_file.close()
+        os.unlink(log_path)
+        os.unlink(template_path)
+
+
+@pytest.mark.nightly
+@pytest.mark.single_device
+def test_kv_cache_no_cross_user_bleed(vllm_server):
+    """Concurrent and staggered requests must not leak data between users.
+
+    Phase 1 (bug #1): all 4 requests sent at once — batched prefill.
+    Phase 2 (bug #2): staggered overlapping requests — prefix cache reuse.
+    """
+    all_failures = []
+
+    # Phase 1: concurrent (triggers batched prefill logits_indices overflow)
+    print("\n--- Phase 1: concurrent requests (batched prefill) ---")
+    for r in range(3):
+        texts = _send_round(vllm_server)
+        all_failures.extend(_check_bleed(texts, f"concurrent r{r + 1}"))
+
+    # Phase 2: staggered with overlap (triggers prefix cache block overwrite)
+    # Longer generation (96 tokens) ensures requests overlap so a prefilling
+    # request can overwrite a prefix block while another is still decoding.
+    print("\n--- Phase 2: staggered requests (prefix cache reuse) ---")
+    for r in range(5):
+        texts = _send_round(vllm_server, stagger_delay=0.8, max_tokens=96)
+        all_failures.extend(_check_bleed(texts, f"staggered r{r + 1}"))
+
+    assert (
+        not all_failures
+    ), f"KV cache bleed in {len(all_failures)} cases:\n" + "\n".join(all_failures[:10])


### PR DESCRIPTION
  ### Ticket
  Closes https://github.com/tenstorrent/tt-xla/issues/3899

  ### Problem description
  Three bugs in the vLLM plugin cause cross-user response contamination (KV cache bleed) when serving multiple concurrent users:

  1. **logits_indices overflow** — batched prefill used cumulative offsets from `query_start_loc` that overflow past each user's padded slot, reading wrong hidden states
  2. **Prefix cache block overwrite** — `paged_fill_cache` writes suffix KV data starting at the shared prefix block, corrupting it for other requests
  3. **Mixed-batch prefix cache bleed** — the initial fix for Bug 2 used a single `min(num_computed_tokens)` roll offset, which is 0 whenever the batch mixes cached and non-cached requests

  ### What's changed

  **`integrations/vllm_plugin/vllm_tt/model_runner.py`**
  - Replace cumulative `query_start_loc` logits_indices with per-user `num_scheduled_tokens - 1`
  - Compute per-row `fill_page_table` by rolling each user's page_table row by their own `num_computed_tokens // block_size`, handling mixed-batch prefix cache states
  - Skip roll and device transfer when no prefix offset needed

  **`integrations/vllm_plugin/vllm_tt/attention.py`**
  - Add `fill_page_table` field to `TTMetadata` (defaults to `page_table`)
  - Use `fill_page_table` instead of `page_table` in `paged_fill_cache` calls

  **`integrations/vllm_plugin/vllm_tt/pooling_runner.py`**
  - Same `logits_indices` fix (no prefix caching fix needed — pooling doesn't use paged attention)

  **`tests/integrations/vllm_plugin/generative/test_kv_cache_bleed.py`** (new)
  - `test_kv_cache_no_cross_user_bleed`: server-based regression test with TinyLlama-1.1B-Chat
  - Phase 1: 3 rounds of concurrent requests (triggers Bug 1)
  - Phase 2: 5 rounds of staggered overlapping requests (triggers Bugs 2/3)
  - Keyword contamination detection across 4 distinct topic prompts with greedy decoding
  - Fails without fix, passes with fix

  ### Checklist
  - [x] `test_kv_cache_no_cross_user_bleed` passes (fails without fix)
  - [x] `test_opt_generation` passes (single-device, batched generation)
  - [x] `test_batched_inference` passes (pooling path)
