### PR TITLE
[DO NOT SUBMIT YET] Add composite op support for torch.gather

### DIFF
--- a/python_package/tt_torch/composite_ops.py
+++ b/python_package/tt_torch/composite_ops.py
@@ -270,6 +270,33 @@ def composite_scaled_dot_product_attention(
     return output
 
 
+def composite_gather(
+    input: Tensor,
+    dim: int,
+    index: Tensor,
+    *,
+    sparse_grad: bool = False,
+    out: Tensor | None = None,
+) -> Tensor:
+    """
+    Creates a composite gather operation for torch-xla using StableHLOCompositeBuilder.
+    Name of the composite op will be "tenstorrent.gather"
+
+    Args:
+        input: tensor to gather from
+        dim: axis along which to index
+        index: tensor with integer dtype which contains the indices to gather
+        sparse_grad: optional bool, if true the gradient computation will be sparse
+        out: preallocated output tensor, will be ignored when generating composite op
+    """
+    attrs = {"dim": dim, "sparse_grad": sparse_grad}
+    builder = StableHLOCompositeBuilder(name="tenstorrent.gather", attr=attrs)
+    input, index = builder.mark_inputs(input, index)
+    output = torch.gather(input, dim, index, sparse_grad=sparse_grad)
+    output = builder.mark_outputs(output)
+    return output
+
+
 ################# module replacements #################
 
 
@@ -459,6 +486,7 @@ replacements = {
         frozenset({0}): composite_topk_values,
         frozenset({1}): composite_topk_indices,
     },
+    torch.gather: composite_gather,
     # module replacements
     torch.nn.LayerNorm: replace_layer_norm_module,
     # TODO: uncomment once https://github.com/tenstorrent/tt-metal/issues/40916 is fixed
@@ -473,4 +501,5 @@ The mapped function must be a key in `replacements` for the rewrite to apply.
 """
 method_name_to_function = {
     "topk": torch.topk,
+    "gather": torch.gather,
 }

--- a/python_package/tt_torch/composite_ops.py
+++ b/python_package/tt_torch/composite_ops.py
@@ -290,7 +290,7 @@ def composite_gather(
         out: preallocated output tensor, will be ignored when generating composite op
     """
     attrs = {"dim": dim, "sparse_grad": sparse_grad}
-    builder = StableHLOCompositeBuilder(name="tenstorrent.gather", attr=attrs)
+    builder = StableHLOCompositeBuilder(name="tenstorrent.gather_dim", attr=attrs)
     input, index = builder.mark_inputs(input, index)
     output = torch.gather(input, dim, index, sparse_grad=sparse_grad)
     output = builder.mark_outputs(output)

--- a/tests/torch/ops/test_composite_ops.py
+++ b/tests/torch/ops/test_composite_ops.py
@@ -15,6 +15,7 @@ from infra.evaluators import TorchComparisonEvaluator
 from infra.utilities.types import Framework
 from torch.nn import functional as F
 from tt_torch.composite_ops import (
+    composite_gather,
     composite_gelu,
     composite_group_norm,
     composite_layer_norm,
@@ -454,6 +455,72 @@ def test_patched_topk_both(input_shape, k):
     run_graph_test(
         TopKBoth(k),
         [input],
+        comparison_config=ComparisonConfig(),
+        framework=Framework.TORCH,
+        torch_options=options,
+    )
+
+
+@pytest.mark.nightly
+@pytest.mark.single_device
+@pytest.mark.parametrize(
+    "input_shape, dim",
+    [((4, 10), 0), ((4, 10), 1), ((2, 3, 8), 2)],
+)
+def test_composite_gather(input_shape, dim):
+    class GatherModel(torch.nn.Module):
+        def __init__(self, dim):
+            super().__init__()
+            self.dim = dim
+
+        def forward(self, x, index):
+            return composite_gather(x, self.dim, index)
+
+    options = {"tt_enable_composite_ops": False}
+
+    input_tensor = torch.randn(*input_shape)
+    # Build an index tensor with the same number of dims, gathering 2 elements along dim
+    index_shape = list(input_shape)
+    index_shape[dim] = 2
+    index = torch.randint(0, input_shape[dim], index_shape)
+
+    with torch._inductor.config.patch({"inplace_buffers": False}):
+        run_graph_test(
+            GatherModel(dim),
+            [input_tensor, index],
+            comparison_config=ComparisonConfig(),
+            framework=Framework.TORCH,
+            torch_options=options,
+        )
+
+
+@pytest.mark.nightly
+@pytest.mark.single_device
+@pytest.mark.parametrize(
+    "input_shape, dim",
+    [((4, 10), 0), ((4, 10), 1), ((2, 3, 8), 2)],
+)
+def test_patched_gather(input_shape, dim):
+    """torch.gather patched via tt_enable_composite_ops → composite_gather selected."""
+
+    class GatherModel(torch.nn.Module):
+        def __init__(self, dim):
+            super().__init__()
+            self.dim = dim
+
+        def forward(self, x, index):
+            return torch.gather(x, self.dim, index)
+
+    options = {"tt_enable_composite_ops": True}
+
+    input_tensor = torch.randn(*input_shape)
+    index_shape = list(input_shape)
+    index_shape[dim] = 2
+    index = torch.randint(0, input_shape[dim], index_shape)
+
+    run_graph_test(
+        GatherModel(dim),
+        [input_tensor, index],
         comparison_config=ComparisonConfig(),
         framework=Framework.TORCH,
         torch_options=options,

--- a/tests/torch/ops/test_gather.py
+++ b/tests/torch/ops/test_gather.py
@@ -71,14 +71,53 @@ def test_gather_replicated(input_shape, index_shape, dim):
     )
 
 
+# Sharded torch.gather patterns that are supported by tt-mlir.
 @pytest.mark.parametrize(
-    "input_shape,index_shape,dim",
+    "input_shape,index_shape,dim,input_spec,index_spec",
     [
-        ((8, 32), (8, 16), 0),
+        # 2D: gather on dim 0; shard the non-gather dim with matched sizes on
+        # both operands across the "batch" axis (factor 2).
+        pytest.param(
+            (8, 16),
+            (8, 16),
+            0,
+            (None, "batch"),
+            (None, "batch"),
+            id="2d_dim0_aligned_batch",
+        ),
+        # Same shape-alignment idea but sharded across the "model" axis
+        # (factor 4 on 8 devices) to exercise a larger shard factor.
+        pytest.param(
+            (8, 16),
+            (8, 16),
+            0,
+            (None, "model"),
+            (None, "model"),
+            id="2d_dim0_aligned_model",
+        ),
+        # 3D, gather on the middle dim; shard the leading (batch) dim with
+        # matched sizes on both operands. Common for per-sample gathers.
+        pytest.param(
+            (4, 8, 16),
+            (4, 4, 16),
+            1,
+            ("batch", None, None),
+            ("batch", None, None),
+            id="3d_dim1_shard_batch",
+        ),
+        # Gather on the last dim; shard the leading non-gather dim with
+        # matched sizes. Common for per-row selection (e.g. top-k values).
+        pytest.param(
+            (8, 16),
+            (8, 8),
+            -1,
+            ("batch", None),
+            ("batch", None),
+            id="2d_negdim_shard_leading",
+        ),
     ],
-    ids=["2d_dim1"],
 )
-def test_gather_sharded(input_shape, index_shape, dim):
+def test_gather_sharded(input_shape, index_shape, dim, input_spec, index_spec):
     xr.set_device_type("TT")
 
     # Setup mesh and shard spec
@@ -90,8 +129,8 @@ def test_gather_sharded(input_shape, index_shape, dim):
     def get_shard_spec(module, args, kwargs):
         input, index = args
         return {
-            input: (None, "batch"),
-            index: (None, "batch"),
+            input: input_spec,
+            index: index_spec,
         }
 
     input = torch.randn(*input_shape, dtype=torch.bfloat16)
@@ -102,6 +141,59 @@ def test_gather_sharded(input_shape, index_shape, dim):
         SimpleGather(dim),
         [input, index],
         framework=Framework.TORCH,
-        # mesh=mesh,
-        # shard_spec_fn=get_shard_spec,
+        mesh=mesh,
+        shard_spec_fn=get_shard_spec,
+    )
+
+
+# Gather pattern that shows up in Deepseek Sparse Attention.
+# Here x is the kv_cache tensor.
+@pytest.mark.parametrize("batch_size", [1, 4, 32, 64])
+@pytest.mark.parametrize("seq_len", [32, 128, 512, 1024, 2048])
+def test_gather_indices(batch_size, seq_len):
+    xr.set_device_type("TT")
+
+    class GatherIndices(nn.Module):
+        def __init__(self, topk_indices: torch.Tensor):
+            super().__init__()
+
+        def forward(self, x, topk_indices):
+            gather_idx = topk_indices.squeeze(1)  # (bsz, topk)
+            index = gather_idx.unsqueeze(-1).expand(
+                -1, -1, x.size(-1)
+            )  # (bsz, topk, kv_lora_rank)
+            gathered_x = torch.gather(x, 1, index)  # (bsz, topk, kv_lora_rank)
+            return gathered_x
+
+    # Setup mesh
+    num_devices = xr.global_runtime_device_count()
+    mesh_shape = (2, 4)
+    device_ids = np.array(range(num_devices))
+    mesh = Mesh(device_ids, mesh_shape, ("batch", "model"))
+
+    def get_shard_spec(gather_module, args, kwargs):
+        mesh_batch_axis_size = mesh.shape()["batch"]
+        # Conditionally shard weights that involve batch axis
+        batch_axis = "batch" if batch_size >= mesh_batch_axis_size else None
+        shard_specs = {}
+        shard_specs[args[0]] = (batch_axis, None, None)  # x
+        shard_specs[args[1]] = (batch_axis, None, None)  # topk_indices
+        # shard_specs[gather_module.topk_indices] = (batch_axis, None, None)
+        return shard_specs
+
+    kv_lora_rank = 512
+    index_topk = 16
+    x = torch.randn(batch_size, seq_len, kv_lora_rank, dtype=torch.bfloat16)
+    topk_indices = torch.stack(
+        [torch.randperm(seq_len)[:index_topk] for _ in range(batch_size)]
+    ).unsqueeze(
+        1
+    )  # (batch_size, 1, index_topk)
+
+    run_graph_test(
+        GatherIndices(topk_indices),
+        [x, topk_indices],
+        framework=Framework.TORCH,
+        shard_spec_fn=get_shard_spec,
+        mesh=mesh,
     )

--- a/tests/torch/ops/test_gather.py
+++ b/tests/torch/ops/test_gather.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import numpy as np
+import pytest
+import torch
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+from infra.testers.compiler_config import CompilerConfig
+from torch import nn
+from torch_xla.distributed.spmd import Mesh
+
+
+class SimpleGather(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.dim = dim
+
+    def forward(self, input, index):
+        return torch.gather(input, self.dim, index)
+
+
+@pytest.mark.parametrize(
+    "input_shape,index_shape,dim",
+    [
+        # ---- 1D: only one dim; index size may be <, ==, or > input size along dim ----
+        pytest.param((32,), (16,), 0, id="1d_dim0_smaller"),
+        pytest.param((32,), (32,), 0, id="1d_dim0_same"),
+        pytest.param((32,), (64,), 0, id="1d_dim0_larger"),
+        pytest.param((32,), (16,), -1, id="1d_negdim"),
+        # ---- 2D: all dims (positive and negative), varying index shapes ----
+        pytest.param((32, 64), (16, 64), 0, id="2d_dim0"),
+        pytest.param((8, 32), (8, 16), 1, id="2d_dim1"),
+        pytest.param((16, 32), (16, 32), 1, id="2d_dim1_same_shape"),
+        pytest.param((16, 32), (16, 64), 1, id="2d_dim1_larger"),
+        pytest.param((16, 32), (8, 16), 1, id="2d_dim1_both_smaller"),
+        pytest.param((32, 64), (16, 32), 0, id="2d_dim0_both_smaller"),
+        pytest.param((32, 64), (16, 64), -2, id="2d_negdim0"),
+        pytest.param((8, 32), (8, 16), -1, id="2d_negdim1"),
+        # ---- 3D: all dims, varying index shapes ----
+        pytest.param((4, 32, 64), (2, 32, 64), 0, id="3d_dim0"),
+        pytest.param((4, 32, 64), (4, 8, 64), 1, id="3d_dim1"),
+        pytest.param((4, 16, 64), (4, 16, 32), 2, id="3d_dim2"),
+        pytest.param((4, 16, 64), (4, 16, 128), 2, id="3d_dim2_larger"),
+        pytest.param((4, 16, 64), (2, 8, 32), 2, id="3d_dim2_all_smaller"),
+        pytest.param((4, 32, 64), (4, 8, 64), -2, id="3d_negdim1"),
+        pytest.param((4, 16, 64), (4, 16, 32), -1, id="3d_negdim2"),
+        # ---- 4D: all dims ----
+        pytest.param((2, 4, 32, 64), (1, 4, 32, 64), 0, id="4d_dim0"),
+        pytest.param((2, 4, 32, 64), (2, 2, 32, 64), 1, id="4d_dim1"),
+        pytest.param((2, 4, 32, 64), (2, 4, 16, 64), 2, id="4d_dim2"),
+        pytest.param((2, 4, 32, 64), (2, 4, 32, 16), 3, id="4d_dim3"),
+        pytest.param((2, 4, 32, 64), (2, 4, 32, 16), -1, id="4d_negdim3"),
+        pytest.param((2, 4, 32, 64), (1, 2, 16, 32), 2, id="4d_dim2_all_smaller"),
+        # ---- 5D ----
+        pytest.param((2, 3, 4, 8, 16), (2, 3, 4, 8, 8), 4, id="5d_dim4"),
+        pytest.param((2, 3, 4, 8, 16), (1, 2, 2, 4, 8), 0, id="5d_dim0_all_smaller"),
+    ],
+)
+def test_gather_replicated(input_shape, index_shape, dim):
+    xr.set_device_type("TT")
+
+    input = torch.randn(*input_shape, dtype=torch.bfloat16)
+    index_max = input_shape[dim]
+    index = torch.randint(0, index_max, index_shape, dtype=torch.int64)
+
+    run_graph_test(
+        SimpleGather(dim),
+        [input, index],
+        framework=Framework.TORCH,
+    )
+
+
+@pytest.mark.parametrize(
+    "input_shape,index_shape,dim",
+    [
+        ((8, 32), (8, 16), 0),
+    ],
+    ids=["2d_dim1"],
+)
+def test_gather_sharded(input_shape, index_shape, dim):
+    xr.set_device_type("TT")
+
+    # Setup mesh and shard spec
+    num_devices = xr.global_runtime_device_count()
+    mesh_shape = (2, num_devices // 2) if num_devices >= 2 else (1, 1)
+    device_ids = np.array(range(num_devices))
+    mesh = Mesh(device_ids, mesh_shape, ("batch", "model"))
+
+    def get_shard_spec(module, args, kwargs):
+        input, index = args
+        return {
+            input: (None, "batch"),
+            index: (None, "batch"),
+        }
+
+    input = torch.randn(*input_shape, dtype=torch.bfloat16)
+    index_max = input_shape[dim]
+    index = torch.randint(0, index_max, index_shape, dtype=torch.int64)
+
+    run_graph_test(
+        SimpleGather(dim),
+        [input, index],
+        framework=Framework.TORCH,
+        # mesh=mesh,
+        # shard_spec_fn=get_shard_spec,
+    )


### PR DESCRIPTION
### Ticket
Fixes https://github.com/tenstorrent/tt-xla/issues/3726
Fixes https://github.com/tenstorrent/tt-xla/issues/4329

### Problem description
We want an easy way to represent torch.gather semantics inside tt-mlir, so that it can get lowered to ttnn.gather (which has the same semantics as torch.gather).

### What's changed
- Added a composite op for torch.gather
- Added op tests for various torch.gather scenarios.

### Checklist
- [ ] New/Existing tests provide coverage for changes
