### PR TITLE
Default batch_size=2 for training in test_all_models_torch

### DIFF
--- a/tests/runner/testers/torch/dynamic_torch_model_tester.py
+++ b/tests/runner/testers/torch/dynamic_torch_model_tester.py
@@ -133,6 +133,8 @@ class DynamicTorchModelTester(TorchModelTester):
             if self._test_metadata
             else None
         )
+        if batch_size is None and self._run_mode == RunMode.TRAINING:
+            batch_size = 2
 
         inputs = self.dynamic_loader.load_inputs(
             run_phase=self.run_phase,

--- a/tests/runner/testers/torch/dynamic_torch_model_tester.py
+++ b/tests/runner/testers/torch/dynamic_torch_model_tester.py
@@ -29,6 +29,8 @@ class DynamicTorchModelTester(TorchModelTester):
     for flexible model loading without subclassing for each model variant.
     """
 
+    DEFAULT_TRAINING_BATCH_SIZE = 2
+
     def __init__(
         self,
         run_mode: RunMode,
@@ -134,7 +136,11 @@ class DynamicTorchModelTester(TorchModelTester):
             else None
         )
         if batch_size is None and self._run_mode == RunMode.TRAINING:
-            batch_size = 2
+            batch_size = self.DEFAULT_TRAINING_BATCH_SIZE
+            logger.info(
+                f"No batch_size specified in test_metadata; defaulting to "
+                f"batch_size={batch_size} for RunMode.TRAINING"
+            )
 
         inputs = self.dynamic_loader.load_inputs(
             run_phase=self.run_phase,

--- a/tests/runner/utils/dynamic_loader.py
+++ b/tests/runner/utils/dynamic_loader.py
@@ -414,9 +414,12 @@ class TorchDynamicLoader(DynamicLoader):
             return self.loader.load_inputs_prefill(**kwargs)
 
         # Default path
+        kwargs = {}
         if "dtype_override" in sig.parameters:
-            return self.loader.load_inputs(dtype_override=torch.bfloat16)
-        return self.loader.load_inputs()
+            kwargs["dtype_override"] = torch.bfloat16
+        if "batch_size" in sig.parameters and batch_size is not None:
+            kwargs["batch_size"] = batch_size
+        return self.loader.load_inputs(**kwargs)
 
     def unpack_forward_output(self, output: Any) -> torch.Tensor:
         """Unpack model output to a single tensor.


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`test_all_models_torch` parametrizes `run_mode` over `inference` and `training`, but training-mode runs use whatever batch size the underlying loader hardcodes (typically 1). There was no centralized way to bump the training batch size without editing each loader or each test's YAML entry.

Two issues blocked a clean default:
1. `TorchDynamicLoader.load_inputs` default path silently dropped `batch_size` — only the `LLM_DECODE`/`LLM_PREFILL` branches forwarded it. So even setting `batch_size: N` in YAML had no effect on regular (non-LLM) torch tests.
2. `DynamicTorchModelTester._get_input_activations` only used `batch_size` from `test_metadata`, with no run-mode-aware default.

This was noticed while triaging `ssd300_resnet50/pytorch-Base-single_device-training`:
```
In training mode an internal BatchNorm operates on a [1, 256, 1, 1]
tensor and rejects batch=1; bump to 2 only when the model is in
training mode so the inference test (EXPECTED_PASSING) keeps batch=1.
```

### What's changed
- `tests/runner/utils/dynamic_loader.py`: default branch of `TorchDynamicLoader.load_inputs` now forwards `batch_size` to the underlying loader if its signature accepts it (mirrors the existing pattern in the LLM branches).
- `tests/runner/testers/torch/dynamic_torch_model_tester.py`: when `run_mode == RunMode.TRAINING` and YAML didn't specify `batch_size`, default to 2.

YAML entries can still override via `batch_size: <n>`. Loaders without a `batch_size` kwarg are unaffected (`inspect`-based forwarding ignores them).

### Checklist
- [ ] New/Existing tests provide coverage for changes