### PR TITLE
Handle ComplexType in simplifyMainFuncOp zero-attr creation

### DIFF
--- a/pjrt_implementation/src/api/module_builder/frontend_passes/shlo_clean_for_xla_ingestion.cc
+++ b/pjrt_implementation/src/api/module_builder/frontend_passes/shlo_clean_for_xla_ingestion.cc
@@ -6,10 +6,12 @@
 #include "api/module_builder/frontend_passes/shlo_clean_for_xla_ingestion.h"
 
 // c++ standard library includes
+#include <complex>
 #include <cstdint>
 #include <optional>
 
 // llvm includes
+#include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
@@ -343,12 +345,19 @@ void simplifyMainFuncOp(mlir::func::FuncOp funcOp) {
     if (auto tensorType = mlir::dyn_cast<mlir::RankedTensorType>(returnType)) {
       auto elementType = tensorType.getElementType();
 
-      // Create zero attribute - getZeroAttr should handle all types
-      auto zeroAttr = builder.getZeroAttr(elementType);
-      TT_FATAL(zeroAttr, "Failed to create zero attribute for element type");
-
-      // Create dense attribute for tensor using splat
-      auto denseAttr = mlir::DenseElementsAttr::get(tensorType, zeroAttr);
+      // mlir::Builder::getZeroAttr does not handle ComplexType, so build the
+      // zero splat manually as (0.0, 0.0) for complex element types.
+      mlir::DenseElementsAttr denseAttr;
+      if (auto complexTy = mlir::dyn_cast<mlir::ComplexType>(elementType)) {
+        auto floatTy = mlir::cast<mlir::FloatType>(complexTy.getElementType());
+        llvm::APFloat zero(floatTy.getFloatSemantics(), 0);
+        denseAttr = mlir::DenseElementsAttr::get(
+            tensorType, std::complex<llvm::APFloat>(zero, zero));
+      } else {
+        auto zeroAttr = builder.getZeroAttr(elementType);
+        TT_FATAL(zeroAttr, "Failed to create zero attribute for element type");
+        denseAttr = mlir::DenseElementsAttr::get(tensorType, zeroAttr);
+      }
 
       // Create constant op
       auto constantOp = builder.create<mlir::stablehlo::ConstantOp>(

--- a/tests/torch/models/krea_realtime/test_transformer.py
+++ b/tests/torch/models/krea_realtime/test_transformer.py
@@ -25,7 +25,7 @@ def test_transformer():
 
 
 @pytest.mark.xfail(
-    reason="Complex dtype (RoPE freqs from torch.polar) unsupported on TT — https://github.com/tenstorrent/tt-xla/issues/4464"
+    reason="error: failed to legalize unresolved materialization from ('tensor<0x2xf64>') to ('tensor<0xcomplex<f64>>') that remained live after conversion — https://github.com/tenstorrent/tt-mlir/issues/8291"
 )
 def test_transformer_sharded():
     _run(sharded=True)

--- a/tests/torch/ops/test_polar.py
+++ b/tests/torch/ops/test_polar.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+import torch
+import torch_xla.runtime as xr
+from infra import ComparisonConfig, Framework, Workload, run_op_test
+from infra.testers.single_chip.op.op_tester import OpTester
+from torch_xla.distributed.spmd import Mesh
+
+
+@pytest.mark.xfail(
+    reason="error: failed to legalize unresolved materialization from ('tensor<0x2xf64>') to ('tensor<0xcomplex<f64>>') that remained live after conversion — https://github.com/tenstorrent/tt-mlir/issues/8291"
+)
+def test_polar_sharded():
+    class Polar(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            # make `angle` a parameter so we have something to attach a shard to
+            self.angle = torch.nn.Parameter(
+                torch.randn(1024, 22, dtype=torch.float64), requires_grad=False
+            )
+
+        def forward(self, abs_):
+            return torch.polar(abs_, self.angle)
+
+    model = Polar()
+
+    num_devices = xr.global_runtime_device_count()
+    mesh_shape = (1, num_devices)
+    mesh = Mesh(np.array(range(num_devices)), mesh_shape, ("batch", "model"))
+
+    def shard_spec_fn(model, args, kwargs):
+        # shard the angle parameter on dim 0 across the "model" axis
+        return {model.angle: ("model", None)}
+
+    abs_ = torch.ones(1024, 22, dtype=torch.float64)
+
+    run_op_test(
+        model,
+        [abs_],
+        framework=Framework.TORCH,
+        mesh=mesh,
+        shard_spec_fn=shard_spec_fn,
+    )


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-xla/issues/4464

### Problem description

- On the sharded compile path, `simplifyMainFuncOp` rebuilds `main`'s body as zero stubs for each return type via `mlir::Builder::getZeroAttr`. That helper returns null for `ComplexType` (only `Float`/`Integer`/`Index` are covered), so any sharded module whose `main` returns a `complex<T>` tensor crashes at: `TT_FATAL @ shlo_clean_for_xla_ingestion.cc:348: zeroAttr Failed to create zero attribute for element type`

### What's changed

- `simplifyMainFuncOp`: handle `ComplexType` element types when emitting the zero splat — build `DenseElementsAttr` from `std::complex<APFloat>(0, 0)` using the underlying float semantics; non-complex types still go through `getZeroAttr` unchanged.

### Checklist
- [x] Verify the changes through local testing in N150


### Logs

- [may6_krea_transformer_before_fix.log](https://github.com/user-attachments/files/27443751/may6_krea_transformer.log)
- [may6_polar_sharded_before_fix.log](https://github.com/user-attachments/files/27443755/may6_polar_sharded_before_fix.log)
- [may6_krea_transformer_after_fix.log](https://github.com/user-attachments/files/27443887/may6_krea_transformer_after_fix.log)
- [may6_polar_sharded_after_fix.log](https://github.com/user-attachments/files/27443888/may6_polar_sharded_after_fix.log)
