### PR TITLE
[Benchmark] Calculate PCC for full prefill and first token

### DIFF
--- a/tests/benchmark/benchmarks/encoder_benchmark.py
+++ b/tests/benchmark/benchmarks/encoder_benchmark.py
@@ -259,7 +259,10 @@ def benchmark_encoder_torch_xla(
     )
 
     # Evaluate PCC
-    pcc_value = compute_pcc(predictions[0], golden_output, required_pcc=required_pcc)
+    pcc_value = compute_pcc(predictions[0], golden_output)
+    assert (
+        pcc_value >= required_pcc
+    ), f"PCC comparison failed. PCC={pcc_value:.6f}, Required={required_pcc}"
     print(f"PCC verification passed with PCC={pcc_value:.6f}")
     evaluation_score = pcc_value
 

--- a/tests/benchmark/benchmarks/llm_benchmark.py
+++ b/tests/benchmark/benchmarks/llm_benchmark.py
@@ -382,18 +382,7 @@ def benchmark_llm_torch_xla(
             decode_only_cache_position = input_args["cache_position"].clone()
             decode_only_cache = input_args["past_key_values"]
 
-    # Transfer model and inputs to device
-    input_args = construct_inputs(
-        tokenizer,
-        model.config,
-        batch_size,
-        max_cache_len,
-        input_prompt=custom_input_prompt,
-        input_prompt_tokens=(token_accuracy.input_prompt if accuracy_testing else None),
-        past_key_values=decode_only_cache if decode_only else None,
-        use_mla_cache=use_mla_cache,
-    )
-    input_args = transfer_to_device(input_args, device)
+    # Transfer model to device
     model = model.to(device, dtype=torch.bfloat16)
 
     # Shard model if shard spec function is provided
@@ -465,8 +454,12 @@ def benchmark_llm_torch_xla(
             logger.info(
                 f"Applied {len(applied)} weight dtype overrides from {weight_dtype_config}"
             )
+
+    # ========================================================
     # PERFORMANCE BENCHMARK
-    # No logits returned to avoid OOM.
+    # ========================================================
+
+    # No logits returned to maximize performance and avoid device DRAM OOM.
     perf_wrapper = LLMSamplingWrapper(
         model,
         read_logits_fn,
@@ -479,6 +472,18 @@ def benchmark_llm_torch_xla(
 
     # Warmup run (skip in decode-only mode)
     if not decode_only:
+        # Construct inputs for warmup run
+        input_args = construct_inputs(
+            tokenizer,
+            model.config,
+            batch_size,
+            max_cache_len,
+            input_prompt=custom_input_prompt,
+            input_prompt_tokens=(
+                token_accuracy.input_prompt if accuracy_testing else None
+            ),
+        )
+        input_args = transfer_to_device(input_args, device)
         print("Warming up...")
         warmup_tokens = min(MIN_STEPS, max_output_tokens)
         _, _ = generate_and_benchmark(
@@ -489,6 +494,7 @@ def benchmark_llm_torch_xla(
             verbose=False,
             collect_logits=False,
         )
+        print("Warmup complete")
 
         tracy.signpost("warmup_complete")
 
@@ -498,9 +504,7 @@ def benchmark_llm_torch_xla(
         model.config,
         batch_size,
         max_cache_len,
-        past_key_values=(
-            input_args["past_key_values"] if not decode_only else decode_only_cache
-        ),
+        past_key_values=(decode_only_cache if decode_only else None),
         input_prompt=custom_input_prompt,
         input_prompt_tokens=(token_accuracy.input_prompt if accuracy_testing else None),
         use_mla_cache=use_mla_cache,
@@ -508,18 +512,19 @@ def benchmark_llm_torch_xla(
 
     if decode_only:
         # Reset to post-prefill decode state (single token input)
-        input_args["input_ids"] = decode_only_input_ids
-        input_args["cache_position"] = decode_only_cache_position
+        input_args["input_ids"] = decode_only_input_ids.clone()
+        input_args["cache_position"] = decode_only_cache_position.clone()
 
     input_args = transfer_to_device(input_args, device)
     if input_output_sharding_spec:
         xs.mark_sharding(input_args["input_ids"], mesh, input_output_sharding_spec)
 
-    # Run perf benchmark
-    print(f"\nStarting performance benchmark...")
     ground_truth_for_benchmark = (
         token_accuracy.reference_tokens if accuracy_testing else None
     )
+
+    # Run perf benchmark
+    print(f"\nStarting performance benchmark...")
     _, iteration_times = generate_and_benchmark(
         compiled_perf_model,
         input_args,
@@ -530,65 +535,73 @@ def benchmark_llm_torch_xla(
         ground_truth_tokens=ground_truth_for_benchmark,
         collect_logits=False,
     )
+    print("\nPerformance benchmark complete")
 
-    # ACCURACY BENCHMARK
-    # Logits moved to CPU each step to avoid OOM.
-    if not decode_only:
-        accuracy_wrapper = LLMSamplingWrapper(
-            model,
-            read_logits_fn,
-            return_logits=True,
-            mesh=mesh,
-            output_sharding_spec=input_output_sharding_spec,
-        )
-        accuracy_wrapper.eval()
-        compiled_accuracy = torch.compile(accuracy_wrapper, backend="tt")
+    # ========================================================
+    # PCC/TOPK BENCHMARK
+    # ========================================================
 
-        accuracy_steps = max_output_tokens
+    # Return logits to calculate PCC/TOPK
+    logits_wrapper = LLMSamplingWrapper(
+        model,
+        read_logits_fn,
+        return_logits=True,
+        mesh=mesh,
+        output_sharding_spec=input_output_sharding_spec,
+    )
+    logits_wrapper.eval()
+    compiled_logits = torch.compile(logits_wrapper, backend="tt")
 
-        # Reconstruct inputs for accuracy run
-        input_args = construct_inputs(
-            tokenizer,
-            model.config,
-            batch_size,
-            max_cache_len,
-            past_key_values=input_args["past_key_values"],
-            input_prompt=custom_input_prompt,
-            input_prompt_tokens=(
-                token_accuracy.input_prompt if accuracy_testing else None
-            ),
-            use_mla_cache=use_mla_cache,
-        )
-        input_args = transfer_to_device(input_args, device)
-        if input_output_sharding_spec:
-            xs.mark_sharding(input_args["input_ids"], mesh, input_output_sharding_spec)
+    logits_steps = max_output_tokens
 
-        print(
-            f"\nStarting accuracy benchmark "
-            f"({accuracy_steps} step{'s' if accuracy_steps > 1 else ''})..."
-        )
-        output_logits, _ = generate_and_benchmark(
-            compiled_accuracy,
-            input_args,
-            device,
-            accuracy_steps,
-            verbose=False,
-            ground_truth_tokens=ground_truth_for_benchmark,
-            collect_logits=True,
-        )
+    # Reconstruct inputs for PCC/TOPK run
+    input_args = construct_inputs(
+        tokenizer,
+        model.config,
+        batch_size,
+        max_cache_len,
+        past_key_values=decode_only_cache if decode_only else None,
+        input_prompt=custom_input_prompt,
+        input_prompt_tokens=(token_accuracy.input_prompt if accuracy_testing else None),
+    )
+
+    if decode_only:
+        # Reset to post-prefill decode state (single token input)
+        input_args["input_ids"] = decode_only_input_ids.clone()
+        input_args["cache_position"] = decode_only_cache_position.clone()
+
+    input_args = transfer_to_device(input_args, device)
+    if input_output_sharding_spec:
+        xs.mark_sharding(input_args["input_ids"], mesh, input_output_sharding_spec)
+
+    print("\nStarting PCC/TOPK benchmark...")
+    output_logits, _ = generate_and_benchmark(
+        compiled_logits,
+        input_args,
+        device,
+        logits_steps,
+        verbose=False,
+        ground_truth_tokens=ground_truth_for_benchmark,
+        collect_logits=True,
+    )
+    print("\nPCC/TOPK benchmark complete")
 
     # Post-processing: derive predicted tokens for accuracy testing
     if accuracy_testing:
-        predicted_tokens = [logits.argmax(dim=-1)[0].item() for logits in output_logits]
+        predicted_tokens = [
+            logits[:, -1, :].argmax(dim=-1)[0].item() for logits in output_logits
+        ]
 
+    # Calculate Time to First Token (TTFT)
     ttft_ns = iteration_times[0] if not decode_only else 0.0
     ttft_ms = ttft_ns / 1e6
 
+    # Calculate decode time
     decode_iteration_times = iteration_times[1:]
     decode_total_time_ns = sum(decode_iteration_times)
     decode_total_time = decode_total_time_ns / 1e9
 
-    # Calculate metrics (ignore first iteration for samples/sec)
+    # Calculate tokens per second per user
     decode_total_tokens = len(decode_iteration_times)
     tokens_per_second = (
         (decode_total_tokens / decode_total_time) if decode_total_time > 0 else 0.0
@@ -657,7 +670,15 @@ def benchmark_llm_torch_xla(
             ]
         )
     elif decode_only:
-        print("PCC verification skipped in decode-only mode")
+        decode_pcc_value = compute_pcc(output_logits[0][0], cpu_output_logits[1][0])
+        assert (
+            decode_pcc_value >= required_pcc
+        ), f"First decode PCC failed. PCC={decode_pcc_value:.6f}, Required={required_pcc}"
+        print(
+            "First decode PCC verification passed with PCC={:.6f}".format(
+                decode_pcc_value
+            )
+        )
     else:
         # Check PCC for prefill
         pcc_value = compute_pcc(output_logits[0][0], cpu_output_logits[0][0])
@@ -666,16 +687,18 @@ def benchmark_llm_torch_xla(
         ), f"Prefill PCC failed. PCC={pcc_value:.6f}, Required={required_pcc}"
         print("Prefill PCC verification passed with PCC={:.6f}".format(pcc_value))
         # Check PCC for first decode token
-        if len(output_logits) > 1 and len(cpu_output_logits) > 1:
-            decode_pcc_value = compute_pcc(output_logits[1][0], cpu_output_logits[1][0])
-            assert (
-                decode_pcc_value >= required_pcc
-            ), f"First decode PCC failed. PCC={decode_pcc_value:.6f}, Required={required_pcc}"
-            print(
-                "First decode PCC verification passed with PCC={:.6f}".format(
-                    decode_pcc_value
-                )
+        assert (
+            len(output_logits) > 1 and len(cpu_output_logits) > 1
+        ), "Not enough logits to check PCC"
+        decode_pcc_value = compute_pcc(output_logits[1][0], cpu_output_logits[1][0])
+        assert (
+            decode_pcc_value >= required_pcc
+        ), f"First decode PCC failed. PCC={decode_pcc_value:.6f}, Required={required_pcc}"
+        print(
+            "First decode PCC verification passed with PCC={:.6f}".format(
+                decode_pcc_value
             )
+        )
 
     # Get device count and mesh info for metrics
     device_count = xr.global_runtime_device_count()

--- a/tests/benchmark/benchmarks/llm_benchmark.py
+++ b/tests/benchmark/benchmarks/llm_benchmark.py
@@ -201,6 +201,21 @@ def transfer_to_device(input_args: dict, device: torch.device) -> dict:
     return input_args
 
 
+def _shard_kv_cache(past_key_values, mesh, kv_cache_sharding_spec):
+    kv_spec = kv_cache_sharding_spec
+    for layer in past_key_values.layers:
+        if isinstance(layer, MLAStaticLayer):
+            if kv_spec is None:
+                kv_spec = ("batch", None, None, None)
+            xs.mark_sharding(layer.compressed_kv, mesh, kv_spec)
+            xs.mark_sharding(layer.k_pe, mesh, kv_spec)
+        else:
+            if kv_spec is None:
+                kv_spec = (None, "model", None, None)
+            xs.mark_sharding(layer.keys, mesh, kv_spec)
+            xs.mark_sharding(layer.values, mesh, kv_spec)
+
+
 def check_transformers_version():
     """
     Check that transformers version is = 5.2.0.
@@ -408,26 +423,6 @@ def benchmark_llm_torch_xla(
             for tensor, shard_spec in shard_specs.items():
                 xs.mark_sharding(tensor, mesh, shard_spec)
 
-        # Also shard KV cache tensors created in input_args
-        # This is hardcoded for all TP models, and should be moved to tt-forge-models.
-        # https://github.com/tenstorrent/tt-xla/issues/4240
-        kv_spec = kv_cache_sharding_spec
-        for layer in input_args["past_key_values"].layers:
-            if isinstance(layer, MLAStaticLayer):
-                if kv_spec is None:
-                    kv_spec = ("batch", None, None, None)
-                xs.mark_sharding(layer.compressed_kv, mesh, kv_spec)
-                xs.mark_sharding(layer.k_pe, mesh, kv_spec)
-            else:
-                if kv_spec is None:
-                    kv_spec = (None, "model", None, None)
-                xs.mark_sharding(layer.keys, mesh, kv_spec)
-                xs.mark_sharding(layer.values, mesh, kv_spec)
-
-        # Shard input_ids
-        if input_output_sharding_spec:
-            xs.mark_sharding(input_args["input_ids"], mesh, input_output_sharding_spec)
-
         # Apply sharding constraint on lm_head output to all_gather logits
         if hasattr(model, "lm_head") and model.lm_head is not None:
             hook = sharding_constraint_hook(model.lm_head, mesh, (None, None, None))
@@ -501,6 +496,12 @@ def benchmark_llm_torch_xla(
             use_mla_cache=use_mla_cache,
         )
         input_args = transfer_to_device(input_args, device)
+        if is_multichip:
+            _shard_kv_cache(input_args["past_key_values"], mesh, kv_cache_sharding_spec)
+            if input_output_sharding_spec:
+                xs.mark_sharding(
+                    input_args["input_ids"], mesh, input_output_sharding_spec
+                )
         print("Warming up...")
         warmup_tokens = min(MIN_STEPS, max_output_tokens)
         _, _ = generate_and_benchmark(
@@ -535,6 +536,8 @@ def benchmark_llm_torch_xla(
         input_args["cache_position"] = decode_only_cache_position.clone()
 
     input_args = transfer_to_device(input_args, device)
+    if is_multichip and decode_only:
+        _shard_kv_cache(input_args["past_key_values"], mesh, kv_cache_sharding_spec)
     if input_output_sharding_spec:
         xs.mark_sharding(input_args["input_ids"], mesh, input_output_sharding_spec)
 
@@ -591,6 +594,8 @@ def benchmark_llm_torch_xla(
         input_args["cache_position"] = decode_only_cache_position.clone()
 
     input_args = transfer_to_device(input_args, device)
+    if is_multichip:
+        _shard_kv_cache(input_args["past_key_values"], mesh, kv_cache_sharding_spec)
     if input_output_sharding_spec:
         xs.mark_sharding(input_args["input_ids"], mesh, input_output_sharding_spec)
 

--- a/tests/benchmark/benchmarks/llm_benchmark.py
+++ b/tests/benchmark/benchmarks/llm_benchmark.py
@@ -370,7 +370,7 @@ def benchmark_llm_torch_xla(
             cpu_wrapper,
             input_args,
             torch.device("cpu"),
-            1,
+            2,
             verbose=False,
             collect_logits=True,
         )
@@ -659,11 +659,21 @@ def benchmark_llm_torch_xla(
     elif decode_only:
         print("PCC verification skipped in decode-only mode")
     else:
-        # Check PCC
+        # Check PCC for prefill
         pcc_value = compute_pcc(
             output_logits[0][0], cpu_output_logits[0][0], required_pcc=required_pcc
         )
-        print("PCC verification passed with PCC={:.6f}".format(pcc_value))
+        print("Prefill PCC verification passed with PCC={:.6f}".format(pcc_value))
+        # Check PCC for first decode token
+        if len(output_logits) > 1 and len(cpu_output_logits) > 1:
+            decode_pcc_value = compute_pcc(
+                output_logits[1][0], cpu_output_logits[1][0], required_pcc=required_pcc
+            )
+            print(
+                "First decode PCC verification passed with PCC={:.6f}".format(
+                    decode_pcc_value
+                )
+            )
 
     # Get device count and mesh info for metrics
     device_count = xr.global_runtime_device_count()

--- a/tests/benchmark/benchmarks/llm_benchmark.py
+++ b/tests/benchmark/benchmarks/llm_benchmark.py
@@ -366,21 +366,35 @@ def benchmark_llm_torch_xla(
     if not accuracy_testing:
         cpu_wrapper = LLMSamplingWrapper(model, read_logits_fn, return_logits=True)
         cpu_wrapper.eval()
-        cpu_output_logits, _ = generate_and_benchmark(
+
+        # Iter 0: prefill. After this, input_args holds the post-prefill decode
+        # state (input_ids=next_token_0, cache_position=[prompt_len]).
+        prefill_logits, _ = generate_and_benchmark(
             cpu_wrapper,
             input_args,
             torch.device("cpu"),
-            2,
+            1,
             verbose=False,
             collect_logits=True,
         )
 
         if decode_only:
-            # Save post-prefill state: CPU prefill populated the KV cache and
-            # updated input_ids to the next token and cache_position to prompt_len.
+            # Snapshot first-decode inputs before CPU iter 1 advances them.
             decode_only_input_ids = input_args["input_ids"].clone()
             decode_only_cache_position = input_args["cache_position"].clone()
             decode_only_cache = input_args["past_key_values"]
+
+        # Iter 1: first decode. Provides the PCC reference for device first decode.
+        decode_logits, _ = generate_and_benchmark(
+            cpu_wrapper,
+            input_args,
+            torch.device("cpu"),
+            1,
+            verbose=False,
+            collect_logits=True,
+        )
+
+        cpu_output_logits = prefill_logits + decode_logits
 
     # Transfer model to device
     model = model.to(device, dtype=torch.bfloat16)
@@ -470,6 +484,8 @@ def benchmark_llm_torch_xla(
     perf_wrapper.eval()
     compiled_perf_model = torch.compile(perf_wrapper, backend="tt")
 
+    warmup_kv_cache = None
+
     # Warmup run (skip in decode-only mode)
     if not decode_only:
         # Construct inputs for warmup run
@@ -482,6 +498,7 @@ def benchmark_llm_torch_xla(
             input_prompt_tokens=(
                 token_accuracy.input_prompt if accuracy_testing else None
             ),
+            use_mla_cache=use_mla_cache,
         )
         input_args = transfer_to_device(input_args, device)
         print("Warming up...")
@@ -496,6 +513,8 @@ def benchmark_llm_torch_xla(
         )
         print("Warmup complete")
 
+        warmup_kv_cache = input_args["past_key_values"]
+
         tracy.signpost("warmup_complete")
 
     # Reconstruct inputs for the perf benchmark run
@@ -504,7 +523,7 @@ def benchmark_llm_torch_xla(
         model.config,
         batch_size,
         max_cache_len,
-        past_key_values=(decode_only_cache if decode_only else None),
+        past_key_values=(decode_only_cache if decode_only else warmup_kv_cache),
         input_prompt=custom_input_prompt,
         input_prompt_tokens=(token_accuracy.input_prompt if accuracy_testing else None),
         use_mla_cache=use_mla_cache,
@@ -563,6 +582,7 @@ def benchmark_llm_torch_xla(
         past_key_values=decode_only_cache if decode_only else None,
         input_prompt=custom_input_prompt,
         input_prompt_tokens=(token_accuracy.input_prompt if accuracy_testing else None),
+        use_mla_cache=use_mla_cache,
     )
 
     if decode_only:

--- a/tests/benchmark/benchmarks/llm_benchmark.py
+++ b/tests/benchmark/benchmarks/llm_benchmark.py
@@ -660,15 +660,17 @@ def benchmark_llm_torch_xla(
         print("PCC verification skipped in decode-only mode")
     else:
         # Check PCC for prefill
-        pcc_value = compute_pcc(
-            output_logits[0][0], cpu_output_logits[0][0], required_pcc=required_pcc
-        )
+        pcc_value = compute_pcc(output_logits[0][0], cpu_output_logits[0][0])
+        assert (
+            pcc_value >= required_pcc
+        ), f"Prefill PCC failed. PCC={pcc_value:.6f}, Required={required_pcc}"
         print("Prefill PCC verification passed with PCC={:.6f}".format(pcc_value))
         # Check PCC for first decode token
         if len(output_logits) > 1 and len(cpu_output_logits) > 1:
-            decode_pcc_value = compute_pcc(
-                output_logits[1][0], cpu_output_logits[1][0], required_pcc=required_pcc
-            )
+            decode_pcc_value = compute_pcc(output_logits[1][0], cpu_output_logits[1][0])
+            assert (
+                decode_pcc_value >= required_pcc
+            ), f"First decode PCC failed. PCC={decode_pcc_value:.6f}, Required={required_pcc}"
             print(
                 "First decode PCC verification passed with PCC={:.6f}".format(
                     decode_pcc_value

--- a/tests/benchmark/benchmarks/vision_benchmark.py
+++ b/tests/benchmark/benchmarks/vision_benchmark.py
@@ -234,7 +234,10 @@ def benchmark_vision_torch_xla(
     )
 
     # Evaluate PCC
-    pcc_value = compute_pcc(predictions[0], golden_output, required_pcc=required_pcc)
+    pcc_value = compute_pcc(predictions[0], golden_output)
+    assert (
+        pcc_value >= required_pcc
+    ), f"PCC comparison failed. PCC={pcc_value:.6f}, Required={required_pcc}"
     print(f"PCC verification passed with PCC={pcc_value:.6f}")
 
     result = create_benchmark_result(

--- a/tests/benchmark/conftest.py
+++ b/tests/benchmark/conftest.py
@@ -21,6 +21,23 @@ def make_validator_positive_int(option_name):
     return validate
 
 
+def make_validator_optimization_level(option_name):
+    """Create an optimization level validator (0, 1, or 2)."""
+
+    def validate(value):
+        try:
+            int_value = int(value)
+            if int_value not in [0, 1, 2]:
+                raise ValueError
+            return int_value
+        except (ValueError, TypeError):
+            raise pytest.UsageError(
+                f"Invalid value for {option_name}: '{value}'. Must be 0, 1, or 2."
+            )
+
+    return validate
+
+
 def pytest_addoption(parser):
     """Adds a custom command-line option to pytest."""
     parser.addoption(
@@ -51,6 +68,14 @@ def pytest_addoption(parser):
         action="store_true",
         default=False,
         help="Enable accuracy testing mode. Uses reference data for TOP1/TOP5 accuracy.",
+    )
+
+    parser.addoption(
+        "--optimization-level",
+        action="store",
+        default=None,
+        type=make_validator_optimization_level("--optimization-level"),
+        help="Optimization level (0, 1, or 2). Overrides default value.",
     )
 
     parser.addoption(
@@ -87,6 +112,11 @@ def batch_size(request):
 @pytest.fixture
 def accuracy_testing(request):
     return request.config.getoption("--accuracy-testing")
+
+
+@pytest.fixture
+def optimization_level(request):
+    return request.config.getoption("--optimization-level")
 
 
 @pytest.fixture

--- a/tests/benchmark/llm_utils/decode_utils.py
+++ b/tests/benchmark/llm_utils/decode_utils.py
@@ -82,7 +82,9 @@ class LLMSamplingWrapper(torch.nn.Module):
             logits_out = logits
             if self.mesh and self.output_sharding_spec:
                 # Ensure logits are replicated for transfer to CPU.
-                replicate_spec = tuple(None for _ in self.output_sharding_spec)
+                # Use tensor rank (not output_sharding_spec length) since logits may be
+                # rank 3 [batch, seq_len, vocab] while output_sharding_spec is rank 2.
+                replicate_spec = tuple(None for _ in range(logits_out.dim()))
                 logits_out = sharding_constraint_tensor(
                     logits, self.mesh, replicate_spec
                 )

--- a/tests/benchmark/llm_utils/decode_utils.py
+++ b/tests/benchmark/llm_utils/decode_utils.py
@@ -64,8 +64,7 @@ class LLMSamplingWrapper(torch.nn.Module):
         logits = self.read_logits_fn(output)
         # Only take logits for last token in prefill.
         # This is a noop for decode.
-        logits_last = logits[:, -1]
-        next_token_ids = logits_last.argmax(dim=-1, keepdim=True)
+        next_token_ids = logits[:, -1].argmax(dim=-1, keepdim=True)
         next_token_ids_replicated = next_token_ids
         if self.mesh and self.output_sharding_spec:
             # Create two versions of next_token_ids, sharded and replicated.
@@ -80,12 +79,12 @@ class LLMSamplingWrapper(torch.nn.Module):
             )
         next_cache_position = cache_position[-1:] + 1
         if self.return_logits:
-            logits_out = logits_last
+            logits_out = logits
             if self.mesh and self.output_sharding_spec:
                 # Ensure logits are replicated for transfer to CPU.
                 replicate_spec = tuple(None for _ in self.output_sharding_spec)
                 logits_out = sharding_constraint_tensor(
-                    logits_last, self.mesh, replicate_spec
+                    logits, self.mesh, replicate_spec
                 )
             return (
                 next_token_ids,

--- a/tests/benchmark/resnet_jax_benchmark.py
+++ b/tests/benchmark/resnet_jax_benchmark.py
@@ -215,7 +215,10 @@ def benchmark_resnet_jax(
     # Convert JAX arrays to PyTorch tensors for PCC comparison
     golden_tensor = torch.from_numpy(np.asarray(golden_output))
     prediction_tensor = torch.from_numpy(np.asarray(predictions[0]))
-    pcc_value = compute_pcc(golden_tensor, prediction_tensor, required_pcc=required_pcc)
+    pcc_value = compute_pcc(golden_tensor, prediction_tensor)
+    assert (
+        pcc_value >= required_pcc
+    ), f"PCC comparison failed. PCC={pcc_value:.6f}, Required={required_pcc}"
     print(f"PCC verification passed with PCC={pcc_value:.6f}")
 
     result = create_benchmark_result(

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -1689,11 +1689,6 @@ def test_llama_3_1_70b_tp(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
-        optimization_level=(
-            optimization_level
-            if optimization_level is not None
-            else DEFAULT_TP_OPTIMIZATION_LEVEL
-        ),
         weight_dtype_overrides={
             "model.layers.*.mlp.gate_proj.weight": "bfp_bf4",
             "model.layers.*.mlp.up_proj.weight": "bfp_bf4",
@@ -1750,11 +1745,6 @@ def test_gpt_oss_20b_tp(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
-        optimization_level=(
-            optimization_level
-            if optimization_level is not None
-            else DEFAULT_TP_OPTIMIZATION_LEVEL
-        ),
         mesh_config_fn=_gpt_oss_20b_mesh_config_fn,
         shard_spec_fn=_gpt_oss_20b_shard_spec_fn,
         trace_enabled=False,
@@ -1787,11 +1777,6 @@ def test_gpt_oss_20b_tp_batch_size_1(
         accuracy_testing=accuracy_testing,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
-        optimization_level=(
-            optimization_level
-            if optimization_level is not None
-            else DEFAULT_TP_OPTIMIZATION_LEVEL
-        ),
         mesh_config_fn=_gpt_oss_20b_mesh_config_fn,
         shard_spec_fn=_gpt_oss_20b_shard_spec_fn,
         batch_size=batch_size if batch_size is not None else 1,
@@ -1825,11 +1810,6 @@ def test_llama_3_1_70b_tp_galaxy(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
-        optimization_level=(
-            optimization_level
-            if optimization_level is not None
-            else DEFAULT_TP_OPTIMIZATION_LEVEL
-        ),
         arch="wormhole_galaxy",
         optimization_level=1,
     )
@@ -1860,11 +1840,11 @@ def test_gpt_oss_20b_tp_galaxy_batch_size_64(
         accuracy_testing=accuracy_testing,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
-        optimization_level=optimization_level if optimization_level is not None else 1,
         batch_size=(
             batch_size if batch_size is not None else 64
         ),  # 128 fails to compile - https://github.com/tenstorrent/tt-xla/issues/3907
         arch="wormhole_galaxy",
+        optimization_level=1,
     )
 
 
@@ -1893,11 +1873,11 @@ def test_gpt_oss_120b_tp_galaxy_batch_size_64(
         accuracy_testing=accuracy_testing,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
-        optimization_level=optimization_level if optimization_level is not None else 1,
         batch_size=(
             batch_size if batch_size is not None else 64
         ),  # 128 fails to compile - https://github.com/tenstorrent/tt-xla/issues/3907
         arch="wormhole_galaxy",
+        optimization_level=1,
         weight_dtype_overrides={
             "model.layers.*.mlp.router.weight": "bfp_bf4",
             "model.layers.*.mlp.experts.gate_up_proj": "bfp_bf4",
@@ -1974,9 +1954,9 @@ def test_gpt_oss_120b_tp_dp_galaxy_batch_size_128(
         accuracy_testing=accuracy_testing,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
-        optimization_level=optimization_level if optimization_level is not None else 1,
         batch_size=128,
         arch="wormhole_galaxy",
+        optimization_level=1,
         mesh_config_fn=_galaxy_mesh_config_fn,
         shard_spec_fn=_moe_throughput_galaxy_shard_spec_fn,
         input_output_sharding_spec=("batch", None),
@@ -2033,9 +2013,9 @@ def test_gpt_oss_120b_tp_qb2(
         accuracy_testing=accuracy_testing,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
-        optimization_level=optimization_level if optimization_level is not None else 1,
         batch_size=batch_size if batch_size is not None else 8,
         arch="qb2-blackhole",
+        optimization_level=1,
         trace_enabled=True,
         experimental_weight_dtype="bfp_bf8",
         weight_dtype_overrides={

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -257,6 +257,7 @@ def test_llama_3_2_1b(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -274,6 +275,11 @@ def test_llama_3_2_1b(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_OPTIMIZATION_LEVEL
+        ),
     )
 
 
@@ -285,6 +291,7 @@ def test_llama_3_2_3b(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -302,6 +309,11 @@ def test_llama_3_2_3b(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_OPTIMIZATION_LEVEL
+        ),
     )
 
 
@@ -313,6 +325,7 @@ def test_gemma_1_1_2b(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.gemma.pytorch.loader import (
         ModelLoader,
@@ -330,6 +343,11 @@ def test_gemma_1_1_2b(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_OPTIMIZATION_LEVEL
+        ),
     )
 
 
@@ -341,6 +359,7 @@ def test_gemma_2_2b(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.gemma.pytorch.loader import (
         ModelLoader,
@@ -358,6 +377,11 @@ def test_gemma_2_2b(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_OPTIMIZATION_LEVEL
+        ),
     )
 
 
@@ -369,6 +393,7 @@ def test_phi1(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.phi1.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -386,6 +411,11 @@ def test_phi1(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_OPTIMIZATION_LEVEL
+        ),
     )
 
 
@@ -397,6 +427,7 @@ def test_phi1_5(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.phi1_5.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -414,6 +445,11 @@ def test_phi1_5(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_OPTIMIZATION_LEVEL
+        ),
     )
 
 
@@ -425,6 +461,7 @@ def test_phi2(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.phi2.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -442,6 +479,11 @@ def test_phi2(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_OPTIMIZATION_LEVEL
+        ),
     )
 
 
@@ -453,6 +495,7 @@ def test_falcon3_1b(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.falcon.pytorch.loader import (
         ModelLoader,
@@ -473,6 +516,11 @@ def test_falcon3_1b(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_OPTIMIZATION_LEVEL
+        ),
     )
 
 
@@ -484,6 +532,7 @@ def test_falcon3_3b(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.falcon.pytorch.loader import (
         ModelLoader,
@@ -504,6 +553,11 @@ def test_falcon3_3b(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_OPTIMIZATION_LEVEL
+        ),
     )
 
 
@@ -515,6 +569,7 @@ def test_qwen_2_5_0_5b(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.qwen_2_5.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -533,6 +588,11 @@ def test_qwen_2_5_0_5b(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_OPTIMIZATION_LEVEL
+        ),
     )
 
 
@@ -544,6 +604,7 @@ def test_qwen_3_0_6b(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -561,6 +622,11 @@ def test_qwen_3_0_6b(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_OPTIMIZATION_LEVEL
+        ),
     )
 
 
@@ -572,6 +638,7 @@ def test_qwen_3_1_7b(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -589,6 +656,11 @@ def test_qwen_3_1_7b(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_OPTIMIZATION_LEVEL
+        ),
     )
 
 
@@ -600,6 +672,7 @@ def test_qwen_3_4b(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -617,6 +690,11 @@ def test_qwen_3_4b(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_OPTIMIZATION_LEVEL
+        ),
     )
 
 
@@ -628,6 +706,7 @@ def test_qwen_2_5_1_5b(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.qwen_2_5.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -645,6 +724,11 @@ def test_qwen_2_5_1_5b(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_OPTIMIZATION_LEVEL
+        ),
     )
 
 
@@ -656,6 +740,7 @@ def test_qwen_2_5_3b(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.qwen_2_5.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -673,6 +758,11 @@ def test_qwen_2_5_3b(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_OPTIMIZATION_LEVEL
+        ),
     )
 
 
@@ -684,6 +774,7 @@ def test_qwen_3_8b(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -701,6 +792,11 @@ def test_qwen_3_8b(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_OPTIMIZATION_LEVEL
+        ),
     )
 
 
@@ -712,6 +808,7 @@ def test_qwen_2_5_7b(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.qwen_2_5.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -729,11 +826,18 @@ def test_qwen_2_5_7b(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_OPTIMIZATION_LEVEL
+        ),
     )
 
 
 # FAILED: KeyError: "L['self'].model.lifted_tensor_0"
-def test_gemma_1_1_7b(output_file, num_layers, request, max_output_tokens):
+def test_gemma_1_1_7b(
+    output_file, num_layers, request, max_output_tokens, optimization_level
+):
     from third_party.tt_forge_models.gemma.pytorch.loader import (
         ModelLoader,
         ModelVariant,
@@ -747,11 +851,18 @@ def test_gemma_1_1_7b(output_file, num_layers, request, max_output_tokens):
         num_layers=num_layers,
         request=request,
         max_output_tokens=max_output_tokens,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_OPTIMIZATION_LEVEL
+        ),
     )
 
 
 # FAILED: TypeError: Phi3ForCausalLM.forward() got an unexpected keyword argument 'cache_position'
-def test_phi3_mini(output_file, num_layers, request, max_output_tokens):
+def test_phi3_mini(
+    output_file, num_layers, request, max_output_tokens, optimization_level
+):
     from third_party.tt_forge_models.phi3.causal_lm.pytorch.loader import (
         ModelLoader,
         ModelVariant,
@@ -765,11 +876,18 @@ def test_phi3_mini(output_file, num_layers, request, max_output_tokens):
         num_layers=num_layers,
         request=request,
         max_output_tokens=max_output_tokens,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_OPTIMIZATION_LEVEL
+        ),
     )
 
 
 # FAILED: KeyError: 'lifted_tensor_0'
-def test_phi3_5_mini(output_file, num_layers, request, max_output_tokens):
+def test_phi3_5_mini(
+    output_file, num_layers, request, max_output_tokens, optimization_level
+):
     from third_party.tt_forge_models.phi3.phi_3_5.pytorch.loader import (
         ModelLoader,
         ModelVariant,
@@ -783,11 +901,18 @@ def test_phi3_5_mini(output_file, num_layers, request, max_output_tokens):
         num_layers=num_layers,
         request=request,
         max_output_tokens=max_output_tokens,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_OPTIMIZATION_LEVEL
+        ),
     )
 
 
 # FAILED: AttributeError: 'MambaConfig' object has no attribute 'num_attention_heads'
-def test_mamba_2_8b(output_file, num_layers, request, max_output_tokens):
+def test_mamba_2_8b(
+    output_file, num_layers, request, max_output_tokens, optimization_level
+):
     from third_party.tt_forge_models.mamba.pytorch.loader import (
         ModelLoader,
         ModelVariant,
@@ -801,6 +926,11 @@ def test_mamba_2_8b(output_file, num_layers, request, max_output_tokens):
         num_layers=num_layers,
         request=request,
         max_output_tokens=max_output_tokens,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_OPTIMIZATION_LEVEL
+        ),
     )
 
 
@@ -812,6 +942,7 @@ def test_falcon3_7b(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.falcon.pytorch.loader import (
         ModelLoader,
@@ -832,6 +963,11 @@ def test_falcon3_7b(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_OPTIMIZATION_LEVEL
+        ),
     )
 
 
@@ -843,6 +979,7 @@ def test_mistral_7b(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.mistral.pytorch.loader import (
         ModelLoader,
@@ -860,6 +997,11 @@ def test_mistral_7b(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_OPTIMIZATION_LEVEL
+        ),
     )
 
 
@@ -872,6 +1014,7 @@ def test_ministral_8b(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.mistral.pytorch.loader import (
         ModelLoader,
@@ -891,6 +1034,11 @@ def test_ministral_8b(
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
         trace_enabled=False,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_OPTIMIZATION_LEVEL
+        ),
     )
 
 
@@ -902,6 +1050,7 @@ def test_llama_3_1_8b(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -920,6 +1069,11 @@ def test_llama_3_1_8b(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_OPTIMIZATION_LEVEL
+        ),
     )
 
 
@@ -931,6 +1085,7 @@ def test_falcon3_7b_tp(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.falcon.pytorch.loader import (
         ModelLoader,
@@ -948,6 +1103,11 @@ def test_falcon3_7b_tp(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_TP_OPTIMIZATION_LEVEL
+        ),
     )
 
 
@@ -959,6 +1119,7 @@ def test_falcon3_10b_tp(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.falcon.pytorch.loader import (
         ModelLoader,
@@ -976,6 +1137,11 @@ def test_falcon3_10b_tp(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_TP_OPTIMIZATION_LEVEL
+        ),
     )
 
 
@@ -987,6 +1153,7 @@ def test_llama_3_1_8b_instruct_tp(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -1004,6 +1171,11 @@ def test_llama_3_1_8b_instruct_tp(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_TP_OPTIMIZATION_LEVEL
+        ),
     )
 
 
@@ -1015,6 +1187,7 @@ def test_mistral_7b_tp(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.mistral.pytorch.loader import (
         ModelLoader,
@@ -1032,6 +1205,11 @@ def test_mistral_7b_tp(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_TP_OPTIMIZATION_LEVEL
+        ),
     )
 
 
@@ -1044,6 +1222,7 @@ def test_ministral_8b_tp(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.mistral.pytorch.loader import (
         ModelLoader,
@@ -1074,6 +1253,7 @@ def test_mistral_nemo_instruct_2407_tp(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.mistral.pytorch.loader import (
         ModelLoader,
@@ -1103,6 +1283,7 @@ def test_mistral_small_24b_instruct_2501_tp(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.mistral.pytorch.loader import (
         ModelLoader,
@@ -1132,6 +1313,7 @@ def test_qwen_2_5_14b_instruct_tp(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.qwen_2_5.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -1161,6 +1343,7 @@ def test_qwen_2_5_32b_instruct_tp(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.qwen_2_5.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -1178,6 +1361,11 @@ def test_qwen_2_5_32b_instruct_tp(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_TP_OPTIMIZATION_LEVEL
+        ),
     )
 
 
@@ -1189,6 +1377,7 @@ def test_qwen_2_5_coder_32b_instruct_tp(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.qwen_2_5_coder.pytorch.loader import (
         ModelLoader,
@@ -1218,6 +1407,7 @@ def test_qwen_3_0_6b_tp(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -1235,6 +1425,11 @@ def test_qwen_3_0_6b_tp(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_TP_OPTIMIZATION_LEVEL
+        ),
     )
 
 
@@ -1246,6 +1441,7 @@ def test_qwen_3_1_7b_tp(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -1263,6 +1459,11 @@ def test_qwen_3_1_7b_tp(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_TP_OPTIMIZATION_LEVEL
+        ),
     )
 
 
@@ -1274,6 +1475,7 @@ def test_qwen_3_8b_tp(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -1303,6 +1505,7 @@ def test_qwen_3_14b_tp(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -1332,6 +1535,7 @@ def test_qwen_3_32b_tp(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -1349,6 +1553,11 @@ def test_qwen_3_32b_tp(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_TP_OPTIMIZATION_LEVEL
+        ),
     )
 
 
@@ -1360,6 +1569,7 @@ def test_llama_3_8b_instruct_tp(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -1377,6 +1587,11 @@ def test_llama_3_8b_instruct_tp(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_TP_OPTIMIZATION_LEVEL
+        ),
     )
 
 
@@ -1388,6 +1603,7 @@ def test_llama_3_1_8b_tp(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -1405,6 +1621,11 @@ def test_llama_3_1_8b_tp(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_TP_OPTIMIZATION_LEVEL
+        ),
     )
 
 
@@ -1416,6 +1637,7 @@ def test_llama_3_8b_tp(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -1433,6 +1655,11 @@ def test_llama_3_8b_tp(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_TP_OPTIMIZATION_LEVEL
+        ),
     )
 
 
@@ -1444,6 +1671,7 @@ def test_llama_3_1_70b_tp(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -1461,6 +1689,11 @@ def test_llama_3_1_70b_tp(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_TP_OPTIMIZATION_LEVEL
+        ),
         weight_dtype_overrides={
             "model.layers.*.mlp.gate_proj.weight": "bfp_bf4",
             "model.layers.*.mlp.up_proj.weight": "bfp_bf4",
@@ -1499,6 +1732,7 @@ def test_gpt_oss_20b_tp(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
         ModelLoader,
@@ -1516,6 +1750,11 @@ def test_gpt_oss_20b_tp(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_TP_OPTIMIZATION_LEVEL
+        ),
         mesh_config_fn=_gpt_oss_20b_mesh_config_fn,
         shard_spec_fn=_gpt_oss_20b_shard_spec_fn,
         trace_enabled=False,
@@ -1531,6 +1770,7 @@ def test_gpt_oss_20b_tp_batch_size_1(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
         ModelLoader,
@@ -1547,6 +1787,11 @@ def test_gpt_oss_20b_tp_batch_size_1(
         accuracy_testing=accuracy_testing,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_TP_OPTIMIZATION_LEVEL
+        ),
         mesh_config_fn=_gpt_oss_20b_mesh_config_fn,
         shard_spec_fn=_gpt_oss_20b_shard_spec_fn,
         batch_size=batch_size if batch_size is not None else 1,
@@ -1562,6 +1807,7 @@ def test_llama_3_1_70b_tp_galaxy(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -1579,6 +1825,11 @@ def test_llama_3_1_70b_tp_galaxy(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=(
+            optimization_level
+            if optimization_level is not None
+            else DEFAULT_TP_OPTIMIZATION_LEVEL
+        ),
         arch="wormhole_galaxy",
         optimization_level=1,
     )
@@ -1592,6 +1843,7 @@ def test_gpt_oss_20b_tp_galaxy_batch_size_64(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
         ModelLoader,
@@ -1608,11 +1860,11 @@ def test_gpt_oss_20b_tp_galaxy_batch_size_64(
         accuracy_testing=accuracy_testing,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=optimization_level if optimization_level is not None else 1,
         batch_size=(
             batch_size if batch_size is not None else 64
         ),  # 128 fails to compile - https://github.com/tenstorrent/tt-xla/issues/3907
         arch="wormhole_galaxy",
-        optimization_level=1,
     )
 
 
@@ -1624,6 +1876,7 @@ def test_gpt_oss_120b_tp_galaxy_batch_size_64(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
         ModelLoader,
@@ -1640,11 +1893,11 @@ def test_gpt_oss_120b_tp_galaxy_batch_size_64(
         accuracy_testing=accuracy_testing,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=optimization_level if optimization_level is not None else 1,
         batch_size=(
             batch_size if batch_size is not None else 64
         ),  # 128 fails to compile - https://github.com/tenstorrent/tt-xla/issues/3907
         arch="wormhole_galaxy",
-        optimization_level=1,
         weight_dtype_overrides={
             "model.layers.*.mlp.router.weight": "bfp_bf4",
             "model.layers.*.mlp.experts.gate_up_proj": "bfp_bf4",
@@ -1704,6 +1957,7 @@ def test_gpt_oss_120b_tp_dp_galaxy_batch_size_128(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
         ModelLoader,
@@ -1720,9 +1974,9 @@ def test_gpt_oss_120b_tp_dp_galaxy_batch_size_128(
         accuracy_testing=accuracy_testing,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=optimization_level if optimization_level is not None else 1,
         batch_size=128,
         arch="wormhole_galaxy",
-        optimization_level=1,
         mesh_config_fn=_galaxy_mesh_config_fn,
         shard_spec_fn=_moe_throughput_galaxy_shard_spec_fn,
         input_output_sharding_spec=("batch", None),
@@ -1762,6 +2016,7 @@ def test_gpt_oss_120b_tp_qb2(
     batch_size,
     max_output_tokens,
     decode_only,
+    optimization_level,
 ):
     from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
         ModelLoader,
@@ -1778,9 +2033,9 @@ def test_gpt_oss_120b_tp_qb2(
         accuracy_testing=accuracy_testing,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=optimization_level if optimization_level is not None else 1,
         batch_size=batch_size if batch_size is not None else 8,
         arch="qb2-blackhole",
-        optimization_level=1,
         trace_enabled=True,
         experimental_weight_dtype="bfp_bf8",
         weight_dtype_overrides={

--- a/tests/benchmark/utils.py
+++ b/tests/benchmark/utils.py
@@ -8,7 +8,6 @@ import os
 import re
 import secrets
 import socket
-from collections.abc import Sequence
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
@@ -206,8 +205,22 @@ def aggregate_ttnn_perf_metrics(ttnn_perf_metrics_output_file, results):
             results["config"]["ttnn_num_graphs"] = num_graphs_with_metrics
 
 
-def _compute_pcc_single(golden_flat: torch.Tensor, device_flat: torch.Tensor) -> float:
-    """Helper to compute PCC between two flattened tensors."""
+def compute_pcc(golden_output: torch.Tensor, device_output: torch.Tensor) -> float:
+    """Compute Pearson Correlation Coefficient between two tensors.
+
+    Args:
+        golden_output: Golden reference tensor
+        device_output: Device output tensor
+
+    Returns:
+        PCC value in [-1, 1].
+
+    Raises:
+        ValueError: If denominator is zero and tensors are not close.
+    """
+    golden_flat = golden_output.to(torch.float32).flatten()
+    device_flat = device_output.to(torch.float32).flatten()
+
     golden_centered = golden_flat - golden_flat.mean()
     device_centered = device_flat - device_flat.mean()
     denom = golden_centered.norm() * device_centered.norm()
@@ -215,85 +228,13 @@ def _compute_pcc_single(golden_flat: torch.Tensor, device_flat: torch.Tensor) ->
     if denom == 0:
         if torch.allclose(golden_flat, device_flat, rtol=1e-2, atol=1e-2):
             return 1.0
-        raise AssertionError(
+        raise ValueError(
             "PCC computation failed: denominator is zero but tensors are not close"
         )
 
     pcc = ((golden_centered @ device_centered) / denom).item()
     # Clamp to [-1, 1] to handle floating-point precision errors
     return max(-1.0, min(1.0, pcc))
-
-
-def compute_pcc(golden_output, device_output, required_pcc: float = 0.99) -> float:
-    """
-    Compute Pearson Correlation Coefficient between golden and device output.
-
-    Supports single tensors or collections of tensors (e.g., multi-scale outputs).
-    For collections, computes PCC for each element individually, then computes the overall
-    PCC by concatenating all tensors into a single flattened tensor before comparison.
-
-    Args:
-        golden_output: Golden output tensor or collection of tensors
-        device_output: Device output tensor or collection of tensors
-        required_pcc: Minimum required PCC threshold
-
-    Returns:
-        Overall PCC value (computed across all concatenated tensor elements).
-
-    Raises:
-        AssertionError: If computed PCC is below required_pcc threshold
-    """
-    # Normalize inputs to iterables for uniform processing
-    is_collection = isinstance(golden_output, Sequence) and not isinstance(
-        golden_output, torch.Tensor
-    )
-    golden_iter = golden_output if is_collection else (golden_output,)
-    device_iter = device_output if is_collection else (device_output,)
-
-    assert len(golden_iter) == len(device_iter), (
-        f"Output length mismatch: golden has {len(golden_iter)} elements, "
-        f"device has {len(device_iter)} elements"
-    )
-
-    # Compute PCC per scale
-    scale_pccs = []
-    for i, (golden, device) in enumerate(zip(golden_iter, device_iter)):
-        golden_flat = golden.to(torch.float32).flatten()
-        device_flat = device.to(torch.float32).flatten()
-        scale_pcc = _compute_pcc_single(golden_flat, device_flat)
-        scale_pccs.append(scale_pcc)
-
-        if is_collection:
-            print(f"  Scale {i} (shape {golden.shape}): PCC={scale_pcc:.6f}")
-
-    # Compute overall PCC
-    golden_all = torch.cat([g.to(torch.float32).flatten() for g in golden_iter])
-    device_all = torch.cat([d.to(torch.float32).flatten() for d in device_iter])
-    pcc_value = _compute_pcc_single(golden_all, device_all)
-
-    # Print results
-    if is_collection:
-        print(
-            f"PCC check: Computing PCC for {len(golden_iter)} output tensors (multi-scale)"
-        )
-        print(
-            f"PCC check: Overall PCC={pcc_value:.6f}, Min scale PCC={min(scale_pccs):.6f}, Required PCC={required_pcc}"
-        )
-    else:
-        print(f"PCC check: Calculated PCC={pcc_value:.6f}, Required PCC={required_pcc}")
-
-    # Validate
-    if is_collection:
-        assert pcc_value >= required_pcc, (
-            f"PCC comparison failed. Overall PCC={pcc_value:.6f}, "
-            f"Min scale PCC={min(scale_pccs):.6f}. Required: pcc={required_pcc}"
-        )
-    else:
-        assert (
-            pcc_value >= required_pcc
-        ), f"PCC comparison failed. Calculated: pcc={pcc_value:.6f}. Required: pcc={required_pcc}"
-
-    return pcc_value
 
 
 def get_benchmark_metadata() -> Dict[str, str]:


### PR DESCRIPTION
### Problem description
Currently in benchmarks LLM PCC is calculated only for logits of prefill generated token.

We want to measure PCC for entire prefill logits, and first decode token logits.

### What's changed
- Return full logits for prefill (`tests/benchmark/llm_utils/decode_utils.py`)
- Calculate PCC for first decode token (`tests/benchmark/benchmarks/llm_benchmark.py`)
- Calculate PCC for decode_only mode too
- Simplify `compute_pcc` util function and delegate assert to caller
- Expose `--optimization-level` pytest fixture for easier PCC debugging

### Checklist
- [ ] [n150 benchmark](https://github.com/tenstorrent/tt-xla/actions/runs/24663243637)
    - [`lama_3_1_8b`](https://github.com/tenstorrent/tt-xla/actions/runs/24663243637/job/72116074809) fails with `AssertionError: First decode PCC failed. PCC=0.911035, Required=0.94`
    - [`qwen_2_5_7b_instruct`](https://github.com/tenstorrent/tt-xla/actions/runs/24663243637/job/72116074941) fails with `AssertionError: First decode PCC failed. PCC=0.501355, Required=0.94`
- [ ] [LLMBOX benchmark](https://github.com/tenstorrent/tt-xla/actions/runs/24663257168)
    - [`gpt_oss_20b_tp_batch_size_1`](https://github.com/tenstorrent/tt-xla/actions/runs/24663257168/job/72116075473) fails with `AssertionError: First decode PCC failed. PCC=0.277369, Required=0.94`
- [ ] [Galaxy benchmark](https://github.com/tenstorrent/tt-xla/actions/runs/24667102178)
    - [`gpt_oss_120b_tp_dp_galaxy_batch_size_128`](https://github.com/tenstorrent/tt-xla/actions/runs/24675401690/job/72160852102) fails with 
`loc("custom-call.18118"): error: 'sdy.sharding_constraint' op sharding doesn't match tensor rank: 2 != 3
2026-04-20 14:30:53.218 ( 705.778s) [        A3610140]      module_builder.cc:839    ERR| Failed to run stablehlo pipeline` 
    - [`gpt_oss_120b_tp_galaxy_batch_size_64 `](https://github.com/tenstorrent/tt-xla/actions/runs/24675401690/job/72160852139) fails with `AssertionError: First decode PCC failed. PCC=0.875079, Required=0.93`

Latest runs:
- [ ] [n150 benchmark](https://github.com/tenstorrent/tt-xla/actions/runs/24735807895)
- [ ] [LLMBOX benchmark](https://github.com/tenstorrent/tt-xla/actions/runs/24836057207)
- [ ] [Galaxy benchmark](https://github.com/tenstorrent/tt-xla/actions/runs/24836078187)

### Notes:
Llama-3.1-70B TP on LLMBOX used to fail when full logits were returned due to [DRAM OOM](https://github.com/tenstorrent/tt-xla/pull/4056):
Although it passes in benchmark listed above, we should wait for https://github.com/tenstorrent/tt-mlir/commit/0df0e24222e7812de4a0f603fc26fa3838eb58fc to get uplifted to be sure.