### PR TITLE
Add 4 layer deepseek and glm tests with weight caching

### DIFF
--- a/.github/workflows/test-matrix-presets/basic-test-nightly.json
+++ b/.github/workflows/test-matrix-presets/basic-test-nightly.json
@@ -13,5 +13,5 @@
   {"runs-on": "p150",                "name": "run_vllm_p150_tests",    "dir": "./tests/integrations/vllm_plugin",         "test-mark": "nightly and single_device",               "shared-runners": "true", "extra-wheel": "vllm"},
   {"runs-on": "n300",                "name": "run_vllm_n300_tests",    "dir": "./tests/integrations/vllm_plugin",         "test-mark": "nightly and data_parallel",               "shared-runners": "true", "extra-wheel": "vllm"},
   {"runs-on": "n300",                "name": "run_vllm_n300_tests",    "dir": "./tests/integrations/vllm_plugin",         "test-mark": "nightly and tensor_parallel and dual_chip", "shared-runners": "true", "extra-wheel": "vllm"},
-  { "runs-on": "galaxy-wh-6u",       "name": "run_torch_galaxy",       "dir": "./tests/torch/graphs",                     "test-mark": "nightly and galaxy" }
+  { "runs-on": "galaxy-wh-6u",       "name": "run_torch_galaxy",       "dir": "./tests/torch",                            "test-mark": "nightly and galaxy" }
 ]

--- a/tests/torch/models/deepseek_v3_2_exp/build_weight_cache.py
+++ b/tests/torch/models/deepseek_v3_2_exp/build_weight_cache.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Build a chunked BF16 weight cache for DeepSeek V3.1, one layer at a time.
+
+Processes each layer independently so peak memory is ~23 GB (one MoE layer)
+instead of ~1.37 TB (all 61 layers). No swap needed on a 512 GB machine.
+
+Usage:
+    python build_weight_cache.py                  # default: 61 layers
+    python build_weight_cache.py --n-layers 10
+    python build_weight_cache.py --n-layers 4 --repo deepseek-ai/DeepSeek-V3.1
+"""
+import argparse
+import json
+import os
+import re
+import sys
+import time
+
+import torch
+from huggingface_hub import hf_hub_download
+from safetensors import safe_open
+from safetensors.torch import load_file as safetensors_load_file
+from safetensors.torch import save_file as safetensors_save_file
+
+# Import the canonical helpers from the test file to stay in sync
+sys.path.insert(0, os.path.dirname(__file__))
+from test_deepseek_v3_2_exp import _rename_hf_key, _weight_dequant
+
+DEEPSEEK_V3_1_REPO = "deepseek-ai/DeepSeek-V3.1"
+
+
+def build_cache(repo_id, n_layers, n_dense_layers=1):
+    repo_slug = repo_id.replace("/", "--")
+    base = os.environ.get("HF_HOME", os.path.expanduser("~/.cache/huggingface"))
+    cache_dir = os.path.join(
+        base, "tt_xla_dequant_cache", f"{repo_slug}_{n_layers}layers"
+    )
+
+    if os.path.isdir(cache_dir) and any(
+        f.endswith(".safetensors") for f in os.listdir(cache_dir)
+    ):
+        print(f"Cache already exists at {cache_dir}, skipping.")
+        print(f"  Files: {sorted(os.listdir(cache_dir))}")
+        print("  Delete the directory to rebuild.")
+        return
+
+    t_total_start = time.perf_counter()
+
+    # Load index
+    index_path = hf_hub_download(repo_id, "model.safetensors.index.json")
+    with open(index_path) as f:
+        index = json.load(f)
+    weight_map = index["weight_map"]
+
+    # Build per-layer mapping: which ckpt keys (and their scales) belong to
+    # which layer/group.
+    # Groups: "shared" (embed, norm, head) and layer_0000..layer_NNNN
+    groups = {}  # group_name -> {ckpt_key: model_key}
+    scale_keys = {}  # ckpt_weight_key -> ckpt_scale_key
+    all_key_to_shard = {}  # ckpt_key -> shard_file (weights + scales)
+
+    for ckpt_key, shard_file in weight_map.items():
+        layer_m = re.match(r"model\.layers\.(\d+)\.", ckpt_key)
+        if layer_m and int(layer_m.group(1)) >= n_layers:
+            continue
+
+        if "weight_scale_inv" in ckpt_key:
+            w_key = ckpt_key.replace(".weight_scale_inv", ".weight")
+            scale_keys[w_key] = ckpt_key
+            all_key_to_shard[ckpt_key] = shard_file
+        else:
+            model_key = _rename_hf_key(ckpt_key, n_dense_layers)
+            if model_key is None:
+                continue
+            all_key_to_shard[ckpt_key] = shard_file
+
+            # Assign to group
+            lm = re.match(r"layers\.(\d+)\.", model_key)
+            group = f"layer_{int(lm.group(1)):04d}" if lm else "shared"
+            groups.setdefault(group, {})[ckpt_key] = model_key
+
+    os.makedirs(cache_dir, exist_ok=True)
+    total_bytes = 0
+
+    for group_name in sorted(groups):
+        t_group_start = time.perf_counter()
+        ckpt_to_model = groups[group_name]
+
+        # Determine which shards we need for this group
+        needed_shard_files = set()
+        for ckpt_key in ckpt_to_model:
+            needed_shard_files.add(all_key_to_shard[ckpt_key])
+            if ckpt_key in scale_keys:
+                needed_shard_files.add(all_key_to_shard[scale_keys[ckpt_key]])
+
+        # Load only the tensors we need from those shards
+        raw = {}
+        needed_ckpt_keys = set(ckpt_to_model.keys())
+        needed_scale_keys = {scale_keys[k] for k in ckpt_to_model if k in scale_keys}
+        all_needed = needed_ckpt_keys | needed_scale_keys
+
+        for shard_name in sorted(needed_shard_files):
+            shard_path = hf_hub_download(repo_id, shard_name)
+            with safe_open(shard_path, framework="pt", device="cpu") as f:
+                for key in f.keys():
+                    if key in all_needed:
+                        raw[key] = f.get_tensor(key)
+
+        # Dequantize and rename
+        state_dict = {}
+        n_dequant = 0
+        for ckpt_key, model_key in ckpt_to_model.items():
+            tensor = raw.get(ckpt_key)
+            if tensor is None:
+                continue
+
+            if tensor.dtype == torch.float8_e4m3fn:
+                sk = scale_keys.get(ckpt_key)
+                scale_inv = raw.get(sk) if sk else None
+                if scale_inv is not None:
+                    tensor = _weight_dequant(tensor, scale_inv)
+                    n_dequant += 1
+                else:
+                    tensor = tensor.to(torch.bfloat16)
+
+            if model_key == "head.weight":
+                tensor = tensor.to(torch.float32)
+            elif tensor.dtype != torch.bfloat16:
+                tensor = tensor.to(torch.bfloat16)
+
+            state_dict[model_key] = tensor
+
+        del raw
+
+        # Save chunk
+        chunk_path = os.path.join(cache_dir, f"{group_name}.safetensors")
+        safetensors_save_file(state_dict, chunk_path)
+        chunk_size = os.path.getsize(chunk_path)
+        total_bytes += chunk_size
+        del state_dict
+
+        t_group_end = time.perf_counter()
+        print(
+            f"  {group_name}: {len(ckpt_to_model)} keys, "
+            f"{n_dequant} dequantized, "
+            f"{chunk_size / 1e9:.1f} GB, "
+            f"{t_group_end - t_group_start:.1f}s",
+            flush=True,
+        )
+
+    t_total_end = time.perf_counter()
+    print(
+        f"\nDone. {len(groups)} chunks, {total_bytes / 1e9:.1f} GB total, "
+        f"{t_total_end - t_total_start:.1f}s",
+        flush=True,
+    )
+    print(f"Cache dir: {cache_dir}")
+
+
+def _stack_experts_for_chunk(chunk):
+    """Convert per-expert weights in a chunk to stacked StackedExperts format.
+
+    Input keys like ``layers.N.ffn.experts.{idx}.{w1,w2,w3}.weight``
+    become ``layers.N.ffn.mlp.experts.{gate,up,down}_proj`` (transposed & stacked).
+    Router keys ``ffn.gate.*`` become ``ffn.mlp.router.gate.*``.
+    All other keys (attention, norms, shared_experts) pass through unchanged.
+    """
+    # Collect per-expert weights
+    expert_weights = {}  # idx -> {w1: tensor, w2: tensor, w3: tensor}
+    layer_prefix = None
+
+    for key in chunk:
+        m = re.match(r"(layers\.\d+\.ffn)\.experts\.(\d+)\.(w[123])\.weight", key)
+        if m:
+            layer_prefix = m.group(1)
+            idx, wname = int(m.group(2)), m.group(3)
+            expert_weights.setdefault(idx, {})[wname] = chunk[key]
+
+    if not expert_weights:
+        return dict(chunk)
+
+    n_experts = max(expert_weights.keys()) + 1
+    result = {}
+
+    # Stack: w1=gate, w3=up, w2=down — with transpose to match StackedExperts
+    gate_proj = torch.stack([expert_weights[i]["w1"].T for i in range(n_experts)])
+    up_proj = torch.stack([expert_weights[i]["w3"].T for i in range(n_experts)])
+    down_proj = torch.stack([expert_weights[i]["w2"].T for i in range(n_experts)])
+
+    inter = gate_proj.shape[-1]
+    hidden = gate_proj.shape[1]
+    dtype = gate_proj.dtype
+
+    mlp_pfx = f"{layer_prefix}.mlp.experts"
+    result[f"{mlp_pfx}.gate_proj"] = gate_proj
+    result[f"{mlp_pfx}.up_proj"] = up_proj
+    result[f"{mlp_pfx}.down_proj"] = down_proj
+    result[f"{mlp_pfx}.gate_proj_bias"] = torch.zeros(n_experts, inter, dtype=dtype)
+    result[f"{mlp_pfx}.up_proj_bias"] = torch.zeros(n_experts, inter, dtype=dtype)
+    result[f"{mlp_pfx}.down_proj_bias"] = torch.zeros(n_experts, hidden, dtype=dtype)
+
+    # Non-expert keys: rename router, pass through rest
+    for key in chunk:
+        if ".ffn.experts." in key:
+            continue  # already handled
+        if ".ffn.gate." in key:
+            new_key = key.replace(".ffn.gate.", ".ffn.mlp.router.gate.")
+            result[new_key] = chunk[key]
+        else:
+            result[key] = chunk[key]
+
+    return result
+
+
+def build_post_sparse_cache(repo_id, n_layers, n_dense_layers):
+    """Build post-sparse cache from existing pre-sparse cache.
+
+    Reads each layer's pre-sparse chunk via mmap, stacks expert weights
+    to match the StackedExperts layout, and saves. Peak memory is ~46 GB
+    (one layer of mmap'd per-expert weights + one layer of stacked tensors).
+    """
+    repo_slug = repo_id.replace("/", "--")
+    base = os.environ.get("HF_HOME", os.path.expanduser("~/.cache/huggingface"))
+    pre_dir = os.path.join(
+        base, "tt_xla_dequant_cache", f"{repo_slug}_{n_layers}layers"
+    )
+    post_dir = os.path.join(
+        base, "tt_xla_dequant_cache", f"{repo_slug}_{n_layers}layers_post_sparse"
+    )
+
+    if not os.path.isdir(pre_dir):
+        print(
+            f"Pre-sparse cache not found at {pre_dir}.\n"
+            "Run without --post-sparse first."
+        )
+        sys.exit(1)
+
+    if os.path.isdir(post_dir) and any(
+        f.endswith(".safetensors") for f in os.listdir(post_dir)
+    ):
+        print(f"Post-sparse cache already exists at {post_dir}, skipping.")
+        print(f"  Files: {sorted(os.listdir(post_dir))}")
+        print("  Delete the directory to rebuild.")
+        return
+
+    os.makedirs(post_dir, exist_ok=True)
+    total_bytes = 0
+    t_start = time.perf_counter()
+
+    for fname in sorted(os.listdir(pre_dir)):
+        if not fname.endswith(".safetensors"):
+            continue
+
+        t_chunk = time.perf_counter()
+        chunk = safetensors_load_file(os.path.join(pre_dir, fname))
+
+        is_moe = any(".ffn.experts." in k for k in chunk)
+        if is_moe:
+            out_dict = _stack_experts_for_chunk(chunk)
+        else:
+            out_dict = dict(chunk)
+
+        out_path = os.path.join(post_dir, fname)
+        safetensors_save_file(out_dict, out_path)
+        sz = os.path.getsize(out_path)
+        total_bytes += sz
+        del chunk, out_dict
+
+        dt = time.perf_counter() - t_chunk
+        tag = " (MoE stacked)" if is_moe else ""
+        print(f"  {fname}: {sz / 1e9:.1f} GB, {dt:.1f}s{tag}", flush=True)
+
+    dt_total = time.perf_counter() - t_start
+    print(
+        f"\nDone. {total_bytes / 1e9:.1f} GB total, {dt_total:.1f}s",
+        flush=True,
+    )
+    print(f"Post-sparse cache dir: {post_dir}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Build BF16 weight cache for DeepSeek V3.1"
+    )
+    parser.add_argument(
+        "--repo", default=DEEPSEEK_V3_1_REPO, help="HuggingFace repo ID"
+    )
+    parser.add_argument("--n-layers", type=int, default=61, help="Number of layers")
+    parser.add_argument(
+        "--n-dense-layers",
+        type=int,
+        default=None,
+        help="Number of dense (non-MoE) layers (default: read from config)",
+    )
+    parser.add_argument(
+        "--post-sparse",
+        action="store_true",
+        help="Build post-sparse cache (stacked experts). Requires pre-sparse cache.",
+    )
+    args = parser.parse_args()
+
+    n_dense_layers = args.n_dense_layers
+    if n_dense_layers is None:
+        config_path = hf_hub_download(args.repo, "config.json")
+        with open(config_path) as f:
+            hf_cfg = json.load(f)
+        n_dense_layers = hf_cfg.get("first_k_dense_replace", 1)
+        print(f"Read n_dense_layers={n_dense_layers} from {args.repo} config")
+
+    if args.post_sparse:
+        build_post_sparse_cache(args.repo, args.n_layers, n_dense_layers)
+    else:
+        build_cache(args.repo, args.n_layers, n_dense_layers)

--- a/tests/torch/models/deepseek_v3_2_exp/build_weight_cache.py
+++ b/tests/torch/models/deepseek_v3_2_exp/build_weight_cache.py
@@ -27,7 +27,7 @@ from safetensors.torch import save_file as safetensors_save_file
 
 # Import the canonical helpers from the test file to stay in sync
 sys.path.insert(0, os.path.dirname(__file__))
-from test_deepseek_v3_2_exp import _rename_hf_key, _weight_dequant
+from test_deepseek_v3_1 import _rename_hf_key, _weight_dequant
 
 DEEPSEEK_V3_1_REPO = "deepseek-ai/DeepSeek-V3.1"
 

--- a/tests/torch/models/deepseek_v3_2_exp/build_weight_cache.py
+++ b/tests/torch/models/deepseek_v3_2_exp/build_weight_cache.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
 """Build a chunked BF16 weight cache for DeepSeek V3.1, one layer at a time.
@@ -16,7 +16,6 @@ import argparse
 import json
 import os
 import re
-import sys
 import time
 
 import torch
@@ -25,23 +24,119 @@ from safetensors import safe_open
 from safetensors.torch import load_file as safetensors_load_file
 from safetensors.torch import save_file as safetensors_save_file
 
-# Import the canonical helpers from the test file to stay in sync
-sys.path.insert(0, os.path.dirname(__file__))
-from test_deepseek_v3_1 import _rename_hf_key, _weight_dequant
-
 DEEPSEEK_V3_1_REPO = "deepseek-ai/DeepSeek-V3.1"
+FP8_BLOCK_SIZE = 128
+
+
+def _dequant_cache_dir(repo_id, n_layers):
+    """Per-model BF16 safetensors cache directory."""
+    repo_slug = repo_id.replace("/", "--")
+    base = os.environ.get("HF_HOME", os.path.expanduser("~/.cache/huggingface"))
+    return os.path.join(base, "tt_xla_dequant_cache", f"{repo_slug}_{n_layers}layers")
+
+
+def _post_sparse_cache_dir(repo_id, n_layers):
+    return _dequant_cache_dir(repo_id, n_layers) + "_post_sparse"
+
+
+def _has_cache(cache_dir):
+    return os.path.isdir(cache_dir) and any(
+        f.endswith(".safetensors") for f in os.listdir(cache_dir)
+    )
+
+
+def _rename_hf_key(ckpt_key, n_dense_layers=1):
+    """Rename a HuggingFace checkpoint key to match modified_model.py naming."""
+    key = ckpt_key
+    if key.startswith("model."):
+        key = key[len("model.") :]
+    if "weight_scale_inv" in key:
+        return None
+    key = key.replace("lm_head.", "head.")
+    key = key.replace("embed_tokens.", "embed.")
+    key = re.sub(r"(layers\.\d+\.)input_layernorm\.", r"\1attn_norm.", key)
+    key = re.sub(r"(layers\.\d+\.)post_attention_layernorm\.", r"\1ffn_norm.", key)
+    key = key.replace("self_attn.indexer.", "attn.indexer.")
+    key = key.replace("self_attn.q_a_proj.", "attn.wq_a.")
+    key = key.replace("self_attn.q_b_proj.", "attn.wq_b.")
+    key = key.replace("self_attn.q_a_layernorm.", "attn.q_norm.")
+    key = key.replace("self_attn.kv_a_proj_with_mqa.", "attn.wkv_a.")
+    key = key.replace("self_attn.kv_b_proj.", "attn.wkv_b.")
+    key = key.replace("self_attn.kv_a_layernorm.", "attn.kv_norm.")
+    key = key.replace("self_attn.o_proj.", "attn.wo.")
+    key = re.sub(r"mlp\.experts\.(\d+)\.gate_proj\.", r"ffn.experts.\1.w1.", key)
+    key = re.sub(r"mlp\.experts\.(\d+)\.down_proj\.", r"ffn.experts.\1.w2.", key)
+    key = re.sub(r"mlp\.experts\.(\d+)\.up_proj\.", r"ffn.experts.\1.w3.", key)
+    key = key.replace("mlp.shared_experts.gate_proj.", "ffn.shared_experts.w1.")
+    key = key.replace("mlp.shared_experts.down_proj.", "ffn.shared_experts.w2.")
+    key = key.replace("mlp.shared_experts.up_proj.", "ffn.shared_experts.w3.")
+    key = key.replace("mlp.gate.e_score_correction_bias", "mlp.gate.bias")
+    key = key.replace("mlp.gate.", "ffn.gate.")
+    layer_m = re.match(r"layers\.(\d+)\.", key)
+    if layer_m:
+        layer_id = int(layer_m.group(1))
+        if layer_id < n_dense_layers:
+            key = key.replace("mlp.gate_proj.", "ffn.w1.")
+            key = key.replace("mlp.down_proj.", "ffn.w2.")
+            key = key.replace("mlp.up_proj.", "ffn.w3.")
+        elif (
+            "mlp.gate_proj." in key or "mlp.down_proj." in key or "mlp.up_proj." in key
+        ):
+            return None
+    return key
+
+
+def _weight_dequant(weight, scale_inv, block_size=FP8_BLOCK_SIZE):
+    """Dequantize FP8 weight: bf16 = fp8 * weight_scale_inv (block-wise)."""
+    orig_shape = weight.shape
+    assert weight.dim() == 2
+    rows, cols = orig_shape
+    pad_rows = (block_size - rows % block_size) % block_size
+    pad_cols = (block_size - cols % block_size) % block_size
+    if pad_rows or pad_cols:
+        weight = torch.nn.functional.pad(weight, (0, pad_cols, 0, pad_rows))
+    padded_rows, padded_cols = weight.shape
+    n_br = padded_rows // block_size
+    n_bc = padded_cols // block_size
+    weight = (
+        weight.view(n_br, block_size, n_bc, block_size)
+        .transpose(1, 2)
+        .contiguous()
+        .view(-1, block_size * block_size)
+    )
+    weight = (
+        (weight.float() * scale_inv.view(-1, 1).float())
+        .to(torch.bfloat16)
+        .view(n_br, n_bc, block_size, block_size)
+        .transpose(1, 2)
+        .contiguous()
+        .view(padded_rows, padded_cols)
+    )
+    return weight[:rows, :cols]
+
+
+def _group_by_shard(ckpt_keys, key_to_shard):
+    shard_to_keys = {}
+    for k in ckpt_keys:
+        shard_to_keys.setdefault(key_to_shard[k], []).append(k)
+    return shard_to_keys
+
+
+def _load_tensors(shard_to_keys, repo_id):
+    """Return {ckpt_key: tensor} for all requested keys, opening each shard once."""
+    out = {}
+    for shard_name, keys in shard_to_keys.items():
+        shard_path = hf_hub_download(repo_id, shard_name)
+        with safe_open(shard_path, framework="pt", device="cpu") as f:
+            for key in keys:
+                out[key] = f.get_tensor(key)
+    return out
 
 
 def build_cache(repo_id, n_layers, n_dense_layers=1):
-    repo_slug = repo_id.replace("/", "--")
-    base = os.environ.get("HF_HOME", os.path.expanduser("~/.cache/huggingface"))
-    cache_dir = os.path.join(
-        base, "tt_xla_dequant_cache", f"{repo_slug}_{n_layers}layers"
-    )
+    cache_dir = _dequant_cache_dir(repo_id, n_layers)
 
-    if os.path.isdir(cache_dir) and any(
-        f.endswith(".safetensors") for f in os.listdir(cache_dir)
-    ):
+    if _has_cache(cache_dir):
         print(f"Cache already exists at {cache_dir}, skipping.")
         print(f"  Files: {sorted(os.listdir(cache_dir))}")
         print("  Delete the directory to rebuild.")
@@ -89,25 +184,12 @@ def build_cache(repo_id, n_layers, n_dense_layers=1):
         t_group_start = time.perf_counter()
         ckpt_to_model = groups[group_name]
 
-        # Determine which shards we need for this group
-        needed_shard_files = set()
-        for ckpt_key in ckpt_to_model:
-            needed_shard_files.add(all_key_to_shard[ckpt_key])
-            if ckpt_key in scale_keys:
-                needed_shard_files.add(all_key_to_shard[scale_keys[ckpt_key]])
-
-        # Load only the tensors we need from those shards
-        raw = {}
         needed_ckpt_keys = set(ckpt_to_model.keys())
         needed_scale_keys = {scale_keys[k] for k in ckpt_to_model if k in scale_keys}
-        all_needed = needed_ckpt_keys | needed_scale_keys
-
-        for shard_name in sorted(needed_shard_files):
-            shard_path = hf_hub_download(repo_id, shard_name)
-            with safe_open(shard_path, framework="pt", device="cpu") as f:
-                for key in f.keys():
-                    if key in all_needed:
-                        raw[key] = f.get_tensor(key)
+        shard_to_keys = _group_by_shard(
+            needed_ckpt_keys | needed_scale_keys, all_key_to_shard
+        )
+        raw = _load_tensors(shard_to_keys, repo_id)
 
         # Dequantize and rename
         state_dict = {}
@@ -222,25 +304,17 @@ def build_post_sparse_cache(repo_id, n_layers, n_dense_layers):
     to match the StackedExperts layout, and saves. Peak memory is ~46 GB
     (one layer of mmap'd per-expert weights + one layer of stacked tensors).
     """
-    repo_slug = repo_id.replace("/", "--")
-    base = os.environ.get("HF_HOME", os.path.expanduser("~/.cache/huggingface"))
-    pre_dir = os.path.join(
-        base, "tt_xla_dequant_cache", f"{repo_slug}_{n_layers}layers"
-    )
-    post_dir = os.path.join(
-        base, "tt_xla_dequant_cache", f"{repo_slug}_{n_layers}layers_post_sparse"
-    )
+    pre_dir = _dequant_cache_dir(repo_id, n_layers)
+    post_dir = _post_sparse_cache_dir(repo_id, n_layers)
 
-    if not os.path.isdir(pre_dir):
+    if not _has_cache(pre_dir):
         print(
-            f"Pre-sparse cache not found at {pre_dir}.\n"
-            "Run without --post-sparse first."
+            f"Pre-sparse cache not found at {pre_dir}, building it first...",
+            flush=True,
         )
-        sys.exit(1)
+        build_cache(repo_id, n_layers, n_dense_layers)
 
-    if os.path.isdir(post_dir) and any(
-        f.endswith(".safetensors") for f in os.listdir(post_dir)
-    ):
+    if _has_cache(post_dir):
         print(f"Post-sparse cache already exists at {post_dir}, skipping.")
         print(f"  Files: {sorted(os.listdir(post_dir))}")
         print("  Delete the directory to rebuild.")
@@ -307,7 +381,7 @@ if __name__ == "__main__":
         config_path = hf_hub_download(args.repo, "config.json")
         with open(config_path) as f:
             hf_cfg = json.load(f)
-        n_dense_layers = hf_cfg.get("first_k_dense_replace", 1)
+        n_dense_layers = hf_cfg["first_k_dense_replace"]
         print(f"Read n_dense_layers={n_dense_layers} from {args.repo} config")
 
     if args.post_sparse:

--- a/tests/torch/models/deepseek_v3_2_exp/build_weight_cache.py
+++ b/tests/torch/models/deepseek_v3_2_exp/build_weight_cache.py
@@ -376,7 +376,9 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*", args.repo):
+    if not re.fullmatch(
+        r"[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*", args.repo
+    ):
         parser.error(f"Invalid repo ID {args.repo!r}: expected 'org/model' format")
 
     n_dense_layers = args.n_dense_layers

--- a/tests/torch/models/deepseek_v3_2_exp/build_weight_cache.py
+++ b/tests/torch/models/deepseek_v3_2_exp/build_weight_cache.py
@@ -376,6 +376,9 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*", args.repo):
+        parser.error(f"Invalid repo ID {args.repo!r}: expected 'org/model' format")
+
     n_dense_layers = args.n_dense_layers
     if n_dense_layers is None:
         config_path = hf_hub_download(args.repo, "config.json")

--- a/tests/torch/models/deepseek_v3_2_exp/build_weight_cache.py
+++ b/tests/torch/models/deepseek_v3_2_exp/build_weight_cache.py
@@ -28,6 +28,17 @@ DEEPSEEK_V3_1_REPO = "deepseek-ai/DeepSeek-V3.1"
 FP8_BLOCK_SIZE = 128
 
 
+def _safe_open_hf(path):
+    """Open a path only if it resolves within the HF cache directory."""
+    real = os.path.realpath(path)
+    base = os.path.realpath(
+        os.environ.get("HF_HOME", os.path.expanduser("~/.cache/huggingface"))
+    )
+    if not real.startswith(base + os.sep):
+        raise ValueError(f"Path outside HF cache: {path}")
+    return open(real)
+
+
 def _dequant_cache_dir(repo_id, n_layers):
     """Per-model BF16 safetensors cache directory."""
     repo_slug = repo_id.replace("/", "--")
@@ -146,7 +157,7 @@ def build_cache(repo_id, n_layers, n_dense_layers=1):
 
     # Load index
     index_path = hf_hub_download(repo_id, "model.safetensors.index.json")
-    with open(index_path) as f:
+    with _safe_open_hf(index_path) as f:
         index = json.load(f)
     weight_map = index["weight_map"]
 
@@ -384,7 +395,7 @@ if __name__ == "__main__":
     n_dense_layers = args.n_dense_layers
     if n_dense_layers is None:
         config_path = hf_hub_download(args.repo, "config.json")
-        with open(config_path) as f:
+        with _safe_open_hf(config_path) as f:
             hf_cfg = json.load(f)
         n_dense_layers = hf_cfg["first_k_dense_replace"]
         print(f"Read n_dense_layers={n_dense_layers} from {args.repo} config")

--- a/tests/torch/models/deepseek_v3_2_exp/modified_model.py
+++ b/tests/torch/models/deepseek_v3_2_exp/modified_model.py
@@ -9,6 +9,50 @@ import torch
 import torch.distributed as dist
 import torch.nn.functional as F
 from torch import nn
+from transformers.cache_utils import Cache
+
+from tests.torch.models.kimi_k2.utils import MLAStaticLayer
+
+
+class MLAStaticLayerModule(nn.Module, MLAStaticLayer):
+    """nn.Module wrapper around ``MLAStaticLayer`` so its ``compressed_kv`` /
+    ``k_pe`` tensors are registered buffers and move with ``model.to(device)``.
+
+    ``MLAStaticLayer`` stores them as plain Python attributes in
+    ``lazy_initialization``, which is fine for kimi_k2's graph tests (the
+    cache is passed in as a top-level arg) but not for us — Transformer owns
+    the cache and needs standard nn.Module semantics.
+    """
+
+    def __init__(self, max_cache_len: int):
+        nn.Module.__init__(self)
+        MLAStaticLayer.__init__(self, max_cache_len=max_cache_len)
+
+    def lazy_initialization(self, compressed_kv: torch.Tensor, k_pe: torch.Tensor):
+        self.max_batch_size, _, _, self.kv_lora_rank = compressed_kv.shape
+        _, _, _, self.pe_rank = k_pe.shape
+        self.register_buffer(
+            "compressed_kv",
+            torch.zeros(
+                (self.max_batch_size, 1, self.max_cache_len, self.kv_lora_rank),
+                dtype=compressed_kv.dtype,
+                device=compressed_kv.device,
+            ),
+            persistent=False,
+        )
+        self.register_buffer(
+            "k_pe",
+            torch.zeros(
+                (self.max_batch_size, 1, self.max_cache_len, self.pe_rank),
+                dtype=k_pe.dtype,
+                device=k_pe.device,
+            ),
+            persistent=False,
+        )
+        if not torch.compiler.is_compiling():
+            torch._dynamo.mark_static_address(self.compressed_kv)
+            torch._dynamo.mark_static_address(self.k_pe)
+        self.is_initialized = True
 
 
 # from kernel import act_quant, fp8_gemm, fp8_index
@@ -772,19 +816,6 @@ class MLA(nn.Module):
             Indexer(args, haddamard_matrix) if args.index_n_heads > 0 else None
         )
         self.register_buffer("hadamard_matrix", haddamard_matrix, persistent=False)
-
-        self.register_buffer(
-            "kv_cache",
-            torch.zeros(args.max_batch_size, 1, args.max_seq_len, self.kv_lora_rank),
-            persistent=False,
-        )
-        self.register_buffer(
-            "pe_cache",
-            torch.zeros(
-                args.max_batch_size, 1, args.max_seq_len, self.qk_rope_head_dim
-            ),
-            persistent=False,
-        )
         self.dequant_wkv_b = None
 
     def forward(
@@ -793,19 +824,20 @@ class MLA(nn.Module):
         start_pos: int,
         freqs_cis: torch.Tensor,
         mask: Optional[torch.Tensor],
+        past_key_value: Cache,
         cache_position: Optional[torch.Tensor] = None,
         attention_mask: Optional[torch.Tensor] = None,
     ):
         """MLA forward with two paths.
 
-        1. Legacy int path (``cache_position is None``): writes to
-           ``self.kv_cache`` / ``self.pe_cache`` via int-slice and runs the
-           MHA prefill branch or the MQA decode branch inline.
+        1. Legacy int path (``cache_position is None``): writes to the
+           ``past_key_value`` cache layer via int-slice and runs the MHA
+           prefill branch or the MQA decode branch inline.
 
         2. Cache path (``cache_position is not None``): writes to the same
-           buffers via ``index_copy_`` and runs attention against the full
-           ``max_cache_len``, gated by the additive ``attention_mask``. Used
-           by ``test_deepseek_v3_1_decode_static_cache``.
+           cache layer via ``index_copy_`` and runs attention against the
+           full ``max_cache_len``, gated by the additive ``attention_mask``.
+           Used by ``test_deepseek_v3_1_decode_static_cache``.
         """
         if cache_position is not None:
             return self._forward_with_cache(
@@ -813,7 +845,11 @@ class MLA(nn.Module):
                 freqs_cis,
                 cache_position,
                 attention_mask,
+                past_key_value,
             )
+        cache_layer = past_key_value.layers[self.layer_idx]
+        kv_cache = cache_layer.compressed_kv
+        pe_cache = cache_layer.k_pe
         bsz, seqlen, _ = x.size()
         end_pos = start_pos + seqlen
         qr = self.q_norm(self.wq_a(x))
@@ -835,8 +871,8 @@ class MLA(nn.Module):
                 .to(kv.dtype)
                 .view_as(kv)
             )
-        self.kv_cache[:bsz, 0, start_pos:end_pos] = kv
-        self.pe_cache[:bsz, 0, start_pos:end_pos] = k_pe.squeeze(2)
+        kv_cache[:bsz, 0, start_pos:end_pos] = kv
+        pe_cache[:bsz, 0, start_pos:end_pos] = k_pe.squeeze(2)
         if mask is not None:  # MHA prefill
             q = torch.cat([q_nope, q_pe], dim=-1)
             kv = self.wkv_b(kv)
@@ -874,8 +910,8 @@ class MLA(nn.Module):
                 "bshd,hdc->bshc", q_nope, wkv_b[:, : self.qk_nope_head_dim]
             )
             scores = (
-                torch.einsum("bshc,btc->bsht", q_nope, self.kv_cache[:bsz, 0, :end_pos])
-                + torch.einsum("bshr,btr->bsht", q_pe, self.pe_cache[:bsz, 0, :end_pos])
+                torch.einsum("bshc,btc->bsht", q_nope, kv_cache[:bsz, 0, :end_pos])
+                + torch.einsum("bshr,btr->bsht", q_pe, pe_cache[:bsz, 0, :end_pos])
             ) * self.softmax_scale
 
             # indexer
@@ -887,7 +923,7 @@ class MLA(nn.Module):
                 scores += index_mask.unsqueeze(2)
 
             scores = scores.softmax(dim=-1)
-            x = torch.einsum("bsht,btc->bshc", scores, self.kv_cache[:bsz, 0, :end_pos])
+            x = torch.einsum("bsht,btc->bshc", scores, kv_cache[:bsz, 0, :end_pos])
             x = torch.einsum("bshc,hdc->bshd", x, wkv_b[:, -self.v_head_dim :])
         x = self.wo(x.flatten(2))
         return x
@@ -898,16 +934,16 @@ class MLA(nn.Module):
         freqs_cis_step: torch.Tensor,
         cache_position: torch.Tensor,
         attention_mask: torch.Tensor,
+        past_key_value: Cache,
     ) -> torch.Tensor:
-        """Cache-path MLA forward using the module-local `self.kv_cache` /
-        `self.pe_cache` buffers (shared with the int path).
+        """Cache-path MLA forward using the HF ``Cache`` passed in.
 
         Writes are tensor-indexed (`index_copy_`), so this is safe under
         `torch.compile` + `torch_xla` SPMD — no Python-int specialization, no
         per-step recompile. Reads span the full `max_cache_len`; the additive
         `attention_mask` masks positions beyond `cache_position.max()`.
 
-        Buffers are shaped `(B, 1, T, D)` — the leading unit dim is
+        Cache layers are shaped `(B, 1, T, D)` — the leading unit dim is
         vestigial (MLA caches a single shared latent across heads), but
         TT-MLIR legalizes `stablehlo.scatter` on the 4D layout while the
         logically-equivalent 3D `(B, T, D)` form currently fails TTIR
@@ -938,13 +974,17 @@ class MLA(nn.Module):
                 .view_as(kv)
             )
 
-        # In-place index_copy_ on a 4D cache sharded only on batch dim.
-        # kv: (B, seqlen, D) -> unsqueeze(1) to (B, 1, seqlen, D) for the scatter.
-        self.kv_cache.index_copy_(2, cache_position, kv.unsqueeze(1))
-        self.pe_cache.index_copy_(2, cache_position, k_pe.squeeze(2).unsqueeze(1))
-
-        kv_full = self.kv_cache.squeeze(1)  # (B, max_cache_len, kv_lora_rank)
-        pe_full = self.pe_cache.squeeze(1)  # (B, max_cache_len, qk_rope_head_dim)
+        # HF-style cache update. index_copy_ runs inside MLAStaticLayer.update
+        # on a 4D cache sharded only on batch dim; kv/k_pe are unsqueezed on
+        # dim 1 to match (B, 1, seqlen, D).
+        compressed_kv_full, k_pe_full = past_key_value.update(
+            kv.unsqueeze(1),
+            k_pe.squeeze(2).unsqueeze(1),
+            self.layer_idx,
+            {"cache_position": cache_position},
+        )
+        kv_full = compressed_kv_full.squeeze(1)
+        pe_full = k_pe_full.squeeze(1)
 
         if self.dequant_wkv_b is None and self.wkv_b.scale is not None:
             self.dequant_wkv_b = weight_dequant(self.wkv_b.weight, self.wkv_b.scale)
@@ -1253,6 +1293,7 @@ class Block(nn.Module):
         start_pos: int,
         freqs_cis: torch.Tensor,
         mask: Optional[torch.Tensor],
+        past_key_value: Cache,
         cache_position: Optional[torch.Tensor] = None,
         attention_mask: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
@@ -1267,6 +1308,7 @@ class Block(nn.Module):
             start_pos,
             freqs_cis,
             mask,
+            past_key_value,
             cache_position=cache_position,
             attention_mask=attention_mask,
         )
@@ -1344,6 +1386,31 @@ class Transformer(nn.Module):
 
         self.register_buffer("freqs_cis", freqs_cis, persistent=False)
 
+        # HF-style shared cache, one MLAStaticLayer per block. Held as an
+        # nn.ModuleList so buffers move with ``.to(device)``; the Cache
+        # wrapper exposes the standard HF ``update(...)`` API used by MLA.
+        mla = self.layers[0].attn
+        self._cache_layers = nn.ModuleList(
+            [
+                MLAStaticLayerModule(max_cache_len=args.max_seq_len)
+                for _ in range(args.n_layers)
+            ]
+        )
+        for cache_layer in self._cache_layers:
+            cache_layer.lazy_initialization(
+                torch.zeros(
+                    args.max_batch_size, 1, 1, mla.kv_lora_rank, dtype=torch.bfloat16
+                ),
+                torch.zeros(
+                    args.max_batch_size,
+                    1,
+                    1,
+                    mla.qk_rope_head_dim,
+                    dtype=torch.bfloat16,
+                ),
+            )
+        self.past_key_values = Cache(layers=list(self._cache_layers))
+
     def forward(
         self,
         tokens: torch.Tensor,
@@ -1355,9 +1422,9 @@ class Transformer(nn.Module):
 
         - When `cache_position is not None`, runs the compile-friendly path:
           `freqs_cis` is tensor-indexed via `index_select(cache_position)`,
-          blocks write to the module-local `self.kv_cache` / `self.pe_cache`
-          buffers via `index_copy_`, and the additive `attention_mask` masks
-          cache slots beyond the current position.
+          blocks write to ``self.past_key_values`` via ``index_copy_``, and
+          the additive ``attention_mask`` masks cache slots beyond the
+          current position.
 
         - Otherwise (legacy int path), `start_pos` + int slice of `freqs_cis`.
         """
@@ -1372,6 +1439,7 @@ class Transformer(nn.Module):
                     0,
                     freqs_cis,
                     None,
+                    self.past_key_values,
                     cache_position=cache_position,
                     attention_mask=attention_mask,
                 )
@@ -1395,7 +1463,9 @@ class Transformer(nn.Module):
         )
         h, residual = self.embed(tokens), None
         for layer in self.layers:
-            h, residual = layer(h, residual, start_pos, freqs_cis, mask)
+            h, residual = layer(
+                h, residual, start_pos, freqs_cis, mask, self.past_key_values
+            )
         h, _ = self.norm(h, residual)
         logits = self.head(h[:, -1].float())
         if world_size > 1:

--- a/tests/torch/models/deepseek_v3_2_exp/modified_model.py
+++ b/tests/torch/models/deepseek_v3_2_exp/modified_model.py
@@ -737,8 +737,9 @@ class MLA(nn.Module):
         softmax_scale (float): Scaling factor for softmax in attention computation.
     """
 
-    def __init__(self, args: ModelArgs, haddamard_matrix):
+    def __init__(self, args: ModelArgs, haddamard_matrix, layer_idx: int = 0):
         super().__init__()
+        self.layer_idx = layer_idx
         self.dim = args.dim
         self.n_heads = args.n_heads
         self.n_local_heads = args.n_heads // world_size
@@ -790,19 +791,28 @@ class MLA(nn.Module):
         start_pos: int,
         freqs_cis: torch.Tensor,
         mask: Optional[torch.Tensor],
+        cache_position: Optional[torch.Tensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
     ):
-        """
-        Forward pass for the Multi-Head Latent Attention (MLA) Layer.
+        """MLA forward with two paths.
 
-        Args:
-            x (torch.Tensor): Input tensor of shape (batch_size, seq_len, dim).
-            start_pos (int): Starting position in the sequence for caching.
-            freqs_cis (torch.Tensor): Precomputed complex exponential values for rotary embeddings.
-            mask (Optional[torch.Tensor]): Mask tensor to exclude certain positions from attention.
+        1. Legacy int path (``cache_position is None``): writes to
+           ``self.kv_cache`` / ``self.pe_cache`` via int-slice and runs the
+           MHA prefill branch or the MQA decode branch inline.
 
-        Returns:
-            torch.Tensor: Output tensor with the same shape as the input.
+        2. Cache path (``cache_position is not None``): writes to the same
+           buffers via a functional scatter-pad and runs attention against
+           the full ``max_cache_len``, gated by the additive
+           ``attention_mask``. This is the compile-friendly path used by
+           ``test_deepseek_v3_1_decode_static_cache``.
         """
+        if cache_position is not None:
+            return self._forward_with_cache(
+                x,
+                freqs_cis,
+                cache_position,
+                attention_mask,
+            )
         bsz, seqlen, _ = x.size()
         end_pos = start_pos + seqlen
         qr = self.q_norm(self.wq_a(x))
@@ -846,6 +856,9 @@ class MLA(nn.Module):
                 ).scatter_(-1, topk_indices, 0)
                 index_mask += mask
                 scores += index_mask.unsqueeze(2)
+            else:
+                # Causal mask: (seqlen, seqlen) → (1, seqlen, 1, seqlen) for broadcast
+                scores += mask[None, :, None, :]
 
             scores = scores.softmax(dim=-1)
             x = torch.einsum("bsht,bthd->bshd", scores, v)
@@ -877,6 +890,98 @@ class MLA(nn.Module):
             x = torch.einsum("bshc,hdc->bshd", x, wkv_b[:, -self.v_head_dim :])
         x = self.wo(x.flatten(2))
         return x
+
+    def _forward_with_cache(
+        self,
+        x: torch.Tensor,
+        freqs_cis_step: torch.Tensor,
+        cache_position: torch.Tensor,
+        attention_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        """Cache-path MLA forward using the module-local `self.kv_cache` /
+        `self.pe_cache` buffers (shared with the int path).
+
+        Writes are tensor-indexed (`index_copy_`), so this is safe under
+        `torch.compile` + `torch_xla` SPMD — no Python-int specialization, no
+        per-step recompile. Reads span the full `max_cache_len`; the additive
+        `attention_mask` masks positions beyond `cache_position.max()`.
+        """
+        bsz, seqlen, _ = x.size()
+
+        qr = self.q_norm(self.wq_a(x))
+        q = self.wq_b(qr)
+        q = q.view(bsz, seqlen, self.n_local_heads, self.qk_head_dim)
+        q_nope, q_pe = torch.split(
+            q, [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1
+        )
+        q_pe = apply_rotary_emb(q_pe, freqs_cis_step)
+
+        kv = self.wkv_a(x)
+        kv, k_pe = torch.split(kv, [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
+        kv = self.kv_norm(kv)  # (B, seqlen, kv_lora_rank)
+        k_pe = apply_rotary_emb(
+            k_pe.unsqueeze(2), freqs_cis_step
+        )  # (B, seqlen, 1, qk_rope_head_dim)
+
+        if self.dtype == "fp8":
+            kv_fp8, kv_scale = act_quant(kv, block_size, self.scale_fmt)
+            kv = (
+                (kv_fp8.view(-1, block_size).float() * kv_scale.view(-1, 1))
+                .to(kv.dtype)
+                .view_as(kv)
+            )
+
+        # Functional cache update: express the tensor-indexed write as a
+        # `torch.where(mask, scatter_pad(kv), cache)` where `scatter_pad(kv)` is
+        # computed as a matmul against a one-hot position matrix. This avoids
+        # `index_put`/`scatter` lowering (unsupported by TT-MLIR on sharded
+        # buffers).
+        #
+        # Important: the result of `torch.where` is a *new* tensor — reassigning
+        # `self.kv_cache = ...` would lose the mark_sharding annotation on the
+        # module buffer, which in turn forces Shardy to propagate sharding
+        # backwards through the A2A-dispatch custom_call's tuple output inside
+        # MoE (which it can't handle). Instead, write back with `.copy_()` so the
+        # module buffer keeps its identity and sharding.
+        k_pe_flat = k_pe.squeeze(2)  # (B, seqlen, qk_rope_head_dim)
+        max_cache_len = self.kv_cache.size(1)
+        slot_range = torch.arange(max_cache_len, device=kv.device)
+        E = (cache_position.unsqueeze(1) == slot_range.unsqueeze(0)).to(kv.dtype)
+        kv_padded = torch.einsum("bsr,sc->bcr", kv, E)
+        k_pe_padded = torch.einsum("bsr,sc->bcr", k_pe_flat, E)
+        mask = (E.sum(dim=0) > 0).view(1, max_cache_len, 1)
+        self.kv_cache.copy_(torch.where(mask, kv_padded, self.kv_cache))
+        self.pe_cache.copy_(torch.where(mask, k_pe_padded, self.pe_cache))
+
+        kv_full = self.kv_cache  # (B, max_cache_len, kv_lora_rank)
+        pe_full = self.pe_cache  # (B, max_cache_len, qk_rope_head_dim)
+
+        if self.dequant_wkv_b is None and self.wkv_b.scale is not None:
+            self.dequant_wkv_b = weight_dequant(self.wkv_b.weight, self.wkv_b.scale)
+        wkv_b = self.wkv_b.weight if self.dequant_wkv_b is None else self.dequant_wkv_b
+        wkv_b = wkv_b.view(self.n_local_heads, -1, self.kv_lora_rank)
+
+        q_nope_latent = torch.einsum(
+            "bshd,hdc->bshc", q_nope, wkv_b[:, : self.qk_nope_head_dim]
+        )  # (B, seqlen, n_heads, kv_lora_rank)
+
+        scores = (
+            torch.einsum("bshc,btc->bsht", q_nope_latent, kv_full)
+            + torch.einsum("bshr,btr->bsht", q_pe, pe_full)
+        ) * self.softmax_scale  # (B, seqlen, n_heads, max_cache_len)
+
+        # attention_mask: (B, 1, seqlen, max_cache_len) -> (B, seqlen, 1, max_cache_len)
+        scores = scores + attention_mask.permute(0, 2, 1, 3)
+        scores = scores.softmax(dim=-1)
+
+        attn_latent = torch.einsum(
+            "bsht,btc->bshc", scores, kv_full
+        )  # (B, seqlen, n_heads, kv_lora_rank)
+        attn_out = torch.einsum(
+            "bshc,hdc->bshd", attn_latent, wkv_b[:, -self.v_head_dim :]
+        )  # (B, seqlen, n_heads, v_head_dim)
+
+        return self.wo(attn_out.flatten(2))
 
 
 class MLP(nn.Module):
@@ -972,7 +1077,8 @@ class Gate(nn.Module):
         Returns:
             Tuple[torch.Tensor, torch.Tensor]: Routing weights and selected expert indices.
         """
-        scores = linear(x.float(), self.weight.float())
+        # fp32 linear has accuracy issues — keep in bf16 for Gate routing.
+        scores = linear(x, self.weight)
         if self.score_func == "softmax":
             scores = scores.softmax(dim=-1)
         else:
@@ -986,11 +1092,20 @@ class Gate(nn.Module):
                 group_scores = scores.amax(dim=-1)
             else:
                 group_scores = scores.topk(2, dim=-1)[0].sum(dim=-1)
-            indices = group_scores.topk(self.topk_groups, dim=-1)[1]
-            mask = scores.new_ones(x.size(0), self.n_groups, dtype=bool).scatter_(
-                1, indices, False
+            group_indices = group_scores.topk(self.topk_groups, dim=-1)[1]
+            # Use one_hot + any instead of scatter_ to avoid SPMD partitioning
+            # bug where scatter indices are not adjusted after all_gather.
+            group_range = torch.arange(
+                self.n_groups, device=scores.device, dtype=group_indices.dtype
             )
-            scores = scores.masked_fill_(mask.unsqueeze(-1), float("-inf")).flatten(1)
+            selected_groups = (group_indices.unsqueeze(-1) == group_range).any(
+                dim=1
+            )  # [BS, n_groups]
+            scores = torch.where(
+                selected_groups.unsqueeze(-1).expand_as(scores),
+                scores,
+                torch.tensor(float("-inf"), dtype=scores.dtype, device=scores.device),
+            ).flatten(1)
         indices = scores.topk(self.topk, dim=-1)[1]
         weights = original_scores.gather(1, indices)
         if self.score_func == "sigmoid":
@@ -1131,7 +1246,8 @@ class Block(nn.Module):
             hadamard_matrix (torch.Tensor): Precomputed Hadamard matrix.
         """
         super().__init__()
-        self.attn = MLA(args, hadamard_matrix)
+        self.layer_id = layer_id
+        self.attn = MLA(args, hadamard_matrix, layer_idx=layer_id)
         self.ffn = (
             MLP(args.dim, args.inter_dim)
             if layer_id < args.n_dense_layers
@@ -1147,24 +1263,23 @@ class Block(nn.Module):
         start_pos: int,
         freqs_cis: torch.Tensor,
         mask: Optional[torch.Tensor],
+        cache_position: Optional[torch.Tensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        """
-        Forward pass for the Transformer block.
-
-        Args:
-            x (torch.Tensor): Input tensor.
-            start_pos (int): Starting position in the sequence.
-            freqs_cis (torch.Tensor): Precomputed complex exponential values for rotary embeddings.
-            mask (Optional[torch.Tensor]): Mask tensor to exclude certain positions from attention.
-
-        Returns:
-            torch.Tensor: Output tensor after block computation.
-        """
+        """Block forward. When `cache_position is not None`, takes the
+        compile-friendly cache path; else the legacy int path."""
         if residual is None:
             x, residual = self.attn_norm(x), x
         else:
             x, residual = self.attn_norm(x, residual)
-        x = self.attn(x, start_pos, freqs_cis, mask)
+        x = self.attn(
+            x,
+            start_pos,
+            freqs_cis,
+            mask,
+            cache_position=cache_position,
+            attention_mask=attention_mask,
+        )
         x, residual = self.ffn_norm(x, residual)
         x = self.ffn(x)
         return x, residual
@@ -1239,18 +1354,45 @@ class Transformer(nn.Module):
 
         self.register_buffer("freqs_cis", freqs_cis, persistent=False)
 
-    def forward(self, tokens: torch.Tensor, start_pos: int = 0):
-        """
-        Forward pass for the Transformer model.
+    def forward(
+        self,
+        tokens: torch.Tensor,
+        start_pos: int = 0,
+        cache_position: Optional[torch.Tensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+    ):
+        """Two-path Transformer forward.
 
-        Args:
-            tokens (torch.Tensor): Input tensor of token IDs with shape (batch_size, seq_len).
-            start_pos (int, optional): Starting position in the sequence for rotary embeddings. Defaults to 0.
+        - When `cache_position is not None`, runs the compile-friendly path:
+          `freqs_cis` is tensor-indexed via `index_select(cache_position)`,
+          blocks write to the module-local `self.kv_cache` / `self.pe_cache`
+          buffers via `index_copy_`, and the additive `attention_mask` masks
+          cache slots beyond the current position.
 
-        Returns:
-            torch.Tensor: Logits tensor of shape (batch_size, vocab_size).
+        - Otherwise (legacy int path), `start_pos` + int slice of `freqs_cis`.
         """
         seqlen = tokens.size(1)
+        if cache_position is not None:
+            freqs_cis = self.freqs_cis.index_select(0, cache_position)
+            h, residual = self.embed(tokens), None
+            for layer in self.layers:
+                h, residual = layer(
+                    h,
+                    residual,
+                    0,
+                    freqs_cis,
+                    None,
+                    cache_position=cache_position,
+                    attention_mask=attention_mask,
+                )
+            h, _ = self.norm(h, residual)
+            logits = self.head(h[:, -1].float())
+            if world_size > 1:
+                all_logits = [torch.empty_like(logits) for _ in range(world_size)]
+                dist.all_gather(all_logits, logits)
+                logits = torch.cat(all_logits, dim=-1)
+            return logits
+
         freqs_cis = self.freqs_cis[start_pos : start_pos + seqlen]
         mask = (
             torch.full(

--- a/tests/torch/models/deepseek_v3_2_exp/modified_model.py
+++ b/tests/torch/models/deepseek_v3_2_exp/modified_model.py
@@ -11,41 +11,68 @@ import torch.nn.functional as F
 from torch import nn
 from transformers.cache_utils import Cache
 
-from tests.torch.models.kimi_k2.utils import MLAStaticLayer
 
+class MLAStaticLayerModule(nn.Module):
+    """nn.Module-owning MLA cache layer, duck-typed for HF's
+    ``CacheLayerMixin`` interface so it drops into ``Cache(layers=[...])``.
 
-class MLAStaticLayerModule(nn.Module, MLAStaticLayer):
-    """nn.Module wrapper around ``MLAStaticLayer`` so its ``compressed_kv`` /
-    ``k_pe`` tensors are registered buffers and move with ``model.to(device)``.
+    Re-implements the small surface (``update``, ``get_seq_length``,
+    ``get_mask_sizes``, ``get_max_cache_shape``, ``is_initialized``) rather
+    than inheriting from ``MLAStaticLayer``. The reason is ownership of the
+    tensors: kimi_k2's ``MLAStaticLayer`` stores ``compressed_kv`` / ``k_pe``
+    as plain Python attributes, so ``model.to(device)`` wouldn't move them.
+    Here they're registered buffers on an nn.Module, which PyTorch traverses
+    normally.
 
-    ``MLAStaticLayer`` stores them as plain Python attributes in
-    ``lazy_initialization``, which is fine for kimi_k2's graph tests (the
-    cache is passed in as a top-level arg) but not for us — Transformer owns
-    the cache and needs standard nn.Module semantics.
+    ``dtype`` and ``device`` are derived from the live buffer so they can
+    never drift out of sync after a ``.to()`` call.
     """
 
-    def __init__(self, max_cache_len: int):
-        nn.Module.__init__(self)
-        MLAStaticLayer.__init__(self, max_cache_len=max_cache_len)
+    is_compileable = True
+    is_sliding = False
 
-    def lazy_initialization(self, compressed_kv: torch.Tensor, k_pe: torch.Tensor):
-        self.max_batch_size, _, _, self.kv_lora_rank = compressed_kv.shape
-        _, _, _, self.pe_rank = k_pe.shape
+    def __init__(self, max_cache_len: int):
+        super().__init__()
+        self.max_cache_len = max_cache_len
+        self.is_initialized = False
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self.compressed_kv.dtype
+
+    @property
+    def device(self) -> torch.device:
+        return self.compressed_kv.device
+
+    def early_initialization(
+        self,
+        batch_size: int,
+        kv_lora_rank: int,
+        pe_rank: int,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> None:
+        """Allocate the cache buffers up-front. Scalar signature, no fake
+        shape-prime tensors — preferred over ``lazy_initialization``.
+        """
+        self.max_batch_size = batch_size
+        self.kv_lora_rank = kv_lora_rank
+        self.pe_rank = pe_rank
         self.register_buffer(
             "compressed_kv",
             torch.zeros(
-                (self.max_batch_size, 1, self.max_cache_len, self.kv_lora_rank),
-                dtype=compressed_kv.dtype,
-                device=compressed_kv.device,
+                (batch_size, 1, self.max_cache_len, kv_lora_rank),
+                dtype=dtype,
+                device=device,
             ),
             persistent=False,
         )
         self.register_buffer(
             "k_pe",
             torch.zeros(
-                (self.max_batch_size, 1, self.max_cache_len, self.pe_rank),
-                dtype=k_pe.dtype,
-                device=k_pe.device,
+                (batch_size, 1, self.max_cache_len, pe_rank),
+                dtype=dtype,
+                device=device,
             ),
             persistent=False,
         )
@@ -53,6 +80,52 @@ class MLAStaticLayerModule(nn.Module, MLAStaticLayer):
             torch._dynamo.mark_static_address(self.compressed_kv)
             torch._dynamo.mark_static_address(self.k_pe)
         self.is_initialized = True
+
+    def lazy_initialization(
+        self, compressed_kv: torch.Tensor, k_pe: torch.Tensor
+    ) -> None:
+        """Back-compat with HF's tensor-based init path. Extracts scalars
+        from sample tensors and delegates to ``early_initialization``.
+        """
+        batch_size, _, _, kv_lora_rank = compressed_kv.shape
+        _, _, _, pe_rank = k_pe.shape
+        self.early_initialization(
+            batch_size=batch_size,
+            kv_lora_rank=kv_lora_rank,
+            pe_rank=pe_rank,
+            dtype=compressed_kv.dtype,
+            device=compressed_kv.device,
+        )
+
+    def update(
+        self,
+        compressed_kv: torch.Tensor,
+        k_pe: torch.Tensor,
+        cache_kwargs: Optional[dict] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if not self.is_initialized:
+            self.lazy_initialization(compressed_kv, k_pe)
+        cache_position = (
+            cache_kwargs.get("cache_position") if cache_kwargs is not None else None
+        )
+        if cache_position is None:
+            cache_position = torch.arange(
+                compressed_kv.shape[-2], device=self.compressed_kv.device
+            )
+        self.compressed_kv.index_copy_(2, cache_position, compressed_kv)
+        self.k_pe.index_copy_(2, cache_position, k_pe)
+        return self.compressed_kv, self.k_pe
+
+    def get_seq_length(self) -> int:
+        if not self.is_initialized:
+            return 0
+        return (self.compressed_kv[0, 0].any(dim=-1)).sum()
+
+    def get_mask_sizes(self, cache_position: torch.Tensor) -> Tuple[int, int]:
+        return self.max_cache_len, 0
+
+    def get_max_cache_shape(self) -> int:
+        return self.max_cache_len
 
 
 # from kernel import act_quant, fp8_gemm, fp8_index
@@ -840,6 +913,11 @@ class MLA(nn.Module):
            Used by ``test_deepseek_v3_1_decode_static_cache``.
         """
         if cache_position is not None:
+            # Cache path doesn't consume start_pos / mask — guard against silent
+            # misuse (e.g., caller leaving stale legacy args on a cache call).
+            assert (
+                start_pos == 0 and mask is None
+            ), "cache path ignores start_pos/mask; pass cache_position+attention_mask only"
             return self._forward_with_cache(
                 x,
                 freqs_cis,
@@ -847,6 +925,9 @@ class MLA(nn.Module):
                 attention_mask,
                 past_key_value,
             )
+        assert (
+            attention_mask is None
+        ), "legacy path ignores attention_mask; pass mask (causal triangle) instead"
         cache_layer = past_key_value.layers[self.layer_idx]
         kv_cache = cache_layer.compressed_kv
         pe_cache = cache_layer.k_pe
@@ -949,6 +1030,14 @@ class MLA(nn.Module):
         logically-equivalent 3D `(B, T, D)` form currently fails TTIR
         legalization.
         """
+        assert (
+            attention_mask is not None
+        ), "cache path requires attention_mask; additive (B, 1, S, max_cache_len) mask"
+        # TODO(deepseek-v3.2): indexer is not yet wired through the cache path.
+        # The legacy int path runs it; skipping silently here would diverge.
+        assert (
+            self.indexer is None
+        ), "cache path does not yet support the v3.2 indexer — use the legacy path"
         bsz, seqlen, _ = x.size()
 
         qr = self.q_norm(self.wq_a(x))
@@ -974,9 +1063,9 @@ class MLA(nn.Module):
                 .view_as(kv)
             )
 
-        # HF-style cache update. index_copy_ runs inside MLAStaticLayer.update
-        # on a 4D cache sharded only on batch dim; kv/k_pe are unsqueezed on
-        # dim 1 to match (B, 1, seqlen, D).
+        # HF-style cache update. index_copy_ runs inside
+        # MLAStaticLayerModule.update on a 4D cache sharded only on batch dim;
+        # kv/k_pe are unsqueezed on dim 1 to match (B, 1, seqlen, D).
         compressed_kv_full, k_pe_full = past_key_value.update(
             kv.unsqueeze(1),
             k_pe.squeeze(2).unsqueeze(1),
@@ -1107,7 +1196,8 @@ class Gate(nn.Module):
         Returns:
             Tuple[torch.Tensor, torch.Tensor]: Routing weights and selected expert indices.
         """
-        # fp32 linear has accuracy issues — keep in bf16 for Gate routing.
+        # TODO(tt-xla#XXXX): fp32 linear hits an accuracy issue in the XLA
+        # lowering path on TT; keep bf16 for Gate routing until fixed.
         scores = linear(x, self.weight)
         if self.score_func == "softmax":
             scores = scores.softmax(dim=-1)
@@ -1122,20 +1212,11 @@ class Gate(nn.Module):
                 group_scores = scores.amax(dim=-1)
             else:
                 group_scores = scores.topk(2, dim=-1)[0].sum(dim=-1)
-            group_indices = group_scores.topk(self.topk_groups, dim=-1)[1]
-            # Use one_hot + any instead of scatter_ to avoid SPMD partitioning
-            # bug where scatter indices are not adjusted after all_gather.
-            group_range = torch.arange(
-                self.n_groups, device=scores.device, dtype=group_indices.dtype
+            indices = group_scores.topk(self.topk_groups, dim=-1)[1]
+            mask = scores.new_ones(x.size(0), self.n_groups, dtype=bool).scatter_(
+                1, indices, False
             )
-            selected_groups = (group_indices.unsqueeze(-1) == group_range).any(
-                dim=1
-            )  # [BS, n_groups]
-            scores = torch.where(
-                selected_groups.unsqueeze(-1).expand_as(scores),
-                scores,
-                torch.tensor(float("-inf"), dtype=scores.dtype, device=scores.device),
-            ).flatten(1)
+            scores = scores.masked_fill_(mask.unsqueeze(-1), float("-inf")).flatten(1)
         indices = scores.topk(self.topk, dim=-1)[1]
         weights = original_scores.gather(1, indices)
         if self.score_func == "sigmoid":
@@ -1386,10 +1467,19 @@ class Transformer(nn.Module):
 
         self.register_buffer("freqs_cis", freqs_cis, persistent=False)
 
-        # HF-style shared cache, one MLAStaticLayer per block. Held as an
-        # nn.ModuleList so buffers move with ``.to(device)``; the Cache
-        # wrapper exposes the standard HF ``update(...)`` API used by MLA.
+        # HF-style shared cache. Two attributes, same underlying layer
+        # instances (no copy — both hold references to the same
+        # MLAStaticLayerModule objects):
+        #   * self._cache_layers  -> nn.ModuleList, gives PyTorch module
+        #                            traversal so buffers ride along with
+        #                            .to(device), state_dict, etc.
+        #   * self.past_key_values -> HF Cache wrapper, gives the update(...)
+        #                            API that MLA._forward_with_cache calls.
+        # Cache itself is not an nn.Module, so we need the ModuleList as well;
+        # don't "clean up" one of them.
         mla = self.layers[0].attn
+        cache_dtype = mla.wkv_a.weight.dtype
+        cache_device = mla.wkv_a.weight.device
         self._cache_layers = nn.ModuleList(
             [
                 MLAStaticLayerModule(max_cache_len=args.max_seq_len)
@@ -1397,17 +1487,12 @@ class Transformer(nn.Module):
             ]
         )
         for cache_layer in self._cache_layers:
-            cache_layer.lazy_initialization(
-                torch.zeros(
-                    args.max_batch_size, 1, 1, mla.kv_lora_rank, dtype=torch.bfloat16
-                ),
-                torch.zeros(
-                    args.max_batch_size,
-                    1,
-                    1,
-                    mla.qk_rope_head_dim,
-                    dtype=torch.bfloat16,
-                ),
+            cache_layer.early_initialization(
+                batch_size=args.max_batch_size,
+                kv_lora_rank=mla.kv_lora_rank,
+                pe_rank=mla.qk_rope_head_dim,
+                dtype=cache_dtype,
+                device=cache_device,
             )
         self.past_key_values = Cache(layers=list(self._cache_layers))
 

--- a/tests/torch/models/deepseek_v3_2_exp/modified_model.py
+++ b/tests/torch/models/deepseek_v3_2_exp/modified_model.py
@@ -775,12 +775,14 @@ class MLA(nn.Module):
 
         self.register_buffer(
             "kv_cache",
-            torch.zeros(args.max_batch_size, args.max_seq_len, self.kv_lora_rank),
+            torch.zeros(args.max_batch_size, 1, args.max_seq_len, self.kv_lora_rank),
             persistent=False,
         )
         self.register_buffer(
             "pe_cache",
-            torch.zeros(args.max_batch_size, args.max_seq_len, self.qk_rope_head_dim),
+            torch.zeros(
+                args.max_batch_size, 1, args.max_seq_len, self.qk_rope_head_dim
+            ),
             persistent=False,
         )
         self.dequant_wkv_b = None
@@ -801,10 +803,9 @@ class MLA(nn.Module):
            MHA prefill branch or the MQA decode branch inline.
 
         2. Cache path (``cache_position is not None``): writes to the same
-           buffers via a functional scatter-pad and runs attention against
-           the full ``max_cache_len``, gated by the additive
-           ``attention_mask``. This is the compile-friendly path used by
-           ``test_deepseek_v3_1_decode_static_cache``.
+           buffers via ``index_copy_`` and runs attention against the full
+           ``max_cache_len``, gated by the additive ``attention_mask``. Used
+           by ``test_deepseek_v3_1_decode_static_cache``.
         """
         if cache_position is not None:
             return self._forward_with_cache(
@@ -834,8 +835,8 @@ class MLA(nn.Module):
                 .to(kv.dtype)
                 .view_as(kv)
             )
-        self.kv_cache[:bsz, start_pos:end_pos] = kv
-        self.pe_cache[:bsz, start_pos:end_pos] = k_pe.squeeze(2)
+        self.kv_cache[:bsz, 0, start_pos:end_pos] = kv
+        self.pe_cache[:bsz, 0, start_pos:end_pos] = k_pe.squeeze(2)
         if mask is not None:  # MHA prefill
             q = torch.cat([q_nope, q_pe], dim=-1)
             kv = self.wkv_b(kv)
@@ -873,8 +874,8 @@ class MLA(nn.Module):
                 "bshd,hdc->bshc", q_nope, wkv_b[:, : self.qk_nope_head_dim]
             )
             scores = (
-                torch.einsum("bshc,btc->bsht", q_nope, self.kv_cache[:bsz, :end_pos])
-                + torch.einsum("bshr,btr->bsht", q_pe, self.pe_cache[:bsz, :end_pos])
+                torch.einsum("bshc,btc->bsht", q_nope, self.kv_cache[:bsz, 0, :end_pos])
+                + torch.einsum("bshr,btr->bsht", q_pe, self.pe_cache[:bsz, 0, :end_pos])
             ) * self.softmax_scale
 
             # indexer
@@ -886,7 +887,7 @@ class MLA(nn.Module):
                 scores += index_mask.unsqueeze(2)
 
             scores = scores.softmax(dim=-1)
-            x = torch.einsum("bsht,btc->bshc", scores, self.kv_cache[:bsz, :end_pos])
+            x = torch.einsum("bsht,btc->bshc", scores, self.kv_cache[:bsz, 0, :end_pos])
             x = torch.einsum("bshc,hdc->bshd", x, wkv_b[:, -self.v_head_dim :])
         x = self.wo(x.flatten(2))
         return x
@@ -905,6 +906,12 @@ class MLA(nn.Module):
         `torch.compile` + `torch_xla` SPMD — no Python-int specialization, no
         per-step recompile. Reads span the full `max_cache_len`; the additive
         `attention_mask` masks positions beyond `cache_position.max()`.
+
+        Buffers are shaped `(B, 1, T, D)` — the leading unit dim is
+        vestigial (MLA caches a single shared latent across heads), but
+        TT-MLIR legalizes `stablehlo.scatter` on the 4D layout while the
+        logically-equivalent 3D `(B, T, D)` form currently fails TTIR
+        legalization.
         """
         bsz, seqlen, _ = x.size()
 
@@ -931,30 +938,13 @@ class MLA(nn.Module):
                 .view_as(kv)
             )
 
-        # Functional cache update: express the tensor-indexed write as a
-        # `torch.where(mask, scatter_pad(kv), cache)` where `scatter_pad(kv)` is
-        # computed as a matmul against a one-hot position matrix. This avoids
-        # `index_put`/`scatter` lowering (unsupported by TT-MLIR on sharded
-        # buffers).
-        #
-        # Important: the result of `torch.where` is a *new* tensor — reassigning
-        # `self.kv_cache = ...` would lose the mark_sharding annotation on the
-        # module buffer, which in turn forces Shardy to propagate sharding
-        # backwards through the A2A-dispatch custom_call's tuple output inside
-        # MoE (which it can't handle). Instead, write back with `.copy_()` so the
-        # module buffer keeps its identity and sharding.
-        k_pe_flat = k_pe.squeeze(2)  # (B, seqlen, qk_rope_head_dim)
-        max_cache_len = self.kv_cache.size(1)
-        slot_range = torch.arange(max_cache_len, device=kv.device)
-        E = (cache_position.unsqueeze(1) == slot_range.unsqueeze(0)).to(kv.dtype)
-        kv_padded = torch.einsum("bsr,sc->bcr", kv, E)
-        k_pe_padded = torch.einsum("bsr,sc->bcr", k_pe_flat, E)
-        mask = (E.sum(dim=0) > 0).view(1, max_cache_len, 1)
-        self.kv_cache.copy_(torch.where(mask, kv_padded, self.kv_cache))
-        self.pe_cache.copy_(torch.where(mask, k_pe_padded, self.pe_cache))
+        # In-place index_copy_ on a 4D cache sharded only on batch dim.
+        # kv: (B, seqlen, D) -> unsqueeze(1) to (B, 1, seqlen, D) for the scatter.
+        self.kv_cache.index_copy_(2, cache_position, kv.unsqueeze(1))
+        self.pe_cache.index_copy_(2, cache_position, k_pe.squeeze(2).unsqueeze(1))
 
-        kv_full = self.kv_cache  # (B, max_cache_len, kv_lora_rank)
-        pe_full = self.pe_cache  # (B, max_cache_len, qk_rope_head_dim)
+        kv_full = self.kv_cache.squeeze(1)  # (B, max_cache_len, kv_lora_rank)
+        pe_full = self.pe_cache.squeeze(1)  # (B, max_cache_len, qk_rope_head_dim)
 
         if self.dequant_wkv_b is None and self.wkv_b.scale is not None:
             self.dequant_wkv_b = weight_dequant(self.wkv_b.weight, self.wkv_b.scale)

--- a/tests/torch/models/deepseek_v3_2_exp/modified_model.py
+++ b/tests/torch/models/deepseek_v3_2_exp/modified_model.py
@@ -1200,9 +1200,10 @@ class Gate(nn.Module):
         Returns:
             Tuple[torch.Tensor, torch.Tensor]: Routing weights and selected expert indices.
         """
-        # TODO(tt-xla#XXXX): fp32 linear hits an accuracy issue in the XLA
+        # TODO(deeseek-v3-2-exp): fp32 linear hits an accuracy issue in the XLA
         # lowering path on TT; keep bf16 for Gate routing until fixed.
-        scores = linear(x, self.weight)
+        # scores = linear(x, self.weight)
+        scores = linear(x.float(), self.weight.float())
         if self.score_func == "softmax":
             scores = scores.softmax(dim=-1)
         else:

--- a/tests/torch/models/deepseek_v3_2_exp/modified_model.py
+++ b/tests/torch/models/deepseek_v3_2_exp/modified_model.py
@@ -1,6 +1,10 @@
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
+
+# This version of the modified model is only for tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_1.py. 
+# For other tests, please use the modified model found in third_party/deepseek/deepseek_v3_2_exp
+
 import math
 from dataclasses import dataclass
 from typing import Literal, Optional, Tuple

--- a/tests/torch/models/deepseek_v3_2_exp/modified_model.py
+++ b/tests/torch/models/deepseek_v3_2_exp/modified_model.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# This version of the modified model is only for tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_1.py. 
+# This version of the modified model is only for tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_1.py.
 # For other tests, please use the modified model found in third_party/deepseek/deepseek_v3_2_exp
 
 import math

--- a/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_1.py
+++ b/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_1.py
@@ -323,19 +323,19 @@ def _fix_meta_buffers(model, args):
     model.hadamard_matrix = hadamard
     # Re-materialize the MLA cache layers on CPU so they're real tensors (not
     # meta) before mark_sharding / .to(device). Each layer holds its own
-    # compressed_kv / k_pe buffers, already lazy-initialized in Transformer
+    # compressed_kv / k_pe buffers, already initialized in Transformer
     # __init__ — but if the model was built on meta, those buffers landed on
-    # meta too. Re-run lazy_initialization with concrete sample tensors.
+    # meta too. Re-run early_initialization directly on CPU.
     mla0 = model.layers[0].attn
+    cache_dtype = mla0.wkv_a.weight.dtype
     for cache_layer in model._cache_layers:
         cache_layer.is_initialized = False
-        cache_layer.lazy_initialization(
-            torch.zeros(
-                args.max_batch_size, 1, 1, mla0.kv_lora_rank, dtype=torch.bfloat16
-            ),
-            torch.zeros(
-                args.max_batch_size, 1, 1, mla0.qk_rope_head_dim, dtype=torch.bfloat16
-            ),
+        cache_layer.early_initialization(
+            batch_size=args.max_batch_size,
+            kv_lora_rank=mla0.kv_lora_rank,
+            pe_rank=mla0.qk_rope_head_dim,
+            dtype=cache_dtype,
+            device=torch.device("cpu"),
         )
     for layer in model.layers:
         attn = layer.attn

--- a/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_1.py
+++ b/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_1.py
@@ -321,22 +321,24 @@ def _fix_meta_buffers(model, args):
         scipy.linalg.hadamard(args.index_head_dim), dtype=torch.bfloat16
     ) * (args.index_head_dim**-0.5)
     model.hadamard_matrix = hadamard
+    # Re-materialize the MLA cache layers on CPU so they're real tensors (not
+    # meta) before mark_sharding / .to(device). Each layer holds its own
+    # compressed_kv / k_pe buffers, already lazy-initialized in Transformer
+    # __init__ — but if the model was built on meta, those buffers landed on
+    # meta too. Re-run lazy_initialization with concrete sample tensors.
+    mla0 = model.layers[0].attn
+    for cache_layer in model._cache_layers:
+        cache_layer.is_initialized = False
+        cache_layer.lazy_initialization(
+            torch.zeros(
+                args.max_batch_size, 1, 1, mla0.kv_lora_rank, dtype=torch.bfloat16
+            ),
+            torch.zeros(
+                args.max_batch_size, 1, 1, mla0.qk_rope_head_dim, dtype=torch.bfloat16
+            ),
+        )
     for layer in model.layers:
         attn = layer.attn
-        attn.kv_cache = torch.zeros(
-            args.max_batch_size,
-            1,
-            args.max_seq_len,
-            attn.kv_lora_rank,
-            dtype=torch.bfloat16,
-        )
-        attn.pe_cache = torch.zeros(
-            args.max_batch_size,
-            1,
-            args.max_seq_len,
-            attn.qk_rope_head_dim,
-            dtype=torch.bfloat16,
-        )
         attn.hadamard_matrix = hadamard
         if attn.indexer is not None:
             attn.indexer.k_cache = torch.zeros(
@@ -419,8 +421,9 @@ def _apply_shard_specs(model, mesh, args, batch_size, tokens_device):
         xs.mark_sharding(attn.wo.weight, mesh, (None, "_axis_0"))
         xs.mark_sharding(attn.wq_a.weight, mesh, (None, "_axis_0"))
         xs.mark_sharding(attn.wkv_a.weight, mesh, (None, "_axis_0"))
-        xs.mark_sharding(attn.kv_cache, mesh, ("_axis_1", None, None, None))
-        xs.mark_sharding(attn.pe_cache, mesh, ("_axis_1", None, None, None))
+        cache_layer = model.past_key_values.layers[layer.layer_id]
+        xs.mark_sharding(cache_layer.compressed_kv, mesh, ("_axis_1", None, None, None))
+        xs.mark_sharding(cache_layer.k_pe, mesh, ("_axis_1", None, None, None))
         ffn = layer.ffn
         if hasattr(ffn, "mlp"):
             mlp = ffn.mlp
@@ -550,9 +553,10 @@ def _build_and_load_model(args, repo_id, prefer_cpu_capable=False):
 
 
 def _reset_caches(model):
+    for cache_layer in model.past_key_values.layers:
+        cache_layer.compressed_kv.zero_()
+        cache_layer.k_pe.zero_()
     for layer in model.layers:
-        layer.attn.kv_cache.zero_()
-        layer.attn.pe_cache.zero_()
         if layer.attn.indexer is not None:
             layer.attn.indexer.k_cache.zero_()
 

--- a/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_1.py
+++ b/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_1.py
@@ -28,6 +28,7 @@ import torch_xla
 import torch_xla.distributed.spmd as xs
 import torch_xla.runtime as xr
 from huggingface_hub import hf_hub_download
+from infra.testers.compiler_config import CompilerConfig
 from modified_model import ModelArgs
 from modified_model import Transformer as ModifiedTransformer
 from modified_model import precompute_freqs_cis
@@ -37,8 +38,6 @@ from safetensors.torch import save_file as safetensors_save_file
 from torch import nn
 from torch_xla.distributed.spmd import Mesh
 from tt_torch.sparse_mlp import A2aSparseMLP, enable_sparse_mlp
-
-from tests.infra.testers.compiler_config import CompilerConfig
 
 DEEPSEEK_V3_1_REPO = "deepseek-ai/DeepSeek-V3.1"
 

--- a/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_1.py
+++ b/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_1.py
@@ -570,10 +570,9 @@ def test_deepseek_v3_1_full_sparse_moe():
     t1 = time.perf_counter()
     print(f"[timing] model build + weight load: {t1 - t0:.1f}s", flush=True)
 
-    tokenizer = AutoTokenizer.from_pretrained(repo_id, trust_remote_code=True)
-    # Left-pad: the model predicts the token *after* the final real token, so
-    # padding must be to the left so position N-1 is "to", not <eos>.
-    tokenizer.padding_side = "left"
+    tokenizer = AutoTokenizer.from_pretrained(
+        repo_id, trust_remote_code=True, add_bos_token=True, padding_side="left"
+    )
     prompt_text = (
         "Tenstorrent is a company that builds AI accelerators. "
         "Their chips are designed to"
@@ -700,9 +699,10 @@ def test_deepseek_v3_1_decode_static_cache():
     t1 = time.perf_counter()
     print(f"[timing] model build + weight load: {t1 - t0:.1f}s", flush=True)
 
-    tokenizer = AutoTokenizer.from_pretrained(repo_id, trust_remote_code=True)
-    tokenizer.padding_side = "left"
-    prompt_text = "Tell me a short story. "
+    tokenizer = AutoTokenizer.from_pretrained(
+        repo_id, trust_remote_code=True, add_bos_token=True, padding_side="left"
+    )
+    prompt_text = "Tell me a short story."
     encoded = tokenizer(
         prompt_text,
         return_tensors="pt",

--- a/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_1.py
+++ b/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_1.py
@@ -346,23 +346,63 @@ def _fix_meta_buffers(model, args):
 
 
 def _build_prefill_attention_mask(
-    batch_size, prompt_len, max_cache_len, dtype=torch.bfloat16
+    batch_size,
+    prompt_len,
+    max_cache_len,
+    token_attention_mask=None,
+    dtype=torch.bfloat16,
 ):
-    """(B, 1, prompt_len, max_cache_len) additive causal mask."""
+    """(B, 1, prompt_len, max_cache_len) additive causal mask.
+
+    If ``token_attention_mask`` (shape ``(B, prompt_len)``, 1=real, 0=pad) is
+    given, also masks out padding slots in the key dimension so queries don't
+    attend to left-pad tokens. The tokenizer runs with ``padding_side="left"``,
+    so those slots are at the front of the sequence.
+    """
     mask = torch.full(
         (batch_size, 1, prompt_len, max_cache_len), float("-inf"), dtype=dtype
     )
     for q_pos in range(prompt_len):
         mask[:, :, q_pos, : q_pos + 1] = 0.0
+    if token_attention_mask is not None:
+        tam = token_attention_mask.to(dtype=dtype)  # (B, prompt_len)
+        pad_k = torch.where(
+            tam > 0,
+            torch.zeros((), dtype=dtype),
+            torch.full((), float("-inf"), dtype=dtype),
+        )  # 0 at real tokens, -inf at pad
+        mask[:, :, :, :prompt_len] = (
+            mask[:, :, :, :prompt_len] + pad_k[:, None, None, :]
+        )
     return mask
 
 
 def _build_decode_attention_mask(
-    batch_size, current_pos_inclusive, max_cache_len, dtype=torch.bfloat16
+    batch_size,
+    current_pos_inclusive,
+    max_cache_len,
+    token_attention_mask=None,
+    prompt_len=None,
+    dtype=torch.bfloat16,
 ):
-    """(B, 1, 1, max_cache_len) additive mask for a single decode step."""
+    """(B, 1, 1, max_cache_len) additive mask for a single decode step.
+
+    If ``token_attention_mask`` + ``prompt_len`` are given, also masks cache
+    slots ``0..prompt_len-1`` where the prompt was padding, so the decode
+    step doesn't attend to left-pad KV entries that prefill wrote in.
+    """
     mask = torch.full((batch_size, 1, 1, max_cache_len), float("-inf"), dtype=dtype)
     mask[:, :, :, :current_pos_inclusive] = 0.0
+    if token_attention_mask is not None and prompt_len is not None:
+        tam = token_attention_mask.to(dtype=dtype)  # (B, prompt_len)
+        pad_k = torch.where(
+            tam > 0,
+            torch.zeros((), dtype=dtype),
+            torch.full((), float("-inf"), dtype=dtype),
+        )
+        mask[:, :, :, :prompt_len] = (
+            mask[:, :, :, :prompt_len] + pad_k[:, None, None, :]
+        )
     return mask
 
 
@@ -529,7 +569,6 @@ def _pcc(a, b):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.llmbox
 def test_deepseek_v3_1_full_sparse_moe():
     """Prefill-only forward on the (4,8) mesh with A2aSparseMLP. Real input,
     real weights, CPU PCC comparison."""
@@ -654,7 +693,6 @@ def test_deepseek_v3_1_full_sparse_moe():
         print("[pcc] SKIPPED — no CPU reference", flush=True)
 
 
-@pytest.mark.llmbox
 def test_deepseek_v3_1_decode_static_cache():
     """Autoregressive greedy decode on TT using the MLACache path.
 
@@ -713,6 +751,12 @@ def test_deepseek_v3_1_decode_static_cache():
     tokens_single = encoded["input_ids"][:, :prompt_seq_len]
     prompt_len = tokens_single.shape[1]
     tokens_cpu = tokens_single.repeat(batch_size, 1)
+    # Tokenizer attention_mask: 1 for real tokens, 0 for left-pad. Used below
+    # to mask pad slots out of prefill/decode attention (pad=<eos>, so without
+    # this queries silently attend to pad KV entries).
+    token_attn_mask_cpu = encoded["attention_mask"][:, :prompt_seq_len].repeat(
+        batch_size, 1
+    )
     print(
         f"[prompt] {prompt_len} tokens x{batch_size}: "
         f"{tokenizer.decode(tokens_single[0])!r}",
@@ -777,7 +821,11 @@ def test_deepseek_v3_1_decode_static_cache():
     tokens_device = tokens_cpu.to(device)
     cache_position_prefill = torch.arange(prompt_len, dtype=torch.long).to(device)
     attn_mask_prefill = _build_prefill_attention_mask(
-        batch_size, prompt_len, args.max_seq_len, dtype=torch.bfloat16
+        batch_size,
+        prompt_len,
+        args.max_seq_len,
+        token_attention_mask=token_attn_mask_cpu,
+        dtype=torch.bfloat16,
     ).to(device)
     t_mv_end = time.perf_counter()
     print(f"[timing] move to device: {t_mv_end - t_mv_start:.1f}s", flush=True)
@@ -814,7 +862,12 @@ def test_deepseek_v3_1_decode_static_cache():
         ).to(device)
         cache_position_decode = torch.tensor([pos], dtype=torch.long).to(device)
         attn_mask_decode = _build_decode_attention_mask(
-            batch_size, pos + 1, args.max_seq_len, dtype=torch.bfloat16
+            batch_size,
+            pos + 1,
+            args.max_seq_len,
+            token_attention_mask=token_attn_mask_cpu,
+            prompt_len=prompt_len,
+            dtype=torch.bfloat16,
         ).to(device)
         t_dec_start = time.perf_counter()
         with torch.no_grad():

--- a/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_1.py
+++ b/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_1.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
 """DeepSeek v3.1 tests on TT (Galaxy 4x8).
@@ -18,7 +18,7 @@ below.
 """
 import json
 import os
-import re
+import sys
 import time
 
 import numpy as np
@@ -32,62 +32,27 @@ from infra.testers.compiler_config import CompilerConfig
 from modified_model import ModelArgs
 from modified_model import Transformer as ModifiedTransformer
 from modified_model import precompute_freqs_cis
-from safetensors import safe_open
 from safetensors.torch import load_file as safetensors_load_file
-from safetensors.torch import save_file as safetensors_save_file
 from torch import nn
 from torch_xla.distributed.spmd import Mesh
 from tt_torch.sparse_mlp import A2aSparseMLP, enable_sparse_mlp
 
+# Import shard-streaming + cache helpers from the builder script (single source of truth)
+sys.path.insert(0, os.path.dirname(__file__))
+from build_weight_cache import (
+    _dequant_cache_dir,
+    _has_cache,
+    _post_sparse_cache_dir,
+    build_cache,
+    build_post_sparse_cache,
+)
+
 DEEPSEEK_V3_1_REPO = "deepseek-ai/DeepSeek-V3.1"
 
-FP8_BLOCK_SIZE = 128
-
 
 # ---------------------------------------------------------------------------
-# Weight loading / dequantization / cache
+# Weight loading / cache
 # ---------------------------------------------------------------------------
-
-
-def _rename_hf_key(ckpt_key, n_dense_layers=1):
-    """Rename a HuggingFace checkpoint key to match modified_model.py naming."""
-    key = ckpt_key
-    if key.startswith("model."):
-        key = key[len("model.") :]
-    if "weight_scale_inv" in key:
-        return None
-    key = key.replace("lm_head.", "head.")
-    key = key.replace("embed_tokens.", "embed.")
-    key = re.sub(r"(layers\.\d+\.)input_layernorm\.", r"\1attn_norm.", key)
-    key = re.sub(r"(layers\.\d+\.)post_attention_layernorm\.", r"\1ffn_norm.", key)
-    key = key.replace("self_attn.indexer.", "attn.indexer.")
-    key = key.replace("self_attn.q_a_proj.", "attn.wq_a.")
-    key = key.replace("self_attn.q_b_proj.", "attn.wq_b.")
-    key = key.replace("self_attn.q_a_layernorm.", "attn.q_norm.")
-    key = key.replace("self_attn.kv_a_proj_with_mqa.", "attn.wkv_a.")
-    key = key.replace("self_attn.kv_b_proj.", "attn.wkv_b.")
-    key = key.replace("self_attn.kv_a_layernorm.", "attn.kv_norm.")
-    key = key.replace("self_attn.o_proj.", "attn.wo.")
-    key = re.sub(r"mlp\.experts\.(\d+)\.gate_proj\.", r"ffn.experts.\1.w1.", key)
-    key = re.sub(r"mlp\.experts\.(\d+)\.down_proj\.", r"ffn.experts.\1.w2.", key)
-    key = re.sub(r"mlp\.experts\.(\d+)\.up_proj\.", r"ffn.experts.\1.w3.", key)
-    key = key.replace("mlp.shared_experts.gate_proj.", "ffn.shared_experts.w1.")
-    key = key.replace("mlp.shared_experts.down_proj.", "ffn.shared_experts.w2.")
-    key = key.replace("mlp.shared_experts.up_proj.", "ffn.shared_experts.w3.")
-    key = key.replace("mlp.gate.e_score_correction_bias", "mlp.gate.bias")
-    key = key.replace("mlp.gate.", "ffn.gate.")
-    layer_m = re.match(r"layers\.(\d+)\.", key)
-    if layer_m:
-        layer_id = int(layer_m.group(1))
-        if layer_id < n_dense_layers:
-            key = key.replace("mlp.gate_proj.", "ffn.w1.")
-            key = key.replace("mlp.down_proj.", "ffn.w2.")
-            key = key.replace("mlp.up_proj.", "ffn.w3.")
-        elif (
-            "mlp.gate_proj." in key or "mlp.down_proj." in key or "mlp.up_proj." in key
-        ):
-            return None
-    return key
 
 
 def load_deepseek_config(repo_id=DEEPSEEK_V3_1_REPO):
@@ -95,109 +60,39 @@ def load_deepseek_config(repo_id=DEEPSEEK_V3_1_REPO):
     config_path = hf_hub_download(repo_id, "config.json")
     with open(config_path) as f:
         hf_cfg = json.load(f)
-    rope_scaling = hf_cfg.get("rope_scaling", {})
+    rope_scaling = hf_cfg["rope_scaling"]
     return ModelArgs(
         vocab_size=hf_cfg["vocab_size"],
         dim=hf_cfg["hidden_size"],
         inter_dim=hf_cfg["intermediate_size"],
         moe_inter_dim=hf_cfg["moe_intermediate_size"],
         n_layers=hf_cfg["num_hidden_layers"],
-        n_dense_layers=hf_cfg.get("first_k_dense_replace", 1),
+        n_dense_layers=hf_cfg["first_k_dense_replace"],
         n_heads=hf_cfg["num_attention_heads"],
-        n_routed_experts=hf_cfg.get("n_routed_experts", 256),
-        n_shared_experts=hf_cfg.get("n_shared_experts", 1),
-        n_activated_experts=hf_cfg.get("num_experts_per_tok", 8),
-        n_expert_groups=hf_cfg.get("n_group", 8),
-        n_limited_groups=hf_cfg.get("topk_group", 4),
-        score_func=hf_cfg.get("scoring_func", "sigmoid"),
-        route_scale=hf_cfg.get("routed_scaling_factor", 2.5),
-        q_lora_rank=hf_cfg.get("q_lora_rank", 1536),
-        kv_lora_rank=hf_cfg.get("kv_lora_rank", 512),
-        qk_nope_head_dim=hf_cfg.get("qk_nope_head_dim", 128),
-        qk_rope_head_dim=hf_cfg.get("qk_rope_head_dim", 64),
-        v_head_dim=hf_cfg.get("v_head_dim", 128),
-        original_seq_len=rope_scaling.get("original_max_position_embeddings", 4096),
-        rope_theta=hf_cfg.get("rope_theta", 10000.0),
-        rope_factor=rope_scaling.get("factor", 40),
-        beta_fast=rope_scaling.get("beta_fast", 32),
-        beta_slow=rope_scaling.get("beta_slow", 1),
-        mscale=rope_scaling.get("mscale", 1.0),
+        n_routed_experts=hf_cfg["n_routed_experts"],
+        n_shared_experts=hf_cfg["n_shared_experts"],
+        n_activated_experts=hf_cfg["num_experts_per_tok"],
+        n_expert_groups=hf_cfg["n_group"],
+        n_limited_groups=hf_cfg["topk_group"],
+        score_func=hf_cfg["scoring_func"],
+        route_scale=hf_cfg["routed_scaling_factor"],
+        q_lora_rank=hf_cfg["q_lora_rank"],
+        kv_lora_rank=hf_cfg["kv_lora_rank"],
+        qk_nope_head_dim=hf_cfg["qk_nope_head_dim"],
+        qk_rope_head_dim=hf_cfg["qk_rope_head_dim"],
+        v_head_dim=hf_cfg["v_head_dim"],
+        original_seq_len=rope_scaling["original_max_position_embeddings"],
+        rope_theta=hf_cfg["rope_theta"],
+        rope_factor=rope_scaling["factor"],
+        beta_fast=rope_scaling["beta_fast"],
+        beta_slow=rope_scaling["beta_slow"],
+        mscale=rope_scaling["mscale"],
+        # index_* keys are V3.2-exp only (sparse-attention indexer); absent in
+        # V3.1. Defaults here correspond to the indexer being disabled.
         index_n_heads=hf_cfg.get("index_n_heads", 0),
         index_head_dim=hf_cfg.get("index_head_dim", 128),
         index_topk=hf_cfg.get("index_topk", 2048),
     )
-
-
-def _weight_dequant(weight, scale_inv, block_size=FP8_BLOCK_SIZE):
-    """Dequantize FP8 weight: bf16 = fp8 * weight_scale_inv (block-wise)."""
-    orig_shape = weight.shape
-    assert weight.dim() == 2
-    rows, cols = orig_shape
-    pad_rows = (block_size - rows % block_size) % block_size
-    pad_cols = (block_size - cols % block_size) % block_size
-    if pad_rows or pad_cols:
-        weight = torch.nn.functional.pad(weight, (0, pad_cols, 0, pad_rows))
-    padded_rows, padded_cols = weight.shape
-    n_br = padded_rows // block_size
-    n_bc = padded_cols // block_size
-    weight = (
-        weight.view(n_br, block_size, n_bc, block_size)
-        .transpose(1, 2)
-        .contiguous()
-        .view(-1, block_size * block_size)
-    )
-    weight = (
-        (weight.float() * scale_inv.view(-1, 1).float())
-        .to(torch.bfloat16)
-        .view(n_br, n_bc, block_size, block_size)
-        .transpose(1, 2)
-        .contiguous()
-        .view(padded_rows, padded_cols)
-    )
-    return weight[:rows, :cols]
-
-
-def _cache_dir_for(repo_id, n_layers):
-    """Per-model BF16 safetensors cache directory (shared with build_weight_cache.py)."""
-    repo_slug = repo_id.replace("/", "--")
-    base = os.environ.get("HF_HOME", os.path.expanduser("~/.cache/huggingface"))
-    return os.path.join(base, "tt_xla_dequant_cache", f"{repo_slug}_{n_layers}layers")
-
-
-def _post_sparse_cache_dir_for(repo_id, n_layers):
-    return _cache_dir_for(repo_id, n_layers) + "_post_sparse"
-
-
-def _has_cache(cache_dir):
-    return os.path.isdir(cache_dir) and any(
-        f.endswith(".safetensors") for f in os.listdir(cache_dir)
-    )
-
-
-def _save_cache_chunked(state_dict, cache_dir):
-    """Save state_dict as per-layer + shared safetensors chunks."""
-    os.makedirs(cache_dir, exist_ok=True)
-    layer_dicts = {}
-    shared = {}
-    for key, tensor in state_dict.items():
-        m = re.match(r"layers\.(\d+)\.", key)
-        if m:
-            layer_dicts.setdefault(int(m.group(1)), {})[key] = tensor
-        else:
-            shared[key] = tensor
-    total_bytes = 0
-    if shared:
-        path = os.path.join(cache_dir, "shared.safetensors")
-        safetensors_save_file(shared, path)
-        total_bytes += os.path.getsize(path)
-    for layer_idx in sorted(layer_dicts):
-        path = os.path.join(cache_dir, f"layer_{layer_idx:04d}.safetensors")
-        safetensors_save_file(layer_dicts[layer_idx], path)
-        sz = os.path.getsize(path)
-        total_bytes += sz
-        del layer_dicts[layer_idx]
-        print(f"  [cache] saved layer {layer_idx} ({sz / 1e9:.1f} GB)", flush=True)
-    return total_bytes
 
 
 def _load_cache_chunked(cache_dir):
@@ -211,93 +106,23 @@ def _load_cache_chunked(cache_dir):
     return state_dict
 
 
-def _dequantize_from_shards(repo_id, n_layers, n_dense_layers):
-    """Read FP8 shards, dequantize, rename keys. Returns a BF16 state_dict."""
-    index_path = hf_hub_download(repo_id, "model.safetensors.index.json")
-    with open(index_path) as f:
-        index = json.load(f)
-    weight_map = index["weight_map"]
-
-    weight_keys = {}
-    scale_keys = {}
-    scale_shards = {}
-    for ckpt_key, shard_file in weight_map.items():
-        layer_m = re.match(r"model\.layers\.(\d+)\.", ckpt_key)
-        if layer_m and int(layer_m.group(1)) >= n_layers:
-            continue
-        if "weight_scale_inv" in ckpt_key:
-            w_key = ckpt_key.replace(".weight_scale_inv", ".weight")
-            scale_keys[w_key] = ckpt_key
-            scale_shards[ckpt_key] = shard_file
-        else:
-            weight_keys[ckpt_key] = shard_file
-
-    all_shards = set(weight_keys.values()) | set(scale_shards.values())
-    raw = {}
-    for idx, shard_name in enumerate(sorted(all_shards)):
-        shard_path = hf_hub_download(repo_id, shard_name)
-        with safe_open(shard_path, framework="pt", device="cpu") as f:
-            for key in f.keys():
-                if key in weight_keys or key in scale_shards:
-                    raw[key] = f.get_tensor(key)
-        print(
-            f"  shard {idx + 1}/{len(all_shards)}: {shard_name} "
-            f"({len(raw)} tensors so far)",
-            flush=True,
-        )
-
-    dequantized = {}
-    n_dequant = 0
-    for ckpt_key in weight_keys:
-        tensor = raw.get(ckpt_key)
-        if tensor is None:
-            continue
-        if tensor.dtype == torch.float8_e4m3fn:
-            scale_key = scale_keys.get(ckpt_key)
-            scale_inv = raw.get(scale_key) if scale_key else None
-            if scale_inv is not None:
-                tensor = _weight_dequant(tensor, scale_inv)
-                n_dequant += 1
-            else:
-                tensor = tensor.to(torch.bfloat16)
-        dequantized[ckpt_key] = tensor
-    del raw
-    print(f"[weights] dequantized {n_dequant} FP8 tensors")
-
-    state_dict = {}
-    for ckpt_key, tensor in dequantized.items():
-        model_key = _rename_hf_key(ckpt_key, n_dense_layers)
-        if model_key is None:
-            continue
-        if model_key == "head.weight":
-            tensor = tensor.to(torch.float32)
-        elif tensor.dtype != torch.bfloat16:
-            tensor = tensor.to(torch.bfloat16)
-        state_dict[model_key] = tensor
-    del dequantized
-    return state_dict
-
-
 def _load_modified_dequantized_weights(model, repo_id, n_layers, n_dense_layers=1):
-    """Dequantize FP8 safetensors -> BF16, cache them, load into ``model``."""
-    cache_dir = _cache_dir_for(repo_id, n_layers)
-    if _has_cache(cache_dir):
-        t0 = time.perf_counter()
-        print(f"[weights] loading cached BF16 weights from {cache_dir}", flush=True)
-        state_dict = _load_cache_chunked(cache_dir)
-        t1 = time.perf_counter()
-        print(
-            f"[timing] cache load (mmap): {t1 - t0:.1f}s ({len(state_dict)} tensors)",
-            flush=True,
-        )
-    else:
+    """Load the dequant cache into ``model``, self-healing it from FP8 shards if absent."""
+    cache_dir = _dequant_cache_dir(repo_id, n_layers)
+    if not _has_cache(cache_dir):
         print(
             f"[weights] no cache at {cache_dir} — dequantizing from FP8...", flush=True
         )
-        state_dict = _dequantize_from_shards(repo_id, n_layers, n_dense_layers)
-        _save_cache_chunked(state_dict, cache_dir)
-        del state_dict
-        state_dict = _load_cache_chunked(cache_dir)
+        build_cache(repo_id, n_layers, n_dense_layers)
+
+    t0 = time.perf_counter()
+    print(f"[weights] loading cached BF16 weights from {cache_dir}", flush=True)
+    state_dict = _load_cache_chunked(cache_dir)
+    print(
+        f"[timing] cache load (mmap): {time.perf_counter() - t0:.1f}s "
+        f"({len(state_dict)} tensors)",
+        flush=True,
+    )
 
     missing, unexpected = model.load_state_dict(state_dict, strict=False, assign=True)
     print(
@@ -493,10 +318,17 @@ def _build_and_load_model(args, repo_id, prefer_cpu_capable=False):
     with torch.device("meta"):
         model = ModifiedTransformer(args)
     mesh_shape = (4, 8)
-    post_sparse_dir = _post_sparse_cache_dir_for(repo_id, args.n_layers)
-    dequant_dir = _cache_dir_for(repo_id, args.n_layers)
+    post_sparse_dir = _post_sparse_cache_dir(repo_id, args.n_layers)
+    dequant_dir = _dequant_cache_dir(repo_id, args.n_layers)
 
     def _load_post_sparse():
+        if not _has_cache(post_sparse_dir):
+            print(
+                f"[weights] post-sparse cache not found at {post_sparse_dir}, "
+                "building... (self-heals pre-sparse if absent)",
+                flush=True,
+            )
+            build_post_sparse_cache(repo_id, args.n_layers, args.n_dense_layers)
         print(f"[weights] loading post-sparse cache from {post_sparse_dir}", flush=True)
         enable_sparse_mlp(model, mesh=mesh_shape, cluster_axis=0, config=args)
         for _, mod in model.named_modules():
@@ -522,32 +354,26 @@ def _build_and_load_model(args, repo_id, prefer_cpu_capable=False):
         enable_sparse_mlp(model, mesh=mesh_shape, cluster_axis=0, config=args)
 
     if prefer_cpu_capable:
-        if _has_cache(dequant_dir):
-            _load_dequant()
-            return model, mesh_shape
-        if _has_cache(post_sparse_dir):
+        if _has_cache(post_sparse_dir) and not _has_cache(dequant_dir):
             print(
                 "[weights] prefer_cpu_capable=True but dequant cache missing; "
                 "falling back to post-sparse cache (CPU forward will be broken)",
                 flush=True,
             )
             _load_post_sparse()
-            return model, mesh_shape
+        else:
+            _load_dequant()
     else:
-        if _has_cache(post_sparse_dir):
-            _load_post_sparse()
-            return model, mesh_shape
-        if _has_cache(dequant_dir):
+        if _has_cache(dequant_dir) and not _has_cache(post_sparse_dir):
             print(
                 "[weights] post-sparse cache missing; falling back to "
                 "dequant cache (slower — runtime expert stacking)",
                 flush=True,
             )
             _load_dequant()
-            return model, mesh_shape
+        else:
+            _load_post_sparse()
 
-    # Neither cache exists — dequantize from FP8 shards (populates dequant cache).
-    _load_dequant()
     return model, mesh_shape
 
 

--- a/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_1.py
+++ b/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_1.py
@@ -325,12 +325,14 @@ def _fix_meta_buffers(model, args):
         attn = layer.attn
         attn.kv_cache = torch.zeros(
             args.max_batch_size,
+            1,
             args.max_seq_len,
             attn.kv_lora_rank,
             dtype=torch.bfloat16,
         )
         attn.pe_cache = torch.zeros(
             args.max_batch_size,
+            1,
             args.max_seq_len,
             attn.qk_rope_head_dim,
             dtype=torch.bfloat16,
@@ -417,8 +419,8 @@ def _apply_shard_specs(model, mesh, args, batch_size, tokens_device):
         xs.mark_sharding(attn.wo.weight, mesh, (None, "_axis_0"))
         xs.mark_sharding(attn.wq_a.weight, mesh, (None, "_axis_0"))
         xs.mark_sharding(attn.wkv_a.weight, mesh, (None, "_axis_0"))
-        xs.mark_sharding(attn.kv_cache, mesh, ("_axis_1", None, None))
-        xs.mark_sharding(attn.pe_cache, mesh, ("_axis_1", None, None))
+        xs.mark_sharding(attn.kv_cache, mesh, ("_axis_1", None, None, None))
+        xs.mark_sharding(attn.pe_cache, mesh, ("_axis_1", None, None, None))
         ffn = layer.ffn
         if hasattr(ffn, "mlp"):
             mlp = ffn.mlp

--- a/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_1.py
+++ b/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_1.py
@@ -1,0 +1,872 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""DeepSeek v3.1 tests on TT (Galaxy 4x8).
+
+Two end-to-end tests, both hand-orchestrated (no dependency on
+``run_graph_test``), so they can build on top of ``origin/main`` without
+tester-infrastructure changes:
+
+- ``test_deepseek_v3_1_full_sparse_moe``: prefill-only, A2aSparseMLP, legacy
+  int-path cache, CPU PCC comparison.
+- ``test_deepseek_v3_1_decode_static_cache``: autoregressive greedy decode
+  through MLACache (``cache_position`` + ``attention_mask``), 2 compiles
+  (prefill + decode), per-step PCC against a CPU int-path reference.
+
+Both share the weight-loading / dequantization / sparse-cache infrastructure
+below.
+"""
+import json
+import os
+import re
+import time
+
+import numpy as np
+import pytest
+import torch
+import torch_xla
+import torch_xla.distributed.spmd as xs
+import torch_xla.runtime as xr
+from huggingface_hub import hf_hub_download
+from modified_model import ModelArgs
+from modified_model import Transformer as ModifiedTransformer
+from modified_model import precompute_freqs_cis
+from safetensors import safe_open
+from safetensors.torch import load_file as safetensors_load_file
+from safetensors.torch import save_file as safetensors_save_file
+from torch import nn
+from torch_xla.distributed.spmd import Mesh
+from tt_torch.sparse_mlp import A2aSparseMLP, enable_sparse_mlp
+
+from tests.infra.testers.compiler_config import CompilerConfig
+
+DEEPSEEK_V3_1_REPO = "deepseek-ai/DeepSeek-V3.1"
+
+FP8_BLOCK_SIZE = 128
+
+
+# ---------------------------------------------------------------------------
+# Weight loading / dequantization / cache
+# ---------------------------------------------------------------------------
+
+
+def _rename_hf_key(ckpt_key, n_dense_layers=1):
+    """Rename a HuggingFace checkpoint key to match modified_model.py naming."""
+    key = ckpt_key
+    if key.startswith("model."):
+        key = key[len("model.") :]
+    if "weight_scale_inv" in key:
+        return None
+    key = key.replace("lm_head.", "head.")
+    key = key.replace("embed_tokens.", "embed.")
+    key = re.sub(r"(layers\.\d+\.)input_layernorm\.", r"\1attn_norm.", key)
+    key = re.sub(r"(layers\.\d+\.)post_attention_layernorm\.", r"\1ffn_norm.", key)
+    key = key.replace("self_attn.indexer.", "attn.indexer.")
+    key = key.replace("self_attn.q_a_proj.", "attn.wq_a.")
+    key = key.replace("self_attn.q_b_proj.", "attn.wq_b.")
+    key = key.replace("self_attn.q_a_layernorm.", "attn.q_norm.")
+    key = key.replace("self_attn.kv_a_proj_with_mqa.", "attn.wkv_a.")
+    key = key.replace("self_attn.kv_b_proj.", "attn.wkv_b.")
+    key = key.replace("self_attn.kv_a_layernorm.", "attn.kv_norm.")
+    key = key.replace("self_attn.o_proj.", "attn.wo.")
+    key = re.sub(r"mlp\.experts\.(\d+)\.gate_proj\.", r"ffn.experts.\1.w1.", key)
+    key = re.sub(r"mlp\.experts\.(\d+)\.down_proj\.", r"ffn.experts.\1.w2.", key)
+    key = re.sub(r"mlp\.experts\.(\d+)\.up_proj\.", r"ffn.experts.\1.w3.", key)
+    key = key.replace("mlp.shared_experts.gate_proj.", "ffn.shared_experts.w1.")
+    key = key.replace("mlp.shared_experts.down_proj.", "ffn.shared_experts.w2.")
+    key = key.replace("mlp.shared_experts.up_proj.", "ffn.shared_experts.w3.")
+    key = key.replace("mlp.gate.e_score_correction_bias", "mlp.gate.bias")
+    key = key.replace("mlp.gate.", "ffn.gate.")
+    layer_m = re.match(r"layers\.(\d+)\.", key)
+    if layer_m:
+        layer_id = int(layer_m.group(1))
+        if layer_id < n_dense_layers:
+            key = key.replace("mlp.gate_proj.", "ffn.w1.")
+            key = key.replace("mlp.down_proj.", "ffn.w2.")
+            key = key.replace("mlp.up_proj.", "ffn.w3.")
+        elif (
+            "mlp.gate_proj." in key or "mlp.down_proj." in key or "mlp.up_proj." in key
+        ):
+            return None
+    return key
+
+
+def load_deepseek_config(repo_id=DEEPSEEK_V3_1_REPO):
+    """Download and parse the HuggingFace config.json into ModelArgs fields."""
+    config_path = hf_hub_download(repo_id, "config.json")
+    with open(config_path) as f:
+        hf_cfg = json.load(f)
+    rope_scaling = hf_cfg.get("rope_scaling", {})
+    return ModelArgs(
+        vocab_size=hf_cfg["vocab_size"],
+        dim=hf_cfg["hidden_size"],
+        inter_dim=hf_cfg["intermediate_size"],
+        moe_inter_dim=hf_cfg["moe_intermediate_size"],
+        n_layers=hf_cfg["num_hidden_layers"],
+        n_dense_layers=hf_cfg.get("first_k_dense_replace", 1),
+        n_heads=hf_cfg["num_attention_heads"],
+        n_routed_experts=hf_cfg.get("n_routed_experts", 256),
+        n_shared_experts=hf_cfg.get("n_shared_experts", 1),
+        n_activated_experts=hf_cfg.get("num_experts_per_tok", 8),
+        n_expert_groups=hf_cfg.get("n_group", 8),
+        n_limited_groups=hf_cfg.get("topk_group", 4),
+        score_func=hf_cfg.get("scoring_func", "sigmoid"),
+        route_scale=hf_cfg.get("routed_scaling_factor", 2.5),
+        q_lora_rank=hf_cfg.get("q_lora_rank", 1536),
+        kv_lora_rank=hf_cfg.get("kv_lora_rank", 512),
+        qk_nope_head_dim=hf_cfg.get("qk_nope_head_dim", 128),
+        qk_rope_head_dim=hf_cfg.get("qk_rope_head_dim", 64),
+        v_head_dim=hf_cfg.get("v_head_dim", 128),
+        original_seq_len=rope_scaling.get("original_max_position_embeddings", 4096),
+        rope_theta=hf_cfg.get("rope_theta", 10000.0),
+        rope_factor=rope_scaling.get("factor", 40),
+        beta_fast=rope_scaling.get("beta_fast", 32),
+        beta_slow=rope_scaling.get("beta_slow", 1),
+        mscale=rope_scaling.get("mscale", 1.0),
+        index_n_heads=hf_cfg.get("index_n_heads", 0),
+        index_head_dim=hf_cfg.get("index_head_dim", 128),
+        index_topk=hf_cfg.get("index_topk", 2048),
+    )
+
+
+def _weight_dequant(weight, scale_inv, block_size=FP8_BLOCK_SIZE):
+    """Dequantize FP8 weight: bf16 = fp8 * weight_scale_inv (block-wise)."""
+    orig_shape = weight.shape
+    assert weight.dim() == 2
+    rows, cols = orig_shape
+    pad_rows = (block_size - rows % block_size) % block_size
+    pad_cols = (block_size - cols % block_size) % block_size
+    if pad_rows or pad_cols:
+        weight = torch.nn.functional.pad(weight, (0, pad_cols, 0, pad_rows))
+    padded_rows, padded_cols = weight.shape
+    n_br = padded_rows // block_size
+    n_bc = padded_cols // block_size
+    weight = (
+        weight.view(n_br, block_size, n_bc, block_size)
+        .transpose(1, 2)
+        .contiguous()
+        .view(-1, block_size * block_size)
+    )
+    weight = (
+        (weight.float() * scale_inv.view(-1, 1).float())
+        .to(torch.bfloat16)
+        .view(n_br, n_bc, block_size, block_size)
+        .transpose(1, 2)
+        .contiguous()
+        .view(padded_rows, padded_cols)
+    )
+    return weight[:rows, :cols]
+
+
+def _cache_dir_for(repo_id, n_layers):
+    """Per-model BF16 safetensors cache directory (shared with build_weight_cache.py)."""
+    repo_slug = repo_id.replace("/", "--")
+    base = os.environ.get("HF_HOME", os.path.expanduser("~/.cache/huggingface"))
+    return os.path.join(base, "tt_xla_dequant_cache", f"{repo_slug}_{n_layers}layers")
+
+
+def _post_sparse_cache_dir_for(repo_id, n_layers):
+    return _cache_dir_for(repo_id, n_layers) + "_post_sparse"
+
+
+def _has_cache(cache_dir):
+    return os.path.isdir(cache_dir) and any(
+        f.endswith(".safetensors") for f in os.listdir(cache_dir)
+    )
+
+
+def _save_cache_chunked(state_dict, cache_dir):
+    """Save state_dict as per-layer + shared safetensors chunks."""
+    os.makedirs(cache_dir, exist_ok=True)
+    layer_dicts = {}
+    shared = {}
+    for key, tensor in state_dict.items():
+        m = re.match(r"layers\.(\d+)\.", key)
+        if m:
+            layer_dicts.setdefault(int(m.group(1)), {})[key] = tensor
+        else:
+            shared[key] = tensor
+    total_bytes = 0
+    if shared:
+        path = os.path.join(cache_dir, "shared.safetensors")
+        safetensors_save_file(shared, path)
+        total_bytes += os.path.getsize(path)
+    for layer_idx in sorted(layer_dicts):
+        path = os.path.join(cache_dir, f"layer_{layer_idx:04d}.safetensors")
+        safetensors_save_file(layer_dicts[layer_idx], path)
+        sz = os.path.getsize(path)
+        total_bytes += sz
+        del layer_dicts[layer_idx]
+        print(f"  [cache] saved layer {layer_idx} ({sz / 1e9:.1f} GB)", flush=True)
+    return total_bytes
+
+
+def _load_cache_chunked(cache_dir):
+    """Load all chunk files via mmap. Returns merged state_dict."""
+    state_dict = {}
+    for fname in sorted(os.listdir(cache_dir)):
+        if not fname.endswith(".safetensors"):
+            continue
+        chunk = safetensors_load_file(os.path.join(cache_dir, fname))
+        state_dict.update(chunk)
+    return state_dict
+
+
+def _dequantize_from_shards(repo_id, n_layers, n_dense_layers):
+    """Read FP8 shards, dequantize, rename keys. Returns a BF16 state_dict."""
+    index_path = hf_hub_download(repo_id, "model.safetensors.index.json")
+    with open(index_path) as f:
+        index = json.load(f)
+    weight_map = index["weight_map"]
+
+    weight_keys = {}
+    scale_keys = {}
+    scale_shards = {}
+    for ckpt_key, shard_file in weight_map.items():
+        layer_m = re.match(r"model\.layers\.(\d+)\.", ckpt_key)
+        if layer_m and int(layer_m.group(1)) >= n_layers:
+            continue
+        if "weight_scale_inv" in ckpt_key:
+            w_key = ckpt_key.replace(".weight_scale_inv", ".weight")
+            scale_keys[w_key] = ckpt_key
+            scale_shards[ckpt_key] = shard_file
+        else:
+            weight_keys[ckpt_key] = shard_file
+
+    all_shards = set(weight_keys.values()) | set(scale_shards.values())
+    raw = {}
+    for idx, shard_name in enumerate(sorted(all_shards)):
+        shard_path = hf_hub_download(repo_id, shard_name)
+        with safe_open(shard_path, framework="pt", device="cpu") as f:
+            for key in f.keys():
+                if key in weight_keys or key in scale_shards:
+                    raw[key] = f.get_tensor(key)
+        print(
+            f"  shard {idx + 1}/{len(all_shards)}: {shard_name} "
+            f"({len(raw)} tensors so far)",
+            flush=True,
+        )
+
+    dequantized = {}
+    n_dequant = 0
+    for ckpt_key in weight_keys:
+        tensor = raw.get(ckpt_key)
+        if tensor is None:
+            continue
+        if tensor.dtype == torch.float8_e4m3fn:
+            scale_key = scale_keys.get(ckpt_key)
+            scale_inv = raw.get(scale_key) if scale_key else None
+            if scale_inv is not None:
+                tensor = _weight_dequant(tensor, scale_inv)
+                n_dequant += 1
+            else:
+                tensor = tensor.to(torch.bfloat16)
+        dequantized[ckpt_key] = tensor
+    del raw
+    print(f"[weights] dequantized {n_dequant} FP8 tensors")
+
+    state_dict = {}
+    for ckpt_key, tensor in dequantized.items():
+        model_key = _rename_hf_key(ckpt_key, n_dense_layers)
+        if model_key is None:
+            continue
+        if model_key == "head.weight":
+            tensor = tensor.to(torch.float32)
+        elif tensor.dtype != torch.bfloat16:
+            tensor = tensor.to(torch.bfloat16)
+        state_dict[model_key] = tensor
+    del dequantized
+    return state_dict
+
+
+def _load_modified_dequantized_weights(model, repo_id, n_layers, n_dense_layers=1):
+    """Dequantize FP8 safetensors -> BF16, cache them, load into ``model``."""
+    cache_dir = _cache_dir_for(repo_id, n_layers)
+    if _has_cache(cache_dir):
+        t0 = time.perf_counter()
+        print(f"[weights] loading cached BF16 weights from {cache_dir}", flush=True)
+        state_dict = _load_cache_chunked(cache_dir)
+        t1 = time.perf_counter()
+        print(
+            f"[timing] cache load (mmap): {t1 - t0:.1f}s ({len(state_dict)} tensors)",
+            flush=True,
+        )
+    else:
+        print(
+            f"[weights] no cache at {cache_dir} — dequantizing from FP8...", flush=True
+        )
+        state_dict = _dequantize_from_shards(repo_id, n_layers, n_dense_layers)
+        _save_cache_chunked(state_dict, cache_dir)
+        del state_dict
+        state_dict = _load_cache_chunked(cache_dir)
+
+    missing, unexpected = model.load_state_dict(state_dict, strict=False, assign=True)
+    print(
+        f"[weights] loaded {len(state_dict)} tensors. "
+        f"Missing: {len(missing)}, Unexpected: {len(unexpected)}"
+    )
+
+
+def _fix_meta_buffers(model, args):
+    """Replace meta-device buffers with properly-computed CPU tensors.
+
+    After meta construction + ``load_state_dict(assign=True)``, non-persistent
+    buffers remain on meta. Recompute them on CPU.
+    """
+    import scipy.linalg
+
+    freqs_cis_complex = precompute_freqs_cis(args)
+    model.freqs_cis = torch.view_as_real(freqs_cis_complex)
+    hadamard = torch.tensor(
+        scipy.linalg.hadamard(args.index_head_dim), dtype=torch.bfloat16
+    ) * (args.index_head_dim**-0.5)
+    model.hadamard_matrix = hadamard
+    for layer in model.layers:
+        attn = layer.attn
+        attn.kv_cache = torch.zeros(
+            args.max_batch_size,
+            args.max_seq_len,
+            attn.kv_lora_rank,
+            dtype=torch.bfloat16,
+        )
+        attn.pe_cache = torch.zeros(
+            args.max_batch_size,
+            args.max_seq_len,
+            attn.qk_rope_head_dim,
+            dtype=torch.bfloat16,
+        )
+        attn.hadamard_matrix = hadamard
+        if attn.indexer is not None:
+            attn.indexer.k_cache = torch.zeros(
+                args.max_batch_size,
+                args.max_seq_len,
+                attn.indexer.head_dim,
+                dtype=torch.bfloat16,
+            )
+
+
+def _build_prefill_attention_mask(
+    batch_size, prompt_len, max_cache_len, dtype=torch.bfloat16
+):
+    """(B, 1, prompt_len, max_cache_len) additive causal mask."""
+    mask = torch.full(
+        (batch_size, 1, prompt_len, max_cache_len), float("-inf"), dtype=dtype
+    )
+    for q_pos in range(prompt_len):
+        mask[:, :, q_pos, : q_pos + 1] = 0.0
+    return mask
+
+
+def _build_decode_attention_mask(
+    batch_size, current_pos_inclusive, max_cache_len, dtype=torch.bfloat16
+):
+    """(B, 1, 1, max_cache_len) additive mask for a single decode step."""
+    mask = torch.full((batch_size, 1, 1, max_cache_len), float("-inf"), dtype=dtype)
+    mask[:, :, :, :current_pos_inclusive] = 0.0
+    return mask
+
+
+def _apply_shard_specs(model, mesh, args, batch_size, tokens_device):
+    """Apply mark_sharding to all weights + the input tokens."""
+    xs.mark_sharding(tokens_device, mesh, ("_axis_1", None))
+    xs.mark_sharding(model.embed.weight, mesh, (None, "_axis_0"))
+    for layer in model.layers:
+        attn = layer.attn
+        xs.mark_sharding(attn.wq_b.weight, mesh, ("_axis_0", None))
+        xs.mark_sharding(attn.wkv_b.weight, mesh, ("_axis_0", None))
+        xs.mark_sharding(attn.wo.weight, mesh, (None, "_axis_0"))
+        xs.mark_sharding(attn.wq_a.weight, mesh, (None, "_axis_0"))
+        xs.mark_sharding(attn.wkv_a.weight, mesh, (None, "_axis_0"))
+        xs.mark_sharding(attn.kv_cache, mesh, ("_axis_1", None, None))
+        xs.mark_sharding(attn.pe_cache, mesh, ("_axis_1", None, None))
+        ffn = layer.ffn
+        if hasattr(ffn, "mlp"):
+            mlp = ffn.mlp
+            xs.mark_sharding(mlp.router.gate.weight, mesh, (None, "_axis_0"))
+            xs.mark_sharding(
+                mlp.experts.gate_proj, mesh, (("_axis_0", "_axis_1"), None, None)
+            )
+            xs.mark_sharding(
+                mlp.experts.up_proj, mesh, (("_axis_0", "_axis_1"), None, None)
+            )
+            xs.mark_sharding(
+                mlp.experts.down_proj, mesh, (("_axis_0", "_axis_1"), None, None)
+            )
+            # Biases are None for DeepSeek v3.1 (no-bias MoE) — skip.
+            if mlp.experts.gate_proj_bias is not None:
+                xs.mark_sharding(
+                    mlp.experts.gate_proj_bias,
+                    mesh,
+                    (("_axis_0", "_axis_1"), None),
+                )
+            if mlp.experts.up_proj_bias is not None:
+                xs.mark_sharding(
+                    mlp.experts.up_proj_bias, mesh, (("_axis_0", "_axis_1"), None)
+                )
+            if mlp.experts.down_proj_bias is not None:
+                xs.mark_sharding(
+                    mlp.experts.down_proj_bias, mesh, (("_axis_0", "_axis_1"), None)
+                )
+            shared = getattr(ffn, "shared_experts", None)
+            if shared is not None:
+                xs.mark_sharding(shared.w1.weight, mesh, (None, "_axis_0"))
+                xs.mark_sharding(shared.w3.weight, mesh, (None, "_axis_0"))
+                xs.mark_sharding(shared.w2.weight, mesh, ("_axis_0", None))
+        else:
+            xs.mark_sharding(ffn.w1.weight, mesh, ("_axis_1", "_axis_0"))
+            xs.mark_sharding(ffn.w3.weight, mesh, ("_axis_1", "_axis_0"))
+            xs.mark_sharding(ffn.w2.weight, mesh, ("_axis_0", "_axis_1"))
+        xs.mark_sharding(layer.attn_norm.weight, mesh, ("_axis_0",))
+        xs.mark_sharding(layer.ffn_norm.weight, mesh, ("_axis_0",))
+    xs.mark_sharding(model.norm.weight, mesh, ("_axis_0",))
+    xs.mark_sharding(model.head.weight, mesh, (None, "_axis_0"))
+
+
+def _build_and_load_model(args, repo_id, prefer_cpu_capable=False):
+    """Build a meta-device ModifiedTransformer and populate real weights.
+
+    Two weight-load paths with different trade-offs. The caller picks via
+    ``prefer_cpu_capable``; whether to actually *run* a CPU reference is a
+    separate concern gated at the test level.
+
+    - Post-sparse cache (``prefer_cpu_capable=False``, default — matches the
+      old-branch speed profile): loads pre-stacked expert weights via mmap,
+      then nulls ``_original_mlp`` + ``original_experts`` to free memory.
+      ``enable_sparse_mlp`` runs on meta, so no runtime expert stacking.
+      CPU forward through the sparse layer will fail — do not call
+      ``model(tokens_cpu, ...)`` after this path.
+    - Dequantized cache (``prefer_cpu_capable=True``): loads the per-expert
+      BF16 cache, then ``enable_sparse_mlp`` runtime-stacks experts while
+      keeping the original MoE module alive via ``cpu_forward_module`` —
+      CPU forward works. For large n_layers this is *much* slower (both
+      the stacking step and the subsequent move-to-device).
+
+    If the preferred path's cache is missing, falls back to the other
+    (logging). If neither cache exists, dequantizes from FP8 shards.
+
+    Returns ``(model, mesh_shape)``.
+    """
+    with torch.device("meta"):
+        model = ModifiedTransformer(args)
+    mesh_shape = (4, 8)
+    post_sparse_dir = _post_sparse_cache_dir_for(repo_id, args.n_layers)
+    dequant_dir = _cache_dir_for(repo_id, args.n_layers)
+
+    def _load_post_sparse():
+        print(f"[weights] loading post-sparse cache from {post_sparse_dir}", flush=True)
+        enable_sparse_mlp(model, mesh=mesh_shape, cluster_axis=0, config=args)
+        for _, mod in model.named_modules():
+            if isinstance(mod, A2aSparseMLP):
+                object.__setattr__(mod, "_original_mlp", None)
+            if hasattr(mod, "original_experts"):
+                mod.original_experts = nn.ModuleList()
+        state_dict = _load_cache_chunked(post_sparse_dir)
+        model.load_state_dict(state_dict, strict=False, assign=True)
+        _fix_meta_buffers(model, args)
+        model.eval()
+
+    def _load_dequant():
+        print(f"[weights] loading dequantized cache from {dequant_dir}", flush=True)
+        _load_modified_dequantized_weights(
+            model,
+            repo_id=repo_id,
+            n_layers=args.n_layers,
+            n_dense_layers=args.n_dense_layers,
+        )
+        _fix_meta_buffers(model, args)
+        model.eval()
+        enable_sparse_mlp(model, mesh=mesh_shape, cluster_axis=0, config=args)
+
+    if prefer_cpu_capable:
+        if _has_cache(dequant_dir):
+            _load_dequant()
+            return model, mesh_shape
+        if _has_cache(post_sparse_dir):
+            print(
+                "[weights] prefer_cpu_capable=True but dequant cache missing; "
+                "falling back to post-sparse cache (CPU forward will be broken)",
+                flush=True,
+            )
+            _load_post_sparse()
+            return model, mesh_shape
+    else:
+        if _has_cache(post_sparse_dir):
+            _load_post_sparse()
+            return model, mesh_shape
+        if _has_cache(dequant_dir):
+            print(
+                "[weights] post-sparse cache missing; falling back to "
+                "dequant cache (slower — runtime expert stacking)",
+                flush=True,
+            )
+            _load_dequant()
+            return model, mesh_shape
+
+    # Neither cache exists — dequantize from FP8 shards (populates dequant cache).
+    _load_dequant()
+    return model, mesh_shape
+
+
+def _reset_caches(model):
+    for layer in model.layers:
+        layer.attn.kv_cache.zero_()
+        layer.attn.pe_cache.zero_()
+        if layer.attn.indexer is not None:
+            layer.attn.indexer.k_cache.zero_()
+
+
+def _pcc(a, b):
+    x = a.to(torch.float64).flatten().numpy()
+    y = b.to(torch.float64).flatten().numpy()
+    vx = x - x.mean()
+    vy = y - y.mean()
+    denom = float(np.linalg.norm(vx) * np.linalg.norm(vy))
+    return float("nan") if denom == 0 else float(np.dot(vx, vy) / denom)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.llmbox
+def test_deepseek_v3_1_full_sparse_moe():
+    """Prefill-only forward on the (4,8) mesh with A2aSparseMLP. Real input,
+    real weights, CPU PCC comparison."""
+    t_start = time.perf_counter()
+
+    os.environ["CONVERT_SHLO_TO_SHARDY"] = "1"
+    xr.set_device_type("TT")
+    torch_xla.runtime.use_spmd()
+
+    from transformers import AutoTokenizer
+
+    batch_size = 32
+    seq_len = 32
+
+    repo_id = DEEPSEEK_V3_1_REPO
+    args = load_deepseek_config(repo_id)
+    args.n_layers = int(os.environ.get("DEEPSEEK_N_LAYERS", args.n_dense_layers + 1))
+    args.max_batch_size = batch_size
+    # max_seq_len must exceed original_seq_len (4096) to activate YaRN mscale.
+    args.max_seq_len = args.original_seq_len + 1
+    print(
+        f"[config] n_layers={args.n_layers}, max_seq_len={args.max_seq_len}", flush=True
+    )
+
+    t0 = time.perf_counter()
+    print(f"[timing] config + init: {t0 - t_start:.1f}s", flush=True)
+
+    # DEEPSEEK_CPU_REFERENCE=1 runs the CPU eager reference and reports PCC.
+    # Requires the dequant cache (which keeps the original MoE alive for CPU
+    # forward); post-sparse cache is incompatible. Disabled by default so
+    # large-layer runs use the fast post-sparse path.
+    run_cpu_reference = os.environ.get("DEEPSEEK_CPU_REFERENCE", "0") == "1"
+
+    model, mesh_shape = _build_and_load_model(
+        args, repo_id, prefer_cpu_capable=run_cpu_reference
+    )
+
+    t1 = time.perf_counter()
+    print(f"[timing] model build + weight load: {t1 - t0:.1f}s", flush=True)
+
+    tokenizer = AutoTokenizer.from_pretrained(repo_id, trust_remote_code=True)
+    # Left-pad: the model predicts the token *after* the final real token, so
+    # padding must be to the left so position N-1 is "to", not <eos>.
+    tokenizer.padding_side = "left"
+    prompt_text = (
+        "Tenstorrent is a company that builds AI accelerators. "
+        "Their chips are designed to"
+    )
+    encoded = tokenizer(
+        prompt_text,
+        return_tensors="pt",
+        max_length=seq_len,
+        truncation=True,
+        padding="max_length",
+    )
+    tokens_single = encoded["input_ids"][:, :seq_len]
+    tokens_cpu = tokens_single.repeat(batch_size, 1)
+    print(
+        f"[input] prompt: {tokenizer.decode(tokens_single[0].tolist())!r}", flush=True
+    )
+
+    # ===== CPU reference (opt-in via DEEPSEEK_CPU_REFERENCE=1) =====
+    cpu_logits = None
+    if run_cpu_reference:
+        print("[cpu] running prefill eagerly (int path)...", flush=True)
+        t_cpu_start = time.perf_counter()
+        with torch.no_grad():
+            cpu_logits = model(tokens_cpu, start_pos=0)
+        t_cpu_end = time.perf_counter()
+        cpu_top5 = cpu_logits[0].topk(5, dim=-1).indices
+        print(f"[timing] CPU prefill: {t_cpu_end - t_cpu_start:.1f}s", flush=True)
+        print(
+            f"[CPU top-5] {[tokenizer.decode([t]) for t in cpu_top5.tolist()]}",
+            flush=True,
+        )
+        _reset_caches(model)
+    else:
+        print(
+            "[cpu] SKIPPED — set DEEPSEEK_CPU_REFERENCE=1 to run CPU golden",
+            flush=True,
+        )
+
+    # ===== TT path =====
+    torch._dynamo.reset()
+
+    num_devices = xr.global_runtime_device_count()
+    device_ids = np.array(range(num_devices))
+    mesh = Mesh(device_ids, mesh_shape, ("_axis_0", "_axis_1"))
+    device = torch_xla.device()
+
+    torch_xla.set_custom_compile_options(
+        CompilerConfig(experimental_weight_dtype="bfp_bf8").to_torch_compile_options()
+    )
+    compiled_model = torch.compile(model, backend="tt")
+
+    t_mv_start = time.perf_counter()
+    model = model.to(device)
+    tokens_device = tokens_cpu.to(device)
+    t_mv_end = time.perf_counter()
+    print(f"[timing] move to device: {t_mv_end - t_mv_start:.1f}s", flush=True)
+
+    _apply_shard_specs(model, mesh, args, batch_size, tokens_device)
+
+    print("[tt] running prefill...", flush=True)
+    t_tt_start = time.perf_counter()
+    with torch.no_grad():
+        tt_logits = compiled_model(tokens_device, start_pos=0)
+    tt_logits_cpu = tt_logits.to("cpu").detach()
+    t_tt_end = time.perf_counter()
+    print(
+        f"[timing] TT prefill (compile + run): {t_tt_end - t_tt_start:.1f}s", flush=True
+    )
+
+    tt_top5 = tt_logits_cpu[0].topk(5, dim=-1).indices
+    print(
+        f"[TT  top-5] {[tokenizer.decode([t]) for t in tt_top5.tolist()]}", flush=True
+    )
+
+    if cpu_logits is not None:
+        pcc = _pcc(tt_logits_cpu, cpu_logits.detach())
+        print(f"[pcc] logits PCC (TT vs CPU) = {pcc:.4f} (required: 0.99)", flush=True)
+    else:
+        print("[pcc] SKIPPED — no CPU reference", flush=True)
+
+
+@pytest.mark.llmbox
+def test_deepseek_v3_1_decode_static_cache():
+    """Autoregressive greedy decode on TT using the MLACache path.
+
+    Two compiles: prefill (prompt_seq_len), decode (seq_len=1, reused).
+    """
+    import torch._dynamo  # noqa: F401
+
+    t_start = time.perf_counter()
+
+    os.environ["CONVERT_SHLO_TO_SHARDY"] = "1"
+    xr.set_device_type("TT")
+    torch_xla.runtime.use_spmd()
+
+    from transformers import AutoTokenizer
+
+    batch_size = 32
+    prompt_seq_len = 32
+    n_decode = 10
+
+    repo_id = DEEPSEEK_V3_1_REPO
+    args = load_deepseek_config(repo_id)
+    args.n_layers = int(os.environ.get("DEEPSEEK_N_LAYERS", args.n_dense_layers + 1))
+    args.max_batch_size = batch_size
+    args.max_seq_len = args.original_seq_len + 1  # = 4097, activates YaRN
+    print(
+        f"[config] n_layers={args.n_layers}, max_seq_len={args.max_seq_len}", flush=True
+    )
+
+    t0 = time.perf_counter()
+    print(f"[timing] config + init: {t0 - t_start:.1f}s", flush=True)
+
+    # DEEPSEEK_CPU_REFERENCE=1 runs the CPU eager reference (prefill + decode
+    # loop) and reports per-step PCC. Requires the dequant cache; post-sparse
+    # cache is incompatible. Disabled by default so 61-layer runs use the fast
+    # post-sparse path.
+    run_cpu_reference = os.environ.get("DEEPSEEK_CPU_REFERENCE", "0") == "1"
+
+    model, mesh_shape = _build_and_load_model(
+        args, repo_id, prefer_cpu_capable=run_cpu_reference
+    )
+
+    t1 = time.perf_counter()
+    print(f"[timing] model build + weight load: {t1 - t0:.1f}s", flush=True)
+
+    tokenizer = AutoTokenizer.from_pretrained(repo_id, trust_remote_code=True)
+    tokenizer.padding_side = "left"
+    prompt_text = "Tell me a short story. "
+    encoded = tokenizer(
+        prompt_text,
+        return_tensors="pt",
+        max_length=prompt_seq_len,
+        truncation=True,
+        padding="max_length",
+    )
+    tokens_single = encoded["input_ids"][:, :prompt_seq_len]
+    prompt_len = tokens_single.shape[1]
+    tokens_cpu = tokens_single.repeat(batch_size, 1)
+    print(
+        f"[prompt] {prompt_len} tokens x{batch_size}: "
+        f"{tokenizer.decode(tokens_single[0])!r}",
+        flush=True,
+    )
+
+    # ===== CPU eager reference (opt-in via DEEPSEEK_CPU_REFERENCE=1) =====
+    cpu_logits_list = []
+    cpu_token_ids = []
+    if run_cpu_reference:
+        print("[cpu] running prefill + decode eagerly (int path)...", flush=True)
+        t_cpu_start = time.perf_counter()
+        with torch.no_grad():
+            logits = model(tokens_cpu, start_pos=0)
+            cpu_logits_list.append(logits[0].detach().clone())
+            next_id = int(logits[0].argmax(dim=-1).item())
+            cpu_token_ids.append(next_id)
+            for step in range(n_decode - 1):
+                next_tokens = torch.full(
+                    (batch_size, 1), next_id, dtype=tokens_cpu.dtype
+                )
+                logits = model(next_tokens, start_pos=prompt_len + step)
+                cpu_logits_list.append(logits[0].detach().clone())
+                next_id = int(logits[0].argmax(dim=-1).item())
+                cpu_token_ids.append(next_id)
+        t_cpu_end = time.perf_counter()
+        print(
+            f"[timing] CPU prefill+decode: {t_cpu_end - t_cpu_start:.1f}s",
+            flush=True,
+        )
+        print(
+            f"[CPU tokens] {[tokenizer.decode([t]) for t in cpu_token_ids]}",
+            flush=True,
+        )
+        print(
+            f"[CPU full]   "
+            f"{tokenizer.decode(tokens_single[0].tolist() + cpu_token_ids)!r}",
+            flush=True,
+        )
+        _reset_caches(model)
+    else:
+        print(
+            "[cpu] SKIPPED — set DEEPSEEK_CPU_REFERENCE=1 to run CPU golden",
+            flush=True,
+        )
+
+    # ===== TT path =====
+    torch._dynamo.reset()
+
+    num_devices = xr.global_runtime_device_count()
+    device_ids = np.array(range(num_devices))
+    mesh = Mesh(device_ids, mesh_shape, ("_axis_0", "_axis_1"))
+    device = torch_xla.device()
+
+    torch_xla.set_custom_compile_options(
+        CompilerConfig(experimental_weight_dtype="bfp_bf8").to_torch_compile_options()
+    )
+    compiled_model = torch.compile(model, backend="tt")
+
+    t_mv_start = time.perf_counter()
+    model = model.to(device)
+    tokens_device = tokens_cpu.to(device)
+    cache_position_prefill = torch.arange(prompt_len, dtype=torch.long).to(device)
+    attn_mask_prefill = _build_prefill_attention_mask(
+        batch_size, prompt_len, args.max_seq_len, dtype=torch.bfloat16
+    ).to(device)
+    t_mv_end = time.perf_counter()
+    print(f"[timing] move to device: {t_mv_end - t_mv_start:.1f}s", flush=True)
+
+    _apply_shard_specs(model, mesh, args, batch_size, tokens_device)
+
+    # ===== Prefill =====
+    print("[tt] running prefill (compile #1)...", flush=True)
+    t_pf_start = time.perf_counter()
+    with torch.no_grad():
+        tt_logits_prefill = compiled_model(
+            tokens_device,
+            cache_position=cache_position_prefill,
+            attention_mask=attn_mask_prefill,
+        )
+    t_pf_end = time.perf_counter()
+    print(
+        f"[timing] TT prefill compile + run: {t_pf_end - t_pf_start:.1f}s",
+        flush=True,
+    )
+    tt_logits_prefill_cpu = tt_logits_prefill.to("cpu").detach()
+    tt_logits_list = [tt_logits_prefill_cpu[0].clone()]
+    tt_token_ids = [int(tt_logits_prefill_cpu[0].argmax(dim=-1).item())]
+    print(
+        f"[tt] prefill top-1: {tokenizer.decode([tt_token_ids[0]])!r}",
+        flush=True,
+    )
+
+    # ===== Decode loop =====
+    for step in range(n_decode - 1):
+        pos = prompt_len + step
+        next_tokens = torch.full(
+            (batch_size, 1), tt_token_ids[-1], dtype=tokens_cpu.dtype
+        ).to(device)
+        cache_position_decode = torch.tensor([pos], dtype=torch.long).to(device)
+        attn_mask_decode = _build_decode_attention_mask(
+            batch_size, pos + 1, args.max_seq_len, dtype=torch.bfloat16
+        ).to(device)
+        t_dec_start = time.perf_counter()
+        with torch.no_grad():
+            tt_logits = compiled_model(
+                next_tokens,
+                cache_position=cache_position_decode,
+                attention_mask=attn_mask_decode,
+            )
+        tt_logits_cpu = tt_logits.to("cpu").detach()
+        t_dec_end = time.perf_counter()
+        tt_logits_list.append(tt_logits_cpu[0].clone())
+        tt_token_ids.append(int(tt_logits_cpu[0].argmax(dim=-1).item()))
+        print(
+            f"[tt] decode step {step + 1}/{n_decode - 1}: "
+            f"time={t_dec_end - t_dec_start:.2f}s "
+            f"tok={tokenizer.decode([tt_token_ids[-1]])!r}",
+            flush=True,
+        )
+
+    print(
+        f"[TT tokens]  {[tokenizer.decode([t]) for t in tt_token_ids]}",
+        flush=True,
+    )
+    print(
+        f"[TT full]    "
+        f"{tokenizer.decode(tokens_single[0].tolist() + tt_token_ids)!r}",
+        flush=True,
+    )
+
+    if cpu_logits_list:
+        print("\n[pcc] per-step logits PCC (TT vs CPU):", flush=True)
+        step_pccs = []
+        for step, (tt_l, cpu_l) in enumerate(zip(tt_logits_list, cpu_logits_list)):
+            pcc = _pcc(tt_l, cpu_l)
+            step_pccs.append(pcc)
+            tt_tok = tt_token_ids[step]
+            cpu_tok = cpu_token_ids[step]
+            match = "OK" if tt_tok == cpu_tok else "MISMATCH"
+            print(
+                f"  step {step}: pcc={pcc:.4f}  "
+                f"tt_tok={tt_tok!r:>10} cpu_tok={cpu_tok!r:>10}  [{match}]",
+                flush=True,
+            )
+        print(
+            f"\n[pcc] min={min(step_pccs):.4f}, max={max(step_pccs):.4f}, "
+            f"avg={sum(step_pccs) / len(step_pccs):.4f}",
+            flush=True,
+        )
+        matches = sum(1 for a, b in zip(tt_token_ids, cpu_token_ids) if a == b)
+        print(
+            f"[tokens] TT==CPU match: {matches}/{len(tt_token_ids)}",
+            flush=True,
+        )
+    else:
+        print("\n[pcc] SKIPPED — no CPU reference", flush=True)

--- a/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_1.py
+++ b/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_1.py
@@ -400,8 +400,13 @@ def _pcc(a, b):
 # ---------------------------------------------------------------------------
 
 @pytest.mark.galaxy
-@pytest.mark.nightly
-@pytest.mark.parametrize("cpu_reference", [True, False] , ids=["cpu_reference", "no_cpu_reference"])
+ @pytest.mark.parametrize(
+      "cpu_reference",                                                                                                                                                                                                                                                                               
+      [                                                                                                                                                                                                                                                                                              
+          pytest.param(True, marks=pytest.mark.nightly, id="cpu_reference"),
+          pytest.param(False, id="no_cpu_reference"),                                                                                                                                                                                                                                                
+      ],                                                                                                                                                                                                                                                                                             
+  )
 @pytest.mark.parametrize("n_layers", [4])
 def test_deepseek_v3_1_decode_static_cache(cpu_reference, n_layers):
     """Autoregressive greedy decode on TT using the MLACache path.

--- a/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_1.py
+++ b/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_1.py
@@ -51,7 +51,7 @@ DEEPSEEK_V3_1_REPO = "deepseek-ai/DeepSeek-V3.1"
 
 
 # ---------------------------------------------------------------------------
-# Weight loading / cache
+# Helpers
 # ---------------------------------------------------------------------------
 
 
@@ -399,132 +399,11 @@ def _pcc(a, b):
 # Tests
 # ---------------------------------------------------------------------------
 
-
-def test_deepseek_v3_1_full_sparse_moe():
-    """Prefill-only forward on the (4,8) mesh with A2aSparseMLP. Real input,
-    real weights, CPU PCC comparison."""
-    t_start = time.perf_counter()
-
-    os.environ["CONVERT_SHLO_TO_SHARDY"] = "1"
-    xr.set_device_type("TT")
-    torch_xla.runtime.use_spmd()
-
-    from transformers import AutoTokenizer
-
-    batch_size = 32
-    seq_len = 32
-
-    repo_id = DEEPSEEK_V3_1_REPO
-    args = load_deepseek_config(repo_id)
-    args.n_layers = int(os.environ.get("DEEPSEEK_N_LAYERS", args.n_dense_layers + 1))
-    args.max_batch_size = batch_size
-    # max_seq_len must exceed original_seq_len (4096) to activate YaRN mscale.
-    args.max_seq_len = args.original_seq_len + 1
-    print(
-        f"[config] n_layers={args.n_layers}, max_seq_len={args.max_seq_len}", flush=True
-    )
-
-    t0 = time.perf_counter()
-    print(f"[timing] config + init: {t0 - t_start:.1f}s", flush=True)
-
-    # DEEPSEEK_CPU_REFERENCE=1 runs the CPU eager reference and reports PCC.
-    # Requires the dequant cache (which keeps the original MoE alive for CPU
-    # forward); post-sparse cache is incompatible. Disabled by default so
-    # large-layer runs use the fast post-sparse path.
-    run_cpu_reference = os.environ.get("DEEPSEEK_CPU_REFERENCE", "0") == "1"
-
-    model, mesh_shape = _build_and_load_model(
-        args, repo_id, prefer_cpu_capable=run_cpu_reference
-    )
-
-    t1 = time.perf_counter()
-    print(f"[timing] model build + weight load: {t1 - t0:.1f}s", flush=True)
-
-    tokenizer = AutoTokenizer.from_pretrained(
-        repo_id, trust_remote_code=True, add_bos_token=True, padding_side="left"
-    )
-    prompt_text = (
-        "Tenstorrent is a company that builds AI accelerators. "
-        "Their chips are designed to"
-    )
-    encoded = tokenizer(
-        prompt_text,
-        return_tensors="pt",
-        max_length=seq_len,
-        truncation=True,
-        padding="max_length",
-    )
-    tokens_single = encoded["input_ids"][:, :seq_len]
-    tokens_cpu = tokens_single.repeat(batch_size, 1)
-    print(
-        f"[input] prompt: {tokenizer.decode(tokens_single[0].tolist())!r}", flush=True
-    )
-
-    # ===== CPU reference (opt-in via DEEPSEEK_CPU_REFERENCE=1) =====
-    cpu_logits = None
-    if run_cpu_reference:
-        print("[cpu] running prefill eagerly (int path)...", flush=True)
-        t_cpu_start = time.perf_counter()
-        with torch.no_grad():
-            cpu_logits = model(tokens_cpu, start_pos=0)
-        t_cpu_end = time.perf_counter()
-        cpu_top5 = cpu_logits[0].topk(5, dim=-1).indices
-        print(f"[timing] CPU prefill: {t_cpu_end - t_cpu_start:.1f}s", flush=True)
-        print(
-            f"[CPU top-5] {[tokenizer.decode([t]) for t in cpu_top5.tolist()]}",
-            flush=True,
-        )
-        _reset_caches(model)
-    else:
-        print(
-            "[cpu] SKIPPED — set DEEPSEEK_CPU_REFERENCE=1 to run CPU golden",
-            flush=True,
-        )
-
-    # ===== TT path =====
-    torch._dynamo.reset()
-
-    num_devices = xr.global_runtime_device_count()
-    device_ids = np.array(range(num_devices))
-    mesh = Mesh(device_ids, mesh_shape, ("_axis_0", "_axis_1"))
-    device = torch_xla.device()
-
-    torch_xla.set_custom_compile_options(
-        CompilerConfig(experimental_weight_dtype="bfp_bf8").to_torch_compile_options()
-    )
-    compiled_model = torch.compile(model, backend="tt")
-
-    t_mv_start = time.perf_counter()
-    model = model.to(device)
-    tokens_device = tokens_cpu.to(device)
-    t_mv_end = time.perf_counter()
-    print(f"[timing] move to device: {t_mv_end - t_mv_start:.1f}s", flush=True)
-
-    _apply_shard_specs(model, mesh, args, batch_size, tokens_device)
-
-    print("[tt] running prefill...", flush=True)
-    t_tt_start = time.perf_counter()
-    with torch.no_grad():
-        tt_logits = compiled_model(tokens_device, start_pos=0)
-    tt_logits_cpu = tt_logits.to("cpu").detach()
-    t_tt_end = time.perf_counter()
-    print(
-        f"[timing] TT prefill (compile + run): {t_tt_end - t_tt_start:.1f}s", flush=True
-    )
-
-    tt_top5 = tt_logits_cpu[0].topk(5, dim=-1).indices
-    print(
-        f"[TT  top-5] {[tokenizer.decode([t]) for t in tt_top5.tolist()]}", flush=True
-    )
-
-    if cpu_logits is not None:
-        pcc = _pcc(tt_logits_cpu, cpu_logits.detach())
-        print(f"[pcc] logits PCC (TT vs CPU) = {pcc:.4f} (required: 0.99)", flush=True)
-    else:
-        print("[pcc] SKIPPED — no CPU reference", flush=True)
-
-
-def test_deepseek_v3_1_decode_static_cache():
+@pytest.mark.galaxy
+@pytest.mark.nightly
+@pytest.mark.parametrize("cpu_reference", [True, False] , ids=["cpu_reference", "no_cpu_reference"])
+@pytest.mark.parametrize("n_layers", [4])
+def test_deepseek_v3_1_decode_static_cache(cpu_reference, n_layers):
     """Autoregressive greedy decode on TT using the MLACache path.
 
     Two compiles: prefill (prompt_seq_len), decode (seq_len=1, reused).
@@ -545,7 +424,7 @@ def test_deepseek_v3_1_decode_static_cache():
 
     repo_id = DEEPSEEK_V3_1_REPO
     args = load_deepseek_config(repo_id)
-    args.n_layers = int(os.environ.get("DEEPSEEK_N_LAYERS", args.n_dense_layers + 1))
+    args.n_layers = n_layers
     args.max_batch_size = batch_size
     args.max_seq_len = args.original_seq_len + 1  # = 4097, activates YaRN
     print(
@@ -559,7 +438,7 @@ def test_deepseek_v3_1_decode_static_cache():
     # loop) and reports per-step PCC. Requires the dequant cache; post-sparse
     # cache is incompatible. Disabled by default so 61-layer runs use the fast
     # post-sparse path.
-    run_cpu_reference = os.environ.get("DEEPSEEK_CPU_REFERENCE", "0") == "1"
+    run_cpu_reference = cpu_reference
 
     model, mesh_shape = _build_and_load_model(
         args, repo_id, prefer_cpu_capable=run_cpu_reference

--- a/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_1.py
+++ b/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_1.py
@@ -399,13 +399,14 @@ def _pcc(a, b):
 # Tests
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.galaxy
 @pytest.mark.parametrize(
-    "cpu_reference",                                                                                                                                                                                                                                                                               
-    [                                                                                                                                                                                                                                                                                              
+    "cpu_reference",
+    [
         pytest.param(True, marks=pytest.mark.nightly, id="cpu_reference"),
-        pytest.param(False, id="no_cpu_reference"),                                                                                                                                                                                                                                                
-    ],                                                                                                                                                                                                                                                                                             
+        pytest.param(False, id="no_cpu_reference"),
+    ],
 )
 @pytest.mark.parametrize("n_layers", [4])
 def test_deepseek_v3_1_decode_static_cache(cpu_reference, n_layers):

--- a/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_1.py
+++ b/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_1.py
@@ -400,13 +400,13 @@ def _pcc(a, b):
 # ---------------------------------------------------------------------------
 
 @pytest.mark.galaxy
- @pytest.mark.parametrize(
-      "cpu_reference",                                                                                                                                                                                                                                                                               
-      [                                                                                                                                                                                                                                                                                              
-          pytest.param(True, marks=pytest.mark.nightly, id="cpu_reference"),
-          pytest.param(False, id="no_cpu_reference"),                                                                                                                                                                                                                                                
-      ],                                                                                                                                                                                                                                                                                             
-  )
+@pytest.mark.parametrize(
+    "cpu_reference",                                                                                                                                                                                                                                                                               
+    [                                                                                                                                                                                                                                                                                              
+        pytest.param(True, marks=pytest.mark.nightly, id="cpu_reference"),
+        pytest.param(False, id="no_cpu_reference"),                                                                                                                                                                                                                                                
+    ],                                                                                                                                                                                                                                                                                             
+)
 @pytest.mark.parametrize("n_layers", [4])
 def test_deepseek_v3_1_decode_static_cache(cpu_reference, n_layers):
     """Autoregressive greedy decode on TT using the MLACache path.

--- a/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_2_exp.py
+++ b/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_2_exp.py
@@ -8,19 +8,35 @@ import torch_xla
 import torch_xla.runtime as xr
 from infra import Framework, run_graph_test
 from infra.evaluators import ComparisonConfig, PccConfig
-from modified_model import ModelArgs
-from modified_model import Transformer as ModifiedTransformer
 from torch_xla.distributed.spmd import Mesh
 from tt_torch.sparse_mlp import enable_sparse_mlp
 
 from tests.utils import failed_ttmlir_compilation
+from third_party.tt_forge_models.deepseek.deepseek_v3_2_exp.pytorch.src.modified_model import (
+    LayerNorm,
+    ModelArgs,
+)
+from third_party.tt_forge_models.deepseek.deepseek_v3_2_exp.pytorch.src.modified_model import (
+    Transformer as ModifiedTransformer,
+)
 
-# This model is modified from the original deepseek_v3_2_exp model.py to:
+
+def _fix_layernorm_dtype(model):
+    # LayerNorm calls x.float() internally and errors on mixed dtype, so
+    # restore fp32 params that .to(bfloat16) silently converted.
+    for module in model.modules():
+        if isinstance(module, LayerNorm):
+            module.weight.data = module.weight.data.to(torch.float32)
+            module.bias.data = module.bias.data.to(torch.float32)
+
+# This model is modified from the original deepseek_v3_2_exp model.py. Comments about each modification made can be found in
+# third_party/tt_forge_models/deepseek/deepseek_v3_2_exp/pytorch/src/modified_model.py. Some of the notable modifications include:
 # 1. Use scipy.linalg.hadamard instead of fast_hadamard_transform
 #    - fast_hadamard_transform requires a CUDA enviroment and fails to install
 # 2. Disable FP8 quantization features (act_quant, fp8_gemm, fp8_index) with stubs
 #    - the original implementation (kernel.py) relies on custom tilelang kernels not supported on TT
 # 3. Avoid torch.view_as_complex/view_as_real operations
+# 4. Allowing an external MLACache, cache_position and k_cache to be passed in and used.
 
 
 @pytest.mark.xfail(
@@ -38,6 +54,7 @@ def test_deepseek_modified_transformer_single_layer():
     model = ModifiedTransformer(args)
 
     model = model.to(torch.bfloat16)
+    _fix_layernorm_dtype(model)
 
     model = model.eval()
     compiled_model = torch.compile(model, backend="tt")
@@ -101,6 +118,7 @@ def test_deepseek_attention_prefill(batch_size):
 
     model = ModifiedTransformer(args)
     model = model.to(torch.bfloat16)
+    _fix_layernorm_dtype(model)
     attention = model.layers[0].attn
 
     hidden_states = torch.randn((batch_size, seq_len, args.dim), dtype=torch.bfloat16)
@@ -173,6 +191,7 @@ def test_deepseek_indexer(batch_size):
 
     model = ModifiedTransformer(args)
     model = model.to(torch.bfloat16)
+    _fix_layernorm_dtype(model)
     indexer = model.layers[0].attn.indexer
 
     # Enable raw score return for testing (returns index_score instead of topk_indices)
@@ -263,6 +282,7 @@ def test_deepseek_v3_2_layer_sparse_moe(batch_size, seq_len):
     # Create full model to get freqs_cis, then extract MoE block (layer 1)
     model = ModifiedTransformer(args)
     model = model.to(torch.bfloat16)
+    _fix_layernorm_dtype(model)
     block = model.layers[1]  # layer_id=1 >= n_dense_layers=1 -> MoE
     freqs_cis = model.freqs_cis[:seq_len]
 

--- a/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_2_exp.py
+++ b/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_2_exp.py
@@ -29,6 +29,7 @@ def _fix_layernorm_dtype(model):
             module.weight.data = module.weight.data.to(torch.float32)
             module.bias.data = module.bias.data.to(torch.float32)
 
+
 # This model is modified from the original deepseek_v3_2_exp model.py. Comments about each modification made can be found in
 # third_party/tt_forge_models/deepseek/deepseek_v3_2_exp/pytorch/src/modified_model.py. Some of the notable modifications include:
 # 1. Use scipy.linalg.hadamard instead of fast_hadamard_transform

--- a/tests/torch/models/glm4_moe/build_weight_cache_glm.py
+++ b/tests/torch/models/glm4_moe/build_weight_cache_glm.py
@@ -27,7 +27,6 @@ import argparse
 import json
 import os
 import re
-import sys
 import time
 
 import torch
@@ -38,11 +37,17 @@ from safetensors.torch import save_file as safetensors_save_file
 GLM_REPO = "zai-org/GLM-4.7"
 
 
-def _cache_dir_for(repo_id, n_layers):
+def _post_sparse_cache_dir(repo_id, n_layers):
     repo_slug = repo_id.replace("/", "--")
     base = os.environ.get("HF_HOME", os.path.expanduser("~/.cache/huggingface"))
     return os.path.join(
         base, "tt_xla_dequant_cache", f"{repo_slug}_{n_layers}layers_post_sparse"
+    )
+
+
+def _has_cache(cache_dir):
+    return os.path.isdir(cache_dir) and any(
+        f.endswith(".safetensors") for f in os.listdir(cache_dir)
     )
 
 
@@ -160,11 +165,9 @@ def _process_moe_layer(layer_idx, n_experts, weight_map, repo_id):
 
 
 def build_post_sparse_cache(repo_id, n_layers, n_dense_layers, n_experts):
-    cache_dir = _cache_dir_for(repo_id, n_layers)
+    cache_dir = _post_sparse_cache_dir(repo_id, n_layers)
 
-    if os.path.isdir(cache_dir) and any(
-        f.endswith(".safetensors") for f in os.listdir(cache_dir)
-    ):
+    if _has_cache(cache_dir):
         print(f"Cache already exists at {cache_dir}, skipping.")
         print(f"  Files: {sorted(os.listdir(cache_dir))}")
         print("  Delete the directory to rebuild.")
@@ -231,8 +234,8 @@ if __name__ == "__main__":
     config_path = hf_hub_download(args.repo, "config.json")
     with open(config_path) as f:
         cfg = json.load(f)
-    n_dense_layers = cfg.get("first_k_dense_replace", 3)
-    n_experts = cfg.get("n_routed_experts", 160)
+    n_dense_layers = cfg["first_k_dense_replace"]
+    n_experts = cfg["n_routed_experts"]
     print(
         f"Repo: {args.repo}\n"
         f"  n_layers={args.n_layers}, n_dense_layers={n_dense_layers}, "

--- a/tests/torch/models/glm4_moe/build_weight_cache_glm.py
+++ b/tests/torch/models/glm4_moe/build_weight_cache_glm.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Build a chunked BF16 post-sparse weight cache for GLM-4.7, one layer at a time.
+
+GLM-4.7 weights are already BF16 on HF (no dequant needed). This builder streams
+safetensors per-layer, stacks per-expert tensors into the post-sparse layout
+(StackedExperts format), and writes one chunk per layer. Peak memory is a few
+GB per layer — no swap needed.
+
+Post-sparse layout matches what `enable_sparse_mlp` produces on a freshly built
+`Glm4MoeForCausalLM`:
+  - Router: `model.layers.N.mlp.gate.*`  -> `model.layers.N.mlp.mlp.router.gate.*`
+  - Experts: per-expert  [out,in]  -> stacked+transposed [E, in, out]
+             `experts.{0..159}.{gate,up,down}_proj.weight`
+             -> `mlp.mlp.experts.{gate,up,down}_proj`
+  - Shared experts pass through under `mlp.shared_experts.*`.
+
+Dense layers (i < first_k_dense_replace) pass through unchanged.
+
+Usage:
+    python build_weight_cache_glm.py --n-layers 4     # smoke / bringup
+    python build_weight_cache_glm.py --n-layers 92    # full GLM-4.7
+"""
+import argparse
+import json
+import os
+import re
+import sys
+import time
+
+import torch
+from huggingface_hub import hf_hub_download
+from safetensors import safe_open
+from safetensors.torch import save_file as safetensors_save_file
+
+GLM_REPO = "zai-org/GLM-4.7"
+
+
+def _cache_dir_for(repo_id, n_layers):
+    repo_slug = repo_id.replace("/", "--")
+    base = os.environ.get("HF_HOME", os.path.expanduser("~/.cache/huggingface"))
+    return os.path.join(
+        base, "tt_xla_dequant_cache", f"{repo_slug}_{n_layers}layers_post_sparse"
+    )
+
+
+def _load_tensors(shard_to_keys, repo_id):
+    """Return {ckpt_key: tensor} for all requested keys, opening each shard once."""
+    out = {}
+    for shard_name, keys in shard_to_keys.items():
+        shard_path = hf_hub_download(repo_id, shard_name)
+        with safe_open(shard_path, framework="pt", device="cpu") as f:
+            for key in keys:
+                out[key] = f.get_tensor(key)
+    return out
+
+
+def _group_by_shard(ckpt_keys, weight_map):
+    shard_to_keys = {}
+    for k in ckpt_keys:
+        shard_to_keys.setdefault(weight_map[k], []).append(k)
+    return shard_to_keys
+
+
+def _process_shared(weight_map, repo_id):
+    """embed_tokens + norm + lm_head, saved as group `shared`."""
+    keys = [
+        "model.embed_tokens.weight",
+        "model.norm.weight",
+        "lm_head.weight",
+    ]
+    keys = [k for k in keys if k in weight_map]
+    shard_to_keys = _group_by_shard(keys, weight_map)
+    raw = _load_tensors(shard_to_keys, repo_id)
+    return {k: raw[k].to(torch.bfloat16) for k in keys}
+
+
+def _process_dense_layer(layer_idx, weight_map, repo_id):
+    """Layer under first_k_dense_replace: pass-through."""
+    prefix = f"model.layers.{layer_idx}"
+    keys = [k for k in weight_map if k.startswith(prefix + ".")]
+    shard_to_keys = _group_by_shard(keys, weight_map)
+    raw = _load_tensors(shard_to_keys, repo_id)
+    return {k: raw[k].to(torch.bfloat16) for k in keys}
+
+
+def _process_moe_layer(layer_idx, n_experts, weight_map, repo_id):
+    """MoE layer: stack per-expert tensors, rename router/shared/expert prefixes."""
+    prefix = f"model.layers.{layer_idx}"
+    all_keys = [k for k in weight_map if k.startswith(prefix + ".")]
+
+    expert_keys = []
+    other_keys = []
+    expert_re = re.compile(
+        rf"^model\.layers\.{layer_idx}\.mlp\.experts\.(\d+)\.(gate_proj|up_proj|down_proj)\.weight$"
+    )
+    for k in all_keys:
+        if expert_re.match(k):
+            expert_keys.append(k)
+        else:
+            other_keys.append(k)
+
+    shard_to_keys = _group_by_shard(expert_keys + other_keys, weight_map)
+    raw = _load_tensors(shard_to_keys, repo_id)
+
+    # Stack experts. HF stores each as nn.Linear convention [out, in]; TT
+    # StackedExperts wants [E, in, out], so we transpose at stack time.
+    gate_list, up_list, down_list = (
+        [None] * n_experts,
+        [None] * n_experts,
+        [None] * n_experts,
+    )
+    for k in expert_keys:
+        m = expert_re.match(k)
+        idx = int(m.group(1))
+        name = m.group(2)
+        t = raw[k].to(torch.bfloat16).T.contiguous()  # [in, out]
+        if name == "gate_proj":
+            gate_list[idx] = t
+        elif name == "up_proj":
+            up_list[idx] = t
+        elif name == "down_proj":
+            down_list[idx] = t
+
+    missing_gate = [i for i, x in enumerate(gate_list) if x is None]
+    if missing_gate:
+        raise ValueError(
+            f"Layer {layer_idx}: missing gate_proj for experts {missing_gate[:5]}..."
+        )
+
+    gate_proj = torch.stack(gate_list, dim=0)
+    up_proj = torch.stack(up_list, dim=0)
+    down_proj = torch.stack(down_list, dim=0)
+    # Free per-expert list memory before saving.
+    del gate_list, up_list, down_list
+
+    state_dict = {
+        f"{prefix}.mlp.mlp.experts.gate_proj": gate_proj,
+        f"{prefix}.mlp.mlp.experts.up_proj": up_proj,
+        f"{prefix}.mlp.mlp.experts.down_proj": down_proj,
+    }
+
+    # Non-expert keys: rename router, pass-through shared/attn/norms.
+    router_weight_key = f"{prefix}.mlp.gate.weight"
+    router_bias_key = f"{prefix}.mlp.gate.e_score_correction_bias"
+    for k in other_keys:
+        t = raw[k].to(torch.bfloat16)
+        if k == router_weight_key:
+            new_key = f"{prefix}.mlp.mlp.router.gate.weight"
+        elif k == router_bias_key:
+            new_key = f"{prefix}.mlp.mlp.router.gate.e_score_correction_bias"
+        else:
+            new_key = k  # shared_experts, self_attn, norms pass through
+        state_dict[new_key] = t
+
+    del raw
+    return state_dict
+
+
+def build_post_sparse_cache(repo_id, n_layers, n_dense_layers, n_experts):
+    cache_dir = _cache_dir_for(repo_id, n_layers)
+
+    if os.path.isdir(cache_dir) and any(
+        f.endswith(".safetensors") for f in os.listdir(cache_dir)
+    ):
+        print(f"Cache already exists at {cache_dir}, skipping.")
+        print(f"  Files: {sorted(os.listdir(cache_dir))}")
+        print("  Delete the directory to rebuild.")
+        return
+
+    t_total = time.perf_counter()
+
+    index_path = hf_hub_download(repo_id, "model.safetensors.index.json")
+    with open(index_path) as f:
+        index = json.load(f)
+    weight_map = index["weight_map"]
+
+    os.makedirs(cache_dir, exist_ok=True)
+    total_bytes = 0
+
+    # Shared group (embed + norm + lm_head)
+    t0 = time.perf_counter()
+    sd = _process_shared(weight_map, repo_id)
+    out_path = os.path.join(cache_dir, "shared.safetensors")
+    safetensors_save_file(sd, out_path)
+    sz = os.path.getsize(out_path)
+    total_bytes += sz
+    del sd
+    print(f"  shared: {sz / 1e9:.2f} GB, {time.perf_counter() - t0:.1f}s", flush=True)
+
+    # Per-layer groups
+    for i in range(n_layers):
+        t_layer = time.perf_counter()
+        if i < n_dense_layers:
+            sd = _process_dense_layer(i, weight_map, repo_id)
+            tag = "dense"
+        else:
+            sd = _process_moe_layer(i, n_experts, weight_map, repo_id)
+            tag = "moe"
+
+        out_path = os.path.join(cache_dir, f"layer_{i:04d}.safetensors")
+        safetensors_save_file(sd, out_path)
+        sz = os.path.getsize(out_path)
+        total_bytes += sz
+        del sd
+
+        print(
+            f"  layer_{i:04d} ({tag}): {sz / 1e9:.2f} GB, "
+            f"{time.perf_counter() - t_layer:.1f}s",
+            flush=True,
+        )
+
+    print(
+        f"\nDone. {total_bytes / 1e9:.1f} GB total, "
+        f"{time.perf_counter() - t_total:.1f}s",
+        flush=True,
+    )
+    print(f"Cache dir: {cache_dir}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Build BF16 post-sparse weight cache for GLM-4.7"
+    )
+    parser.add_argument("--repo", default=GLM_REPO, help="HuggingFace repo ID")
+    parser.add_argument("--n-layers", type=int, default=92, help="Number of layers")
+    args = parser.parse_args()
+
+    config_path = hf_hub_download(args.repo, "config.json")
+    with open(config_path) as f:
+        cfg = json.load(f)
+    n_dense_layers = cfg.get("first_k_dense_replace", 3)
+    n_experts = cfg.get("n_routed_experts", 160)
+    print(
+        f"Repo: {args.repo}\n"
+        f"  n_layers={args.n_layers}, n_dense_layers={n_dense_layers}, "
+        f"n_experts={n_experts}",
+        flush=True,
+    )
+
+    build_post_sparse_cache(args.repo, args.n_layers, n_dense_layers, n_experts)

--- a/tests/torch/models/glm4_moe/build_weight_cache_glm.py
+++ b/tests/torch/models/glm4_moe/build_weight_cache_glm.py
@@ -231,7 +231,9 @@ if __name__ == "__main__":
     parser.add_argument("--n-layers", type=int, default=92, help="Number of layers")
     args = parser.parse_args()
 
-    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*", args.repo):
+    if not re.fullmatch(
+        r"[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*", args.repo
+    ):
         parser.error(f"Invalid repo ID {args.repo!r}: expected 'org/model' format")
 
     config_path = hf_hub_download(args.repo, "config.json")

--- a/tests/torch/models/glm4_moe/build_weight_cache_glm.py
+++ b/tests/torch/models/glm4_moe/build_weight_cache_glm.py
@@ -37,6 +37,17 @@ from safetensors.torch import save_file as safetensors_save_file
 GLM_REPO = "zai-org/GLM-4.7"
 
 
+def _safe_open_hf(path):
+    """Open a path only if it resolves within the HF cache directory."""
+    real = os.path.realpath(path)
+    base = os.path.realpath(
+        os.environ.get("HF_HOME", os.path.expanduser("~/.cache/huggingface"))
+    )
+    if not real.startswith(base + os.sep):
+        raise ValueError(f"Path outside HF cache: {path}")
+    return open(real)
+
+
 def _post_sparse_cache_dir(repo_id, n_layers):
     repo_slug = repo_id.replace("/", "--")
     base = os.environ.get("HF_HOME", os.path.expanduser("~/.cache/huggingface"))
@@ -176,7 +187,7 @@ def build_post_sparse_cache(repo_id, n_layers, n_dense_layers, n_experts):
     t_total = time.perf_counter()
 
     index_path = hf_hub_download(repo_id, "model.safetensors.index.json")
-    with open(index_path) as f:
+    with _safe_open_hf(index_path) as f:
         index = json.load(f)
     weight_map = index["weight_map"]
 
@@ -237,7 +248,7 @@ if __name__ == "__main__":
         parser.error(f"Invalid repo ID {args.repo!r}: expected 'org/model' format")
 
     config_path = hf_hub_download(args.repo, "config.json")
-    with open(config_path) as f:
+    with _safe_open_hf(config_path) as f:
         cfg = json.load(f)
     n_dense_layers = cfg["first_k_dense_replace"]
     n_experts = cfg["n_routed_experts"]

--- a/tests/torch/models/glm4_moe/build_weight_cache_glm.py
+++ b/tests/torch/models/glm4_moe/build_weight_cache_glm.py
@@ -231,6 +231,9 @@ if __name__ == "__main__":
     parser.add_argument("--n-layers", type=int, default=92, help="Number of layers")
     args = parser.parse_args()
 
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*", args.repo):
+        parser.error(f"Invalid repo ID {args.repo!r}: expected 'org/model' format")
+
     config_path = hf_hub_download(args.repo, "config.json")
     with open(config_path) as f:
         cfg = json.load(f)

--- a/tests/torch/models/glm4_moe/test_glm4_7.py
+++ b/tests/torch/models/glm4_moe/test_glm4_7.py
@@ -1,0 +1,1008 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""GLM-4.7 full sparse-MoE prefill test on Galaxy (4,8) mesh.
+
+Loads real BF16 weights via a post-sparse cache built by
+``build_weight_cache_glm.py``. Runs a single prefill through
+``Glm4MoeForCausalLM`` with ``A2aSparseMLP`` MoE layers, and prints the
+top-k next-token predictions. No CPU reference.
+"""
+import json
+import os
+import re
+import sys
+import time
+
+import numpy as np
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from huggingface_hub import hf_hub_download
+from infra.testers.compiler_config import CompilerConfig
+from safetensors import safe_open
+from safetensors.torch import load_file as safetensors_load_file
+from torch import nn
+from torch_xla.distributed.spmd import Mesh, mark_sharding
+from transformers import AutoTokenizer
+from transformers.cache_utils import StaticCache
+from transformers.models.glm4_moe.configuration_glm4_moe import Glm4MoeConfig
+from transformers.models.glm4_moe.modeling_glm4_moe import (
+    Glm4MoeForCausalLM,
+    Glm4MoeRotaryEmbedding,
+)
+from tt_torch.sparse_mlp import A2aSparseMLP, build_expert_mapping, enable_sparse_mlp
+
+GLM_REPO = "zai-org/GLM-4.7"
+
+
+# TODO(issue): link tracking issue once filed.
+# Stock Glm4MoeTopkRouter.forward (transformers modeling_glm4_moe.py) upcasts
+# both input and weight to float32 before the gate linear. On TT, the fp32
+# linear kernel has accuracy issues large enough to flip top-k routing
+# decisions; wrong expert selections then compound nonlinearly across the
+# MoE stack and produce degenerate output (e.g. " chip chip chip ..." at
+# 92 layers). DeepSeek v3.1 hits the same issue and works around it in
+# tests/torch/models/deepseek_v3_2_exp/modified_model.py:1080 with the
+# comment: "fp32 linear has accuracy issues — keep in bf16 for Gate routing".
+# We apply the same workaround here by keeping the router linear in bf16.
+def _patch_router_bf16():
+    import torch.nn.functional as F  # noqa: F401
+    from transformers.models.glm4_moe.modeling_glm4_moe import Glm4MoeTopkRouter
+
+    def _bf16_forward(self, hidden_states):
+        hidden_states = hidden_states.view(-1, self.config.hidden_size)
+        return F.linear(hidden_states, self.weight)
+
+    Glm4MoeTopkRouter.forward = _bf16_forward
+
+
+# ---------- helpers ----------
+def _post_sparse_cache_dir(repo_id, n_layers):
+    repo_slug = repo_id.replace("/", "--")
+    base = os.environ.get("HF_HOME", os.path.expanduser("~/.cache/huggingface"))
+    return os.path.join(
+        base, "tt_xla_dequant_cache", f"{repo_slug}_{n_layers}layers_post_sparse"
+    )
+
+
+def _has_cache(cache_dir):
+    return os.path.isdir(cache_dir) and any(
+        f.endswith(".safetensors") for f in os.listdir(cache_dir)
+    )
+
+
+def _load_cache_chunked(cache_dir):
+    state_dict = {}
+    for fname in sorted(os.listdir(cache_dir)):
+        if not fname.endswith(".safetensors"):
+            continue
+        state_dict.update(safetensors_load_file(os.path.join(cache_dir, fname)))
+    return state_dict
+
+
+def _restore_router_bias_fp32(model):
+    """HF declares ``e_score_correction_bias`` in ``_keep_in_fp32_modules_strict``
+    because bf16 truncation at its magnitude (~5) gives ~0.04 rounding error,
+    which is enough to flip MoE routing decisions. Our cache stores all tensors
+    as bf16 indiscriminately; cast this buffer back to fp32 after load."""
+    from transformers.models.glm4_moe.modeling_glm4_moe import Glm4MoeTopkRouter
+
+    n_fixed = 0
+    for module in model.modules():
+        if isinstance(module, Glm4MoeTopkRouter):
+            if module.e_score_correction_bias.dtype != torch.float32:
+                module.e_score_correction_bias = module.e_score_correction_bias.to(
+                    torch.float32
+                )
+                n_fixed += 1
+    if n_fixed:
+        print(
+            f"[precision] restored e_score_correction_bias to fp32 in {n_fixed} routers",
+            flush=True,
+        )
+
+
+def _fix_meta_expert_mapping(model):
+    """Rebuild A2aSparseMLP.expert_mapping on CPU (meta path leaves it empty)."""
+    for _, mod in model.named_modules():
+        if isinstance(mod, A2aSparseMLP):
+            mapping = build_expert_mapping(mod.num_experts, mod.num_devices)
+            mod.expert_mapping = mapping
+
+
+def _materialize_rope_buffer(model, config):
+    """Re-initialize Glm4MoeRotaryEmbedding on CPU. Its inv_freq buffer is
+    computed from config during __init__, so a meta-built model has meta
+    inv_freq with no data. Replace the module with a fresh CPU instance."""
+    model.model.rotary_emb = Glm4MoeRotaryEmbedding(config, device="cpu")
+
+
+def _build_and_load_model_post_sparse(config, repo_id, mesh_shape):
+    """Meta-init + enable_sparse_mlp + load post-sparse cache. Fast, TT-only."""
+    cache_dir = _post_sparse_cache_dir(repo_id, config.num_hidden_layers)
+    if not _has_cache(cache_dir):
+        raise RuntimeError(
+            f"Post-sparse cache not found at {cache_dir}. "
+            f"Run: python build_weight_cache_glm.py --n-layers {config.num_hidden_layers}"
+        )
+
+    print(
+        f"[weights] meta-building Glm4MoeForCausalLM (n_layers={config.num_hidden_layers})",
+        flush=True,
+    )
+    t0 = time.perf_counter()
+    with torch.device("meta"):
+        model = Glm4MoeForCausalLM(config)
+    print(f"[timing] meta init: {time.perf_counter() - t0:.1f}s", flush=True)
+
+    t0 = time.perf_counter()
+    enable_sparse_mlp(model, mesh=mesh_shape, cluster_axis=0, config=config)
+    # Free original expert references — cache has stacked form; no CPU forward.
+    for _, mod in model.named_modules():
+        if isinstance(mod, A2aSparseMLP):
+            object.__setattr__(mod, "_original_mlp", None)
+        if hasattr(mod, "original_experts"):
+            mod.original_experts = nn.ModuleList()
+    print(f"[timing] enable_sparse_mlp: {time.perf_counter() - t0:.1f}s", flush=True)
+
+    t0 = time.perf_counter()
+    print(f"[weights] loading post-sparse cache from {cache_dir}", flush=True)
+    state_dict = _load_cache_chunked(cache_dir)
+    missing, unexpected = model.load_state_dict(state_dict, strict=False, assign=True)
+    print(f"[timing] cache load: {time.perf_counter() - t0:.1f}s", flush=True)
+    print(
+        f"[weights] loaded {len(state_dict)} tensors; "
+        f"missing={len(missing)}, unexpected={len(unexpected)}",
+        flush=True,
+    )
+    if missing:
+        print(f"[weights] missing (first 5): {missing[:5]}", flush=True)
+    if unexpected:
+        print(f"[weights] unexpected (first 5): {unexpected[:5]}", flush=True)
+
+    _fix_meta_expert_mapping(model)
+    _materialize_rope_buffer(model, config)
+    _restore_router_bias_fp32(model)
+    model.eval()
+    return model
+
+
+def _load_cpu_state_dict_shard_on_demand(config, repo_id):
+    """Read only the HF shards needed for the given n_layers. Returns CPU state_dict.
+
+    Applies the ``qwen2_moe`` per-expert -> fused conversion that transformers
+    runs automatically in ``from_pretrained`` (GLM-4.7 is aliased to
+    ``qwen2_moe`` in conversion_mapping.py). MoE layer weights on disk live at
+    ``experts.{j}.{gate,up,down}_proj.weight`` but the ``Glm4MoeNaiveMoe``
+    module expects fused ``experts.gate_up_proj [E, 2*inter, H]`` and
+    ``experts.down_proj [E, H, inter]``.
+
+    Filters out keys for layers beyond n_layers and any mtp/next-n keys.
+    """
+    index_path = hf_hub_download(repo_id, "model.safetensors.index.json")
+    with open(index_path) as f:
+        weight_map = json.load(f)["weight_map"]
+
+    n_layers = config.num_hidden_layers
+    n_dense = config.first_k_dense_replace
+    n_experts = config.n_routed_experts
+
+    expert_re = re.compile(
+        r"^model\.layers\.(\d+)\.mlp\.experts\.(\d+)\.(gate_proj|up_proj|down_proj)\.weight$"
+    )
+
+    # Bucket keys by shard for efficient reads.
+    wanted = {}
+    for ckpt_key, shard in weight_map.items():
+        m = re.match(r"model\.layers\.(\d+)\.", ckpt_key)
+        if m and int(m.group(1)) >= n_layers:
+            continue
+        if ckpt_key.startswith("mtp.") or ".mtp." in ckpt_key:
+            continue
+        wanted.setdefault(shard, []).append(ckpt_key)
+
+    # Accumulators for per-expert stacking:
+    # (layer_idx, expert_idx, name) -> tensor
+    expert_tensors = {}
+    state_dict = {}
+
+    for shard, keys in wanted.items():
+        path = hf_hub_download(repo_id, shard)
+        with safe_open(path, framework="pt", device="cpu") as f:
+            for k in keys:
+                t = f.get_tensor(k).to(torch.bfloat16)
+                m = expert_re.match(k)
+                if m:
+                    layer_idx = int(m.group(1))
+                    if layer_idx < n_dense:
+                        raise RuntimeError(
+                            f"Unexpected per-expert key on dense layer: {k}"
+                        )
+                    expert_tensors[(layer_idx, int(m.group(2)), m.group(3))] = t
+                else:
+                    state_dict[k] = t
+
+    # Fuse per-expert -> gate_up_proj + down_proj per MoE layer.
+    moe_layers = sorted({lk[0] for lk in expert_tensors.keys()})
+    for layer_idx in moe_layers:
+        gate_stack = torch.stack(
+            [expert_tensors[(layer_idx, j, "gate_proj")] for j in range(n_experts)],
+            dim=0,
+        )  # [E, inter, H]
+        up_stack = torch.stack(
+            [expert_tensors[(layer_idx, j, "up_proj")] for j in range(n_experts)],
+            dim=0,
+        )  # [E, inter, H]
+        down_stack = torch.stack(
+            [expert_tensors[(layer_idx, j, "down_proj")] for j in range(n_experts)],
+            dim=0,
+        )  # [E, H, inter]
+        # Concatenate gate + up on dim 1 (out-features axis).
+        gate_up = torch.cat(
+            [gate_stack, up_stack], dim=1
+        ).contiguous()  # [E, 2*inter, H]
+        del gate_stack, up_stack
+
+        state_dict[f"model.layers.{layer_idx}.mlp.experts.gate_up_proj"] = gate_up
+        state_dict[f"model.layers.{layer_idx}.mlp.experts.down_proj"] = (
+            down_stack.contiguous()
+        )
+
+        # Drop source tensors for this layer to keep peak memory in check.
+        for j in range(n_experts):
+            for name in ("gate_proj", "up_proj", "down_proj"):
+                expert_tensors.pop((layer_idx, j, name), None)
+
+    return state_dict
+
+
+def _build_and_load_model_for_cpu(config, repo_id, mesh_shape):
+    """Meta-init + shard-on-demand HF load + enable_sparse_mlp with originals alive."""
+    print(
+        f"[weights] shard-on-demand HF load (n_layers={config.num_hidden_layers})",
+        flush=True,
+    )
+    t0 = time.perf_counter()
+    with torch.device("meta"):
+        model = Glm4MoeForCausalLM(config)
+    print(f"[timing] meta init: {time.perf_counter() - t0:.1f}s", flush=True)
+
+    t0 = time.perf_counter()
+    state_dict = _load_cpu_state_dict_shard_on_demand(config, repo_id)
+    print(
+        f"[timing] HF shard load: {time.perf_counter() - t0:.1f}s "
+        f"({len(state_dict)} tensors)",
+        flush=True,
+    )
+
+    t0 = time.perf_counter()
+    missing, unexpected = model.load_state_dict(state_dict, strict=False, assign=True)
+    # Free the state_dict dict now that params reference the tensors directly.
+    del state_dict
+    print(
+        f"[timing] load_state_dict: {time.perf_counter() - t0:.1f}s "
+        f"(missing={len(missing)}, unexpected={len(unexpected)})",
+        flush=True,
+    )
+    if missing:
+        print(f"[weights] missing (first 5): {missing[:5]}", flush=True)
+    if unexpected:
+        print(f"[weights] unexpected (first 5): {unexpected[:5]}", flush=True)
+
+    _materialize_rope_buffer(model, config)
+    _restore_router_bias_fp32(model)
+
+    t0 = time.perf_counter()
+    enable_sparse_mlp(model, mesh=mesh_shape, cluster_axis=0, config=config)
+    # enable_sparse_mlp stacks experts: creates NEW stacked tensors AND keeps
+    # original per-expert tensors alive via _original_mlp / original_experts so
+    # CPU forward works. Peak memory doubles transiently.
+    print(f"[timing] enable_sparse_mlp: {time.perf_counter() - t0:.1f}s", flush=True)
+
+    model.eval()
+    return model
+
+
+def _release_cpu_originals(model):
+    """After CPU forward, drop the per-expert original tensors so they don't
+    get transferred to TT. A2aSparseMLP keeps them alive via
+    ``_original_mlp`` and ``original_experts``."""
+    for _, mod in model.named_modules():
+        if isinstance(mod, A2aSparseMLP):
+            object.__setattr__(mod, "_original_mlp", None)
+        if hasattr(mod, "original_experts"):
+            mod.original_experts = nn.ModuleList()
+    import gc
+
+    gc.collect()
+
+
+def _build_and_load_model(config, repo_id, mesh_shape, prefer_cpu_capable=False):
+    if prefer_cpu_capable:
+        return _build_and_load_model_for_cpu(config, repo_id, mesh_shape)
+    return _build_and_load_model_post_sparse(config, repo_id, mesh_shape)
+
+
+def _pcc(a, b):
+    x = a.to(torch.float64).flatten().numpy()
+    y = b.to(torch.float64).flatten().numpy()
+    vx = x - x.mean()
+    vy = y - y.mean()
+    denom = float(np.linalg.norm(vx) * np.linalg.norm(vy))
+    return float("nan") if denom == 0 else float(np.dot(vx, vy) / denom)
+
+
+def _build_full_attention_mask(token_attn_mask, max_cache_len, batch_size):
+    """2D attention mask of shape (B, max_cache_len), matching examples/pytorch/llama.py.
+
+    ``token_attn_mask`` is the tokenizer's [B, prompt_len] mask (1=real, 0=pad).
+    The returned mask has the prompt's mask in the first prompt_len slots and
+    1s in the remaining slots (future decode positions are valid). HF's
+    ``create_causal_mask`` converts this to a proper 4D causal+pad-aware
+    mask internally — no NaN risk. The same mask object is reused across
+    prefill and every decode step (no per-step rebuild).
+
+    Sized to ``max_cache_len`` to prevent transformers from implicitly padding
+    or recompiling, per the comment in the Llama example.
+    """
+    prompt_len = token_attn_mask.shape[1]
+    full = torch.ones((batch_size, max_cache_len), dtype=token_attn_mask.dtype)
+    full[:, :prompt_len] = token_attn_mask
+    return full
+
+
+def _apply_shard_specs(
+    model, mesh, input_ids, position_ids, cache_position, static_cache, config
+):
+    """Mark sharding on inputs, kv cache, and every parameter."""
+    num_dense = config.first_k_dense_replace
+
+    # Inputs
+    mark_sharding(input_ids, mesh, ("_axis_1", None))
+    mark_sharding(position_ids, mesh, (None, None))
+    mark_sharding(cache_position, mesh, (None,))
+
+    # KV cache per layer
+    for layer_cache in static_cache.layers:
+        mark_sharding(layer_cache.keys, mesh, ("_axis_1", None, None, None))
+        mark_sharding(layer_cache.values, mesh, ("_axis_1", None, None, None))
+
+    base = model.model  # Glm4MoeModel
+    mark_sharding(base.embed_tokens.weight, mesh, (None, "_axis_0"))
+    mark_sharding(base.norm.weight, mesh, ("_axis_0",))
+    mark_sharding(model.lm_head.weight, mesh, (None, "_axis_0"))
+
+    for i, decoder_layer in enumerate(base.layers):
+        attn = decoder_layer.self_attn
+        mark_sharding(attn.q_proj.weight, mesh, ("_axis_0", None))
+        mark_sharding(attn.k_proj.weight, mesh, ("_axis_0", None))
+        mark_sharding(attn.v_proj.weight, mesh, ("_axis_0", None))
+        mark_sharding(attn.o_proj.weight, mesh, (None, "_axis_0"))
+        if attn.q_proj.bias is not None:
+            mark_sharding(attn.q_proj.bias, mesh, ("_axis_0",))
+            mark_sharding(attn.k_proj.bias, mesh, ("_axis_0",))
+            mark_sharding(attn.v_proj.bias, mesh, ("_axis_0",))
+        # GLM-4.7 has use_qk_norm=True
+        if hasattr(attn, "q_norm"):
+            mark_sharding(attn.q_norm.weight, mesh, ("_axis_0",))
+            mark_sharding(attn.k_norm.weight, mesh, ("_axis_0",))
+
+        mark_sharding(decoder_layer.input_layernorm.weight, mesh, ("_axis_0",))
+        mark_sharding(decoder_layer.post_attention_layernorm.weight, mesh, ("_axis_0",))
+
+        mlp_wrapper = decoder_layer.mlp
+        if i < num_dense:
+            # Dense Glm4MoeMLP: weight is [out, in] in nn.Linear convention
+            mark_sharding(mlp_wrapper.gate_proj.weight, mesh, ("_axis_1", "_axis_0"))
+            mark_sharding(mlp_wrapper.up_proj.weight, mesh, ("_axis_1", "_axis_0"))
+            mark_sharding(mlp_wrapper.down_proj.weight, mesh, ("_axis_0", "_axis_1"))
+        else:
+            inner = mlp_wrapper.mlp  # A2aSparseMLP
+            mark_sharding(inner.router.gate.weight, mesh, (None, "_axis_0"))
+            mark_sharding(
+                inner.experts.gate_proj,
+                mesh,
+                (("_axis_0", "_axis_1"), None, None),
+            )
+            mark_sharding(
+                inner.experts.up_proj,
+                mesh,
+                (("_axis_0", "_axis_1"), None, None),
+            )
+            mark_sharding(
+                inner.experts.down_proj,
+                mesh,
+                (("_axis_0", "_axis_1"), None, None),
+            )
+            if inner.experts.gate_proj_bias is not None:
+                mark_sharding(
+                    inner.experts.gate_proj_bias,
+                    mesh,
+                    (("_axis_0", "_axis_1"), None),
+                )
+            if inner.experts.up_proj_bias is not None:
+                mark_sharding(
+                    inner.experts.up_proj_bias,
+                    mesh,
+                    (("_axis_0", "_axis_1"), None),
+                )
+            if inner.experts.down_proj_bias is not None:
+                mark_sharding(
+                    inner.experts.down_proj_bias,
+                    mesh,
+                    (("_axis_0", "_axis_1"), None),
+                )
+            shared = getattr(mlp_wrapper, "shared_experts", None)
+            if shared is not None:
+                mark_sharding(shared.gate_proj.weight, mesh, (None, "_axis_0"))
+                mark_sharding(shared.up_proj.weight, mesh, (None, "_axis_0"))
+                mark_sharding(shared.down_proj.weight, mesh, ("_axis_0", None))
+
+
+class _LogitsOnly(nn.Module):
+    """Wrap Glm4MoeForCausalLM so torch.compile sees a pure tensor output.
+
+    Accepts a 4D additive attention_mask (B, 1, S, max_cache_len) to bypass
+    HF's internal mask construction — HF's eager attention adds this directly
+    to the attention scores, so left-pad masking works without HF
+    round-tripping a 2D tokenizer mask.
+    """
+
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(
+        self, input_ids, position_ids, past_key_values, cache_position, attention_mask
+    ):
+        out = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            cache_position=cache_position,
+            use_cache=True,
+        )
+        return out.logits
+
+
+# ---------- test ----------
+@pytest.mark.llmbox
+@pytest.mark.nightly
+def test_glm4_7_full_sparse_moe():
+    t_start = time.perf_counter()
+
+    os.environ["CONVERT_SHLO_TO_SHARDY"] = "1"
+    xr.set_device_type("TT")
+    torch_xla.runtime.use_spmd()
+    _patch_router_bf16()
+
+    batch_size = 32
+    seq_len = 32
+    n_layers = int(os.environ.get("GLM_N_LAYERS", 4))
+    mesh_shape = (4, 8)
+    run_cpu_reference = os.environ.get("GLM_CPU_REFERENCE", "0") == "1"
+
+    # ----- Config -----
+    config = Glm4MoeConfig.from_pretrained(GLM_REPO)
+    config.num_hidden_layers = n_layers
+    config.use_cache = True
+    config._attn_implementation = "eager"
+    # Don't build MTP/next-n head — not needed for prefill.
+    if hasattr(config, "num_nextn_predict_layers"):
+        config.num_nextn_predict_layers = 0
+    print(
+        f"[config] n_layers={n_layers}, n_dense={config.first_k_dense_replace}, "
+        f"n_experts={config.n_routed_experts}, top_k={config.num_experts_per_tok}, "
+        f"cpu_reference={run_cpu_reference}",
+        flush=True,
+    )
+
+    # ----- Model + weights -----
+    model = _build_and_load_model(
+        config, GLM_REPO, mesh_shape, prefer_cpu_capable=run_cpu_reference
+    )
+
+    # ----- Tokenizer / inputs -----
+    tokenizer = AutoTokenizer.from_pretrained(
+        GLM_REPO, trust_remote_code=True, padding_side="left"
+    )
+    prompt_text = (
+        "Tenstorrent is a company that builds AI accelerators. "
+        "Their chips are designed to"
+    )
+    encoded = tokenizer(
+        prompt_text,
+        return_tensors="pt",
+        max_length=seq_len,
+        truncation=True,
+        padding="max_length",
+    )
+    tokens_single = encoded["input_ids"][:, :seq_len]
+    tokens_cpu = tokens_single.repeat(batch_size, 1)
+    token_attn_mask_cpu = encoded["attention_mask"][:, :seq_len].repeat(batch_size, 1)
+    print(
+        f"[input] prompt: {tokenizer.decode(tokens_single[0].tolist())!r}", flush=True
+    )
+    print(
+        f"[input] real tokens: {int(token_attn_mask_cpu[0].sum())}/{seq_len}",
+        flush=True,
+    )
+
+    # HF default: position_ids = cache_position.unsqueeze(0). RoPE is purely
+    # relative, so absolute offset doesn't affect attention scores.
+    cache_position = torch.arange(seq_len)
+    position_ids = cache_position.unsqueeze(0).expand(batch_size, -1).contiguous()
+
+    # StaticCache — sized exactly to the prefill (no decode in this test).
+    max_cache_len = seq_len
+
+    def _make_static_cache():
+        cache = StaticCache(
+            config=config,
+            max_batch_size=batch_size,
+            max_cache_len=max_cache_len,
+            device="cpu",
+            dtype=torch.bfloat16,
+        )
+        cache.early_initialization(
+            batch_size=batch_size,
+            num_heads=config.num_key_value_heads,
+            head_dim=config.head_dim,
+            dtype=torch.bfloat16,
+            device="cpu",
+        )
+        return cache
+
+    full_attn_mask = _build_full_attention_mask(
+        token_attn_mask_cpu, max_cache_len, batch_size
+    )
+
+    # ===== CPU reference (opt-in via GLM_CPU_REFERENCE=1) =====
+    cpu_logits = None
+    if run_cpu_reference:
+        print("[cpu] running prefill eagerly...", flush=True)
+        t_cpu_start = time.perf_counter()
+        cpu_cache = _make_static_cache()
+        with torch.no_grad():
+            cpu_out = model(
+                input_ids=tokens_cpu,
+                attention_mask=full_attn_mask,
+                position_ids=position_ids,
+                past_key_values=cpu_cache,
+                cache_position=cache_position,
+                use_cache=True,
+            )
+        # Detach + clone so cpu_logits doesn't keep cpu_out's graph alive.
+        cpu_logits = cpu_out.logits.detach().clone()
+        del cpu_out, cpu_cache
+        print(
+            f"[timing] CPU prefill: {time.perf_counter() - t_cpu_start:.1f}s",
+            flush=True,
+        )
+        cpu_top5 = cpu_logits[0, -1].topk(5)
+        cpu_tokens = [tokenizer.decode([t]) for t in cpu_top5.indices.tolist()]
+        print(f"[CPU top-5] tokens={cpu_tokens}", flush=True)
+        print(f"[CPU top-5] logits={cpu_top5.values.tolist()}", flush=True)
+
+        # Drop the per-expert originals so only stacked weights transfer to TT.
+        _release_cpu_originals(model)
+    else:
+        print("[cpu] SKIPPED — set GLM_CPU_REFERENCE=1 to run CPU golden", flush=True)
+
+    # ----- TT path -----
+    torch._dynamo.reset()
+
+    num_devices = xr.global_runtime_device_count()
+    device_ids = np.array(range(num_devices))
+    mesh = Mesh(device_ids, mesh_shape, ("_axis_0", "_axis_1"))
+    device = torch_xla.device()
+
+    # Use "none" (or empty) to skip experimental_weight_dtype and run full bf16.
+    weight_dtype = os.environ.get("GLM_WEIGHT_DTYPE", "bfp_bf8")
+    print(f"[compile] experimental_weight_dtype={weight_dtype}", flush=True)
+    if weight_dtype and weight_dtype.lower() != "none":
+        torch_xla.set_custom_compile_options(
+            CompilerConfig(
+                experimental_weight_dtype=weight_dtype
+            ).to_torch_compile_options()
+        )
+
+    # Move to device — use to_empty + load_state_dict for meta path; to() for CPU path.
+    t0 = time.perf_counter()
+    model = model.to(device)
+    tokens_device = tokens_cpu.to(device)
+    position_ids_device = position_ids.to(device)
+    cache_position_device = cache_position.to(device)
+    full_attn_mask_device = full_attn_mask.to(device)
+    tt_cache = _make_static_cache()
+    for layer_cache in tt_cache.layers:
+        layer_cache.keys = layer_cache.keys.to(device)
+        layer_cache.values = layer_cache.values.to(device)
+    print(f"[timing] move to device: {time.perf_counter() - t0:.1f}s", flush=True)
+
+    _apply_shard_specs(
+        model,
+        mesh,
+        tokens_device,
+        position_ids_device,
+        cache_position_device,
+        tt_cache,
+        config,
+    )
+    mark_sharding(full_attn_mask_device, mesh, ("_axis_1", None))
+
+    wrapped = _LogitsOnly(model)
+    compiled_model = torch.compile(wrapped, backend="tt")
+
+    print("[tt] running prefill (compile + run)...", flush=True)
+    t0 = time.perf_counter()
+    with torch.no_grad():
+        logits = compiled_model(
+            tokens_device,
+            position_ids_device,
+            tt_cache,
+            cache_position_device,
+            full_attn_mask_device,
+        )
+    logits_tt_cpu = logits.to("cpu").detach()
+    print(f"[timing] TT prefill: {time.perf_counter() - t0:.1f}s", flush=True)
+
+    # Top-5 next-token predictions from the last prefill position.
+    top5 = logits_tt_cpu[0, -1].topk(5)
+    tokens = [tokenizer.decode([t]) for t in top5.indices.tolist()]
+    print(f"[TT top-5] tokens={tokens}", flush=True)
+    print(f"[TT top-5] logits={top5.values.tolist()}", flush=True)
+
+    if cpu_logits is not None:
+        pcc = _pcc(logits_tt_cpu, cpu_logits)
+        print(f"[pcc] logits PCC (TT vs CPU) = {pcc:.4f} (required: 0.99)", flush=True)
+        assert pcc >= 0.99, f"PCC {pcc:.4f} below required 0.99"
+
+    print(f"[timing] total: {time.perf_counter() - t_start:.1f}s", flush=True)
+
+
+# ---------- decode test ----------
+@pytest.mark.llmbox
+@pytest.mark.nightly
+def test_glm4_7_decode_static_cache():
+    """Autoregressive greedy decode on TT using StaticCache.
+
+    Two torch.compile traces: prefill (seq=prompt_len) and decode (seq=1).
+    With GLM_CPU_REFERENCE=1, also runs CPU eager reference and compares
+    per-step logits PCC.
+    """
+    t_start = time.perf_counter()
+
+    os.environ["CONVERT_SHLO_TO_SHARDY"] = "1"
+    xr.set_device_type("TT")
+    torch_xla.runtime.use_spmd()
+    _patch_router_bf16()
+
+    batch_size = 32
+    prompt_seq_len = 32
+    n_decode = 10
+    n_layers = int(os.environ.get("GLM_N_LAYERS", 4))
+    mesh_shape = (4, 8)
+    run_cpu_reference = os.environ.get("GLM_CPU_REFERENCE", "0") == "1"
+
+    # ----- Config -----
+    config = Glm4MoeConfig.from_pretrained(GLM_REPO)
+    config.num_hidden_layers = n_layers
+    config.use_cache = True
+    config._attn_implementation = "eager"
+    if hasattr(config, "num_nextn_predict_layers"):
+        config.num_nextn_predict_layers = 0
+    print(
+        f"[config] n_layers={n_layers}, n_dense={config.first_k_dense_replace}, "
+        f"n_experts={config.n_routed_experts}, cpu_reference={run_cpu_reference}",
+        flush=True,
+    )
+
+    # ----- Model + weights -----
+    model = _build_and_load_model(
+        config, GLM_REPO, mesh_shape, prefer_cpu_capable=run_cpu_reference
+    )
+
+    # ----- Tokenizer / inputs -----
+    tokenizer = AutoTokenizer.from_pretrained(
+        GLM_REPO, trust_remote_code=True, padding_side="left"
+    )
+    prompt_text = (
+        "Tenstorrent is a company that builds AI accelerators. "
+        "Their chips are designed to"
+    )
+    use_chat_template = os.environ.get("GLM_USE_CHAT_TEMPLATE", "0") == "1"
+    if use_chat_template:
+        # GLM-4.7 is instruction + thinking-mode tuned. Raw prompts are OOD.
+        # apply_chat_template produces [gMASK]<sop><|user|>...<|assistant|><think>.
+        # apply_chat_template return type varies by transformers version; render
+        # to a string then tokenize ourselves to be robust.
+        rendered = tokenizer.apply_chat_template(
+            [{"role": "user", "content": prompt_text}],
+            add_generation_prompt=True,
+            tokenize=False,
+        )
+        chat_enc = tokenizer(rendered, return_tensors="pt", add_special_tokens=False)
+        chat_ids = chat_enc["input_ids"]  # (1, L)
+        L = chat_ids.shape[1]
+        if L > prompt_seq_len:
+            raise ValueError(
+                f"chat template yielded {L} tokens, exceeds prompt_seq_len={prompt_seq_len}"
+            )
+        # Left-pad with pad_token to prompt_seq_len.
+        pad_id = tokenizer.pad_token_id
+        tokens_single = torch.full((1, prompt_seq_len), pad_id, dtype=chat_ids.dtype)
+        tokens_single[:, prompt_seq_len - L :] = chat_ids
+        attn_single = torch.zeros((1, prompt_seq_len), dtype=torch.long)
+        attn_single[:, prompt_seq_len - L :] = 1
+        print(
+            f"[tokenize] chat template ({L} tokens): "
+            f"{tokenizer.decode(chat_ids[0].tolist())!r}",
+            flush=True,
+        )
+    else:
+        encoded = tokenizer(
+            prompt_text,
+            return_tensors="pt",
+            max_length=prompt_seq_len,
+            truncation=True,
+            padding="max_length",
+        )
+        tokens_single = encoded["input_ids"][:, :prompt_seq_len]
+        attn_single = encoded["attention_mask"][:, :prompt_seq_len]
+    tokens_cpu = tokens_single.repeat(batch_size, 1)
+    token_attn_mask_cpu = attn_single.repeat(batch_size, 1)
+    prompt_real_len = int(token_attn_mask_cpu[0].sum())
+    print(
+        f"[input] prompt: {tokenizer.decode(tokens_single[0].tolist())!r}", flush=True
+    )
+    print(
+        f"[input] real tokens: {prompt_real_len}/{prompt_seq_len}",
+        flush=True,
+    )
+
+    max_cache_len = prompt_seq_len + n_decode
+
+    def _make_static_cache():
+        cache = StaticCache(
+            config=config,
+            max_batch_size=batch_size,
+            max_cache_len=max_cache_len,
+            device="cpu",
+            dtype=torch.bfloat16,
+        )
+        cache.early_initialization(
+            batch_size=batch_size,
+            num_heads=config.num_key_value_heads,
+            head_dim=config.head_dim,
+            dtype=torch.bfloat16,
+            device="cpu",
+        )
+        return cache
+
+    # HF default: position_ids = cache_position.unsqueeze(0). RoPE is purely
+    # relative, so absolute offset doesn't affect attention scores.
+    prefill_cache_position = torch.arange(prompt_seq_len)
+    prefill_position_ids = (
+        prefill_cache_position.unsqueeze(0).expand(batch_size, -1).contiguous()
+    )
+    # Single 2D attention_mask sized to max_cache_len, reused across prefill
+    # and every decode step. HF's create_causal_mask handles the conversion.
+    full_attn_mask = _build_full_attention_mask(
+        token_attn_mask_cpu, max_cache_len, batch_size
+    )
+
+    # ===== CPU reference =====
+    cpu_logits_list = []
+    cpu_token_ids = []
+    if run_cpu_reference:
+        print("[cpu] running prefill + decode eagerly...", flush=True)
+        t_cpu_start = time.perf_counter()
+        cpu_cache = _make_static_cache()
+        with torch.no_grad():
+            # Prefill
+            cpu_out = model(
+                input_ids=tokens_cpu,
+                attention_mask=full_attn_mask,
+                position_ids=prefill_position_ids,
+                past_key_values=cpu_cache,
+                cache_position=prefill_cache_position,
+                use_cache=True,
+            )
+            # Keep last-position logits only (batch 0).
+            last_logits = cpu_out.logits[:, -1].detach().clone()
+            cpu_logits_list.append(last_logits[0])
+            next_id = int(last_logits[0].argmax(dim=-1).item())
+            cpu_token_ids.append(next_id)
+            del cpu_out, last_logits
+
+            # Decode — real token positions continue from prompt_real_len.
+            # Same full_attn_mask is reused; only input_ids/position_ids/cache_position change.
+            for step in range(n_decode - 1):
+                cache_slot = prompt_seq_len + step
+                real_pos = cache_slot
+                next_tokens = torch.full(
+                    (batch_size, 1), next_id, dtype=tokens_cpu.dtype
+                )
+                pos_ids = torch.tensor([[real_pos]], dtype=torch.long).repeat(
+                    batch_size, 1
+                )
+                cache_pos = torch.tensor([cache_slot], dtype=torch.long)
+                cpu_out = model(
+                    input_ids=next_tokens,
+                    attention_mask=full_attn_mask,
+                    position_ids=pos_ids,
+                    past_key_values=cpu_cache,
+                    cache_position=cache_pos,
+                    use_cache=True,
+                )
+                last_logits = cpu_out.logits[:, -1].detach().clone()
+                cpu_logits_list.append(last_logits[0])
+                next_id = int(last_logits[0].argmax(dim=-1).item())
+                cpu_token_ids.append(next_id)
+                del cpu_out, last_logits
+        del cpu_cache
+        print(
+            f"[timing] CPU prefill+decode: {time.perf_counter() - t_cpu_start:.1f}s",
+            flush=True,
+        )
+        print(
+            f"[CPU tokens] {[tokenizer.decode([t]) for t in cpu_token_ids]}",
+            flush=True,
+        )
+        print(
+            f"[CPU full]   "
+            f"{tokenizer.decode(tokens_single[0].tolist() + cpu_token_ids)!r}",
+            flush=True,
+        )
+        # Drop CPU originals before TT path.
+        _release_cpu_originals(model)
+    else:
+        print("[cpu] SKIPPED — set GLM_CPU_REFERENCE=1 to run CPU golden", flush=True)
+
+    # ===== TT path =====
+    torch._dynamo.reset()
+
+    num_devices = xr.global_runtime_device_count()
+    device_ids = np.array(range(num_devices))
+    mesh = Mesh(device_ids, mesh_shape, ("_axis_0", "_axis_1"))
+    device = torch_xla.device()
+
+    weight_dtype = os.environ.get("GLM_WEIGHT_DTYPE", "bfp_bf8")
+    print(f"[compile] experimental_weight_dtype={weight_dtype}", flush=True)
+    if weight_dtype and weight_dtype.lower() != "none":
+        torch_xla.set_custom_compile_options(
+            CompilerConfig(
+                experimental_weight_dtype=weight_dtype
+            ).to_torch_compile_options()
+        )
+
+    # Move model + tokens + fresh KV cache to device
+    t0 = time.perf_counter()
+    model = model.to(device)
+    tokens_device = tokens_cpu.to(device)
+    prefill_position_ids_device = prefill_position_ids.to(device)
+    prefill_cache_position_device = prefill_cache_position.to(device)
+    full_attn_mask_device = full_attn_mask.to(device)
+    tt_cache = _make_static_cache()
+    for layer_cache in tt_cache.layers:
+        layer_cache.keys = layer_cache.keys.to(device)
+        layer_cache.values = layer_cache.values.to(device)
+    print(f"[timing] move to device: {time.perf_counter() - t0:.1f}s", flush=True)
+
+    _apply_shard_specs(
+        model,
+        mesh,
+        tokens_device,
+        prefill_position_ids_device,
+        prefill_cache_position_device,
+        tt_cache,
+        config,
+    )
+    mark_sharding(full_attn_mask_device, mesh, ("_axis_1", None))
+
+    wrapped = _LogitsOnly(model)
+    compiled_model = torch.compile(wrapped, backend="tt")
+
+    tt_logits_list = []
+    tt_token_ids = []
+
+    # ----- TT prefill -----
+    print("[tt] running prefill (compile #1)...", flush=True)
+    t0 = time.perf_counter()
+    with torch.no_grad():
+        logits = compiled_model(
+            tokens_device,
+            prefill_position_ids_device,
+            tt_cache,
+            prefill_cache_position_device,
+            full_attn_mask_device,
+        )
+    prefill_last = logits[:, -1].to("cpu").detach()
+    print(f"[timing] TT prefill: {time.perf_counter() - t0:.1f}s", flush=True)
+    tt_logits_list.append(prefill_last[0])
+    next_id = int(prefill_last[0].argmax(dim=-1).item())
+    tt_token_ids.append(next_id)
+    print(f"[tt] prefill top-1: {tokenizer.decode([next_id])!r}", flush=True)
+
+    # ----- TT decode loop -----
+    # Same full_attn_mask_device is reused (shape stable, no per-step rebuild).
+    for step in range(n_decode - 1):
+        cache_slot = prompt_seq_len + step
+        real_pos = cache_slot
+        next_tokens_cpu = torch.full((batch_size, 1), next_id, dtype=tokens_cpu.dtype)
+        next_tokens_device = next_tokens_cpu.to(device)
+        pos_ids_device = (
+            torch.tensor([[real_pos]], dtype=torch.long)
+            .repeat(batch_size, 1)
+            .to(device)
+        )
+        cache_pos_device = torch.tensor([cache_slot], dtype=torch.long).to(device)
+
+        mark_sharding(next_tokens_device, mesh, ("_axis_1", None))
+        mark_sharding(pos_ids_device, mesh, (None, None))
+        mark_sharding(cache_pos_device, mesh, (None,))
+
+        t_step = time.perf_counter()
+        with torch.no_grad():
+            logits = compiled_model(
+                next_tokens_device,
+                pos_ids_device,
+                tt_cache,
+                cache_pos_device,
+                full_attn_mask_device,
+            )
+        step_last = logits[:, -1].to("cpu").detach()
+        next_id = int(step_last[0].argmax(dim=-1).item())
+        tt_logits_list.append(step_last[0])
+        tt_token_ids.append(next_id)
+        tok_str = tokenizer.decode([next_id])
+        top5 = step_last[0].topk(5)
+        top5_toks = [tokenizer.decode([t]) for t in top5.indices.tolist()]
+        print(
+            f"[tt] decode step {step + 1}/{n_decode - 1}: "
+            f"time={time.perf_counter() - t_step:.2f}s tok={tok_str!r} "
+            f"top5={list(zip(top5_toks, [round(v, 2) for v in top5.values.tolist()]))}",
+            flush=True,
+        )
+
+    print(
+        f"[TT tokens] {[tokenizer.decode([t]) for t in tt_token_ids]}",
+        flush=True,
+    )
+    print(
+        f"[TT full]   "
+        f"{tokenizer.decode(tokens_single[0].tolist() + tt_token_ids)!r}",
+        flush=True,
+    )
+
+    # Per-step PCC comparison
+    if cpu_logits_list:
+        print("", flush=True)
+        print("[pcc] per-step logits PCC (TT vs CPU):", flush=True)
+        pccs = []
+        matches = 0
+        for i, (tt_l, cpu_l) in enumerate(zip(tt_logits_list, cpu_logits_list)):
+            p = _pcc(tt_l, cpu_l)
+            pccs.append(p)
+            tt_tok = int(tt_l.argmax().item())
+            cpu_tok = int(cpu_l.argmax().item())
+            match = tt_tok == cpu_tok
+            matches += int(match)
+            tag = "OK" if match else "MISMATCH"
+            print(
+                f"  step {i}: pcc={p:.4f}  tt_tok={tt_tok:>10} "
+                f"cpu_tok={cpu_tok:>10}  [{tag}]",
+                flush=True,
+            )
+        print(
+            f"[pcc] min={min(pccs):.4f}, max={max(pccs):.4f}, "
+            f"avg={sum(pccs) / len(pccs):.4f}",
+            flush=True,
+        )
+        print(f"[tokens] TT==CPU match: {matches}/{len(tt_logits_list)}", flush=True)
+
+    print(f"[timing] total: {time.perf_counter() - t_start:.1f}s", flush=True)

--- a/tests/torch/models/glm4_moe/test_glm4_7.py
+++ b/tests/torch/models/glm4_moe/test_glm4_7.py
@@ -21,7 +21,6 @@ import torch_xla
 import torch_xla.runtime as xr
 from huggingface_hub import hf_hub_download
 from infra.testers.compiler_config import CompilerConfig
-from safetensors import safe_open
 from safetensors.torch import load_file as safetensors_load_file
 from torch import nn
 from torch_xla.distributed.spmd import Mesh, mark_sharding
@@ -33,6 +32,16 @@ from transformers.models.glm4_moe.modeling_glm4_moe import (
     Glm4MoeRotaryEmbedding,
 )
 from tt_torch.sparse_mlp import A2aSparseMLP, build_expert_mapping, enable_sparse_mlp
+
+# Import shard-streaming + cache helpers from the builder script (single source of truth)
+sys.path.insert(0, os.path.dirname(__file__))
+from build_weight_cache_glm import (
+    _group_by_shard,
+    _has_cache,
+    _load_tensors,
+    _post_sparse_cache_dir,
+    build_post_sparse_cache,
+)
 
 GLM_REPO = "zai-org/GLM-4.7"
 
@@ -59,20 +68,6 @@ def _patch_router_bf16():
 
 
 # ---------- helpers ----------
-def _post_sparse_cache_dir(repo_id, n_layers):
-    repo_slug = repo_id.replace("/", "--")
-    base = os.environ.get("HF_HOME", os.path.expanduser("~/.cache/huggingface"))
-    return os.path.join(
-        base, "tt_xla_dequant_cache", f"{repo_slug}_{n_layers}layers_post_sparse"
-    )
-
-
-def _has_cache(cache_dir):
-    return os.path.isdir(cache_dir) and any(
-        f.endswith(".safetensors") for f in os.listdir(cache_dir)
-    )
-
-
 def _load_cache_chunked(cache_dir):
     state_dict = {}
     for fname in sorted(os.listdir(cache_dir)):
@@ -123,9 +118,15 @@ def _build_and_load_model_post_sparse(config, repo_id, mesh_shape):
     """Meta-init + enable_sparse_mlp + load post-sparse cache. Fast, TT-only."""
     cache_dir = _post_sparse_cache_dir(repo_id, config.num_hidden_layers)
     if not _has_cache(cache_dir):
-        raise RuntimeError(
-            f"Post-sparse cache not found at {cache_dir}. "
-            f"Run: python build_weight_cache_glm.py --n-layers {config.num_hidden_layers}"
+        print(
+            f"[weights] post-sparse cache not found at {cache_dir}, building...",
+            flush=True,
+        )
+        build_post_sparse_cache(
+            repo_id,
+            config.num_hidden_layers,
+            config.first_k_dense_replace,
+            config.n_routed_experts,
         )
 
     print(
@@ -193,36 +194,33 @@ def _load_cpu_state_dict_shard_on_demand(config, repo_id):
         r"^model\.layers\.(\d+)\.mlp\.experts\.(\d+)\.(gate_proj|up_proj|down_proj)\.weight$"
     )
 
-    # Bucket keys by shard for efficient reads.
-    wanted = {}
-    for ckpt_key, shard in weight_map.items():
+    # Filter out keys for layers >= n_layers and any mtp/next-n keys.
+    wanted_keys = []
+    for ckpt_key in weight_map:
         m = re.match(r"model\.layers\.(\d+)\.", ckpt_key)
         if m and int(m.group(1)) >= n_layers:
             continue
         if ckpt_key.startswith("mtp.") or ".mtp." in ckpt_key:
             continue
-        wanted.setdefault(shard, []).append(ckpt_key)
+        wanted_keys.append(ckpt_key)
 
-    # Accumulators for per-expert stacking:
-    # (layer_idx, expert_idx, name) -> tensor
-    expert_tensors = {}
+    shard_to_keys = _group_by_shard(wanted_keys, weight_map)
+    raw = _load_tensors(shard_to_keys, repo_id)
+
+    # Split into per-expert (for fusion below) vs. pass-through.
+    expert_tensors = {}  # (layer_idx, expert_idx, name) -> tensor
     state_dict = {}
-
-    for shard, keys in wanted.items():
-        path = hf_hub_download(repo_id, shard)
-        with safe_open(path, framework="pt", device="cpu") as f:
-            for k in keys:
-                t = f.get_tensor(k).to(torch.bfloat16)
-                m = expert_re.match(k)
-                if m:
-                    layer_idx = int(m.group(1))
-                    if layer_idx < n_dense:
-                        raise RuntimeError(
-                            f"Unexpected per-expert key on dense layer: {k}"
-                        )
-                    expert_tensors[(layer_idx, int(m.group(2)), m.group(3))] = t
-                else:
-                    state_dict[k] = t
+    for k, t in raw.items():
+        t = t.to(torch.bfloat16)
+        m = expert_re.match(k)
+        if m:
+            layer_idx = int(m.group(1))
+            if layer_idx < n_dense:
+                raise RuntimeError(f"Unexpected per-expert key on dense layer: {k}")
+            expert_tensors[(layer_idx, int(m.group(2)), m.group(3))] = t
+        else:
+            state_dict[k] = t
+    del raw
 
     # Fuse per-expert -> gate_up_proj + down_proj per MoE layer.
     moe_layers = sorted({lk[0] for lk in expert_tensors.keys()})
@@ -573,15 +571,9 @@ def test_glm4_7_full_sparse_moe():
     mesh = Mesh(device_ids, mesh_shape, ("_axis_0", "_axis_1"))
     device = torch_xla.device()
 
-    # Use "none" (or empty) to skip experimental_weight_dtype and run full bf16.
-    weight_dtype = os.environ.get("GLM_WEIGHT_DTYPE", "bfp_bf8")
-    print(f"[compile] experimental_weight_dtype={weight_dtype}", flush=True)
-    if weight_dtype and weight_dtype.lower() != "none":
-        torch_xla.set_custom_compile_options(
-            CompilerConfig(
-                experimental_weight_dtype=weight_dtype
-            ).to_torch_compile_options()
-        )
+    torch_xla.set_custom_compile_options(
+        CompilerConfig(experimental_weight_dtype="bfp_bf8").to_torch_compile_options()
+    )
 
     # Move to device — use to_empty + load_state_dict for meta path; to() for CPU path.
     t0 = time.perf_counter()
@@ -687,45 +679,15 @@ def test_glm4_7_decode_static_cache():
         "Tenstorrent is a company that builds AI accelerators. "
         "Their chips are designed to"
     )
-    use_chat_template = os.environ.get("GLM_USE_CHAT_TEMPLATE", "0") == "1"
-    if use_chat_template:
-        # GLM-4.7 is instruction + thinking-mode tuned. Raw prompts are OOD.
-        # apply_chat_template produces [gMASK]<sop><|user|>...<|assistant|><think>.
-        # apply_chat_template return type varies by transformers version; render
-        # to a string then tokenize ourselves to be robust.
-        rendered = tokenizer.apply_chat_template(
-            [{"role": "user", "content": prompt_text}],
-            add_generation_prompt=True,
-            tokenize=False,
-        )
-        chat_enc = tokenizer(rendered, return_tensors="pt", add_special_tokens=False)
-        chat_ids = chat_enc["input_ids"]  # (1, L)
-        L = chat_ids.shape[1]
-        if L > prompt_seq_len:
-            raise ValueError(
-                f"chat template yielded {L} tokens, exceeds prompt_seq_len={prompt_seq_len}"
-            )
-        # Left-pad with pad_token to prompt_seq_len.
-        pad_id = tokenizer.pad_token_id
-        tokens_single = torch.full((1, prompt_seq_len), pad_id, dtype=chat_ids.dtype)
-        tokens_single[:, prompt_seq_len - L :] = chat_ids
-        attn_single = torch.zeros((1, prompt_seq_len), dtype=torch.long)
-        attn_single[:, prompt_seq_len - L :] = 1
-        print(
-            f"[tokenize] chat template ({L} tokens): "
-            f"{tokenizer.decode(chat_ids[0].tolist())!r}",
-            flush=True,
-        )
-    else:
-        encoded = tokenizer(
-            prompt_text,
-            return_tensors="pt",
-            max_length=prompt_seq_len,
-            truncation=True,
-            padding="max_length",
-        )
-        tokens_single = encoded["input_ids"][:, :prompt_seq_len]
-        attn_single = encoded["attention_mask"][:, :prompt_seq_len]
+    encoded = tokenizer(
+        prompt_text,
+        return_tensors="pt",
+        max_length=prompt_seq_len,
+        truncation=True,
+        padding="max_length",
+    )
+    tokens_single = encoded["input_ids"][:, :prompt_seq_len]
+    attn_single = encoded["attention_mask"][:, :prompt_seq_len]
     tokens_cpu = tokens_single.repeat(batch_size, 1)
     token_attn_mask_cpu = attn_single.repeat(batch_size, 1)
     prompt_real_len = int(token_attn_mask_cpu[0].sum())
@@ -844,14 +806,9 @@ def test_glm4_7_decode_static_cache():
     mesh = Mesh(device_ids, mesh_shape, ("_axis_0", "_axis_1"))
     device = torch_xla.device()
 
-    weight_dtype = os.environ.get("GLM_WEIGHT_DTYPE", "bfp_bf8")
-    print(f"[compile] experimental_weight_dtype={weight_dtype}", flush=True)
-    if weight_dtype and weight_dtype.lower() != "none":
-        torch_xla.set_custom_compile_options(
-            CompilerConfig(
-                experimental_weight_dtype=weight_dtype
-            ).to_torch_compile_options()
-        )
+    torch_xla.set_custom_compile_options(
+        CompilerConfig(experimental_weight_dtype="bfp_bf8").to_torch_compile_options()
+    )
 
     # Move model + tokens + fresh KV cache to device
     t0 = time.perf_counter()

--- a/tests/torch/models/glm4_moe/test_glm4_7.py
+++ b/tests/torch/models/glm4_moe/test_glm4_7.py
@@ -441,33 +441,6 @@ def _apply_shard_specs(
                 mark_sharding(shared.down_proj.weight, mesh, ("_axis_0", None))
 
 
-class _LogitsOnly(nn.Module):
-    """Wrap Glm4MoeForCausalLM so torch.compile sees a pure tensor output.
-
-    Accepts a 4D additive attention_mask (B, 1, S, max_cache_len) to bypass
-    HF's internal mask construction — HF's eager attention adds this directly
-    to the attention scores, so left-pad masking works without HF
-    round-tripping a 2D tokenizer mask.
-    """
-
-    def __init__(self, model):
-        super().__init__()
-        self.model = model
-
-    def forward(
-        self, input_ids, position_ids, past_key_values, cache_position, attention_mask
-    ):
-        out = self.model(
-            input_ids=input_ids,
-            attention_mask=attention_mask,
-            position_ids=position_ids,
-            past_key_values=past_key_values,
-            cache_position=cache_position,
-            use_cache=True,
-        )
-        return out.logits
-
-
 # ---------- test ----------
 @pytest.mark.llmbox
 @pytest.mark.nightly
@@ -634,20 +607,20 @@ def test_glm4_7_full_sparse_moe():
     )
     mark_sharding(full_attn_mask_device, mesh, ("_axis_1", None))
 
-    wrapped = _LogitsOnly(model)
-    compiled_model = torch.compile(wrapped, backend="tt")
+    compiled_model = torch.compile(model, backend="tt")
 
     print("[tt] running prefill (compile + run)...", flush=True)
     t0 = time.perf_counter()
     with torch.no_grad():
-        logits = compiled_model(
-            tokens_device,
-            position_ids_device,
-            tt_cache,
-            cache_position_device,
-            full_attn_mask_device,
+        out = compiled_model(
+            input_ids=tokens_device,
+            attention_mask=full_attn_mask_device,
+            position_ids=position_ids_device,
+            past_key_values=tt_cache,
+            cache_position=cache_position_device,
+            use_cache=True,
         )
-    logits_tt_cpu = logits.to("cpu").detach()
+    logits_tt_cpu = out.logits.to("cpu").detach()
     print(f"[timing] TT prefill: {time.perf_counter() - t0:.1f}s", flush=True)
 
     # Top-5 next-token predictions from the last prefill position.
@@ -904,8 +877,7 @@ def test_glm4_7_decode_static_cache():
     )
     mark_sharding(full_attn_mask_device, mesh, ("_axis_1", None))
 
-    wrapped = _LogitsOnly(model)
-    compiled_model = torch.compile(wrapped, backend="tt")
+    compiled_model = torch.compile(model, backend="tt")
 
     tt_logits_list = []
     tt_token_ids = []
@@ -914,14 +886,15 @@ def test_glm4_7_decode_static_cache():
     print("[tt] running prefill (compile #1)...", flush=True)
     t0 = time.perf_counter()
     with torch.no_grad():
-        logits = compiled_model(
-            tokens_device,
-            prefill_position_ids_device,
-            tt_cache,
-            prefill_cache_position_device,
-            full_attn_mask_device,
+        out = compiled_model(
+            input_ids=tokens_device,
+            attention_mask=full_attn_mask_device,
+            position_ids=prefill_position_ids_device,
+            past_key_values=tt_cache,
+            cache_position=prefill_cache_position_device,
+            use_cache=True,
         )
-    prefill_last = logits[:, -1].to("cpu").detach()
+    prefill_last = out.logits[:, -1].to("cpu").detach()
     print(f"[timing] TT prefill: {time.perf_counter() - t0:.1f}s", flush=True)
     tt_logits_list.append(prefill_last[0])
     next_id = int(prefill_last[0].argmax(dim=-1).item())
@@ -948,14 +921,15 @@ def test_glm4_7_decode_static_cache():
 
         t_step = time.perf_counter()
         with torch.no_grad():
-            logits = compiled_model(
-                next_tokens_device,
-                pos_ids_device,
-                tt_cache,
-                cache_pos_device,
-                full_attn_mask_device,
+            out = compiled_model(
+                input_ids=next_tokens_device,
+                attention_mask=full_attn_mask_device,
+                position_ids=pos_ids_device,
+                past_key_values=tt_cache,
+                cache_position=cache_pos_device,
+                use_cache=True,
             )
-        step_last = logits[:, -1].to("cpu").detach()
+        step_last = out.logits[:, -1].to("cpu").detach()
         next_id = int(step_last[0].argmax(dim=-1).item())
         tt_logits_list.append(step_last[0])
         tt_token_ids.append(next_id)

--- a/tests/torch/models/glm4_moe/test_glm4_7.py
+++ b/tests/torch/models/glm4_moe/test_glm4_7.py
@@ -630,7 +630,7 @@ def test_glm4_7_full_sparse_moe():
 
 
 # ---------- decode test ----------
-@pytest.mark.llmbox
+@pytest.mark.galaxy
 @pytest.mark.nightly
 def test_glm4_7_decode_static_cache():
     """Autoregressive greedy decode on TT using StaticCache.

--- a/tests/torch/models/glm4_moe/test_glm4_7.py
+++ b/tests/torch/models/glm4_moe/test_glm4_7.py
@@ -445,8 +445,13 @@ def _apply_shard_specs(
 # ---------------------------------------------------------------------------
 
 @pytest.mark.galaxy
-@pytest.mark.nightly
-@pytest.mark.parametrize("cpu_reference", [True, False], ids=["cpu_reference", "no_cpu_reference"])
+ @pytest.mark.parametrize(
+      "cpu_reference",                                                                                                                                                                                                                                                                               
+      [                                                                                                                                                                                                                                                                                              
+          pytest.param(True, marks=pytest.mark.nightly, id="cpu_reference"),
+          pytest.param(False, id="no_cpu_reference"),                                                                                                                                                                                                                                                
+      ],                                                                                                                                                                                                                                                                                             
+  )
 @pytest.mark.parametrize("n_layers", [4])
 def test_glm4_7_decode_static_cache(cpu_reference, n_layers):
     """Autoregressive greedy decode on TT using StaticCache.

--- a/tests/torch/models/glm4_moe/test_glm4_7.py
+++ b/tests/torch/models/glm4_moe/test_glm4_7.py
@@ -65,9 +65,11 @@ def _patch_router_bf16():
 
     Glm4MoeTopkRouter.forward = _bf16_forward
 
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _load_cache_chunked(cache_dir):
     state_dict = {}
@@ -444,13 +446,14 @@ def _apply_shard_specs(
 # Tests
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.galaxy
 @pytest.mark.parametrize(
-    "cpu_reference",                                                                                                                                                                                                                                                                               
-    [                                                                                                                                                                                                                                                                                              
+    "cpu_reference",
+    [
         pytest.param(True, marks=pytest.mark.nightly, id="cpu_reference"),
-        pytest.param(False, id="no_cpu_reference"),                                                                                                                                                                                                                                                
-    ],                                                                                                                                                                                                                                                                                             
+        pytest.param(False, id="no_cpu_reference"),
+    ],
 )
 @pytest.mark.parametrize("n_layers", [4])
 def test_glm4_7_decode_static_cache(cpu_reference, n_layers):

--- a/tests/torch/models/glm4_moe/test_glm4_7.py
+++ b/tests/torch/models/glm4_moe/test_glm4_7.py
@@ -6,7 +6,7 @@
 Loads real BF16 weights via a post-sparse cache built by
 ``build_weight_cache_glm.py``. Runs a single prefill through
 ``Glm4MoeForCausalLM`` with ``A2aSparseMLP`` MoE layers, and prints the
-top-k next-token predictions. No CPU reference.
+top-k next-token predictions. CPU reference can be run by setting ``cpu_reference`` to True.
 """
 import json
 import os
@@ -46,7 +46,6 @@ from build_weight_cache_glm import (
 GLM_REPO = "zai-org/GLM-4.7"
 
 
-# TODO(issue): link tracking issue once filed.
 # Stock Glm4MoeTopkRouter.forward (transformers modeling_glm4_moe.py) upcasts
 # both input and weight to float32 before the gate linear. On TT, the fp32
 # linear kernel has accuracy issues large enough to flip top-k routing
@@ -66,8 +65,10 @@ def _patch_router_bf16():
 
     Glm4MoeTopkRouter.forward = _bf16_forward
 
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
-# ---------- helpers ----------
 def _load_cache_chunked(cache_dir):
     state_dict = {}
     for fname in sorted(os.listdir(cache_dir)):
@@ -439,200 +440,15 @@ def _apply_shard_specs(
                 mark_sharding(shared.down_proj.weight, mesh, ("_axis_0", None))
 
 
-# ---------- test ----------
-@pytest.mark.llmbox
-@pytest.mark.nightly
-def test_glm4_7_full_sparse_moe():
-    t_start = time.perf_counter()
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
 
-    os.environ["CONVERT_SHLO_TO_SHARDY"] = "1"
-    xr.set_device_type("TT")
-    torch_xla.runtime.use_spmd()
-    _patch_router_bf16()
-
-    batch_size = 32
-    seq_len = 32
-    n_layers = int(os.environ.get("GLM_N_LAYERS", 4))
-    mesh_shape = (4, 8)
-    run_cpu_reference = os.environ.get("GLM_CPU_REFERENCE", "0") == "1"
-
-    # ----- Config -----
-    config = Glm4MoeConfig.from_pretrained(GLM_REPO)
-    config.num_hidden_layers = n_layers
-    config.use_cache = True
-    config._attn_implementation = "eager"
-    # Don't build MTP/next-n head — not needed for prefill.
-    if hasattr(config, "num_nextn_predict_layers"):
-        config.num_nextn_predict_layers = 0
-    print(
-        f"[config] n_layers={n_layers}, n_dense={config.first_k_dense_replace}, "
-        f"n_experts={config.n_routed_experts}, top_k={config.num_experts_per_tok}, "
-        f"cpu_reference={run_cpu_reference}",
-        flush=True,
-    )
-
-    # ----- Model + weights -----
-    model = _build_and_load_model(
-        config, GLM_REPO, mesh_shape, prefer_cpu_capable=run_cpu_reference
-    )
-
-    # ----- Tokenizer / inputs -----
-    tokenizer = AutoTokenizer.from_pretrained(
-        GLM_REPO, trust_remote_code=True, padding_side="left"
-    )
-    prompt_text = (
-        "Tenstorrent is a company that builds AI accelerators. "
-        "Their chips are designed to"
-    )
-    encoded = tokenizer(
-        prompt_text,
-        return_tensors="pt",
-        max_length=seq_len,
-        truncation=True,
-        padding="max_length",
-    )
-    tokens_single = encoded["input_ids"][:, :seq_len]
-    tokens_cpu = tokens_single.repeat(batch_size, 1)
-    token_attn_mask_cpu = encoded["attention_mask"][:, :seq_len].repeat(batch_size, 1)
-    print(
-        f"[input] prompt: {tokenizer.decode(tokens_single[0].tolist())!r}", flush=True
-    )
-    print(
-        f"[input] real tokens: {int(token_attn_mask_cpu[0].sum())}/{seq_len}",
-        flush=True,
-    )
-
-    # HF default: position_ids = cache_position.unsqueeze(0). RoPE is purely
-    # relative, so absolute offset doesn't affect attention scores.
-    cache_position = torch.arange(seq_len)
-    position_ids = cache_position.unsqueeze(0).expand(batch_size, -1).contiguous()
-
-    # StaticCache — sized exactly to the prefill (no decode in this test).
-    max_cache_len = seq_len
-
-    def _make_static_cache():
-        cache = StaticCache(
-            config=config,
-            max_batch_size=batch_size,
-            max_cache_len=max_cache_len,
-            device="cpu",
-            dtype=torch.bfloat16,
-        )
-        cache.early_initialization(
-            batch_size=batch_size,
-            num_heads=config.num_key_value_heads,
-            head_dim=config.head_dim,
-            dtype=torch.bfloat16,
-            device="cpu",
-        )
-        return cache
-
-    full_attn_mask = _build_full_attention_mask(
-        token_attn_mask_cpu, max_cache_len, batch_size
-    )
-
-    # ===== CPU reference (opt-in via GLM_CPU_REFERENCE=1) =====
-    cpu_logits = None
-    if run_cpu_reference:
-        print("[cpu] running prefill eagerly...", flush=True)
-        t_cpu_start = time.perf_counter()
-        cpu_cache = _make_static_cache()
-        with torch.no_grad():
-            cpu_out = model(
-                input_ids=tokens_cpu,
-                attention_mask=full_attn_mask,
-                position_ids=position_ids,
-                past_key_values=cpu_cache,
-                cache_position=cache_position,
-                use_cache=True,
-            )
-        # Detach + clone so cpu_logits doesn't keep cpu_out's graph alive.
-        cpu_logits = cpu_out.logits.detach().clone()
-        del cpu_out, cpu_cache
-        print(
-            f"[timing] CPU prefill: {time.perf_counter() - t_cpu_start:.1f}s",
-            flush=True,
-        )
-        cpu_top5 = cpu_logits[0, -1].topk(5)
-        cpu_tokens = [tokenizer.decode([t]) for t in cpu_top5.indices.tolist()]
-        print(f"[CPU top-5] tokens={cpu_tokens}", flush=True)
-        print(f"[CPU top-5] logits={cpu_top5.values.tolist()}", flush=True)
-
-        # Drop the per-expert originals so only stacked weights transfer to TT.
-        _release_cpu_originals(model)
-    else:
-        print("[cpu] SKIPPED — set GLM_CPU_REFERENCE=1 to run CPU golden", flush=True)
-
-    # ----- TT path -----
-    torch._dynamo.reset()
-
-    num_devices = xr.global_runtime_device_count()
-    device_ids = np.array(range(num_devices))
-    mesh = Mesh(device_ids, mesh_shape, ("_axis_0", "_axis_1"))
-    device = torch_xla.device()
-
-    torch_xla.set_custom_compile_options(
-        CompilerConfig(experimental_weight_dtype="bfp_bf8").to_torch_compile_options()
-    )
-
-    # Move to device — use to_empty + load_state_dict for meta path; to() for CPU path.
-    t0 = time.perf_counter()
-    model = model.to(device)
-    tokens_device = tokens_cpu.to(device)
-    position_ids_device = position_ids.to(device)
-    cache_position_device = cache_position.to(device)
-    full_attn_mask_device = full_attn_mask.to(device)
-    tt_cache = _make_static_cache()
-    for layer_cache in tt_cache.layers:
-        layer_cache.keys = layer_cache.keys.to(device)
-        layer_cache.values = layer_cache.values.to(device)
-    print(f"[timing] move to device: {time.perf_counter() - t0:.1f}s", flush=True)
-
-    _apply_shard_specs(
-        model,
-        mesh,
-        tokens_device,
-        position_ids_device,
-        cache_position_device,
-        tt_cache,
-        config,
-    )
-    mark_sharding(full_attn_mask_device, mesh, ("_axis_1", None))
-
-    compiled_model = torch.compile(model, backend="tt")
-
-    print("[tt] running prefill (compile + run)...", flush=True)
-    t0 = time.perf_counter()
-    with torch.no_grad():
-        out = compiled_model(
-            input_ids=tokens_device,
-            attention_mask=full_attn_mask_device,
-            position_ids=position_ids_device,
-            past_key_values=tt_cache,
-            cache_position=cache_position_device,
-            use_cache=True,
-        )
-    logits_tt_cpu = out.logits.to("cpu").detach()
-    print(f"[timing] TT prefill: {time.perf_counter() - t0:.1f}s", flush=True)
-
-    # Top-5 next-token predictions from the last prefill position.
-    top5 = logits_tt_cpu[0, -1].topk(5)
-    tokens = [tokenizer.decode([t]) for t in top5.indices.tolist()]
-    print(f"[TT top-5] tokens={tokens}", flush=True)
-    print(f"[TT top-5] logits={top5.values.tolist()}", flush=True)
-
-    if cpu_logits is not None:
-        pcc = _pcc(logits_tt_cpu, cpu_logits)
-        print(f"[pcc] logits PCC (TT vs CPU) = {pcc:.4f} (required: 0.99)", flush=True)
-        assert pcc >= 0.99, f"PCC {pcc:.4f} below required 0.99"
-
-    print(f"[timing] total: {time.perf_counter() - t_start:.1f}s", flush=True)
-
-
-# ---------- decode test ----------
 @pytest.mark.galaxy
 @pytest.mark.nightly
-def test_glm4_7_decode_static_cache():
+@pytest.mark.parametrize("cpu_reference", [True, False], ids=["cpu_reference", "no_cpu_reference"])
+@pytest.mark.parametrize("n_layers", [4])
+def test_glm4_7_decode_static_cache(cpu_reference, n_layers):
     """Autoregressive greedy decode on TT using StaticCache.
 
     Two torch.compile traces: prefill (seq=prompt_len) and decode (seq=1).
@@ -649,9 +465,8 @@ def test_glm4_7_decode_static_cache():
     batch_size = 32
     prompt_seq_len = 32
     n_decode = 10
-    n_layers = int(os.environ.get("GLM_N_LAYERS", 4))
     mesh_shape = (4, 8)
-    run_cpu_reference = os.environ.get("GLM_CPU_REFERENCE", "0") == "1"
+    run_cpu_reference = cpu_reference
 
     # ----- Config -----
     config = Glm4MoeConfig.from_pretrained(GLM_REPO)

--- a/tests/torch/models/glm4_moe/test_glm4_7.py
+++ b/tests/torch/models/glm4_moe/test_glm4_7.py
@@ -445,13 +445,13 @@ def _apply_shard_specs(
 # ---------------------------------------------------------------------------
 
 @pytest.mark.galaxy
- @pytest.mark.parametrize(
-      "cpu_reference",                                                                                                                                                                                                                                                                               
-      [                                                                                                                                                                                                                                                                                              
-          pytest.param(True, marks=pytest.mark.nightly, id="cpu_reference"),
-          pytest.param(False, id="no_cpu_reference"),                                                                                                                                                                                                                                                
-      ],                                                                                                                                                                                                                                                                                             
-  )
+@pytest.mark.parametrize(
+    "cpu_reference",                                                                                                                                                                                                                                                                               
+    [                                                                                                                                                                                                                                                                                              
+        pytest.param(True, marks=pytest.mark.nightly, id="cpu_reference"),
+        pytest.param(False, id="no_cpu_reference"),                                                                                                                                                                                                                                                
+    ],                                                                                                                                                                                                                                                                                             
+)
 @pytest.mark.parametrize("n_layers", [4])
 def test_glm4_7_decode_static_cache(cpu_reference, n_layers):
     """Autoregressive greedy decode on TT using StaticCache.


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/3927

### Problem description
We want to run deepseek v3 and glm 4.7 on galaxy end-to-end.

### What's changed
@btsoiTT added `test_deepseek_v3_1_decode_static_cache` and `test_glm4_7_decode_static_cache` tests that use a weight caching mechanism to reduce runtime peak memory usage. This also allows weights to be cached and re-used locally. More details about these changes can be found [in this comment](https://github.com/tenstorrent/tt-xla/issues/3927#issuecomment-4306868627).

A next step for these tests is to clean them up to use existing test infra where possible. It would be great to get these tests in nightly CI first to catch any breaking changes.

The full end-to-end tests (`n_layers=32`) require a bh galaxy with swap in order to run without hitting OOM. For now, the 4 layer versions of the tests have been added to `basic-test-nightly.yml` to run on the wh galaxy until a bh galaxy with swap is ready to use. 

[Edit]: this test makes changes to the modified_model.py for deepseek v3.2. Other tests using this modified_model.py have been updated to import the model from tt-forge-models. 


### Checklist
- [x] New/Existing tests provide coverage for changes