### PR TITLE
sparse_mlp: pad batch to tile-align tokens for bsz<32 support

### DIFF
--- a/python_package/tt_torch/sparse_mlp.py
+++ b/python_package/tt_torch/sparse_mlp.py
@@ -15,6 +15,7 @@ Usage:
     model = enable_sparse_mlp(model)  # Replace MLP layers with SparseMLP
 """
 
+import math
 from typing import Any, Dict, List, Optional, Type
 
 import torch
@@ -527,6 +528,27 @@ class A2aSparseMLP(nn.Module):
             self.router(router_input), self.num_experts
         )
 
+        # Pad batch so (batch * seq_len) is a multiple of TILE (32). The
+        # downstream MoE ops (moe_expert_token_remap, sparse_matmul) assume
+        # tile-aligned token counts and either segfault or fail validation
+        # otherwise — typical trigger is small-batch decode (e.g. bsz=8
+        # seq_len=1 → 8 tokens; pad batch by 4× → 32 tokens).
+        # Solve for pad_batch directly: padded_batch must be a multiple of
+        # TILE // gcd(seq_len, TILE) (the smallest k such that k*seq_len is
+        # a multiple of TILE), so padded_batch*seq_len is always a multiple
+        # of TILE regardless of seq_len. Padded entries carry zero router
+        # scores/indices and are sliced off the output before return.
+        TILE = 32
+        batch_step = TILE // math.gcd(seq_len, TILE)
+        padded_batch = math.ceil(batch_size / batch_step) * batch_step
+        pad_batch = padded_batch - batch_size
+        if pad_batch > 0:
+            # F.pad's pad-tuple is (last dim ... first dim) pairs of (left, right).
+            hidden_states = F.pad(hidden_states, (0, 0, 0, 0, 0, pad_batch))
+            # router_indices / router_scores are [B*S, K] / [B*S, E] (flat).
+            router_indices = F.pad(router_indices, (0, 0, 0, pad_batch * seq_len))
+            router_scores = F.pad(router_scores, (0, 0, 0, pad_batch * seq_len))
+
         # 2. Dispatch: route tokens to devices along cluster_axis
         # Dispatch accepts [B, S, H] and [B*S, K] directly.
         effective_dispatch = self.dispatch_devices
@@ -672,7 +694,12 @@ class A2aSparseMLP(nn.Module):
             topk_weights.permute(1, 0).unsqueeze(1).unsqueeze(-1)
         )  # [K, 1, B*S, 1]
         output = (combined * topk_weights).sum(dim=0)  # [1, B*S, H]
-        output = output.view(batch_size, seq_len, hidden_size)
+        output = output.view(padded_batch, seq_len, hidden_size)
+        if pad_batch > 0:
+            # Drop the padded batch entries (and matching router_scores rows)
+            # so callers see the original [batch_size, ...] shape.
+            output = output[:batch_size]
+            router_scores = router_scores[: batch_size * seq_len]
 
         return output.to(hidden_states.dtype), router_scores
 

--- a/tests/torch/graphs/test_mlp.py
+++ b/tests/torch/graphs/test_mlp.py
@@ -558,6 +558,71 @@ def test_gpt_oss_mlp(variant, variant_config, arch, mlp_type, request):
     )
 
 
+"""GPT-OSS sparse MLP small-batch decode (tile-padding path)"""
+
+
+@pytest.mark.nightly
+@parametrize_arch(["llmbox"])
+@pytest.mark.parametrize(
+    "decode_batch,decode_seq_len",
+    [(8, 1), (1, 1), (2, 8), (5, 5)],
+    ids=["bsz8_sl1", "bsz1_sl1", "bsz2_sl8", "bsz5_sl5"],
+)
+def test_gpt_oss_sparse_mlp_small_batch(decode_batch, decode_seq_len, arch):
+    """
+    Exercises A2aSparseMLP's tile-padding path: when decode_batch * decode_seq_len
+    is not a multiple of TILE (32), forward must pad the batch dim and slice it
+    off the output. Mirrors small-batch decode (e.g. bsz=8 seq_len=1 -> 8 tokens,
+    pad to 32). bsz5_sl5 covers the gcd(seq_len, TILE)=1 path where padded_batch
+    must be a multiple of TILE itself.
+    """
+    xr.set_device_type("TT")
+
+    loader = GPTOSSModelLoader(variant=GPTOSSModelVariant.GPT_OSS_20B, num_layers=1)
+    config = loader.load_config()
+
+    model = AutoModelForCausalLM.from_config(
+        config, trust_remote_code=True, torch_dtype=torch.bfloat16
+    )
+    model.eval()
+    mlp = model.model.layers[0].mlp
+
+    hidden_states = torch.randn(
+        (decode_batch, decode_seq_len, config.hidden_size), dtype=torch.bfloat16
+    )
+
+    # llmbox: (2, 4) mesh, cluster_axis=0 -> 2-way dispatch.
+    num_devices = xr.global_runtime_device_count()
+    mesh_dim0 = 2
+    mesh_shape = (mesh_dim0, num_devices // mesh_dim0)
+    device_ids = np.array(range(num_devices))
+    mesh = Mesh(device_ids, mesh_shape, ("batch", "model"))
+    mlp = enable_sparse_mlp(mlp, mesh=mesh_shape, cluster_axis=0)
+
+    def get_shard_spec(mlp, args, kwargs):
+        return {
+            mlp.router.weight: (None, "batch"),
+            mlp.router.bias: (None,),
+            mlp.experts.gate_up_proj: (("batch", "model"), None, None),
+            mlp.experts.gate_up_proj_bias: (("batch", "model"), None),
+            mlp.experts.down_proj: (("batch", "model"), None, None),
+            mlp.experts.down_proj_bias: (("batch", "model"), None),
+        }
+
+    # Small-batch sparse MoE in bf16 sees slightly worse PCC than the seq=128
+    # case — relax the threshold to match the existing 120B/single_device entry.
+    comparison_config = ComparisonConfig(pcc=PccConfig(required_pcc=0.98))
+
+    run_graph_test(
+        mlp,
+        [hidden_states],
+        comparison_config=comparison_config,
+        framework=Framework.TORCH,
+        mesh=mesh,
+        shard_spec_fn=get_shard_spec,
+    )
+
+
 @pytest.mark.nightly
 def test_a2a_sparse_mlp_cpu_parity():
     """Verify A2aSparseMLP produces the same results as the original MLP on CPU.


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Downstream MoE ops in A2aSparseMLP.forward — moe_expert_token_remap, sparse_matmul, all_to_all_dispatch — assume the (batch * seq_len) token count is a multiple of TILE (32). Small-batch decode (e.g. bsz=8 seq_len=1 -> 8 tokens) violates this and either segfaults or fails op validation.

### What's changed
Pad batch dim by F.pad before dispatch so total tokens are tile-aligned. Padded entries get zero router scores/indices, run through dispatch / sparse_matmul / combine alongside real tokens, and are sliced off the final output via output[:batch_size] before return so callers see the original [batch_size, seq_len, hidden] shape unchanged.

### Checklist
- [ ] New/Existing tests provide coverage for changes
