### PR TITLE
Add initial support for composite torch.gather

### DIFF
--- a/python_package/tt_torch/composite_ops.py
+++ b/python_package/tt_torch/composite_ops.py
@@ -270,6 +270,33 @@ def composite_scaled_dot_product_attention(
     return output
 
 
+def composite_gather(
+    input: Tensor,
+    dim: int,
+    index: Tensor,
+    *,
+    sparse_grad: bool = False,
+    out: Tensor | None = None,
+) -> Tensor:
+    """
+    Creates a composite gather operation for torch-xla using StableHLOCompositeBuilder.
+    Name of the composite op will be "tenstorrent.gather"
+
+    Args:
+        input: tensor to gather from
+        dim: axis along which to index
+        index: tensor with integer dtype which contains the indices to gather
+        sparse_grad: optional bool, if true the gradient computation will be sparse
+        out: preallocated output tensor, will be ignored when generating composite op
+    """
+    attrs = {"dim": dim, "sparse_grad": sparse_grad}
+    builder = StableHLOCompositeBuilder(name="tenstorrent.gather", attr=attrs)
+    input, index = builder.mark_inputs(input, index)
+    output = torch.gather(input, dim, index, sparse_grad=sparse_grad)
+    output = builder.mark_outputs(output)
+    return output
+
+
 ################# module replacements #################
 
 
@@ -459,6 +486,7 @@ replacements = {
         frozenset({0}): composite_topk_values,
         frozenset({1}): composite_topk_indices,
     },
+    torch.gather: composite_gather,
     # module replacements
     torch.nn.LayerNorm: replace_layer_norm_module,
     # TODO: uncomment once https://github.com/tenstorrent/tt-metal/issues/40916 is fixed
@@ -473,4 +501,5 @@ The mapped function must be a key in `replacements` for the rewrite to apply.
 """
 method_name_to_function = {
     "topk": torch.topk,
+    "gather": torch.gather,
 }

--- a/tests/torch/ops/test_composite_ops.py
+++ b/tests/torch/ops/test_composite_ops.py
@@ -15,6 +15,7 @@ from infra.evaluators import TorchComparisonEvaluator
 from infra.utilities.types import Framework
 from torch.nn import functional as F
 from tt_torch.composite_ops import (
+    composite_gather,
     composite_gelu,
     composite_group_norm,
     composite_layer_norm,
@@ -454,6 +455,72 @@ def test_patched_topk_both(input_shape, k):
     run_graph_test(
         TopKBoth(k),
         [input],
+        comparison_config=ComparisonConfig(),
+        framework=Framework.TORCH,
+        torch_options=options,
+    )
+
+
+@pytest.mark.nightly
+@pytest.mark.single_device
+@pytest.mark.parametrize(
+    "input_shape, dim",
+    [((4, 10), 0), ((4, 10), 1), ((2, 3, 8), 2)],
+)
+def test_composite_gather(input_shape, dim):
+    class GatherModel(torch.nn.Module):
+        def __init__(self, dim):
+            super().__init__()
+            self.dim = dim
+
+        def forward(self, x, index):
+            return composite_gather(x, self.dim, index)
+
+    options = {"tt_enable_composite_ops": False}
+
+    input_tensor = torch.randn(*input_shape)
+    # Build an index tensor with the same number of dims, gathering 2 elements along dim
+    index_shape = list(input_shape)
+    index_shape[dim] = 2
+    index = torch.randint(0, input_shape[dim], index_shape)
+
+    with torch._inductor.config.patch({"inplace_buffers": False}):
+        run_graph_test(
+            GatherModel(dim),
+            [input_tensor, index],
+            comparison_config=ComparisonConfig(),
+            framework=Framework.TORCH,
+            torch_options=options,
+        )
+
+
+@pytest.mark.nightly
+@pytest.mark.single_device
+@pytest.mark.parametrize(
+    "input_shape, dim",
+    [((4, 10), 0), ((4, 10), 1), ((2, 3, 8), 2)],
+)
+def test_patched_gather(input_shape, dim):
+    """torch.gather patched via tt_enable_composite_ops → composite_gather selected."""
+
+    class GatherModel(torch.nn.Module):
+        def __init__(self, dim):
+            super().__init__()
+            self.dim = dim
+
+        def forward(self, x, index):
+            return torch.gather(x, self.dim, index)
+
+    options = {"tt_enable_composite_ops": True}
+
+    input_tensor = torch.randn(*input_shape)
+    index_shape = list(input_shape)
+    index_shape[dim] = 2
+    index = torch.randint(0, input_shape[dim], index_shape)
+
+    run_graph_test(
+        GatherModel(dim),
+        [input_tensor, index],
         comparison_config=ComparisonConfig(),
         framework=Framework.TORCH,
         torch_options=options,

--- a/tests/torch/ops/test_gather.py
+++ b/tests/torch/ops/test_gather.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import numpy as np
+import pytest
+import torch
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+from infra.testers.compiler_config import CompilerConfig
+from torch import nn
+from torch_xla.distributed.spmd import Mesh
+
+
+class SimpleGather(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.dim = dim
+
+    def forward(self, input, index):
+        return torch.gather(input, self.dim, index)
+
+
+# Note, 1D and >4D tensors are not supported by ttnn.gather. A workaround will be added
+# to tt-mlir in the future to support them.
+@pytest.mark.parametrize(
+    "input_shape,index_shape,dim",
+    [
+        # ---- 2D: all dims (positive and negative), varying index shapes ----
+        pytest.param((32, 64), (16, 64), 0, id="2d_dim0"),
+        pytest.param((8, 32), (8, 16), 1, id="2d_dim1"),
+        pytest.param((16, 32), (16, 32), 1, id="2d_dim1_same_shape"),
+        pytest.param((16, 32), (16, 64), 1, id="2d_dim1_larger"),
+        pytest.param((16, 32), (8, 16), 1, id="2d_dim1_both_smaller"),
+        pytest.param((32, 64), (16, 32), 0, id="2d_dim0_both_smaller"),
+        pytest.param((32, 64), (16, 64), -2, id="2d_negdim0"),
+        pytest.param((8, 32), (8, 16), -1, id="2d_negdim1"),
+        # ---- 3D: all dims, varying index shapes ----
+        pytest.param((4, 32, 64), (2, 32, 64), 0, id="3d_dim0"),
+        pytest.param((4, 32, 64), (4, 8, 64), 1, id="3d_dim1"),
+        pytest.param((4, 16, 64), (4, 16, 32), 2, id="3d_dim2"),
+        pytest.param((4, 16, 64), (4, 16, 128), 2, id="3d_dim2_larger"),
+        pytest.param((4, 16, 64), (2, 8, 32), 2, id="3d_dim2_all_smaller"),
+        pytest.param((4, 32, 64), (4, 8, 64), -2, id="3d_negdim1"),
+        pytest.param((4, 16, 64), (4, 16, 32), -1, id="3d_negdim2"),
+        # ---- 4D: all dims ----
+        pytest.param((2, 4, 32, 64), (1, 4, 32, 64), 0, id="4d_dim0"),
+        pytest.param((2, 4, 32, 64), (2, 2, 32, 64), 1, id="4d_dim1"),
+        pytest.param((2, 4, 32, 64), (2, 4, 16, 64), 2, id="4d_dim2"),
+        pytest.param((2, 4, 32, 64), (2, 4, 32, 16), 3, id="4d_dim3"),
+        pytest.param((2, 4, 32, 64), (2, 4, 32, 16), -1, id="4d_negdim3"),
+        pytest.param((2, 4, 32, 64), (1, 2, 16, 32), 2, id="4d_dim2_all_smaller"),
+    ],
+)
+def test_gather_replicated(input_shape, index_shape, dim):
+    xr.set_device_type("TT")
+
+    input = torch.randn(*input_shape, dtype=torch.bfloat16)
+    index_max = input_shape[dim]
+    index = torch.randint(0, index_max, index_shape, dtype=torch.int64)
+
+    run_graph_test(
+        SimpleGather(dim),
+        [input, index],
+        framework=Framework.TORCH,
+    )


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/3726
Fixes https://github.com/tenstorrent/tt-xla/issues/4329

### Problem description
We want an easy way to represent torch.gather semantics inside tt-mlir, so that it can get lowered to ttnn.gather (which has the same semantics as torch.gather).

### What's changed
- Added a composite op for torch.gather
- Added op tests for various single-device torch.gather scenarios (where both input and index tensors are replicated)

### Important notes
- This does NOT add support for sharded gathers, or 1D and >4D input and index tensors (due to a metal limitation).
    - This tt-mlir PR will add support for the above when merged in and uplifted: https://github.com/tenstorrent/tt-mlir/pull/8085

### Checklist
- [x] New/Existing tests provide coverage for changes
