### PR TITLE
[vLLM] Expand and optimize CPU sampling for non-greedy serving 

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -1358,7 +1358,11 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             sampling_device = (
                 torch.device("cpu") if self.tt_config.cpu_sampling else self.device
             )
-            logger.warning_once("Sampling on %s (cpu_sampling=%s)", sampling_device, self.tt_config.cpu_sampling)
+            logger.warning_once(
+                "Sampling on %s (cpu_sampling=%s)",
+                sampling_device,
+                self.tt_config.cpu_sampling,
+            )
             sampling_metadata = XLASupportedSamplingMetadata.from_input_batch(
                 self.input_batch,
                 self.max_num_reqs,
@@ -1904,7 +1908,9 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             if not self.tt_config.cpu_sampling:
                 self._precompile_sample_from_logits()
             else:
-                logger.warning("cpu_sampling=True: skipping device sampling precompilation")
+                logger.warning(
+                    "cpu_sampling=True: skipping device sampling precompilation"
+                )
             self._precompile_gather_logprobs()
 
     def profile_run(
@@ -2216,14 +2222,18 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 for i in range(topk_vals.size(0)):
                     p = float(top_p[i].item())
                     if p < 1.0:
-                        sorted_vals, sort_idx = torch.sort(topk_vals[i], descending=True)
+                        sorted_vals, sort_idx = torch.sort(
+                            topk_vals[i], descending=True
+                        )
                         probs = torch.softmax(sorted_vals, dim=-1)
                         mask = torch.cumsum(probs, dim=-1) - probs >= p
-                        sorted_vals[mask] = float('-inf')
+                        sorted_vals[mask] = float("-inf")
                         topk_vals[i].scatter_(0, sort_idx, sorted_vals)
 
             greedy = torch.argmax(topk_vals, dim=-1)
-            gumbel = -torch.log(-torch.log(torch.rand_like(topk_vals.float()) + 1e-20) + 1e-20)
+            gumbel = -torch.log(
+                -torch.log(torch.rand_like(topk_vals.float()) + 1e-20) + 1e-20
+            )
             random = torch.argmax(topk_vals + gumbel, dim=-1)
             sampled_local = torch.where(temp < 1e-6, greedy, random)
             return topk_idx.gather(-1, sampled_local.unsqueeze(-1))
@@ -2234,23 +2244,27 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     k = int(top_k[i].item())
                     if k > 0 and k < logits.size(1):
                         topk_vals, _ = torch.topk(logits[i], k)
-                        logits[i][logits[i] < topk_vals[-1]] = float('-inf')
+                        logits[i][logits[i] < topk_vals[-1]] = float("-inf")
 
             if has_topp:
                 for i in range(logits.size(0)):
                     p = float(top_p[i].item())
                     if p < 1.0:
-                        sorted_logits, sorted_indices = torch.sort(logits[i], descending=True)
+                        sorted_logits, sorted_indices = torch.sort(
+                            logits[i], descending=True
+                        )
                         probs = torch.softmax(sorted_logits, dim=-1)
                         mask = torch.cumsum(probs, dim=-1) - probs >= p
-                        sorted_logits[mask] = float('-inf')
+                        sorted_logits[mask] = float("-inf")
                         logits[i].scatter_(0, sorted_indices, sorted_logits)
 
             # Gumbel-max: mathematically equivalent to softmax + multinomial
             # but implemented as argmax(logits + Gumbel noise) — avoids
             # torch.multinomial which processes each batch element sequentially.
             greedy = torch.argmax(logits, dim=-1)
-            gumbel = -torch.log(-torch.log(torch.rand_like(logits.float()) + 1e-20) + 1e-20)
+            gumbel = -torch.log(
+                -torch.log(torch.rand_like(logits.float()) + 1e-20) + 1e-20
+            )
             random = torch.argmax(logits + gumbel, dim=-1)
             return torch.where(temp < 1e-6, greedy, random).unsqueeze(-1)
 

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -2196,31 +2196,63 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         temp = torch.where(temp < 1e-6, torch.ones_like(temp), temp)
         logits = logits / temp.unsqueeze(1)
 
-        if sampling_metadata.top_k is not None:
-            top_k = sampling_metadata.top_k.cpu()
-            for i in range(logits.size(0)):
-                k = int(top_k[i].item())
-                if k > 0 and k < logits.size(1):
-                    topk_vals, _ = torch.topk(logits[i], k)
-                    logits[i][logits[i] < topk_vals[-1]] = float('-inf')
+        has_topk = sampling_metadata.top_k is not None
+        has_topp = sampling_metadata.top_p is not None
+        top_k = sampling_metadata.top_k.cpu() if has_topk else None
+        top_p = sampling_metadata.top_p.cpu() if has_topp else None
 
-        if sampling_metadata.top_p is not None:
-            top_p = sampling_metadata.top_p.cpu()
-            for i in range(logits.size(0)):
-                p = float(top_p[i].item())
-                if p < 1.0:
-                    sorted_logits, sorted_indices = torch.sort(logits[i], descending=True)
-                    probs = torch.softmax(sorted_logits, dim=-1)
-                    mask = torch.cumsum(probs, dim=-1) - probs >= p
-                    sorted_logits[mask] = float('-inf')
-                    logits[i].scatter_(0, sorted_indices, sorted_logits)
+        # Fast path: all requests share the same k > 0 — single batched topk
+        # reduces vocab from 128K to k before top-p sort.
+        uniform_k = 0
+        if has_topk:
+            k = int(top_k[0].item())
+            if 0 < k < logits.size(1) and (top_k == k).all():
+                uniform_k = k
 
-        # Sample from distribution
-        probs = torch.softmax(logits, dim=-1)
-        greedy = torch.argmax(logits, dim=-1)
-        random = torch.multinomial(probs, num_samples=1).squeeze(-1)
-        out_tokens = torch.where(temp < 1e-6, greedy, random).unsqueeze(-1)
-        return out_tokens
+        if uniform_k > 0:
+            topk_vals, topk_idx = torch.topk(logits, uniform_k, dim=-1)
+
+            if has_topp:
+                for i in range(topk_vals.size(0)):
+                    p = float(top_p[i].item())
+                    if p < 1.0:
+                        sorted_vals, sort_idx = torch.sort(topk_vals[i], descending=True)
+                        probs = torch.softmax(sorted_vals, dim=-1)
+                        mask = torch.cumsum(probs, dim=-1) - probs >= p
+                        sorted_vals[mask] = float('-inf')
+                        topk_vals[i].scatter_(0, sort_idx, sorted_vals)
+
+            greedy = torch.argmax(topk_vals, dim=-1)
+            gumbel = -torch.log(-torch.log(torch.rand_like(topk_vals.float()) + 1e-20) + 1e-20)
+            random = torch.argmax(topk_vals + gumbel, dim=-1)
+            sampled_local = torch.where(temp < 1e-6, greedy, random)
+            return topk_idx.gather(-1, sampled_local.unsqueeze(-1))
+        else:
+            # Slow path: mixed k values or k=0 — per-request filtering on full vocab.
+            if has_topk:
+                for i in range(logits.size(0)):
+                    k = int(top_k[i].item())
+                    if k > 0 and k < logits.size(1):
+                        topk_vals, _ = torch.topk(logits[i], k)
+                        logits[i][logits[i] < topk_vals[-1]] = float('-inf')
+
+            if has_topp:
+                for i in range(logits.size(0)):
+                    p = float(top_p[i].item())
+                    if p < 1.0:
+                        sorted_logits, sorted_indices = torch.sort(logits[i], descending=True)
+                        probs = torch.softmax(sorted_logits, dim=-1)
+                        mask = torch.cumsum(probs, dim=-1) - probs >= p
+                        sorted_logits[mask] = float('-inf')
+                        logits[i].scatter_(0, sorted_indices, sorted_logits)
+
+            # Gumbel-max: mathematically equivalent to softmax + multinomial
+            # but implemented as argmax(logits + Gumbel noise) — avoids
+            # torch.multinomial which processes each batch element sequentially.
+            greedy = torch.argmax(logits, dim=-1)
+            gumbel = -torch.log(-torch.log(torch.rand_like(logits.float()) + 1e-20) + 1e-20)
+            random = torch.argmax(logits + gumbel, dim=-1)
+            return torch.where(temp < 1e-6, greedy, random).unsqueeze(-1)
 
     @torch.compile(backend="tt", fullgraph=True, dynamic=False)
     def gather_logprobs(

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -447,6 +447,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         )
 
         if self.tt_config.cpu_sampling:
+            logger.warning("cpu_sampling=True: using CPU sampling path")
             self.sample_from_logits_func = self.sample_from_logits_cpu
         else:
             self.sample_from_logits_func = self.sample_from_logits
@@ -1357,6 +1358,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             sampling_device = (
                 torch.device("cpu") if self.tt_config.cpu_sampling else self.device
             )
+            logger.warning_once("Sampling on %s (cpu_sampling=%s)", sampling_device, self.tt_config.cpu_sampling)
             sampling_metadata = XLASupportedSamplingMetadata.from_input_batch(
                 self.input_batch,
                 self.max_num_reqs,
@@ -1901,6 +1903,8 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             self._precompile_structured_decoding()
             if not self.tt_config.cpu_sampling:
                 self._precompile_sample_from_logits()
+            else:
+                logger.warning("cpu_sampling=True: skipping device sampling precompilation")
             self._precompile_gather_logprobs()
 
     def profile_run(
@@ -2167,13 +2171,56 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         """
         Sample on CPU instead of compiling a device sampling graph.
 
-        This function mainly exists as a workaround for https://github.com/tenstorrent/tt-xla/issues/3610.
-        Only support greedy sampling for now to reduce maintenance overhead.
+        Supports greedy, temperature, top-k/top-p, and penalty-based sampling.
+        All operations run on CPU to avoid compiling a device sampling graph.
         """
-        device = logits.device
         logits = logits.cpu()
-        out_tokens = torch.argmax(logits, dim=-1, keepdim=True)
-        return out_tokens.to(device)
+
+        if not sampling_metadata.no_penalties:
+            output_counts = sampling_metadata.output_token_counts.cpu()
+            occurred_output = output_counts > 0
+            prompt_mask = sampling_metadata.prompt_token_mask.cpu()
+            rep_pen = sampling_metadata.repetition_penalties.cpu().unsqueeze(1)
+            rep_mask = occurred_output | prompt_mask
+            penalty_factor = torch.where(logits > 0, torch.reciprocal(rep_pen), rep_pen)
+            logits = torch.where(rep_mask, logits * penalty_factor, logits)
+            freq_pen = sampling_metadata.frequency_penalties.cpu().unsqueeze(1)
+            logits -= freq_pen * output_counts.to(logits.dtype)
+            pres_pen = sampling_metadata.presence_penalties.cpu().unsqueeze(1)
+            logits -= pres_pen * occurred_output.to(logits.dtype)
+
+        if sampling_metadata.all_greedy:
+            return torch.argmax(logits, dim=-1, keepdim=True)
+
+        temp = sampling_metadata.temperature.cpu()
+        temp = torch.where(temp < 1e-6, torch.ones_like(temp), temp)
+        logits = logits / temp.unsqueeze(1)
+
+        if sampling_metadata.top_k is not None:
+            top_k = sampling_metadata.top_k.cpu()
+            for i in range(logits.size(0)):
+                k = int(top_k[i].item())
+                if k > 0 and k < logits.size(1):
+                    topk_vals, _ = torch.topk(logits[i], k)
+                    logits[i][logits[i] < topk_vals[-1]] = float('-inf')
+
+        if sampling_metadata.top_p is not None:
+            top_p = sampling_metadata.top_p.cpu()
+            for i in range(logits.size(0)):
+                p = float(top_p[i].item())
+                if p < 1.0:
+                    sorted_logits, sorted_indices = torch.sort(logits[i], descending=True)
+                    probs = torch.softmax(sorted_logits, dim=-1)
+                    mask = torch.cumsum(probs, dim=-1) - probs >= p
+                    sorted_logits[mask] = float('-inf')
+                    logits[i].scatter_(0, sorted_indices, sorted_logits)
+
+        # Sample from distribution
+        probs = torch.softmax(logits, dim=-1)
+        greedy = torch.argmax(logits, dim=-1)
+        random = torch.multinomial(probs, num_samples=1).squeeze(-1)
+        out_tokens = torch.where(temp < 1e-6, greedy, random).unsqueeze(-1)
+        return out_tokens
 
     @torch.compile(backend="tt", fullgraph=True, dynamic=False)
     def gather_logprobs(

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -2183,29 +2183,29 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         logits = logits.cpu()
 
         if not sampling_metadata.no_penalties:
-            output_counts = sampling_metadata.output_token_counts.cpu()
+            output_counts = sampling_metadata.output_token_counts
             occurred_output = output_counts > 0
-            prompt_mask = sampling_metadata.prompt_token_mask.cpu()
-            rep_pen = sampling_metadata.repetition_penalties.cpu().unsqueeze(1)
+            prompt_mask = sampling_metadata.prompt_token_mask
+            rep_pen = sampling_metadata.repetition_penalties.unsqueeze(1)
             rep_mask = occurred_output | prompt_mask
             penalty_factor = torch.where(logits > 0, torch.reciprocal(rep_pen), rep_pen)
             logits = torch.where(rep_mask, logits * penalty_factor, logits)
-            freq_pen = sampling_metadata.frequency_penalties.cpu().unsqueeze(1)
+            freq_pen = sampling_metadata.frequency_penalties.unsqueeze(1)
             logits -= freq_pen * output_counts.to(logits.dtype)
-            pres_pen = sampling_metadata.presence_penalties.cpu().unsqueeze(1)
+            pres_pen = sampling_metadata.presence_penalties.unsqueeze(1)
             logits -= pres_pen * occurred_output.to(logits.dtype)
 
         if sampling_metadata.all_greedy:
             return torch.argmax(logits, dim=-1, keepdim=True)
 
-        temp = sampling_metadata.temperature.cpu()
+        temp = sampling_metadata.temperature
         temp = torch.where(temp < 1e-6, torch.ones_like(temp), temp)
         logits = logits / temp.unsqueeze(1)
 
         has_topk = sampling_metadata.top_k is not None
         has_topp = sampling_metadata.top_p is not None
-        top_k = sampling_metadata.top_k.cpu() if has_topk else None
-        top_p = sampling_metadata.top_p.cpu() if has_topp else None
+        top_k = sampling_metadata.top_k if has_topk else None
+        top_p = sampling_metadata.top_p if has_topp else None
 
         # Fast path: all requests share the same k > 0 — single batched topk
         # reduces vocab from 128K to k before top-p sort.

--- a/tests/integrations/vllm_plugin/sampling/test_cpu_sampling.py
+++ b/tests/integrations/vllm_plugin/sampling/test_cpu_sampling.py
@@ -41,9 +41,9 @@ def assert_coherent(text: str, label: str) -> None:
     words = text.lower().split()
     assert len(words) >= 3, f"[{label}] Output too short: {text!r}"
     ascii_ratio = sum(1 for c in text if ord(c) < 128) / max(len(text), 1)
-    assert ascii_ratio > 0.8, (
-        f"[{label}] Non-ASCII garbage ({ascii_ratio:.0%}): {text!r}"
-    )
+    assert (
+        ascii_ratio > 0.8
+    ), f"[{label}] Non-ASCII garbage ({ascii_ratio:.0%}): {text!r}"
 
 
 @pytest.mark.single_device
@@ -86,14 +86,12 @@ def test_cpu_sampling_top_k():
 @pytest.mark.nightly
 def test_cpu_sampling_repetition_penalty():
     """Repetition penalty produces coherent output and suppresses loops."""
-    params = vllm.SamplingParams(
-        temperature=0.6, repetition_penalty=1.1, max_tokens=32
-    )
+    params = vllm.SamplingParams(temperature=0.6, repetition_penalty=1.1, max_tokens=32)
     text = llm().generate([PROMPT], params)[0].outputs[0].text
     assert_coherent(text, "rep_penalty=1.1")
     # With penalty active, a tight repetition loop should not fill the output.
     words = text.lower().split()
     most_common = max(set(words), key=words.count)
-    assert words.count(most_common) <= len(words) // 2, (
-        f"Output looks like a repetition loop: {text!r}"
-    )
+    assert (
+        words.count(most_common) <= len(words) // 2
+    ), f"Output looks like a repetition loop: {text!r}"

--- a/tests/integrations/vllm_plugin/sampling/test_cpu_sampling.py
+++ b/tests/integrations/vllm_plugin/sampling/test_cpu_sampling.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Correctness tests for the cpu_sampling path.
+
+cpu_sampling=True runs all sampling ops on CPU instead of compiling a
+device sampling graph. These tests verify that the CPU path produces
+coherent output for the full set of sampling parameters it supports:
+greedy, temperature, top-k, top-p, and repetition penalties.
+"""
+import pytest
+import vllm
+from conftest import get_or_create_llm
+
+MODEL = "meta-llama/Llama-3.2-1B-Instruct"
+PROMPT = "Tell me a quick story"
+
+LLM_ARGS = {
+    "model": MODEL,
+    "max_num_batched_tokens": 128,
+    "max_num_seqs": 1,
+    "max_model_len": 128,
+    "gpu_memory_utilization": 0.002,
+    "additional_config": {
+        "enable_const_eval": False,
+        "min_context_len": 32,
+        "cpu_sampling": True,
+    },
+}
+
+
+def llm():
+    return get_or_create_llm("cpu_sampling_1b", **LLM_ARGS)
+
+
+def assert_coherent(text: str, label: str) -> None:
+    """Assert output is coherent English, not garbage tokens."""
+    print(f"\n--- {label} ---")
+    print(f"  prompt: {PROMPT!r}")
+    print(f"  output: {text!r}")
+    words = text.lower().split()
+    assert len(words) >= 3, f"[{label}] Output too short: {text!r}"
+    ascii_ratio = sum(1 for c in text if ord(c) < 128) / max(len(text), 1)
+    assert ascii_ratio > 0.8, (
+        f"[{label}] Non-ASCII garbage ({ascii_ratio:.0%}): {text!r}"
+    )
+
+
+@pytest.mark.single_device
+@pytest.mark.nightly
+def test_cpu_sampling_greedy():
+    """Greedy (temperature=0) on CPU sampling path produces coherent output."""
+    params = vllm.SamplingParams(temperature=0, max_tokens=32)
+    text = llm().generate([PROMPT], params)[0].outputs[0].text
+    assert_coherent(text, "greedy")
+
+
+@pytest.mark.single_device
+@pytest.mark.nightly
+def test_cpu_sampling_temperature():
+    """Non-greedy temperature sampling produces coherent output."""
+    params = vllm.SamplingParams(temperature=0.6, max_tokens=32)
+    text = llm().generate([PROMPT], params)[0].outputs[0].text
+    assert_coherent(text, "temperature=0.6")
+
+
+@pytest.mark.single_device
+@pytest.mark.nightly
+def test_cpu_sampling_top_p():
+    """top_p filtering produces coherent output."""
+    params = vllm.SamplingParams(temperature=0.8, top_p=0.9, max_tokens=32)
+    text = llm().generate([PROMPT], params)[0].outputs[0].text
+    assert_coherent(text, "top_p=0.9")
+
+
+@pytest.mark.single_device
+@pytest.mark.nightly
+def test_cpu_sampling_top_k():
+    """top_k filtering produces coherent output."""
+    params = vllm.SamplingParams(temperature=0.8, top_k=50, max_tokens=32)
+    text = llm().generate([PROMPT], params)[0].outputs[0].text
+    assert_coherent(text, "top_k=50")
+
+
+@pytest.mark.single_device
+@pytest.mark.nightly
+def test_cpu_sampling_repetition_penalty():
+    """Repetition penalty produces coherent output and suppresses loops."""
+    params = vllm.SamplingParams(
+        temperature=0.6, repetition_penalty=1.1, max_tokens=32
+    )
+    text = llm().generate([PROMPT], params)[0].outputs[0].text
+    assert_coherent(text, "rep_penalty=1.1")
+    # With penalty active, a tight repetition loop should not fill the output.
+    words = text.lower().split()
+    most_common = max(set(words), key=words.count)
+    assert words.count(most_common) <= len(words) // 2, (
+        f"Output looks like a repetition loop: {text!r}"
+    )


### PR DESCRIPTION
## Ticket

Closes #4370

## Problem

- `sample_from_logits_cpu` only supported greedy decoding. Device-side non-greedy sampling is currently ~5 tok/s due to and (improvements WIP, but more involved) so `cpu_sampling=True` is the practical path for non-greedy serving that was used for tt-cloud-console demo last 3 weeks.  Merging these changes since they are small and contained while device sampling is improved.

## What's changed

- `model_runner.py`: extend `sample_from_logits_cpu` to support temperature scaling, repetition/frequency/presence penalties, top-k, and top-p
- `model_runner.py`: replace `torch.softmax + torch.multinomial` with the Gumbel-max trick — `argmax(logits + Gumbel noise)` is mathematically equivalent to `multinomial(softmax(logits))` but avoids `multinomial` which processes each batch element sequentially
- `model_runner.py`: add batched top-k fast path — when all requests share the same `top_k > 0`, a single `torch.topk` call reduces vocab from 128K to k elements before top-p and Gumbel-max, eliminating per-request loops (see details in ticket).
- `test_cpu_sampling.py` (new): correctness tests for cpu_sampling covering greedy, temperature, top-k, top-p, and repetition penalty using Llama-3.2-1B-Instruct

## Checklist

- [x] Non-greedy output coherent on Llama-3.1-8B at batch 2 (19.0 tok/s, 3 weeks of demo use)
- [x] Greedy throughput unchanged
- [x] `test_cpu_sampling.py` passing
- [x] Run vllm nightly on CI passing: https://github.com/tenstorrent/tt-xla/actions/runs/24802050427
