### PR TITLE
[vLLM] Add batch=32 test coverage for on-device sampling and p150 vllm tests

### DIFF
--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -183,6 +183,7 @@ jobs:
           --dir wheels \
           --name ${{ steps.strings.outputs.wheel_artifact_name }}
         if [[ "${{ matrix.build.name }}" == "run_vllm_n150_tests" || \
+              "${{ matrix.build.name }}" == "run_vllm_p150_tests" || \
               "${{ matrix.build.name }}" == "run_vllm_n300_tests" || \
               "${{ matrix.build.name }}" == "run_vllm_llmbox_tests" ]]; then
           echo "Downloading wheel from: ${{ github.repository }} run_id ${{ steps.strings.outputs.artifact_run_id }} name ${{ steps.strings.outputs.wheel_release_vllm_tt_artifact_name }}"
@@ -373,6 +374,7 @@ jobs:
       run: |
         source venv/activate
         if [[ "${{ matrix.build.name }}" == "run_vllm_n150_tests" || \
+              "${{ matrix.build.name }}" == "run_vllm_p150_tests" || \
               "${{ matrix.build.name }}" == "run_vllm_n300_tests" || \
               "${{ matrix.build.name }}" == "run_vllm_llmbox_tests" ]]; then
           uv pip install -r $(pwd)/integrations/vllm_plugin/requirements-vllm-plugin.txt
@@ -385,6 +387,7 @@ jobs:
                2>&1 | tee pytest.log
 
         if [[ "${{ matrix.build.name }}" == "run_vllm_n150_tests" || \
+              "${{ matrix.build.name }}" == "run_vllm_p150_tests" || \
               "${{ matrix.build.name }}" == "run_vllm_n300_tests" || \
               "${{ matrix.build.name }}" == "run_vllm_llmbox_tests" ]]; then
           uv pip uninstall vllm transformers

--- a/.github/workflows/test-matrix-presets/vllm-model-tests-nightly.json
+++ b/.github/workflows/test-matrix-presets/vllm-model-tests-nightly.json
@@ -1,5 +1,6 @@
 [
     { "runs-on": "n150",               "name": "run_vllm_n150_tests",   "dir": "./tests/integrations/vllm_plugin",        "test-mark": "nightly and single_device", "shared-runners": "true" },
+    { "runs-on": "p150",               "name": "run_vllm_p150_tests",   "dir": "./tests/integrations/vllm_plugin",        "test-mark": "nightly and single_device", "shared-runners": "true" },
     { "runs-on": "n300",               "name": "run_vllm_n300_tests",   "dir": "./tests/integrations/vllm_plugin",        "test-mark": "nightly and data_parallel", "shared-runners": "true" },
     { "runs-on": "n300",               "name": "run_vllm_n300_tests",   "dir": "./tests/integrations/vllm_plugin",        "test-mark": "nightly and tensor_parallel and dual_chip", "shared-runners": "true" },
     { "runs-on": "n300-llmbox",        "name": "run_vllm_llmbox_tests", "dir": "./tests/integrations/vllm_plugin",        "test-mark": "nightly and tensor_parallel and llmbox", "shared-runners": "true" }

--- a/.github/workflows/test-matrix-presets/vllm-model-tests.json
+++ b/.github/workflows/test-matrix-presets/vllm-model-tests.json
@@ -1,5 +1,6 @@
 [
     { "runs-on": "n150",               "name": "run_vllm_n150_tests",   "dir": "./tests/integrations/vllm_plugin",        "test-mark": "push and single_device", "shared-runners": "true" },
+    { "runs-on": "p150",               "name": "run_vllm_p150_tests",   "dir": "./tests/integrations/vllm_plugin",        "test-mark": "push and single_device", "shared-runners": "true" },
     { "runs-on": "n300",               "name": "run_vllm_n300_tests",   "dir": "./tests/integrations/vllm_plugin",        "test-mark": "push and data_parallel", "shared-runners": "true" },
     { "runs-on": "n300",               "name": "run_vllm_n300_tests",   "dir": "./tests/integrations/vllm_plugin",        "test-mark": "push and tensor_parallel and dual_chip", "shared-runners": "true" },
     { "runs-on": "n300-llmbox",        "name": "run_vllm_llmbox_tests", "dir": "./tests/integrations/vllm_plugin",        "test-mark": "push and tensor_parallel and llmbox", "shared-runners": "true" }

--- a/tests/integrations/vllm_plugin/generative/test_opt_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_opt_generation.py
@@ -67,9 +67,9 @@ def test_opt_generation_large_batch(batch_size):
     sampling_params = vllm.SamplingParams(temperature=0.8, top_p=0.95, max_tokens=16)
     llm_args = {
         "model": "facebook/opt-125m",
-        "max_num_batched_tokens": batch_size * 128,
+        "max_num_batched_tokens": batch_size * 32,
         "max_num_seqs": batch_size,
-        "max_model_len": 128,
+        "max_model_len": 32,
         "gpu_memory_utilization": 0.001,
         "additional_config": {
             "enable_const_eval": False,

--- a/tests/integrations/vllm_plugin/generative/test_opt_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_opt_generation.py
@@ -55,3 +55,29 @@ def test_opt_generation_multibatch():
     output_text2 = output[1].outputs[0].text
     print(f"prompt: {prompts[0]}, output: {output_text1}")
     print(f"prompt: {prompts[1]}, output: {output_text2}")
+
+
+@pytest.mark.nightly
+@pytest.mark.single_device
+@pytest.mark.parametrize(
+    "batch_size", [8, 16, 32], ids=["batch8", "batch16", "batch32"]
+)
+def test_opt_generation_large_batch(batch_size):
+    prompts = ["The quick brown fox"] * batch_size
+    sampling_params = vllm.SamplingParams(temperature=0.8, top_p=0.95, max_tokens=16)
+    llm_args = {
+        "model": "facebook/opt-125m",
+        "max_num_batched_tokens": batch_size * 128,
+        "max_num_seqs": batch_size,
+        "max_model_len": 128,
+        "gpu_memory_utilization": 0.001,
+        "additional_config": {
+            "enable_const_eval": False,
+            "min_context_len": 32,
+        },
+    }
+    llm = vllm.LLM(**llm_args)
+    outputs = llm.generate(prompts, sampling_params)
+    assert len(outputs) == batch_size
+    for i, out in enumerate(outputs):
+        print(f"[{i}] {out.outputs[0].text}")

--- a/tests/integrations/vllm_plugin/sampling/test_sampling_params_synthetic.py
+++ b/tests/integrations/vllm_plugin/sampling/test_sampling_params_synthetic.py
@@ -123,6 +123,40 @@ def test_non_greedy(device, vocab_size):
 
 @pytest.mark.push
 @pytest.mark.single_device
+def test_greedy_batch32(device):
+    """Greedy at batch=32 produces valid tokens for all sequences."""
+    batch_size = 32
+    vocab_size = 201088  # gpt-oss-120b, largest production vocab
+    logits_cpu = torch.randn(batch_size, vocab_size, dtype=torch.float32)
+    expected = run_sampler_greedy(logits_cpu, None)
+
+    compiled_fn = torch.compile(run_sampler_greedy, backend="tt", dynamic=False)
+    actual = compiled_fn(logits_cpu.to(device), None).cpu()
+
+    assert actual.shape == (batch_size, 1)
+    assert torch.equal(
+        actual, expected
+    ), f"Greedy mismatch at batch=32: {actual} vs {expected}"
+
+
+@pytest.mark.push
+@pytest.mark.single_device
+def test_non_greedy_batch32(device):
+    """Stochastic sampling at batch=32 runs without OOM and returns valid tokens."""
+    batch_size = 32
+    vocab_size = 201088  # gpt-oss-120b, largest production vocab
+    logits_cpu = torch.randn(batch_size, vocab_size, dtype=torch.float32)
+
+    compiled_fn = torch.compile(run_sampler, backend="tt", dynamic=False)
+    metadata_dev = make_metadata(batch_size=batch_size, device=device)
+    actual = compiled_fn(logits_cpu.to(device), metadata_dev).cpu()
+
+    assert actual.shape == (batch_size, 1)
+    assert_valid_tokens(actual, vocab_size)
+
+
+@pytest.mark.push
+@pytest.mark.single_device
 @pytest.mark.parametrize("vocab_size", VOCAB_SIZES)
 def test_combined(device, vocab_size):
     """Different param combinations on the same logits produce diverse tokens.


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-xla/issues/3610

### Problem description
- Running opt-125m with batch size 32 caused an OOM crash on TT hardware. The root cause was the MoreH cumsum op during on-device top-p filtering over-allocating DRAM proportional to batch size, exhausting per-bank space despite sufficient total DRAM. The underlying issue is now resolved, but there was no test coverage at batch=32 to guard against regression.
- vllm tests like llama were failing on blackhole due to SDPA op issues and not tested, recently.

### What's changed

**`tests/integrations/vllm_plugin/sampling/test_sampling_params_synthetic.py`**:
- Add `test_greedy_batch32` (push) — greedy argmax at batch=32 using the largest production vocab size (gpt-oss-120b, 201088)
- Add `test_non_greedy_batch32` (push) — stochastic (top-k/top-p) sampling at batch=32; directly exercises the cumsum path that previously OOM'd

**`tests/integrations/vllm_plugin/generative/test_opt_generation.py`**:
- Add `test_opt_generation_large_batch` (nightly) — parametrized over batch sizes 8, 16, and 32

**`.github/workflows/test-matrix-presets/vllm-model-tests.json`, `vllm-model-tests-nightly.json`**:
- Add p150 (Blackhole) to vLLM push and nightly test matrices, mirroring the existing n150 single_device jobs
- Add run_vllm_p150_tests to call-test.yml like run_vllm_n150_tests so nightly tests work

### Checklist
- [x] New tests in push/onPR and vllm nightly passing on branch: https://github.com/tenstorrent/tt-xla/actions/runs/24700367061