### PR TITLE
[Mochi] Remove xfail mark from mochi tests

### DIFF
--- a/tests/torch/graphs/test_mochi_causal_conv3d.py
+++ b/tests/torch/graphs/test_mochi_causal_conv3d.py
@@ -43,22 +43,12 @@ class MochiCausalConv3dWrapper(torch.nn.Module):
             768,
             768,
             id="in_and_out_div32",
-            marks=pytest.mark.xfail(
-                reason=failed_runtime(
-                    "L1 OOM: https://github.com/tenstorrent/tt-xla/issues/3108"
-                )
-            ),
         ),
         pytest.param(12, 512, id="in_not_div32"),
         pytest.param(
             512,
             12,
             id="out_not_div32",
-            marks=pytest.mark.xfail(
-                reason=failed_runtime(
-                    "L1 OOM: https://github.com/tenstorrent/tt-xla/issues/3108"
-                )
-            ),
         ),
         pytest.param(12, 34, id="neither_div32"),
     ],

--- a/tests/torch/models/mochi/test_mochi_vae.py
+++ b/tests/torch/models/mochi/test_mochi_vae.py
@@ -24,11 +24,6 @@ _DRAM_OOM_SKIP_REASON = (
         pytest.param(
             ModelVariant.MOCHI,
             marks=[
-                pytest.mark.xfail(
-                    reason=failed_runtime(
-                        "L1 OOM: https://github.com/tenstorrent/tt-xla/issues/3108"
-                    )
-                ),
                 pytest.mark.record_test_properties(
                     category=Category.MODEL_TEST,
                     model_info=ModelLoader.get_model_info(ModelVariant.MOCHI),


### PR DESCRIPTION
### What's changed
Since this [issue](https://github.com/tenstorrent/tt-xla/issues/4018) is closed, I am removing `xfail` mark from `mochi` tests.