### PR TITLE
Fix A2aSparseMLP dense down-proj reshape

### DIFF
--- a/python_package/tt_torch/sparse_mlp.py
+++ b/python_package/tt_torch/sparse_mlp.py
@@ -617,7 +617,7 @@ class A2aSparseMLP(nn.Module):
                     activated = (up_out + 1) * glu
 
             # Down: bmm over experts — [E, T, inter] @ [E, inter, H] → [E, T, H]
-            act_per_expert = activated.permute(0, 1, 3, 2, 4).reshape(
+            act_per_expert = activated.reshape(
                 dim_a * dim_b * M, E, self.intermediate_size
             )
             act_per_expert = act_per_expert.permute(


### PR DESCRIPTION
### Ticket
N/A

### Problem description
There was an extra permute added in the dense path for A2ASparseMLP.

`activated` has shape [dim_a, dim_b, M, E, self.intermediate_size] because both up out and gate out have that shape, which can be seen few lines above this one.


### Checklist
- [ ] New/Existing tests provide coverage for changes
