### PR TITLE
Removing monkeypatch for jax.random.uniform

### DIFF
--- a/python_package/jax_plugin_tt/monkeypatch.py
+++ b/python_package/jax_plugin_tt/monkeypatch.py
@@ -289,47 +289,6 @@ def _create_flax_apply_patch_config(mark_weight_func):
     ]
 
 
-def _create_uniform_patch_config():
-    """
-    Create a MonkeyPatchConfig for patching jax._src.random._uniform.
-    """
-
-    if not (_is_module_imported("numpy")):
-        return []
-
-    import numpy as np
-
-    # The ttir.rand op requires shape argument to be int32, so to avoid
-    # type conversion during lowering in MLIR, we do it here in the patch.
-    def patch_uniform(config):
-        def with_shape_int32(*args, **kwargs):
-            # If "shape" is keyword argument
-            if "shape" in kwargs:
-                shape = kwargs["shape"]
-                kwargs["shape"] = tuple(np.int32(s) for s in shape)
-            # If "shape" is positional argument
-            else:
-                # convention: (key, shape, dtype, ...)
-                shape = args[1]
-                new_shape = tuple(np.int32(s) for s in shape)
-                args = (args[0], new_shape) + args[2:]
-
-            return jax.lax.composite(
-                lambda *inner_args, **inner_kwargs: config.backup(
-                    *inner_args, **inner_kwargs
-                ),
-                "tenstorrent.uniform",
-            )(*args, **kwargs)
-
-        return with_shape_int32
-
-    return [
-        MonkeyPatchConfig(
-            target_module=random,
-            target_function="_uniform",
-            replacement_factory=patch_uniform,
-        )
-    ]
 
 
 def _create_absl_handler_close_patch_config():
@@ -390,9 +349,6 @@ def _get_monkeypatches():
     # Add flax patches
     mark_weight = _setup_mark_weight_primitive()
     patches.extend(_create_flax_apply_patch_config(mark_weight))
-
-    # Add uniform patch
-    patches.extend(_create_uniform_patch_config())
 
     # Add absl patch
     patches.extend(_create_absl_handler_close_patch_config())

--- a/python_package/jax_plugin_tt/monkeypatch.py
+++ b/python_package/jax_plugin_tt/monkeypatch.py
@@ -289,8 +289,6 @@ def _create_flax_apply_patch_config(mark_weight_func):
     ]
 
 
-
-
 def _create_absl_handler_close_patch_config():
     """Create a MonkeyPatchConfig for patching absl's PythonHandler.close.
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Removes the monkeypatch that was introduced in: https://github.com/tenstorrent/tt-xla/pull/1502
The patch was introduced as the workaround to the stablehlo.bitcast_convert which is now merged with https://github.com/tenstorrent/tt-mlir/pull/7679 

### Checklist
- [ ] New/Existing tests provide coverage for changes
