### PR TITLE
Clean up getting started docs to use mnist + tinyllama model demos

### DIFF
--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -36,8 +36,14 @@ To install a wheel and run an example model, do the following:
 
 #### Step 1. Install the Latest Wheel:
 
+Download the latest wheel with pip.
 ```bash
 pip install pjrt-plugin-tt --extra-index-url https://pypi.eng.aws.tenstorrent.com/
+```
+
+Run the tt-forge-install script to install missing system dependencies.
+```
+tt-forge-install
 ```
 
 #### Step 2. Run some models:

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -42,23 +42,15 @@ pip install pjrt-plugin-tt --extra-index-url https://pypi.eng.aws.tenstorrent.co
 
 #### Step 2. Run a Model:
 
-- Navigate to the section of the [TT-Forge repo that contains TT-XLA demos](https://github.com/tenstorrent/tt-forge/tree/main/demos/tt-xla)
-
-- For this walkthrough, the [demo in the **TT-Forge** repo](https://github.com/tenstorrent/tt-forge/blob/main/demos/tt-xla/nlp/jax/gpt_demo.py) is used. In the **jax** folder, in the **requirements.txt** file, you can see that **flax** and **transformers** are necessary to run the demo. Install them:
-
-   ```bash
-   pip install flax transformers
-   ```
-
-- Download the [**gpt_demo.py** file ](https://github.com/tenstorrent/tt-forge/blob/main/demos/tt-xla/nlp/jax/gpt_demo.py ) The demo you are about to run takes a piece of text and tries to predict the next word that logically follows.
+- Download the [**mnist.py** example](https://github.com/tenstorrent/tt-xla/blob/main/examples/pytorch/mnist.py) from the TT-XLA repo. This demo runs a simple CNN model on a Tenstorrent device and compares the output against a CPU reference.
 
 - Run the model:
 
    ```bash
-   python gpt_demo.py
+   python mnist.py
    ```
 
-- If all goes well you should see the prompt "The capital of France is", the predicted next token, the probability it will occur, and a list of other ranked options that could follow instead.
+- If all goes well you should see the model output and a PCC (Pearson Correlation Coefficient) check confirming the TT device output matches the CPU reference.
 
 ---
 
@@ -86,36 +78,19 @@ This section walks through the installation steps for using a Docker container f
 
 #### Step 2: Running Models in Docker
 
-- Inside your running Docker container, clone the TT-Forge repo:
+- Inside your running Docker container, download the [**mnist.py** example](https://github.com/tenstorrent/tt-xla/blob/main/examples/pytorch/mnist.py) from the TT-XLA repo:
 
    ```bash
-   git clone https://github.com/tenstorrent/tt-forge.git
+   wget https://raw.githubusercontent.com/tenstorrent/tt-xla/main/examples/pytorch/mnist.py
    ```
 
-- Set the path for Python:
+- Run the model:
 
    ```bash
-   export PYTHONPATH=/tt-forge:$PYTHONPATH
+   python mnist.py
    ```
 
-- Navigate into TT-Forge and run the following command:
-
-   ```bash
-   git submodule update --init --recursive
-   ```
-
-- Run a model. For this example, the **demo.py** for **opt_125m** is used. Similar to **gpt2**, this model predicts what the next word in a sentence is likely to be.  The **requirements.txt** file shows that you need to install **flax** and **transformers**:
-
-   ```bash
-   pip install flax transformers
-   ```
-
-- After completing installation, run the following:
-
-   ```bash
-   python demos/tt-xla/nlp/pytorch/opt_demo.py
-   ```
-- If all goes well, you should get an example prompt saying 'The capital of France is.' The prediction for the next term is listed, along with the probability it will occur. This is followed by a table of other likely choices.
+- If all goes well you should see the model output and a PCC (Pearson Correlation Coefficient) check confirming the TT device output matches the CPU reference.
 
 ---
 
@@ -248,6 +223,6 @@ For more information please visit [pre-commit](https://pre-commit.com/).
 
 ## Where to Go Next
 
-- Try more demos in the [TT-XLA folder in the TT-Forge repo](https://github.com/tenstorrent/tt-forge/tree/main/demos/tt-xla)
+- Try more examples in the [TT-XLA examples directory](https://github.com/tenstorrent/tt-xla/tree/main/examples)
 - Learn about [Improving Model Performance](./performance.md)
 - Explore [Code Generation](./getting_started_codegen.md) to convert models into standalone code

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -40,17 +40,44 @@ To install a wheel and run an example model, do the following:
 pip install pjrt-plugin-tt --extra-index-url https://pypi.eng.aws.tenstorrent.com/
 ```
 
-#### Step 2. Run a Model:
+#### Step 2. Run some models:
 
-- Download the [**mnist.py** example](https://github.com/tenstorrent/tt-xla/blob/main/examples/pytorch/mnist.py) from the TT-XLA repo. This demo runs a simple CNN model on a Tenstorrent device and compares the output against a CPU reference.
+Use `wget` to fetch each demo script into your current directory, and install packages with pip when noted.
 
-- Run the model:
+**MNIST (small CNN)**
 
-   ```bash
-   python mnist.py
-   ```
+The [**mnist.py**](https://github.com/tenstorrent/tt-xla/blob/main/examples/pytorch/mnist.py) example runs a simple CNN on a Tenstorrent device and compares the output against a CPU reference.
 
-- If all goes well you should see the model output and a PCC (Pearson Correlation Coefficient) check confirming the TT device output matches the CPU reference.
+```bash
+wget https://raw.githubusercontent.com/tenstorrent/tt-xla/main/examples/pytorch/mnist.py
+python mnist.py
+```
+
+You should see the model output and a PCC (Pearson Correlation Coefficient) check confirming the TT device output matches the CPU reference.
+
+**Tiny Llama (Hugging Face `transformers`)**
+
+The [**tiny_llama_demo.py**](https://github.com/tenstorrent/tt-forge/blob/main/demos/tt-xla/nlp/pytorch/tiny_llama_demo.py) example in the TT-Forge repo loads a small LLM from Hugging Face, compiles it with `torch.compile(..., backend="tt")`, and prints top-token predictions. You must download the script and install [`transformers`](https://pypi.org/project/transformers/) (and its dependencies); the wheel install in Step 1 does not include them. The first run also downloads model weights from Hugging Face over the network.
+
+```bash
+wget https://raw.githubusercontent.com/tenstorrent/tt-forge/main/demos/tt-xla/nlp/pytorch/tiny_llama_demo.py
+pip install transformers
+python tiny_llama_demo.py
+```
+
+You should see the prompt "The capital of France is", the predicted next token, the probability it will occur, and a list of other ranked options that could follow instead, for example:
+```
+Prompt: `The capital of France is`
+Top prediction: `Paris`
+
+Rank   Token           Probability
+-----------------------------------
+1      'Paris'         36.9141%
+2      'located'       10.0098%
+3      'the'           8.8867%
+4      'a'             4.2480%
+5      'in'            2.5391%
+```
 
 ---
 
@@ -78,19 +105,42 @@ This section walks through the installation steps for using a Docker container f
 
 #### Step 2: Running Models in Docker
 
-- Inside your running Docker container, download the [**mnist.py** example](https://github.com/tenstorrent/tt-xla/blob/main/examples/pytorch/mnist.py) from the TT-XLA repo:
+Use `wget` to fetch each demo script into your current directory, and install packages with pip when noted.
 
-   ```bash
-   wget https://raw.githubusercontent.com/tenstorrent/tt-xla/main/examples/pytorch/mnist.py
-   ```
+**MNIST (small CNN)**
 
-- Run the model:
+The [**mnist.py**](https://github.com/tenstorrent/tt-xla/blob/main/examples/pytorch/mnist.py) example runs a simple CNN on a Tenstorrent device and compares the output against a CPU reference.
 
-   ```bash
-   python mnist.py
-   ```
+```bash
+wget https://raw.githubusercontent.com/tenstorrent/tt-xla/main/examples/pytorch/mnist.py
+python mnist.py
+```
 
-- If all goes well you should see the model output and a PCC (Pearson Correlation Coefficient) check confirming the TT device output matches the CPU reference.
+You should see the model output and a PCC (Pearson Correlation Coefficient) check confirming the TT device output matches the CPU reference.
+
+**Tiny Llama (Hugging Face `transformers`)**
+
+The [**tiny_llama_demo.py**](https://github.com/tenstorrent/tt-forge/blob/main/demos/tt-xla/nlp/pytorch/tiny_llama_demo.py) example in the TT-Forge repo loads a small LLM from Hugging Face, compiles it with `torch.compile(..., backend="tt")`, and prints top-token predictions. You must download the script and install [`transformers`](https://pypi.org/project/transformers/) (and its dependencies); the slim image does not include them. The first run also downloads model weights from Hugging Face over the network.
+
+```bash
+wget https://raw.githubusercontent.com/tenstorrent/tt-forge/main/demos/tt-xla/nlp/pytorch/tiny_llama_demo.py
+pip install transformers
+python tiny_llama_demo.py
+```
+
+You should see the prompt "The capital of France is", the predicted next token, the probability it will occur, and a list of other ranked options that could follow instead, for example:
+```
+Prompt: `The capital of France is`
+Top prediction: `Paris`
+
+Rank   Token           Probability
+-----------------------------------
+1      'Paris'         36.9141%
+2      'located'       10.0098%
+3      'the'           8.8867%
+4      'a'             4.2480%
+5      'in'            2.5391%
+```
 
 ---
 

--- a/examples/pytorch/mnist.py
+++ b/examples/pytorch/mnist.py
@@ -96,12 +96,12 @@ def test_mnist():
 
     tt_output = run_mnist()
     cpu_output = run_mnist_cpu()
-    
+
     print("TT device output:")
     print(tt_output)
     print("CPU output:")
     print(cpu_output)
-    
+
     tt_output_cpu = tt_output.cpu()
 
     tt_flat = tt_output_cpu.flatten().float()

--- a/examples/pytorch/mnist.py
+++ b/examples/pytorch/mnist.py
@@ -96,7 +96,12 @@ def test_mnist():
 
     tt_output = run_mnist()
     cpu_output = run_mnist_cpu()
-
+    
+    print("TT device output:")
+    print(tt_output)
+    print("CPU output:")
+    print(cpu_output)
+    
     tt_output_cpu = tt_output.cpu()
 
     tt_flat = tt_output_cpu.flatten().float()
@@ -115,6 +120,4 @@ def test_mnist():
 if __name__ == "__main__":
     # By default torch_xla uses the CPU device so we have to set it to TT device.
     xr.set_device_type("TT")
-
-    output = run_mnist()
-    print(output)
+    test_mnist()


### PR DESCRIPTION
### Ticket
Related: #4245 

### Problem description
Current getting started docs are too complex, and don't work due to several issues.

### What's changed
- Provide mnist model as user entrypoint - requiring no dependency on tt-forge-models or external libs
- Remove mentions of gpt model and opt model
- Improve mnist.py model output when run without pytest
- Suggest use of tt-forge-install CLI tool to sync system SFPI version
- Add @ddilbazTT's tinyllama prefill demo as an LLM example

### Checklist
- Tested locally, described in PR comments.