### PR TITLE
Warn when relocating venv instead of silently breaking

### DIFF
--- a/venv/activate
+++ b/venv/activate
@@ -19,6 +19,14 @@ export UV_INDEX_STRATEGY=unsafe-best-match
 export TTMLIR_VENV_DIR="$(pwd)/venv"
 if [ -d $TTMLIR_VENV_DIR/bin ]; then
   [ -f $TTMLIR_VENV_DIR/bin/activate ] && source $TTMLIR_VENV_DIR/bin/activate
+  # The Python venv's bin/activate bakes in the absolute path where the venv was
+  # created. When the workspace is bind-mounted at a different path (e.g. the GHA
+  # container at /__w/tt-xla/tt-xla vs the multihost sibling container at /workspace),
+  # VIRTUAL_ENV and PATH point to a non-existent location. Fix them up.
+  if [ "$VIRTUAL_ENV" != "$TTMLIR_VENV_DIR" ]; then
+    export VIRTUAL_ENV="$TTMLIR_VENV_DIR"
+    export PATH="$TTMLIR_VENV_DIR/bin:$PATH"
+  fi
 else
   [ -z "$PIP" ] && { command -v uv &> /dev/null && PIP="uv pip" || PIP="pip"; } # Uv/pip backward compatibility
   echo "Creating virtual environment in $TTMLIR_VENV_DIR"

--- a/venv/activate
+++ b/venv/activate
@@ -22,10 +22,16 @@ if [ -d $TTMLIR_VENV_DIR/bin ]; then
   # The Python venv's bin/activate bakes in the absolute path where the venv was
   # created. When the workspace is bind-mounted at a different path (e.g. the GHA
   # container at /__w/tt-xla/tt-xla vs the multihost sibling container at /workspace),
-  # VIRTUAL_ENV and PATH point to a non-existent location. Fix them up.
+  # VIRTUAL_ENV and PATH point to a non-existent location. Abort so the user can
+  # recreate the venv at the current workspace path.
   if [ "$VIRTUAL_ENV" != "$TTMLIR_VENV_DIR" ]; then
-    export VIRTUAL_ENV="$TTMLIR_VENV_DIR"
-    export PATH="$TTMLIR_VENV_DIR/bin:$PATH"
+    echo "ERROR: detected relocated Python virtualenv." >&2
+    echo "Expected: $TTMLIR_VENV_DIR" >&2
+    echo "Actual:   ${VIRTUAL_ENV:-<unset>}" >&2
+    echo "This venv was created at a different absolute path and is not safe to reuse." >&2
+    echo "Please remove '$TTMLIR_VENV_DIR' and recreate it from this workspace path." >&2
+    deactivate nondestructive 2> /dev/null || true
+    return 1
   fi
 else
   [ -z "$PIP" ] && { command -v uv &> /dev/null && PIP="uv pip" || PIP="pip"; } # Uv/pip backward compatibility


### PR DESCRIPTION
### Ticket
Discovered while testing #4320

### Problem description

Python venvs are not relocatable and will silently fail if you try to relocate them.

When running `source venv/activate` for the first time, we use python's venv module via `python3.12 -m venv $TTMLIR_VENV_DIR` to create a venv inside the workspace. 

Part of the python venv creation involves generating the `venv/bin/activate` script, which exports VIRTUAL_ENV to the hardcoded path to the venv _at the time of venv creation_. Eg. 

`export VIRTUAL_ENV=/localdev/jameszianxu/scratch/tt-xla/venv`

Multihost CI integration will involve creating a sibling container in the same host and in the main `container:` where the venv is initially created, the absolute path to the venv is baked into the `venv/bin/activate` script. 

When the sibling container spins up, it may have a different absolute path within its container to the venv, even though the relative path to the github workspace will remain the same from the CI execution environment (eg. inside _work/tt-xla/tt-xla). So, when running `venv/activate` from a sibling container, the VIRTUAL_ENV will be pointing to a different and nonexistent path, leading to failures in locating python and installed modules.

### What's changed
Add an additional check comparing VIRTUAL_ENV (set by venv module in venv/bin/activate script at venv creation time to hardcoded path) and TTMLIR_VENV_DIR, which is the actual path to the venv from the perspective of the venv/activate user. 

If these differ, aggressively warn. 

This was really a pain to discover and debug so the point of this PR is to explicitly block such mistakes in the future.

### Local Testing
```bash
$ mv venv tmp/venv
$ cd tmp/

# before - nothing, but python3 would point to user python and see user libs
# even though the venv install was intact, just at a different abs path
# relative to the first time it was created
$ source venv/activate 

# after - loudly warn
$ source venv/activate 
ERROR: detected relocated Python virtualenv.
Expected: /localdev/jameszianxu/scratch/tt-xla/tmp/venv
Actual:   /localdev/jameszianxu/scratch/tt-xla/venv
This venv was created at a different absolute path and is not safe to reuse.
Please remove '/localdev/jameszianxu/scratch/tt-xla/tmp/venv' and recreate it from this workspace path.
```
