### PR TITLE
Nightly Maintance May1

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -33,7 +33,7 @@ test_config:
   gpt_oss/pytorch-20B-tensor_parallel-inference:
     supported_archs: [n300-llmbox, galaxy-wh-6u, lb-blackhole]
     status: EXPECTED_PASSING
-    required_pcc: 0.97
+    required_pcc: 0.98
     inject_custom_moe: true
 
   gpt_oss/pytorch-120B-tensor_parallel-inference:
@@ -183,7 +183,6 @@ test_config:
   qwen_2/causal_lm/pytorch-Qwq_32B-tensor_parallel-inference:
     supported_archs: [n300-llmbox, lb-blackhole]
     status: EXPECTED_PASSING
-    assert_pcc: false  # https://github.com/tenstorrent/tt-xla/issues/3781
 
   qwen_2_5/causal_lm/pytorch-72B_Instruct-tensor_parallel-inference:
     supported_archs: [galaxy-wh-6u]
@@ -201,7 +200,6 @@ test_config:
 
   olmo3/causal_lm/pytorch-3_32b_think-tensor_parallel-inference:
     supported_archs: [n300-llmbox, lb-blackhole]
-    required_pcc: 0.98
     status: EXPECTED_PASSING
 
   olmo3/causal_lm/pytorch-3_1125_32b-tensor_parallel-inference:

--- a/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
@@ -15,8 +15,6 @@ test_config:
   qwen_2_5/causal_lm/pytorch-7B_Instruct-llm_decode-seq_1-batch_1-tensor_parallel-mesh_default-inference:
     supported_archs: ["n300-llmbox", "lb-blackhole"]
     status: EXPECTED_PASSING
-    assert_pcc: false
-    required_pcc: 0.98
 
   qwen_2_5/causal_lm/pytorch-14B_Instruct-llm_decode-seq_1-batch_1-tensor_parallel-mesh_default-inference:
     supported_archs: ["n300-llmbox", "lb-blackhole"]


### PR DESCRIPTION
### Ticket
close https://github.com/tenstorrent/tt-xla/issues/3781

### Problem description
Nightly Maintance May1

### What's changed

Since the model is now passing in weekly runs, I’ve updated the configuration file accordingly.
```
test_all_models_torch[gpt_oss/pytorch-20B-tensor_parallel-inference]                                                                        language    red         bfloat16       galaxy-wh-6u  PASSED                     PASSING       0.9845631757101179     0.97       PCC_EN   tensor_parallel  187.072   RAISE_PCC               
test_all_models_torch[gpt_oss/pytorch-20B-tensor_parallel-inference]                                                                        language    red         bfloat16       n300-llmbox   PASSED                     PASSING       0.9846757781854556     0.97       PCC_EN   tensor_parallel  909.003   RAISE_PCC               
test_all_models_torch[olmo3/causal_lm/pytorch-3_32b_think-tensor_parallel-inference]                                                        language    red         bfloat16       n300-llmbox   PASSED                     PASSING       0.9987799955716705     0.98       PCC_EN   tensor_parallel  260.677   RAISE_PCC_099           

test_all_models_torch[qwen_2/causal_lm/pytorch-Qwq_32B-tensor_parallel-inference]                                                           language    red         bfloat16       n300-llmbox   PASSED                     PASSING       0.9973866782881995     0.99       PCC_DIS  tensor_parallel  220.161   ENABLE_PCC_099          
test_llms_torch[qwen_2_5/causal_lm/pytorch-7B_Instruct-llm_decode-seq_1-batch_1-tensor_parallel-mesh_default-inference]                     language    red         bfloat16       n300-llmbox   PASSED                     PASSING       0.9968469538847958     0.98       PCC_DIS  tensor_parallel  208.880   ENABLE_PCC,RAISE_PCC_099

```

### Checklist
- [ ] New/Existing tests provide coverage for changes
