### PR TITLE
[Krea Realtime 14B] Add initial tests for each part of the pipeline

### DIFF
--- a/tests/torch/models/krea_realtime/test_text_encoder.py
+++ b/tests/torch/models/krea_realtime/test_text_encoder.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Krea Realtime — UMT5 text encoder component test."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+from infra.utilities.torch_multichip_utils import get_mesh
+
+from third_party.tt_forge_models.krea_realtime_video.pytorch import (
+    ModelLoader,
+    ModelVariant,
+)
+
+
+@pytest.mark.skip(
+    reason="OOM on single device — UMT5-XXL exceeds single-chip memory; sharded variant runs"
+)
+def test_text_encoder():
+    _run(sharded=False)
+
+
+@pytest.mark.nightly
+@pytest.mark.model_test
+def test_text_encoder_sharded():
+    _run(sharded=True)
+
+
+def _run(sharded: bool):
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.TEXT_ENCODER)
+    encoder = loader.load_model(dtype_override=torch.bfloat16)
+    inputs = loader.load_inputs(dtype_override=torch.bfloat16)
+
+    mesh = None
+    shard_spec_fn = None
+    if sharded:
+        mesh_shape, mesh_names = loader.get_mesh_config(
+            xr.global_runtime_device_count()
+        )
+        mesh = get_mesh(mesh_shape, mesh_names)
+        shard_spec_fn = loader.load_shard_spec
+
+    run_graph_test(
+        encoder,
+        inputs,
+        framework=Framework.TORCH,
+        mesh=mesh,
+        shard_spec_fn=shard_spec_fn,
+    )

--- a/tests/torch/models/krea_realtime/test_transformer.py
+++ b/tests/torch/models/krea_realtime/test_transformer.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Krea Realtime — CausalWanModel (14B DiT) component test."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+from infra.utilities.torch_multichip_utils import get_mesh
+
+from third_party.tt_forge_models.krea_realtime_video.pytorch import (
+    ModelLoader,
+    ModelVariant,
+)
+
+
+@pytest.mark.skip(
+    reason="OOM on single device — CausalWanModel exceeds single-chip memory; sharded variant runs"
+)
+def test_transformer():
+    _run(sharded=False)
+
+
+@pytest.mark.xfail(
+    reason="Complex dtype (RoPE freqs from torch.polar) unsupported on TT — https://github.com/tenstorrent/tt-xla/issues/4464"
+)
+def test_transformer_sharded():
+    _run(sharded=True)
+
+
+def _run(sharded: bool):
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.TRANSFORMER)
+    model = loader.load_model(dtype_override=torch.bfloat16)
+    inputs = loader.load_inputs(dtype_override=torch.bfloat16)
+
+    mesh = None
+    shard_spec_fn = None
+    if sharded:
+        mesh_shape, mesh_names = loader.get_mesh_config(
+            xr.global_runtime_device_count()
+        )
+        mesh = get_mesh(mesh_shape, mesh_names)
+        shard_spec_fn = loader.load_shard_spec
+
+    run_graph_test(
+        model,
+        inputs,
+        framework=Framework.TORCH,
+        mesh=mesh,
+        shard_spec_fn=shard_spec_fn,
+    )

--- a/tests/torch/models/krea_realtime/test_vae_decoder.py
+++ b/tests/torch/models/krea_realtime/test_vae_decoder.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Krea Realtime — AutoencoderKLWan (3D causal VAE) decoder component test."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+
+from third_party.tt_forge_models.krea_realtime_video.pytorch import (
+    ModelLoader,
+    ModelVariant,
+)
+
+
+@pytest.mark.xfail(
+    reason="VAE temporal slice fails on TT (out-of-range slice on size-1 dim) — https://github.com/tenstorrent/tt-xla/issues/4465"
+)
+def test_vae_decoder():
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.VAE)
+    model = loader.load_model(dtype_override=torch.bfloat16)
+    inputs = loader.load_inputs(dtype_override=torch.bfloat16)
+
+    run_graph_test(
+        model,
+        inputs,
+        framework=Framework.TORCH,
+    )


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-xla/issues/4463

### Problem description

- Add initial bringup tests for each component of the Krea Realtime Video 14B pipeline & test it in Wormhole.

### What's changed

| File | Component | Tests |
|------|-----------|-------|
| `test_text_encoder.py` | UMT5-XXL text encoder | `test_text_encoder` (skip — OOM single device), `test_text_encoder_sharded` (pass — 2 chips) |
| `test_transformer.py` | CausalWanModel (14B autoregressive DiT) | `test_transformer` (skip — OOM single device), `test_transformer_sharded` (xfail — 4 chips — [#4464](https://github.com/tenstorrent/tt-xla/issues/4464)) |
| `test_vae_decoder.py` | 3D Causal VAE decoder | `test_vae_decoder` (xfail — single chip — [#4465](https://github.com/tenstorrent/tt-xla/issues/4465)) |

Model loading, input generation, wrapper modules, shard specs, and mesh config are provided by `third_party/tt_forge_models/krea_realtime_video/pytorch` (see https://github.com/tenstorrent/tt-forge-models/pull/633). 

Notable implementation details carried in `tt_forge_models`:
- Components are loaded independently via `from_pretrained(subfolder=...)` — no full pipeline is instantiated. `text_encoder` and `vae` are sourced from `Wan-AI/Wan2.1-T2V-14B-Diffusers`; only the `transformer` comes from `krea/krea-realtime-video`.
- `CausalWanWrapper` simplifies the transformer's 8-argument forward to `(x, t, context)` and monkey-patches the [CUDA-hardcoded sinusoidal embedding](https://huggingface.co/krea/krea-realtime-video/blob/main/transformer/model.py#L33) with a device-agnostic version.
- `VAEDecoderWrapper` exposes decoder-only path `(z) -> tensor`.

### Checklist
- [x] verify changes through local testing in Wormhole

### Logs

- [may4_decoder.log](https://github.com/user-attachments/files/27370731/may4_decoder.log)
- [may4_text_encoder_sharded.log](https://github.com/user-attachments/files/27370735/may4_text_encoder_sharded.log)
- [may4_transformer_sharded.log](https://github.com/user-attachments/files/27370741/may4_transformer_sharded.log)

