### PR TITLE
[vLLM plugin] Fix 1D mesh shape and tensor sharding for tensor parallelism

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -1780,12 +1780,12 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 hsize,
                 self.max_num_reqs,
             )
-            if self.enable_tensor_parallel:
-                xs.mark_sharding(
-                    dummy_hidden,
-                    self.mesh,
-                    (None, None if num_tokens == 1 else "batch", "model"),
-                )
+            # Mark dummy inputs to match the generated hidden_states shardings
+            # (during execution) to avoid re-compilation of select_hidden_states
+            # graph later.
+            if self.enable_tensor_parallel and self.use_2d_mesh:
+                xs.mark_sharding(dummy_hidden, self.mesh, (None, None, "model"))
+
             self.select_hidden_states(dummy_hidden, indices)
 
         xm.wait_device_ops()
@@ -1803,8 +1803,6 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             (self.max_num_reqs, hsize), dtype=self._hidden_states_dtype
         )
         dummy_hidden = dummy_hidden.to(self.device)
-        if self.enable_tensor_parallel:
-            xs.mark_sharding(dummy_hidden, self.mesh, (None, None))
         self.compute_logits(dummy_hidden)
 
         xm.wait_device_ops()
@@ -2167,13 +2165,15 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
     def select_hidden_states(self, hidden_states, indices_do_sample):
         batch_indices = torch.arange(indices_do_sample.shape[0], dtype=torch.int32)
         result = hidden_states[batch_indices, indices_do_sample, :]
-        if self.enable_tensor_parallel:
+        if self.enable_tensor_parallel and self.use_2d_mesh:
             result = sharding_constraint_tensor(result, self.mesh, (None, None))
         return result
 
     @torch.compile(backend="tt", fullgraph=True, dynamic=False)
     def compute_logits(self, sample_hidden_states: torch.Tensor) -> torch.Tensor:
         logits = self.model.compute_logits(sample_hidden_states)
+        if self.enable_tensor_parallel and not self.use_2d_mesh:
+            logits = sharding_constraint_tensor(logits, self.mesh, (None, None))
         return logits
 
     @torch.compile(backend="tt", fullgraph=True, dynamic=False)

--- a/integrations/vllm_plugin/vllm_tt/vllm_distributed_utils.py
+++ b/integrations/vllm_plugin/vllm_tt/vllm_distributed_utils.py
@@ -74,7 +74,6 @@ class XlaMergedColumnParallelLinear(nn.Module):
             start_idx = end_idx
 
         if merged_column_parallel_linear.bias is not None:
-            logger.info(f"loading bias for merged column parallel linear")
             start_idx = 0
             for i, output_size in enumerate(self.output_sizes):
                 end_idx = start_idx + output_size

--- a/integrations/vllm_plugin/vllm_tt/vllm_utils.py
+++ b/integrations/vllm_plugin/vllm_tt/vllm_utils.py
@@ -36,6 +36,6 @@ def determine_mesh_shape(num_devices: int, use_2d_mesh: bool) -> tuple[int, int]
             return mesh_shape
     else:
         # For 1D mesh, all devices are in one dimension.
-        mesh_shape = (1, num_devices)
+        mesh_shape = (num_devices, 1)
         logger.info(f"Using 1D mesh shape for {num_devices} devices: {mesh_shape}")
         return mesh_shape

--- a/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
@@ -83,9 +83,9 @@ def test_tensor_parallel_generation_llmbox_small(
 @pytest.mark.parametrize(
     ["model_name", "enable_const_eval", "experimental_weight_dtype", "use_2d_mesh"],
     [
-        pytest.param("Qwen/Qwen3-32B", False, "", "True"),
-        pytest.param("Qwen/Qwen2.5-32B", False, "", "False"),
-        pytest.param("meta-llama/Llama-3.1-70B", True, "bfp_bf8", "True"),
+        pytest.param("Qwen/Qwen3-32B", False, "", True),
+        pytest.param("Qwen/Qwen2.5-32B", False, "", False),
+        pytest.param("meta-llama/Llama-3.1-70B", True, "bfp_bf8", True),
     ],
 )
 def test_tensor_parallel_generation_llmbox_large(


### PR DESCRIPTION
### Ticket
closes #4420 

### Problem description
Generative models are hanging for 1D mesh shape.

### What's changed
- Correct 1D mesh shape from (1, num_devices) to (num_devices, 1)
- Fix the sharding for dummy inputs to avoid geneating additional graphs
- Fix test parameter types for use_2d_mesh (str -> bool)

### Checklist
- [X] New/Existing tests provide coverage for changes
