### PR TITLE
Add support for new ForgePrefillModel class in testing infra

### DIFF
--- a/tests/runner/test_models.py
+++ b/tests/runner/test_models.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
-import inspect
 import os
 import shutil
 import socket
@@ -58,7 +57,23 @@ MODELS_ROOT_TORCH, test_entries_torch = TorchDynamicLoader.setup_test_discovery(
     PROJECT_ROOT
 )
 MODELS_ROOT_JAX, test_entries_jax = JaxDynamicLoader.setup_test_discovery(PROJECT_ROOT)
-all_test_entries = test_entries_torch + test_entries_jax
+
+# setup_test_discovery adds the models root to sys.path, so ForgeFocusModel
+# can now be imported from the same namespace as the dynamically loaded loaders.
+from tt_forge_models.base import ForgeFocusModel  # noqa: E402
+
+
+def _is_focus_loader(entry) -> bool:
+    """Return True if the entry's loader class is a ForgeFocusModel subclass."""
+    return issubclass(entry.variant_info[1], ForgeFocusModel)
+
+
+# Regular (non-focus) torch entries drive test_all_models_torch. Focus loaders
+# only participate in LLM-phase tests (see _llm_test_params below).
+test_entries_torch_regular = [
+    entry for entry in test_entries_torch if not _is_focus_loader(entry)
+]
+all_test_entries = test_entries_torch_regular + test_entries_jax
 
 
 def _run_model_test_impl(
@@ -297,7 +312,7 @@ def _run_model_test_impl(
 )
 @pytest.mark.parametrize(
     "test_entry",
-    test_entries_torch,
+    test_entries_torch_regular,
     ids=DynamicLoader.create_test_id_generator(MODELS_ROOT_TORCH),
 )
 def test_all_models_torch(
@@ -383,10 +398,15 @@ def test_all_models_jax(
 # LLM Specific tests for decode and prefill phases. Separate test to avoid impacting
 # original test names in test_all_models_torch and no need for collection-time deselection logic.
 
-# Build list of (test_entry, run_phase) pairs based on loader capabilities
+# Build list of (test_entry, run_phase) pairs based on loader capabilities.
+# Focus loaders are dedicated to the prefill phase; regular (non-focus) loaders
+# provide decode (and, for legacy non-focus loaders, prefill via hasattr).
 _llm_test_params = []
 for entry in test_entries_torch:
     ModelLoader = entry.variant_info[1]
+    if _is_focus_loader(entry):
+        _llm_test_params.append((entry, RunPhase.LLM_PREFILL))
+        continue
     if hasattr(ModelLoader, "load_inputs_decode"):
         _llm_test_params.append((entry, RunPhase.LLM_DECODE))
     if hasattr(ModelLoader, "load_inputs_prefill"):
@@ -417,15 +437,13 @@ def _generate_mesh_shape_id(mesh_shape):
 
 
 def _supports_strategy_shard_spec(model_loader_cls) -> bool:
-    """Return True if loader.load_shard_spec supports strategy/batch_axis kwargs."""
-    if not hasattr(model_loader_cls, "load_shard_spec"):
-        return False
-    try:
-        signature = inspect.signature(model_loader_cls.load_shard_spec)
-    except (TypeError, ValueError):
-        return False
-    params = signature.parameters
-    return "strategy" in params and "batch_axis" in params
+    """Return True if loader.load_shard_spec supports strategy/batch_axis kwargs.
+
+    ForgeFocusModel subclasses are required to implement
+    ``load_shard_spec(model, strategy, batch_axis)`` per base.py, so this
+    simply checks for focus-loader identity.
+    """
+    return issubclass(model_loader_cls, ForgeFocusModel)
 
 
 # Mesh shapes that support explicit FSDP/Megatron sharding strategies.

--- a/tests/runner/test_models.py
+++ b/tests/runner/test_models.py
@@ -399,8 +399,7 @@ def test_all_models_jax(
 # original test names in test_all_models_torch and no need for collection-time deselection logic.
 
 # Build list of (test_entry, run_phase) pairs based on loader capabilities.
-# Focus loaders are dedicated to the prefill phase; regular (non-focus) loaders
-# provide decode (and, for legacy non-focus loaders, prefill via hasattr).
+# Focus loaders own the prefill phase; regular ModelLoaders provide decode.
 _llm_test_params = []
 for entry in test_entries_torch:
     ModelLoader = entry.variant_info[1]
@@ -409,8 +408,6 @@ for entry in test_entries_torch:
         continue
     if hasattr(ModelLoader, "load_inputs_decode"):
         _llm_test_params.append((entry, RunPhase.LLM_DECODE))
-    if hasattr(ModelLoader, "load_inputs_prefill"):
-        _llm_test_params.append((entry, RunPhase.LLM_PREFILL))
 
 
 def _generate_llm_test_id(param_tuple):

--- a/tests/runner/test_models.py
+++ b/tests/runner/test_models.py
@@ -58,20 +58,20 @@ MODELS_ROOT_TORCH, test_entries_torch = TorchDynamicLoader.setup_test_discovery(
 )
 MODELS_ROOT_JAX, test_entries_jax = JaxDynamicLoader.setup_test_discovery(PROJECT_ROOT)
 
-# setup_test_discovery adds the models root to sys.path, so ForgeFocusModel
+# setup_test_discovery adds the models root to sys.path, so ForgePrefillModel
 # can now be imported from the same namespace as the dynamically loaded loaders.
-from tt_forge_models.base import ForgeFocusModel  # noqa: E402
+from tt_forge_models.base import ForgePrefillModel  # noqa: E402
 
 
-def _is_focus_loader(entry) -> bool:
-    """Return True if the entry's loader class is a ForgeFocusModel subclass."""
-    return issubclass(entry.variant_info[1], ForgeFocusModel)
+def _is_prefill_loader(entry) -> bool:
+    """Return True if the entry's loader class is a ForgePrefillModel subclass."""
+    return issubclass(entry.variant_info[1], ForgePrefillModel)
 
 
-# Regular (non-focus) torch entries drive test_all_models_torch. Focus loaders
+# Regular (non-prefill) torch entries drive test_all_models_torch. Prefill loaders
 # only participate in LLM-phase tests (see _llm_test_params below).
 test_entries_torch_regular = [
-    entry for entry in test_entries_torch if not _is_focus_loader(entry)
+    entry for entry in test_entries_torch if not _is_prefill_loader(entry)
 ]
 all_test_entries = test_entries_torch_regular + test_entries_jax
 
@@ -399,11 +399,11 @@ def test_all_models_jax(
 # original test names in test_all_models_torch and no need for collection-time deselection logic.
 
 # Build list of (test_entry, run_phase) pairs based on loader capabilities.
-# Focus loaders own the prefill phase; regular ModelLoaders provide decode.
+# Prefill loaders own the prefill phase; regular ModelLoaders provide decode.
 _llm_test_params = []
 for entry in test_entries_torch:
     ModelLoader = entry.variant_info[1]
-    if _is_focus_loader(entry):
+    if _is_prefill_loader(entry):
         _llm_test_params.append((entry, RunPhase.LLM_PREFILL))
         continue
     if hasattr(ModelLoader, "load_inputs_decode"):
@@ -436,11 +436,11 @@ def _generate_mesh_shape_id(mesh_shape):
 def _supports_strategy_shard_spec(model_loader_cls) -> bool:
     """Return True if loader.load_shard_spec supports strategy/batch_axis kwargs.
 
-    ForgeFocusModel subclasses are required to implement
+    ForgePrefillModel subclasses are required to implement
     ``load_shard_spec(model, strategy, batch_axis)`` per base.py, so this
-    simply checks for focus-loader identity.
+    simply checks for prefill-loader identity.
     """
-    return issubclass(model_loader_cls, ForgeFocusModel)
+    return issubclass(model_loader_cls, ForgePrefillModel)
 
 
 # Mesh shapes that support explicit FSDP/Megatron sharding strategies.

--- a/tests/runner/testers/torch/dynamic_torch_model_tester.py
+++ b/tests/runner/testers/torch/dynamic_torch_model_tester.py
@@ -5,7 +5,6 @@
 """Dynamic Torch model tester implementation."""
 
 import collections
-import inspect
 from typing import Any
 
 import torch
@@ -194,28 +193,22 @@ class DynamicTorchModelTester(TorchModelTester):
         if loader_shard_spec_fn is None:
             return None
 
-        supports_strategy_kwargs = False
-        try:
-            # TODO(umales): Remove inspect check, once we migrate to custom loader class for
-            # Focus models.
-            signature = inspect.signature(self.dynamic_loader.loader.load_shard_spec)
-            params = signature.parameters
-            supports_strategy_kwargs = "strategy" in params and "batch_axis" in params
-        except (TypeError, ValueError):
-            supports_strategy_kwargs = False
+        # Lazy import to match the namespace of dynamically loaded model
+        # modules, so isinstance checks see the same class object.
+        from tt_forge_models.base import ForgeFocusModel
 
         # Build the weight shard spec function.
         # When shard_inputs is on, the mesh uses ("data", "model") axes, so FSDP
         # specs must use "data" instead of "batch" — handled by batch_axis arg.
         # (Megatron ignores batch_axis — its non-model axis is always None.)
         batch_axis = "data" if shard_inputs else "batch"
-        if supports_strategy_kwargs:
+        if isinstance(self.dynamic_loader.loader, ForgeFocusModel):
             weight_fn = lambda model: self.dynamic_loader.loader.load_shard_spec(
                 model, strategy=str(strategy), batch_axis=batch_axis
             )
         else:
-            # Backward-compat fallback: ignore explicit strategy if loader does
-            # not support strategy kwargs.
+            # Backward-compat fallback: ignore explicit strategy if loader is
+            # not a ForgeFocusModel (its load_shard_spec has no strategy kwargs).
             weight_fn = loader_shard_spec_fn
 
         if shard_inputs:

--- a/tests/runner/testers/torch/dynamic_torch_model_tester.py
+++ b/tests/runner/testers/torch/dynamic_torch_model_tester.py
@@ -195,20 +195,20 @@ class DynamicTorchModelTester(TorchModelTester):
 
         # Lazy import to match the namespace of dynamically loaded model
         # modules, so isinstance checks see the same class object.
-        from tt_forge_models.base import ForgeFocusModel
+        from tt_forge_models.base import ForgePrefillModel
 
         # Build the weight shard spec function.
         # When shard_inputs is on, the mesh uses ("data", "model") axes, so FSDP
         # specs must use "data" instead of "batch" — handled by batch_axis arg.
         # (Megatron ignores batch_axis — its non-model axis is always None.)
         batch_axis = "data" if shard_inputs else "batch"
-        if isinstance(self.dynamic_loader.loader, ForgeFocusModel):
+        if isinstance(self.dynamic_loader.loader, ForgePrefillModel):
             weight_fn = lambda model: self.dynamic_loader.loader.load_shard_spec(
                 model, strategy=str(strategy), batch_axis=batch_axis
             )
         else:
             # Backward-compat fallback: ignore explicit strategy if loader is
-            # not a ForgeFocusModel (its load_shard_spec has no strategy kwargs).
+            # not a ForgePrefillModel (its load_shard_spec has no strategy kwargs).
             weight_fn = loader_shard_spec_fn
 
         if shard_inputs:

--- a/tests/runner/utils/dynamic_loader.py
+++ b/tests/runner/utils/dynamic_loader.py
@@ -199,9 +199,9 @@ class DynamicLoader:
         """Dynamically import a loader.py and return its module.
 
         Returning the module (rather than just ``ModelLoader``) lets callers
-        inspect sibling classes — e.g. ``ForgeFocusModel`` subclasses living in
-        the same file — without having to recompute the dashed ``sys.modules``
-        key used below.
+        inspect sibling classes — e.g. ``ForgePrefillModel`` subclasses living
+        in the same file — without having to recompute the dashed
+        ``sys.modules`` key used below.
 
         Args:
             loader_path: Path to the loader.py file
@@ -248,9 +248,9 @@ class DynamicLoader:
     def get_model_variants(cls, loader_path: str, loader_paths: Dict, models_root: str):
         """Fill loader_paths[loader_path] with (variant_name, LoaderCls) tuples.
 
-        Registers the primary ``ModelLoader`` plus any ``ForgeFocusModel``
+        Registers the primary ``ModelLoader`` plus any ``ForgePrefillModel``
         subclass defined in the same module, so one loader.py can host both
-        non-focus and focus loaders.
+        regular and prefill-specialized loaders.
 
         Args:
             loader_path: Path to the loader.py file
@@ -263,16 +263,16 @@ class DynamicLoader:
 
             # Lazy import: must come from the same namespace the dynamically
             # loaded module uses, so issubclass sees the same class object.
-            from tt_forge_models.base import ForgeFocusModel
+            from tt_forge_models.base import ForgePrefillModel
 
             loader_classes = [ModelLoader]
             for attr_name in dir(mod):
                 attr = getattr(mod, attr_name)
                 if not isinstance(attr, type):
                     continue
-                if attr is ForgeFocusModel or attr is ModelLoader:
+                if attr is ForgePrefillModel or attr is ModelLoader:
                     continue
-                if not issubclass(attr, ForgeFocusModel):
+                if not issubclass(attr, ForgePrefillModel):
                     continue
                 if getattr(attr, "__module__", None) != mod.__name__:
                     continue
@@ -428,10 +428,10 @@ class TorchDynamicLoader(DynamicLoader):
         if run_phase == RunPhase.LLM_PREFILL:
             # Lazy import to ensure we get the same class object as the
             # dynamically imported loader modules.
-            from tt_forge_models.base import ForgeFocusModel
+            from tt_forge_models.base import ForgePrefillModel
 
-            assert isinstance(self.loader, ForgeFocusModel), (
-                f"{type(self.loader).__name__} must be a ForgeFocusModel "
+            assert isinstance(self.loader, ForgePrefillModel), (
+                f"{type(self.loader).__name__} must be a ForgePrefillModel "
                 f"subclass for run_phase={run_phase}"
             )
 

--- a/tests/runner/utils/dynamic_loader.py
+++ b/tests/runner/utils/dynamic_loader.py
@@ -196,14 +196,18 @@ class DynamicLoader:
 
     @classmethod
     def import_model_loader(cls, loader_path: str, models_root: str):
-        """Dynamically import and return ModelLoader class from a loader.py path, ensuring relative imports work.
+        """Dynamically import a loader.py and return ``(module, ModelLoader)``.
+
+        Returning the module lets callers inspect sibling classes (e.g.
+        ``ForgeFocusModel`` subclasses living in the same file) without having
+        to recompute the dashed ``sys.modules`` key used below.
 
         Args:
             loader_path: Path to the loader.py file
             models_root: Root directory of the models
 
         Returns:
-            ModelLoader class from the imported module
+            Tuple of (module object, ModelLoader class)
         """
         # Import the base module first to ensure it's available
         models_parent = os.path.dirname(models_root)
@@ -236,11 +240,15 @@ class DynamicLoader:
         sys.modules[module_path] = mod
         spec.loader.exec_module(mod)
 
-        return mod.ModelLoader
+        return mod, mod.ModelLoader
 
     @classmethod
     def get_model_variants(cls, loader_path: str, loader_paths: Dict, models_root: str):
-        """Fill loader_paths[loader_path] with (variant_name, ModelLoader) tuples by querying the loader; on failure, log and continue.
+        """Fill loader_paths[loader_path] with (variant_name, LoaderCls) tuples.
+
+        Registers the primary ``ModelLoader`` plus any ``ForgeFocusModel``
+        subclass defined in the same module, so one loader.py can host both
+        non-focus and focus loaders.
 
         Args:
             loader_path: Path to the loader.py file
@@ -248,16 +256,32 @@ class DynamicLoader:
             models_root: Root directory of the models
         """
         try:
-            # Import the ModelLoader class from the module
-            ModelLoader = cls.import_model_loader(loader_path, models_root)
-            variants = ModelLoader.query_available_variants()
+            mod, ModelLoader = cls.import_model_loader(loader_path, models_root)
 
-            # Store variant_name, ModelLoader together for usage, or empty one if no variants found.
-            if variants:
-                for variant_name in variants.keys():
-                    loader_paths[loader_path].append((variant_name, ModelLoader))
-            else:
-                loader_paths[loader_path].append((None, ModelLoader))
+            # Lazy import: must come from the same namespace the dynamically
+            # loaded module uses, so issubclass sees the same class object.
+            from tt_forge_models.base import ForgeFocusModel
+
+            loader_classes = [ModelLoader]
+            for attr_name in dir(mod):
+                attr = getattr(mod, attr_name)
+                if not isinstance(attr, type):
+                    continue
+                if attr is ForgeFocusModel or attr is ModelLoader:
+                    continue
+                if not issubclass(attr, ForgeFocusModel):
+                    continue
+                if getattr(attr, "__module__", None) != mod.__name__:
+                    continue
+                loader_classes.append(attr)
+
+            for LoaderCls in loader_classes:
+                variants = LoaderCls.query_available_variants()
+                if variants:
+                    for variant_name in variants.keys():
+                        loader_paths[loader_path].append((variant_name, LoaderCls))
+                else:
+                    loader_paths[loader_path].append((None, LoaderCls))
 
         except Exception as e:
             logger.warning(f"Cannot import path: {loader_path}: {e}")
@@ -399,19 +423,20 @@ class TorchDynamicLoader(DynamicLoader):
             return self.loader.load_inputs_decode(**kwargs)
 
         if run_phase == RunPhase.LLM_PREFILL:
-            assert hasattr(
-                self.loader, "load_inputs_prefill"
-            ), f"{type(self.loader).__name__} missing load_inputs_prefill for run_phase={run_phase}"
+            # Lazy import to ensure we get the same class object as the
+            # dynamically imported loader modules.
+            from tt_forge_models.base import ForgeFocusModel
 
-            prefill_sig = inspect.signature(self.loader.load_inputs_prefill)
-            kwargs = {}
-            if "dtype_override" in prefill_sig.parameters:
-                kwargs["dtype_override"] = torch.bfloat16
-            if "seq_len" in prefill_sig.parameters and seq_len is not None:
-                kwargs["seq_len"] = seq_len
-            if "batch_size" in prefill_sig.parameters and batch_size is not None:
-                kwargs["batch_size"] = batch_size
-            return self.loader.load_inputs_prefill(**kwargs)
+            assert isinstance(self.loader, ForgeFocusModel), (
+                f"{type(self.loader).__name__} must be a ForgeFocusModel "
+                f"subclass for run_phase={run_phase}"
+            )
+
+            return self.loader.load_inputs_prefill(
+                dtype_override=torch.bfloat16,
+                batch_size=batch_size,
+                seq_len=seq_len,
+            )
 
         # Default path
         kwargs = {}

--- a/tests/runner/utils/dynamic_loader.py
+++ b/tests/runner/utils/dynamic_loader.py
@@ -195,19 +195,21 @@ class DynamicLoader:
         return models_root
 
     @classmethod
-    def import_model_loader(cls, loader_path: str, models_root: str):
-        """Dynamically import a loader.py and return ``(module, ModelLoader)``.
+    def import_loader_module(cls, loader_path: str, models_root: str):
+        """Dynamically import a loader.py and return its module.
 
-        Returning the module lets callers inspect sibling classes (e.g.
-        ``ForgeFocusModel`` subclasses living in the same file) without having
-        to recompute the dashed ``sys.modules`` key used below.
+        Returning the module (rather than just ``ModelLoader``) lets callers
+        inspect sibling classes — e.g. ``ForgeFocusModel`` subclasses living in
+        the same file — without having to recompute the dashed ``sys.modules``
+        key used below.
 
         Args:
             loader_path: Path to the loader.py file
             models_root: Root directory of the models
 
         Returns:
-            Tuple of (module object, ModelLoader class)
+            The imported module object. Callers access ``mod.ModelLoader`` (and
+            any sibling classes) directly.
         """
         # Import the base module first to ensure it's available
         models_parent = os.path.dirname(models_root)
@@ -240,7 +242,7 @@ class DynamicLoader:
         sys.modules[module_path] = mod
         spec.loader.exec_module(mod)
 
-        return mod, mod.ModelLoader
+        return mod
 
     @classmethod
     def get_model_variants(cls, loader_path: str, loader_paths: Dict, models_root: str):
@@ -256,7 +258,8 @@ class DynamicLoader:
             models_root: Root directory of the models
         """
         try:
-            mod, ModelLoader = cls.import_model_loader(loader_path, models_root)
+            mod = cls.import_loader_module(loader_path, models_root)
+            ModelLoader = mod.ModelLoader
 
             # Lazy import: must come from the same namespace the dynamically
             # loaded module uses, so issubclass sees the same class object.

--- a/tests/runner/validate_test_config.py
+++ b/tests/runner/validate_test_config.py
@@ -185,8 +185,8 @@ def _has_method(tree: ast.Module, class_name: str, method_name: str) -> bool:
     """Check if a given class defines a specific method (e.g. load_inputs_decode).
 
     Only methods declared directly in the class body are considered; inherited
-    methods are intentionally invisible so a focus subclass doesn't falsely claim
-    ownership of phases its parent owns (which would duplicate test IDs).
+    methods are intentionally invisible so a prefill subclass doesn't falsely
+    claim ownership of phases its parent owns (which would duplicate test IDs).
     """
     for node in ast.walk(tree):
         if not isinstance(node, ast.ClassDef):
@@ -200,12 +200,12 @@ def _has_method(tree: ast.Module, class_name: str, method_name: str) -> bool:
     return False
 
 
-def _find_focus_class_name(tree: ast.Module) -> str:
-    """Return the name of the class that inherits from ForgeFocusModel, if any.
+def _find_prefill_class_name(tree: ast.Module) -> str:
+    """Return the name of the class that inherits from ForgePrefillModel, if any.
 
     Detection is by AST base reference (Name or Attribute), so any class whose
-    declared bases include ``ForgeFocusModel`` is recognised regardless of how
-    it's named.
+    declared bases include ``ForgePrefillModel`` is recognised regardless of
+    how it's named.
     """
     for node in ast.walk(tree):
         if not isinstance(node, ast.ClassDef):
@@ -216,7 +216,7 @@ def _find_focus_class_name(tree: ast.Module) -> str:
                 base_name = base.id
             elif isinstance(base, ast.Attribute):
                 base_name = base.attr
-            if base_name == "ForgeFocusModel":
+            if base_name == "ForgePrefillModel":
                 return node.name
     return ""
 
@@ -426,25 +426,26 @@ class TestConfigValidator:
                 else:
                     torch_models.append((rel_path, None))
 
-                # ForgeFocusModel subclasses (e.g. ModelLoaderFocus) live alongside
-                # ModelLoader and own the prefill phase with their own _VARIANTS
-                # subset; fall back to ModelLoader's variants if not overridden.
-                focus_class_name = _find_focus_class_name(tree)
-                focus_variants = []
-                if focus_class_name:
-                    focus_variants = (
+                # ForgePrefillModel subclasses (e.g. ModelLoaderPrefill) live
+                # alongside ModelLoader and own the prefill phase with their own
+                # _VARIANTS subset; fall back to ModelLoader's variants if not
+                # overridden.
+                prefill_class_name = _find_prefill_class_name(tree)
+                prefill_variants = []
+                if prefill_class_name:
+                    prefill_variants = (
                         _extract_variants_for_class(
-                            tree, enum_members, focus_class_name
+                            tree, enum_members, prefill_class_name
                         )
                         or variants
                     )
 
                 for method_name, phase_str in LLM_PHASES.items():
                     if phase_str == "llm_prefill":
-                        if focus_class_name and _has_method(
-                            tree, focus_class_name, method_name
+                        if prefill_class_name and _has_method(
+                            tree, prefill_class_name, method_name
                         ):
-                            target_variants = focus_variants
+                            target_variants = prefill_variants
                         else:
                             continue
                     else:

--- a/tests/runner/validate_test_config.py
+++ b/tests/runner/validate_test_config.py
@@ -126,13 +126,15 @@ def _extract_variants_from_dict_node(dict_node: ast.Dict, enum_members: dict) ->
     return variants
 
 
-def _extract_variants_dict_keys(tree: ast.Module, enum_members: dict) -> list:
-    """Extract _VARIANTS dict keys from ModelLoader class, resolving ModelVariant.MEMBER references.
+def _extract_variants_for_class(
+    tree: ast.Module, enum_members: dict, class_name: str
+) -> list:
+    """Extract _VARIANTS dict keys from a given class, resolving ModelVariant.MEMBER references.
 
     Also checks module-level _VARIANTS if the class attribute references a name rather than a dict literal.
 
     Returns:
-        List of variant string values. Empty list if no _VARIANTS found.
+        List of variant string values. Empty list if class or _VARIANTS not found.
     """
     # First, collect any module-level _VARIANTS = {...} dict
     module_level_variants_dict = None
@@ -150,7 +152,7 @@ def _extract_variants_dict_keys(tree: ast.Module, enum_members: dict) -> list:
     for node in ast.walk(tree):
         if not isinstance(node, ast.ClassDef):
             continue
-        if node.name != "ModelLoader":
+        if node.name != class_name:
             continue
 
         for stmt in node.body:
@@ -173,24 +175,50 @@ def _extract_variants_dict_keys(tree: ast.Module, enum_members: dict) -> list:
                     module_level_variants_dict, enum_members
                 )
 
-        # If ModelLoader exists but has no _VARIANTS assignment, return empty
+        # Class exists but has no _VARIANTS assignment
         return []
 
     return []
 
 
-def _has_llm_method(tree: ast.Module, method_name: str) -> bool:
-    """Check if ModelLoader class defines a specific method (e.g. load_inputs_decode)."""
+def _has_method(tree: ast.Module, class_name: str, method_name: str) -> bool:
+    """Check if a given class defines a specific method (e.g. load_inputs_decode).
+
+    Only methods declared directly in the class body are considered; inherited
+    methods are intentionally invisible so a focus subclass doesn't falsely claim
+    ownership of phases its parent owns (which would duplicate test IDs).
+    """
     for node in ast.walk(tree):
         if not isinstance(node, ast.ClassDef):
             continue
-        if node.name != "ModelLoader":
+        if node.name != class_name:
             continue
         for stmt in node.body:
             if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 if stmt.name == method_name:
                     return True
     return False
+
+
+def _find_focus_class_name(tree: ast.Module) -> str:
+    """Return the name of the class that inherits from ForgeFocusModel, if any.
+
+    Detection is by AST base reference (Name or Attribute), so any class whose
+    declared bases include ``ForgeFocusModel`` is recognised regardless of how
+    it's named.
+    """
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        for base in node.bases:
+            base_name = None
+            if isinstance(base, ast.Name):
+                base_name = base.id
+            elif isinstance(base, ast.Attribute):
+                base_name = base.attr
+            if base_name == "ForgeFocusModel":
+                return node.name
+    return ""
 
 
 class TestConfigValidator:
@@ -389,7 +417,7 @@ class TestConfigValidator:
                 continue
 
             enum_members = _extract_model_variant_enum(tree)
-            variants = _extract_variants_dict_keys(tree, enum_members)
+            variants = _extract_variants_for_class(tree, enum_members, "ModelLoader")
 
             if is_torch:
                 if variants:
@@ -398,14 +426,37 @@ class TestConfigValidator:
                 else:
                     torch_models.append((rel_path, None))
 
-                # Check for LLM methods
+                # ForgeFocusModel subclasses (e.g. ModelLoaderFocus) live alongside
+                # ModelLoader and own the prefill phase with their own _VARIANTS
+                # subset; fall back to ModelLoader's variants if not overridden.
+                focus_class_name = _find_focus_class_name(tree)
+                focus_variants = []
+                if focus_class_name:
+                    focus_variants = (
+                        _extract_variants_for_class(
+                            tree, enum_members, focus_class_name
+                        )
+                        or variants
+                    )
+
                 for method_name, phase_str in LLM_PHASES.items():
-                    if _has_llm_method(tree, method_name):
-                        if variants:
-                            for v in variants:
-                                llm_models.append((rel_path, v, phase_str))
+                    if phase_str == "llm_prefill":
+                        if focus_class_name and _has_method(
+                            tree, focus_class_name, method_name
+                        ):
+                            target_variants = focus_variants
                         else:
-                            llm_models.append((rel_path, None, phase_str))
+                            continue
+                    else:
+                        if not _has_method(tree, "ModelLoader", method_name):
+                            continue
+                        target_variants = variants
+
+                    if target_variants:
+                        for v in target_variants:
+                            llm_models.append((rel_path, v, phase_str))
+                    else:
+                        llm_models.append((rel_path, None, phase_str))
             else:
                 # JAX
                 if variants:


### PR DESCRIPTION
### Ticket
None

### Problem description
The test runner needs a clear way to know which loaders support the focused prefill path. Inheritance from a dedicated base class is the cleanest signal for this, replacing the previous signature-inspection approach.

### What's changed
- Test discovery in `dynamic_loader.py` is extended so that `get_model_variants` no longer assumes one class per loader. It now also picks up any `ForgePrefillModel` subclass defined alongside the regular `ModelLoader`, registering each as its own variant set. To make this work, the helper that imports a `loader.py` was renamed `import_model_loader → import_loader_module` and changed to return the loaded module itself rather than the `ModelLoader` class — discovery can then iterate the module's attributes directly (`mod.ModelLoader` plus any sibling prefill class) instead of trying to look the module up later in `sys.modules`. That lookup would have failed: dynamic loader files are registered under a deliberately invalid dashed tt-forge-models... key, while attributes' `__module__` carries the underscore form, so the lookup raises KeyError and would silently drop most loaders.
- For `validate_test_config.py`, same generalization at AST level. Helpers now take a class name (new. `_extract_variants_for_class`, `_has_method`); a new `_find_prefill_class_name` returns whichever class subclasses `ForgePrefillModel`. `_has_method` ignores inherited methods so a prefill subclass doesn't double-claim its parent's phases. Phase routing mirrors the runtime: prefill is validated against the prefill class, decode and other phases against `ModelLoader.` The prefill class reuses `ModelLoader's _VARIANTS ` when it doesn't declare its own.
- Dispatch in `dynamic_loader.py` and `dynamic_torch_model_tester.py` switches from signature-based checks to inheritance check against ForgePrefillModel
- In `test_models.py`, the parametrization for `test_all_models_torch` and `test_all_models_op_by_op` is taken from a filtered list (now `test_entries_torch_regular`) that excludes prefill loaders, keeping those suites identical to before. The unfiltered list feeds `_llm_test_params`, which routes prefill loaders to `LLM_PREFILL` and regular `ModelLoaders` with `load_inputs_decode` to `LLM_DECODE`, eliminating the previous signature-based fallback path.
- Relevant `tt_forge_models` [PR](https://github.com/tenstorrent/tt-forge-models/pull/612)

### Checklist
- [ ] New/Existing tests provide coverage for changes
