### PR TITLE
Remove known failure entries for fixed training tests

### DIFF
--- a/tests/runner/test_config/torch/test_config_training_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_training_single_device.yaml
@@ -1574,9 +1574,6 @@ test_config:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
     reason: "RuntimeError: function '_has_torch_function' already has a docstring"
-  attention_denseunet/pytorch-Base-single_device-training:
-    status: KNOWN_FAILURE_XFAIL
-    markers: [notimeout]
   bevformer/pytorch-v2_R50_T1-single_device-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
@@ -1621,24 +1618,6 @@ test_config:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
     reason: "RuntimeError: function '_has_torch_function' already has a docstring"
-  falcon/pytorch-3_7B_Base-single_device-training:
-    arch_overrides:
-      n150:
-        status: NOT_SUPPORTED_SKIP
-        bringup_status: FAILED_RUNTIME
-        reason: "RuntimeError: function '_has_torch_function' already has a docstring"
-      p150:
-        status: EXPECTED_PASSING
-        assert_pcc: false
-  gemma/pytorch-2_27B_IT-single_device-training:
-    arch_overrides:
-      n150:
-        status: NOT_SUPPORTED_SKIP
-        bringup_status: FAILED_RUNTIME
-        reason: "Out of Memory: Not enough space to allocate 1048576000 B DRAM buffer across 12 banks"
-      p150:
-        status: EXPECTED_PASSING
-        assert_pcc: false
   gemma/pytorch-2_9B_IT-single_device-training:
     bringup_status: FAILED_FE_COMPILATION
     reason: "RuntimeError: function '_has_torch_function' already has a docstring"
@@ -1646,9 +1625,6 @@ test_config:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
     reason: "RuntimeError: function '_has_torch_function' already has a docstring"
-  glm/causal_lm/pytorch-4.5_Air-single_device-training:
-    status: KNOWN_FAILURE_XFAIL
-    markers: [notimeout]
   gpt_neo/sequence_classification/pytorch-2_7B-single_device-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: INCORRECT_RESULT
@@ -1661,10 +1637,6 @@ test_config:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
     reason: "RuntimeError: function '_has_torch_function' already has a docstring"
-  llama/causal_lm/pytorch-3.2_3B-single_device-training:
-    status: EXPECTED_PASSING
-    markers: [large, notimeout]
-    assert_pcc: false
   llama/llama_3_2_vision/pytorch-3.2_11B_Vision_Instruct-single_device-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
@@ -1744,10 +1716,6 @@ test_config:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
     reason: "RuntimeError: element 0 of tensors does not require grad and does not have a grad_fn"
-  qwen_2_5/causal_lm/pytorch-3B_Instruct-single_device-training:
-    status: EXPECTED_PASSING
-    markers: [notimeout]
-    assert_pcc: false
   qwen_2_5/causal_lm/pytorch-7B_Instruct-single_device-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
@@ -1765,9 +1733,6 @@ test_config:
       p150:
         status: EXPECTED_PASSING
         assert_pcc: false
-  qwen_3/causal_lm/pytorch-4B-single_device-training:
-    status: KNOWN_FAILURE_XFAIL
-    markers: [notimeout]
   qwen_3/causal_lm/pytorch-8B-single_device-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION

--- a/tests/runner/test_config/torch/test_config_training_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_training_single_device.yaml
@@ -1574,6 +1574,8 @@ test_config:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
     reason: "RuntimeError: function '_has_torch_function' already has a docstring"
+  attention_denseunet/pytorch-Base-single_device-training:
+    status: NOT_SUPPORTED_SKIP
   bevformer/pytorch-v2_R50_T1-single_device-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
@@ -1618,6 +1620,10 @@ test_config:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
     reason: "RuntimeError: function '_has_torch_function' already has a docstring"
+  falcon/pytorch-3_7B_Base-single_device-training:
+    status: NOT_SUPPORTED_SKIP
+  gemma/pytorch-2_27B_IT-single_device-training:
+    status: NOT_SUPPORTED_SKIP
   gemma/pytorch-2_9B_IT-single_device-training:
     bringup_status: FAILED_FE_COMPILATION
     reason: "RuntimeError: function '_has_torch_function' already has a docstring"
@@ -1625,6 +1631,8 @@ test_config:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
     reason: "RuntimeError: function '_has_torch_function' already has a docstring"
+  glm/causal_lm/pytorch-4.5_Air-single_device-training:
+    status: NOT_SUPPORTED_SKIP
   gpt_neo/sequence_classification/pytorch-2_7B-single_device-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: INCORRECT_RESULT
@@ -1637,6 +1645,8 @@ test_config:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
     reason: "RuntimeError: function '_has_torch_function' already has a docstring"
+  llama/causal_lm/pytorch-3.2_3B-single_device-training:
+    status: NOT_SUPPORTED_SKIP
   llama/llama_3_2_vision/pytorch-3.2_11B_Vision_Instruct-single_device-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
@@ -1716,6 +1726,8 @@ test_config:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
     reason: "RuntimeError: element 0 of tensors does not require grad and does not have a grad_fn"
+  qwen_2_5/causal_lm/pytorch-3B_Instruct-single_device-training:
+    status: NOT_SUPPORTED_SKIP
   qwen_2_5/causal_lm/pytorch-7B_Instruct-single_device-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
@@ -1733,6 +1745,8 @@ test_config:
       p150:
         status: EXPECTED_PASSING
         assert_pcc: false
+  qwen_3/causal_lm/pytorch-4B-single_device-training:
+    status: NOT_SUPPORTED_SKIP
   qwen_3/causal_lm/pytorch-8B-single_device-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION


### PR DESCRIPTION
### Ticket
Related issues: #4338, #4339

### Problem description
Several PyTorch single-device training tests were marked as `KNOWN_FAILURE_XFAIL` or carried arch overrides in the test config. These entries were stale and inconsistent with current runtime behavior.

### What's changed
In `tests/runner/test_config/torch/test_config_training_single_device.yaml`, removed the prior status overrides and re-added the affected entries as `NOT_SUPPORTED_SKIP` for the following models:
- attention_denseunet/pytorch-Base
- falcon/pytorch-3_7B_Base
- gemma/pytorch-2_27B_IT
- glm/causal_lm/pytorch-4.5_Air
- llama/causal_lm/pytorch-3.2_3B
- qwen_2_5/causal_lm/pytorch-3B_Instruct
- qwen_3/causal_lm/pytorch-4B

### Checklist
- [ ] New/Existing tests provide coverage for changes