### PR TITLE
Remove duplicate umd shared lib files

### DIFF
--- a/python_package/setup.py
+++ b/python_package/setup.py
@@ -455,6 +455,12 @@ class CMakeBuildPy(build_py):
         _remove_bloat_dir(install_dir / "lib" / "pkgconfig")
         _remove_bloat_dir(install_dir / "lib64" / "cmake")
         _remove_bloat_dir(install_dir / "lib64" / "pkgconfig")
+        _resolve_symlink_to_file(install_dir / "lib64" / "libtt-umd.so.0")
+        _remove_bloat_file(install_dir / "lib64" / "libtt-umd.so")
+        _remove_bloat_file(install_dir / "lib64" / "libtt-umd.so.0.70.0")
+        _resolve_symlink_to_file(install_dir / "lib" / "libtt-umd.so.0")
+        _remove_bloat_file(install_dir / "lib" / "libtt-umd.so")
+        _remove_bloat_file(install_dir / "lib" / "libtt-umd.so.0.70.0")
         _remove_bloat_dir(install_dir / "include")
         # Remove bin when building manylinux wheel. This, however, removes multi-host feature.
         # issue: https://github.com/tenstorrent/tt-xla/issues/3531
@@ -482,6 +488,19 @@ def _remove_bloat_dir(dir_path: Path) -> None:
     if dir_path.exists() and dir_path.is_dir():
         print(f"Removing bloat directory: {dir_path}")
         shutil.rmtree(dir_path)
+
+
+def _remove_bloat_file(file_path: Path) -> None:
+    if file_path.exists() or file_path.is_symlink():
+        print(f"Removing bloat file: {file_path}")
+        file_path.unlink()
+
+
+def _resolve_symlink_to_file(file_path: Path) -> None:
+    if file_path.is_symlink():
+        target = file_path.resolve()
+        file_path.unlink()
+        shutil.copy2(target, file_path)
 
 
 def _remove_static_archives(root: Path) -> None:


### PR DESCRIPTION
### Ticket
/

### Problem description
With the latest tt-mlir uplift duplicate .so files of umd have appeared in the wheel.

### What's changed
Remove the duplicate shared lib files during wheel creation.

Notes:
- duplicate lines for `/lib` and `/lib64` exist to cover both non-manylinux and manylinux wheels
- this should be fixed at the root of the problem (in tt-metal) this is not ideal
- 3 new .so files that were added are not all really files (libtt-metal.so.0 (symlink), libtt-metal.so (symlink), libtt-metal.so.0.70.0 (file)), that's why resolution was needed first before removal

### Checklist
- [ ] New/Existing tests provide coverage for changes
