### PR TITLE
Revert hanging tests to opt-lvl=1

### DIFF
--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -1120,6 +1120,7 @@ def test_mistral_small_24b_instruct_2501_tp(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=1,  # flaky: occasionally hangs in CI with optimization_level=2
     )
 
 
@@ -1290,6 +1291,7 @@ def test_qwen_3_8b_tp(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        optimization_level=1,  # flaky: occasionally hangs in CI with optimization_level=2
     )
 
 
@@ -1463,6 +1465,7 @@ def test_llama_3_1_70b_tp(
             "model.layers.*.mlp.gate_proj.weight": "bfp_bf4",
             "model.layers.*.mlp.up_proj.weight": "bfp_bf4",
         },
+        optimization_level=1,  # flaky: occasionally hangs in CI with optimization_level=2
     )
 
 


### PR DESCRIPTION
In the nightly after upgrading opt-level to 2, these 3 tests hung, even though they pass on local loudbox. Reverting to opt-level 1.