### PR TITLE
[Issue #26] Enable DiT and VAE decoder to work in single pipeline

### DIFF
--- a/tests/torch/models/wan2_2/monkey_patch.py
+++ b/tests/torch/models/wan2_2/monkey_patch.py
@@ -62,113 +62,81 @@ def _disable_tt_torch_function_override() -> None:
         # Mode wasn't on the stack or was already popped – ignore.
         pass
 
+    
+# ---------------------------------------------------------------------------
+# VAE Decoder monkey patches
+# ---------------------------------------------------------------------------
 
-def _patch_tt_torch_getitem_clamp() -> None:
-    """Extend `TorchFunctionOverride` to silently clamp out-of-range slice
-    endpoints on tensor `__getitem__`.
+    
+import torch
+from contextlib import contextmanager
+_ORIG_GETITEM = torch.Tensor.__getitem__
 
+
+def _clamp_slice(s: slice, size: int) -> slice:
+    start, stop, step = s.start, s.stop, s.step
+
+    # Python slice.indices(size) implements canonical in-range slicing semantics.
+    # But it returns concrete start/stop/step, so preserve normal behavior.
+    start, stop, step = slice(start, stop, step).indices(size)
+
+    return slice(start, stop, step)
+
+
+def _normalize_index(idx, shape):
+    if not isinstance(idx, tuple):
+        idx = (idx,)
+
+    out = []
+    dim = 0
+
+    for item in idx:
+        if item is Ellipsis:
+            remaining_explicit = sum(
+                x is not Ellipsis and x is not None
+                for x in idx[idx.index(item) + 1:]
+            )
+            fill = len(shape) - dim - remaining_explicit
+            out.extend([slice(None)] * fill)
+            dim += fill
+            continue
+
+        if item is None:
+            out.append(item)
+            continue
+
+        if isinstance(item, slice):
+            out.append(_clamp_slice(item, shape[dim]))
+            dim += 1
+            continue
+
+        # Leave tensor / bool / advanced indices untouched.
+        out.append(item)
+        dim += 1
+
+    return tuple(out)
+
+
+def _safe_getitem(self, idx):
+    return _ORIG_GETITEM(self, _normalize_index(idx, self.shape))
+
+
+@contextmanager
+def safe_xla_slicing():
+    """
     CPU silently clamps slice `start` / `stop` values lying outside
     `[-size, size]`; torch-xla's lazy backend raises "Value out of range"
     instead. Upstream diffusers' `AutoencoderKLWan` (used by the Wan 2.2
     VAE decoder) relies on the CPU behavior — e.g. `x[:, :, -2:, :, :]`
-    on a size-1 temporal dim. Intercept `Tensor.__getitem__` inside the
-    existing `TorchFunctionMode` and rewrite the index in range before
-    re-dispatching.
+    on a size-1 temporal dim. Intercept `Tensor.__getitem__` and rewrite
+    the index in range before re-dispatching.
     """
+    old = torch.Tensor.__getitem__
+    torch.Tensor.__getitem__ = _safe_getitem
     try:
-        import tt_torch.torch_overrides as overrides
-    except ImportError:
-        return
-
-    import torch
-
-    def _clamp_oob_slice(tensor, idx):
-        def clamp(s, size):
-            start, stop, step = s.start, s.stop, s.step
-            # Negative step uses different CPython bounds
-            # (`max(-1, start + size)` vs. `max(0, start + size)`) that do
-            # not round-trip through torch-xla's canonicalization — silent
-            # wrong results would be worse than the raised error.
-            if isinstance(step, int) and step < 0:
-                return s
-            changed = False
-            if isinstance(start, int):
-                if start < -size:
-                    start, changed = -size, True
-                elif start > size:
-                    start, changed = size, True
-            if isinstance(stop, int):
-                if stop < -size:
-                    stop, changed = -size, True
-                elif stop > size:
-                    stop, changed = size, True
-            return slice(start, stop, s.step) if changed else s
-
-        def dims_consumed(s):
-            # Bool masks broadcast across `ndim` input dims and collapse
-            # into one output dim; every other indexer covers exactly one.
-            if isinstance(s, torch.Tensor) and s.dtype == torch.bool:
-                return s.ndim
-            return 1
-
-        if isinstance(idx, slice):
-            return clamp(idx, tensor.shape[0]) if tensor.ndim else idx
-
-        if not isinstance(idx, tuple):
-            return idx
-
-        # Resolve `Ellipsis` span: dims the tuple explicitly addresses vs.
-        # what's left for `...`. `None` / newaxis inserts an output dim
-        # without consuming an input dim, so it's excluded from the count.
-        explicit = sum(
-            dims_consumed(s) for s in idx if s is not Ellipsis and s is not None
-        )
-        ellipsis_span = tensor.ndim - explicit
-
-        out = []
-        changed = False
-        dim = 0
-        for s in idx:
-            if s is Ellipsis:
-                out.append(s)
-                dim += ellipsis_span
-            elif s is None:
-                out.append(s)
-            elif isinstance(s, slice) and dim < tensor.ndim:
-                clamped = clamp(s, tensor.shape[dim])
-                out.append(clamped)
-                changed = changed or clamped is not s
-                dim += 1
-            else:
-                out.append(s)
-                dim += dims_consumed(s)
-
-        # Preserve the original `idx` object on no-op so the caller's
-        # identity check can short-circuit re-dispatch.
-        return tuple(out) if changed else idx
-
-    original_torch_function = overrides.TorchFunctionOverride.__torch_function__
-
-    def patched_torch_function(self, func, types, args, kwargs=None):
-        if (
-            func.__name__ == "__getitem__"
-            and len(args) >= 2
-            and isinstance(args[0], torch.Tensor)
-        ):
-            new_idx = _clamp_oob_slice(args[0], args[1])
-            # Identity check: helper returns the original `args[1]` when
-            # nothing needed clamping, so the common case pays one walk
-            # and no re-dispatch.
-            if new_idx is not args[1]:
-                return func(args[0], new_idx, *args[2:], **(kwargs or {}))
-        return original_torch_function(self, func, types, args, kwargs)
-
-    overrides.TorchFunctionOverride.__torch_function__ = patched_torch_function
-
-
-# ---------------------------------------------------------------------------
-# VAE Decoder monkey patches
-# ---------------------------------------------------------------------------
+        yield
+    finally:
+        torch.Tensor.__getitem__ = old
 
 
 def _patch_wan_resample_rep_sentinel() -> None:

--- a/tests/torch/models/wan2_2/shared.py
+++ b/tests/torch/models/wan2_2/shared.py
@@ -22,6 +22,7 @@ import torch
 import torch.nn as nn
 from infra.utilities import Mesh
 from infra.utilities.torch_multichip_utils import enable_spmd, get_mesh
+from tests.infra.testers.compiler_config import CompilerConfig
 
 MODEL_ID = "Wan-AI/Wan2.2-TI2V-5B-Diffusers"
 
@@ -403,7 +404,8 @@ def run_component(
     xr.set_device_type("TT")
     device = xm.xla_device()
 
-    torch_xla.set_custom_compile_options({"optimization_level": 1})
+    compiler_config = CompilerConfig(optimization_level=1, experimental_enable_dram_space_saving_optimization=True)
+    torch_xla.set_custom_compile_options(compiler_config.to_torch_compile_options())
 
     # Move the raw wrapper and inputs to device first. shard_fn needs to see
     # XLA tensors, so sharding must happen *after* this move.

--- a/tests/torch/models/wan2_2/test_vae_decoder.py
+++ b/tests/torch/models/wan2_2/test_vae_decoder.py
@@ -23,9 +23,10 @@ from infra.utilities.torch_multichip_utils import enable_spmd
 from tests.infra.testers.compiler_config import CompilerConfig
 
 from .monkey_patch import (
-    _patch_tt_torch_getitem_clamp,
     _patch_wan_resample_avoid_4d_fold,
     _patch_wan_resample_rep_sentinel,
+    _disable_tt_torch_function_override,
+    safe_xla_slicing,
 )
 from .shared import (
     RESOLUTIONS,
@@ -40,9 +41,9 @@ from .shared import (
 # Monkey patches
 # ---------------------------------------------------------------------------
 
-_patch_tt_torch_getitem_clamp()
 _patch_wan_resample_rep_sentinel()
 _patch_wan_resample_avoid_4d_fold()
+_disable_tt_torch_function_override()
 
 # ---------------------------------------------------------------------------
 # Tests
@@ -105,12 +106,14 @@ def _run(resolution: str, sharded: bool):
 
     with torch.no_grad():
         warmup_start = time.perf_counter_ns()
-        _ = compiled(*inputs_on_device)
+        with safe_xla_slicing():
+            _ = compiled(*inputs_on_device)
         torch_xla.sync(wait=True)
         warmup_end = time.perf_counter_ns()
 
         warm_start = time.perf_counter_ns()
-        tt_out = compiled(*inputs_on_device)
+        with safe_xla_slicing():
+            tt_out = compiled(*inputs_on_device)
         torch_xla.sync(wait=True)
         warm_end = time.perf_counter_ns()
 

--- a/tests/torch/models/wan2_2/test_wan22_e2e.py
+++ b/tests/torch/models/wan2_2/test_wan22_e2e.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 import torch
 
-from .monkey_patch import _patch_apply_lora_scale, _patch_tt_torch_getitem_clamp, _patch_wan_resample_rep_sentinel, _patch_wan_resample_avoid_4d_fold
+from .monkey_patch import _patch_apply_lora_scale, _patch_wan_resample_rep_sentinel, _patch_wan_resample_avoid_4d_fold, safe_xla_slicing, _disable_tt_torch_function_override
 from .shared import (
     LATENT_CHANNELS,
     RESOLUTIONS,
@@ -57,10 +57,10 @@ RESOLUTION = "480p"  # "480p" or "720p"
 NUM_STEPS = 40  # denoising steps
 GUIDANCE_SCALE = 5.0  # matches diffusers / Wan repo default; CFG on
 
-TT_TEXT_ENCODER = False
+TT_TEXT_ENCODER = True
 TT_VAE_ENCODER = False  # only used when MODE == "i2v"
 TT_DIT = True
-TT_VAE_DECODER = False
+TT_VAE_DECODER = True
 
 # Mesh shared by every component that runs on TT in this pipeline. Built once
 # so callers pass the same mesh object each time. None means CPU-only run.
@@ -69,6 +69,7 @@ _mesh = (
     if (TT_TEXT_ENCODER or TT_VAE_ENCODER or TT_DIT or TT_VAE_DECODER)
     else None
 )
+# _mesh = None
 
 # Simple single-subject prompt for smoke-test readability. Failure is
 # immediately obvious by eye; success is unambiguous. Fallback options
@@ -119,9 +120,9 @@ def _output_path() -> Path:
 # ---------------------------------------------------------------------------
 
 _patch_apply_lora_scale()
-_patch_tt_torch_getitem_clamp()
 _patch_wan_resample_rep_sentinel()
 _patch_wan_resample_avoid_4d_fold()
+_disable_tt_torch_function_override()
 
 # ---------------------------------------------------------------------------
 # Test
@@ -291,14 +292,15 @@ def _run_vae(vae, latents: torch.Tensor, mesh) -> torch.Tensor:
     # VAE decoder has bf16 weights — cast at the boundary (same pattern as
     # the DiT call in _denoise). Unscaling happens in float32 for precision.
     decoder_wrapper = VAEDecoderWrapper(vae).eval().bfloat16()
-    return run_component(
-        decoder_wrapper,
-        [latents_unscaled.to(torch.bfloat16)],
-        on_tt=TT_VAE_DECODER,
-        mesh=mesh,
-        shard_module=decoder_wrapper.vae,
-        shard_fn=shard_vae_decoder_specs,
-    )
+    with safe_xla_slicing():
+        return run_component(
+            decoder_wrapper,
+            [latents_unscaled.to(torch.bfloat16)],
+            on_tt=TT_VAE_DECODER,
+            mesh=mesh,
+            shard_module=decoder_wrapper.vae,
+            shard_fn=shard_vae_decoder_specs,
+        )
 
 
 def _postprocess_and_save(pixels: torch.Tensor, out_path: Path) -> None:


### PR DESCRIPTION
[Issue #26] Enable DiT and VAE decoder to work in single pipeline

fixes: https://github.com/tenstorrent/forge-tt-deploy-demos/issues/26