### PR TITLE
[HunyuanVideo-1.5-Diffusers-480p_t2v_distilled] Add initial tests for each part of the pipeline

### DIFF
--- a/tests/torch/models/Hunyuan_1_5/shared.py
+++ b/tests/torch/models/Hunyuan_1_5/shared.py
@@ -1,0 +1,245 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Shared helpers for HunyuanVideo 1.5 (480p t2v distilled) component tests.
+
+Exposes:
+  - load_text_encoder / load_text_encoder_2 / load_transformer / load_vae:
+    HuggingFace model loaders
+  - hunyuan_mesh: 2D ("batch", "model") SPMD mesh — adapts to device count
+  - shard_text_encoder_specs / shard_transformer_specs:
+    per-component shard spec functions for run_graph_test.
+"""
+
+import torch
+from diffusers import HunyuanVideo15Pipeline
+from infra.utilities import Mesh
+from infra.utilities.torch_multichip_utils import get_mesh
+
+# ---------------------------------------------------------------------------
+# Model + dtype
+# ---------------------------------------------------------------------------
+
+REPO_ID = "hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_t2v_distilled"
+DTYPE = torch.bfloat16
+
+
+# ---------------------------------------------------------------------------
+# Default inference shape
+# ---------------------------------------------------------------------------
+
+NUM_FRAMES = 17  # smallest valid (4k+1) — for smoke
+NUM_LATENT_FRAMES = 5  # (17-1)//4 + 1
+LATENT_H = 30  # 480 // 16
+LATENT_W = 53  # 848 // 16
+
+# Channel configs
+NUM_CHANNELS_LATENTS = 32  # VAE latent channels
+TRANSFORMER_IN_CHANNELS = 65  # 32 latent + 32 cond + 1 mask (concat)
+
+# Text encoder dims
+TEXT_EMBED_DIM = 3584  # Qwen2.5-VL hidden_state dim
+TEXT_EMBED_2_DIM = 1472  # ByT5 hidden_state dim
+
+# Image embeds (zeros for t2v; pipeline builds these and passes to transformer)
+IMAGE_EMBED_DIM = 1152  # transformer.config.image_embed_dim
+IMAGE_EMBED_SEQ = 64  # pipeline.vision_num_semantic_tokens default
+
+# Token sequence lengths (from default prompt)
+TEXT_TOKEN_MAX_LEN = 1108  # Qwen2.5-VL tokenized prompt length
+TEXT_TOKEN_2_MAX_LEN = 256  # ByT5 tokenizer_2_max_length default
+TRANSFORMER_TEXT_SEQ = 1000  # encoder_hidden_states seq dim into transformer
+TRANSFORMER_TEXT_2_SEQ = 256  # encoder_hidden_states_2 seq dim
+
+
+# ---------------------------------------------------------------------------
+# Component loaders (real weights from HuggingFace)
+# ---------------------------------------------------------------------------
+
+
+def _load_pipe():
+    """Load the full HunyuanVideo 1.5 pipeline on CPU in bfloat16."""
+    return HunyuanVideo15Pipeline.from_pretrained(REPO_ID, torch_dtype=DTYPE)
+
+
+def load_text_encoder():
+    """Load the Qwen2.5-VL text encoder (text_encoder)."""
+    return _load_pipe().text_encoder.eval()
+
+
+def load_text_encoder_2():
+    """Load the ByT5 text encoder (text_encoder_2)."""
+    return _load_pipe().text_encoder_2.eval()
+
+
+def load_transformer():
+    """Load the HunyuanVideo15Transformer3DModel (DiT)."""
+    return _load_pipe().transformer.eval()
+
+
+def load_vae():
+    """Load the AutoencoderKLHunyuanVideo15 VAE."""
+    return _load_pipe().vae.eval()
+
+
+# ---------------------------------------------------------------------------
+# SPMD mesh
+# ---------------------------------------------------------------------------
+
+# (batch, model) shapes by device count
+_MESH_SHAPES = {32: (8, 4), 8: (2, 4), 4: (1, 4), 2: (1, 2), 1: (1, 1)}
+
+
+def hunyuan_mesh() -> Mesh:
+    """2D ("batch", "model") SPMD mesh sized to current device count."""
+    import torch_xla.runtime as xr
+
+    n = xr.global_runtime_device_count()
+    if n not in _MESH_SHAPES:
+        raise ValueError(
+            f"Unsupported device count: {n}. "
+            f"Expected one of {sorted(_MESH_SHAPES)}."
+        )
+    return get_mesh(_MESH_SHAPES[n], ("batch", "model"))
+
+
+# ---------------------------------------------------------------------------
+# Qwen2.5-VL (text_encoder) sharding
+# ---------------------------------------------------------------------------
+
+
+def shard_text_encoder_specs(encoder) -> dict:
+    """Build shard specs for Qwen2.5-VL text encoder weights.
+
+    Mesh axes: ("batch", "model")
+    Column-parallel (q, k, v, gate, up):  ("model", "batch")
+    Row-parallel   (o, down):              ("batch", "model")
+    """
+    specs = {}
+
+    # Embedding (vocab, hidden_size)
+    if hasattr(encoder, "embed_tokens"):
+        specs[encoder.embed_tokens.weight] = (None, "batch")
+
+    layers = getattr(encoder, "layers", None)
+    if layers is None:
+        return specs
+
+    for layer in layers:
+        # Self-attention
+        sa = layer.self_attn
+        specs[sa.q_proj.weight] = ("model", "batch")
+        if sa.q_proj.bias is not None:
+            specs[sa.q_proj.bias] = ("model",)
+        specs[sa.k_proj.weight] = ("model", "batch")
+        if sa.k_proj.bias is not None:
+            specs[sa.k_proj.bias] = ("model",)
+        specs[sa.v_proj.weight] = ("model", "batch")
+        if sa.v_proj.bias is not None:
+            specs[sa.v_proj.bias] = ("model",)
+        specs[sa.o_proj.weight] = ("batch", "model")
+
+        # MLP (gate / up / down — Llama/Qwen-style)
+        mlp = layer.mlp
+        specs[mlp.gate_proj.weight] = ("model", "batch")
+        specs[mlp.up_proj.weight] = ("model", "batch")
+        specs[mlp.down_proj.weight] = ("batch", "model")
+
+        # Norms (replicated; small)
+        specs[layer.input_layernorm.weight] = ("batch",)
+        specs[layer.post_attention_layernorm.weight] = ("batch",)
+
+    if hasattr(encoder, "norm"):
+        specs[encoder.norm.weight] = ("batch",)
+
+    return specs
+
+
+# text_encoder_2 (ByT5, 0.22B params) is small enough to fit on a single chip — no sharding needed.
+
+
+# ---------------------------------------------------------------------------
+# HunyuanVideo15Transformer3DModel sharding
+# ---------------------------------------------------------------------------
+
+
+def shard_transformer_specs(transformer) -> dict:
+    """Build shard specs for HunyuanVideo15Transformer3DModel weights.
+
+    Mesh axes: ("batch", "model")
+    Column-parallel (Q, K, V, FFN up):  ("model", "batch")
+    Row-parallel   (O, FFN down):        ("batch", "model")
+    """
+    specs = {}
+
+    # Patch embedding (Conv3d -> inner_dim)
+    if hasattr(transformer.x_embedder, "proj"):
+        specs[transformer.x_embedder.proj.weight] = ("batch", None, None, None, None)
+        if transformer.x_embedder.proj.bias is not None:
+            specs[transformer.x_embedder.proj.bias] = ("batch",)
+
+    # Per-block sharding (dual-stream blocks)
+    for block in transformer.transformer_blocks:
+        # AdaLayerNormZero modulation projections (hidden -> 6*hidden)
+        for norm_name in ("norm1", "norm1_context"):
+            if hasattr(block, norm_name) and hasattr(
+                getattr(block, norm_name), "linear"
+            ):
+                lin = getattr(block, norm_name).linear
+                specs[lin.weight] = ("model", "batch")
+                if lin.bias is not None:
+                    specs[lin.bias] = ("model",)
+
+        # Joint attention projections
+        if hasattr(block, "attn"):
+            attn = block.attn
+            for proj_name in (
+                "to_q",
+                "to_k",
+                "to_v",
+                "add_q_proj",
+                "add_k_proj",
+                "add_v_proj",
+            ):
+                if hasattr(attn, proj_name):
+                    proj = getattr(attn, proj_name)
+                    specs[proj.weight] = ("model", "batch")
+                    if proj.bias is not None:
+                        specs[proj.bias] = ("model",)
+            for proj_name in ("to_out", "to_add_out"):
+                if hasattr(attn, proj_name):
+                    out = getattr(attn, proj_name)
+                    # to_out is typically nn.ModuleList([Linear, Dropout]) in diffusers Attention
+                    target = (
+                        out[0]
+                        if isinstance(out, (torch.nn.Sequential, torch.nn.ModuleList))
+                        else out
+                    )
+                    specs[target.weight] = ("batch", "model")
+                    if target.bias is not None:
+                        specs[target.bias] = ("batch",)
+
+        # FeedForward (img + context streams)
+        for ff_name in ("ff", "ff_context"):
+            if hasattr(block, ff_name):
+                ff = getattr(block, ff_name)
+                # net[0] is activation wrapper (GELU/GEGLU/ApproximateGELU) — has .proj Linear
+                if hasattr(ff.net[0], "proj"):
+                    specs[ff.net[0].proj.weight] = ("model", "batch")
+                    if ff.net[0].proj.bias is not None:
+                        specs[ff.net[0].proj.bias] = ("model",)
+                # net[2] is output Linear
+                specs[ff.net[2].weight] = ("batch", "model")
+                if ff.net[2].bias is not None:
+                    specs[ff.net[2].bias] = ("batch",)
+
+    # Output projection
+    specs[transformer.proj_out.weight] = (None, "batch")
+    if transformer.proj_out.bias is not None:
+        specs[transformer.proj_out.bias] = (None,)
+
+    return specs
+
+
+# VAE runs single-device (1.26B params fits); current TT-XLA hits a hang during decode — to debug.

--- a/tests/torch/models/Hunyuan_1_5/test_text_encoder.py
+++ b/tests/torch/models/Hunyuan_1_5/test_text_encoder.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+HunyuanVideo 1.5 — Qwen2.5-VL text encoder component test.
+
+Size: 7.07B params
+
+IN:  input_ids       (1, 1108) int64
+     attention_mask  (1, 1108) int64
+OUT: model output (Qwen2_5_VLTextModelOutputWithPast) — last_hidden_state shape (1, 1108, 3584) bfloat16
+"""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+
+from tests.torch.models.Hunyuan_1_5.shared import (
+    TEXT_TOKEN_MAX_LEN,
+    hunyuan_mesh,
+    load_text_encoder,
+    shard_text_encoder_specs,
+)
+
+
+@pytest.mark.skip(
+    reason="model size > 7B — won't fit on a single chip; sharded variant runs"
+)
+def test_text_encoder():
+    _run(sharded=False)
+
+
+@pytest.mark.xfail(
+    reason="PCC drop (got 0.9712937232386395, required >= 0.99) — https://github.com/tenstorrent/tt-xla/issues/4484"
+)
+@pytest.mark.nightly
+@pytest.mark.model_test
+def test_text_encoder_sharded():
+    _run(sharded=True)
+
+
+def _run(sharded: bool):
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    encoder = load_text_encoder()
+
+    vocab_size = encoder.config.vocab_size
+    input_ids = torch.randint(0, vocab_size, (1, TEXT_TOKEN_MAX_LEN), dtype=torch.long)
+    attention_mask = torch.ones(1, TEXT_TOKEN_MAX_LEN, dtype=torch.long)
+
+    mesh = hunyuan_mesh() if sharded else None
+    shard_spec_fn = shard_text_encoder_specs if sharded else None
+
+    run_graph_test(
+        encoder,
+        [input_ids, attention_mask],
+        framework=Framework.TORCH,
+        mesh=mesh,
+        shard_spec_fn=shard_spec_fn,
+    )

--- a/tests/torch/models/Hunyuan_1_5/test_text_encoder_2.py
+++ b/tests/torch/models/Hunyuan_1_5/test_text_encoder_2.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+HunyuanVideo 1.5 — ByT5 text encoder component test (text_encoder_2).
+
+Size: 0.22B params
+
+IN:  input_ids       (1, 256) int64
+     attention_mask  (1, 256) float32
+OUT: model output (BaseModelOutput) — last_hidden_state shape (1, 256, 1472) bfloat16
+"""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+
+from tests.torch.models.Hunyuan_1_5.shared import (
+    TEXT_TOKEN_2_MAX_LEN,
+    load_text_encoder_2,
+)
+
+
+@pytest.mark.nightly
+@pytest.mark.model_test
+def test_text_encoder_2():
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    encoder = load_text_encoder_2()
+
+    vocab_size = encoder.config.vocab_size
+    input_ids = torch.randint(
+        0, vocab_size, (1, TEXT_TOKEN_2_MAX_LEN), dtype=torch.long
+    )
+    # Pipeline calls text_encoder_2 with attention_mask.float() — match that
+    attention_mask = torch.ones(1, TEXT_TOKEN_2_MAX_LEN, dtype=torch.float32)
+
+    run_graph_test(
+        encoder,
+        [input_ids, attention_mask],
+        framework=Framework.TORCH,
+    )

--- a/tests/torch/models/Hunyuan_1_5/test_transformer.py
+++ b/tests/torch/models/Hunyuan_1_5/test_transformer.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+HunyuanVideo 1.5 — HunyuanVideo15Transformer3DModel (DiT) component test.
+
+Size: 8.33B params
+
+IN:  hidden_states           (1, 65, 5, 30, 53)   bfloat16  (32 latent + 32 cond + 1 mask)
+     timestep                (1,)                 bfloat16
+     encoder_hidden_states   (1, 1000, 3584)      bfloat16  (Qwen embeds)
+     encoder_attention_mask  (1, 1000)            bfloat16
+     encoder_hidden_states_2 (1, 256, 1472)       bfloat16  (ByT5 embeds)
+     encoder_attention_mask_2(1, 256)             bfloat16
+     image_embeds            (1, N, 1152)         bfloat16  (zeros for t2v)
+OUT: noise_pred              (1, 32, 5, 30, 53)   bfloat16
+
+In the pipeline only the transformer's hidden_states output is used; the
+wrapper extracts that tensor (return_dict=False, then [0]) so it returns
+a plain tensor instead of a model output object.
+"""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+
+from tests.torch.models.Hunyuan_1_5.shared import (
+    DTYPE,
+    IMAGE_EMBED_DIM,
+    IMAGE_EMBED_SEQ,
+    LATENT_H,
+    LATENT_W,
+    NUM_LATENT_FRAMES,
+    TEXT_EMBED_2_DIM,
+    TEXT_EMBED_DIM,
+    TRANSFORMER_IN_CHANNELS,
+    TRANSFORMER_TEXT_2_SEQ,
+    TRANSFORMER_TEXT_SEQ,
+    hunyuan_mesh,
+    load_transformer,
+    shard_transformer_specs,
+)
+
+
+class HunyuanVideo15TransformerWrapper(torch.nn.Module):
+    """Wrap HunyuanVideo15Transformer3DModel with a tensor-only forward."""
+
+    def __init__(self, transformer):
+        super().__init__()
+        self.transformer = transformer
+
+    def forward(
+        self,
+        hidden_states,
+        timestep,
+        encoder_hidden_states,
+        encoder_attention_mask,
+        encoder_hidden_states_2,
+        encoder_attention_mask_2,
+        image_embeds,
+    ):
+        return self.transformer(
+            hidden_states=hidden_states,
+            image_embeds=image_embeds,
+            timestep=timestep,
+            encoder_hidden_states=encoder_hidden_states,
+            encoder_attention_mask=encoder_attention_mask,
+            encoder_hidden_states_2=encoder_hidden_states_2,
+            encoder_attention_mask_2=encoder_attention_mask_2,
+            return_dict=False,
+        )[0]
+
+
+@pytest.mark.skip(
+    reason="model size > 8B — won't fit on a single chip; sharded variant runs"
+)
+def test_transformer():
+    _run(sharded=False)
+
+
+@pytest.mark.xfail(
+    reason="SPMD compilation gives trivial mesh size [1,1] -> 'Device count mismatch: 2 vs 1' at execute — https://github.com/tenstorrent/tt-xla/issues/4486"
+)
+def test_transformer_sharded():
+    _run(sharded=True)
+
+
+def _run(sharded: bool):
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    wrapper = HunyuanVideo15TransformerWrapper(load_transformer()).eval()
+
+    hidden_states = torch.randn(
+        1,
+        TRANSFORMER_IN_CHANNELS,
+        NUM_LATENT_FRAMES,
+        LATENT_H,
+        LATENT_W,
+        dtype=DTYPE,
+    )
+    timestep = torch.tensor([1000.0], dtype=DTYPE)
+    encoder_hidden_states = torch.randn(
+        1, TRANSFORMER_TEXT_SEQ, TEXT_EMBED_DIM, dtype=DTYPE
+    )
+    encoder_attention_mask = torch.ones(1, TRANSFORMER_TEXT_SEQ, dtype=DTYPE)
+    encoder_hidden_states_2 = torch.randn(
+        1, TRANSFORMER_TEXT_2_SEQ, TEXT_EMBED_2_DIM, dtype=DTYPE
+    )
+    encoder_attention_mask_2 = torch.ones(1, TRANSFORMER_TEXT_2_SEQ, dtype=DTYPE)
+    image_embeds = torch.zeros(1, IMAGE_EMBED_SEQ, IMAGE_EMBED_DIM, dtype=DTYPE)
+
+    mesh = hunyuan_mesh() if sharded else None
+    shard_spec_fn = (
+        (lambda m: shard_transformer_specs(m.transformer)) if sharded else None
+    )
+
+    run_graph_test(
+        wrapper,
+        [
+            hidden_states,
+            timestep,
+            encoder_hidden_states,
+            encoder_attention_mask,
+            encoder_hidden_states_2,
+            encoder_attention_mask_2,
+            image_embeds,
+        ],
+        framework=Framework.TORCH,
+        mesh=mesh,
+        shard_spec_fn=shard_spec_fn,
+    )

--- a/tests/torch/models/Hunyuan_1_5/test_vae_decoder.py
+++ b/tests/torch/models/Hunyuan_1_5/test_vae_decoder.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+HunyuanVideo 1.5 — AutoencoderKLHunyuanVideo15 decoder component test.
+
+Size: 1.26B params
+
+IN:  z       (1, 32, 5, 30, 53)    bfloat16
+OUT: sample  (1, 3, 17, 480, 848)  bfloat16
+"""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+
+from tests.torch.models.Hunyuan_1_5.shared import (
+    DTYPE,
+    LATENT_H,
+    LATENT_W,
+    NUM_CHANNELS_LATENTS,
+    NUM_LATENT_FRAMES,
+    load_vae,
+)
+
+
+class VAEDecoderWrapper(torch.nn.Module):
+    """Wrap AutoencoderKLHunyuanVideo15 so the forward signature is just (z) -> tensor.
+
+    Default `vae(z)` runs encode+decode and returns a model-output object;
+    we want only the decoder, with a plain tensor out.
+    """
+
+    def __init__(self, vae):
+        super().__init__()
+        self.vae = vae
+
+    def forward(self, z):
+        return self.vae.decode(z, return_dict=False)[0]
+
+
+@pytest.mark.skip(
+    reason="hang on TT — investigation pending — https://github.com/tenstorrent/tt-xla/issues/4485"
+)
+def test_vae_decoder():
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    wrapper = VAEDecoderWrapper(load_vae()).eval()
+
+    z = torch.randn(
+        1,
+        NUM_CHANNELS_LATENTS,
+        NUM_LATENT_FRAMES,
+        LATENT_H,
+        LATENT_W,
+        dtype=DTYPE,
+    )
+
+    run_graph_test(
+        wrapper,
+        [z],
+        framework=Framework.TORCH,
+    )


### PR DESCRIPTION
## Ticket

- closes https://github.com/tenstorrent/tt-xla/issues/4470

## Problem description
- Add initial tests for each part of the `HunyuanVideo-1.5-Diffusers-480p_t2v_distilled`'s pipeline
- Initial target device: Wormhole

## What's changed

| File | Component | Tests |
|------|-----------|-------|
| `test_text_encoder.py` | Qwen2.5-VL text encoder (7.07B) | `test_text_encoder` (skip — model > 7B, won't fit on single chip), `test_text_encoder_sharded` (xfail — PCC drop — [#4484](https://github.com/tenstorrent/tt-xla/issues/4484)) |
| `test_text_encoder_2.py` | ByT5 text encoder (0.22B) | `test_text_encoder_2` (pass — single chip) |
| `test_transformer.py` | HunyuanVideo15Transformer3DModel (8.33B DiT) | `test_transformer` (skip — model > 8B, won't fit on single chip), `test_transformer_sharded` (xfail — SPMD trivial-mesh / Device count mismatch — [#4486](https://github.com/tenstorrent/tt-xla/issues/4486)) |
| `test_vae_decoder.py` | AutoencoderKLHunyuanVideo15 (1.26B) | `test_vae_decoder` (skip — hang on TT — [#4485](https://github.com/tenstorrent/tt-xla/issues/4485)) |

Shared infrastructure (`tests/torch/models/Hunyuan_1_5/shared.py`):

- `HEIGHT / WIDTH / NUM_FRAMES / NUM_LATENT_FRAMES / LATENT_H / LATENT_W` — default inference shape constants
- `NUM_CHANNELS_LATENTS / TRANSFORMER_IN_CHANNELS / TEXT_EMBED_DIM / TEXT_EMBED_2_DIM / IMAGE_EMBED_DIM / IMAGE_EMBED_SEQ` — model dim constants
- `TEXT_TOKEN_MAX_LEN / TEXT_TOKEN_2_MAX_LEN / TRANSFORMER_TEXT_SEQ / TRANSFORMER_TEXT_2_SEQ` — token / sequence length constants
- `load_text_encoder / load_text_encoder_2 / load_transformer / load_vae` — real-weight loaders
- `hunyuan_mesh` — adaptive 2D `(batch, model)` SPMD mesh (1 / 2 / 4 / 8 / 32 devices)
- `shard_text_encoder_specs / shard_transformer_specs` — per-component shard spec functions

## Checklist
- [x] Verify the changes through local testing in WH

### Logs

- [apr30_hunyuan_1_5_decoder_shareded.log](https://github.com/user-attachments/files/27244423/apr30_hunyuan_1_5_decoder_shareded.log)
- [apr30_hunyuan_1_5_encoder_2.log](https://github.com/user-attachments/files/27244426/apr30_hunyuan_1_5_encoder_2.log)
- [apr30_hunyuan_1_5_encoder_sharded.log](https://github.com/user-attachments/files/27244427/apr30_hunyuan_1_5_encoder_sharded.log)
- [apr30_hunyuan_1_5_transformer_sharded.log](https://github.com/user-attachments/files/27244429/apr30_hunyuan_1_5_transformer_sharded_1.log)
