### PR TITLE
Add passing p150 vLLM single_device tests to basic-test matrices

### DIFF
--- a/.github/workflows/test-matrix-presets/basic-test-nightly.json
+++ b/.github/workflows/test-matrix-presets/basic-test-nightly.json
@@ -10,6 +10,7 @@
   { "runs-on": "n300-llmbox",        "name": "run_torch_multi_chip",   "dir": "./tests/torch",                            "test-mark": "nightly and llmbox",                      "shared-runners": "false" },
   {"runs-on": "n300-llmbox",         "name": "run_vllm_llmbox_tests",  "dir": "./tests/integrations/vllm_plugin",         "test-mark": "nightly and tensor_parallel and llmbox",  "shared-runners": "true", "extra-wheel": "vllm"},
   {"runs-on": "n150",                "name": "run_vllm_n150_tests",    "dir": "./tests/integrations/vllm_plugin",         "test-mark": "nightly and single_device",               "shared-runners": "true", "extra-wheel": "vllm"},
+  {"runs-on": "p150",                "name": "run_vllm_p150_tests",    "dir": "./tests/integrations/vllm_plugin",         "test-mark": "nightly and single_device",               "shared-runners": "true", "extra-wheel": "vllm"},
   {"runs-on": "n300",                "name": "run_vllm_n300_tests",    "dir": "./tests/integrations/vllm_plugin",         "test-mark": "nightly and data_parallel",               "shared-runners": "true", "extra-wheel": "vllm"},
   {"runs-on": "n300",                "name": "run_vllm_n300_tests",    "dir": "./tests/integrations/vllm_plugin",         "test-mark": "nightly and tensor_parallel and dual_chip", "shared-runners": "true", "extra-wheel": "vllm"},
   { "runs-on": "galaxy-wh-6u",       "name": "run_torch_galaxy",       "dir": "./tests/torch/graphs",                     "test-mark": "nightly and galaxy" }

--- a/.github/workflows/test-matrix-presets/basic-test.json
+++ b/.github/workflows/test-matrix-presets/basic-test.json
@@ -10,6 +10,7 @@
   {"runs-on": "n300-llmbox",        "name": "run_jax_8_devices",      "dir": "./tests/jax/multi_chip/llmbox/8_devices", "test-mark": "push",                    "shared-runners": "true" },
   {"runs-on": "n300-llmbox",        "name": "run_torch_multi_chip",   "dir": "./tests/torch",                           "test-mark": "push and llmbox",         "shared-runners": "true" },
   {"runs-on": "n150",               "name": "run_vllm_n150_tests",    "dir": "./tests/integrations/vllm_plugin",        "test-mark": "push and single_device",  "shared-runners": "true", "extra-wheel": "vllm"},
+  {"runs-on": "p150",               "name": "run_vllm_p150_tests",    "dir": "./tests/integrations/vllm_plugin",        "test-mark": "push and single_device",  "shared-runners": "true", "extra-wheel": "vllm"},
   {"runs-on": "n300",               "name": "run_vllm_n300_tests",    "dir": "./tests/integrations/vllm_plugin",        "test-mark": "push and data_parallel",  "shared-runners": "true", "extra-wheel": "vllm"},
   {"runs-on": "n300",               "name": "run_vllm_n300_tests",    "dir": "./tests/integrations/vllm_plugin",        "test-mark": "push and tensor_parallel and dual_chip", "shared-runners": "true", "extra-wheel": "vllm"},
   {"runs-on": "n300-llmbox",        "name": "run_vllm_llmbox_tests",  "dir": "./tests/integrations/vllm_plugin",        "test-mark": "push and tensor_parallel and llmbox", "shared-runners": "true", "extra-wheel": "vllm"},


### PR DESCRIPTION
### Ticket
None

### Problem description
- p150 vllm tests were not running in nightly or onPR/onPush by accident

### What's changed
- Companion to #4285 (commit 307bbcde2), which added p150 to vllm-model-tests{,-nightly}.json but missed the equivalent entries in basic-test{,-nightly}.json — so push/nightly basic runs still skip p150.

### Checklist
- [x] p150 vllm job passing in nightly: https://github.com/tenstorrent/tt-xla/actions/runs/25330417865
- [x] p150 vllm job passing in push: https://github.com/tenstorrent/tt-xla/actions/runs/25334369582 
