### PR TITLE
[Krea Realtime 14B] Add initial tests for each part of the pipeline

### DIFF
--- a/tests/torch/models/krea_realtime/shared.py
+++ b/tests/torch/models/krea_realtime/shared.py
@@ -1,0 +1,205 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Shared helpers for Krea Realtime 14B component tests.
+
+Exposes:
+  - load_text_encoder / load_transformer / load_vae: HuggingFace model loaders
+  - krea_mesh: 2D ("batch", "model") SPMD mesh — adapts to device count
+  - shard_text_encoder_specs / shard_transformer_specs: per-component shard
+    spec functions returning dict[Tensor, partition_spec] for run_graph_test.
+"""
+
+import torch
+from diffusers import ModularPipeline
+from infra.utilities import Mesh
+from infra.utilities.torch_multichip_utils import get_mesh
+
+# ---------------------------------------------------------------------------
+# Model + dtype
+# ---------------------------------------------------------------------------
+
+REPO_ID = "krea/krea-realtime-video"
+DTYPE = torch.bfloat16
+
+
+# ---------------------------------------------------------------------------
+# Default inference shape
+# ---------------------------------------------------------------------------
+
+HEIGHT = 480
+WIDTH = 832
+NUM_BLOCKS = 1
+MAX_SEQ_LEN = 512  # text token length
+
+LATENT_H = HEIGHT // 8  # 60
+LATENT_W = WIDTH // 8  # 104
+NUM_FRAMES_PER_BLOCK = 3
+NUM_LATENT_FRAMES = NUM_BLOCKS * NUM_FRAMES_PER_BLOCK  # 3
+NUM_CHANNELS_LATENTS = 16
+TEXT_EMBED_DIM = 4096
+
+# KV-cache config
+KV_CACHE_NUM_FRAMES = 3
+FRAME_SEQ_LENGTH = 1560
+SEQ_LENGTH = 32760
+LOCAL_ATTN_SIZE = KV_CACHE_NUM_FRAMES + NUM_FRAMES_PER_BLOCK  # 6
+KV_CACHE_SIZE = LOCAL_ATTN_SIZE * FRAME_SEQ_LENGTH  # 9360
+
+
+# ---------------------------------------------------------------------------
+# Component loaders (real weights from HuggingFace)
+# ---------------------------------------------------------------------------
+
+
+def _load_pipe():
+    """Load the full Krea ModularPipeline on CPU in bfloat16."""
+    pipe = ModularPipeline.from_pretrained(REPO_ID, trust_remote_code=True)
+    pipe.load_components(
+        trust_remote_code=True,
+        device_map="cpu",
+        torch_dtype={"default": DTYPE, "vae": DTYPE},
+    )
+    return pipe
+
+
+def load_text_encoder():
+    """Load the UMT5 text encoder."""
+    return _load_pipe().text_encoder.eval()
+
+
+def load_transformer():
+    """Load the CausalWanModel transformer (the 14B DiT)."""
+    return _load_pipe().transformer.eval()
+
+
+def load_vae():
+    """Load the 3D causal VAE."""
+    return _load_pipe().vae.eval()
+
+
+# ---------------------------------------------------------------------------
+# SPMD mesh
+# ---------------------------------------------------------------------------
+
+# (batch, model) shapes by device count
+_MESH_SHAPES = {32: (8, 4), 8: (2, 4), 4: (1, 4), 2: (1, 2), 1: (1, 1)}
+
+
+def krea_mesh() -> Mesh:
+    """2D ("batch", "model") SPMD mesh sized to current device count."""
+    import torch_xla.runtime as xr
+
+    n = xr.global_runtime_device_count()
+    if n not in _MESH_SHAPES:
+        raise ValueError(
+            f"Unsupported device count: {n}. "
+            f"Expected one of {sorted(_MESH_SHAPES)}."
+        )
+    return get_mesh(_MESH_SHAPES[n], ("batch", "model"))
+
+
+# ---------------------------------------------------------------------------
+# UMT5 sharding
+# ---------------------------------------------------------------------------
+
+
+def shard_text_encoder_specs(encoder) -> dict:
+    """Build shard specs for UMT5EncoderModel weights.
+
+    Mesh axes: ("batch", "model")
+    Column-parallel (q, k, v, wi_0, wi_1):  ("model", "batch")
+    Row-parallel   (o, wo):                 ("batch", "model")
+    """
+    specs = {encoder.shared.weight: (None, "batch")}
+
+    for block in encoder.encoder.block:
+        sa = block.layer[0].SelfAttention
+        specs[sa.q.weight] = ("model", "batch")
+        specs[sa.k.weight] = ("model", "batch")
+        specs[sa.v.weight] = ("model", "batch")
+        specs[sa.o.weight] = ("batch", "model")
+        specs[block.layer[0].layer_norm.weight] = ("batch",)
+
+        ffn = block.layer[1].DenseReluDense
+        specs[ffn.wi_0.weight] = ("model", "batch")
+        specs[ffn.wi_1.weight] = ("model", "batch")
+        specs[ffn.wo.weight] = ("batch", "model")
+        specs[block.layer[1].layer_norm.weight] = ("batch",)
+
+    specs[encoder.encoder.final_layer_norm.weight] = ("batch",)
+    return specs
+
+
+# ---------------------------------------------------------------------------
+# CausalWanModel (transformer) sharding
+# ---------------------------------------------------------------------------
+
+
+def shard_transformer_specs(transformer) -> dict:
+    """Build shard specs for CausalWanModel weights.
+
+    Mesh axes: ("batch", "model")
+    Column-parallel (Q, K, V, FFN up):  ("model", "batch")
+    Row-parallel   (O, FFN down):        ("batch", "model")
+
+    Krea has self-attn + cross-attn per block (autoregressive video).
+    """
+    specs = {
+        # Patch embedding (Conv3d 16 -> 5120)
+        transformer.patch_embedding.weight: ("batch", None, None, None, None),
+        transformer.patch_embedding.bias: ("batch",),
+    }
+
+    # text_embedding: Sequential[Linear(4096,5120), GELU, Linear(5120,5120)]
+    specs[transformer.text_embedding[0].weight] = ("model", "batch")
+    specs[transformer.text_embedding[0].bias] = ("model",)
+    specs[transformer.text_embedding[2].weight] = ("batch", "model")
+    specs[transformer.text_embedding[2].bias] = ("batch",)
+
+    # time_embedding: Sequential[Linear(256,5120), SiLU, Linear(5120,5120)]
+    specs[transformer.time_embedding[0].weight] = ("model", "batch")
+    specs[transformer.time_embedding[0].bias] = ("model",)
+    specs[transformer.time_embedding[2].weight] = ("batch", "model")
+    specs[transformer.time_embedding[2].bias] = ("batch",)
+
+    # time_projection: Sequential[SiLU, Linear(5120, 30720)]
+    specs[transformer.time_projection[1].weight] = ("model", "batch")
+    specs[transformer.time_projection[1].bias] = ("model",)
+
+    # Per-block sharding
+    for block in transformer.blocks:
+        # Only norm3 has a learnable weight (elementwise_affine=True);
+        # norm1 and norm2 use elementwise_affine=False.
+        if hasattr(block.norm3, "weight") and block.norm3.weight is not None:
+            specs[block.norm3.weight] = ("batch",)
+
+        for attn in (block.self_attn, block.cross_attn):
+            specs[attn.q.weight] = ("model", "batch")
+            specs[attn.q.bias] = ("model",)
+            specs[attn.k.weight] = ("model", "batch")
+            specs[attn.k.bias] = ("model",)
+            specs[attn.v.weight] = ("model", "batch")
+            specs[attn.v.bias] = ("model",)
+            specs[attn.o.weight] = ("batch", "model")
+            specs[attn.o.bias] = ("batch",)
+            if hasattr(attn.norm_q, "weight") and attn.norm_q.weight is not None:
+                specs[attn.norm_q.weight] = ("model",)
+            if hasattr(attn.norm_k, "weight") and attn.norm_k.weight is not None:
+                specs[attn.norm_k.weight] = ("model",)
+
+        # FFN: Sequential[Linear(5120,13824), GELU, Linear(13824,5120)]
+        specs[block.ffn[0].weight] = ("model", "batch")
+        specs[block.ffn[0].bias] = ("model",)
+        specs[block.ffn[2].weight] = ("batch", "model")
+        specs[block.ffn[2].bias] = ("batch",)
+
+    # Head: Linear(5120 -> 64) - small output, shard input dim
+    specs[transformer.head.head.weight] = (None, "batch")
+    specs[transformer.head.head.bias] = (None,)
+
+    return specs
+
+
+# VAE is small enough to fit on a single chip — no sharding needed.

--- a/tests/torch/models/krea_realtime/test_text_encoder.py
+++ b/tests/torch/models/krea_realtime/test_text_encoder.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Krea Realtime — UMT5 text encoder component test.
+
+IN:  input_ids       (1, 512) int64
+     attention_mask  (1, 512) int64
+OUT: last_hidden_state (1, 512, 4096) bfloat16
+"""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+
+from tests.torch.models.krea_realtime.shared import (
+    MAX_SEQ_LEN,
+    krea_mesh,
+    load_text_encoder,
+    shard_text_encoder_specs,
+)
+
+
+@pytest.mark.skip(
+    reason="OOM on single device — UMT5-XXL exceeds single-chip memory; sharded variant runs"
+)
+def test_text_encoder():
+    _run(sharded=False)
+
+
+@pytest.mark.nightly
+@pytest.mark.model_test
+def test_text_encoder_sharded():
+    _run(sharded=True)
+
+
+def _run(sharded: bool):
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    encoder = load_text_encoder()
+
+    vocab_size = encoder.config.vocab_size
+    input_ids = torch.randint(0, vocab_size, (1, MAX_SEQ_LEN), dtype=torch.long)
+    attention_mask = torch.ones(1, MAX_SEQ_LEN, dtype=torch.long)
+
+    mesh = krea_mesh() if sharded else None
+    shard_spec_fn = shard_text_encoder_specs if sharded else None
+
+    run_graph_test(
+        encoder,
+        [input_ids, attention_mask],
+        framework=Framework.TORCH,
+        mesh=mesh,
+        shard_spec_fn=shard_spec_fn,
+    )

--- a/tests/torch/models/krea_realtime/test_transformer.py
+++ b/tests/torch/models/krea_realtime/test_transformer.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Krea Realtime — CausalWanModel (14B DiT) component test.
+
+IN:  x        (1, 16, 3, 60, 104)  bfloat16   noisy latents
+     t        (1, 3)               float32    timestep per latent frame
+     context  (1, 512, 4096)       bfloat16   text embeddings
+OUT: noise_pred (1, 16, 3, 60, 104) bfloat16
+
+KV / cross-attention caches are built fresh inside the wrapper each forward,
+so callers only need to supply tensor positionals (x, t, context).
+"""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+
+from tests.torch.models.krea_realtime.shared import (
+    DTYPE,
+    KV_CACHE_SIZE,
+    LATENT_H,
+    LATENT_W,
+    MAX_SEQ_LEN,
+    NUM_CHANNELS_LATENTS,
+    NUM_FRAMES_PER_BLOCK,
+    NUM_LATENT_FRAMES,
+    SEQ_LENGTH,
+    TEXT_EMBED_DIM,
+    krea_mesh,
+    load_transformer,
+    shard_transformer_specs,
+)
+
+
+def fixed_sinusoidal_embedding_1d(dim, position):
+    """Device-agnostic replacement for Krea's CUDA-hardcoded version.
+
+    Upstream: https://huggingface.co/krea/krea-realtime-video/blob/main/transformer/model.py#L33
+    The original uses `device=torch.cuda.current_device()`, which crashes on
+    CPU/TT. We replace it with `device=position.device`.
+    """
+    assert dim % 2 == 0
+    half = dim // 2
+    position = position.type(torch.float64)
+    sinusoid = torch.outer(
+        position,
+        torch.pow(
+            10000,
+            -torch.arange(half, device=position.device, dtype=torch.float64).div(half),
+        ),
+    )
+    return torch.cat([torch.cos(sinusoid), torch.sin(sinusoid)], dim=1)
+
+
+class CausalWanWrapper(torch.nn.Module):
+    """Wrap CausalWanModel so the forward signature is just (x, t, context).
+
+    KV / cross-attention caches are rebuilt fresh each forward (zero-init,
+    on the same device as the inputs). This keeps the test stateless and
+    side-effect-free.
+    """
+
+    def __init__(self, transformer):
+        super().__init__()
+        self.transformer = transformer
+
+        # Patch out the CUDA-hardcoded time embedding via the model's module namespace.
+        transformer.forward.__globals__["sinusoidal_embedding_1d"] = (
+            fixed_sinusoidal_embedding_1d
+        )
+
+        # Set the per-block self-attention attributes that WanRTSetupKVCache sets.
+        for blk in self.transformer.blocks:
+            blk.self_attn.local_attn_size = -1
+            blk.self_attn.num_frame_per_block = NUM_FRAMES_PER_BLOCK
+
+        # Cache shapes (computed once; tensors are built per-forward)
+        self._num_blocks = len(self.transformer.blocks)
+        self._num_heads = self.transformer.config.num_heads
+        self._head_dim = self.transformer.config.dim // self._num_heads
+
+    def _make_caches(self, device, dtype):
+        kv_shape = [1, KV_CACHE_SIZE, self._num_heads, self._head_dim]
+        ca_shape = [1, MAX_SEQ_LEN, self._num_heads, self._head_dim]
+        kv_cache = [
+            {
+                "k": torch.zeros(kv_shape, dtype=dtype, device=device).contiguous(),
+                "v": torch.zeros(kv_shape, dtype=dtype, device=device).contiguous(),
+                "global_end_index": 0,
+                "local_end_index": 0,
+            }
+            for _ in range(self._num_blocks)
+        ]
+        crossattn_cache = [
+            {
+                "k": torch.zeros(ca_shape, dtype=dtype, device=device).contiguous(),
+                "v": torch.zeros(ca_shape, dtype=dtype, device=device).contiguous(),
+                "is_init": False,
+            }
+            for _ in range(self._num_blocks)
+        ]
+        return kv_cache, crossattn_cache
+
+    def forward(self, x, t, context):
+        kv_cache, crossattn_cache = self._make_caches(x.device, x.dtype)
+        return self.transformer(
+            x=x,
+            t=t,
+            context=context,
+            kv_cache=kv_cache,
+            seq_len=SEQ_LENGTH,
+            crossattn_cache=crossattn_cache,
+            current_start=0,
+            cache_start=None,
+        )
+
+
+@pytest.mark.skip(
+    reason="OOM on single device — CausalWanModel exceeds single-chip memory; sharded variant runs"
+)
+def test_transformer():
+    _run(sharded=False)
+
+
+@pytest.mark.xfail(
+    reason="Complex dtype (RoPE freqs from torch.polar) unsupported on TT — https://github.com/tenstorrent/tt-xla/issues/4464"
+)
+def test_transformer_sharded():
+    _run(sharded=True)
+
+
+def _run(sharded: bool):
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    wrapper = CausalWanWrapper(load_transformer()).eval()
+
+    x = torch.randn(
+        1,
+        NUM_CHANNELS_LATENTS,
+        NUM_LATENT_FRAMES,
+        LATENT_H,
+        LATENT_W,
+        dtype=DTYPE,
+    )
+    t = torch.full((1, NUM_FRAMES_PER_BLOCK), 1000.0, dtype=torch.float32)
+    context = torch.randn(1, MAX_SEQ_LEN, TEXT_EMBED_DIM, dtype=DTYPE)
+
+    mesh = krea_mesh() if sharded else None
+    shard_spec_fn = (
+        (lambda m: shard_transformer_specs(m.transformer)) if sharded else None
+    )
+
+    run_graph_test(
+        wrapper,
+        [x, t, context],
+        framework=Framework.TORCH,
+        mesh=mesh,
+        shard_spec_fn=shard_spec_fn,
+    )

--- a/tests/torch/models/krea_realtime/test_vae_decoder.py
+++ b/tests/torch/models/krea_realtime/test_vae_decoder.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Krea Realtime — AutoencoderKLWan (3D causal VAE) decoder component test.
+
+IN:  z       (1, 16, 3, 60, 104)   bfloat16
+OUT: sample  (1, 3, 9, 480, 832)   bfloat16
+"""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+
+from tests.torch.models.krea_realtime.shared import (
+    DTYPE,
+    LATENT_H,
+    LATENT_W,
+    NUM_CHANNELS_LATENTS,
+    NUM_LATENT_FRAMES,
+    load_vae,
+)
+
+
+class VAEDecoderWrapper(torch.nn.Module):
+    """Wrap AutoencoderKLWan so the forward signature is just (z) -> tensor.
+
+    Default `vae(z)` runs encode+decode and returns a model-output object;
+    we want only the decoder, with a plain tensor out.
+    """
+
+    def __init__(self, vae):
+        super().__init__()
+        self.vae = vae
+
+    def forward(self, z):
+        return self.vae.decode(z, return_dict=False)[0]
+
+
+@pytest.mark.xfail(
+    reason="VAE temporal slice fails on TT (out-of-range slice on size-1 dim) — https://github.com/tenstorrent/tt-xla/issues/4465"
+)
+def test_vae_decoder():
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    wrapper = VAEDecoderWrapper(load_vae()).eval()
+
+    z = torch.randn(
+        1,
+        NUM_CHANNELS_LATENTS,
+        NUM_LATENT_FRAMES,
+        LATENT_H,
+        LATENT_W,
+        dtype=DTYPE,
+    )
+
+    run_graph_test(
+        wrapper,
+        [z],
+        framework=Framework.TORCH,
+    )


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-xla/issues/4463

### Problem description

- Add initial tests for each part of the pipeline
- Initial target device: Wormhole

### What's changed

 | File | Component | Tests |
|------|-----------|-------|
| `test_text_encoder.py` | UMT5-XXL text encoder | `test_text_encoder` (skip — OOM single device), `test_text_encoder_sharded` (pass — 2 chips ) |
| `test_transformer.py` | CausalWanModel (14B autoregressive DiT) | `test_transformer` (skip — OOM single device), `test_transformer_sharded` (xfail — 4 chips — [#4464](https://github.com/tenstorrent/tt-xla/issues/4464)) |
| `test_vae_decoder.py` | 3D Causal VAE decoder | `test_vae_decoder` (xfail — single chip — [#4465](https://github.com/tenstorrent/tt-xla/issues/4465)) |

Shared infrastructure (`tests/torch/models/krea_realtime/shared.py`):

- `HEIGHT / WIDTH / NUM_BLOCKS / MAX_SEQ_LEN` — default inference shape constants
- `KV_CACHE_NUM_FRAMES / FRAME_SEQ_LENGTH / SEQ_LENGTH / KV_CACHE_SIZE` — KV-cache config constants
- `load_text_encoder / load_transformer / load_vae` — real-weight loaders
- `krea_mesh` — adaptive 2D `(batch, model)` SPMD mesh (1 / 2 / 4 / 8 / 32 devices)
- `shard_text_encoder_specs / shard_transformer_specs` — per-component shard spec functions

Test-specific extras:

- `test_transformer.py` includes `fixed_sinusoidal_embedding_1d`, a runtime monkey-patch that replaces Krea's [CUDA-hardcoded time-embedding helper](https://huggingface.co/krea/krea-realtime-video/blob/main/transformer/model.py#L33) with a device-agnostic version, so the test runs without modifying the upstream package code.
- `test_transformer.py` includes `CausalWanWrapper`, a thin `nn.Module` adapter that exposes `forward(x, t, context)` and rebuilds zero-init KV / cross-attention caches per call (Krea's transformer expects 8 args including `list[dict]` caches; `run_graph_test` only accepts tensor positionals).

### Checklist
- [x] Verify the changes through local testing in WH


### Logs

- [apr29_krea_transformer_sharded.log](https://github.com/user-attachments/files/27215938/apr29_krea_transformer_sharded.log)
- [apr29_krea_decoder.log](https://github.com/user-attachments/files/27215940/apr29_krea_decoder.log)
- [apr29_krea_encoder_sharded.log](https://github.com/user-attachments/files/27215944/apr29_krea_encoder_shard_2_chips.log)
