### PR TITLE
Handle empty tensor copy-to-host by skipping runtime memcpy for zero-size buffers

### DIFF
--- a/pjrt_implementation/src/api/buffer_instance.cc
+++ b/pjrt_implementation/src/api/buffer_instance.cc
@@ -513,6 +513,17 @@ PJRT_Error *onBufferToHostBuffer(PJRT_Buffer_ToHostBuffer_Args *args) {
     return nullptr;
   }
 
+  // Empty tensors (e.g. shape [0]) have zero bytes and no device-side
+  // allocation, so there is nothing to copy. Return a ready event immediately
+  // to avoid calling into the runtime with null buffer pointers.
+  if (buffer->logicalTensorSize() == 0) {
+    std::unique_ptr<EventInstance> event = EventInstance::createInstance();
+    EventInstance::markAsReadyAndCallback(event.get(),
+                                          tt_pjrt_status::kSuccess);
+    args->event = *event.release();
+    return nullptr;
+  }
+
   return *ErrorInstance::makeError(
               buffer->copyToHost(
                   args->dst, args->dst_size,

--- a/tests/torch/ops/test_empty.py
+++ b/tests/torch/ops/test_empty.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Minimal torch.empty empty-tensor host-transfer repro."""
+
+import pytest
+import torch
+import torch_xla.core.xla_model as xm
+import torch_xla.runtime as xr
+from utils import Category
+
+
+@pytest.mark.nightly
+@pytest.mark.single_device
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    torch_op_name="torch.empty",
+)
+def test_empty():
+    class Empty(torch.nn.Module):
+        def forward(self, x):
+            return torch.empty((0,), device=x.device, dtype=torch.int64)
+
+    xr.set_device_type("TT")
+
+    model = torch.compile(Empty(), backend="tt")
+    device = xm.xla_device()
+    model = model.to(device)
+    input_tensor = torch.tensor(0, dtype=torch.int64).to(device)
+
+    with torch.no_grad():
+        output = model(input_tensor)
+
+    host_output = output.to("cpu")
+
+    assert host_output.numel() == 0
+    assert host_output.shape == torch.Size([0])
+    assert host_output.dtype == torch.int64


### PR DESCRIPTION
### Ticket

- closes https://github.com/tenstorrent/tt-xla/issues/4260

### Problem description

- Empty tensors crash during device-to-host copy. The tt-mlir runtime's getRawHostDataPtr() returns nullptr for zero-size buffers, and handleBufferCast() throws `Buffer pointers must not be null`, causing a fatal abort.

### What's changed

- Added an early return in onBufferToHostBuffer() when `logicalTensorSize() == 0`. Mirrors the existing `!args->dst` early return pattern. Since there is no data to copy, we skip the runtime memcpy and return a ready event immediately. This prevents the null pointer from reaching tt-mlir's `handleBufferCast()`.

### Checklist
- [x] Verify the changes through local testing in N150

### Logs

**Before fix**

- [apr15_empty_before_fix.log](https://github.com/user-attachments/files/26757205/apr15_empty_before_fix.log)
- [apr15_vilt_mlm_before_fix.log](https://github.com/user-attachments/files/26757157/apr15_vilt_mlm_before_fix.log)
- [apr15_vilt_qa_before_fix.log](https://github.com/user-attachments/files/26757158/apr15_vilt_qa_before_fix.log)

**After fix**

- [apr15_empty_after_fix.log](https://github.com/user-attachments/files/26757194/apr15_empty_after_fix.log)
- [apr15_vilt_mlm_after_fix.log](https://github.com/user-attachments/files/26757195/apr15_vilt_mlm_after_fix.log)
- [apr15_vilt_qa_after_fix.log](https://github.com/user-attachments/files/26757196/apr15_vilt_qa_after_fix.log)

