### PR TITLE
[CI] Fix uplift automerge

### DIFF
--- a/.github/workflows/schedule-uplift.yml
+++ b/.github/workflows/schedule-uplift.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Enable Pull Request Automerge and Add Comment with Commit List
         if: ${{ steps.create-pr.outputs.pull-request-number }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           gh pr merge --squash --auto "${{ steps.create-pr.outputs.pull-request-number }}"
           gh pr comment ${{ steps.create-pr.outputs.pull-request-number }} --body "$(cat ${{ runner.temp }}/commit_list.txt)"


### PR DESCRIPTION
### Problem description
Automerged uplifts do not perform on push

### What's changed
Bot token is used to set auto merge which doesn't have privileges to run other worflows

### Checklist
- [ ] New/Existing tests provide coverage for changes
