### PR TITLE
Update test config for pi_0 model

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -757,14 +757,12 @@ test_config:
     reason: "Can't convert shape rank (https://github.com/tenstorrent/tt-xla/issues/3392)"
 
   pi_0/pytorch-lerobot_pi0_libero_base-single_device-inference:
-    status: NOT_SUPPORTED_SKIP
-    reason: "Hangs - https://github.com/tenstorrent/tt-xla/issues/3922"
-    bringup_status: FAILED_RUNTIME
+    status: EXPECTED_PASSING
+    assert_pcc: false
+    reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.8219157204385233. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/3786"
 
   pi_0/pytorch-pi0_base-single_device-inference:
-    status: NOT_SUPPORTED_SKIP
-    reason: "Hangs - https://github.com/tenstorrent/tt-xla/issues/3922"
-    bringup_status: FAILED_RUNTIME
+    status: EXPECTED_PASSING
 
   opt/qa/pytorch-1.3b-single_device-inference:
     status: EXPECTED_PASSING

--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -757,11 +757,13 @@ test_config:
     reason: "Can't convert shape rank (https://github.com/tenstorrent/tt-xla/issues/3392)"
 
   pi_0/pytorch-lerobot_pi0_libero_base-single_device-inference:
+    supported_archs: ["p150"]
     status: EXPECTED_PASSING
     assert_pcc: false
     reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.8219157204385233. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/3786"
 
   pi_0/pytorch-pi0_base-single_device-inference:
+    supported_archs: ["p150"]
     status: EXPECTED_PASSING
 
   opt/qa/pytorch-1.3b-single_device-inference:


### PR DESCRIPTION
### Ticket
- https://github.com/tenstorrent/tt-xla/issues/3922

### Problem description
- The pi_0 models (pi0_libero_base and pi0_base) were previously marked as NOT_SUPPORTED_SKIP with FAILED_RUNTIME bringup status due to hanging (https://github.com/tenstorrent/tt-xla/issues/3922). 
- These models are now able to run successfully and should be updated in the test config.
- However, pi_0 models require ~26GB peak system RAM. The n150/n300 CI runners have 47GB total, but with 20-30% baseline usage the available memory can drop as low as ~21GB, causing the test process to be OOM-killed. The p150 runners have 90GB total, providing sufficient headroom.

Runner | Total RAM | Available RAM | Usage(before test starts) | Result
-- | -- | -- | -- | --
[n150](https://github.com/tenstorrent/tt-xla/actions/runs/24199978826/job/70643762839#step:17:318) | 47.1 GB | 36.6 GB | 22.4% | Passed
[n300](https://github.com/tenstorrent/tt-xla/actions/runs/24199996498/job/70643868299#step:17:321) | 47.1 GB | 37.4 GB | 20.8% | Passed
[p150](https://github.com/tenstorrent/tt-xla/actions/runs/24200016792/job/70643788415#step:17:318) | 90.5 GB | 80.4 GB | 11.1% | Passed
[n150](https://github.com/tenstorrent/tt-xla/actions/runs/24227124873/job/70730584871#step:17:180) (later) | 31.4 GB | 21.7 GB | 30.8% | Killed (OOM)

### Note on torchcodec process isolation
- When both pi_0 variants run in the same process (without --forked), the second variant crashes with:
`RuntimeError: register_fake(...): the operator torchcodec_ns::create_from_file already has an fake impl registered`
- This is a known limitation of torch.library.register_fake() — operator registrations persist in PyTorch's global C++ dispatcher and cannot be deregistered within the same process. The test framework's RequirementsManager purges sys.modules between tests, but re-importing torchcodec triggers duplicate C++ operator registration, which is fatal.
- This does not affect any automated CI pipeline:
    --> Nightly and Run Test (model-test-passing.json) use name: "`run_forge_models`", which gets the `--forked` flag — each test runs in its own subprocess.
    --> PR CI does not run pi_0 (no push marker).
    --> The issue only manifests in Run Test Single (name: "Test", no --forked). Workaround: pass --forked in the args field.

### What's changed
- Updated `pi_0/pytorch-lerobot_pi0_libero_base-single_device-inference` from `NOT_SUPPORTED_SKIP` to `EXPECTED_PASSING` with `assert_pcc: false` due to a known PCC drop (pcc=0.82 vs required 0.99, tracked in https://github.com/tenstorrent/tt-xla/issues/3786).
- Updated `pi_0/pytorch-pi0_base-single_device-inference` from `NOT_SUPPORTED_SKIP` to `EXPECTED_PASSING`.
- Removed bringup_status: FAILED_RUNTIME from both models as they no longer hang.
- Restricted both pi_0 models to supported_archs: ["p150"] only, as n150/n300 runners lack consistent memory headroom for the ~26GB peak usage.

### Checklist
- [x] New/Existing tests provide coverage for changes


### Logs
- [pi0_base.log](https://github.com/user-attachments/files/26645185/pi0_base.log)
- [pi0_libero.log](https://github.com/user-attachments/files/26645186/pi0_libero.log)
- Both variants pass on Run_Test Workflow(p150) - [log](https://github.com/tenstorrent/tt-xla/actions/runs/24280749594)
