### PR TITLE
Fix experimental import from ttnn python module

### DIFF
--- a/python_package/pjrt_plugin_tt/wrapper.py
+++ b/python_package/pjrt_plugin_tt/wrapper.py
@@ -143,13 +143,19 @@ class ProxyModule(ModuleType):
 
     def __init__(self, package_name: str):
         super().__init__(package_name)
-        self._package_name = package_name
+        object.__setattr__(self, "_package_name", package_name)
 
     def __getattr__(self, name):
         original = sys.modules.get(f"{self._package_name}._original")
         if original is None:
             raise AttributeError(f"module '{self.__name__}' has no attribute '{name}'")
         return getattr(original, name)
+
+    def __setattr__(self, name, value):
+        object.__setattr__(self, name, value)
+        original = sys.modules.get(f"{self._package_name}._original")
+        if original is not None and original is not self:
+            setattr(original, name, value)
 
 
 @contextmanager


### PR DESCRIPTION
Fixes errors of type: `NameError: name 'experimental' is not defined.` for dynamically added names.

The `ttnn` wrapper in `python_package/pjrt_plugin_tt/wrapper.py` installs a `ProxyModule` as `sys.modules["ttnn"]` during `with proxy_import("ttnn"): from ttnn._original import *` to handle circular imports. Inside that context, metal's `ttnn/__init__.py` imports `ttnn.experimental_loader`, which calls `create_module_if_not_exists("ttnn.experimental")` in `decorators.py`. That helper walks parents via `sys.modules` and does `setattr(parent, "experimental", new_module)`, so the experimental attribute lands on the proxy, not on `ttnn._original`. The fix adds a `__setattr__` to `ProxyModule` that mirrors every attribute assignment to `sys.modules["ttnn._original"]`, so attributes set on the proxy during its lifetime also end up in _original's globals where the executing module can see them.

Validated the fix on an n300 card, on tt-mlir uplift branch.