### PR TITLE
Add bounded training workflow reduction tools

### DIFF
--- a/tests/runner/README.md
+++ b/tests/runner/README.md
@@ -76,8 +76,9 @@ Bounded rerun path:
   - `pytest -vv -s tests/runner/test_models.py::test_all_models_torch[<test-id>]`
   - with `TTMLIR_LOGGER_LEVEL=DEBUG`
   - and `TT_RUNTIME_DEBUG=ON`
-- use `--pytest-bin` to point at a repo-local pytest, for example:
-  - `.venv/bin/pytest`
+- `--pytest-bin` is restricted to the literal `pytest` command; select a repo-local
+  or virtualenv pytest by activating the environment or prepending its `bin`
+  directory to `PATH`
 - this path writes `runtime_rerun.log` and then extracts debug evidence from that log if possible
 - before launching pytest, the tool now probes the paired Python environment for:
   - `psutil`
@@ -99,7 +100,7 @@ Current owner heuristics:
   - attempt log only until real debug-log capture exists
 
 Notes:
-- this tool is still draft-only and does not rerun tests
+- this tool is draft-only; it reruns tests only when `--execute-rerun` is explicitly supplied and does not file issues or mutate source YAML
 - without `--debug-log-root`, the next manual step remains to capture real `TTMLIR_LOGGER_LEVEL=DEBUG` and `TT_RUNTIME_DEBUG=ON` evidence before filing
 
 ## Bounded Workflow Validation

--- a/tests/runner/README.md
+++ b/tests/runner/README.md
@@ -1,0 +1,124 @@
+# Runner Utilities
+
+## Frontend Training Failure Triage
+
+Use `frontend_training_failure_triage.py` to generate bounded frontend triage artifacts for training failures whose current config reason suggests missing `unpack_forward_output` support.
+
+Example:
+
+```sh
+python3 tests/runner/frontend_training_failure_triage.py \
+  --output-root artifacts/frontend_training_triage_prd006_seed \
+  --test-id yolov6/pytorch-N-single_device-training \
+  --test-id distilbert/question_answering/pytorch-Base_Cased_Distilled_Squad-single_device-training \
+  --test-id fpn/pytorch-ResNet50_Backbone_with_FPN_V2-single_device-training \
+  --test-id maptr/pytorch-Tiny_R50_24e_Av2-single_device-training
+```
+
+Outputs:
+- per-test folder with `manifest.json` and either `draft_issue.md` or `attempt.log`
+- `summary.json` with run-level counts
+- `review_report.md` for human review
+- `config_refresh_recommendations.json` for stale-reason candidates
+- `config_refresh_patch.yaml` as a reviewable proposed YAML refresh artifact
+
+Selection rule:
+- defaults to rows in `tests/runner/test_config/torch/test_config_training_single_device.yaml` whose reason is exactly:
+  - `tt-forge-models doesn't implement unpack_forward_output for this model.`
+
+Current inspection surface:
+- training config source:
+  - `tests/runner/test_config/torch/test_config_training_single_device.yaml`
+- shared helper registry:
+  - `third_party/tt_forge_models/training_utils.py`
+- model-specific loader inspection:
+  - `third_party/tt_forge_models/**/pytorch/loader.py`
+
+Notes:
+- this tool is draft-only; it does not file issues or mutate the training config
+- stale-reason suspects are surfaced separately when the loader already implements `unpack_forward_output`
+
+## Runtime Training Failure Reduction
+
+Use `runtime_training_failure_reduction.py` to generate bounded runtime-reduction artifacts for training failures whose config metadata already indicates runtime or metal-style problems.
+
+Example:
+
+```sh
+python3 tests/runner/runtime_training_failure_reduction.py \
+  --output-root artifacts/runtime_training_reduction_prd006_seed \
+  --debug-log-root artifacts/runtime_debug_logs \
+  --test-id pointpillars/pytorch-pointpillars-single_device-training \
+  --test-id beit/image_classification/pytorch-Base_Patch16_224-single_device-training \
+  --test-id convnextv2/image_classification/pytorch-Atto-single_device-training \
+  --test-id xlstm/pytorch-single_device-training
+```
+
+Outputs:
+- per-test folder with `manifest.json` and either `draft_issue.md` or `attempt.log`
+- optional per-test `debug_evidence.md` when a matching runtime debug log is supplied
+- optional per-test `runtime_rerun.log` when `--execute-rerun` is used and no matching debug log exists
+- `summary.json` with run-level counts
+- `review_report.md` for human review
+
+Debug evidence intake:
+- optional `--debug-log-root` accepts either:
+  - a directory containing per-test log files named after sanitized test ids
+  - a single debug log file
+- when debug logs are present, the tool extracts:
+  - `Executing operation` lines
+  - runtime signal lines such as `TT_FATAL` and `RuntimeError`
+  - nearby `ttnn` / MLIR context lines
+- this does not rerun the test, but it upgrades the bounded runtime packet from config-only routing to evidence-backed reduction artifacts
+
+Bounded rerun path:
+- optional `--execute-rerun` tries:
+  - `pytest -vv -s tests/runner/test_models.py::test_all_models_torch[<test-id>]`
+  - with `TTMLIR_LOGGER_LEVEL=DEBUG`
+  - and `TT_RUNTIME_DEBUG=ON`
+- use `--pytest-bin` to point at a repo-local pytest, for example:
+  - `.venv/bin/pytest`
+- this path writes `runtime_rerun.log` and then extracts debug evidence from that log if possible
+- before launching pytest, the tool now probes the paired Python environment for:
+  - `psutil`
+  - `pytest`
+  - `torch`
+  - `torch_xla`
+- if those imports fail, the tool records a `rerun precondition violation` attempt log instead of pretending a runtime draft is ready
+- use `--force-run-skipped` only for bounded debug capture of selected `NOT_SUPPORTED_SKIP` rows; it sets `TT_XLA_FORCE_RUN_SKIPPED_TEST_IDS` for the subprocess and does not mutate source YAML
+
+Selection rule:
+- defaults to rows in `tests/runner/test_config/torch/test_config_training_single_device.yaml` whose `bringup_status` is `FAILED_RUNTIME` or whose reason contains a strong runtime keyword
+
+Current owner heuristics:
+- memory allocation, L1, DRAM, `TT_FATAL`, and device-buffer failures:
+  - `tt-metal` draft candidate
+- other bounded runtime failures:
+  - `tt-alchemist` draft candidate
+- hangs:
+  - attempt log only until real debug-log capture exists
+
+Notes:
+- this tool is still draft-only and does not rerun tests
+- without `--debug-log-root`, the next manual step remains to capture real `TTMLIR_LOGGER_LEVEL=DEBUG` and `TT_RUNTIME_DEBUG=ON` evidence before filing
+
+## Bounded Workflow Validation
+
+Use `bounded_training_workflow_validation.py` to validate bounded frontend and runtime workflow outputs against the PRD-006 review rubric.
+
+Example:
+
+```sh
+python3 tests/runner/bounded_training_workflow_validation.py \
+  --frontend-output-root artifacts/frontend_training_triage_prd006_seed_v6 \
+  --runtime-output-root artifacts/runtime_training_reduction_prd006_seed_v2 \
+  --output-root artifacts/bounded_training_workflow_validation_prd006
+```
+
+Outputs:
+- `validation_summary.json`
+- `validation_review_packet.md`
+
+Notes:
+- this validator is evidence-based and artifact-only
+- it does not file issues or rerun tests

--- a/tests/runner/bounded_training_workflow_validation.py
+++ b/tests/runner/bounded_training_workflow_validation.py
@@ -1,0 +1,204 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validate bounded frontend/runtime workflow outputs against the PRD-006 rubric."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class ValidationRecord:
+    test_id: str
+    workflow_path: str
+    binary_result: str
+    evidence_path: str
+    failed_conditions: list[str]
+    corrective_steps: list[str]
+    failure_taxonomy: str | None
+
+
+@dataclass
+class ValidationSummary:
+    frontend_output_root: str
+    runtime_output_root: str
+    total_items: int
+    pass_count: int
+    fail_count: int
+    error_count: int
+    records: list[dict[str, Any]]
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def validate_record(manifest: dict[str, Any], workflow_path: str) -> ValidationRecord:
+    failed_conditions: list[str] = []
+    corrective_steps: list[str] = []
+
+    if not manifest.get("test_id"):
+        failed_conditions.append("missing cohort identity")
+        corrective_steps.append("ensure manifest.json records the exact test_id for the cohort row")
+
+    if workflow_path == "frontend":
+        path_explicit = manifest.get("classification") == "frontend"
+    else:
+        path_explicit = bool(manifest.get("owner_hint"))
+    if not path_explicit:
+        failed_conditions.append("workflow path or owner classification is not explicit")
+        corrective_steps.append("record explicit workflow-path classification in the manifest")
+
+    evidence_present = bool(manifest.get("draft_issue_path") or manifest.get("attempt_log_path"))
+    if not evidence_present:
+        failed_conditions.append("evidence bundle link is missing")
+        corrective_steps.append("emit either draft_issue.md or attempt.log and persist its path in the manifest")
+
+    outcome_explicit = bool(manifest.get("draft_issue_path") or manifest.get("attempt_log_path"))
+    if not outcome_explicit:
+        failed_conditions.append("recommendation or reduction outcome is not explicit")
+        corrective_steps.append("record whether the item produced a draft packet or an attempt log")
+
+    blockers_present = False
+    if workflow_path == "frontend":
+        blockers_present = bool(manifest.get("next_manual_step"))
+    else:
+        blockers_present = bool(manifest.get("next_manual_step"))
+    if not blockers_present:
+        failed_conditions.append("remaining blocker or next manual step is missing")
+        corrective_steps.append("record the next manual step in the manifest")
+
+    if workflow_path == "frontend":
+        contract_ok = all(
+            key in manifest
+            for key in (
+                "test_id",
+                "classification",
+                "reason",
+                "draft_issue_path",
+                "attempt_log_path",
+                "next_manual_step",
+            )
+        )
+    else:
+        contract_ok = all(
+            key in manifest
+            for key in (
+                "test_id",
+                "bringup_status",
+                "classification",
+                "owner_hint",
+                "reason",
+                "draft_issue_path",
+                "attempt_log_path",
+                "next_manual_step",
+            )
+        )
+    if not contract_ok:
+        failed_conditions.append("output does not match the shared packet contract")
+        corrective_steps.append("populate the required manifest fields for the workflow path")
+
+    if failed_conditions:
+        if not evidence_present:
+            binary_result = "error"
+            failure_taxonomy = "precondition_violation"
+        else:
+            binary_result = "fail"
+            failure_taxonomy = "goal_not_achieved"
+    else:
+        binary_result = "pass"
+        failure_taxonomy = None
+
+    return ValidationRecord(
+        test_id=manifest.get("test_id", ""),
+        workflow_path=workflow_path,
+        binary_result=binary_result,
+        evidence_path=manifest.get("draft_issue_path") or manifest.get("attempt_log_path") or "",
+        failed_conditions=failed_conditions,
+        corrective_steps=corrective_steps,
+        failure_taxonomy=failure_taxonomy,
+    )
+
+
+def collect_manifests(output_root: Path) -> list[Path]:
+    return sorted(output_root.glob("*/manifest.json"))
+
+
+def write_summary(path: Path, summary: ValidationSummary) -> None:
+    path.write_text(json.dumps(asdict(summary), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_review_packet(path: Path, summary: ValidationSummary) -> None:
+    lines = [
+        "# Bounded Training Workflow Validation Review Packet",
+        "",
+        "## Summary",
+        f"- total items: `{summary.total_items}`",
+        f"- pass: `{summary.pass_count}`",
+        f"- fail: `{summary.fail_count}`",
+        f"- error: `{summary.error_count}`",
+        "",
+        "## Per-Item Results",
+    ]
+    for record in summary.records:
+        lines.extend(
+            [
+                f"- `{record['test_id']}`",
+                f"  - workflow: `{record['workflow_path']}`",
+                f"  - result: `{record['binary_result']}`",
+                f"  - evidence: `{record['evidence_path']}`",
+            ]
+        )
+        if record["failed_conditions"]:
+            lines.append(f"  - failed conditions: `{'; '.join(record['failed_conditions'])}`")
+            lines.append(f"  - corrective steps: `{'; '.join(record['corrective_steps'])}`")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--frontend-output-root", type=Path, required=True)
+    parser.add_argument("--runtime-output-root", type=Path, required=True)
+    parser.add_argument("--output-root", type=Path, required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    records: list[ValidationRecord] = []
+
+    for manifest_path in collect_manifests(args.frontend_output_root):
+        records.append(validate_record(load_json(manifest_path), "frontend"))
+    for manifest_path in collect_manifests(args.runtime_output_root):
+        records.append(validate_record(load_json(manifest_path), "runtime"))
+
+    summary = ValidationSummary(
+        frontend_output_root=str(args.frontend_output_root),
+        runtime_output_root=str(args.runtime_output_root),
+        total_items=len(records),
+        pass_count=sum(1 for record in records if record.binary_result == "pass"),
+        fail_count=sum(1 for record in records if record.binary_result == "fail"),
+        error_count=sum(1 for record in records if record.binary_result == "error"),
+        records=[asdict(record) for record in records],
+    )
+    args.output_root.mkdir(parents=True, exist_ok=True)
+    write_summary(args.output_root / "validation_summary.json", summary)
+    write_review_packet(args.output_root / "validation_review_packet.md", summary)
+
+    print(
+        "Validated "
+        f"{summary.total_items} bounded workflow item(s) "
+        f"(pass={summary.pass_count}, fail={summary.fail_count}, error={summary.error_count})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/runner/bounded_training_workflow_validation.py
+++ b/tests/runner/bounded_training_workflow_validation.py
@@ -46,25 +46,39 @@ def validate_record(manifest: dict[str, Any], workflow_path: str) -> ValidationR
 
     if not manifest.get("test_id"):
         failed_conditions.append("missing cohort identity")
-        corrective_steps.append("ensure manifest.json records the exact test_id for the cohort row")
+        corrective_steps.append(
+            "ensure manifest.json records the exact test_id for the cohort row"
+        )
 
     if workflow_path == "frontend":
         path_explicit = manifest.get("classification") == "frontend"
     else:
         path_explicit = bool(manifest.get("owner_hint"))
     if not path_explicit:
-        failed_conditions.append("workflow path or owner classification is not explicit")
-        corrective_steps.append("record explicit workflow-path classification in the manifest")
+        failed_conditions.append(
+            "workflow path or owner classification is not explicit"
+        )
+        corrective_steps.append(
+            "record explicit workflow-path classification in the manifest"
+        )
 
-    evidence_present = bool(manifest.get("draft_issue_path") or manifest.get("attempt_log_path"))
+    evidence_present = bool(
+        manifest.get("draft_issue_path") or manifest.get("attempt_log_path")
+    )
     if not evidence_present:
         failed_conditions.append("evidence bundle link is missing")
-        corrective_steps.append("emit either draft_issue.md or attempt.log and persist its path in the manifest")
+        corrective_steps.append(
+            "emit either draft_issue.md or attempt.log and persist its path in the manifest"
+        )
 
-    outcome_explicit = bool(manifest.get("draft_issue_path") or manifest.get("attempt_log_path"))
+    outcome_explicit = bool(
+        manifest.get("draft_issue_path") or manifest.get("attempt_log_path")
+    )
     if not outcome_explicit:
         failed_conditions.append("recommendation or reduction outcome is not explicit")
-        corrective_steps.append("record whether the item produced a draft packet or an attempt log")
+        corrective_steps.append(
+            "record whether the item produced a draft packet or an attempt log"
+        )
 
     blockers_present = False
     if workflow_path == "frontend":
@@ -103,7 +117,9 @@ def validate_record(manifest: dict[str, Any], workflow_path: str) -> ValidationR
         )
     if not contract_ok:
         failed_conditions.append("output does not match the shared packet contract")
-        corrective_steps.append("populate the required manifest fields for the workflow path")
+        corrective_steps.append(
+            "populate the required manifest fields for the workflow path"
+        )
 
     if failed_conditions:
         if not evidence_present:
@@ -120,7 +136,9 @@ def validate_record(manifest: dict[str, Any], workflow_path: str) -> ValidationR
         test_id=manifest.get("test_id", ""),
         workflow_path=workflow_path,
         binary_result=binary_result,
-        evidence_path=manifest.get("draft_issue_path") or manifest.get("attempt_log_path") or "",
+        evidence_path=manifest.get("draft_issue_path")
+        or manifest.get("attempt_log_path")
+        or "",
         failed_conditions=failed_conditions,
         corrective_steps=corrective_steps,
         failure_taxonomy=failure_taxonomy,
@@ -132,7 +150,9 @@ def collect_manifests(output_root: Path) -> list[Path]:
 
 
 def write_summary(path: Path, summary: ValidationSummary) -> None:
-    path.write_text(json.dumps(asdict(summary), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    path.write_text(
+        json.dumps(asdict(summary), indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
 
 
 def write_review_packet(path: Path, summary: ValidationSummary) -> None:
@@ -157,8 +177,12 @@ def write_review_packet(path: Path, summary: ValidationSummary) -> None:
             ]
         )
         if record["failed_conditions"]:
-            lines.append(f"  - failed conditions: `{'; '.join(record['failed_conditions'])}`")
-            lines.append(f"  - corrective steps: `{'; '.join(record['corrective_steps'])}`")
+            lines.append(
+                f"  - failed conditions: `{'; '.join(record['failed_conditions'])}`"
+            )
+            lines.append(
+                f"  - corrective steps: `{'; '.join(record['corrective_steps'])}`"
+            )
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 

--- a/tests/runner/bounded_training_workflow_validation.py
+++ b/tests/runner/bounded_training_workflow_validation.py
@@ -36,93 +36,103 @@ class ValidationSummary:
     records: list[dict[str, Any]]
 
 
+_FRONTEND_REQUIRED_MANIFEST_KEYS = (
+    "test_id",
+    "classification",
+    "reason",
+    "draft_issue_path",
+    "attempt_log_path",
+    "next_manual_step",
+)
+_RUNTIME_REQUIRED_MANIFEST_KEYS = (
+    "test_id",
+    "bringup_status",
+    "classification",
+    "owner_hint",
+    "reason",
+    "draft_issue_path",
+    "attempt_log_path",
+    "next_manual_step",
+)
+
+
 def load_json(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def evidence_path(manifest: dict[str, Any]) -> str:
+    return manifest.get("draft_issue_path") or manifest.get("attempt_log_path") or ""
+
+
+def path_is_explicit(manifest: dict[str, Any], workflow_path: str) -> bool:
+    if workflow_path == "frontend":
+        return manifest.get("classification") == "frontend"
+    return bool(manifest.get("owner_hint"))
+
+
+def required_manifest_keys(workflow_path: str) -> tuple[str, ...]:
+    if workflow_path == "frontend":
+        return _FRONTEND_REQUIRED_MANIFEST_KEYS
+    return _RUNTIME_REQUIRED_MANIFEST_KEYS
+
+
+def record_failure(
+    failed_conditions: list[str],
+    corrective_steps: list[str],
+    condition: str,
+    corrective_step: str,
+) -> None:
+    failed_conditions.append(condition)
+    corrective_steps.append(corrective_step)
 
 
 def validate_record(manifest: dict[str, Any], workflow_path: str) -> ValidationRecord:
     failed_conditions: list[str] = []
     corrective_steps: list[str] = []
+    output_evidence_path = evidence_path(manifest)
 
     if not manifest.get("test_id"):
-        failed_conditions.append("missing cohort identity")
-        corrective_steps.append(
-            "ensure manifest.json records the exact test_id for the cohort row"
+        record_failure(
+            failed_conditions,
+            corrective_steps,
+            "missing cohort identity",
+            "ensure manifest.json records the exact test_id for the cohort row",
         )
 
-    if workflow_path == "frontend":
-        path_explicit = manifest.get("classification") == "frontend"
-    else:
-        path_explicit = bool(manifest.get("owner_hint"))
-    if not path_explicit:
-        failed_conditions.append(
-            "workflow path or owner classification is not explicit"
-        )
-        corrective_steps.append(
-            "record explicit workflow-path classification in the manifest"
+    if not path_is_explicit(manifest, workflow_path):
+        record_failure(
+            failed_conditions,
+            corrective_steps,
+            "workflow path or owner classification is not explicit",
+            "record explicit workflow-path classification in the manifest",
         )
 
-    evidence_present = bool(
-        manifest.get("draft_issue_path") or manifest.get("attempt_log_path")
-    )
-    if not evidence_present:
-        failed_conditions.append("evidence bundle link is missing")
-        corrective_steps.append(
-            "emit either draft_issue.md or attempt.log and persist its path in the manifest"
+    if not output_evidence_path:
+        record_failure(
+            failed_conditions,
+            corrective_steps,
+            "evidence bundle link is missing",
+            "emit either draft_issue.md or attempt.log and persist its path in the manifest",
         )
 
-    outcome_explicit = bool(
-        manifest.get("draft_issue_path") or manifest.get("attempt_log_path")
-    )
-    if not outcome_explicit:
-        failed_conditions.append("recommendation or reduction outcome is not explicit")
-        corrective_steps.append(
-            "record whether the item produced a draft packet or an attempt log"
+    if not manifest.get("next_manual_step"):
+        record_failure(
+            failed_conditions,
+            corrective_steps,
+            "remaining blocker or next manual step is missing",
+            "record the next manual step in the manifest",
         )
 
-    blockers_present = False
-    if workflow_path == "frontend":
-        blockers_present = bool(manifest.get("next_manual_step"))
-    else:
-        blockers_present = bool(manifest.get("next_manual_step"))
-    if not blockers_present:
-        failed_conditions.append("remaining blocker or next manual step is missing")
-        corrective_steps.append("record the next manual step in the manifest")
-
-    if workflow_path == "frontend":
-        contract_ok = all(
-            key in manifest
-            for key in (
-                "test_id",
-                "classification",
-                "reason",
-                "draft_issue_path",
-                "attempt_log_path",
-                "next_manual_step",
-            )
-        )
-    else:
-        contract_ok = all(
-            key in manifest
-            for key in (
-                "test_id",
-                "bringup_status",
-                "classification",
-                "owner_hint",
-                "reason",
-                "draft_issue_path",
-                "attempt_log_path",
-                "next_manual_step",
-            )
-        )
-    if not contract_ok:
-        failed_conditions.append("output does not match the shared packet contract")
-        corrective_steps.append(
-            "populate the required manifest fields for the workflow path"
+    if not all(key in manifest for key in required_manifest_keys(workflow_path)):
+        record_failure(
+            failed_conditions,
+            corrective_steps,
+            "output does not match the shared packet contract",
+            "populate the required manifest fields for the workflow path",
         )
 
     if failed_conditions:
-        if not evidence_present:
+        if not output_evidence_path:
             binary_result = "error"
             failure_taxonomy = "precondition_violation"
         else:
@@ -136,9 +146,7 @@ def validate_record(manifest: dict[str, Any], workflow_path: str) -> ValidationR
         test_id=manifest.get("test_id", ""),
         workflow_path=workflow_path,
         binary_result=binary_result,
-        evidence_path=manifest.get("draft_issue_path")
-        or manifest.get("attempt_log_path")
-        or "",
+        evidence_path=output_evidence_path,
         failed_conditions=failed_conditions,
         corrective_steps=corrective_steps,
         failure_taxonomy=failure_taxonomy,
@@ -147,6 +155,34 @@ def validate_record(manifest: dict[str, Any], workflow_path: str) -> ValidationR
 
 def collect_manifests(output_root: Path) -> list[Path]:
     return sorted(output_root.glob("*/manifest.json"))
+
+
+def validate_manifests(output_root: Path, workflow_path: str) -> list[ValidationRecord]:
+    return [
+        validate_record(load_json(manifest_path), workflow_path)
+        for manifest_path in collect_manifests(output_root)
+    ]
+
+
+def count_records(records: list[ValidationRecord], binary_result: str) -> int:
+    return sum(1 for record in records if record.binary_result == binary_result)
+
+
+def build_validation_summary(
+    *,
+    frontend_output_root: Path,
+    runtime_output_root: Path,
+    records: list[ValidationRecord],
+) -> ValidationSummary:
+    return ValidationSummary(
+        frontend_output_root=str(frontend_output_root),
+        runtime_output_root=str(runtime_output_root),
+        total_items=len(records),
+        pass_count=count_records(records, "pass"),
+        fail_count=count_records(records, "fail"),
+        error_count=count_records(records, "error"),
+        records=[asdict(record) for record in records],
+    )
 
 
 def write_summary(path: Path, summary: ValidationSummary) -> None:
@@ -196,21 +232,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 
 def main(argv: list[str]) -> int:
     args = parse_args(argv)
-    records: list[ValidationRecord] = []
+    records = [
+        *validate_manifests(args.frontend_output_root, "frontend"),
+        *validate_manifests(args.runtime_output_root, "runtime"),
+    ]
 
-    for manifest_path in collect_manifests(args.frontend_output_root):
-        records.append(validate_record(load_json(manifest_path), "frontend"))
-    for manifest_path in collect_manifests(args.runtime_output_root):
-        records.append(validate_record(load_json(manifest_path), "runtime"))
-
-    summary = ValidationSummary(
-        frontend_output_root=str(args.frontend_output_root),
-        runtime_output_root=str(args.runtime_output_root),
-        total_items=len(records),
-        pass_count=sum(1 for record in records if record.binary_result == "pass"),
-        fail_count=sum(1 for record in records if record.binary_result == "fail"),
-        error_count=sum(1 for record in records if record.binary_result == "error"),
-        records=[asdict(record) for record in records],
+    summary = build_validation_summary(
+        frontend_output_root=args.frontend_output_root,
+        runtime_output_root=args.runtime_output_root,
+        records=records,
     )
     args.output_root.mkdir(parents=True, exist_ok=True)
     write_summary(args.output_root / "validation_summary.json", summary)

--- a/tests/runner/conftest.py
+++ b/tests/runner/conftest.py
@@ -20,6 +20,12 @@ from tests.runner.test_utils import (
 from tests.utils import BringupStatus, Category
 
 _BRINGUP_STAGE_FILE = "._bringup_stage.txt"
+_FORCE_RUN_SKIPPED_ENV = "TT_XLA_FORCE_RUN_SKIPPED_TEST_IDS"
+
+
+def _force_run_skipped_test_ids() -> set[str]:
+    raw = os.getenv(_FORCE_RUN_SKIPPED_ENV, "")
+    return {item.strip() for item in raw.split(",") if item.strip()}
 
 # Models to skip on lb-blackhole: S3-dependent models (no S3 bucket access on the runner)
 # and models that hang indefinitely during execution.
@@ -147,6 +153,7 @@ def pytest_collection_modifyitems(config, items):
     combined_test_config = torch_test_config | jax_test_config | torch_llm_test_config
 
     deselected = []
+    force_run_skipped_ids = _force_run_skipped_test_ids()
 
     for item in items:
 
@@ -156,6 +163,8 @@ def pytest_collection_modifyitems(config, items):
             nodeid = nodeid[nodeid.index("[") + 1 : -1]
 
         meta = ModelTestConfig(combined_test_config.get(nodeid), arch)
+        if nodeid in force_run_skipped_ids and meta.status == ModelTestStatus.NOT_SUPPORTED_SKIP:
+            meta.status = ModelTestStatus.UNSPECIFIED
         item._test_meta = meta  # attach for fixture access
 
         # Uncomment this to print info for each test collected.

--- a/tests/runner/conftest.py
+++ b/tests/runner/conftest.py
@@ -27,6 +27,7 @@ def _force_run_skipped_test_ids() -> set[str]:
     raw = os.getenv(_FORCE_RUN_SKIPPED_ENV, "")
     return {item.strip() for item in raw.split(",") if item.strip()}
 
+
 # Models to skip on lb-blackhole: S3-dependent models (no S3 bucket access on the runner)
 # and models that hang indefinitely during execution.
 _LB_BLACKHOLE_SKIP_MODELS = {
@@ -163,7 +164,10 @@ def pytest_collection_modifyitems(config, items):
             nodeid = nodeid[nodeid.index("[") + 1 : -1]
 
         meta = ModelTestConfig(combined_test_config.get(nodeid), arch)
-        if nodeid in force_run_skipped_ids and meta.status == ModelTestStatus.NOT_SUPPORTED_SKIP:
+        if (
+            nodeid in force_run_skipped_ids
+            and meta.status == ModelTestStatus.NOT_SUPPORTED_SKIP
+        ):
             meta.status = ModelTestStatus.UNSPECIFIED
         item._test_meta = meta  # attach for fixture access
 

--- a/tests/runner/frontend_training_failure_triage.py
+++ b/tests/runner/frontend_training_failure_triage.py
@@ -1,0 +1,489 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generate bounded frontend training-failure triage bundles.
+
+This tool turns a bounded set of training failures from the model test YAML into
+review-ready frontend triage artifacts. It is intentionally planning-driven and
+bounded: it focuses on rows whose current reason indicates that
+``tt-forge-models`` does not implement ``unpack_forward_output`` for the model.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+_DEFAULT_CONFIG_PATH = (
+    _PROJECT_ROOT / "tests" / "runner" / "test_config" / "torch" / "test_config_training_single_device.yaml"
+)
+_DEFAULT_OUTPUT_ROOT = _PROJECT_ROOT / "artifacts" / "frontend_training_triage"
+_TRAINING_UTILS_PATH = _PROJECT_ROOT / "third_party" / "tt_forge_models" / "training_utils.py"
+_UNPACK_REASON = "tt-forge-models doesn't implement unpack_forward_output for this model."
+_KNOWN_FRONTEND_SIGNATURES = (
+    "unpack_forward_output",
+    "deformable_im2col",
+    "decoder_input_ids",
+    "decoder_inputs_embeds",
+    "Expected more than 1 value per channel",
+    "targets required",
+    "targets should not be none",
+    "'NoneType' object has no attribute 'max'",
+)
+
+
+@dataclass
+class TriageResult:
+    test_id: str
+    classification: str
+    reason: str | None
+    stale_reason_suspected: bool
+    resolution: str
+    next_manual_step: str
+    loader_path: str
+    loader_exists: bool
+    has_custom_unpack_forward_output: bool
+    training_utils_path: str
+    output_dir: str
+    draft_issue_path: str | None
+    attempt_log_path: str | None
+
+
+@dataclass
+class TriageSummary:
+    config_path: str
+    output_root: str
+    selected_test_count: int
+    frontend_count: int
+    draft_issue_count: int
+    attempt_log_count: int
+    stale_reason_suspected_count: int
+    results: list[dict[str, Any]]
+
+
+@dataclass
+class ConfigRefreshRecommendation:
+    test_id: str
+    loader_path: str
+    current_reason: str | None
+    recommended_action: str
+    rationale: str
+    next_manual_step: str
+
+
+def load_training_config(config_path: Path) -> dict[str, Any]:
+    with config_path.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected mapping at {config_path}, got {type(data).__name__}")
+    test_config = data.get("test_config", data)
+    if not isinstance(test_config, dict):
+        raise ValueError(
+            f"Expected 'test_config' mapping at {config_path}, got {type(test_config).__name__}"
+        )
+    return test_config
+
+
+def build_loader_path(project_root: Path, test_id: str) -> Path:
+    parts = test_id.split("/")
+    if len(parts) < 2:
+        raise ValueError(f"Unsupported test_id format: {test_id}")
+
+    model_path_parts = parts[:-1]
+    framework_and_variant = parts[-1]
+    framework = framework_and_variant.split("-", 1)[0]
+    return (
+        project_root
+        / "third_party"
+        / "tt_forge_models"
+        / Path(*model_path_parts)
+        / framework
+        / "loader.py"
+    )
+
+
+def loader_has_custom_unpack_forward_output(loader_path: Path) -> bool:
+    if not loader_path.is_file():
+        return False
+
+    tree = ast.parse(loader_path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "ModelLoader":
+            for stmt in node.body:
+                if isinstance(stmt, ast.FunctionDef) and stmt.name == "unpack_forward_output":
+                    return True
+            return False
+    return False
+
+
+def classify_frontend_reason(reason: str | None) -> str:
+    if not reason:
+        return "no_draft_attempt_log"
+
+    if reason == _UNPACK_REASON:
+        return "frontend"
+
+    if any(token in reason for token in _KNOWN_FRONTEND_SIGNATURES):
+        return "frontend"
+
+    return "no_draft_attempt_log"
+
+
+def sanitize_test_id(test_id: str) -> str:
+    return re.sub(r"[^A-Za-z0-9._-]+", "_", test_id)
+
+
+def write_manifest(path: Path, result: TriageResult) -> None:
+    path.write_text(json.dumps(asdict(result), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_summary(path: Path, summary: TriageSummary) -> None:
+    path.write_text(json.dumps(asdict(summary), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_review_report(path: Path, summary: TriageSummary) -> None:
+    draft_rows = [result for result in summary.results if result["draft_issue_path"]]
+    stale_rows = [result for result in summary.results if result["stale_reason_suspected"]]
+    attempt_rows = [result for result in summary.results if result["attempt_log_path"]]
+
+    lines = [
+        "# Frontend Training Failure Triage Review Report",
+        "",
+        "## Summary",
+        f"- selected tests: `{summary.selected_test_count}`",
+        f"- frontend-classified rows: `{summary.frontend_count}`",
+        f"- draft issue packets: `{summary.draft_issue_count}`",
+        f"- attempt logs: `{summary.attempt_log_count}`",
+        f"- stale reason suspected: `{summary.stale_reason_suspected_count}`",
+        "",
+        "## Draft Candidates",
+    ]
+
+    if draft_rows:
+        for row in draft_rows:
+            lines.extend(
+                [
+                    f"- `{row['test_id']}`",
+                    f"  - draft: `{row['draft_issue_path']}`",
+                    f"  - loader: `{row['loader_path']}`",
+                ]
+            )
+    else:
+        lines.append("- None")
+
+    lines.extend(["", "## Stale Reason Suspected"])
+    if stale_rows:
+        for row in stale_rows:
+            lines.extend(
+                [
+                    f"- `{row['test_id']}`",
+                    f"  - resolution: `{row['resolution']}`",
+                    f"  - next step: `{row['next_manual_step']}`",
+                ]
+            )
+    else:
+        lines.append("- None")
+
+    lines.extend(["", "## Attempt Logs"])
+    if attempt_rows:
+        for row in attempt_rows:
+            lines.extend(
+                [
+                    f"- `{row['test_id']}`",
+                    f"  - attempt log: `{row['attempt_log_path']}`",
+                ]
+            )
+    else:
+        lines.append("- None")
+
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_config_refresh_recommendations(
+    path: Path, recommendations: list[ConfigRefreshRecommendation]
+) -> None:
+    payload = [asdict(recommendation) for recommendation in recommendations]
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_config_refresh_patch(path: Path, recommendations: list[ConfigRefreshRecommendation]) -> None:
+    test_config: dict[str, Any] = {}
+    for recommendation in recommendations:
+        test_config[recommendation.test_id] = {
+            "reason": "REVIEW_NEEDED: stale frontend failure reason suspected",
+            "notes": {
+                "previous_reason": recommendation.current_reason,
+                "recommended_action": recommendation.recommended_action,
+                "rationale": recommendation.rationale,
+                "next_manual_step": recommendation.next_manual_step,
+            },
+        }
+
+    payload = {"test_config": test_config}
+    path.write_text(yaml.safe_dump(payload, sort_keys=True), encoding="utf-8")
+
+
+def write_draft_issue(path: Path, result: TriageResult) -> None:
+    body = f"""# Frontend Training Failure Triage Draft
+
+## Summary
+`{result.test_id}` currently fails in the bounded training cohort with a frontend-style signal:
+`{result.reason}`
+
+## Training-Failure Classification
+- classification: `{result.classification}`
+- likely owner: `tt-forge-models` model loader / training-helper review
+- loader path: `{result.loader_path}`
+- custom `unpack_forward_output` present: `{str(result.has_custom_unpack_forward_output).lower()}`
+
+## Failure Signature And Repro Context
+- bounded cohort reason: `{result.reason}`
+- config source: `tests/runner/test_config/torch/test_config_training_single_device.yaml`
+- workflow target: frontend issue analysis
+
+## Evidence Links
+- loader path: `{result.loader_path}`
+- shared helper path: `{result.training_utils_path}`
+
+## What Was Tried
+- matched the training-failure row against the bounded frontend cohort rule
+- resolved the corresponding `tt_forge_models` loader path from the test identifier
+- inspected whether the loader implements `unpack_forward_output`
+
+## Owner / Next Action Suggestion
+- inspect whether the model should override `unpack_forward_output` in the loader
+- if the output type is unambiguous and shared across models, consider extending `training_utils.py`
+- keep filing draft-only until a human confirms the owner and proposed fix shape
+
+## Open Questions / Handoff Notes
+- does the model output need a model-specific unpacking rule or a shared handler registration?
+- is CPU-only inspection required to confirm the expected training output tensor?
+"""
+    path.write_text(body, encoding="utf-8")
+
+
+def write_attempt_log(path: Path, result: TriageResult) -> None:
+    body = f"""workflow_path=frontend
+test_id={result.test_id}
+reason={result.reason}
+loader_path={result.loader_path}
+loader_exists={str(result.loader_exists).lower()}
+custom_unpack_forward_output={str(result.has_custom_unpack_forward_output).lower()}
+resolution={result.resolution}
+
+No draft issue packet was generated.
+
+Attempted steps:
+1. Read bounded training config row from the provided YAML.
+2. Classified the failure using the frontend signature rules.
+3. Resolved the expected loader path from the test identifier.
+4. Inspected the loader AST for a custom `unpack_forward_output` implementation.
+
+Blocked decision:
+- {result.resolution}
+
+Next manual step:
+- {result.next_manual_step}
+"""
+    path.write_text(body, encoding="utf-8")
+
+
+def decide_resolution(
+    *,
+    classification: str,
+    loader_exists: bool,
+    has_custom_unpack_forward_output: bool,
+) -> tuple[str, str]:
+    if classification != "frontend":
+        return (
+            "frontend signature rule did not match strongly enough for a draft packet",
+            "inspect the model loader and relevant runtime evidence before promoting this row to a review-ready draft.",
+        )
+    if not loader_exists:
+        return (
+            "expected tt_forge_models loader does not exist at the derived path",
+            "confirm the loader location or reconcile the test identifier with the current tt_forge_models layout.",
+        )
+    if has_custom_unpack_forward_output:
+        return (
+            "loader already implements custom unpack_forward_output, so the YAML failure reason may be stale or the remaining failure is subtler than the bounded draft rule",
+            "inspect the custom loader implementation and refresh the failing reason with current runtime evidence before drafting an issue.",
+        )
+    return (
+        "bounded frontend draft rule matched: loader lacks custom unpack_forward_output and is a candidate for model/helper review",
+        "review the generated draft issue and confirm whether the fix belongs in the model loader or shared training_utils handler registry.",
+    )
+
+
+def build_config_refresh_recommendation(
+    result: TriageResult,
+) -> ConfigRefreshRecommendation | None:
+    if not result.stale_reason_suspected:
+        return None
+
+    return ConfigRefreshRecommendation(
+        test_id=result.test_id,
+        loader_path=result.loader_path,
+        current_reason=result.reason,
+        recommended_action="refresh_yaml_failure_reason",
+        rationale=result.resolution,
+        next_manual_step=result.next_manual_step,
+    )
+
+
+def triage_test_entry(
+    *,
+    project_root: Path,
+    config_path: Path,
+    test_id: str,
+    entry: dict[str, Any],
+    output_root: Path,
+) -> TriageResult:
+    reason = entry.get("reason")
+    classification = classify_frontend_reason(reason)
+    loader_path = build_loader_path(project_root, test_id)
+    loader_exists = loader_path.is_file()
+    has_custom_unpack = loader_has_custom_unpack_forward_output(loader_path)
+    resolution, next_manual_step = decide_resolution(
+        classification=classification,
+        loader_exists=loader_exists,
+        has_custom_unpack_forward_output=has_custom_unpack,
+    )
+    stale_reason_suspected = classification == "frontend" and loader_exists and has_custom_unpack
+
+    output_dir = output_root / sanitize_test_id(test_id)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    draft_issue_path: Path | None = None
+    attempt_log_path: Path | None = None
+    should_write_draft = classification == "frontend" and loader_exists and not has_custom_unpack
+
+    result = TriageResult(
+        test_id=test_id,
+        classification=classification,
+        reason=reason,
+        stale_reason_suspected=stale_reason_suspected,
+        resolution=resolution,
+        next_manual_step=next_manual_step,
+        loader_path=str(loader_path),
+        loader_exists=loader_exists,
+        has_custom_unpack_forward_output=has_custom_unpack,
+        training_utils_path=str(_TRAINING_UTILS_PATH),
+        output_dir=str(output_dir),
+        draft_issue_path=None,
+        attempt_log_path=None,
+    )
+
+    write_manifest(output_dir / "manifest.json", result)
+
+    if should_write_draft:
+        draft_issue_path = output_dir / "draft_issue.md"
+        write_draft_issue(draft_issue_path, result)
+    else:
+        attempt_log_path = output_dir / "attempt.log"
+        write_attempt_log(attempt_log_path, result)
+
+    result.draft_issue_path = str(draft_issue_path) if draft_issue_path else None
+    result.attempt_log_path = str(attempt_log_path) if attempt_log_path else None
+    write_manifest(output_dir / "manifest.json", result)
+    return result
+
+
+def collect_selected_tests(config: dict[str, Any], requested_tests: list[str]) -> list[str]:
+    if requested_tests:
+        missing = [test_id for test_id in requested_tests if test_id not in config]
+        if missing:
+            missing_text = ", ".join(sorted(missing))
+            raise KeyError(f"Requested test ids not found in config: {missing_text}")
+        return requested_tests
+
+    selected = []
+    for test_id, entry in config.items():
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("reason") == _UNPACK_REASON:
+            selected.append(test_id)
+    return selected
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=_DEFAULT_CONFIG_PATH)
+    parser.add_argument("--output-root", type=Path, default=_DEFAULT_OUTPUT_ROOT)
+    parser.add_argument(
+        "--test-id",
+        action="append",
+        default=[],
+        help="Specific test id to triage. Repeat for multiple tests. Defaults to all bounded unpack_forward_output rows.",
+    )
+    parser.add_argument("--project-root", type=Path, default=_PROJECT_ROOT)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    config = load_training_config(args.config)
+    selected_tests = collect_selected_tests(config, args.test_id)
+    results: list[TriageResult] = []
+
+    for test_id in selected_tests:
+        results.append(
+            triage_test_entry(
+                project_root=args.project_root,
+                config_path=args.config,
+                test_id=test_id,
+                entry=config[test_id],
+                output_root=args.output_root,
+            )
+        )
+
+    summary = TriageSummary(
+        config_path=str(args.config),
+        output_root=str(args.output_root),
+        selected_test_count=len(results),
+        frontend_count=sum(1 for result in results if result.classification == "frontend"),
+        draft_issue_count=sum(1 for result in results if result.draft_issue_path is not None),
+        attempt_log_count=sum(1 for result in results if result.attempt_log_path is not None),
+        stale_reason_suspected_count=sum(1 for result in results if result.stale_reason_suspected),
+        results=[asdict(result) for result in results],
+    )
+    args.output_root.mkdir(parents=True, exist_ok=True)
+    write_summary(args.output_root / "summary.json", summary)
+    write_review_report(args.output_root / "review_report.md", summary)
+    recommendations = [
+        recommendation
+        for recommendation in (
+            build_config_refresh_recommendation(result) for result in results
+        )
+        if recommendation is not None
+    ]
+    write_config_refresh_recommendations(
+        args.output_root / "config_refresh_recommendations.json",
+        recommendations,
+    )
+    write_config_refresh_patch(
+        args.output_root / "config_refresh_patch.yaml",
+        recommendations,
+    )
+
+    print(
+        "Generated "
+        f"{len(selected_tests)} frontend triage bundle(s) in {args.output_root} "
+        f"(drafts={summary.draft_issue_count}, attempt_logs={summary.attempt_log_count}, "
+        f"stale_reason_suspected={summary.stale_reason_suspected_count})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/runner/frontend_training_failure_triage.py
+++ b/tests/runner/frontend_training_failure_triage.py
@@ -170,6 +170,15 @@ def validate_safe_path_component(component: str, label: str) -> str:
     return component
 
 
+def validate_safe_test_id(test_id: str) -> str:
+    parts = test_id.split("/")
+    if len(parts) < 2:
+        raise ValueError(f"Unsupported test_id format: {test_id}")
+    for part in parts:
+        validate_safe_path_component(part, "test_id")
+    return test_id
+
+
 def require_path_within(path: Path, root: Path, label: str) -> Path:
     resolved_root = root.expanduser().resolve()
     resolved_path = path.expanduser().resolve()
@@ -416,7 +425,8 @@ def triage_test_entry(
 ) -> TriageResult:
     reason = entry.get("reason")
     classification = classify_frontend_reason(reason)
-    loader_path = build_loader_path(project_root, test_id)
+    safe_test_id = validate_safe_test_id(test_id)
+    loader_path = build_loader_path(project_root, safe_test_id)
     loader_exists = loader_path.is_file()
     has_custom_unpack = loader_has_custom_unpack_forward_output(loader_path)
     resolution, next_manual_step = decide_resolution(
@@ -428,7 +438,7 @@ def triage_test_entry(
         classification == "frontend" and loader_exists and has_custom_unpack
     )
 
-    output_dir = build_output_dir(output_root, test_id)
+    output_dir = build_output_dir(output_root, safe_test_id)
     output_dir.mkdir(parents=True, exist_ok=True)
 
     draft_issue_path: Path | None = None

--- a/tests/runner/frontend_training_failure_triage.py
+++ b/tests/runner/frontend_training_failure_triage.py
@@ -25,11 +25,20 @@ import yaml
 
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 _DEFAULT_CONFIG_PATH = (
-    _PROJECT_ROOT / "tests" / "runner" / "test_config" / "torch" / "test_config_training_single_device.yaml"
+    _PROJECT_ROOT
+    / "tests"
+    / "runner"
+    / "test_config"
+    / "torch"
+    / "test_config_training_single_device.yaml"
 )
 _DEFAULT_OUTPUT_ROOT = _PROJECT_ROOT / "artifacts" / "frontend_training_triage"
-_TRAINING_UTILS_PATH = _PROJECT_ROOT / "third_party" / "tt_forge_models" / "training_utils.py"
-_UNPACK_REASON = "tt-forge-models doesn't implement unpack_forward_output for this model."
+_TRAINING_UTILS_PATH = (
+    _PROJECT_ROOT / "third_party" / "tt_forge_models" / "training_utils.py"
+)
+_UNPACK_REASON = (
+    "tt-forge-models doesn't implement unpack_forward_output for this model."
+)
 _KNOWN_FRONTEND_SIGNATURES = (
     "unpack_forward_output",
     "deformable_im2col",
@@ -40,6 +49,7 @@ _KNOWN_FRONTEND_SIGNATURES = (
     "targets should not be none",
     "'NoneType' object has no attribute 'max'",
 )
+_SAFE_PATH_COMPONENT_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
 
 
 @dataclass
@@ -85,7 +95,9 @@ def load_training_config(config_path: Path) -> dict[str, Any]:
     with config_path.open("r", encoding="utf-8") as f:
         data = yaml.safe_load(f) or {}
     if not isinstance(data, dict):
-        raise ValueError(f"Expected mapping at {config_path}, got {type(data).__name__}")
+        raise ValueError(
+            f"Expected mapping at {config_path}, got {type(data).__name__}"
+        )
     test_config = data.get("test_config", data)
     if not isinstance(test_config, dict):
         raise ValueError(
@@ -99,17 +111,21 @@ def build_loader_path(project_root: Path, test_id: str) -> Path:
     if len(parts) < 2:
         raise ValueError(f"Unsupported test_id format: {test_id}")
 
-    model_path_parts = parts[:-1]
+    model_path_parts = [
+        validate_safe_path_component(part, "test_id model path") for part in parts[:-1]
+    ]
     framework_and_variant = parts[-1]
-    framework = framework_and_variant.split("-", 1)[0]
-    return (
-        project_root
-        / "third_party"
-        / "tt_forge_models"
-        / Path(*model_path_parts)
-        / framework
-        / "loader.py"
+    framework = validate_safe_path_component(
+        framework_and_variant.split("-", 1)[0],
+        "test_id framework",
     )
+    models_root = (
+        project_root.expanduser().resolve() / "third_party" / "tt_forge_models"
+    ).resolve()
+    loader_path = (
+        models_root.joinpath(*model_path_parts) / framework / "loader.py"
+    ).resolve()
+    return require_path_within(loader_path, models_root, "loader path")
 
 
 def loader_has_custom_unpack_forward_output(loader_path: Path) -> bool:
@@ -120,7 +136,10 @@ def loader_has_custom_unpack_forward_output(loader_path: Path) -> bool:
     for node in ast.walk(tree):
         if isinstance(node, ast.ClassDef) and node.name == "ModelLoader":
             for stmt in node.body:
-                if isinstance(stmt, ast.FunctionDef) and stmt.name == "unpack_forward_output":
+                if (
+                    isinstance(stmt, ast.FunctionDef)
+                    and stmt.name == "unpack_forward_output"
+                ):
                     return True
             return False
     return False
@@ -143,17 +162,59 @@ def sanitize_test_id(test_id: str) -> str:
     return re.sub(r"[^A-Za-z0-9._-]+", "_", test_id)
 
 
+def validate_safe_path_component(component: str, label: str) -> str:
+    if component in {"", ".", ".."} or not _SAFE_PATH_COMPONENT_PATTERN.fullmatch(
+        component
+    ):
+        raise ValueError(f"Unsafe {label} component: {component!r}")
+    return component
+
+
+def require_path_within(path: Path, root: Path, label: str) -> Path:
+    resolved_root = root.expanduser().resolve()
+    resolved_path = path.expanduser().resolve()
+    try:
+        resolved_path.relative_to(resolved_root)
+    except ValueError as exc:
+        raise ValueError(
+            f"{label} must stay within {resolved_root}: {resolved_path}"
+        ) from exc
+    return resolved_path
+
+
+def build_output_dir(output_root: Path, test_id: str) -> Path:
+    safe_name = validate_safe_path_component(
+        sanitize_test_id(test_id), "output directory"
+    )
+    resolved_root = output_root.expanduser().resolve()
+    return require_path_within(
+        resolved_root / safe_name, resolved_root, "output directory"
+    )
+
+
+def build_output_file(output_root: Path, file_name: str) -> Path:
+    safe_name = validate_safe_path_component(file_name, "output file")
+    resolved_root = output_root.expanduser().resolve()
+    return require_path_within(resolved_root / safe_name, resolved_root, "output file")
+
+
 def write_manifest(path: Path, result: TriageResult) -> None:
-    path.write_text(json.dumps(asdict(result), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    path.write_text(
+        json.dumps(asdict(result), indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
 
 
 def write_summary(path: Path, summary: TriageSummary) -> None:
-    path.write_text(json.dumps(asdict(summary), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    path.write_text(
+        json.dumps(asdict(summary), indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
 
 
 def write_review_report(path: Path, summary: TriageSummary) -> None:
     draft_rows = [result for result in summary.results if result["draft_issue_path"]]
-    stale_rows = [result for result in summary.results if result["stale_reason_suspected"]]
+    stale_rows = [
+        result for result in summary.results if result["stale_reason_suspected"]
+    ]
     attempt_rows = [result for result in summary.results if result["attempt_log_path"]]
 
     lines = [
@@ -213,10 +274,14 @@ def write_config_refresh_recommendations(
     path: Path, recommendations: list[ConfigRefreshRecommendation]
 ) -> None:
     payload = [asdict(recommendation) for recommendation in recommendations]
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
 
 
-def write_config_refresh_patch(path: Path, recommendations: list[ConfigRefreshRecommendation]) -> None:
+def write_config_refresh_patch(
+    path: Path, recommendations: list[ConfigRefreshRecommendation]
+) -> None:
     test_config: dict[str, Any] = {}
     for recommendation in recommendations:
         test_config[recommendation.test_id] = {
@@ -359,14 +424,18 @@ def triage_test_entry(
         loader_exists=loader_exists,
         has_custom_unpack_forward_output=has_custom_unpack,
     )
-    stale_reason_suspected = classification == "frontend" and loader_exists and has_custom_unpack
+    stale_reason_suspected = (
+        classification == "frontend" and loader_exists and has_custom_unpack
+    )
 
-    output_dir = output_root / sanitize_test_id(test_id)
+    output_dir = build_output_dir(output_root, test_id)
     output_dir.mkdir(parents=True, exist_ok=True)
 
     draft_issue_path: Path | None = None
     attempt_log_path: Path | None = None
-    should_write_draft = classification == "frontend" and loader_exists and not has_custom_unpack
+    should_write_draft = (
+        classification == "frontend" and loader_exists and not has_custom_unpack
+    )
 
     result = TriageResult(
         test_id=test_id,
@@ -399,7 +468,9 @@ def triage_test_entry(
     return result
 
 
-def collect_selected_tests(config: dict[str, Any], requested_tests: list[str]) -> list[str]:
+def collect_selected_tests(
+    config: dict[str, Any], requested_tests: list[str]
+) -> list[str]:
     if requested_tests:
         missing = [test_id for test_id in requested_tests if test_id not in config]
         if missing:
@@ -432,6 +503,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 
 def main(argv: list[str]) -> int:
     args = parse_args(argv)
+    output_root = args.output_root.expanduser().resolve()
     config = load_training_config(args.config)
     selected_tests = collect_selected_tests(config, args.test_id)
     results: list[TriageResult] = []
@@ -443,23 +515,31 @@ def main(argv: list[str]) -> int:
                 config_path=args.config,
                 test_id=test_id,
                 entry=config[test_id],
-                output_root=args.output_root,
+                output_root=output_root,
             )
         )
 
     summary = TriageSummary(
         config_path=str(args.config),
-        output_root=str(args.output_root),
+        output_root=str(output_root),
         selected_test_count=len(results),
-        frontend_count=sum(1 for result in results if result.classification == "frontend"),
-        draft_issue_count=sum(1 for result in results if result.draft_issue_path is not None),
-        attempt_log_count=sum(1 for result in results if result.attempt_log_path is not None),
-        stale_reason_suspected_count=sum(1 for result in results if result.stale_reason_suspected),
+        frontend_count=sum(
+            1 for result in results if result.classification == "frontend"
+        ),
+        draft_issue_count=sum(
+            1 for result in results if result.draft_issue_path is not None
+        ),
+        attempt_log_count=sum(
+            1 for result in results if result.attempt_log_path is not None
+        ),
+        stale_reason_suspected_count=sum(
+            1 for result in results if result.stale_reason_suspected
+        ),
         results=[asdict(result) for result in results],
     )
-    args.output_root.mkdir(parents=True, exist_ok=True)
-    write_summary(args.output_root / "summary.json", summary)
-    write_review_report(args.output_root / "review_report.md", summary)
+    output_root.mkdir(parents=True, exist_ok=True)
+    write_summary(build_output_file(output_root, "summary.json"), summary)
+    write_review_report(build_output_file(output_root, "review_report.md"), summary)
     recommendations = [
         recommendation
         for recommendation in (
@@ -468,11 +548,11 @@ def main(argv: list[str]) -> int:
         if recommendation is not None
     ]
     write_config_refresh_recommendations(
-        args.output_root / "config_refresh_recommendations.json",
+        build_output_file(output_root, "config_refresh_recommendations.json"),
         recommendations,
     )
     write_config_refresh_patch(
-        args.output_root / "config_refresh_patch.yaml",
+        build_output_file(output_root, "config_refresh_patch.yaml"),
         recommendations,
     )
 

--- a/tests/runner/frontend_training_failure_triage.py
+++ b/tests/runner/frontend_training_failure_triage.py
@@ -128,21 +128,33 @@ def build_loader_path(project_root: Path, test_id: str) -> Path:
     return require_path_within(loader_path, models_root, "loader path")
 
 
+def find_model_loader_class(tree: ast.AST) -> ast.ClassDef | None:
+    return next(
+        (
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ClassDef) and node.name == "ModelLoader"
+        ),
+        None,
+    )
+
+
+def class_defines_method(class_node: ast.ClassDef, method_name: str) -> bool:
+    return any(
+        isinstance(stmt, ast.FunctionDef) and stmt.name == method_name
+        for stmt in class_node.body
+    )
+
+
 def loader_has_custom_unpack_forward_output(loader_path: Path) -> bool:
     if not loader_path.is_file():
         return False
 
     tree = ast.parse(loader_path.read_text(encoding="utf-8"))
-    for node in ast.walk(tree):
-        if isinstance(node, ast.ClassDef) and node.name == "ModelLoader":
-            for stmt in node.body:
-                if (
-                    isinstance(stmt, ast.FunctionDef)
-                    and stmt.name == "unpack_forward_output"
-                ):
-                    return True
-            return False
-    return False
+    model_loader = find_model_loader_class(tree)
+    return bool(
+        model_loader and class_defines_method(model_loader, "unpack_forward_output")
+    )
 
 
 def classify_frontend_reason(reason: str | None) -> str:
@@ -219,6 +231,22 @@ def write_summary(path: Path, summary: TriageSummary) -> None:
     )
 
 
+def append_result_section(
+    lines: list[str],
+    title: str,
+    rows: list[dict[str, Any]],
+    fields: tuple[tuple[str, str], ...],
+) -> None:
+    lines.extend(["", f"## {title}"])
+    if not rows:
+        lines.append("- None")
+        return
+
+    for row in rows:
+        lines.append(f"- `{row['test_id']}`")
+        lines.extend([f"  - {label}: `{row[key]}`" for label, key in fields])
+
+
 def write_review_report(path: Path, summary: TriageSummary) -> None:
     draft_rows = [result for result in summary.results if result["draft_issue_path"]]
     stale_rows = [
@@ -235,46 +263,25 @@ def write_review_report(path: Path, summary: TriageSummary) -> None:
         f"- draft issue packets: `{summary.draft_issue_count}`",
         f"- attempt logs: `{summary.attempt_log_count}`",
         f"- stale reason suspected: `{summary.stale_reason_suspected_count}`",
-        "",
-        "## Draft Candidates",
     ]
-
-    if draft_rows:
-        for row in draft_rows:
-            lines.extend(
-                [
-                    f"- `{row['test_id']}`",
-                    f"  - draft: `{row['draft_issue_path']}`",
-                    f"  - loader: `{row['loader_path']}`",
-                ]
-            )
-    else:
-        lines.append("- None")
-
-    lines.extend(["", "## Stale Reason Suspected"])
-    if stale_rows:
-        for row in stale_rows:
-            lines.extend(
-                [
-                    f"- `{row['test_id']}`",
-                    f"  - resolution: `{row['resolution']}`",
-                    f"  - next step: `{row['next_manual_step']}`",
-                ]
-            )
-    else:
-        lines.append("- None")
-
-    lines.extend(["", "## Attempt Logs"])
-    if attempt_rows:
-        for row in attempt_rows:
-            lines.extend(
-                [
-                    f"- `{row['test_id']}`",
-                    f"  - attempt log: `{row['attempt_log_path']}`",
-                ]
-            )
-    else:
-        lines.append("- None")
+    append_result_section(
+        lines,
+        "Draft Candidates",
+        draft_rows,
+        (("draft", "draft_issue_path"), ("loader", "loader_path")),
+    )
+    append_result_section(
+        lines,
+        "Stale Reason Suspected",
+        stale_rows,
+        (("resolution", "resolution"), ("next step", "next_manual_step")),
+    )
+    append_result_section(
+        lines,
+        "Attempt Logs",
+        attempt_rows,
+        (("attempt log", "attempt_log_path"),),
+    )
 
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
@@ -482,19 +489,59 @@ def collect_selected_tests(
     config: dict[str, Any], requested_tests: list[str]
 ) -> list[str]:
     if requested_tests:
-        missing = [test_id for test_id in requested_tests if test_id not in config]
-        if missing:
-            missing_text = ", ".join(sorted(missing))
-            raise KeyError(f"Requested test ids not found in config: {missing_text}")
+        require_requested_tests(config, requested_tests)
         return requested_tests
 
-    selected = []
-    for test_id, entry in config.items():
-        if not isinstance(entry, dict):
-            continue
-        if entry.get("reason") == _UNPACK_REASON:
-            selected.append(test_id)
-    return selected
+    return [
+        test_id
+        for test_id, entry in config.items()
+        if is_frontend_candidate_entry(entry)
+    ]
+
+
+def require_requested_tests(config: dict[str, Any], requested_tests: list[str]) -> None:
+    missing = [test_id for test_id in requested_tests if test_id not in config]
+    if missing:
+        missing_text = ", ".join(sorted(missing))
+        raise KeyError(f"Requested test ids not found in config: {missing_text}")
+
+
+def is_frontend_candidate_entry(entry: Any) -> bool:
+    return isinstance(entry, dict) and entry.get("reason") == _UNPACK_REASON
+
+
+def count_results(results: list[TriageResult], field_name: str) -> int:
+    return sum(1 for result in results if getattr(result, field_name))
+
+
+def build_triage_summary(
+    *, config_path: Path, output_root: Path, results: list[TriageResult]
+) -> TriageSummary:
+    return TriageSummary(
+        config_path=str(config_path),
+        output_root=str(output_root),
+        selected_test_count=len(results),
+        frontend_count=sum(
+            1 for result in results if result.classification == "frontend"
+        ),
+        draft_issue_count=count_results(results, "draft_issue_path"),
+        attempt_log_count=count_results(results, "attempt_log_path"),
+        stale_reason_suspected_count=count_results(results, "stale_reason_suspected"),
+        results=[asdict(result) for result in results],
+    )
+
+
+def write_config_refresh_outputs(
+    output_root: Path, recommendations: list[ConfigRefreshRecommendation]
+) -> None:
+    write_config_refresh_recommendations(
+        build_output_file(output_root, "config_refresh_recommendations.json"),
+        recommendations,
+    )
+    write_config_refresh_patch(
+        build_output_file(output_root, "config_refresh_patch.yaml"),
+        recommendations,
+    )
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
@@ -516,36 +563,19 @@ def main(argv: list[str]) -> int:
     output_root = args.output_root.expanduser().resolve()
     config = load_training_config(args.config)
     selected_tests = collect_selected_tests(config, args.test_id)
-    results: list[TriageResult] = []
-
-    for test_id in selected_tests:
-        results.append(
-            triage_test_entry(
-                project_root=args.project_root,
-                config_path=args.config,
-                test_id=test_id,
-                entry=config[test_id],
-                output_root=output_root,
-            )
+    results = [
+        triage_test_entry(
+            project_root=args.project_root,
+            config_path=args.config,
+            test_id=test_id,
+            entry=config[test_id],
+            output_root=output_root,
         )
+        for test_id in selected_tests
+    ]
 
-    summary = TriageSummary(
-        config_path=str(args.config),
-        output_root=str(output_root),
-        selected_test_count=len(results),
-        frontend_count=sum(
-            1 for result in results if result.classification == "frontend"
-        ),
-        draft_issue_count=sum(
-            1 for result in results if result.draft_issue_path is not None
-        ),
-        attempt_log_count=sum(
-            1 for result in results if result.attempt_log_path is not None
-        ),
-        stale_reason_suspected_count=sum(
-            1 for result in results if result.stale_reason_suspected
-        ),
-        results=[asdict(result) for result in results],
+    summary = build_triage_summary(
+        config_path=args.config, output_root=output_root, results=results
     )
     output_root.mkdir(parents=True, exist_ok=True)
     write_summary(build_output_file(output_root, "summary.json"), summary)
@@ -557,14 +587,7 @@ def main(argv: list[str]) -> int:
         )
         if recommendation is not None
     ]
-    write_config_refresh_recommendations(
-        build_output_file(output_root, "config_refresh_recommendations.json"),
-        recommendations,
-    )
-    write_config_refresh_patch(
-        build_output_file(output_root, "config_refresh_patch.yaml"),
-        recommendations,
-    )
+    write_config_refresh_outputs(output_root, recommendations)
 
     print(
         "Generated "

--- a/tests/runner/runtime_training_failure_reduction.py
+++ b/tests/runner/runtime_training_failure_reduction.py
@@ -17,6 +17,7 @@ import argparse
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 from dataclasses import asdict, dataclass
@@ -47,6 +48,7 @@ _RUNTIME_KEYWORDS = (
 )
 _DEBUG_LOG_SUFFIXES = (".log", ".txt")
 _SAFE_PATH_COMPONENT_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
+_PYTEST_COMMAND = "pytest"
 
 
 @dataclass
@@ -133,15 +135,20 @@ def detect_rerun_invalid_execution(log_path: Path | None) -> str | None:
 
 
 def build_pytest_node_id(test_id: str) -> str:
-    return f"tests/runner/test_models.py::test_all_models_torch[{test_id}]"
+    safe_test_id = validate_safe_test_id(test_id)
+    return f"tests/runner/test_models.py::test_all_models_torch[{safe_test_id}]"
 
 
 def build_rerun_command(pytest_bin: str, test_id: str) -> list[str]:
-    return [pytest_bin, "-vv", "-s", build_pytest_node_id(test_id)]
+    validate_pytest_command_name(pytest_bin)
+    return [_PYTEST_COMMAND, "-vv", "-s", build_pytest_node_id(test_id)]
 
 
 def derive_python_bin(pytest_bin: str) -> str | None:
-    pytest_path = Path(pytest_bin)
+    try:
+        pytest_path = Path(resolve_pytest_executable(pytest_bin))
+    except (FileNotFoundError, ValueError):
+        return None
     if pytest_path.parent.name == "bin":
         candidate = pytest_path.parent / "python"
         if candidate.exists():
@@ -210,6 +217,39 @@ def validate_safe_path_component(component: str, label: str) -> str:
     ):
         raise ValueError(f"Unsafe {label} component: {component!r}")
     return component
+
+
+def validate_safe_test_id(test_id: str) -> str:
+    parts = test_id.split("/")
+    if len(parts) < 2:
+        raise ValueError(f"Unsupported test_id format: {test_id}")
+    for part in parts:
+        validate_safe_path_component(part, "test_id")
+    return test_id
+
+
+def validate_pytest_command_name(pytest_bin: str) -> str:
+    if pytest_bin != _PYTEST_COMMAND:
+        raise ValueError(
+            "--pytest-bin only accepts 'pytest'; adjust PATH to select the environment"
+        )
+    return pytest_bin
+
+
+def resolve_pytest_executable(pytest_bin: str) -> str:
+    validate_pytest_command_name(pytest_bin)
+    resolved = shutil.which(_PYTEST_COMMAND)
+    if resolved is None:
+        raise FileNotFoundError(_PYTEST_COMMAND)
+
+    resolved_path = Path(resolved).resolve()
+    if resolved_path.name != _PYTEST_COMMAND or not resolved_path.is_file():
+        raise ValueError(f"Resolved pytest executable is invalid: {resolved_path}")
+    if not os.access(resolved_path, os.X_OK):
+        raise ValueError(
+            f"Resolved pytest executable is not executable: {resolved_path}"
+        )
+    return str(resolved_path)
 
 
 def require_path_within(path: Path, root: Path, label: str) -> Path:
@@ -312,16 +352,25 @@ def run_bounded_rerun(
     timeout_sec: int,
     force_run_skipped: bool = False,
 ) -> tuple[int | None, str]:
-    command = build_rerun_command(pytest_bin, test_id)
+    safe_test_id = validate_safe_test_id(test_id)
+    try:
+        safe_pytest_bin = validate_pytest_command_name(pytest_bin)
+    except ValueError as exc:
+        command = [_PYTEST_COMMAND, "-vv", "-s", build_pytest_node_id(safe_test_id)]
+        log_path.write_text(f"invalid pytest binary: {exc}\n", encoding="utf-8")
+        return None, " ".join(command)
+
+    command = build_rerun_command(safe_pytest_bin, safe_test_id)
     env = dict(os.environ)
     env["TTMLIR_LOGGER_LEVEL"] = "DEBUG"
     env["TT_RUNTIME_DEBUG"] = "ON"
     if force_run_skipped:
-        env["TT_XLA_FORCE_RUN_SKIPPED_TEST_IDS"] = test_id
+        env["TT_XLA_FORCE_RUN_SKIPPED_TEST_IDS"] = safe_test_id
 
     try:
+        resolve_pytest_executable(safe_pytest_bin)
         completed = subprocess.run(
-            command,
+            [_PYTEST_COMMAND, "-vv", "-s", build_pytest_node_id(safe_test_id)],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
@@ -334,7 +383,7 @@ def run_bounded_rerun(
         return completed.returncode, " ".join(command)
     except FileNotFoundError:
         log_path.write_text(
-            f"pytest binary not found: {pytest_bin}\n", encoding="utf-8"
+            f"pytest binary not found: {safe_pytest_bin}\n", encoding="utf-8"
         )
         return None, " ".join(command)
     except subprocess.TimeoutExpired as exc:
@@ -783,8 +832,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     )
     parser.add_argument(
         "--pytest-bin",
-        default="pytest",
-        help="Pytest executable to use for --execute-rerun. Default: pytest",
+        default=_PYTEST_COMMAND,
+        choices=[_PYTEST_COMMAND],
+        help=(
+            "Pytest executable to use for --execute-rerun. Only 'pytest' is accepted; "
+            "adjust PATH to select the environment."
+        ),
     )
     parser.add_argument(
         "--rerun-timeout-sec",

--- a/tests/runner/runtime_training_failure_reduction.py
+++ b/tests/runner/runtime_training_failure_reduction.py
@@ -6,9 +6,9 @@
 
 This tool creates review-ready reduction artifacts for training failures whose
 current config metadata points to runtime or metal-style failures. It is a
-bounded planning-driven implementation: it does not rerun tests, but it
-normalizes the current runtime evidence and branches into draft packet or
-attempt-log outputs using explicit heuristics.
+bounded planning-driven implementation: by default it normalizes current
+runtime evidence without rerunning tests, and optional bounded reruns capture
+explicit logs before branching into draft packet or attempt-log outputs.
 """
 
 from __future__ import annotations
@@ -49,6 +49,25 @@ _RUNTIME_KEYWORDS = (
 _DEBUG_LOG_SUFFIXES = (".log", ".txt")
 _SAFE_PATH_COMPONENT_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
 _PYTEST_COMMAND = "pytest"
+_TT_METAL_SIGNAL_TOKENS = (
+    "TT_FATAL",
+    "Buffer must be allocated on device",
+    "Out of Memory",
+    "beyond max L1 size",
+    "Not enough space to allocate",
+)
+_RUNTIME_SIGNAL_TOKENS = _TT_METAL_SIGNAL_TOKENS + ("RuntimeError",)
+_TTNN_MLIR_TOKENS = ("ttnn.", "tt.device", "ttnn::", "stablehlo.")
+_INVALID_EXECUTION_NEXT_STEPS = {
+    "rerun executed with PJRT_DEVICE=CPU instead of TT hardware": (
+        "configure the rerun environment so the test runs on TT hardware and emits runtime debug markers, "
+        "then rerun the bounded runtime capture."
+    ),
+    "rerun timed out before TT runtime evidence was captured": (
+        "capture a staged or narrower debug run that emits TT runtime markers before the hang point, "
+        "or choose a runtime row that reaches operation-level evidence within the bounded timeout."
+    ),
+}
 
 
 @dataclass
@@ -93,6 +112,30 @@ class DebugEvidence:
     ttnn_mlir_lines: list[str]
 
 
+@dataclass
+class RerunCapture:
+    debug_log_path: Path | None
+    rerun_attempted: bool = False
+    rerun_command: str | None = None
+    rerun_log_path: str | None = None
+    rerun_returncode: int | None = None
+
+
+def contains_all(text: str, tokens: tuple[str, ...]) -> bool:
+    return all(token in text for token in tokens)
+
+
+def contains_any(text: str, tokens: tuple[str, ...]) -> bool:
+    return any(token in text for token in tokens)
+
+
+def module_not_found_detail(text: str) -> str:
+    missing = [
+        line.strip() for line in text.splitlines() if "ModuleNotFoundError" in line
+    ]
+    return "; ".join(missing) if missing else "pytest environment dependency missing"
+
+
 def detect_rerun_precondition_failure(log_path: Path | None) -> str | None:
     if log_path is None or not log_path.exists():
         return None
@@ -102,20 +145,10 @@ def detect_rerun_precondition_failure(log_path: Path | None) -> str | None:
         return text.strip()
     if "TT-Metal installation could not be found" in text:
         return "rerun precondition violation: torch_xla could not locate TT-Metal installation"
-    if (
-        "Native library" in text
-        and "pjrt_plugin_tt.so" in text
-        and "does not exist" in text
-    ):
+    if contains_all(text, ("Native library", "pjrt_plugin_tt.so", "does not exist")):
         return "rerun precondition violation: torch_xla loaded source pjrt_plugin_tt without native plugin library"
     if "ImportError while loading conftest" in text and "ModuleNotFoundError" in text:
-        missing = []
-        for line in text.splitlines():
-            if "ModuleNotFoundError" in line:
-                missing.append(line.strip())
-        detail = (
-            "; ".join(missing) if missing else "pytest environment dependency missing"
-        )
+        detail = module_not_found_detail(text)
         return f"rerun precondition violation: {detail}"
     return None
 
@@ -301,33 +334,22 @@ def find_debug_log(debug_log_root: Path | None, test_id: str) -> Path | None:
     return None
 
 
+def matching_lines(
+    lines: list[str], tokens: tuple[str, ...], *, strip: bool = True
+) -> list[str]:
+    matched = [line for line in lines if contains_any(line, tokens)]
+    if strip:
+        return [line.strip() for line in matched]
+    return [line.rstrip() for line in matched]
+
+
 def extract_debug_evidence(debug_log_path: Path) -> DebugEvidence | None:
     lines = debug_log_path.read_text(encoding="utf-8").splitlines()
     executing_operation_lines = [
         line.strip() for line in lines if "Executing operation" in line
     ]
-    runtime_signal_lines = [
-        line.strip()
-        for line in lines
-        if any(
-            token in line
-            for token in (
-                "TT_FATAL",
-                "beyond max L1 size",
-                "Not enough space to allocate",
-                "Buffer must be allocated on device",
-                "RuntimeError",
-                "Out of Memory",
-            )
-        )
-    ]
-    ttnn_mlir_lines = [
-        line.rstrip()
-        for line in lines
-        if any(
-            token in line for token in ("ttnn.", "tt.device", "ttnn::", "stablehlo.")
-        )
-    ]
+    runtime_signal_lines = matching_lines(lines, _RUNTIME_SIGNAL_TOKENS)
+    ttnn_mlir_lines = matching_lines(lines, _TTNN_MLIR_TOKENS, strip=False)
 
     if (
         not executing_operation_lines
@@ -341,6 +363,48 @@ def extract_debug_evidence(debug_log_path: Path) -> DebugEvidence | None:
         executing_operation_lines=executing_operation_lines[:5],
         runtime_signal_lines=runtime_signal_lines[:8],
         ttnn_mlir_lines=ttnn_mlir_lines[:12],
+    )
+
+
+def capture_runtime_log(
+    *,
+    debug_log_root: Path | None,
+    test_id: str,
+    output_dir: Path,
+    execute_rerun: bool,
+    pytest_bin: str,
+    rerun_timeout_sec: int,
+    force_run_skipped: bool,
+) -> RerunCapture:
+    debug_log_path = find_debug_log(debug_log_root, test_id)
+    if debug_log_path is not None or not execute_rerun:
+        return RerunCapture(debug_log_path=debug_log_path)
+
+    rerun_log_file = output_dir / "runtime_rerun.log"
+    environment_precondition_failure = probe_rerun_environment(pytest_bin)
+    if environment_precondition_failure is not None:
+        rerun_log_file.write_text(
+            environment_precondition_failure + "\n", encoding="utf-8"
+        )
+        return RerunCapture(
+            debug_log_path=rerun_log_file,
+            rerun_command=" ".join(build_rerun_command(pytest_bin, test_id)),
+            rerun_log_path=str(rerun_log_file),
+        )
+
+    rerun_returncode, rerun_command = run_bounded_rerun(
+        pytest_bin=pytest_bin,
+        test_id=test_id,
+        log_path=rerun_log_file,
+        timeout_sec=rerun_timeout_sec,
+        force_run_skipped=force_run_skipped,
+    )
+    return RerunCapture(
+        debug_log_path=rerun_log_file,
+        rerun_attempted=True,
+        rerun_command=rerun_command,
+        rerun_log_path=str(rerun_log_file),
+        rerun_returncode=rerun_returncode,
     )
 
 
@@ -396,6 +460,25 @@ def run_bounded_rerun(
         return None, " ".join(command)
 
 
+def debug_signal_text(debug_evidence: DebugEvidence | None) -> str:
+    if debug_evidence is None:
+        return ""
+    return " ".join(
+        debug_evidence.executing_operation_lines + debug_evidence.runtime_signal_lines
+    )
+
+
+def has_runtime_debug_context(debug_evidence: DebugEvidence | None) -> bool:
+    return bool(
+        debug_evidence
+        and (
+            debug_evidence.executing_operation_lines
+            or debug_evidence.runtime_signal_lines
+            or debug_evidence.ttnn_mlir_lines
+        )
+    )
+
+
 def classify_runtime_entry(
     bringup_status: str | None,
     reason: str | None,
@@ -403,34 +486,21 @@ def classify_runtime_entry(
 ) -> tuple[str, str, str]:
     reason = reason or ""
     bringup_status = bringup_status or ""
-    debug_signal_text = (
-        " ".join(
-            (
-                debug_evidence.executing_operation_lines
-                + debug_evidence.runtime_signal_lines
-            )
-        )
-        if debug_evidence
-        else ""
-    )
-    signal_text = f"{reason} {debug_signal_text}"
+    signal_text = f"{reason} {debug_signal_text(debug_evidence)}"
 
-    if any(
-        token in signal_text
-        for token in (
-            "TT_FATAL",
-            "Buffer must be allocated on device",
-            "Out of Memory",
-            "beyond max L1 size",
-            "Not enough space to allocate",
-        )
-    ):
+    if contains_any(signal_text, _TT_METAL_SIGNAL_TOKENS):
         return (
             "draft_issue",
             "tt-metal",
             "runtime op/device or memory failure signature suggests tt-metal ownership",
         )
-    if "FAILED_RUNTIME" in bringup_status and "Test Hangs" in reason:
+    if "FAILED_RUNTIME" not in bringup_status:
+        return (
+            "attempt_log",
+            "unknown",
+            "row does not match the bounded runtime-reduction selection strongly enough for a draft packet",
+        )
+    if "Test Hangs" in reason:
         if debug_evidence and debug_evidence.executing_operation_lines:
             return (
                 "draft_issue",
@@ -442,26 +512,16 @@ def classify_runtime_entry(
             "unknown",
             "runtime hang requires real debug-log capture and cannot be confidently assigned from config-only evidence",
         )
-    if "FAILED_RUNTIME" in bringup_status:
-        if debug_evidence and (
-            debug_evidence.executing_operation_lines
-            or debug_evidence.runtime_signal_lines
-            or debug_evidence.ttnn_mlir_lines
-        ):
-            return (
-                "draft_issue",
-                "tt-alchemist",
-                "runtime failure has captured debug evidence and is reduction-worthy for tt-alchemist follow-through",
-            )
+    if has_runtime_debug_context(debug_evidence):
         return (
             "draft_issue",
             "tt-alchemist",
-            "runtime failure is reduction-worthy but needs op-level extraction and tt-alchemist follow-through",
+            "runtime failure has captured debug evidence and is reduction-worthy for tt-alchemist follow-through",
         )
     return (
-        "attempt_log",
-        "unknown",
-        "row does not match the bounded runtime-reduction selection strongly enough for a draft packet",
+        "draft_issue",
+        "tt-alchemist",
+        "runtime failure is reduction-worthy but needs op-level extraction and tt-alchemist follow-through",
     )
 
 
@@ -475,6 +535,22 @@ def write_summary(path: Path, summary: RuntimeReductionSummary) -> None:
     path.write_text(
         json.dumps(asdict(summary), indent=2, sort_keys=True) + "\n", encoding="utf-8"
     )
+
+
+def append_result_section(
+    lines: list[str],
+    title: str,
+    rows: list[dict[str, Any]],
+    fields: tuple[tuple[str, str], ...],
+) -> None:
+    lines.extend(["", f"## {title}"])
+    if not rows:
+        lines.append("- None")
+        return
+
+    for row in rows:
+        lines.append(f"- `{row['test_id']}`")
+        lines.extend([f"  - {label}: `{row[key]}`" for label, key in fields])
 
 
 def write_review_report(path: Path, summary: RuntimeReductionSummary) -> None:
@@ -495,49 +571,37 @@ def write_review_report(path: Path, summary: RuntimeReductionSummary) -> None:
         f"- tt-alchemist draft candidates: `{summary.tt_alchemist_draft_count}`",
         f"- attempt logs: `{summary.attempt_log_count}`",
         f"- debug evidence captured: `{summary.debug_evidence_count}`",
-        "",
-        "## TT-Metal Draft Candidates",
     ]
-    if tt_metal_rows:
-        for row in tt_metal_rows:
-            lines.extend(
-                [
-                    f"- `{row['test_id']}`",
-                    f"  - draft: `{row['draft_issue_path']}`",
-                    f"  - reduction signal: `{row['reduction_signal']}`",
-                    f"  - debug evidence: `{row['debug_evidence_path']}`",
-                ]
-            )
-    else:
-        lines.append("- None")
-
-    lines.extend(["", "## TT-Alchemist Draft Candidates"])
-    if tt_alchemist_rows:
-        for row in tt_alchemist_rows:
-            lines.extend(
-                [
-                    f"- `{row['test_id']}`",
-                    f"  - draft: `{row['draft_issue_path']}`",
-                    f"  - reduction signal: `{row['reduction_signal']}`",
-                    f"  - debug evidence: `{row['debug_evidence_path']}`",
-                ]
-            )
-    else:
-        lines.append("- None")
-
-    lines.extend(["", "## Attempt Logs"])
-    if attempt_rows:
-        for row in attempt_rows:
-            lines.extend(
-                [
-                    f"- `{row['test_id']}`",
-                    f"  - attempt log: `{row['attempt_log_path']}`",
-                    f"  - next step: `{row['next_manual_step']}`",
-                    f"  - debug evidence: `{row['debug_evidence_path']}`",
-                ]
-            )
-    else:
-        lines.append("- None")
+    append_result_section(
+        lines,
+        "TT-Metal Draft Candidates",
+        tt_metal_rows,
+        (
+            ("draft", "draft_issue_path"),
+            ("reduction signal", "reduction_signal"),
+            ("debug evidence", "debug_evidence_path"),
+        ),
+    )
+    append_result_section(
+        lines,
+        "TT-Alchemist Draft Candidates",
+        tt_alchemist_rows,
+        (
+            ("draft", "draft_issue_path"),
+            ("reduction signal", "reduction_signal"),
+            ("debug evidence", "debug_evidence_path"),
+        ),
+    )
+    append_result_section(
+        lines,
+        "Attempt Logs",
+        attempt_rows,
+        (
+            ("attempt log", "attempt_log_path"),
+            ("next step", "next_manual_step"),
+            ("debug evidence", "debug_evidence_path"),
+        ),
+    )
 
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
@@ -643,6 +707,59 @@ def write_debug_evidence(path: Path, debug_evidence: DebugEvidence) -> None:
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
+def apply_rerun_classification_override(
+    classification: str,
+    owner_hint: str,
+    reduction_signal: str,
+    rerun_precondition_failure: str | None,
+    rerun_invalid_execution: str | None,
+) -> tuple[str, str, str]:
+    rerun_blocker = rerun_precondition_failure or rerun_invalid_execution
+    if rerun_blocker is None:
+        return classification, owner_hint, reduction_signal
+    return "attempt_log", "unknown", rerun_blocker
+
+
+def choose_next_manual_step(
+    *,
+    classification: str,
+    debug_evidence: DebugEvidence | None,
+    rerun_precondition_failure: str | None,
+    rerun_invalid_execution: str | None,
+    execute_rerun: bool,
+    rerun_attempted: bool,
+) -> str:
+    if classification == "draft_issue" and debug_evidence:
+        return (
+            "review the extracted runtime and TTNN/MLIR evidence, "
+            "trim to the smallest repro-worthy snippet, then attach it before filing."
+        )
+    if rerun_precondition_failure is not None:
+        return (
+            "install the missing pytest/runtime dependencies in the chosen TT-XLA environment, "
+            "then rerun the bounded runtime capture."
+        )
+    if rerun_invalid_execution is not None:
+        return _INVALID_EXECUTION_NEXT_STEPS.get(
+            rerun_invalid_execution,
+            (
+                "inspect the skip or early-runtime failure in the bounded rerun log, then decide whether to keep this row "
+                "as an explicit blocker case or replace it with a row that reaches TT runtime markers."
+            ),
+        )
+    if execute_rerun and rerun_attempted:
+        return (
+            "inspect the bounded rerun log, confirm whether runtime debug markers were emitted, "
+            "and refine the rerun command or environment before filing."
+        )
+    if classification == "draft_issue":
+        return (
+            "re-run the failing test with TTMLIR_LOGGER_LEVEL=DEBUG and TT_RUNTIME_DEBUG=ON, "
+            "capture the Executing operation line and enclosing TTNN MLIR, then attach the reduction evidence before filing."
+        )
+    return "capture real debug logs with TTMLIR_LOGGER_LEVEL=DEBUG and TT_RUNTIME_DEBUG=ON before assigning ownership."
+
+
 def reduce_test_entry(
     *,
     test_id: str,
@@ -659,99 +776,45 @@ def reduce_test_entry(
     output_dir = build_output_dir(output_root, test_id)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    debug_log_path = find_debug_log(debug_log_root, test_id)
-    rerun_attempted = False
-    rerun_command = None
-    rerun_log_path = None
-    rerun_returncode = None
-
-    if debug_log_path is None and execute_rerun:
-        environment_precondition_failure = probe_rerun_environment(pytest_bin)
-        if environment_precondition_failure is not None:
-            rerun_attempted = False
-            rerun_command = build_rerun_command(pytest_bin, test_id)
-            rerun_log_file = output_dir / "runtime_rerun.log"
-            rerun_log_file.write_text(
-                environment_precondition_failure + "\n", encoding="utf-8"
-            )
-            rerun_log_path = str(rerun_log_file)
-            debug_log_path = rerun_log_file
-        else:
-            rerun_attempted = True
-            rerun_log_file = output_dir / "runtime_rerun.log"
-            rerun_returncode, rerun_command = run_bounded_rerun(
-                pytest_bin=pytest_bin,
-                test_id=test_id,
-                log_path=rerun_log_file,
-                timeout_sec=rerun_timeout_sec,
-                force_run_skipped=force_run_skipped,
-            )
-            rerun_log_path = str(rerun_log_file)
-            debug_log_path = rerun_log_file
+    rerun_capture = capture_runtime_log(
+        debug_log_root=debug_log_root,
+        test_id=test_id,
+        output_dir=output_dir,
+        execute_rerun=execute_rerun,
+        pytest_bin=pytest_bin,
+        rerun_timeout_sec=rerun_timeout_sec,
+        force_run_skipped=force_run_skipped,
+    )
 
     debug_evidence = (
-        extract_debug_evidence(debug_log_path)
-        if debug_log_path and debug_log_path.exists()
+        extract_debug_evidence(rerun_capture.debug_log_path)
+        if rerun_capture.debug_log_path and rerun_capture.debug_log_path.exists()
         else None
     )
-    rerun_precondition_failure = detect_rerun_precondition_failure(debug_log_path)
-    rerun_invalid_execution = detect_rerun_invalid_execution(debug_log_path)
+    rerun_precondition_failure = detect_rerun_precondition_failure(
+        rerun_capture.debug_log_path
+    )
+    rerun_invalid_execution = detect_rerun_invalid_execution(
+        rerun_capture.debug_log_path
+    )
     classification, owner_hint, reduction_signal = classify_runtime_entry(
         bringup_status, reason, debug_evidence
     )
-
-    if rerun_precondition_failure is not None:
-        classification = "attempt_log"
-        owner_hint = "unknown"
-        reduction_signal = rerun_precondition_failure
-    elif rerun_invalid_execution is not None:
-        classification = "attempt_log"
-        owner_hint = "unknown"
-        reduction_signal = rerun_invalid_execution
-
-    if classification == "draft_issue" and debug_evidence:
-        next_manual_step = (
-            "review the extracted runtime and TTNN/MLIR evidence, "
-            "trim to the smallest repro-worthy snippet, then attach it before filing."
-        )
-    elif rerun_precondition_failure is not None:
-        next_manual_step = (
-            "install the missing pytest/runtime dependencies in the chosen TT-XLA environment, "
-            "then rerun the bounded runtime capture."
-        )
-    elif (
-        rerun_invalid_execution
-        == "rerun executed with PJRT_DEVICE=CPU instead of TT hardware"
-    ):
-        next_manual_step = (
-            "configure the rerun environment so the test runs on TT hardware and emits runtime debug markers, "
-            "then rerun the bounded runtime capture."
-        )
-    elif (
-        rerun_invalid_execution
-        == "rerun timed out before TT runtime evidence was captured"
-    ):
-        next_manual_step = (
-            "capture a staged or narrower debug run that emits TT runtime markers before the hang point, "
-            "or choose a runtime row that reaches operation-level evidence within the bounded timeout."
-        )
-    elif rerun_invalid_execution is not None:
-        next_manual_step = (
-            "inspect the skip or early-runtime failure in the bounded rerun log, then decide whether to keep this row "
-            "as an explicit blocker case or replace it with a row that reaches TT runtime markers."
-        )
-    elif execute_rerun and rerun_attempted:
-        next_manual_step = (
-            "inspect the bounded rerun log, confirm whether runtime debug markers were emitted, "
-            "and refine the rerun command or environment before filing."
-        )
-    elif classification == "draft_issue":
-        next_manual_step = (
-            "re-run the failing test with TTMLIR_LOGGER_LEVEL=DEBUG and TT_RUNTIME_DEBUG=ON, "
-            "capture the Executing operation line and enclosing TTNN MLIR, then attach the reduction evidence before filing."
-        )
-    else:
-        next_manual_step = "capture real debug logs with TTMLIR_LOGGER_LEVEL=DEBUG and TT_RUNTIME_DEBUG=ON before assigning ownership."
+    classification, owner_hint, reduction_signal = apply_rerun_classification_override(
+        classification,
+        owner_hint,
+        reduction_signal,
+        rerun_precondition_failure,
+        rerun_invalid_execution,
+    )
+    next_manual_step = choose_next_manual_step(
+        classification=classification,
+        debug_evidence=debug_evidence,
+        rerun_precondition_failure=rerun_precondition_failure,
+        rerun_invalid_execution=rerun_invalid_execution,
+        execute_rerun=execute_rerun,
+        rerun_attempted=rerun_capture.rerun_attempted,
+    )
 
     result = RuntimeReductionResult(
         test_id=test_id,
@@ -761,12 +824,14 @@ def reduce_test_entry(
         owner_hint=owner_hint,
         reduction_signal=reduction_signal,
         runtime_debug_captured=debug_evidence is not None,
-        debug_log_path=str(debug_log_path) if debug_log_path else None,
+        debug_log_path=(
+            str(rerun_capture.debug_log_path) if rerun_capture.debug_log_path else None
+        ),
         debug_evidence_path=None,
-        rerun_attempted=rerun_attempted,
-        rerun_command=rerun_command,
-        rerun_log_path=rerun_log_path,
-        rerun_returncode=rerun_returncode,
+        rerun_attempted=rerun_capture.rerun_attempted,
+        rerun_command=rerun_capture.rerun_command,
+        rerun_log_path=rerun_capture.rerun_log_path,
+        rerun_returncode=rerun_capture.rerun_returncode,
         force_run_skipped=force_run_skipped,
         next_manual_step=next_manual_step,
         output_dir=str(output_dir),
@@ -796,23 +861,53 @@ def collect_selected_tests(
     config: dict[str, Any], requested_tests: list[str]
 ) -> list[str]:
     if requested_tests:
-        missing = [test_id for test_id in requested_tests if test_id not in config]
-        if missing:
-            missing_text = ", ".join(sorted(missing))
-            raise KeyError(f"Requested test ids not found in config: {missing_text}")
+        require_requested_tests(config, requested_tests)
         return requested_tests
 
-    selected = []
-    for test_id, entry in config.items():
-        if not isinstance(entry, dict):
-            continue
-        bringup_status = entry.get("bringup_status")
-        reason = entry.get("reason", "")
-        if bringup_status == "FAILED_RUNTIME" or any(
-            token in reason for token in _RUNTIME_KEYWORDS
-        ):
-            selected.append(test_id)
-    return selected
+    return [
+        test_id
+        for test_id, entry in config.items()
+        if is_runtime_candidate_entry(entry)
+    ]
+
+
+def require_requested_tests(config: dict[str, Any], requested_tests: list[str]) -> None:
+    missing = [test_id for test_id in requested_tests if test_id not in config]
+    if missing:
+        missing_text = ", ".join(sorted(missing))
+        raise KeyError(f"Requested test ids not found in config: {missing_text}")
+
+
+def is_runtime_candidate_entry(entry: Any) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    reason = entry.get("reason") or ""
+    return entry.get("bringup_status") == "FAILED_RUNTIME" or contains_any(
+        reason, _RUNTIME_KEYWORDS
+    )
+
+
+def count_results(results: list[RuntimeReductionResult], field_name: str) -> int:
+    return sum(1 for result in results if getattr(result, field_name))
+
+
+def build_runtime_summary(
+    *, config_path: Path, output_root: Path, results: list[RuntimeReductionResult]
+) -> RuntimeReductionSummary:
+    return RuntimeReductionSummary(
+        config_path=str(config_path),
+        output_root=str(output_root),
+        selected_test_count=len(results),
+        tt_metal_draft_count=sum(
+            1 for result in results if result.owner_hint == "tt-metal"
+        ),
+        tt_alchemist_draft_count=sum(
+            1 for result in results if result.owner_hint == "tt-alchemist"
+        ),
+        attempt_log_count=count_results(results, "attempt_log_path"),
+        debug_evidence_count=count_results(results, "runtime_debug_captured"),
+        results=[asdict(result) for result in results],
+    )
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
@@ -882,23 +977,8 @@ def main(argv: list[str]) -> int:
         for test_id in selected_tests
     ]
 
-    summary = RuntimeReductionSummary(
-        config_path=str(args.config),
-        output_root=str(output_root),
-        selected_test_count=len(results),
-        tt_metal_draft_count=sum(
-            1 for result in results if result.owner_hint == "tt-metal"
-        ),
-        tt_alchemist_draft_count=sum(
-            1 for result in results if result.owner_hint == "tt-alchemist"
-        ),
-        attempt_log_count=sum(
-            1 for result in results if result.attempt_log_path is not None
-        ),
-        debug_evidence_count=sum(
-            1 for result in results if result.runtime_debug_captured
-        ),
-        results=[asdict(result) for result in results],
+    summary = build_runtime_summary(
+        config_path=args.config, output_root=output_root, results=results
     )
     output_root.mkdir(parents=True, exist_ok=True)
     write_summary(build_output_file(output_root, "summary.json"), summary)

--- a/tests/runner/runtime_training_failure_reduction.py
+++ b/tests/runner/runtime_training_failure_reduction.py
@@ -1,0 +1,751 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generate bounded runtime training-failure reduction bundles.
+
+This tool creates review-ready reduction artifacts for training failures whose
+current config metadata points to runtime or metal-style failures. It is a
+bounded planning-driven implementation: it does not rerun tests, but it
+normalizes the current runtime evidence and branches into draft packet or
+attempt-log outputs using explicit heuristics.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+_DEFAULT_CONFIG_PATH = (
+    _PROJECT_ROOT / "tests" / "runner" / "test_config" / "torch" / "test_config_training_single_device.yaml"
+)
+_DEFAULT_OUTPUT_ROOT = _PROJECT_ROOT / "artifacts" / "runtime_training_reduction"
+_RUNTIME_KEYWORDS = (
+    "FAILED_RUNTIME",
+    "TT_FATAL",
+    "L1",
+    "DRAM",
+    "Buffer must be allocated on device",
+    "Test Hangs",
+    "Out of Memory",
+    "RuntimeError",
+)
+_DEBUG_LOG_SUFFIXES = (".log", ".txt")
+
+
+@dataclass
+class RuntimeReductionResult:
+    test_id: str
+    bringup_status: str | None
+    reason: str | None
+    classification: str
+    owner_hint: str
+    reduction_signal: str
+    runtime_debug_captured: bool
+    debug_log_path: str | None
+    debug_evidence_path: str | None
+    rerun_attempted: bool
+    rerun_command: str | None
+    rerun_log_path: str | None
+    rerun_returncode: int | None
+    force_run_skipped: bool
+    next_manual_step: str
+    output_dir: str
+    draft_issue_path: str | None
+    attempt_log_path: str | None
+
+
+@dataclass
+class RuntimeReductionSummary:
+    config_path: str
+    output_root: str
+    selected_test_count: int
+    tt_metal_draft_count: int
+    tt_alchemist_draft_count: int
+    attempt_log_count: int
+    debug_evidence_count: int
+    results: list[dict[str, Any]]
+
+
+@dataclass
+class DebugEvidence:
+    source_path: str
+    executing_operation_lines: list[str]
+    runtime_signal_lines: list[str]
+    ttnn_mlir_lines: list[str]
+
+
+def detect_rerun_precondition_failure(log_path: Path | None) -> str | None:
+    if log_path is None or not log_path.exists():
+        return None
+
+    text = log_path.read_text(encoding="utf-8")
+    if text.startswith("rerun precondition violation:"):
+        return text.strip()
+    if "TT-Metal installation could not be found" in text:
+        return "rerun precondition violation: torch_xla could not locate TT-Metal installation"
+    if "Native library" in text and "pjrt_plugin_tt.so" in text and "does not exist" in text:
+        return "rerun precondition violation: torch_xla loaded source pjrt_plugin_tt without native plugin library"
+    if "ImportError while loading conftest" in text and "ModuleNotFoundError" in text:
+        missing = []
+        for line in text.splitlines():
+            if "ModuleNotFoundError" in line:
+                missing.append(line.strip())
+        detail = "; ".join(missing) if missing else "pytest environment dependency missing"
+        return f"rerun precondition violation: {detail}"
+    return None
+
+
+def detect_rerun_invalid_execution(log_path: Path | None) -> str | None:
+    if log_path is None or not log_path.exists():
+        return None
+
+    text = log_path.read_text(encoding="utf-8")
+    if "Defaulting to PJRT_DEVICE=CPU" in text:
+        return "rerun executed with PJRT_DEVICE=CPU instead of TT hardware"
+    if "SKIPPED" in text:
+        return "rerun was skipped before TT runtime evidence was captured"
+    if "TIMEOUT after" in text:
+        return "rerun timed out before TT runtime evidence was captured"
+    return None
+
+
+def build_pytest_node_id(test_id: str) -> str:
+    return f"tests/runner/test_models.py::test_all_models_torch[{test_id}]"
+
+
+def build_rerun_command(pytest_bin: str, test_id: str) -> list[str]:
+    return [pytest_bin, "-vv", "-s", build_pytest_node_id(test_id)]
+
+
+def derive_python_bin(pytest_bin: str) -> str | None:
+    pytest_path = Path(pytest_bin)
+    if pytest_path.parent.name == "bin":
+        candidate = pytest_path.parent / "python"
+        if candidate.exists():
+            return str(candidate)
+    return None
+
+
+def probe_rerun_environment(pytest_bin: str) -> str | None:
+    python_bin = derive_python_bin(pytest_bin)
+    if python_bin is None:
+        return None
+
+    probe = (
+        "import importlib\n"
+        "mods=['psutil','pytest','torch','torch_xla']\n"
+        "missing=[]\n"
+        "for m in mods:\n"
+        "    try:\n"
+        "        importlib.import_module(m)\n"
+        "    except Exception as e:\n"
+        "        missing.append(f\"MISSING::{m}: {e}\")\n"
+        "print('\\n'.join(missing))\n"
+    )
+    completed = subprocess.run(
+        [python_bin, "-c", probe],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+    output = completed.stdout.strip()
+    missing_lines = [line.strip() for line in output.splitlines() if line.strip().startswith("MISSING::")]
+    if missing_lines:
+        detail = "; ".join(line.replace("MISSING::", "", 1) for line in missing_lines)
+        return f"rerun precondition violation: {detail}"
+    return None
+
+
+def load_training_config(config_path: Path) -> dict[str, Any]:
+    with config_path.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected mapping at {config_path}, got {type(data).__name__}")
+    test_config = data.get("test_config", data)
+    if not isinstance(test_config, dict):
+        raise ValueError(
+            f"Expected 'test_config' mapping at {config_path}, got {type(test_config).__name__}"
+        )
+    return test_config
+
+
+def sanitize_test_id(test_id: str) -> str:
+    return re.sub(r"[^A-Za-z0-9._-]+", "_", test_id)
+
+
+def find_debug_log(debug_log_root: Path | None, test_id: str) -> Path | None:
+    if debug_log_root is None or not debug_log_root.exists():
+        return None
+
+    if debug_log_root.is_file():
+        return debug_log_root
+
+    base_name = sanitize_test_id(test_id)
+    for suffix in _DEBUG_LOG_SUFFIXES:
+        candidate = debug_log_root / f"{base_name}{suffix}"
+        if candidate.is_file():
+            return candidate
+
+    return None
+
+
+def extract_debug_evidence(debug_log_path: Path) -> DebugEvidence | None:
+    lines = debug_log_path.read_text(encoding="utf-8").splitlines()
+    executing_operation_lines = [line.strip() for line in lines if "Executing operation" in line]
+    runtime_signal_lines = [
+        line.strip()
+        for line in lines
+        if any(
+            token in line
+            for token in (
+                "TT_FATAL",
+                "beyond max L1 size",
+                "Not enough space to allocate",
+                "Buffer must be allocated on device",
+                "RuntimeError",
+                "Out of Memory",
+            )
+        )
+    ]
+    ttnn_mlir_lines = [
+        line.rstrip()
+        for line in lines
+        if any(token in line for token in ("ttnn.", "tt.device", "ttnn::", "stablehlo."))
+    ]
+
+    if not executing_operation_lines and not runtime_signal_lines and not ttnn_mlir_lines:
+        return None
+
+    return DebugEvidence(
+        source_path=str(debug_log_path),
+        executing_operation_lines=executing_operation_lines[:5],
+        runtime_signal_lines=runtime_signal_lines[:8],
+        ttnn_mlir_lines=ttnn_mlir_lines[:12],
+    )
+
+
+def run_bounded_rerun(
+    *,
+    pytest_bin: str,
+    test_id: str,
+    log_path: Path,
+    timeout_sec: int,
+    force_run_skipped: bool = False,
+) -> tuple[int | None, str]:
+    command = build_rerun_command(pytest_bin, test_id)
+    env = dict(os.environ)
+    env["TTMLIR_LOGGER_LEVEL"] = "DEBUG"
+    env["TT_RUNTIME_DEBUG"] = "ON"
+    if force_run_skipped:
+        env["TT_XLA_FORCE_RUN_SKIPPED_TEST_IDS"] = test_id
+
+    try:
+        completed = subprocess.run(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            env=env,
+            timeout=timeout_sec,
+            check=False,
+        )
+        log_path.write_text(completed.stdout, encoding="utf-8")
+        return completed.returncode, " ".join(command)
+    except FileNotFoundError:
+        log_path.write_text(f"pytest binary not found: {pytest_bin}\n", encoding="utf-8")
+        return None, " ".join(command)
+    except subprocess.TimeoutExpired as exc:
+        output = exc.stdout or ""
+        if isinstance(output, bytes):
+            output = output.decode("utf-8", errors="replace")
+        log_path.write_text(output + f"\nTIMEOUT after {timeout_sec}s\n", encoding="utf-8")
+        return None, " ".join(command)
+
+
+def classify_runtime_entry(
+    bringup_status: str | None,
+    reason: str | None,
+    debug_evidence: DebugEvidence | None = None,
+) -> tuple[str, str, str]:
+    reason = reason or ""
+    bringup_status = bringup_status or ""
+    debug_signal_text = " ".join(
+        (debug_evidence.executing_operation_lines + debug_evidence.runtime_signal_lines)
+    ) if debug_evidence else ""
+    signal_text = f"{reason} {debug_signal_text}"
+
+    if any(
+        token in signal_text
+        for token in (
+            "TT_FATAL",
+            "Buffer must be allocated on device",
+            "Out of Memory",
+            "beyond max L1 size",
+            "Not enough space to allocate",
+        )
+    ):
+        return (
+            "draft_issue",
+            "tt-metal",
+            "runtime op/device or memory failure signature suggests tt-metal ownership",
+        )
+    if "FAILED_RUNTIME" in bringup_status and "Test Hangs" in reason:
+        if debug_evidence and debug_evidence.executing_operation_lines:
+            return (
+                "draft_issue",
+                "tt-alchemist",
+                "runtime hang now has executing-operation evidence and is reduction-worthy for tt-alchemist follow-through",
+            )
+        return (
+            "attempt_log",
+            "unknown",
+            "runtime hang requires real debug-log capture and cannot be confidently assigned from config-only evidence",
+        )
+    if "FAILED_RUNTIME" in bringup_status:
+        if debug_evidence and (
+            debug_evidence.executing_operation_lines
+            or debug_evidence.runtime_signal_lines
+            or debug_evidence.ttnn_mlir_lines
+        ):
+            return (
+                "draft_issue",
+                "tt-alchemist",
+                "runtime failure has captured debug evidence and is reduction-worthy for tt-alchemist follow-through",
+            )
+        return (
+            "draft_issue",
+            "tt-alchemist",
+            "runtime failure is reduction-worthy but needs op-level extraction and tt-alchemist follow-through",
+        )
+    return (
+        "attempt_log",
+        "unknown",
+        "row does not match the bounded runtime-reduction selection strongly enough for a draft packet",
+    )
+
+
+def write_manifest(path: Path, result: RuntimeReductionResult) -> None:
+    path.write_text(json.dumps(asdict(result), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_summary(path: Path, summary: RuntimeReductionSummary) -> None:
+    path.write_text(json.dumps(asdict(summary), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_review_report(path: Path, summary: RuntimeReductionSummary) -> None:
+    tt_metal_rows = [result for result in summary.results if result["owner_hint"] == "tt-metal"]
+    tt_alchemist_rows = [result for result in summary.results if result["owner_hint"] == "tt-alchemist"]
+    attempt_rows = [result for result in summary.results if result["attempt_log_path"]]
+
+    lines = [
+        "# Runtime Training Failure Reduction Review Report",
+        "",
+        "## Summary",
+        f"- selected tests: `{summary.selected_test_count}`",
+        f"- tt-metal draft candidates: `{summary.tt_metal_draft_count}`",
+        f"- tt-alchemist draft candidates: `{summary.tt_alchemist_draft_count}`",
+        f"- attempt logs: `{summary.attempt_log_count}`",
+        f"- debug evidence captured: `{summary.debug_evidence_count}`",
+        "",
+        "## TT-Metal Draft Candidates",
+    ]
+    if tt_metal_rows:
+        for row in tt_metal_rows:
+            lines.extend(
+                [
+                    f"- `{row['test_id']}`",
+                    f"  - draft: `{row['draft_issue_path']}`",
+                    f"  - reduction signal: `{row['reduction_signal']}`",
+                    f"  - debug evidence: `{row['debug_evidence_path']}`",
+                ]
+            )
+    else:
+        lines.append("- None")
+
+    lines.extend(["", "## TT-Alchemist Draft Candidates"])
+    if tt_alchemist_rows:
+        for row in tt_alchemist_rows:
+            lines.extend(
+                [
+                    f"- `{row['test_id']}`",
+                    f"  - draft: `{row['draft_issue_path']}`",
+                    f"  - reduction signal: `{row['reduction_signal']}`",
+                    f"  - debug evidence: `{row['debug_evidence_path']}`",
+                ]
+            )
+    else:
+        lines.append("- None")
+
+    lines.extend(["", "## Attempt Logs"])
+    if attempt_rows:
+        for row in attempt_rows:
+            lines.extend(
+                [
+                    f"- `{row['test_id']}`",
+                    f"  - attempt log: `{row['attempt_log_path']}`",
+                    f"  - next step: `{row['next_manual_step']}`",
+                    f"  - debug evidence: `{row['debug_evidence_path']}`",
+                ]
+            )
+    else:
+        lines.append("- None")
+
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_draft_issue(path: Path, result: RuntimeReductionResult) -> None:
+    issue_title = "TT-Metal" if result.owner_hint == "tt-metal" else "TT-Alchemist"
+    config_evidence = (
+        result.reason
+        or "No config reason recorded; draft is based on captured runtime debug evidence."
+    )
+    body = f"""# {issue_title} Runtime Reduction Draft
+
+## Summary
+`{result.test_id}` is a bounded runtime-reduction candidate with current config evidence:
+`{config_evidence}`
+
+## Runtime Classification
+- owner hint: `{result.owner_hint}`
+- classification: `{result.classification}`
+- bringup status: `{result.bringup_status}`
+- reduction signal: `{result.reduction_signal}`
+- runtime debug captured: `{result.runtime_debug_captured}`
+
+## Failure Context
+- config source: `tests/runner/test_config/torch/test_config_training_single_device.yaml`
+- current reason: `{config_evidence}`
+- planned workflow target: metal/runtime reduction
+- debug log: `{result.debug_log_path}`
+- debug evidence: `{result.debug_evidence_path}`
+
+## What Was Tried
+- selected the row from the bounded runtime cohort based on runtime-oriented config evidence
+- normalized the bringup status, reason, and any available runtime debug evidence into a runtime reduction signal
+- mapped the row to a draft-owner path using explicit bounded heuristics
+
+## Next Manual Step
+- {result.next_manual_step}
+
+## Review Gate
+- draft only
+- no external issue filing has occurred
+"""
+    path.write_text(body, encoding="utf-8")
+
+
+def write_attempt_log(path: Path, result: RuntimeReductionResult) -> None:
+    body = f"""workflow_path=runtime
+test_id={result.test_id}
+bringup_status={result.bringup_status}
+reason={result.reason}
+owner_hint={result.owner_hint}
+reduction_signal={result.reduction_signal}
+runtime_debug_captured={result.runtime_debug_captured}
+debug_log_path={result.debug_log_path}
+debug_evidence_path={result.debug_evidence_path}
+rerun_attempted={result.rerun_attempted}
+rerun_returncode={result.rerun_returncode}
+force_run_skipped={result.force_run_skipped}
+
+No draft issue packet was generated.
+
+Attempted steps:
+1. Read bounded runtime-style config row from the provided YAML.
+2. Normalized the row into a runtime reduction signal.
+3. Applied explicit owner heuristics for tt-metal, tt-alchemist, or no-draft fallback.
+
+Blocked decision:
+- {result.reduction_signal}
+
+Next manual step:
+- {result.next_manual_step}
+"""
+    path.write_text(body, encoding="utf-8")
+
+
+def write_debug_evidence(path: Path, debug_evidence: DebugEvidence) -> None:
+    lines = [
+        "# Runtime Debug Evidence",
+        "",
+        f"- source log: `{debug_evidence.source_path}`",
+        "",
+        "## Executing Operation Lines",
+    ]
+    if debug_evidence.executing_operation_lines:
+        lines.extend([f"- `{line}`" for line in debug_evidence.executing_operation_lines])
+    else:
+        lines.append("- None")
+
+    lines.extend(["", "## Runtime Signal Lines"])
+    if debug_evidence.runtime_signal_lines:
+        lines.extend([f"- `{line}`" for line in debug_evidence.runtime_signal_lines])
+    else:
+        lines.append("- None")
+
+    lines.extend(["", "## TTNN / MLIR Context"])
+    if debug_evidence.ttnn_mlir_lines:
+        lines.extend([f"- `{line}`" for line in debug_evidence.ttnn_mlir_lines])
+    else:
+        lines.append("- None")
+
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def reduce_test_entry(
+    *,
+    test_id: str,
+    entry: dict[str, Any],
+    output_root: Path,
+    debug_log_root: Path | None = None,
+    execute_rerun: bool = False,
+    pytest_bin: str = "pytest",
+    rerun_timeout_sec: int = 900,
+    force_run_skipped: bool = False,
+) -> RuntimeReductionResult:
+    bringup_status = entry.get("bringup_status")
+    reason = entry.get("reason")
+    output_dir = output_root / sanitize_test_id(test_id)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    debug_log_path = find_debug_log(debug_log_root, test_id)
+    rerun_attempted = False
+    rerun_command = None
+    rerun_log_path = None
+    rerun_returncode = None
+
+    if debug_log_path is None and execute_rerun:
+        environment_precondition_failure = probe_rerun_environment(pytest_bin)
+        if environment_precondition_failure is not None:
+            rerun_attempted = False
+            rerun_command = build_rerun_command(pytest_bin, test_id)
+            rerun_log_file = output_dir / "runtime_rerun.log"
+            rerun_log_file.write_text(environment_precondition_failure + "\n", encoding="utf-8")
+            rerun_log_path = str(rerun_log_file)
+            debug_log_path = rerun_log_file
+        else:
+            rerun_attempted = True
+            rerun_log_file = output_dir / "runtime_rerun.log"
+            rerun_returncode, rerun_command = run_bounded_rerun(
+                pytest_bin=pytest_bin,
+                test_id=test_id,
+                log_path=rerun_log_file,
+                timeout_sec=rerun_timeout_sec,
+                force_run_skipped=force_run_skipped,
+            )
+            rerun_log_path = str(rerun_log_file)
+            debug_log_path = rerun_log_file
+
+    debug_evidence = extract_debug_evidence(debug_log_path) if debug_log_path and debug_log_path.exists() else None
+    rerun_precondition_failure = detect_rerun_precondition_failure(debug_log_path)
+    rerun_invalid_execution = detect_rerun_invalid_execution(debug_log_path)
+    classification, owner_hint, reduction_signal = classify_runtime_entry(bringup_status, reason, debug_evidence)
+
+    if rerun_precondition_failure is not None:
+        classification = "attempt_log"
+        owner_hint = "unknown"
+        reduction_signal = rerun_precondition_failure
+    elif rerun_invalid_execution is not None:
+        classification = "attempt_log"
+        owner_hint = "unknown"
+        reduction_signal = rerun_invalid_execution
+
+    if classification == "draft_issue" and debug_evidence:
+        next_manual_step = (
+            "review the extracted runtime and TTNN/MLIR evidence, "
+            "trim to the smallest repro-worthy snippet, then attach it before filing."
+        )
+    elif rerun_precondition_failure is not None:
+        next_manual_step = (
+            "install the missing pytest/runtime dependencies in the chosen TT-XLA environment, "
+            "then rerun the bounded runtime capture."
+        )
+    elif rerun_invalid_execution == "rerun executed with PJRT_DEVICE=CPU instead of TT hardware":
+        next_manual_step = (
+            "configure the rerun environment so the test runs on TT hardware and emits runtime debug markers, "
+            "then rerun the bounded runtime capture."
+        )
+    elif rerun_invalid_execution == "rerun timed out before TT runtime evidence was captured":
+        next_manual_step = (
+            "capture a staged or narrower debug run that emits TT runtime markers before the hang point, "
+            "or choose a runtime row that reaches operation-level evidence within the bounded timeout."
+        )
+    elif rerun_invalid_execution is not None:
+        next_manual_step = (
+            "inspect the skip or early-runtime failure in the bounded rerun log, then decide whether to keep this row "
+            "as an explicit blocker case or replace it with a row that reaches TT runtime markers."
+        )
+    elif execute_rerun and rerun_attempted:
+        next_manual_step = (
+            "inspect the bounded rerun log, confirm whether runtime debug markers were emitted, "
+            "and refine the rerun command or environment before filing."
+        )
+    elif classification == "draft_issue":
+        next_manual_step = (
+            "re-run the failing test with TTMLIR_LOGGER_LEVEL=DEBUG and TT_RUNTIME_DEBUG=ON, "
+            "capture the Executing operation line and enclosing TTNN MLIR, then attach the reduction evidence before filing."
+        )
+    else:
+        next_manual_step = (
+            "capture real debug logs with TTMLIR_LOGGER_LEVEL=DEBUG and TT_RUNTIME_DEBUG=ON before assigning ownership."
+        )
+
+    result = RuntimeReductionResult(
+        test_id=test_id,
+        bringup_status=bringup_status,
+        reason=reason,
+        classification=classification,
+        owner_hint=owner_hint,
+        reduction_signal=reduction_signal,
+        runtime_debug_captured=debug_evidence is not None,
+        debug_log_path=str(debug_log_path) if debug_log_path else None,
+        debug_evidence_path=None,
+        rerun_attempted=rerun_attempted,
+        rerun_command=rerun_command,
+        rerun_log_path=rerun_log_path,
+        rerun_returncode=rerun_returncode,
+        force_run_skipped=force_run_skipped,
+        next_manual_step=next_manual_step,
+        output_dir=str(output_dir),
+        draft_issue_path=None,
+        attempt_log_path=None,
+    )
+
+    if debug_evidence is not None:
+        debug_evidence_path = output_dir / "debug_evidence.md"
+        write_debug_evidence(debug_evidence_path, debug_evidence)
+        result.debug_evidence_path = str(debug_evidence_path)
+
+    if classification == "draft_issue":
+        draft_issue_path = output_dir / "draft_issue.md"
+        write_draft_issue(draft_issue_path, result)
+        result.draft_issue_path = str(draft_issue_path)
+    else:
+        attempt_log_path = output_dir / "attempt.log"
+        write_attempt_log(attempt_log_path, result)
+        result.attempt_log_path = str(attempt_log_path)
+
+    write_manifest(output_dir / "manifest.json", result)
+    return result
+
+
+def collect_selected_tests(config: dict[str, Any], requested_tests: list[str]) -> list[str]:
+    if requested_tests:
+        missing = [test_id for test_id in requested_tests if test_id not in config]
+        if missing:
+            missing_text = ", ".join(sorted(missing))
+            raise KeyError(f"Requested test ids not found in config: {missing_text}")
+        return requested_tests
+
+    selected = []
+    for test_id, entry in config.items():
+        if not isinstance(entry, dict):
+            continue
+        bringup_status = entry.get("bringup_status")
+        reason = entry.get("reason", "")
+        if bringup_status == "FAILED_RUNTIME" or any(token in reason for token in _RUNTIME_KEYWORDS):
+            selected.append(test_id)
+    return selected
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=_DEFAULT_CONFIG_PATH)
+    parser.add_argument("--output-root", type=Path, default=_DEFAULT_OUTPUT_ROOT)
+    parser.add_argument(
+        "--debug-log-root",
+        type=Path,
+        default=None,
+        help="Optional directory of per-test runtime debug logs named after sanitized test ids, or a single debug log file.",
+    )
+    parser.add_argument(
+        "--execute-rerun",
+        action="store_true",
+        help="If no matching debug log exists, attempt a bounded pytest rerun with TTMLIR_LOGGER_LEVEL=DEBUG and TT_RUNTIME_DEBUG=ON.",
+    )
+    parser.add_argument(
+        "--pytest-bin",
+        default="pytest",
+        help="Pytest executable to use for --execute-rerun. Default: pytest",
+    )
+    parser.add_argument(
+        "--rerun-timeout-sec",
+        type=int,
+        default=900,
+        help="Timeout in seconds for each bounded rerun attempt.",
+    )
+    parser.add_argument(
+        "--force-run-skipped",
+        action="store_true",
+        help=(
+            "For --execute-rerun only: run selected NOT_SUPPORTED_SKIP rows by setting "
+            "TT_XLA_FORCE_RUN_SKIPPED_TEST_IDS for the subprocess. This is intended for "
+            "bounded debug capture and does not mutate source YAML."
+        ),
+    )
+    parser.add_argument(
+        "--test-id",
+        action="append",
+        default=[],
+        help="Specific test id to reduce. Repeat for multiple tests. Defaults to all bounded runtime-style rows.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    config = load_training_config(args.config)
+    selected_tests = collect_selected_tests(config, args.test_id)
+    results = [
+        reduce_test_entry(
+            test_id=test_id,
+            entry=config[test_id],
+            output_root=args.output_root,
+            debug_log_root=args.debug_log_root,
+            execute_rerun=args.execute_rerun,
+            pytest_bin=args.pytest_bin,
+            rerun_timeout_sec=args.rerun_timeout_sec,
+            force_run_skipped=args.force_run_skipped,
+        )
+        for test_id in selected_tests
+    ]
+
+    summary = RuntimeReductionSummary(
+        config_path=str(args.config),
+        output_root=str(args.output_root),
+        selected_test_count=len(results),
+        tt_metal_draft_count=sum(1 for result in results if result.owner_hint == "tt-metal"),
+        tt_alchemist_draft_count=sum(1 for result in results if result.owner_hint == "tt-alchemist"),
+        attempt_log_count=sum(1 for result in results if result.attempt_log_path is not None),
+        debug_evidence_count=sum(1 for result in results if result.runtime_debug_captured),
+        results=[asdict(result) for result in results],
+    )
+    args.output_root.mkdir(parents=True, exist_ok=True)
+    write_summary(args.output_root / "summary.json", summary)
+    write_review_report(args.output_root / "review_report.md", summary)
+
+    print(
+        "Generated "
+        f"{len(selected_tests)} runtime reduction bundle(s) in {args.output_root} "
+        f"(tt_metal={summary.tt_metal_draft_count}, tt_alchemist={summary.tt_alchemist_draft_count}, "
+        f"attempt_logs={summary.attempt_log_count})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/runner/runtime_training_failure_reduction.py
+++ b/tests/runner/runtime_training_failure_reduction.py
@@ -27,7 +27,12 @@ import yaml
 
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 _DEFAULT_CONFIG_PATH = (
-    _PROJECT_ROOT / "tests" / "runner" / "test_config" / "torch" / "test_config_training_single_device.yaml"
+    _PROJECT_ROOT
+    / "tests"
+    / "runner"
+    / "test_config"
+    / "torch"
+    / "test_config_training_single_device.yaml"
 )
 _DEFAULT_OUTPUT_ROOT = _PROJECT_ROOT / "artifacts" / "runtime_training_reduction"
 _RUNTIME_KEYWORDS = (
@@ -41,6 +46,7 @@ _RUNTIME_KEYWORDS = (
     "RuntimeError",
 )
 _DEBUG_LOG_SUFFIXES = (".log", ".txt")
+_SAFE_PATH_COMPONENT_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
 
 
 @dataclass
@@ -94,14 +100,20 @@ def detect_rerun_precondition_failure(log_path: Path | None) -> str | None:
         return text.strip()
     if "TT-Metal installation could not be found" in text:
         return "rerun precondition violation: torch_xla could not locate TT-Metal installation"
-    if "Native library" in text and "pjrt_plugin_tt.so" in text and "does not exist" in text:
+    if (
+        "Native library" in text
+        and "pjrt_plugin_tt.so" in text
+        and "does not exist" in text
+    ):
         return "rerun precondition violation: torch_xla loaded source pjrt_plugin_tt without native plugin library"
     if "ImportError while loading conftest" in text and "ModuleNotFoundError" in text:
         missing = []
         for line in text.splitlines():
             if "ModuleNotFoundError" in line:
                 missing.append(line.strip())
-        detail = "; ".join(missing) if missing else "pytest environment dependency missing"
+        detail = (
+            "; ".join(missing) if missing else "pytest environment dependency missing"
+        )
         return f"rerun precondition violation: {detail}"
     return None
 
@@ -150,7 +162,7 @@ def probe_rerun_environment(pytest_bin: str) -> str | None:
         "    try:\n"
         "        importlib.import_module(m)\n"
         "    except Exception as e:\n"
-        "        missing.append(f\"MISSING::{m}: {e}\")\n"
+        '        missing.append(f"MISSING::{m}: {e}")\n'
         "print('\\n'.join(missing))\n"
     )
     completed = subprocess.run(
@@ -162,7 +174,11 @@ def probe_rerun_environment(pytest_bin: str) -> str | None:
         check=False,
     )
     output = completed.stdout.strip()
-    missing_lines = [line.strip() for line in output.splitlines() if line.strip().startswith("MISSING::")]
+    missing_lines = [
+        line.strip()
+        for line in output.splitlines()
+        if line.strip().startswith("MISSING::")
+    ]
     if missing_lines:
         detail = "; ".join(line.replace("MISSING::", "", 1) for line in missing_lines)
         return f"rerun precondition violation: {detail}"
@@ -173,7 +189,9 @@ def load_training_config(config_path: Path) -> dict[str, Any]:
     with config_path.open("r", encoding="utf-8") as f:
         data = yaml.safe_load(f) or {}
     if not isinstance(data, dict):
-        raise ValueError(f"Expected mapping at {config_path}, got {type(data).__name__}")
+        raise ValueError(
+            f"Expected mapping at {config_path}, got {type(data).__name__}"
+        )
     test_config = data.get("test_config", data)
     if not isinstance(test_config, dict):
         raise ValueError(
@@ -186,16 +204,57 @@ def sanitize_test_id(test_id: str) -> str:
     return re.sub(r"[^A-Za-z0-9._-]+", "_", test_id)
 
 
+def validate_safe_path_component(component: str, label: str) -> str:
+    if component in {"", ".", ".."} or not _SAFE_PATH_COMPONENT_PATTERN.fullmatch(
+        component
+    ):
+        raise ValueError(f"Unsafe {label} component: {component!r}")
+    return component
+
+
+def require_path_within(path: Path, root: Path, label: str) -> Path:
+    resolved_root = root.expanduser().resolve()
+    resolved_path = path.expanduser().resolve()
+    try:
+        resolved_path.relative_to(resolved_root)
+    except ValueError as exc:
+        raise ValueError(
+            f"{label} must stay within {resolved_root}: {resolved_path}"
+        ) from exc
+    return resolved_path
+
+
+def build_output_dir(output_root: Path, test_id: str) -> Path:
+    safe_name = validate_safe_path_component(
+        sanitize_test_id(test_id), "output directory"
+    )
+    resolved_root = output_root.expanduser().resolve()
+    return require_path_within(
+        resolved_root / safe_name, resolved_root, "output directory"
+    )
+
+
+def build_output_file(output_root: Path, file_name: str) -> Path:
+    safe_name = validate_safe_path_component(file_name, "output file")
+    resolved_root = output_root.expanduser().resolve()
+    return require_path_within(resolved_root / safe_name, resolved_root, "output file")
+
+
 def find_debug_log(debug_log_root: Path | None, test_id: str) -> Path | None:
     if debug_log_root is None or not debug_log_root.exists():
         return None
 
     if debug_log_root.is_file():
-        return debug_log_root
+        return debug_log_root.expanduser().resolve()
 
-    base_name = sanitize_test_id(test_id)
+    resolved_root = debug_log_root.expanduser().resolve()
+    base_name = validate_safe_path_component(sanitize_test_id(test_id), "debug log")
     for suffix in _DEBUG_LOG_SUFFIXES:
-        candidate = debug_log_root / f"{base_name}{suffix}"
+        candidate = require_path_within(
+            resolved_root / f"{base_name}{suffix}",
+            resolved_root,
+            "debug log",
+        )
         if candidate.is_file():
             return candidate
 
@@ -204,7 +263,9 @@ def find_debug_log(debug_log_root: Path | None, test_id: str) -> Path | None:
 
 def extract_debug_evidence(debug_log_path: Path) -> DebugEvidence | None:
     lines = debug_log_path.read_text(encoding="utf-8").splitlines()
-    executing_operation_lines = [line.strip() for line in lines if "Executing operation" in line]
+    executing_operation_lines = [
+        line.strip() for line in lines if "Executing operation" in line
+    ]
     runtime_signal_lines = [
         line.strip()
         for line in lines
@@ -223,10 +284,16 @@ def extract_debug_evidence(debug_log_path: Path) -> DebugEvidence | None:
     ttnn_mlir_lines = [
         line.rstrip()
         for line in lines
-        if any(token in line for token in ("ttnn.", "tt.device", "ttnn::", "stablehlo."))
+        if any(
+            token in line for token in ("ttnn.", "tt.device", "ttnn::", "stablehlo.")
+        )
     ]
 
-    if not executing_operation_lines and not runtime_signal_lines and not ttnn_mlir_lines:
+    if (
+        not executing_operation_lines
+        and not runtime_signal_lines
+        and not ttnn_mlir_lines
+    ):
         return None
 
     return DebugEvidence(
@@ -266,13 +333,17 @@ def run_bounded_rerun(
         log_path.write_text(completed.stdout, encoding="utf-8")
         return completed.returncode, " ".join(command)
     except FileNotFoundError:
-        log_path.write_text(f"pytest binary not found: {pytest_bin}\n", encoding="utf-8")
+        log_path.write_text(
+            f"pytest binary not found: {pytest_bin}\n", encoding="utf-8"
+        )
         return None, " ".join(command)
     except subprocess.TimeoutExpired as exc:
         output = exc.stdout or ""
         if isinstance(output, bytes):
             output = output.decode("utf-8", errors="replace")
-        log_path.write_text(output + f"\nTIMEOUT after {timeout_sec}s\n", encoding="utf-8")
+        log_path.write_text(
+            output + f"\nTIMEOUT after {timeout_sec}s\n", encoding="utf-8"
+        )
         return None, " ".join(command)
 
 
@@ -283,9 +354,16 @@ def classify_runtime_entry(
 ) -> tuple[str, str, str]:
     reason = reason or ""
     bringup_status = bringup_status or ""
-    debug_signal_text = " ".join(
-        (debug_evidence.executing_operation_lines + debug_evidence.runtime_signal_lines)
-    ) if debug_evidence else ""
+    debug_signal_text = (
+        " ".join(
+            (
+                debug_evidence.executing_operation_lines
+                + debug_evidence.runtime_signal_lines
+            )
+        )
+        if debug_evidence
+        else ""
+    )
     signal_text = f"{reason} {debug_signal_text}"
 
     if any(
@@ -339,16 +417,24 @@ def classify_runtime_entry(
 
 
 def write_manifest(path: Path, result: RuntimeReductionResult) -> None:
-    path.write_text(json.dumps(asdict(result), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    path.write_text(
+        json.dumps(asdict(result), indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
 
 
 def write_summary(path: Path, summary: RuntimeReductionSummary) -> None:
-    path.write_text(json.dumps(asdict(summary), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    path.write_text(
+        json.dumps(asdict(summary), indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
 
 
 def write_review_report(path: Path, summary: RuntimeReductionSummary) -> None:
-    tt_metal_rows = [result for result in summary.results if result["owner_hint"] == "tt-metal"]
-    tt_alchemist_rows = [result for result in summary.results if result["owner_hint"] == "tt-alchemist"]
+    tt_metal_rows = [
+        result for result in summary.results if result["owner_hint"] == "tt-metal"
+    ]
+    tt_alchemist_rows = [
+        result for result in summary.results if result["owner_hint"] == "tt-alchemist"
+    ]
     attempt_rows = [result for result in summary.results if result["attempt_log_path"]]
 
     lines = [
@@ -487,7 +573,9 @@ def write_debug_evidence(path: Path, debug_evidence: DebugEvidence) -> None:
         "## Executing Operation Lines",
     ]
     if debug_evidence.executing_operation_lines:
-        lines.extend([f"- `{line}`" for line in debug_evidence.executing_operation_lines])
+        lines.extend(
+            [f"- `{line}`" for line in debug_evidence.executing_operation_lines]
+        )
     else:
         lines.append("- None")
 
@@ -519,7 +607,7 @@ def reduce_test_entry(
 ) -> RuntimeReductionResult:
     bringup_status = entry.get("bringup_status")
     reason = entry.get("reason")
-    output_dir = output_root / sanitize_test_id(test_id)
+    output_dir = build_output_dir(output_root, test_id)
     output_dir.mkdir(parents=True, exist_ok=True)
 
     debug_log_path = find_debug_log(debug_log_root, test_id)
@@ -534,7 +622,9 @@ def reduce_test_entry(
             rerun_attempted = False
             rerun_command = build_rerun_command(pytest_bin, test_id)
             rerun_log_file = output_dir / "runtime_rerun.log"
-            rerun_log_file.write_text(environment_precondition_failure + "\n", encoding="utf-8")
+            rerun_log_file.write_text(
+                environment_precondition_failure + "\n", encoding="utf-8"
+            )
             rerun_log_path = str(rerun_log_file)
             debug_log_path = rerun_log_file
         else:
@@ -550,10 +640,16 @@ def reduce_test_entry(
             rerun_log_path = str(rerun_log_file)
             debug_log_path = rerun_log_file
 
-    debug_evidence = extract_debug_evidence(debug_log_path) if debug_log_path and debug_log_path.exists() else None
+    debug_evidence = (
+        extract_debug_evidence(debug_log_path)
+        if debug_log_path and debug_log_path.exists()
+        else None
+    )
     rerun_precondition_failure = detect_rerun_precondition_failure(debug_log_path)
     rerun_invalid_execution = detect_rerun_invalid_execution(debug_log_path)
-    classification, owner_hint, reduction_signal = classify_runtime_entry(bringup_status, reason, debug_evidence)
+    classification, owner_hint, reduction_signal = classify_runtime_entry(
+        bringup_status, reason, debug_evidence
+    )
 
     if rerun_precondition_failure is not None:
         classification = "attempt_log"
@@ -574,12 +670,18 @@ def reduce_test_entry(
             "install the missing pytest/runtime dependencies in the chosen TT-XLA environment, "
             "then rerun the bounded runtime capture."
         )
-    elif rerun_invalid_execution == "rerun executed with PJRT_DEVICE=CPU instead of TT hardware":
+    elif (
+        rerun_invalid_execution
+        == "rerun executed with PJRT_DEVICE=CPU instead of TT hardware"
+    ):
         next_manual_step = (
             "configure the rerun environment so the test runs on TT hardware and emits runtime debug markers, "
             "then rerun the bounded runtime capture."
         )
-    elif rerun_invalid_execution == "rerun timed out before TT runtime evidence was captured":
+    elif (
+        rerun_invalid_execution
+        == "rerun timed out before TT runtime evidence was captured"
+    ):
         next_manual_step = (
             "capture a staged or narrower debug run that emits TT runtime markers before the hang point, "
             "or choose a runtime row that reaches operation-level evidence within the bounded timeout."
@@ -600,9 +702,7 @@ def reduce_test_entry(
             "capture the Executing operation line and enclosing TTNN MLIR, then attach the reduction evidence before filing."
         )
     else:
-        next_manual_step = (
-            "capture real debug logs with TTMLIR_LOGGER_LEVEL=DEBUG and TT_RUNTIME_DEBUG=ON before assigning ownership."
-        )
+        next_manual_step = "capture real debug logs with TTMLIR_LOGGER_LEVEL=DEBUG and TT_RUNTIME_DEBUG=ON before assigning ownership."
 
     result = RuntimeReductionResult(
         test_id=test_id,
@@ -643,7 +743,9 @@ def reduce_test_entry(
     return result
 
 
-def collect_selected_tests(config: dict[str, Any], requested_tests: list[str]) -> list[str]:
+def collect_selected_tests(
+    config: dict[str, Any], requested_tests: list[str]
+) -> list[str]:
     if requested_tests:
         missing = [test_id for test_id in requested_tests if test_id not in config]
         if missing:
@@ -657,7 +759,9 @@ def collect_selected_tests(config: dict[str, Any], requested_tests: list[str]) -
             continue
         bringup_status = entry.get("bringup_status")
         reason = entry.get("reason", "")
-        if bringup_status == "FAILED_RUNTIME" or any(token in reason for token in _RUNTIME_KEYWORDS):
+        if bringup_status == "FAILED_RUNTIME" or any(
+            token in reason for token in _RUNTIME_KEYWORDS
+        ):
             selected.append(test_id)
     return selected
 
@@ -708,13 +812,14 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 
 def main(argv: list[str]) -> int:
     args = parse_args(argv)
+    output_root = args.output_root.expanduser().resolve()
     config = load_training_config(args.config)
     selected_tests = collect_selected_tests(config, args.test_id)
     results = [
         reduce_test_entry(
             test_id=test_id,
             entry=config[test_id],
-            output_root=args.output_root,
+            output_root=output_root,
             debug_log_root=args.debug_log_root,
             execute_rerun=args.execute_rerun,
             pytest_bin=args.pytest_bin,
@@ -726,17 +831,25 @@ def main(argv: list[str]) -> int:
 
     summary = RuntimeReductionSummary(
         config_path=str(args.config),
-        output_root=str(args.output_root),
+        output_root=str(output_root),
         selected_test_count=len(results),
-        tt_metal_draft_count=sum(1 for result in results if result.owner_hint == "tt-metal"),
-        tt_alchemist_draft_count=sum(1 for result in results if result.owner_hint == "tt-alchemist"),
-        attempt_log_count=sum(1 for result in results if result.attempt_log_path is not None),
-        debug_evidence_count=sum(1 for result in results if result.runtime_debug_captured),
+        tt_metal_draft_count=sum(
+            1 for result in results if result.owner_hint == "tt-metal"
+        ),
+        tt_alchemist_draft_count=sum(
+            1 for result in results if result.owner_hint == "tt-alchemist"
+        ),
+        attempt_log_count=sum(
+            1 for result in results if result.attempt_log_path is not None
+        ),
+        debug_evidence_count=sum(
+            1 for result in results if result.runtime_debug_captured
+        ),
         results=[asdict(result) for result in results],
     )
-    args.output_root.mkdir(parents=True, exist_ok=True)
-    write_summary(args.output_root / "summary.json", summary)
-    write_review_report(args.output_root / "review_report.md", summary)
+    output_root.mkdir(parents=True, exist_ok=True)
+    write_summary(build_output_file(output_root, "summary.json"), summary)
+    write_review_report(build_output_file(output_root, "review_report.md"), summary)
 
     print(
         "Generated "

--- a/tests/runner/test_bounded_training_workflow_validation.py
+++ b/tests/runner/test_bounded_training_workflow_validation.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from tests.runner.bounded_training_workflow_validation import validate_record
+
+
+def test_validate_record_passes_for_frontend_manifest():
+    manifest = {
+        "test_id": "yolov6/pytorch-N-single_device-training",
+        "classification": "frontend",
+        "reason": "frontend reason",
+        "draft_issue_path": "/tmp/draft.md",
+        "attempt_log_path": None,
+        "next_manual_step": "review draft",
+    }
+    record = validate_record(manifest, "frontend")
+    assert record.binary_result == "pass"
+    assert record.failed_conditions == []
+
+
+def test_validate_record_passes_for_runtime_manifest():
+    manifest = {
+        "test_id": "pointpillars/pytorch-pointpillars-single_device-training",
+        "bringup_status": "FAILED_RUNTIME",
+        "classification": "draft_issue",
+        "owner_hint": "tt-metal",
+        "reason": "runtime reason",
+        "draft_issue_path": "/tmp/draft.md",
+        "attempt_log_path": None,
+        "next_manual_step": "capture debug logs",
+    }
+    record = validate_record(manifest, "runtime")
+    assert record.binary_result == "pass"
+    assert record.failed_conditions == []
+
+
+def test_validate_record_fails_when_evidence_missing():
+    manifest = {
+        "test_id": "stable_diffusion_unet/pytorch-Base-single_device-training",
+        "classification": "frontend",
+        "reason": "frontend reason",
+        "draft_issue_path": None,
+        "attempt_log_path": None,
+        "next_manual_step": "inspect logs",
+    }
+    record = validate_record(manifest, "frontend")
+    assert record.binary_result == "error"
+    assert "evidence bundle link is missing" in record.failed_conditions

--- a/tests/runner/test_config/torch/test_config_training_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_training_single_device.yaml
@@ -1061,6 +1061,8 @@ test_config:
     assert_pcc: false
   beit/pytorch-Base-single_device-training:
     status: KNOWN_FAILURE_XFAIL
+    bringup_status: FAILED_RUNTIME
+    reason: "TT_FATAL: Input rank 4 and begins 2 must have the same size (assert.hpp:104)"
     markers: [notimeout]
   beit/pytorch-Large-single_device-training:
     status: KNOWN_FAILURE_XFAIL

--- a/tests/runner/test_frontend_training_failure_triage.py
+++ b/tests/runner/test_frontend_training_failure_triage.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import yaml
+
+from tests.runner.frontend_training_failure_triage import (
+    _UNPACK_REASON,
+    build_loader_path,
+    classify_frontend_reason,
+    collect_selected_tests,
+    loader_has_custom_unpack_forward_output,
+    load_training_config,
+    triage_test_entry,
+)
+
+
+def test_build_loader_path_for_nested_model_family(tmp_path: Path):
+    loader_path = build_loader_path(
+        tmp_path,
+        "distilbert/question_answering/pytorch-Base_Cased_Distilled_Squad-single_device-training",
+    )
+    assert loader_path == (
+        tmp_path
+        / "third_party"
+        / "tt_forge_models"
+        / "distilbert"
+        / "question_answering"
+        / "pytorch"
+        / "loader.py"
+    )
+
+
+def test_loader_has_custom_unpack_forward_output_detects_method(tmp_path: Path):
+    loader_path = tmp_path / "loader.py"
+    loader_path.write_text(
+        """
+class ModelLoader:
+    def unpack_forward_output(self, output):
+        return output
+""",
+        encoding="utf-8",
+    )
+    assert loader_has_custom_unpack_forward_output(loader_path) is True
+
+
+def test_loader_has_custom_unpack_forward_output_false_when_missing(tmp_path: Path):
+    loader_path = tmp_path / "loader.py"
+    loader_path.write_text(
+        """
+class ModelLoader:
+    def load_model(self):
+        return None
+""",
+        encoding="utf-8",
+    )
+    assert loader_has_custom_unpack_forward_output(loader_path) is False
+
+
+def test_collect_selected_tests_defaults_to_unpack_reason_only():
+    config = {
+        "a": {"reason": _UNPACK_REASON},
+        "b": {"reason": "runtime failure"},
+    }
+    assert collect_selected_tests(config, []) == ["a"]
+
+
+def test_classify_frontend_reason_recognizes_known_signature():
+    assert classify_frontend_reason(_UNPACK_REASON) == "frontend"
+    assert classify_frontend_reason("missing decoder_input_ids in training") == "frontend"
+    assert classify_frontend_reason("L1 allocation failure") == "no_draft_attempt_log"
+
+
+def test_load_training_config_requires_mapping(tmp_path: Path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("- not-a-mapping\n", encoding="utf-8")
+    try:
+        load_training_config(config_path)
+    except ValueError as exc:
+        assert "Expected mapping" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for non-mapping YAML")
+
+
+def test_triage_test_entry_writes_draft_issue_for_missing_custom_unpack(tmp_path: Path):
+    project_root = tmp_path / "repo"
+    loader_path = (
+        project_root
+        / "third_party"
+        / "tt_forge_models"
+        / "yolov6"
+        / "pytorch"
+        / "loader.py"
+    )
+    loader_path.parent.mkdir(parents=True)
+    loader_path.write_text(
+        """
+class ModelLoader:
+    def load_model(self):
+        return None
+""",
+        encoding="utf-8",
+    )
+    output_root = tmp_path / "artifacts"
+
+    result = triage_test_entry(
+        project_root=project_root,
+        config_path=project_root / "config.yaml",
+        test_id="yolov6/pytorch-N-single_device-training",
+        entry={"reason": _UNPACK_REASON},
+        output_root=output_root,
+    )
+
+    assert result.draft_issue_path is not None
+    assert result.attempt_log_path is None
+    draft_issue = Path(result.draft_issue_path)
+    manifest = Path(result.output_dir) / "manifest.json"
+    assert draft_issue.is_file()
+    assert manifest.is_file()
+    manifest_data = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    assert manifest_data["classification"] == "frontend"
+    assert manifest_data["has_custom_unpack_forward_output"] is False
+
+
+def test_triage_test_entry_writes_attempt_log_when_custom_unpack_exists(tmp_path: Path):
+    project_root = tmp_path / "repo"
+    loader_path = (
+        project_root
+        / "third_party"
+        / "tt_forge_models"
+        / "maptr"
+        / "pytorch"
+        / "loader.py"
+    )
+    loader_path.parent.mkdir(parents=True)
+    loader_path.write_text(
+        """
+class ModelLoader:
+    def unpack_forward_output(self, output):
+        return output
+""",
+        encoding="utf-8",
+    )
+    output_root = tmp_path / "artifacts"
+
+    result = triage_test_entry(
+        project_root=project_root,
+        config_path=project_root / "config.yaml",
+        test_id="maptr/pytorch-Tiny_R50_24e_Av2-single_device-training",
+        entry={"reason": _UNPACK_REASON},
+        output_root=output_root,
+    )
+
+    assert result.draft_issue_path is None
+    assert result.attempt_log_path is not None
+    attempt_log = Path(result.attempt_log_path)
+    assert attempt_log.is_file()
+    assert "No draft issue packet was generated." in attempt_log.read_text(encoding="utf-8")

--- a/tests/runner/test_frontend_training_failure_triage.py
+++ b/tests/runner/test_frontend_training_failure_triage.py
@@ -9,10 +9,11 @@ import yaml
 from tests.runner.frontend_training_failure_triage import (
     _UNPACK_REASON,
     build_loader_path,
+    build_output_dir,
     classify_frontend_reason,
     collect_selected_tests,
-    loader_has_custom_unpack_forward_output,
     load_training_config,
+    loader_has_custom_unpack_forward_output,
     triage_test_entry,
 )
 
@@ -31,6 +32,18 @@ def test_build_loader_path_for_nested_model_family(tmp_path: Path):
         / "pytorch"
         / "loader.py"
     )
+
+
+def test_build_loader_path_rejects_path_traversal_component(tmp_path: Path):
+    try:
+        build_loader_path(
+            tmp_path,
+            "../question_answering/pytorch-Base_Cased_Distilled_Squad-single_device-training",
+        )
+    except ValueError as exc:
+        assert "Unsafe test_id model path component" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for unsafe test_id path component")
 
 
 def test_loader_has_custom_unpack_forward_output_detects_method(tmp_path: Path):
@@ -69,7 +82,9 @@ def test_collect_selected_tests_defaults_to_unpack_reason_only():
 
 def test_classify_frontend_reason_recognizes_known_signature():
     assert classify_frontend_reason(_UNPACK_REASON) == "frontend"
-    assert classify_frontend_reason("missing decoder_input_ids in training") == "frontend"
+    assert (
+        classify_frontend_reason("missing decoder_input_ids in training") == "frontend"
+    )
     assert classify_frontend_reason("L1 allocation failure") == "no_draft_attempt_log"
 
 
@@ -157,4 +172,12 @@ class ModelLoader:
     assert result.attempt_log_path is not None
     attempt_log = Path(result.attempt_log_path)
     assert attempt_log.is_file()
-    assert "No draft issue packet was generated." in attempt_log.read_text(encoding="utf-8")
+    assert "No draft issue packet was generated." in attempt_log.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_build_output_dir_keeps_sanitized_id_under_output_root(tmp_path: Path):
+    output_root = tmp_path / "artifacts"
+    output_dir = build_output_dir(output_root, "../../escape")
+    output_dir.relative_to(output_root.resolve())

--- a/tests/runner/test_runtime_training_failure_reduction.py
+++ b/tests/runner/test_runtime_training_failure_reduction.py
@@ -1,0 +1,436 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+from tests.runner.runtime_training_failure_reduction import (
+    build_pytest_node_id,
+    build_rerun_command,
+    derive_python_bin,
+    extract_debug_evidence,
+    classify_runtime_entry,
+    collect_selected_tests,
+    find_debug_log,
+    probe_rerun_environment,
+    reduce_test_entry,
+)
+
+
+def test_build_pytest_node_id_uses_training_test_id():
+    assert (
+        build_pytest_node_id("pointpillars/pytorch-pointpillars-single_device-training")
+        == "tests/runner/test_models.py::test_all_models_torch[pointpillars/pytorch-pointpillars-single_device-training]"
+    )
+
+
+def test_build_rerun_command_uses_pytest_and_node_id():
+    command = build_rerun_command(
+        "/tmp/pytest-bin",
+        "pointpillars/pytorch-pointpillars-single_device-training",
+    )
+    assert command == [
+        "/tmp/pytest-bin",
+        "-vv",
+        "-s",
+        "tests/runner/test_models.py::test_all_models_torch[pointpillars/pytorch-pointpillars-single_device-training]",
+    ]
+
+
+def test_derive_python_bin_from_pytest_path():
+    tmp_bin = Path("/tmp/env/bin")
+    # derive_python_bin only resolves when the sibling python path exists.
+    # Use a temp layout in the next tests for behavior proof.
+    assert derive_python_bin("/tmp/env/bin/pytest") is None
+
+
+def test_probe_rerun_environment_reports_missing_modules(tmp_path: Path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_python = bin_dir / "python"
+    fake_python.write_text(
+        "\n".join(
+            [
+                "#!/bin/sh",
+                "echo \"MISSING::psutil: No module named 'psutil'\"",
+                "echo \"MISSING::torch: No module named 'torch'\"",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+    fake_pytest = bin_dir / "pytest"
+    fake_pytest.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    fake_pytest.chmod(0o755)
+    result = probe_rerun_environment(str(fake_pytest))
+    assert result is not None
+    assert "psutil" in result
+    assert "torch" in result
+
+
+def test_probe_rerun_environment_ignores_non_missing_warning_output(tmp_path: Path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_python = bin_dir / "python"
+    fake_python.write_text(
+        "\n".join(
+            [
+                "#!/bin/sh",
+                "echo \"WARNING:root:Defaulting to PJRT_DEVICE=CPU\"",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+    fake_pytest = bin_dir / "pytest"
+    fake_pytest.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    fake_pytest.chmod(0o755)
+    assert probe_rerun_environment(str(fake_pytest)) is None
+
+
+def test_classify_runtime_entry_tt_metal_for_memory_signal():
+    classification, owner_hint, reduction_signal = classify_runtime_entry(
+        "FAILED_RUNTIME",
+        "Statically allocated circular buffers on core range [(x=0,y=0) - (x=7,y=7)] grow to 2003264 B which is beyond max L1 size of 1499136 B",
+    )
+    assert classification == "draft_issue"
+    assert owner_hint == "tt-metal"
+    assert "tt-metal ownership" in reduction_signal
+
+
+def test_classify_runtime_entry_tt_alchemist_for_generic_runtime_signal():
+    classification, owner_hint, reduction_signal = classify_runtime_entry(
+        "FAILED_RUNTIME",
+        "RuntimeError: Index put requires the source and destination dtypes match, got Float for the destination and BFloat16 for the source.",
+    )
+    assert classification == "draft_issue"
+    assert owner_hint == "tt-alchemist"
+    assert "reduction-worthy" in reduction_signal
+
+
+def test_classify_runtime_entry_attempt_log_for_hang():
+    classification, owner_hint, reduction_signal = classify_runtime_entry(
+        "FAILED_RUNTIME",
+        "RuntimeError: Test Hangs",
+    )
+    assert classification == "attempt_log"
+    assert owner_hint == "unknown"
+    assert "hang" in reduction_signal
+
+
+def test_classify_runtime_entry_uses_debug_evidence_for_hang(tmp_path: Path):
+    log_path = tmp_path / "hang.log"
+    log_path.write_text(
+        "INFO Executing operation: ttnn.matmul\nRuntimeError: Test Hangs\n",
+        encoding="utf-8",
+    )
+    debug_evidence = extract_debug_evidence(log_path)
+    classification, owner_hint, reduction_signal = classify_runtime_entry(
+        "FAILED_RUNTIME",
+        "RuntimeError: Test Hangs",
+        debug_evidence,
+    )
+    assert classification == "draft_issue"
+    assert owner_hint == "tt-alchemist"
+    assert "executing-operation evidence" in reduction_signal
+
+
+def test_collect_selected_tests_defaults_to_runtime_rows():
+    config = {
+        "a": {"bringup_status": "FAILED_RUNTIME", "reason": "RuntimeError: Test Hangs"},
+        "b": {"bringup_status": "FAILED_FE_COMPILATION", "reason": "frontend"},
+        "c": {"reason": "RuntimeError: TT_FATAL conv2d"},
+    }
+    assert collect_selected_tests(config, []) == ["a", "c"]
+
+
+def test_find_debug_log_matches_sanitized_test_id(tmp_path: Path):
+    log_path = tmp_path / "pointpillars_pytorch-pointpillars-single_device-training.log"
+    log_path.write_text("Executing operation: ttnn.matmul\n", encoding="utf-8")
+    resolved = find_debug_log(tmp_path, "pointpillars/pytorch-pointpillars-single_device-training")
+    assert resolved == log_path
+
+
+def test_extract_debug_evidence_pulls_runtime_signals(tmp_path: Path):
+    log_path = tmp_path / "runtime.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "INFO Executing operation: ttnn.conv2d",
+                "RuntimeError: TT_FATAL conv2d device failure",
+                "%0 = ttnn.conv2d %arg0, %arg1 : tensor<...>",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    evidence = extract_debug_evidence(log_path)
+    assert evidence is not None
+    assert evidence.executing_operation_lines == ["INFO Executing operation: ttnn.conv2d"]
+    assert "TT_FATAL" in evidence.runtime_signal_lines[0]
+    assert "ttnn.conv2d" in evidence.ttnn_mlir_lines[0]
+
+
+def test_reduce_test_entry_writes_tt_metal_draft(tmp_path: Path):
+    result = reduce_test_entry(
+        test_id="pointpillars/pytorch-pointpillars-single_device-training",
+        entry={
+            "bringup_status": "FAILED_RUNTIME",
+            "reason": "Statically allocated circular buffers on core range [(x=0,y=0) - (x=7,y=7)] grow to 2003264 B which is beyond max L1 size of 1499136 B",
+        },
+        output_root=tmp_path / "artifacts",
+    )
+    assert result.owner_hint == "tt-metal"
+    assert result.draft_issue_path is not None
+    assert Path(result.draft_issue_path).is_file()
+
+
+def test_reduce_test_entry_attaches_debug_evidence_when_present(tmp_path: Path):
+    debug_root = tmp_path / "logs"
+    debug_root.mkdir()
+    log_path = debug_root / "densenet_pytorch-121_Xray-single_device-training.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "INFO Executing operation: ttnn.add",
+                "RuntimeError: Index put requires the source and destination dtypes match",
+                "%0 = ttnn.add %arg0, %arg1 : tensor<...>",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    result = reduce_test_entry(
+        test_id="densenet/pytorch-121_Xray-single_device-training",
+        entry={
+            "bringup_status": "FAILED_RUNTIME",
+            "reason": "RuntimeError: dtype mismatch",
+        },
+        output_root=tmp_path / "artifacts",
+        debug_log_root=debug_root,
+    )
+    assert result.runtime_debug_captured is True
+    assert result.debug_log_path == str(log_path)
+    assert result.debug_evidence_path is not None
+    assert Path(result.debug_evidence_path).is_file()
+    assert "trim to the smallest repro-worthy snippet" in result.next_manual_step
+
+
+def test_reduce_test_entry_can_attempt_bounded_rerun(tmp_path: Path):
+    fake_pytest = tmp_path / "fake_pytest.sh"
+    fake_pytest.write_text(
+        "\n".join(
+            [
+                "#!/bin/sh",
+                "echo \"INFO Executing operation: ttnn.add\"",
+                "echo \"RuntimeError: Index put requires the source and destination dtypes match\"",
+                "echo \"%0 = ttnn.add %arg0, %arg1 : tensor<...>\"",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    fake_pytest.chmod(0o755)
+    result = reduce_test_entry(
+        test_id="densenet/pytorch-121_Xray-single_device-training",
+        entry={
+            "bringup_status": "FAILED_RUNTIME",
+            "reason": "RuntimeError: dtype mismatch",
+        },
+        output_root=tmp_path / "artifacts",
+        execute_rerun=True,
+        pytest_bin=str(fake_pytest),
+        rerun_timeout_sec=5,
+    )
+    assert result.rerun_attempted is True
+    assert result.rerun_command is not None
+    assert result.rerun_log_path is not None
+    assert result.runtime_debug_captured is True
+    assert result.debug_evidence_path is not None
+    assert Path(result.rerun_log_path).is_file()
+    assert result.owner_hint == "tt-alchemist"
+
+
+def test_reduce_test_entry_can_force_run_skipped_rows_for_bounded_debug(tmp_path: Path):
+    fake_pytest = tmp_path / "fake_pytest.sh"
+    fake_pytest.write_text(
+        "\n".join(
+            [
+                "#!/bin/sh",
+                "echo \"force=$TT_XLA_FORCE_RUN_SKIPPED_TEST_IDS\"",
+                "echo \"INFO Executing operation: ttnn.matmul\"",
+                "echo \"RuntimeError: Test Hangs\"",
+                "echo \"%0 = ttnn.matmul %arg0, %arg1 : tensor<...>\"",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    fake_pytest.chmod(0o755)
+    test_id = "stable_diffusion_unet/pytorch-Base-single_device-training"
+    result = reduce_test_entry(
+        test_id=test_id,
+        entry={
+            "status": "NOT_SUPPORTED_SKIP",
+            "bringup_status": "FAILED_RUNTIME",
+            "reason": "RuntimeError: Test Hangs",
+        },
+        output_root=tmp_path / "artifacts",
+        execute_rerun=True,
+        pytest_bin=str(fake_pytest),
+        rerun_timeout_sec=5,
+        force_run_skipped=True,
+    )
+    assert result.force_run_skipped is True
+    assert result.rerun_attempted is True
+    assert result.runtime_debug_captured is True
+    assert result.debug_evidence_path is not None
+    assert result.draft_issue_path is not None
+    assert result.owner_hint == "tt-alchemist"
+    assert result.rerun_log_path is not None
+    assert f"force={test_id}" in Path(result.rerun_log_path).read_text(encoding="utf-8")
+
+
+def test_reduce_test_entry_surfaces_rerun_precondition_failure(tmp_path: Path):
+    fake_pytest = tmp_path / "fake_pytest_fail.sh"
+    fake_pytest.write_text(
+        "\n".join(
+            [
+                "#!/bin/sh",
+                "echo \"ImportError while loading conftest '/tmp/tests/conftest.py'.\"",
+                "echo \"E   ModuleNotFoundError: No module named 'psutil'\"",
+                "exit 4",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    fake_pytest.chmod(0o755)
+    result = reduce_test_entry(
+        test_id="densenet/pytorch-121_Xray-single_device-training",
+        entry={
+            "bringup_status": "FAILED_RUNTIME",
+            "reason": "RuntimeError: dtype mismatch",
+        },
+        output_root=tmp_path / "artifacts",
+        execute_rerun=True,
+        pytest_bin=str(fake_pytest),
+        rerun_timeout_sec=5,
+    )
+    assert result.rerun_attempted is True
+    assert result.classification == "attempt_log"
+    assert result.owner_hint == "unknown"
+    assert result.attempt_log_path is not None
+    assert "precondition violation" in result.reduction_signal
+    assert "missing pytest/runtime dependencies" in result.next_manual_step
+
+
+def test_reduce_test_entry_fast_fails_on_environment_preflight(tmp_path: Path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_python = bin_dir / "python"
+    fake_python.write_text(
+        "#!/bin/sh\necho \"MISSING::torch: No module named 'torch'\"\n",
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+    fake_pytest = bin_dir / "pytest"
+    fake_pytest.write_text("#!/bin/sh\necho should-not-run\nexit 99\n", encoding="utf-8")
+    fake_pytest.chmod(0o755)
+    result = reduce_test_entry(
+        test_id="densenet/pytorch-121_Xray-single_device-training",
+        entry={
+            "bringup_status": "FAILED_RUNTIME",
+            "reason": "RuntimeError: dtype mismatch",
+        },
+        output_root=tmp_path / "artifacts",
+        execute_rerun=True,
+        pytest_bin=str(fake_pytest),
+        rerun_timeout_sec=5,
+    )
+    assert result.rerun_attempted is False
+    assert result.rerun_returncode is None
+    assert result.classification == "attempt_log"
+    assert "torch" in result.reduction_signal
+
+
+def test_reduce_test_entry_surfaces_cpu_fallback_or_skip_as_attempt_log(tmp_path: Path):
+    fake_pytest = tmp_path / "fake_pytest_cpu_skip.sh"
+    fake_pytest.write_text(
+        "\n".join(
+            [
+                "#!/bin/sh",
+                "echo \"WARNING:root:Defaulting to PJRT_DEVICE=CPU\"",
+                "echo \"tests/runner/test_models.py::test_all_models_torch[densenet/pytorch-121_Xray-single_device-training] SKIPPED\"",
+                "exit 0",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    fake_pytest.chmod(0o755)
+    result = reduce_test_entry(
+        test_id="densenet/pytorch-121_Xray-single_device-training",
+        entry={
+            "bringup_status": "FAILED_RUNTIME",
+            "reason": "RuntimeError: dtype mismatch",
+        },
+        output_root=tmp_path / "artifacts",
+        execute_rerun=True,
+        pytest_bin=str(fake_pytest),
+        rerun_timeout_sec=5,
+    )
+    assert result.rerun_attempted is True
+    assert result.classification == "attempt_log"
+    assert result.owner_hint == "unknown"
+    assert "PJRT_DEVICE=CPU" in result.reduction_signal
+    assert "TT hardware" in result.next_manual_step
+
+
+def test_reduce_test_entry_surfaces_timeout_as_attempt_log(tmp_path: Path):
+    fake_pytest = tmp_path / "fake_pytest_timeout.sh"
+    fake_pytest.write_text(
+        "\n".join(
+            [
+                "#!/bin/sh",
+                "echo \"Running tests/runner/test_models.py::test_all_models_torch[stable_diffusion_unet/pytorch-Base-single_device-training]\"",
+                "echo \"TIMEOUT after 240s\"",
+                "exit 0",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    fake_pytest.chmod(0o755)
+    result = reduce_test_entry(
+        test_id="stable_diffusion_unet/pytorch-Base-single_device-training",
+        entry={
+            "bringup_status": "FAILED_RUNTIME",
+            "reason": "RuntimeError: Test Hangs",
+        },
+        output_root=tmp_path / "artifacts",
+        execute_rerun=True,
+        pytest_bin=str(fake_pytest),
+        rerun_timeout_sec=5,
+        force_run_skipped=True,
+    )
+    assert result.rerun_attempted is True
+    assert result.classification == "attempt_log"
+    assert "timed out" in result.reduction_signal
+    assert "narrower debug run" in result.next_manual_step
+
+
+def test_reduce_test_entry_writes_attempt_log_for_hang(tmp_path: Path):
+    result = reduce_test_entry(
+        test_id="beit/image_classification/pytorch-Base_Patch16_224-single_device-training",
+        entry={
+            "bringup_status": "FAILED_RUNTIME",
+            "reason": "RuntimeError: Test Hangs",
+        },
+        output_root=tmp_path / "artifacts",
+    )
+    assert result.owner_hint == "unknown"
+    assert result.attempt_log_path is not None
+    assert Path(result.attempt_log_path).is_file()

--- a/tests/runner/test_runtime_training_failure_reduction.py
+++ b/tests/runner/test_runtime_training_failure_reduction.py
@@ -5,16 +5,22 @@
 from pathlib import Path
 
 from tests.runner.runtime_training_failure_reduction import (
+    build_output_dir,
     build_pytest_node_id,
     build_rerun_command,
-    derive_python_bin,
-    extract_debug_evidence,
     classify_runtime_entry,
     collect_selected_tests,
+    derive_python_bin,
+    extract_debug_evidence,
     find_debug_log,
     probe_rerun_environment,
     reduce_test_entry,
 )
+
+
+def write_executable_script(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o700)
 
 
 def test_build_pytest_node_id_uses_training_test_id():
@@ -48,7 +54,8 @@ def test_probe_rerun_environment_reports_missing_modules(tmp_path: Path):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     fake_python = bin_dir / "python"
-    fake_python.write_text(
+    write_executable_script(
+        fake_python,
         "\n".join(
             [
                 "#!/bin/sh",
@@ -57,12 +64,9 @@ def test_probe_rerun_environment_reports_missing_modules(tmp_path: Path):
             ]
         )
         + "\n",
-        encoding="utf-8",
     )
-    fake_python.chmod(0o755)
     fake_pytest = bin_dir / "pytest"
-    fake_pytest.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
-    fake_pytest.chmod(0o755)
+    write_executable_script(fake_pytest, "#!/bin/sh\nexit 0\n")
     result = probe_rerun_environment(str(fake_pytest))
     assert result is not None
     assert "psutil" in result
@@ -73,20 +77,18 @@ def test_probe_rerun_environment_ignores_non_missing_warning_output(tmp_path: Pa
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     fake_python = bin_dir / "python"
-    fake_python.write_text(
+    write_executable_script(
+        fake_python,
         "\n".join(
             [
                 "#!/bin/sh",
-                "echo \"WARNING:root:Defaulting to PJRT_DEVICE=CPU\"",
+                'echo "WARNING:root:Defaulting to PJRT_DEVICE=CPU"',
             ]
         )
         + "\n",
-        encoding="utf-8",
     )
-    fake_python.chmod(0o755)
     fake_pytest = bin_dir / "pytest"
-    fake_pytest.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
-    fake_pytest.chmod(0o755)
+    write_executable_script(fake_pytest, "#!/bin/sh\nexit 0\n")
     assert probe_rerun_environment(str(fake_pytest)) is None
 
 
@@ -149,8 +151,16 @@ def test_collect_selected_tests_defaults_to_runtime_rows():
 def test_find_debug_log_matches_sanitized_test_id(tmp_path: Path):
     log_path = tmp_path / "pointpillars_pytorch-pointpillars-single_device-training.log"
     log_path.write_text("Executing operation: ttnn.matmul\n", encoding="utf-8")
-    resolved = find_debug_log(tmp_path, "pointpillars/pytorch-pointpillars-single_device-training")
+    resolved = find_debug_log(
+        tmp_path, "pointpillars/pytorch-pointpillars-single_device-training"
+    )
     assert resolved == log_path
+
+
+def test_runtime_build_output_dir_keeps_sanitized_id_under_output_root(tmp_path: Path):
+    output_root = tmp_path / "artifacts"
+    output_dir = build_output_dir(output_root, "../../escape")
+    output_dir.relative_to(output_root.resolve())
 
 
 def test_extract_debug_evidence_pulls_runtime_signals(tmp_path: Path):
@@ -168,7 +178,9 @@ def test_extract_debug_evidence_pulls_runtime_signals(tmp_path: Path):
     )
     evidence = extract_debug_evidence(log_path)
     assert evidence is not None
-    assert evidence.executing_operation_lines == ["INFO Executing operation: ttnn.conv2d"]
+    assert evidence.executing_operation_lines == [
+        "INFO Executing operation: ttnn.conv2d"
+    ]
     assert "TT_FATAL" in evidence.runtime_signal_lines[0]
     assert "ttnn.conv2d" in evidence.ttnn_mlir_lines[0]
 
@@ -220,19 +232,18 @@ def test_reduce_test_entry_attaches_debug_evidence_when_present(tmp_path: Path):
 
 def test_reduce_test_entry_can_attempt_bounded_rerun(tmp_path: Path):
     fake_pytest = tmp_path / "fake_pytest.sh"
-    fake_pytest.write_text(
+    write_executable_script(
+        fake_pytest,
         "\n".join(
             [
                 "#!/bin/sh",
-                "echo \"INFO Executing operation: ttnn.add\"",
-                "echo \"RuntimeError: Index put requires the source and destination dtypes match\"",
-                "echo \"%0 = ttnn.add %arg0, %arg1 : tensor<...>\"",
+                'echo "INFO Executing operation: ttnn.add"',
+                'echo "RuntimeError: Index put requires the source and destination dtypes match"',
+                'echo "%0 = ttnn.add %arg0, %arg1 : tensor<...>"',
             ]
         )
         + "\n",
-        encoding="utf-8",
     )
-    fake_pytest.chmod(0o755)
     result = reduce_test_entry(
         test_id="densenet/pytorch-121_Xray-single_device-training",
         entry={
@@ -255,20 +266,19 @@ def test_reduce_test_entry_can_attempt_bounded_rerun(tmp_path: Path):
 
 def test_reduce_test_entry_can_force_run_skipped_rows_for_bounded_debug(tmp_path: Path):
     fake_pytest = tmp_path / "fake_pytest.sh"
-    fake_pytest.write_text(
+    write_executable_script(
+        fake_pytest,
         "\n".join(
             [
                 "#!/bin/sh",
-                "echo \"force=$TT_XLA_FORCE_RUN_SKIPPED_TEST_IDS\"",
-                "echo \"INFO Executing operation: ttnn.matmul\"",
-                "echo \"RuntimeError: Test Hangs\"",
-                "echo \"%0 = ttnn.matmul %arg0, %arg1 : tensor<...>\"",
+                'echo "force=$TT_XLA_FORCE_RUN_SKIPPED_TEST_IDS"',
+                'echo "INFO Executing operation: ttnn.matmul"',
+                'echo "RuntimeError: Test Hangs"',
+                'echo "%0 = ttnn.matmul %arg0, %arg1 : tensor<...>"',
             ]
         )
         + "\n",
-        encoding="utf-8",
     )
-    fake_pytest.chmod(0o755)
     test_id = "stable_diffusion_unet/pytorch-Base-single_device-training"
     result = reduce_test_entry(
         test_id=test_id,
@@ -295,7 +305,8 @@ def test_reduce_test_entry_can_force_run_skipped_rows_for_bounded_debug(tmp_path
 
 def test_reduce_test_entry_surfaces_rerun_precondition_failure(tmp_path: Path):
     fake_pytest = tmp_path / "fake_pytest_fail.sh"
-    fake_pytest.write_text(
+    write_executable_script(
+        fake_pytest,
         "\n".join(
             [
                 "#!/bin/sh",
@@ -305,9 +316,7 @@ def test_reduce_test_entry_surfaces_rerun_precondition_failure(tmp_path: Path):
             ]
         )
         + "\n",
-        encoding="utf-8",
     )
-    fake_pytest.chmod(0o755)
     result = reduce_test_entry(
         test_id="densenet/pytorch-121_Xray-single_device-training",
         entry={
@@ -331,14 +340,12 @@ def test_reduce_test_entry_fast_fails_on_environment_preflight(tmp_path: Path):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     fake_python = bin_dir / "python"
-    fake_python.write_text(
+    write_executable_script(
+        fake_python,
         "#!/bin/sh\necho \"MISSING::torch: No module named 'torch'\"\n",
-        encoding="utf-8",
     )
-    fake_python.chmod(0o755)
     fake_pytest = bin_dir / "pytest"
-    fake_pytest.write_text("#!/bin/sh\necho should-not-run\nexit 99\n", encoding="utf-8")
-    fake_pytest.chmod(0o755)
+    write_executable_script(fake_pytest, "#!/bin/sh\necho should-not-run\nexit 99\n")
     result = reduce_test_entry(
         test_id="densenet/pytorch-121_Xray-single_device-training",
         entry={
@@ -358,19 +365,18 @@ def test_reduce_test_entry_fast_fails_on_environment_preflight(tmp_path: Path):
 
 def test_reduce_test_entry_surfaces_cpu_fallback_or_skip_as_attempt_log(tmp_path: Path):
     fake_pytest = tmp_path / "fake_pytest_cpu_skip.sh"
-    fake_pytest.write_text(
+    write_executable_script(
+        fake_pytest,
         "\n".join(
             [
                 "#!/bin/sh",
-                "echo \"WARNING:root:Defaulting to PJRT_DEVICE=CPU\"",
-                "echo \"tests/runner/test_models.py::test_all_models_torch[densenet/pytorch-121_Xray-single_device-training] SKIPPED\"",
+                'echo "WARNING:root:Defaulting to PJRT_DEVICE=CPU"',
+                'echo "tests/runner/test_models.py::test_all_models_torch[densenet/pytorch-121_Xray-single_device-training] SKIPPED"',
                 "exit 0",
             ]
         )
         + "\n",
-        encoding="utf-8",
     )
-    fake_pytest.chmod(0o755)
     result = reduce_test_entry(
         test_id="densenet/pytorch-121_Xray-single_device-training",
         entry={
@@ -391,19 +397,18 @@ def test_reduce_test_entry_surfaces_cpu_fallback_or_skip_as_attempt_log(tmp_path
 
 def test_reduce_test_entry_surfaces_timeout_as_attempt_log(tmp_path: Path):
     fake_pytest = tmp_path / "fake_pytest_timeout.sh"
-    fake_pytest.write_text(
+    write_executable_script(
+        fake_pytest,
         "\n".join(
             [
                 "#!/bin/sh",
-                "echo \"Running tests/runner/test_models.py::test_all_models_torch[stable_diffusion_unet/pytorch-Base-single_device-training]\"",
-                "echo \"TIMEOUT after 240s\"",
+                'echo "Running tests/runner/test_models.py::test_all_models_torch[stable_diffusion_unet/pytorch-Base-single_device-training]"',
+                'echo "TIMEOUT after 240s"',
                 "exit 0",
             ]
         )
         + "\n",
-        encoding="utf-8",
     )
-    fake_pytest.chmod(0o755)
     result = reduce_test_entry(
         test_id="stable_diffusion_unet/pytorch-Base-single_device-training",
         entry={

--- a/tests/runner/test_runtime_training_failure_reduction.py
+++ b/tests/runner/test_runtime_training_failure_reduction.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 from pathlib import Path
 
 from tests.runner.runtime_training_failure_reduction import (
@@ -19,8 +20,9 @@ from tests.runner.runtime_training_failure_reduction import (
 
 
 def write_executable_script(path: Path, body: str) -> None:
-    path.write_text(body, encoding="utf-8")
-    path.chmod(0o700)
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o700)
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        f.write(body)
 
 
 def test_build_pytest_node_id_uses_training_test_id():

--- a/tests/runner/test_runtime_training_failure_reduction.py
+++ b/tests/runner/test_runtime_training_failure_reduction.py
@@ -25,6 +25,10 @@ def write_executable_script(path: Path, body: str) -> None:
         f.write(body)
 
 
+def prepend_path(monkeypatch, bin_dir: Path) -> None:
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+
+
 def test_build_pytest_node_id_uses_training_test_id():
     assert (
         build_pytest_node_id("pointpillars/pytorch-pointpillars-single_device-training")
@@ -34,11 +38,11 @@ def test_build_pytest_node_id_uses_training_test_id():
 
 def test_build_rerun_command_uses_pytest_and_node_id():
     command = build_rerun_command(
-        "/tmp/pytest-bin",
+        "pytest",
         "pointpillars/pytorch-pointpillars-single_device-training",
     )
     assert command == [
-        "/tmp/pytest-bin",
+        "pytest",
         "-vv",
         "-s",
         "tests/runner/test_models.py::test_all_models_torch[pointpillars/pytorch-pointpillars-single_device-training]",
@@ -52,7 +56,7 @@ def test_derive_python_bin_from_pytest_path():
     assert derive_python_bin("/tmp/env/bin/pytest") is None
 
 
-def test_probe_rerun_environment_reports_missing_modules(tmp_path: Path):
+def test_probe_rerun_environment_reports_missing_modules(tmp_path: Path, monkeypatch):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     fake_python = bin_dir / "python"
@@ -69,13 +73,16 @@ def test_probe_rerun_environment_reports_missing_modules(tmp_path: Path):
     )
     fake_pytest = bin_dir / "pytest"
     write_executable_script(fake_pytest, "#!/bin/sh\nexit 0\n")
-    result = probe_rerun_environment(str(fake_pytest))
+    prepend_path(monkeypatch, bin_dir)
+    result = probe_rerun_environment("pytest")
     assert result is not None
     assert "psutil" in result
     assert "torch" in result
 
 
-def test_probe_rerun_environment_ignores_non_missing_warning_output(tmp_path: Path):
+def test_probe_rerun_environment_ignores_non_missing_warning_output(
+    tmp_path: Path, monkeypatch
+):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     fake_python = bin_dir / "python"
@@ -91,7 +98,8 @@ def test_probe_rerun_environment_ignores_non_missing_warning_output(tmp_path: Pa
     )
     fake_pytest = bin_dir / "pytest"
     write_executable_script(fake_pytest, "#!/bin/sh\nexit 0\n")
-    assert probe_rerun_environment(str(fake_pytest)) is None
+    prepend_path(monkeypatch, bin_dir)
+    assert probe_rerun_environment("pytest") is None
 
 
 def test_classify_runtime_entry_tt_metal_for_memory_signal():
@@ -232,8 +240,10 @@ def test_reduce_test_entry_attaches_debug_evidence_when_present(tmp_path: Path):
     assert "trim to the smallest repro-worthy snippet" in result.next_manual_step
 
 
-def test_reduce_test_entry_can_attempt_bounded_rerun(tmp_path: Path):
-    fake_pytest = tmp_path / "fake_pytest.sh"
+def test_reduce_test_entry_can_attempt_bounded_rerun(tmp_path: Path, monkeypatch):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_pytest = bin_dir / "pytest"
     write_executable_script(
         fake_pytest,
         "\n".join(
@@ -246,6 +256,7 @@ def test_reduce_test_entry_can_attempt_bounded_rerun(tmp_path: Path):
         )
         + "\n",
     )
+    prepend_path(monkeypatch, bin_dir)
     result = reduce_test_entry(
         test_id="densenet/pytorch-121_Xray-single_device-training",
         entry={
@@ -254,7 +265,7 @@ def test_reduce_test_entry_can_attempt_bounded_rerun(tmp_path: Path):
         },
         output_root=tmp_path / "artifacts",
         execute_rerun=True,
-        pytest_bin=str(fake_pytest),
+        pytest_bin="pytest",
         rerun_timeout_sec=5,
     )
     assert result.rerun_attempted is True
@@ -266,8 +277,12 @@ def test_reduce_test_entry_can_attempt_bounded_rerun(tmp_path: Path):
     assert result.owner_hint == "tt-alchemist"
 
 
-def test_reduce_test_entry_can_force_run_skipped_rows_for_bounded_debug(tmp_path: Path):
-    fake_pytest = tmp_path / "fake_pytest.sh"
+def test_reduce_test_entry_can_force_run_skipped_rows_for_bounded_debug(
+    tmp_path: Path, monkeypatch
+):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_pytest = bin_dir / "pytest"
     write_executable_script(
         fake_pytest,
         "\n".join(
@@ -281,6 +296,7 @@ def test_reduce_test_entry_can_force_run_skipped_rows_for_bounded_debug(tmp_path
         )
         + "\n",
     )
+    prepend_path(monkeypatch, bin_dir)
     test_id = "stable_diffusion_unet/pytorch-Base-single_device-training"
     result = reduce_test_entry(
         test_id=test_id,
@@ -291,7 +307,7 @@ def test_reduce_test_entry_can_force_run_skipped_rows_for_bounded_debug(tmp_path
         },
         output_root=tmp_path / "artifacts",
         execute_rerun=True,
-        pytest_bin=str(fake_pytest),
+        pytest_bin="pytest",
         rerun_timeout_sec=5,
         force_run_skipped=True,
     )
@@ -305,8 +321,12 @@ def test_reduce_test_entry_can_force_run_skipped_rows_for_bounded_debug(tmp_path
     assert f"force={test_id}" in Path(result.rerun_log_path).read_text(encoding="utf-8")
 
 
-def test_reduce_test_entry_surfaces_rerun_precondition_failure(tmp_path: Path):
-    fake_pytest = tmp_path / "fake_pytest_fail.sh"
+def test_reduce_test_entry_surfaces_rerun_precondition_failure(
+    tmp_path: Path, monkeypatch
+):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_pytest = bin_dir / "pytest"
     write_executable_script(
         fake_pytest,
         "\n".join(
@@ -319,6 +339,7 @@ def test_reduce_test_entry_surfaces_rerun_precondition_failure(tmp_path: Path):
         )
         + "\n",
     )
+    prepend_path(monkeypatch, bin_dir)
     result = reduce_test_entry(
         test_id="densenet/pytorch-121_Xray-single_device-training",
         entry={
@@ -327,7 +348,7 @@ def test_reduce_test_entry_surfaces_rerun_precondition_failure(tmp_path: Path):
         },
         output_root=tmp_path / "artifacts",
         execute_rerun=True,
-        pytest_bin=str(fake_pytest),
+        pytest_bin="pytest",
         rerun_timeout_sec=5,
     )
     assert result.rerun_attempted is True
@@ -338,7 +359,9 @@ def test_reduce_test_entry_surfaces_rerun_precondition_failure(tmp_path: Path):
     assert "missing pytest/runtime dependencies" in result.next_manual_step
 
 
-def test_reduce_test_entry_fast_fails_on_environment_preflight(tmp_path: Path):
+def test_reduce_test_entry_fast_fails_on_environment_preflight(
+    tmp_path: Path, monkeypatch
+):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     fake_python = bin_dir / "python"
@@ -348,6 +371,7 @@ def test_reduce_test_entry_fast_fails_on_environment_preflight(tmp_path: Path):
     )
     fake_pytest = bin_dir / "pytest"
     write_executable_script(fake_pytest, "#!/bin/sh\necho should-not-run\nexit 99\n")
+    prepend_path(monkeypatch, bin_dir)
     result = reduce_test_entry(
         test_id="densenet/pytorch-121_Xray-single_device-training",
         entry={
@@ -356,7 +380,7 @@ def test_reduce_test_entry_fast_fails_on_environment_preflight(tmp_path: Path):
         },
         output_root=tmp_path / "artifacts",
         execute_rerun=True,
-        pytest_bin=str(fake_pytest),
+        pytest_bin="pytest",
         rerun_timeout_sec=5,
     )
     assert result.rerun_attempted is False
@@ -365,8 +389,12 @@ def test_reduce_test_entry_fast_fails_on_environment_preflight(tmp_path: Path):
     assert "torch" in result.reduction_signal
 
 
-def test_reduce_test_entry_surfaces_cpu_fallback_or_skip_as_attempt_log(tmp_path: Path):
-    fake_pytest = tmp_path / "fake_pytest_cpu_skip.sh"
+def test_reduce_test_entry_surfaces_cpu_fallback_or_skip_as_attempt_log(
+    tmp_path: Path, monkeypatch
+):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_pytest = bin_dir / "pytest"
     write_executable_script(
         fake_pytest,
         "\n".join(
@@ -379,6 +407,7 @@ def test_reduce_test_entry_surfaces_cpu_fallback_or_skip_as_attempt_log(tmp_path
         )
         + "\n",
     )
+    prepend_path(monkeypatch, bin_dir)
     result = reduce_test_entry(
         test_id="densenet/pytorch-121_Xray-single_device-training",
         entry={
@@ -387,7 +416,7 @@ def test_reduce_test_entry_surfaces_cpu_fallback_or_skip_as_attempt_log(tmp_path
         },
         output_root=tmp_path / "artifacts",
         execute_rerun=True,
-        pytest_bin=str(fake_pytest),
+        pytest_bin="pytest",
         rerun_timeout_sec=5,
     )
     assert result.rerun_attempted is True
@@ -397,8 +426,10 @@ def test_reduce_test_entry_surfaces_cpu_fallback_or_skip_as_attempt_log(tmp_path
     assert "TT hardware" in result.next_manual_step
 
 
-def test_reduce_test_entry_surfaces_timeout_as_attempt_log(tmp_path: Path):
-    fake_pytest = tmp_path / "fake_pytest_timeout.sh"
+def test_reduce_test_entry_surfaces_timeout_as_attempt_log(tmp_path: Path, monkeypatch):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_pytest = bin_dir / "pytest"
     write_executable_script(
         fake_pytest,
         "\n".join(
@@ -411,6 +442,7 @@ def test_reduce_test_entry_surfaces_timeout_as_attempt_log(tmp_path: Path):
         )
         + "\n",
     )
+    prepend_path(monkeypatch, bin_dir)
     result = reduce_test_entry(
         test_id="stable_diffusion_unet/pytorch-Base-single_device-training",
         entry={
@@ -419,7 +451,7 @@ def test_reduce_test_entry_surfaces_timeout_as_attempt_log(tmp_path: Path):
         },
         output_root=tmp_path / "artifacts",
         execute_rerun=True,
-        pytest_bin=str(fake_pytest),
+        pytest_bin="pytest",
         rerun_timeout_sec=5,
         force_run_skipped=True,
     )


### PR DESCRIPTION
## Summary

- Add bounded training workflow runner utilities for frontend triage, runtime reduction, and output validation.
- Add runtime reducer support for debug-log intake, bounded pytest reruns, timeout/precondition classification, and explicit `--force-run-skipped` capture of selected skipped rows.
- Refactor the runner/report/validator control flow to remove the C-grade cyclomatic complexity hotspots while keeping the bounded rerun security constraints intact.
- Mark `beit/pytorch-Base-single_device-training` with `bringup_status: FAILED_RUNTIME` and the captured TT_FATAL reason while keeping `KNOWN_FAILURE_XFAIL` execution policy.

## Workflow

```mermaid
flowchart TD
    A[Training config row] --> B{Bounded PRD-006 selector}
    B -->|Frontend-style reason| C[Frontend triage runner]
    B -->|Runtime or metal signal| D[Runtime reduction runner]
    C --> E{Loader evidence}
    E -->|Missing custom unpack handler| F[Draft frontend issue packet]
    E -->|Stale or weak signal| G[Attempt log and config refresh recommendation]
    D --> H{Runtime evidence}
    H -->|Debug log or bounded rerun evidence| I[Draft runtime reduction packet]
    H -->|Precondition, skip, timeout, or weak evidence| J[Attempt log with next manual step]
    F --> K[Shared packet contract validator]
    G --> K
    I --> K
    J --> K
    K --> L[Review-ready PR artifacts]
```

## Validation

- `PYTHONPATH=/Users/dfredriksen/Desktop/tt-xla-prd006-runtime-pr /Users/dfredriksen/Desktop/tt-xla/.venv/bin/pytest --noconftest tests/runner/test_frontend_training_failure_triage.py tests/runner/test_runtime_training_failure_reduction.py tests/runner/test_bounded_training_workflow_validation.py`
  - `35 passed`
- `/Users/dfredriksen/Desktop/tt-xla/.venv/bin/python tests/runner/validate_test_config.py`
  - validation passed
  - `0 unknown tests`
  - existing unlisted discovered-test warnings remain
- `/tmp/tt-xla-black-venv/bin/pre-commit run --files tests/runner/README.md tests/runner/bounded_training_workflow_validation.py tests/runner/conftest.py tests/runner/frontend_training_failure_triage.py tests/runner/runtime_training_failure_reduction.py tests/runner/test_bounded_training_workflow_validation.py tests/runner/test_config/torch/test_config_training_single_device.yaml tests/runner/test_frontend_training_failure_triage.py tests/runner/test_runtime_training_failure_reduction.py`
  - passed
- `/tmp/tt-xla-black-venv/bin/radon cc -s -a tests/runner/frontend_training_failure_triage.py tests/runner/runtime_training_failure_reduction.py tests/runner/bounded_training_workflow_validation.py`
  - no C-grade functions remain in these three runner files
  - average complexity: `3.05`

## Notes

- Draft PR for review of bounded PRD-006 tooling before deciding whether these utilities should become a repo-native workflow entrypoint.
- VM evidence for the final config-backed runtime row lives at `/localdev/dfredriksen/tt-xla/artifacts/runtime_training_reduction_prd006_vm_beit_config_final_v1`.
