### PR TITLE
Fix shard_spec_fn type mismatch in batch parallel RMSNorm test

### DIFF
--- a/tests/torch/ops/test_composite_ops.py
+++ b/tests/torch/ops/test_composite_ops.py
@@ -109,7 +109,9 @@ def test_patched_rms_norm_functional_single_device(
 
 
 @pytest.mark.nightly
-@pytest.mark.skip(reason="Skipping test, issue: https://github.com/tenstorrent/tt-xla/issues/4256")
+@pytest.mark.skip(
+    reason="Skipping test, issue: https://github.com/tenstorrent/tt-xla/issues/4256"
+)
 @pytest.mark.dual_chip
 @pytest.mark.parametrize("use_weight", [True, False])
 @pytest.mark.parametrize(
@@ -141,9 +143,9 @@ def test_patched_rms_norm_functional_batch_parallel(
 
     def get_shard_spec(args, kwargs):
         shard_specs = {}
-        shard_specs[args[0]] = ("batch", None, None) # input tensor
+        shard_specs[args[0]] = ("batch", None, None)  # input tensor
         if args[1] is not None:
-            shard_specs[args[1]] = (None,) # weight
+            shard_specs[args[1]] = (None,)  # weight
         return shard_specs
 
     run_graph_test(

--- a/tests/torch/ops/test_composite_ops.py
+++ b/tests/torch/ops/test_composite_ops.py
@@ -109,9 +109,7 @@ def test_patched_rms_norm_functional_single_device(
 
 
 @pytest.mark.nightly
-@pytest.mark.xfail(
-    reason="To be investigated - https://github.com/tenstorrent/tt-xla/issues/4138"
-)
+@pytest.mark.skip(reason="Skipping test, issue: https://github.com/tenstorrent/tt-xla/issues/4256")
 @pytest.mark.dual_chip
 @pytest.mark.parametrize("use_weight", [True, False])
 @pytest.mark.parametrize(
@@ -141,11 +139,12 @@ def test_patched_rms_norm_functional_batch_parallel(
     device_ids = np.array(range(num_devices))
     mesh = xs.Mesh(device_ids, mesh_shape, ("model", "batch"))
 
-    # Mark sharding for inputs along batch dimension.
-    shard_specs = {}
-    shard_specs[input_tensor] = ("batch", None)
-    if use_weight:
-        shard_specs[weight] = (None,)
+    def get_shard_spec(args, kwargs):
+        shard_specs = {}
+        shard_specs[args[0]] = ("batch", None, None) # input tensor
+        if args[1] is not None:
+            shard_specs[args[1]] = (None,) # weight
+        return shard_specs
 
     run_graph_test(
         model,
@@ -154,7 +153,7 @@ def test_patched_rms_norm_functional_batch_parallel(
         framework=Framework.TORCH,
         torch_options=options,
         mesh=mesh,
-        shard_spec_fn=shard_specs,
+        shard_spec_fn=get_shard_spec,
     )
 
 


### PR DESCRIPTION
### Ticket
fixes: https://github.com/tenstorrent/tt-xla/issues/4138

### Problem description
The test passed a plain dict as `shard_spec_fn`, but the test infrastructure at [torch_device_runner.py:138](https://github.com/tenstorrent/tt-xla/blob/7dd262e7941327e2bd1c9a6c0fb1525adca2c238/tests/infra/runners/torch_device_runner.py#L138) calls `inspect.signature(workload.shard_spec_fn)` on it to determine the sharding mode (data-parallel vs tensor-parallel) based on parameter names. `inspect.signature()` on a dict raises TypeError because a dict isn't callable. The fix is to wrap the shard specs in a `get_shard_spec(args, kwargs)` function that returns the dict, matching the convention used by every other SPMD test.

Also skipping the test because of a new found issue that will be discussed as a part of https://github.com/tenstorrent/tt-xla/issues/4256
