### PR TITLE
Support sparse MoE for GLM-4, DeepSeek V3, and Kimi K2

### DIFF
--- a/python_package/tt_torch/custom_ops.py
+++ b/python_package/tt_torch/custom_ops.py
@@ -907,30 +907,73 @@ def sparse_matmul(
     This operation performs matrix multiplication where computation is skipped
     for sparse (zero) blocks based on the sparsity tensor.
 
+    Accepts flexible input formats for MoE data flow:
+        - Gate-up (b_sparse): dispatch output [1, BD, S, H] or canonical [A, B, M, K]
+        - Down (a_sparse): activation output [BD, S, E, inter] or canonical [A, E, M, K]
+    Format conversion to canonical 4D is handled internally.
+
     Args:
-        input_tensor_a: First input tensor. Shape depends on sparse mode:
-            - is_input_a_sparse=True, is_input_b_sparse=True: [1, E, M, K]
-            - is_input_a_sparse=False, is_input_b_sparse=True: [A, B, M, K]
-            - is_input_a_sparse=True, is_input_b_sparse=False: [A, E, M, K]
-        input_tensor_b: Second input tensor (expert weights). Shape:
-            - [1, E, K, N] for all modes
-        sparsity: Sparsity mask tensor (bfloat16, ROW_MAJOR). Shape depends on mode:
-            - is_input_a_sparse=True, is_input_b_sparse=True: [1, 1, 1, E]
-            - is_input_a_sparse=False, is_input_b_sparse=True: [A, B, 1, E]
-            - is_input_a_sparse=True, is_input_b_sparse=False: [1, 1, A, E]
-        nnz: Number of non-zero elements in sparsity tensor. If None, inferred at runtime.
+        input_tensor_a: First input tensor (see above for accepted formats).
+        input_tensor_b: Expert weights [1, E, K, N].
+        sparsity: Sparsity mask tensor.
+        nnz: Number of non-zero elements. If None, inferred at runtime.
         is_input_a_sparse: Whether input_tensor_a is sparse.
         is_input_b_sparse: Whether input_tensor_b is sparse.
 
     Returns:
-        Output tensor with sparse results. Shape depends on mode:
-            - is_input_a_sparse=True, is_input_b_sparse=True: [1, E, M, N]
-            - is_input_a_sparse=False, is_input_b_sparse=True: [A, B, 1, E, M, N]
-            - is_input_a_sparse=True, is_input_b_sparse=False: [A, E, M, N]
+        Output tensor. For auto-converted inputs, returns clean shapes:
+            - Gate-up with dispatch input: [BD, S, E, N]
+            - Down with activation input: [BD, S, E, N]
+            - Otherwise: canonical sparse_matmul output shapes
     """
     device = input_tensor_a.device
 
+    # Detect MoE inputs that need normalization to 4D canonical form.
+    # Gate-up from dispatch: [1, BD, S, H] → [BD, S, 1, H]
+    # Down from activation:  [BD, S, E, inter] → [BD*S, E, 1, inter]
+    _moe_shape = None
+    E_experts = input_tensor_b.shape[1]
+
+    if not is_input_a_sparse and is_input_b_sparse:
+        if input_tensor_a.dim() == 4 and input_tensor_a.shape[0] == 1:
+            _, BD, S, H = input_tensor_a.shape
+            _moe_shape = (BD, S)
+    elif is_input_a_sparse and not is_input_b_sparse:
+        # Detect MoE format [BD, S, E, inter] vs canonical [A, E, M, K].
+        # Use sparsity dim: canonical has A == sparsity.shape[2] (reduced),
+        # MoE format has BD != reduced. This works even when S == E_global.
+        if input_tensor_a.dim() == 4 and input_tensor_a.shape[1] != E_experts:
+            BD, S, _, _ = input_tensor_a.shape
+            _moe_shape = (BD, S)
+
     if device.type == "xla":
+        # Pre-tile MoE tensors so the M (tile) dimension is already 32-aligned.
+        # This avoids MLIR workaround reshape/permute overhead entirely.
+        #
+        # Gate-up: [1, BD, S, H] → [BD, S//M, M, H]  (reshape only)
+        #   output: [BD, S//M, 1, E, M, N] → squeeze → [BD, S//M, E, M, N] (5D)
+        #   caller does bias add on 5D, activation, then reshapes for down.
+        #
+        # Down: caller sends [BD*S//M, E, M, inter] (already canonical [A,E,M,K])
+        #   → not detected as _moe_shape, passes through directly
+        #   output: [BD*S//M, E, M, H] — caller does bias add, permute, reshape.
+        if _moe_shape is not None:
+            BD, S = _moe_shape
+            reduced = sparsity.shape[2]
+            M = (BD * S) // reduced
+
+            if not is_input_a_sparse and is_input_b_sparse:
+                H = input_tensor_a.shape[-1]
+                split_seq = S % M == 0 and S >= M
+                if split_seq:
+                    input_tensor_a = input_tensor_a.reshape(BD, S // M, M, H)
+                    sparsity = sparsity.reshape(BD, S // M, 1, E_experts)
+                else:
+                    # Decode: tile on BD instead
+                    input_tensor_a = input_tensor_a.reshape(BD // M, M, S, H)
+                    input_tensor_a = input_tensor_a.permute(0, 2, 1, 3)
+                    sparsity = sparsity.reshape(BD // M, S, 1, E_experts)
+
         frontend_attributes = {
             "is_input_a_sparse": str(is_input_a_sparse),
             "is_input_b_sparse": str(is_input_b_sparse),
@@ -938,27 +981,19 @@ def sparse_matmul(
         if nnz is not None:
             frontend_attributes["nnz"] = str(nnz)
 
-        # Compute output shape based on sparse mode
         if is_input_a_sparse and is_input_b_sparse:
-            # [1, E, M, K] @ [1, E, K, N] -> [1, E, M, N]
             output_shape = list(input_tensor_a.shape)
             output_shape[-1] = input_tensor_b.shape[-1]
         elif not is_input_a_sparse and is_input_b_sparse:
-            # [A, B, M, K] @ [1, E, K, N] -> [A, B, 1, E, M, N]
-            A, B, M, K = input_tensor_a.shape
-            E = input_tensor_b.shape[1]
-            N = input_tensor_b.shape[-1]
-            output_shape = [A, B, 1, E, M, N]
+            A, B, M_dim, K = input_tensor_a.shape
+            output_shape = [A, B, 1, E_experts, M_dim, input_tensor_b.shape[-1]]
         elif is_input_a_sparse and not is_input_b_sparse:
-            # [A, E, M, K] @ [1, E, K, N] -> [A, E, M, N]
             output_shape = list(input_tensor_a.shape)
             output_shape[-1] = input_tensor_b.shape[-1]
         else:
-            raise ValueError(
-                "Invalid sparse mode: both is_input_a_sparse and is_input_b_sparse cannot be False"
-            )
+            raise ValueError("Both sparse flags cannot be False")
 
-        return stablehlo_custom_call.stablehlo_custom_call(
+        result = stablehlo_custom_call.stablehlo_custom_call(
             [input_tensor_a, input_tensor_b, sparsity],
             "tt.sparse_matmul",
             [output_shape],
@@ -966,61 +1001,83 @@ def sparse_matmul(
             frontend_attributes=frontend_attributes,
         )
 
+        # Convert tiled sparse_matmul outputs.
+        if _moe_shape is not None:
+            if not is_input_a_sparse and is_input_b_sparse:
+                # [A, B, 1, E, M, N] → [A, B, E, M, N] (5D tiled)
+                result = result.squeeze(2).squeeze(-2)
+
+        return result
+
     elif device.type == "cpu":
-        # CPU fallback: loop over experts to avoid broadcasting weights
-        # across large batch dimensions (can exceed 1TB for D=8, E=32).
-        input_b_casted = input_tensor_b.to(input_tensor_a.dtype)
+        _tiled = _moe_shape is not None
+        if _tiled:
+            BD, S = _moe_shape
+            reduced = sparsity.shape[2]
+            E_sp = sparsity.shape[-1]
+            M = (BD * S) // reduced
+
+            if not is_input_a_sparse and is_input_b_sparse:
+                input_tensor_a = input_tensor_a.view(
+                    BD, S // M, M, input_tensor_a.shape[-1]
+                )
+                sparsity = sparsity.view(BD, S // M, 1, E_sp)
+            elif is_input_a_sparse and not is_input_b_sparse:
+                E_in = input_tensor_a.shape[2]
+                K_in = input_tensor_a.shape[-1]
+                input_tensor_a = input_tensor_a.reshape(BD * S // M, M, E_in, K_in)
+                input_tensor_a = input_tensor_a.permute(0, 2, 1, 3).contiguous()
+                sparsity = sparsity.view(1, 1, BD * S // M, E_sp)
+
+        orig_dtype = input_tensor_a.dtype
+        input_tensor_a = input_tensor_a.float()
+        sparsity = sparsity.float()
+        input_b_casted = input_tensor_b.float()
+        E = E_experts
+        N = input_tensor_b.shape[-1]
+
+        # Find active experts from sparsity to skip inactive ones
+        if not (is_input_a_sparse and is_input_b_sparse):
+            active_experts = set()
+            sp_flat = sparsity.view(-1, E)
+            for e in range(E):
+                if sp_flat[:, e].any():
+                    active_experts.add(e)
 
         if is_input_a_sparse and is_input_b_sparse:
-            # [1, E, M, K] @ [1, E, K, N] -> [1, E, M, N]
-            E = input_tensor_b.shape[1]
-            N = input_tensor_b.shape[-1]
-            M = input_tensor_a.shape[2]
-            output = torch.zeros(1, E, M, N, dtype=input_tensor_a.dtype, device=device)
-            for e in range(E):
-                if sparsity[0, 0, 0, e] > 0:
-                    output[0, e] = torch.matmul(
-                        input_tensor_a[0, e], input_b_casted[0, e]
-                    )
-            return output
+            output = torch.matmul(input_tensor_a, input_b_casted)
+            return output.to(orig_dtype)
 
         elif not is_input_a_sparse and is_input_b_sparse:
-            # [A, B, M, K] @ [1, E, K, N] -> [A, B, 1, E, M, N]
-            A, B, M, K = input_tensor_a.shape
-            E = input_tensor_b.shape[1]
-            N = input_tensor_b.shape[-1]
+            A, B, M_dim, K = input_tensor_a.shape
             output = torch.zeros(
-                A, B, 1, E, M, N, dtype=input_tensor_a.dtype, device=device
+                A, B, 1, E, M_dim, N, dtype=torch.float32, device=device
             )
-            for e in range(E):
-                mask_e = sparsity[:, :, 0, e]  # [A, B]
-                if mask_e.any():
-                    # [A, B, M, K] @ [K, N] -> [A, B, M, N]
-                    out_e = torch.matmul(input_tensor_a, input_b_casted[0, e])
-                    output[:, :, 0, e, :, :] = out_e * mask_e.unsqueeze(-1).unsqueeze(
-                        -1
-                    )
-            return output
+            for e in active_experts:
+                mask_e = sparsity[:, :, 0, e]
+                out_e = torch.matmul(input_tensor_a, input_b_casted[0, e])
+                output[:, :, 0, e, :, :] = out_e * mask_e.unsqueeze(-1).unsqueeze(-1)
+            if _tiled:
+                output = output.squeeze(2).permute(0, 1, 3, 2, 4).contiguous()
+                output = output.view(BD, S, E, N)
+            return output.to(orig_dtype)
 
         elif is_input_a_sparse and not is_input_b_sparse:
-            # [A, E, M, K] @ [1, E, K, N] -> [A, E, M, N]
             A = input_tensor_a.shape[0]
-            E = input_tensor_b.shape[1]
-            M = input_tensor_a.shape[2]
-            N = input_tensor_b.shape[-1]
-            output = torch.zeros(A, E, M, N, dtype=input_tensor_a.dtype, device=device)
-            for e in range(E):
-                mask_e = sparsity[0, 0, :, e]  # [A]
-                if mask_e.any():
-                    # [A, M, K] @ [K, N] -> [A, M, N]
-                    out_e = torch.matmul(input_tensor_a[:, e], input_b_casted[0, e])
-                    output[:, e] = out_e * mask_e.unsqueeze(-1).unsqueeze(-1)
-            return output
+            M_dim = input_tensor_a.shape[2]
+            output = torch.zeros(A, E, M_dim, N, dtype=torch.float32, device=device)
+            for e in active_experts:
+                mask_e = sparsity[0, 0, :, e]
+                out_e = torch.matmul(input_tensor_a[:, e], input_b_casted[0, e])
+                output[:, e] = out_e * mask_e.unsqueeze(-1).unsqueeze(-1)
+            if _tiled:
+                output = output.view(BD, S // M, E, M, N)
+                output = output.permute(0, 1, 3, 2, 4).contiguous()
+                output = output.view(BD, S, E, N)
+            return output.to(orig_dtype)
 
         else:
-            raise ValueError(
-                "Invalid sparse mode: both is_input_a_sparse and is_input_b_sparse cannot be False"
-            )
+            raise ValueError("Both sparse flags cannot be False")
     else:
         raise ValueError(f"Unsupported device type: {device.type}")
 
@@ -1035,21 +1092,48 @@ def sparse_matmul_fake(
     is_input_b_sparse: bool = True,
 ) -> torch.Tensor:
     """FakeTensor implementation of sparse_matmul for torch dynamo tracing."""
-    if is_input_a_sparse and is_input_b_sparse:
+    E = input_tensor_b.shape[1]
+    N = input_tensor_b.shape[-1]
+
+    # Detect MoE inputs (same logic as real op)
+    _moe_shape = None
+    if not is_input_a_sparse and is_input_b_sparse:
+        if input_tensor_a.dim() == 4 and input_tensor_a.shape[0] == 1:
+            # A2aSparseMLP dispatch layout: [1, BD, S, H]
+            _, BD, S, _ = input_tensor_a.shape
+            _moe_shape = (BD, S)
+        elif input_tensor_a.dim() == 4 and input_tensor_a.shape[2] == 1:
+            # SparseMLP layout: [BD, S, 1, H]
+            BD, S, _, _ = input_tensor_a.shape
+            _moe_shape = (BD, S)
+    elif is_input_a_sparse and not is_input_b_sparse:
+        if input_tensor_a.dim() == 4 and input_tensor_a.shape[1] != E:
+            BD, S, _, _ = input_tensor_a.shape
+            _moe_shape = (BD, S)
+
+    if _moe_shape is not None:
+        BD, S = _moe_shape
+        reduced = sparsity.shape[2]
+        M = (BD * S) // reduced
+        if not is_input_a_sparse and is_input_b_sparse:
+            # Gate-up: tiled output [A, B, E, M, N] (5D)
+            split_seq = S % M == 0 and S >= M
+            A = BD if split_seq else BD // M
+            B = S // M if split_seq else S
+            output_shape = [A, B, E, M, N]
+        else:
+            output_shape = [BD, S, E, N]
+    elif is_input_a_sparse and is_input_b_sparse:
         output_shape = list(input_tensor_a.shape)
-        output_shape[-1] = input_tensor_b.shape[-1]
+        output_shape[-1] = N
     elif not is_input_a_sparse and is_input_b_sparse:
         A, B, M, K = input_tensor_a.shape
-        E = input_tensor_b.shape[1]
-        N = input_tensor_b.shape[-1]
         output_shape = [A, B, 1, E, M, N]
     elif is_input_a_sparse and not is_input_b_sparse:
         output_shape = list(input_tensor_a.shape)
-        output_shape[-1] = input_tensor_b.shape[-1]
+        output_shape[-1] = N
     else:
-        raise ValueError(
-            "Invalid sparse mode: both is_input_a_sparse and is_input_b_sparse cannot be False"
-        )
+        raise ValueError("Both sparse flags cannot be False")
 
     return torch.zeros(
         output_shape, dtype=input_tensor_a.dtype, device=input_tensor_a.device
@@ -1072,22 +1156,36 @@ def all_to_all_dispatch(
     Selectively routes tokens based on expert_indices and expert_mapping,
     sending each token only to devices that hold its selected experts.
 
-    Args:
-        input_tensor: Input tokens [B, 1, S, H], bfloat16
-        expert_indices: Selected expert IDs per token [B, 1, S, K], int64
-        expert_mapping: One-hot expert-to-device mapping [1, 1, E, D], int64
-        num_devices: Number of devices along dispatch axis (D)
-        cluster_axis: Mesh axis to dispatch along (0=rows, 1=cols)
+    Accepts flexible input formats:
+        - input_tensor: [B, S, H] (3D) or [B, 1, S, H] (4D)
+        - expert_indices: [B*S, K] (2D) or [B, S, K] (3D) or [B, 1, S, K] (4D)
+        - expert_mapping: [1, 1, E, D]
 
     Returns:
         dispatched_tokens: [1, B*D, S, H] sparsely populated tokens
         expert_metadata: [1, B*D, S, K] all-gathered expert indices
     """
     device = input_tensor.device
-    B, _, S, H = input_tensor.shape
-    K = expert_indices.shape[-1]
 
     if device.type == "xla":
+        # Canonicalize inputs to 4D for runtime compatibility.
+        if input_tensor.dim() == 3:
+            B, S, H = input_tensor.shape
+            input_tensor = input_tensor.reshape(B, 1, S, H)
+        elif input_tensor.dim() == 4:
+            B, _, S, H = input_tensor.shape
+        else:
+            raise ValueError(
+                f"input_tensor must be rank 3 or 4, got {input_tensor.dim()}"
+            )
+
+        # Canonicalize expert_indices to 4D [B, 1, S, K]
+        K = expert_indices.shape[-1]
+        if expert_indices.dim() == 2:
+            expert_indices = expert_indices.reshape(B, S, K).unsqueeze(1)
+        elif expert_indices.dim() == 3:
+            expert_indices = expert_indices.unsqueeze(1)
+
         BD = B * num_devices
         output_shapes = [[1, BD, S, H], [1, BD, S, K]]
         output_dtypes = [input_tensor.dtype, expert_indices.dtype]
@@ -1106,10 +1204,19 @@ def all_to_all_dispatch(
         )
 
     elif device.type == "cpu":
-        # CPU fallback: simulate dispatch by repeating tokens D times.
-        # Shape must match fake kernel: [1, B*D, S, H] and [1, B*D, S, K].
-        # On real hardware, dispatch selectively routes tokens; on CPU we
-        # replicate so that downstream sparse_matmul sees all tokens.
+        # Normalize to 4D [B, 1, S, H] for the CPU fallback kernel.
+        if input_tensor.dim() == 3:
+            B, S, H = input_tensor.shape
+            input_tensor = input_tensor.unsqueeze(1)  # [B, 1, S, H]
+        else:
+            B, _, S, H = input_tensor.shape
+
+        K = expert_indices.shape[-1]
+        if expert_indices.dim() == 2:
+            expert_indices = expert_indices.view(B, 1, S, K)
+        elif expert_indices.dim() == 3:
+            expert_indices = expert_indices.unsqueeze(1)  # [B, 1, S, K]
+
         x = input_tensor.permute(1, 0, 2, 3)  # [1, B, S, H]
         m = expert_indices.permute(1, 0, 2, 3)  # [1, B, S, K]
         if num_devices > 1:
@@ -1129,7 +1236,10 @@ def all_to_all_dispatch_fake(
     num_devices: int = 1,
     cluster_axis: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    B, _, S, H = input_tensor.shape
+    if input_tensor.dim() == 3:
+        B, S, H = input_tensor.shape
+    else:
+        B, _, S, H = input_tensor.shape
     K = expert_indices.shape[-1]
     BD = B * num_devices
 
@@ -1160,40 +1270,41 @@ def all_to_all_combine(
     Inverse of dispatch: gathers expert computation results from all devices
     and restores tokens to their original device and order.
 
+    Accepts flexible input formats:
+        - [E_local, B*D, S, H]: canonical (E first)
+        - [B*D, S, E_local, H]: natural MoE output (E at dim -2), auto-permuted
+
     Args:
-        input_tensor: Expert outputs, bfloat16. Shape depends on output_shard_dim:
-            - output_shard_dim=1: [E_local, B*D, S, H] (default)
-            - output_shard_dim=2: [E_local, S, B*D, H] (decode-optimized, avoids tile waste on S=1)
+        input_tensor: Expert outputs (see above for accepted formats).
         expert_metadata: Routing metadata from dispatch [1, B*D, S, K], int64
         expert_mapping: One-hot expert-to-device mapping [1, 1, E, D], int64
         num_devices: Number of devices along dispatch axis (D)
         cluster_axis: Mesh axis to combine along (0=rows, 1=cols)
         num_experts_per_tok: Number of selected experts per token (K)
         output_shard_dim: Dimension index for the BD shard dimension (1 or 2).
-            Use 2 for decode to place BD on dim -2 and avoid tile padding on S=1.
+            Auto-detected by the compiler; callers typically omit this.
 
     Returns:
-        combined: Shape depends on output_shard_dim:
-            - output_shard_dim=1: [K, B, S, H]
-            - output_shard_dim=2: [K, S, B, H]
+        combined: [K, B, S, H]
     """
     device = input_tensor.device
     K = num_experts_per_tok
 
-    if output_shard_dim == 1:
-        E_local, BD, S, H = input_tensor.shape
-    elif output_shard_dim == 2:
-        E_local, S, BD, H = input_tensor.shape
-    else:
-        raise ValueError(f"output_shard_dim must be 1 or 2, got {output_shard_dim}")
-
-    B = BD // num_devices
-
     if device.type == "xla":
+        if input_tensor.dim() != 4:
+            raise ValueError(f"input_tensor must be rank 4, got {input_tensor.dim()}")
+
+        # metadata is [1, 1, tokens, K] where tokens = BD*S.
+        tokens = expert_metadata.shape[2]
+        H = input_tensor.shape[-1]
+        tokens_per_device = tokens // num_devices
+
         if output_shard_dim == 1:
-            output_shape = [K, B, S, H]
+            output_shape = [K, tokens_per_device, 1, H]
+        elif output_shard_dim == 2:
+            output_shape = [K, 1, tokens_per_device, H]
         else:
-            output_shape = [K, S, B, H]
+            raise ValueError(f"output_shard_dim must be 1 or 2, got {output_shard_dim}")
 
         frontend_attributes = {
             "num_devices": str(num_devices),
@@ -1211,32 +1322,36 @@ def all_to_all_combine(
         )
 
     elif device.type == "cpu":
-        # CPU fallback: dispatch repeats tokens D times, so BD = B * D.
-        # Combine reverses this by taking only the first B entries (all
-        # D copies are identical on CPU since dispatch just replicates).
-        B_local = BD // num_devices
-        metadata_indices = expert_metadata[0]  # [BD, S, K]
+        # metadata is [1, 1, tokens, K] where tokens = BD*S.
+        tokens = expert_metadata.shape[2]
+        H = input_tensor.shape[-1]
+        tokens_per_device = tokens // num_devices
 
-        if output_shard_dim == 1:
-            combined = torch.zeros(
-                K, B_local, S, H, dtype=input_tensor.dtype, device=device
-            )
-            for b in range(B_local):
-                for s in range(S):
-                    for k in range(K):
-                        expert_id = metadata_indices[b, s, k].item()
-                        if 0 <= expert_id < E_local:
-                            combined[k, b, s, :] = input_tensor[expert_id, b, s, :]
+        # Normalize input to [E, tokens, H] for indexing.
+        E_local = input_tensor.shape[0]
+        input_flat = input_tensor.reshape(E_local, tokens, H)
+
+        # metadata indices: [1, 1, tokens, K] → [tokens, K]
+        metadata_indices = expert_metadata[0, 0].long()  # [tokens, K]
+
+        combined = torch.zeros(
+            K, tokens_per_device, H, dtype=input_tensor.dtype, device=device
+        )
+        for k in range(K):
+            expert_ids = metadata_indices[:tokens_per_device, k]  # [tokens_per_device]
+            valid = (expert_ids >= 0) & (expert_ids < E_local)
+            expert_ids_clamped = expert_ids.clamp(0, E_local - 1)
+            t_idx = torch.arange(tokens_per_device, device=device)
+            gathered = input_flat[
+                expert_ids_clamped, t_idx, :
+            ]  # [tokens_per_device, H]
+            combined[k] = gathered * valid.unsqueeze(-1).to(gathered.dtype)
+
+        # Reshape to match output_shard_dim format: [K, tokens_per_device, H] → [K, 1, tpd, H]
+        if output_shard_dim == 2:
+            combined = combined.unsqueeze(1)  # [K, 1, tokens_per_device, H]
         else:
-            combined = torch.zeros(
-                K, S, B_local, H, dtype=input_tensor.dtype, device=device
-            )
-            for b in range(B_local):
-                for s in range(S):
-                    for k in range(K):
-                        expert_id = metadata_indices[b, s, k].item()
-                        if 0 <= expert_id < E_local:
-                            combined[k, s, b, :] = input_tensor[expert_id, s, b, :]
+            combined = combined.unsqueeze(2)  # [K, tokens_per_device, 1, H]
 
         return combined
 
@@ -1256,18 +1371,27 @@ def all_to_all_combine_fake(
 ) -> torch.Tensor:
     K = num_experts_per_tok
 
+    if input_tensor.dim() != 4:
+        raise ValueError(f"input_tensor must be rank 4, got {input_tensor.dim()}")
+
+    # metadata is [1, 1, tokens, K].
+    tokens = expert_metadata.shape[2]
+    H = input_tensor.shape[-1]
+    tokens_per_device = tokens // num_devices
+
     if output_shard_dim == 1:
-        _, BD, S, H = input_tensor.shape
-        B = BD // num_devices
         return torch.zeros(
-            [K, B, S, H], dtype=input_tensor.dtype, device=input_tensor.device
+            [K, tokens_per_device, 1, H],
+            dtype=input_tensor.dtype,
+            device=input_tensor.device,
         )
-    else:
-        _, S, BD, H = input_tensor.shape
-        B = BD // num_devices
+    if output_shard_dim == 2:
         return torch.zeros(
-            [K, S, B, H], dtype=input_tensor.dtype, device=input_tensor.device
+            [K, 1, tokens_per_device, H],
+            dtype=input_tensor.dtype,
+            device=input_tensor.device,
         )
+    raise ValueError(f"output_shard_dim must be 1 or 2, got {output_shard_dim}")
 
 
 @torch.library.custom_op(
@@ -1277,47 +1401,51 @@ def moe_expert_token_remap(
     topk_tensor: torch.Tensor,
     expert_mapping: torch.Tensor,
     expert_metadata: torch.Tensor,
-    reduction_size: int = 16,
+    num_devices: int = 1,
+    reduction_size: int = 32,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Convert global expert routing to local device expert mapping and sparsity.
 
-    Remaps global expert indices from dispatch metadata to local per-device
-    expert indices and creates a sparsity pattern for efficient sparse_matmul.
-
-    The batch dimension B should include all dispatch groups (B = BD = batch *
-    dispatch_devices) so the kernel processes all tokens and produces correctly
-    sized outputs without needing post-hoc tiling.
-
-    Args:
-        topk_tensor: Routing scores [1, B, S, E], bfloat16
-        expert_mapping: Expert-to-device mapping [1, 1, E, D], int64
-        expert_metadata: Expert indices from dispatch [1, B, S, K], int64
-        reduction_size: Group size for sparsity reduction (default 16)
+    Accepts flexible topk_tensor formats:
+        - [B*S, E] (2D): router scores, internally repeated for num_devices
+        - [1, BD, S, E] (4D): pre-repeated (legacy)
 
     Returns:
-        mapping: Expert routing weights [1, B, S, E], bfloat16 (compound-sharded to E_local on device)
-        reduced: Sparsity pattern [1, 1, ceil(B*S/reduction_size), E], bfloat16 (compound-sharded to E_local on device)
+        mapping: [1, BD, S, E], bfloat16
+        reduced: [1, 1, ceil(BD*S/reduction_size), E], bfloat16
     """
     import math
 
     device = topk_tensor.device
-    D, B, S, E = topk_tensor.shape
-    K = expert_metadata.shape[-1]
-    num_devices = expert_mapping.shape[-1]
-    E_local = E // num_devices
-
-    reduced_seq = math.ceil(B * S / reduction_size)
 
     if device.type == "xla":
+        # metadata is [1, 1, tokens, K] where tokens = BD*S.
+        tokens = expert_metadata.shape[2]
+        E = topk_tensor.shape[-1]
+        reduced_seq = math.ceil(tokens / reduction_size)
+
+        # Canonicalize topk_tensor to 4D [1, 1, tokens, E].
+        if topk_tensor.dim() == 2:
+            BS = topk_tensor.shape[0]
+            topk_tensor = topk_tensor.unsqueeze(0)  # [1, B*S, E]
+            if num_devices > 1:
+                topk_tensor = topk_tensor.repeat(1, num_devices, 1)  # [1, BD*S, E]
+            topk_tensor = topk_tensor.unsqueeze(0)  # [1, 1, tokens, E]
+        elif topk_tensor.dim() == 3:
+            if num_devices > 1:
+                topk_tensor = topk_tensor.repeat(1, num_devices, 1)
+            topk_tensor = topk_tensor.unsqueeze(0)
+
         output_shapes = [
-            [1, B, S, E],
+            [1, 1, tokens, E],
             [1, 1, reduced_seq, E],
         ]
         output_dtypes = [topk_tensor.dtype, topk_tensor.dtype]
 
         frontend_attributes = {
             "reduction_size": str(reduction_size),
+            "num_devices": str(num_devices),
         }
 
         return stablehlo_custom_call.stablehlo_custom_call(
@@ -1328,23 +1456,42 @@ def moe_expert_token_remap(
             frontend_attributes=frontend_attributes,
         )
 
-    # CPU fallback: uses global E shape (compiler shards to E_local on device)
-    # Populate ALL experts so downstream sparse_matmul produces valid output
-    # for every device (not just device 0).
-    mapping = torch.zeros(1, B, S, E, dtype=topk_tensor.dtype, device=device)
+    # CPU fallback (vectorized)
+    # metadata is [1, 1, tokens, K] where tokens = BD*S.
+    tokens = expert_metadata.shape[2]
+    K = expert_metadata.shape[-1]
+    E = topk_tensor.shape[-1]
+    reduced_seq = math.ceil(tokens / reduction_size)
+
+    # Normalize topk_tensor to [1, 1, tokens, E].
+    if topk_tensor.dim() == 2:
+        BS = topk_tensor.shape[0]
+        topk_tensor = topk_tensor.unsqueeze(0)  # [1, B*S, E]
+        if num_devices > 1:
+            topk_tensor = topk_tensor.repeat(1, num_devices, 1)
+        topk_tensor = topk_tensor.unsqueeze(0)  # [1, 1, tokens, E]
+    elif topk_tensor.dim() == 3:
+        if num_devices > 1:
+            topk_tensor = topk_tensor.repeat(1, num_devices, 1)
+        topk_tensor = topk_tensor.unsqueeze(0)
+
+    D, _, tokens_dim, E = topk_tensor.shape
+
+    mapping = torch.zeros(1, 1, tokens, E, dtype=topk_tensor.dtype, device=device)
     reduced = torch.zeros(1, 1, reduced_seq, E, dtype=topk_tensor.dtype, device=device)
 
-    for d in range(D):
-        for b in range(B):
-            for s in range(S):
-                for k in range(K):
-                    global_expert = expert_metadata[d, b, s, k].item()
-                    mapping[0, b, s, global_expert] = topk_tensor[
-                        d, b, s, global_expert
-                    ]
-                    chunk_idx = (b * S + s) // reduction_size
-                    if chunk_idx < reduced_seq:
-                        reduced[0, 0, chunk_idx, global_expert] = 1.0
+    # expert_metadata: [1, 1, tokens, K] — selected expert indices
+    # topk_tensor: [1, 1, tokens, E] — router scores
+    indices = expert_metadata.long()  # [1, 1, tokens, K]
+    # Gather scores for selected experts and scatter into mapping
+    scores = torch.gather(topk_tensor[0, 0], dim=-1, index=indices[0, 0])
+    mapping[0, 0].scatter_(-1, indices[0, 0], scores)
+
+    # Build reduced sparsity: any selected expert in each M-token chunk → 1.0
+    chunk_idx = torch.arange(tokens, device=device) // reduction_size
+    for k_idx in range(K):
+        expert_ids = indices[0, 0, :, k_idx]  # [tokens]
+        reduced[0, 0, chunk_idx, expert_ids.long()] = 1.0
 
     return mapping, reduced
 
@@ -1354,16 +1501,18 @@ def moe_expert_token_remap_fake(
     topk_tensor: torch.Tensor,
     expert_mapping: torch.Tensor,
     expert_metadata: torch.Tensor,
-    reduction_size: int = 16,
+    num_devices: int = 1,
+    reduction_size: int = 32,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     import math
 
-    D, B, S, E = topk_tensor.shape
-    num_devices = expert_mapping.shape[-1]
-    reduced_seq = math.ceil(B * S / reduction_size)
+    # metadata is [1, 1, tokens, K]
+    tokens = expert_metadata.shape[2]
+    E = topk_tensor.shape[-1]
+    reduced_seq = math.ceil(tokens / reduction_size)
 
     mapping = torch.zeros(
-        [1, B, S, E], dtype=topk_tensor.dtype, device=topk_tensor.device
+        [1, 1, tokens, E], dtype=topk_tensor.dtype, device=topk_tensor.device
     )
     reduced = torch.zeros(
         [1, 1, reduced_seq, E],

--- a/python_package/tt_torch/sparse_mlp.py
+++ b/python_package/tt_torch/sparse_mlp.py
@@ -26,6 +26,169 @@ ACTIVATION_GPT_OSS = "gpt_oss"  # clamp, sigmoid, alpha, glu
 ACTIVATION_DEEPSEEK = "deepseek"  # SiLU (swish) for gate * up
 
 
+def _topk_to_sparse_scores(topk_weights, topk_indices, num_experts):
+    """Convert topk scores [BS, K] to sparse scores [BS, E].
+
+    Uses one_hot + einsum instead of scatter_ for XLA compatibility.
+    """
+    one_hot = (
+        topk_indices.unsqueeze(-1)
+        == torch.arange(num_experts, device=topk_indices.device)
+    ).to(
+        topk_weights.dtype
+    )  # [BS, K, E]
+    return torch.einsum("bk,bke->be", topk_weights, one_hot)
+
+
+def _unpack_router_output(router_out, num_experts):
+    """Unpack router output to (scores [BS, E], indices [BS, K]).
+
+    Handles routers returning 2 values (scores, indices) or 3 values
+    (logits, scores, indices) like GptOssTopKRouter. Converts topk-only
+    scores [BS, K] to sparse scores [BS, E] when needed.
+    """
+    scores, indices = router_out[-2], router_out[-1]
+    if scores.shape[-1] != num_experts:
+        scores = _topk_to_sparse_scores(scores, indices, num_experts)
+    return scores, indices
+
+
+def _moe_activation(
+    gate_up_out, activation_type, alpha=1.702, limit=7.0, interleaved=True
+):
+    """Apply gate-up activation for MoE experts.
+
+    Args:
+        gate_up_out: Fused gate+up projection output [..., inter*2].
+        activation_type: "deepseek" (SiLU) or "gpt_oss" (clamp+sigmoid+glu).
+        alpha: Sigmoid scaling factor (gpt_oss only).
+        limit: Clamp bound (gpt_oss only).
+        interleaved: If True, gate/up are interleaved [g0,u0,g1,u1,...].
+                     If False, contiguous [g0,g1,...,u0,u1,...].
+    """
+    half = gate_up_out.shape[-1] // 2
+    if interleaved:
+        gate_out = gate_up_out[..., ::2]
+        up_out = gate_up_out[..., 1::2]
+    else:
+        gate_out = gate_up_out[..., :half]
+        up_out = gate_up_out[..., half:]
+
+    if activation_type == ACTIVATION_DEEPSEEK:
+        return F.silu(gate_out) * up_out
+    else:
+        gate_out = gate_out.clamp(max=limit)
+        up_out = up_out.clamp(-limit, limit)
+        glu = gate_out * torch.sigmoid(gate_out * alpha)
+        return (up_out + 1) * glu
+
+
+class _SparseForwardMixin:
+    """Mixin that adds sparse_forward() for expert wrapper classes."""
+
+    def sparse_forward(
+        self,
+        dispatched,
+        sparsity_remap,
+        activation_type,
+        alpha=1.702,
+        limit=7.0,
+        output_shape=None,
+    ):
+        return _sparse_expert_forward(
+            self,
+            dispatched,
+            sparsity_remap,
+            activation_type,
+            alpha,
+            limit,
+            output_shape,
+        )
+
+
+def _sparse_expert_forward(
+    experts,
+    dispatched,
+    sparsity_remap,
+    activation_type,
+    alpha=1.702,
+    limit=7.0,
+    output_shape=None,
+):
+    """Unified sparse_matmul forward for MoE experts.
+
+    Works with both fused (w3=None, w1=gate_up) and separate (w3=up) expert weights.
+
+    Gate/up output is 5D tiled: [A, B, E, M, N] where A*B*M = BD*S.
+    Down input is reshaped to canonical [A*B, E, M, K].
+    Down output [A*B, E, M, H] is untiled to [BD, S, E, H].
+    """
+    E = experts.w2.shape[0]
+    w1 = experts.w1.unsqueeze(0)  # [1, E, H, N1]
+    w2 = experts.w2.view(1, E, experts.intermediate_size, -1)  # [1, E, inter, H]
+
+    # Gate (or gate+up fused): output [A, B, E, M, N1] (5D tiled)
+    w1_out = torch.ops.tt.sparse_matmul(
+        dispatched,
+        w1,
+        sparsity_remap,
+        nnz=0,
+        is_input_a_sparse=False,
+        is_input_b_sparse=True,
+    )
+    if experts.w1_bias is not None:
+        w1_out = w1_out + experts.w1_bias.view(1, 1, E, 1, -1)
+
+    if experts.w3 is not None:
+        # Separate gate/up: 2 sparse_matmuls
+        w3 = experts.w3.unsqueeze(0)  # [1, E, H, inter]
+        w3_out = torch.ops.tt.sparse_matmul(
+            dispatched,
+            w3,
+            sparsity_remap,
+            nnz=0,
+            is_input_a_sparse=False,
+            is_input_b_sparse=True,
+        )
+        if experts.w3_bias is not None:
+            w3_out = w3_out + experts.w3_bias.view(1, 1, E, 1, -1)
+
+        if activation_type == ACTIVATION_DEEPSEEK:
+            activated = F.silu(w1_out) * w3_out
+        else:
+            w1_out = w1_out.clamp(max=limit)
+            w3_out = w3_out.clamp(-limit, limit)
+            glu = w1_out * torch.sigmoid(w1_out * alpha)
+            activated = (w3_out + 1) * glu
+    else:
+        # Fused gate_up: 1 sparse_matmul, split via activation
+        activated = _moe_activation(w1_out, activation_type, alpha, limit)
+
+    # Reshape 5D → 4D canonical for down: [A, B, E, M, K] → [A*B, E, M, K]
+    A, B = activated.shape[0], activated.shape[1]
+    M = activated.shape[3]
+    activated = activated.reshape(A * B, E, M, experts.intermediate_size)
+
+    # Down: output [A*B, E, M, H] (canonical)
+    down_out = torch.ops.tt.sparse_matmul(
+        activated,
+        w2,
+        sparsity_remap,
+        nnz=0,
+        is_input_a_sparse=True,
+        is_input_b_sparse=False,
+    )
+    if experts.w2_bias is not None:
+        down_out = down_out + experts.w2_bias.view(1, E, 1, -1)
+
+    # Untile: [A*B, E, M, H] → [E, BD, S, H]
+    # Single permute to move E to front; A*B and M are adjacent so reshape merges them.
+    BD, S = output_shape
+    H = down_out.shape[-1]
+    down_out = down_out.permute(1, 0, 2, 3)  # [E, A*B, M, H]
+    return down_out.reshape(E, 1, BD * S, H)
+
+
 class SparseMLP(nn.Module):
     """
     Sparse MLP implementation that uses sparse_matmul for MoE computation.
@@ -33,11 +196,7 @@ class SparseMLP(nn.Module):
     This module wraps an existing MLP and replaces dense expert computation
     with sparse_matmul operations that skip inactive experts.
 
-    Uses INTERLEAVED gate_up_proj layout directly from original model:
-    - Weights stored as [g0, u0, g1, u1, ...] (interleaved)
-    - Split with [::2]/[1::2] strided slices
-    - TP sharding works because UpdateGlobalToLocalShapes pass handles
-      strided slices where stride == shard_factor
+    Uses separate gate_proj, up_proj, down_proj weights — 3 sparse_matmuls.
     """
 
     def __init__(
@@ -49,150 +208,131 @@ class SparseMLP(nn.Module):
     ):
         super().__init__()
 
-        # Note: We intentionally do NOT store original_mlp to avoid memory duplication.
-        # Only store references to the components we actually need.
         self.num_experts = num_experts
         self.num_experts_per_tok = num_experts_per_tok
 
         # Copy references to original module's components
-        # Keep same structure as original MLP: router + experts
         self.router = original_mlp.router
-        self.experts = original_mlp.experts  # Keep same structure for sharding
+        self.experts = original_mlp.experts
 
-        # Use INTERLEAVED gate_up_proj directly (no conversion needed)
-        # The UpdateGlobalToLocalShapes pass now handles strided slices
-        # where stride == shard_factor, making [::2]/[1::2] TP-compatible.
-        if hasattr(self.experts, "gate_up_proj"):
-            # intermediate_size is half of the last dimension (interleaved)
+        if hasattr(self.experts, "gate_proj"):
+            self.intermediate_size = self.experts.gate_proj.shape[-1]
+        elif hasattr(self.experts, "gate_up_proj"):
             self.intermediate_size = self.experts.gate_up_proj.shape[-1] // 2
         else:
-            raise ValueError("Expected fused gate_up_proj in experts module")
+            raise ValueError("Expected gate_proj or gate_up_proj in experts module")
 
-        # Get hidden_size from config or infer from down_proj shape
         if config is not None and hasattr(config, "hidden_size"):
             hidden_size = config.hidden_size
         else:
-            # Infer from down_proj shape: [E, inter, hidden]
             hidden_size = self.experts.down_proj.shape[-1]
 
-        # GPT-OSS specific activation parameters
+        # Activation parameters
         self.alpha = getattr(self.experts, "alpha", 1.702)
         self.limit = getattr(self.experts, "limit", 7.0)
 
     def forward(self, hidden_states):
         batch_size, seq_len, hidden_size = hidden_states.shape
 
-        # 1. Router Execution
-        # GptOssTopKRouter returns (router_logits, router_scores, router_indices):
-        #   router_out[0]: raw logits [B, S, E]
-        #   router_out[1]: softmax(top_k_logits) compact probs [B, S, top_k]
-        #   router_out[-1]: top-k indices [B, S, top_k]
-        router_out = self.router(hidden_states)
-        router_scores = router_out[1]  # [B, S, top_k] compact softmax probabilities
-        router_indices = router_out[-1]  # [B, S, top_k] compact indices
-
-        # 2. Create Sparsity Mask [batch, seq, 1, num_experts]
-        sparsity = torch.zeros(
-            batch_size,
-            seq_len,
-            1,
-            self.num_experts,
-            dtype=hidden_states.dtype,
-            device=hidden_states.device,
+        # 1. Router — pass 3D for RouterAdapter (handles 3D→2D internally),
+        # flatten to 2D for raw routers (e.g. GptOssTopKRouter).
+        router_input = hidden_states
+        if not hasattr(self.router, "gate"):
+            router_input = hidden_states.view(-1, hidden_size)
+        router_scores, router_indices = _unpack_router_output(
+            self.router(router_input), self.num_experts
         )
 
-        # Reshape indices for scatter: [batch, seq, 1, top_k]
+        # 2. Sparsity Mask [batch, seq, 1, num_experts] via one-hot
         topk_indices_unsqueezed = router_indices.view(
             batch_size, seq_len, 1, self.num_experts_per_tok
         )
+        expert_range = torch.arange(self.num_experts, device=hidden_states.device)
+        one_hot = (topk_indices_unsqueezed.unsqueeze(-1) == expert_range).to(
+            hidden_states.dtype
+        )  # [batch, seq, 1, K, E]
+        sparsity = one_hot.sum(dim=-2)  # [batch, seq, 1, E]
 
-        sparsity.scatter_(
-            dim=-1,
-            index=topk_indices_unsqueezed,
-            src=torch.ones_like(topk_indices_unsqueezed, dtype=hidden_states.dtype),
-        )
-
-        # 3. Reshape Input for sparse_matmul [batch, seq, 1, hidden]
+        # 3. Input [batch, seq, 1, hidden]
         hidden_4d = hidden_states.view(batch_size, seq_len, 1, hidden_size)
 
-        # 4. Fused Gate+Up Projection
-        # gate_up_weight: [1, E, hidden, inter*2]
-        gate_up_proj = self.experts.gate_up_proj.unsqueeze(0)
-        gate_up_out = torch.ops.tt.sparse_matmul(
-            hidden_4d,
-            gate_up_proj,
-            sparsity,
-            nnz=0,  # Let runtime calculate
-            is_input_a_sparse=False,
-            is_input_b_sparse=True,
-        )
+        has_fused = hasattr(self.experts, "gate_up_proj")
 
-        # Output: [batch, seq, 1, E, M, inter*2] where M=1
-        # Reshape to [batch, seq, E, inter*2]
-        gate_up_out = gate_up_out.view(
-            batch_size, seq_len, self.num_experts, self.intermediate_size * 2
-        )
-        gate_up_out = gate_up_out + self.experts.gate_up_proj_bias
+        if has_fused:
+            # Fused gate_up: 1 sparse_matmul for gate+up
+            gate_up_proj = self.experts.gate_up_proj.unsqueeze(0)
+            gate_up_out = torch.ops.tt.sparse_matmul(
+                hidden_4d,
+                gate_up_proj,
+                sparsity,
+                nnz=0,
+                is_input_a_sparse=False,
+                is_input_b_sparse=True,
+            )
+            gate_up_out = gate_up_out.view(
+                batch_size, seq_len, self.num_experts, self.intermediate_size * 2
+            )
+            if self.experts.gate_up_proj_bias is not None:
+                gate_up_out = gate_up_out + self.experts.gate_up_proj_bias
+            activated = _moe_activation(
+                gate_up_out, ACTIVATION_GPT_OSS, self.alpha, self.limit
+            )
+        else:
+            # Separate gate/up: 2 sparse_matmuls
+            gate_proj = self.experts.gate_proj.unsqueeze(0)
+            gate_out = torch.ops.tt.sparse_matmul(
+                hidden_4d,
+                gate_proj,
+                sparsity,
+                nnz=0,
+                is_input_a_sparse=False,
+                is_input_b_sparse=True,
+            )
+            gate_out = gate_out.view(
+                batch_size, seq_len, self.num_experts, self.intermediate_size
+            )
+            if self.experts.gate_proj_bias is not None:
+                gate_out = gate_out + self.experts.gate_proj_bias
 
-        # 5. Split & Activation (Interleaved Layout)
-        # Slicing works for TP because stride (2) matches shard_factor
-        gate_out = gate_up_out[..., ::2]  # Even indices
-        up_out = gate_up_out[..., 1::2]  # Odd indices
+            up_proj = self.experts.up_proj.unsqueeze(0)
+            up_out = torch.ops.tt.sparse_matmul(
+                hidden_4d,
+                up_proj,
+                sparsity,
+                nnz=0,
+                is_input_a_sparse=False,
+                is_input_b_sparse=True,
+            )
+            up_out = up_out.view(
+                batch_size, seq_len, self.num_experts, self.intermediate_size
+            )
+            if self.experts.up_proj_bias is not None:
+                up_out = up_out + self.experts.up_proj_bias
 
-        gate_out = gate_out.clamp(max=self.limit)
-        up_out = up_out.clamp(-self.limit, self.limit)
-        glu = gate_out * torch.sigmoid(gate_out * self.alpha)
-        activated = (up_out + 1) * glu
+            activated = F.silu(gate_out) * up_out
 
-        # 6. Down Projection setup
-        # activated: [batch*seq, E, 1, inter]
+        # 7. Down projection
         activated_reshaped = activated.view(
             batch_size * seq_len, self.num_experts, 1, self.intermediate_size
         )
-
-        # sparsity_down: [1, 1, batch*seq, E]
         sparsity_down = sparsity.view(1, 1, batch_size * seq_len, self.num_experts)
-
-        # Reshape down_proj for sparse_matmul
-        # down_proj: [1, E, inter, hidden]
         down_proj = self.experts.down_proj.view(
             1, self.num_experts, self.intermediate_size, hidden_size
         )
-
-        # 7. Down Projection (sparse_matmul)
-        # down_weight: [1, E, inter, hidden]
-        # Output: [batch*seq, E, M, hidden] where M=1
         down_out = torch.ops.tt.sparse_matmul(
             activated_reshaped,
             down_proj,
             sparsity_down,
             nnz=0,
-            is_input_a_sparse=True,  # Activations are sparse (only TopK are valid)
+            is_input_a_sparse=True,
             is_input_b_sparse=False,
         )
-
-        # Squeeze M dimension: [batch*seq, E, 1, hidden] -> [batch*seq, E, hidden]
         down_out = down_out.squeeze(2)
-        down_out = down_out + self.experts.down_proj_bias
+        if self.experts.down_proj_bias is not None:
+            down_out = down_out + self.experts.down_proj_bias
 
-        # 8. Weighted Sum & Final Output
-        # router_scores is compact [B, S, top_k] — scatter to [B*S, E] so non-selected
-        # experts are zeroed out, then weight expert outputs by their softmax probability.
-        # down_out: [BS, E, H], output: [BS, H]
-        scores_flat = router_scores.view(batch_size * seq_len, self.num_experts_per_tok)
-        indices_flat = router_indices.view(
-            batch_size * seq_len, self.num_experts_per_tok
-        ).long()
-        scattered = torch.zeros(
-            batch_size * seq_len,
-            self.num_experts,
-            dtype=hidden_states.dtype,
-            device=hidden_states.device,
-        )
-        scattered.scatter_(1, indices_flat, scores_flat)
-        output = (down_out * scattered.unsqueeze(-1)).sum(dim=1)
-
-        # Reshape back to [batch, seq, hidden]
+        # 8. Weighted Sum
+        output = (down_out * router_scores.unsqueeze(-1)).sum(dim=1)
         output = output.view(batch_size, seq_len, hidden_size)
 
         return output, router_scores
@@ -235,6 +375,48 @@ def build_expert_mapping(num_experts, num_devices, mesh_shape=None):
     return mapping
 
 
+class FusedExpertsWrapper(_SparseForwardMixin, nn.Module):
+    """Wraps an experts module that has gate_up_proj and adds sparse_forward().
+
+    Original attribute names (gate_up_proj, down_proj, etc.) remain accessible
+    for shard specs. w1/w2/w3 aliases are used by _sparse_expert_forward.
+    """
+
+    def __init__(self, experts):
+        super().__init__()
+        self._experts = experts
+        self.intermediate_size = experts.gate_up_proj.shape[-1] // 2
+
+    @property
+    def w1(self):
+        return self._experts.gate_up_proj
+
+    @property
+    def w1_bias(self):
+        return getattr(self._experts, "gate_up_proj_bias", None)
+
+    @property
+    def w2(self):
+        return self._experts.down_proj
+
+    @property
+    def w2_bias(self):
+        return getattr(self._experts, "down_proj_bias", None)
+
+    @property
+    def w3(self):
+        return None  # fused — no separate up proj
+
+    def forward(self, *args, **kwargs):
+        """Delegate to original experts forward for CPU golden path."""
+        return self._experts(*args, **kwargs)
+
+    def __getattr__(self, name):
+        if name.startswith("_") or name in ("intermediate_size", "training"):
+            return super().__getattr__(name)
+        return getattr(self._experts, name)
+
+
 class A2aSparseMLP(nn.Module):
     """
     Sparse MLP with all-to-all dispatch/combine for multi-device expert parallelism.
@@ -264,6 +446,7 @@ class A2aSparseMLP(nn.Module):
         config: Optional[object] = None,
         activation_type: str = ACTIVATION_GPT_OSS,
         dispatch_devices: Optional[int] = None,
+        cpu_forward_module: Optional[nn.Module] = None,
     ):
         super().__init__()
 
@@ -279,21 +462,25 @@ class A2aSparseMLP(nn.Module):
         self.dispatch_devices = (
             dispatch_devices if dispatch_devices is not None else num_devices
         )
-        # When True, uses fused moe_expert_token_remap kernel for sparsity
-        # and runs the entire sparse_matmul pathway with E_local (experts per device).
-        self.use_fused_remap = True
         # When True, uses dense torch.matmul instead of sparse_matmul.
         # Skips remap (no sparsity mask needed). Demo-style approach.
         self.use_dense_matmul = False
 
+        # Keep original MLP for CPU golden path.
+        # cpu_forward_module overrides original_mlp when the adapter wrapping
+        # doesn't have its own forward (e.g. DeepseekV3MoEToA2AAdapter).
+        # Use object.__setattr__ to avoid nn.Module registering it as a submodule,
+        # which would cause Dynamo to try tracing it (and fail on numpy ops).
+        object.__setattr__(
+            self,
+            "_original_mlp",
+            cpu_forward_module if cpu_forward_module is not None else original_mlp,
+        )
+
         # Copy references to original module's components
         self.router = original_mlp.router
         self.experts = original_mlp.experts
-
-        if hasattr(self.experts, "gate_up_proj"):
-            self.intermediate_size = self.experts.gate_up_proj.shape[-1] // 2
-        else:
-            raise ValueError("Expected fused gate_up_proj in experts module")
+        self.intermediate_size = self.experts.intermediate_size
 
         if config is not None and hasattr(config, "hidden_size"):
             hidden_size = config.hidden_size
@@ -310,336 +497,167 @@ class A2aSparseMLP(nn.Module):
         mapping = build_expert_mapping(num_experts, num_devices)
         self.register_buffer("expert_mapping", mapping)
 
+    @torch.compiler.disable
+    def _cpu_forward(self, hidden_states):
+        """CPU golden path: call original MLP forward directly.
+
+        Decorated with @torch.compiler.disable so Dynamo won't trace into it —
+        original forward may contain numpy ops or other incompatible constructs.
+        """
+        result = self._original_mlp(hidden_states)
+        if isinstance(result, tuple):
+            return result
+        return result, None
+
     def forward(self, hidden_states):
         batch_size, seq_len, hidden_size = hidden_states.shape
         K = self.num_experts_per_tok
 
-        # 1. Router
-        # Monkey-patched router returns (router_logits [T,E], router_scores [T,E], router_indices [T,K]).
-        # router_scores is full sparse [T, E] (matching 4.57.1 behavior).
-        hidden_flat = hidden_states.view(batch_size * seq_len, hidden_size)
-        router_logits, router_scores, router_indices = self.router(hidden_flat)
-        router_logits = router_logits.view(batch_size, seq_len, -1)  # [B, S, E]
-        router_indices = router_indices.view(batch_size, seq_len, K)  # [B, S, K]
-        # CPU golden path: use original per-expert loop for PCC reference.
+        # CPU golden path
         if hidden_states.device.type == "cpu":
-            routed_out = self.experts(
-                hidden_states.view(batch_size * seq_len, hidden_size),
-                router_indices=router_indices.view(batch_size * seq_len, K),
-                routing_weights=router_scores,
-            )
-            return routed_out.view(batch_size, seq_len, hidden_size), router_scores
+            return self._cpu_forward(hidden_states)
 
-        # 2. Reshape for dispatch: tt-metal expects [B, 1, S, H] format
-        x = hidden_states.view(batch_size, 1, seq_len, hidden_size)
-        expert_indices = router_indices.view(batch_size, 1, seq_len, K)
+        # 1. Router — pass 3D for RouterAdapter (handles 3D→2D internally),
+        # flatten to 2D for raw routers (e.g. GptOssTopKRouter).
+        router_input = hidden_states
+        if not hasattr(self.router, "gate"):
+            router_input = hidden_states.view(-1, hidden_size)
+        router_scores, router_indices = _unpack_router_output(
+            self.router(router_input), self.num_experts
+        )
 
-        # 3. Dispatch: route tokens to devices along cluster_axis
-        # BD = B * dispatch_devices (devices along the dispatch axis)
+        # 2. Dispatch: route tokens to devices along cluster_axis
+        # Dispatch accepts [B, S, H] and [B*S, K] directly.
         effective_dispatch = self.dispatch_devices
         dispatched, metadata = torch.ops.tt.all_to_all_dispatch(
-            x,
-            expert_indices,
+            hidden_states,
+            router_indices,
             self.expert_mapping,
             num_devices=effective_dispatch,
             cluster_axis=self.cluster_axis,
         )
-        # dispatched: [1, B*dispatch_devices, S, H]
-        # metadata:   [1, B*dispatch_devices, S, K]
-
-        BD = dispatched.shape[1]  # B * dispatch_devices
-        M = 32
-
-        # 4. Determine which dimension to split by M
-        # Prefer seq_len; fall back to BD; assert if neither works
-        split_seq = seq_len % M == 0 and seq_len >= M
-        split_bd = BD % M == 0 and BD >= M
-        assert (
-            split_seq or split_bd
-        ), f"Neither seq_len ({seq_len}) nor BD ({BD}) is divisible by M={M}"
-        if split_seq:
-            dim_a, dim_b = BD, seq_len // M
-        else:
-            dim_a, dim_b = BD // M, seq_len
-
-        # 5. Expert computation
+        # dispatched: [1, BD, S, H],  metadata: [1, BD, S, K]
+        # Reshape metadata to [1, 1, BD*S, K] so combine's output_shard_dim=2
+        # sees tokens on dim 2 (matching demo layout). Just a reshape, no permute.
+        BD = dispatched.shape[1]
+        metadata = metadata.reshape(1, 1, BD * seq_len, metadata.shape[-1])
         E = self.num_experts
+        if self.use_dense_matmul:
+            # Dense matmul with M=32 tiling to avoid large intermediate tensors.
+            # torch.matmul doesn't go through custom_ops, so tiling is done here.
+            M = 32
+            split_seq = seq_len % M == 0 and seq_len >= M
+            split_bd = BD % M == 0 and BD >= M
+            assert (
+                split_seq or split_bd
+            ), f"Neither seq_len ({seq_len}) nor BD ({BD}) is divisible by M={M}"
+            dim_a = BD if split_seq else BD // M
+            dim_b = seq_len // M if split_seq else seq_len
 
-        if getattr(self, "use_dense_matmul", False):
-            # ===== Dense matmul path (demo-style) =====
-            # No remap/sparsity needed. Dispatch already routed tokens to
-            # the right devices; dense matmul computes ALL E_local experts.
-            # Compiler compound-shards E→E_local on device.
-            gate_up_proj = self.experts.gate_up_proj.unsqueeze(0)  # [1, E, H, inter*2]
             down_proj = self.experts.down_proj.view(
                 1, E, self.intermediate_size, -1
             )  # [1, E, inter, H]
-            gate_up_bias = self.experts.gate_up_proj_bias
             down_bias = self.experts.down_proj_bias
 
-            # Reshape dispatched for matmul
+            # Tile dispatched [1, BD, S, H] → [dim_a, dim_b, M, H]
             if split_seq:
                 hidden_4d = dispatched.view(BD, seq_len // M, M, hidden_size)
-            elif dim_b == 1:
-                hidden_4d = dispatched.view(BD // M, 1, M, hidden_size)
             else:
                 hidden_4d = dispatched.view(BD // M, M, seq_len, hidden_size)
                 hidden_4d = hidden_4d.permute(0, 2, 1, 3)
 
-            # Gate+Up: [dim_a, dim_b, 1, M, H] @ [1, E, H, inter*2]
-            #        → [dim_a, dim_b, E, M, inter*2]
-            hidden_5d = hidden_4d.unsqueeze(2)
-            gate_up_out = torch.matmul(hidden_5d, gate_up_proj)
-            gate_up_out = gate_up_out.permute(
-                0, 1, 3, 2, 4
-            )  # [dim_a, dim_b, M, E, inter*2]
-            gate_up_out = gate_up_out + gate_up_bias
+            tokens = hidden_4d.reshape(-1, hidden_size)
+            has_fused = hasattr(self.experts, "gate_up_proj")
 
-            # Activation
-            # We can un-interleave these experts in init and save the overhead of strided slicing on device.
-            # Issue : https://github.com/tenstorrent/tt-xla/issues/3668
-            gate_out = gate_up_out[..., ::2]
-            up_out = gate_up_out[..., 1::2]
-            if self.activation_type == ACTIVATION_DEEPSEEK:
-                activated = F.silu(gate_out) * up_out
+            if has_fused:
+                # Fused gate_up: single matmul
+                gate_up_proj = self.experts.gate_up_proj  # [E, H, inter*2]
+                gate_up_bias = self.experts.gate_up_proj_bias
+                weights_gu_flat = gate_up_proj.permute(1, 0, 2).reshape(
+                    hidden_size, E * self.intermediate_size * 2
+                )
+                gate_up_flat = torch.matmul(tokens, weights_gu_flat)
+                gate_up_out = gate_up_flat.view(
+                    dim_a, dim_b, M, E, self.intermediate_size * 2
+                )
+                if gate_up_bias is not None:
+                    gate_up_out = gate_up_out + gate_up_bias
+                activated = _moe_activation(
+                    gate_up_out, self.activation_type, self.alpha, self.limit
+                )
             else:
-                gate_out = gate_out.clamp(max=self.limit)
-                up_out = up_out.clamp(-self.limit, self.limit)
-                glu = gate_out * torch.sigmoid(gate_out * self.alpha)
-                activated = (up_out + 1) * glu
+                # Separate gate/up: two matmuls
+                gate_proj = self.experts.gate_proj  # [E, H, inter]
+                up_proj = self.experts.up_proj  # [E, H, inter]
+                gate_bias = self.experts.gate_proj_bias
+                up_bias = self.experts.up_proj_bias
 
-            # Down: [dim_a*dim_b, E, M, inter] @ [1, E, inter, H]
-            #      → [dim_a*dim_b, E, M, H]
-            activated_reshaped = (
-                activated.permute(0, 1, 3, 2, 4)
-                .contiguous()
-                .view(dim_a * dim_b, E, M, self.intermediate_size)
+                weights_gate_flat = gate_proj.permute(1, 0, 2).reshape(
+                    hidden_size, E * self.intermediate_size
+                )
+                gate_flat = torch.matmul(tokens, weights_gate_flat)
+                gate_out = gate_flat.view(dim_a, dim_b, M, E, self.intermediate_size)
+                if gate_bias is not None:
+                    gate_out = gate_out + gate_bias
+
+                weights_up_flat = up_proj.permute(1, 0, 2).reshape(
+                    hidden_size, E * self.intermediate_size
+                )
+                up_flat = torch.matmul(tokens, weights_up_flat)
+                up_out = up_flat.view(dim_a, dim_b, M, E, self.intermediate_size)
+                if up_bias is not None:
+                    up_out = up_out + up_bias
+
+                if self.activation_type == ACTIVATION_DEEPSEEK:
+                    activated = F.silu(gate_out) * up_out
+                else:
+                    gate_out = gate_out.clamp(max=self.limit)
+                    up_out = up_out.clamp(-self.limit, self.limit)
+                    glu = gate_out * torch.sigmoid(gate_out * self.alpha)
+                    activated = (up_out + 1) * glu
+
+            # Down: bmm over experts — [E, T, inter] @ [E, inter, H] → [E, T, H]
+            act_per_expert = activated.permute(0, 1, 3, 2, 4).reshape(
+                dim_a * dim_b * M, E, self.intermediate_size
             )
-            down_out = torch.matmul(activated_reshaped, down_proj)
+            act_per_expert = act_per_expert.permute(
+                1, 0, 2
+            )  # [E, dim_a*dim_b*M, inter]
+            down_per_expert = down_proj.squeeze(0)  # [E, inter, H]
+            down_out = torch.bmm(
+                act_per_expert, down_per_expert
+            )  # [E, dim_a*dim_b*M, H]
+            down_out = down_out.permute(1, 0, 2)  # [dim_a*dim_b*M, E, H]
+            down_out = down_out.view(dim_a, dim_b, M, E, hidden_size)
 
-            # Reshape for combine: [E, BD, S, H]
+            # Untile → [E, 1, BD*S, H] for combine with output_shard_dim=2
             down_out = down_out.view(dim_a, dim_b, E, M, hidden_size)
             down_out = down_out.permute(0, 1, 3, 2, 4)  # [dim_a, dim_b, M, E, H]
-            down_out = down_out + down_bias
-            if split_seq:
-                down_out = down_out.permute(3, 0, 1, 2, 4).contiguous()
-                down_out = down_out.view(E, BD, seq_len, hidden_size)
-            elif dim_b == 1:
-                down_out = down_out.squeeze(1)
-                down_out = down_out.permute(2, 0, 1, 3).contiguous()
-                down_out = down_out.view(E, BD, hidden_size).unsqueeze(1)
-            else:
-                down_out = down_out.permute(3, 0, 2, 1, 4).contiguous()
-                down_out = down_out.view(E, BD, seq_len, hidden_size)
-
-        elif self.use_fused_remap:
-            # ===== Fused moe_expert_token_remap path =====
-            # Output uses global E shape; compiler compound-shards E→E_local on device.
-            # Weights [E, H, inter*2] → [1, E, H, inter*2] similarly sharded.
-            D = effective_dispatch
-
-            # Build topk_tensor [1, BD, S, E] — fold D into batch dim so the
-            # kernel sees BD tokens and produces BD*S/M reduced entries.
-            topk_3d = router_logits  # [B, S, E] raw logits for remap kernel
-            topk_repeated = topk_3d.repeat(D, 1, 1)  # [BD, S, E]
-            topk_tensor = topk_repeated.unsqueeze(0)  # [1, BD, S, E]
-
-            # metadata already [1, BD, S, K] — pass as-is
-            remap_mapping, sparsity_remap = torch.ops.tt.moe_expert_token_remap(
-                topk_tensor,
-                self.expert_mapping,
-                metadata,
-                reduction_size=M,
-            )
-            # remap_mapping: [1, BD, S, E_local] — routing weights for local experts
-            # sparsity_remap: [1, 1, ceil(BD*S/M), E] (global E shape)
-            sparsity = sparsity_remap.view(dim_a, dim_b, 1, E)
-
-            # Weights: [E, H, inter*2] → [1, E, H, inter*2] (compiler shards E→E_local)
-            gate_up_proj = self.experts.gate_up_proj.unsqueeze(0)
-            down_proj = self.experts.down_proj.view(1, E, self.intermediate_size, -1)
-            gate_up_bias = self.experts.gate_up_proj_bias
-            down_bias = self.experts.down_proj_bias
-
-            # Reshape dispatched for sparse_matmul
-            if split_seq:
-                hidden_4d = dispatched.view(BD, seq_len // M, M, hidden_size)
-            elif dim_b == 1:
-                hidden_4d = dispatched.view(BD // M, 1, M, hidden_size)
-            else:
-                hidden_4d = dispatched.view(BD // M, M, seq_len, hidden_size)
-                hidden_4d = hidden_4d.permute(0, 2, 1, 3)
-
-            # Gate+Up sparse_matmul with E_local sparsity
-            gate_up_out = torch.ops.tt.sparse_matmul(
-                hidden_4d,
-                gate_up_proj,
-                sparsity,
-                nnz=0,
-                is_input_a_sparse=False,
-                is_input_b_sparse=True,
-            )
-            gate_up_out = gate_up_out.squeeze(2)  # [dim_a, dim_b, E_local, M, inter*2]
-            gate_up_out = gate_up_out.permute(
-                0, 1, 3, 2, 4
-            )  # [dim_a, dim_b, M, E_local, inter*2]
-            gate_up_out = gate_up_out + gate_up_bias
-
-            # Activation
-            gate_out = gate_up_out[..., ::2]
-            up_out = gate_up_out[..., 1::2]
-            if self.activation_type == ACTIVATION_DEEPSEEK:
-                activated = F.silu(gate_out) * up_out
-            else:
-                gate_out = gate_out.clamp(max=self.limit)
-                up_out = up_out.clamp(-self.limit, self.limit)
-                glu = gate_out * torch.sigmoid(gate_out * self.alpha)
-                activated = (up_out + 1) * glu
-
-            # Down sparse_matmul (sparsity already expanded to E)
-            activated_reshaped = (
-                activated.permute(0, 1, 3, 2, 4)
-                .contiguous()
-                .view(dim_a * dim_b, E, M, self.intermediate_size)
-            )
-            sparsity_down = sparsity.view(1, 1, dim_a * dim_b, E)
-            down_out = torch.ops.tt.sparse_matmul(
-                activated_reshaped,
-                down_proj,
-                sparsity_down,
-                nnz=0,
-                is_input_a_sparse=True,
-                is_input_b_sparse=False,
-            )
-
-            # Reshape for combine: [E, BD, S, H]
-            down_out = down_out.view(dim_a, dim_b, E, M, hidden_size)
-            down_out = down_out.permute(0, 1, 3, 2, 4)  # [dim_a, dim_b, M, E, H]
-            down_out = down_out + down_bias
-            if split_seq:
-                down_out = down_out.permute(3, 0, 1, 2, 4).contiguous()
-                down_out = down_out.view(E, BD, seq_len, hidden_size)
-            elif dim_b == 1:
-                down_out = down_out.squeeze(1)
-                down_out = down_out.permute(2, 0, 1, 3).contiguous()
-                down_out = down_out.view(E, BD, hidden_size).unsqueeze(1)
-            else:
-                down_out = down_out.permute(3, 0, 2, 1, 4).contiguous()
-                down_out = down_out.view(E, BD, seq_len, hidden_size)
+            if down_bias is not None:
+                down_out = down_out + down_bias
+            # E to front, merge all spatial dims into one token dim
+            down_out = down_out.permute(3, 0, 1, 2, 4)  # [E, dim_a, dim_b, M, H]
+            down_out = down_out.reshape(E, 1, BD * seq_len, hidden_size)
 
         else:
-            # ===== Manual sparsity construction path (E_total throughout) =====
-            if split_seq:
-                metadata_full = metadata[0].view(BD, seq_len // M, M, K)
-                metadata_flat = metadata_full.reshape(BD, (seq_len // M) * M, K)
-                sparsity_flat = torch.zeros(
-                    BD,
-                    (seq_len // M) * M,
-                    1,
-                    E,
-                    dtype=hidden_states.dtype,
-                    device=hidden_states.device,
-                )
-                sparsity_flat.scatter_(
-                    dim=-1,
-                    index=metadata_flat.unsqueeze(2),
-                    src=torch.ones_like(
-                        metadata_flat.unsqueeze(2), dtype=hidden_states.dtype
-                    ),
-                )
-                sparsity = (
-                    sparsity_flat.view(BD, seq_len // M, M, E).sum(dim=2).clamp(max=1.0)
-                )
-                sparsity = sparsity.unsqueeze(2)
-            else:
-                metadata_full = metadata[0].view(BD // M, M, seq_len, K)
-                metadata_flat = metadata_full.reshape((BD // M) * M, seq_len, K)
-                sparsity_flat = torch.zeros(
-                    (BD // M) * M,
-                    seq_len,
-                    1,
-                    E,
-                    dtype=hidden_states.dtype,
-                    device=hidden_states.device,
-                )
-                sparsity_flat.scatter_(
-                    dim=-1,
-                    index=metadata_flat.unsqueeze(2),
-                    src=torch.ones_like(
-                        metadata_flat.unsqueeze(2), dtype=hidden_states.dtype
-                    ),
-                )
-                sparsity = (
-                    sparsity_flat.view(BD // M, M, seq_len, E).sum(dim=1).clamp(max=1.0)
-                )
-                sparsity = sparsity.unsqueeze(2)
-
-            gate_up_proj = self.experts.gate_up_proj.unsqueeze(0)
-            down_proj = self.experts.down_proj.view(1, E, self.intermediate_size, -1)
-            gate_up_bias = self.experts.gate_up_proj_bias
-            down_bias = self.experts.down_proj_bias
-
-            if split_seq:
-                hidden_4d = dispatched.view(BD, seq_len // M, M, hidden_size)
-            elif dim_b == 1:
-                hidden_4d = dispatched.view(BD // M, 1, M, hidden_size)
-            else:
-                hidden_4d = dispatched.view(BD // M, M, seq_len, hidden_size)
-                hidden_4d = hidden_4d.permute(0, 2, 1, 3)
-
-            gate_up_out = torch.ops.tt.sparse_matmul(
-                hidden_4d,
-                gate_up_proj,
-                sparsity,
-                nnz=0,
-                is_input_a_sparse=False,
-                is_input_b_sparse=True,
-            )
-            gate_up_out = gate_up_out.squeeze(2)
-            gate_up_out = gate_up_out.permute(0, 1, 3, 2, 4)
-            gate_up_out = gate_up_out + gate_up_bias
-
-            gate_out = gate_up_out[..., ::2]
-            up_out = gate_up_out[..., 1::2]
-            if self.activation_type == ACTIVATION_DEEPSEEK:
-                activated = F.silu(gate_out) * up_out
-            else:
-                gate_out = gate_out.clamp(max=self.limit)
-                up_out = up_out.clamp(-self.limit, self.limit)
-                glu = gate_out * torch.sigmoid(gate_out * self.alpha)
-                activated = (up_out + 1) * glu
-
-            activated_reshaped = (
-                activated.permute(0, 1, 3, 2, 4)
-                .contiguous()
-                .view(dim_a * dim_b, E, M, self.intermediate_size)
-            )
-            sparsity_down = sparsity.view(1, 1, dim_a * dim_b, E)
-            down_out = torch.ops.tt.sparse_matmul(
-                activated_reshaped,
-                down_proj,
-                sparsity_down,
-                nnz=0,
-                is_input_a_sparse=True,
-                is_input_b_sparse=False,
+            # ===== Fused moe_expert_token_remap path =====
+            _, sparsity_remap = torch.ops.tt.moe_expert_token_remap(
+                router_scores,
+                self.expert_mapping,
+                metadata,
+                num_devices=effective_dispatch,
             )
 
-            down_out = down_out.view(dim_a, dim_b, E, M, hidden_size)
-            down_out = down_out.permute(0, 1, 3, 2, 4)
-            down_out = down_out + down_bias
-            if split_seq:
-                down_out = down_out.permute(3, 0, 1, 2, 4).contiguous()
-                down_out = down_out.view(E, BD, seq_len, hidden_size)
-            elif dim_b == 1:
-                down_out = down_out.squeeze(1)
-                down_out = down_out.permute(2, 0, 1, 3).contiguous()
-                down_out = down_out.view(E, BD, hidden_size).unsqueeze(1)
-            else:
-                down_out = down_out.permute(3, 0, 2, 1, 4).contiguous()
-                down_out = down_out.view(E, BD, seq_len, hidden_size)
+            down_out = self.experts.sparse_forward(
+                dispatched,
+                sparsity_remap,
+                self.activation_type,
+                self.alpha,
+                self.limit,
+                output_shape=(BD, seq_len),
+            )
 
-        # Combine: gather expert outputs back along cluster_axis
-        decode_mode = dim_b == 1 and not split_seq
+        # sparse_forward returns [E, 1, BD*S, H] — combine with output_shard_dim=2.
         combined = torch.ops.tt.all_to_all_combine(
             down_out,
             metadata,
@@ -647,215 +665,24 @@ class A2aSparseMLP(nn.Module):
             num_devices=effective_dispatch,
             cluster_axis=self.cluster_axis,
             num_experts_per_tok=K,
-            output_shard_dim=2 if decode_mode else 1,
+            output_shard_dim=2,
         )
+        # combined: [K, 1, B*S, H] with output_shard_dim=2
 
         # Weighted sum
-        # router_scores is full sparse [T, E]; gather compact [T, K] weights.
-        indices_flat = router_indices.view(batch_size * seq_len, K)
-        one_hot = torch.nn.functional.one_hot(
-            indices_flat.long(), num_classes=self.num_experts
-        ).to(
+        E = self.num_experts
+        expert_range = torch.arange(E, device=router_scores.device)
+        one_hot = (router_indices.unsqueeze(-1) == expert_range).to(
             router_scores.dtype
-        )  # [T, K, E]
-        topk_weights = torch.einsum("te,tke->tk", router_scores, one_hot)  # [T, K]
-        if seq_len == 1:
-            topk_weights = topk_weights.view(batch_size, K)
-            topk_weights = topk_weights.permute(1, 0).unsqueeze(-1)  # [K, B, 1]
-            output = (combined.squeeze(1) * topk_weights).sum(dim=0)  # [B, H]
-            output = output.unsqueeze(1)  # [B, 1, H]
-        else:
-            topk_weights = topk_weights.view(batch_size, seq_len, K)
-            topk_weights = topk_weights.permute(2, 0, 1).unsqueeze(-1)  # [K, B, S, 1]
-            output = (combined * topk_weights).sum(dim=0)  # [B, S, H]
-
-        return output.to(hidden_states.dtype), router_scores
-
-
-class A2aSparseStackedMlp(nn.Module):
-    """
-    Sparse MLP with all-to-all dispatch/combine for multi-device expert parallelism.
-
-    Same as A2aSparseMLP but pre-deinterleaves gate_up_proj weights and biases
-    in __init__ so the forward pass uses contiguous splits ([:inter] / [inter:])
-    instead of strided slices ([::2] / [1::2]).
-    """
-
-    def __init__(
-        self,
-        original_mlp,
-        num_experts: int,
-        num_experts_per_tok: int,
-        num_devices: int = 1,
-        cluster_axis: int = -1,
-        config: Optional[object] = None,
-    ):
-        super().__init__()
-
-        self.num_experts = num_experts
-        self.num_experts_per_tok = num_experts_per_tok
-        self.num_devices = num_devices
-        self.cluster_axis = cluster_axis
-
-        # Copy references to original module's components
-        self.router = original_mlp.router
-        orig_experts = original_mlp.experts
-
-        if hasattr(orig_experts, "gate_up_proj"):
-            self.intermediate_size = orig_experts.gate_up_proj.shape[-1] // 2
-        else:
-            raise ValueError("Expected fused gate_up_proj in experts module")
-
-        if config is not None and hasattr(config, "hidden_size"):
-            hidden_size = config.hidden_size
-        else:
-            hidden_size = orig_experts.down_proj.shape[-1]
-
-        # GPT-OSS specific activation parameters
-        self.alpha = getattr(orig_experts, "alpha", 1.702)
-        self.limit = getattr(orig_experts, "limit", 7.0)
-
-        # New experts container — preserves layer.mlp.experts.* path for shard_specs
-        # (shard_specs is built after replacement)
-        self.experts = nn.Module()
-
-        # De-interleave gate_up_proj: [g0, u0, g1, u1, ...] -> [g0, g1, ..., u0, u1, ...]
-        # Pre-reshape to [1, E, H, inter*2] for sparse_matmul (no unsqueeze in forward)
-        orig_w = orig_experts.gate_up_proj
-        gate_w = orig_w[..., ::2].contiguous()
-        up_w = orig_w[..., 1::2].contiguous()
-        self.experts.gate_up_proj = nn.Parameter(
-            torch.cat([gate_w, up_w], dim=-1).unsqueeze(0)
-        )
-
-        orig_b = orig_experts.gate_up_proj_bias
-        gate_b = orig_b[..., ::2].contiguous()
-        up_b = orig_b[..., 1::2].contiguous()
-        self.experts.gate_up_proj_bias = nn.Parameter(torch.cat([gate_b, up_b], dim=-1))
-
-        # Down proj / bias — pre-reshape to [1, E, inter, H] for sparse_matmul
-        self.experts.down_proj = nn.Parameter(
-            orig_experts.down_proj.data.view(
-                1, num_experts, self.intermediate_size, hidden_size
-            )
-        )
-        self.experts.down_proj_bias = orig_experts.down_proj_bias
-
-        # Expert-to-device mapping [1, 1, E, D]
-        mapping = build_expert_mapping(num_experts, num_devices)
-        self.register_buffer("expert_mapping", mapping)
-
-    def forward(self, hidden_states):
-        batch_size, seq_len, hidden_size = hidden_states.shape
-        K = self.num_experts_per_tok
-
-        # 1. Router
-        # GptOssTopKRouter returns (router_logits, router_scores, router_indices):
-        #   router_out[1]: softmax(top_k_logits) compact probs [B, S, top_k]
-        #   router_out[-1]: top-k indices [B, S, top_k]
-        router_out = self.router(hidden_states)
-        router_scores = router_out[1]  # [B, S, top_k] compact softmax probabilities
-        router_indices = router_out[-1]  # [B, S, top_k] compact indices
-
-        # 2. Reshape for dispatch: tt-metal expects [B, 1, S, H] format
-        x = hidden_states.view(batch_size, 1, seq_len, hidden_size)
-        expert_indices = router_indices.view(batch_size, 1, seq_len, K)
-
-        # 3. Dispatch: route tokens to devices with selected experts
-        dispatched, metadata = torch.ops.tt.all_to_all_dispatch(
-            x,
-            expert_indices,
-            self.expert_mapping,
-            num_devices=self.num_devices,
-            cluster_axis=self.cluster_axis,
-        )
-        # dispatched: [1, B*D, S, H]
-        # metadata:   [1, B*D, S, K]
-
-        BD = dispatched.shape[1]
-
-        # 4. Build sparsity mask from metadata
-        metadata_indices = metadata.view(BD, seq_len, 1, K)  # [BD, S, 1, K]
-        sparsity = torch.zeros(
-            BD,
-            seq_len,
-            1,
-            self.num_experts,
-            dtype=hidden_states.dtype,
-            device=hidden_states.device,
-        )
-        sparsity.scatter_(
-            dim=-1,
-            index=metadata_indices,
-            src=torch.ones_like(metadata_indices, dtype=hidden_states.dtype),
-        )
-
-        # 5. Gate+Up projection (stacked layout)
-        hidden_4d = dispatched.view(BD, seq_len, 1, hidden_size)
-        gate_up_out = torch.ops.tt.sparse_matmul(
-            hidden_4d,
-            self.experts.gate_up_proj,
-            sparsity,
-            nnz=0,
-            is_input_a_sparse=False,
-            is_input_b_sparse=True,
-        )
-        gate_up_out = gate_up_out.view(
-            BD, seq_len, self.num_experts, self.intermediate_size * 2
-        )
-        gate_up_out = gate_up_out + self.experts.gate_up_proj_bias
-
-        # 6. Split & Activation (contiguous stacked layout)
-        gate_up_out = gate_up_out.clamp(max=self.limit)
-        gate_out = gate_up_out[..., : self.intermediate_size]
-        up_out = gate_up_out[..., self.intermediate_size :]
-
-        # gate_out = gate_out.clamp(max=self.limit)
-        up_out = up_out.clamp(min=-self.limit)
-        glu = gate_out * torch.sigmoid(gate_out * self.alpha)
-        activated = (up_out + 1) * glu
-
-        # 7. Down projection
-        activated_reshaped = activated.view(
-            BD * seq_len, self.num_experts, 1, self.intermediate_size
-        )
-        sparsity_down = sparsity.view(1, 1, BD * seq_len, self.num_experts)
-
-        down_out = torch.ops.tt.sparse_matmul(
-            activated_reshaped,
-            self.experts.down_proj,
-            sparsity_down,
-            nnz=0,
-            is_input_a_sparse=True,
-            is_input_b_sparse=False,
-        )
-        down_out = down_out.squeeze(2)
-        down_out = down_out + self.experts.down_proj_bias
-
-        # 8. Reshape for combine: [E, BD, S, H]
-        down_out = down_out.view(BD, seq_len, self.num_experts, hidden_size)
-        down_out = down_out.permute(2, 0, 1, 3)
-
-        # 9. Combine: gather expert outputs back to original positions
-        combined = torch.ops.tt.all_to_all_combine(
-            down_out,
-            metadata,
-            self.expert_mapping,
-            num_devices=self.num_devices,
-            cluster_axis=self.cluster_axis,
-            num_experts_per_tok=K,
-        )
-        # combined: [K, B, S, H]
-
-        # 10. Weighted sum
-        # router_scores is compact [B, S, K] softmax probabilities — use directly.
-        topk_weights = router_scores.view(batch_size, seq_len, K)
-        topk_weights = topk_weights.permute(2, 0, 1).unsqueeze(-1)
-
-        output = (combined * topk_weights).sum(dim=0)
+        )  # [B*S, K, E]
+        topk_weights = torch.einsum("nke,ne->nk", one_hot, router_scores)  # [B*S, K]
+        topk_weights = (
+            topk_weights.permute(1, 0).unsqueeze(1).unsqueeze(-1)
+        )  # [K, 1, B*S, 1]
+        output = (combined * topk_weights).sum(dim=0)  # [1, B*S, H]
         output = output.view(batch_size, seq_len, hidden_size)
 
-        return output, router_scores
+        return output.to(hidden_states.dtype), router_scores
 
 
 class DeepseekV3MoEToA2AAdapter(nn.Module):
@@ -868,93 +695,254 @@ class DeepseekV3MoEToA2AAdapter(nn.Module):
 
     A2aSparseMLP expects:
     - router: returns (scores, indices)
-    - experts: gate_up_proj [E, H, inter*2], down_proj [E, inter, H], biases
+    - experts: gate_proj [E, H, inter], up_proj [E, H, inter], down_proj [E, inter, H], biases
     """
 
     class RouterAdapter(nn.Module):
-        """Wraps MoEGate to return (scores, indices) for A2aSparseMLP."""
+        """Wraps MoEGate to return (scores, indices) for A2aSparseMLP.
 
-        def __init__(self, gate: nn.Module, n_experts: int):
+        Supports three gate patterns:
+        1. Deepseek-style: gate returns (topk_idx, topk_weight)
+        2. Other gates: gate returns (topk_weight, topk_idx)
+        3. Raw-logits gates (e.g. Glm4MoeTopkRouter): gate returns a single
+           router_logits tensor. Requires route_tokens_to_experts_fn to convert
+           logits -> (topk_idx, topk_weight).
+        """
+
+        def __init__(
+            self, gate: nn.Module, n_experts: int, route_tokens_to_experts_fn=None
+        ):
             super().__init__()
             self.gate = gate
             self.n_experts = n_experts
+            self._route_fn = route_tokens_to_experts_fn
+            # Deepseek-style MoEGate returns (topk_idx, topk_weight) and expects
+            # 3D [batch, seq, hidden] input, flattening internally. Other gates
+            # (e.g. deepseek_v3_2_exp Gate) return (weights, indices) and operate
+            # on a flattened 2D [batch * seq, hidden] input.
+            self._gate_returns_idx_first = hasattr(gate, "n_routed_experts")
 
         def forward(self, hidden_states):
-            topk_idx, topk_weight = self.gate(hidden_states)
-            bsz_seq = topk_idx.shape[0]
-            # Build sparse scores so gather(scores, indices) gives topk_weight
-            scores = torch.zeros(
-                bsz_seq,
-                self.n_experts,
-                dtype=topk_weight.dtype,
-                device=topk_weight.device,
-            )
-            scores.scatter_(1, topk_idx, topk_weight)
+            gate_input = hidden_states
+            if hidden_states.dim() == 3 and not self._gate_returns_idx_first:
+                gate_input = hidden_states.view(-1, hidden_states.shape[-1])
+
+            gate_output = self.gate(gate_input)
+
+            if self._route_fn is not None:
+                # Raw-logits gate: use external routing function
+                topk_idx, topk_weight = self._route_fn(gate_output)
+            elif isinstance(gate_output, (tuple, list)):
+                out1, out2 = gate_output
+                if self._gate_returns_idx_first:
+                    topk_idx, topk_weight = out1, out2
+                else:
+                    topk_weight, topk_idx = out1, out2
+            else:
+                raise ValueError(
+                    f"Gate returned a single tensor but no route_tokens_to_experts_fn "
+                    f"was provided. Gate type: {type(self.gate).__name__}"
+                )
+
+            scores = _topk_to_sparse_scores(topk_weight, topk_idx, self.n_experts)
             return scores, topk_idx
 
-    class StackedExperts(nn.Module):
-        """Stacks DeepseekV3MLP experts into gate_up_proj, down_proj format."""
+    class PreStackedFusedExperts(_SparseForwardMixin, nn.Module):
+        """Wraps experts that already have stacked fused weights (e.g. Glm4MoeNaiveMoe).
+
+        Expects gate_up_proj [E, 2*inter, H] and down_proj [E, H, inter] in nn.Linear
+        convention (out_features, in_features). Transposes and splits into separate
+        gate_proj [E, H, inter], up_proj [E, H, inter], down_proj [E, inter, H]
+        stored as actual Parameters for shard spec compatibility.
+
+        Also keeps reference to original experts module for CPU golden path.
+        """
+
+        def __init__(self, experts):
+            super().__init__()
+            self.original_experts = experts
+            # gate_up_proj: [E, 2*inter, H] -> transpose -> [E, H, 2*inter] -> split
+            gate_up_t = experts.gate_up_proj.data.transpose(1, 2)  # [E, H, 2*inter]
+            inter = gate_up_t.shape[-1] // 2
+            self.intermediate_size = inter
+            self.gate_proj = nn.Parameter(gate_up_t[..., :inter].contiguous())
+            self.up_proj = nn.Parameter(gate_up_t[..., inter:].contiguous())
+            # down_proj: [E, H, inter] -> transpose -> [E, inter, H]
+            self.down_proj = nn.Parameter(
+                experts.down_proj.data.transpose(1, 2).contiguous()
+            )
+
+        # No bias for pre-stacked fused experts
+        gate_proj_bias = None
+        up_proj_bias = None
+        down_proj_bias = None
+
+        # Aliases for _sparse_expert_forward (w1=gate, w2=down, w3=up)
+        w1 = property(lambda self: self.gate_proj)
+        w1_bias = None
+        w2 = property(lambda self: self.down_proj)
+        w2_bias = None
+        w3 = property(lambda self: self.up_proj)
+        w3_bias = None
+
+    class StackedExperts(_SparseForwardMixin, nn.Module):
+        """Stacks expert weights into w1 (gate), w2 (down), w3 (up) format.
+
+        Supports expert layouts with separate projections:
+        - DeepseekV3MLP: gate_proj, up_proj, down_proj
+        - DeepseekV3-2 Expert: w1 (gate), w3 (up), w2 (down)
+
+        Also keeps references to original expert modules for CPU golden path.
+        """
+
+        @staticmethod
+        def _get_expert_layers(exp):
+            """Return (gate_layer, up_layer, down_layer) from an expert module."""
+            if hasattr(exp, "gate_proj"):
+                return exp.gate_proj, exp.up_proj, exp.down_proj
+            elif hasattr(exp, "w1"):
+                return exp.w1, exp.w3, exp.w2
+            else:
+                raise ValueError(
+                    f"Expert {type(exp).__name__} has neither gate_proj/up_proj/down_proj "
+                    "nor w1/w3/w2 attributes."
+                )
 
         def __init__(self, expert_list):
             super().__init__()
             experts_list = [e for e in expert_list if e is not None]
             if not experts_list:
                 experts_list = list(expert_list)
+
+            # Keep original experts for CPU golden path
+            self.original_experts = nn.ModuleList(experts_list)
+
             first = experts_list[0]
-            hidden_size = first.gate_proj.in_features
-            inter = first.gate_proj.out_features
+            gate_layer, _, _ = self._get_expert_layers(first)
+            inter = gate_layer.out_features
+            has_bias = gate_layer.bias is not None
 
-            gate_up_list = []
-            down_list = []
+            gate_list, up_list, down_list = [], [], []
+            gate_bias_list, up_bias_list, down_bias_list = [], [], []
             for exp in experts_list:
-                # gate_proj.weight [inter, H], up_proj.weight [inter, H] -> interleave [H, inter*2]
-                gate_up = torch.empty(
-                    hidden_size,
-                    inter * 2,
-                    dtype=exp.gate_proj.weight.dtype,
-                    device=exp.gate_proj.weight.device,
-                )
-                gate_up[:, 0::2] = exp.gate_proj.weight.T
-                gate_up[:, 1::2] = exp.up_proj.weight.T
-                gate_up_list.append(gate_up)
-                down_list.append(exp.down_proj.weight.T)
+                g, u, d = self._get_expert_layers(exp)
+                gate_list.append(g.weight.T)
+                up_list.append(u.weight.T)
+                down_list.append(d.weight.T)
+                if has_bias:
+                    gate_bias_list.append(g.bias)
+                    up_bias_list.append(u.bias)
+                    down_bias_list.append(d.bias)
 
-            num_experts = len(gate_up_list)
-            gate_up_proj = torch.stack(gate_up_list, dim=0)
-            down_proj = torch.stack(down_list, dim=0)
-            self.gate_up_proj = nn.Parameter(gate_up_proj)
-            self.down_proj = nn.Parameter(down_proj)
-            self.gate_up_proj_bias = nn.Parameter(
-                torch.zeros(
-                    num_experts,
-                    inter * 2,
-                    dtype=gate_up_proj.dtype,
-                    device=gate_up_proj.device,
-                )
-            )
-            self.down_proj_bias = nn.Parameter(
-                torch.zeros(
-                    num_experts,
-                    hidden_size,
-                    dtype=down_proj.dtype,
-                    device=down_proj.device,
-                )
-            )
+            self.gate_proj = nn.Parameter(torch.stack(gate_list, dim=0))
+            self.up_proj = nn.Parameter(torch.stack(up_list, dim=0))
+            self.down_proj = nn.Parameter(torch.stack(down_list, dim=0))
+            self.intermediate_size = inter
+            if has_bias:
+                self.gate_proj_bias = nn.Parameter(torch.stack(gate_bias_list, dim=0))
+                self.up_proj_bias = nn.Parameter(torch.stack(up_bias_list, dim=0))
+                self.down_proj_bias = nn.Parameter(torch.stack(down_bias_list, dim=0))
+            else:
+                self.gate_proj_bias = None
+                self.up_proj_bias = None
+                self.down_proj_bias = None
+
+        # Aliases for unified _sparse_expert_forward (w1=gate, w2=down, w3=up)
+        w1 = property(lambda self: self.gate_proj)
+        w1_bias = property(lambda self: self.gate_proj_bias)
+        w2 = property(lambda self: self.down_proj)
+        w2_bias = property(lambda self: self.down_proj_bias)
+        w3 = property(lambda self: self.up_proj)
+        w3_bias = property(lambda self: self.up_proj_bias)
 
     def __init__(self, moe_module):
         super().__init__()
-        self.router = self.RouterAdapter(
-            moe_module.gate, moe_module.gate.n_routed_experts
+        experts_module = moe_module.experts
+
+        # Detect pre-stacked fused experts (e.g. Glm4MoeNaiveMoe) that have
+        # gate_up_proj as a Parameter directly rather than a list of expert modules.
+        pre_stacked_fused = (
+            hasattr(experts_module, "gate_up_proj")
+            and isinstance(experts_module.gate_up_proj, nn.Parameter)
+            and not hasattr(experts_module, "__iter__")
         )
-        experts_list = [e for e in moe_module.experts if e is not None]
-        if not experts_list:
-            experts_list = list(moe_module.experts)
-        if len(experts_list) != moe_module.gate.n_routed_experts:
-            raise ValueError(
-                "DeepseekV3MoEToA2AAdapter requires ep_size=1 (all experts on one process). "
-                f"Got {len(experts_list)} experts, expected {moe_module.gate.n_routed_experts}."
+
+        if pre_stacked_fused:
+            n_experts = getattr(experts_module, "num_experts", None)
+            if n_experts is None:
+                n_experts = experts_module.gate_up_proj.shape[0]
+        else:
+            n_experts = getattr(moe_module.gate, "n_routed_experts", None)
+            if n_experts is None:
+                n_experts = len([e for e in experts_module if e is not None])
+                if n_experts == 0:
+                    n_experts = len(list(experts_module))
+
+        # Detect gates that return raw logits (e.g. Glm4MoeTopkRouter) and need
+        # a separate routing function to produce (topk_idx, topk_weight).
+        route_fn = None
+        if hasattr(moe_module, "route_tokens_to_experts"):
+            route_fn = self._build_route_fn(moe_module)
+        self.router = self.RouterAdapter(moe_module.gate, n_experts, route_fn)
+
+        if pre_stacked_fused:
+            self.experts = self.PreStackedFusedExperts(experts_module)
+        else:
+            experts_list = [e for e in experts_module if e is not None]
+            if not experts_list:
+                experts_list = list(experts_module)
+            if len(experts_list) != n_experts:
+                raise ValueError(
+                    "DeepseekV3MoEToA2AAdapter requires ep_size=1 (all experts on one process). "
+                    f"Got {len(experts_list)} experts, expected {n_experts}."
+                )
+            self.experts = self.StackedExperts(experts_list)
+
+    @staticmethod
+    def _build_route_fn(moe_module):
+        """Build a standalone routing function from a MoE module's route_tokens_to_experts.
+
+        Captures config values as constants so the function doesn't depend on the
+        original moe_module being alive during tracing.
+        """
+        gate = moe_module.gate
+        n_routed_experts = moe_module.n_routed_experts
+        n_group = moe_module.n_group
+        topk_group = moe_module.topk_group
+        top_k = moe_module.top_k
+        norm_topk_prob = moe_module.norm_topk_prob
+        routed_scaling_factor = moe_module.routed_scaling_factor
+
+        def route_tokens_to_experts(router_logits):
+            router_logits = router_logits.sigmoid()
+            router_logits_for_choice = router_logits + gate.e_score_correction_bias
+            group_scores = (
+                router_logits_for_choice.view(-1, n_group, n_routed_experts // n_group)
+                .topk(2, dim=-1)[0]
+                .sum(dim=-1)
             )
-        self.experts = self.StackedExperts(experts_list)
+            group_idx = torch.topk(group_scores, k=topk_group, dim=-1, sorted=False)[1]
+            group_mask = torch.zeros_like(group_scores)
+            group_mask.scatter_(1, group_idx, 1)
+            score_mask = (
+                group_mask.unsqueeze(-1)
+                .expand(-1, n_group, n_routed_experts // n_group)
+                .reshape(-1, n_routed_experts)
+            )
+            scores_for_choice = router_logits_for_choice.masked_fill(
+                ~score_mask.bool(), 0.0
+            )
+            topk_indices = torch.topk(scores_for_choice, k=top_k, dim=-1, sorted=False)[
+                1
+            ]
+            topk_weights = router_logits.gather(1, topk_indices)
+            if norm_topk_prob:
+                denominator = topk_weights.sum(dim=-1, keepdim=True) + 1e-20
+                topk_weights /= denominator
+            topk_weights = topk_weights * routed_scaling_factor
+            return topk_indices, topk_weights
+
+        return route_tokens_to_experts
 
 
 class A2aSparseMLPWithSharedExperts(nn.Module):
@@ -993,15 +981,22 @@ def create_a2a_from_deepseek_v3_moe(
             Defaults to num_devices when None (single-axis dispatch).
     """
     adapter = DeepseekV3MoEToA2AAdapter(moe_module)
+    num_experts = getattr(config, "n_routed_experts", None) or getattr(
+        config, "num_local_experts", len(list(moe_module.experts))
+    )
+    num_experts_per_tok = getattr(config, "num_experts_per_tok", None) or getattr(
+        config, "n_activated_experts", 6
+    )
     a2a_mlp = A2aSparseMLP(
         adapter,
-        num_experts=config.n_routed_experts,
-        num_experts_per_tok=config.num_experts_per_tok,
+        num_experts=num_experts,
+        num_experts_per_tok=num_experts_per_tok,
         num_devices=num_devices,
         cluster_axis=cluster_axis,
         config=config,
         activation_type=ACTIVATION_DEEPSEEK,
         dispatch_devices=dispatch_devices,
+        cpu_forward_module=moe_module,
     )
     shared_experts = getattr(moe_module, "shared_experts", None)
     return A2aSparseMLPWithSharedExperts(a2a_mlp, shared_experts)
@@ -1018,8 +1013,8 @@ def _is_moe_mlp(module: nn.Module) -> bool:
     if any(pattern in module_name for pattern in moe_patterns):
         return True
 
-    # Check if module has router and experts attributes (common MoE pattern)
-    has_router = hasattr(module, "router")
+    # Check if module has router/gate and experts attributes (common MoE pattern)
+    has_router = hasattr(module, "router") or hasattr(module, "gate")
     has_experts = hasattr(module, "experts")
 
     return has_router and has_experts
@@ -1033,8 +1028,9 @@ def _get_moe_config(module: nn.Module) -> Optional[tuple]:
         if hasattr(module, "experts"):
             experts = module.experts
             num_experts = getattr(experts, "num_experts", None)
-            # Try fused gate_up_proj (expected input format)
-            if num_experts is None and hasattr(experts, "gate_up_proj"):
+            if num_experts is None and hasattr(experts, "gate_proj"):
+                num_experts = experts.gate_proj.shape[0]
+            elif num_experts is None and hasattr(experts, "gate_up_proj"):
                 num_experts = experts.gate_up_proj.shape[0]
 
         # Try to get num_experts_per_tok from router
@@ -1085,13 +1081,7 @@ def enable_sparse_mlp(
         if not should_replace:
             return False
 
-        module_type_name = type(module).__name__.lower()
-
-        if (
-            "deepseek" in module_type_name
-            and hasattr(module, "gate")
-            and hasattr(module, "experts")
-        ):
+        if hasattr(module, "gate") and hasattr(module, "experts"):
             sparse_mlp = create_a2a_from_deepseek_v3_moe(
                 moe_module=module,
                 config=config,
@@ -1121,6 +1111,15 @@ def enable_sparse_mlp(
 
         num_experts, num_experts_per_tok = moe_config
 
+        # Wrap fused experts (e.g. GptOssExperts) with FusedExpertsWrapper
+        # so they have sparse_forward() like StackedExperts
+        if (
+            hasattr(module, "experts")
+            and hasattr(module.experts, "gate_up_proj")
+            and not hasattr(module.experts, "sparse_forward")
+        ):
+            module.experts = FusedExpertsWrapper(module.experts)
+
         sparse_mlp = A2aSparseMLP(
             module,
             num_experts=num_experts,
@@ -1129,6 +1128,7 @@ def enable_sparse_mlp(
             cluster_axis=cluster_axis,
             config=config,
             dispatch_devices=dispatch_devices,
+            cpu_forward_module=module,
         )
 
         setattr(parent, name, sparse_mlp)
@@ -1174,24 +1174,25 @@ def get_moe_shard_specs(
     shard_specs = original_spec_fn(model)
     for layer in model.model.layers:
         if isinstance(layer.mlp, A2aSparseMLP):
-            # Full expert weights are needed on all devices for the sparse matmuls, so shard with None (replicated) for E dimension.
-            shard_specs[layer.mlp.experts.gate_up_proj] = (
-                (mesh_names[0], mesh_names[1]),
-                None,
-                None,
-            )
-            shard_specs[layer.mlp.experts.gate_up_proj_bias] = (
-                (mesh_names[0], mesh_names[1]),
-                None,
-            )
-            shard_specs[layer.mlp.experts.down_proj] = (
-                (mesh_names[0], mesh_names[1]),
-                None,
-                None,
-            )
-            shard_specs[layer.mlp.experts.down_proj_bias] = (
-                (mesh_names[0], mesh_names[1]),
-                None,
-            )
+            experts = layer.mlp.experts
+            compound = (mesh_names[0], mesh_names[1])
+
+            if hasattr(experts, "gate_up_proj"):
+                # Fused gate_up (e.g. GPT-OSS via FusedExpertsWrapper)
+                shard_specs[experts.gate_up_proj] = (compound, None, None)
+                if experts.gate_up_proj_bias is not None:
+                    shard_specs[experts.gate_up_proj_bias] = (compound, None)
+            else:
+                # Separate gate/up (e.g. Deepseek via StackedExperts)
+                shard_specs[experts.gate_proj] = (compound, None, None)
+                shard_specs[experts.up_proj] = (compound, None, None)
+                if experts.gate_proj_bias is not None:
+                    shard_specs[experts.gate_proj_bias] = (compound, None)
+                if experts.up_proj_bias is not None:
+                    shard_specs[experts.up_proj_bias] = (compound, None)
+
+            shard_specs[experts.down_proj] = (compound, None, None)
+            if experts.down_proj_bias is not None:
+                shard_specs[experts.down_proj_bias] = (compound, None)
 
     return shard_specs

--- a/tests/torch/models/deepseek_v3_2_exp/modified_model.py
+++ b/tests/torch/models/deepseek_v3_2_exp/modified_model.py
@@ -425,7 +425,7 @@ class LayerNorm(nn.Module):
 
     def forward(self, x: torch.Tensor):
         return F.layer_norm(
-            x.float(), (self.dim,), self.weight, self.bias, self.eps
+            x.float(), (self.dim,), self.weight.float(), self.bias.float(), self.eps
         ).type_as(x)
 
 

--- a/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_2_exp.py
+++ b/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_2_exp.py
@@ -11,6 +11,7 @@ from infra.evaluators import ComparisonConfig, PccConfig
 from modified_model import ModelArgs
 from modified_model import Transformer as ModifiedTransformer
 from torch_xla.distributed.spmd import Mesh
+from tt_torch.sparse_mlp import enable_sparse_mlp
 
 from tests.utils import failed_ttmlir_compilation
 
@@ -235,6 +236,111 @@ def test_deepseek_indexer(batch_size):
             freqs_cis,
             attention_mask,
         ],
+        framework=Framework.TORCH,
+        mesh=mesh,
+        shard_spec_fn=get_shard_spec,
+        comparison_config=comparison_config,
+    )
+
+
+@pytest.mark.nightly
+@pytest.mark.llmbox
+@pytest.mark.parametrize("batch_size", [32, 64])
+@pytest.mark.parametrize("seq_len", [1, 32, 128])
+def test_deepseek_v3_2_layer_sparse_moe(batch_size, seq_len):
+    xr.set_device_type("TT")
+    torch_xla.runtime.use_spmd()
+
+    args = ModelArgs(
+        n_layers=2,
+        q_lora_rank=3072,
+        max_batch_size=batch_size,
+        max_seq_len=seq_len * 2,
+    )
+
+    # Create full model to get freqs_cis, then extract MoE block (layer 1)
+    model = ModifiedTransformer(args)
+    model = model.to(torch.bfloat16)
+    block = model.layers[1]  # layer_id=1 >= n_dense_layers=1 -> MoE
+    freqs_cis = model.freqs_cis[:seq_len]
+
+    mesh_shape = (2, 4)
+    enable_sparse_mlp(block, mesh=mesh_shape, cluster_axis=0, config=args)
+    block.eval()
+
+    hidden_states = torch.randn((batch_size, seq_len, args.dim), dtype=torch.bfloat16)
+    mask = torch.full((seq_len, seq_len), float("-inf"), dtype=torch.bfloat16).triu_(1)
+
+    num_devices = xr.global_runtime_device_count()
+    device_ids = np.array(range(num_devices))
+    mesh = Mesh(device_ids, mesh_shape, ("_axis_0", "_axis_1"))
+
+    def get_shard_spec(block, args, kwargs):
+        shard_specs = {}
+
+        # x: [batch, seq, dim]
+        shard_specs[args[0]] = ("_axis_1", None, "_axis_0")
+
+        # Attention weights — all parallelism on _axis_0 (matches hidden on _axis_0)
+        attn = block.attn
+        shard_specs[attn.wq_b.weight] = ("_axis_0", None)
+        shard_specs[attn.wkv_b.weight] = ("_axis_0", None)
+        shard_specs[attn.wo.weight] = (None, "_axis_0")
+        shard_specs[attn.wq_a.weight] = (None, "_axis_0")
+        shard_specs[attn.wkv_a.weight] = (None, "_axis_0")
+
+        # KV caches [max_batch, max_seq, dim] — batch on _axis_1
+        shard_specs[attn.kv_cache] = ("_axis_1", None, None)
+        shard_specs[attn.pe_cache] = ("_axis_1", None, None)
+
+        # Indexer
+        if attn.indexer is not None:
+            shard_specs[attn.indexer.wq_b.weight] = ("_axis_0", None)
+            shard_specs[attn.indexer.wk.weight] = (None, "_axis_0")
+            shard_specs[attn.indexer.weights_proj.weight] = (None, "_axis_0")
+            shard_specs[attn.indexer.k_cache] = ("_axis_1", None, None)
+
+        # A2aSparseMLP
+        ffn = block.ffn
+        mlp = ffn.mlp if hasattr(ffn, "mlp") else ffn
+        shard_specs[mlp.router.gate.weight] = (None, "_axis_0")
+        shard_specs[mlp.experts.gate_proj] = (
+            ("_axis_0", "_axis_1"),
+            None,
+            None,
+        )
+        shard_specs[mlp.experts.up_proj] = (
+            ("_axis_0", "_axis_1"),
+            None,
+            None,
+        )
+        shard_specs[mlp.experts.down_proj] = (
+            ("_axis_0", "_axis_1"),
+            None,
+            None,
+        )
+
+        # Shared experts
+        shared = getattr(ffn, "shared_experts", None)
+        if shared is not None:
+            shard_specs[shared.w1.weight] = (None, "_axis_0")
+            shard_specs[shared.w3.weight] = (None, "_axis_0")
+            shard_specs[shared.w2.weight] = ("_axis_0", None)
+
+        # Norms
+        shard_specs[block.attn_norm.weight] = ("_axis_0",)
+        shard_specs[block.ffn_norm.weight] = ("_axis_0",)
+
+        return shard_specs
+
+    comparison_config = ComparisonConfig(
+        # seq_len = 1 has low pcc (0.92-) so disable pcc check temporarily
+        pcc=PccConfig(enabled=False if seq_len == 1 else True, required_pcc=0.99),
+    )
+
+    run_graph_test(
+        block,
+        [hidden_states, None, 0, freqs_cis, mask],
         framework=Framework.TORCH,
         mesh=mesh,
         shard_spec_fn=get_shard_spec,

--- a/tests/torch/models/glm4_moe/test_glm4_moe.py
+++ b/tests/torch/models/glm4_moe/test_glm4_moe.py
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+from infra.evaluators import ComparisonConfig, PccConfig
+from infra.testers.compiler_config import CompilerConfig
+from torch_xla.distributed.spmd import Mesh
+from transformers.cache_utils import StaticCache
+from transformers.models.glm4_moe.configuration_glm4_moe import Glm4MoeConfig
+from transformers.models.glm4_moe.modeling_glm4_moe import (
+    Glm4MoeDecoderLayer,
+    Glm4MoeModel,
+)
+from tt_torch.sparse_mlp import enable_sparse_mlp
+
+
+@pytest.mark.nightly
+@pytest.mark.llmbox
+@pytest.mark.parametrize("batch_size", [32])
+@pytest.mark.parametrize("seq_len", [1, 32, 128])
+def test_glm4_moe_layer_sparse_moe(batch_size, seq_len):
+    """Test single MoE decoder layer with A2aSparseMLP on (2,4) mesh."""
+    xr.set_device_type("TT")
+    torch_xla.runtime.use_spmd()
+
+    config = Glm4MoeConfig.from_pretrained("zai-org/GLM-4.7")
+    # first_k_dense_replace=3, so need at least 4 layers for MoE
+    config.num_hidden_layers = 4
+    config.use_cache = False
+    config._attn_implementation = "eager"
+
+    # layer_idx=3 >= first_k_dense_replace=3 -> MoE layer
+    layer = Glm4MoeDecoderLayer(config, layer_idx=3)
+    layer = layer.eval().to(torch.bfloat16)
+
+    mesh_shape = (2, 4)
+    enable_sparse_mlp(layer, mesh=mesh_shape, cluster_axis=0, config=config)
+
+    hidden_states = torch.randn(
+        (batch_size, seq_len, config.hidden_size), dtype=torch.bfloat16
+    )
+    position_ids = torch.arange(seq_len).unsqueeze(0)
+    # position_embeddings: (cos, sin) each [batch, seq, head_dim]
+    head_dim = config.hidden_size // config.num_attention_heads
+    rotary_dim = int(head_dim * config.partial_rotary_factor)
+    cos = torch.randn(batch_size, seq_len, rotary_dim, dtype=torch.bfloat16)
+    sin = torch.randn(batch_size, seq_len, rotary_dim, dtype=torch.bfloat16)
+
+    num_devices = xr.global_runtime_device_count()
+    device_ids = np.array(range(num_devices))
+    mesh = Mesh(device_ids, mesh_shape, ("_axis_0", "_axis_1"))
+
+    def get_shard_spec(layer, args, kwargs):
+        shard_specs = {}
+
+        # hidden_states: [batch, seq, hidden]
+        shard_specs[args[0]] = ("_axis_1", None, "_axis_0")
+
+        # Attention weights
+        attn = layer.self_attn
+        shard_specs[attn.q_proj.weight] = ("_axis_0", None)
+        shard_specs[attn.k_proj.weight] = ("_axis_0", None)
+        shard_specs[attn.v_proj.weight] = ("_axis_0", None)
+        shard_specs[attn.o_proj.weight] = (None, "_axis_0")
+        if attn.q_proj.bias is not None:
+            shard_specs[attn.q_proj.bias] = ("_axis_0",)
+            shard_specs[attn.k_proj.bias] = ("_axis_0",)
+            shard_specs[attn.v_proj.bias] = ("_axis_0",)
+
+        # MoE (A2aSparseMLPWithSharedExperts)
+        mlp_wrapper = layer.mlp
+        mlp = mlp_wrapper.mlp if hasattr(mlp_wrapper, "mlp") else mlp_wrapper
+        shard_specs[mlp.router.gate.weight] = (None, "_axis_0")
+        shard_specs[mlp.experts.gate_proj] = (
+            ("_axis_0", "_axis_1"),
+            None,
+            None,
+        )
+        shard_specs[mlp.experts.up_proj] = (
+            ("_axis_0", "_axis_1"),
+            None,
+            None,
+        )
+        shard_specs[mlp.experts.down_proj] = (
+            ("_axis_0", "_axis_1"),
+            None,
+            None,
+        )
+        if mlp.experts.gate_proj_bias is not None:
+            shard_specs[mlp.experts.gate_proj_bias] = (("_axis_0", "_axis_1"), None)
+        if mlp.experts.up_proj_bias is not None:
+            shard_specs[mlp.experts.up_proj_bias] = (("_axis_0", "_axis_1"), None)
+        if mlp.experts.down_proj_bias is not None:
+            shard_specs[mlp.experts.down_proj_bias] = (("_axis_0", "_axis_1"), None)
+
+        # Shared experts
+        shared = getattr(mlp_wrapper, "shared_experts", None)
+        if shared is not None:
+            shard_specs[shared.gate_proj.weight] = (None, "_axis_0")
+            shard_specs[shared.up_proj.weight] = (None, "_axis_0")
+            shard_specs[shared.down_proj.weight] = ("_axis_0", None)
+
+        # Norms
+        shard_specs[layer.input_layernorm.weight] = ("_axis_0",)
+        shard_specs[layer.post_attention_layernorm.weight] = ("_axis_0",)
+
+        return shard_specs
+
+    comparison_config = ComparisonConfig(
+        pcc=PccConfig(enabled=True, required_pcc=0.99),
+    )
+
+    run_graph_test(
+        layer,
+        [hidden_states, None, position_ids, None, False, None, (cos, sin)],
+        framework=Framework.TORCH,
+        mesh=mesh,
+        shard_spec_fn=get_shard_spec,
+        comparison_config=comparison_config,
+    )

--- a/tests/torch/models/kimi_k2/test_kimi_k2.py
+++ b/tests/torch/models/kimi_k2/test_kimi_k2.py
@@ -14,6 +14,7 @@ from infra import Framework, run_graph_test
 from infra.evaluators import ComparisonConfig, PccConfig
 from torch_xla.distributed.spmd import Mesh
 from transformers import DynamicCache
+from tt_torch.sparse_mlp import create_a2a_from_deepseek_v3_moe, enable_sparse_mlp
 
 from tests.utils import failed_ttmlir_compilation
 
@@ -22,6 +23,8 @@ from .modeling_deepseek import (
     DeepseekV3Attention,
     DeepseekV3DecoderLayer,
     DeepseekV3ForCausalLM,
+    DeepseekV3Model,
+    DeepseekV3MoE,
 )
 from .original_modeling_deepseek import DeepseekV3Attention as OrigDeepseekV3Attention
 from .utils import MLACache
@@ -306,6 +309,120 @@ def test_kimi_k2_layer():
         framework=Framework.TORCH,
         mesh=mesh,
         shard_spec_fn=get_shard_spec,
+    )
+
+
+@pytest.mark.nightly
+@pytest.mark.llmbox
+@pytest.mark.parametrize("batch_size", [32])
+@pytest.mark.parametrize("seq_len", [1, 32])
+def test_kimi_k2_layer_sparse_moe(batch_size, seq_len):
+    xr.set_device_type("TT")
+    torch_xla.runtime.use_spmd()
+
+    # Load full Kimi K2 config from JSON file
+    config_path = os.path.join(os.path.dirname(__file__), "config.json")
+    config = DeepseekV3Config.from_json_file(config_path)
+    config._attn_implementation = "eager"
+    config.num_hidden_layers = 2
+
+    layer = DeepseekV3DecoderLayer(config, layer_idx=1)
+    layer = layer.eval().to(torch.bfloat16)
+
+    max_cache_len = 1024
+    hidden_states = torch.randn(
+        (batch_size, seq_len, config.hidden_size), dtype=torch.bfloat16
+    )
+    attention_mask = torch.rand(
+        batch_size, 1, seq_len, max_cache_len, dtype=torch.bfloat16
+    )
+    cache_positions = torch.randint(0, max_cache_len, (seq_len,), dtype=torch.long)
+    num_devices = xr.global_runtime_device_count()
+    mesh_shape = (2, 4)
+    device_ids = np.array(range(num_devices))
+    mesh = Mesh(device_ids, mesh_shape, ("_axis_0", "_axis_1"))
+    enable_sparse_mlp(layer, mesh=mesh_shape, cluster_axis=0, config=config)
+
+    position_ids = torch.arange(seq_len).unsqueeze(0)
+    static_cache = MLACache(
+        config=config,
+        max_batch_size=batch_size,
+        max_cache_len=max_cache_len,
+        device="cpu",
+        dtype=torch.bfloat16,
+    )
+    past_key_states = static_cache
+
+    num_devices = xr.global_runtime_device_count()
+    device_ids = np.array(range(num_devices))
+
+    def get_shard_spec(layer, args, kwargs):
+        shard_specs = {}
+
+        shard_specs[args[0]] = ("_axis_1", None, "_axis_0")
+        shard_specs[args[1]] = ("_axis_1", None, None, None)
+        shard_specs[args[3].layers[1].compressed_kv] = ("_axis_1", None, None, None)
+        shard_specs[args[3].layers[1].k_pe] = ("_axis_1", None, None, None)
+
+        shard_specs[layer.self_attn.q_b_proj.weight] = ("_axis_0", None)
+        shard_specs[layer.self_attn.kv_b_proj.weight] = ("_axis_0", None)
+        shard_specs[layer.self_attn.o_proj.weight] = (None, "_axis_0")
+
+        shard_specs[layer.self_attn.q_a_proj.weight] = (None, "_axis_0")
+        shard_specs[layer.self_attn.kv_a_proj_with_mqa.weight] = (None, "_axis_0")
+
+        # A2aSparseMLP: experts compound-sharded (axis_0, axis_1)
+        mlp_wrapper = layer.mlp
+        mlp = mlp_wrapper.mlp if hasattr(mlp_wrapper, "mlp") else mlp_wrapper
+        shard_specs[mlp.router.gate.weight] = (None, "_axis_0")
+        shard_specs[mlp.experts.gate_proj] = (
+            ("_axis_0", "_axis_1"),
+            None,
+            None,
+        )
+        shard_specs[mlp.experts.up_proj] = (
+            ("_axis_0", "_axis_1"),
+            None,
+            None,
+        )
+        shard_specs[mlp.experts.down_proj] = (
+            ("_axis_0", "_axis_1"),
+            None,
+            None,
+        )
+
+        # Shared experts (if present, on wrapper not on inner A2aSparseMLP)
+        shared = getattr(mlp_wrapper, "shared_experts", None)
+        if shared is not None:
+            shard_specs[shared.gate_proj.weight] = (None, "_axis_0")
+            shard_specs[shared.up_proj.weight] = (None, "_axis_0")
+            shard_specs[shared.down_proj.weight] = ("_axis_0", None)
+
+        # Layernorm: hidden replicated → weight not sharded
+        shard_specs[layer.input_layernorm.weight] = ("_axis_0",)
+        shard_specs[layer.post_attention_layernorm.weight] = ("_axis_0",)
+
+        return shard_specs
+
+    comparison_config = ComparisonConfig(
+        pcc=PccConfig(enabled=True, required_pcc=0.98),
+    )
+
+    run_graph_test(
+        layer,
+        [
+            hidden_states,
+            attention_mask,
+            position_ids,
+            past_key_states,
+            False,
+            True,
+            cache_positions,
+        ],
+        framework=Framework.TORCH,
+        mesh=mesh,
+        shard_spec_fn=get_shard_spec,
+        comparison_config=comparison_config,
     )
 
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
We need to support glm, deepseek, and kimi k2 models using sparse MoE

### What's changed
- Add GLM-4 support: PreStackedFusedExperts for pre-stacked fused weights, raw-logits router handling via _build_route_fn
- Add DeepSeek V3 / Kimi K2 support: StackedExperts with separate gate/up/down projections
- Skip unnecessary bias adds when model has no bias (DeepSeek, Kimi, GLM-4)
- Unify router output handling across GptOss (3-value), DeepSeek (2-value), and GLM-4 (raw logits) via _unpack_router_output / _topk_to_sparse_scores
- Extract _SparseForwardMixin to deduplicate sparse_forward() across 3 classes
- Add GLM-4 MoE layer test


### Checklist
- [ ] New/Existing tests provide coverage for changes
