### PR TITLE
Add gpt_oss_120b batch 128 galaxy perf test to uplift regression

### DIFF
--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -75,7 +75,7 @@ jobs:
         { "accuracy-testing": false },
         { "runs-on": "n150", "filter": ["resnet","llama_3_1_8b_instruct","qwen_3_4b_embedding"] },
         { "runs-on": "n300-llmbox", "filter": ["llama_3_1_70b_tp", "gpt_oss_20b_tp"] },
-        { "runs-on": "galaxy-wh-6u", "filter": ["llama_3_1_70b_tp_galaxy"] } ]'
+        { "runs-on": "galaxy-wh-6u", "filter": ["llama_3_1_70b_tp_galaxy", "gpt_oss_120b_tp_dp_galaxy_batch_size_128"] } ]'
       sh-runner: false
       skip-device-perf: true
       perf_regression_check: false


### PR DESCRIPTION
### Ticket
/

### Problem description
The uplift regression perf-benchmark job in the On PR workflow runs a filtered subset of benchmarks to catch perf regressions from tt-mlir and transformers uplifts. The `gpt_oss_120b` batch 128 (TP+DP) galaxy benchmark (`test_gpt_oss_120b_tp_dp_galaxy_batch_size_128`, added in #4205) is not covered.

### What's changed
Added `gpt_oss_120b_tp_dp_galaxy_batch_size_128` to the `galaxy-wh-6u` filter in the `perf-benchmark` job of `.github/workflows/pr-main.yml`, mirroring #3818 (which added `gpt_oss_20b_tp` to `n300-llmbox`).

### Blocker
:warning: **Do not merge before #4312 is fixed.** The perf regression check pulls the baseline from the wrong test variant (batch_size_64 instead of batch_size_128), causing false regression failures for this benchmark.

### Checklist
- [ ] New/Existing tests provide coverage for changes