### PR TITLE
Add claude skill for benchmark reports

### DIFF
--- a/.claude/skills/ci-benchmark-analyzer/SKILL.md
+++ b/.claude/skills/ci-benchmark-analyzer/SKILL.md
@@ -1,0 +1,266 @@
+---
+name: ci-benchmark-analyzer
+description: Analyze CI benchmark workflow runs from GitHub Actions for the tt-xla project. Produces a markdown report covering failed jobs (with root-cause error extraction via logs and Glean), successful model performance metrics (samples/sec, TTFT, device perf), perf regressions/improvements vs previous nightly, and the full dependency commit chain (tt-xla, tt-mlir, tt-metal). Use this skill whenever the user wants to analyze a CI run, review nightly benchmark results, investigate CI failures, check benchmark performance from a workflow run, or asks about "latest nightly" results. Also trigger when the user pastes a GitHub Actions run URL or mentions a run ID in the context of performance analysis, or asks about perf regressions.
+---
+
+# CI Benchmark Analyzer
+
+Analyzes GitHub Actions benchmark workflow runs for the `tenstorrent/tt-xla` repository. Produces a structured markdown report with an actionable summary, failure diagnosis, performance comparison against the previous nightly, and detailed per-model metrics.
+
+## Input Handling
+
+The user specifies a run in one of these ways:
+
+| Input | How to resolve |
+|-------|---------------|
+| GitHub Actions URL | Extract run ID from `actions/runs/<ID>` in the URL |
+| Numeric run ID | Use directly |
+| `latest nightly` | Query the latest completed run of the "On nightly" workflow (ID `184422752`) |
+| `latest benchmark` | Query the latest completed run of "Performance Benchmark" workflow (ID `184422748`) |
+| `latest experimental` | Query the latest completed run of "On nightly Experimental" workflow (ID `187864533`) |
+
+To resolve "latest" variants:
+```bash
+gh api "repos/tenstorrent/tt-xla/actions/workflows/<WORKFLOW_ID>/runs?per_page=1&status=completed" --jq '.workflow_runs[0].id'
+```
+
+If the run is still in progress, note that in the report header and analyze only the completed jobs.
+
+## Report Storage
+
+Save reports to `nightly-reports/` directory (relative to cwd) so that previous results accumulate and are accessible for future comparison. Naming convention:
+
+```
+nightly-reports/
+  nightly_<RUN_ID>_<YYYY-MM-DD>.md
+```
+
+Always produce a fresh report file named after the current run ID — each run gets its own new file. The filename already encodes the run date, so there's no need for an "updated on" or "last updated" line in the report body.
+
+Before generating, check `nightly-reports/` for the most recent prior report and use it as comparison context (read-only). If no prior report exists, fetch the previous nightly run from GitHub (see step 4) to establish a baseline.
+
+## Workflow
+
+### 1. Gather run metadata
+
+```bash
+gh api repos/tenstorrent/tt-xla/actions/runs/<RUN_ID> \
+  --jq '{id, name, head_sha, head_branch, event, status, conclusion, created_at, updated_at, html_url}'
+```
+
+### 2. Resolve the dependency commit chain
+
+This is important context for anyone reading the report — it tells them exactly which versions of the three core repos were used.
+
+**tt-xla commit**: `head_sha` from step 1.
+
+**tt-mlir commit**: Read `third_party/CMakeLists.txt` at that commit and extract `TT_MLIR_VERSION`:
+```bash
+gh api repos/tenstorrent/tt-xla/contents/third_party/CMakeLists.txt?ref=<HEAD_SHA> \
+  --jq '.content' | base64 -d | grep 'set(TT_MLIR_VERSION'
+```
+Parse the SHA from the `set(TT_MLIR_VERSION "...")` line.
+
+**tt-metal commit**: Read tt-mlir's `third_party/CMakeLists.txt` at the tt-mlir commit:
+```bash
+gh api repos/tenstorrent/tt-mlir/contents/third_party/CMakeLists.txt?ref=<TT_MLIR_SHA> \
+  --jq '.content' | base64 -d | grep 'set(TT_METAL_VERSION'
+```
+
+### 3. List all jobs and classify them
+
+```bash
+gh api "repos/tenstorrent/tt-xla/actions/runs/<RUN_ID>/jobs?per_page=100" --paginate
+```
+
+The response may span multiple pages. Collect all jobs.
+
+**Focus exclusively on perf benchmark jobs** (name contains `perf-benchmark / run-perf-benchmarks / perf`). Ignore all other job categories (build, test, forge, release, notify, etc.) entirely — they are not relevant to this report.
+
+Separate failed perf jobs into two categories:
+- **Model failures**: the benchmark itself failed (compilation error, runtime crash, device error)
+- **Perf regression failures**: the job failed because the `Check perf regression` step detected >5% regression — these are NOT errors, they are perf signals
+
+You can distinguish them by checking the job logs: regression failures have `"Performance regression > 5% detected!"` in the log, while model failures have stack traces, `TT_FATAL`, `AssertionError`, etc.
+
+### 4. Get previous nightly for comparison
+
+**Always compare against the immediately preceding nightly from GitHub** — never use local report files as a substitute. Nightlies run daily and a local report may be days old, making the diff misleading.
+
+Find the nightly run that ran just before the current one:
+```bash
+gh api "repos/tenstorrent/tt-xla/actions/workflows/184422752/runs?per_page=5&status=completed" \
+  --jq '.workflow_runs[] | {id, created_at, head_sha}'
+```
+Pick the run whose `created_at` is the most recent date **earlier** than the current run's `created_at`. Then use the comparison script to compute diffs:
+```bash
+python <skill-path>/scripts/compare_nightlies.py <CURRENT_RUN_ID> <PREVIOUS_RUN_ID> \
+  --output-dir /tmp/perf_compare_<RUN_ID> --threshold 10
+```
+
+The script outputs `comparison.json` with per-model diffs categorized as `regression`, `improvement`, `stable`, `new`, or `missing`.
+
+Local reports in `nightly-reports/` are read-only context (e.g. to check if a failure is recurring) — they are **not** the baseline for perf diffs.
+
+**Perf diff convention** (used consistently everywhere in the report):
+- **Positive % = improvement** (model got faster, more samples/sec)
+- **Negative % = regression** (model got slower, fewer samples/sec)
+
+Example: "llama_3_2_1b: +15.3%" means it's 15.3% faster than the previous nightly.
+
+### 5. Analyze failed perf benchmark jobs
+
+For each failed perf benchmark job (model failures only, not regression check failures):
+
+1. **Fetch the job log**:
+```bash
+gh api repos/tenstorrent/tt-xla/actions/jobs/<JOB_DATABASE_ID>/logs
+```
+
+2. **Extract the root error** by scanning the log for these patterns (in priority order):
+   - `TT_FATAL` or `TT_THROW` — device/runtime fatal error. Extract the error message and walk up the stack trace for the nearest `ttnn::` or `tt::tt_metal::` reference.
+   - `AssertionError:` or `AssertionError:` — Python assertion failures. Extract the full assertion message.
+   - `error:` lines in MLIR output — compilation failures.
+   - `FAILED` in pytest output — test failure. Look for the short test summary.
+   - `RuntimeError:` — Python runtime errors.
+   - `Performance regression > 5% detected!` — this is a perf regression, NOT an error. Classify it separately.
+   - Generic: last `##[error]` line before job end.
+
+3. **Use Glean extensively for deeper context**: Search Glean with the core error message to find related issues, discussions, or documentation. This is critical — it tells the reader whether this is a known issue, whether someone is already working on a fix, and what the broader impact might be.
+   ```
+   mcp__glean_default__search: "<core error message> tt-xla" or "<op name> failure"
+   mcp__glean_default__chat: "What is known about this error in tt-xla/tt-mlir: <error message>"
+   ```
+   Include any relevant findings (linked issues, Slack threads, related PRs) in the failure section. If Glean returns nothing, note that explicitly — a novel error with no prior context is important information.
+
+### 6. Analyze successful perf benchmark jobs
+
+For each successful perf benchmark job, download and parse the perf report artifact using the bundled script:
+
+```bash
+python <skill-path>/scripts/fetch_perf_reports.py <RUN_ID> --output-dir /tmp/perf_reports_<RUN_ID>
+```
+
+This produces `summary.json` with extracted metrics for all jobs. Key metrics per model:
+- **Samples/sec** = `total_samples / total_time`
+- **TTFT (ms)** = `ttft` value (LLM models only; absent for vision/encoder models)
+- **Device FW duration (s)** = `device_fw_duration` (only when device perf ran)
+- **Device type**: from `device_info.device_type`
+
+### 7. Generate the report
+
+Write to `nightly-reports/nightly_<RUN_ID>_<YYYY-MM-DD>.md`. Create the directory if needed.
+
+## Report Template
+
+The summary is the most important section — it's what people read first and sometimes the only thing they read. Make it actionable.
+
+```markdown
+# CI Benchmark Report — Run <RUN_ID>
+
+## Summary
+
+**Perf benchmarks**: X/Y passed
+
+### Failures
+Models that failed to run (excluding perf regression check failures).
+Each entry links to its detailed section below.
+- [model_a (n150)](#model_a-n150) — <one-line error summary>
+- [model_b (n300-llmbox)](#model_b-n300-llmbox) — <one-line error summary>
+
+[If no failures, write "None".]
+[Format anchors as: model_display_name-device_type, e.g. #llama_3_2_1b-n150]
+
+Keep the summary focused on models that actually failed to run — perf regressions and improvements are covered in the Performance Results tables below.
+```
+
+The Run Info and Dependency Chain sections go at the END of the report (see "Run Info & Dependency Chain" below).
+
+## Failed Jobs
+
+For each failed model, create a subsection with an anchor matching the summary link:
+
+```markdown
+### <a id="model_a-n150"></a>model_a (n150)
+- **Job**: [link to job](<job_url>)
+- **Error**: <concise root cause>
+  ```
+  <relevant error snippet, 3-5 lines max>
+  ```
+- **Context**: <Glean findings — related issues, known problem, etc.>
+```
+
+## Performance Results
+
+Group by device type. Include the perf diff column showing change vs previous nightly.
+
+**Filter: Only include models with ≥5% change in Samples/sec OR ≥5% change in TTFT vs the previous nightly.** Models with smaller changes in both metrics are considered stable and should be omitted from the tables. Always include models marked "new" (not present in previous nightly) and models with `missing`/"—" previous values where a diff can't be computed. At the end of each device section, add a line like: `_N stable models omitted (<5% change in both Samples/sec and TTFT)._`
+
+```markdown
+### n150 Models
+
+| Model | Samples/sec | Diff | TTFT (ms) | TTFT Diff | Device FW (s) | Job |
+|-------|------------|------|-----------|-----------|---------------|-----|
+| model_a | 36.5 | +15.3% | 147.8 | +8.2% | 1.89 | [link](...) |
+| model_b | 12.3 | -5.2% | 780.6 | -12.1% | — | [link](...) |
+| model_c | 27.9 | **-23.5%** | 200.1 | +3.0% | 1.45 | [link](...) |
+
+[Bold diffs that exceed 10% in either direction]
+[Use "—" for metrics not present (vision/encoder models have no TTFT)]
+[Use "new" in Diff columns for models not in the previous nightly]
+[TTFT Diff: positive = TTFT got lower/faster (improvement), negative = TTFT got higher/slower (regression)]
+```
+
+Adjust the template based on what's actually in the run — if there are no failures, write "None" under Failures.
+
+## Run Info & Dependency Chain (report footer)
+
+Place the run metadata and dependency chain at the END of the report, after Performance Results. Use bulleted form, omit the event/Status fields, and show both nightly URLs as full URLs (no `[report](...)` link):
+
+```markdown
+## Run Info
+
+- **Workflow**: <workflow name>
+- **Branch**: <head_branch>
+- **URL**: <html_url>
+- **Previous nightly**: <prev_html_url>
+
+## Dependency Chain
+
+| Repo | Commit | Link |
+|------|--------|------|
+| tt-xla | `<short_sha>` | [full SHA](https://github.com/tenstorrent/tt-xla/commit/<sha>) |
+| tt-mlir | `<short_sha>` | [full SHA](https://github.com/tenstorrent/tt-mlir/commit/<sha>) |
+| tt-metal | `<short_sha>` | [full SHA](https://github.com/tenstorrent/tt-metal/commit/<sha>) |
+```
+
+The filename already encodes the run date — no need for an "updated on" line in the body.
+
+## Scripts
+
+Two helper scripts are bundled:
+
+### `scripts/fetch_perf_reports.py`
+Batch-downloads all perf report artifacts for a run and extracts metrics.
+```bash
+python <skill-path>/scripts/fetch_perf_reports.py <RUN_ID> --output-dir /tmp/perf_reports_<RUN_ID>
+```
+Output: `summary.json` with per-model metrics.
+
+### `scripts/compare_nightlies.py`
+Compares perf between two runs and categorizes models as regression/improvement/stable.
+```bash
+python <skill-path>/scripts/compare_nightlies.py <CURRENT_RUN_ID> <PREVIOUS_RUN_ID> \
+  --output-dir /tmp/perf_compare_<RUN_ID> --threshold 10
+```
+Output: `comparison.json` with per-model diffs. Convention: positive % = faster (improvement), negative % = slower (regression).
+
+## Notes
+
+- The `gh` CLI must be authenticated with access to `tenstorrent/tt-xla` (and `tenstorrent/tt-mlir` for commit chain resolution).
+- Artifact downloads require appropriate permissions. If an artifact has expired (default 90 days), note it in the report.
+- For very large runs (nightly has 50+ jobs), use the bundled scripts to batch-process artifacts rather than downloading one by one.
+- Device perf measurements (`device_fw_duration`) are only present when the workflow ran with `skip-device-perf: false` AND the device perf step succeeded. Their absence is not an error.
+- TTFT is only meaningful for LLM models (test_llms.py tests). Vision and encoder models won't have it.
+- When Glean returns no results for a failure, note that explicitly in the report — a novel error with no prior context is itself important.
+- Perf regression check failures in CI use a 5% threshold, but for the report summary we use 10% to highlight only significant changes. Models between 5-10% regression may still appear in the detailed tables.

--- a/.claude/skills/ci-benchmark-analyzer/SKILL.md
+++ b/.claude/skills/ci-benchmark-analyzer/SKILL.md
@@ -85,6 +85,8 @@ You can distinguish them by checking the job logs: regression failures have `"Pe
 
 ### 4. Get previous nightly for comparison
 
+**Always run the perf comparison yourself** — the CI `Check perf regression` step is unreliable and may fail silently or use stale baselines. The comparison script is the source of truth for regressions and improvements in this report.
+
 **Always compare against the immediately preceding nightly from GitHub** — never use local report files as a substitute. Nightlies run daily and a local report may be days old, making the diff misleading.
 
 Find the nightly run that ran just before the current one:
@@ -92,13 +94,15 @@ Find the nightly run that ran just before the current one:
 gh api "repos/tenstorrent/tt-xla/actions/workflows/184422752/runs?per_page=5&status=completed" \
   --jq '.workflow_runs[] | {id, created_at, head_sha}'
 ```
-Pick the run whose `created_at` is the most recent date **earlier** than the current run's `created_at`. Then use the comparison script to compute diffs:
+Pick the run whose `created_at` is the most recent date **earlier** than the current run's `created_at`. Then run the comparison script with a 5% threshold so both summary-relevant directions are captured:
 ```bash
 python <skill-path>/scripts/compare_nightlies.py <CURRENT_RUN_ID> <PREVIOUS_RUN_ID> \
-  --output-dir /tmp/perf_compare_<RUN_ID> --threshold 10
+  --output-dir /tmp/perf_compare_<RUN_ID> --threshold 5
 ```
 
-The script outputs `comparison.json` with per-model diffs categorized as `regression`, `improvement`, `stable`, `new`, or `missing`.
+The script outputs `comparison.json` with per-model diffs categorized as `regression`, `improvement`, `stable`, `new`, or `missing`. Use `diff_percent` to apply the report's asymmetric thresholds:
+- **Summary regressions**: `diff_percent <= -10`
+- **Summary improvements**: `diff_percent >= +5`
 
 Local reports in `nightly-reports/` are read-only context (e.g. to check if a failure is recurring) — they are **not** the baseline for perf diffs.
 
@@ -119,19 +123,31 @@ gh api repos/tenstorrent/tt-xla/actions/jobs/<JOB_DATABASE_ID>/logs
 
 2. **Extract the root error** by scanning the log for these patterns (in priority order):
    - `TT_FATAL` or `TT_THROW` — device/runtime fatal error. Extract the error message and walk up the stack trace for the nearest `ttnn::` or `tt::tt_metal::` reference.
-   - `AssertionError:` or `AssertionError:` — Python assertion failures. Extract the full assertion message.
+   - `AssertionError:` — Python assertion failures. Extract the full assertion message.
    - `error:` lines in MLIR output — compilation failures.
    - `FAILED` in pytest output — test failure. Look for the short test summary.
    - `RuntimeError:` — Python runtime errors.
-   - `Performance regression > 5% detected!` — this is a perf regression, NOT an error. Classify it separately.
+   - `Performance regression > 5% detected!` — this is a perf signal, NOT a job failure to report under "Failures".
    - Generic: last `##[error]` line before job end.
 
-3. **Use Glean extensively for deeper context**: Search Glean with the core error message to find related issues, discussions, or documentation. This is critical — it tells the reader whether this is a known issue, whether someone is already working on a fix, and what the broader impact might be.
+3. **Classify with a short, universal label.** The reader scans these — they need to recognize the failure mode at a glance, not read prose. Don't editorialize ("marginally", "extremely", "very low"), don't speculate about meaning ("logits diverged from reference", "optimizer assigned L1-resident layout"), and don't restate the obvious. Just name the failure mode and, if useful, append the bare numbers from the log. Examples:
+
+   | Log signal | Label |
+   |------------|-------|
+   | `AssertionError: ... PCC failed. PCC=X, Required=Y` | `PCC below threshold: PCC=X, Required=Y` |
+   | `TT_FATAL: Out of Memory: ... L1 buffer ...` | `L1 OOM: <size> B across <N> banks` |
+   | `TT_THROW: ... circular buffers ... clash with L1 buffers ...` | `CB/L1 clash: <core range>` |
+   | `error:` from MLIR output | `Compilation error: <op or pass name>` |
+   | Other `RuntimeError` / `TT_FATAL` | `Runtime error: <one-clause excerpt>` |
+
+   The same label is used in the Summary bullet AND in the Failed Jobs subsection's `**Error**` line — they must match.
+
+4. **Use Glean to find prior context — but stay factual.** Search for the error and surface what's already documented:
    ```
    mcp__glean_default__search: "<core error message> tt-xla" or "<op name> failure"
    mcp__glean_default__chat: "What is known about this error in tt-xla/tt-mlir: <error message>"
    ```
-   Include any relevant findings (linked issues, Slack threads, related PRs) in the failure section. If Glean returns nothing, note that explicitly — a novel error with no prior context is important information.
+   Include only what the linked sources say: issue numbers, filer, file date, related PRs, Slack threads, owner. Do **not** draw conclusions Glean didn't state — no "no fix has merged yet", no "PCC=0.41 indicates the logits are nearly random", no characterizations of severity. If the issue itself says a fix is in flight, you can quote that; if it doesn't, leave it out. If Glean returns nothing, note that explicitly.
 
 ### 6. Analyze successful perf benchmark jobs
 
@@ -153,7 +169,7 @@ Write to `nightly-reports/nightly_<RUN_ID>_<YYYY-MM-DD>.md`. Create the director
 
 ## Report Template
 
-The summary is the most important section — it's what people read first and sometimes the only thing they read. Make it actionable.
+The summary is the most important section — it's what people read first and sometimes the only thing they read. Keep it short, factual, and scannable. Three sections only: Failures, Perf Regressions, Perf Improvements. No prose preambles, no "Note:" callouts about commits being identical or measurement variance — the dependency chain at the bottom already shows the SHAs, the reader can compare.
 
 ```markdown
 # CI Benchmark Report — Run <RUN_ID>
@@ -163,15 +179,23 @@ The summary is the most important section — it's what people read first and so
 **Perf benchmarks**: X/Y passed
 
 ### Failures
-Models that failed to run (excluding perf regression check failures).
-Each entry links to its detailed section below.
-- [model_a (n150)](#model_a-n150) — <one-line error summary>
-- [model_b (n300-llmbox)](#model_b-n300-llmbox) — <one-line error summary>
+- [model_a (n150)](#model_a-n150) — <short universal label>
+- [model_b (n300-llmbox)](#model_b-n300-llmbox) — <short universal label>
 
-[If no failures, write "None".]
-[Format anchors as: model_display_name-device_type, e.g. #llama_3_2_1b-n150]
+[If none, write "None".]
+[Anchor format: model_display_name-device_type, e.g. #llama_3_2_1b-n150]
 
-Keep the summary focused on models that actually failed to run — perf regressions and improvements are covered in the Performance Results tables below.
+### Perf Regressions
+Models with `diff_percent <= -10` in `comparison.json` (Samples/sec dropped >10% vs previous nightly).
+- model_c (n150): -15.3%
+
+[If none, write "None". Always derive from the comparison script — never trust the CI "Check perf regression" step.]
+
+### Perf Improvements
+Models with `diff_percent >= +5` in `comparison.json` (Samples/sec improved >5% vs previous nightly).
+- model_d (n150): +12.1%
+
+[If none, write "None".]
 ```
 
 The Run Info and Dependency Chain sections go at the END of the report (see "Run Info & Dependency Chain" below).
@@ -183,32 +207,42 @@ For each failed model, create a subsection with an anchor matching the summary l
 ```markdown
 ### <a id="model_a-n150"></a>model_a (n150)
 - **Job**: [link to job](<job_url>)
-- **Error**: <concise root cause>
+- **Error**: <short universal label — same wording as the Summary bullet>
   ```
   <relevant error snippet, 3-5 lines max>
   ```
-- **Context**: <Glean findings — related issues, known problem, etc.>
+- **Context**: <factual references only — issue numbers, filer + file date, related PRs, owners, Slack threads. State whether it's a known issue and link it. Do not write "no fix has merged yet", do not interpret PCC values, do not speculate about cause unless the linked issue states it explicitly.>
 ```
+
+**Good Context examples** (terse, factual, link-driven):
+- `Tracked in tt-xla#4394, tt-mlir#8044 (filed by pdeviTT, 2026-04-21, open). Owner: Vladan Kovacevic, pdeviTT.`
+- `Known issue from tt-xla#4318 (new decode PCC check, merged 2026-04-24). Active investigation in #tt-forge-models-code-changes Slack thread "Qwen PCC Drop Debugging". Owner: pdeviTT.`
+
+**Avoid**:
+- "No fix has merged yet" (unstated assumption — leave it out, the issue link tells the reader)
+- "PCC=0.41 indicates the logits are nearly random" (interpretation Glean didn't state)
+- "Root cause: ..." unless the linked issue explicitly identifies it
 
 ## Performance Results
 
-Group by device type. Include the perf diff column showing change vs previous nightly.
+Group by device type. Tables show Samples/sec and the diff vs previous nightly.
 
-**Filter: Only include models with ≥5% change in Samples/sec OR ≥5% change in TTFT vs the previous nightly.** Models with smaller changes in both metrics are considered stable and should be omitted from the tables. Always include models marked "new" (not present in previous nightly) and models with `missing`/"—" previous values where a diff can't be computed. At the end of each device section, add a line like: `_N stable models omitted (<5% change in both Samples/sec and TTFT)._`
+**TTFT is intentionally omitted for now** — it will be reintroduced once we're tracking it properly. Don't add a TTFT column, don't include TTFT diffs, and don't add explanatory notes about TTFT/measurement variance.
+
+**Filter: Only include models with ≥5% change in Samples/sec vs the previous nightly.** Models with smaller changes are stable and should be omitted from the tables. Always include models marked `new` (not present in previous nightly) and `missing` rows where a diff can't be computed. At the end of each device section, add: `_N stable models omitted (<5% change in Samples/sec)._`
 
 ```markdown
 ### n150 Models
 
-| Model | Samples/sec | Diff | TTFT (ms) | TTFT Diff | Device FW (s) | Job |
-|-------|------------|------|-----------|-----------|---------------|-----|
-| model_a | 36.5 | +15.3% | 147.8 | +8.2% | 1.89 | [link](...) |
-| model_b | 12.3 | -5.2% | 780.6 | -12.1% | — | [link](...) |
-| model_c | 27.9 | **-23.5%** | 200.1 | +3.0% | 1.45 | [link](...) |
+| Model | Samples/sec | Diff | Device FW (s) | Job |
+|-------|------------|------|---------------|-----|
+| model_a | 36.5 | +15.3% | 1.89 | [link](...) |
+| model_b | 12.3 | -5.2% | — | [link](...) |
+| model_c | 27.9 | **-23.5%** | 1.45 | [link](...) |
 
-[Bold diffs that exceed 10% in either direction]
-[Use "—" for metrics not present (vision/encoder models have no TTFT)]
-[Use "new" in Diff columns for models not in the previous nightly]
-[TTFT Diff: positive = TTFT got lower/faster (improvement), negative = TTFT got higher/slower (regression)]
+[Bold diffs ≤ -10% — these are the regressions surfaced in the Summary]
+[Use "—" for metrics not present (Device FW only when device perf step ran successfully)]
+[Use "new" in Diff column for models not in the previous nightly]
 ```
 
 Adjust the template based on what's actually in the run — if there are no failures, write "None" under Failures.
@@ -251,9 +285,9 @@ Output: `summary.json` with per-model metrics.
 Compares perf between two runs and categorizes models as regression/improvement/stable.
 ```bash
 python <skill-path>/scripts/compare_nightlies.py <CURRENT_RUN_ID> <PREVIOUS_RUN_ID> \
-  --output-dir /tmp/perf_compare_<RUN_ID> --threshold 10
+  --output-dir /tmp/perf_compare_<RUN_ID> --threshold 5
 ```
-Output: `comparison.json` with per-model diffs. Convention: positive % = faster (improvement), negative % = slower (regression).
+Output: `comparison.json` with per-model diffs. Convention: positive % = faster (improvement), negative % = slower (regression). Use `--threshold 5` so the report can apply asymmetric thresholds (regressions ≤ -10%, improvements ≥ +5%) at filter time.
 
 ## Notes
 
@@ -261,6 +295,5 @@ Output: `comparison.json` with per-model diffs. Convention: positive % = faster 
 - Artifact downloads require appropriate permissions. If an artifact has expired (default 90 days), note it in the report.
 - For very large runs (nightly has 50+ jobs), use the bundled scripts to batch-process artifacts rather than downloading one by one.
 - Device perf measurements (`device_fw_duration`) are only present when the workflow ran with `skip-device-perf: false` AND the device perf step succeeded. Their absence is not an error.
-- TTFT is only meaningful for LLM models (test_llms.py tests). Vision and encoder models won't have it.
 - When Glean returns no results for a failure, note that explicitly in the report — a novel error with no prior context is itself important.
-- Perf regression check failures in CI use a 5% threshold, but for the report summary we use 10% to highlight only significant changes. Models between 5-10% regression may still appear in the detailed tables.
+- The CI `Check perf regression` job is unreliable; always run `compare_nightlies.py` to derive regressions and improvements yourself. Summary thresholds are asymmetric: regressions surface at `diff_percent <= -10`, improvements at `diff_percent >= +5`. Detail tables show all `|diff_percent| >= 5`.

--- a/.claude/skills/ci-benchmark-analyzer/SKILL.md
+++ b/.claude/skills/ci-benchmark-analyzer/SKILL.md
@@ -134,15 +134,25 @@ gh api repos/tenstorrent/tt-xla/actions/jobs/<JOB_DATABASE_ID>/logs
 
    | Log signal | Label |
    |------------|-------|
-   | `AssertionError: ... PCC failed. PCC=X, Required=Y` | `PCC below threshold: PCC=X, Required=Y` |
+   | `AssertionError: First decode PCC failed. PCC=X, Required=Y` | `First decode PCC failed. PCC=X, Required=Y` |
+   | `AssertionError: <other> PCC failed. PCC=X, Required=Y` | `<other> PCC failed. PCC=X, Required=Y` |
    | `TT_FATAL: Out of Memory: ... L1 buffer ...` | `L1 OOM: <size> B across <N> banks` |
    | `TT_THROW: ... circular buffers ... clash with L1 buffers ...` | `CB/L1 clash: <core range>` |
    | `error:` from MLIR output | `Compilation error: <op or pass name>` |
    | Other `RuntimeError` / `TT_FATAL` | `Runtime error: <one-clause excerpt>` |
 
+   **PCC labels**: use the AssertionError message verbatim (after `AssertionError: `) as the label — do NOT strip the step qualifier ("First decode", "Prefill", etc.). The step where PCC failed is essential diagnostic context.
+
    The same label is used in the Summary bullet AND in the Failed Jobs subsection's `**Error**` line — they must match.
 
-4. **Use Glean to find prior context — but stay factual.** Search for the error and surface what's already documented:
+4. **For device timeout / hang failures**, the hanging op is critical context. After identifying the `TIMEOUT: device timeout in fetch queue wait` error, scan the job log for the op being executed at the time of hang. Look for lines like:
+   - `BinaryNg`, `UnaryWithParam`, `MatmulMultiCore`, or other kernel/op names appearing shortly before the timeout
+   - tt-triage output lines that list the op name and its arguments
+   - Patterns like `Running op: <op_name>` or `Dispatching kernel: <name>`
+
+   Include the hanging op in the **Context** subsection under a "Hang details" note, e.g.: `Hang details: timed out during BinaryNg op (from job log)`. This makes it immediately actionable for the tt-metal/tt-mlir owners debugging the hang.
+
+5. **Use Glean to find prior context — but stay factual.** Search for the error and surface what's already documented:
    ```
    mcp__glean_default__search: "<core error message> tt-xla" or "<op name> failure"
    mcp__glean_default__chat: "What is known about this error in tt-xla/tt-mlir: <error message>"
@@ -214,9 +224,14 @@ For each failed model, create a subsection with an anchor matching the summary l
 - **Context**: <factual references only — issue numbers, filer + file date, related PRs, owners, Slack threads. State whether it's a known issue and link it. Do not write "no fix has merged yet", do not interpret PCC values, do not speculate about cause unless the linked issue states it explicitly.>
 ```
 
+**All issue and PR references must be hyperlinked** — never write bare `tt-xla#NNNN` text. Use full markdown links:
+- tt-xla issues/PRs: `[tt-xla#NNNN](https://github.com/tenstorrent/tt-xla/issues/NNNN)` (use `/pull/NNNN` for PRs)
+- tt-mlir issues/PRs: `[tt-mlir#NNNN](https://github.com/tenstorrent/tt-mlir/issues/NNNN)`
+- tt-metal issues/PRs: `[tt-metal#NNNN](https://github.com/tenstorrent/tt-metal/issues/NNNN)`
+
 **Good Context examples** (terse, factual, link-driven):
-- `Tracked in tt-xla#4394, tt-mlir#8044 (filed by pdeviTT, 2026-04-21, open). Owner: Vladan Kovacevic, pdeviTT.`
-- `Known issue from tt-xla#4318 (new decode PCC check, merged 2026-04-24). Active investigation in #tt-forge-models-code-changes Slack thread "Qwen PCC Drop Debugging". Owner: pdeviTT.`
+- `Tracked in [tt-xla#4394](https://github.com/tenstorrent/tt-xla/issues/4394), [tt-mlir#8044](https://github.com/tenstorrent/tt-mlir/issues/8044) (filed by pdeviTT, 2026-04-21, open). Owner: Vladan Kovacevic, pdeviTT.`
+- `Known issue from [tt-xla#4318](https://github.com/tenstorrent/tt-xla/pull/4318) (new decode PCC check, merged 2026-04-24). Active investigation in #tt-forge-models-code-changes Slack thread "Qwen PCC Drop Debugging". Owner: pdeviTT.`
 
 **Avoid**:
 - "No fix has merged yet" (unstated assumption — leave it out, the issue link tells the reader)

--- a/.claude/skills/ci-benchmark-analyzer/evals/evals.json
+++ b/.claude/skills/ci-benchmark-analyzer/evals/evals.json
@@ -1,0 +1,44 @@
+{
+  "skill_name": "ci-benchmark-analyzer",
+  "evals": [
+    {
+      "id": 0,
+      "prompt": "Analyze the latest nightly CI benchmark run and write a report",
+      "expected_output": "A markdown report file with: dependency commit chain (tt-xla, tt-mlir, tt-metal), summary of passed/failed jobs, error details for failed perf jobs with Glean context, and a performance metrics table grouped by device type",
+      "files": [],
+      "assertions": [
+        {"name": "report-file-exists", "type": "file_check", "description": "Report file exists and has substantial content (>500 chars)"},
+        {"name": "has-commit-chain", "type": "content_check", "description": "Report contains dependency chain with tt-xla, tt-mlir, and tt-metal commit SHAs"},
+        {"name": "has-perf-table", "type": "content_check", "description": "Report contains a performance metrics table with samples/sec data"},
+        {"name": "has-run-url", "type": "content_check", "description": "Report includes the GitHub Actions run URL"}
+      ]
+    },
+    {
+      "id": 1,
+      "prompt": "Can you analyze this benchmark run? https://github.com/tenstorrent/tt-xla/actions/runs/23750430329",
+      "expected_output": "A markdown report for the manual Performance Benchmark run. All perf jobs succeeded, so the report should focus on metrics tables (samples/sec, TTFT) grouped by device type, plus the commit chain",
+      "files": [],
+      "assertions": [
+        {"name": "report-file-exists", "type": "file_check", "description": "Report file exists and has substantial content (>500 chars)"},
+        {"name": "has-commit-chain", "type": "content_check", "description": "Report contains dependency chain with tt-xla, tt-mlir, and tt-metal commit SHAs"},
+        {"name": "has-perf-table", "type": "content_check", "description": "Report contains a performance metrics table with samples/sec data"},
+        {"name": "has-run-url", "type": "content_check", "description": "Report includes the GitHub Actions run URL"}
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Analyze CI run 23774094450 — I want to understand why some perf benchmarks failed in the nightly",
+      "expected_output": "A markdown report highlighting the failed perf benchmark jobs with extracted error messages and Glean context, plus performance tables for the successful jobs",
+      "files": [],
+      "assertions": [
+        {"name": "report-file-exists", "type": "file_check", "description": "Report file exists and has substantial content (>500 chars)"},
+        {"name": "has-commit-chain", "type": "content_check", "description": "Report contains dependency chain with tt-xla, tt-mlir, and tt-metal commit SHAs"},
+        {"name": "has-perf-table", "type": "content_check", "description": "Report contains a performance metrics table with samples/sec data"},
+        {"name": "has-run-url", "type": "content_check", "description": "Report includes the GitHub Actions run URL"},
+        {"name": "has-failure-section", "type": "content_check", "description": "Report contains a dedicated section analyzing failed jobs"},
+        {"name": "has-error-details", "type": "content_check", "description": "Report includes actual error messages extracted from logs, not just 'failed'"},
+        {"name": "has-glean-context", "type": "content_check", "description": "Report mentions Glean search results or explicitly notes no prior context found"}
+      ]
+    }
+  ]
+}

--- a/.claude/skills/ci-benchmark-analyzer/scripts/compare_nightlies.py
+++ b/.claude/skills/ci-benchmark-analyzer/scripts/compare_nightlies.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""
+Compare perf metrics between two nightly CI runs and produce a structured diff.
+
+Usage:
+    python compare_nightlies.py <CURRENT_RUN_ID> <PREVIOUS_RUN_ID> \
+        [--repo OWNER/REPO] [--output-dir DIR] [--threshold 10]
+
+Outputs summary.json with per-model diffs categorized as regression/improvement/stable.
+
+The comparison is based on samples/sec (total_samples / total_time).
+Perf diff convention:
+  - POSITIVE % = model got FASTER (improvement)
+  - NEGATIVE % = model got SLOWER (regression)
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+
+def run_gh(args: list[str]):
+    """Run a gh API command and return parsed JSON."""
+    cmd = ["gh", "api"] + args
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Error: {' '.join(cmd)}", file=sys.stderr)
+        print(result.stderr, file=sys.stderr)
+        return None
+    return json.loads(result.stdout)
+
+
+def get_perf_artifacts(repo: str, run_id: str) -> list[dict]:
+    """Get perf-report artifacts for a run."""
+    artifacts = []
+    page = 1
+    while True:
+        data = run_gh(
+            [f"repos/{repo}/actions/runs/{run_id}/artifacts?per_page=100&page={page}"]
+        )
+        if not data or not data.get("artifacts"):
+            break
+        for a in data["artifacts"]:
+            if a["name"].startswith("perf-reports-") and not a.get("expired"):
+                artifacts.append(a)
+        if len(data["artifacts"]) < 100:
+            break
+        page += 1
+    return artifacts
+
+
+def download_and_parse_report(repo: str, artifact_id: int, tmp_dir: Path) -> dict | None:
+    """Download a perf-report artifact and parse its JSON."""
+    result = subprocess.run(
+        ["gh", "api", f"repos/{repo}/actions/artifacts/{artifact_id}/zip"],
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        return None
+
+    zip_path = tmp_dir / f"art_{artifact_id}.zip"
+    zip_path.write_bytes(result.stdout)
+
+    try:
+        with zipfile.ZipFile(zip_path) as zf:
+            for name in zf.namelist():
+                if name.endswith(".json") and "perf_report" in name:
+                    with zf.open(name) as f:
+                        return json.loads(f.read())
+    except (zipfile.BadZipFile, json.JSONDecodeError):
+        pass
+    finally:
+        zip_path.unlink(missing_ok=True)
+    return None
+
+
+def extract_model_metrics(report: dict) -> dict:
+    """Extract key metrics from a perf report."""
+    measurements = {m["measurement_name"]: m["value"] for m in report.get("measurements", [])}
+    total_samples = measurements.get("total_samples", 0)
+    total_time = measurements.get("total_time", 0)
+
+    return {
+        "display_name": report.get("config", {}).get("display_name", "unknown"),
+        "device_type": report.get("device_info", {}).get("device_type", "unknown"),
+        "samples_per_sec": total_samples / total_time if total_time > 0 else 0,
+        "ttft_ms": measurements.get("ttft"),
+        "device_fw_duration_s": measurements.get("device_fw_duration"),
+        "total_samples": total_samples,
+        "total_time_s": total_time,
+        "job_id_url": report.get("config", {}).get("job_id_url"),
+    }
+
+
+def compute_diff(current: float, previous: float) -> float | None:
+    """Compute percent change. Positive = improvement (faster), negative = regression (slower)."""
+    if previous <= 0:
+        return None
+    return round(((current - previous) / previous) * 100, 2)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Compare perf between two CI runs")
+    parser.add_argument("current_run_id", help="Current (newer) run ID")
+    parser.add_argument("previous_run_id", help="Previous (older) run ID")
+    parser.add_argument("--repo", default="tenstorrent/tt-xla")
+    parser.add_argument("--output-dir", default=None, help="Output directory")
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=10.0,
+        help="Percent threshold for flagging regressions/improvements (default: 10)",
+    )
+    args = parser.parse_args()
+
+    output_dir = Path(args.output_dir or f"/tmp/perf_compare_{args.current_run_id}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    tmp_dir = Path(tempfile.mkdtemp())
+
+    # Fetch artifacts for both runs
+    print(f"Fetching artifacts for current run {args.current_run_id}...", file=sys.stderr)
+    current_artifacts = get_perf_artifacts(args.repo, args.current_run_id)
+    print(f"  Found {len(current_artifacts)} perf report artifacts", file=sys.stderr)
+
+    print(f"Fetching artifacts for previous run {args.previous_run_id}...", file=sys.stderr)
+    previous_artifacts = get_perf_artifacts(args.repo, args.previous_run_id)
+    print(f"  Found {len(previous_artifacts)} perf report artifacts", file=sys.stderr)
+
+    # Download and parse all reports
+    print("Downloading current run reports...", file=sys.stderr)
+    current_models = {}
+    for art in current_artifacts:
+        report = download_and_parse_report(args.repo, art["id"], tmp_dir)
+        if report:
+            metrics = extract_model_metrics(report)
+            key = f"{metrics['display_name']}_{metrics['device_type']}"
+            current_models[key] = metrics
+
+    print("Downloading previous run reports...", file=sys.stderr)
+    previous_models = {}
+    for art in previous_artifacts:
+        report = download_and_parse_report(args.repo, art["id"], tmp_dir)
+        if report:
+            metrics = extract_model_metrics(report)
+            key = f"{metrics['display_name']}_{metrics['device_type']}"
+            previous_models[key] = metrics
+
+    print(
+        f"Parsed {len(current_models)} current, {len(previous_models)} previous models",
+        file=sys.stderr,
+    )
+
+    # Compute diffs
+    comparisons = []
+    for key, curr in sorted(current_models.items()):
+        prev = previous_models.get(key)
+        if not prev:
+            comparisons.append(
+                {
+                    **curr,
+                    "previous_samples_per_sec": None,
+                    "previous_ttft_ms": None,
+                    "diff_percent": None,
+                    "category": "new",
+                    "diff_ttft_percent": None,
+                }
+            )
+            continue
+
+        sps_diff = compute_diff(curr["samples_per_sec"], prev["samples_per_sec"])
+        ttft_diff = None
+        if curr.get("ttft_ms") is not None and prev.get("ttft_ms") is not None and prev["ttft_ms"] > 0:
+            # For TTFT, lower is better, so invert: negative change in TTFT = improvement
+            ttft_diff = round(((prev["ttft_ms"] - curr["ttft_ms"]) / prev["ttft_ms"]) * 100, 2)
+
+        if sps_diff is None:
+            category = "unknown"
+        elif sps_diff <= -args.threshold:
+            category = "regression"
+        elif sps_diff >= args.threshold:
+            category = "improvement"
+        else:
+            category = "stable"
+
+        comparisons.append(
+            {
+                **curr,
+                "previous_samples_per_sec": round(prev["samples_per_sec"], 2),
+                "previous_ttft_ms": round(prev["ttft_ms"], 2) if prev.get("ttft_ms") is not None else None,
+                "diff_percent": sps_diff,
+                "category": category,
+                "diff_ttft_percent": ttft_diff,
+            }
+        )
+
+    # Also find models that were in previous but missing from current (disappeared)
+    for key, prev in sorted(previous_models.items()):
+        if key not in current_models:
+            comparisons.append(
+                {
+                    "display_name": prev["display_name"],
+                    "device_type": prev["device_type"],
+                    "samples_per_sec": None,
+                    "previous_samples_per_sec": round(prev["samples_per_sec"], 2),
+                    "previous_ttft_ms": round(prev["ttft_ms"], 2) if prev.get("ttft_ms") is not None else None,
+                    "diff_percent": None,
+                    "category": "missing",
+                    "ttft_ms": None,
+                    "device_fw_duration_s": None,
+                    "total_samples": None,
+                    "total_time_s": None,
+                    "job_id_url": None,
+                    "diff_ttft_percent": None,
+                }
+            )
+
+    # Categorize
+    regressions = [c for c in comparisons if c["category"] == "regression"]
+    improvements = [c for c in comparisons if c["category"] == "improvement"]
+    stable = [c for c in comparisons if c["category"] == "stable"]
+    new_models = [c for c in comparisons if c["category"] == "new"]
+    missing = [c for c in comparisons if c["category"] == "missing"]
+
+    summary = {
+        "current_run_id": args.current_run_id,
+        "previous_run_id": args.previous_run_id,
+        "threshold_percent": args.threshold,
+        "total_models_compared": len([c for c in comparisons if c["category"] not in ("new", "missing")]),
+        "regressions": len(regressions),
+        "improvements": len(improvements),
+        "stable": len(stable),
+        "new_models": len(new_models),
+        "missing_models": len(missing),
+        "models": {
+            "regressions": sorted(regressions, key=lambda x: x["diff_percent"] or 0),
+            "improvements": sorted(
+                improvements, key=lambda x: x["diff_percent"] or 0, reverse=True
+            ),
+            "stable": sorted(stable, key=lambda x: x["display_name"]),
+            "new": new_models,
+            "missing": missing,
+        },
+        "all_comparisons": sorted(comparisons, key=lambda x: (x["device_type"], x["display_name"])),
+    }
+
+    summary_path = output_dir / "comparison.json"
+    summary_path.write_text(json.dumps(summary, indent=2))
+    print(f"\nComparison written to {summary_path}", file=sys.stderr)
+
+    # Print summary to stdout
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/ci-benchmark-analyzer/scripts/compare_nightlies.py
+++ b/.claude/skills/ci-benchmark-analyzer/scripts/compare_nightlies.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
 """
 Compare perf metrics between two nightly CI runs and produce a structured diff.
 
@@ -54,7 +57,9 @@ def get_perf_artifacts(repo: str, run_id: str) -> list[dict]:
     return artifacts
 
 
-def download_and_parse_report(repo: str, artifact_id: int, tmp_dir: Path) -> dict | None:
+def download_and_parse_report(
+    repo: str, artifact_id: int, tmp_dir: Path
+) -> dict | None:
     """Download a perf-report artifact and parse its JSON."""
     result = subprocess.run(
         ["gh", "api", f"repos/{repo}/actions/artifacts/{artifact_id}/zip"],
@@ -81,7 +86,9 @@ def download_and_parse_report(repo: str, artifact_id: int, tmp_dir: Path) -> dic
 
 def extract_model_metrics(report: dict) -> dict:
     """Extract key metrics from a perf report."""
-    measurements = {m["measurement_name"]: m["value"] for m in report.get("measurements", [])}
+    measurements = {
+        m["measurement_name"]: m["value"] for m in report.get("measurements", [])
+    }
     total_samples = measurements.get("total_samples", 0)
     total_time = measurements.get("total_time", 0)
 
@@ -123,11 +130,16 @@ def main():
     tmp_dir = Path(tempfile.mkdtemp())
 
     # Fetch artifacts for both runs
-    print(f"Fetching artifacts for current run {args.current_run_id}...", file=sys.stderr)
+    print(
+        f"Fetching artifacts for current run {args.current_run_id}...", file=sys.stderr
+    )
     current_artifacts = get_perf_artifacts(args.repo, args.current_run_id)
     print(f"  Found {len(current_artifacts)} perf report artifacts", file=sys.stderr)
 
-    print(f"Fetching artifacts for previous run {args.previous_run_id}...", file=sys.stderr)
+    print(
+        f"Fetching artifacts for previous run {args.previous_run_id}...",
+        file=sys.stderr,
+    )
     previous_artifacts = get_perf_artifacts(args.repo, args.previous_run_id)
     print(f"  Found {len(previous_artifacts)} perf report artifacts", file=sys.stderr)
 
@@ -174,9 +186,15 @@ def main():
 
         sps_diff = compute_diff(curr["samples_per_sec"], prev["samples_per_sec"])
         ttft_diff = None
-        if curr.get("ttft_ms") is not None and prev.get("ttft_ms") is not None and prev["ttft_ms"] > 0:
+        if (
+            curr.get("ttft_ms") is not None
+            and prev.get("ttft_ms") is not None
+            and prev["ttft_ms"] > 0
+        ):
             # For TTFT, lower is better, so invert: negative change in TTFT = improvement
-            ttft_diff = round(((prev["ttft_ms"] - curr["ttft_ms"]) / prev["ttft_ms"]) * 100, 2)
+            ttft_diff = round(
+                ((prev["ttft_ms"] - curr["ttft_ms"]) / prev["ttft_ms"]) * 100, 2
+            )
 
         if sps_diff is None:
             category = "unknown"
@@ -191,7 +209,11 @@ def main():
             {
                 **curr,
                 "previous_samples_per_sec": round(prev["samples_per_sec"], 2),
-                "previous_ttft_ms": round(prev["ttft_ms"], 2) if prev.get("ttft_ms") is not None else None,
+                "previous_ttft_ms": (
+                    round(prev["ttft_ms"], 2)
+                    if prev.get("ttft_ms") is not None
+                    else None
+                ),
                 "diff_percent": sps_diff,
                 "category": category,
                 "diff_ttft_percent": ttft_diff,
@@ -207,7 +229,11 @@ def main():
                     "device_type": prev["device_type"],
                     "samples_per_sec": None,
                     "previous_samples_per_sec": round(prev["samples_per_sec"], 2),
-                    "previous_ttft_ms": round(prev["ttft_ms"], 2) if prev.get("ttft_ms") is not None else None,
+                    "previous_ttft_ms": (
+                        round(prev["ttft_ms"], 2)
+                        if prev.get("ttft_ms") is not None
+                        else None
+                    ),
                     "diff_percent": None,
                     "category": "missing",
                     "ttft_ms": None,
@@ -230,7 +256,9 @@ def main():
         "current_run_id": args.current_run_id,
         "previous_run_id": args.previous_run_id,
         "threshold_percent": args.threshold,
-        "total_models_compared": len([c for c in comparisons if c["category"] not in ("new", "missing")]),
+        "total_models_compared": len(
+            [c for c in comparisons if c["category"] not in ("new", "missing")]
+        ),
         "regressions": len(regressions),
         "improvements": len(improvements),
         "stable": len(stable),
@@ -245,7 +273,9 @@ def main():
             "new": new_models,
             "missing": missing,
         },
-        "all_comparisons": sorted(comparisons, key=lambda x: (x["device_type"], x["display_name"])),
+        "all_comparisons": sorted(
+            comparisons, key=lambda x: (x["device_type"], x["display_name"])
+        ),
     }
 
     summary_path = output_dir / "comparison.json"

--- a/.claude/skills/ci-benchmark-analyzer/scripts/fetch_perf_reports.py
+++ b/.claude/skills/ci-benchmark-analyzer/scripts/fetch_perf_reports.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""
+Batch-download perf report artifacts for a GitHub Actions run and extract metrics.
+
+Usage:
+    python fetch_perf_reports.py <RUN_ID> [--output-dir DIR] [--repo OWNER/REPO]
+
+Outputs:
+    - One JSON file per perf-report artifact in the output directory
+    - summary.json with extracted metrics for all jobs
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+
+def run_gh(args: list[str], parse_json: bool = True):
+    """Run a gh CLI command and return parsed output."""
+    cmd = ["gh", "api"] + args
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Error running: {' '.join(cmd)}", file=sys.stderr)
+        print(result.stderr, file=sys.stderr)
+        return None
+    if parse_json:
+        return json.loads(result.stdout)
+    return result.stdout
+
+
+def get_run_jobs(repo: str, run_id: str) -> list[dict]:
+    """Get all jobs for a run, handling pagination."""
+    jobs = []
+    page = 1
+    while True:
+        data = run_gh(
+            [f"repos/{repo}/actions/runs/{run_id}/jobs?per_page=100&page={page}"]
+        )
+        if not data or not data.get("jobs"):
+            break
+        jobs.extend(data["jobs"])
+        if len(data["jobs"]) < 100:
+            break
+        page += 1
+    return jobs
+
+
+def get_artifacts(repo: str, run_id: str) -> list[dict]:
+    """Get all artifacts for a run, handling pagination."""
+    artifacts = []
+    page = 1
+    while True:
+        data = run_gh(
+            [f"repos/{repo}/actions/runs/{run_id}/artifacts?per_page=100&page={page}"]
+        )
+        if not data or not data.get("artifacts"):
+            break
+        artifacts.extend(data["artifacts"])
+        if len(data["artifacts"]) < 100:
+            break
+        page += 1
+    return artifacts
+
+
+def download_artifact(repo: str, artifact_id: int, output_dir: Path) -> Path | None:
+    """Download and extract a single artifact zip."""
+    zip_path = output_dir / f"artifact_{artifact_id}.zip"
+    extract_dir = output_dir / f"artifact_{artifact_id}"
+
+    result = subprocess.run(
+        ["gh", "api", f"repos/{repo}/actions/artifacts/{artifact_id}/zip"],
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        print(f"Failed to download artifact {artifact_id}", file=sys.stderr)
+        return None
+
+    zip_path.write_bytes(result.stdout)
+
+    try:
+        with zipfile.ZipFile(zip_path) as zf:
+            json_files = [f for f in zf.namelist() if f.endswith(".json")]
+            if not json_files:
+                return None
+            extract_dir.mkdir(exist_ok=True)
+            for jf in json_files:
+                zf.extract(jf, extract_dir)
+        return extract_dir
+    except zipfile.BadZipFile:
+        print(f"Bad zip for artifact {artifact_id}", file=sys.stderr)
+        return None
+    finally:
+        zip_path.unlink(missing_ok=True)
+
+
+def extract_metrics(report: dict) -> dict:
+    """Extract key metrics from a perf report JSON."""
+    measurements = {m["measurement_name"]: m["value"] for m in report.get("measurements", [])}
+
+    total_samples = measurements.get("total_samples", 0)
+    total_time = measurements.get("total_time", 0)
+    samples_per_sec = total_samples / total_time if total_time > 0 else None
+
+    return {
+        "model": report.get("model", "unknown"),
+        "display_name": report.get("config", {}).get("display_name", "unknown"),
+        "device_type": report.get("device_info", {}).get("device_type", "unknown"),
+        "device_count": report.get("device_info", {}).get("device_count", 1),
+        "arch": report.get("device_info", {}).get("arch", "unknown"),
+        "batch_size": report.get("batch_size"),
+        "input_sequence_length": report.get("input_sequence_length"),
+        "samples_per_sec": round(samples_per_sec, 2) if samples_per_sec else None,
+        "ttft_ms": round(measurements["ttft"], 2) if "ttft" in measurements else None,
+        "device_fw_duration_s": (
+            round(measurements["device_fw_duration"], 4)
+            if "device_fw_duration" in measurements
+            else None
+        ),
+        "device_kernel_duration_s": (
+            round(measurements["device_kernel_duration"], 4)
+            if "device_kernel_duration" in measurements
+            else None
+        ),
+        "total_samples": total_samples,
+        "total_time_s": round(total_time, 4) if total_time else None,
+        "job_id_url": report.get("config", {}).get("job_id_url"),
+        "num_graphs": report.get("config", {}).get("ttnn_num_graphs"),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Fetch and process perf report artifacts")
+    parser.add_argument("run_id", help="GitHub Actions run ID")
+    parser.add_argument(
+        "--output-dir",
+        default=None,
+        help="Directory for outputs (default: /tmp/perf_reports_<RUN_ID>)",
+    )
+    parser.add_argument(
+        "--repo",
+        default="tenstorrent/tt-xla",
+        help="GitHub repo (default: tenstorrent/tt-xla)",
+    )
+    args = parser.parse_args()
+
+    output_dir = Path(args.output_dir or f"/tmp/perf_reports_{args.run_id}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Fetching jobs for run {args.run_id}...", file=sys.stderr)
+    jobs = get_run_jobs(args.repo, args.run_id)
+
+    # Identify perf benchmark jobs
+    perf_jobs = {}
+    for job in jobs:
+        if "perf-benchmark" in job["name"] and "perf " in job["name"]:
+            perf_jobs[str(job["id"])] = {
+                "name": job["name"],
+                "conclusion": job["conclusion"],
+                "url": job["url"],
+            }
+
+    print(f"Found {len(perf_jobs)} perf benchmark jobs", file=sys.stderr)
+
+    print("Fetching artifacts...", file=sys.stderr)
+    artifacts = get_artifacts(args.repo, args.run_id)
+
+    # Match perf-report artifacts to jobs
+    perf_artifacts = []
+    for art in artifacts:
+        if art["name"].startswith("perf-reports-"):
+            if art.get("expired"):
+                print(f"Artifact expired: {art['name']}", file=sys.stderr)
+                continue
+            perf_artifacts.append(art)
+
+    print(f"Found {len(perf_artifacts)} perf report artifacts", file=sys.stderr)
+
+    # Download and process each artifact
+    all_metrics = []
+    for art in perf_artifacts:
+        print(f"  Downloading {art['name']}...", file=sys.stderr)
+        extract_dir = download_artifact(args.repo, art["id"], output_dir)
+        if not extract_dir:
+            continue
+
+        # Find and process JSON files
+        for json_file in extract_dir.rglob("*.json"):
+            try:
+                report = json.loads(json_file.read_text())
+                # Copy report to output dir with a meaningful name
+                display = report.get("config", {}).get("display_name", "unknown")
+                dest = output_dir / f"{display}.json"
+                json_file.rename(dest) if not dest.exists() else None
+                metrics = extract_metrics(report)
+                metrics["artifact_name"] = art["name"]
+                all_metrics.append(metrics)
+            except (json.JSONDecodeError, KeyError) as e:
+                print(f"  Error processing {json_file}: {e}", file=sys.stderr)
+
+    # Sort by device type then model name
+    all_metrics.sort(key=lambda m: (m["device_type"], m["display_name"]))
+
+    # Write summary
+    summary = {
+        "run_id": args.run_id,
+        "total_perf_jobs": len(perf_jobs),
+        "successful_reports": len(all_metrics),
+        "failed_jobs": [
+            {"name": j["name"], "url": j["url"]}
+            for j in perf_jobs.values()
+            if j["conclusion"] == "failure"
+        ],
+        "metrics": all_metrics,
+    }
+
+    summary_path = output_dir / "summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2))
+    print(f"\nSummary written to {summary_path}", file=sys.stderr)
+
+    # Also print summary to stdout for piping
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/ci-benchmark-analyzer/scripts/fetch_perf_reports.py
+++ b/.claude/skills/ci-benchmark-analyzer/scripts/fetch_perf_reports.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
 """
 Batch-download perf report artifacts for a GitHub Actions run and extract metrics.
 
@@ -100,7 +103,9 @@ def download_artifact(repo: str, artifact_id: int, output_dir: Path) -> Path | N
 
 def extract_metrics(report: dict) -> dict:
     """Extract key metrics from a perf report JSON."""
-    measurements = {m["measurement_name"]: m["value"] for m in report.get("measurements", [])}
+    measurements = {
+        m["measurement_name"]: m["value"] for m in report.get("measurements", [])
+    }
 
     total_samples = measurements.get("total_samples", 0)
     total_time = measurements.get("total_time", 0)
@@ -134,7 +139,9 @@ def extract_metrics(report: dict) -> dict:
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Fetch and process perf report artifacts")
+    parser = argparse.ArgumentParser(
+        description="Fetch and process perf report artifacts"
+    )
     parser.add_argument("run_id", help="GitHub Actions run ID")
     parser.add_argument(
         "--output-dir",


### PR DESCRIPTION
Added claude skill for analyzing and comparing performance benchmark runs and writing reports.

Next step is to add the generated .md report on nightly summary.

Report example: [nightly_25295105114_2026-05-04.md](https://github.com/user-attachments/files/27371357/nightly_25295105114_2026-05-04.md)
