### PR TITLE
Bring up GPT-2 Medium, MPNet, Nomic Embed

### DIFF
--- a/tests/benchmark/test_encoders.py
+++ b/tests/benchmark/test_encoders.py
@@ -153,6 +153,114 @@ def test_encoder(
             json.dump(results, file, indent=2)
 
 
+def test_mpnet_all_base_v2(output_file, num_layers, request):
+    from third_party.tt_forge_models.mpnet.sentence_embedding_generation.pytorch.loader import (
+        ModelLoader,
+    )
+
+    data_format = "bfloat16"
+    input_sequence_length = 128
+
+    loader = create_model_loader(ModelLoader, num_layers=num_layers)
+    if num_layers is not None and loader is None:
+        pytest.fail(
+            "num_layers override requested but ModelLoader does not support it."
+        )
+    model_info_name = loader.get_model_info().name
+    print(f"\nLoading model {model_info_name}...")
+    model = loader.load_model(dtype_override=DTYPE_MAP[data_format])
+
+    load_inputs_fn = get_default_inputs
+
+    tokenizer = loader.tokenizer
+    tokenizer.padding_side = "right"
+    preprocess_fn = lambda sentences, device: {
+        k: v.to(device)
+        for k, v in tokenizer(
+            sentences,
+            padding="max_length",
+            truncation=True,
+            max_length=input_sequence_length,
+            return_tensors="pt",
+        ).items()
+    }
+
+    output_processor_fn = lambda out, inputs: apply_mean_pooling(
+        out.last_hidden_state, inputs["attention_mask"]
+    )
+
+    test_encoder(
+        model=model,
+        model_info_name=model_info_name,
+        output_file=output_file,
+        display_name="mpnet_all_base_v2",
+        request=request,
+        load_inputs_fn=load_inputs_fn,
+        preprocess_fn=preprocess_fn,
+        output_processor_fn=output_processor_fn,
+        data_format=data_format,
+        num_layers=num_layers,
+        batch_size=1,
+        input_sequence_length=input_sequence_length,
+        loop_count=32,
+        optimization_level=1,
+    )
+
+
+def test_nomic_embed_text_v1_5(output_file, num_layers, request):
+    from third_party.tt_forge_models.nomic_embed.sentence_embedding_generation.pytorch.loader import (
+        ModelLoader,
+    )
+
+    data_format = "bfloat16"
+    input_sequence_length = 128
+
+    loader = create_model_loader(ModelLoader, num_layers=num_layers)
+    if num_layers is not None and loader is None:
+        pytest.fail(
+            "num_layers override requested but ModelLoader does not support it."
+        )
+    model_info_name = loader.get_model_info().name
+    print(f"\nLoading model {model_info_name}...")
+    model = loader.load_model(dtype_override=DTYPE_MAP[data_format])
+
+    load_inputs_fn = get_default_inputs
+
+    tokenizer = loader.tokenizer
+    tokenizer.padding_side = "right"
+    preprocess_fn = lambda sentences, device: {
+        k: v.to(device)
+        for k, v in tokenizer(
+            sentences,
+            padding="max_length",
+            truncation=True,
+            max_length=input_sequence_length,
+            return_tensors="pt",
+        ).items()
+    }
+
+    output_processor_fn = lambda out, inputs: apply_mean_pooling(
+        out.last_hidden_state, inputs["attention_mask"]
+    )
+
+    test_encoder(
+        model=model,
+        model_info_name=model_info_name,
+        output_file=output_file,
+        display_name="nomic_embed_text_v1_5",
+        request=request,
+        load_inputs_fn=load_inputs_fn,
+        preprocess_fn=preprocess_fn,
+        output_processor_fn=output_processor_fn,
+        data_format=data_format,
+        num_layers=num_layers,
+        batch_size=1,
+        input_sequence_length=input_sequence_length,
+        loop_count=32,
+        optimization_level=1,
+    )
+
+
 def test_bert(output_file, num_layers, request):
     from third_party.tt_forge_models.bert.sentence_embedding_generation.pytorch.loader import (
         ModelLoader,

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -526,6 +526,34 @@ def test_qwen_2_5_0_5b(
     )
 
 
+def test_gpt2_medium(
+    output_file,
+    num_layers,
+    request,
+    accuracy_testing,
+    batch_size,
+    max_output_tokens,
+    decode_only,
+):
+    from third_party.tt_forge_models.gpt2.pytorch.loader import (
+        ModelLoader,
+        ModelVariant,
+    )
+
+    variant = ModelVariant.GPT2_MEDIUM
+    test_llm(
+        ModelLoaderModule=ModelLoader,
+        variant=variant,
+        output_file=output_file,
+        num_layers=num_layers,
+        request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
+        max_output_tokens=max_output_tokens,
+        decode_only=decode_only,
+    )
+
+
 def test_qwen_3_0_6b(
     output_file,
     num_layers,

--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -1252,8 +1252,19 @@ test_config:
   gpt2/pytorch-Default-single_device-inference:
     status: EXPECTED_PASSING
 
+  gpt2/pytorch-Medium-single_device-inference:
+    status: EXPECTED_PASSING
+
   gpt2/pytorch-Sequence_Classification-single_device-inference:
     status: EXPECTED_PASSING
+
+  mpnet/sentence_embedding_generation/pytorch-sentence-transformers/all-mpnet-base-v2-single_device-inference:
+    status: EXPECTED_PASSING
+    required_pcc: 0.99
+
+  nomic_embed/sentence_embedding_generation/pytorch-nomic-ai/nomic-embed-text-v1.5-single_device-inference:
+    status: EXPECTED_PASSING
+    required_pcc: 0.99
 
   yolov9/pytorch-T-single_device-inference:
     required_pcc: 0.94


### PR DESCRIPTION
## Summary
- **GPT-2 Medium** (`openai-community/gpt2-medium`): LLM benchmark test + YAML config
- **all-mpnet-base-v2** (`sentence-transformers/all-mpnet-base-v2`): Encoder benchmark + YAML
- **nomic-embed-text-v1.5** (`nomic-ai/nomic-embed-text-v1.5`): Encoder benchmark + YAML
- **Qwen3-Embedding-0.6B**: Already on main, no changes needed

## Bringup results (Blackhole, bf16)
| Model | PCC | Samples/sec | opt_level |
|-------|-----|-------------|-----------|
| MPNet all-base-v2 | 0.9995 | 186 | 1 |
| Nomic Embed v1.5 | 0.9998 | 77 | 1 |
| GPT-2 Medium (1-layer) | 0.9998 | 77 | 1 |

## Known issues
- GPT-2 Medium full-model benchmark blocked by `tt_torch.weight_dtype` import removed from pip package
- Nomic Embed does not support `num_layers` reduction (custom NomicBert strict loading)

## Dependencies
- tenstorrent/tt-forge-models#581

## Test plan
- [x] `pytest -svv tests/benchmark/test_encoders.py::test_mpnet_all_base_v2` — PASSED
- [x] `pytest -svv tests/benchmark/test_encoders.py::test_nomic_embed_text_v1_5` — PASSED
- [x] `pytest -svv tests/benchmark/test_llms.py::test_gpt2_medium --num-layers 1` — PASSED (via 1-layer)
- [x] Test runner model discovery for all 3 models — verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)