### PR TITLE
added Dummy Function for onLoadedExecutableGetDeviceAssignment

### DIFF
--- a/pjrt_implementation/inc/api/loaded_executable_instance.h
+++ b/pjrt_implementation/inc/api/loaded_executable_instance.h
@@ -177,6 +177,10 @@ onLoadedExecutableIsDeleted(PJRT_LoadedExecutable_IsDeleted_Args *args);
 // Implements PJRT_LoadedExecutable_Execute API function.
 PJRT_Error *onLoadedExecutableExecute(PJRT_LoadedExecutable_Execute_Args *args);
 
+// Implements PJRT_LoadedExecutable_GetDeviceAssignment API function.
+PJRT_Error *onLoadedExecutableGetDeviceAssignment(
+    PJRT_LoadedExecutable_GetDeviceAssignment_Args *args);
+
 } // namespace internal
 
 } // namespace tt::pjrt

--- a/pjrt_implementation/src/api/loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/loaded_executable_instance.cc
@@ -57,6 +57,8 @@ void LoadedExecutableInstance::bindApi(PJRT_Api *api) {
       internal::onLoadedExecutableGetExecutable;
   api->PJRT_LoadedExecutable_AddressableDevices =
       internal::onLoadedExecutableAddressableDevices;
+  api->PJRT_LoadedExecutable_GetDeviceAssignment =                                                                                                              
+      internal::onLoadedExecutableGetDeviceAssignment;
   api->PJRT_LoadedExecutable_Delete = internal::onLoadedExecutableDelete;
   api->PJRT_LoadedExecutable_IsDeleted = internal::onLoadedExecutableIsDeleted;
   api->PJRT_LoadedExecutable_Execute = internal::onLoadedExecutableExecute;
@@ -295,6 +297,16 @@ PJRT_Error *onLoadedExecutableAddressableDevices(
 
   return nullptr;
 }
+
+PJRT_Error *onLoadedExecutableGetDeviceAssignment(
+    PJRT_LoadedExecutable_GetDeviceAssignment_Args *args) {                                                                                                   
+
+      args->serialized_bytes_size = 0;                                                                                                                            
+  args->serialized_device_assignment = nullptr;
+  args->serialized_device_assignment_deleter =                                                                                                                
+      +[](PJRT_DeviceAssignmentSerialized *) {};
+  return nullptr;                                                                                                                                             
+} 
 
 PJRT_Error *onLoadedExecutableDelete(PJRT_LoadedExecutable_Delete_Args *args) {
   ZoneScoped;

--- a/pjrt_implementation/src/api/loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/loaded_executable_instance.cc
@@ -57,7 +57,7 @@ void LoadedExecutableInstance::bindApi(PJRT_Api *api) {
       internal::onLoadedExecutableGetExecutable;
   api->PJRT_LoadedExecutable_AddressableDevices =
       internal::onLoadedExecutableAddressableDevices;
-  api->PJRT_LoadedExecutable_GetDeviceAssignment =                                                                                                              
+  api->PJRT_LoadedExecutable_GetDeviceAssignment =
       internal::onLoadedExecutableGetDeviceAssignment;
   api->PJRT_LoadedExecutable_Delete = internal::onLoadedExecutableDelete;
   api->PJRT_LoadedExecutable_IsDeleted = internal::onLoadedExecutableIsDeleted;
@@ -299,14 +299,14 @@ PJRT_Error *onLoadedExecutableAddressableDevices(
 }
 
 PJRT_Error *onLoadedExecutableGetDeviceAssignment(
-    PJRT_LoadedExecutable_GetDeviceAssignment_Args *args) {                                                                                                   
+    PJRT_LoadedExecutable_GetDeviceAssignment_Args *args) {
 
-      args->serialized_bytes_size = 0;                                                                                                                            
+  args->serialized_bytes_size = 0;
   args->serialized_device_assignment = nullptr;
-  args->serialized_device_assignment_deleter =                                                                                                                
+  args->serialized_device_assignment_deleter =
       +[](PJRT_DeviceAssignmentSerialized *) {};
-  return nullptr;                                                                                                                                             
-} 
+  return nullptr;
+}
 
 PJRT_Error *onLoadedExecutableDelete(PJRT_LoadedExecutable_Delete_Args *args) {
   ZoneScoped;

--- a/pjrt_implementation/src/stubs.inc
+++ b/pjrt_implementation/src/stubs.inc
@@ -72,7 +72,6 @@
   // (if at all).
   _STUB(PJRT_Executable_GetCostAnalysis);
   _STUB(PJRT_Executable_ParameterMemoryKinds);
-  _STUB(PJRT_LoadedExecutable_GetDeviceAssignment);
 
   // This is not required to be implemented by all platforms. It should return
   // memory stats that allow callers to estimate device memory usage when


### PR DESCRIPTION
### Ticket
Related to tenstorrent/tt-mlir/issues/7664

### Problem description
Running AF3 on **jax version==0.8.2** results in the following stack trace:
```
2026-04-16 13:26:37.741 (   0.215s) [        ABA34140]loaded_executable_insta:264      1| LoadedExecutableInstance::PJRT_LoadedExecutable_GetExecutable
2026-04-16 13:26:37.741 (   0.215s) [        ABA34140]loaded_executable_insta:284      1| LoadedExecutableInstance::PJRT_LoadedExecutable_AddressableDevices
2026-04-16 13:26:37.741 (   0.215s) [        ABA34140]              stubs.inc:75    WARN| STUB: PJRT_LoadedExecutable_GetDeviceAssignment
2026-04-16 13:26:37.741 (   0.215s) [        ABA34140]      error_instance.cc:61       1| ErrorInstance::PJRT_Error_GetCode
2026-04-16 13:26:37.741 (   0.215s) [        ABA34140]      error_instance.cc:52       1| ErrorInstance::PJRT_Error_Message
F0416 13:26:37.741599 3335356 pjrt_c_api_helpers.cc:257] Unexpected error status Error code: 12
*** Check failure stack trace: ***
    @     0x7fe48b38df64  absl::lts_20250814::log_internal::LogMessage::SendToLog()
    @     0x7fe48b38dee6  absl::lts_20250814::log_internal::LogMessage::Flush()
    @     0x7fe48b4cdaa3  pjrt::LogFatalIfPjrtError()
    @     0x7fe48b4b1fe8  xla::PjRtCApiLoadedExecutable::InitDeviceAssignment()
    @     0x7fe48b4b1ca0  xla::PjRtCApiLoadedExecutable::PjRtCApiLoadedExecutable()
    @     0x7fe48b4a6140  xla::InitializeArgsAndCompile()
    @     0x7fe48b4a64f8  xla::PjRtCApiClient::CompileAndLoad()
    @     0x7fe487cf1d50  xla::ifrt::PjRtLoadedExecutable::Create()
    @     0x7fe487cea754  xla::ifrt::PjRtCompiler::CompileAndLoad()
    @     0x7fe487b9152e  jax::PyClient::CompileAndLoadIfrtProgram()
    @     0x7fe487b92bed  jax::PyClient::CompileAndLoad()
    @     0x7fe487b9fd49  nanobind::detail::func_create<>()::{lambda()#1}::__invoke()
    @     0x7fe487c71131  nanobind::detail::nb_func_vectorcall_complex()
    @     0x7fe487c719e8  nanobind::detail::nb_bound_method_vectorcall()
    @           0x549975  PyObject_Vectorcall
    @           0x5d6f09  _PyEval_EvalFrameDefault
    @           0x549975  PyObject_Vectorcall
    @     0x7fe487c6825d  nanobind::detail::obj_vectorcall()
    @     0x7fe49162dad3  nanobind::detail::api<>::operator()<>()
    @     0x7fe49162c5bf  jax::WeakrefLRUCache::Call()
    @     0x7fe49162fda3  nanobind::detail::func_create<>()::{lambda()#1}::__invoke()
    @     0x7fe487c71131  nanobind::detail::nb_func_vectorcall_complex()
    @           0x54a811  _PyObject_Call_Prepend
    @           0x5a3458  (unknown)
    @           0x548f75  _PyObject_MakeTpCall
    @           0x5d6f09  _PyEval_EvalFrameDefault
    @           0x549975  PyObject_Vectorcall
    @     0x7fe48b430eb3  jax::(anonymous namespace)::PjitFunction::Call()
    @     0x7fe48b42f3bf  PjitFunction_tp_vectorcall
    @           0x5db0ba  _PyEval_EvalFrameDefault
    @           0x6f9ab5  (unknown)
    @           0x64f3bd  (unknown)
    @           0x54b199  PyObject_Call
    @           0x5db0ba  _PyEval_EvalFrameDefault
    @           0x54cb74  (unknown)
    @           0x54b199  PyObject_Call
    @           0x5db0ba  _PyEval_EvalFrameDefault
    @           0x549975  PyObject_Vectorcall
    @           0x5a2f90  (unknown)
    @           0x584ebd  _PyObject_GenericGetAttrWithDict
    @           0x58475d  PyObject_GetAttr
    @           0x5d7364  _PyEval_EvalFrameDefault
    @           0x5d543b  PyEval_EvalCode
    @           0x6085d2  (unknown)
    @           0x6b4d03  (unknown)
    @           0x6b4a6a  _PyRun_SimpleFileObject
    @           0x6b489f  _PyRun_AnyFileObject
    @           0x6bc905  Py_RunMain
    @           0x6bc3ed  Py_BytesMain
    @     0x7fe4aba5f1ca  (unknown)
    @     0x7fe4aba5f28b  __libc_start_main
    @           0x6576c5  _start
Fatal Python error: Aborted
```
AFAIK the ```InitDeviceAssignment()``` is being called here because of the jax version and our PJRT C API version being [103](https://github.com/tenstorrent/tt-xla/pull/3740)
### What's changed
The code just creates a dummy function, so essentially it's the same as [open-xla's](https://github.com/openxla/xla/blob/main/xla/pjrt/c_api_client/pjrt_c_api_client.cc#L2833)

### Checklist
- [ ] New/Existing tests provide coverage for changes
