### PR TITLE
[Benchmark] Add check for fused ops in benchmarks

### DIFF
--- a/.github/workflows/call-filtered-perf-tests.yml
+++ b/.github/workflows/call-filtered-perf-tests.yml
@@ -45,6 +45,11 @@ on:
         required: false
         type: boolean
         default: false
+      check_fusions:
+        description: "Verify expected fusion ops are present in compiled IR"
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   packages: write
@@ -101,3 +106,4 @@ jobs:
       regression_check: ${{ inputs.regression_check || false }}
       sh-runner: ${{ inputs.sh-runner || false }}
       use_docker_wheel: ${{ inputs.use_docker_wheel || false }}
+      check_fusions: ${{ inputs.check_fusions }}

--- a/.github/workflows/call-filtered-perf-tests.yml
+++ b/.github/workflows/call-filtered-perf-tests.yml
@@ -49,7 +49,7 @@ on:
         description: "Verify expected fusion ops are present in compiled IR"
         required: false
         type: boolean
-        default: true
+        default: false
 
 permissions:
   packages: write

--- a/.github/workflows/call-perf-test.yml
+++ b/.github/workflows/call-perf-test.yml
@@ -44,6 +44,11 @@ on:
         required: false
         type: boolean
         default: false
+      check_fusions:
+        description: "Verify expected fusion ops are present in compiled IR"
+        required: false
+        type: boolean
+        default: true
 
 env:
   GH_TOKEN: ${{ github.token }}
@@ -182,7 +187,7 @@ jobs:
         export PYTHONPATH="${{ steps.strings.outputs.work-dir }}:$PYTHONPATH"
 
         source venv/activate
-        pytest -svv --confcutdir=tests/benchmark ${{ matrix.build.pytest }} ${{ matrix.build.accuracy-testing && '--accuracy-testing' || '' }} ${{ matrix.build.batch-size && format('--batch-size {0}', matrix.build.batch-size) || '' }} --output-file ${{ steps.strings.outputs.perf_report_json_file }}
+        pytest -svv --confcutdir=tests/benchmark ${{ matrix.build.pytest }} ${{ matrix.build.accuracy-testing && '--accuracy-testing' || '' }} ${{ matrix.build.batch-size && format('--batch-size {0}', matrix.build.batch-size) || '' }} ${{ inputs.check_fusions && '--check-fusions' || '' }} --output-file ${{ steps.strings.outputs.perf_report_json_file }}
 
     - name: Dump stablehlo to report
       id: dump-stablehlo

--- a/.github/workflows/call-perf-test.yml
+++ b/.github/workflows/call-perf-test.yml
@@ -48,7 +48,7 @@ on:
         description: "Verify expected fusion ops are present in compiled IR"
         required: false
         type: boolean
-        default: true
+        default: false
 
 env:
   GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/manual-benchmark.yml
+++ b/.github/workflows/manual-benchmark.yml
@@ -62,6 +62,11 @@ on:
         required: false
         type: boolean
         default: false
+      check_fusions:
+        description: "Verify expected fusion ops are present in compiled IR"
+        required: false
+        type: boolean
+        default: false
 
 
 permissions:
@@ -137,6 +142,7 @@ jobs:
       regression_check: ${{ inputs.regression_check || false }}
       sh-runner: ${{ inputs.sh-runner || false }}
       wheel_build: ${{ inputs.manylinux_build && 'manylinux' || 'release' }}
+      check_fusions: ${{ inputs.check_fusions }}
 
   fail-notify:
     if: always()

--- a/tests/benchmark/benchmarks/llm_benchmark.py
+++ b/tests/benchmark/benchmarks/llm_benchmark.py
@@ -6,6 +6,7 @@
 import os
 import socket
 import sys
+import time
 from typing import Optional, Union
 
 import numpy as np
@@ -263,6 +264,8 @@ def benchmark_llm_torch_xla(
     input_output_sharding_spec=None,
     kv_cache_sharding_spec=None,
     use_mla_cache: bool = False,
+    expected_ops: list = None,
+    check_fusions_enabled: bool = False,
 ):
     """
     Benchmark an LLM (Large Language Model) using PyTorch and torch-xla.
@@ -480,6 +483,7 @@ def benchmark_llm_torch_xla(
         output_sharding_spec=input_output_sharding_spec,
     )
     perf_wrapper.eval()
+    before_compile_ts = time.time()
     compiled_perf_model = torch.compile(perf_wrapper, backend="tt")
 
     warmup_kv_cache = None
@@ -760,5 +764,15 @@ def benchmark_llm_torch_xla(
         device_count=device_count,
         mesh_shape=mesh_shape,
     )
+
+    if check_fusions_enabled and expected_ops:
+        from fusion_check import check_fusions
+
+        check_fusions(
+            expected_ops=expected_ops,
+            export_model_name=export_model_name,
+            modules_dir=MODULE_EXPORT_PATH,
+            before_compile_ts=before_compile_ts,
+        )
 
     return result

--- a/tests/benchmark/benchmarks/llm_benchmark.py
+++ b/tests/benchmark/benchmarks/llm_benchmark.py
@@ -6,7 +6,6 @@
 import os
 import socket
 import sys
-import time
 from typing import Optional, Union
 
 import numpy as np
@@ -17,6 +16,7 @@ import torch_xla.distributed.spmd as xs
 import torch_xla.runtime as xr
 import tracy
 import transformers
+from fusion_check import check_fusions
 from infra import MLACache, MLAStaticLayer
 from llm_utils import (
     generate_and_benchmark,
@@ -483,7 +483,6 @@ def benchmark_llm_torch_xla(
         output_sharding_spec=input_output_sharding_spec,
     )
     perf_wrapper.eval()
-    before_compile_ts = time.time()
     compiled_perf_model = torch.compile(perf_wrapper, backend="tt")
 
     warmup_kv_cache = None
@@ -766,13 +765,10 @@ def benchmark_llm_torch_xla(
     )
 
     if check_fusions_enabled and expected_ops:
-        from fusion_check import check_fusions
-
         check_fusions(
             expected_ops=expected_ops,
             export_model_name=export_model_name,
             modules_dir=MODULE_EXPORT_PATH,
-            before_compile_ts=before_compile_ts,
         )
 
     return result

--- a/tests/benchmark/conftest.py
+++ b/tests/benchmark/conftest.py
@@ -93,6 +93,16 @@ def pytest_addoption(parser):
         help="Run prefill on CPU and only decode on device. Measures decode-only throughput.",
     )
 
+    parser.addoption(
+        "--check-fusions",
+        action="store_true",
+        default=False,
+        help=(
+            "Verify that expected fusion ops are present in the compiled IR. "
+            "Tests must declare expected_ops to use this feature."
+        ),
+    )
+
 
 @pytest.fixture
 def output_file(request):
@@ -127,3 +137,8 @@ def max_output_tokens(request):
 @pytest.fixture
 def decode_only(request):
     return request.config.getoption("--decode-only")
+
+
+@pytest.fixture
+def check_fusions(request):
+    return request.config.getoption("--check-fusions")

--- a/tests/benchmark/fusion_check.py
+++ b/tests/benchmark/fusion_check.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Fusion-pattern verification for benchmark tests.
+
+Accepts a list of expected op strings (e.g. ["ttnn.rms_norm", "ttnn.scaled_dot_product_attention"]),
+globs the IR files produced by the current run, and searches for each op by simple
+string match. A pattern must appear in every graph file.
+
+IR type is inferred from the op prefix e.g. "ttnn." -> ttnn, "ttir." -> ttir.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _infer_ir_type(op: str) -> str:
+    """Derive IR stage from op name prefix (e.g. "ttnn.rms_norm" -> "ttnn")."""
+    return op.split(".")[0] if "." in op else "ttnn"
+
+
+def _collect_ir_files(
+    modules_dir: str | Path,
+    ir_type: str,
+    export_model_name: str,
+    min_mtime: float,
+) -> list[Path]:
+    """
+    Return graph-IR files produced by the current benchmark run.
+
+    Globs `{modules_dir}/irs/{ir_type}_{export_model_name}_*.mlir` and
+    filters to files whose mtime is >= min_mtime (to exclude stale files
+    from previous runs). Sorted for deterministic iteration.
+    """
+    irs_dir = Path(modules_dir) / "irs"
+    if not irs_dir.is_dir():
+        return []
+
+    prefix = f"{ir_type}_{export_model_name}_"
+    return sorted(
+        p for p in irs_dir.glob(f"{prefix}*.mlir") if p.stat().st_mtime >= min_mtime
+    )
+
+
+def check_fusions(
+    expected_ops: list[str | tuple[str, int]],
+    export_model_name: str,
+    modules_dir: str | Path,
+    before_compile_ts: float,
+) -> None:
+    """
+    Verify that expected ops appear in the IR produced by this benchmark run.
+
+    For each op in expected_ops the IR type is inferred from the op's prefix
+    (e.g. "ttnn." -> ttnn IR files). The op must be present in every matching
+    graph file.
+
+    Args:
+        expected_ops: List of op strings like "ttnn.rms_norm".
+        export_model_name: Model export name used to glob IR file names.
+        modules_dir: Directory containing the "irs/" subdirectory.
+        before_compile_ts: Unix timestamp recorded before compilation; only
+            IR files newer than this are considered to belong to the current run.
+
+    Raises:
+        AssertionError: if any op is absent from any graph file for this run,
+            or if no IR files can be found.
+    """
+    if not expected_ops:
+        return
+
+    failures: list[str] = []
+
+    for entry in expected_ops:
+        op = entry[0] if isinstance(entry, tuple) else entry
+        ir_type = _infer_ir_type(op)
+
+        ir_files = _collect_ir_files(
+            modules_dir=modules_dir,
+            ir_type=ir_type,
+            export_model_name=export_model_name,
+            min_mtime=before_compile_ts,
+        )
+        if not ir_files:
+            failures.append(
+                f"Op '{op}': no IR files found "
+                f"(looked for {ir_type}_{export_model_name}_*.mlir under "
+                f"{modules_dir}/irs/ with mtime >= {before_compile_ts})"
+            )
+            continue
+
+        missing_in = [f for f in ir_files if op not in f.read_text()]
+        if missing_in:
+            failures.append(
+                f"Op '{op}' missing in {len(missing_in)}/{len(ir_files)} "
+                f"{ir_type} graph file(s): {[f.name for f in missing_in]}"
+            )
+
+    if failures:
+        raise AssertionError("Fusion check failed:\n" + "\n".join(failures))

--- a/tests/benchmark/fusion_check.py
+++ b/tests/benchmark/fusion_check.py
@@ -6,10 +6,9 @@
 Fusion-pattern verification for benchmark tests.
 
 Accepts a list of expected op strings (e.g. ["ttnn.rms_norm", "ttnn.scaled_dot_product_attention"]),
-globs the IR files produced by the current run, and searches for each op by simple
-string match. A pattern must appear in every graph file.
+globs the ttnn IR files produced by the current run, and searches for each op
+by simple string match. A pattern must appear in every graph file.
 
-IR type is inferred from the op prefix e.g. "ttnn." -> ttnn, "ttir." -> ttir.
 The current run is identified by `export_model_name`, which embeds a unique
 `_run<hex>_` token, so files from previous runs are naturally excluded.
 """
@@ -19,42 +18,15 @@ from __future__ import annotations
 from pathlib import Path
 
 
-def _infer_ir_type(op: str) -> str:
-    """Derive IR stage from op name prefix (e.g. "ttnn.rms_norm" -> "ttnn")."""
-    return op.split(".")[0] if "." in op else "ttnn"
-
-
-def _collect_ir_files(
-    modules_dir: str | Path,
-    ir_type: str,
-    export_model_name: str,
-) -> list[Path]:
-    """
-    Return graph-IR files produced by the current benchmark run.
-
-    Globs `{modules_dir}/irs/{ir_type}_{export_model_name}_*.mlir`. The
-    `export_model_name` carries a unique `_run<hex>_` token so the match is
-    already scoped to the current run. Sorted for deterministic iteration.
-    """
-    irs_dir = Path(modules_dir) / "irs"
-    if not irs_dir.is_dir():
-        return []
-
-    prefix = f"{ir_type}_{export_model_name}_"
-    return sorted(irs_dir.glob(f"{prefix}*.mlir"))
-
-
 def check_fusions(
     expected_ops: list[str],
     export_model_name: str,
     modules_dir: str | Path,
 ) -> None:
     """
-    Verify that expected ops appear in the IR produced by this benchmark run.
+    Verify that expected ops appear in the ttnn IR produced by this benchmark run.
 
-    For each op in expected_ops the IR type is inferred from the op's prefix
-    (e.g. "ttnn." -> ttnn IR files). The op must be present in every matching
-    graph file.
+    Each op must be present in every matching ttnn graph file.
 
     Args:
         expected_ops: List of op strings like "ttnn.rms_norm".
@@ -69,29 +41,25 @@ def check_fusions(
     if not expected_ops:
         return
 
-    failures: list[str] = []
+    irs_dir = Path(modules_dir) / "irs"
+    prefix = f"ttnn_{export_model_name}_"
+    ir_files = sorted(irs_dir.glob(f"{prefix}*.mlir")) if irs_dir.is_dir() else []
 
-    for op in expected_ops:
-        ir_type = _infer_ir_type(op)
-
-        ir_files = _collect_ir_files(
-            modules_dir=modules_dir,
-            ir_type=ir_type,
-            export_model_name=export_model_name,
+    if not ir_files:
+        raise AssertionError(
+            f"Fusion check failed: no IR files found "
+            f"(looked for {prefix}*.mlir under {modules_dir}/irs/)"
         )
-        if not ir_files:
-            failures.append(
-                f"Op '{op}': no IR files found "
-                f"(looked for {ir_type}_{export_model_name}_*.mlir under "
-                f"{modules_dir}/irs/)"
-            )
-            continue
 
-        missing_in = [f for f in ir_files if op not in f.read_text()]
+    ir_contents = [(f, f.read_text()) for f in ir_files]
+
+    failures: list[str] = []
+    for op in expected_ops:
+        missing_in = [f.name for f, text in ir_contents if op not in text]
         if missing_in:
             failures.append(
                 f"Op '{op}' missing in {len(missing_in)}/{len(ir_files)} "
-                f"{ir_type} graph file(s): {[f.name for f in missing_in]}"
+                f"ttnn graph file(s): {missing_in}"
             )
 
     if failures:

--- a/tests/benchmark/fusion_check.py
+++ b/tests/benchmark/fusion_check.py
@@ -10,6 +10,8 @@ globs the IR files produced by the current run, and searches for each op by simp
 string match. A pattern must appear in every graph file.
 
 IR type is inferred from the op prefix e.g. "ttnn." -> ttnn, "ttir." -> ttir.
+The current run is identified by `export_model_name`, which embeds a unique
+`_run<hex>_` token, so files from previous runs are naturally excluded.
 """
 
 from __future__ import annotations
@@ -26,30 +28,26 @@ def _collect_ir_files(
     modules_dir: str | Path,
     ir_type: str,
     export_model_name: str,
-    min_mtime: float,
 ) -> list[Path]:
     """
     Return graph-IR files produced by the current benchmark run.
 
-    Globs `{modules_dir}/irs/{ir_type}_{export_model_name}_*.mlir` and
-    filters to files whose mtime is >= min_mtime (to exclude stale files
-    from previous runs). Sorted for deterministic iteration.
+    Globs `{modules_dir}/irs/{ir_type}_{export_model_name}_*.mlir`. The
+    `export_model_name` carries a unique `_run<hex>_` token so the match is
+    already scoped to the current run. Sorted for deterministic iteration.
     """
     irs_dir = Path(modules_dir) / "irs"
     if not irs_dir.is_dir():
         return []
 
     prefix = f"{ir_type}_{export_model_name}_"
-    return sorted(
-        p for p in irs_dir.glob(f"{prefix}*.mlir") if p.stat().st_mtime >= min_mtime
-    )
+    return sorted(irs_dir.glob(f"{prefix}*.mlir"))
 
 
 def check_fusions(
-    expected_ops: list[str | tuple[str, int]],
+    expected_ops: list[str],
     export_model_name: str,
     modules_dir: str | Path,
-    before_compile_ts: float,
 ) -> None:
     """
     Verify that expected ops appear in the IR produced by this benchmark run.
@@ -61,9 +59,8 @@ def check_fusions(
     Args:
         expected_ops: List of op strings like "ttnn.rms_norm".
         export_model_name: Model export name used to glob IR file names.
+            Already unique per run via the `_run<hex>_` token it embeds.
         modules_dir: Directory containing the "irs/" subdirectory.
-        before_compile_ts: Unix timestamp recorded before compilation; only
-            IR files newer than this are considered to belong to the current run.
 
     Raises:
         AssertionError: if any op is absent from any graph file for this run,
@@ -74,21 +71,19 @@ def check_fusions(
 
     failures: list[str] = []
 
-    for entry in expected_ops:
-        op = entry[0] if isinstance(entry, tuple) else entry
+    for op in expected_ops:
         ir_type = _infer_ir_type(op)
 
         ir_files = _collect_ir_files(
             modules_dir=modules_dir,
             ir_type=ir_type,
             export_model_name=export_model_name,
-            min_mtime=before_compile_ts,
         )
         if not ir_files:
             failures.append(
                 f"Op '{op}': no IR files found "
                 f"(looked for {ir_type}_{export_model_name}_*.mlir under "
-                f"{modules_dir}/irs/ with mtime >= {before_compile_ts})"
+                f"{modules_dir}/irs/)"
             )
             continue
 

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -63,6 +63,8 @@ def test_llm(
     input_output_sharding_spec=None,
     kv_cache_sharding_spec=None,
     use_mla_cache: bool = False,
+    expected_ops: list = None,
+    check_fusions: bool = False,
 ):
     """Test LLM model with the given variant and optional configuration overrides.
 
@@ -159,6 +161,8 @@ def test_llm(
         input_output_sharding_spec=input_output_sharding_spec,
         kv_cache_sharding_spec=kv_cache_sharding_spec,
         use_mla_cache=use_mla_cache,
+        expected_ops=expected_ops,
+        check_fusions_enabled=check_fusions,
     )
 
     if output_file:
@@ -261,6 +265,7 @@ def test_llama_3_2_1b(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -283,6 +288,11 @@ def test_llama_3_2_1b(
             if optimization_level is not None
             else DEFAULT_OPTIMIZATION_LEVEL
         ),
+        expected_ops=[
+            "ttnn.scaled_dot_product_attention",
+            "ttnn.rms_norm",
+        ],
+        check_fusions=check_fusions,
     )
 
 


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-xla/issues/4264

### Problem description
Fusing failures are not caught in perf benchmarks.

### What's changed
- Added a simple search for listed ops in generated IRs.
- Added timestamp to avoid searching stale IRs from previous run.
- Added `--check-fusion` flag and `Check fusion` option in CI (disabled by default)

E.g. `tests/benchmark/test_llms.py`
```
def test_llama_3_2_1b(
    output_file,
    num_layers,
    request,
    accuracy_testing,
    batch_size,
    max_output_tokens,
    decode_only,
    optimization_level,
    check_fusions,
):
    from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
        ModelLoader,
        ModelVariant,
    )

    variant = ModelVariant.LLAMA_3_2_1B_INSTRUCT
    test_llm(
        ModelLoaderModule=ModelLoader,
        variant=variant,
        output_file=output_file,
        num_layers=num_layers,
        request=request,
        accuracy_testing=accuracy_testing,
        batch_size=batch_size,
        max_output_tokens=max_output_tokens,
        decode_only=decode_only,
        optimization_level=(
            optimization_level
            if optimization_level is not None
            else DEFAULT_OPTIMIZATION_LEVEL
        ),
        expected_ops=[                                                 <---- Fused ops to search for in IRs
            "ttnn.scaled_dot_product_attention",
            "ttnn.rms_norm",
        ],                                            
        check_fusions=check_fusions,                                   <---- Flag for fused ops search
    )
```

### Checklist
- [ ] [llama_3_2_1b with correct --check-fusions](https://github.com/tenstorrent/tt-xla/actions/runs/25065109630)
- [ ] [llama_3_2_1b with incorrect --check-fusions](https://github.com/tenstorrent/tt-xla/actions/runs/25065256717)
