### PR TITLE
Uplift Transformers to 5.5.1

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -314,7 +314,7 @@
       },
       {
         "name": "kimi_k2_5_tp_galaxy_2_layers",
-        "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==5.2.0 tiktoken",
+        "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==5.5.1 tiktoken",
         "pytest": "tests/benchmark/test_llms.py::test_kimi_k2_5_tp_galaxy_2_layers",
         "runs-on": "galaxy-wh-6u"
       },

--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -24,52 +24,52 @@
       },
       {
         "name": "mnist",
-        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_vision.py::test_mnist"
       },
       {
         "name": "resnet",
-        "pyreq": "datasets loguru pytest requests tabulate timm tqdm transformers==5.2.0 torch==2.10.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm tqdm transformers==5.5.1 torch==2.10.0",
         "pytest": "tests/benchmark/test_vision.py::test_resnet50"
       },
       {
         "name": "mobilenetv2",
-        "pyreq": "datasets loguru pytest requests tabulate timm tqdm transformers==5.2.0 torch==2.10.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm tqdm transformers==5.5.1 torch==2.10.0",
         "pytest": "tests/benchmark/test_vision.py::test_mobilenetv2"
       },
       {
         "name": "efficientnet",
-        "pyreq": "datasets loguru pytest requests tabulate timm tqdm transformers==5.2.0 torch==2.10.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm tqdm transformers==5.5.1 torch==2.10.0",
         "pytest": "tests/benchmark/test_vision.py::test_efficientnet"
       },
       {
         "name": "segformer",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_vision.py::test_segformer"
       },
       {
         "name": "swin",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_vision.py::test_swin"
       },
       {
         "name": "ufld_v2",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_vision.py::test_ufld_v2"
       },
       {
         "name": "unet",
-        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_vision.py::test_unet"
       },
       {
         "name": "vit",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_vision.py::test_vit"
       },
       {
         "name": "vovnet",
-        "pyreq": "datasets loguru pytest pytorchcv requests tabulate timm tqdm transformers==5.2.0 torch==2.10.0",
+        "pyreq": "datasets loguru pytest pytorchcv requests tabulate timm tqdm transformers==5.5.1 torch==2.10.0",
         "pytest": "tests/benchmark/test_vision.py::test_vovnet"
       },
       {
@@ -79,236 +79,236 @@
       },
       {
         "name": "llama_3_2_1b_instruct",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_2_1b"
       },
       {
         "name": "llama_3_2_3b_instruct",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_2_3b"
       },
       {
         "name": "llama_3_1_8b_instruct",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b"
       },
       {
         "name": "falcon3_7b_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "falcon3_10b_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_10b_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "llama_3_1_8b_instruct_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b_instruct_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "ministral_8b_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_ministral_8b_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "mistral_nemo_instruct_2407_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_mistral_nemo_instruct_2407_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "mistral_small_24b_instruct_2501_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_mistral_small_24b_instruct_2501_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "qwen_2_5_14b_instruct_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_14b_instruct_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "qwen_2_5_coder_32b_instruct_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_coder_32b_instruct_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "qwen_3_8b_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_8b_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "qwen_3_14b_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_14b_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "qwen_3_32b_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_32b_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "test_llama_3_1_70b_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "llama_3_1_70b_tp_galaxy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp_galaxy",
         "runs-on": "galaxy-wh-6u"
       },
       {
         "name": "gpt_oss_20b_tp",
-        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "gpt_oss_20b_tp_batch_size_1",
-        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_batch_size_1",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "test_gpt_oss_20b_tp_galaxy_batch_size_64",
-        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_galaxy_batch_size_64",
         "runs-on": "galaxy-wh-6u"
       },
       {
         "name": "test_gpt_oss_120b_tp_dp_galaxy_batch_size_128",
-        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_120b_tp_dp_galaxy_batch_size_128",
         "runs-on": "galaxy-wh-6u"
       },
       {
         "name": "gpt_oss_120b_tp_qb2",
-        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_120b_tp_qb2",
         "runs-on": "qb2-blackhole"
       },
       {
         "name": "microsoft_phi-1",
-        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_phi1"
       },
       {
         "name": "microsoft_phi-1_5",
-        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_phi1_5"
       },
       {
         "name": "microsoft_phi-2",
-        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_phi2"
       },
       {
         "name": "google_gemma-1.1-2b-it",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_gemma_1_1_2b"
       },
       {
         "name": "tiiuae_falcon3-1b-base",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_1b"
       },
       {
         "name": "tiiuae_falcon3-3b-base",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_3b"
       },
       {
         "name": "tiiuae_falcon3-7b-base",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b"
       },
       {
         "name": "qwen_2_5_0_5b_instruct",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_0_5b"
       },
       {
         "name": "qwen_2_5_1_5b_instruct",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_1_5b"
       },
       {
         "name": "qwen_2_5_3b_instruct",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_3b"
       },
       {
         "name": "qwen_3_0_6b",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_0_6b"
       },
       {
         "name": "qwen_3_1_7b",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_1_7b"
       },
       {
         "name": "qwen_3_4b",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_4b"
       },
       {
         "name": "qwen_3_8b",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_8b"
       },
       {
         "name": "qwen_2_5_7b_instruct",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_7b"
       },
       {
         "name": "mistral_7b",
-        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.2.0 protobuf sentencepiece",
+        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.5.1 protobuf sentencepiece",
         "pytest": "tests/benchmark/test_llms.py::test_mistral_7b"
       },
       {
         "name": "ministral_8b",
-        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_ministral_8b"
       },
       {
         "name": "qwen_3_4b_embedding",
-        "pyreq": "datasets loguru pytest requests timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_encoders.py::test_qwen3_embedding_4b"
       },
       {
         "name": "bert",
-        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_encoders.py::test_bert"
       },
       {
         "name": "unet_for_conditional_generation",
-        "pyreq": "accelerate datasets diffusers==0.36.0 loguru pytest requests torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "accelerate datasets diffusers==0.36.0 loguru pytest requests torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_encoders.py::test_unet_for_conditional_generation"
       },
       {
         "name": "deepseek_v3_2_exp_tp_galaxy_2_layers",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_deepseek_v3_2_exp_tp_galaxy_2_layers",
         "runs-on": "galaxy-wh-6u"
       },
       {
         "name": "kimi_k2_tp_galaxy_2_layers",
-        "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==5.2.0 tiktoken",
+        "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==5.5.1 tiktoken",
         "pytest": "tests/benchmark/test_llms.py::test_kimi_k2_tp_galaxy_2_layers",
         "runs-on": "galaxy-wh-6u"
       },
@@ -320,210 +320,210 @@
       },
       {
         "name": "llama_3_2_1b_instruct_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_2_1b",
         "accuracy-testing": true
       },
       {
         "name": "llama_3_2_3b_instruct_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_2_3b",
         "accuracy-testing": true
       },
       {
         "name": "llama_3_1_8b_instruct_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b",
         "accuracy-testing": true
       },
       {
         "name": "mistral_7b_accuracy",
-        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.2.0 protobuf sentencepiece",
+        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.5.1 protobuf sentencepiece",
         "pytest": "tests/benchmark/test_llms.py::test_mistral_7b",
         "accuracy-testing": true
       },
       {
         "name": "qwen_2_5_7b_instruct_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_7b",
         "accuracy-testing": true
       },
       {
         "name": "google_gemma-1.1-2b-it_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_gemma_1_1_2b",
         "accuracy-testing": true
       },
       {
         "name": "google_gemma-2-2b-it_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_gemma_2_2b",
         "accuracy-testing": true
       },
       {
         "name": "microsoft_phi-1_accuracy",
-        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_phi1",
         "accuracy-testing": true
       },
       {
         "name": "microsoft_phi-1_5_accuracy",
-        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_phi1_5",
         "accuracy-testing": true
       },
       {
         "name": "microsoft_phi-2_accuracy",
-        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_phi2",
         "accuracy-testing": true
       },
       {
         "name": "tiiuae_falcon3-1b-base_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_1b",
         "accuracy-testing": true
       },
       {
         "name": "tiiuae_falcon3-3b-base_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_3b",
         "accuracy-testing": true
       },
       {
         "name": "tiiuae_falcon3-7b-base_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b",
         "accuracy-testing": true
       },
       {
         "name": "qwen_2_5_0_5b_instruct_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_0_5b",
         "accuracy-testing": true
       },
       {
         "name": "qwen_2_5_1_5b_instruct_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_1_5b",
         "accuracy-testing": true
       },
       {
         "name": "qwen_2_5_3b_instruct_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_3b",
         "accuracy-testing": true
       },
       {
         "name": "qwen_3_0_6b_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_0_6b",
         "accuracy-testing": true
       },
       {
         "name": "qwen_3_1_7b_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_1_7b",
         "accuracy-testing": true
       },
       {
         "name": "qwen_3_4b_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_4b",
         "accuracy-testing": true
       },
       {
         "name": "qwen_3_8b_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_8b",
         "accuracy-testing": true
       },
       {
         "name": "ministral_8b_accuracy",
-        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_ministral_8b",
         "accuracy-testing": true
       },
       {
         "name": "falcon3_7b_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "falcon3_10b_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_10b_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "llama_3_1_8b_instruct_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b_instruct_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "ministral_8b_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_ministral_8b_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "mistral_nemo_instruct_2407_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_mistral_nemo_instruct_2407_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "mistral_small_24b_instruct_2501_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_mistral_small_24b_instruct_2501_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "qwen_2_5_14b_instruct_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_14b_instruct_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "qwen_2_5_coder_32b_instruct_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_coder_32b_instruct_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "qwen_3_8b_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_8b_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "qwen_3_14b_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_14b_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "qwen_3_32b_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_32b_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "llama_3_1_70b_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true,
@@ -531,35 +531,35 @@
       },
       {
         "name": "gpt_oss_20b_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "llama_3_1_70b_tp_galaxy_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp_galaxy",
         "runs-on": "galaxy-wh-6u",
         "accuracy-testing": true
       },
       {
         "name": "gpt_oss_20b_tp_galaxy_accuracy",
-        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_galaxy_batch_size_64",
         "runs-on": "galaxy-wh-6u",
         "accuracy-testing": true
       },
       {
         "name": "gpt_oss_120b_tp_galaxy_accuracy",
-        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_120b_tp_galaxy_batch_size_64",
         "runs-on": "galaxy-wh-6u",
         "accuracy-testing": true
       },
       {
         "name": "gpt_oss_120b_tp_dp_galaxy_accuracy",
-        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_120b_tp_dp_galaxy_batch_size_128",
         "runs-on": "galaxy-wh-6u",
         "accuracy-testing": true

--- a/examples/pytorch/llama.py
+++ b/examples/pytorch/llama.py
@@ -195,7 +195,7 @@ def construct_inputs(
         max_cache_len: Maximum cache length
 
     Returns:
-        Dictionary containing input_ids, past_key_values, cache_position, and use_cache
+        Dictionary containing input_ids, past_key_values, position_ids, and use_cache
     """
     inputs = tokenizer(
         input_prompt,
@@ -224,7 +224,8 @@ def construct_inputs(
         dtype=torch.bfloat16,
         device="cpu",
     )
-    cache_position: torch.Tensor = torch.arange(0, inputs.input_ids.shape[1])
+    seq_len: int = inputs.input_ids.shape[1]
+    position_ids: torch.Tensor = torch.arange(0, seq_len).unsqueeze(0)
 
     # Attention mask is needed to ignore padding tokens in left-padded batches. The mask should match max_cache_len
     # to prevent recompilation or implicit padding by transformers, which can cause degenerate output.
@@ -237,7 +238,7 @@ def construct_inputs(
     input_args = {
         "input_ids": inputs.input_ids,
         "past_key_values": static_cache,
-        "cache_position": cache_position,
+        "position_ids": position_ids,
         "use_cache": True,
         "attention_mask": full_attention_mask,
     }
@@ -250,8 +251,8 @@ def construct_inputs(
     print(f"Input attention mask shape: {inputs.attention_mask.shape}")
     print(f"Full attention mask shape (pre-allocated): {full_attention_mask.shape}")
     print(f"Full attention mask: {full_attention_mask}")
-    print(f"Cache position shape: {cache_position.shape}")
-    print(f"Cache position: {cache_position}")
+    print(f"Position IDs shape: {position_ids.shape}")
+    print(f"Position IDs: {position_ids}")
     print(f"Actual sequence length (non-padding): {inputs.attention_mask.sum().item()}")
     print("=" * 50)
 
@@ -275,8 +276,10 @@ def transfer_to_device(
     for layer in input_args["past_key_values"].layers:
         layer.keys = layer.keys.to(device)
         layer.values = layer.values.to(device)
+        layer.cumulative_length = layer.cumulative_length.to(device)
+        layer.device = device
     input_args["input_ids"] = input_args["input_ids"].to(device)
-    input_args["cache_position"] = input_args["cache_position"].to(device)
+    input_args["position_ids"] = input_args["position_ids"].to(device)
     input_args["attention_mask"] = input_args["attention_mask"].to(device)
 
     model = model.to(device)
@@ -290,7 +293,7 @@ def mark_sharding_on_inputs_and_model(
     """
     Mark sharding on inputs and model internals.
     If mark_sharding is not called on a tensor, it is fully replicated across all devices.
-        i.e. on cache_positions, input_ids
+        i.e. on position_ids, input_ids
 
     Args:
         model: Model instance
@@ -364,9 +367,10 @@ def run_generate(
             # Update inputs for next iteration
             input_args["input_ids"] = next_token_id.unsqueeze(-1).to(device)
 
-            host_cache_pos = input_args["cache_position"].to("cpu")
-            host_cache_pos = torch.tensor([host_cache_pos[-1:] + 1])
-            input_args["cache_position"] = host_cache_pos.to(device)
+            host_pos = input_args["position_ids"].to("cpu")
+            input_args["position_ids"] = torch.tensor(
+                [[host_pos[0, -1].item() + 1]]
+            ).to(device)
 
     print()
     if not is_interactive:

--- a/tests/benchmark/benchmarks/llm_benchmark.py
+++ b/tests/benchmark/benchmarks/llm_benchmark.py
@@ -199,6 +199,13 @@ def transfer_to_device(input_args: dict, device: torch.device) -> dict:
         else:
             layer.keys = layer.keys.to(device)
             layer.values = layer.values.to(device)
+            # CL must be on device: StaticLayer.update() does
+            # torch.arange(kv_length, device=self.device) + self.cumulative_length,
+            # which fails if CL is on CPU and self.device is XLA.
+            # Zero before moving so the fresh cache starts at position 0.
+            layer.cumulative_length.zero_()
+            layer.cumulative_length = layer.cumulative_length.to(device)
+            layer.device = device
     input_args["input_ids"] = input_args["input_ids"].to(device)
     input_args["cache_position"] = input_args["cache_position"].to(device)
     return input_args
@@ -221,18 +228,18 @@ def _shard_kv_cache(past_key_values, mesh, kv_cache_sharding_spec):
 
 def check_transformers_version():
     """
-    Check that transformers version is = 5.2.0.
+    Check that transformers version is = 5.5.0.
     Raises RuntimeError if version is incompatible.
     """
     import packaging.version
 
     current_version = packaging.version.parse(transformers.__version__)
-    max_version = packaging.version.parse("5.2.0")
+    max_version = packaging.version.parse("5.5.0")
 
     if current_version != max_version:
         raise RuntimeError(
             f"Transformers version {transformers.__version__} is not supported. "
-            f"Please use version 5.2.0"
+            f"Please use version 5.5.0"
         )
 
 
@@ -538,13 +545,24 @@ def benchmark_llm_torch_xla(
 
         tracy.signpost("warmup_complete")
 
-    # Reconstruct inputs for the perf benchmark run
+    # Reconstruct inputs for the perf benchmark run.
+    existing_cache = (
+        input_args["past_key_values"] if not decode_only else decode_only_cache
+    )
+
+    # Reset cumulative_length to 0 on CPU
+    for layer in existing_cache.layers:
+        if hasattr(layer, "cumulative_length"):
+            if layer.cumulative_length.device.type != "cpu":
+                layer.cumulative_length = layer.cumulative_length.cpu()
+            layer.cumulative_length.zero_()
+
     input_args = construct_inputs(
         tokenizer,
         model.config,
         batch_size,
         max_cache_len,
-        past_key_values=(decode_only_cache if decode_only else warmup_kv_cache),
+        past_key_values=existing_cache,
         input_prompt=custom_input_prompt,
         input_prompt_tokens=(token_accuracy.input_prompt if accuracy_testing else None),
         use_mla_cache=use_mla_cache,

--- a/tests/benchmark/benchmarks/llm_benchmark.py
+++ b/tests/benchmark/benchmarks/llm_benchmark.py
@@ -228,18 +228,18 @@ def _shard_kv_cache(past_key_values, mesh, kv_cache_sharding_spec):
 
 def check_transformers_version():
     """
-    Check that transformers version is = 5.5.0.
+    Check that transformers version is = 5.5.1.
     Raises RuntimeError if version is incompatible.
     """
     import packaging.version
 
     current_version = packaging.version.parse(transformers.__version__)
-    max_version = packaging.version.parse("5.5.0")
+    max_version = packaging.version.parse("5.5.1")
 
     if current_version != max_version:
         raise RuntimeError(
             f"Transformers version {transformers.__version__} is not supported. "
-            f"Please use version 5.5.0"
+            f"Please use version 5.5.1"
         )
 
 

--- a/tests/benchmark/llm_utils/decode_utils.py
+++ b/tests/benchmark/llm_utils/decode_utils.py
@@ -55,10 +55,11 @@ class LLMSamplingWrapper(torch.nn.Module):
         self.output_sharding_spec = output_sharding_spec
 
     def forward(self, input_ids, past_key_values, cache_position, use_cache=True):
+        position_ids = cache_position.unsqueeze(0)
         output = self.model(
             input_ids=input_ids,
             past_key_values=past_key_values,
-            cache_position=cache_position,
+            position_ids=position_ids,
             use_cache=use_cache,
         )
         logits = self.read_logits_fn(output)

--- a/tests/benchmark/llm_utils/decode_utils.py
+++ b/tests/benchmark/llm_utils/decode_utils.py
@@ -60,6 +60,7 @@ class LLMSamplingWrapper(torch.nn.Module):
             input_ids=input_ids,
             past_key_values=past_key_values,
             position_ids=position_ids,
+            cache_position=cache_position,
             use_cache=use_cache,
         )
         logits = self.read_logits_fn(output)

--- a/tests/infra/runners/torch_device_runner.py
+++ b/tests/infra/runners/torch_device_runner.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import copy
 import inspect
 
 import torch
@@ -74,16 +75,32 @@ def to_device(x, device, depth=5, moved=None):
         if isinstance(x, type):
             return x
         result = x.to(device)
+        # If .to() returned the same object (already on target device), clone it so
+        # in-place mutations on the result don't affect the original (e.g. StaticCache
+        # cumulative_length.add_() would otherwise corrupt the workload's source state).
+        if result is x and isinstance(x, torch.Tensor):
+            result = result.clone()
         moved[obj_id] = result
         return result
     # Handle objects with attributes by recursively processing all fields.
-    # This is done in-place.
+    # Use copy.copy to avoid mutating the original object (e.g. StaticCache.cumulative_length
+    # would otherwise accumulate across multiple runs of the same workload).
     elif hasattr(x, "__dict__"):
-        for attr_name in x.__dict__:
-            attr_value = getattr(x, attr_name)
-            setattr(x, attr_name, to_device(attr_value, device, depth - 1, moved))
-        moved[obj_id] = x
-        return x
+        new_obj = copy.copy(x)
+        for attr_name in list(x.__dict__):
+            setattr(
+                new_obj,
+                attr_name,
+                to_device(getattr(x, attr_name), device, depth - 1, moved),
+            )
+        # Sync the 'device' attribute (str or torch.device) to the target device
+        # so it stays consistent with any tensors that were just moved.
+        if "device" in new_obj.__dict__ and isinstance(
+            new_obj.__dict__["device"], (str, torch.device)
+        ):
+            new_obj.device = device
+        moved[obj_id] = new_obj
+        return new_obj
     else:
         return x
 

--- a/tests/infra/runners/torch_device_runner.py
+++ b/tests/infra/runners/torch_device_runner.py
@@ -75,32 +75,46 @@ def to_device(x, device, depth=5, moved=None):
         if isinstance(x, type):
             return x
         result = x.to(device)
-        # If .to() returned the same object (already on target device), clone it so
-        # in-place mutations on the result don't affect the original (e.g. StaticCache
-        # cumulative_length.add_() would otherwise corrupt the workload's source state).
+        # nn.Module.to() is in-place (returns self). Clone tensors that didn't move
+        # so mutations in one run don't corrupt the workload's source state.
         if result is x and isinstance(x, torch.Tensor):
             result = result.clone()
         moved[obj_id] = result
         return result
-    # Handle objects with attributes by recursively processing all fields.
-    # Use copy.copy to avoid mutating the original object (e.g. StaticCache.cumulative_length
-    # would otherwise accumulate across multiple runs of the same workload).
     elif hasattr(x, "__dict__"):
-        new_obj = copy.copy(x)
-        for attr_name in list(x.__dict__):
-            setattr(
-                new_obj,
-                attr_name,
-                to_device(getattr(x, attr_name), device, depth - 1, moved),
-            )
-        # Sync the 'device' attribute (str or torch.device) to the target device
-        # so it stays consistent with any tensors that were just moved.
-        if "device" in new_obj.__dict__ and isinstance(
-            new_obj.__dict__["device"], (str, torch.device)
-        ):
-            new_obj.device = device
-        moved[obj_id] = new_obj
-        return new_obj
+        if callable(x):
+            # Compiled torch functions are callable and may have circular refs in
+            # __dict__ (dynamo internals), so copy.copy is unsafe. Mutate in-place.
+            moved[obj_id] = x  # guard before recursion to break circular refs
+            for attr_name in list(x.__dict__):
+                setattr(
+                    x,
+                    attr_name,
+                    to_device(getattr(x, attr_name), device, depth - 1, moved),
+                )
+            if "device" in x.__dict__ and isinstance(
+                x.__dict__["device"], (str, torch.device)
+            ):
+                x.device = device
+            return x
+        else:
+            # Non-callable plain objects (e.g. transformers StaticCache/StaticLayer)
+            # are NOT nn.Modules — they have no .to() and get mutated in-place without
+            # a copy. Use copy.copy so each run gets a fresh object, preventing
+            # accumulated cache state from corrupting subsequent forward passes.
+            new_obj = copy.copy(x)
+            moved[obj_id] = new_obj  # guard before recursion to break circular refs
+            for attr_name in list(x.__dict__):
+                setattr(
+                    new_obj,
+                    attr_name,
+                    to_device(getattr(x, attr_name), device, depth - 1, moved),
+                )
+            if "device" in new_obj.__dict__ and isinstance(
+                new_obj.__dict__["device"], (str, torch.device)
+            ):
+                new_obj.device = device
+            return new_obj
     else:
         return x
 

--- a/tests/infra/testers/single_chip/model/torch_model_tester.py
+++ b/tests/infra/testers/single_chip/model/torch_model_tester.py
@@ -307,7 +307,47 @@ class TorchModelTester(ModelTester):
         logger.warning(f"Grads: {cpu_none_grads} are None")
 
         forward_result = self._compare(tt_res, cpu_res)
-        backward_result = self._compare(tt_grads, cpu_grads)
+
+        # Stream gradient comparison one parameter at a time. Comparing the full
+        # grad pytree in one call doubles memory (fp32→fp64 cast in
+        # _match_data_types) and creates large intermediates, peaking at 20+GB
+        # host RSS for 0.5-0.6B param models and OOM-killing on CI runners.
+        backward_result = ComparisonResult(
+            passed=True,
+            error_message=None,
+            pcc=None,
+            atol=None,
+            allclose=True,
+            equal=True,
+        )
+        backward_error_messages = []
+        for name in list(tt_grads.keys()):
+            tt_v = tt_grads.pop(name)
+            cpu_v = cpu_grads.pop(name)
+            r = self._compare(tt_v, cpu_v)
+            if r.atol is not None:
+                backward_result.atol = (
+                    r.atol
+                    if backward_result.atol is None
+                    else max(backward_result.atol, r.atol)
+                )
+            if r.pcc is not None:
+                backward_result.pcc = (
+                    r.pcc
+                    if backward_result.pcc is None
+                    else min(backward_result.pcc, r.pcc)
+                )
+            if r.allclose is False:
+                backward_result.allclose = False
+            if r.equal is False:
+                backward_result.equal = False
+            if not r.passed:
+                backward_result.passed = False
+                if r.error_message:
+                    backward_error_messages.append(f"[{name}] {r.error_message}")
+            del tt_v, cpu_v, r
+        if backward_error_messages:
+            backward_result.error_message = "\n".join(backward_error_messages)
 
         # Only the first result is recorded in the report properties,
         # and only want to report on the backward result

--- a/tests/torch/graphs/test_attention.py
+++ b/tests/torch/graphs/test_attention.py
@@ -326,7 +326,15 @@ def test_llama_attention_decode(variant, variant_config, arch):
     )
     past_key_states = static_cache
 
-    cache_positions = torch.randint(0, max_cache_len, (seq_len,), dtype=torch.long)
+    # Pre-initialize the cache so lazy_initialization doesn't fire inside the TT trace,
+    # which would cause scatter to compile into the graph and hit paged_update_cache failures.
+    static_cache.early_initialization(
+        batch_size=batch_size,
+        num_heads=num_key_value_heads,
+        head_dim=config.head_dim,
+        dtype=torch.bfloat16,
+        device="cpu",
+    )
 
     run_graph_test(
         attention,
@@ -335,7 +343,6 @@ def test_llama_attention_decode(variant, variant_config, arch):
             position_embeddings,
             attention_mask,
             past_key_states,
-            cache_positions,
         ],
         framework=Framework.TORCH,
         mesh=mesh,
@@ -779,7 +786,15 @@ def test_qwen3_attention_decode(variant, variant_config, arch):
     )
     past_key_states = static_cache
 
-    cache_positions = torch.randint(0, max_cache_len, (seq_len,), dtype=torch.long)
+    # Pre-initialize the cache so lazy_initialization doesn't fire inside the TT trace,
+    # which would cause scatter to compile into the graph and hit paged_update_cache failures.
+    static_cache.early_initialization(
+        batch_size=batch_size,
+        num_heads=getattr(config, "num_key_value_heads", config.num_attention_heads),
+        head_dim=config.head_dim,
+        dtype=torch.bfloat16,
+        device="cpu",
+    )
 
     run_graph_test(
         attention,
@@ -788,7 +803,6 @@ def test_qwen3_attention_decode(variant, variant_config, arch):
             position_embeddings,
             attention_mask,
             past_key_states,
-            cache_positions,
         ],
         framework=Framework.TORCH,
         mesh=mesh,
@@ -1462,7 +1476,15 @@ def test_qwen2_5_attention_decode(variant, variant_config, arch):
     )
     past_key_states = static_cache
 
-    cache_positions = torch.randint(0, max_cache_len, (seq_len,), dtype=torch.long)
+    # Pre-initialize the cache so lazy_initialization doesn't fire inside the TT trace,
+    # which would cause scatter to compile into the graph and hit paged_update_cache failures.
+    static_cache.early_initialization(
+        batch_size=batch_size,
+        num_heads=getattr(config, "num_key_value_heads", config.num_attention_heads),
+        head_dim=head_dim,
+        dtype=torch.bfloat16,
+        device="cpu",
+    )
 
     run_graph_test(
         attention,
@@ -1471,7 +1493,6 @@ def test_qwen2_5_attention_decode(variant, variant_config, arch):
             position_embeddings,
             attention_mask,
             past_key_states,
-            cache_positions,
         ],
         framework=Framework.TORCH,
         mesh=mesh,
@@ -1876,7 +1897,15 @@ def test_gemma_attention_decode(variant, variant_config, arch):
     )
     past_key_states = static_cache
 
-    cache_positions = torch.randint(0, max_cache_len, (seq_len,), dtype=torch.long)
+    # Pre-initialize the cache so lazy_initialization doesn't fire inside the TT trace,
+    # which would cause scatter to compile into the graph and hit paged_update_cache failures.
+    static_cache.early_initialization(
+        batch_size=batch_size,
+        num_heads=num_key_value_heads,
+        head_dim=config.head_dim,
+        dtype=torch.bfloat16,
+        device="cpu",
+    )
 
     run_graph_test(
         attention,
@@ -1885,7 +1914,6 @@ def test_gemma_attention_decode(variant, variant_config, arch):
             position_embeddings,
             attention_mask,
             past_key_states,
-            cache_positions,
         ],
         framework=Framework.TORCH,
         mesh=mesh,
@@ -2177,7 +2205,15 @@ def test_mistral_attention_decode(variant, variant_config, arch):
     )
     past_key_states = static_cache
 
-    cache_positions = torch.randint(0, max_cache_len, (seq_len,), dtype=torch.long)
+    # Pre-initialize the cache so lazy_initialization doesn't fire inside the TT trace,
+    # which would cause scatter to compile into the graph and hit paged_update_cache failures.
+    static_cache.early_initialization(
+        batch_size=batch_size,
+        num_heads=getattr(config, "num_key_value_heads", config.num_attention_heads),
+        head_dim=head_dim,
+        dtype=torch.bfloat16,
+        device="cpu",
+    )
 
     if arch == "llmbox":
         num_devices = xr.global_runtime_device_count()
@@ -2204,7 +2240,6 @@ def test_mistral_attention_decode(variant, variant_config, arch):
             position_embeddings,
             attention_mask,
             past_key_states,
-            cache_positions,
         ],
         framework=Framework.TORCH,
         mesh=mesh,
@@ -2564,7 +2599,17 @@ def test_gpt_oss_attention_decode(variant, variant_config, arch):
     )
     past_key_states = static_cache
 
-    cache_positions = torch.randint(0, max_cache_len, (seq_len,), dtype=torch.long)
+    # Pre-initialize the cache so lazy_initialization doesn't fire inside the TT trace,
+    # which would cause scatter to compile into the graph and hit paged_update_cache failures.
+    static_cache.early_initialization(
+        batch_size=batch_size,
+        num_heads=getattr(config, "num_key_value_heads", config.num_attention_heads),
+        head_dim=getattr(
+            config, "head_dim", config.hidden_size // config.num_attention_heads
+        ),
+        dtype=torch.bfloat16,
+        device="cpu",
+    )
 
     run_graph_test(
         attention,
@@ -2573,7 +2618,6 @@ def test_gpt_oss_attention_decode(variant, variant_config, arch):
             position_embeddings,
             attention_mask,
             past_key_states,
-            cache_positions,
         ],
         framework=Framework.TORCH,
         mesh=mesh,
@@ -2691,7 +2735,15 @@ def test_glm_4_attention_decode(variant, variant_config, arch):
     )
     past_key_states = static_cache
 
-    cache_positions = torch.randint(0, max_cache_len, (seq_len,), dtype=torch.long)
+    # Pre-initialize the cache so lazy_initialization doesn't fire inside the TT trace,
+    # which would cause scatter to compile into the graph and hit paged_update_cache failures.
+    static_cache.early_initialization(
+        batch_size=batch_size,
+        num_heads=getattr(config, "num_key_value_heads", config.num_attention_heads),
+        head_dim=head_dim,
+        dtype=torch.bfloat16,
+        device="cpu",
+    )
 
     if arch == "llmbox":
         num_devices = xr.global_runtime_device_count()
@@ -2721,7 +2773,6 @@ def test_glm_4_attention_decode(variant, variant_config, arch):
             position_embeddings,
             attention_mask,
             past_key_states,
-            cache_positions,
         ],
         framework=Framework.TORCH,
         mesh=mesh,

--- a/tests/torch/graphs/test_attention.py
+++ b/tests/torch/graphs/test_attention.py
@@ -2478,6 +2478,8 @@ def test_gpt_oss_attention_prefill(variant, variant_config, arch):
     config = loader.load_config()
     config._attn_implementation = "eager"
     attention = GptOssAttention(config, layer_idx=0).to(torch.bfloat16)
+    # sinks is nn.Parameter(torch.empty(...)) — uninitialized bits → bfloat16 NaN
+    attention.sinks.data.zero_()
     batch_size = 1
     if arch in ("llmbox", "galaxy"):
         batch_size = 2 if arch == "llmbox" else 4
@@ -2500,6 +2502,7 @@ def test_gpt_oss_attention_prefill(variant, variant_config, arch):
             shard_specs[attention.v_proj.bias] = ("model",)
             shard_specs[attention.o_proj.weight] = ("batch", "model")
             shard_specs[attention.o_proj.bias] = ("batch",)
+            shard_specs[attention.sinks] = ("model",)
 
             return shard_specs
 

--- a/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_2_exp.py
+++ b/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_2_exp.py
@@ -15,7 +15,7 @@ from modified_model import ModelArgs
 from modified_model import Transformer as ModifiedTransformer
 from safetensors.torch import load_file as safetensors_load_file
 from torch_xla.distributed.spmd import Mesh
-from transformers import AutoTokenizer
+from transformers import PreTrainedTokenizerFast
 from tt_torch.sparse_mlp import enable_sparse_mlp
 
 from tests.utils import failed_ttmlir_compilation
@@ -320,9 +320,11 @@ def test_deepseek_v3_2_moe_block(batch_size, seq_len):
     ffn = block.ffn
     ffn.eval()
 
-    tokenizer = AutoTokenizer.from_pretrained(
-        repo_id, trust_remote_code=True, padding_side="right"
-    )
+    # AutoTokenizer.from_pretrained internally loads model config to determine tokenizer
+    # class, which triggers a transformers 5.5 rope_scaling/max_position_embeddings bug
+    # for unregistered model types (deepseek_v32). PreTrainedTokenizerFast loads only
+    # tokenizer.json without touching model config.
+    tokenizer = PreTrainedTokenizerFast.from_pretrained(repo_id, padding_side="right")
     encoded = tokenizer(
         "Tell me a short story.",
         return_tensors="pt",

--- a/tests/torch/models/glm4_moe/test_glm4_moe.py
+++ b/tests/torch/models/glm4_moe/test_glm4_moe.py
@@ -118,7 +118,7 @@ def test_glm4_moe_layer_sparse_moe(batch_size, seq_len):
 
     run_graph_test(
         layer,
-        [hidden_states, None, position_ids, None, False, None, (cos, sin)],
+        [hidden_states, None, position_ids, None, False, (cos, sin)],
         framework=Framework.TORCH,
         mesh=mesh,
         shard_spec_fn=get_shard_spec,

--- a/tests/torch/models/kimi_k2/test_kimi_k2.py
+++ b/tests/torch/models/kimi_k2/test_kimi_k2.py
@@ -100,8 +100,15 @@ def test_kimi_k2_attention_prefill():
         device="cpu",
         dtype=torch.bfloat16,
     )
+    for cache_layer in static_cache.layers:
+        cache_layer.lazy_initialization(
+            torch.zeros(batch_size, 1, 1, config.kv_lora_rank, dtype=torch.bfloat16),
+            torch.zeros(
+                batch_size, 1, 1, config.qk_rope_head_dim, dtype=torch.bfloat16
+            ),
+        )
     past_key_states = static_cache
-    cache_positions = torch.randint(0, max_cache_len, (seq_len,), dtype=torch.long)
+    cache_positions = torch.arange(seq_len, dtype=torch.long)
     position_ids = torch.arange(seq_len).unsqueeze(0)
 
     def get_shard_spec(attention, args, kwargs):
@@ -344,7 +351,7 @@ def test_kimi_k2_layer_sparse_moe(batch_size, seq_len):
     attention_mask = torch.rand(
         batch_size, 1, seq_len, max_cache_len, dtype=torch.bfloat16
     )
-    cache_positions = torch.randint(0, max_cache_len, (seq_len,), dtype=torch.long)
+    cache_positions = torch.arange(seq_len, dtype=torch.long)
     num_devices = xr.global_runtime_device_count()
     mesh_shape = (2, 4)
     device_ids = np.array(range(num_devices))
@@ -359,6 +366,13 @@ def test_kimi_k2_layer_sparse_moe(batch_size, seq_len):
         device="cpu",
         dtype=torch.bfloat16,
     )
+    for cache_layer in static_cache.layers:
+        cache_layer.lazy_initialization(
+            torch.zeros(batch_size, 1, 1, config.kv_lora_rank, dtype=torch.bfloat16),
+            torch.zeros(
+                batch_size, 1, 1, config.qk_rope_head_dim, dtype=torch.bfloat16
+            ),
+        )
     past_key_states = static_cache
 
     num_devices = xr.global_runtime_device_count()

--- a/tests/torch/models/llama3/test_llama_step_n300.py
+++ b/tests/torch/models/llama3/test_llama_step_n300.py
@@ -88,20 +88,19 @@ def test_llama_step(run_mode):
         dtype=torch.bfloat16,
     )
 
-    cache_position: torch.Tensor = torch.arange(0, inputs.input_ids.shape[1])
+    seq_len: int = inputs.input_ids.shape[1]
+    position_ids: torch.Tensor = torch.arange(0, seq_len).unsqueeze(0)
     input_args = {
         "input_ids": inputs.input_ids,
         "past_key_values": static_cache,
-        "cache_position": cache_position,
+        "position_ids": position_ids,
         "use_cache": True,
     }
 
-    # In decode mode, use only the first token and reset cache position
+    # In decode mode, use only the first token at position 0
     if run_mode == LLMRunMode.DECODE:
-        input_args["input_ids"] = input_args["input_ids"][
-            :, :1
-        ]  # Take first token, keep batch dim
-        input_args["cache_position"] = torch.tensor([0])  # Set cache position to [0]
+        input_args["input_ids"] = input_args["input_ids"][:, :1]
+        input_args["position_ids"] = torch.tensor([[0]])
 
     # CPU comparison for validation
     cpu_output_logits: List[torch.Tensor] = []
@@ -112,18 +111,22 @@ def test_llama_step(run_mode):
         cpu_tok = tokenizer.decode(cpu_logits[:, -1].argmax(dim=-1))
         print("Cpu tok: ", cpu_tok)
 
-    # Move model and inputs to device.
+    # Move model and inputs to device. Reset cumulative_length so CPU run state
+    # doesn't corrupt the TT run (CPU run incremented it to seq_len).
     for layer in static_cache.layers:
+        layer.cumulative_length.zero_()
         layer.keys = layer.keys.to(device)
         layer.values = layer.values.to(device)
+        layer.cumulative_length = layer.cumulative_length.to(device)
+        layer.device = device
     input_args["input_ids"] = input_args["input_ids"].to(device)
-    input_args["cache_position"] = input_args["cache_position"].to(device)
+    input_args["position_ids"] = input_args["position_ids"].to(device)
 
     model = model.to(device)
 
     # Mark shardings on model and inputs.
     xs.mark_sharding(input_args["input_ids"], mesh, (None, None))
-    xs.mark_sharding(input_args["cache_position"], mesh, (None,))
+    xs.mark_sharding(input_args["position_ids"], mesh, (None, None))
 
     kv_cache_key_shard_specs = []
     kv_cache_value_shard_specs = []
@@ -167,9 +170,10 @@ def test_llama_step(run_mode):
         next_token = output_logits[:, -1].argmax(dim=-1).unsqueeze(-1)
         input_args["input_ids"] = next_token.to(device)
 
-        host_cache_pos = input_args["cache_position"].to("cpu")
-        host_cache_pos = torch.tensor([host_cache_pos[-1:] + 1])
-        input_args["cache_position"] = host_cache_pos.to(device)
+        host_pos = input_args["position_ids"].to("cpu")
+        input_args["position_ids"] = torch.tensor([[host_pos[0, -1].item() + 1]]).to(
+            device
+        )
 
     # Assert that KV cache shard specs are preserved after execution
     for i, layer in enumerate(input_args["past_key_values"].layers):

--- a/venv/requirements-dev.txt
+++ b/venv/requirements-dev.txt
@@ -36,7 +36,7 @@ tabulate
 timm
 torchvision==0.25+cpu
 torchxrayvision
-transformers==5.5.0
+transformers==5.5.1
 
 wheel
 matplotlib

--- a/venv/requirements-dev.txt
+++ b/venv/requirements-dev.txt
@@ -36,7 +36,7 @@ tabulate
 timm
 torchvision==0.25+cpu
 torchxrayvision
-transformers==5.2.0
+transformers==5.5.0
 
 wheel
 matplotlib


### PR DESCRIPTION
### Problem description

Transformers 5.5.1 introduced several breaking changes to the attention and cache APIs that affected model tests, the LLaMA example, and the perf benchmark infra. This PR brings `tt-xla` and related submodules up to date with Transformers 5.5.1. This version of transformers is also required for the next major uplift of vLLM

---

### Breaking changes in Transformers 5.5 and how it's handled

**`cache_position` deprecated → `position_ids`**

`cache_position` is no longer passed to attention modules in 5.5; `position_ids` replaces it. Updated `examples/pytorch/llama.py` and `tests/torch/models/llama3/test_llama_step_n300.py` to pass a 2D `position_ids` tensor instead and remove `cache_position` from all input dicts and device transfers.
_Note:  custom models not registered in transformers such as kimi_k2/kimi_k2_5 and DeepSeek V3.2 still rely on `cache_position` for their cache write paths so it is still left unchanged in `LLMSamplingWrapper`. Standard transformers models accept it via `**kwargs` and ignore it and so are unaffected.

**`StaticCache` lazy initialization now fires during tracing**

In 5.5, `StaticCache` defers internal buffer allocation until the first forward pass. This caused `paged_update_cache` legalization failures. Fixed by calling `static_cache.early_initialization(...)` explicitly across all attention decode tests.

**`StaticCache.cumulative_length` accumulates in-place across runs**

`torch_device_runner.py`'s `to_device` was mutating the source object in-place, causing `cumulative_length` to accumulate across repeated runs of the same workload. Fixed with `copy.copy` on objects with `__dict__` and `.clone()` on tensors that return `self` from `.to()`.

**`return_dict=False` now propagates into sub-models (5.5)**

Setting `return_dict=False` on the top-level OWL-ViT model in 5.5 propagates into `vision_model` and other sub-models, breaking `.vision_model_output` attribute access. Removed `return_dict=False` from the OWL-ViT loader and updated `post_process` to use attribute access (`outputs.logits`, `outputs.pred_boxes`) instead of tuple indexing.

**`GptOssAttention.sinks` uninitialized → NaN in bfloat16**

`sinks` is declared as `nn.Parameter(torch.empty(...))`. After `.to(torch.bfloat16)`, uninitialized float32 bits can produce bfloat16 NaN, corrupting softmax output across all heads. Added `attention.sinks.data.zero_()` in both prefill and decode tests, and added `attention.sinks` to the TP shard spec (`"model"` dim) to match the head sharding. (need to test further)

**GLM4-MoE and Kimi-K2 test fixes**

Minor API changes in 5.5 broke the GLM4-MoE loader and Kimi-K2 prefill test (`cache_positions` arg removed, `lazy_initialization` required before tracing). Both updated accordingly.

**DeepSeek V3.2 Exp tokenizer: `AutoTokenizer` triggers 5.5 `rope_scaling` bug**

`AutoTokenizer.from_pretrained` loads the model config to detect the tokenizer class. For `deepseek_v32` (unregistered in transformers 5.5), this triggers `convert_rope_params_to_dict` before `max_position_embeddings` is set on the config, causing a `KeyError`. Switched to `PreTrainedTokenizerFast.from_pretrained`, which loads `tokenizer.json` directly without touching the model config.

---

### What's changed

- `venv/requirements-dev.txt`: bump `transformers==5.2.0` → `5.5.1`
- `examples/pytorch/llama.py`: `cache_position` → `position_ids`; move `cumulative_length` to device
- `tests/infra/runners/torch_device_runner.py`: `copy.copy` + tensor clone to prevent StaticCache state corruption across runs
- `tests/torch/graphs/test_attention.py`: `early_initialization` for all StaticCache decode tests; `sinks.zero_()` + shard spec fix for GptOss prefill/decode
- `tests/torch/models/llama3/test_llama_step_n300.py`: remove `cache_position`, use `position_ids`
- `tests/torch/models/glm4_moe/test_glm4_moe.py`: 5.5 API compat
- `tests/torch/models/kimi_k2/test_kimi_k2.py`: `cache_positions` removal + `lazy_initialization`
- `tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_2_exp.py`: `AutoTokenizer` → `PreTrainedTokenizerFast` to avoid 5.5 `rope_scaling` bug
- `tests/benchmark/benchmarks/llm_benchmark.py`, `decode_utils.py`: perf benchmark updated for 5.5 StaticCache API; `cache_position` still kept in `LLMSamplingWrapper` inner model call for compatibility with custom models (kimi_k2/k2_5, DeepSeek V3.2)
- `.github/workflows/perf-bench-matrix.json`: transformer version and benchmark config updates (all models including kimi_k2_5)
- `third_party/tt_forge_models` (submodule): OWL-ViT loader fix for `return_dict` propagation; DeepSeek V3.2 Exp loader fixes for tokenizer loading and Indexer k_cache safety fallback (merged via [tt-forge-models#700](https://github.com/tenstorrent/tt-forge-models/pull/700))

### Checklist
- [x] Merge tt-forge-models changes
- [x] Merge fixes in tt-mlir
- [x] Clean up perf infra changes to remove all `cache_position` references (unless necessary)
- [x] Ensure nightly tests are all on par
- [x] Ensure no major perf regressions