### PR TITLE
Add GPT-OSS 120B TP8-DP4-EP32 benchmark on Galaxy

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -195,6 +195,12 @@
         "runs-on": "galaxy-wh-6u"
       },
       {
+        "name": "test_gpt_oss_120b_tp_dp_galaxy_batch_size_128",
+        "pyreq": "datasets loguru pytest requests accelerate torch==2.9.0 tqdm transformers==5.2.0",
+        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_120b_tp_dp_galaxy_batch_size_128",
+        "runs-on": "galaxy-wh-6u"
+      },
+      {
         "name": "microsoft_phi-1",
         "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_phi1"

--- a/tests/benchmark/benchmarks/llm_benchmark.py
+++ b/tests/benchmark/benchmarks/llm_benchmark.py
@@ -219,6 +219,8 @@ def benchmark_llm_torch_xla(
     max_output_tokens=None,
     decode_only: bool = False,
     weight_dtype_overrides: dict = None,
+    input_output_sharding_spec=None,
+    kv_cache_sharding_spec=None,
 ):
     """
     Benchmark an LLM (Large Language Model) using PyTorch and torch-xla.
@@ -377,9 +379,15 @@ def benchmark_llm_torch_xla(
                 xs.mark_sharding(tensor, mesh, shard_spec)
 
         # Also shard KV cache tensors created in input_args
+        # This is hardcoded for all TP models, and should be moded to tt-forge-models.
+        kv_spec = kv_cache_sharding_spec or (None, "model", None, None)
         for layer in input_args["past_key_values"].layers:
-            xs.mark_sharding(layer.keys, mesh, (None, "model", None, None))
-            xs.mark_sharding(layer.values, mesh, (None, "model", None, None))
+            xs.mark_sharding(layer.keys, mesh, kv_spec)
+            xs.mark_sharding(layer.values, mesh, kv_spec)
+
+        # Shard input_ids
+        if input_output_sharding_spec:
+            xs.mark_sharding(input_args["input_ids"], mesh, input_output_sharding_spec)
 
         # Apply sharding constraint on lm_head output to all_gather logits
         if hasattr(model, "lm_head") and model.lm_head is not None:
@@ -423,7 +431,13 @@ def benchmark_llm_torch_xla(
             )
     # PERFORMANCE BENCHMARK
     # No logits returned to avoid OOM.
-    perf_wrapper = LLMSamplingWrapper(model, read_logits_fn, return_logits=False)
+    perf_wrapper = LLMSamplingWrapper(
+        model,
+        read_logits_fn,
+        return_logits=False,
+        mesh=mesh,
+        output_sharding_spec=input_output_sharding_spec,
+    )
     perf_wrapper.eval()
     compiled_perf_model = torch.compile(perf_wrapper, backend="tt")
 
@@ -461,6 +475,8 @@ def benchmark_llm_torch_xla(
         input_args["cache_position"] = decode_only_cache_position
 
     input_args = transfer_to_device(input_args, device)
+    if input_output_sharding_spec:
+        xs.mark_sharding(input_args["input_ids"], mesh, input_output_sharding_spec)
 
     # Run perf benchmark
     print(f"\nStarting performance benchmark...")
@@ -481,7 +497,13 @@ def benchmark_llm_torch_xla(
     # ACCURACY BENCHMARK
     # Logits moved to CPU each step to avoid OOM.
     if not decode_only:
-        accuracy_wrapper = LLMSamplingWrapper(model, read_logits_fn, return_logits=True)
+        accuracy_wrapper = LLMSamplingWrapper(
+            model,
+            read_logits_fn,
+            return_logits=True,
+            mesh=mesh,
+            output_sharding_spec=input_output_sharding_spec,
+        )
         accuracy_wrapper.eval()
         compiled_accuracy = torch.compile(accuracy_wrapper, backend="tt")
 
@@ -500,6 +522,8 @@ def benchmark_llm_torch_xla(
             ),
         )
         input_args = transfer_to_device(input_args, device)
+        if input_output_sharding_spec:
+            xs.mark_sharding(input_args["input_ids"], mesh, input_output_sharding_spec)
 
         print(
             f"\nStarting accuracy benchmark "

--- a/tests/benchmark/benchmarks/llm_benchmark.py
+++ b/tests/benchmark/benchmarks/llm_benchmark.py
@@ -379,7 +379,8 @@ def benchmark_llm_torch_xla(
                 xs.mark_sharding(tensor, mesh, shard_spec)
 
         # Also shard KV cache tensors created in input_args
-        # This is hardcoded for all TP models, and should be moded to tt-forge-models.
+        # This is hardcoded for all TP models, and should be moved to tt-forge-models.
+        # https://github.com/tenstorrent/tt-xla/issues/4240
         kv_spec = kv_cache_sharding_spec or (None, "model", None, None)
         for layer in input_args["past_key_values"].layers:
             xs.mark_sharding(layer.keys, mesh, kv_spec)

--- a/tests/benchmark/benchmarks/llm_benchmark.py
+++ b/tests/benchmark/benchmarks/llm_benchmark.py
@@ -541,9 +541,7 @@ def benchmark_llm_torch_xla(
 
     # Post-processing: derive predicted tokens for accuracy testing
     if accuracy_testing:
-        predicted_tokens = [
-            logits[:, -1].argmax(dim=-1)[0].item() for logits in output_logits
-        ]
+        predicted_tokens = [logits.argmax(dim=-1)[0].item() for logits in output_logits]
 
     ttft_ns = iteration_times[0] if not decode_only else 0.0
     ttft_ms = ttft_ns / 1e6

--- a/tests/benchmark/llm_utils/decode_utils.py
+++ b/tests/benchmark/llm_utils/decode_utils.py
@@ -61,9 +61,12 @@ class LLMSamplingWrapper(torch.nn.Module):
             use_cache=use_cache,
         )
         logits = self.read_logits_fn(output)
-        next_token_ids = logits[:, -1].argmax(dim=-1, keepdim=True)
+        # Only take logits for last token in prefill.
+        # This is a noop for decode.
+        logits_last = logits[:, -1]
+        next_token_ids = logits_last.argmax(dim=-1, keepdim=True)
         next_token_ids_replicated = next_token_ids
-        if self.mesh is not None and self.output_sharding_spec is not None:
+        if self.mesh and self.output_sharding_spec:
             # Create two versions of next_token_ids, sharded and replicated.
             # The sharded version is used as input for the next decode step. Passing the replicated version as the input created a differenct graph and trigers recompilation.
             # The replicated version is used for transfer to CPU. Using the sharded version for the transfer create a new graph with a single all gather and triggers recompilation.
@@ -76,11 +79,18 @@ class LLMSamplingWrapper(torch.nn.Module):
             )
         next_cache_position = cache_position[-1:] + 1
         if self.return_logits:
+            logits_out = logits_last
+            if self.mesh and self.output_sharding_spec:
+                # Ensure logits are replicated for transfer to CPU.
+                replicate_spec = tuple(None for _ in self.output_sharding_spec)
+                logits_out = sharding_constraint_tensor(
+                    logits_last, self.mesh, replicate_spec
+                )
             return (
                 next_token_ids,
                 next_token_ids_replicated,
                 next_cache_position,
-                logits,
+                logits_out,
             )
         return next_token_ids, next_token_ids_replicated, next_cache_position
 

--- a/tests/benchmark/llm_utils/decode_utils.py
+++ b/tests/benchmark/llm_utils/decode_utils.py
@@ -68,8 +68,8 @@ class LLMSamplingWrapper(torch.nn.Module):
         next_token_ids_replicated = next_token_ids
         if self.mesh and self.output_sharding_spec:
             # Create two versions of next_token_ids, sharded and replicated.
-            # The sharded version is used as input for the next decode step. Passing the replicated version as the input created a differenct graph and trigers recompilation.
-            # The replicated version is used for transfer to CPU. Using the sharded version for the transfer create a new graph with a single all gather and triggers recompilation.
+            # The sharded version is used as input for the next decode step. Passing the replicated version as the input creates a different graph and triggers recompilation.
+            # The replicated version is used for transfer to CPU. Using the sharded version for the transfer creates a new graph with a single all gather and triggers recompilation.
             replicate_spec = tuple(None for _ in self.output_sharding_spec)
             next_token_ids = sharding_constraint_tensor(
                 next_token_ids, self.mesh, self.output_sharding_spec

--- a/tests/benchmark/llm_utils/decode_utils.py
+++ b/tests/benchmark/llm_utils/decode_utils.py
@@ -17,10 +17,11 @@ from typing import Optional
 import torch
 import tracy
 from transformers.cache_utils import StaticCache
+from tt_torch.sharding import sharding_constraint_tensor
 
 
 class LLMSamplingWrapper(torch.nn.Module):
-    """Wraps an LLM to perform sampling (token selection, cache positionupdate) on device.
+    """Wraps an LLM to perform sampling (token selection, cache position update) on device.
 
     By keeping token selection and cache_position increment inside the compiled
     graph, intermediate tensors stay on device between decode steps, eliminating
@@ -31,6 +32,10 @@ class LLMSamplingWrapper(torch.nn.Module):
         read_logits_fn: Function to extract logits from model output.
         return_logits: If True, forward() returns (next_token_ids, next_cache_position, logits).
             If False, returns (next_token_ids, next_cache_position) only.
+        mesh: Optional SPMD mesh for sharding constraints.
+        output_sharding_spec: Optional sharding spec for output token ids.
+            When both mesh and output_sharding_spec are provided, applies a
+            sharding constraint on next_token_ids and produces a replicated copy.
     """
 
     def __init__(
@@ -38,11 +43,15 @@ class LLMSamplingWrapper(torch.nn.Module):
         model: torch.nn.Module,
         read_logits_fn,
         return_logits: bool = True,
+        mesh=None,
+        output_sharding_spec=None,
     ):
         super().__init__()
         self.model = model
         self.read_logits_fn = read_logits_fn
         self.return_logits = return_logits
+        self.mesh = mesh
+        self.output_sharding_spec = output_sharding_spec
 
     def forward(self, input_ids, past_key_values, cache_position, use_cache=True):
         output = self.model(
@@ -52,12 +61,28 @@ class LLMSamplingWrapper(torch.nn.Module):
             use_cache=use_cache,
         )
         logits = self.read_logits_fn(output)
-        last_token_logits = logits[:, -1]
-        next_token_ids = last_token_logits.argmax(dim=-1, keepdim=True)
+        next_token_ids = logits[:, -1].argmax(dim=-1, keepdim=True)
+        next_token_ids_replicated = next_token_ids
+        if self.mesh is not None and self.output_sharding_spec is not None:
+            # Create two versions of next_token_ids, sharded and replicated.
+            # The sharded version is used as input for the next decode step. Passing the replicated version as the input created a differenct graph and trigers recompilation.
+            # The replicated version is used for transfer to CPU. Using the sharded version for the transfer create a new graph with a single all gather and triggers recompilation.
+            replicate_spec = tuple(None for _ in self.output_sharding_spec)
+            next_token_ids = sharding_constraint_tensor(
+                next_token_ids, self.mesh, self.output_sharding_spec
+            )
+            next_token_ids_replicated = sharding_constraint_tensor(
+                next_token_ids, self.mesh, replicate_spec
+            )
         next_cache_position = cache_position[-1:] + 1
         if self.return_logits:
-            return next_token_ids, next_cache_position, last_token_logits
-        return next_token_ids, next_cache_position
+            return (
+                next_token_ids,
+                next_token_ids_replicated,
+                next_cache_position,
+                logits,
+            )
+        return next_token_ids, next_token_ids_replicated, next_cache_position
 
 
 def assert_eval_no_dropout(model: torch.nn.Module, *, verbose: bool = False) -> None:
@@ -208,10 +233,15 @@ def generate_and_benchmark(
             output = model(**input_args)
 
             if collect_logits:
-                next_token_ids, next_cache_position, logits = output
+                (
+                    next_token_ids,
+                    next_token_ids_replicated,
+                    next_cache_position,
+                    logits,
+                ) = output
                 output_logits.append(logits.to("cpu"))
             else:
-                next_token_ids, next_cache_position = output
+                next_token_ids, next_token_ids_replicated, next_cache_position = output
 
             if ground_truth_tokens is not None:
                 input_args["input_ids"] = gt_cpu[step].to(device)
@@ -221,9 +251,7 @@ def generate_and_benchmark(
             input_args["cache_position"] = next_cache_position
 
             if tokenizer:
-                decoded = tokenizer.batch_decode(
-                    next_token_ids.to("cpu").view(batch_size, -1)
-                )
+                decoded = tokenizer.batch_decode(next_token_ids_replicated.to("cpu"))
                 for i in range(batch_size):
                     generated_texts[i] += decoded[i]
 

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -1654,30 +1654,28 @@ def _moe_throughput_galaxy_shard_spec_fn(model_loader, model):
     Expert weights are sharded across both model and batch axes EP - 32.
     """
 
-    batch_axis = None
-
     shard_specs = {}
 
-    shard_specs[model.model.embed_tokens.weight] = (None, batch_axis)
-    shard_specs[model.model.norm.weight] = (batch_axis,)
+    shard_specs[model.model.embed_tokens.weight] = (None, None)
+    shard_specs[model.model.norm.weight] = (None,)
     # HF [vocab, hidden]: TP shard vocab (first dim); tt-metal transposes/pads on device — see tt-metal_galaxy_parallelism
     shard_specs[model.lm_head.weight] = (None, None)
 
     for layer in model.model.layers:
-        shard_specs[layer.self_attn.q_proj.weight] = ("model", batch_axis)
-        shard_specs[layer.self_attn.k_proj.weight] = ("model", batch_axis)
-        shard_specs[layer.self_attn.v_proj.weight] = ("model", batch_axis)
-        shard_specs[layer.self_attn.o_proj.weight] = (batch_axis, "model")
+        shard_specs[layer.self_attn.q_proj.weight] = ("model", None)
+        shard_specs[layer.self_attn.k_proj.weight] = ("model", None)
+        shard_specs[layer.self_attn.v_proj.weight] = ("model", None)
+        shard_specs[layer.self_attn.o_proj.weight] = (None, "model")
         shard_specs[layer.self_attn.sinks] = ("model",)
-        shard_specs[layer.mlp.router.weight] = (None, batch_axis)
+        shard_specs[layer.mlp.router.weight] = (None, None)
         # This is a temporary sharding spec to enable gpt oss to not get OOM on galaxy.
         # Once the MoE module is refactored, this should be changed to EP 32.
         shard_specs[layer.mlp.experts.gate_up_proj] = ("model", "batch", None)
         shard_specs[layer.mlp.experts.gate_up_proj_bias] = ("model", None)
         shard_specs[layer.mlp.experts.down_proj] = ("model", None, "batch")
         shard_specs[layer.mlp.experts.down_proj_bias] = ("model", "batch")
-        shard_specs[layer.input_layernorm.weight] = (batch_axis,)
-        shard_specs[layer.post_attention_layernorm.weight] = (batch_axis,)
+        shard_specs[layer.input_layernorm.weight] = (None,)
+        shard_specs[layer.post_attention_layernorm.weight] = (None,)
 
     return shard_specs
 

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -1670,10 +1670,12 @@ def _moe_throughput_galaxy_shard_spec_fn(model_loader, model):
         shard_specs[layer.self_attn.o_proj.weight] = (batch_axis, "model")
         shard_specs[layer.self_attn.sinks] = ("model",)
         shard_specs[layer.mlp.router.weight] = (None, batch_axis)
-        shard_specs[layer.mlp.experts.gate_up_proj] = (("model", "batch"), None, None)
-        shard_specs[layer.mlp.experts.gate_up_proj_bias] = (("model", "batch"), None)
-        shard_specs[layer.mlp.experts.down_proj] = (("model", "batch"), None, None)
-        shard_specs[layer.mlp.experts.down_proj_bias] = (("model", "batch"), None)
+        # This is a temporary sharding spec to enable gpt oss to not get OOM on galaxy.
+        # Once the MoE module is refactored, this should be changed to EP 32.
+        shard_specs[layer.mlp.experts.gate_up_proj] = ("model", "batch", None)
+        shard_specs[layer.mlp.experts.gate_up_proj_bias] = ("model", None)
+        shard_specs[layer.mlp.experts.down_proj] = ("model", None, "batch")
+        shard_specs[layer.mlp.experts.down_proj_bias] = ("model", "batch")
         shard_specs[layer.input_layernorm.weight] = (batch_axis,)
         shard_specs[layer.post_attention_layernorm.weight] = (batch_axis,)
 

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -59,6 +59,8 @@ def test_llm(
     max_output_tokens=None,
     decode_only: bool = False,
     weight_dtype_overrides: dict = None,
+    input_output_sharding_spec=None,
+    kv_cache_sharding_spec=None,
 ):
     """Test LLM model with the given variant and optional configuration overrides.
 
@@ -150,6 +152,8 @@ def test_llm(
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
         weight_dtype_overrides=weight_dtype_overrides,
+        input_output_sharding_spec=input_output_sharding_spec,
+        kv_cache_sharding_spec=kv_cache_sharding_spec,
     )
 
     if output_file:
@@ -1631,4 +1635,81 @@ def test_gpt_oss_120b_tp_galaxy_batch_size_64(
             "model.layers.*.mlp.experts.gate_up_proj": "bfp_bf4",
             "model.layers.*.mlp.experts.down_proj": "bfp_bf4",
         },
+    )
+
+
+def _galaxy_mesh_config_fn(model_loader, num_devices):
+    """4x8 wormhole_galaxy mesh"""
+
+    if num_devices != 32:
+        raise ValueError("wormhole_galaxy benchmarks expect 32 devices (4x8 mesh).")
+    return (4, 8), ("batch", "model")
+
+
+def _moe_throughput_galaxy_shard_spec_fn(model_loader, model):
+    """Sharding specs for MoE models optimized for throughput on 4x8 galaxy mesh.
+    TP - 8 : DP - 4 : EP - 32
+    Inputs are sharded on the batch axis DP - 4. One tile per device so batch 128 should be used.
+    Attention weights are sharded on model axis TP - 8 and replicated along the batch axis.
+    Expert weights are sharded across both model and batch axes EP - 32.
+    """
+
+    batch_axis = None
+
+    shard_specs = {}
+
+    shard_specs[model.model.embed_tokens.weight] = (None, batch_axis)
+    shard_specs[model.model.norm.weight] = (batch_axis,)
+    # HF [vocab, hidden]: TP shard vocab (first dim); tt-metal transposes/pads on device — see tt-metal_galaxy_parallelism
+    shard_specs[model.lm_head.weight] = (None, None)
+
+    for layer in model.model.layers:
+        shard_specs[layer.self_attn.q_proj.weight] = ("model", batch_axis)
+        shard_specs[layer.self_attn.k_proj.weight] = ("model", batch_axis)
+        shard_specs[layer.self_attn.v_proj.weight] = ("model", batch_axis)
+        shard_specs[layer.self_attn.o_proj.weight] = (batch_axis, "model")
+        shard_specs[layer.self_attn.sinks] = ("model",)
+        shard_specs[layer.mlp.router.weight] = (None, batch_axis)
+        shard_specs[layer.mlp.experts.gate_up_proj] = (("model", "batch"), None, None)
+        shard_specs[layer.mlp.experts.gate_up_proj_bias] = (("model", "batch"), None)
+        shard_specs[layer.mlp.experts.down_proj] = (("model", "batch"), None, None)
+        shard_specs[layer.mlp.experts.down_proj_bias] = (("model", "batch"), None)
+        shard_specs[layer.input_layernorm.weight] = (batch_axis,)
+        shard_specs[layer.post_attention_layernorm.weight] = (batch_axis,)
+
+    return shard_specs
+
+
+def test_gpt_oss_120b_tp_dp_galaxy_batch_size_128(
+    output_file,
+    num_layers,
+    request,
+    accuracy_testing,
+    batch_size,
+    max_output_tokens,
+    decode_only,
+):
+    from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
+        ModelLoader,
+        ModelVariant,
+    )
+
+    variant = ModelVariant.GPT_OSS_120B
+    test_llm_tp(
+        ModelLoader,
+        variant,
+        output_file,
+        num_layers=num_layers,
+        request=request,
+        accuracy_testing=accuracy_testing,
+        max_output_tokens=max_output_tokens,
+        decode_only=decode_only,
+        batch_size=128,
+        arch="wormhole_galaxy",
+        optimization_level=1,
+        mesh_config_fn=_galaxy_mesh_config_fn,
+        shard_spec_fn=_moe_throughput_galaxy_shard_spec_fn,
+        input_output_sharding_spec=("batch", None),
+        kv_cache_sharding_spec=("batch", "model", None, None),
+        trace_enabled=True,
     )


### PR DESCRIPTION
## Summary
- Add GPT-OSS 120B benchmark with TP=8, DP=4, EP=32 on a 4x8 Galaxy mesh (batch size 128)
- Extend benchmark framework with `input_output_sharding_spec` and `kv_cache_sharding_spec` parameters for flexible input/KV cache sharding
- Update `LLMSamplingWrapper` to produce sharded and replicated copies of `next_token_ids` to avoid recompilation during decode
- Add the new test to the perf-bench CI matrix

## What's changed
- **`tests/benchmark/test_llms.py`**: New test `test_gpt_oss_120b_tp_dp_galaxy_batch_size_128` with a 4x8 mesh config and MoE sharding specs — attention weights TP=8, expert weights EP=32, inputs DP=4
- **`tests/benchmark/benchmarks/llm_benchmark.py`**: New `input_output_sharding_spec` and `kv_cache_sharding_spec` parameters to allow per-test control of input and KV cache sharding (previously hardcoded)
- **`tests/benchmark/llm_utils/decode_utils.py`**: `LLMSamplingWrapper` now returns both sharded and replicated `next_token_ids` — sharded version feeds the next decode step, replicated version transfers to CPU without triggering an extra all-gather graph
- **`.github/workflows/perf-bench-matrix.json`**: Added the new test to the CI matrix on `galaxy-wh-6u`

## Perf benchmark run
https://github.com/tenstorrent/tt-xla/actions/runs/24247948813

## Known Issues
- PCC is bad and needs to be debugged — tracked in #4206

