### PR TITLE
Wire up D2M Fusion Option into LLM Benchmarks + Test GPT-OSS-20B with D2M Fusion Enabled

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -543,13 +543,6 @@
         "accuracy-testing": true
       },
       {
-        "name": "gpt_oss_20b_tp_d2m_accuracy",
-        "pyreq": "datasets loguru pytest requests accelerate torch==2.9.0 tqdm transformers==5.2.0",
-        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_d2m",
-        "runs-on": "n300-llmbox",
-        "accuracy-testing": true
-      },
-      {
         "name": "llama_3_1_70b_tp_galaxy_accuracy",
         "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp_galaxy",

--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -177,9 +177,9 @@
         "runs-on": "n300-llmbox"
       },
       {
-        "name": "gpt_oss_20b_tp_d2m_subgraphs",
+        "name": "gpt_oss_20b_tp_d2m",
         "pyreq": "datasets loguru pytest requests accelerate torch==2.9.0 tqdm transformers==5.2.0",
-        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_d2m_subgraphs",
+        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_d2m",
         "runs-on": "n300-llmbox"
       },
       {
@@ -543,9 +543,9 @@
         "accuracy-testing": true
       },
       {
-        "name": "gpt_oss_20b_tp_d2m_subgraphs_accuracy",
+        "name": "gpt_oss_20b_tp_d2m_accuracy",
         "pyreq": "datasets loguru pytest requests accelerate torch==2.9.0 tqdm transformers==5.2.0",
-        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_d2m_subgraphs",
+        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_d2m",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },

--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -177,6 +177,12 @@
         "runs-on": "n300-llmbox"
       },
       {
+        "name": "gpt_oss_20b_tp_d2m_subgraphs",
+        "pyreq": "datasets loguru pytest requests accelerate torch==2.9.0 tqdm transformers==5.2.0",
+        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_d2m_subgraphs",
+        "runs-on": "n300-llmbox"
+      },
+      {
         "name": "gpt_oss_20b_tp_batch_size_1",
         "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_batch_size_1",
@@ -533,6 +539,13 @@
         "name": "gpt_oss_20b_tp_accuracy",
         "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp",
+        "runs-on": "n300-llmbox",
+        "accuracy-testing": true
+      },
+      {
+        "name": "gpt_oss_20b_tp_d2m_subgraphs_accuracy",
+        "pyreq": "datasets loguru pytest requests accelerate torch==2.9.0 tqdm transformers==5.2.0",
+        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_d2m_subgraphs",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },

--- a/pjrt_implementation/inc/api/compile_options.h
+++ b/pjrt_implementation/inc/api/compile_options.h
@@ -118,6 +118,10 @@ struct CompileOptions {
   // Enable DRAM space saving optimization pass (TTNNMemoryManagement).
   bool experimental_enable_dram_space_saving_optimization = false;
 
+  // Enable D2M subgraph creation pass for d2m elementwise fusion.
+  // Only effective when optimization_level >= 1 (optimizer must be enabled)
+  bool enable_create_d2m_subgraphs = false;
+
   // Enable collection of TTNN performance metrics during execution.
   bool ttnn_perf_metrics_enabled = false;
 

--- a/pjrt_implementation/src/api/compile_options.cc
+++ b/pjrt_implementation/src/api/compile_options.cc
@@ -70,6 +70,9 @@ CompileOptions CompileOptions::parse(
       internal::parseBoolOption(
           compile_options, "experimental-enable-dram-space-saving-optimization")
           .value_or(options.experimental_enable_dram_space_saving_optimization);
+  options.enable_create_d2m_subgraphs =
+      internal::parseBoolOption(compile_options, "enable_create_d2m_subgraphs")
+          .value_or(options.enable_create_d2m_subgraphs);
   options.ttnn_perf_metrics_enabled =
       internal::parseBoolOption(compile_options, "ttnn_perf_metrics_enabled")
           .value_or(false);

--- a/pjrt_implementation/src/api/module_builder/module_builder.cc
+++ b/pjrt_implementation/src/api/module_builder/module_builder.cc
@@ -1087,6 +1087,8 @@ tt_pjrt_status ModuleBuilder::convertFromTTIRToTTNN(
       compile_options.enable_const_eval_inputs_to_system_memory;
   options.dramSpaceSavingOptimizationEnabled =
       compile_options.experimental_enable_dram_space_saving_optimization;
+  options.enableCreateD2MSubgraphs =
+      compile_options.enable_create_d2m_subgraphs;
   options.ttnnPerfMetricsEnabled = compile_options.ttnn_perf_metrics_enabled;
 
   // Auto-number performance metrics output file if enabled

--- a/tests/benchmark/benchmarks/llm_benchmark.py
+++ b/tests/benchmark/benchmarks/llm_benchmark.py
@@ -269,6 +269,7 @@ def benchmark_llm_torch_xla(
     expected_ops: list = None,
     check_fusions_enabled: bool = False,
     use_indexer_cache: bool = False,
+    enable_create_d2m_subgraphs: bool = False,
 ):
     """
     Benchmark an LLM (Large Language Model) using PyTorch and torch-xla.
@@ -468,6 +469,8 @@ def benchmark_llm_torch_xla(
         options["fp32_dest_acc_en"] = fp32_dest_acc_en
     if experimental_kv_cache_dtype is not None:
         options["experimental-kv-cache-dtype"] = experimental_kv_cache_dtype
+    if enable_create_d2m_subgraphs:
+        options["enable_create_d2m_subgraphs"] = enable_create_d2m_subgraphs
 
     torch_xla.set_custom_compile_options(options)
 

--- a/tests/benchmark/benchmarks/llm_benchmark.py
+++ b/tests/benchmark/benchmarks/llm_benchmark.py
@@ -332,6 +332,12 @@ def benchmark_llm_torch_xla(
             "Please use -t text-generation"
         )
 
+    if enable_create_d2m_subgraphs and optimization_level < 1:
+        raise ValueError(
+            f"optimization_level must be >= 1 when enable_create_d2m_subgraphs "
+            f"is enabled, got optimization_level={optimization_level}"
+        )
+
     # Check transformers version
     check_transformers_version()
 

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -66,6 +66,7 @@ def test_llm(
     expected_ops: list = None,
     check_fusions: bool = False,
     use_indexer_cache: bool = False,
+    enable_create_d2m_subgraphs: bool = False,
 ):
     """Test LLM model with the given variant and optional configuration overrides.
 
@@ -165,6 +166,7 @@ def test_llm(
         expected_ops=expected_ops,
         check_fusions_enabled=check_fusions,
         use_indexer_cache=use_indexer_cache,
+        enable_create_d2m_subgraphs=enable_create_d2m_subgraphs,
     )
 
     if output_file:
@@ -1763,6 +1765,41 @@ def test_gpt_oss_20b_tp(
         shard_spec_fn=_gpt_oss_20b_shard_spec_fn,
         trace_enabled=False,
         optimization_level=1,
+    )
+
+
+# Test with D2M fusion enabled (enable-create-d2m-subgraphs=true).
+def test_gpt_oss_20b_tp_d2m_subgraphs(
+    output_file,
+    num_layers,
+    request,
+    accuracy_testing,
+    batch_size,
+    max_output_tokens,
+    decode_only,
+    optimization_level,
+):
+    from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
+        ModelLoader,
+        ModelVariant,
+    )
+
+    variant = ModelVariant.GPT_OSS_20B
+    test_llm_tp(
+        ModelLoader,
+        variant,
+        output_file,
+        num_layers=num_layers,
+        request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
+        max_output_tokens=max_output_tokens,
+        decode_only=decode_only,
+        mesh_config_fn=_gpt_oss_20b_mesh_config_fn,
+        shard_spec_fn=_gpt_oss_20b_shard_spec_fn,
+        trace_enabled=False,
+        optimization_level=1,
+        enable_create_d2m_subgraphs=True,
     )
 
 

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -1769,7 +1769,7 @@ def test_gpt_oss_20b_tp(
 
 
 # Test with D2M fusion enabled (enable-create-d2m-subgraphs=true).
-def test_gpt_oss_20b_tp_d2m_subgraphs(
+def test_gpt_oss_20b_tp_d2m(
     output_file,
     num_layers,
     request,

--- a/tests/infra/testers/compiler_config.py
+++ b/tests/infra/testers/compiler_config.py
@@ -72,6 +72,10 @@ class CompilerConfig:
     # useful when generating code.
     codegen_try_recover_structure: bool = False
 
+    # Enable D2M subgraph creation pass for d2m elementwise fusion.
+    # Only effective when optimization_level >= 1 (optimizer must be enabled)
+    enable_create_d2m_subgraphs: bool = False
+
     def to_jax_compiler_options(self) -> Dict[str, str]:
         """
         Convert CompilerConfig to JAX compiler_options dictionary format.
@@ -113,6 +117,9 @@ class CompilerConfig:
 
         if self.codegen_try_recover_structure:
             options["codegen_try_recover_structure"] = "true"
+
+        if self.enable_create_d2m_subgraphs:
+            options["enable_create_d2m_subgraphs"] = "true"
 
         return options
 

--- a/tests/infra/testers/compiler_config.py
+++ b/tests/infra/testers/compiler_config.py
@@ -119,6 +119,11 @@ class CompilerConfig:
             options["codegen_try_recover_structure"] = "true"
 
         if self.enable_create_d2m_subgraphs:
+            if self.optimization_level < 1:
+                raise ValueError(
+                    f"optimization_level must be >= 1 when enable_create_d2m_subgraphs "
+                    f"is enabled, got optimization_level={self.optimization_level}"
+                )
             options["enable_create_d2m_subgraphs"] = "true"
 
         return options


### PR DESCRIPTION
### Problem description
Gpt-oss-20B is being brought up with optimizer + d2m enabled. There should be a test for this path in tt-xla. This requires an option which enables d2m fusion to be exposed.

### What's changed
- Wired up option `enable-create-d2m-subgraphs` into `llm_benchmark.py`
- added test `test_gpt_oss_20b_tp_d2m` in `test_llms.py` and `perf-bench-matrix.json`
### Checklist
- [x] New/Existing tests provide coverage for changes
