### PR TITLE
Add a claude skill to compare failures between 2 nightlies

### DIFF
--- a/.claude/skills/compare-nightly/SKILL.md
+++ b/.claude/skills/compare-nightly/SKILL.md
@@ -43,10 +43,37 @@ The script outputs a Markdown report covering New / Persisting / Fixed sections 
 Pass `--json` to get structured JSON output instead if you need to post-process results.
 
 The script handles:
-- Parsing `# ownership-area`, `## root-cause`, and `- test_id (arch) -> [job-link](url)` lines
+- Parsing `# ownership-area`, `## root-cause`, and `- test_id (arch) -> [link](url)` lines
+  (any link label is accepted, e.g. `[job-link]`, `[baseline job]`, `[comparison]`)
 - Normalising test IDs to ignore hardware arch suffixes when matching across runs
+  (strips *all* trailing arch tokens, longest-first)
 - Merging multiple arch variants of the same test into a single bullet line
 - Rendering the final Markdown sections (or JSON)
+
+**Matching across runs is two-pass.** Pass 1 matches on the arch-normalised test
+ID. Pass 2 then reconciles the leftovers by token signature, to absorb the case
+where the two analyze-nightly passes labelled the SAME underlying failure with
+different naming conventions (e.g. a `perf vllm_bge_m3` label vs a
+`test_vllm_benchmarks.py::...[bge_m3]` pytest nodeid). Without this, such a
+failure was double-counted as both New *and* Fixed — the known cause of inflated
+new/fixed counts. Reconciliation requires ≥2 shared discriminating tokens and
+≥0.8 containment (so e.g. `qwen3_4b` is never merged with `qwen3_8b`, nor
+`batch1` with `batch32`), and uses greedy best-first assignment.
+
+**Trust the script's counts** — do not hand-correct them as "unreliable." When
+the two files use inconsistent naming, the script now reconciles automatically:
+- Reconciled pairs are reported as **persisting** and tagged
+  `_(matched across naming drift)_`, with a `> **Note:**` block at the top of the
+  report and `WARNING:` lines on stderr listing each reconciled pair.
+- A test that **persists but changes failure mode** (e.g. `pcc=nan` ->
+  `std::bad_alloc`) is tagged `_(root cause changed: "..." -> "...")_`.
+- The stderr summary line reports `N new, N persisting (N reconciled across
+  naming drift), N fixed`.
+
+In `--json` mode the object additionally contains a `reconciled` array (the
+persisting items that were matched via pass 2) and a `warnings` array (one string
+per reconciled pair). Each persisting item carries `reconciled`,
+`root_cause_changed`, and `root_cause_baseline` fields.
 
 If the script is unavailable or the output needs manual correction, fall back to parsing
 the files by hand: for each bullet line extract `test_id` (text before the first ` (`),
@@ -118,7 +145,12 @@ is `third_party/tt_forge_models`, apply the following extra steps instead of the
 ## Step 4 — Match failures across runs
 
 If `analyse_failures.py` was used in Step 2 it already computed and rendered the
-three sets. Incorporate that output into the Step 5 report.
+three sets, including any naming-drift reconciliation. Incorporate that output
+into the Step 5 report verbatim — keep its `> **Note:**` block and the
+`_(matched across naming drift)_` / `_(root cause changed: ...)_` tags. Do **not**
+second-guess or hand-correct the counts; the reconciliation logic exists
+precisely to handle the naming-convention mismatch that previously made manual
+correction necessary.
 
 If falling back to manual comparison: a failure in COMPARISON_FAILURES matches a
 failure in BASELINE_FAILURES when the test_id strings are identical, or differ only
@@ -126,6 +158,16 @@ in a trailing hardware arch token (e.g. `-n150`, `-p150`, `-n300-llmbox`). Compu
 - **New**: in COMPARISON_FAILURES but not in BASELINE_FAILURES
 - **Persisting**: in both
 - **Fixed**: in BASELINE_FAILURES but not in COMPARISON_FAILURES
+
+When matching by hand, also reconcile entries that name the **same underlying
+test under different conventions** — most commonly a perf label such as
+`perf vllm_bge_m3` in one file vs a pytest nodeid such as
+`test_vllm_benchmarks.py::...[bge_m3]` in the other. These are the SAME test;
+classify them as **persisting**, not as both new and fixed. Match on the shared
+discriminating tokens (model name, size, batch), and keep the size/batch distinct
+(`qwen3_4b` ≠ `qwen3_8b`, `batch1` ≠ `batch32`). If a persisting test's root
+cause differs between the two files, note the change rather than treating it as
+two separate failures.
 
 ## Step 5 — Produce the report
 

--- a/.claude/skills/compare-nightly/SKILL.md
+++ b/.claude/skills/compare-nightly/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: compare-nightly
+description: Compare two nightly GitHub Actions runs and classify failures as new, persisting, or fixed
+disable-model-invocation: true
+allowed-tools: Read, Read(/tmp/**), Write(/tmp/**), Glob, Grep, Skill, Bash(gh api *), Bash(gh api * > /tmp/**), Bash(jq *), Bash(mkdir -p /tmp/**), Bash(rm -rf /tmp/**), Bash(python3 *), Bash(for *)
+context: fork
+argument-hint: baseline-run-id comparison-run-id
+model: opus
+---
+
+Compare two nightly GitHub Actions runs and classify every test failure as:
+- **New**: failing in the comparison run but not in the baseline run
+- **Persisting**: failing in both runs
+- **Fixed**: failing in the baseline run but not in the comparison run
+
+The baseline run-id is $0 (typically the older/yesterday run).
+The comparison run-id is $1 (typically the newer/today run).
+The GitHub repo is github.com/tenstorrent/tt-xla.
+
+## Step 1 — Analyze each run using analyze-nightly
+
+Invoke the analyze-nightly skill twice using the Skill tool, once for each run, passing the
+"save" argument so results are stored to disk:
+
+1. Invoke skill `analyze-nightly` with args `$0 save`
+   — waits for completion, then reads `/tmp/nightly-analysis-$0.md` (baseline analysis)
+2. Invoke skill `analyze-nightly` with args `$1 save`
+   — waits for completion, then reads `/tmp/nightly-analysis-$1.md` (comparison analysis)
+
+Do not proceed to Step 2 until both analyses are complete and both files exist.
+
+## Step 2 — Extract failures and compare using analyse_failures.py
+
+A reference Python script `analyse_failures.py` lives alongside this skill file.
+Copy it to /tmp/ and run it to parse both analysis files and produce the comparison:
+
+```bash
+cp .claude/skills/compare-nightly/analyse_failures.py /tmp/analyse_failures.py
+python3 /tmp/analyse_failures.py /tmp/nightly-analysis-$0.md /tmp/nightly-analysis-$1.md
+```
+
+The script outputs a Markdown report covering New / Persisting / Fixed sections directly.
+Pass `--json` to get structured JSON output instead if you need to post-process results.
+
+The script handles:
+- Parsing `# ownership-area`, `## root-cause`, and `- test_id (arch) -> [job-link](url)` lines
+- Normalising test IDs to ignore hardware arch suffixes when matching across runs
+- Merging multiple arch variants of the same test into a single bullet line
+- Rendering the final Markdown sections (or JSON)
+
+If the script is unavailable or the output needs manual correction, fall back to parsing
+the files by hand: for each bullet line extract `test_id` (text before the first ` (`),
+`arch` (text between `(` and `)`), `root_cause` (most recent `##` heading), and
+`job_url` (URL inside `[job-link](...)`). Build two lists — BASELINE_FAILURES and
+COMPARISON_FAILURES — then proceed to Step 4.
+
+## Step 3 — Collect commits merged between the two runs
+
+Fetch the head SHA that each run was triggered on:
+`gh api "repos/tenstorrent/tt-xla/actions/runs/{run-id}" --jq '.head_sha'`
+
+Do this for both $0 (baseline SHA) and $1 (comparison SHA).
+
+Then fetch the full list of commits on the main branch between those two SHAs (exclusive
+of the baseline SHA, inclusive of the comparison SHA):
+`gh api "repos/tenstorrent/tt-xla/compare/{baseline-sha}...{comparison-sha}" --jq '.commits[] | {sha: .sha, short_sha: .sha[0:8], author: .commit.author.name, message: (.commit.message | split("\n")[0])}'`
+
+If the API returns an empty list or an error, note it and continue.
+
+For each commit, produce a structured per-commit summary using a for loop.
+
+### Per-commit summary
+
+For each commit SHA, fetch the full commit details in a single call:
+`gh api "repos/tenstorrent/tt-xla/commits/{sha}" --jq '{message: .commit.message, files: ([.files[].filename | split("/")[0]] | unique)}'`
+
+This returns:
+- `message`: the full commit message (title + body, which often includes the PR description)
+- `files`: top-level directories of changed files
+
+From the commit body, derive:
+- **Why:** one sentence explaining the motivation (use the PR description body if present; otherwise infer from the commit title)
+- **Benefit:** one sentence on what this improves for users or the project
+
+Produce a structured summary:
+```
+**`{short_sha}`** — {commit title} (by {author})
+- **Why:** {motivation}
+- **Files:** {comma-separated list of top-level directories or key files changed}
+- **Benefit:** {what this improves}
+```
+
+Separate each commit summary with a horizontal rule (`---`).
+
+### Special handling for tt_forge_models uplift commits
+
+If a commit title contains "Uplift third_party/tt_forge_models" or a changed file path
+is `third_party/tt_forge_models`, apply the following extra steps instead of the generic
+"Files" line:
+
+1. Extract the old and new submodule SHAs from the commit's patch. Fetch the commit and
+   find the file entry for `third_party/tt_forge_models`:
+   `gh api "repos/tenstorrent/tt-xla/commits/{sha}" --jq '.files[] | select(.filename == "third_party/tt_forge_models") | .patch'`
+   Parse the patch for lines `-Subproject commit {OLD_SUB_SHA}` and `+Subproject commit {NEW_SUB_SHA}`.
+
+2. List commits in the tt-forge-models submodule between those two pointers:
+   `gh api "repos/tenstorrent/tt-forge-models/compare/{OLD_SUB_SHA}...{NEW_SUB_SHA}" --jq '.commits[] | {sha: .sha[0:8], full_sha: .sha, message: (.commit.message | split("\n")[0])}'`
+
+3. For each submodule commit, fetch the top-level model directories changed:
+   `gh api "repos/tenstorrent/tt-forge-models/commits/{full_sha}" --jq '[.files[].filename | split("/")[0]] | unique | .[]'`
+
+4. Replace the **Files** line with a **Models affected** table:
+
+   | Submodule commit | Change | Model(s) |
+   |---|---|---|
+   | `{short_sha}` | {commit title} | `model_a`, `model_b` |
+
+## Step 4 — Match failures across runs
+
+If `analyse_failures.py` was used in Step 2 it already computed and rendered the
+three sets. Incorporate that output into the Step 5 report.
+
+If falling back to manual comparison: a failure in COMPARISON_FAILURES matches a
+failure in BASELINE_FAILURES when the test_id strings are identical, or differ only
+in a trailing hardware arch token (e.g. `-n150`, `-p150`, `-n300-llmbox`). Compute:
+- **New**: in COMPARISON_FAILURES but not in BASELINE_FAILURES
+- **Persisting**: in both
+- **Fixed**: in BASELINE_FAILURES but not in COMPARISON_FAILURES
+
+## Step 5 — Produce the report
+
+Output the following Markdown report. Do not emit a section if it is empty.
+
+```
+# Commits Merged Between Runs
+
+_(baseline: {baseline-sha}, comparison: {comparison-sha})_
+
+**`{short_sha}`** — {commit title} (by {author})
+- **Why:** {motivation}
+- **Files:** {top-level directories changed}
+- **Benefit:** {what this improves}
+
+---
+
+**`{short_sha}`** — Uplift third_party/tt_forge_models (by {author})
+
+| Submodule commit | Change | Model(s) |
+|---|---|---|
+| `{sub_sha}` | {submodule commit title} | `model_a`, `model_b` |
+
+---
+
+# New Failures (in $1, not in $0)
+
+## {root-cause}
+- {test_id} ({arch}) -> [job-link]({job_url})
+
+# Persisting Failures (in both $0 and $1)
+
+## {root-cause}
+- {test_id} ({arch}) -> [job-link]({job_url in $1}) [also in baseline]({job_url in $0})
+
+# Fixed Since Baseline (in $0, not in $1)
+
+## {root-cause}
+- {test_id} ({arch}) -> [baseline job]({job_url in $0})
+```
+
+Group failures within each section by root cause (same heading = same root cause).
+If the same test fails on multiple hardware arches with the same root cause, list it
+once with all arches as a comma-separated list in the ({arch}) field.
+
+## Constraints
+
+- Never run any `gh` command that modifies repository state (no issue/PR creation,
+  branch changes, etc.). Read-only calls only.
+- Never execute multiple commands separated by a semicolon.
+- Clean up temporary files written by this skill in /tmp/ when done, but do NOT
+  delete the `/tmp/nightly-analysis-*.md` files until after comparison is complete.
+- If an analyze-nightly invocation fails, note it and continue — do not abort.
+- If a run has already been analyzed and `/tmp/nightly-analysis-{run-id}.md` exists,
+  you may skip re-invoking analyze-nightly for that run and read the cached file directly.

--- a/.claude/skills/compare-nightly/analyse_failures.py
+++ b/.claude/skills/compare-nightly/analyse_failures.py
@@ -8,22 +8,173 @@ Parse two nightly analysis markdown files (produced by analyze-nightly with the
 
 Usage:
     python3 analyse_failures.py <baseline.md> <comparison.md>
+    python3 analyse_failures.py <baseline.md> <comparison.md> --json
 
 Output:
-    Prints three JSON arrays to stdout:
-        { "new": [...], "persisting": [...], "fixed": [...] }
+    Markdown report (default) or, with --json, a structured object:
+        { "new": [...], "persisting": [...], "fixed": [...],
+          "reconciled": [...] }
 
-Each item in the arrays is a dict with keys:
+Each failure record is a dict with keys:
     test_id, arch, root_cause, ownership_area,
     baseline_url (persisting/fixed only), comparison_url (new/persisting only)
+
+Matching across runs is done in two passes:
+  1. Exact match on the arch-normalised test_id.
+  2. Fuzzy reconciliation of the leftovers, to absorb the case where the two
+     analyze-nightly passes labelled the SAME underlying failure with different
+     naming conventions (e.g. a "perf vllm_bge_m3" label vs a
+     "test_vllm_benchmarks.py::...[bge_m3]" pytest nodeid). Without this, such a
+     failure is double-counted as both New and Fixed. Reconciled pairs are
+     reclassified as Persisting and reported, with a warning, so the drift is
+     visible rather than silently inflating the counts.
 """
 
 import json
 import re
 import sys
 
+# ---------------------------------------------------------------------------
+# Arch handling
+# ---------------------------------------------------------------------------
 
-def parse_analysis_file(path: str) -> list[dict]:
+# Known hardware-arch tokens that may be appended to a test id. Longest first so
+# the alternation prefers the most specific match (e.g. "n300-llmbox" before
+# "n300", "n150-perf" before "n150").
+ARCH_TOKENS = sorted(
+    [
+        "n150-perf",
+        "p150-perf",
+        "n300-llmbox",
+        "galaxy-wh-6u",
+        "qb2-blackhole",
+        "n300-perf",
+        "llmbox",
+        "blackhole",
+        "galaxy",
+        "n150",
+        "p150",
+        "n300",
+        "qb2",
+    ],
+    key=len,
+    reverse=True,
+)
+
+_ARCH_ALT = "|".join(re.escape(t) for t in ARCH_TOKENS)
+# A trailing arch token preceded by a separator, OR any "galaxy..." variant.
+_ARCH_SUFFIX_RE = re.compile(
+    rf"[-_ ]({_ARCH_ALT}|galaxy[-\w]*)$",
+    flags=re.IGNORECASE,
+)
+
+
+def normalise_test_id(test_id: str) -> str:
+    """
+    Return a canonical key for matching failures across runs.
+
+    Two test_ids are considered the same logical test when they differ only in
+    hardware arch suffix(es). Strips *all* trailing arch tokens (looping, since a
+    test id can carry more than one), e.g. "...-n150", "...-p150-perf".
+    """
+    prev = None
+    out = test_id.strip()
+    while out != prev:
+        prev = out
+        out = _ARCH_SUFFIX_RE.sub("", out).strip()
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Token signatures (for fuzzy cross-naming reconciliation)
+# ---------------------------------------------------------------------------
+
+# Words that carry no discriminating signal — boilerplate from pytest nodeids,
+# file paths, perf labels, and run-mode tags. Dropping these (consistently on
+# both sides) lets a perf label and a pytest nodeid for the same test share a
+# token signature.
+_BOILERPLATE = {
+    "test",
+    "tests",
+    "perf",
+    "py",
+    "pytest",
+    "torch",
+    "pytorch",
+    "jax",
+    "models",
+    "model",
+    "graphs",
+    "single",
+    "device",
+    "causal",
+    "lm",
+    "tt",
+    "xla",
+    "inference",
+    "training",
+    "default",
+    "instruct",
+    "it",
+    "base",
+}
+
+
+def signature(test_id: str) -> frozenset:
+    """
+    Return the set of discriminating tokens for a test id.
+
+    Lowercased, split on any non-alphanumeric run, with boilerplate, arch
+    tokens, and single-digit noise removed. Used only to reconcile leftovers
+    that did not match exactly; it deliberately ignores naming convention,
+    file path, and ordering.
+    """
+    raw = normalise_test_id(test_id).lower()
+    tokens = re.split(r"[^a-z0-9]+", raw)
+    arch_set = {t.lower() for t in ARCH_TOKENS}
+    sig = set()
+    for tok in tokens:
+        if not tok:
+            continue
+        if tok in _BOILERPLATE:
+            continue
+        if tok in arch_set:
+            continue
+        if tok.isdigit() and len(tok) == 1:
+            continue  # lone digit from e.g. "qwen2.5" -> drop noisy "2","5"
+        sig.add(tok)
+    return frozenset(sig)
+
+
+# Reconciliation thresholds. A leftover-new and a leftover-fixed are treated as
+# the same logical test when they share at least MIN_SHARED discriminating
+# tokens AND the smaller signature is at least MIN_CONTAINMENT contained in the
+# larger. 0.8 (not 0.75) so that e.g. {vllm,bge,m3,batch1} vs
+# {vllm,bge,m3,batch32} (containment 0.75) is NOT merged, while a label fully
+# contained in a nodeid (containment ~1.0) is.
+MIN_SHARED = 2
+MIN_CONTAINMENT = 0.8
+
+
+def _match_score(a: frozenset, b: frozenset):
+    """Return (shared_count, containment) or None if below thresholds."""
+    if not a or not b:
+        return None
+    shared = len(a & b)
+    if shared < MIN_SHARED:
+        return None
+    containment = shared / min(len(a), len(b))
+    if containment < MIN_CONTAINMENT:
+        return None
+    return (shared, containment)
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_analysis_file(path: str) -> list:
     """Return a flat list of failure records from an analyze-nightly markdown file."""
     records = []
     current_area = ""
@@ -50,11 +201,11 @@ def parse_analysis_file(path: str) -> list[dict]:
 
             content = line[2:].strip()
 
-            # Extract job URL from [job-link]({url})
-            url_match = re.search(r"\[job-link\]\(([^)]+)\)", content)
+            # Extract job URL from [job-link]({url}) (accept any link label)
+            url_match = re.search(r"\[[^\]]*\]\((https?://[^)]+)\)", content)
             job_url = url_match.group(1) if url_match else ""
 
-            # Strip the " -> [job-link](...)" suffix
+            # Strip the " -> ..." suffix
             arrow_idx = content.find(" -> ")
             if arrow_idx != -1:
                 content = content[:arrow_idx].strip()
@@ -81,108 +232,192 @@ def parse_analysis_file(path: str) -> list[dict]:
     return records
 
 
-def normalise_test_id(test_id: str) -> str:
-    """
-    Return a canonical key for matching failures across runs.
-
-    Two test_ids are considered the same logical test when they differ only in
-    hardware arch suffix. Strip trailing arch tokens of the form:
-        -n150, -p150, -n300-llmbox, -galaxy-wh-6u, -n150-perf, etc.
-    """
-    return re.sub(
-        r"[-_](n150|p150|n300|n300-llmbox|galaxy[-\w]*|n150-perf|p150-perf)$",
-        "",
-        test_id,
-        flags=re.IGNORECASE,
-    )
+# ---------------------------------------------------------------------------
+# Comparison
+# ---------------------------------------------------------------------------
 
 
-def compare(baseline: list[dict], comparison: list[dict]) -> dict:
-    """Return {"new": [...], "persisting": [...], "fixed": [...]}."""
+def _baseline_url_for(comp_record: dict, base_records: list) -> str:
+    """Pick the baseline job URL whose arch matches the comparison variant."""
+    for b in base_records:
+        if b["arch"] and b["arch"] == comp_record["arch"]:
+            return b["job_url"]
+    return base_records[0]["job_url"] if base_records else ""
+
+
+def _make_persisting(comp_records: list, base_records: list, reconciled: bool):
+    """Build persisting items from grouped comparison + baseline records."""
+    base_cause = base_records[0]["root_cause"] if base_records else ""
+    items = []
+    for comp_r in comp_records:
+        item = {
+            **comp_r,
+            "comparison_url": comp_r["job_url"],
+            "baseline_url": _baseline_url_for(comp_r, base_records),
+            "root_cause_baseline": base_cause,
+            "root_cause_changed": bool(
+                base_cause and base_cause != comp_r["root_cause"]
+            ),
+            "reconciled": reconciled,
+        }
+        items.append(item)
+    return items
+
+
+def compare(baseline: list, comparison: list) -> dict:
+    """Return {"new", "persisting", "fixed", "reconciled", "warnings"}."""
 
     def key(r: dict) -> str:
         return normalise_test_id(r["test_id"])
 
-    baseline_by_key: dict[str, list[dict]] = {}
+    baseline_by_key = {}
     for r in baseline:
         baseline_by_key.setdefault(key(r), []).append(r)
 
-    comparison_by_key: dict[str, list[dict]] = {}
+    comparison_by_key = {}
     for r in comparison:
         comparison_by_key.setdefault(key(r), []).append(r)
 
     baseline_keys = set(baseline_by_key)
     comparison_keys = set(comparison_by_key)
 
+    persisting_items = []
+    # Pass 1: exact arch-normalised match.
+    for k in baseline_keys & comparison_keys:
+        persisting_items.extend(
+            _make_persisting(comparison_by_key[k], baseline_by_key[k], reconciled=False)
+        )
+
+    # Leftovers after exact matching.
+    new_keys = comparison_keys - baseline_keys
+    fixed_keys = baseline_keys - comparison_keys
+
+    # Pass 2: fuzzy reconciliation of leftovers across naming conventions.
+    # Build candidate pairs, then greedily assign best-first so that e.g.
+    # batch1<->batch1 wins over batch1<->batch32.
+    new_sigs = {k: signature(k) for k in new_keys}
+    fixed_sigs = {k: signature(k) for k in fixed_keys}
+
+    candidates = []
+    for nk in new_keys:
+        for fk in fixed_keys:
+            score = _match_score(new_sigs[nk], fixed_sigs[fk])
+            if score is not None:
+                candidates.append((score, nk, fk))
+    # Highest (shared, containment) first.
+    candidates.sort(key=lambda c: c[0], reverse=True)
+
+    matched_new = set()
+    matched_fixed = set()
+    reconciled_pairs = []  # (new_key, fixed_key)
+    for _score, nk, fk in candidates:
+        if nk in matched_new or fk in matched_fixed:
+            continue
+        matched_new.add(nk)
+        matched_fixed.add(fk)
+        reconciled_pairs.append((nk, fk))
+
+    reconciled_items = []
+    warnings = []
+    for nk, fk in reconciled_pairs:
+        reconciled_items.extend(
+            _make_persisting(
+                comparison_by_key[nk], baseline_by_key[fk], reconciled=True
+            )
+        )
+        warnings.append(
+            f'reconciled (naming drift): comparison "{nk}" <-> baseline "{fk}"'
+        )
+    persisting_items.extend(reconciled_items)
+
     new_items = []
-    for k in comparison_keys - baseline_keys:
+    for k in new_keys - matched_new:
         for r in comparison_by_key[k]:
             new_items.append({**r, "comparison_url": r["job_url"]})
 
     fixed_items = []
-    for k in baseline_keys - comparison_keys:
+    for k in fixed_keys - matched_fixed:
         for r in baseline_by_key[k]:
             fixed_items.append({**r, "baseline_url": r["job_url"]})
 
-    persisting_items = []
-    for k in baseline_keys & comparison_keys:
-        for comp_r in comparison_by_key[k]:
-            base_r = baseline_by_key[k][0]
-            persisting_items.append(
-                {
-                    **comp_r,
-                    "comparison_url": comp_r["job_url"],
-                    "baseline_url": base_r["job_url"],
-                }
-            )
+    return {
+        "new": new_items,
+        "persisting": persisting_items,
+        "fixed": fixed_items,
+        "reconciled": reconciled_items,
+        "warnings": warnings,
+    }
 
-    return {"new": new_items, "persisting": persisting_items, "fixed": fixed_items}
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
 
 
 def render_markdown(result: dict, baseline_run: str, comparison_run: str) -> str:
-    """Render the comparison result as a Markdown report (Steps 4-5 of the skill)."""
     lines = []
 
-    def section(title: str, items: list[dict], url_key: str, extra_key: str = ""):
+    if result.get("warnings"):
+        lines.append(
+            "> **Note:** the two analysis files used inconsistent test-ID naming "
+            "for some failures; the following were matched across naming "
+            "conventions and counted as *persisting* (not new+fixed):"
+        )
+        for w in result["warnings"]:
+            lines.append(f"> - {w}")
+        lines.append("")
+
+    def section(title, items, url_key, link_label, extra_key="", extra_label=""):
         if not items:
             return
         lines.append(f"\n# {title}\n")
-        by_cause: dict[str, list[dict]] = {}
+        by_cause = {}
         for item in items:
             by_cause.setdefault(item["root_cause"] or "Unknown", []).append(item)
         for cause, group in by_cause.items():
             lines.append(f"## {cause}\n")
-            # Merge arches for the same test_id
-            by_test: dict[str, list[dict]] = {}
+            by_test = {}
             for item in group:
                 by_test.setdefault(item["test_id"], []).append(item)
             for test_id, variants in by_test.items():
                 arches = ", ".join(sorted({v["arch"] for v in variants if v["arch"]}))
                 arch_str = f" ({arches})" if arches else ""
-                primary_url = variants[0].get(url_key, "")
-                link = f"[job-link]({primary_url})" if primary_url else ""
-                if extra_key and variants[0].get(extra_key):
-                    extra_link = f" [also in baseline]({variants[0][extra_key]})"
-                else:
-                    extra_link = ""
-                lines.append(f"- {test_id}{arch_str} -> {link}{extra_link}")
+                primary = variants[0]
+                url = primary.get(url_key, "")
+                link = f"[{link_label}]({url})" if url else ""
+                extra = ""
+                if extra_key and primary.get(extra_key):
+                    extra = f" [{extra_label}]({primary[extra_key]})"
+                note = ""
+                if primary.get("root_cause_changed"):
+                    note = (
+                        f' _(root cause changed: "{primary.get("root_cause_baseline")}"'
+                        f' -> "{primary["root_cause"]}")_'
+                    )
+                if primary.get("reconciled"):
+                    note += " _(matched across naming drift)_"
+                lines.append(f"- {test_id}{arch_str} -> {link}{extra}{note}")
             lines.append("")
 
     section(
         f"New Failures (in {comparison_run}, not in {baseline_run})",
         result["new"],
         url_key="comparison_url",
+        link_label="job-link",
     )
     section(
         f"Persisting Failures (in both {baseline_run} and {comparison_run})",
         result["persisting"],
         url_key="comparison_url",
+        link_label="job-link",
         extra_key="baseline_url",
+        extra_label="also in baseline",
     )
     section(
         f"Fixed Since Baseline (in {baseline_run}, not in {comparison_run})",
         result["fixed"],
         url_key="baseline_url",
+        link_label="baseline job",
     )
 
     return "\n".join(lines)
@@ -195,7 +430,6 @@ def main():
 
     baseline_path, comparison_path = sys.argv[1], sys.argv[2]
 
-    # Optional: extract run IDs from filenames like nightly-analysis-12345678.md
     def run_id_from_path(p: str) -> str:
         m = re.search(r"(\d{8,})", p)
         return m.group(1) if m else p
@@ -213,10 +447,12 @@ def main():
     else:
         print(render_markdown(result, baseline_run, comparison_run))
 
-    # Print a terse summary to stderr so it's visible without polluting stdout
+    for w in result["warnings"]:
+        print(f"WARNING: {w}", file=sys.stderr)
     print(
         f"\nSummary: {len(result['new'])} new, "
-        f"{len(result['persisting'])} persisting, "
+        f"{len(result['persisting'])} persisting "
+        f"({len(result['reconciled'])} reconciled across naming drift), "
         f"{len(result['fixed'])} fixed",
         file=sys.stderr,
     )

--- a/.claude/skills/compare-nightly/analyse_failures.py
+++ b/.claude/skills/compare-nightly/analyse_failures.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Parse two nightly analysis markdown files (produced by analyze-nightly with the
+"save" argument) and classify every test failure as New, Persisting, or Fixed.
+
+Usage:
+    python3 analyse_failures.py <baseline.md> <comparison.md>
+
+Output:
+    Prints three JSON arrays to stdout:
+        { "new": [...], "persisting": [...], "fixed": [...] }
+
+Each item in the arrays is a dict with keys:
+    test_id, arch, root_cause, ownership_area,
+    baseline_url (persisting/fixed only), comparison_url (new/persisting only)
+"""
+
+import json
+import re
+import sys
+
+
+def parse_analysis_file(path: str) -> list[dict]:
+    """Return a flat list of failure records from an analyze-nightly markdown file."""
+    records = []
+    current_area = ""
+    current_cause = ""
+
+    with open(path) as f:
+        for line in f:
+            line = line.rstrip()
+
+            # # Ownership area heading
+            if line.startswith("# ") and not line.startswith("## "):
+                current_area = line[2:].strip()
+                current_cause = ""
+                continue
+
+            # ## Root-cause heading
+            if line.startswith("## "):
+                current_cause = line[3:].strip()
+                continue
+
+            # - {test-or-step-name} ({arch-list}) -> [job-link]({url})
+            if not line.startswith("- "):
+                continue
+
+            content = line[2:].strip()
+
+            # Extract job URL from [job-link]({url})
+            url_match = re.search(r"\[job-link\]\(([^)]+)\)", content)
+            job_url = url_match.group(1) if url_match else ""
+
+            # Strip the " -> [job-link](...)" suffix
+            arrow_idx = content.find(" -> ")
+            if arrow_idx != -1:
+                content = content[:arrow_idx].strip()
+
+            # Split "test_id (arch)" — last parenthesised group is the arch
+            paren_match = re.search(r"^(.*?)\s+\(([^)]+)\)\s*$", content)
+            if paren_match:
+                test_id = paren_match.group(1).strip()
+                arch = paren_match.group(2).strip()
+            else:
+                test_id = content
+                arch = ""
+
+            records.append(
+                {
+                    "test_id": test_id,
+                    "arch": arch,
+                    "root_cause": current_cause,
+                    "ownership_area": current_area,
+                    "job_url": job_url,
+                }
+            )
+
+    return records
+
+
+def normalise_test_id(test_id: str) -> str:
+    """
+    Return a canonical key for matching failures across runs.
+
+    Two test_ids are considered the same logical test when they differ only in
+    hardware arch suffix. Strip trailing arch tokens of the form:
+        -n150, -p150, -n300-llmbox, -galaxy-wh-6u, -n150-perf, etc.
+    """
+    return re.sub(
+        r"[-_](n150|p150|n300|n300-llmbox|galaxy[-\w]*|n150-perf|p150-perf)$",
+        "",
+        test_id,
+        flags=re.IGNORECASE,
+    )
+
+
+def compare(baseline: list[dict], comparison: list[dict]) -> dict:
+    """Return {"new": [...], "persisting": [...], "fixed": [...]}."""
+
+    def key(r: dict) -> str:
+        return normalise_test_id(r["test_id"])
+
+    baseline_by_key: dict[str, list[dict]] = {}
+    for r in baseline:
+        baseline_by_key.setdefault(key(r), []).append(r)
+
+    comparison_by_key: dict[str, list[dict]] = {}
+    for r in comparison:
+        comparison_by_key.setdefault(key(r), []).append(r)
+
+    baseline_keys = set(baseline_by_key)
+    comparison_keys = set(comparison_by_key)
+
+    new_items = []
+    for k in comparison_keys - baseline_keys:
+        for r in comparison_by_key[k]:
+            new_items.append({**r, "comparison_url": r["job_url"]})
+
+    fixed_items = []
+    for k in baseline_keys - comparison_keys:
+        for r in baseline_by_key[k]:
+            fixed_items.append({**r, "baseline_url": r["job_url"]})
+
+    persisting_items = []
+    for k in baseline_keys & comparison_keys:
+        for comp_r in comparison_by_key[k]:
+            base_r = baseline_by_key[k][0]
+            persisting_items.append(
+                {
+                    **comp_r,
+                    "comparison_url": comp_r["job_url"],
+                    "baseline_url": base_r["job_url"],
+                }
+            )
+
+    return {"new": new_items, "persisting": persisting_items, "fixed": fixed_items}
+
+
+def render_markdown(result: dict, baseline_run: str, comparison_run: str) -> str:
+    """Render the comparison result as a Markdown report (Steps 4-5 of the skill)."""
+    lines = []
+
+    def section(title: str, items: list[dict], url_key: str, extra_key: str = ""):
+        if not items:
+            return
+        lines.append(f"\n# {title}\n")
+        by_cause: dict[str, list[dict]] = {}
+        for item in items:
+            by_cause.setdefault(item["root_cause"] or "Unknown", []).append(item)
+        for cause, group in by_cause.items():
+            lines.append(f"## {cause}\n")
+            # Merge arches for the same test_id
+            by_test: dict[str, list[dict]] = {}
+            for item in group:
+                by_test.setdefault(item["test_id"], []).append(item)
+            for test_id, variants in by_test.items():
+                arches = ", ".join(sorted({v["arch"] for v in variants if v["arch"]}))
+                arch_str = f" ({arches})" if arches else ""
+                primary_url = variants[0].get(url_key, "")
+                link = f"[job-link]({primary_url})" if primary_url else ""
+                if extra_key and variants[0].get(extra_key):
+                    extra_link = f" [also in baseline]({variants[0][extra_key]})"
+                else:
+                    extra_link = ""
+                lines.append(f"- {test_id}{arch_str} -> {link}{extra_link}")
+            lines.append("")
+
+    section(
+        f"New Failures (in {comparison_run}, not in {baseline_run})",
+        result["new"],
+        url_key="comparison_url",
+    )
+    section(
+        f"Persisting Failures (in both {baseline_run} and {comparison_run})",
+        result["persisting"],
+        url_key="comparison_url",
+        extra_key="baseline_url",
+    )
+    section(
+        f"Fixed Since Baseline (in {baseline_run}, not in {comparison_run})",
+        result["fixed"],
+        url_key="baseline_url",
+    )
+
+    return "\n".join(lines)
+
+
+def main():
+    if len(sys.argv) < 3:
+        print(__doc__)
+        sys.exit(1)
+
+    baseline_path, comparison_path = sys.argv[1], sys.argv[2]
+
+    # Optional: extract run IDs from filenames like nightly-analysis-12345678.md
+    def run_id_from_path(p: str) -> str:
+        m = re.search(r"(\d{8,})", p)
+        return m.group(1) if m else p
+
+    baseline_run = run_id_from_path(baseline_path)
+    comparison_run = run_id_from_path(comparison_path)
+
+    baseline = parse_analysis_file(baseline_path)
+    comparison = parse_analysis_file(comparison_path)
+
+    result = compare(baseline, comparison)
+
+    if "--json" in sys.argv:
+        print(json.dumps(result, indent=2))
+    else:
+        print(render_markdown(result, baseline_run, comparison_run))
+
+    # Print a terse summary to stderr so it's visible without polluting stdout
+    print(
+        f"\nSummary: {len(result['new'])} new, "
+        f"{len(result['persisting'])} persisting, "
+        f"{len(result['fixed'])} fixed",
+        file=sys.stderr,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/pull-main-summary/SKILL.md
+++ b/.claude/skills/pull-main-summary/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: pull-main-summary
+description: Stash local changes, pull latest main, and display a structured commit summary. For tt_forge_models uplift commits, shows the affected models from the submodule log.
+allowed-tools: Bash(git stash), Bash(git checkout *), Bash(git pull), Bash(git log *), Bash(git show *), Bash(git diff *), Bash(for *), Bash(echo *), Bash(grep *)
+context: fork
+model: opus
+---
+
+You are summarizing what changed in the `main` branch of the tt-xla repository.
+
+## Step 1: Prepare the working tree
+
+1. If there are any local changes, stash them with `git stash`. If there are none, continue.
+2. Checkout to `main` if not already on it: `git checkout main`.
+3. Record the current HEAD before pulling: run `git rev-parse HEAD` and save it as `OLD_HEAD`.
+4. Pull latest changes: `git pull`.
+5. If the pull brought no new commits (HEAD == OLD_HEAD), output: "Already up to date. No new commits." and stop.
+
+## Step 2: Get the list of new commits
+
+Run:
+```
+git log --oneline {OLD_HEAD}..HEAD
+```
+This gives you the list of new commits. If the list is empty, output "No new commits." and stop.
+
+## Step 3: For each new commit, produce a structured summary
+
+For each commit hash in the list above, run:
+```
+git show --stat --format="%s%n%b" {hash}
+```
+
+Then produce a summary with these fields:
+- **Why:** One sentence explaining the motivation (use the PR description body if available).
+- **Files changed:** Top-level directories or key file names affected.
+- **Benefit:** What this improves for users or the project.
+
+## Step 4: Special handling for tt_forge_models uplift commits
+
+If a commit title contains `Uplift third_party/tt_forge_models`, do the following extra steps:
+
+1. Extract the old and new submodule pointers from the commit diff:
+   ```
+   git show {hash} -- third_party/tt_forge_models
+   ```
+   This shows `-Subproject commit {OLD_SUB}` and `+Subproject commit {NEW_SUB}`.
+
+2. List commits in the submodule between those two pointers:
+   ```
+   git log --oneline {OLD_SUB}..{NEW_SUB}
+   ```
+   Run this from the repo root (git will resolve it via the submodule).
+
+3. For each submodule commit, run:
+   ```
+   git show --name-only --format="%s" {sub_hash}
+   ```
+   Extract the top-level model directory name from each changed file path (the first path component, e.g. `qwen_2`, `deepseek`, `sam`).
+
+4. In the commit summary, replace the generic "Files changed" with a **Models affected** table:
+
+   | Submodule commit | Change | Model(s) |
+   |---|---|---|
+   | `{short_hash}` | {commit title} | `model_a`, `model_b` |
+
+## Output format
+
+For each commit:
+
+```
+**`{short_hash}`** — {commit title}
+- **Why:** {motivation}
+- **Files:** {key files or directories}
+- **Benefit:** {what improves}
+```
+
+For tt_forge_models uplift commits, replace the Files line with the models table from Step 4.
+
+Separate each commit summary with a horizontal rule (`---`).
+
+Always respect these constraints:
+- Never run any command that modifies the GitHub repository state.
+- Never execute multiple commands separated by a semicolon.
+- Use for loops in bash when iterating over multiple commit hashes.


### PR DESCRIPTION
### Problem description
To check regression, we need to check previous day's nightly and current nightly and check if there are any new failures. This is a manual process and it takes more time. 
A skill can be added to do this task which saves good amount of time

### What's changed
* A new skill added to compare 2 nightly runs and it provides a report of
          - New failures in today's nightly
          - Persistent failures in both nightlies
          - Fixed failures from previous nightly
          - Also the list of commits between 2 run ids which will be useful to proceed with bisecting as below
<img width="1145" height="499" alt="Screenshot 2026-04-22 at 12 25 36 PM" src="https://github.com/user-attachments/assets/b865cc19-be86-4b6a-ba9b-8d90d11ec34d" />

### Checklist
- [x] New/Existing tests provide coverage for changes. 
Tested for yesterday and today's nightly run and the result is as follows and time taken to complete is 8 minutes on average

<img width="1812" height="963" alt="Screenshot 2026-04-22 at 12 25 54 PM" src="https://github.com/user-attachments/assets/fb46be95-4d4c-4abd-b482-f07e7d0dd910" />
<img width="1576" height="224" alt="Screenshot 2026-04-22 at 12 26 18 PM" src="https://github.com/user-attachments/assets/73a6d64a-4d7d-45f2-bb88-f7bd41184148" />
