### PR TITLE
[Benchmark] gpt_oss_120b benchmark test for QB2

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -201,6 +201,12 @@
         "runs-on": "galaxy-wh-6u"
       },
       {
+        "name": "gpt_oss_120b_tp_qb2",
+        "pyreq": "datasets loguru pytest requests accelerate torch==2.9.0 tqdm transformers==5.2.0",
+        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_120b_tp_qb2",
+        "runs-on": "qb2-blackhole"
+      },
+      {
         "name": "microsoft_phi-1",
         "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_phi1"

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -1713,3 +1713,65 @@ def test_gpt_oss_120b_tp_dp_galaxy_batch_size_128(
         kv_cache_sharding_spec=("batch", "model", None, None),
         trace_enabled=True,
     )
+
+
+def _gpt_oss_120b_qb2_mesh_config_fn(model_loader, num_devices):
+    return (1, 4), ("batch", "model")
+
+
+def _gpt_oss_120b_qb2_shard_spec_fn(model_loader, model):
+    """QB2 (1,4) mesh shard specs — model-axis-only, no batch sharding."""
+    shard_specs = {}
+    shard_specs[model.model.embed_tokens.weight] = (None, None)
+    shard_specs[model.model.norm.weight] = (None,)
+
+    for layer in model.model.layers:
+        shard_specs[layer.self_attn.q_proj.weight] = ("model", None)
+        shard_specs[layer.self_attn.k_proj.weight] = ("model", None)
+        shard_specs[layer.self_attn.v_proj.weight] = ("model", None)
+        shard_specs[layer.self_attn.o_proj.weight] = (None, "model")
+        shard_specs[layer.self_attn.sinks] = (None,)
+        shard_specs[layer.mlp.experts.gate_up_proj] = ("model", None, None)
+        shard_specs[layer.mlp.experts.gate_up_proj_bias] = ("model", None)
+        shard_specs[layer.mlp.experts.down_proj] = ("model", None, None)
+        shard_specs[layer.mlp.experts.down_proj_bias] = ("model", None)
+    return shard_specs
+
+
+def test_gpt_oss_120b_tp_qb2(
+    output_file,
+    num_layers,
+    request,
+    accuracy_testing,
+    batch_size,
+    max_output_tokens,
+    decode_only,
+):
+    from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
+        ModelLoader,
+        ModelVariant,
+    )
+
+    variant = ModelVariant.GPT_OSS_120B
+    test_llm_tp(
+        ModelLoader,
+        variant,
+        output_file,
+        num_layers=num_layers,
+        request=request,
+        accuracy_testing=accuracy_testing,
+        max_output_tokens=max_output_tokens,
+        decode_only=decode_only,
+        batch_size=batch_size if batch_size is not None else 8,
+        arch="blackhole_qb2",
+        optimization_level=1,
+        trace_enabled=False,
+        experimental_weight_dtype="",
+        weight_dtype_overrides={
+            "default": "bfp_bf8",
+            "model.layers.*.mlp.experts.gate_up_proj": "bfp_bf4",
+            "model.layers.*.mlp.experts.down_proj": "bfp_bf4",
+        },
+        mesh_config_fn=_gpt_oss_120b_qb2_mesh_config_fn,
+        shard_spec_fn=_gpt_oss_120b_qb2_shard_spec_fn,
+    )

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -1772,7 +1772,7 @@ def test_gpt_oss_120b_tp_qb2(
             "model.layers.*.mlp.experts.gate_up_proj": "bfp_bf4",
             "model.layers.*.mlp.experts.down_proj": "bfp_bf4",
         },
-        required_pcc=0.93, # set for now as it's ~0.93 on test runs locally
+        required_pcc=0.93,  # set for now as it's ~0.93 on test runs locally
         mesh_config_fn=_gpt_oss_120b_qb2_mesh_config_fn,
-        shard_spec_fn=_gpt_oss_120b_qb2_shard_spec_fn,
+        # shard_spec_fn=_gpt_oss_120b_qb2_shard_spec_fn,
     )

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -1765,7 +1765,7 @@ def test_gpt_oss_120b_tp_qb2(
         batch_size=batch_size if batch_size is not None else 8,
         arch="qb2-blackhole",
         optimization_level=1,
-        trace_enabled=False,
+        trace_enabled=True,
         experimental_weight_dtype="bfp_bf8",
         weight_dtype_overrides={
             "default": "bfp_bf8",

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -1763,15 +1763,16 @@ def test_gpt_oss_120b_tp_qb2(
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
         batch_size=batch_size if batch_size is not None else 8,
-        arch="blackhole_qb2",
+        arch="qb2-blackhole",
         optimization_level=1,
         trace_enabled=False,
-        experimental_weight_dtype="",
+        experimental_weight_dtype="bfp_bf8",
         weight_dtype_overrides={
             "default": "bfp_bf8",
             "model.layers.*.mlp.experts.gate_up_proj": "bfp_bf4",
             "model.layers.*.mlp.experts.down_proj": "bfp_bf4",
         },
+        required_pcc=0.93, # set for now as it's ~0.93 on test runs locally
         mesh_config_fn=_gpt_oss_120b_qb2_mesh_config_fn,
         shard_spec_fn=_gpt_oss_120b_qb2_shard_spec_fn,
     )

--- a/tests/benchmark/utils.py
+++ b/tests/benchmark/utils.py
@@ -62,6 +62,8 @@ def get_device_type(arch: str, device_count: int) -> str:
             return "p150"
         if device_count == 2:
             return "p300"
+        if device_count == 4:
+            return "qb2-blackhole"
 
     return "unknown"
 


### PR DESCRIPTION
### Ticket
#3954 

### Problem description
GPT-OSS 120B does not have a benchmark test for Blackhole QB2. 

### What's changed
- Added `test_gpt_oss_120b_tp_qb2` benchmark test targeting `qb2-blackhole` with batch size 8 and dense mlp.
- Added QB2-specific mesh configuration `(1, 4)`.
- Added QB2-specific shard specs.
- Configured mixed precision: global `experimental_weight_dtype=bfp_bf8` for all weights, plus per-tensor `weight_dtype_overrides` with `bfp_bf4` for `gate_up_proj` and `down_proj` expert weights.
- Lowered PCC threshold to 0.93 for now.
- Added `qb2-blackhole` entry to `perf-bench-matrix.json` for CI.
- Added 4-device blackhole case (`qb2-blackhole`) to `get_device_type()` in benchmark utils.

### Checklist
- [x] New/Existing tests provide coverage for changes
