### PR TITLE
Add docker cli install in tt-xla-ci container for multihost call-test integration

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -1,4 +1,5 @@
 ARG MLIR_TAG=latest
+ARG DOCKER_CLI_IMAGE=docker:27.5.1-cli
 
 #============================================================================
 # Base image
@@ -22,11 +23,16 @@ RUN /tmp/install-tt-triage.sh || true
 # CI image
 #============================================================================
 
+FROM ${DOCKER_CLI_IMAGE} as docker-cli
+
 FROM ghcr.io/tenstorrent/tt-mlir/tt-mlir-ci-ubuntu-24-04:${MLIR_TAG} as ci
 SHELL ["/bin/bash", "-c"]
 
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
+
+# Install only the Docker CLI so this image can talk to a mounted host daemon.
+COPY --from=docker-cli /usr/local/bin/docker /usr/local/bin/docker
 
 # Install requirements.txt as global Python 3.11 packages
 COPY --chown=root:root --chmod=777 .github/docker_install.sh /tmp/script.sh

--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -1,5 +1,5 @@
 ARG MLIR_TAG=latest
-ARG DOCKER_CLI_IMAGE=docker:27.5.1-cli
+ARG DOCKER_CLI_IMAGE=docker:cli
 
 #============================================================================
 # Base image


### PR DESCRIPTION
### Ticket
Needed for #4230 

### Problem description
Need to use docker run/exec/stop/rm commands from inside our `container:`  to facilitate multihost integration without requiring a container escape. 

### What's changed
Install latest docker:cli image and copy into local. Based on precedent that metal-internal-workflows provisioning doesn't pin the docker version either.

There is a risk of version skew between host daemon from provisioning and the version installed inside the container, but I expect that to fail loudly, and will verify that it works before merging anything currently. 

### Checklist
- [] New/Existing tests provide coverage for changes
