### PR TITLE
Ignore hidden .tracy_artifacts directory in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,4 @@ tests/benchmark/reference_outputs/*.refpt
 /modules/
 
 # Tracy profiling files
-/tracy_artifacts/
+/.tracy_artifacts/


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The `.gitignore` entry for tracy profiling artifacts referenced `/tracy_artifacts/`, but the actual directory is created as `/.tracy_artifacts/` (hidden).

### What's changed
Updated the `.gitignore` pattern from `/tracy_artifacts/` to `/.tracy_artifacts/` so tracy profiling output is properly ignored.

### Checklist
- [x] New/Existing tests provide coverage for changes