### PR TITLE
[vLLM] Support metal trace for Llama/RoPE models

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -1390,11 +1390,23 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             # temperature scaling) for the top-k logprobs. We can't enforce it
             # due to recompilations outside torch.compiled code, so just make
             # sure `sample_from_logits` does not modify the logits in-place.
-            logprobs = (
-                self.gather_logprobs(logits, selected_token_ids)
-                if sampling_metadata.logprobs
-                else None
-            )
+            if not sampling_metadata.logprobs:
+                logprobs = None
+            elif self.tt_config.enable_trace:
+                # TODO(#4387): remove once trace-insertion pass handles
+                # ttir.embedding on on-device indices. The on-device
+                # gather_logprobs graph fails trace at opt_level=1, so
+                # fall back to CPU — post-processing is cheap and only
+                # the sampled-token id + logits need to move to host.
+                logits_cpu = logits.cpu()
+                tokens_cpu = selected_token_ids.cpu()
+                logprobs = self.sampler.gather_logprobs(
+                    self.sampler.compute_logprobs(logits_cpu),
+                    self.model_config.max_logprobs,
+                    token_ids=tokens_cpu.squeeze(-1),
+                )
+            else:
+                logprobs = self.gather_logprobs(logits, selected_token_ids)
 
             # Remove padding on cpu and keep dynamic op outside of xla graph.
             selected_token_ids = selected_token_ids.cpu()[:num_reqs]
@@ -1920,7 +1932,11 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 logger.warning(
                     "cpu_sampling=True: skipping device sampling precompilation"
                 )
-            self._precompile_gather_logprobs()
+            # TODO(#4387): precompile fails trace-insertion at opt_level=1;
+            # skip when trace is on. Paired with the CPU fallback at the
+            # runtime call site. Remove both once the compiler bug is fixed.
+            if not self.tt_config.enable_trace:
+                self._precompile_gather_logprobs()
 
     def profile_run(
         self,

--- a/integrations/vllm_plugin/vllm_tt/overrides.py
+++ b/integrations/vllm_plugin/vllm_tt/overrides.py
@@ -7,6 +7,8 @@ from typing import OrderedDict
 import torch
 import torch.nn as nn
 from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.rotary_embedding.base import RotaryEmbedding
+from vllm.model_executor.layers.rotary_embedding.common import ApplyRotaryEmb
 
 from .logger import tt_init_logger
 
@@ -83,15 +85,75 @@ class TTRMSNorm(nn.Module):
             return x, residual
 
 
+class TTRotaryEmbedding(nn.Module):
+    """TT-compatible RotaryEmbedding that computes cos/sin on-the-fly.
+
+    vLLM's RotaryEmbedding pre-builds a cos_sin_cache and uses index_select
+    (gather) with position_ids at runtime. This lowers to ttir.embedding which
+    requires indices on host via from_device, breaking metal trace mode.
+
+    This replacement computes cos/sin from inv_freq and positions using math
+    ops (outer product + cos/sin) that stay entirely on device.
+    """
+
+    def __init__(self, layer: nn.Module):
+        super().__init__()
+        assert isinstance(layer, RotaryEmbedding)
+        self.head_size = layer.head_size
+        self.rotary_dim = layer.rotary_dim
+        self.is_neox_style = layer.is_neox_style
+        # Delegates to the subclass implementation for correct frequency scaling
+        # (e.g. Llama3RotaryEmbedding applies frequency-dependent scaling)
+        inv_freq = layer._compute_inv_freq(layer.base)
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+
+    def _apply_rotary(
+        self,
+        x: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        num_tokens: int,
+    ) -> torch.Tensor:
+        orig_shape = x.shape
+        x = x.view(num_tokens, -1, self.head_size)
+        x_rot = ApplyRotaryEmb.forward_static(
+            x[..., : self.rotary_dim], cos, sin, self.is_neox_style
+        )
+        if self.rotary_dim == self.head_size:
+            return x_rot.reshape(orig_shape)
+        return torch.cat((x_rot, x[..., self.rotary_dim :]), dim=-1).reshape(orig_shape)
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        query: torch.Tensor,
+        key: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        positions_flat = positions.flatten().to(torch.float32)
+        num_tokens = positions_flat.shape[0]
+
+        freqs = torch.outer(positions_flat, self.inv_freq)
+        cos = freqs.cos().to(query.dtype)
+        sin = freqs.sin().to(query.dtype)
+
+        query = self._apply_rotary(query, cos, sin, num_tokens)
+        if key is not None:
+            key = self._apply_rotary(key, cos, sin, num_tokens)
+        return query, key
+
+
 def get_fqn(module):
     return module.__class__.__qualname__
 
 
 def tt_rmsnorm_module(layer: torch.nn.Module) -> torch.nn.Module:
     assert isinstance(layer, RMSNorm)
-    tt_layer = TTRMSNorm(layer)
-    logger.debug("Wrapped RMSNorm module %s with TT-compatible version", layer)
-    return tt_layer
+    return TTRMSNorm(layer)
+
+
+def tt_rotary_embedding_module(layer: torch.nn.Module) -> torch.nn.Module:
+    assert isinstance(layer, RotaryEmbedding)
+    return TTRotaryEmbedding(layer)
 
 
 MODULE_TYPE_TO_TT_OVERRIDE = OrderedDict(
@@ -100,24 +162,35 @@ MODULE_TYPE_TO_TT_OVERRIDE = OrderedDict(
     ]
 )
 
+# isinstance-based overrides for classes where subclasses need the same treatment
+ISINSTANCE_OVERRIDES = [
+    (RotaryEmbedding, tt_rotary_embedding_module),
+]
+
 
 def replace_modules(model: torch.nn.Module) -> None:
     logger.info(
         "Replacing vLLM modules with TT-compatible overrides where necessary..."
     )
 
-    def _process_module(module, name=None, parent=None):
-        if get_fqn(module) in MODULE_TYPE_TO_TT_OVERRIDE:
-            tt_override_cls = MODULE_TYPE_TO_TT_OVERRIDE[get_fqn(module)]
-            replacement_module = tt_override_cls(module)
+    def _find_override(module):
+        fqn = get_fqn(module)
+        if fqn in MODULE_TYPE_TO_TT_OVERRIDE:
+            return MODULE_TYPE_TO_TT_OVERRIDE[fqn](module)
+        for base_cls, override_fn in ISINSTANCE_OVERRIDES:
+            if isinstance(module, base_cls):
+                return override_fn(module)
+        return None
 
+    def _process_module(module, name=None, parent=None):
+        replacement = _find_override(module)
+        if replacement is not None:
             assert (
                 parent is not None and name is not None
             ), "Top Level module is not expected to be wrapped."
-            logger.debug("replace %s with %s", module, replacement_module)
-            setattr(parent, name, replacement_module)
-
-            module = replacement_module
+            logger.debug("replace %s with %s", module, replacement)
+            setattr(parent, name, replacement)
+            module = replacement
 
         for child_name, child_module in list(module.named_children()):
             _process_module(child_module, child_name, module)

--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -94,12 +94,15 @@ class TTConfig:
     # Flag to enable 2D mesh for tensor parallel execution.
     use_2d_mesh: bool = True
 
+    enable_trace: bool = False
+
     def get_pjrt_compile_config(self) -> dict:
         return {
             "enable_const_eval": self.enable_const_eval,
             "enable_const_eval_on_cpu": self.enable_const_eval_on_cpu,
             "optimization_level": self.optimization_level,
             "experimental_weight_dtype": self.experimental_weight_dtype,
+            "enable_trace": "true" if self.enable_trace else "false",
         }
 
 

--- a/tests/integrations/vllm_plugin/generative/test_llama3_3b_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_llama3_3b_generation.py
@@ -27,3 +27,32 @@ def test_llama3_3b_generation():
 
     output_text = llm.generate(prompts, sampling_params)[0].outputs[0].text
     print(f"prompt: {prompts[0]}, output: {output_text}")
+
+
+@pytest.mark.nightly
+@pytest.mark.single_device
+def test_llama3_3b_generation_trace():
+    """Trace variant: greedy + device sampling so the metal-trace path is exercised."""
+    prompts = [
+        "I like taking walks in the",
+    ]
+    sampling_params = vllm.SamplingParams(temperature=0, max_tokens=32)
+    llm_args = {
+        "model": "meta-llama/Llama-3.2-3B",
+        "max_num_batched_tokens": 128,
+        "max_num_seqs": 1,
+        "max_model_len": 128,
+        "gpu_memory_utilization": 0.002,
+        "additional_config": {
+            "cpu_sampling": False,
+            "enable_trace": True,
+            "enable_const_eval": True,
+            "experimental_weight_dtype": "bfp_bf8",
+            "optimization_level": 1,
+        },
+    }
+    llm = vllm.LLM(**llm_args)
+
+    output_text = llm.generate(prompts, sampling_params)[0].outputs[0].text
+    print(f"prompt: {prompts[0]}, output: {output_text}")
+    assert len(output_text) > 0, "Expected non-empty generation"

--- a/tests/integrations/vllm_plugin/sampling/test_trace_logprobs.py
+++ b/tests/integrations/vllm_plugin/sampling/test_trace_logprobs.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Regression guard for SamplingParams(logprobs=N) + enable_trace.
+
+The on-device gather_logprobs graph fails trace-insertion at opt_level=1
+(tracked in tt-xla#4387). Until that compiler bug is fixed, model_runner
+routes logprob post-processing through a CPU fallback whenever
+enable_trace=True. This test exercises the path at opt_level=1 to ensure
+the fallback stays wired up.
+
+When the compiler bug is fixed, remove the CPU fallback in
+model_runner.py and the startup skip of _precompile_gather_logprobs
+together; this test should keep passing via the on-device path.
+"""
+import pytest
+import vllm
+
+
+@pytest.mark.nightly
+@pytest.mark.single_device
+def test_opt125m_trace_logprobs():
+    """Logprobs + trace at opt_level=1: exercised via CPU fallback."""
+    llm = vllm.LLM(
+        model="facebook/opt-125m",
+        max_num_batched_tokens=128,
+        max_num_seqs=1,
+        max_model_len=128,
+        gpu_memory_utilization=0.001,
+        additional_config={
+            "cpu_sampling": False,
+            "enable_trace": True,
+            "enable_const_eval": True,
+            "experimental_weight_dtype": "bfp_bf8",
+            "optimization_level": 1,
+        },
+    )
+    sp = vllm.SamplingParams(temperature=0, max_tokens=8, logprobs=1)
+    out = llm.generate(["Hello, my name is"], sp)[0]
+    assert out.outputs[0].logprobs is not None


### PR DESCRIPTION
## Ticket

Closes #4220
Related: #4387 (follow-up compiler bug for `gather_logprobs` under trace)

## Problem description

Metal trace (`enable_trace`) gives a decode-side speedup through vLLM (small to large depending on model) but fails on all Llama/RoPE models because vLLM's `RotaryEmbedding` gathers from a pre-built `cos_sin_cache` using `position_ids`. That lowers to `ttir.embedding`, which requires `from_device` on the indices and violates the trace constraint that all outputs must remain on-device. A second graph — `gather_logprobs` — hits the same class of failure at `opt_level=1`.

Both are worked around at the vLLM integration layer following the existing `TTRMSNorm` precedent in `overrides.py`; a compiler-side fix (#4387) would make vLLM's native paths work and is a candidate follow-up. See follow-up comment for full design rationale and perf numbers.

## What's changed

- `integrations/vllm_plugin/vllm_tt/platform.py`: add `enable_trace` field to `TTConfig` (default `False`), wired through `get_pjrt_compile_config()`.
- `integrations/vllm_plugin/vllm_tt/overrides.py`: add `TTRotaryEmbedding` replacing vLLM's `RotaryEmbedding` and its subclasses (e.g. `Llama3RotaryEmbedding`). Introduces an `ISINSTANCE_OVERRIDES` dispatch alongside the existing fqn-based map so subclasses inherit the override.
- `integrations/vllm_plugin/vllm_tt/model_runner.py`: (a) skip `_precompile_gather_logprobs` at startup when `enable_trace=True`; (b) route `gather_logprobs` through CPU at the runtime call site when `enable_trace=True`. Both tagged `TODO(#4387)`.
- `tests/integrations/vllm_plugin/sampling/test_trace_logprobs.py`: new regression test exercising the CPU-fallback path at `opt_level=1`.
- `tests/integrations/vllm_plugin/generative/test_llama3_3b_generation.py`: add `test_llama3_3b_generation_trace` variant (greedy + device sampling + bfp8 + const-eval + opt_level=1) to exercise the metal-trace path end-to-end on a RoPE model.

## Checklist

- [x] Unit / integration tests added
- [x] Benchmark numbers verified locally (posted as follow-up comment)