### PR TITLE
Add vLLM decode tests with prefill length fixed to 1

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -290,6 +290,12 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             min_token_size=self.tt_config.min_context_len,
             max_token_size=self.max_model_len,
         )
+        if self.tt_config.decode_only:
+            # Restrict all num_tokens bucketing to the decode shape so every
+            # precompile pass (and anything else that reads
+            # self.num_tokens_paddings) only compiles num_tokens=1.
+            self.num_tokens_paddings = [1]
+            logger.info("decode_only=True; restricting num_tokens_paddings to [1].")
 
         # In case `max_num_tokens < max(num_tokens_paddings)` use the actual
         # padded max value to pre-allocate data structures and pre-compile.
@@ -1899,9 +1905,12 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         Precompile all the subgraphs with possible input shapes.
         """
         torch._dynamo.config.dynamic_shapes = False
+        decode_only = self.tt_config.decode_only
         with self.maybe_setup_dummy_loras(self.lora_config):
-            self._precompile_mm_encoder()
             self._precompile_backbone()
+            if self.tt_config.decode_only:
+                return
+            self._precompile_mm_encoder()
             self._precompile_select_hidden_states()
             self._precompile_compute_logits()
             self._precompile_structured_decoding()
@@ -1917,6 +1926,8 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self,
         num_tokens: int,
     ) -> None:
+        if self.tt_config.decode_only:
+            return
         logger.info(f"Profiling run with num_tokens={num_tokens}.")
         torch._dynamo.config.dynamic_shapes = False
         # Profile with multimodal encoder & encoder cache.

--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -72,6 +72,17 @@ class TTConfig:
     # Perform token sampling on CPU instead of compiling a sampling graph for device
     cpu_sampling: bool = False
 
+    # When True, `capture_model` precompiles only the graphs needed for decode
+    # (num_tokens == 1):
+    #   - `_precompile_backbone` is restricted to the decode shape.
+    #   - `_precompile_select_hidden_states` is restricted to the decode shape.
+    #   - `_precompile_mm_encoder` and `_precompile_structured_decoding` are
+    #     skipped entirely (multimodal and structured-output decoding are not
+    #     exercised in a plain decode-only run).
+    # Useful for speeding up startup when only decode performance matters
+    # (e.g. local debugging of decode-only tests).
+    decode_only: bool = False
+
     # Override number of hidden layers (0 = use model default)
     # For debugging and testing purposes, we allow overriding the number of hidden
     # layers in the model config to enable testing with smaller models or to

--- a/tests/integrations/vllm_plugin/generative/test_decode.py
+++ b/tests/integrations/vllm_plugin/generative/test_decode.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import vllm
+
+
+@pytest.mark.nightly
+@pytest.mark.single_device
+def test_decode():
+    llm_args = {
+        "model": "meta-llama/Llama-3.2-3B",
+        "max_num_batched_tokens": 128,
+        "max_num_seqs": 1,
+        "max_model_len": 16,
+        "gpu_memory_utilization": 0.002,
+        "additional_config": {
+            "enable_const_eval": False,
+            "min_context_len": 1,
+            "num_hidden_layers": 1,
+            "decode_only": True,
+        },
+    }
+    llm = vllm.LLM(**llm_args)


### PR DESCRIPTION
Use prefill length 1 so the run does not compile across varying prefill sizes; the coverage target is decode, not prefill compilation.

### Ticket
https://github.com/tenstorrent/tt-xla/issues/4296

### Problem description
Add a QOL test that focuses on decode by specifying a vLLM test with prefill length fixed to 1. Users of this test is expected to change the model themselves but keep min_context_len and max_model_len fixed to 1.

### What's changed
add a new test with prefill length fixed to 1. 

### Checklist
- [ ] New/Existing tests provide coverage for changes
