### PR TITLE
Switch accuracy metrics to quantile-based (p5) + mean over full batch

### DIFF
--- a/.github/scripts/check_regression.py
+++ b/.github/scripts/check_regression.py
@@ -31,19 +31,24 @@ def check_accuracy(prev_report, current_report):
     for m in current_report.get("measurements", []):
         current[m["measurement_name"]] = float(m["value"])
 
-    print(
-        f"Previous: top1={prev.get('top1_accuracy')}  top5={prev.get('top5_accuracy')}"
-    )
-    print(
-        f"Current:  top1={current.get('top1_accuracy')}  top5={current.get('top5_accuracy')}"
-    )
+    # Each metric is checked independently.  If the previous report lacks a key
+    # (e.g. first run after the metric rename), check_regression() sees prev=None
+    # and skips gracefully — no false failures during transition.
+    metrics = [
+        ("Top-1 accuracy (p5)", "top1_accuracy_p5"),
+        ("Top-5 accuracy (p5)", "top5_accuracy_p5"),
+        ("Top-1 accuracy (mean)", "top1_accuracy_mean"),
+        ("Top-5 accuracy (mean)", "top5_accuracy_mean"),
+    ]
 
-    failed = check_regression(
-        "Top-1 accuracy", prev.get("top1_accuracy"), current.get("top1_accuracy")
-    )
-    failed |= check_regression(
-        "Top-5 accuracy", prev.get("top5_accuracy"), current.get("top5_accuracy")
-    )
+    failed = False
+    for label, key in metrics:
+        prev_val = prev.get(key)
+        current_val = current.get(key)
+
+        print(f"{label}: prev={prev_val}  current={current_val}")
+        failed |= check_regression(label, prev_val, current_val)
+
     return failed
 
 

--- a/tests/benchmark/benchmarks/llm_benchmark.py
+++ b/tests/benchmark/benchmarks/llm_benchmark.py
@@ -617,11 +617,16 @@ def benchmark_llm_torch_xla(
     )
     print("\nPCC/TOPK benchmark complete")
 
-    # Post-processing: derive predicted tokens for accuracy testing
+    # Post-processing: derive predicted tokens for accuracy testing (all users)
     if accuracy_testing:
-        predicted_tokens = [
-            logits[:, -1, :].argmax(dim=-1)[0].item() for logits in output_logits
-        ]
+        batch_size_for_accuracy = output_logits[0].shape[0]
+        per_user_predictions = []
+        for user_idx in range(batch_size_for_accuracy):
+            user_tokens = [
+                logits[:, -1, :].argmax(dim=-1)[user_idx].item()
+                for logits in output_logits
+            ]
+            per_user_predictions.append(user_tokens)
 
     # Calculate Time to First Token (TTFT)
     ttft_ns = iteration_times[0] if not decode_only else 0.0
@@ -678,25 +683,54 @@ def benchmark_llm_torch_xla(
     ]
 
     if accuracy_testing:
-        # Compute token accuracy from predictions (after generation completes)
-        top1_accuracy, top5_accuracy = token_accuracy.compute_accuracy(predicted_tokens)
+        # Compute per-user token accuracy across the batch
+        all_top1 = []
+        all_top5 = []
+        for user_idx, user_tokens in enumerate(per_user_predictions):
+            user_top1, user_top5 = token_accuracy.compute_accuracy(user_tokens)
+            all_top1.append(user_top1)
+            all_top5.append(user_top5)
+
+        all_top1 = np.array(all_top1)
+        all_top5 = np.array(all_top5)
+
+        # Use 5th-percentile (p5) as primary metric: "95% of users are at or above this"
+        # This catches broken users that averaging would hide.
+        top1_p5 = float(np.percentile(all_top1, 5))
+        top5_p5 = float(np.percentile(all_top5, 5))
+
+        num_users = len(all_top1)
         print(
-            "Token accuracy: TOP1={:.2f}%, TOP5={:.2f}%".format(
-                top1_accuracy * 100, top5_accuracy * 100
-            )
+            f"Token accuracy over {num_users} users:\n"
+            f"  TOP1 — min={all_top1.min()*100:.2f}%  p5={top1_p5*100:.2f}%  "
+            f"median={np.median(all_top1)*100:.2f}%  mean={all_top1.mean()*100:.2f}%  "
+            f"max={all_top1.max()*100:.2f}%\n"
+            f"  TOP5 — min={all_top5.min()*100:.2f}%  p5={top5_p5*100:.2f}%  "
+            f"median={np.median(all_top5)*100:.2f}%  mean={all_top5.mean()*100:.2f}%  "
+            f"max={all_top5.max()*100:.2f}%"
         )
 
-        # Store accuracy scores
-        evaluation_score = top1_accuracy  # Use TOP1 as primary score
+        # Store p5 and mean accuracy scores for regression tracking
+        evaluation_score = top1_p5  # Use TOP1 p5 as primary score
+        top1_mean = float(all_top1.mean())
+        top5_mean = float(all_top5.mean())
         custom_measurements.extend(
             [
                 {
-                    "measurement_name": "top1_accuracy",
-                    "value": top1_accuracy * 100,  # Store as percentage
+                    "measurement_name": "top1_accuracy_p5",
+                    "value": top1_p5 * 100,
                 },
                 {
-                    "measurement_name": "top5_accuracy",
-                    "value": top5_accuracy * 100,  # Store as percentage
+                    "measurement_name": "top5_accuracy_p5",
+                    "value": top5_p5 * 100,
+                },
+                {
+                    "measurement_name": "top1_accuracy_mean",
+                    "value": top1_mean * 100,
+                },
+                {
+                    "measurement_name": "top5_accuracy_mean",
+                    "value": top5_mean * 100,
                 },
             ]
         )


### PR DESCRIPTION
### Ticket
Closes #4363

### Problem description
**Before:** TOP1/TOP5 accuracy was computed using only user 0's predictions. This is fragile — a single user's result isn't representative of the whole batch.

Plain averaging hides problems too: if 95% of users have 0.95 accuracy and 5% have 0.2, the average is 0.91 — but the worst users are essentially broken.

### What's changed

**Accuracy metrics (`llm_benchmark.py`):**

Accuracy is computed per-user across the entire batch, then reported using both **p5** (5th percentile) and **mean** as tracked metrics:

| Measurement | Meaning |
|---|---|
| `top1_accuracy_p5` / `top5_accuracy_p5` | "95% of users are at or above this" — catches broken users |
| `top1_accuracy_mean` / `top5_accuracy_mean` | Average across all users — catches overall degradation |

The print output shows a full distribution (min / p5 / median / mean / max) for both TOP1 and TOP5:
```
Token accuracy over 32 users:
  TOP1 — min=84.38%  p5=84.38%  median=84.38%  mean=84.38%  max=84.38%
  TOP5 — min=98.44%  p5=98.44%  median=98.44%  mean=98.44%  max=98.44%
```

Some models exhibit per-user accuracy divergence even with identical inputs due to numerical precision differences across batch positions on device. The p5 metric is specifically designed to catch these cases.

**Regression checker (`check_regression.py`):**

Updated `check_accuracy()` to check all 4 metrics with distinct failure labels ("Top-1 accuracy (p5) regression" vs "Top-1 accuracy (mean) regression"), so CI logs pinpoint *what* degraded.

**Transition handling:** The measurement keys are renamed (`top1_accuracy` → `top1_accuracy_p5`, etc.). On the first run after merge, Superset still has the old keys, so none of the new keys match — all 4 checks see `prev=None` and skip gracefully. No false failures. Full regression checking activates automatically on the second run once Superset has the new keys.

### Validation results (same build, same machine, batch_size=32)

Comparing the old user[0]-only metric against the new per-batch metrics:

| Model | Old TOP1 (user 0) | New TOP1 (p5) | New TOP1 (mean) | Old TOP5 (user 0) | New TOP5 (p5) | New TOP5 (mean) |
|-------|------|------|------|------|------|------|
| Llama-3.2-1B | 84.38% | 84.38% | 84.38% | 98.44% | 98.44% | 98.44% |
| Qwen-2.5-0.5B | 90.62% | 90.62% | 90.62% | 100.00% | 100.00% | 100.00% |
| Gemma-1.1-2B | 90.62% | 90.62% | 90.62% | 100.00% | 100.00% | 100.00% |
| Phi-2 | 87.50% | 87.50% | 87.50% | 100.00% | 100.00% | 100.00% |
| Mistral-7B | 100.00% | 100.00% | 100.00% | 100.00% | 100.00% | 100.00% |

> On single chip tests all 32 users produce identical accuracy (min = max) for these 5 models. The p5 metric will diverge from mean on models that exhibit per-user numerical precision variance across batch positions.