### PR TITLE
Disable kimi_k2 in CI

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -307,12 +307,6 @@
         "pytest": "tests/benchmark/test_encoders.py::test_unet_for_conditional_generation"
       },
       {
-        "name": "kimi_k2_tp_galaxy_2_layers",
-        "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==5.2.0 tiktoken",
-        "pytest": "tests/benchmark/test_llms.py::test_kimi_k2_tp_galaxy_2_layers",
-        "runs-on": "galaxy-wh-6u"
-      },
-      {
         "name": "llama_3_2_1b_instruct_accuracy",
         "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_2_1b",


### PR DESCRIPTION
### Problem description
kimi_k2_tp_galaxy_2_layers is failing in benchmarks CI since it is added.

### What's changed
Disabling kimi in benchmarks CI until the fix lands: https://github.com/tenstorrent/tt-xla/issues/4399