### PR TITLE
[vLLM] Add weight_dtype_overrides support to TTConfig

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -1545,6 +1545,19 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     vllm_config=self.vllm_config, model_config=self.model_config
                 ).eval()
                 replace_modules(model)
+
+                # Apply per-layer weight dtype overrides before moving to device
+                if self.tt_config.weight_dtype_overrides:
+                    from tt_torch.weight_dtype import apply_weight_dtype_overrides
+
+                    applied = apply_weight_dtype_overrides(
+                        model, self.tt_config.weight_dtype_overrides
+                    )
+                    logger.info(
+                        f"Applied {len(applied)} weight dtype overrides "
+                        f"from TTConfig.weight_dtype_overrides"
+                    )
+
                 model = model.to(self.device)
 
                 if self.enable_tensor_parallel:

--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: Portions (c) 2025 Tenstorrent AI ULC
 
 import contextlib
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Optional, Union, cast
 
 import torch
@@ -79,6 +79,13 @@ class TTConfig:
     # the vllm_config before the model is loaded. We also store the original and
     # target number of layers to filter the weights accordingly during loading.
     num_hidden_layers: int = 0
+
+    # Per-layer weight dtype overrides as a dict mapping parameter name patterns
+    # (fnmatch globs) to dtype strings ("bfp_bf4", "bfp_bf8", "bf16").
+    # An optional "default" key applies to all weight parameters not matched by
+    # other patterns. Applied after model loading, before compilation.
+    # Example: {"model.layers.*.mlp.experts.gate_up_proj": "bfp_bf4", "default": "bfp_bf8"}
+    weight_dtype_overrides: Optional[dict] = None
 
     # Flag to enable 2D mesh for tensor parallel execution.
     use_2d_mesh: bool = True


### PR DESCRIPTION
### Ticket
Closes #4365

### Problem description
We needed weight dtype override support in vLLM plugin.

### What's changed
Add per-layer weight dtype override support to the vLLM plugin, enabling MoE models like GPT OSS 120B to use different quantization levels for different layer types (e.g. bf16 for router weights, bfp_bf4 for expert weights, bfp_bf8 as default).

Changes:
- Add `weight_dtype_overrides: Optional[dict]` field to TTConfig
- Apply overrides via `apply_weight_dtype_overrides()` in load_model() after model loading but before device transfer and compilation
