### PR TITLE
Graceful shutdown of CallbackWorker in torch_plugin_tt

### DIFF
--- a/pjrt_implementation/inc/api/event_instance.h
+++ b/pjrt_implementation/inc/api/event_instance.h
@@ -80,6 +80,14 @@ public:
   // lazily on first access.
   static CallbackWorker &getCallbackWorker();
 
+  // Shuts down the CallbackWorker: drains pending callbacks, joins the
+  // worker thread, and switches `enqueue` to synchronous execution on the
+  // caller's thread for any callbacks that arrive afterwards. Intended to
+  // be invoked from a Python `atexit` hook (via `tt_pjrt_shutdown`) so
+  // that pending and post-hook callbacks all run while Python state and
+  // the GIL are still valid.
+  static void destroyCallbackWorker();
+
   // See comment below for `m_indestructible`.
   void setIndestructible() { m_indestructible = true; }
   bool isIndestructible() const { return m_indestructible; }

--- a/pjrt_implementation/inc/api/event_instance.h
+++ b/pjrt_implementation/inc/api/event_instance.h
@@ -81,12 +81,9 @@ public:
   static CallbackWorker &getCallbackWorker();
 
   // Shuts down the CallbackWorker: drains pending callbacks, joins the
-  // worker thread, and switches `enqueue` to synchronous execution on the
-  // caller's thread for any callbacks that arrive afterwards. Intended to
-  // be invoked from a Python `atexit` hook (via `tt_pjrt_shutdown`) so
-  // that pending and post-hook callbacks all run while Python state and
-  // the GIL are still valid.
-  static void destroyCallbackWorker();
+  // worker thread, and switches enqueue() to synchronous execution on the
+  // caller's thread for any callbacks that arrive afterwards.
+  static void shutdownCallbackWorker();
 
   // See comment below for `m_indestructible`.
   void setIndestructible() { m_indestructible = true; }

--- a/pjrt_implementation/inc/utils/callback_worker.h
+++ b/pjrt_implementation/inc/utils/callback_worker.h
@@ -52,8 +52,20 @@ public:
   // Enqueue a callback for asynchronous execution on the worker thread.
   // Lock-free for producers. If the queue is full, this call sleeps briefly
   // and retries until the item is successfully enqueued.
+  //
+  // Once `shutdown()` has completed, the worker thread is gone, so the
+  // callback is executed synchronously on the caller's thread instead of
+  // being enqueued. This handles enqueues that arrive during Python
+  // finalization after the shutdown hook has already drained the worker.
   void enqueue(PJRT_Event_OnReadyCallback callback_function, void *user_arg,
                PJRT_Error *error);
+
+  // Drains any pending callbacks, signals the worker thread to exit, and
+  // joins it. Idempotent. After this returns, `enqueue` will run callbacks
+  // synchronously on the caller's thread. Intended to be invoked from a
+  // Python `atexit` hook so the worker can finish its work while the host
+  // interpreter (GIL + modules) is still alive.
+  void shutdown();
 
 private:
   // Worker thread main loop.

--- a/pjrt_implementation/inc/utils/callback_worker.h
+++ b/pjrt_implementation/inc/utils/callback_worker.h
@@ -53,18 +53,15 @@ public:
   // Lock-free for producers. If the queue is full, this call sleeps briefly
   // and retries until the item is successfully enqueued.
   //
-  // Once `shutdown()` has completed, the worker thread is gone, so the
+  // Once shutdown() has completed, the worker thread is gone, so the
   // callback is executed synchronously on the caller's thread instead of
-  // being enqueued. This handles enqueues that arrive during Python
-  // finalization after the shutdown hook has already drained the worker.
+  // being enqueued.
   void enqueue(PJRT_Event_OnReadyCallback callback_function, void *user_arg,
                PJRT_Error *error);
 
   // Drains any pending callbacks, signals the worker thread to exit, and
-  // joins it. Idempotent. After this returns, `enqueue` will run callbacks
-  // synchronously on the caller's thread. Intended to be invoked from a
-  // Python `atexit` hook so the worker can finish its work while the host
-  // interpreter (GIL + modules) is still alive.
+  // joins it. After this returns, `enqueue` will run callbacks
+  // synchronously on the caller's thread. Idempotent.
   void shutdown();
 
 private:

--- a/pjrt_implementation/src/api/event_instance.cc
+++ b/pjrt_implementation/src/api/event_instance.cc
@@ -24,9 +24,33 @@
 
 namespace tt::pjrt {
 
+namespace {
+
+// Heap-allocated so it can be explicitly destroyed via
+// `EventInstance::destroyCallbackWorker()` before process teardown, rather
+// than relying on static destruction order.
+std::unique_ptr<CallbackWorker> g_callback_worker;
+std::once_flag g_callback_worker_init_flag;
+
+} // namespace
+
 CallbackWorker &EventInstance::getCallbackWorker() {
-  static CallbackWorker instance;
-  return instance;
+  std::call_once(g_callback_worker_init_flag, []() {
+    g_callback_worker = std::make_unique<CallbackWorker>();
+  });
+  return *g_callback_worker;
+}
+
+void EventInstance::destroyCallbackWorker() {
+  // Drain and join the worker thread but keep the object alive. Later
+  // `enqueue` calls (e.g. from Python finalization GC destructing torch
+  // buffers after this hook has fired) will fall back to synchronous
+  // execution on the caller's thread instead of crashing on a destroyed
+  // worker. The object itself is cleaned up later as part of normal
+  // process teardown, when no more callbacks can be enqueued.
+  if (g_callback_worker) {
+    g_callback_worker->shutdown();
+  }
 }
 
 std::unique_ptr<EventInstance> EventInstance::createInstance() {

--- a/pjrt_implementation/src/api/event_instance.cc
+++ b/pjrt_implementation/src/api/event_instance.cc
@@ -24,34 +24,12 @@
 
 namespace tt::pjrt {
 
-namespace {
-
-// Heap-allocated so it can be explicitly destroyed via
-// `EventInstance::destroyCallbackWorker()` before process teardown, rather
-// than relying on static destruction order.
-std::unique_ptr<CallbackWorker> g_callback_worker;
-std::once_flag g_callback_worker_init_flag;
-
-} // namespace
-
 CallbackWorker &EventInstance::getCallbackWorker() {
-  std::call_once(g_callback_worker_init_flag, []() {
-    g_callback_worker = std::make_unique<CallbackWorker>();
-  });
-  return *g_callback_worker;
+  static CallbackWorker instance;
+  return instance;
 }
 
-void EventInstance::destroyCallbackWorker() {
-  // Drain and join the worker thread but keep the object alive. Later
-  // `enqueue` calls (e.g. from Python finalization GC destructing torch
-  // buffers after this hook has fired) will fall back to synchronous
-  // execution on the caller's thread instead of crashing on a destroyed
-  // worker. The object itself is cleaned up later as part of normal
-  // process teardown, when no more callbacks can be enqueued.
-  if (g_callback_worker) {
-    g_callback_worker->shutdown();
-  }
-}
+void EventInstance::shutdownCallbackWorker() { getCallbackWorker().shutdown(); }
 
 std::unique_ptr<EventInstance> EventInstance::createInstance() {
   struct make_unique_enabler : public EventInstance {};

--- a/pjrt_implementation/src/dylib_entry_point.cc
+++ b/pjrt_implementation/src/dylib_entry_point.cc
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // https://llvm.org/LICENSE.txt
 
+#include "api/event_instance.h"
 #include "api_bindings.h"
 
 // Provides the shared library exports.
@@ -20,3 +21,11 @@ void InitializeAPI(PJRT_Api *api) { bindApi(api); }
 
 } // namespace
 } // namespace tt::pjrt
+
+// Performs controlled shutdown of plugin-owned resources that must be torn
+// down while the host Python interpreter (GIL + modules) is still alive.
+// Invoked from Python via `atexit` / ctypes before interpreter finalization
+// tears down state that in-flight callbacks depend on.
+extern "C" PJRT_PLUGIN_EXPORTED void tt_pjrt_shutdown() {
+  tt::pjrt::EventInstance::destroyCallbackWorker();
+}

--- a/pjrt_implementation/src/dylib_entry_point.cc
+++ b/pjrt_implementation/src/dylib_entry_point.cc
@@ -23,9 +23,7 @@ void InitializeAPI(PJRT_Api *api) { bindApi(api); }
 } // namespace tt::pjrt
 
 // Performs controlled shutdown of plugin-owned resources that must be torn
-// down while the host Python interpreter (GIL + modules) is still alive.
-// Invoked from Python via `atexit` / ctypes before interpreter finalization
-// tears down state that in-flight callbacks depend on.
+// down. Initiated by the host before shutdown.
 extern "C" PJRT_PLUGIN_EXPORTED void tt_pjrt_shutdown() {
-  tt::pjrt::EventInstance::destroyCallbackWorker();
+  tt::pjrt::EventInstance::shutdownCallbackWorker();
 }

--- a/pjrt_implementation/src/utils/callback_worker.cc
+++ b/pjrt_implementation/src/utils/callback_worker.cc
@@ -17,8 +17,15 @@ CallbackWorker::CallbackWorker(size_t queue_capacity)
     : m_queue(queue_capacity),
       m_worker_thread(&CallbackWorker::workerLoop, this) {}
 
-CallbackWorker::~CallbackWorker() {
-  m_shutdown.store(true, std::memory_order_release);
+CallbackWorker::~CallbackWorker() { shutdown(); }
+
+void CallbackWorker::shutdown() {
+  bool expected = false;
+  if (!m_shutdown.compare_exchange_strong(expected, true,
+                                          std::memory_order_acq_rel)) {
+    return;
+  }
+
   m_work_available.release();
 
   if (m_worker_thread.joinable()) {
@@ -28,6 +35,14 @@ CallbackWorker::~CallbackWorker() {
 
 void CallbackWorker::enqueue(PJRT_Event_OnReadyCallback callback_function,
                              void *user_arg, PJRT_Error *error) {
+  if (m_shutdown.load(std::memory_order_acquire)) {
+    // Worker thread has exited; execute synchronously on the caller's
+    // thread so the callback is not lost. Hit during Python finalization
+    // after `shutdown()` has drained the worker.
+    callback_function(error, user_arg);
+    return;
+  }
+
   CallbackWorkItem item{callback_function, user_arg, error};
 
   while (!m_queue.tryPush(std::move(item))) {

--- a/pjrt_implementation/src/utils/callback_worker.cc
+++ b/pjrt_implementation/src/utils/callback_worker.cc
@@ -37,8 +37,7 @@ void CallbackWorker::enqueue(PJRT_Event_OnReadyCallback callback_function,
                              void *user_arg, PJRT_Error *error) {
   if (m_shutdown.load(std::memory_order_acquire)) {
     // Worker thread has exited; execute synchronously on the caller's
-    // thread so the callback is not lost. Hit during Python finalization
-    // after `shutdown()` has drained the worker.
+    // thread so the callback is not lost.
     callback_function(error, user_arg);
     return;
   }

--- a/python_package/jax_plugin_tt/__init__.py
+++ b/python_package/jax_plugin_tt/__init__.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import jax._src.xla_bridge as xb
 from pjrt_plugin_tt import (
     get_library_path,
+    register_shutdown_hook,
     setup_tt_metal_home,
     setup_tt_pjrt_plugin_dir,
 )
@@ -26,5 +27,7 @@ def initialize():
         library_path=str(library_path),
         options=None,
     )
+
+    register_shutdown_hook()
 
     setup_monkey_patches()

--- a/python_package/jax_plugin_tt/__init__.py
+++ b/python_package/jax_plugin_tt/__init__.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import jax._src.xla_bridge as xb
 from pjrt_plugin_tt import (
     get_library_path,
-    register_shutdown_hook,
     setup_tt_metal_home,
     setup_tt_pjrt_plugin_dir,
 )
@@ -27,7 +26,5 @@ def initialize():
         library_path=str(library_path),
         options=None,
     )
-
-    register_shutdown_hook()
 
     setup_monkey_patches()

--- a/python_package/pjrt_plugin_tt/__init__.py
+++ b/python_package/pjrt_plugin_tt/__init__.py
@@ -9,12 +9,16 @@ This package contains the actual PJRT plugin binary and tt-mlir dependencies.
 Both JAX and PyTorch/XLA plugins reference this package.
 """
 
+import atexit
+import ctypes
 import os
 from pathlib import Path
 
 from ttxla_tools.logging import logger
 
 TT_PJRT_PLUGIN_NAME = "pjrt_plugin_tt.so"
+
+_shutdown_hook_registered = False
 
 
 def setup_tt_pjrt_plugin_dir():
@@ -125,3 +129,29 @@ def get_library_path() -> Path:
         )
 
     return library_path
+
+
+def register_shutdown_hook():
+    """
+    Register a Python `atexit` handler that drives controlled shutdown of
+    plugin-owned resources (currently the internal `CallbackWorker` thread)
+    before the interpreter tears down modules and destroys the GIL.
+
+    The handler invokes the exported `tt_pjrt_shutdown` C symbol via ctypes.
+    ctypes releases the GIL around foreign calls, allowing the worker thread
+    to drain any pending event callbacks (which may re-enter Python, e.g.
+    torch `TensorImpl` destructors) against a live interpreter.
+
+    Safe to call multiple times; the hook is registered at most once.
+    """
+    global _shutdown_hook_registered
+    if _shutdown_hook_registered:
+        return
+
+    library_path = get_library_path()
+    lib = ctypes.CDLL(str(library_path))
+    lib.tt_pjrt_shutdown.restype = None
+    lib.tt_pjrt_shutdown.argtypes = []
+
+    atexit.register(lib.tt_pjrt_shutdown)
+    _shutdown_hook_registered = True

--- a/python_package/pjrt_plugin_tt/__init__.py
+++ b/python_package/pjrt_plugin_tt/__init__.py
@@ -131,16 +131,12 @@ def get_library_path() -> Path:
     return library_path
 
 
-def register_shutdown_hook():
+def register_shutdown_hook() -> None:
     """
     Register a Python `atexit` handler that drives controlled shutdown of
-    plugin-owned resources (currently the internal `CallbackWorker` thread)
-    before the interpreter tears down modules and destroys the GIL.
-
-    The handler invokes the exported `tt_pjrt_shutdown` C symbol via ctypes.
-    ctypes releases the GIL around foreign calls, allowing the worker thread
-    to drain any pending event callbacks (which may re-enter Python, e.g.
-    torch `TensorImpl` destructors) against a live interpreter.
+    plugin-owned resources before the interpreter tears down modules and
+    destroys the GIL. The handler invokes the exported `tt_pjrt_shutdown`
+    C symbol via ctypes.
 
     Safe to call multiple times; the hook is registered at most once.
     """

--- a/python_package/torch_plugin_tt/__init__.py
+++ b/python_package/torch_plugin_tt/__init__.py
@@ -9,6 +9,7 @@ import torch_xla
 import tt_torch  # registers "tt" backend for torch.compile
 from pjrt_plugin_tt import (
     get_library_path,
+    register_shutdown_hook,
     setup_tt_metal_home,
     setup_tt_pjrt_plugin_dir,
 )
@@ -29,6 +30,7 @@ class TTPlugin(DevicePlugin):
         super().__init__()
         setup_tt_pjrt_plugin_dir()
         setup_tt_metal_home()
+        register_shutdown_hook()
 
         # For using the PJRT plugin with `torch_xla` we need to set
         # `XLA_STABLEHLO_COMPILE` env variable to `1` to enable stablehlo compilation.


### PR DESCRIPTION
Torch XLA doesn't close the PJRT client object through the proper API call, which later causes race conditions during Python process teardown with the newly added CallbackWorker which still holds some Python references when teardown starts. This PR solves issue https://github.com/tenstorrent/tt-xla/issues/4303.

Some notes for reviewers:
- Shutdown was intentionally NOT registered in JAX plugin, JAX should handle everything correctly. Looking for feedback on whether we should call `shutdown()` in `onClientDestroy` which is called from JAX, or just let it be called during `CallbackWorker`'s destruction.
- The exported function was added to `dylib_entry_point.cc` which is not the obvious place for it, but adding it to its own translation unit like `dylib_exit.cc` would require the extraction of some macro definitions in `dylib_entry_point.cc.inc` to their own `.h` file, which seemed excessive to me, so I left it as it is.