### PR TITLE
[Hunyuan Video] Add initial tests for each part of the pipeline

### DIFF
--- a/tests/torch/models/hunyuan_video/__init__.py
+++ b/tests/torch/models/hunyuan_video/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/torch/models/hunyuan_video/test_text_encoder.py
+++ b/tests/torch/models/hunyuan_video/test_text_encoder.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""HunyuanVideo — LLaMA text encoder component test."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+from infra.testers.single_chip.model.torch_model_tester import _mask_jax_accelerator
+from infra.utilities.torch_multichip_utils import get_mesh
+
+from third_party.tt_forge_models.hunyuan_video.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.skip(reason="OOM on single device; sharded variant runs")
+def test_text_encoder():
+    _run(sharded=False)
+
+
+@pytest.mark.nightly
+@pytest.mark.model_test
+def test_text_encoder_sharded():
+    _run(sharded=True)
+
+
+def _run(sharded: bool):
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.TEXT_ENCODER)
+    encoder = loader.load_model(dtype_override=torch.bfloat16)
+    inputs = loader.load_inputs(dtype_override=torch.bfloat16)
+
+    mesh = None
+    shard_spec_fn = None
+    if sharded:
+        mesh_shape, mesh_names = loader.get_mesh_config(
+            xr.global_runtime_device_count()
+        )
+        mesh = get_mesh(mesh_shape, mesh_names)
+        shard_spec_fn = loader.load_shard_spec
+
+    with _mask_jax_accelerator():
+        run_graph_test(
+            encoder,
+            inputs,
+            framework=Framework.TORCH,
+            mesh=mesh,
+            shard_spec_fn=shard_spec_fn,
+        )

--- a/tests/torch/models/hunyuan_video/test_text_encoder_2.py
+++ b/tests/torch/models/hunyuan_video/test_text_encoder_2.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""HunyuanVideo — CLIP text encoder component test (text_encoder_2)."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+from infra.testers.single_chip.model.torch_model_tester import _mask_jax_accelerator
+from infra.utilities.torch_multichip_utils import get_mesh
+
+from third_party.tt_forge_models.hunyuan_video.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.skip
+def test_text_encoder_2():
+    _run(sharded=False)
+
+
+@pytest.mark.nightly
+@pytest.mark.model_test
+def test_text_encoder_2_sharded():
+    _run(sharded=True)
+
+
+def _run(sharded: bool):
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.TEXT_ENCODER_2)
+    encoder = loader.load_model(dtype_override=torch.bfloat16)
+    inputs = loader.load_inputs(dtype_override=torch.bfloat16)
+
+    mesh = None
+    shard_spec_fn = None
+    if sharded:
+        mesh_shape, mesh_names = loader.get_mesh_config(
+            xr.global_runtime_device_count()
+        )
+        mesh = get_mesh(mesh_shape, mesh_names)
+        shard_spec_fn = loader.load_shard_spec
+
+    with _mask_jax_accelerator():
+        run_graph_test(
+            encoder,
+            inputs,
+            framework=Framework.TORCH,
+            mesh=mesh,
+            shard_spec_fn=shard_spec_fn,
+        )

--- a/tests/torch/models/hunyuan_video/test_transformer.py
+++ b/tests/torch/models/hunyuan_video/test_transformer.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""HunyuanVideo — HunyuanVideoTransformer3DModel (DiT) component test."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+from infra.utilities.torch_multichip_utils import get_mesh
+
+from third_party.tt_forge_models.hunyuan_video.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.skip
+def test_transformer():
+    _run(sharded=False)
+
+
+@pytest.mark.xfail(
+    reason="Out of Memory: Not enough space to allocate 75497472 B DRAM buffer across 12 banks - https://github.com/tenstorrent/tt-xla/issues/4790"
+)
+def test_transformer_sharded():
+    _run(sharded=True)
+
+
+def _run(sharded: bool):
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.TRANSFORMER)
+    model = loader.load_model(dtype_override=torch.bfloat16)
+    inputs = loader.load_inputs(dtype_override=torch.bfloat16)
+
+    mesh = None
+    shard_spec_fn = None
+    if sharded:
+        mesh_shape, mesh_names = loader.get_mesh_config(
+            xr.global_runtime_device_count()
+        )
+        mesh = get_mesh(mesh_shape, mesh_names)
+        shard_spec_fn = loader.load_shard_spec
+
+    run_graph_test(
+        model,
+        inputs,
+        framework=Framework.TORCH,
+        mesh=mesh,
+        shard_spec_fn=shard_spec_fn,
+    )

--- a/tests/torch/models/hunyuan_video/test_vae_decoder.py
+++ b/tests/torch/models/hunyuan_video/test_vae_decoder.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""HunyuanVideo — AutoencoderKLHunyuanVideo decoder component test."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+from infra.testers.single_chip.model.torch_model_tester import _mask_jax_accelerator
+from infra.utilities.torch_multichip_utils import get_mesh
+
+from third_party.tt_forge_models.hunyuan_video.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.skip
+def test_vae_decoder():
+    _run(sharded=False)
+
+
+@pytest.mark.xfail(
+    reason="loc(gather.64): error: 'ttir.concat' op Output tensor dimension 2 does not match the sum of input tensor - https://github.com/tenstorrent/tt-xla/issues/4792"
+)
+@pytest.mark.nightly
+@pytest.mark.model_test
+def test_vae_decoder_sharded():
+    _run(sharded=True)
+
+
+def _run(sharded: bool):
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.VAE)
+    model = loader.load_model(dtype_override=torch.bfloat16)
+    inputs = loader.load_inputs(dtype_override=torch.bfloat16)
+
+    mesh = None
+    shard_spec_fn = None
+    if sharded:
+        mesh_shape, mesh_names = loader.get_mesh_config(
+            xr.global_runtime_device_count()
+        )
+        mesh = get_mesh(mesh_shape, mesh_names)
+        shard_spec_fn = loader.load_shard_spec
+
+    with _mask_jax_accelerator():
+        run_graph_test(
+            model,
+            inputs,
+            framework=Framework.TORCH,
+            mesh=mesh,
+            shard_spec_fn=shard_spec_fn,
+        )


### PR DESCRIPTION
### Ticket

- fixes #4642 

### Problem description

- Add initial bringup tests for each component of the Hunyuan Video pipeline and  test in Wormhole.

### What's changed

| File | Component | Tests |
|------|-----------|-------|
| `test_text_encoder.py` | LLaMA-3 encoder | `test_text_encoder` (`test_text_encoder_sharded` (pass — 2 chips) |
| `test_text_encoder_2.py` | CLIP text encoder | `test_text_encoder` (`test_text_encoder_2_sharded` (pass — 2 chips) |
| `test_transformer.py` | HunyuanVideoTransformer3DModel   | `test_transformer` (`test_transformer_sharded` (xfail - #4790  - 2 chips) |
| `test_vae_decoder.py` | AutoencoderKLHunyuanVideo | `test_vae_decoder` ( test_vae_decoder_sharded (xfail - 2 chips - #4792 ) |

### Checklist
- [x] verify changes through local testing in Wormhole

### Logs
[hunyuan_video_may20_logs.zip](https://github.com/user-attachments/files/28047309/hunyuan_video_may20_logs.zip)

