### PR TITLE
Remove empty nightly groups

### DIFF
--- a/.github/workflows/test-matrix-presets/model-test-passing.json
+++ b/.github/workflows/test-matrix-presets/model-test-passing.json
@@ -14,9 +14,7 @@
   { "runs-on": "n150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "n150 and nightly and expected_passing and large", "shared-runners": "true" },
   { "runs-on": "p150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "p150 and nightly and expected_passing and large", "shared-runners": "true" },
   { "runs-on": "n300-llmbox", "name": "run_forge_models_llm_multichip", "dir": "./tests/runner/test_models.py::test_llms_torch", "test-mark": "n300-llmbox and nightly and tensor_parallel and expected_passing", "parallel-groups": 1 },
-  { "runs-on": "n150", "name": "run_forge_models_llm", "dir": "./tests/runner/test_models.py::test_llms_torch", "test-mark": "n150 and nightly and expected_passing and single_device and large", "parallel-groups": 1, "shared-runners": "true" },
   { "runs-on": "n150", "name": "run_forge_models_llm", "dir": "./tests/runner/test_models.py::test_llms_torch", "test-mark": "n150 and nightly and expected_passing and single_device and not large", "parallel-groups": 1 },
-  { "runs-on": "p150", "name": "run_forge_models_llm", "dir": "./tests/runner/test_models.py::test_llms_torch", "test-mark": "p150 and nightly and expected_passing and single_device and large", "parallel-groups": 1, "shared-runners": "true" },
   { "runs-on": "p150", "name": "run_forge_models_llm", "dir": "./tests/runner/test_models.py::test_llms_torch", "test-mark": "p150 and nightly and expected_passing and single_device and not large", "parallel-groups": 1 },
   { "runs-on": "galaxy-wh-6u", "name": "run_forge_models_llm_multichip", "dir": "./tests/runner/test_models.py::test_llms_torch", "test-mark": "galaxy-wh-6u and nightly and tensor_parallel and expected_passing", "parallel-groups": 1 }
 ]


### PR DESCRIPTION
Commit eef6ae1cd ("Expand prefill testing to support various meshes and multichip strategies (#3423)")                                             
Before this commit, exactly one entry in tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml carried markers: [nightly, large]:                 
```
llama/causal_lm/pytorch-3.2_1B-llm_prefill-seq_2048-batch_2-single_device-inference:
status: EXPECTED_PASSING 
markers: [nightly, large]
```                                                                                                           
 In eef6ae1cd, the prefill tests were re-parameterized — batch_2 variants were replaced by batch_1/batch_4 (and test IDs gained mesh_default). In the rewrite, the single large-marked entry was not carried over. After the commit, grep "markers:.*large" returns nothing in the torch_llm configs, so the workflow group run_forge_models_llm (shard 25) matching single_device and large finds nothing.
https://github.com/tenstorrent/tt-xla/actions/runs/24540958167/job/71806996904
https://github.com/tenstorrent/tt-xla/actions/runs/24540958167/job/71806997084