### PR TITLE
[Benchmark] Bring back gpt_oss_120b in accuracy tests

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -533,6 +533,20 @@
         "accuracy-testing": true
       },
       {
+        "name": "gpt_oss_120b_tp_galaxy_accuracy",
+        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.2.0",
+        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_120b_tp_galaxy_batch_size_64",
+        "runs-on": "galaxy-wh-6u",
+        "accuracy-testing": true
+      },
+      {
+        "name": "gpt_oss_120b_tp_dp_galaxy_accuracy",
+        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.2.0",
+        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_120b_tp_dp_galaxy_batch_size_128",
+        "runs-on": "galaxy-wh-6u",
+        "accuracy-testing": true
+      },
+      {
         "name": "vllm_llama_3_2_3b",
         "pyreq": "loguru pytest torch==2.9.1 transformers==4.57.6 vllm==0.16.0",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[llama-3.2-3b]",

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -1938,6 +1938,42 @@ def test_gpt_oss_120b_tp_dp_galaxy_batch_size_128(
     )
 
 
+def test_gpt_oss_120b_tp_galaxy_batch_size_64(
+    output_file,
+    num_layers,
+    request,
+    accuracy_testing,
+    batch_size,
+    max_output_tokens,
+    decode_only,
+    optimization_level,
+):
+    from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
+        ModelLoader,
+        ModelVariant,
+    )
+
+    variant = ModelVariant.GPT_OSS_120B
+    test_llm_tp(
+        ModelLoader,
+        variant,
+        output_file,
+        num_layers=num_layers,
+        request=request,
+        accuracy_testing=accuracy_testing,
+        max_output_tokens=max_output_tokens,
+        decode_only=decode_only,
+        batch_size=batch_size if batch_size is not None else 64,
+        arch="wormhole_galaxy",
+        optimization_level=1,
+        mesh_config_fn=_galaxy_mesh_config_fn,
+        shard_spec_fn=_moe_throughput_galaxy_shard_spec_fn,
+        input_output_sharding_spec=("batch", None),
+        kv_cache_sharding_spec=("batch", "model", None, None),
+        trace_enabled=True,
+    )
+
+
 def _gpt_oss_120b_qb2_mesh_config_fn(model_loader, num_devices):
     return (1, 4), ("batch", "model")
 


### PR DESCRIPTION
### Problem description
~All benchmarks failed on [latest nightly](https://github.com/tenstorrent/tt-xla/actions/runs/25351022480) due to torch version missmatch.~
This is [reverted](https://github.com/tenstorrent/tt-xla/commit/85731442c3e161559276dddb24ea3741271a0f59).

### What's changed
~- Aligned torch version in CI.~
- Restored gpt_oss_120b accuracy tests. 


### Checklist
- [ ] [Llama-3.2-1B n150 benchmark](https://github.com/tenstorrent/tt-xla/actions/runs/25380948309)
