### PR TITLE
Update PyTorch tag in torch-xla build script

### DIFF
--- a/scripts/build_torch_xla.sh
+++ b/scripts/build_torch_xla.sh
@@ -25,7 +25,7 @@ set -euo pipefail
 
 # ── Configuration ────────────────────────────────────────────────────────────
 PYTHON_VERSION="3.12"
-PYTORCH_TAG="v2.9.1"
+PYTORCH_TAG="v2.10.0"
 PYTORCH_XLA_REPO="https://github.com/tenstorrent/pytorch-xla.git"
 PYTORCH_XLA_BRANCH="master"
 BAZEL_VERSION="7.4.1"


### PR DESCRIPTION
### Problem description
PyTorch is uplifted in #4443; so torch-xla build script needs to be updated to target torch==2.10.0

### What's changed
Update the torch-xla build script.