### PR TITLE
Fix mesh shape when the graph has no inputs

### DIFF
--- a/pjrt_implementation/src/api/loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/loaded_executable_instance.cc
@@ -167,7 +167,11 @@ std::unordered_set<int> LoadedExecutableInstance::getDeviceIds(
   if (device_ids.size() == 0) {
     TT_FATAL(!m_addressable_devices.empty(),
              "No addressable devices available");
-    device_ids.emplace(m_addressable_devices.front()->getGlobalDeviceId());
+    size_t target = std::max<size_t>(
+        1, std::min(num_devices, m_addressable_devices.size()));
+    for (size_t i = 0; i < target; ++i) {
+      device_ids.emplace(m_addressable_devices[i]->getGlobalDeviceId());
+    }
   }
 
   return device_ids;

--- a/pjrt_implementation/src/api/module_builder/module_builder.cc
+++ b/pjrt_implementation/src/api/module_builder/module_builder.cc
@@ -845,6 +845,13 @@ tt_pjrt_status ModuleBuilder::runCompilerStableHLOPipeline(
                                           mlir::PassManager::Nesting::Implicit);
   mlir::tt::stablehlo::StableHLOPipelineOptions stablehlo_pipeline_options;
   stablehlo_pipeline_options.resultPresharded = result_presharded;
+  // Forward the open parent mesh shape so AnalyzeMeshPass can use it as the
+  // fallback for modules with no shardings.
+  if (current_mesh_shape.has_value() && current_mesh_shape->size() == 2) {
+    stablehlo_pipeline_options.meshShape = {
+        static_cast<int64_t>((*current_mesh_shape)[0]),
+        static_cast<int64_t>((*current_mesh_shape)[1])};
+  }
   mlir::tt::stablehlo::createStableHLOPipeline(stablehlo_pipeline_pm,
                                                stablehlo_pipeline_options);
 

--- a/pjrt_implementation/src/api/module_builder/module_builder.cc
+++ b/pjrt_implementation/src/api/module_builder/module_builder.cc
@@ -81,6 +81,18 @@ namespace tt::pjrt::module_builder {
 
 const std::string c_mlir_format_name = "mlir";
 
+static bool moduleHasAnyFuncArguments(mlir::OwningOpRef<mlir::ModuleOp> &m) {
+  bool found = false;
+  m.get().walk([&](mlir::func::FuncOp funcOp) {
+    if (funcOp.getNumArguments() > 0) {
+      found = true;
+      return mlir::WalkResult::interrupt();
+    }
+    return mlir::WalkResult::advance();
+  });
+  return found;
+}
+
 // Maps per-axis fabric config to TTNN mesh topology for CCL operations.
 static std::vector<mlir::tt::ttcore::Topology>
 fabricConfigToMeshTopology(const tt::runtime::MeshFabricConfig &fabricConfig) {
@@ -845,9 +857,9 @@ tt_pjrt_status ModuleBuilder::runCompilerStableHLOPipeline(
                                           mlir::PassManager::Nesting::Implicit);
   mlir::tt::stablehlo::StableHLOPipelineOptions stablehlo_pipeline_options;
   stablehlo_pipeline_options.resultPresharded = result_presharded;
-  // Forward the open parent mesh shape so AnalyzeMeshPass can use it as the
-  // fallback for modules with no shardings.
-  if (current_mesh_shape.has_value() && current_mesh_shape->size() == 2) {
+
+  if (current_mesh_shape.has_value() && current_mesh_shape->size() == 2 &&
+      !moduleHasAnyFuncArguments(mlir_module)) {
     stablehlo_pipeline_options.meshShape = {
         static_cast<int64_t>((*current_mesh_shape)[0]),
         static_cast<int64_t>((*current_mesh_shape)[1])};

--- a/pjrt_implementation/src/api/module_builder/module_builder.cc
+++ b/pjrt_implementation/src/api/module_builder/module_builder.cc
@@ -81,16 +81,20 @@ namespace tt::pjrt::module_builder {
 
 const std::string c_mlir_format_name = "mlir";
 
-static bool moduleHasAnyFuncArguments(mlir::OwningOpRef<mlir::ModuleOp> &m) {
-  bool found = false;
+// Returns true if the public entry point of the module has at least one
+// argument.
+static bool
+moduleHasAnyFuncArguments(const mlir::OwningOpRef<mlir::ModuleOp> &m) {
+  std::vector<mlir::func::FuncOp> public_func_ops;
   m.get().walk([&](mlir::func::FuncOp funcOp) {
-    if (funcOp.getNumArguments() > 0) {
-      found = true;
-      return mlir::WalkResult::interrupt();
+    if (funcOp.isPublic()) {
+      public_func_ops.push_back(funcOp);
     }
-    return mlir::WalkResult::advance();
   });
-  return found;
+  TT_FATAL(public_func_ops.size() == 1,
+           "Expected exactly one public function in module, got {}",
+           public_func_ops.size());
+  return public_func_ops[0].getNumArguments() > 0;
 }
 
 // Maps per-axis fabric config to TTNN mesh topology for CCL operations.


### PR DESCRIPTION
### Ticket
Related to https://github.com/tenstorrent/tt-xla/issues/4053
Depends on https://github.com/tenstorrent/tt-mlir/pull/8167

### Problem description
When graph has no inputs we get a device mismatch since it opens a 1x1 mesh by default.

### What's changed
- Pass mesh shape to stablehlo pipeline
- Use all devices available

Note:
We might still want to handle 1x1 -> 1xN transfers?

### Checklist
- [ ] New/Existing tests provide coverage for changes
