### PR TITLE
Clamp OOB negative slices via FX pass in tt_torch (#4465)

### DIFF
--- a/python_package/tt_torch/backend/backend.py
+++ b/python_package/tt_torch/backend/backend.py
@@ -29,6 +29,7 @@ from .passes import (
     bypass_assert_tensor_metadata,
     bypass_dtype_promotion_and_redundant_cast,
     bypass_redundant_getitem,
+    clamp_neg_slice_starts,
     handle_composite_ops,
     insert_argument_type_markers,
     rewrite_adaptive_avgpool_to_mean,
@@ -190,6 +191,8 @@ class XLAExecutor:
             # Calling legalize_graph rebuilds the graph in topological order(from usage information), and fixes up the prev/next pointers in the process - which fixes our issue.
             # All this is a problem because DynamoBridge Partitioner can get confused by wrong next nodes and partition the graph in a way which fails to execute.
             legalize_graph(program.graph_module)
+
+            clamp_neg_slice_starts(program.graph_module)
 
             # Collect the params and constants from the exported program.
             self.params_and_consts = self._build_params_and_consts(program)

--- a/python_package/tt_torch/backend/passes.py
+++ b/python_package/tt_torch/backend/passes.py
@@ -308,6 +308,39 @@ def bypass_redundant_getitem(gm):
     return gm
 
 
+def clamp_neg_slice_starts(gm):
+    """
+    Clamp out-of-range negative `start` values on aten.slice.Tensor nodes.
+
+    Eager `x[..., -N:, ...]` clamps when N > dim size, but the strict
+    aten.slice.Tensor overload rejects start < -size. Normalize the literal in
+    the FX graph so downstream lowering sees a legal index.
+    """
+    changed = False
+    for node in gm.graph.nodes:
+        if (
+            node.op != "call_function"
+            or node.target is not torch.ops.aten.slice.Tensor
+            or len(node.args) <= 2
+        ):
+            continue
+        self_node, dim, start = node.args[0], node.args[1], node.args[2]
+        if not isinstance(start, int) or not isinstance(dim, int):
+            continue
+        val = self_node.meta.get("val")
+        if val is None:
+            continue
+        size = val.shape[dim]
+        if not isinstance(size, int):
+            continue
+        if start < -size:
+            node.args = (self_node, dim, -size, *node.args[3:])
+            changed = True
+    if changed:
+        gm.recompile()
+    return gm
+
+
 def run_shape_prop(gm, example_inputs):
     """
     Propagates shape and dtype information through the graph.

--- a/tests/torch/models/krea_realtime/test_vae_decoder.py
+++ b/tests/torch/models/krea_realtime/test_vae_decoder.py
@@ -16,9 +16,9 @@ from third_party.tt_forge_models.krea_realtime_video.pytorch import (
 )
 
 
-@pytest.mark.xfail(
-    reason="VAE temporal slice fails on TT (out-of-range slice on size-1 dim) — https://github.com/tenstorrent/tt-xla/issues/4465"
-)
+# @pytest.mark.xfail(
+#     reason="Out of Memory: Not enough space to allocate 4907335680 B DRAM buffer across 12 banks, where each bank needs to store 408944640 B, but bank size is 1071821792 B - https://github.com/tenstorrent/tt-xla/issues/4551"
+# )
 def test_vae_decoder():
     xr.set_device_type("TT")
     torch.manual_seed(42)

--- a/tests/torch/ops/test_slice.py
+++ b/tests/torch/ops/test_slice.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import ComparisonConfig, Framework, Workload
+from infra.testers.single_chip.op.op_tester import OpTester
+
+
+class _SliceModel(torch.nn.Module):
+    def forward(self, x):
+        return x[:, :, -2:, :, :]
+
+
+@pytest.mark.nightly
+@pytest.mark.single_device
+def test_slice():
+    xr.set_device_type("TT")
+
+    model = _SliceModel().eval()
+    x = torch.randn(1, 16, 1, 60, 104, dtype=torch.bfloat16).to(torch_xla.device())
+
+    tester = OpTester(comparison_config=ComparisonConfig(), framework=Framework.TORCH)
+    workload = Workload(framework=Framework.TORCH, model=model, args=[x])
+    tester.test(workload)


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-xla/issues/4465

### Problem description

- `x[..., -N:, ...]` fails on the tt backend when `N > dim_size` (e.g. `-CACHE_T:` on a size-1 dim in the krea VAE decoder).
- On CPU, `Tensor.__getitem__` silently clamps the out-of-range negative start. On XLA tensors it lazy-lowers straight to the strict `aten.slice.Tensor`, which rejects `start < -size` and raises `RuntimeError: Value out of range`.
- Same code path the diffusers `AutoencoderKLWan` decoder relies on, so this blocks krea VAE compilation outright.

### What's changed

- For each `aten.slice.Tensor` node in the FX graph whose `start < -dim_size`, rewrite the literal to `-dim_size`. Produces the same output CPU eager `__getitem__` would (it clamps silently) and lets the strict `aten.slice` overload accept the arg.
- Implemented as `clamp_neg_slice_starts` in `python_package/tt_torch/backend/passes.py`; called from `_call_experimental_compile` (`backend.py`) after `legalize_graph`, so it runs before the torch_xla bridge's FX collector validates the graph.
- Added `tests/torch/ops/test_slice.py` (repro for the model's issue) to catch regressions in nightly until the model passes e2e.


### Checklist
- [x] Verify the changes through local testing in N150

### Logs

- [may8_slice_before_fix.log](https://github.com/user-attachments/files/27516019/may8_slice_bf.log)
- [may8_vae_decoder_before_fix.log](https://github.com/user-attachments/files/27516022/may8_vae_decoder_bf.log)






