### PR TITLE
Bring up DeBERTa-v3-base on TT hardware

### DIFF
--- a/tests/benchmark/test_encoders.py
+++ b/tests/benchmark/test_encoders.py
@@ -153,6 +153,65 @@ def test_encoder(
             json.dump(results, file, indent=2)
 
 
+def test_deberta_v3_base(output_file, num_layers, request):
+    from third_party.tt_forge_models.deberta.sentence_embedding_generation.pytorch.loader import (
+        ModelLoader,
+    )
+
+    # Configuration
+    data_format = "bfloat16"
+    input_sequence_length = 128
+
+    # Load model with specified dtype
+    loader = create_model_loader(ModelLoader, num_layers=num_layers)
+    if num_layers is not None and loader is None:
+        pytest.fail(
+            "num_layers override requested but ModelLoader does not support it."
+        )
+    model_info_name = loader.get_model_info().name
+    print(f"\nLoading model {model_info_name}...")
+    model = loader.load_model(dtype_override=DTYPE_MAP[data_format])
+
+    # Create function for loading raw inputs
+    load_inputs_fn = get_default_inputs
+
+    # Create input preprocessing function
+    tokenizer = loader.tokenizer
+    tokenizer.padding_side = "right"
+    preprocess_fn = lambda sentences, device: {
+        k: v.to(device)
+        for k, v in tokenizer(
+            sentences,
+            padding="max_length",
+            truncation=True,
+            max_length=input_sequence_length,
+            return_tensors="pt",
+        ).items()
+    }
+
+    # Create output processing function (mean pooling)
+    output_processor_fn = lambda out, inputs: apply_mean_pooling(
+        out.last_hidden_state, inputs["attention_mask"]
+    )
+
+    test_encoder(
+        model=model,
+        model_info_name=model_info_name,
+        output_file=output_file,
+        display_name="deberta_v3_base",
+        request=request,
+        load_inputs_fn=load_inputs_fn,
+        preprocess_fn=preprocess_fn,
+        output_processor_fn=output_processor_fn,
+        data_format=data_format,
+        num_layers=num_layers,
+        batch_size=1,
+        input_sequence_length=input_sequence_length,
+        loop_count=32,
+        optimization_level=1,
+    )
+
+
 def test_bert(output_file, num_layers, request):
     from third_party.tt_forge_models.bert.sentence_embedding_generation.pytorch.loader import (
         ModelLoader,

--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -718,6 +718,10 @@ test_config:
   bert/sentence_embedding_generation/pytorch-emrecan/bert-base-turkish-cased-mean-nli-stsb-tr-single_device-inference:
     status: EXPECTED_PASSING
 
+  deberta/sentence_embedding_generation/pytorch-microsoft/deberta-v3-base-single_device-inference:
+    status: EXPECTED_PASSING
+    required_pcc: 0.99
+
   yolos/pytorch-single_device-inference:
     required_pcc: 0.96 # https://github.com/tenstorrent/tt-xla/issues/1168 https://github.com/tenstorrent/tt-xla/issues/2759
     assert_pcc: false # PCC: 0.9592 - https://github.com/tenstorrent/tt-xla/actions/runs/21091184273


### PR DESCRIPTION
## Summary
- Add `test_deberta_v3_base` benchmark test in `test_encoders.py`
- Add YAML config entry (`EXPECTED_PASSING`, `required_pcc: 0.99`)
- Uplift `tt_forge_models` submodule to include DeBERTa loader

## Bringup results (Blackhole, bf16)
| Layers | PCC | opt_level | Samples/sec |
|--------|-----|-----------|-------------|
| 1 | 0.9989 | 1 | 72.4 |
| 2 | 0.9980 | 1 | 37.5 |
| 12 (full) | 0.9981 | 1 | 9.3 |

**Note:** `opt_level=2` degrades PCC to 0.929 on this model; benchmark uses `opt_level=1`.

## Dependencies
- tenstorrent/tt-forge-models#580

## Test plan
- [x] `pytest -svv tests/benchmark/test_encoders.py::test_deberta_v3_base --num-layers 1` — PASSED
- [x] `pytest -svv tests/benchmark/test_encoders.py::test_deberta_v3_base --num-layers 2` — PASSED
- [x] `pytest -svv tests/benchmark/test_encoders.py::test_deberta_v3_base` (full model) — PASSED
- [x] Test runner discovery and execution — PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)