### PR TITLE
[vLLM plugin] Fix 2D-mesh device-sampler garbage output (and add coherence check)

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -2172,6 +2172,10 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
     @torch.compile(backend="tt", fullgraph=True, dynamic=False)
     def compute_logits(self, sample_hidden_states: torch.Tensor) -> torch.Tensor:
         logits = self.model.compute_logits(sample_hidden_states)
+        # Replicate logits for SPMD. Hooks can't reach ParallelLMHead
+        # (quant_method.apply bypasses __call__) and all_gather is a
+        # no-op (world_size=1). Must be inside the compiled graph —
+        # external sharding_constraint between compiled functions breaks.
         if self.enable_tensor_parallel:
             logits = sharding_constraint_tensor(logits, self.mesh, (None, None))
         return logits

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -2172,7 +2172,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
     @torch.compile(backend="tt", fullgraph=True, dynamic=False)
     def compute_logits(self, sample_hidden_states: torch.Tensor) -> torch.Tensor:
         logits = self.model.compute_logits(sample_hidden_states)
-        if self.enable_tensor_parallel and not self.use_2d_mesh:
+        if self.enable_tensor_parallel:
             logits = sharding_constraint_tensor(logits, self.mesh, (None, None))
         return logits
 

--- a/tests/integrations/vllm_plugin/generative/conftest.py
+++ b/tests/integrations/vllm_plugin/generative/conftest.py
@@ -2,7 +2,50 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 """Shared conftest for vLLM generative tests."""
+import re
+
 import psutil
+
+# Common English function words used by `assert_output_coherent` to detect
+# the 2D-mesh sampler garbage-output bug (issue #4440). Coherent natural-
+# language continuations contain several of these per ~30-token output;
+# token-soup garbage contains ~zero.
+_STOPWORDS = frozenset(
+    """
+    the a an and or but i you he she it we they is are was were be been
+    have has had do does did of to in on at for with by from as that this
+    my your her his their can will would should like go get make me so
+    not if when what how there here
+    """.split()
+)
+_WORD_RE = re.compile(r"[A-Za-z']+")
+_MIN_STOPWORD_RATIO = 0.10
+_MAX_NON_LATIN_RATIO = 0.03
+_MIN_WORDS = 5
+
+
+def assert_output_coherent(text: str) -> None:
+    """Heuristic assertion: text is English natural-language, not token soup.
+
+    Tuned for the English prompts used in the generative TP tests
+    (e.g. "I like taking walks in the"). Re-tune thresholds if a test
+    introduces non-English prompts or code-completion prompts.
+    """
+    s = text.strip()
+    assert s, f"empty output: {text!r}"
+    nlr = sum(1 for c in s if ord(c) > 127) / len(s)
+    assert nlr <= _MAX_NON_LATIN_RATIO, (
+        f"non-Latin char ratio too high ({nlr:.3f} > {_MAX_NON_LATIN_RATIO}): "
+        f"{text!r}"
+    )
+    words = [w.lower() for w in _WORD_RE.findall(s)]
+    assert words, f"output has no word characters: {text!r}"
+    if len(words) < _MIN_WORDS:
+        return
+    sr = sum(1 for w in words if w in _STOPWORDS) / len(words)
+    assert (
+        sr >= _MIN_STOPWORD_RATIO
+    ), f"stopword ratio too low ({sr:.3f} < {_MIN_STOPWORD_RATIO}): {text!r}"
 
 
 def check_host_memory(model_name: str) -> float:

--- a/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 import vllm
-from conftest import check_host_memory
+from conftest import assert_output_coherent, check_host_memory
 
 
 @pytest.mark.push
@@ -33,6 +33,7 @@ def test_tensor_parallel_generation_n300(model_name: str, use_2d_mesh: bool):
 
     output_text = llm.generate(prompts, sampling_params)[0].outputs[0].text
     print(f"prompt: {prompts[0]}, output: {output_text}")
+    assert_output_coherent(output_text)
 
 
 @pytest.mark.push
@@ -73,6 +74,7 @@ def test_tensor_parallel_generation_llmbox_small(
 
     output_text = llm.generate(prompts, sampling_params)[0].outputs[0].text
     print(f"prompt: {prompts[0]}, output: {output_text}")
+    assert_output_coherent(output_text)
 
     check_host_memory(model_name)
 
@@ -116,5 +118,6 @@ def test_tensor_parallel_generation_llmbox_large(
 
     output_text = llm.generate(prompts, sampling_params)[0].outputs[0].text
     print(f"prompt: {prompts[0]}, output: {output_text}")
+    assert_output_coherent(output_text)
 
     check_host_memory(model_name)


### PR DESCRIPTION
## Ticket

Closes #4440

## Problem description

- Tensor-parallel generative tests with 2D mesh + on-device sampling produced token-soup garbage (e.g. `'.presentientes winner actually! Bool volunte vertexlek language("");\n ReIGHlek...'`), while 1D mesh and 2D-mesh-with-CPU-sampling were both fine. Bisected to PR #3820 which gated the post-`compute_logits` replication-constraint to the 1D-mesh path only — the device sampler then operated on logits still sharded along the `model` axis.

- A second issue surfaced during the investigation: the bug had been landing as PASSED in CI because the tests asserted only that `llm.generate(...)` completed, not that its output was coherent. A small heuristic check is added so token-soup output now hard-fails.

## What's changed

- `integrations/vllm_plugin/vllm_tt/model_runner.py`: drop the `not self.use_2d_mesh` guard in `compute_logits` so the `sharding_constraint_tensor((None, None))` replication applies for both 1D and 2D mesh — restores pre-#3820 behavior. (Pre-commit isort also reordered two unrelated import lines in the same file.)
- `tests/integrations/vllm_plugin/generative/conftest.py`: add `assert_output_coherent` — flags empty output, >3% non-Latin chars, or <10% common-English-stopword ratio as garbage.
- `tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py`: call `assert_output_coherent(output_text)` after `llm.generate(...)` in the three TP generation tests (`_n300`, `_llmbox_small`, `_llmbox_large`).

See follow-up comment for the bisect, root-cause walkthrough, and heuristic tuning.

## Checklist

- [x] Bug reproduces and clears with the patch on Qwen3-8B (smallest reproducer) and Qwen3-32B (the original failing test).
- [x] New `assert_output_coherent` validated against 8 known-good and 6 known-garbage outputs from local runs and CI logs (issue #4440).
