### PR TITLE
Add pytest.mark for vulcan models, exclude them from experimental nightly, add qb2-blackhole to ALLOWED_ARCHES

### DIFF
--- a/.github/workflows/test-matrix-presets/model-test-experimental.json
+++ b/.github/workflows/test-matrix-presets/model-test-experimental.json
@@ -1,8 +1,8 @@
 [
-  { "runs-on": "n150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "n150 and unspecified and inference and single_device", "parallel-groups": 3 },
-  { "runs-on": "p150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "p150 and unspecified and inference and single_device", "parallel-groups": 3 },
-  { "runs-on": "n150", "name": "run_forge_models_llm", "dir": "./tests/runner/test_models.py::test_llms_torch", "test-mark": "n150 and unspecified and inference and single_device", "parallel-groups": 2 },
-  { "runs-on": "p150", "name": "run_forge_models_llm", "dir": "./tests/runner/test_models.py::test_llms_torch", "test-mark": "p150 and unspecified and inference and single_device", "parallel-groups": 2 },
-  { "runs-on": "n150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "n150 and unspecified and inference and single_device", "parallel-groups": 1 },
-  { "runs-on": "p150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "p150 and unspecified and inference and single_device", "parallel-groups": 1 }
+  { "runs-on": "n150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "n150 and unspecified and inference and single_device and not vulcan", "parallel-groups": 3 },
+  { "runs-on": "p150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "p150 and unspecified and inference and single_device and not vulcan", "parallel-groups": 3 },
+  { "runs-on": "n150", "name": "run_forge_models_llm", "dir": "./tests/runner/test_models.py::test_llms_torch", "test-mark": "n150 and unspecified and inference and single_device and not vulcan", "parallel-groups": 2 },
+  { "runs-on": "p150", "name": "run_forge_models_llm", "dir": "./tests/runner/test_models.py::test_llms_torch", "test-mark": "p150 and unspecified and inference and single_device and not vulcan", "parallel-groups": 2 },
+  { "runs-on": "n150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "n150 and unspecified and inference and single_device and not vulcan", "parallel-groups": 1 },
+  { "runs-on": "p150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "p150 and unspecified and inference and single_device and not vulcan", "parallel-groups": 1 }
 ]

--- a/tests/runner/conftest.py
+++ b/tests/runner/conftest.py
@@ -170,6 +170,10 @@ def pytest_collection_modifyitems(config, items):
             # Add "red" marker for RED models to enable filtering like: -m red
             if model_group == ModelGroup.RED:
                 item.add_marker(pytest.mark.red)
+            elif model_group == ModelGroup.GENERALITY:
+                item.add_marker(pytest.mark.generality)
+            elif model_group == ModelGroup.VULCAN:
+                item.add_marker(pytest.mark.vulcan)
 
             # Apply schedule markers if not already specified in config
             has_schedule_marker = any(

--- a/tests/runner/test_config/constants.py
+++ b/tests/runner/test_config/constants.py
@@ -5,7 +5,14 @@
 """Shared constants for test configuration validation, loading, and discovery."""
 
 # Allowed architecture identifiers for arch_overrides and --arch option
-ALLOWED_ARCHES = {"n150", "p150", "n300", "n300-llmbox", "galaxy-wh-6u"}
+ALLOWED_ARCHES = {
+    "n150",
+    "p150",
+    "n300",
+    "n300-llmbox",
+    "galaxy-wh-6u",
+    "qb2-blackhole",
+}
 
 # Allowed fields in test_config YAML entries
 ALLOWED_FIELDS = {


### PR DESCRIPTION
### Ticket
None

### Problem description
- We want to be able to run vulcan models locally or on CI using -m vulcan
- We want vulcan models to be able to be merged to tt_forge_models but not get run in experimental-nightly which currently runs everything in tt-forge-models that is not explicitly added to tt-xla test_config files.
- We want to be able to qualify tests against blackhole quietbox-2 on CI

### What's changed
- Add support for automatically tag models with pytest.mark.vulcan (and pytest.mark.generality while we're here)
- Exclude vulcan models from experimental nightly job
- Add qb2-blackhole to test_models.py ALLOWED_ARCHES dict so can target CI w/o error

### Checklist
- [x] Tested collect-only -m vulcan works
- [x] tested -m vulcan with some tests on CI against QB2: https://github.com/tenstorrent/tt-xla/actions/runs/24370363374
