### PR TITLE
[vLLM] Replace sort-based sampling with multi-core topk for 2x non-greedy speedup

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/sampler.py
+++ b/integrations/vllm_plugin/vllm_tt/sampler.py
@@ -2,11 +2,33 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Sampler layer implementing XLA supported operations."""
 
+import math
+
 import torch
 import torch.nn as nn
 from vllm.v1.outputs import LogprobsTensors, SamplerOutput
 
 from .metadata import XLASupportedSamplingMetadata
+
+# Multi-core topk parameters.
+# ttnn.topk uses a multi-core bitonic sort when input dim is a power of 2 and
+# < 65536.  We split the vocab into chunks of at most this size, pad each
+# chunk to the next power of 2, and run topk per chunk.  All chunk topk results
+# are concatenated to form the candidate set for sampling.
+_TOPK_MAX_CHUNK_SIZE = 32768  # largest power-of-2 below 65536
+_TOPK_K_PER_CHUNK = 32  # candidates kept per chunk
+
+
+def _next_power_of_2(n: int) -> int:
+    return 1 << (n - 1).bit_length()
+
+
+def _get_topk_split_params(vocab_size: int) -> tuple[int, int]:
+    """Return (chunk_size, padded_chunk_size) for chunked topk."""
+    num_chunks = math.ceil(vocab_size / _TOPK_MAX_CHUNK_SIZE)
+    chunk_size = math.ceil(vocab_size / num_chunks)
+    return chunk_size, _next_power_of_2(chunk_size)
+
 
 _SAMPLING_EPS = 1e-5
 
@@ -185,18 +207,31 @@ class Sampler(nn.Module):
         if sampling_metadata.min_p is not None:
             logits = self.apply_min_p(logits, sampling_metadata.min_p)
 
-        # Apply top_k and/or top_p.
-        logits = apply_top_k_top_p(
+        # Apply top_k and/or top_p using multi-core topk pre-filtering.
+        # This splits vocab into power-of-2 chunks (<= 32768) to trigger
+        # multi-core ttnn.topk (0.18ms per chunk vs 9ms single-core), then
+        # applies top-k/top-p on the small candidate set.
+        filtered_logits, candidate_indices = apply_top_k_top_p_fast(
             logits,
             sampling_metadata.top_k,
             sampling_metadata.top_p,
         )
 
-        # Random sample.
-        probs = logits.softmax(dim=-1, dtype=torch.float32)
-        random_sampled = self.random_sample(
-            probs, sampling_metadata.generators, sampling_metadata.q_samples
+        # Random sample on reduced candidate set.
+        probs = filtered_logits.softmax(dim=-1, dtype=torch.float32)
+
+        # If seeded sampling, gather q_samples at candidate positions.
+        q_samples_reduced = None
+        if sampling_metadata.q_samples is not None:
+            q_samples_reduced = sampling_metadata.q_samples.gather(1, candidate_indices)
+
+        random_sampled_local = self.random_sample(
+            probs, sampling_metadata.generators, q_samples_reduced
         )
+        # Map local candidate index back to global vocab index.
+        random_sampled = candidate_indices.gather(
+            1, random_sampled_local.unsqueeze(-1)
+        ).squeeze(-1)
 
         sampled = torch.where(
             sampling_metadata.temperature < _SAMPLING_EPS,
@@ -291,48 +326,62 @@ class Sampler(nn.Module):
         return probs.div_(q).argmax(dim=-1).view(-1)
 
 
-def apply_top_k_top_p(
+def apply_top_k_top_p_fast(
     logits: torch.Tensor,
     k: torch.Tensor | None,
     p: torch.Tensor | None,
-) -> torch.Tensor:
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Top-k/top-p filtering via multi-core ttnn.topk.
+
+    Splits vocab into power-of-2 chunks (<= 32768) so torch.topk compiles
+    to multi-core ttnn.topk (~0.18ms/chunk) instead of single-core ttnn.sort
+    (~9ms). Returns (filtered_logits, candidate_indices) where both tensors
+    have shape [batch, num_chunks * k_per_chunk] and candidate_indices holds
+    global vocab positions.
+
+    The top-k and top-p filters are applied on the small candidate set
+    (~128 tokens) rather than the full vocab.
     """
-    Apply top-k and top-p optimized for TPU.
+    vocab_size = logits.shape[-1]
+    chunk_size, padded_chunk_size = _get_topk_split_params(vocab_size)
 
-    This algorithm avoids using torch.scatter which is extremely slow on TPU.
-    This is achieved by finding a "cut-off" element in the original logit, and
-    after thresholding the logit using this cut-off, the remaining elements
-    shall constitute the top-p set.
+    # Split vocab, pad each chunk to power-of-2, run topk.
+    chunks = torch.split(logits, chunk_size, dim=-1)
+    topk_values_list = []
+    topk_indices_list = []
+    for i, chunk in enumerate(chunks):
+        if chunk.shape[-1] < padded_chunk_size:
+            chunk = torch.nn.functional.pad(
+                chunk, (0, padded_chunk_size - chunk.shape[-1]), value=float("-inf")
+            )
+        vals, inds = torch.topk(chunk, k=_TOPK_K_PER_CHUNK, dim=-1)
+        topk_values_list.append(vals)
+        # Offset local chunk indices to global vocab positions.
+        topk_indices_list.append(inds + i * chunk_size)
 
-    Note: in the case of tie (i.e. multiple cut-off elements present in the
-    logit), all tie elements are included in the top-p set. In other words,
-    this function does not break ties. Instead, these tie tokens have equal
-    chance of being chosen during final sampling, so we can consider the tie
-    being broken then.
-    """
-    probs = logits.softmax(dim=-1)
-    probs_sort, _ = probs.sort(dim=-1, descending=False)
+    # Concat: [batch, num_chunks * k_per_chunk]
+    all_values = torch.cat(topk_values_list, dim=-1)
+    all_indices = torch.cat(topk_indices_list, dim=-1)
 
-    if k is not None:
-        top_k_count = probs_sort.size(1) - k.to(torch.long)  # shape: (batch, )
-        top_k_count = top_k_count.clamp(max=probs_sort.size(1) - 1).unsqueeze(dim=1)
-        top_k_cutoff = probs_sort.gather(-1, top_k_count)
+    # Apply top-k and top-p on the small candidate set.
+    if k is not None or p is not None:
+        probs = all_values.softmax(dim=-1)
+        probs_sort, _ = probs.sort(dim=-1, descending=False)
 
-        # Make sure the disabled top-k rows (k<=0 or k==vocab_size) are no-op.
-        no_top_k_mask = ((k <= 0) | (k == logits.shape[1])).unsqueeze(dim=1)
-        top_k_cutoff.masked_fill_(no_top_k_mask, -float("inf"))
+        if k is not None:
+            top_k_count = probs_sort.size(1) - k.to(torch.long)
+            top_k_count = top_k_count.clamp(max=probs_sort.size(1) - 1).unsqueeze(1)
+            top_k_cutoff = probs_sort.gather(-1, top_k_count)
+            no_top_k_mask = ((k <= 0) | (k >= vocab_size)).unsqueeze(1)
+            top_k_cutoff.masked_fill_(no_top_k_mask, -float("inf"))
+            all_values = all_values.masked_fill(probs < top_k_cutoff, -float("inf"))
 
-        elements_to_discard = probs < top_k_cutoff
-        logits.masked_fill_(elements_to_discard, -float("inf"))
+        if p is not None:
+            cumprob = torch.cumsum(probs_sort, dim=-1)
+            top_p_mask = cumprob <= 1 - p.unsqueeze(1)
+            top_p_mask[:, -1] = False
+            top_p_count = top_p_mask.sum(dim=-1).unsqueeze(1)
+            top_p_cutoff = probs_sort.gather(-1, top_p_count)
+            all_values = all_values.masked_fill(probs < top_p_cutoff, -float("inf"))
 
-    if p is not None:
-        cumprob = torch.cumsum(probs_sort, dim=-1)
-        top_p_mask = cumprob <= 1 - p.unsqueeze(dim=1)
-        top_p_mask[:, -1] = False  # at least one
-
-        top_p_count = top_p_mask.sum(dim=-1).unsqueeze(1)
-        top_p_cutoff = probs_sort.gather(-1, top_p_count)
-        elements_to_discard = probs < top_p_cutoff
-        logits.masked_fill_(elements_to_discard, -float("inf"))
-
-    return logits
+    return all_values, all_indices

--- a/tests/torch/ops/test_topk.py
+++ b/tests/torch/ops/test_topk.py
@@ -5,7 +5,7 @@
 import pytest
 import torch
 from benchmark.utils import compute_pcc
-from infra import Framework, run_op_test_with_random_inputs
+from infra import Framework, run_op_test, run_op_test_with_random_inputs
 from utils import Category
 
 
@@ -189,4 +189,78 @@ def test_topk_both(input_shape: tuple, k: int):
         dtype=torch.float32,
         framework=Framework.TORCH,
         custom_comparator=topk_both_comparator,
+    )
+
+
+# ---------------------------------------------------------------------------
+# vLLM sampling shapes: power-of-2 chunks used in apply_top_k_top_p_fast
+# ---------------------------------------------------------------------------
+
+
+def _topk_vllm_comparator(device_output, golden_output, args, kwargs):
+    """Correct comparator for topk: gathered values must match, not exact indices.
+
+    topk ordering is non-deterministic — CPU may return [0,1,2,3] while
+    device returns [3,2,1,0]. Both are valid. Compare by gathering original
+    values at the returned indices and checking cosine similarity.
+    """
+    device_vals, device_idx = device_output
+    golden_vals, golden_idx = golden_output
+    input_tensor = args[0]
+
+    device_idx = device_idx.cpu()
+    golden_idx = golden_idx.cpu()
+
+    device_gathered = torch.gather(input_tensor, -1, device_idx)
+    golden_gathered = torch.gather(input_tensor, -1, golden_idx)
+    cos_sim = torch.nn.functional.cosine_similarity(
+        device_gathered.flatten().unsqueeze(0).float(),
+        golden_gathered.flatten().unsqueeze(0).float(),
+    )
+    idx_match = (device_idx == golden_idx).float().mean().item()
+    k = device_idx.shape[-1]
+    print(
+        f"\n  values_cos_sim={cos_sim.item():.6f}"
+        f"  index_exact_match={idx_match:.3f} ({int(idx_match * k)}/{k})"
+        f"  (ordering non-deterministic — only values matter)"
+    )
+    assert cos_sim > 0.99, f"topk gathered values wrong: cos_sim={cos_sim.item():.6f}"
+
+
+@pytest.mark.nightly
+@pytest.mark.single_device
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    torch_op_name="torch.topk",
+)
+@pytest.mark.parametrize(
+    ["input_shape", "k"],
+    [
+        pytest.param((1, 32768), 32, id="32768-k32"),
+        pytest.param((1, 32768), 64, id="32768-k64"),
+        pytest.param((1, 16384), 32, id="16384-k32"),
+        pytest.param((1, 65536), 32, id="65536-k32"),
+    ],
+)
+def test_topk_vllm_sampling_shapes(input_shape: tuple, k: int):
+    """topk on power-of-2 shapes used in vLLM chunked sampling (apply_top_k_top_p_fast).
+
+    Splits the vocab into 32768-element power-of-2 chunks and runs topk(k=32)
+    per chunk to get candidates for Gumbel-max sampling. Ordering is
+    non-deterministic so correctness is verified via gathered value similarity.
+    """
+
+    class TopKBoth(torch.nn.Module):
+        def __init__(self, k):
+            super().__init__()
+            self.k = k
+
+        def forward(self, x):
+            return torch.topk(x, self.k, dim=-1)
+
+    run_op_test(
+        TopKBoth(k),
+        [torch.randn(*input_shape, dtype=torch.float32)],
+        framework=Framework.TORCH,
+        custom_comparator=_topk_vllm_comparator,
     )


### PR DESCRIPTION
## Ticket

#3940

## Problem

- Non-greedy (temperature > 0) vLLM sampling was slow: `apply_top_k_top_p` sorted the full probability distribution (`probs.sort()`) over the entire vocabulary (128k tokens for Llama). This compiled to single-core `SortDeviceOperation` at ~30ms/token, making non-greedy roughly 3x slower than greedy.

## What's changed

- `sampler.py`: replace `apply_top_k_top_p` (full-vocab sort) with `apply_top_k_top_p_fast` — splits vocab into power-of-2 chunks (≤ 32768), runs `torch.topk(k=32)` per chunk, and Gumbel-max samples from the ~128 resulting candidates. Compiles to multi-core `ttnn.topk` (~0.18ms/chunk) instead of single-core `SortDeviceOperation` (~30ms)
- `test_topk.py`: add `test_topk_vllm_sampling_shapes` covering power-of-2 chunk sizes (16384/32768/65536, k=32/64) with correct value-based comparator
-  Side effect: workarounds #4422 (`ttnn.sort` aborts under metal-trace capture on Wormhole) by removing full-vocab sort from the sampler graph.

## Checklist

- [x] Non-greedy output coherent on Llama 3.1-8B and 3.2-1B
- [x] Greedy throughput unchanged, Non-greedy 2x+ speedup vs sort baseline
- [x] Used this change for recent single chip + multichip (gemma4-31B-it) demos
- [x] vLLM Nightly at TOTT passing (except for known hang in n300-llmbox): https://github.com/tenstorrent/tt-xla/actions/runs/25337040803
- [x] tenstorrent/tt-mlir#7773 uplifted into tt-xla
- [x] Add composite op support to torch.gather via https://github.com/tenstorrent/tt-xla/pull/4373