### PR TITLE
Maintain Torch LLM configuration files

### DIFF
--- a/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
@@ -9,14 +9,10 @@
 
 test_config:
   falcon/pytorch-3_1B_Base-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
-    status: NOT_SUPPORTED_SKIP
-    reason: "Hang - https://github.com/tenstorrent/tt-xla/issues/3838"
-    bringup_status: FAILED_RUNTIME
+    status: EXPECTED_PASSING
 
   falcon/pytorch-3_3B_Base-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
-    status: NOT_SUPPORTED_SKIP
-    reason: "Hang - https://github.com/tenstorrent/tt-xla/issues/3838"
-    bringup_status: FAILED_RUNTIME
+    status: EXPECTED_PASSING
 
   falcon/pytorch-3_7B_Base-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.
@@ -27,19 +23,14 @@ test_config:
     status: EXPECTED_PASSING
 
   qwen_2_5/causal_lm/pytorch-0.5B_Instruct-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
-    status: NOT_SUPPORTED_SKIP
-    reason: "Hang - https://github.com/tenstorrent/tt-xla/issues/3838"
-    bringup_status: FAILED_RUNTIME
+    status: EXPECTED_PASSING
 
   qwen_2_5/causal_lm/pytorch-1.5B_Instruct-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
-    status: NOT_SUPPORTED_SKIP
-    reason: "Hang - https://github.com/tenstorrent/tt-xla/issues/3838"
-    bringup_status: FAILED_RUNTIME
+    status: EXPECTED_PASSING
+    required_pcc: 0.98
 
   qwen_2_5/causal_lm/pytorch-3B_Instruct-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
-    status: NOT_SUPPORTED_SKIP
-    reason: "Hang - https://github.com/tenstorrent/tt-xla/issues/3838"
-    bringup_status: FAILED_RUNTIME
+    status: EXPECTED_PASSING
 
   qwen_2_5/causal_lm/pytorch-7B_Instruct-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.
@@ -102,9 +93,7 @@ test_config:
     status: EXPECTED_PASSING
 
   qwen_3/causal_lm/pytorch-4B-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
-    status: NOT_SUPPORTED_SKIP
-    reason: "Hang - https://github.com/tenstorrent/tt-xla/issues/3838"
-    bringup_status: FAILED_RUNTIME
+    status: EXPECTED_PASSING
 
   qwen_3/causal_lm/pytorch-8B-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/3838

### Problem description
Since the ticket was recently closed, I re-tested the models associated with it

### What's changed
ci run: https://github.com/tenstorrent/tt-xla/actions/runs/24733202480

```
test_llms_torch[falcon/pytorch-3_1B_Base-llm_decode-seq_1-batch_1-single_device-mesh_default-inference]                  language    red    bfloat16       n150  PASSED            PASSING       0.9992382036865545  0.99       PCC_EN  single_device  113.768  N/A     
test_llms_torch[falcon/pytorch-3_3B_Base-llm_decode-seq_1-batch_1-single_device-mesh_default-inference]                  language    red    bfloat16       n150  PASSED            PASSING       0.9994985233197237  0.99       PCC_EN  single_device  103.860  N/A     
test_llms_torch[qwen_2_5/causal_lm/pytorch-0.5B_Instruct-llm_decode-seq_1-batch_1-single_device-mesh_default-inference]  language    red    bfloat16       n150  PASSED            PASSING       0.9964624783023818  0.99       PCC_EN  single_device  116.525  N/A     
test_llms_torch[qwen_2_5/causal_lm/pytorch-1.5B_Instruct-llm_decode-seq_1-batch_1-single_device-mesh_default-inference]  language    red    bfloat16       n150  INCORRECT_RESULT  PASSING       0.9848909529879805  0.99       PCC_EN  single_device  103.044  N/A     
test_llms_torch[qwen_2_5/causal_lm/pytorch-3B_Instruct-llm_decode-seq_1-batch_1-single_device-mesh_default-inference]    language    red    bfloat16       n150  PASSED            PASSING       0.9996093953088389  0.99       PCC_EN  single_device  171.216  N/A     
test_llms_torch[qwen_3/causal_lm/pytorch-4B-llm_decode-seq_1-batch_1-single_device-mesh_default-inference]               language    red    bfloat16       n150  PASSED            PASSING       0.999498937576518   0.99       PCC_EN  single_device  219.806  N/A     


```
### Checklist
- [ ] New/Existing tests provide coverage for changes
