### PR TITLE
Uplift PJRT C API header from v0.106 to v0.110

### DIFF
--- a/.github/workflows/schedule-uplift-pjrt-api.yml
+++ b/.github/workflows/schedule-uplift-pjrt-api.yml
@@ -63,8 +63,11 @@ jobs:
           if [ "$NEEDS_UPLIFT" = "true" ]; then
             echo "Uplift needed: v$LOCAL_MAJOR.$LOCAL_MINOR -> v$UPSTREAM_MAJOR.$UPSTREAM_MINOR"
 
-            OLD_API_FIELDS=$(grep -oP '_PJRT_API_STRUCT_FIELD\(\K[^)]+' "$LOCAL_FILE" | sort -u)
-            NEW_API_FIELDS=$(grep -oP '_PJRT_API_STRUCT_FIELD\(\K[^)]+' "$UPSTREAM_FILE" | sort -u)
+            # Join lines before matching so macro invocations split across
+            # multiple lines are still captured
+            # (clang-format wraps long identifiers.)
+            OLD_API_FIELDS=$(tr '\n' ' ' < "$LOCAL_FILE" | grep -oP '_PJRT_API_STRUCT_FIELD\(\s*\K\w+' | sort -u)
+            NEW_API_FIELDS=$(tr '\n' ' ' < "$UPSTREAM_FILE" | grep -oP '_PJRT_API_STRUCT_FIELD\(\s*\K\w+' | sort -u)
 
             # Update stubs.inc file with new API entries
             STUBS_FILE="pjrt_implementation/src/stubs.inc"

--- a/pjrt_implementation/src/api/loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/loaded_executable_instance.cc
@@ -468,6 +468,21 @@ onLoadedExecutableExecute(PJRT_LoadedExecutable_Execute_Args *args) {
   ZoneScoped;
   DLOG_F(LOG_DEBUG, "LoadedExecutableInstance::PJRT_LoadedExecutable_Execute");
 
+  // We don't support the major-to-minor data layout transpose for callbacks
+  // (added in PJRT API v0.110). If a client activates it we would silently
+  // produce results with unexpected layout, leading to hard-to-debug PCC
+  // mismatches, so fail loudly instead.
+  if (args->options &&
+      args->options->struct_size >=
+          PJRT_STRUCT_SIZE(PJRT_ExecuteOptions,
+                           use_major_to_minor_data_layout_for_callbacks) &&
+      args->options->use_major_to_minor_data_layout_for_callbacks) {
+    DLOG_F(ERROR,
+           "PJRT_ExecuteOptions::use_major_to_minor_data_layout_for_callbacks "
+           "is not supported by the tt-xla plugin.");
+    return *ErrorInstance::makeError(tt_pjrt_status::kUnimplemented).release();
+  }
+
   LoadedExecutableInstance *instance =
       LoadedExecutableInstance::unwrap(args->executable);
 

--- a/pjrt_implementation/src/stubs.inc
+++ b/pjrt_implementation/src/stubs.inc
@@ -181,3 +181,4 @@
   _STUB(PJRT_LoadedExecutable_AddressableDeviceLogicalIds);
   _STUB(PJRT_Buffer_Bitcast);
   _STUB(PJRT_Error_ForEachPayload);
+  _STUB(PJRT_TopologyDescription_GetMemorySpaceKindIds);

--- a/pjrt_implementation/src/stubs.inc
+++ b/pjrt_implementation/src/stubs.inc
@@ -166,6 +166,8 @@
   _STUB(PJRT_TopologyDescription_Attributes);
   _STUB(PJRT_TopologyDescription_Deserialize);
   _STUB(PJRT_TopologyDescription_Fingerprint);
+  _STUB(PJRT_TopologyDescription_MakeCanonicalShapeForMemorySpace);
+  _STUB(PJRT_TopologyDescription_GetMemorySpaceKindIds);
   _STUB(PJRT_Compile);
   _STUB(PJRT_AsyncHostToDeviceTransferManager_Destroy);
   _STUB(PJRT_AsyncHostToDeviceTransferManager_Device);
@@ -181,4 +183,3 @@
   _STUB(PJRT_LoadedExecutable_AddressableDeviceLogicalIds);
   _STUB(PJRT_Buffer_Bitcast);
   _STUB(PJRT_Error_ForEachPayload);
-  _STUB(PJRT_TopologyDescription_GetMemorySpaceKindIds);

--- a/third_party/pjrt_c_api/xla/pjrt/c/pjrt_c_api.h
+++ b/third_party/pjrt_c_api/xla/pjrt/c/pjrt_c_api.h
@@ -85,6 +85,7 @@ typedef enum {
   PJRT_Extension_Type_Collectives,
   PJRT_Extension_Type_MultiSlice,
   PJRT_Extension_Type_HostMemoryAllocator,
+  PJRT_Extension_Type_XlaTransform,
 } PJRT_Extension_Type;
 
 // PJRT_Extension_Base contains a type and a pointer to next
@@ -119,7 +120,7 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_Extension_Base, next);
 // Changes include:
 // * Adding a new field to the PJRT_Api or argument structs
 // * Renaming a method or argument (doesn't affect ABI)
-#define PJRT_API_MINOR 106
+#define PJRT_API_MINOR 110
 
 // The plugin should set the major_version and minor_version of
 // PJRT_Api.pjrt_api_version to be the `PJRT_API_MAJOR` and `PJRT_API_MINOR` in
@@ -186,6 +187,28 @@ typedef enum {
   PJRT_Error_Code_UNAUTHENTICATED = 16
 } PJRT_Error_Code;
 
+typedef void (*PJRT_Error_PayloadVisitor)(const char *key, size_t key_size,
+                                          const char *value, size_t value_size,
+                                          void *user_arg);
+
+typedef struct PJRT_Error_FunctionTable {
+  size_t struct_size;
+  size_t instance_size;
+  PJRT_Extension_Base *extension_start;
+  void (*destroy)(PJRT_Error *error);
+  void (*message)(const PJRT_Error *error, const char **message,
+                  size_t *message_size);
+  PJRT_Error_Code (*get_code)(const PJRT_Error *error);
+  void (*for_each_payload)(const PJRT_Error *error,
+                           PJRT_Error_PayloadVisitor visitor, void *user_arg);
+} PJRT_Error_FunctionTable;
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_Error_FunctionTable, for_each_payload);
+
+struct PJRT_Error {
+  const struct PJRT_Error_FunctionTable *vtable;
+};
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_Error, vtable);
+
 struct PJRT_Error_GetCode_Args {
   size_t struct_size;
   PJRT_Extension_Base *extension_start;
@@ -195,10 +218,6 @@ struct PJRT_Error_GetCode_Args {
 PJRT_DEFINE_STRUCT_TRAITS(PJRT_Error_GetCode_Args, code);
 
 typedef PJRT_Error *PJRT_Error_GetCode(PJRT_Error_GetCode_Args *args);
-
-typedef void (*PJRT_Error_PayloadVisitor)(const char *key, size_t key_size,
-                                          const char *value, size_t value_size,
-                                          void *user_arg);
 
 struct PJRT_Error_ForEachPayload_Args {
   size_t struct_size;
@@ -1916,8 +1935,6 @@ typedef struct PJRT_Chunk {
 // `xla::CopyToDeviceStream`.
 typedef struct PJRT_CopyToDeviceStream PJRT_CopyToDeviceStream;
 
-struct PJRT_TransferMetadata;
-
 // Returns PJRT_Error* created by PJRT_CallbackError in case of error.
 // Otherwise, returns nullptr. The callback must call
 // `chunk->deleter(chunk->data, chunk->deleter_arg)` when it's finished with
@@ -2000,8 +2017,12 @@ struct PJRT_ExecuteOptions {
   int *task_ids;
   int64_t *incarnation_ids;
   PJRT_MultiSlice_Config *multi_slice_config;
+  // If true, transpose the array from the device native format into major to
+  // minor format.
+  bool use_major_to_minor_data_layout_for_callbacks;
 };
-PJRT_DEFINE_STRUCT_TRAITS(PJRT_ExecuteOptions, multi_slice_config);
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_ExecuteOptions,
+                          use_major_to_minor_data_layout_for_callbacks);
 
 struct PJRT_LoadedExecutable_Execute_Args {
   size_t struct_size;
@@ -2907,6 +2928,43 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_TopologyDescription_Fingerprint_Args,
 typedef PJRT_Error *PJRT_TopologyDescription_Fingerprint(
     PJRT_TopologyDescription_Fingerprint_Args *args);
 
+struct PJRT_TopologyDescription_MakeCanonicalShapeForMemorySpace_Args {
+  size_t struct_size;
+  PJRT_Extension_Base *extension_start;
+  const PJRT_TopologyDescription *topology;
+  int memory_space_kind_id;
+  // Input shape
+  const int64_t *dims;
+  size_t num_dims;
+  PJRT_Buffer_Type element_type;
+  // Optional input layout
+  const PJRT_Buffer_MemoryLayout *layout; // optional
+
+  // Output shape (serialized ShapeProto)
+  const char *serialized_shape;                   // out
+  size_t serialized_shape_size;                   // out
+  void (*serialized_shape_deleter)(const char *); // out
+};
+PJRT_DEFINE_STRUCT_TRAITS(
+    PJRT_TopologyDescription_MakeCanonicalShapeForMemorySpace_Args,
+    serialized_shape_deleter);
+
+typedef PJRT_Error *PJRT_TopologyDescription_MakeCanonicalShapeForMemorySpace(
+    PJRT_TopologyDescription_MakeCanonicalShapeForMemorySpace_Args *args);
+
+struct PJRT_TopologyDescription_GetMemorySpaceKindIds_Args {
+  size_t struct_size;
+  PJRT_Extension_Base *extension_start;
+  const PJRT_TopologyDescription *topology;
+  const int *memory_space_kind_ids; // out
+  size_t num_memory_space_kind_ids; // out
+};
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_TopologyDescription_GetMemorySpaceKindIds_Args,
+                          num_memory_space_kind_ids);
+
+typedef PJRT_Error *PJRT_TopologyDescription_GetMemorySpaceKindIds(
+    PJRT_TopologyDescription_GetMemorySpaceKindIds_Args *args);
+
 struct PJRT_Compile_Args {
   size_t struct_size;
   PJRT_Extension_Base *extension_start;
@@ -3101,11 +3159,14 @@ typedef struct PJRT_Api {
   _PJRT_API_STRUCT_FIELD(PJRT_TopologyDescription_Fingerprint);
   _PJRT_API_STRUCT_FIELD(PJRT_Executable_ParameterMemoryKinds);
   _PJRT_API_STRUCT_FIELD(PJRT_Device_ClearMemoryStats);
+  _PJRT_API_STRUCT_FIELD(
+      PJRT_TopologyDescription_MakeCanonicalShapeForMemorySpace);
+  _PJRT_API_STRUCT_FIELD(PJRT_TopologyDescription_GetMemorySpaceKindIds);
 } PJRT_Api;
 
 enum {
   PJRT_Api_STRUCT_SIZE =
-      PJRT_STRUCT_SIZE(PJRT_Api, PJRT_Device_ClearMemoryStats)
+      PJRT_STRUCT_SIZE(PJRT_Api, PJRT_TopologyDescription_GetMemorySpaceKindIds)
 };
 
 #undef _PJRT_API_STRUCT_FIELD


### PR DESCRIPTION
## Description

This PR uplifts the PJRT C API header from the upstream [OpenXLA repository](https://github.com/openxla/xla).

- **Version change:** `v0.106` -> `v0.110`
- **Source file:** https://github.com/openxla/xla/blob/main/xla/pjrt/c/pjrt_c_api.h

## Checklist

- [x] Review the changes in `pjrt_c_api.h` and ensure backward compatibility with the tt-xla implementation.
- [x] Review the changes in `stubs.inc` and discuss with the team whether a new feature should be flagged as useful for implementation.
- [x] Move the new signatures in `stubs.inc` to the most appropriate group in the same file.
- [x] Run PJRT unit tests (scheduled automatically upon PR creation).
- [x] Run the `model-test-extended.json` test matrix against this branch (needs to be run manually) -> https://github.com/tenstorrent/tt-xla/actions/runs/26396639240