### PR TITLE
[Accuracy benchmark] Fix reference generator and bump transformers to 5.2.0 in accuracy tests

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -322,15 +322,13 @@
         "name": "llama_3_1_8b_instruct_accuracy",
         "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b",
-        "accuracy-testing": true,
-        "batch-size": 16
+        "accuracy-testing": true
       },
       {
         "name": "mistral_7b_accuracy",
         "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==5.2.0 protobuf sentencepiece",
         "pytest": "tests/benchmark/test_llms.py::test_mistral_7b",
-        "accuracy-testing": true,
-        "batch-size": 8
+        "accuracy-testing": true
       },
       {
         "name": "qwen_2_5_7b_instruct_accuracy",
@@ -354,15 +352,13 @@
         "name": "microsoft_phi-1_accuracy",
         "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_phi1",
-        "accuracy-testing": true,
-        "batch-size": 16
+        "accuracy-testing": true
       },
       {
         "name": "microsoft_phi-1_5_accuracy",
         "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_phi1_5",
-        "accuracy-testing": true,
-        "batch-size": 16
+        "accuracy-testing": true
       },
       {
         "name": "microsoft_phi-2_accuracy",
@@ -386,8 +382,7 @@
         "name": "tiiuae_falcon3-7b-base_accuracy",
         "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b",
-        "accuracy-testing": true,
-        "batch-size": 4
+        "accuracy-testing": true
       },
       {
         "name": "qwen_2_5_0_5b_instruct_accuracy",
@@ -405,8 +400,7 @@
         "name": "qwen_2_5_3b_instruct_accuracy",
         "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_3b",
-        "accuracy-testing": true,
-        "batch-size": 16
+        "accuracy-testing": true
       },
       {
         "name": "qwen_3_0_6b_accuracy",
@@ -457,8 +451,7 @@
         "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b_instruct_tp",
         "runs-on": "n300-llmbox",
-        "accuracy-testing": true,
-        "batch-size": 16
+        "accuracy-testing": true
       },
       {
         "name": "ministral_8b_tp_accuracy",

--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -308,153 +308,153 @@
       },
       {
         "name": "llama_3_2_1b_instruct_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_2_1b",
         "accuracy-testing": true
       },
       {
         "name": "llama_3_2_3b_instruct_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_2_3b",
         "accuracy-testing": true
       },
       {
         "name": "llama_3_1_8b_instruct_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b",
         "accuracy-testing": true,
         "batch-size": 16
       },
       {
         "name": "mistral_7b_accuracy",
-        "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==4.57.1 protobuf sentencepiece",
+        "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==5.2.0 protobuf sentencepiece",
         "pytest": "tests/benchmark/test_llms.py::test_mistral_7b",
         "accuracy-testing": true,
         "batch-size": 8
       },
       {
         "name": "qwen_2_5_7b_instruct_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_7b",
         "accuracy-testing": true
       },
       {
         "name": "google_gemma-1.1-2b-it_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_gemma_1_1_2b",
         "accuracy-testing": true
       },
       {
         "name": "google_gemma-2-2b-it_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_gemma_2_2b",
         "accuracy-testing": true
       },
       {
         "name": "microsoft_phi-1_accuracy",
-        "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_phi1",
         "accuracy-testing": true,
         "batch-size": 16
       },
       {
         "name": "microsoft_phi-1_5_accuracy",
-        "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_phi1_5",
         "accuracy-testing": true,
         "batch-size": 16
       },
       {
         "name": "microsoft_phi-2_accuracy",
-        "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_phi2",
         "accuracy-testing": true
       },
       {
         "name": "tiiuae_falcon3-1b-base_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_1b",
         "accuracy-testing": true
       },
       {
         "name": "tiiuae_falcon3-3b-base_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_3b",
         "accuracy-testing": true
       },
       {
         "name": "tiiuae_falcon3-7b-base_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b",
         "accuracy-testing": true,
         "batch-size": 4
       },
       {
         "name": "qwen_2_5_0_5b_instruct_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_0_5b",
         "accuracy-testing": true
       },
       {
         "name": "qwen_2_5_1_5b_instruct_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_1_5b",
         "accuracy-testing": true
       },
       {
         "name": "qwen_2_5_3b_instruct_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_3b",
         "accuracy-testing": true,
         "batch-size": 16
       },
       {
         "name": "qwen_3_0_6b_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_0_6b",
         "accuracy-testing": true
       },
       {
         "name": "qwen_3_1_7b_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_1_7b",
         "accuracy-testing": true
       },
       {
         "name": "qwen_3_4b_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_4b",
         "accuracy-testing": true
       },
       {
         "name": "qwen_3_8b_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_8b",
         "accuracy-testing": true
       },
       {
         "name": "ministral_8b_accuracy",
-        "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_ministral_8b",
         "accuracy-testing": true
       },
       {
         "name": "falcon3_7b_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "falcon3_10b_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_10b_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "llama_3_1_8b_instruct_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b_instruct_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true,
@@ -462,63 +462,63 @@
       },
       {
         "name": "ministral_8b_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_ministral_8b_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "mistral_nemo_instruct_2407_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_mistral_nemo_instruct_2407_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "mistral_small_24b_instruct_2501_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_mistral_small_24b_instruct_2501_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "qwen_2_5_14b_instruct_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_14b_instruct_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "qwen_2_5_coder_32b_instruct_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_coder_32b_instruct_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "qwen_3_8b_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_8b_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "qwen_3_14b_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_14b_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "qwen_3_32b_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_32b_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "llama_3_1_70b_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true,
@@ -526,28 +526,28 @@
       },
       {
         "name": "gpt_oss_20b_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests accelerate torch==2.9.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests accelerate torch==2.9.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "llama_3_1_70b_tp_galaxy_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp_galaxy",
         "runs-on": "galaxy-wh-6u",
         "accuracy-testing": true
       },
       {
         "name": "gpt_oss_20b_tp_galaxy_accuracy",
-        "pyreq": "datasets loguru pytest requests accelerate torch==2.9.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests accelerate torch==2.9.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_galaxy_batch_size_64",
         "runs-on": "galaxy-wh-6u",
         "accuracy-testing": true
       },
       {
         "name": "gpt_oss_120b_tp_galaxy_accuracy",
-        "pyreq": "datasets loguru pytest requests accelerate torch==2.9.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets loguru pytest requests accelerate torch==2.9.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_120b_tp_galaxy_batch_size_64",
         "runs-on": "galaxy-wh-6u",
         "accuracy-testing": true

--- a/tests/benchmark/llm_utils/reference_generator.py
+++ b/tests/benchmark/llm_utils/reference_generator.py
@@ -46,15 +46,6 @@ def generate_reference_outputs(total_length, output_file, model_name):
     # Load model and tokenizer from HuggingFace
     config = AutoConfig.from_pretrained(model_name)
 
-    # Qwen only: add rope scaling to the config, for long context support.
-    # https://huggingface.co/Qwen/Qwen2.5-7B-Instruct#processing-long-texts
-    if "Qwen" in model_name:
-        config.rope_scaling = {
-            "factor": 4.0,
-            "original_max_position_embeddings": 32768,
-            "type": "yarn",
-        }
-
     tokenizer = AutoTokenizer.from_pretrained(model_name)
     model = AutoModelForCausalLM.from_pretrained(
         model_name,

--- a/tests/benchmark/llm_utils/reference_generator.py
+++ b/tests/benchmark/llm_utils/reference_generator.py
@@ -19,12 +19,7 @@ from pathlib import Path
 
 import torch
 import transformers
-from llm_utils.decode_utils import (
-    LLMSamplingWrapper,
-    extract_topk,
-    generate_and_benchmark,
-    init_static_cache,
-)
+from llm_utils.decode_utils import extract_topk, init_static_cache
 from loguru import logger
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 
@@ -100,39 +95,39 @@ def generate_reference_outputs(total_length, output_file, model_name):
         dtype=torch.bfloat16,
     )
 
-    # Construct input_args dict matching the format used by device benchmarks
-    input_args = {
-        "input_ids": tokens_1d[:split_point].unsqueeze(0),  # [1, split_point]
-        "past_key_values": static_cache,
-        "cache_position": torch.arange(0, split_point),
-        "use_cache": True,
-    }
-    ground_truth_tokens = tokens_1d[split_point:]  # [decode_len]
-    decode_len = len(ground_truth_tokens)
-
     logger.info(f"Generating reference topk on CPU (split_point={split_point})")
 
-    cpu_wrapper = LLMSamplingWrapper(
-        model, lambda output: output.logits, return_logits=True
-    )
-    cpu_wrapper.eval()
-    output_logits, _ = generate_and_benchmark(
-        cpu_wrapper,
-        input_args,
-        torch.device("cpu"),
-        decode_len,
-        verbose=False,
-        ground_truth_tokens=ground_truth_tokens,
-        collect_logits=True,
-    )
-
-    # Post-processing: extract top-k predictions from raw logits
     all_top1 = []
     all_top5 = []
-    for logits in output_logits:
-        top1, top5 = extract_topk(logits, k=5)
-        all_top1.append(top1.squeeze(0).cpu())
-        all_top5.append(top5.squeeze(0).cpu())
+
+    with torch.no_grad():
+        # Prefill: process all split_point tokens, capture ALL position logits
+        prefill_output = model(
+            input_ids=tokens_1d[:split_point].unsqueeze(0),
+            past_key_values=static_cache,
+            cache_position=torch.arange(0, split_point),
+            use_cache=True,
+        )
+        prefill_logits = prefill_output.logits[0]  # [split_point, vocab_size]
+        for pos in range(split_point):
+            top1, top5 = extract_topk(prefill_logits[pos], k=5)
+            all_top1.append(top1.view(-1).cpu())
+            all_top5.append(top5.view(-1, 5).cpu())
+
+        # Decode: process remaining tokens one at a time (teacher forcing)
+        decode_steps = total_length - 1 - split_point
+        for step in range(decode_steps):
+            token_idx = split_point + step
+            decode_output = model(
+                input_ids=tokens_1d[token_idx].view(1, 1),
+                past_key_values=static_cache,
+                cache_position=torch.tensor([token_idx]),
+                use_cache=True,
+            )
+            logits = decode_output.logits[0, -1]  # [vocab_size]
+            top1, top5 = extract_topk(logits, k=5)
+            all_top1.append(top1.view(-1).cpu())
+            all_top5.append(top5.view(-1, 5).cpu())
 
     top1_tokens = torch.cat(all_top1, dim=0)  # [total_length - 1]
     top5_tokens = torch.cat(all_top5, dim=0)  # [total_length - 1, 5]


### PR DESCRIPTION
### Ticket
Closes #4146 

### Problem description
The reference generator was using LLMSamplingWrapper which only returns the last position's logits, discarding all prefill predictions. This produced 64 predictions instead of the expected 127, but was hidden because existing .refpt files predated the breaking change.

### What's changed
Solving minor bugs in reference generation, and cleanup after transformers version uplift.
- Replace LLMSamplingWrapper with direct model calls that capture all position logits during prefill. Bump transformers from 4.57.1 to 5.2.0 across all accuracy test configs.
- Remove unnecessary Qwen rope_scaling override in reference generator.
- Remove batch-size override from perf-benchmark-matrix because now tests pass with default batch size 32