### PR TITLE
Fix Whisper large-v3/turbo PCC drop

### DIFF
--- a/tests/torch/models/whisper/test_whisper.py
+++ b/tests/torch/models/whisper/test_whisper.py
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from infra import ComparisonConfig, RunMode
+import torch
+from infra import RunMode
 from utils import BringupStatus, Category, failed_ttmlir_compilation
 
 from third_party.tt_forge_models.whisper.pytorch import ModelLoader, ModelVariant
@@ -20,7 +21,10 @@ _FAILING_VARIANTS = [
     ModelVariant.WHISPER_LARGE,
 ]
 
-_NO_ASSERT_PCC_VARIANTS = [
+# whisper-large-v3 and large-v3-turbo have torch_dtype=float16 in their HuggingFace configs
+# (previously float32 in transformers 4.57.1), causing a PCC drop from >0.99 to ~0.53.
+# Smaller models still have float32 in config and are unaffected.
+_FLOAT16_CONFIG_VARIANTS = [
     ModelVariant.WHISPER_LARGE_V3,
     ModelVariant.WHISPER_LARGE_V3_TURBO,
 ]
@@ -74,10 +78,8 @@ def inference_tester(request) -> WhisperTester:
     """Fixture that returns a WhisperTester configured for each model variant."""
     variant, bringup_status = request.param
     request.node.bringup_status = bringup_status
-    comparison_config = ComparisonConfig()
-    if variant in _NO_ASSERT_PCC_VARIANTS:
-        comparison_config.pcc.disable()
-    return WhisperTester(variant, comparison_config=comparison_config)
+    dtype_override = torch.float32 if variant in _FLOAT16_CONFIG_VARIANTS else None
+    return WhisperTester(variant, dtype_override=dtype_override)
 
 
 # ----- Tests -----

--- a/tests/torch/models/whisper/tester.py
+++ b/tests/torch/models/whisper/tester.py
@@ -2,8 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Dict, Sequence
+from typing import Any, Dict, Optional, Sequence
 
+import torch
 from infra import ComparisonConfig, Model, RunMode, TorchModelTester
 
 from third_party.tt_forge_models.whisper.pytorch import ModelLoader
@@ -19,15 +20,17 @@ class WhisperTester(TorchModelTester):
         variant_name,
         comparison_config: ComparisonConfig = ComparisonConfig(),
         run_mode: RunMode = RunMode.INFERENCE,
+        dtype_override: Optional[torch.dtype] = None,
         **kwargs,
     ) -> None:
         self._variant_name = variant_name
+        self._dtype_override = dtype_override
         self._model_loader = ModelLoader(variant_name)
         super().__init__(comparison_config, run_mode, **kwargs)
 
     # @override
     def _get_model(self) -> Model:
-        model = self._model_loader.load_model()
+        model = self._model_loader.load_model(dtype_override=self._dtype_override)
         model = WhisperWrapper(model, variant=self._variant_name)
         return model
 


### PR DESCRIPTION
### Ticket
#4127 

### Problem description
Transformers 5.x respects the HuggingFace config's torch_dtype when calling from_pretrained. `whisper-large-v3` and `whisper-large-v3-turbo` have `torch_dtype=float16` in their configs now but used to have `float32` in 4.57.1, so they now load in `float16`. This causes a drop in PCC from >0.99 to ~0.53. Smaller models (medium and below) still have `torch_dtype=float32` in config and were unaffected.

### What's changed
Force `torch_dtype=torch.float32` to restore the pre-uplift behavior. Added dtype_override specification option to whisper tester.

### Checklist
- [x] New/Existing tests provide coverage for changes
