### PR TITLE
Multihost Exabox Support- Custom rankfile, multi bh galaxy presets

### DIFF
--- a/pjrt_implementation/src/api/client_instance.cc
+++ b/pjrt_implementation/src/api/client_instance.cc
@@ -50,6 +50,10 @@ static std::string getRankBindingPath(const std::string &metal_home) {
        "tests/tt_metal/distributed/config/dual_galaxy_rank_bindings.yaml"},
       {"quad_galaxy",
        "tests/tt_metal/distributed/config/quad_galaxy_rank_bindings.yaml"},
+       {"dual_exabox_galaxy",
+        "tests/tt_metal/distributed/config/16x4_dual_bh_galaxy_rank_bindings.yaml"},
+       {"quad_exabox_galaxy",
+        "tests/tt_metal/distributed/config/32x4_quad_bh_galaxy_rank_bindings.yaml"},
   };
 
   const char *rank_binding = std::getenv("TT_DISTRIBUTED_RANK_BINDING");
@@ -109,6 +113,8 @@ static tt_pjrt_status launchDistributedRuntime() {
   // Network interface name for MPI (eg. cnx1, enp10s0f1np1)
   const char *tt_distributed_tcp_iface =
       std::getenv("TT_DISTRIBUTED_TCP_IFACE");
+  // Path to an MPI rankfile, needed for >2 hosts when using a rank binding file
+  const char *rank_file_path = std::getenv("TT_DISTRIBUTED_RANK_FILE_PATH");
 
   if (!metal_home) {
     LOG_F(ERROR, "TT_METAL_RUNTIME_ROOT environment variable is not set");
@@ -183,6 +189,10 @@ static tt_pjrt_status launchDistributedRuntime() {
     distributed_options.multiProcessArgs->withHostsFilePath(hosts_file);
   }
 
+  if (rank_file_path) {
+    distributed_options.multiProcessArgs->withRankFilePath(rank_file_path);
+  }
+  
   tt::runtime::setCurrentHostRuntime(tt::runtime::HostRuntime::Distributed);
   tt::runtime::launchDistributedRuntime(distributed_options);
 

--- a/pjrt_implementation/src/api/client_instance.cc
+++ b/pjrt_implementation/src/api/client_instance.cc
@@ -50,10 +50,10 @@ static std::string getRankBindingPath(const std::string &metal_home) {
        "tests/tt_metal/distributed/config/dual_galaxy_rank_bindings.yaml"},
       {"quad_galaxy",
        "tests/tt_metal/distributed/config/quad_galaxy_rank_bindings.yaml"},
-       {"dual_exabox_galaxy",
-        "tests/tt_metal/distributed/config/16x4_dual_bh_galaxy_rank_bindings.yaml"},
-       {"quad_exabox_galaxy",
-        "tests/tt_metal/distributed/config/32x4_quad_bh_galaxy_rank_bindings.yaml"},
+      {"dual_exabox_galaxy", "tests/tt_metal/distributed/config/"
+                             "16x4_dual_bh_galaxy_rank_bindings.yaml"},
+      {"quad_exabox_galaxy", "tests/tt_metal/distributed/config/"
+                             "32x4_quad_bh_galaxy_rank_bindings.yaml"},
   };
 
   const char *rank_binding = std::getenv("TT_DISTRIBUTED_RANK_BINDING");
@@ -192,7 +192,7 @@ static tt_pjrt_status launchDistributedRuntime() {
   if (rank_file_path) {
     distributed_options.multiProcessArgs->withRankFilePath(rank_file_path);
   }
-  
+
   tt::runtime::setCurrentHostRuntime(tt::runtime::HostRuntime::Distributed);
   tt::runtime::launchDistributedRuntime(distributed_options);
 

--- a/tests/torch/multi_host/experimental/remote_docker.sh
+++ b/tests/torch/multi_host/experimental/remote_docker.sh
@@ -12,7 +12,10 @@ shift
 
 # Capture the entire remaining command as one block
 REMOTE_COMMAND="$*"
+
+# This username must, on baremetal, have keyless ssh from controller to worker
 USERNAME="ubuntu"
+
 CONTAINER_NAME="ubuntu-host-mapped"
 
 # SSH Options:

--- a/tests/torch/multi_host/experimental/remote_docker.sh
+++ b/tests/torch/multi_host/experimental/remote_docker.sh
@@ -25,7 +25,7 @@ CONTAINER_NAME="ubuntu-host-mapped"
 SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
 
 # Use bash -c inside docker exec to handle the complex MPI environment string
-ssh -A $SSH_OPTS -l $USERNAME "$HOST" sudo docker exec \
+ssh -A $SSH_OPTS -l $USERNAME "$HOST" docker exec \
   -u root \
   -e LD_LIBRARY_PATH=/opt/ttmlir-toolchain/lib:/lib/x86_64-linux-gnu \
   $CONTAINER_NAME bash -c "'$REMOTE_COMMAND'"

--- a/tests/torch/multi_host/experimental/remote_docker.sh
+++ b/tests/torch/multi_host/experimental/remote_docker.sh
@@ -12,6 +12,8 @@ shift
 
 # Capture the entire remaining command as one block
 REMOTE_COMMAND="$*"
+USERNAME="ubuntu"
+CONTAINER_NAME="ubuntu-host-mapped"
 
 # SSH Options:
 # StrictHostKeyChecking=no: Don't ask to verify the host
@@ -20,7 +22,7 @@ REMOTE_COMMAND="$*"
 SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
 
 # Use bash -c inside docker exec to handle the complex MPI environment string
-ssh -A $SSH_OPTS -l ubuntu "$HOST" sudo docker exec \
+ssh -A $SSH_OPTS -l $USERNAME "$HOST" sudo docker exec \
   -u root \
   -e LD_LIBRARY_PATH=/opt/ttmlir-toolchain/lib:/lib/x86_64-linux-gnu \
-  ubuntu-host-mapped bash -c "'$REMOTE_COMMAND'"
+  $CONTAINER_NAME bash -c "'$REMOTE_COMMAND'"


### PR DESCRIPTION
### Ticket
None

### Problem description
Exabox multihost operations require additional configs from tt-xla.

### What's changed
- Support rankfile for quad usage (>2 hosts) - `TT_DISTRIBUTED_RANK_FILE_PATH`
- Add dual_exabox_galaxy and quad_exabox_galaxy rank binding presets
- Clarify remote_docker.sh configuration 
- Remove sudo from docker exec remote_docker.sh wrapper due to permissions on exabox

### Checklist
- [x] New/Existing tests provide coverage for changes
