### PR TITLE
Fix masked_scatter decomposition to resolve OOM error in gemma3 multimodal models

### DIFF
--- a/python_package/tt_torch/backend/decompositions.py
+++ b/python_package/tt_torch/backend/decompositions.py
@@ -331,9 +331,42 @@ def copy_default(
 def masked_scatter(
     data: torch.Tensor, mask: torch.Tensor, source: torch.Tensor
 ) -> torch.Tensor:
-    # Custom decomposition for masked_scatter
-    # Decomposes masked_scatter into basic operations: broadcast, reshape, cumsum, clamp, gather, where
+    """
+    Custom decomposition for masked_scatter
+    Decomposes masked_scatter into basic operations: broadcast, reshape, cumsum, clamp, gather, where
+
+    Row-wise fast path: O(B*S) cumsum instead of O(B*S*H).
+    The flat cumsum on B*S*H elements OOMs on TT hardware (TTNN allocates one 32x32
+    tile per output element, so 277*2560=709k elements → 2.9 GB for the cumsum alone).
+
+    The fast path is valid when the mask is row-constant (same True/False for every
+    element in a row).
+    """
+    H = data.shape[-1] if data.ndim >= 2 else 0
+    n_true = source.numel() // H if H > 0 else 0
+    _row_constant = (
+        data.ndim >= 2
+        and mask.ndim >= 2
+        and (
+            mask.stride(-1) == 0
+            or mask.ndim < data.ndim
+            or (n_true > 0 and source.numel() == n_true * H)
+        )
+    )
+
     mask, data = torch.broadcast_tensors(mask, data)
+
+    if _row_constant and n_true > 0:
+        mask_outer = mask[..., 0]
+        mask_f = mask_outer.reshape(-1)
+        data_2d = data.reshape(-1, H)
+        source_2d = source.reshape(n_true, H)
+        mask_i = mask_f.long()
+        source_idx = torch.cumsum(mask_i, 0) - 1
+        source_idx = torch.clamp(source_idx, 0, n_true - 1)
+        gathered = source_2d[source_idx]
+        result = torch.where(mask_f.unsqueeze(-1), gathered, data_2d)
+        return result.view_as(data)
 
     mask_f = mask.reshape(-1)
     data_flat = data.reshape(-1)

--- a/tests/torch/ops/test_masked_scatter.py
+++ b/tests/torch/ops/test_masked_scatter.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from infra import Framework, run_op_test
+from utils import Category
+
+
+class MaskedScatter(torch.nn.Module):
+    def forward(self, data, mask, source):
+        return data.masked_scatter(mask, source)
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.single_device
+@pytest.mark.record_test_properties(category=Category.OP_TEST)
+def test_masked_scatter_row_constant():
+    """Row-constant mask: every element along the last dim shares the same
+    boolean value (the row is either fully True or fully False). This mirrors
+    the multimodal image-token pattern used by Gemma3/LLaVA/DeepSeek-OCR."""
+    seq_len, hidden = 32, 64
+    n_true = 16
+
+    data = torch.randn(1, seq_len, hidden, dtype=torch.bfloat16)
+    source = torch.randn(1, n_true, hidden, dtype=torch.bfloat16)
+
+    mask = torch.zeros(1, seq_len, hidden, dtype=torch.bool)
+    mask[0, :n_true, :] = True
+
+    run_op_test(
+        MaskedScatter(),
+        [data, mask, source],
+        framework=Framework.TORCH,
+    )
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.single_device
+@pytest.mark.record_test_properties(category=Category.OP_TEST)
+def test_masked_scatter_mixed_mask():
+    """Mixed mask: True/False values are randomly distributed across elements
+    (not row-constant), exercising the generic flat decomposition path."""
+    data = torch.randn(4, 8, 16, dtype=torch.bfloat16)
+    mask = torch.randint(0, 2, (4, 8, 16), dtype=torch.bool)
+    source = torch.randn(int(mask.sum().item()), dtype=torch.bfloat16)
+
+    run_op_test(
+        MaskedScatter(),
+        [data, mask, source],
+        framework=Framework.TORCH,
+    )


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/4007)

### Problem description
Gemma 3 multimodal variants was failed with the OOM error
Out of Memory: Not enough space to allocate 2904555520 B DRAM buffer across 12 banks, where each bank needs to store 242049024 B, but bank size is 1071821792 B

### What's changed
Resolved the OOM error by adding a fast path for the common case where the mask is row-constant. Instead of running cumsum over the full B×S×H flat tensor (709k elements)  detect this via mask.stride(-1) == 0 and run cumsum only over the B×S token dimension (277 elements), then gather entire feature rows at once.

### Logs

[deepseek_ocr.log](https://github.com/user-attachments/files/27446976/deepseek_ocr.log)
[gemma3_12b_llava_70b.log](https://github.com/user-attachments/files/27446983/gemma3_12b_llava_70b.log)
[gemma3_4b.log](https://github.com/user-attachments/files/27446987/gemma3_4b.log)

Sanity Test Log - [masked_scatter.log](https://github.com/user-attachments/files/27482331/masked_scatter.log)

### Checklist
- [ ] New/Existing tests provide coverage for changes
