### PR TITLE
Allow TT_RUNTIME_USING_DUALT3K to force fabric 2D init in non-distributed context

### DIFF
--- a/pjrt_implementation/src/api/client_instance.cc
+++ b/pjrt_implementation/src/api/client_instance.cc
@@ -478,16 +478,18 @@ tt_pjrt_status ClientInstance::compileMlirProgram(
 
 tt::runtime::MeshFabricConfig
 ClientInstance::computeFabricConfig(const std::vector<uint32_t> &mesh_shape) {
-  // Distributed uses FABRIC_1D for now.
+
+  // [Workaround] Override fabric config to FABRIC_2D due to device init bugs
+  // under default 1D ring + topology auto-detection required for dual t3k
+  // and single bh galaxy in exabox cluster
+  if (std::getenv("TT_RUNTIME_USING_DUALT3K") != nullptr &&
+      std::string(std::getenv("TT_RUNTIME_USING_DUALT3K")) != "0") {
+    return tt::runtime::MeshFabricConfig{tt::runtime::FabricConfig::FABRIC_2D,
+                                         {}};
+  }
+
   if (std::getenv("TT_RUNTIME_ENABLE_DISTRIBUTED") != nullptr &&
       std::string(std::getenv("TT_RUNTIME_ENABLE_DISTRIBUTED")) != "0") {
-
-    // [Workaround] Override fabric config to FABRIC_2D for dual t3k cluster
-    if (std::getenv("TT_RUNTIME_USING_DUALT3K") != nullptr &&
-        std::string(std::getenv("TT_RUNTIME_USING_DUALT3K")) != "0") {
-      return tt::runtime::MeshFabricConfig{tt::runtime::FabricConfig::FABRIC_2D,
-                                           {}};
-    }
 
     uint32_t num_devices = 1;
     for (auto dim : mesh_shape) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/43210

### Problem description
MeshDevice init for single BH galaxy does not work when it is cabled into the exabox cluster as part of a quad in the 4x32 config. Automatic topology detection fails under FABRIC_1D_RING, which is the default used for singledevice in tt-xla.

This is not expected and a metal bug. It seems to be part of a larger class of bugs where mesh device init in different fabric config contexts breaks on various topologies in a way correlated with their physical cabling. 

### What's changed
Move TT_RUNTIME_USING_DUALT3K variable to force fabric 2D init in distributed context to global context, now that this bug has been observed in singledevice context on single bh glx in exabox cluster. This is not necessary in general for bh glx, just the ones in exabox.

### Checklist
- [x] No CI coverage for this topology. Tested with `TT_RUNTIME_USING_DUALT3K=1 pytest -svv tests/torch/test_torch_xla_basic.py::test_fully_replicated_graph[True]` on exabox single BH galaxy, which fails without setting the env variable.
