### PR TITLE
[vLLM] Split KV cache into separate K/V tensors to fix decode perf regression

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/attention.py
+++ b/integrations/vllm_plugin/vllm_tt/attention.py
@@ -101,7 +101,8 @@ class TTAttentionBackend(AttentionBackend):
         head_size: int,
         cache_dtype_str: str = "auto",
     ) -> tuple[int, ...]:
-        return (2, num_blocks, num_kv_heads, block_size, head_size)
+        # Shape for one of the two separate K/V tensors per layer.
+        return (num_blocks, num_kv_heads, block_size, head_size)
 
     @staticmethod
     def swap_blocks(
@@ -274,8 +275,9 @@ class TTAttentionBackendImpl(AttentionImpl):
         # Prepare inputs and metadata
         inputs = self._prepare_inputs(query, key, value, attn_metadata)
 
-        # Handle paged attention if KV cache exists
-        if kv_cache.numel() > 1:
+        # kv_cache is [k_cache, v_cache] after init, but a scalar placeholder
+        # during profiling — isinstance distinguishes the two cases.
+        if isinstance(kv_cache, (list, tuple)) and kv_cache[0].numel() > 0:
             self._handle_paged_attention(inputs, kv_cache, attn_metadata)
 
         # Compute attention based on mode:
@@ -442,7 +444,7 @@ class TTAttentionBackendImpl(AttentionImpl):
         return query, key, value
 
     def _handle_paged_attention(
-        self, inputs, kv_cache: torch.Tensor, attn_metadata: TTMetadata
+        self, inputs, kv_cache: list[torch.Tensor], attn_metadata: TTMetadata
     ):
         """Handle paged attention cache updates."""
         k_cache = kv_cache[0]
@@ -488,9 +490,9 @@ class TTAttentionBackendImpl(AttentionImpl):
                     ),
                 )
 
-        # Update the KV cache
-        new_kv_cache = torch.stack([k_cache, v_cache], dim=0)
-        kv_cache.copy_(new_kv_cache)
+        # Preserve tensor identity so XLA reuses the traced graph.
+        kv_cache[0].copy_(k_cache)
+        kv_cache[1].copy_(v_cache)
 
     def _compute_full_attention(
         self, inputs, attn_metadata: TTMetadata
@@ -521,7 +523,7 @@ class TTAttentionBackendImpl(AttentionImpl):
         return output
 
     def _compute_decode_attention(
-        self, inputs, kv_cache: torch.Tensor, attn_metadata: TTMetadata
+        self, inputs, kv_cache: list[torch.Tensor], attn_metadata: TTMetadata
     ) -> torch.Tensor:
         """Compute attention for decode phase (paged)."""
         k_cache = kv_cache[0]

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -2058,11 +2058,12 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     )
                     dtype = kv_cache_spec.dtype
 
-                    tpu_kv_cache = torch.zeros(kv_cache_shape, dtype=dtype).to(
-                        self.device
-                    )
+                    # Allocate separate K and V cache tensors to avoid
+                    # slice/concat copies in the compiled decode graph.
+                    k_cache = torch.zeros(kv_cache_shape, dtype=dtype).to(self.device)
+                    v_cache = torch.zeros(kv_cache_shape, dtype=dtype).to(self.device)
 
-                    kv_caches[layer_name] = tpu_kv_cache
+                    kv_caches[layer_name] = [k_cache, v_cache]
                 else:
                     raise NotImplementedError
 
@@ -2076,10 +2077,11 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         )
 
         if self.enable_tensor_parallel:
-            # Shard KV Cache
-            for cache in self.kv_caches:
-                assert cache.ndim == 5, "KV cache tensor must be 5D."
-                xs.mark_sharding(cache, self.mesh, (None, None, "batch", None, None))
+            # Shard KV Cache — each entry is [k_cache, v_cache]
+            for kv_pair in self.kv_caches:
+                for cache in kv_pair:
+                    assert cache.ndim == 4, "KV cache tensor must be 4D."
+                    xs.mark_sharding(cache, self.mesh, (None, "batch", None, None))
 
         if has_kv_transfer_group():
             get_kv_transfer_group().register_kv_caches(kv_caches)
@@ -2492,8 +2494,14 @@ def copy_kv_blocks(
     ):
         return
 
-    src_device = next(iter(src_kv_caches.values())).device
-    dst_device = next(iter(dst_kv_caches.values())).device
+    src_val = next(iter(src_kv_caches.values()))
+    dst_val = next(iter(dst_kv_caches.values()))
+    src_device = (
+        src_val[0].device if isinstance(src_val, (list, tuple)) else src_val.device
+    )
+    dst_device = (
+        dst_val[0].device if isinstance(dst_val, (list, tuple)) else dst_val.device
+    )
 
     src_indices, dst_indices = _make_src_and_dst_indices(
         src_block_ids=src_block_ids,
@@ -2504,9 +2512,13 @@ def copy_kv_blocks(
 
     _copy_fn = _insert_blocks_to_tpu if direction == "h2d" else _swap_out_tpu_blocks
     for layer_name in src_kv_caches:
-        src_tensor = src_kv_caches[layer_name]
-        dst_tensor = dst_kv_caches[layer_name]
-        _copy_fn(src_tensor, dst_tensor, src_indices, dst_indices)
+        src_kv = src_kv_caches[layer_name]
+        dst_kv = dst_kv_caches[layer_name]
+        if isinstance(src_kv, (list, tuple)):
+            for src_tensor, dst_tensor in zip(src_kv, dst_kv):
+                _copy_fn(src_tensor, dst_tensor, src_indices, dst_indices)
+        else:
+            _copy_fn(src_kv, dst_kv, src_indices, dst_indices)
 
 
 def _get_padded_num_kv_cache_update_slices(


### PR DESCRIPTION
## Ticket

Fixes #4197

## Problem

Decode throughput scaled inversely with `gpu_memory_utilization` — 3.2x slower at 10x cache size, compiler crash at 0.5+. First observed serving Llama-3.1-8B on N150 (11 → 2.5 tok/s from 0.1 → 0.9).

The combined `(2, num_blocks, ...)` KV cache layout forced a slice → update → concat pattern per layer per decode step, compiling to 3 full-cache-sized copies in the TTNN graph. All scaled linearly with `num_blocks`.

## What's changed

- **`attention.py`**: `get_kv_cache_shape` returns `(num_blocks, heads, block_size, head_dim)` — single cache shape, no `(2, ...)` prefix. `_handle_paged_attention` replaces `torch.stack` + `copy_` with direct `kv_cache[0].copy_(k_cache)`. Forward check updated for list-based cache.
- **`model_runner.py`**: `initialize_kv_cache` allocates `[k_cache, v_cache]` per layer. TP sharding and `copy_kv_blocks` updated to handle the list format.

## Results

Huge perf increase. OPT-125M, single N150:
  - `gpu_memory_utilization=0.005`: 61.9 → **74.8 tok/s** (1.2x)
  - `gpu_memory_utilization=0.1`: 12.0 → **76.0 tok/s** (6.3x)
  - `gpu_memory_utilization=0.2`: 6.3 → **80.7 tok/s** (12.8x)
  - `gpu_memory_utilization=0.5`: FAILED → **80.2 tok/s**
  - `gpu_memory_utilization=0.8`: FAILED → **79.9 tok/s**

Cherry-picked to tt-inference-server on P150 running demos:
- Llama-3.1-8B-Instruct and Qwen3-8B: 10.5 → **18-19 tok/s** (~1.8x) at default `gpu_memory_utilization=0.1`

## Checklist

- [x] OPT-125M single and multi batch — pass
- [x] Benchmarked at 0.005, 0.05, 0.1, 0.2, 0.5, 0.8
- [x] Llama-3.1-8B / Qwen3-8B on tt-inference-server — validated