### PR TITLE
Manual tools test workflow

### DIFF
--- a/.github/workflows/manual-test-tools.yml
+++ b/.github/workflows/manual-test-tools.yml
@@ -1,8 +1,6 @@
 name: Test tooling packages
 
 on:
-  pull_request:
-    branches: [ "main" ]
   workflow_dispatch:
     inputs:
       mlir_override:

--- a/.github/workflows/manual-test-tools.yml
+++ b/.github/workflows/manual-test-tools.yml
@@ -1,10 +1,12 @@
-name: Test Tool Packages
+name: Test tooling packages
 
 on:
+  pull_request:
+    branches: [ "main" ]
   workflow_dispatch:
     inputs:
       mlir_override:
-        description: 'Git SHA of commit in tenstorrent/tt-mlir'
+        description: 'Git hash of commit in tenstorrent/tt-mlir'
         required: false
         type: string
 
@@ -14,7 +16,7 @@ permissions:
   checks: write
   contents: read
 
-run-name: 'Test Tool Packages ( mlir: ${{ inputs.mlir_override || ''latest'' }} )'
+run-name: 'Test tooling packages ( mlir: ${{ inputs.mlir_override || ''latest'' }} )'
 
 jobs:
   build-image:

--- a/.github/workflows/manual-test-tools.yml
+++ b/.github/workflows/manual-test-tools.yml
@@ -1,0 +1,41 @@
+name: Test Tool Packages
+
+on:
+  workflow_dispatch:
+    inputs:
+      mlir_override:
+        description: 'Git SHA of commit in tenstorrent/tt-mlir'
+        required: false
+        type: string
+
+permissions:
+  actions: write
+  packages: write
+  checks: write
+  contents: read
+
+run-name: 'Test Tool Packages ( mlir: ${{ inputs.mlir_override || ''latest'' }} )'
+
+jobs:
+  build-image:
+    uses: ./.github/workflows/call-build-docker.yml
+    secrets: inherit
+    with:
+      mlir_override: ${{ inputs.mlir_override }}
+
+  build-ttxla:
+    needs: build-image
+    uses: ./.github/workflows/call-build.yml
+    secrets: inherit
+    with:
+      docker_image: ${{ needs.build-image.outputs.docker-image }}
+      mlir_override: ${{ inputs.mlir_override }}
+
+  test-tools:
+    needs: [ build-image, build-ttxla ]
+    uses: ./.github/workflows/call-test-tools.yml
+    secrets: inherit
+    with:
+      docker_image: ${{ needs.build-image.outputs.docker-image }}
+      wheel_artifact_name: xla-whl-release${{ needs.build-ttxla.outputs.artifact_suffix }}
+      artifacts_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}


### PR DESCRIPTION
This PR adds a manual workflow that can be dispatched from tt-mlir repo on tt-metal uplift to preform tooling test (ttnn, tracy) that can become broken during tt-metal uplift into tt-mlir.