### PR TITLE
Add `run_forge_models_llm_multichip` to forked test runners

### DIFF
--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -256,10 +256,8 @@ jobs:
       run: |
         # NOTE: Torch tests must be run in separate processes to avoid current issues with test isolation
         # See issue: https://github.com/tenstorrent/tt-xla/issues/795
-        # NOTE: Forked not used for multichip machines until https://github.com/tenstorrent/tt-xla/issues/1824
-        # is fixed. This is accomplished by specifically excluding run_forge_models_multichip from the list here.
         PYTEST_FORKED=""
-        for n in run_torch run_large_jax_models run_forge_models run_forge_models_llm run_forge_models_torch run_jax_training run_large_jax_training extended_models run_large_torch_models; do
+        for n in run_torch run_large_jax_models run_forge_models run_forge_models_llm run_forge_models_llm_multichip run_forge_models_torch run_jax_training run_large_jax_training extended_models run_large_torch_models; do
           if [[ "${{ matrix.build.name }}" == "$n" ]]; then
             PYTEST_FORKED="--forked"; break
           fi


### PR DESCRIPTION
### Ticket
None

### Problem description
Within one runner, for multichip prefill tests, if one test OOMs on device, subsequent tests won't be executed as multichip prefill tests don't run with `--forked` flag.
Now that https://github.com/tenstorrent/tt-xla/issues/1824 is resolved we can add `--forked` back. Thanks @ndrakulicTT for the find!

### What's changed
`run_forge_models_llm_multichip` runs with `--forked` flag now.

### Checklist
- [ ] New/Existing tests provide coverage for changes
