### PR TITLE
Add NVIDIA pytest validation lane

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -25,6 +25,8 @@ markers =
     tensor_parallel: marks test as tensor parallel
     # Multi-chip Configuration
     single_device: marks test for single device (wormhole_b0, p150)
+    n150: marks test for n150 architecture
+    p150: marks test for p150 architecture
     dual_chip: marks test for dual chip (n300)
     llmbox: marks test for llmbox (llmbox)
     galaxy: marks test for galaxy (galaxy)

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,6 +9,7 @@ markers =
     notimeout: marks tests that should use a default (240min) timeout instead of calculated duration
     model_test: marks test as model test, to be executed in a separate job in nightly tests
     large: marks model tests as large, to be executed in a separate runner with more resources
+    nvidia: marks tests that validate CPU-vs-CUDA execution on NVIDIA GPUs
     # ModelTestStatus
     known_failure_xfail: Test is a known failure (marked xfail)
     not_supported_skip: Test is not supported on this architecture (marked skip)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import psutil
 import pytest
 import torch
+
 try:
     import torch_xla.runtime as xr
 except ImportError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,8 +18,12 @@ from pathlib import Path
 import psutil
 import pytest
 import torch
-import torch_xla.runtime as xr
-from infra import DeviceConnectorFactory, Framework
+try:
+    import torch_xla.runtime as xr
+except ImportError:
+    xr = None
+from infra.connectors.device_connector_factory import DeviceConnectorFactory
+from infra.utilities.types import Framework
 from loguru import logger
 
 from third_party.tt_forge_models.config import ModelInfo
@@ -479,7 +483,10 @@ def initialize_device_connectors():
 
     Done to make sure it is executed before any other jax command during tests.
     """
-    DeviceConnectorFactory.create_connector(Framework.JAX)
+    try:
+        DeviceConnectorFactory.create_connector(Framework.JAX)
+    except Exception as e:
+        logger.info(f"Skipping JAX connector initialization: {e}")
     DeviceConnectorFactory.create_connector(Framework.TORCH)
 
 
@@ -531,7 +538,10 @@ def _release_dynamo_bridge_tensors():
     objects and their parent caches survive, holding all model-weight XLA tensors
     (~26 GB for 8B TP). We find these by type and clear their parent dicts.
     """
-    from torch_xla._dynamo.dynamo_bridge import GraphInputMatcher
+    try:
+        from torch_xla._dynamo.dynamo_bridge import GraphInputMatcher
+    except ImportError:
+        return
 
     for obj in gc.get_objects():
         try:
@@ -567,6 +577,8 @@ def clear_torchxla_computation_cache():
     This helps avoid consteval-associated DRAM leaks as described in https://github.com/tenstorrent/tt-xla/issues/1940
     """
     yield
+    if xr is None:
+        return
     try:
         xr.clear_computation_cache()
     except Exception as e:

--- a/tests/infra/__init__.py
+++ b/tests/infra/__init__.py
@@ -2,37 +2,55 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Exposes only what is really needed to write tests, nothing else."""
+"""Minimal public surface for infra.
 
-# isort: off
-# NOTE: Import order matters here - evaluators must come before connectors
-# to avoid circular import (connectors -> utilities -> runners -> connectors)
-from .evaluators import ComparisonConfig
-from .connectors import DeviceConnectorFactory, JaxDeviceConnector
+Keep imports here narrow and backend-tolerant so torch/CUDA-only validation does not
+eagerly require the full TT/XLA or JAX runtime stacks during collection.
+"""
 
-# isort: on
-from .testers import (
-    JaxModelTester,
-    RunMode,
-    TorchModelTester,
-    run_graph_test,
-    run_graph_test_with_random_inputs,
-    run_jax_multichip_graph_test_with_random_inputs,
-    run_jax_multichip_op_test_with_random_inputs,
-    run_op_test,
-    run_op_test_with_random_inputs,
-    serialize_jax_multichip_op,
-    serialize_jax_multichip_op_with_random_inputs,
-)
-from .utilities import (
-    Framework,
-    Model,
-    ShardingMode,
-    enable_shardy,
-    initialize_flax_linen_parameters_on_cpu,
-    make_flax_linen_parameters_partition_specs_on_cpu,
-    make_partition_spec,
-    random_image,
-    random_tensor,
-)
-from .workloads import JaxMultichipWorkload, Workload
+from .connectors.device_connector_factory import DeviceConnectorFactory
+from .utilities.types import Framework, Model
+
+try:
+    from .evaluators.evaluation_config import ComparisonConfig
+except Exception:
+    ComparisonConfig = None
+
+try:
+    from .testers.single_chip.model.model_tester import RunMode
+except Exception:
+    RunMode = None
+
+try:
+    from .testers.single_chip.model.torch_model_tester import TorchModelTester
+except Exception:
+    TorchModelTester = None
+
+try:
+    from .testers.single_chip.model.jax_model_tester import JaxModelTester
+except Exception:
+    JaxModelTester = None
+
+try:
+    from .testers.graph.graph_test import (
+        run_graph_test,
+        run_graph_test_with_random_inputs,
+    )
+    from .testers.multichip.graph.jax_multichip_graph_tester import (
+        run_jax_multichip_graph_test_with_random_inputs,
+    )
+    from .testers.multichip.op.jax_multichip_op_tester import (
+        run_jax_multichip_op_test_with_random_inputs,
+        serialize_jax_multichip_op,
+        serialize_jax_multichip_op_with_random_inputs,
+    )
+    from .testers.op.op_test import run_op_test, run_op_test_with_random_inputs
+except Exception:
+    run_graph_test = None
+    run_graph_test_with_random_inputs = None
+    run_jax_multichip_graph_test_with_random_inputs = None
+    run_jax_multichip_op_test_with_random_inputs = None
+    serialize_jax_multichip_op = None
+    serialize_jax_multichip_op_with_random_inputs = None
+    run_op_test = None
+    run_op_test_with_random_inputs = None

--- a/tests/infra/connectors/__init__.py
+++ b/tests/infra/connectors/__init__.py
@@ -4,5 +4,8 @@
 
 from .device_connector import DeviceConnector, DeviceType
 from .device_connector_factory import DeviceConnectorFactory
-from .jax_device_connector import JaxDeviceConnector, jax_device_connector
 from .torch_device_connector import TorchDeviceConnector, torch_device_connector
+
+# Keep JAX connector import lazy so torch/CUDA-only lanes do not require the JAX stack.
+JaxDeviceConnector = None
+jax_device_connector = None

--- a/tests/infra/connectors/device_connector.py
+++ b/tests/infra/connectors/device_connector.py
@@ -9,13 +9,14 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Sequence
 
-from infra.utilities import Device
+from infra.utilities.types import Device
 
 
 class DeviceType(Enum):
     """Supported devices."""
 
     CPU = "cpu"
+    CUDA = "cuda"
     TT = "tt"
 
 
@@ -86,3 +87,7 @@ class DeviceConnector(ABC):
     def get_number_of_cpus(self) -> int:
         """Returns number of available CPUs."""
         return self._number_of_devices(DeviceType.CPU)
+
+    def get_number_of_cuda_devices(self) -> int:
+        """Returns number of available CUDA devices."""
+        return self._number_of_devices(DeviceType.CUDA)

--- a/tests/infra/connectors/device_connector_factory.py
+++ b/tests/infra/connectors/device_connector_factory.py
@@ -6,6 +6,7 @@ from infra.utilities import Framework
 
 from .device_connector import DeviceConnector
 from .torch_device_connector import TorchDeviceConnector, torch_device_connector
+
 jax_device_connector = None
 
 

--- a/tests/infra/connectors/device_connector_factory.py
+++ b/tests/infra/connectors/device_connector_factory.py
@@ -5,8 +5,8 @@
 from infra.utilities import Framework
 
 from .device_connector import DeviceConnector
-from .jax_device_connector import JaxDeviceConnector, jax_device_connector
 from .torch_device_connector import TorchDeviceConnector, torch_device_connector
+jax_device_connector = None
 
 
 class DeviceConnectorFactory:
@@ -18,6 +18,12 @@ class DeviceConnectorFactory:
     def create_connector(framework: Framework) -> DeviceConnector:
         if framework == Framework.JAX:
             global jax_device_connector
+            try:
+                from .jax_device_connector import JaxDeviceConnector
+            except Exception as e:
+                raise RuntimeError(
+                    "JAX device connector is unavailable in this environment"
+                ) from e
 
             if jax_device_connector is None:
                 jax_device_connector = JaxDeviceConnector()

--- a/tests/infra/connectors/torch_device_connector.py
+++ b/tests/infra/connectors/torch_device_connector.py
@@ -5,10 +5,7 @@
 import os
 
 import torch
-import torch_xla
-import torch_xla.core.xla_model as xm
-import torch_xla.runtime as xr
-from infra.utilities import Device
+from infra.utilities.types import Device
 
 from .device_connector import DeviceConnector, DeviceType
 
@@ -18,37 +15,52 @@ class TorchDeviceConnector(DeviceConnector):
 
     def __init__(self) -> None:
         super().__init__()
-        xr.runtime.set_device_type("TT")
-        # Only initialize cache if not already initialized (avoids assertion
-        # error when tests have already performed XLA operations before using
-        # the comparison evaluator)
-        if not torch_xla._XLAC._xla_computation_cache_is_initialized():
-            xr.initialize_cache(self.get_cache_dir())
+        self._tt_runtime_initialized = False
 
     @staticmethod
     def get_cache_dir() -> str:
         return f"{os.getcwd()}/tmp/"
+
+    def _supported_devices(self):
+        return [DeviceType.CPU, DeviceType.CUDA, DeviceType.TT]
+
+    def _ensure_tt_runtime_initialized(self) -> None:
+        if self._tt_runtime_initialized:
+            return
+
+        import torch_xla
+        import torch_xla.runtime as xr
+
+        xr.runtime.set_device_type("TT")
+        if not torch_xla._XLAC._xla_computation_cache_is_initialized():
+            xr.initialize_cache(self.get_cache_dir())
+        self._tt_runtime_initialized = True
 
     # @override
     def _connect_device(self, device_type: DeviceType, device_num: int = 0) -> Device:
         # Custom TT devices are discovered through XLA plugin. In case of CPUs, we
         # want to fallback to a regular CPU on host, which torch sees natively
         # through `torch.device("cpu")`.
-        return (
-            torch_xla.device(device_num)
-            if device_type == DeviceType.TT
-            else torch.device(device_type.value)
-        )
+        if device_type == DeviceType.TT:
+            self._ensure_tt_runtime_initialized()
+            import torch_xla
+
+            return torch_xla.device(device_num)
+
+        return torch.device(device_type.value)
 
     # @override
     def _number_of_devices(self, device_type: DeviceType) -> int:
         # Torch does not have an API to retrieve number of CPUs, so we use system
         # lib `os`.
-        return (
-            len(xm.get_xla_supported_devices())
-            if device_type == DeviceType.TT
-            else os.cpu_count()
-        )
+        if device_type == DeviceType.TT:
+            self._ensure_tt_runtime_initialized()
+            import torch_xla.core.xla_model as xm
+
+            return len(xm.get_xla_supported_devices())
+        if device_type == DeviceType.CUDA:
+            return torch.cuda.device_count()
+        return os.cpu_count()
 
 
 # Global singleton instance.

--- a/tests/infra/evaluators/__init__.py
+++ b/tests/infra/evaluators/__init__.py
@@ -2,7 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from .comparison_evaluator import ComparisonEvaluator
+"""Minimal evaluator exports."""
+
 from .evaluation_config import (
     AllcloseConfig,
     AtolConfig,
@@ -12,30 +13,24 @@ from .evaluation_config import (
     QualityConfig,
 )
 from .evaluator import ComparisonResult, EvaluationResult, Evaluator, QualityResult
-from .evaluator_factory import EvaluatorFactory
-from .jax_comparison_evaluator import JaxComparisonEvaluator
-from .quality_evaluator import QualityEvaluator
-from .torch_comparison_evaluator import TorchComparisonEvaluator
+from .comparison_evaluator import ComparisonEvaluator
 
-__all__ = [
-    # Base classes
-    "Evaluator",
-    "EvaluationResult",
-    "ComparisonResult",
-    "QualityResult",
-    # Comparison evaluators
-    "ComparisonEvaluator",
-    "JaxComparisonEvaluator",
-    "TorchComparisonEvaluator",
-    # Quality evaluator
-    "QualityEvaluator",
-    "QualityConfig",
-    "ImageGenQualityConfig",
-    # Factory
-    "EvaluatorFactory",
-    # Config
-    "ComparisonConfig",
-    "PccConfig",
-    "AtolConfig",
-    "AllcloseConfig",
-]
+try:
+    from .evaluator_factory import EvaluatorFactory
+except Exception:
+    EvaluatorFactory = None
+
+try:
+    from .jax_comparison_evaluator import JaxComparisonEvaluator
+except Exception:
+    JaxComparisonEvaluator = None
+
+try:
+    from .torch_comparison_evaluator import TorchComparisonEvaluator
+except Exception:
+    TorchComparisonEvaluator = None
+
+try:
+    from .quality_evaluator import QualityEvaluator
+except Exception:
+    QualityEvaluator = None

--- a/tests/infra/evaluators/__init__.py
+++ b/tests/infra/evaluators/__init__.py
@@ -4,6 +4,7 @@
 
 """Minimal evaluator exports."""
 
+from .comparison_evaluator import ComparisonEvaluator
 from .evaluation_config import (
     AllcloseConfig,
     AtolConfig,
@@ -13,7 +14,6 @@ from .evaluation_config import (
     QualityConfig,
 )
 from .evaluator import ComparisonResult, EvaluationResult, Evaluator, QualityResult
-from .comparison_evaluator import ComparisonEvaluator
 
 try:
     from .evaluator_factory import EvaluatorFactory

--- a/tests/infra/evaluators/comparison_evaluator.py
+++ b/tests/infra/evaluators/comparison_evaluator.py
@@ -6,7 +6,7 @@ import math
 from abc import abstractmethod
 from typing import Tuple
 
-from infra.utilities import PyTree, Tensor
+from infra.utilities.types import PyTree, Tensor
 
 from .evaluation_config import AllcloseConfig, AtolConfig, ComparisonConfig, PccConfig
 from .evaluator import ComparisonResult, Evaluator

--- a/tests/infra/evaluators/evaluator_factory.py
+++ b/tests/infra/evaluators/evaluator_factory.py
@@ -6,13 +6,12 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
-from infra.utilities import Framework
+from infra.utilities.types import Framework
 
 from .comparison_evaluator import ComparisonEvaluator
 from .evaluation_config import ComparisonConfig, QualityConfig
 from .evaluator import Evaluator
 from .jax_comparison_evaluator import JaxComparisonEvaluator
-from .quality_evaluator import QualityEvaluator
 from .torch_comparison_evaluator import TorchComparisonEvaluator
 
 
@@ -93,7 +92,7 @@ class EvaluatorFactory:
         quality_config: Optional[QualityConfig],
         metric_names: Optional[List[str]],
         metric_kwargs: Optional[Dict[str, Dict[str, Any]]],
-    ) -> QualityEvaluator:
+    ) -> "QualityEvaluator":
         """
         Create QualityEvaluator with specified metrics.
 
@@ -109,6 +108,8 @@ class EvaluatorFactory:
             raise ValueError("metric_names is required for quality evaluators")
         if quality_config is None:
             quality_config = QualityConfig()
+
+        from .quality_evaluator import QualityEvaluator
 
         return QualityEvaluator(
             metric_names=metric_names,

--- a/tests/infra/evaluators/torch_comparison_evaluator.py
+++ b/tests/infra/evaluators/torch_comparison_evaluator.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
-from infra.runners import run_on_cpu
-from infra.utilities import Framework, PyTree
+from infra.runners.utils import run_on_cpu
+from infra.utilities.types import Framework, PyTree
 from torch.utils._pytree import tree_flatten, tree_map
 from transformers import Cache, DynamicCache, EncoderDecoderCache
 

--- a/tests/infra/runners/__init__.py
+++ b/tests/infra/runners/__init__.py
@@ -2,8 +2,31 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from .device_runner import DeviceRunner
-from .device_runner_factory import DeviceRunnerFactory
-from .jax_device_runner import JaxDeviceRunner
-from .torch_device_runner import TorchDeviceRunner, to_device
-from .utils import run_on_cpu, run_on_tt_device
+"""Minimal runner exports.
+
+Avoid eager imports of backend-specific runners so torch/CUDA-only collection does
+not recursively pull TT/XLA and JAX machinery through package barrels.
+"""
+
+from .utils import run_on_cpu, run_on_cuda_device, run_on_tt_device
+
+try:
+    from .device_runner import DeviceRunner
+except Exception:
+    DeviceRunner = None
+
+try:
+    from .device_runner_factory import DeviceRunnerFactory
+except Exception:
+    DeviceRunnerFactory = None
+
+try:
+    from .jax_device_runner import JaxDeviceRunner
+except Exception:
+    JaxDeviceRunner = None
+
+try:
+    from .torch_device_runner import TorchDeviceRunner, to_device
+except Exception:
+    TorchDeviceRunner = None
+    to_device = None

--- a/tests/infra/runners/device_runner.py
+++ b/tests/infra/runners/device_runner.py
@@ -5,9 +5,9 @@
 from abc import ABC, abstractmethod
 from typing import Optional
 
-from infra.connectors import DeviceConnector, DeviceType
-from infra.utilities import Device, Tensor
-from infra.workloads import Workload
+from infra.connectors.device_connector import DeviceConnector, DeviceType
+from infra.utilities.types import Device, Tensor
+from infra.workloads.workload import Workload
 
 
 class DeviceRunner(ABC):
@@ -28,6 +28,10 @@ class DeviceRunner(ABC):
     def run_on_tt_device(self, workload: Workload, device_num: int = 0) -> Tensor:
         """Runs `workload` on TT device."""
         return self.run_on_device(workload, DeviceType.TT, device_num)
+
+    def run_on_cuda_device(self, workload: Workload, device_num: int = 0) -> Tensor:
+        """Runs `workload` on CUDA device."""
+        return self.run_on_device(workload, DeviceType.CUDA, device_num)
 
     def run_on_device(
         self, workload: Workload, device_type: DeviceType, device_num: int = 0

--- a/tests/infra/runners/device_runner_factory.py
+++ b/tests/infra/runners/device_runner_factory.py
@@ -3,11 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from infra.connectors import DeviceConnectorFactory
-from infra.utilities import Framework
+from infra.utilities.types import Framework
 
 from .device_runner import DeviceRunner
-from .jax_device_runner import JaxDeviceRunner
-from .torch_device_runner import TorchDeviceRunner
 
 
 class DeviceRunnerFactory:
@@ -18,8 +16,12 @@ class DeviceRunnerFactory:
         connector = DeviceConnectorFactory.create_connector(framework)
 
         if framework == Framework.JAX:
+            from .jax_device_runner import JaxDeviceRunner
+
             return JaxDeviceRunner(connector)
         elif framework == Framework.TORCH:
+            from .torch_device_runner import TorchDeviceRunner
+
             return TorchDeviceRunner(connector)
         else:
             raise ValueError(f"Unsupported framework {framework}")

--- a/tests/infra/runners/torch_device_runner.py
+++ b/tests/infra/runners/torch_device_runner.py
@@ -10,6 +10,7 @@ from infra.utilities import Device, Tensor
 from infra.workloads import Workload
 from infra.workloads.torch_workload import TorchWorkload
 from torch.utils._pytree import tree_map
+
 try:
     import torch_xla.distributed.spmd as xs
 except ImportError:
@@ -173,9 +174,7 @@ class TorchDeviceRunner(DeviceRunner):
 
         if shard_specs is not None and is_multichip and device.type != "cpu":
             if xs is None:
-                raise RuntimeError(
-                    "torch_xla is required for multichip torch sharding"
-                )
+                raise RuntimeError("torch_xla is required for multichip torch sharding")
             for tensor, shard_spec in shard_specs.items():
                 xs.mark_sharding(tensor, workload.mesh, shard_spec)
 

--- a/tests/infra/runners/torch_device_runner.py
+++ b/tests/infra/runners/torch_device_runner.py
@@ -5,12 +5,15 @@
 import inspect
 
 import torch
-import torch_xla.distributed.spmd as xs
 from infra.connectors import DeviceConnector
 from infra.utilities import Device, Tensor
 from infra.workloads import Workload
 from infra.workloads.torch_workload import TorchWorkload
 from torch.utils._pytree import tree_map
+try:
+    import torch_xla.distributed.spmd as xs
+except ImportError:
+    xs = None
 
 from .device_runner import DeviceRunner
 
@@ -169,6 +172,10 @@ class TorchDeviceRunner(DeviceRunner):
         )
 
         if shard_specs is not None and is_multichip and device.type != "cpu":
+            if xs is None:
+                raise RuntimeError(
+                    "torch_xla is required for multichip torch sharding"
+                )
             for tensor, shard_spec in shard_specs.items():
                 xs.mark_sharding(tensor, workload.mesh, shard_spec)
 

--- a/tests/infra/runners/utils.py
+++ b/tests/infra/runners/utils.py
@@ -5,7 +5,7 @@
 from functools import wraps
 from typing import Callable
 
-from infra.utilities import Framework
+from infra.utilities.types import Framework
 from infra.workloads.workload import Workload
 
 from .device_runner_factory import DeviceRunnerFactory
@@ -22,6 +22,23 @@ def run_on_tt_device(framework: Framework):
             )
             runner = DeviceRunnerFactory.create_runner(framework)
             return runner.run_on_tt_device(workload)
+
+        return wrapper
+
+    return decorator
+
+
+def run_on_cuda_device(framework: Framework):
+    """Runs any decorated function `f` on CUDA device."""
+
+    def decorator(f: Callable):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            workload = Workload(
+                framework=framework, executable=f, args=args, kwargs=kwargs
+            )
+            runner = DeviceRunnerFactory.create_runner(framework)
+            return runner.run_on_cuda_device(workload)
 
         return wrapper
 

--- a/tests/infra/testers/__init__.py
+++ b/tests/infra/testers/__init__.py
@@ -2,19 +2,42 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from .base_tester import BaseTester
-from .multichip import (
-    run_jax_multichip_graph_test_with_random_inputs,
-    run_jax_multichip_op_test_with_random_inputs,
-    serialize_jax_multichip_op,
-    serialize_jax_multichip_op_with_random_inputs,
-)
-from .single_chip import (
-    JaxModelTester,
-    RunMode,
-    TorchModelTester,
-    run_graph_test,
-    run_graph_test_with_random_inputs,
-    run_op_test,
-    run_op_test_with_random_inputs,
-)
+"""Minimal tester exports."""
+
+try:
+    from .base_tester import BaseTester
+except Exception:
+    BaseTester = None
+
+try:
+    from .single_chip.model.model_tester import RunMode
+    from .single_chip.model.torch_model_tester import TorchModelTester
+    from .single_chip.model.jax_model_tester import JaxModelTester
+except Exception:
+    RunMode = None
+    TorchModelTester = None
+    JaxModelTester = None
+
+try:
+    from .single_chip.graph.graph_tester import (
+        run_graph_test,
+        run_graph_test_with_random_inputs,
+    )
+    from .single_chip.op.op_tester import run_op_test, run_op_test_with_random_inputs
+    from .multichip.graph.jax_multichip_graph_tester import (
+        run_jax_multichip_graph_test_with_random_inputs,
+    )
+    from .multichip.op.jax_multichip_op_tester import (
+        run_jax_multichip_op_test_with_random_inputs,
+        serialize_jax_multichip_op,
+        serialize_jax_multichip_op_with_random_inputs,
+    )
+except Exception:
+    run_graph_test = None
+    run_graph_test_with_random_inputs = None
+    run_op_test = None
+    run_op_test_with_random_inputs = None
+    run_jax_multichip_graph_test_with_random_inputs = None
+    run_jax_multichip_op_test_with_random_inputs = None
+    serialize_jax_multichip_op = None
+    serialize_jax_multichip_op_with_random_inputs = None

--- a/tests/infra/testers/__init__.py
+++ b/tests/infra/testers/__init__.py
@@ -10,20 +10,15 @@ except Exception:
     BaseTester = None
 
 try:
+    from .single_chip.model.jax_model_tester import JaxModelTester
     from .single_chip.model.model_tester import RunMode
     from .single_chip.model.torch_model_tester import TorchModelTester
-    from .single_chip.model.jax_model_tester import JaxModelTester
 except Exception:
     RunMode = None
     TorchModelTester = None
     JaxModelTester = None
 
 try:
-    from .single_chip.graph.graph_tester import (
-        run_graph_test,
-        run_graph_test_with_random_inputs,
-    )
-    from .single_chip.op.op_tester import run_op_test, run_op_test_with_random_inputs
     from .multichip.graph.jax_multichip_graph_tester import (
         run_jax_multichip_graph_test_with_random_inputs,
     )
@@ -32,6 +27,11 @@ try:
         serialize_jax_multichip_op,
         serialize_jax_multichip_op_with_random_inputs,
     )
+    from .single_chip.graph.graph_tester import (
+        run_graph_test,
+        run_graph_test_with_random_inputs,
+    )
+    from .single_chip.op.op_tester import run_op_test, run_op_test_with_random_inputs
 except Exception:
     run_graph_test = None
     run_graph_test_with_random_inputs = None

--- a/tests/infra/testers/base_tester.py
+++ b/tests/infra/testers/base_tester.py
@@ -15,7 +15,8 @@ from infra.evaluators import (
     QualityConfig,
 )
 from infra.runners import DeviceRunner, DeviceRunnerFactory
-from infra.utilities import Framework, sanitize_test_name
+from infra.utilities.types import Framework
+from infra.utilities.utils import sanitize_test_name
 
 from tests.infra.utilities.filecheck_utils import (
     run_filecheck,

--- a/tests/infra/testers/single_chip/__init__.py
+++ b/tests/infra/testers/single_chip/__init__.py
@@ -2,6 +2,25 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from .graph.graph_tester import run_graph_test, run_graph_test_with_random_inputs
-from .model import JaxModelTester, RunMode, TorchModelTester
-from .op.op_tester import run_op_test, run_op_test_with_random_inputs
+"""Minimal single-chip tester exports."""
+
+try:
+    from .model.model_tester import RunMode
+    from .model.torch_model_tester import TorchModelTester
+    from .model.jax_model_tester import JaxModelTester
+except Exception:
+    RunMode = None
+    TorchModelTester = None
+    JaxModelTester = None
+
+try:
+    from .graph.graph_tester import run_graph_test, run_graph_test_with_random_inputs
+except Exception:
+    run_graph_test = None
+    run_graph_test_with_random_inputs = None
+
+try:
+    from .op.op_tester import run_op_test, run_op_test_with_random_inputs
+except Exception:
+    run_op_test = None
+    run_op_test_with_random_inputs = None

--- a/tests/infra/testers/single_chip/__init__.py
+++ b/tests/infra/testers/single_chip/__init__.py
@@ -5,9 +5,9 @@
 """Minimal single-chip tester exports."""
 
 try:
+    from .model.jax_model_tester import JaxModelTester
     from .model.model_tester import RunMode
     from .model.torch_model_tester import TorchModelTester
-    from .model.jax_model_tester import JaxModelTester
 except Exception:
     RunMode = None
     TorchModelTester = None

--- a/tests/infra/testers/single_chip/model/__init__.py
+++ b/tests/infra/testers/single_chip/model/__init__.py
@@ -9,6 +9,14 @@ from tests.runner.utils import (
     TorchDynamicLoader,
 )
 
-from .jax_model_tester import JaxModelTester
 from .model_tester import RunMode
-from .torch_model_tester import TorchModelTester
+
+try:
+    from .torch_model_tester import TorchModelTester
+except Exception:
+    TorchModelTester = None
+
+try:
+    from .jax_model_tester import JaxModelTester
+except Exception:
+    JaxModelTester = None

--- a/tests/infra/testers/single_chip/model/model_tester.py
+++ b/tests/infra/testers/single_chip/model/model_tester.py
@@ -11,8 +11,8 @@ from enum import Enum
 from typing import Callable, Optional, Tuple
 
 from infra.evaluators import ComparisonConfig, ComparisonResult
-from infra.utilities import Framework, Mesh, Model, ShardSpec, Tensor
-from infra.workloads import Workload
+from infra.utilities.types import Framework, Mesh, Model, ShardSpec, Tensor
+from infra.workloads.workload import Workload
 
 from tests.infra.testers.compiler_config import CompilerConfig
 

--- a/tests/infra/testers/single_chip/model/torch_model_tester.py
+++ b/tests/infra/testers/single_chip/model/torch_model_tester.py
@@ -8,6 +8,7 @@ from contextlib import contextmanager
 from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Set, Tuple
 
 import torch
+
 try:
     import torch_xla
     import torch_xla.runtime as xr
@@ -95,9 +96,11 @@ class TorchModelTester(ModelTester):
         )
         # Set custom compile options if provided.
         # Use explicit API for passing compiler options.
-        if compiler_config is not None and not os.environ.get(
-            "TT_COMPILE_ONLY_SYSTEM_DESC"
-        ) and torch_xla is not None:
+        if (
+            compiler_config is not None
+            and not os.environ.get("TT_COMPILE_ONLY_SYSTEM_DESC")
+            and torch_xla is not None
+        ):
             torch_xla.set_custom_compile_options(
                 compiler_config.to_torch_compile_options()
             )

--- a/tests/infra/testers/single_chip/model/torch_model_tester.py
+++ b/tests/infra/testers/single_chip/model/torch_model_tester.py
@@ -8,12 +8,17 @@ from contextlib import contextmanager
 from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Set, Tuple
 
 import torch
-import torch_xla
-import torch_xla.runtime as xr
+try:
+    import torch_xla
+    import torch_xla.runtime as xr
+except ImportError:
+    torch_xla = None
+    xr = None
 from infra.evaluators import ComparisonConfig
-from infra.utilities import Framework, compile_torch_workload_for_tt_device
-from infra.workloads import TorchWorkload, Workload
-from tt_torch.sharding import sharding_constraint_tensor
+from infra.utilities.types import Framework
+from infra.utilities.utils import compile_torch_workload_for_tt_device
+from infra.workloads.torch_workload import TorchWorkload
+from infra.workloads.workload import Workload
 from ttxla_tools.logging import logger
 
 from tests.infra.evaluators import ComparisonResult
@@ -92,7 +97,7 @@ class TorchModelTester(ModelTester):
         # Use explicit API for passing compiler options.
         if compiler_config is not None and not os.environ.get(
             "TT_COMPILE_ONLY_SYSTEM_DESC"
-        ):
+        ) and torch_xla is not None:
             torch_xla.set_custom_compile_options(
                 compiler_config.to_torch_compile_options()
             )
@@ -215,6 +220,7 @@ class TorchModelTester(ModelTester):
         For tensor parallel training, gradients must be sharded identically to parameters.
         This method marks gradient tensors with the same shard specs as their parameters.
         """
+        from tt_torch.sharding import sharding_constraint_tensor
 
         assert (
             self._workload.shard_spec_fn is not None
@@ -241,6 +247,8 @@ class TorchModelTester(ModelTester):
             )
 
     def _test_training(self) -> Tuple[ComparisonResult, ...]:
+        if torch_xla is None:
+            raise RuntimeError("torch_xla is required for TT training tests")
         # Initialize XLA computation client to properly set up autograd engine device queues
         # before any backward passes. See: https://github.com/pytorch/xla/issues/4174
         torch_xla._XLAC._init_computation_client()

--- a/tests/infra/utilities/__init__.py
+++ b/tests/infra/utilities/__init__.py
@@ -2,21 +2,42 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from .jax_multichip_utils import (
-    ShardingMode,
-    enable_shardy,
-    initialize_flax_linen_parameters_on_cpu,
-    make_easydel_parameters_partition_specs,
-    make_flax_linen_parameters_partition_specs_on_cpu,
-    make_partition_spec,
-)
+"""Minimal utility exports."""
+
 from .types import Device, Framework, Mesh, Model, PyTree, ShardSpec, Tensor
-from .utils import (
-    compile_jax_multichip_workload,
-    compile_jax_workload_for_cpu,
-    compile_jax_workload_for_tt_device,
-    compile_torch_workload_for_tt_device,
-    random_image,
-    random_tensor,
-    sanitize_test_name,
-)
+
+try:
+    from .utils import (
+        compile_jax_multichip_workload,
+        compile_jax_workload_for_cpu,
+        compile_jax_workload_for_tt_device,
+        compile_torch_workload_for_tt_device,
+        random_image,
+        random_tensor,
+        sanitize_test_name,
+    )
+except Exception:
+    compile_jax_multichip_workload = None
+    compile_jax_workload_for_cpu = None
+    compile_jax_workload_for_tt_device = None
+    compile_torch_workload_for_tt_device = None
+    random_image = None
+    random_tensor = None
+    sanitize_test_name = None
+
+try:
+    from .jax_multichip_utils import (
+        ShardingMode,
+        enable_shardy,
+        initialize_flax_linen_parameters_on_cpu,
+        make_easydel_parameters_partition_specs,
+        make_flax_linen_parameters_partition_specs_on_cpu,
+        make_partition_spec,
+    )
+except Exception:
+    ShardingMode = None
+    enable_shardy = None
+    initialize_flax_linen_parameters_on_cpu = None
+    make_easydel_parameters_partition_specs = None
+    make_flax_linen_parameters_partition_specs_on_cpu = None
+    make_partition_spec = None

--- a/tests/infra/utilities/torch_multichip_utils.py
+++ b/tests/infra/utilities/torch_multichip_utils.py
@@ -5,6 +5,7 @@ import os
 from typing import Tuple
 
 import numpy as np
+
 try:
     import torch_xla.runtime as xr
     from torch_xla.distributed.spmd import Mesh

--- a/tests/infra/utilities/torch_multichip_utils.py
+++ b/tests/infra/utilities/torch_multichip_utils.py
@@ -5,8 +5,12 @@ import os
 from typing import Tuple
 
 import numpy as np
-import torch_xla.runtime as xr
-from torch_xla.distributed.spmd import Mesh
+try:
+    import torch_xla.runtime as xr
+    from torch_xla.distributed.spmd import Mesh
+except ImportError:
+    xr = None
+    Mesh = None
 
 
 def get_mesh(mesh_shape: Tuple[int], mesh_names: Tuple[str]) -> Mesh:
@@ -18,7 +22,8 @@ def get_mesh(mesh_shape: Tuple[int], mesh_names: Tuple[str]) -> Mesh:
     Returns:
         Mesh or None: A Mesh object if mesh_shape is provided, otherwise None.
     """
-
+    if xr is None or Mesh is None:
+        raise RuntimeError("torch_xla is required for torch multichip mesh creation")
     num_devices = xr.global_runtime_device_count()
     device_ids = np.array(range(num_devices))
     mesh = Mesh(device_ids, mesh_shape, mesh_names) if mesh_shape is not None else None
@@ -33,6 +38,8 @@ def enable_spmd():
     Note:
         - This cannot be disabled once set. See: https://github.com/pytorch/xla/issues/9578
     """
+    if xr is None:
+        raise RuntimeError("torch_xla is required for torch multichip SPMD")
     # In the pytorch-xla fork this enables the ConvertStableHloToSdy pass.
     # The tt-mlir stablehlo compiler pipeline expects input shlo from pytorch/xla to contain shardy annotations.
     os.environ["CONVERT_SHLO_TO_SHARDY"] = "1"

--- a/tests/infra/utilities/types.py
+++ b/tests/infra/utilities/types.py
@@ -8,6 +8,7 @@ from enum import Enum
 from typing import Any, Dict, Tuple, Union
 
 import torch
+
 try:
     import jax
     from flax import linen, nnx
@@ -18,6 +19,7 @@ except ImportError:
     nnx = None
     jax_pytree = Any
 from torch.utils._pytree import PyTree as torch_pytree
+
 try:
     from torch_xla.distributed.spmd import Mesh as TorchXLAMesh
 except ImportError:

--- a/tests/infra/utilities/types.py
+++ b/tests/infra/utilities/types.py
@@ -5,17 +5,26 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Dict, Tuple, Union
+from typing import Any, Dict, Tuple, Union
 
-import jax
 import torch
-from flax import linen, nnx
-from jaxtyping import PyTree as jax_pytree
+try:
+    import jax
+    from flax import linen, nnx
+    from jaxtyping import PyTree as jax_pytree
+except ImportError:
+    jax = None
+    linen = None
+    nnx = None
+    jax_pytree = Any
 from torch.utils._pytree import PyTree as torch_pytree
-from torch_xla.distributed.spmd import Mesh
+try:
+    from torch_xla.distributed.spmd import Mesh as TorchXLAMesh
+except ImportError:
+    TorchXLAMesh = Any
 
 # Convenience alias. Used to jointly represent tensors from different frameworks.
-Tensor = Union[jax.Array, torch.Tensor]
+Tensor = Union[(jax.Array if jax is not None else Any), torch.Tensor]
 
 # Convenience alias. Used to jointly represent models (commonly called NN modules) from
 # different frameworks.
@@ -23,16 +32,20 @@ Tensor = Union[jax.Array, torch.Tensor]
 # huggingface models.
 # NOTE FlaxPreTrainedModel was removed from transformers 5.x (Flax support dropped).
 # EasyDel models (nnx.Module subclasses) and custom linen.Module models cover all JAX cases.
-Model = Union[nnx.Module, linen.Module, torch.nn.Module]
+Model = Union[
+    (nnx.Module if nnx is not None else Any),
+    (linen.Module if linen is not None else Any),
+    torch.nn.Module,
+]
 
 # Convenience alias. Used to jointly represent physical HW/device from different
 # frameworks.
-Device = Union[jax.Device, torch.device]
+Device = Union[(jax.Device if jax is not None else Any), torch.device]
 
 # Convenience alias.
 PyTree = Union[jax_pytree, torch_pytree]
 
-Mesh = Mesh
+Mesh = TorchXLAMesh
 
 ShardSpec = Dict[Tensor, Tuple[str, ...]]
 

--- a/tests/infra/utilities/utils.py
+++ b/tests/infra/utilities/utils.py
@@ -3,17 +3,24 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import re
-from typing import Tuple, Union
+from typing import Any, Tuple, Union
 
-import jax
-import jax.numpy as jnp
 import torch
-from infra.runners import run_on_cpu
-from infra.utilities import Framework, Tensor
+from infra.runners.utils import run_on_cpu
+from infra.utilities.types import Framework, Tensor
 from infra.workloads import JaxMultichipWorkload, Workload
-from jax._src.typing import DTypeLike
-from jax.experimental.shard_map import shard_map
-from jax.sharding import NamedSharding
+try:
+    import jax
+    import jax.numpy as jnp
+    from jax._src.typing import DTypeLike
+    from jax.experimental.shard_map import shard_map
+    from jax.sharding import NamedSharding
+except ImportError:
+    jax = None
+    jnp = None
+    DTypeLike = Any
+    shard_map = None
+    NamedSharding = None
 
 
 def sanitize_test_name(test_name: str) -> str:
@@ -43,6 +50,8 @@ def sanitize_test_name(test_name: str) -> str:
 
 def random_image(image_size: int, framework: Framework = Framework.JAX) -> Tensor:
     """Create a random input image with the given image size."""
+    if jnp is None:
+        raise RuntimeError("jax is required for random_image")
     return random_tensor(
         (image_size, image_size, 3),
         dtype=jnp.uint8,
@@ -159,6 +168,8 @@ def create_jax_inference_tester(
     model_tester_class, variant_or_args, format: str, compiler_config=None, **kwargs
 ):
     """Generic JAX inference tester creator."""
+    if jnp is None:
+        raise RuntimeError("jax is required for create_jax_inference_tester")
     from infra.testers.compiler_config import CompilerConfig
 
     if format == "float32":
@@ -203,6 +214,8 @@ def create_torch_inference_tester(
 
 def compile_jax_workload_for_cpu(workload: Workload) -> None:
     """Compile JAX workload for CPU using jax.jit."""
+    if jax is None:
+        raise RuntimeError("jax is required for compile_jax_workload_for_cpu")
     workload.compiled_executable = jax.jit(
         workload.executable,
         static_argnames=workload.static_argnames,
@@ -213,6 +226,8 @@ def compile_jax_workload_for_tt_device(
     workload: Workload, compiler_options: dict = None
 ) -> None:
     """Compile JAX workload for TT device using jax.jit with compiler options."""
+    if jax is None:
+        raise RuntimeError("jax is required for compile_jax_workload_for_tt_device")
     workload.compiled_executable = jax.jit(
         workload.executable,
         static_argnames=workload.static_argnames,
@@ -258,3 +273,5 @@ def compile_jax_multichip_workload(
         static_argnames=workload.static_argnames,
         compiler_options=compiler_options or {},
     )
+    if jax is None or jnp is None:
+        raise RuntimeError("jax is required for random_jax_tensor")

--- a/tests/infra/utilities/utils.py
+++ b/tests/infra/utilities/utils.py
@@ -9,6 +9,7 @@ import torch
 from infra.runners.utils import run_on_cpu
 from infra.utilities.types import Framework, Tensor
 from infra.workloads import JaxMultichipWorkload, Workload
+
 try:
     import jax
     import jax.numpy as jnp

--- a/tests/infra/workloads/__init__.py
+++ b/tests/infra/workloads/__init__.py
@@ -4,6 +4,7 @@
 
 from .torch_workload import TorchWorkload
 from .workload import Workload
+
 try:
     from .jax_workload import JaxMultichipWorkload
 except Exception:

--- a/tests/infra/workloads/__init__.py
+++ b/tests/infra/workloads/__init__.py
@@ -2,6 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from .jax_workload import JaxMultichipWorkload
 from .torch_workload import TorchWorkload
 from .workload import Workload
+try:
+    from .jax_workload import JaxMultichipWorkload
+except Exception:
+    JaxMultichipWorkload = None

--- a/tests/infra/workloads/torch_workload.py
+++ b/tests/infra/workloads/torch_workload.py
@@ -6,8 +6,7 @@ from __future__ import annotations
 
 from typing import Any, Callable, Mapping, Optional, Sequence
 
-from infra.utilities import Framework, Mesh, Model
-from infra.utilities.torch_multichip_utils import enable_spmd
+from infra.utilities.types import Framework, Mesh, Model
 
 from .workload import Workload
 
@@ -53,4 +52,6 @@ class TorchWorkload(Workload):
         is_multichip = self.mesh and len(self.mesh.device_ids) > 1
 
         if has_shard_specs and is_multichip:
+            from infra.utilities.torch_multichip_utils import enable_spmd
+
             enable_spmd()

--- a/tests/infra/workloads/workload.py
+++ b/tests/infra/workloads/workload.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Mapping, Optional, Sequence
 
 from infra.connectors.torch_device_connector import TorchDeviceConnector
 from infra.utilities.types import Framework, Mesh, Model
+
 try:
     import torch_xla.runtime as xr
 except ImportError:

--- a/tests/infra/workloads/workload.py
+++ b/tests/infra/workloads/workload.py
@@ -8,11 +8,20 @@ import shutil
 from pathlib import Path
 from typing import Any, Callable, Mapping, Optional, Sequence
 
-import torch_xla.runtime as xr
 from infra.connectors.torch_device_connector import TorchDeviceConnector
-from infra.utilities import Framework, Mesh, Model
-from tt_jax import serialize_compiled_artifacts_to_disk
-from tt_torch import parse_compiled_artifacts_from_cache_to_disk
+from infra.utilities.types import Framework, Mesh, Model
+try:
+    import torch_xla.runtime as xr
+except ImportError:
+    xr = None
+try:
+    from tt_jax import serialize_compiled_artifacts_to_disk
+except ImportError:
+    serialize_compiled_artifacts_to_disk = None
+try:
+    from tt_torch import parse_compiled_artifacts_from_cache_to_disk
+except ImportError:
+    parse_compiled_artifacts_from_cache_to_disk = None
 
 
 class Workload:
@@ -86,6 +95,8 @@ class Workload:
             compiler_options: Optional JAX compiler options dict (ignored for Torch)
         """
         if self.is_jax:
+            if serialize_compiled_artifacts_to_disk is None:
+                raise RuntimeError("tt_jax is required for JAX workload serialization")
             # Get the executable to serialize
             executable = self.model if self.model else self.executable
             if executable is None:
@@ -100,6 +111,10 @@ class Workload:
                 **self.kwargs,
             )
         elif self.is_torch:
+            if xr is None or parse_compiled_artifacts_from_cache_to_disk is None:
+                raise RuntimeError(
+                    "torch_xla and tt_torch are required for torch workload serialization"
+                )
             cache_dir = TorchDeviceConnector.get_cache_dir()
 
             # Clear existing cache files to ensure we get exactly one file

--- a/tests/random_weights.py
+++ b/tests/random_weights.py
@@ -127,9 +127,8 @@ def _patch_transformers_models():
         # returns a top-level config but the model class expects a sub-config
         # like text_config). Extract the sub-config when there's a mismatch.
         expected_config_class = getattr(cls, "config_class", None)
-        if (
-            expected_config_class is not None
-            and not isinstance(config, expected_config_class)
+        if expected_config_class is not None and not isinstance(
+            config, expected_config_class
         ):
             if hasattr(config, "get_text_config"):
                 text_config = config.get_text_config()

--- a/tests/runner/conftest.py
+++ b/tests/runner/conftest.py
@@ -8,9 +8,6 @@ import pytest
 
 from tests.runner.requirements import RequirementsManager
 from tests.runner.test_config.constants import ALLOWED_ARCHES
-from tests.runner.test_config.jax import test_config as jax_test_config
-from tests.runner.test_config.torch import test_config as torch_test_config
-from tests.runner.test_config.torch_llm import test_config as torch_llm_test_config
 from tests.runner.test_utils import (
     ModelTestConfig,
     ModelTestStatus,
@@ -83,6 +80,12 @@ def pytest_addoption(parser):
         choices=sorted(ALLOWED_ARCHES),
         help="Target architecture (e.g., n150, p150) for which to match via arch_overrides in test_config files",
     )
+    parser.addoption(
+        "--nvidia-cohort-json",
+        action="store",
+        default=None,
+        help="Path to a JSON manifest containing NVIDIA validation cohort rows with tt-xla test_case_id entries.",
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -118,6 +121,12 @@ def pytest_collection_modifyitems(config, items):
     arch = config.getoption("--arch")
 
     # Merge torch and jax test configs once outside the loop
+    from tests.runner.test_config.jax import test_config as jax_test_config
+    from tests.runner.test_config.torch import test_config as torch_test_config
+    from tests.runner.test_config.torch_llm import (
+        test_config as torch_llm_test_config,
+    )
+
     combined_test_config = torch_test_config | jax_test_config | torch_llm_test_config
 
     deselected = []

--- a/tests/runner/conftest.py
+++ b/tests/runner/conftest.py
@@ -123,9 +123,7 @@ def pytest_collection_modifyitems(config, items):
     # Merge torch and jax test configs once outside the loop
     from tests.runner.test_config.jax import test_config as jax_test_config
     from tests.runner.test_config.torch import test_config as torch_test_config
-    from tests.runner.test_config.torch_llm import (
-        test_config as torch_llm_test_config,
-    )
+    from tests.runner.test_config.torch_llm import test_config as torch_llm_test_config
 
     combined_test_config = torch_test_config | jax_test_config | torch_llm_test_config
 

--- a/tests/runner/test_models.py
+++ b/tests/runner/test_models.py
@@ -87,6 +87,7 @@ def _run_model_test_impl(
     print(f"[DEBUG] ModelLoader.__module__={ModelLoader.__module__}", flush=True)
     try:
         import inspect
+
         print(f"[DEBUG] load_config source={inspect.getfile(ModelLoader)}", flush=True)
     except TypeError:
         print(f"[DEBUG] load_config source=<built-in class>", flush=True)

--- a/tests/runner/test_models_nvidia.py
+++ b/tests/runner/test_models_nvidia.py
@@ -8,16 +8,18 @@ from dataclasses import dataclass
 
 import pytest
 import torch
-
 from infra.testers.single_chip.model.model_tester import RunMode
+
 from tests.infra.evaluators.evaluator import Evaluator
+from tests.infra.utilities.types import Framework
 from tests.runner.requirements import RequirementsManager
-from tests.runner.test_utils import record_model_test_properties, update_test_metadata_for_exception
+from tests.runner.test_utils import (
+    record_model_test_properties,
+    update_test_metadata_for_exception,
+)
 from tests.runner.testers import DynamicTorchCudaModelTester
 from tests.runner.utils import DynamicLoader, TorchDynamicLoader
-from tests.infra.utilities.types import Framework
 from third_party.tt_forge_models.config import Parallelism
-
 
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 

--- a/tests/runner/test_models_nvidia.py
+++ b/tests/runner/test_models_nvidia.py
@@ -1,0 +1,181 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+from dataclasses import dataclass
+
+import pytest
+import torch
+
+from infra.testers.single_chip.model.model_tester import RunMode
+from tests.infra.evaluators.evaluator import Evaluator
+from tests.runner.requirements import RequirementsManager
+from tests.runner.test_utils import record_model_test_properties, update_test_metadata_for_exception
+from tests.runner.testers import DynamicTorchCudaModelTester
+from tests.runner.utils import DynamicLoader, TorchDynamicLoader
+from tests.infra.utilities.types import Framework
+from third_party.tt_forge_models.config import Parallelism
+
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+MODELS_ROOT_TORCH, test_entries_torch = TorchDynamicLoader.setup_test_discovery(
+    PROJECT_ROOT
+)
+TEST_ENTRY_BY_ID = {
+    DynamicLoader.generate_test_id(entry, MODELS_ROOT_TORCH): entry
+    for entry in test_entries_torch
+}
+
+
+@dataclass
+class NvidiaManifestRow:
+    model_id: str
+    test_case_id: str
+
+
+class NvidiaModelInfo:
+    """Minimal model-info surface for report-property compatibility."""
+
+    def __init__(self, test_case_id: str, model_id: str):
+        self.name = test_case_id
+        self.model = model_id
+        self.variant = model_id
+        self.group = None
+        self.task = "nvidia_validation"
+        self.source = "ModelSource.HUGGING_FACE"
+        self.framework = Framework.TORCH
+
+    def to_report_dict(self):
+        return {
+            "name": self.name,
+            "model": self.model,
+            "variant": self.variant,
+            "group": None,
+            "task": self.task,
+            "source": self.source,
+            "framework": str(self.framework),
+        }
+
+
+def _load_nvidia_rows(path: str) -> list[NvidiaManifestRow]:
+    obj = json.loads(open(path).read())
+    models = obj.get("models") or []
+    rows = []
+    for row in models:
+        test_case_id = row.get("test_case_id")
+        model_id = row.get("model_id") or row.get("pretrained_model_name")
+        if not test_case_id or not model_id:
+            continue
+        if test_case_id not in TEST_ENTRY_BY_ID:
+            continue
+        rows.append(NvidiaManifestRow(model_id=model_id, test_case_id=test_case_id))
+    return rows
+
+
+def pytest_generate_tests(metafunc):
+    if "nvidia_row" not in metafunc.fixturenames:
+        return
+
+    cohort_path = metafunc.config.getoption("--nvidia-cohort-json")
+    if not cohort_path:
+        metafunc.parametrize("nvidia_row", [], ids=[])
+        return
+
+    rows = _load_nvidia_rows(cohort_path)
+    metafunc.parametrize(
+        "nvidia_row",
+        rows,
+        ids=[row.test_case_id for row in rows],
+    )
+
+
+def _run_model_test_impl_nvidia(
+    nvidia_row,
+    record_property,
+    test_metadata,
+    request,
+    captured_output_fixture,
+):
+    test_entry = TEST_ENTRY_BY_ID[nvidia_row.test_case_id]
+    loader_path = test_entry.path
+    variant, ModelLoader = test_entry.variant_info
+
+    with RequirementsManager.for_loader(loader_path):
+        loader = ModelLoader(variant=variant)
+        model_info = NvidiaModelInfo(
+            test_case_id=nvidia_row.test_case_id,
+            model_id=nvidia_row.model_id,
+        )
+
+        succeeded = False
+        comparison_result = None
+        tester = None
+
+        try:
+            tester = DynamicTorchCudaModelTester(
+                run_mode=RunMode.INFERENCE,
+                loader=loader,
+                comparison_config=test_metadata.to_comparison_config(),
+                parallelism=Parallelism.SINGLE_DEVICE,
+                test_metadata=test_metadata,
+            )
+            comparison_result = tester.test(request=request)
+            succeeded = all(result.passed for result in comparison_result)
+            Evaluator._assert_on_results(comparison_result)
+        except Exception as e:
+            try:
+                captured = captured_output_fixture.readouterr()
+                stdout, stderr = captured.out, captured.err
+            except ValueError:
+                stdout, stderr = None, None
+            update_test_metadata_for_exception(
+                test_metadata, e, stdout=stdout, stderr=stderr
+            )
+            raise
+        finally:
+            comparison_config = tester._comparison_config if tester else None
+            model_size = getattr(tester, "_model_size", None) if tester else None
+            record_model_test_properties(
+                record_property,
+                request,
+                model_info=model_info,
+                test_metadata=test_metadata,
+                run_mode=RunMode.INFERENCE,
+                parallelism=Parallelism.SINGLE_DEVICE,
+                test_passed=succeeded,
+                comparison_results=list(comparison_result) if comparison_result else [],
+                comparison_config=comparison_config,
+                model_size=model_size,
+                weights_dtype="float32",
+            )
+
+
+@pytest.mark.model_test
+@pytest.mark.no_auto_properties
+@pytest.mark.nvidia
+@pytest.mark.inference
+@pytest.mark.single_device
+def test_models_torch_nvidia(
+    nvidia_row,
+    record_property,
+    test_metadata,
+    request,
+    captured_output_fixture,
+):
+    if nvidia_row is None:
+        pytest.skip("No NVIDIA cohort rows selected")
+
+    if not os.environ.get("CUDA_VISIBLE_DEVICES") and not torch.cuda.is_available():
+        pytest.skip("CUDA not available for NVIDIA validation")
+
+    _run_model_test_impl_nvidia(
+        nvidia_row=nvidia_row,
+        record_property=record_property,
+        test_metadata=test_metadata,
+        request=request,
+        captured_output_fixture=captured_output_fixture,
+    )

--- a/tests/runner/test_models_nvidia.py
+++ b/tests/runner/test_models_nvidia.py
@@ -5,6 +5,7 @@
 import json
 import os
 from dataclasses import dataclass
+from pathlib import Path
 
 import pytest
 import torch
@@ -35,17 +36,17 @@ TEST_ENTRY_BY_ID = {
 
 @dataclass
 class NvidiaManifestRow:
-    model_id: str
     test_case_id: str
+    display_name: str
 
 
 class NvidiaModelInfo:
     """Minimal model-info surface for report-property compatibility."""
 
-    def __init__(self, test_case_id: str, model_id: str):
+    def __init__(self, test_case_id: str, display_name: str):
         self.name = test_case_id
-        self.model = model_id
-        self.variant = model_id
+        self.model = display_name
+        self.variant = display_name
         self.group = None
         self.task = "nvidia_validation"
         self.source = "ModelSource.HUGGING_FACE"
@@ -64,17 +65,27 @@ class NvidiaModelInfo:
 
 
 def _load_nvidia_rows(path: str) -> list[NvidiaManifestRow]:
-    obj = json.loads(open(path).read())
+    obj = json.loads(Path(path).read_text())
     models = obj.get("models") or []
     rows = []
     for row in models:
         test_case_id = row.get("test_case_id")
-        model_id = row.get("model_id") or row.get("pretrained_model_name")
-        if not test_case_id or not model_id:
+        display_name = (
+            row.get("display_name")
+            or row.get("model_id")
+            or row.get("pretrained_model_name")
+            or test_case_id
+        )
+        if not test_case_id:
             continue
         if test_case_id not in TEST_ENTRY_BY_ID:
             continue
-        rows.append(NvidiaManifestRow(model_id=model_id, test_case_id=test_case_id))
+        rows.append(
+            NvidiaManifestRow(
+                test_case_id=test_case_id,
+                display_name=display_name,
+            )
+        )
     return rows
 
 
@@ -110,7 +121,7 @@ def _run_model_test_impl_nvidia(
         loader = ModelLoader(variant=variant)
         model_info = NvidiaModelInfo(
             test_case_id=nvidia_row.test_case_id,
-            model_id=nvidia_row.model_id,
+            display_name=nvidia_row.display_name,
         )
 
         succeeded = False

--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -18,6 +18,7 @@ from typing import Any, List, Optional
 import numpy as np
 import pytest
 import torch
+
 try:
     import torch_xla
     import torch_xla.core.xla_model as xm

--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -18,13 +18,20 @@ from typing import Any, List, Optional
 import numpy as np
 import pytest
 import torch
-import torch_xla
-import torch_xla.core.xla_model as xm
-import torch_xla.runtime as xr
+try:
+    import torch_xla
+    import torch_xla.core.xla_model as xm
+    import torch_xla.runtime as xr
+    from infra.utilities.torch_multichip_utils import get_mesh
+    from torch_xla.distributed.spmd import Mesh
+except ImportError:
+    torch_xla = None
+    xm = None
+    xr = None
+    get_mesh = None
+    Mesh = None
 from infra import ComparisonConfig, RunMode, TorchModelTester
 from infra.utilities.failing_reasons import FailingReasons, FailingReasonsFinder
-from infra.utilities.torch_multichip_utils import get_mesh
-from torch_xla.distributed.spmd import Mesh
 
 from tests.utils import BringupStatus, Category
 from third_party.tt_forge_models.config import Parallelism
@@ -695,7 +702,7 @@ def get_xla_device_arch():
     Returns:
         str: Architecture name ('wormhole' or 'blackhole'), or empty string if not found
     """
-    if os.environ.get("TT_COMPILE_ONLY_SYSTEM_DESC"):
+    if os.environ.get("TT_COMPILE_ONLY_SYSTEM_DESC") or xr is None:
         return ""
 
     all_attributes = xr.global_runtime_device_attributes()

--- a/tests/runner/testers/__init__.py
+++ b/tests/runner/testers/__init__.py
@@ -2,11 +2,21 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from .jax import DynamicJaxModelTester, DynamicJaxMultiChipModelTester
-from .torch import DynamicTorchModelTester
+try:
+    from .torch import DynamicTorchCudaModelTester, DynamicTorchModelTester
+except Exception:
+    DynamicTorchCudaModelTester = None
+    DynamicTorchModelTester = None
+
+try:
+    from .jax import DynamicJaxModelTester, DynamicJaxMultiChipModelTester
+except Exception:
+    DynamicJaxModelTester = None
+    DynamicJaxMultiChipModelTester = None
 
 __all__ = [
     "DynamicJaxModelTester",
     "DynamicJaxMultiChipModelTester",
+    "DynamicTorchCudaModelTester",
     "DynamicTorchModelTester",
 ]

--- a/tests/runner/testers/torch/__init__.py
+++ b/tests/runner/testers/torch/__init__.py
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from .dynamic_torch_model_tester import DynamicTorchModelTester
 from .dynamic_torch_cuda_model_tester import DynamicTorchCudaModelTester
+from .dynamic_torch_model_tester import DynamicTorchModelTester
 
 __all__ = [
     "DynamicTorchCudaModelTester",

--- a/tests/runner/testers/torch/__init__.py
+++ b/tests/runner/testers/torch/__init__.py
@@ -3,7 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .dynamic_torch_model_tester import DynamicTorchModelTester
+from .dynamic_torch_cuda_model_tester import DynamicTorchCudaModelTester
 
 __all__ = [
+    "DynamicTorchCudaModelTester",
     "DynamicTorchModelTester",
 ]

--- a/tests/runner/testers/torch/dynamic_torch_cuda_model_tester.py
+++ b/tests/runner/testers/torch/dynamic_torch_cuda_model_tester.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dynamic Torch model tester for CPU-vs-CUDA validation."""
+
+import torch
+
+from .dynamic_torch_model_tester import DynamicTorchModelTester
+
+
+class DynamicTorchCudaModelTester(DynamicTorchModelTester):
+    """Torch tester that validates CUDA outputs against CPU golden outputs."""
+
+    def _test_inference(self, request=None):
+        assert torch.cuda.is_available(), "CUDA device not available"
+
+        cpu_res = self._run_on_cpu(self._workload)
+        cuda_res = self._device_runner.run_on_cuda_device(self._workload)
+
+        return (self._compare(cuda_res, cpu_res),)

--- a/tests/runner/testers/torch/dynamic_torch_model_tester.py
+++ b/tests/runner/testers/torch/dynamic_torch_model_tester.py
@@ -8,14 +8,17 @@ import collections
 from typing import Any
 
 import torch
-import torch_xla.runtime as xr
-from infra.evaluators import ComparisonConfig
+try:
+    import torch_xla.runtime as xr
+    from infra.utilities.torch_multichip_utils import get_mesh
+except ImportError:
+    xr = None
+    get_mesh = None
+from infra.evaluators.evaluation_config import ComparisonConfig
 from infra.testers.compiler_config import CompilerConfig
-from infra.testers.single_chip.model import RunMode, TorchModelTester
-from infra.utilities.torch_multichip_utils import get_mesh
+from infra.testers.single_chip.model.model_tester import RunMode
+from infra.testers.single_chip.model.torch_model_tester import TorchModelTester
 from loguru import logger
-from tt_torch.sparse_mlp import enable_sparse_mlp, get_moe_shard_specs
-
 from tests.runner.test_utils import RunPhase
 from tests.runner.utils import TorchDynamicLoader
 from third_party.tt_forge_models.config import Parallelism
@@ -140,6 +143,8 @@ class DynamicTorchModelTester(TorchModelTester):
         )
 
         if self.parallelism == Parallelism.DATA_PARALLEL:
+            if xr is None:
+                raise RuntimeError("torch_xla is required for data parallel TT tests")
             num_devices = xr.global_runtime_device_count()
             if isinstance(inputs, collections.abc.Mapping):
                 inputs = {
@@ -175,6 +180,9 @@ class DynamicTorchModelTester(TorchModelTester):
         if self.parallelism == Parallelism.SINGLE_DEVICE:
             return None
 
+        if xr is None or get_mesh is None:
+            raise RuntimeError("torch_xla is required for multi-device TT tests")
+
         num_devices = xr.global_runtime_device_count()
         if self.parallelism == Parallelism.DATA_PARALLEL:
             mesh_shape, mesh_names = (1, num_devices), ("model", "data")
@@ -194,6 +202,8 @@ class DynamicTorchModelTester(TorchModelTester):
 
     def _inject_custom_moe(self, model):
         """Injects a custom MoE implementation into the model if specified in test metadata."""
+        from tt_torch.sparse_mlp import enable_sparse_mlp, get_moe_shard_specs
+
         logger.info(
             "Custom MoE injection enabled for this test - using sparse_mlp.py implementation in tt_torch"
         )

--- a/tests/runner/testers/torch/dynamic_torch_model_tester.py
+++ b/tests/runner/testers/torch/dynamic_torch_model_tester.py
@@ -8,6 +8,7 @@ import collections
 from typing import Any
 
 import torch
+
 try:
     import torch_xla.runtime as xr
     from infra.utilities.torch_multichip_utils import get_mesh
@@ -19,6 +20,7 @@ from infra.testers.compiler_config import CompilerConfig
 from infra.testers.single_chip.model.model_tester import RunMode
 from infra.testers.single_chip.model.torch_model_tester import TorchModelTester
 from loguru import logger
+
 from tests.runner.test_utils import RunPhase
 from tests.runner.utils import TorchDynamicLoader
 from third_party.tt_forge_models.config import Parallelism

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,6 +11,7 @@ import jax.lax as jlx
 import jax.numpy as jnp
 import pytest
 import torch
+
 try:
     import torch_xla
 except ImportError:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,8 +11,11 @@ import jax.lax as jlx
 import jax.numpy as jnp
 import pytest
 import torch
-import torch_xla
-from infra import Framework
+try:
+    import torch_xla
+except ImportError:
+    torch_xla = None
+from infra.utilities.types import Framework
 
 
 class StrEnum(Enum):
@@ -192,6 +195,8 @@ def is_galaxy(request):
 
 def get_torch_device_arch() -> TTArch:
     """Returns the architecture of the connected TT device."""
+    if torch_xla is None:
+        raise RuntimeError("torch_xla is required to query TT device architecture")
     device_kind = torch_xla._XLAC._xla_device_kind("xla")
     if "Wormhole_b0" in device_kind:
         return TTArch.WORMHOLE_B0


### PR DESCRIPTION
## Summary

This PR adds a manifest-driven NVIDIA validation lane to `tt-xla` so a selected set of PyTorch model tests can be run as CPU-vs-CUDA comparisons using the existing evaluator stack. The new path stays inside the current `tests/runner` and `tests/infra` structure rather than introducing a separate harness.

At a high level, the change does three things. It adds a new pytest entrypoint for NVIDIA validation, adds a CUDA tester that compares CPU golden outputs to CUDA outputs, and extends the device connector and runner layers so the existing workload abstractions can execute on CUDA without forcing full TT/XLA initialization during collection.

```mermaid
flowchart LR
    A[Manifest row\ntest_case_id] --> B[test_models_nvidia.py]
    B --> C[Loader discovery\nexisting tt-xla model loaders]
    C --> D[DynamicTorchCudaModelTester]
    D --> E[CPU golden run]
    D --> F[CUDA run]
    E --> G[Existing comparison evaluators]
    F --> G
    G --> H[validated pass / fail]
```

## What Changed

The new entrypoint is `tests/runner/test_models_nvidia.py`. It accepts `--nvidia-cohort-json`, resolves each `test_case_id` against the branch-local loader registry, and records results through the same report-property path the rest of the repository already uses.

The CUDA execution path is implemented in `tests/runner/testers/torch/dynamic_torch_cuda_model_tester.py`. This is intentionally small: it reuses the existing Torch tester and comparison machinery, but swaps the TT target path for a CUDA target path.

Supporting changes in `tests/infra` make CUDA execution fit the existing abstractions. The connector layer now knows about `DeviceType.CUDA`, the runner layer can execute workloads on CUDA, and several imports were made lazy so collection for the NVIDIA lane does not immediately bootstrap TT/XLA-only dependencies.

The manifest contract in `test_models_nvidia.py` was also tightened. Execution is keyed by `test_case_id`; display metadata is optional. That matches how the lane really works and avoids treating `model_id` as a required execution contract when it is only descriptive metadata.

## Validation

Local validation:
- `python3 -m py_compile` passed on the new and changed NVIDIA lane files
- `pre-commit run --all-files` passed on the branch after formatting and import cleanup

Host-backed validation on the AWS A10G machine:
- `pytest --collect-only -q tests/runner/test_models_nvidia.py --nvidia-cohort-json /tmp/results-main-nvidia-cohort.json`
  - result: `72 tests collected in 9.16s`
- `pytest -q "tests/runner/test_models_nvidia.py::test_models_torch_nvidia[bart/question_answering/pytorch-bart-large-finetuned-squadv1]" --nvidia-cohort-json /tmp/results-main-nvidia-cohort.json`
  - result: `1 passed`

Earlier bounded proof on the same host also passed for:
- `squeezebert/pytorch-Mnli`
- `bert_tiny_finetuned_mnli/sequence_classification/pytorch-bert-tiny-finetuned-mnli`

## Current Limits

This lane is real and usable, but it is not the end of the NVIDIA bringup work.

Collection still surfaces loader-discovery warnings for optional dependencies that are not installed on the validation host. That noise is real, but it does not invalidate the proof cases above. The `results_main.yaml` TT-pass source cohort is also only partially runnable in the current host environment. The current truthful split is `72 runnable / 28 blocked`, so the blocked portion should be treated as follow-on loader or dependency adaptation work rather than silently assumed to be covered by this PR.
