### PR TITLE
Weekly maintenance updates - Apr 11

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_data_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_data_parallel.yaml
@@ -126,7 +126,6 @@ test_config:
   albert/masked_lm/pytorch-Large_v2-data_parallel-inference:
     supported_archs: [n300]
     status: EXPECTED_PASSING
-    required_pcc: 0.98
 
   albert/token_classification/pytorch-Large_v2-data_parallel-inference:
     supported_archs: [n300]
@@ -727,9 +726,7 @@ test_config:
 
   albert/token_classification/pytorch-Xxlarge_v2-data_parallel-inference:
     supported_archs: [n300]
-    assert_pcc: false
     status: EXPECTED_PASSING
-    reason: "Calculated: pcc=0.9272822141647339. Required: pcc=0.99."
 
   regnet/pytorch-Y_120-data_parallel-inference:
     supported_archs: [n300]

--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -73,7 +73,7 @@ test_config:
     status: EXPECTED_PASSING
 
   xglm/pytorch-1.7b-single_device-inference:
-    required_pcc: 0.97 # PCC was >0.99 while it was calculated in f32. ATOL is outrageously bad so a drop is not unexpected; also https://github.com/tenstorrent/tt-xla/issues/2944
+    required_pcc: 0.98 # PCC was >0.99 while it was calculated in f32. ATOL is outrageously bad so a drop is not unexpected; also https://github.com/tenstorrent/tt-xla/issues/2944
     status: EXPECTED_PASSING
 
   resnet/pytorch-ResNet50_HuggingFace-single_device-inference:
@@ -283,7 +283,6 @@ test_config:
     status: EXPECTED_PASSING
 
   dpr/reader/pytorch-Reader_Multiset_Base-single_device-inference:
-    assert_pcc: false # PCC: 0.9345 - https://github.com/tenstorrent/tt-xla/actions/runs/21091184273
     status: EXPECTED_PASSING
 
   efficientnet/pytorch-B0-single_device-inference:
@@ -573,9 +572,11 @@ test_config:
   phi2/token_classification/pytorch-Phi_2_Pytdml-single_device-inference:
     arch_overrides:
       p150:
+        required_pcc: 0.98
         status: EXPECTED_PASSING
       n150:
         status: EXPECTED_PASSING
+        required_pcc: 0.98
 
   phi2/sequence_classification/pytorch-Phi_2-single_device-inference:
     status: EXPECTED_PASSING
@@ -904,8 +905,11 @@ test_config:
     status: EXPECTED_PASSING
 
   qwen_2_5_coder/pytorch-1.5B-single_device-inference:
-    assert_pcc: false
     status: EXPECTED_PASSING
+    arch_overrides:
+      n150:
+        required_pcc: 0.98
+        status: EXPECTED_PASSING
 
   retinanet/pytorch-ResNet34_Backbone_with_FPN-single_device-inference:
     assert_pcc: false
@@ -941,12 +945,7 @@ test_config:
     status: EXPECTED_PASSING
 
   qwen_2_5_coder/pytorch-1.5B_Instruct-single_device-inference:
-    arch_overrides:
-      n150:
-        required_pcc: 0.98
-        status: EXPECTED_PASSING
-      p150:
-        status: EXPECTED_PASSING
+      status: EXPECTED_PASSING
 
   qwen_2_5_coder/pytorch-0.5B-single_device-inference:
     status: EXPECTED_PASSING

--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -209,6 +209,7 @@ test_config:
     supported_archs: [n300-llmbox]
     assert_pcc: false # PCC comparison failed. Calculated: pcc=0.9757716745992953. Required: pcc=0.99
     status: EXPECTED_PASSING
+    required_pcc: 0.97
 
   mistral/pytorch-mistral_small_3.2_24b_instruct_2506-tensor_parallel-inference:
     supported_archs: [n300-llmbox]


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Weekly maintenance updates - Apr 11
ci run: https://github.com/tenstorrent/tt-xla/actions/runs/24278438093

### What's changed
Since the following models are passing in the latest weekly run, I have updated the configuration files accordingly.

```
test_all_models_torch[albert/masked_lm/pytorch-Large_v2-data_parallel-inference]                                                           language    generality  bfloat16       n300         PASSED                     PASSING       0.9950646604824124     0.98       PCC_EN   data_parallel    91.740   RAISE_PCC_099 

test_all_models_torch[albert/token_classification/pytorch-Xxlarge_v2-data_parallel-inference]                                              language    generality  bfloat16       n300         PASSED                     PASSING       0.9960426338937718     0.99       PCC_DIS  data_parallel    66.944   ENABLE_PCC_099

test_all_models_torch[dpr/reader/pytorch-Reader_Multiset_Base-single_device-inference]                                                     language    generality  bfloat16       n150         PASSED                     PASSING       0.999741121185756      0.99       PCC_DIS  single_device    58.715   ENABLE_PCC_099

test_all_models_torch[qwen_2_5_coder/pytorch-1.5B-single_device-inference]                                                                 language    generality  bfloat16       p150         PASSED                     PASSING       0.9953428826373427     0.99       PCC_DIS  single_device    67.519   ENABLE_PCC_099
test_all_models_torch[qwen_2_5_coder/pytorch-1.5B-single_device-inference]                                                                 language    generality  bfloat16       n150         INCORRECT_RESULT           PASSING       0.983890484373543      0.99       PCC_DIS  single_device    80.820   N/A           

test_all_models_torch[qwen_2_5_coder/pytorch-1.5B_Instruct-single_device-inference]                                                        language    generality  bfloat16       n150         PASSED                     PASSING       0.9958706820608456     0.98       PCC_EN   single_device    101.676  RAISE_PCC_099 


test_all_models_torch[xglm/pytorch-1.7b-single_device-inference]                                                                           language    generality  bfloat16       n150         PASSED                     PASSING       0.9886072197196654     0.97       PCC_EN   single_device    125.374  RAISE_PCC     
test_all_models_torch[xglm/pytorch-1.7b-single_device-inference]                                                                           language    generality  bfloat16       p150         PASSED                     PASSING       0.9883935103843051     0.97       PCC_EN   single_device    91.262   RAISE_PCC     

test_all_models_torch[mistral/pytorch-mistral_small_3.1_24b_instruct_2503-tensor_parallel-inference]                                       language    generality  bfloat16       n300-llmbox  INCORRECT_RESULT           PASSING       0.9733573518020272     0.99       PCC_DIS  tensor_parallel  797.715  N/A           

```

### Checklist
- [ ] New/Existing tests provide coverage for changes
