### PR TITLE
[HunyuanVideo-1.5-Diffusers-480p_t2v_distilled] Add initial tests for each part of the pipeline

### DIFF
--- a/tests/torch/models/Hunyuan_1_5/__init__.py
+++ b/tests/torch/models/Hunyuan_1_5/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/torch/models/Hunyuan_1_5/test_text_encoder.py
+++ b/tests/torch/models/Hunyuan_1_5/test_text_encoder.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""HunyuanVideo 1.5 — Qwen2.5-VL text encoder component test."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+from infra.utilities.torch_multichip_utils import get_mesh
+
+from third_party.tt_forge_models.hunyuan_1_5.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.skip(
+    reason="model size > 7B — won't fit on a single chip; sharded variant runs"
+)
+def test_text_encoder():
+    _run(sharded=False)
+
+
+@pytest.mark.nightly
+@pytest.mark.model_test
+def test_text_encoder_sharded():
+    _run(sharded=True)
+
+
+def _run(sharded: bool):
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.TEXT_ENCODER)
+    encoder = loader.load_model(dtype_override=torch.bfloat16)
+    inputs = loader.load_inputs(dtype_override=torch.bfloat16)
+
+    mesh = None
+    shard_spec_fn = None
+    if sharded:
+        mesh_shape, mesh_names = loader.get_mesh_config(
+            xr.global_runtime_device_count()
+        )
+        mesh = get_mesh(mesh_shape, mesh_names)
+        shard_spec_fn = loader.load_shard_spec
+
+    run_graph_test(
+        encoder,
+        inputs,
+        framework=Framework.TORCH,
+        mesh=mesh,
+        shard_spec_fn=shard_spec_fn,
+    )

--- a/tests/torch/models/Hunyuan_1_5/test_text_encoder_2.py
+++ b/tests/torch/models/Hunyuan_1_5/test_text_encoder_2.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""HunyuanVideo 1.5 — ByT5 text encoder component test (text_encoder_2)."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+
+from third_party.tt_forge_models.hunyuan_1_5.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.xfail(
+    reason="PCC drop (got 0.9712937232386395, required >= 0.99) — https://github.com/tenstorrent/tt-xla/issues/4484"
+)
+@pytest.mark.nightly
+@pytest.mark.model_test
+def test_text_encoder_2():
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.TEXT_ENCODER_2)
+    encoder = loader.load_model(dtype_override=torch.bfloat16)
+    inputs = loader.load_inputs(dtype_override=torch.bfloat16)
+
+    run_graph_test(
+        encoder,
+        inputs,
+        framework=Framework.TORCH,
+    )

--- a/tests/torch/models/Hunyuan_1_5/test_transformer.py
+++ b/tests/torch/models/Hunyuan_1_5/test_transformer.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""HunyuanVideo 1.5 — HunyuanVideo15Transformer3DModel (DiT) component test."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+from infra.utilities.torch_multichip_utils import get_mesh
+
+from third_party.tt_forge_models.hunyuan_1_5.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.skip(
+    reason="model size > 8B — won't fit on a single chip; sharded variant runs"
+)
+def test_transformer():
+    _run(sharded=False)
+
+
+@pytest.mark.xfail(
+    reason="SPMD compilation gives trivial mesh size [1,1] -> 'Device count mismatch: 2 vs 1' at execute — https://github.com/tenstorrent/tt-xla/issues/4486"
+)
+def test_transformer_sharded():
+    _run(sharded=True)
+
+
+def _run(sharded: bool):
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.TRANSFORMER)
+    model = loader.load_model(dtype_override=torch.bfloat16)
+    inputs = loader.load_inputs(dtype_override=torch.bfloat16)
+
+    mesh = None
+    shard_spec_fn = None
+    if sharded:
+        mesh_shape, mesh_names = loader.get_mesh_config(
+            xr.global_runtime_device_count()
+        )
+        mesh = get_mesh(mesh_shape, mesh_names)
+        shard_spec_fn = loader.load_shard_spec
+
+    run_graph_test(
+        model,
+        inputs,
+        framework=Framework.TORCH,
+        mesh=mesh,
+        shard_spec_fn=shard_spec_fn,
+    )

--- a/tests/torch/models/Hunyuan_1_5/test_vae_decoder.py
+++ b/tests/torch/models/Hunyuan_1_5/test_vae_decoder.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""HunyuanVideo 1.5 — AutoencoderKLHunyuanVideo15 decoder component test."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+
+from third_party.tt_forge_models.hunyuan_1_5.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.skip(
+    reason="hang on TT — investigation pending — https://github.com/tenstorrent/tt-xla/issues/4485"
+)
+def test_vae_decoder():
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.VAE)
+    model = loader.load_model(dtype_override=torch.bfloat16)
+    inputs = loader.load_inputs(dtype_override=torch.bfloat16)
+
+    run_graph_test(
+        model,
+        inputs,
+        framework=Framework.TORCH,
+    )

--- a/tests/torch/models/krea_realtime/__init__.py
+++ b/tests/torch/models/krea_realtime/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
### Ticket

- closes https://github.com/tenstorrent/tt-xla/issues/4470

### Problem description
Add initial bringup tests for each component of the HunyuanVideo 1.5 (480p t2v distilled) pipeline & test it in Wormhole.

### What's changed

| File | Component | Tests |
|------|-----------|-------|
| `test_text_encoder.py` | Qwen2.5-VL text encoder (7.07B) | `test_text_encoder` (skip — model > 7B, won't fit on single chip), `test_text_encoder_sharded` (pass — 2 chips) |
| `test_text_encoder_2.py` | ByT5 text encoder (0.22B) | `test_text_encoder_2` (xfail — single chip — PCC drop — #4484) |
| `test_transformer.py` | HunyuanVideo15Transformer3DModel (8.33B DiT) | `test_transformer` (skip — model > 8B, won't fit on single chip), `test_transformer_sharded` (xfail — 2 chips — SPMD trivial-mesh / device count mismatch — #4486) |
| `test_vae_decoder.py` | AutoencoderKLHunyuanVideo15 (1.26B) | `test_vae_decoder` (skip — hang on TT — #4485) |

Model loading, input generation, wrapper modules, shard specs, and mesh config are provided by `third_party/tt_forge_models/hunyuan_1_5/pytorch` (see tenstorrent/tt-forge-models#636).

Notable implementation details carried in `tt_forge_models`:
- Components are loaded independently via `from_pretrained(subfolder=...)` — no full pipeline is instantiated. All four components (`text_encoder`, `text_encoder_2`, `transformer`, `vae`) are sourced from `hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_t2v_distilled`.
- `HunyuanVideo15TransformerWrapper` flattens the DiT's multi-argument forward to a tensor-only signature `(hidden_states, timestep, encoder_hidden_states, ...) → noise_pred`.
- `VAEDecoderWrapper` exposes decoder-only path `(z) → tensor`, bypassing the default encode+decode round-trip.
- **Note:** Added empty `__init__.py` to `tests/torch/models/Hunyuan_1_5/` and `tests/torch/models/krea_realtime/` to give each test module a unique fully-qualified name. Without it, pytest collection fails with `import file mismatch` because both directories contain files with the same basenames (`test_text_encoder.py`, `test_transformer.py`, `test_vae_decoder.py`). 


### Checklist
- [x] Verify changes through local testing in Wormhole

### Logs

- [may5_Hunyuan_1_5_encoder_2.log](https://github.com/user-attachments/files/27408292/may5_Hunyuan_1_5_encoder_2.log)
- [may5_Hunyuan_1_5_encoder_sharded.log](https://github.com/user-attachments/files/27408295/may5_Hunyuan_1_5_encoder_sharded.log)
- [may5_Hunyuan_1_5_transformer_sharded.log](https://github.com/user-attachments/files/27408296/may5_Hunyuan_1_5_transformer_sharded.log)
- [may5_hunyuanVideo_1_5_vae_decoder.log](https://github.com/user-attachments/files/27408299/may5_hunyuanVideo_1_5_vae_decoder.log)
