### PR TITLE
Shallow clone pytorch in manual build TorchXLA 

### DIFF
--- a/scripts/build_torch_xla.sh
+++ b/scripts/build_torch_xla.sh
@@ -142,7 +142,8 @@ if [[ -d "${PYTORCH_DIR}" ]]; then
     fi
 else
     info "Cloning PyTorch ${PYTORCH_TAG}..."
-    git clone --recursive --branch "${PYTORCH_TAG}" https://github.com/pytorch/pytorch "${PYTORCH_DIR}"
+    git clone --depth=1 --shallow-submodules --recursive --jobs=8 \
+        --branch "${PYTORCH_TAG}" https://github.com/pytorch/pytorch "${PYTORCH_DIR}"
 fi
 
 # ── Step 4: Clone/verify PyTorch-XLA (Tenstorrent fork) ─────────────────────


### PR DESCRIPTION
### Ticket
personal grievance

### Problem description
In ptxla manual build CI workflow we are spending time and bandwidth pulling the entire history of dozens of nested submodules, we don't need to for pytorch build.

### What's changed
Shallow clone pytorch and its submodules

Evidence: https://github.com/tenstorrent/tt-xla/actions/runs/25229221645/job/73980369282 runs in 1h2m successfully w/ shallow clone
