### PR TITLE
Add optional forge_models_override input to manual test CI workflows

### DIFF
--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -43,6 +43,11 @@ on:
         required: false
         type: string
         default: ''
+      forge_models_override:
+        description: 'Git SHA of commit (or branch name) in tenstorrent/tt-forge-models'
+        required: false
+        type: string
+        default: ''
 
 env:
   GH_TOKEN: ${{ github.token }} # for gh cli tool
@@ -118,6 +123,20 @@ jobs:
           tests/
           venv/
           examples/
+
+    - name: Override tt_forge_models ref
+      if: ${{ inputs.forge_models_override != '' }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        # Resolve short SHAs/refs via GitHub API, fall back to raw input
+        REF="${{ inputs.forge_models_override }}"
+        RESOLVED=$(gh api repos/tenstorrent/tt-forge-models/commits/$REF --jq .sha 2>/dev/null || echo "$REF")
+        cd third_party/tt_forge_models
+        git fetch --depth=1 origin $RESOLVED
+        git checkout FETCH_HEAD
+        echo "tt_forge_models checked out at $(git rev-parse HEAD)"
 
     - name: Fetch job id
       id: fetch-job-id
@@ -311,7 +330,7 @@ jobs:
     # Ensure test_config files for tt-forge-models test are valid, especially on PR's for uplifting tt-forge-models
     # but still run tests even in case of failure here, will still treat overall job as failed.
     - name: Validate Forge Models Tests test config file
-      if: ${{ steps.strings.outputs.forge-models-test == 'true' && strategy.job-index == 0 }}
+      if: ${{ steps.strings.outputs.forge-models-test == 'true' && strategy.job-index == 0 && inputs.forge_models_override == '' }}
       shell: bash
       run: |
         source venv/activate

--- a/.github/workflows/manual-test-single.yml
+++ b/.github/workflows/manual-test-single.yml
@@ -54,6 +54,10 @@ on:
           description: 'Git SHA of commit in tenstorrent/tt-mlir'
           required: false
           type: string
+      forge_models_override:
+          description: 'Git SHA of commit (or branch name) in tenstorrent/tt-forge-models'
+          required: false
+          type: string
       torchxla_build_run_id:
         description: 'Manual torch-xla build run ID'
         required: false
@@ -117,3 +121,4 @@ jobs:
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
       torchxla_build_run_id: ${{ inputs.torchxla_build_run_id }}
+      forge_models_override: ${{ inputs.forge_models_override }}

--- a/.github/workflows/manual-test.yml
+++ b/.github/workflows/manual-test.yml
@@ -37,6 +37,10 @@ on:
         description: 'Git SHA of commit in tenstorrent/tt-mlir'
         required: false
         type: string
+      forge_models_override:
+        description: 'Git SHA of commit (or branch name) in tenstorrent/tt-forge-models'
+        required: false
+        type: string
       manylinux_build:
         description: 'Build and use manylinux wheel'
         required: false
@@ -92,6 +96,7 @@ jobs:
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
       wheel_build: ${{ inputs.manylinux_build && 'manylinux' || 'release' }}
       torchxla_build_run_id: ${{ inputs.torchxla_build_run_id }}
+      forge_models_override: ${{ inputs.forge_models_override }}
 
   test-multihost-dualt3k:
     if: always() && !cancelled() && !failure() && inputs.run_multihost_dualt3k


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/4274

### Problem description
- We need an easy way to run tt-xla model tests with different tt-forge-models versions, especially when agentic workflows want to kick off tt-xla CI for their new tt-forge-models updates. But also, for humans.

### What's changed
- Add new optional input to manual-test.yml and manual-test-single.yaml for testing against a specific tt-forge-models SHA or branch without changing the submodule pointer. The override is applied at test time (not build time) since forge models only affect test discovery/runtime.
- Skip test_config validation when forge_models_override is set, since model names may not match tt-xla's configs yet and defeat purpose of run. It remains part of onPR for merging tt-forge-models uplifts.
- Resolve short SHAs via GitHub API before fetching, since git fetch --depth=1 on shallow clones can't resolve abbreviated SHAs from the remote

### Checklist
- [x] Tested both flows, will add links in comment
