### PR TITLE
sparse_mlp: remove no-op view/permute and fix shared expert double-counting on CPU

### DIFF
--- a/python_package/tt_torch/sparse_mlp.py
+++ b/python_package/tt_torch/sparse_mlp.py
@@ -630,9 +630,6 @@ class A2aSparseMLP(nn.Module):
             down_out = down_out.permute(1, 0, 2)  # [dim_a*dim_b*M, E, H]
             down_out = down_out.view(dim_a, dim_b, M, E, hidden_size)
 
-            # Untile → [E, 1, BD*S, H] for combine with output_shard_dim=2
-            down_out = down_out.view(dim_a, dim_b, E, M, hidden_size)
-            down_out = down_out.permute(0, 1, 3, 2, 4)  # [dim_a, dim_b, M, E, H]
             if down_bias is not None:
                 down_out = down_out + down_bias
             # E to front, merge all spatial dims into one token dim
@@ -957,7 +954,11 @@ class A2aSparseMLPWithSharedExperts(nn.Module):
 
     def forward(self, hidden_states):
         out, _ = self.mlp(hidden_states)
-        if self.shared_experts is not None:
+        # On CPU, _cpu_forward delegates to the original MoE which already adds
+        # shared_experts internally (DS V4 MoE.forward: y += self.shared_experts(x)).
+        # On TT, dispatch/combine produces routed-only output, so shared must be
+        # added here. Skip on CPU to avoid double-counting.
+        if self.shared_experts is not None and hidden_states.device.type != "cpu":
             out = out + self.shared_experts(hidden_states)
         return out
 


### PR DESCRIPTION
## Summary
- Remove no-op `view`+`permute` pair in dense matmul path that crashed Dynamo compilation with `use_dense_matmul=True`
- Add `device.type != "cpu"` guard in `A2aSparseMLPWithSharedExperts.forward` to avoid double-counting shared experts on CPU (the original MoE already adds them internally via `y += self.shared_experts(x)`)

## Error with no-op lines present (`use_dense_matmul=True`)

Dynamo fails during fake-tensor tracing because the preceding `permute` leaves a non-contiguous tensor that cannot be viewed:

```
torch._dynamo.exc.TorchRuntimeError: Dynamo failed to run FX node with fake tensors:
  call_method view(*(FakeTensor(..., device='xla:0', size=(64, 1, 32, 256, 4096),
                    dtype=torch.bfloat16), 64, 1, 256, 32, 4096), **{}):
  got ValueError('Cannot view a tensor with shape torch.Size([64, 1, 32, 256, 4096])
  and strides (131072, 131072, 4096, 8388608, 1) as a tensor with shape (64, 1, 256, 32, 4096)!')

from user code:
   File "python_package/tt_torch/sparse_mlp.py", line 664, in forward
     down_out = down_out.view(dim_a, dim_b, E, M, hidden_size)
```