### PR TITLE
PyTorch and vLLM uplift

### DIFF
--- a/.github/workflows/call-perf-test.yml
+++ b/.github/workflows/call-perf-test.yml
@@ -129,6 +129,9 @@ jobs:
       shell: bash
       run: |
         if ! command -v gh &> /dev/null; then
+          if [ -f /etc/apt/sources.list.d/archive_uri-https_apt_llvm_org_noble_-noble.list ]; then
+            rm -f /etc/apt/sources.list.d/archive_uri-https_apt_llvm_org_noble_-noble.list
+          fi
           apt-get update -y -qq
           apt-get install -y -qq --no-install-recommends curl
           curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
@@ -162,6 +165,9 @@ jobs:
     - name: Install system dependencies
       shell: bash
       run: |
+        if [ -f /etc/apt/sources.list.d/archive_uri-https_apt_llvm_org_noble_-noble.list ]; then
+          rm -f /etc/apt/sources.list.d/archive_uri-https_apt_llvm_org_noble_-noble.list
+        fi
         apt-get update -y -qq
         apt-get install -y -qq --no-install-recommends ${{ matrix.build.libreq }}
 
@@ -170,7 +176,9 @@ jobs:
       run: |
         source venv/activate
         pip install ${{ matrix.build.pyreq }}
-        pip install torchvision==0.24.0+cpu --index-url https://download.pytorch.org/whl/cpu
+        # Install correct torch-xla version from requirements.txt
+        pip install $(grep "torch-xla@" python_package/requirements.txt)
+        pip install torchvision==0.25.0+cpu --index-url https://download.pytorch.org/whl/cpu
 
     - name: Create perf report directory
       run: mkdir -p ${{ steps.strings.outputs.perf_report_path }}

--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -19,493 +19,493 @@
     "tests": [
       {
         "name": "resnet_jax",
-        "pyreq": "pytest tqdm loguru requests transformers==4.57.1 datasets flax==0.10.4 torch==2.9.0",
+        "pyreq": "pytest tqdm loguru requests transformers==4.57.1 datasets flax==0.10.4 torch==2.10.0",
         "pytest": "tests/benchmark/resnet_jax_benchmark.py::test_resnet_jax"
       },
       {
         "name": "mnist",
-        "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_vision.py::test_mnist"
       },
       {
         "name": "resnet",
-        "pyreq": "datasets loguru pytest requests tabulate timm tqdm transformers==5.2.0 torch==2.9.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm tqdm transformers==5.2.0 torch==2.10.0",
         "pytest": "tests/benchmark/test_vision.py::test_resnet50"
       },
       {
         "name": "mobilenetv2",
-        "pyreq": "datasets loguru pytest requests tabulate timm tqdm transformers==5.2.0 torch==2.9.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm tqdm transformers==5.2.0 torch==2.10.0",
         "pytest": "tests/benchmark/test_vision.py::test_mobilenetv2"
       },
       {
         "name": "efficientnet",
-        "pyreq": "datasets loguru pytest requests tabulate timm tqdm transformers==5.2.0 torch==2.9.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm tqdm transformers==5.2.0 torch==2.10.0",
         "pytest": "tests/benchmark/test_vision.py::test_efficientnet"
       },
       {
         "name": "segformer",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_vision.py::test_segformer"
       },
       {
         "name": "swin",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_vision.py::test_swin"
       },
       {
         "name": "ufld_v2",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_vision.py::test_ufld_v2"
       },
       {
         "name": "unet",
-        "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_vision.py::test_unet"
       },
       {
         "name": "vit",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_vision.py::test_vit"
       },
       {
         "name": "vovnet",
-        "pyreq": "datasets loguru pytest pytorchcv requests tabulate timm tqdm transformers==5.2.0 torch==2.9.0",
+        "pyreq": "datasets loguru pytest pytorchcv requests tabulate timm tqdm transformers==5.2.0 torch==2.10.0",
         "pytest": "tests/benchmark/test_vision.py::test_vovnet"
       },
       {
         "name": "bge_m3_encode",
-        "pyreq": "datasets FlagEmbedding loguru pytest requests timm torch==2.9.0 tqdm transformers==4.57.1",
+        "pyreq": "datasets FlagEmbedding loguru pytest requests timm torch==2.10.0 tqdm transformers==4.57.1",
         "pytest": "tests/benchmark/test_encoders.py::test_bge_m3"
       },
       {
         "name": "llama_3_2_1b_instruct",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_2_1b"
       },
       {
         "name": "llama_3_2_3b_instruct",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_2_3b"
       },
       {
         "name": "llama_3_1_8b_instruct",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b"
       },
       {
         "name": "falcon3_7b_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "falcon3_10b_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_10b_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "llama_3_1_8b_instruct_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b_instruct_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "ministral_8b_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_ministral_8b_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "mistral_nemo_instruct_2407_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_mistral_nemo_instruct_2407_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "mistral_small_24b_instruct_2501_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_mistral_small_24b_instruct_2501_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "qwen_2_5_14b_instruct_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_14b_instruct_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "qwen_2_5_coder_32b_instruct_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_coder_32b_instruct_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "qwen_3_8b_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_8b_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "qwen_3_14b_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_14b_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "qwen_3_32b_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_32b_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "test_llama_3_1_70b_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "llama_3_1_70b_tp_galaxy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp_galaxy",
         "runs-on": "galaxy-wh-6u"
       },
       {
         "name": "gpt_oss_20b_tp",
-        "pyreq": "datasets loguru pytest requests accelerate torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "gpt_oss_20b_tp_batch_size_1",
-        "pyreq": "datasets loguru pytest requests accelerate torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_batch_size_1",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "test_gpt_oss_20b_tp_galaxy_batch_size_64",
-        "pyreq": "datasets loguru pytest requests accelerate torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_galaxy_batch_size_64",
         "runs-on": "galaxy-wh-6u"
       },
       {
         "name": "test_gpt_oss_120b_tp_dp_galaxy_batch_size_128",
-        "pyreq": "datasets loguru pytest requests accelerate torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_120b_tp_dp_galaxy_batch_size_128",
         "runs-on": "galaxy-wh-6u"
       },
       {
         "name": "gpt_oss_120b_tp_qb2",
-        "pyreq": "datasets loguru pytest requests accelerate torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_120b_tp_qb2",
         "runs-on": "qb2-blackhole"
       },
       {
         "name": "microsoft_phi-1",
-        "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_phi1"
       },
       {
         "name": "microsoft_phi-1_5",
-        "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_phi1_5"
       },
       {
         "name": "microsoft_phi-2",
-        "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_phi2"
       },
       {
         "name": "google_gemma-1.1-2b-it",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_gemma_1_1_2b"
       },
       {
         "name": "tiiuae_falcon3-1b-base",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_1b"
       },
       {
         "name": "tiiuae_falcon3-3b-base",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_3b"
       },
       {
         "name": "tiiuae_falcon3-7b-base",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b"
       },
       {
         "name": "qwen_2_5_0_5b_instruct",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_0_5b"
       },
       {
         "name": "qwen_2_5_1_5b_instruct",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_1_5b"
       },
       {
         "name": "qwen_2_5_3b_instruct",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_3b"
       },
       {
         "name": "qwen_3_0_6b",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_0_6b"
       },
       {
         "name": "qwen_3_1_7b",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_1_7b"
       },
       {
         "name": "qwen_3_4b",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_4b"
       },
       {
         "name": "qwen_3_8b",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_8b"
       },
       {
         "name": "qwen_2_5_7b_instruct",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_7b"
       },
       {
         "name": "mistral_7b",
-        "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==5.2.0 protobuf sentencepiece",
+        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.2.0 protobuf sentencepiece",
         "pytest": "tests/benchmark/test_llms.py::test_mistral_7b"
       },
       {
         "name": "ministral_8b",
-        "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_ministral_8b"
       },
       {
         "name": "qwen_3_4b_embedding",
-        "pyreq": "datasets loguru pytest requests timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_encoders.py::test_qwen3_embedding_4b"
       },
       {
         "name": "bert",
-        "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_encoders.py::test_bert"
       },
       {
         "name": "unet_for_conditional_generation",
-        "pyreq": "accelerate datasets diffusers==0.36.0 loguru pytest requests torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "accelerate datasets diffusers==0.36.0 loguru pytest requests torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_encoders.py::test_unet_for_conditional_generation"
       },
       {
         "name": "llama_3_2_1b_instruct_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_2_1b",
         "accuracy-testing": true
       },
       {
         "name": "llama_3_2_3b_instruct_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_2_3b",
         "accuracy-testing": true
       },
       {
         "name": "llama_3_1_8b_instruct_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b",
         "accuracy-testing": true
       },
       {
         "name": "mistral_7b_accuracy",
-        "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==5.2.0 protobuf sentencepiece",
+        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.2.0 protobuf sentencepiece",
         "pytest": "tests/benchmark/test_llms.py::test_mistral_7b",
         "accuracy-testing": true
       },
       {
         "name": "qwen_2_5_7b_instruct_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_7b",
         "accuracy-testing": true
       },
       {
         "name": "google_gemma-1.1-2b-it_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_gemma_1_1_2b",
         "accuracy-testing": true
       },
       {
         "name": "google_gemma-2-2b-it_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_gemma_2_2b",
         "accuracy-testing": true
       },
       {
         "name": "microsoft_phi-1_accuracy",
-        "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_phi1",
         "accuracy-testing": true
       },
       {
         "name": "microsoft_phi-1_5_accuracy",
-        "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_phi1_5",
         "accuracy-testing": true
       },
       {
         "name": "microsoft_phi-2_accuracy",
-        "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_phi2",
         "accuracy-testing": true
       },
       {
         "name": "tiiuae_falcon3-1b-base_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_1b",
         "accuracy-testing": true
       },
       {
         "name": "tiiuae_falcon3-3b-base_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_3b",
         "accuracy-testing": true
       },
       {
         "name": "tiiuae_falcon3-7b-base_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b",
         "accuracy-testing": true
       },
       {
         "name": "qwen_2_5_0_5b_instruct_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_0_5b",
         "accuracy-testing": true
       },
       {
         "name": "qwen_2_5_1_5b_instruct_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_1_5b",
         "accuracy-testing": true
       },
       {
         "name": "qwen_2_5_3b_instruct_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_3b",
         "accuracy-testing": true
       },
       {
         "name": "qwen_3_0_6b_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_0_6b",
         "accuracy-testing": true
       },
       {
         "name": "qwen_3_1_7b_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_1_7b",
         "accuracy-testing": true
       },
       {
         "name": "qwen_3_4b_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_4b",
         "accuracy-testing": true
       },
       {
         "name": "qwen_3_8b_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 torchvision==0.24.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_8b",
         "accuracy-testing": true
       },
       {
         "name": "ministral_8b_accuracy",
-        "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_ministral_8b",
         "accuracy-testing": true
       },
       {
         "name": "falcon3_7b_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "falcon3_10b_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_10b_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "llama_3_1_8b_instruct_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b_instruct_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "ministral_8b_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_ministral_8b_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "mistral_nemo_instruct_2407_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_mistral_nemo_instruct_2407_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "mistral_small_24b_instruct_2501_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_mistral_small_24b_instruct_2501_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "qwen_2_5_14b_instruct_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_14b_instruct_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "qwen_2_5_coder_32b_instruct_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_coder_32b_instruct_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "qwen_3_8b_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_8b_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "qwen_3_14b_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_14b_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "qwen_3_32b_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_32b_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "llama_3_1_70b_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true,
@@ -513,21 +513,21 @@
       },
       {
         "name": "gpt_oss_20b_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests accelerate torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "llama_3_1_70b_tp_galaxy_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp_galaxy",
         "runs-on": "galaxy-wh-6u",
         "accuracy-testing": true
       },
       {
         "name": "gpt_oss_20b_tp_galaxy_accuracy",
-        "pyreq": "datasets loguru pytest requests accelerate torch==2.9.0 tqdm transformers==5.2.0",
+        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_galaxy_batch_size_64",
         "runs-on": "galaxy-wh-6u",
         "accuracy-testing": true
@@ -548,7 +548,7 @@
       },
       {
         "name": "vllm_llama_3_2_3b",
-        "pyreq": "loguru pytest torch==2.9.1 transformers==4.57.6 vllm==0.16.0",
+        "pyreq": "loguru pytest torch==2.10.0 transformers==4.57.6 vllm==0.19.0",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[llama-3.2-3b]",
         "vllm": true,
         "skip-stablehlo-dump": true,
@@ -559,7 +559,7 @@
       },
       {
         "name": "vllm_llama_3_2_3b_batch32",
-        "pyreq": "loguru pytest torch==2.9.1 transformers==4.57.6 vllm==0.16.0",
+        "pyreq": "loguru pytest torch==2.10.0 transformers==4.57.6 vllm==0.19.0",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[llama-3.2-3b-batch32]",
         "vllm": true,
         "skip-stablehlo-dump": true,

--- a/integrations/vllm_plugin/requirements-vllm-plugin.txt
+++ b/integrations/vllm_plugin/requirements-vllm-plugin.txt
@@ -1,2 +1,2 @@
-vllm==0.16.0
+vllm==0.19.0
 transformers==4.57.6

--- a/integrations/vllm_plugin/setup.py
+++ b/integrations/vllm_plugin/setup.py
@@ -51,7 +51,7 @@ setup(
     version="0.1",
     packages=find_packages(),
     install_requires=[
-        "vllm==0.16.0",
+        "vllm==0.19.0",
         "transformers==4.57.6",
     ],
     python_requires=">=3.12, <3.13",

--- a/integrations/vllm_plugin/vllm_tt/input_batch.py
+++ b/integrations/vllm_plugin/vllm_tt/input_batch.py
@@ -703,6 +703,11 @@ class InputBatch:
         return PoolingMetadata(
             prompt_lens=prompt_lens_tensor,
             prompt_token_ids=self.sampling_metadata.prompt_token_ids,
+            prompt_token_ids_cpu=(
+                self.sampling_metadata.prompt_token_ids.to("cpu")
+                if self.sampling_metadata.prompt_token_ids is not None
+                else None
+            ),
             pooling_params=pooling_params,
             pooling_states=pooling_states,
         )

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -24,6 +24,7 @@ from vllm.config import (
     ParallelConfig,
     VllmConfig,
     get_layers_from_vllm_config,
+    set_current_vllm_config,
     update_config,
 )
 from vllm.distributed.kv_transfer import get_kv_transfer_group, has_kv_transfer_group
@@ -58,7 +59,7 @@ from vllm.multimodal.utils import group_mm_kwargs_by_modality
 from vllm.sampling_params import SamplingType
 from vllm.sequence import IntermediateTensors
 from vllm.tasks import GenerationTask, PoolingTask, SupportedTask
-from vllm.utils.math_utils import cdiv, prev_power_of_2
+from vllm.utils.math_utils import cdiv
 from vllm.utils.platform_utils import is_pin_memory_available
 from vllm.v1.attention.backend import AttentionType
 from vllm.v1.kv_cache_interface import (
@@ -100,7 +101,7 @@ from .overrides import replace_modules
 from .platform import TTConfig
 from .sampler import Sampler
 from .vllm_distributed_utils import shard_model
-from .vllm_utils import determine_mesh_shape
+from .vllm_utils import determine_mesh_shape, prev_power_of_2
 
 
 def add_kv_sharing_layers_to_kv_cache_groups(
@@ -1570,9 +1571,10 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     # Temporarily replace the method
                     model_loader.get_all_weights = filtered_get_all_weights
 
-                model = model_loader.load_model(
-                    vllm_config=self.vllm_config, model_config=self.model_config
-                ).eval()
+                with set_current_vllm_config(self.vllm_config):
+                    model = model_loader.load_model(
+                        vllm_config=self.vllm_config, model_config=self.model_config
+                    ).eval()
                 replace_modules(model)
                 model = model.to(self.device)
 
@@ -1816,6 +1818,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             (self.max_num_reqs, hsize), dtype=self._hidden_states_dtype
         )
         dummy_hidden = dummy_hidden.to(self.device)
+
         self.compute_logits(dummy_hidden)
 
         xm.wait_device_ops()
@@ -1882,8 +1885,10 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 vocab_size=self.vocab_size,
             )
             sampling_metadata.all_greedy = all_greedy
-            with self.maybe_select_dummy_loras(
-                self.lora_config, np.array([self.max_num_reqs], dtype=np.int32)
+            with (
+                self.maybe_select_dummy_loras(
+                    self.lora_config, np.array([self.max_num_reqs], dtype=np.int32)
+                ),
             ):
                 self.sample_from_logits(dummy_logits, sampling_metadata)
 
@@ -1913,8 +1918,10 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         dummy_tokens = torch.zeros((self.max_num_reqs, 1), dtype=torch.int64).to(
             self.device
         )
-        with self.maybe_select_dummy_loras(
-            self.lora_config, np.array([self.max_num_reqs], dtype=np.int32)
+        with (
+            self.maybe_select_dummy_loras(
+                self.lora_config, np.array([self.max_num_reqs], dtype=np.int32)
+            ),
         ):
             self.gather_logprobs(dummy_logits, dummy_tokens)
 
@@ -1928,7 +1935,6 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         Precompile all the subgraphs with possible input shapes.
         """
         torch._dynamo.config.dynamic_shapes = False
-        decode_only = self.tt_config.decode_only
         with self.maybe_setup_dummy_loras(self.lora_config):
             self._precompile_backbone()
             if self.tt_config.decode_only:

--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from vllm.attention.selector import AttentionSelectorConfig
     from vllm.config import VllmConfig
     from vllm.config.cache import BlockSize
-    from vllm.inputs import ProcessorInputs, PromptType
+    from vllm.inputs import PromptType
     from vllm.pooling_params import PoolingParams
     from vllm.sampling_params import SamplingParams
 
@@ -132,6 +132,7 @@ class TTPlatform(Platform):
         cls,
         selected_backend: "AttentionBackendEnum",
         attn_selector_config: "AttentionSelectorConfig",
+        num_heads: int | None = None,
     ) -> str:
         if attn_selector_config.use_sparse:
             raise NotImplementedError(
@@ -275,6 +276,11 @@ class TTPlatform(Platform):
             )
 
     @classmethod
+    def update_block_size_for_backend(cls, vllm_config: "VllmConfig") -> int:
+        # TT backend requires a block size divisible by 32 for optimal performance.
+        return 32
+
+    @classmethod
     def is_pin_memory_available(cls):
         logger.warning("Pin memory is not supported on TT.")
         return False
@@ -288,7 +294,6 @@ class TTPlatform(Platform):
         cls,
         prompt: "PromptType",
         params: "ParamsType",
-        processed_inputs: "ProcessorInputs",
     ) -> None:
         pass
 

--- a/integrations/vllm_plugin/vllm_tt/pooling_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/pooling_runner.py
@@ -23,6 +23,7 @@ from vllm.config import (
     ParallelConfig,
     VllmConfig,
     get_layers_from_vllm_config,
+    set_current_vllm_config,
     update_config,
 )
 from vllm.distributed.kv_transfer import get_kv_transfer_group, has_kv_transfer_group
@@ -54,7 +55,7 @@ from vllm.multimodal.inputs import (
 from vllm.multimodal.utils import group_mm_kwargs_by_modality
 from vllm.sequence import IntermediateTensors
 from vllm.tasks import GenerationTask, PoolingTask, SupportedTask
-from vllm.utils.math_utils import cdiv, prev_power_of_2
+from vllm.utils.math_utils import cdiv
 from vllm.utils.platform_utils import is_pin_memory_available
 from vllm.v1.attention.backend import AttentionType
 from vllm.v1.kv_cache_interface import (
@@ -96,7 +97,7 @@ from .logger import tt_init_logger
 from .overrides import replace_modules
 from .platform import TTConfig
 from .vllm_distributed_utils import shard_model
-from .vllm_utils import determine_mesh_shape
+from .vllm_utils import determine_mesh_shape, prev_power_of_2
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
@@ -1473,9 +1474,10 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     # Temporarily replace the method
                     model_loader.get_all_weights = filtered_get_all_weights
 
-                model = model_loader.load_model(
-                    vllm_config=self.vllm_config, model_config=self.model_config
-                ).eval()
+                with set_current_vllm_config(self.vllm_config):
+                    model = model_loader.load_model(
+                        vllm_config=self.vllm_config, model_config=self.model_config
+                    ).eval()
                 replace_modules(model)
                 model = model.to(self.device)
 
@@ -1577,9 +1579,12 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             layer_name: attn_metadata for layer_name in layer_names
         }
 
-        with self.maybe_select_dummy_loras(
-            self.lora_config, np.array([num_tokens], dtype=np.int32)
-        ), set_forward_context(per_layer_attn_metadata, self.vllm_config, 0):
+        with (
+            self.maybe_select_dummy_loras(
+                self.lora_config, np.array([num_tokens], dtype=np.int32)
+            ),
+            set_forward_context(per_layer_attn_metadata, self.vllm_config, 0),
+        ):
             out = self.model(
                 input_ids=input_ids, positions=position_ids, inputs_embeds=inputs_embeds
             )

--- a/integrations/vllm_plugin/vllm_tt/scheduler/ascend_scheduler.py
+++ b/integrations/vllm_plugin/vllm_tt/scheduler/ascend_scheduler.py
@@ -18,6 +18,7 @@ from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
 from vllm.utils.math_utils import cdiv
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 from vllm.v1.core.sched.output import NewRequestData, SchedulerOutput
+from vllm.v1.core.sched.request_queue import create_request_queue
 from vllm.v1.core.sched.scheduler import Scheduler
 from vllm.v1.engine import EngineCoreEventType, EngineCoreOutputs
 from vllm.v1.kv_cache_interface import KVCacheConfig
@@ -51,13 +52,6 @@ class AscendScheduler(Scheduler):
         )
         self.scheduled_req_ids: set[str] = set()
         self.running: list[Request] = []
-        # Optional execution mode gate (None=auto, 1=prefill, 0=decode)
-        self._forced_mode: Optional[int] = None
-
-    def set_forced_mode(self, mode: Optional[int]) -> None:
-        # mode must be None, 0 (decode) or 1 (prefill)
-        assert mode in (None, 0, 1)
-        self._forced_mode = mode
 
     def schedule(self) -> SchedulerOutput:
         # Super's schedule handles chunked prefill which is schedule both prefill and decode in one request.
@@ -67,15 +61,6 @@ class AscendScheduler(Scheduler):
         scheduled_resumed_reqs: list[Request] = []
         scheduled_running_reqs: list[Request] = []
         preempted_reqs: list[Request] = []
-
-        # Copied from scheduler.py
-        # NOTE: structured_output_request_ids maps
-        # a request's (request that uses structured output)
-        # request_id to the running request index.
-        # This will helps us determine to slice the grammar bitmask
-        # and only applies valid mask for requests that
-        # uses structured decoding.
-        structured_output_request_ids: dict[str, int] = {}
 
         req_to_new_block_ids: dict[str, KVCacheBlocks] = {}
         num_scheduled_tokens: dict[str, int] = {}
@@ -89,21 +74,25 @@ class AscendScheduler(Scheduler):
         # Record scheduled LoRA requests.
         scheduled_loras: set[int] = set()
 
-        # Use a temporary deque to collect requests that need to be skipped
+        # Use a temporary queue to collect requests that need to be skipped
         # and put back at the head of the waiting queue later
-        skipped_waiting_requests: deque[Request] = deque()
+        step_skipped_waiting = create_request_queue(self.policy)
 
         # Schedule prefill requests first (unless decode is forced).
         req_index = 0
-        while self.waiting and token_budget > 0 and self._forced_mode != 0:
+        while (self.waiting or self.skipped_waiting) and token_budget > 0:
             if len(self.running) == self.max_num_running_reqs:
                 break
 
-            request = self.waiting.peek_request()
+            request_queue = self._select_waiting_queue_for_scheduling()
+            if request_queue is None:
+                break
+
+            request = request_queue.peek_request()
 
             def skip_cur_request(req=request):
-                self.waiting.pop_request()
-                skipped_waiting_requests.appendleft(req)
+                request_queue.pop_request()
+                step_skipped_waiting.prepend_request(req)
 
             # P/D: skip request if still waiting for remote kvs.
             if request.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
@@ -115,14 +104,14 @@ class AscendScheduler(Scheduler):
                     continue
 
             # Skip request if the structured output request is still waiting
-            # for FSM compilation.
-            if request.status == RequestStatus.WAITING_FOR_FSM:
+            # for structured output grammar compilation.
+            if request.status == RequestStatus.WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR:
                 structured_output_req = request.structured_output_request
                 if structured_output_req and structured_output_req.grammar:
-                    # unblock request if FSM is now ready
+                    # unblock request if ready
                     request.status = RequestStatus.WAITING
                 else:
-                    # skip request if FSM is still not ready
+                    # skip request if not ready
                     skip_cur_request()
                     continue
 
@@ -196,7 +185,7 @@ class AscendScheduler(Scheduler):
                     self.finished_req_ids.add(  # type: ignore
                         request.request_id
                     )  # type: ignore
-                    self.waiting.pop_request()
+                    request_queue.pop_request()
                     continue
 
                 if num_new_tokens > token_budget:
@@ -236,11 +225,11 @@ class AscendScheduler(Scheduler):
                     num_external_computed_tokens,
                 )
 
-            self.waiting.pop_request()
+            request = request_queue.pop_request()
             if load_kv_async:
                 # If loading async, allocate memory and put request
                 # into the WAITING_FOR_REMOTE_KV state.
-                skipped_waiting_requests.appendleft(request)
+                step_skipped_waiting.prepend_request(request)
                 request.status = RequestStatus.WAITING_FOR_REMOTE_KVS
                 continue
 
@@ -256,8 +245,6 @@ class AscendScheduler(Scheduler):
             else:
                 raise RuntimeError(f"Invalid request status: {request.status}")
 
-            if request.use_structured_output:
-                structured_output_request_ids[request.request_id] = req_index
             req_index += 1
 
             if self.lora_config and request.lora_request:
@@ -273,12 +260,12 @@ class AscendScheduler(Scheduler):
                 request.num_cached_tokens = num_computed_tokens
 
         # Put back any skipped requests at the head of the waiting queue
-        if skipped_waiting_requests:
-            self.waiting.extendleft(skipped_waiting_requests)  # type: ignore
+        if step_skipped_waiting:
+            self.skipped_waiting.prepend_requests(step_skipped_waiting)
 
         # If no prefill requests are scheduled (or prefill skipped),
         # schedule decode requests next (unless prefill is forced).
-        if len(self.scheduled_req_ids) == 0 and self._forced_mode != 1:
+        if len(self.scheduled_req_ids) == 0:
             req_index = 0
             while req_index < len(self.running) and token_budget > 0:
                 request = self.running[req_index]
@@ -358,8 +345,6 @@ class AscendScheduler(Scheduler):
 
                 # Schedule the request.
                 scheduled_running_reqs.append(request)
-                if request.use_structured_output:
-                    structured_output_request_ids[request.request_id] = req_index
                 self.scheduled_req_ids.add(request.request_id)
                 req_to_new_block_ids[request.request_id] = new_blocks
                 num_scheduled_tokens[request.request_id] = num_new_tokens
@@ -440,14 +425,6 @@ class AscendScheduler(Scheduler):
             free_encoder_mm_hashes=self.encoder_cache_manager.get_freed_mm_hashes(),
         )
 
-        # Generate grammar bitmask after creating scheduler output
-        grammar_output = self.get_grammar_bitmask(scheduler_output)
-        if grammar_output is not None:
-            scheduler_output.structured_output_request_ids = (
-                grammar_output.structured_output_request_ids
-            )
-            scheduler_output.grammar_bitmask = grammar_output.grammar_bitmask
-
         # NOTE(Kuntai): this function is designed for multiple purposes:
         # 1. Plan the KV cache store
         # 2. Wrap up all the KV cache load / save ops into an opaque object
@@ -471,7 +448,14 @@ class AscendScheduler(Scheduler):
         # 3. If some tokens (e.g. spec tokens) are rejected later, the number of
         #    computed tokens will be adjusted in update_from_output.
         for req_id, num_scheduled_token in num_scheduled_tokens.items():
-            self.requests[req_id].num_computed_tokens += num_scheduled_token
+            request = self.requests[req_id]
+            request.num_computed_tokens += num_scheduled_token
+            request.is_prefill_chunk = request.num_computed_tokens < (
+                request.num_tokens + request.num_output_placeholders
+            )
+            scheduler_output.has_structured_output_requests |= (
+                request.use_structured_output and not request.is_prefill_chunk
+            )
 
         self.finished_req_ids = set()  # type: ignore
         return scheduler_output
@@ -523,6 +507,9 @@ class AscendScheduler(Scheduler):
         For example, the API server can abort a request when the client
         disconnects.
         """
+        if request_ids is None:
+            return
+
         for req_id in request_ids:
             request = self.requests.get(req_id)
             if request is None:

--- a/integrations/vllm_plugin/vllm_tt/vllm_utils.py
+++ b/integrations/vllm_plugin/vllm_tt/vllm_utils.py
@@ -39,3 +39,8 @@ def determine_mesh_shape(num_devices: int, use_2d_mesh: bool) -> tuple[int, int]
         mesh_shape = (num_devices, 1)
         logger.info(f"Using 1D mesh shape for {num_devices} devices: {mesh_shape}")
         return mesh_shape
+
+
+def prev_power_of_2(n: int) -> int:
+    """The previous power of 2 (inclusive)"""
+    return 0 if n <= 0 else 1 << (n.bit_length() - 1)

--- a/pjrt_implementation/inc/utils/callback_worker.h
+++ b/pjrt_implementation/inc/utils/callback_worker.h
@@ -40,7 +40,7 @@ struct CallbackWorkItem {
 // internal worker thread.
 class CallbackWorker {
 public:
-  explicit CallbackWorker(size_t queue_capacity = 1024);
+  explicit CallbackWorker(size_t queue_capacity = 8192);
 
   // Signals shutdown and joins the worker thread.
   ~CallbackWorker();

--- a/python_package/requirements.txt
+++ b/python_package/requirements.txt
@@ -2,9 +2,9 @@
 jax==0.7.1
 jaxlib==0.7.1
 requests
-torch@https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl
+torch@https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl
 loguru
-torch-xla@https://pypi.eng.aws.tenstorrent.com/torch-xla/torch_xla-2.9.0%2Bgit44ecef3-cp312-cp312-linux_x86_64.whl
+torch-xla@https://pypi.eng.aws.tenstorrent.com/torch-xla/torch_xla-2.9.0%2Bgit5c82b10-cp312-cp312-linux_x86_64.whl
 
 # Pin nanobind to match tt-metal's version (v2.10.2) for ABI compatibility.
 # A mismatch causes segfaults in nb_type_c2p when PythonModelRunner converts

--- a/python_package/tt_torch/__init__.py
+++ b/python_package/tt_torch/__init__.py
@@ -2,6 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# Apply XLA Dynamo guard repr patch and TorchDynamo compatibility patches globally to fix TorchDynamo errors
+from .utils import apply_dynamo_compatibility_patches, apply_xla_dynamo_guard_repr_patch
+
+# Apply patches globally
+apply_xla_dynamo_guard_repr_patch()
+apply_dynamo_compatibility_patches()
+
 # Import module so "tt" backend is registered
 import tt_torch.backend.backend
 

--- a/python_package/tt_torch/utils.py
+++ b/python_package/tt_torch/utils.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Portions (c) 2026 Tenstorrent AI ULC
+
+"""
+Shared utilities for TT-Torch backend integration.
+"""
+
+import contextlib
+
+import torch
+
+
+class MockStream:
+    """Mock stream class for TorchDynamo compilation with TT devices."""
+
+    def __init__(self, device_index=0):
+        self.device = torch.device("cpu", device_index)
+
+
+def cpu_device_index():
+    """Return CPU device index for TorchDynamo compatibility."""
+    return 0
+
+
+def cpu_stream(device_index=0):
+    """Return mock CPU stream for TorchDynamo compatibility."""
+    return MockStream(device_index)
+
+
+def apply_dynamo_compatibility_patches():
+    """Apply TorchDynamo compatibility patches for TT devices."""
+    torch._C._accelerator_getDeviceIndex = cpu_device_index
+    torch._C._accelerator_getStream = cpu_stream
+
+
+@contextlib.contextmanager
+def torch_dynamo_tt_device_compatibility():
+    """
+    Context manager to temporarily patch torch accelerator functions for TorchDynamo compilation with TT devices.
+
+    This fixes TorchDynamo compilation errors when using TT devices by temporarily patching:
+    - torch._C._accelerator_getDeviceIndex() to return CPU device index
+    - torch._C._accelerator_getStream() to return CPU stream
+
+    TorchDynamo calls these functions during compilation but they fail with TT devices,
+    so we temporarily redirect them to CPU equivalents during compilation.
+    """
+    # Store original functions
+    original_get_device_index = getattr(torch._C, "_accelerator_getDeviceIndex", None)
+    original_get_stream = getattr(torch._C, "_accelerator_getStream", None)
+
+    try:
+        # Apply patches
+        apply_dynamo_compatibility_patches()
+        yield
+    finally:
+        # Restore original functions
+        if original_get_device_index is not None:
+            torch._C._accelerator_getDeviceIndex = original_get_device_index
+        if original_get_stream is not None:
+            torch._C._accelerator_getStream = original_get_stream
+
+
+def apply_xla_dynamo_guard_repr_patch() -> None:
+    """
+    Apply patch to PyTorch Dynamo guard system to prevent XLA tensor materialization.
+
+    This patches GuardBuilder.id_match_unchecked to avoid calling repr() on XLA tensors
+    during guard construction, which would trigger expensive ReplicateShardedData operations.
+    PyTorch uses repr(val) only to annotate verbose guard strings, so we replace it with
+    a cheap metadata-only string for XLA tensors.
+
+    The patch is safe to call multiple times (no-op after first application).
+    Side effects: Modifies torch._dynamo.guards.GuardBuilder.id_match_unchecked globally.
+    """
+    try:
+        from torch._dynamo.guards import GuardBuilder, get_verbose_code_parts
+        from torch._dynamo.source import LocalSource, TypeSource
+        from torch._guards import Guard
+    except ImportError:
+        # Silently skip if Dynamo modules are not available
+        return
+
+    # Check if patch is already applied
+    if getattr(GuardBuilder.id_match_unchecked, "_tt_xla_guard_repr_patch", False):
+        return
+
+    def id_match_unchecked(self, guard, recompile_hint=None) -> None:
+        # PyTorch uses repr(val) only to annotate verbose guard strings.
+        # For XLA tensors/parameters, repr() calls tensor.to("cpu"), which
+        # materializes sharded weights via ReplicateShardedData during guard
+        # construction. Replace it with a cheap metadata-only string.
+        if isinstance(guard.originating_source, TypeSource):
+            return self.TYPE_MATCH(
+                Guard(guard.originating_source.base, GuardBuilder.TYPE_MATCH)
+            )
+
+        ref = self.arg_ref(guard)
+        val = self.get(guard)
+        id_val = self.id_ref(val, guard.name)
+
+        # Generate safe string representation without materializing XLA tensors
+        try:
+            if isinstance(val, torch.Tensor) and val.device.type == "xla":
+                type_repr = f"<{type(val).__name__} device={val.device}>"
+            else:
+                type_repr = repr(val)
+        except Exception:
+            # Fallback for any repr() failures
+            type_repr = f"<{type(val).__name__}>"
+
+        code = f"___check_obj_id({ref}, {id_val}), type={type_repr}"
+        self._set_guard_export_info(guard, [code], provided_func_name="ID_MATCH")
+        self.get_guard_manager(guard).add_id_match_guard(
+            id_val, get_verbose_code_parts(code, guard, recompile_hint)
+        )
+
+        # Handle LocalSource for Module objects
+        if isinstance(guard.originating_source, LocalSource):
+            if isinstance(val, torch.nn.Module):
+                local_name = guard.originating_source.local_name
+                weak_id = self.lookup_weakrefs(val)
+                if weak_id is not None:
+                    self.id_matched_objs[local_name] = weak_id
+
+    # Mark the function as patched and apply the patch
+    id_match_unchecked._tt_xla_guard_repr_patch = True
+    GuardBuilder.id_match_unchecked = id_match_unchecked

--- a/tests/integrations/vllm_plugin/sampling/test_sampling_params.py
+++ b/tests/integrations/vllm_plugin/sampling/test_sampling_params.py
@@ -22,7 +22,11 @@ import signal
 import pytest
 import vllm
 from conftest import TEST_TIMEOUT_SECONDS, get_or_create_llm
-from vllm.sampling_params import RequestOutputKind, StructuredOutputsParams
+from vllm.sampling_params import (
+    RepetitionDetectionParams,
+    RequestOutputKind,
+    StructuredOutputsParams,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -650,6 +654,28 @@ def test_repetition_penalty_end_to_end(llm):
     )
 
 
+@for_targets(single_device="nightly")
+def test_repetition_detection(llm, prompt):
+    """Smoke test that repetition_detection doesn't break the pipeline.
+
+    Scheduler-level stop condition handled by upstream vLLM (no device graph
+    involvement). Single-device only — verifying our plugin doesn't break
+    the upstream behavior is sufficient; no need to cross with TP targets.
+    """
+    rd = RepetitionDetectionParams(max_pattern_size=3, min_count=3)
+    params = vllm.SamplingParams(
+        temperature=0.0, max_tokens=32, repetition_detection=rd
+    )
+    output = llm.generate(prompt, params, use_tqdm=False)[0].outputs[0]
+    print(
+        f"[TESTOUT test_repetition_detection] "
+        f"{len(output.token_ids)} tokens, finish_reason={output.finish_reason}, "
+        f"stop_reason={output.stop_reason}, text: {output.text[:60]!r}"
+    )
+
+    assert len(output.token_ids) > 0, "Should produce output with repetition_detection"
+
+
 @for_targets(single_device="nightly", n300="nightly", n300_llmbox="nightly")
 def test_parameter_boundary_values(llm, prompt):
     """Test boundary and edge case values don't crash."""
@@ -954,10 +980,13 @@ def test_truncate_prompt_tokens(llm, prompt):
     full_params = vllm.SamplingParams(temperature=0.0, max_tokens=16)
     out_full = llm.generate(prompt, full_params, use_tqdm=False)[0].outputs[0]
 
-    trunc_params = vllm.SamplingParams(
-        temperature=0.0, max_tokens=16, truncate_prompt_tokens=4
-    )
-    out_trunc = llm.generate(prompt, trunc_params, use_tqdm=False)[0].outputs[0]
+    trunc_params = vllm.SamplingParams(temperature=0.0, max_tokens=16)
+    out_trunc = llm.generate(
+        prompt,
+        trunc_params,
+        use_tqdm=False,
+        tokenization_kwargs={"truncate_prompt_tokens": 4},
+    )[0].outputs[0]
 
     print(
         f"[TESTOUT test_truncate_prompt_tokens] "

--- a/tests/runner/test_config/torch/test_config_inference_data_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_data_parallel.yaml
@@ -218,7 +218,8 @@ test_config:
 
   swin/image_classification/pytorch-S-data_parallel-inference:
     supported_archs: [n300]
-    status: EXPECTED_PASSING
+    status: KNOWN_FAILURE_XFAIL
+    reason: "PyTroch 2.10 bug causing compilation failure - https://github.com/tenstorrent/tt-xla/issues/3723"
 
   mlp_mixer/pytorch-Mixer_S16_224-data_parallel-inference:
     supported_archs: [n300]

--- a/tests/runner/test_config/torch/test_config_inference_data_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_data_parallel.yaml
@@ -219,7 +219,7 @@ test_config:
   swin/image_classification/pytorch-S-data_parallel-inference:
     supported_archs: [n300]
     status: KNOWN_FAILURE_XFAIL
-    reason: "PyTroch 2.10 bug causing compilation failure - https://github.com/tenstorrent/tt-xla/issues/3723"
+    reason: "PyTorch 2.10 bug causing compilation failure - https://github.com/tenstorrent/tt-xla/issues/3723"
 
   mlp_mixer/pytorch-Mixer_S16_224-data_parallel-inference:
     supported_archs: [n300]

--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -606,8 +606,8 @@ test_config:
     status: EXPECTED_PASSING
 
   yoloworld/pytorch-Small_640-single_device-inference:
-    status: EXPECTED_PASSING
-    required_pcc: 0.98 # https://github.com/tenstorrent/tt-xla/issues/2727
+    status: KNOWN_FAILURE_XFAIL
+    reason: "PyTroch 2.10 bug causing compilation failure - https://github.com/tenstorrent/tt-xla/issues/3752"
 
   yoloworld/pytorch-Small_1280-single_device-inference:
     status: EXPECTED_PASSING
@@ -757,13 +757,14 @@ test_config:
 
   pi_0/pytorch-lerobot_pi0_libero_base-single_device-inference:
     supported_archs: ["p150"]
-    status: EXPECTED_PASSING
+    status: KNOWN_FAILURE_XFAIL
     assert_pcc: false
-    reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.8219157204385233. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/3786"
+    reason: "Need to update requirments. (https://github.com/tenstorrent/tt-xla/issues/3767)"
 
   pi_0/pytorch-pi0_base-single_device-inference:
     supported_archs: ["p150"]
-    status: EXPECTED_PASSING
+    status: KNOWN_FAILURE_XFAIL
+    reason: "Need to update requirments. (https://github.com/tenstorrent/tt-xla/issues/3767)"
 
   opt/qa/pytorch-1.3b-single_device-inference:
     status: EXPECTED_PASSING
@@ -2342,7 +2343,8 @@ test_config:
     bringup_status: FAILED_RUNTIME
 
   efficientdet/pytorch-D0-single_device-inference:
-    status: EXPECTED_PASSING
+    status: KNOWN_FAILURE_XFAIL
+    reason: "PyTroch 2.10 bug causing compilation failure - https://github.com/tenstorrent/tt-xla/issues/3752"
 
   efficientdet/pytorch-D1-single_device-inference:
     status: EXPECTED_PASSING

--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -607,7 +607,7 @@ test_config:
 
   yoloworld/pytorch-Small_640-single_device-inference:
     status: KNOWN_FAILURE_XFAIL
-    reason: "PyTroch 2.10 bug causing compilation failure - https://github.com/tenstorrent/tt-xla/issues/3752"
+    reason: "PyTorch 2.10 bug causing compilation failure - https://github.com/tenstorrent/tt-xla/issues/3752"
 
   yoloworld/pytorch-Small_1280-single_device-inference:
     status: EXPECTED_PASSING
@@ -759,12 +759,12 @@ test_config:
     supported_archs: ["p150"]
     status: KNOWN_FAILURE_XFAIL
     assert_pcc: false
-    reason: "Need to update requirments. (https://github.com/tenstorrent/tt-xla/issues/3767)"
+    reason: "Need to update requirements. (https://github.com/tenstorrent/tt-xla/issues/3767)"
 
   pi_0/pytorch-pi0_base-single_device-inference:
     supported_archs: ["p150"]
     status: KNOWN_FAILURE_XFAIL
-    reason: "Need to update requirments. (https://github.com/tenstorrent/tt-xla/issues/3767)"
+    reason: "Need to update requirements. (https://github.com/tenstorrent/tt-xla/issues/3767)"
 
   opt/qa/pytorch-1.3b-single_device-inference:
     status: EXPECTED_PASSING
@@ -2344,7 +2344,7 @@ test_config:
 
   efficientdet/pytorch-D0-single_device-inference:
     status: KNOWN_FAILURE_XFAIL
-    reason: "PyTroch 2.10 bug causing compilation failure - https://github.com/tenstorrent/tt-xla/issues/3752"
+    reason: "PyTorch 2.10 bug causing compilation failure - https://github.com/tenstorrent/tt-xla/issues/3752"
 
   efficientdet/pytorch-D1-single_device-inference:
     status: EXPECTED_PASSING

--- a/venv/requirements-dev.txt
+++ b/venv/requirements-dev.txt
@@ -34,8 +34,7 @@ sentencepiece
 setuptools
 tabulate
 timm
-# torchvision 0.23.0 causes torch v2.8.0 to be installed, which isn't supported by our torch_xla whl
-torchvision==0.24.1+cpu
+torchvision==0.25+cpu
 torchxrayvision
 transformers==5.2.0
 


### PR DESCRIPTION
### Ticket
closes #4561 

### What's changed
Following packages are uplifted.
- PyTorch 2.9.1 -> 2.10.0
- torchvision 0.24.1+cpu -> 0.25.0+cpu
- vLLM 0.16.0 -> 0.19.0
- torch-xla (re-build against torch 2.10.0)

Perf-benchmark tests are updated to use updated packages.

### Checklist
- [X] New/Existing tests provide coverage for changes
