### PR TITLE
Add PRD-003 docs validator pytest harness

### DIFF
--- a/docs/src/emitpy_tutorial.md
+++ b/docs/src/emitpy_tutorial.md
@@ -40,6 +40,17 @@ ird reserve --docker-image ghcr.io/tenstorrent/tt-xla/tt-xla-ird-ubuntu-24-04:la
 
 > **Tip:** The `[additional ird options]` should include your typical IRD configuration like architecture, number of chips, etc.
 
+After the container starts, confirm it matches the source-build prerequisites:
+
+```bash
+cat /etc/os-release
+python3.12 --version
+```
+
+The image must report Ubuntu 24.04 and Python 3.12 before continuing. If either
+check fails, use a TT-XLA IRD image tag that satisfies those prerequisites before
+running `source venv/activate`.
+
 ### Step 2: Clone and Setup TT-XLA
 
 Inside your Docker container, clone the repository:

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -255,6 +255,17 @@ Install from source if you are a developer who wants to develop for TT-XLA.
    `python_package/requirements.txt` and `venv/requirements-dev.txt`, and
    exports the TT-XLA/TT-MLIR environment variables needed by the build.
 
+   For IRD or other non-privileged validation lanes where `/opt/tenstorrent/sfpi`
+   is managed by the image, prefer the pinned user-local SFPI toolchain:
+
+   ```bash
+   cmake -G Ninja -B build -DTT_USE_SYSTEM_SFPI=OFF
+   cmake --build build
+   ```
+
+   This avoids relying on a preinstalled system SFPI package and lets the pinned
+   `tt-metal` revision fetch the matching SFPI release into the build tree.
+
 5. To verify that everything is working correctly, run the following command:
 
    ```bash

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -38,12 +38,22 @@ To install a wheel and run an example model, do the following:
 
 Download the latest wheel with pip.
 ```bash
-pip install pjrt-plugin-tt --extra-index-url https://pypi.eng.aws.tenstorrent.com/
+python -m pip install --upgrade pip
+python -m pip install pjrt-plugin-tt --extra-index-url https://pypi.eng.aws.tenstorrent.com/
 ```
 
 Run the tt-forge-install script to install missing system dependencies.
-```
+```bash
 tt-forge-install
+```
+
+Confirm the installed wheel version and TT device visibility before running demos.
+These commands should complete without error and print the installed
+`pjrt-plugin-tt` version followed by the visible TT devices.
+
+```bash
+python -c "import importlib.metadata as m; print(m.version('pjrt-plugin-tt'))"
+python -c "import jax; print(jax.devices('tt'))"
 ```
 
 #### Step 2. Run some models:
@@ -95,6 +105,7 @@ This section walks through the installation steps for using a Docker container f
 #### Step 1. Run the Docker container:
 
    ```bash
+   docker pull ghcr.io/tenstorrent/tt-xla-slim:latest
    docker run -it --rm \
    --device /dev/tenstorrent \
    -v /dev/hugepages-1G:/dev/hugepages-1G \
@@ -107,6 +118,18 @@ This section walks through the installation steps for using a Docker container f
 
    ```bash
    docker ps
+   ```
+
+For a non-interactive readiness check, run the container with the same device
+mounts and ask JAX to list TT devices. The command should complete without
+error and print the visible TT devices.
+
+   ```bash
+   docker run --rm \
+   --device /dev/tenstorrent \
+   -v /dev/hugepages-1G:/dev/hugepages-1G \
+   ghcr.io/tenstorrent/tt-xla-slim:latest \
+   python -c "import jax; print(jax.devices('tt'))"
    ```
 
 #### Step 2: Running Models in Docker
@@ -176,6 +199,16 @@ Install from source if you are a developer who wants to develop for TT-XLA.
    sudo apt install libnsl-dev
    ```
 
+- Confirm the required tools are available before building:
+
+   ```bash
+   python3.12 --version
+   clang-20 --version
+   gcc-13 --version
+   ninja --version
+   cmake --version
+   ```
+
 #### Step 2: Building the TT-MLIR Toolchain
 
 - Before compiling TT-XLA, the TT-MLIR toolchain needs to be built:
@@ -217,6 +250,10 @@ Install from source if you are a developer who wants to develop for TT-XLA.
    cmake -G Ninja -B build # -DCMAKE_BUILD_TYPE=Debug in case you want debug build
    cmake --build build
    ```
+
+   The `source venv/activate` command creates `venv` on first use, installs
+   `python_package/requirements.txt` and `venv/requirements-dev.txt`, and
+   exports the TT-XLA/TT-MLIR environment variables needed by the build.
 
 5. To verify that everything is working correctly, run the following command:
 

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -47,6 +47,12 @@ Run the tt-forge-install script to install missing system dependencies.
 tt-forge-install
 ```
 
+`tt-forge-install` may install OS packages with `sudo apt-get`. Run it from a
+shell that has sudo/root privileges. On pre-provisioned CI or IRD images where
+system dependencies are already installed and sudo is intentionally unavailable,
+continue only if the readiness checks below pass; otherwise ask the environment
+owner to install the missing system packages.
+
 Confirm the installed wheel version and TT device visibility before running demos.
 These commands should complete without error and print the installed
 `pjrt-plugin-tt` version followed by the visible TT devices.

--- a/tests/runner/prd003_doc_validator.md
+++ b/tests/runner/prd003_doc_validator.md
@@ -1,0 +1,33 @@
+# PRD-003 Docs Validator
+
+The PRD-003 validator is a pytest entrypoint for the TT-XLA documentation
+installation harness. It emits contract records for the Phase 1 documentation
+flows and defaults to fail-closed behavior when a command is ambiguous.
+
+## Local Pytest Command
+
+```bash
+PYTHONPATH=. TT_XLA_PRD003_OUTPUT_ROOT=artifacts/prd003_doc_validator_pytest \
+TT_XLA_PRD003_RUN_ID=prd003-doc-validator-pytest-$(date +%Y%m%d%H%M%S) \
+pytest -q --noconftest tests/runner/test_prd003_doc_validator.py
+```
+
+Use `--noconftest` for minimal local environments where TT-XLA runtime
+dependencies such as `torch` are not installed. The test itself only requires
+the Python standard library and pytest.
+
+## Environment
+
+- `TT_XLA_PRD003_OUTPUT_ROOT`: artifact root for JSONL records and summaries.
+- `TT_XLA_PRD003_RUN_ID`: run identity embedded in emitted records.
+- `TT_XLA_PRD003_TARGET_ID`: target identity, defaulting to `local`.
+- `TT_XLA_PRD003_EXECUTE`: set to `1` only for an explicitly prepared VM run.
+- `TT_XLA_PRD003_REQUIRE_PASS`: set to `1` when the docs are expected to be
+  executable end to end; default behavior expects the current fail-closed
+  documentation-gap baseline.
+
+## Outputs
+
+- `records/jsonl/results.jsonl`
+- `records/by-flow/<flow-id>.result.json`
+- `summaries/coverage-summary.json`

--- a/tests/runner/prd003_doc_validator.md
+++ b/tests/runner/prd003_doc_validator.md
@@ -32,6 +32,11 @@ the Python standard library and pytest.
   executable end to end; default behavior expects fail-closed documentation
   gaps and explicit hardware-gate infrastructure errors.
 
+For IRD source-build validation, the harness tracks the documented command with
+`-DTT_USE_SYSTEM_SFPI=OFF` so the pinned `tt-metal` revision uses its matching
+user-local SFPI toolchain instead of a potentially stale system package under
+`/opt/tenstorrent/sfpi`.
+
 ## Outputs
 
 - `records/jsonl/results.jsonl`

--- a/tests/runner/prd003_doc_validator.md
+++ b/tests/runner/prd003_doc_validator.md
@@ -1,8 +1,13 @@
-# PRD-003 Docs Validator
+# PRD-003 Docs and Demo Validator
 
-The PRD-003 validator is a pytest entrypoint for the TT-XLA documentation
-installation harness. It emits contract records for the Phase 1 documentation
-flows and defaults to fail-closed behavior when a command is ambiguous.
+The PRD-003 validator is a pytest entrypoint for the TT-XLA documentation and
+demo validation harness. It emits contract records for the Phase 1
+documentation/install flows and the P0/P1 hardware-sensitive demo gates.
+
+Documentation flows default to fail-closed behavior when a command is
+ambiguous. Hardware-sensitive demo gates default to explicit
+`infra-unavailable` records until an IRD or equivalent TT hardware target is
+proven and execution is enabled.
 
 ## Local Pytest Command
 
@@ -21,10 +26,11 @@ the Python standard library and pytest.
 - `TT_XLA_PRD003_OUTPUT_ROOT`: artifact root for JSONL records and summaries.
 - `TT_XLA_PRD003_RUN_ID`: run identity embedded in emitted records.
 - `TT_XLA_PRD003_TARGET_ID`: target identity, defaulting to `local`.
-- `TT_XLA_PRD003_EXECUTE`: set to `1` only for an explicitly prepared VM run.
+- `TT_XLA_PRD003_EXECUTE`: set to `1` only for an explicitly prepared VM or
+  IRD-equivalent TT hardware run.
 - `TT_XLA_PRD003_REQUIRE_PASS`: set to `1` when the docs are expected to be
-  executable end to end; default behavior expects the current fail-closed
-  documentation-gap baseline.
+  executable end to end; default behavior expects fail-closed documentation
+  gaps and explicit hardware-gate infrastructure errors.
 
 ## Outputs
 

--- a/tests/runner/prd003_doc_validator.py
+++ b/tests/runner/prd003_doc_validator.py
@@ -85,6 +85,32 @@ PHASE1_DOC_FLOWS: list[dict[str, Any]] = [
         },
     },
     {
+        "flow_id": "CORPUS-WHEEL-002",
+        "surface_id": "wheel-system-deps",
+        "surface_type": "doc",
+        "priority": "P0",
+        "source_mode": "documented",
+        "source_path": "docs/src/getting_started.md",
+        "source_section": "Installing a Wheel and Running an Example",
+        "command": "tt-forge-install",
+        "expected_target": {
+            "execution_target": "vm",
+            "target_id": "local",
+            "os_image": "ubuntu-24.04",
+            "runtime": "bash",
+        },
+        "success_signal": {"type": "exit_zero", "value": ""},
+        "doc_clarity": {
+            "fail_closed": True,
+            "blocker_ids": ["DOC-GAP-007"],
+            "notes": (
+                "The system dependency installer requires sudo/root privileges; "
+                "pre-provisioned CI or IRD images may skip it only after the "
+                "documented device readiness checks pass."
+            ),
+        },
+    },
+    {
         "flow_id": "CORPUS-SOURCE-001",
         "surface_id": "source-system-deps",
         "surface_type": "doc",

--- a/tests/runner/prd003_doc_validator.py
+++ b/tests/runner/prd003_doc_validator.py
@@ -173,7 +173,10 @@ PHASE1_DOC_FLOWS: list[dict[str, Any]] = [
             "os_image": "ubuntu-22.04",
             "runtime": "python",
         },
-        "success_signal": {"type": "artifact_exists", "value": "dist/pjrt_plugin_tt*.whl"},
+        "success_signal": {
+            "type": "artifact_exists",
+            "value": "dist/pjrt_plugin_tt*.whl",
+        },
         "doc_clarity": {
             "fail_closed": True,
             "blocker_ids": ["DOC-GAP-004"],
@@ -202,7 +205,9 @@ def utc_now() -> str:
 
 def write_json(path: Path, payload: Any) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(f"{json.dumps(payload, indent=2, sort_keys=True)}\n", encoding="utf-8")
+    path.write_text(
+        f"{json.dumps(payload, indent=2, sort_keys=True)}\n", encoding="utf-8"
+    )
 
 
 def write_text(path: Path, text: str) -> None:
@@ -311,7 +316,9 @@ def classify_execution(
         record["reason_code"] = "broken-command"
         record["severity"] = "high"
         record["summary"] = f"{flow['flow_id']} exited non-zero."
-        record["actionability"]["recommended_fix"] = "Fix the documented command or prerequisites."
+        record["actionability"][
+            "recommended_fix"
+        ] = "Fix the documented command or prerequisites."
         record["actionability"]["next_step"] = "open-docs-or-install-defect"
         return record
 
@@ -340,7 +347,9 @@ def classify_execution(
         record["summary"] = (
             f"{flow['flow_id']} exited zero but did not match the expected success signal."
         )
-        record["actionability"]["recommended_fix"] = "Align the command or expected success signal."
+        record["actionability"][
+            "recommended_fix"
+        ] = "Align the command or expected success signal."
         record["actionability"]["next_step"] = "open-validation-defect"
     return record
 
@@ -373,9 +382,9 @@ def execute_flow(
         record["reason_code"] = "timeout"
         record["summary"] = f"{flow_id} timed out after {timeout_seconds} seconds."
         record["evidence"]["exit_code"] = 124
-        record["actionability"]["recommended_fix"] = (
-            "Increase timeout or split the validation step."
-        )
+        record["actionability"][
+            "recommended_fix"
+        ] = "Increase timeout or split the validation step."
         record["actionability"]["next_step"] = "rerun-with-adjusted-timeout"
         return record
 
@@ -388,7 +397,9 @@ def build_summary(run_id: str, records: list[dict[str, Any]]) -> dict[str, Any]:
     counts_by_status: dict[str, int] = {}
     blockers: dict[str, int] = {}
     for record in records:
-        counts_by_status[record["status"]] = counts_by_status.get(record["status"], 0) + 1
+        counts_by_status[record["status"]] = (
+            counts_by_status.get(record["status"], 0) + 1
+        )
         for flag in record["doc_clarity"]["flags"]:
             blockers[flag] = blockers.get(flag, 0) + 1
     return {
@@ -446,7 +457,9 @@ def run_validation(
                 f"{flow_id} was not executed because execute mode was not enabled."
             )
         records.append(record)
-        write_json(output_root / "records" / "by-flow" / f"{flow_id}.result.json", record)
+        write_json(
+            output_root / "records" / "by-flow" / f"{flow_id}.result.json", record
+        )
 
     jsonl_path = output_root / "records" / "jsonl" / "results.jsonl"
     jsonl_path.parent.mkdir(parents=True, exist_ok=True)
@@ -456,7 +469,9 @@ def run_validation(
     )
     summary = build_summary(run_id, records)
     write_json(output_root / "summaries" / "coverage-summary.json", summary)
-    return ValidationRun(run_id=run_id, output_root=output_root, records=records, summary=summary)
+    return ValidationRun(
+        run_id=run_id, output_root=output_root, records=records, summary=summary
+    )
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/tests/runner/prd003_doc_validator.py
+++ b/tests/runner/prd003_doc_validator.py
@@ -1,0 +1,486 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""PRD-003 docs/install validation harness.
+
+This runner emits PRD-003 contract records for the phase-1 docs/install
+surfaces. It is intentionally fail-closed: manifest entries with unresolved
+doc-clarity blockers are recorded as documentation failures instead of running
+ambiguous package install, Docker, or source-build commands.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import platform
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+CONTRACT_VERSION = "1.0.0"
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUTPUT_ROOT = PROJECT_ROOT / "artifacts" / "prd003_doc_validator"
+
+
+PHASE1_DOC_FLOWS: list[dict[str, Any]] = [
+    {
+        "flow_id": "CORPUS-DOCKER-001",
+        "surface_id": "docker-container-start",
+        "surface_type": "doc",
+        "priority": "P0",
+        "source_mode": "documented",
+        "source_path": "docs/src/getting_started.md",
+        "source_section": "Using a Docker Container to Run an Example",
+        "command": (
+            "docker run -it --rm --device /dev/tenstorrent "
+            "-v /dev/hugepages-1G:/dev/hugepages-1G "
+            "ghcr.io/tenstorrent/tt-xla-slim:latest"
+        ),
+        "expected_target": {
+            "execution_target": "vm",
+            "target_id": "local",
+            "os_image": "ubuntu-22.04",
+            "runtime": "docker",
+        },
+        "success_signal": {"type": "exit_zero", "value": ""},
+        "doc_clarity": {
+            "fail_closed": True,
+            "blocker_ids": ["DOC-GAP-006"],
+            "notes": (
+                "Docker launch lacks a non-interactive readiness check and assumes "
+                "TT device passthrough."
+            ),
+        },
+    },
+    {
+        "flow_id": "CORPUS-WHEEL-001",
+        "surface_id": "wheel-install-latest",
+        "surface_type": "doc",
+        "priority": "P0",
+        "source_mode": "documented",
+        "source_path": "docs/src/getting_started.md",
+        "source_section": "Installing a Wheel and Running an Example",
+        "command": (
+            "pip install pjrt-plugin-tt "
+            "--extra-index-url https://pypi.eng.aws.tenstorrent.com/"
+        ),
+        "expected_target": {
+            "execution_target": "vm",
+            "target_id": "local",
+            "os_image": "ubuntu-22.04",
+            "runtime": "python",
+        },
+        "success_signal": {"type": "exit_zero", "value": ""},
+        "doc_clarity": {
+            "fail_closed": True,
+            "blocker_ids": ["DOC-GAP-003"],
+            "notes": "Private index access and expected wheel version are not specified.",
+        },
+    },
+    {
+        "flow_id": "CORPUS-SOURCE-001",
+        "surface_id": "source-system-deps",
+        "surface_type": "doc",
+        "priority": "P0",
+        "source_mode": "documented",
+        "source_path": "docs/src/getting_started.md",
+        "source_section": "Building from Source",
+        "command": (
+            "sudo apt install protobuf-compiler libprotobuf-dev && "
+            "sudo apt install ccache && "
+            "sudo apt install libnuma-dev && "
+            "sudo apt install libhwloc-dev && "
+            "sudo apt install libboost-all-dev"
+        ),
+        "expected_target": {
+            "execution_target": "vm",
+            "target_id": "local",
+            "os_image": "ubuntu-22.04",
+            "runtime": "bash",
+        },
+        "success_signal": {"type": "exit_zero", "value": ""},
+        "doc_clarity": {
+            "fail_closed": True,
+            "blocker_ids": ["DOC-GAP-003"],
+            "notes": (
+                "Required Python, Clang, GCC, Ninja, and CMake versions lack "
+                "install commands."
+            ),
+        },
+    },
+    {
+        "flow_id": "CORPUS-SOURCE-002",
+        "surface_id": "source-clone",
+        "surface_type": "doc",
+        "priority": "P0",
+        "source_mode": "documented",
+        "source_path": "docs/src/getting_started.md",
+        "source_section": "Building from Source",
+        "command": "git clone https://github.com/tenstorrent/tt-xla.git",
+        "expected_target": {
+            "execution_target": "vm",
+            "target_id": "local",
+            "os_image": "ubuntu-22.04",
+            "runtime": "git",
+        },
+        "success_signal": {"type": "artifact_exists", "value": "tt-xla"},
+        "doc_clarity": {
+            "fail_closed": True,
+            "blocker_ids": ["DOC-GAP-003"],
+            "notes": "Repo branch/ref is not pinned for repeatable validation.",
+        },
+    },
+    {
+        "flow_id": "CORPUS-SOURCE-004",
+        "surface_id": "source-build",
+        "surface_type": "doc",
+        "priority": "P0",
+        "source_mode": "documented",
+        "source_path": "docs/src/getting_started.md",
+        "source_section": "Building from Source",
+        "command": "source venv/activate && cmake -G Ninja -B build && cmake --build build",
+        "expected_target": {
+            "execution_target": "vm",
+            "target_id": "local",
+            "os_image": "ubuntu-22.04",
+            "runtime": "cmake",
+        },
+        "success_signal": {"type": "exit_zero", "value": ""},
+        "doc_clarity": {
+            "fail_closed": True,
+            "blocker_ids": ["DOC-GAP-004"],
+            "notes": "The creation and ownership of venv/activate are not documented.",
+        },
+    },
+    {
+        "flow_id": "CORPUS-SOURCE-006",
+        "surface_id": "source-wheel-build",
+        "surface_type": "doc",
+        "priority": "P1",
+        "source_mode": "documented",
+        "source_path": "docs/src/getting_started.md",
+        "source_section": "Building from Source",
+        "command": "python setup.py bdist_wheel",
+        "expected_target": {
+            "execution_target": "vm",
+            "target_id": "local",
+            "os_image": "ubuntu-22.04",
+            "runtime": "python",
+        },
+        "success_signal": {"type": "artifact_exists", "value": "dist/pjrt_plugin_tt*.whl"},
+        "doc_clarity": {
+            "fail_closed": True,
+            "blocker_ids": ["DOC-GAP-004"],
+            "notes": "Source-build environment setup is not fully specified before wheel build.",
+        },
+    },
+]
+
+
+@dataclass
+class ValidationRun:
+    run_id: str
+    output_root: Path
+    records: list[dict[str, Any]]
+    summary: dict[str, Any]
+
+
+def utc_now() -> str:
+    return (
+        dt.datetime.now(dt.timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"{json.dumps(payload, indent=2, sort_keys=True)}\n", encoding="utf-8")
+
+
+def write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def redact(text: str) -> str:
+    redacted = text
+    for pattern, replacement in (
+        (r"(?i)(token|password|secret|api[_-]?key)=\S+", r"\1=<redacted>"),
+        (r"(?i)(authorization:\s*bearer\s+)[A-Za-z0-9._\-]+", r"\1<redacted>"),
+    ):
+        redacted = re.sub(pattern, replacement, redacted)
+    return redacted
+
+
+def base_record(
+    flow: dict[str, Any],
+    run_id: str,
+    output_root: Path,
+    target_id: str,
+) -> dict[str, Any]:
+    flow_id = str(flow["flow_id"])
+    environment = dict(flow["expected_target"])
+    environment["target_id"] = target_id
+    return {
+        "contract_version": CONTRACT_VERSION,
+        "run_id": run_id,
+        "record_id": f"{run_id}-{flow_id}",
+        "timestamp_utc": utc_now(),
+        "repo": "tt-xla",
+        "ref": "local",
+        "surface_type": flow["surface_type"],
+        "surface_id": flow["surface_id"],
+        "flow_id": flow_id,
+        "environment": environment,
+        "status": "error",
+        "reason_code": "unknown-error",
+        "severity": "medium",
+        "summary": "",
+        "evidence": {
+            "doc_path": flow["source_path"],
+            "doc_section": flow["source_section"],
+            "command": flow["command"],
+            "exit_code": None,
+            "stdout_ref": str(output_root / "logs" / f"{flow_id}.stdout.log"),
+            "stderr_ref": str(output_root / "logs" / f"{flow_id}.stderr.log"),
+            "artifact_refs": [
+                str(output_root / "snapshots" / "commands" / f"{flow_id}.command.txt")
+            ],
+        },
+        "doc_clarity": {
+            "is_ambiguous": False,
+            "flags": [],
+            "notes": "",
+        },
+        "actionability": {
+            "owner_team": "tt-xla",
+            "recommended_fix": "none",
+            "next_step": "keep-monitoring",
+        },
+    }
+
+
+def fail_closed_record(
+    flow: dict[str, Any],
+    run_id: str,
+    output_root: Path,
+    target_id: str,
+) -> dict[str, Any]:
+    record = base_record(flow, run_id, output_root, target_id)
+    clarity = flow["doc_clarity"]
+    record["status"] = "fail"
+    record["reason_code"] = "doc-ambiguous-step"
+    record["severity"] = "high"
+    record["summary"] = (
+        f"{flow['flow_id']} was not executed because the documented flow is ambiguous."
+    )
+    record["evidence"]["stdout_ref"] = None
+    record["evidence"]["stderr_ref"] = None
+    record["doc_clarity"] = {
+        "is_ambiguous": True,
+        "flags": list(clarity["blocker_ids"]),
+        "notes": clarity["notes"],
+    }
+    record["actionability"] = {
+        "owner_team": "tt-xla",
+        "recommended_fix": (
+            "Document prerequisites, pinned refs, success criteria, or accepted defaults "
+            "before execution."
+        ),
+        "next_step": "resolve-doc-clarity-blocker",
+    }
+    return record
+
+
+def classify_execution(
+    record: dict[str, Any],
+    flow: dict[str, Any],
+    completed: subprocess.CompletedProcess[str],
+) -> dict[str, Any]:
+    record["evidence"]["exit_code"] = completed.returncode
+    if completed.returncode != 0:
+        record["status"] = "fail"
+        record["reason_code"] = "broken-command"
+        record["severity"] = "high"
+        record["summary"] = f"{flow['flow_id']} exited non-zero."
+        record["actionability"]["recommended_fix"] = "Fix the documented command or prerequisites."
+        record["actionability"]["next_step"] = "open-docs-or-install-defect"
+        return record
+
+    signal = flow["success_signal"]
+    signal_type = signal["type"]
+    signal_value = signal["value"]
+    matched = False
+    if signal_type == "exit_zero":
+        matched = True
+    elif signal_type == "stdout_contains":
+        matched = signal_value in completed.stdout
+    elif signal_type == "stdout_regex":
+        matched = re.search(signal_value, completed.stdout) is not None
+    elif signal_type == "artifact_exists":
+        matched = bool(signal_value)
+
+    if matched:
+        record["status"] = "pass"
+        record["reason_code"] = "ok"
+        record["severity"] = "low"
+        record["summary"] = f"{flow['flow_id']} completed with expected success signal."
+    else:
+        record["status"] = "fail"
+        record["reason_code"] = "assertion-failed"
+        record["severity"] = "high"
+        record["summary"] = (
+            f"{flow['flow_id']} exited zero but did not match the expected success signal."
+        )
+        record["actionability"]["recommended_fix"] = "Align the command or expected success signal."
+        record["actionability"]["next_step"] = "open-validation-defect"
+    return record
+
+
+def execute_flow(
+    flow: dict[str, Any],
+    run_id: str,
+    output_root: Path,
+    target_id: str,
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    record = base_record(flow, run_id, output_root, target_id)
+    flow_id = str(flow["flow_id"])
+    stdout_path = output_root / "logs" / f"{flow_id}.stdout.log"
+    stderr_path = output_root / "logs" / f"{flow_id}.stderr.log"
+    try:
+        completed = subprocess.run(
+            flow["command"],
+            shell=True,
+            cwd=PROJECT_ROOT,
+            text=True,
+            capture_output=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        write_text(stdout_path, redact(exc.stdout or ""))
+        write_text(stderr_path, redact(exc.stderr or ""))
+        record["status"] = "error"
+        record["reason_code"] = "timeout"
+        record["summary"] = f"{flow_id} timed out after {timeout_seconds} seconds."
+        record["evidence"]["exit_code"] = 124
+        record["actionability"]["recommended_fix"] = (
+            "Increase timeout or split the validation step."
+        )
+        record["actionability"]["next_step"] = "rerun-with-adjusted-timeout"
+        return record
+
+    write_text(stdout_path, redact(completed.stdout))
+    write_text(stderr_path, redact(completed.stderr))
+    return classify_execution(record, flow, completed)
+
+
+def build_summary(run_id: str, records: list[dict[str, Any]]) -> dict[str, Any]:
+    counts_by_status: dict[str, int] = {}
+    blockers: dict[str, int] = {}
+    for record in records:
+        counts_by_status[record["status"]] = counts_by_status.get(record["status"], 0) + 1
+        for flag in record["doc_clarity"]["flags"]:
+            blockers[flag] = blockers.get(flag, 0) + 1
+    return {
+        "run_id": run_id,
+        "contract_version": CONTRACT_VERSION,
+        "repo": "tt-xla",
+        "ref": "local",
+        "platform": platform.platform(),
+        "record_count": len(records),
+        "counts_by_status": counts_by_status,
+        "doc_clarity_blockers": blockers,
+        "top_recommended_next_steps": sorted(
+            {record["actionability"]["next_step"] for record in records}
+        ),
+        "ended_at_utc": utc_now(),
+    }
+
+
+def run_validation(
+    output_root: Path = DEFAULT_OUTPUT_ROOT,
+    run_id: str = "prd003-doc-validator-pytest",
+    target_id: str = "local",
+    execute: bool = False,
+    timeout_seconds: int = 1800,
+) -> ValidationRun:
+    output_root.mkdir(parents=True, exist_ok=True)
+    records = []
+    write_json(
+        output_root / "manifest" / "tt-xla-prd003-manifest.lock.json",
+        {
+            "contract_version": CONTRACT_VERSION,
+            "execute": execute,
+            "platform": platform.platform(),
+            "run_id": run_id,
+            "target_id": target_id,
+            "timestamp_utc": utc_now(),
+        },
+    )
+
+    for flow in PHASE1_DOC_FLOWS:
+        flow_id = str(flow["flow_id"])
+        write_text(
+            output_root / "snapshots" / "commands" / f"{flow_id}.command.txt",
+            f"{flow['command']}\n",
+        )
+        if flow["doc_clarity"].get("fail_closed"):
+            record = fail_closed_record(flow, run_id, output_root, target_id)
+        elif execute:
+            record = execute_flow(flow, run_id, output_root, target_id, timeout_seconds)
+        else:
+            record = base_record(flow, run_id, output_root, target_id)
+            record["status"] = "error"
+            record["reason_code"] = "infra-unavailable"
+            record["summary"] = (
+                f"{flow_id} was not executed because execute mode was not enabled."
+            )
+        records.append(record)
+        write_json(output_root / "records" / "by-flow" / f"{flow_id}.result.json", record)
+
+    jsonl_path = output_root / "records" / "jsonl" / "results.jsonl"
+    jsonl_path.parent.mkdir(parents=True, exist_ok=True)
+    jsonl_path.write_text(
+        "".join(f"{json.dumps(record, sort_keys=True)}\n" for record in records),
+        encoding="utf-8",
+    )
+    summary = build_summary(run_id, records)
+    write_json(output_root / "summaries" / "coverage-summary.json", summary)
+    return ValidationRun(run_id=run_id, output_root=output_root, records=records, summary=summary)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run PRD-003 docs/install validation.")
+    parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
+    parser.add_argument("--run-id", default="prd003-doc-validator-cli")
+    parser.add_argument("--target-id", default="local")
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument("--timeout-seconds", type=int, default=1800)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    result = run_validation(
+        output_root=args.output_root,
+        run_id=args.run_id,
+        target_id=args.target_id,
+        execute=args.execute,
+        timeout_seconds=args.timeout_seconds,
+    )
+    print(json.dumps(result.summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/runner/prd003_doc_validator.py
+++ b/tests/runner/prd003_doc_validator.py
@@ -2,12 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""PRD-003 docs/install validation harness.
+"""PRD-003 docs/demo validation harness.
 
-This runner emits PRD-003 contract records for the phase-1 docs/install
-surfaces. It is intentionally fail-closed: manifest entries with unresolved
-doc-clarity blockers are recorded as documentation failures instead of running
-ambiguous package install, Docker, or source-build commands.
+This runner emits PRD-003 contract records for the phase-1 docs/install and
+hardware-sensitive demo surfaces. It is intentionally conservative: unresolved
+doc-clarity blockers fail closed, while hardware-sensitive gates emit explicit
+infrastructure-unavailable records unless an IRD or equivalent target has been
+proven and execution is enabled.
 """
 
 from __future__ import annotations
@@ -186,6 +187,135 @@ PHASE1_DOC_FLOWS: list[dict[str, Any]] = [
 ]
 
 
+PHASE1_IRD_DEMO_GATES: list[dict[str, Any]] = [
+    {
+        "flow_id": "IRD-GATE-001",
+        "surface_id": "source-tt-device-discovery",
+        "surface_type": "demo",
+        "priority": "P0",
+        "source_mode": "documented",
+        "source_path": "docs/src/getting_started.md",
+        "source_section": "Building from Source",
+        "command": "python -c \"import jax; print(jax.devices('tt'))\"",
+        "expected_target": {
+            "execution_target": "ird",
+            "target_id": "unavailable",
+            "hardware": "tt",
+            "os_image": "unknown",
+            "runtime": "scheduler",
+        },
+        "success_signal": {"type": "stdout_regex", "value": r"TTDevice\\("},
+        "doc_clarity": {"fail_closed": False, "blocker_ids": [], "notes": ""},
+        "infra_unavailable": {
+            "reason_code": "infra-unavailable",
+            "summary": "IRD target was unavailable before TT device discovery could be scheduled.",
+            "recommended_fix": (
+                "Confirm IRD quota, queue policy, target identifiers, and "
+                "reservation mechanism."
+            ),
+        },
+    },
+    {
+        "flow_id": "IRD-GATE-002",
+        "surface_id": "jax-simple-regression",
+        "surface_type": "demo",
+        "priority": "P0",
+        "source_mode": "source-backed",
+        "source_path": "examples/jax",
+        "source_section": "JAX demo gate",
+        "command": "pytest -q tests/jax/single_chip",
+        "expected_target": {
+            "execution_target": "ird",
+            "target_id": "unavailable",
+            "hardware": "tt",
+            "os_image": "unknown",
+            "runtime": "scheduler",
+        },
+        "success_signal": {"type": "exit_zero", "value": ""},
+        "doc_clarity": {"fail_closed": False, "blocker_ids": [], "notes": ""},
+        "infra_unavailable": {
+            "reason_code": "infra-unavailable",
+            "summary": "IRD target was unavailable before JAX demo gate could be scheduled.",
+            "recommended_fix": "Provide a reachable IRD or equivalent TT hardware lane.",
+        },
+    },
+    {
+        "flow_id": "IRD-GATE-003",
+        "surface_id": "pytorch-mnist",
+        "surface_type": "demo",
+        "priority": "P0",
+        "source_mode": "source-backed",
+        "source_path": "examples/pytorch/mnist.py",
+        "source_section": "PyTorch MNIST demo",
+        "command": "python examples/pytorch/mnist.py",
+        "expected_target": {
+            "execution_target": "ird",
+            "target_id": "unavailable",
+            "hardware": "tt",
+            "os_image": "unknown",
+            "runtime": "scheduler",
+        },
+        "success_signal": {"type": "exit_zero", "value": ""},
+        "doc_clarity": {"fail_closed": False, "blocker_ids": [], "notes": ""},
+        "infra_unavailable": {
+            "reason_code": "infra-unavailable",
+            "summary": "IRD target was unavailable before PyTorch demo gate could be scheduled.",
+            "recommended_fix": "Provide a reachable IRD or equivalent TT hardware lane.",
+        },
+    },
+    {
+        "flow_id": "IRD-GATE-008",
+        "surface_id": "tinyllama-vllm-service",
+        "surface_type": "demo",
+        "priority": "P1",
+        "source_mode": "source-backed",
+        "source_path": "examples/vllm/TinyLlama-1.1B-Chat-v1.0",
+        "source_section": "vLLM service gate",
+        "command": "bash examples/vllm/TinyLlama-1.1B-Chat-v1.0/service.sh",
+        "expected_target": {
+            "execution_target": "ird",
+            "target_id": "unavailable",
+            "hardware": "tt",
+            "os_image": "unknown",
+            "runtime": "scheduler",
+        },
+        "success_signal": {"type": "http_ready", "value": "/v1/models"},
+        "doc_clarity": {"fail_closed": False, "blocker_ids": [], "notes": ""},
+        "infra_unavailable": {
+            "reason_code": "infra-unavailable",
+            "summary": "IRD target was unavailable before vLLM service gate could be scheduled.",
+            "recommended_fix": "Provide a reachable IRD or equivalent TT hardware lane.",
+        },
+    },
+    {
+        "flow_id": "IRD-GATE-009",
+        "surface_id": "tinyllama-vllm-client",
+        "surface_type": "demo",
+        "priority": "P1",
+        "source_mode": "source-backed",
+        "source_path": "examples/vllm/TinyLlama-1.1B-Chat-v1.0/responses_client.py",
+        "source_section": "vLLM client gate",
+        "command": "python examples/vllm/TinyLlama-1.1B-Chat-v1.0/responses_client.py",
+        "expected_target": {
+            "execution_target": "ird",
+            "target_id": "unavailable",
+            "hardware": "tt",
+            "os_image": "unknown",
+            "runtime": "scheduler",
+        },
+        "success_signal": {"type": "stdout_contains", "value": "response"},
+        "doc_clarity": {"fail_closed": False, "blocker_ids": [], "notes": ""},
+        "infra_unavailable": {
+            "reason_code": "infra-unavailable",
+            "summary": "IRD target was unavailable before vLLM client gate could be scheduled.",
+            "recommended_fix": "Provide a reachable IRD or equivalent TT hardware lane.",
+        },
+    },
+]
+
+PHASE1_FLOWS: list[dict[str, Any]] = PHASE1_DOC_FLOWS + PHASE1_IRD_DEMO_GATES
+
+
 @dataclass
 class ValidationRun:
     run_id: str
@@ -312,6 +442,29 @@ def fail_closed_record(
             "before execution."
         ),
         "next_step": "resolve-doc-clarity-blocker",
+    }
+    return record
+
+
+def infra_unavailable_record(
+    flow: dict[str, Any],
+    run_id: str,
+    output_root: Path,
+    target_id: str,
+) -> dict[str, Any]:
+    record = base_record(flow, run_id, output_root, target_id)
+    infra = flow["infra_unavailable"]
+    record["status"] = "error"
+    record["reason_code"] = infra["reason_code"]
+    record["severity"] = "medium"
+    record["summary"] = infra["summary"]
+    record["evidence"]["exit_code"] = None
+    record["evidence"]["stdout_ref"] = None
+    record["evidence"]["stderr_ref"] = None
+    record["actionability"] = {
+        "owner_team": "infra-validation",
+        "recommended_fix": infra["recommended_fix"],
+        "next_step": "retry-after-target-proof",
     }
     return record
 
@@ -451,7 +604,7 @@ def run_validation(
         },
     )
 
-    for flow in PHASE1_DOC_FLOWS:
+    for flow in PHASE1_FLOWS:
         flow_id = str(flow["flow_id"])
         write_text(
             output_root / "snapshots" / "commands" / f"{flow_id}.command.txt",
@@ -459,6 +612,8 @@ def run_validation(
         )
         if flow["doc_clarity"].get("fail_closed"):
             record = fail_closed_record(flow, run_id, output_root, target_id)
+        elif flow.get("infra_unavailable") and not execute:
+            record = infra_unavailable_record(flow, run_id, output_root, target_id)
         elif execute:
             record = execute_flow(flow, run_id, output_root, target_id, timeout_seconds)
         else:

--- a/tests/runner/prd003_doc_validator.py
+++ b/tests/runner/prd003_doc_validator.py
@@ -24,7 +24,8 @@ from typing import Any
 
 CONTRACT_VERSION = "1.0.0"
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
-DEFAULT_OUTPUT_ROOT = PROJECT_ROOT / "artifacts" / "prd003_doc_validator"
+SAFE_OUTPUT_ROOT = PROJECT_ROOT / "artifacts"
+DEFAULT_OUTPUT_ROOT = SAFE_OUTPUT_ROOT / "prd003_doc_validator"
 
 
 PHASE1_DOC_FLOWS: list[dict[str, Any]] = [
@@ -212,6 +213,17 @@ def write_json(path: Path, payload: Any) -> None:
 def write_text(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
+
+
+def resolve_output_root(output_root: Path) -> Path:
+    root = output_root if output_root.is_absolute() else PROJECT_ROOT / output_root
+    resolved = root.resolve(strict=False)
+    safe_root = SAFE_OUTPUT_ROOT.resolve(strict=False)
+    try:
+        resolved.relative_to(safe_root)
+    except ValueError as exc:
+        raise ValueError(f"output_root must be under {safe_root}") from exc
+    return resolved
 
 
 def redact(text: str) -> str:
@@ -424,6 +436,7 @@ def run_validation(
     execute: bool = False,
     timeout_seconds: int = 1800,
 ) -> ValidationRun:
+    output_root = resolve_output_root(output_root)
     output_root.mkdir(parents=True, exist_ok=True)
     records = []
     write_json(

--- a/tests/runner/prd003_doc_validator.py
+++ b/tests/runner/prd003_doc_validator.py
@@ -22,7 +22,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-
 CONTRACT_VERSION = "1.0.0"
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_OUTPUT_ROOT = PROJECT_ROOT / "artifacts" / "prd003_doc_validator"

--- a/tests/runner/prd003_doc_validator.py
+++ b/tests/runner/prd003_doc_validator.py
@@ -145,7 +145,11 @@ PHASE1_DOC_FLOWS: list[dict[str, Any]] = [
         "source_mode": "documented",
         "source_path": "docs/src/getting_started.md",
         "source_section": "Building from Source",
-        "command": "source venv/activate && cmake -G Ninja -B build && cmake --build build",
+        "command": (
+            "source venv/activate && "
+            "cmake -G Ninja -B build -DTT_USE_SYSTEM_SFPI=OFF && "
+            "cmake --build build"
+        ),
         "expected_target": {
             "execution_target": "vm",
             "target_id": "local",
@@ -156,7 +160,11 @@ PHASE1_DOC_FLOWS: list[dict[str, Any]] = [
         "doc_clarity": {
             "fail_closed": True,
             "blocker_ids": ["DOC-GAP-004"],
-            "notes": "The creation and ownership of venv/activate are not documented.",
+            "notes": (
+                "The source-build flow now documents the IRD-safe user-local "
+                "SFPI path, but the creation and ownership of venv/activate are "
+                "not fully specified."
+            ),
         },
     },
     {

--- a/tests/runner/test_prd003_doc_validator.py
+++ b/tests/runner/test_prd003_doc_validator.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+from pathlib import Path
+
+from tests.runner.prd003_doc_validator import CONTRACT_VERSION, run_validation
+
+
+REQUIRED_RECORD_FIELDS = {
+    "contract_version",
+    "run_id",
+    "record_id",
+    "timestamp_utc",
+    "repo",
+    "ref",
+    "surface_type",
+    "surface_id",
+    "flow_id",
+    "environment",
+    "status",
+    "reason_code",
+    "severity",
+    "summary",
+    "evidence",
+    "doc_clarity",
+    "actionability",
+}
+
+
+def _env_flag(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def test_prd003_doc_validator_emits_contract_records(tmp_path: Path):
+    output_root = Path(os.getenv("TT_XLA_PRD003_OUTPUT_ROOT", tmp_path / "prd003_doc_validator"))
+    run_id = os.getenv("TT_XLA_PRD003_RUN_ID", "prd003-doc-validator-pytest")
+    target_id = os.getenv("TT_XLA_PRD003_TARGET_ID", "local")
+    execute = _env_flag("TT_XLA_PRD003_EXECUTE")
+    require_pass = _env_flag("TT_XLA_PRD003_REQUIRE_PASS")
+
+    result = run_validation(
+        output_root=output_root,
+        run_id=run_id,
+        target_id=target_id,
+        execute=execute,
+    )
+
+    results_path = result.output_root / "records" / "jsonl" / "results.jsonl"
+    summary_path = result.output_root / "summaries" / "coverage-summary.json"
+
+    assert results_path.is_file()
+    assert summary_path.is_file()
+    assert result.summary["contract_version"] == CONTRACT_VERSION
+    assert result.summary["record_count"] == 6
+
+    records = [
+        json.loads(line)
+        for line in results_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert len(records) == 6
+    assert all(REQUIRED_RECORD_FIELDS <= record.keys() for record in records)
+    assert all(record["contract_version"] == CONTRACT_VERSION for record in records)
+    assert all(record["repo"] == "tt-xla" for record in records)
+    assert all(record["evidence"]["command"] for record in records)
+
+    if require_pass:
+        assert result.summary["counts_by_status"] == {"pass": 6}
+    else:
+        assert result.summary["counts_by_status"] == {"fail": 6}
+        assert all(record["reason_code"] == "doc-ambiguous-step" for record in records)
+        assert all(record["doc_clarity"]["is_ambiguous"] for record in records)

--- a/tests/runner/test_prd003_doc_validator.py
+++ b/tests/runner/test_prd003_doc_validator.py
@@ -35,7 +35,9 @@ def _env_flag(name: str) -> bool:
 
 
 def test_prd003_doc_validator_emits_contract_records(tmp_path: Path):
-    output_root = Path(os.getenv("TT_XLA_PRD003_OUTPUT_ROOT", tmp_path / "prd003_doc_validator"))
+    output_root = Path(
+        os.getenv("TT_XLA_PRD003_OUTPUT_ROOT", tmp_path / "prd003_doc_validator")
+    )
     run_id = os.getenv("TT_XLA_PRD003_RUN_ID", "prd003-doc-validator-pytest")
     target_id = os.getenv("TT_XLA_PRD003_TARGET_ID", "local")
     execute = _env_flag("TT_XLA_PRD003_EXECUTE")

--- a/tests/runner/test_prd003_doc_validator.py
+++ b/tests/runner/test_prd003_doc_validator.py
@@ -10,6 +10,7 @@ import pytest
 
 from tests.runner.prd003_doc_validator import (
     CONTRACT_VERSION,
+    PHASE1_FLOWS,
     PROJECT_ROOT,
     run_validation,
 )
@@ -61,25 +62,38 @@ def test_prd003_doc_validator_emits_contract_records():
     assert results_path.is_file()
     assert summary_path.is_file()
     assert result.summary["contract_version"] == CONTRACT_VERSION
-    assert result.summary["record_count"] == 6
+    assert result.summary["record_count"] == len(PHASE1_FLOWS)
 
     records = [
         json.loads(line)
         for line in results_path.read_text(encoding="utf-8").splitlines()
         if line.strip()
     ]
-    assert len(records) == 6
+    assert len(records) == len(PHASE1_FLOWS)
     assert all(REQUIRED_RECORD_FIELDS <= record.keys() for record in records)
     assert all(record["contract_version"] == CONTRACT_VERSION for record in records)
     assert all(record["repo"] == "tt-xla" for record in records)
     assert all(record["evidence"]["command"] for record in records)
 
     if require_pass:
-        assert result.summary["counts_by_status"] == {"pass": 6}
+        assert result.summary["counts_by_status"] == {"pass": len(PHASE1_FLOWS)}
     else:
-        assert result.summary["counts_by_status"] == {"fail": 6}
-        assert all(record["reason_code"] == "doc-ambiguous-step" for record in records)
-        assert all(record["doc_clarity"]["is_ambiguous"] for record in records)
+        assert result.summary["counts_by_status"] == {"error": 5, "fail": 6}
+        doc_records = [
+            record
+            for record in records
+            if record["reason_code"] == "doc-ambiguous-step"
+        ]
+        demo_records = [
+            record for record in records if record["reason_code"] == "infra-unavailable"
+        ]
+        assert len(doc_records) == 6
+        assert len(demo_records) == 5
+        assert all(record["doc_clarity"]["is_ambiguous"] for record in doc_records)
+        assert all(
+            record["environment"]["execution_target"] == "ird"
+            for record in demo_records
+        )
 
 
 def test_prd003_doc_validator_rejects_output_paths_outside_artifacts(tmp_path: Path):

--- a/tests/runner/test_prd003_doc_validator.py
+++ b/tests/runner/test_prd003_doc_validator.py
@@ -78,7 +78,7 @@ def test_prd003_doc_validator_emits_contract_records():
     if require_pass:
         assert result.summary["counts_by_status"] == {"pass": len(PHASE1_FLOWS)}
     else:
-        assert result.summary["counts_by_status"] == {"error": 5, "fail": 6}
+        assert result.summary["counts_by_status"] == {"error": 5, "fail": 7}
         doc_records = [
             record
             for record in records
@@ -87,7 +87,7 @@ def test_prd003_doc_validator_emits_contract_records():
         demo_records = [
             record for record in records if record["reason_code"] == "infra-unavailable"
         ]
-        assert len(doc_records) == 6
+        assert len(doc_records) == 7
         assert len(demo_records) == 5
         assert all(record["doc_clarity"]["is_ambiguous"] for record in doc_records)
         assert all(

--- a/tests/runner/test_prd003_doc_validator.py
+++ b/tests/runner/test_prd003_doc_validator.py
@@ -6,7 +6,13 @@ import json
 import os
 from pathlib import Path
 
-from tests.runner.prd003_doc_validator import CONTRACT_VERSION, run_validation
+import pytest
+
+from tests.runner.prd003_doc_validator import (
+    CONTRACT_VERSION,
+    PROJECT_ROOT,
+    run_validation,
+)
 
 REQUIRED_RECORD_FIELDS = {
     "contract_version",
@@ -33,9 +39,9 @@ def _env_flag(name: str) -> bool:
     return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
-def test_prd003_doc_validator_emits_contract_records(tmp_path: Path):
+def test_prd003_doc_validator_emits_contract_records():
     output_root = Path(
-        os.getenv("TT_XLA_PRD003_OUTPUT_ROOT", tmp_path / "prd003_doc_validator")
+        os.getenv("TT_XLA_PRD003_OUTPUT_ROOT", "artifacts/prd003_doc_validator_pytest")
     )
     run_id = os.getenv("TT_XLA_PRD003_RUN_ID", "prd003-doc-validator-pytest")
     target_id = os.getenv("TT_XLA_PRD003_TARGET_ID", "local")
@@ -74,3 +80,11 @@ def test_prd003_doc_validator_emits_contract_records(tmp_path: Path):
         assert result.summary["counts_by_status"] == {"fail": 6}
         assert all(record["reason_code"] == "doc-ambiguous-step" for record in records)
         assert all(record["doc_clarity"]["is_ambiguous"] for record in records)
+
+
+def test_prd003_doc_validator_rejects_output_paths_outside_artifacts(tmp_path: Path):
+    with pytest.raises(ValueError, match="output_root must be under"):
+        run_validation(output_root=tmp_path / "outside")
+
+    with pytest.raises(ValueError, match="output_root must be under"):
+        run_validation(output_root=PROJECT_ROOT / ".." / "prd003-outside")

--- a/tests/runner/test_prd003_doc_validator.py
+++ b/tests/runner/test_prd003_doc_validator.py
@@ -8,7 +8,6 @@ from pathlib import Path
 
 from tests.runner.prd003_doc_validator import CONTRACT_VERSION, run_validation
 
-
 REQUIRED_RECORD_FIELDS = {
     "contract_version",
     "run_id",


### PR DESCRIPTION
## Summary

Adds a self-contained PRD-003 documentation and demo validation harness under `tests/runner` and a focused pytest wrapper that emits versioned contract records for the current TT-XLA Phase 1 baseline.

This also reduces PRD-003 documentation ambiguity blockers by adding deterministic wheel verification, Docker readiness, source-build environment checks, IRD image preflight checks, the IRD-safe user-local SFPI source-build path, and the `tt-forge-install` sudo/root precondition to `docs/src/getting_started.md`.

The harness intentionally defaults to fail-closed behavior when documented install steps are ambiguous. Hardware-sensitive JAX, PyTorch, and vLLM demo gates emit explicit `infra-unavailable` records unless an IRD or equivalent TT hardware target is proven and execution is enabled.

## Changes

- Add `tests/runner/prd003_doc_validator.py` for Phase 1 docs/install and hardware-gate contract records.
- Add `tests/runner/test_prd003_doc_validator.py` to exercise the harness through pytest.
- Add `tests/runner/prd003_doc_validator.md` with the focused local command and output locations.
- Add P0/P1 hardware gate records for TT device discovery, JAX, PyTorch MNIST, and TinyLlama vLLM service/client gates.
- Constrain validator artifact output paths under repo `artifacts/`.
- Update `docs/src/getting_started.md` with explicit wheel version and device checks.
- Add a non-interactive Docker readiness check.
- Document source-build tool verification and the existing `venv/activate` setup behavior.
- Document the TT-XLA IRD image preflight for Ubuntu 24.04 and Python 3.12 before `source venv/activate`.
- Document the IRD/non-privileged source-build path with `-DTT_USE_SYSTEM_SFPI=OFF` and track that command in the PRD-003 validator manifest.
- Document that `tt-forge-install` may require sudo/root to install system packages and represent that precondition in the validator manifest.

## Validation

```bash
python3 -m py_compile tests/runner/prd003_doc_validator.py tests/runner/test_prd003_doc_validator.py
PYTHONPATH=. TT_XLA_PRD003_OUTPUT_ROOT=artifacts/prd003_doc_validator_pytest TT_XLA_PRD003_RUN_ID=prd003-full-surface-2026-05-05 /Users/dfredriksen/Desktop/tt-xla/.venv/bin/pytest -q --noconftest tests/runner/test_prd003_doc_validator.py
/Users/dfredriksen/Desktop/tt-xla/.venv/bin/python -m black --check tests/runner/prd003_doc_validator.py tests/runner/test_prd003_doc_validator.py
/Users/dfredriksen/Desktop/tt-xla/.venv/bin/python -m isort --profile black --check-only tests/runner/prd003_doc_validator.py tests/runner/test_prd003_doc_validator.py
git diff --check -- tests/runner/prd003_doc_validator.py tests/runner/test_prd003_doc_validator.py tests/runner/prd003_doc_validator.md
```

Focused pytest result: `2 passed`.

Original contract artifact check: 11 records emitted, status counts `{"fail": 6, "error": 5}`, reason counts `{"doc-ambiguous-step": 6, "infra-unavailable": 5}`.

Post-rebase validation on 2026-05-07:

```bash
PYTHONPATH=. TT_XLA_PRD003_OUTPUT_ROOT=artifacts/prd003_doc_validator_pytest TT_XLA_PRD003_RUN_ID=prd003-full-surface-2026-05-07 /Users/dfredriksen/Desktop/tt-xla/.venv/bin/pytest -q --noconftest tests/runner/test_prd003_doc_validator.py
git diff --check
```

Result: `2 passed`; whitespace check clean.

Post-SFPI mitigation validation on 2026-05-07 from a `/tmp` clone because the Desktop worktree was blocked by macOS privacy controls:

```bash
/tmp/ttxla-prd003-check-venv/bin/python -m py_compile tests/runner/prd003_doc_validator.py tests/runner/test_prd003_doc_validator.py
PYTHONPATH=. TT_XLA_PRD003_OUTPUT_ROOT=artifacts/prd003_doc_validator_pytest TT_XLA_PRD003_RUN_ID=prd003-sfpi-off-docs-20260507 /tmp/ttxla-prd003-check-venv/bin/python -m pytest -q --noconftest tests/runner/test_prd003_doc_validator.py
/tmp/ttxla-prd003-check-venv/bin/python -m black --check tests/runner/prd003_doc_validator.py tests/runner/test_prd003_doc_validator.py
/tmp/ttxla-prd003-check-venv/bin/python -m isort --profile black --check-only tests/runner/prd003_doc_validator.py tests/runner/test_prd003_doc_validator.py
git diff --check
```

Result: `2 passed`; formatting and whitespace checks clean.

Post-wheel-sudo-precondition validation on 2026-05-07 from the same `/tmp` clone:

```bash
/tmp/ttxla-prd003-check-venv/bin/python -m py_compile tests/runner/prd003_doc_validator.py tests/runner/test_prd003_doc_validator.py
PYTHONPATH=. TT_XLA_PRD003_OUTPUT_ROOT=artifacts/prd003_doc_validator_pytest TT_XLA_PRD003_RUN_ID=prd003-wheel-sudo-docs-20260507 /tmp/ttxla-prd003-check-venv/bin/python -m pytest -q --noconftest tests/runner/test_prd003_doc_validator.py
/tmp/ttxla-prd003-check-venv/bin/python -m black --check tests/runner/prd003_doc_validator.py tests/runner/test_prd003_doc_validator.py
/tmp/ttxla-prd003-check-venv/bin/python -m isort --profile black --check-only tests/runner/prd003_doc_validator.py tests/runner/test_prd003_doc_validator.py
git diff --check
```

Result: `2 passed`; formatting and whitespace checks clean. Latest contract expectations are 12 records with status counts `{"fail": 7, "error": 5}`.

## IRD Evidence

IRD image preflight re-tested on 2026-05-07:

- Current `TT_MLIR_VERSION`: `bb1deb417cef0e2c60147072cf7b6926a49ccca7`.
- Current TT-XLA IRD tag: `ghcr.io/tenstorrent/tt-xla/tt-xla-ird-ubuntu-24-04:dt-f5b21139b293d267b9fbf54d1b8d15e56d3574ce122a34486458e1b3386a9c54`.
- `latest` resolves to digest `sha256:f3bc1f22cf8de3d360e2d26dd306d0532d280bf95df25ab4886be8a2951615a0`.
- Local Docker probes for both the immutable tag and `latest` report Ubuntu 24.04 and Python 3.12.3.
- IRD job `73989` on `aus-wh-01` with `ghcr.io/tenstorrent/tt-xla/tt-xla-ird-ubuntu-24-04:latest` reports Ubuntu 24.04.4 and Python 3.12.3.
- Image deficiency issue #4540 is closed with the retest evidence.

IRD P0 source-build attempts on 2026-05-07:

- IRD job `74002` used the corrected TT-XLA image and ran from `/tmp` to avoid `/home` quota issues.
- The run cloned this branch at `a4200dfa3`, initialized submodules, completed `source venv/activate`, installed Python dependencies, and reached `cmake --build build`.
- Build failed while configuring `tt-metal` because installed SFPI is `7.44.0` and pinned tt-metal requires `7.45.0`.
- Follow-up IRD probe job `74004` confirmed the standard job user cannot apply `install_dependencies.sh --sfpi`: `sudo -n true` requires a password, `/opt/tenstorrent/sfpi` is root-owned, and the image still reports `riscv-tt-elf-g++ (tenstorrent/sfpi:7.44.0[530])`.
- Follow-up IRD probe job `74006` configured this branch with `-DTT_USE_SYSTEM_SFPI=OFF`; TT-XLA propagated the setting into TT-MLIR and tt-metal, and tt-metal used a user-local pinned compiler at `runtime/sfpi/compiler/bin/riscv-tt-elf-g++` reporting `tenstorrent/sfpi:7.45.0[537]`.
- Full source-build lane job `74011` completed with `-DTT_USE_SYSTEM_SFPI=OFF` from commit `252fb0ae6`.
- Slurm status for job `74011`: `COMPLETED`, exit `0:0`, elapsed `01:06:52`.
- Source build marker: `PRD003_FULL_SOURCE_BUILD_EXIT=0`.
- Source build marker: `PRD003_FULL_SOURCE_BUILD_OK`.
- Source build cache evidence: `TT_USE_SYSTEM_SFPI:BOOL=OFF`.
- Source build compiler evidence: user-local SFPI compiler `tenstorrent/sfpi:7.45.0[537]`.
- Post-build TT device discovery marker: `PRD003_TT_DEVICE_DISCOVERY_EXIT=0`.
- Post-build TT device discovery output included `[TTDevice(id=0, arch=Wormhole_b0), TTDevice(id=1, arch=Wormhole_b0)]`.
- The discovery log emitted a non-fatal ethernet-core warning while still returning exit `0`.
- The system image still contains stale `/opt/tenstorrent/sfpi`, but PRD-003 source-build validation no longer needs passwordless sudo or an image republish to get past that precondition.
- Tracked in #4580.

IRD P0 wheel/demo lane on 2026-05-07:

- IRD job `74015` ran from commit `252fb0ae6` on Ubuntu 24.04.4 / Python 3.12.3.
- `wheel-install`: exit `0`; installed `pjrt-plugin-tt-1.1.0`.
- `tt-forge-install`: exit `1`; attempted `sudo apt-get install` of `sfpi_7.41.0_x86_64_debian.deb` and failed because the standard IRD job user has no interactive sudo password.
- `tt-device-discovery`: exit `0`; output included `[TTDevice(id=0, arch=Wormhole_b0)]`.
- `jax-simple-regression`: exit `0`; loss decreased from `8837.03125` to `1703.0545654296875`.
- `pytorch-mnist`: exit `0`; PCC `0.9938569068908691`, max diff `0.015625`.
- The latest commit `6e771c50f` documents the `tt-forge-install` sudo/root precondition and adds a fail-closed validator record for it.

## Current Baseline

- Docs/install flows still fail closed where docs remain ambiguous.
- Hardware-sensitive demo gates are present in the contract.
- IRD lane scheduling is proven on `aus-wh-01`.
- The TT-XLA IRD image preflight is proven for Ubuntu 24.04 and Python 3.12.
- P0 wheel-path hardware validation has passed for wheel install, TT device discovery, JAX simple regression, and PyTorch MNIST.
- The `tt-forge-install` system dependency step is now documented as requiring sudo/root or a pre-provisioned environment.
- P0 source-build execution passes with the documented `-DTT_USE_SYSTEM_SFPI=OFF` path and TT device discovery succeeds after the source build.
- `DOC-GAP-003`: partially addressed by wheel version and TT device verification.
- `DOC-GAP-004`: partially addressed by documenting `venv/activate` setup behavior, source-build tool checks, and the IRD-safe SFPI setting.
- `DOC-GAP-006`: partially addressed by adding a non-interactive Docker readiness command.
- `DOC-GAP-007`: added for the wheel system dependency installer precondition exposed by `tt-forge-install`.

The passing pytest result means the harness correctly emits PRD-003 contract records for the full Phase 1 surface. It does not mean every underlying install command or hardware demo is passing.

## Remaining Work

- Decide whether the `tt-forge-install` sudo/root precondition should be handled by a privileged/pre-provisioned IRD lane or left as documented environment setup.
- Re-run or classify the remaining non-P0 hardware-sensitive demo flows. The current validator manifest treats vLLM as P1.
- Re-run the PRD-003 harness on a prepared VM/TT hardware target and decide which doc blockers can be removed from the manifest.
