### PR TITLE
Prioritize runtime_reason over static_reason in record_model_test_properties

### DIFF
--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -657,7 +657,7 @@ def record_model_test_properties(
         else:
             bringup_status = BringupStatus.INCORRECT_RESULT
 
-        reason = static_reason or runtime_reason or "Not specified"
+        reason = runtime_reason or static_reason or "Not specified"
 
     tags = {
         "test_name": str(request.node.originalname),


### PR DESCRIPTION
### Ticket
N/A

### Problem description
In `record_model_test_properties`, the `reason` field was assigned as `static_reason or runtime_reason or "Not specified"`. This meant a statically configured reason would always shadow a more specific runtime reason produced during the actual test run, making the recorded reason less informative when both were present.

### What's changed
Swapped the order so `runtime_reason` takes precedence over `static_reason`:

```python
reason = runtime_reason or static_reason or "Not specified"
```

This ensures the most relevant (runtime) reason is captured when recording model test properties, while still falling back to the static reason and finally to `"Not specified"` when neither is available.

### Checklist
- [ ] New/Existing tests provide coverage for changes