### PR TITLE
Testing models using sliding attention

### DIFF
--- a/examples/pytorch/mistral_8b.py
+++ b/examples/pytorch/mistral_8b.py
@@ -1,0 +1,184 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import os
+from typing import List
+
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from transformers import AutoModelForCausalLM, AutoTokenizer, PreTrainedTokenizer
+from transformers.cache_utils import StaticCache
+from transformers.configuration_utils import PretrainedConfig
+from tt_torch.transformers_overrides import (
+    override_cache_sliding_window_layers,
+    override_ministral_sliding_window_causal_mask,
+)
+
+MODEL_NAME = "mistralai/Ministral-8B-Instruct-2410"
+DEFAULT_PROMPT = "Who would win in a fight - a dinosaur or a cow named Moo Moo?"
+MAX_LENGTH = 256
+BATCH_SIZE = 1
+
+
+# --------------------------------
+# Mistral 8B Generation Loop Example
+# --------------------------------
+def mistral_8b():
+    # Set up config variables.
+    model_name = "mistralai/Ministral-8B-Instruct-2410"
+
+    # Connect the device
+    device: torch.device = torch_xla.device()
+    model, tokenizer = _load_model_and_tokenizer(model_name)
+
+    input_args, formmatted_prompts = _prepare_inputs(
+        [DEFAULT_PROMPT], tokenizer, model.config, BATCH_SIZE, MAX_LENGTH
+    )
+    max_tokens_to_generate = 20
+
+    for layer in input_args["past_key_values"].layers:
+        layer.keys = layer.keys.to(device)
+        layer.values = layer.values.to(device)
+        if isinstance(getattr(layer, "cumulative_length", None), torch.Tensor):
+            layer.cumulative_length = layer.cumulative_length.to(device)
+        if hasattr(layer, "device"):
+            layer.device = device
+
+    input_args["input_ids"] = input_args["input_ids"].to(device)
+    input_args["cache_position"] = input_args["cache_position"].to(device)
+    input_args["attention_mask"] = input_args["attention_mask"].to(device)
+    model = model.to(device)
+
+    torch_xla.set_custom_compile_options({"experimental_weight_dtype": "bfp_bf8"})
+    compiled_model = torch.compile(model, backend="tt")
+    output_tokens: List[List[str]] = [[] for _ in range(1)]
+    with torch.no_grad():
+        for step in range(max_tokens_to_generate):
+            output = compiled_model(**input_args)
+            print(
+                f"[Step {step}] {'Prefill' if step == 0 else 'Decode'} ...", flush=True
+            )
+            logits = output.logits.to("cpu")
+            next_token_id = logits[:, -1].argmax(dim=-1)
+            output_text = [tokenizer.decode(next_token_id[0])]
+            for i, output_tokens_list in enumerate(output_tokens):
+                output_tokens_list.append(output_text[i])
+
+            if torch.all(next_token_id == tokenizer.eos_token_id):
+                print()  # Add newline after generation completes
+                break
+
+            # Update inputs for next iteration
+            input_args["input_ids"] = next_token_id.unsqueeze(-1).to(device)
+
+            host_cache_pos = input_args["cache_position"].to("cpu")
+            host_cache_pos = torch.tensor([host_cache_pos[-1:] + 1])
+            input_args["cache_position"] = host_cache_pos.to(device)
+
+    print()
+    for i in range(1):
+        print(f"=" * 80)
+        print(f"Result for user {i}:")
+        print(f"-" * 80)
+        print("PROMPT:")
+        print(formmatted_prompts[i])
+        print(f"-" * 80)
+        print("GENERATED:")
+        print("".join(output_tokens[i]))
+        print(f"=" * 80)
+        print()
+
+
+def _load_model_and_tokenizer(model_name: str):
+    model = AutoModelForCausalLM.from_pretrained(model_name, dtype=torch.bfloat16)
+    override_ministral_sliding_window_causal_mask()
+    model = model.eval()
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    return model, tokenizer
+
+
+def _prepare_inputs(
+    input_prompt: List[str],
+    tokenizer: PreTrainedTokenizer,
+    model_config: PretrainedConfig,
+    batch_size: int,
+    max_cache_len: int,
+) -> tuple[dict, List[str]]:
+
+    formatted_prompts = []
+    for prompt in input_prompt:
+        if tokenizer.chat_template is not None:
+            messages = [{"role": "user", "content": prompt}]
+            formatted_prompt = tokenizer.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True
+            )
+        else:
+            formatted_prompt = prompt
+        formatted_prompts.append(formatted_prompt)
+
+    prompt_lengths = [
+        len(tokenizer.encode(p, add_special_tokens=False)) for p in formatted_prompts
+    ]
+    max_length = max(prompt_lengths)
+
+    inputs = tokenizer(
+        formatted_prompts,
+        return_tensors="pt",
+        max_length=max_length,
+        padding="max_length",
+        padding_side="left",
+        return_attention_mask=True,
+    )
+    seq_len = inputs.input_ids.shape[1]
+
+    static_cache = StaticCache(
+        config=model_config,
+        max_cache_len=max_cache_len,
+    )
+
+    text_config = model_config.get_text_config(decoder=True)
+    head_dim = getattr(
+        text_config,
+        "head_dim",
+        text_config.hidden_size // text_config.num_attention_heads,
+    )
+    static_cache.early_initialization(
+        batch_size=batch_size,
+        num_heads=text_config.num_key_value_heads,
+        head_dim=head_dim,
+        dtype=torch.bfloat16,
+        device="cpu",
+    )
+
+    sliding_window = getattr(text_config, "sliding_window", max_cache_len)
+    # Override the cache sliding window layers to use the torch.compile/TT-friendly version
+    override_cache_sliding_window_layers(static_cache, max_cache_len, sliding_window)
+
+    # Attention mask is needed to ignore padding tokens in left-padded batches. The mask should match max_cache_len
+    # to prevent recompilation or implicit padding by transformers, which can cause degenerate output.
+    prompt_len = inputs.input_ids.shape[1]
+    full_attention_mask = torch.ones(
+        (batch_size, max_cache_len), dtype=inputs.attention_mask.dtype
+    )
+    full_attention_mask[:, :prompt_len] = inputs.attention_mask
+
+    cache_position = torch.arange(0, seq_len)
+
+    input_args = {
+        "input_ids": inputs.input_ids,
+        "past_key_values": static_cache,
+        "cache_position": cache_position,
+        "use_cache": True,
+        "attention_mask": full_attention_mask,
+    }
+    return input_args, formatted_prompts
+
+
+if __name__ == "__main__":
+    xr.set_device_type("TT")
+    mistral_8b()

--- a/examples/pytorch/olmo3_1025_7b.py
+++ b/examples/pytorch/olmo3_1025_7b.py
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import os
+from typing import List
+
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from transformers import AutoModelForCausalLM, AutoTokenizer, PreTrainedTokenizer
+from transformers.cache_utils import StaticCache
+from transformers.configuration_utils import PretrainedConfig
+from tt_torch.transformers_overrides import (
+    override_cache_sliding_window_layers,
+    override_olmo3_sliding_window_causal_mask,
+)
+
+MODEL_NAME = "allenai/Olmo-3-1025-7B"
+DEFAULT_PROMPT = "Who would win in a fight - a dinosaur or a cow named Moo Moo?"
+MAX_LENGTH = 256
+BATCH_SIZE = 1
+
+
+# --------------------------------
+# Olmo 3 1025 7B Generation Loop Example
+# --------------------------------
+def olmo3_1025_7b():
+    # Set up config variables.
+    model_name = "allenai/Olmo-3-1025-7B"
+
+    # Connect the device
+    device: torch.device = torch_xla.device()
+    model, tokenizer = _load_model_and_tokenizer(model_name)
+
+    input_args, formmatted_prompts = _prepare_inputs(
+        [DEFAULT_PROMPT], tokenizer, model.config, BATCH_SIZE, MAX_LENGTH
+    )
+    max_tokens_to_generate = 20
+
+    for layer in input_args["past_key_values"].layers:
+        layer.keys = layer.keys.to(device)
+        layer.values = layer.values.to(device)
+        if isinstance(getattr(layer, "cumulative_length", None), torch.Tensor):
+            layer.cumulative_length = layer.cumulative_length.to(device)
+        if hasattr(layer, "device"):
+            layer.device = device
+
+    input_args["input_ids"] = input_args["input_ids"].to(device)
+    input_args["cache_position"] = input_args["cache_position"].to(device)
+    input_args["attention_mask"] = input_args["attention_mask"].to(device)
+    model = model.to(device)
+
+    torch_xla.set_custom_compile_options({"experimental_weight_dtype": "bfp_bf8"})
+    compiled_model = torch.compile(model, backend="tt")
+    output_tokens: List[List[str]] = [[] for _ in range(1)]
+    with torch.no_grad():
+        for step in range(max_tokens_to_generate):
+            output = compiled_model(**input_args)
+            print(
+                f"[Step {step}] {'Prefill' if step == 0 else 'Decode'} ...", flush=True
+            )
+            logits = output.logits.to("cpu")
+            next_token_id = logits[:, -1].argmax(dim=-1)
+            output_text = [tokenizer.decode(next_token_id[0])]
+            for i, output_tokens_list in enumerate(output_tokens):
+                output_tokens_list.append(output_text[i])
+
+            if torch.all(next_token_id == tokenizer.eos_token_id):
+                print()  # Add newline after generation completes
+                break
+
+            # Update inputs for next iteration
+            input_args["input_ids"] = next_token_id.unsqueeze(-1).to(device)
+
+            host_cache_pos = input_args["cache_position"].to("cpu")
+            host_cache_pos = torch.tensor([host_cache_pos[-1:] + 1])
+            input_args["cache_position"] = host_cache_pos.to(device)
+
+    print()
+    for i in range(1):
+        print(f"=" * 80)
+        print(f"Result for user {i}:")
+        print(f"-" * 80)
+        print("PROMPT:")
+        print(formmatted_prompts[i])
+        print(f"-" * 80)
+        print("GENERATED:")
+        print("".join(output_tokens[i]))
+        print(f"=" * 80)
+        print()
+
+
+def _load_model_and_tokenizer(model_name: str):
+    model = AutoModelForCausalLM.from_pretrained(model_name, dtype=torch.bfloat16)
+    override_olmo3_sliding_window_causal_mask()
+    model = model.eval()
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    return model, tokenizer
+
+
+def _prepare_inputs(
+    input_prompt: List[str],
+    tokenizer: PreTrainedTokenizer,
+    model_config: PretrainedConfig,
+    batch_size: int,
+    max_cache_len: int,
+) -> tuple[dict, List[str]]:
+
+    formatted_prompts = []
+    for prompt in input_prompt:
+        if tokenizer.chat_template is not None:
+            messages = [{"role": "user", "content": prompt}]
+            formatted_prompt = tokenizer.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True
+            )
+        else:
+            formatted_prompt = prompt
+        formatted_prompts.append(formatted_prompt)
+
+    prompt_lengths = [
+        len(tokenizer.encode(p, add_special_tokens=False)) for p in formatted_prompts
+    ]
+    max_length = max(prompt_lengths)
+
+    inputs = tokenizer(
+        formatted_prompts,
+        return_tensors="pt",
+        max_length=max_length,
+        padding="max_length",
+        padding_side="left",
+        return_attention_mask=True,
+    )
+    seq_len = inputs.input_ids.shape[1]
+
+    static_cache = StaticCache(
+        config=model_config,
+        max_batch_size=batch_size,
+        max_cache_len=max_cache_len,
+        device="cpu",
+        dtype=torch.bfloat16,
+    )
+
+    text_config = model_config.get_text_config(decoder=True)
+    head_dim = getattr(
+        text_config,
+        "head_dim",
+        text_config.hidden_size // text_config.num_attention_heads,
+    )
+    num_key_value_heads = model_config.num_key_value_heads
+    static_cache.early_initialization(
+        batch_size=batch_size,
+        num_heads=num_key_value_heads,
+        head_dim=head_dim,
+        dtype=torch.bfloat16,
+        device="cpu",
+    )
+
+    sliding_window = getattr(model_config, "sliding_window", max_cache_len)
+    # Override the cache sliding window layers to use the torch.compile/TT-friendly version
+    override_cache_sliding_window_layers(static_cache, max_cache_len, sliding_window)
+
+    # Attention mask is needed to ignore padding tokens in left-padded batches. The mask should match max_cache_len
+    # to prevent recompilation or implicit padding by transformers, which can cause degenerate output.
+    prompt_len = inputs.input_ids.shape[1]
+    full_attention_mask = torch.ones(
+        (batch_size, max_cache_len), dtype=inputs.attention_mask.dtype
+    )
+    full_attention_mask[:, :prompt_len] = inputs.attention_mask
+
+    cache_position = torch.arange(0, seq_len)
+
+    input_args = {
+        "input_ids": inputs.input_ids,
+        "past_key_values": static_cache,
+        "cache_position": cache_position,
+        "use_cache": True,
+        "attention_mask": full_attention_mask,
+    }
+    return input_args, formatted_prompts
+
+
+if __name__ == "__main__":
+    xr.set_device_type("TT")
+    olmo3_1025_7b()

--- a/examples/pytorch/olmo3_1125_32b.py
+++ b/examples/pytorch/olmo3_1125_32b.py
@@ -1,0 +1,234 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from typing import List
+
+import numpy as np
+import torch
+import torch_xla
+import torch_xla.distributed.spmd as xs
+import torch_xla.runtime as xr
+from torch_xla.distributed.spmd import Mesh
+from transformers import AutoModelForCausalLM, AutoTokenizer, PreTrainedTokenizer
+from transformers.cache_utils import StaticCache
+from transformers.configuration_utils import PretrainedConfig
+from tt_torch.transformers_overrides import (
+    override_cache_sliding_window_layers,
+    override_olmo3_sliding_window_causal_mask,
+)
+
+MODEL_NAME = "allenai/Olmo-3-1125-32B"
+DEFAULT_PROMPT = "Who would win in a fight - a dinosaur or a cow named Moo Moo?"
+MAX_LENGTH = 256
+BATCH_SIZE = 1
+
+
+def setup_spmd():
+    """Initializes SPMD mode in torch_xla (same as examples/pytorch/llama.py)."""
+    print("Setting up XLA environment...")
+    os.environ["CONVERT_SHLO_TO_SHARDY"] = "1"
+    xr.use_spmd()
+    print("XLA environment configured.")
+
+
+def create_device_mesh() -> Mesh:
+    """Create a 1 x N device mesh for tensor parallelism (same layout as llama.py)."""
+    num_devices = xr.global_runtime_device_count()
+    mesh_shape = (1, num_devices)
+    device_ids = np.array(range(num_devices))
+    mesh = Mesh(device_ids, mesh_shape, ("batch", "model"))
+    print(f"Created device mesh: {mesh_shape} with {num_devices} devices")
+    return mesh
+
+
+def mark_sharding_on_inputs_and_model(
+    model: torch.nn.Module, input_args: dict, mesh: Mesh
+):
+    """
+    Mark sharding on KV cache tensors and model weights (mirrors llama.py).
+
+    Tensors without mark_sharding (e.g. input_ids, cache_position) stay replicated.
+    """
+    for layer in input_args["past_key_values"].layers:
+        xs.mark_sharding(layer.keys, mesh, (None, "model", None, None))
+        xs.mark_sharding(layer.values, mesh, (None, "model", None, None))
+
+    for layer in model.model.layers:
+        xs.mark_sharding(layer.mlp.up_proj.weight, mesh, ("model", None))
+        xs.mark_sharding(layer.mlp.gate_proj.weight, mesh, ("model", None))
+        xs.mark_sharding(layer.mlp.down_proj.weight, mesh, (None, "model"))
+
+        xs.mark_sharding(layer.self_attn.q_proj.weight, mesh, ("model", None))
+        xs.mark_sharding(layer.self_attn.k_proj.weight, mesh, ("model", None))
+        xs.mark_sharding(layer.self_attn.v_proj.weight, mesh, ("model", None))
+        xs.mark_sharding(layer.self_attn.o_proj.weight, mesh, (None, "model"))
+
+
+# --------------------------------
+# Olmo 3 1125 32B Generation Loop Example
+# --------------------------------
+def olmo3_1125_32b():
+    # Set up config variables.
+    model_name = "allenai/Olmo-3-1125-32B"
+
+    num_devices = xr.global_runtime_device_count()
+    is_spmd = num_devices > 1
+    if is_spmd:
+        setup_spmd()
+
+    device: torch.device = torch_xla.device()
+    mesh: Mesh | None = create_device_mesh() if is_spmd else None
+
+    model, tokenizer = _load_model_and_tokenizer(model_name)
+
+    input_args, formmatted_prompts = _prepare_inputs(
+        [DEFAULT_PROMPT], tokenizer, model.config, BATCH_SIZE, MAX_LENGTH
+    )
+    max_tokens_to_generate = 20
+
+    for layer in input_args["past_key_values"].layers:
+        layer.keys = layer.keys.to(device)
+        layer.values = layer.values.to(device)
+        if isinstance(getattr(layer, "cumulative_length", None), torch.Tensor):
+            layer.cumulative_length = layer.cumulative_length.to(device)
+        if hasattr(layer, "device"):
+            layer.device = device
+
+    input_args["input_ids"] = input_args["input_ids"].to(device)
+    input_args["cache_position"] = input_args["cache_position"].to(device)
+    input_args["attention_mask"] = input_args["attention_mask"].to(device)
+    model = model.to(device)
+
+    if is_spmd and mesh is not None:
+        mark_sharding_on_inputs_and_model(model, input_args, mesh)
+
+    torch_xla.set_custom_compile_options({"experimental_weight_dtype": "bfp_bf8"})
+    compiled_model = torch.compile(model, backend="tt")
+    output_tokens: List[List[str]] = [[] for _ in range(1)]
+    with torch.no_grad():
+        for step in range(max_tokens_to_generate):
+            output = compiled_model(**input_args)
+            print(
+                f"[Step {step}] {'Prefill' if step == 0 else 'Decode'} ...", flush=True
+            )
+            logits = output.logits.to("cpu")
+            next_token_id = logits[:, -1].argmax(dim=-1)
+            output_text = [tokenizer.decode(next_token_id[0])]
+            for i, output_tokens_list in enumerate(output_tokens):
+                output_tokens_list.append(output_text[i])
+
+            if torch.all(next_token_id == tokenizer.eos_token_id):
+                print()  # Add newline after generation completes
+                break
+
+            # Update inputs for next iteration
+            input_args["input_ids"] = next_token_id.unsqueeze(-1).to(device)
+
+            host_cache_pos = input_args["cache_position"].to("cpu")
+            host_cache_pos = torch.tensor([host_cache_pos[-1:] + 1])
+            input_args["cache_position"] = host_cache_pos.to(device)
+
+    print()
+    for i in range(1):
+        print(f"=" * 80)
+        print(f"Result for user {i}:")
+        print(f"-" * 80)
+        print("PROMPT:")
+        print(formmatted_prompts[i])
+        print(f"-" * 80)
+        print("GENERATED:")
+        print("".join(output_tokens[i]))
+        print(f"=" * 80)
+        print()
+
+
+def _load_model_and_tokenizer(model_name: str):
+    model = AutoModelForCausalLM.from_pretrained(model_name, dtype=torch.bfloat16)
+    override_olmo3_sliding_window_causal_mask()
+    model = model.eval()
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    return model, tokenizer
+
+
+def _prepare_inputs(
+    input_prompt: List[str],
+    tokenizer: PreTrainedTokenizer,
+    model_config: PretrainedConfig,
+    batch_size: int,
+    max_cache_len: int,
+) -> tuple[dict, List[str]]:
+
+    formatted_prompts = []
+    for prompt in input_prompt:
+        if tokenizer.chat_template is not None:
+            messages = [{"role": "user", "content": prompt}]
+            formatted_prompt = tokenizer.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True
+            )
+        else:
+            formatted_prompt = prompt
+        formatted_prompts.append(formatted_prompt)
+
+    prompt_lengths = [
+        len(tokenizer.encode(p, add_special_tokens=False)) for p in formatted_prompts
+    ]
+    max_length = max(prompt_lengths)
+
+    inputs = tokenizer(
+        formatted_prompts,
+        return_tensors="pt",
+        max_length=max_length,
+        padding="max_length",
+        padding_side="left",
+        return_attention_mask=True,
+    )
+    seq_len = inputs.input_ids.shape[1]
+
+    static_cache = StaticCache(
+        config=model_config,
+        max_cache_len=max_cache_len,
+    )
+
+    text_config = model_config.get_text_config(decoder=True)
+    head_dim = getattr(text_config, "head_dim", None) or (
+        text_config.hidden_size // text_config.num_attention_heads
+    )
+    static_cache.early_initialization(
+        batch_size=batch_size,
+        num_heads=text_config.num_key_value_heads,
+        head_dim=head_dim,
+        dtype=torch.bfloat16,
+        device="cpu",
+    )
+
+    sliding_window = getattr(text_config, "sliding_window", max_cache_len)
+    # Override the cache sliding window layers to use the torch.compile/TT-friendly version
+    override_cache_sliding_window_layers(static_cache, max_cache_len, sliding_window)
+
+    # Attention mask is needed to ignore padding tokens in left-padded batches. The mask should match max_cache_len
+    # to prevent recompilation or implicit padding by transformers, which can cause degenerate output.
+    prompt_len = inputs.input_ids.shape[1]
+    full_attention_mask = torch.ones(
+        (batch_size, max_cache_len), dtype=inputs.attention_mask.dtype
+    )
+    full_attention_mask[:, :prompt_len] = inputs.attention_mask
+
+    cache_position = torch.arange(0, seq_len)
+
+    input_args = {
+        "input_ids": inputs.input_ids,
+        "past_key_values": static_cache,
+        "cache_position": cache_position,
+        "use_cache": True,
+        "attention_mask": full_attention_mask,
+    }
+    return input_args, formatted_prompts
+
+
+if __name__ == "__main__":
+    xr.set_device_type("TT")
+    olmo3_1125_32b()

--- a/python_package/tt_torch/transformers_overrides.py
+++ b/python_package/tt_torch/transformers_overrides.py
@@ -21,6 +21,32 @@ def override_gpt_oss_sliding_window_causal_mask():
     gpt_oss_mod.create_sliding_window_causal_mask = tt_create_sliding_window_causal_mask
 
 
+def override_olmo3_sliding_window_causal_mask():
+    """
+    Override olmo3's modeling so that its
+    create_sliding_window_causal_mask points to the TT-friendly version.
+    """
+    import transformers.models.olmo3.modeling_olmo3 as olmo3_mod
+
+    olmo3_mod.create_sliding_window_causal_mask = tt_create_sliding_window_causal_mask
+
+
+def override_ministral_sliding_window_causal_mask():
+    """
+    Override ministral's modeling so that its
+    create_sliding_window_causal_mask points to the TT-friendly version.
+
+    Note: ministral (mistralai/Ministral-*) uses a separate module
+    transformers.models.ministral.modeling_ministral, distinct from
+    transformers.models.mistral.modeling_mistral.
+    """
+    import transformers.models.ministral.modeling_ministral as ministral_mod
+
+    ministral_mod.create_sliding_window_causal_mask = (
+        tt_create_sliding_window_causal_mask
+    )
+
+
 def override_cache_sliding_window_layers(
     cache: StaticCache,
     max_cache_len: int,
@@ -81,7 +107,9 @@ def tt_create_sliding_window_causal_mask(
         layer_idx = past_key_values.is_sliding.index(True)
     else:
         layer_idx = 0
-    sliding_window = past_key_values.layers[layer_idx].max_cache_len
+    _layer = past_key_values.layers[layer_idx]
+    # DynamicSlidingWindowLayer exposes .sliding_window; static layers use .max_cache_len
+    sliding_window = getattr(_layer, "sliding_window", None) or _layer.max_cache_len
 
     batch_size = inputs_embeds.shape[0]
     query_length = cache_position.shape[0]
@@ -150,7 +178,7 @@ class TTStaticSlidingWindowLayer(StaticLayer):
         cache_kwargs: Optional[dict[str, Any]] = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         if not self.is_initialized:
-            self.lazy_initialization(key_states)
+            self.lazy_initialization(key_states, value_states)
 
         n = key_states.shape[-2]
 
@@ -180,7 +208,8 @@ class TTStaticSlidingWindowLayer(StaticLayer):
         """Return constant (kv_length, kv_offset) — used by create_causal_mask."""
         return self.max_cache_len, 0
 
+    @torch.compiler.disable
     def get_seq_length(self) -> int:
         if not self.is_initialized:
             return 0
-        return (self.keys[0, 0].any(dim=-1)).sum().item()
+        return (self.keys[0, 0].cpu().any(dim=-1)).sum().item()

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -22,6 +22,7 @@ XFAIL_DIRS: dict[str, str] = {
 # Specific files with known issues - tests will be marked as xfail with the given reason
 XFAIL_FILES: dict[str, str] = {
     "pytorch/gpt_oss_20b.py": "Gpt-oss example requires llmbox or galaxy",
+    "pytorch/olmo3_1125_32b.py": "Olmo3 32B example requires n300-llmbox",
     "jax/codegen/cpp/resnet.py": "FlaxResNetModel removed in transformers 5.x",
     "jax/codegen/python/resnet.py": "FlaxResNetModel removed in transformers 5.x",
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/4171

### Problem description
Since PR  https://github.com/tenstorrent/tt-xla/pull/3688 was merged into main, I’ve been testing models with sliding attention, replacing the previously hardcoded full attention.

Model variants yet to be tested
allenai/Olmo-3-1025-7B
allenai/Olmo-3-1125-32B
mistralai/Ministral-8B-Instruct-2410

Taken this branch as reference: https://github.com/tenstorrent/tt-xla/compare/main...jazpur/gemma-4

### What's changed
Added a test file in the examples folder; tests passed successfully

logs:
[mistral.log](https://github.com/user-attachments/files/27126975/mistral.log)
[olmo3_7b.log](https://github.com/user-attachments/files/27126979/olmo3_7b.log)
[olmo3_32b.log](https://github.com/user-attachments/files/27126989/olmo3_32b.log)

### Checklist
- [ ] New/Existing tests provide coverage for changes

