### PR TITLE
[Cog VideoX 5B] Add initial tests for each part of the pipeline

### DIFF
--- a/tests/torch/models/cog_videox/__init__.py
+++ b/tests/torch/models/cog_videox/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/torch/models/cog_videox/test_text_encoder.py
+++ b/tests/torch/models/cog_videox/test_text_encoder.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""CogVideoX-5b — T5 v1.1-XXL text encoder component test."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+
+from third_party.tt_forge_models.cog_videox.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.xfail(
+    reason="AssertionError: Evaluation result 0 failed: PCC comparison failed. Calculated: pcc=0.9685751315163685 - https://github.com/tenstorrent/tt-xla/issues/4647"
+)
+def test_text_encoder():
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.TEXT_ENCODER)
+    model = loader.load_model(dtype_override=torch.bfloat16)
+    inputs = loader.load_inputs(dtype_override=torch.bfloat16)
+
+    run_graph_test(
+        model,
+        inputs,
+        framework=Framework.TORCH,
+    )

--- a/tests/torch/models/cog_videox/test_transformer.py
+++ b/tests/torch/models/cog_videox/test_transformer.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""CogVideoX-5b — CogVideoXTransformer3DModel (DiT) component test."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+
+from third_party.tt_forge_models.cog_videox.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.xfail(
+    reason="Out of Memory: Not enough space to allocate 3183476736 B DRAM buffer across 12 bank - https://github.com/tenstorrent/tt-xla/issues/4646"
+)
+def test_transformer():
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.TRANSFORMER)
+    model = loader.load_model(dtype_override=torch.bfloat16)
+    inputs = loader.load_inputs(dtype_override=torch.bfloat16)
+
+    run_graph_test(
+        model,
+        inputs,
+        framework=Framework.TORCH,
+    )

--- a/tests/torch/models/cog_videox/test_vae_decoder.py
+++ b/tests/torch/models/cog_videox/test_vae_decoder.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""CogVideoX-5b — AutoencoderKLCogVideoX decoder component test."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+
+from third_party.tt_forge_models.cog_videox.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.xfail(
+    reason="AssertionError: Evaluation result 0 failed: PCC comparison failed. Calculated: pcc=-0.7399767808716264 - https://github.com/tenstorrent/tt-xla/issues/4791"
+)
+def test_vae_decoder():
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.VAE)
+    model = loader.load_model(dtype_override=torch.bfloat16)
+    inputs = loader.load_inputs(dtype_override=torch.bfloat16)
+
+    run_graph_test(
+        model,
+        inputs,
+        framework=Framework.TORCH,
+    )


### PR DESCRIPTION
### Ticket

- fixes #4645 

### Problem description

- Add initial bringup tests for each component of the Hunyuan Video pipeline and  test in Wormhole.

### What's changed

| File | Component | Tests |
|------|-----------|-------|
| `test_text_encoder.py` | T5 v1.1-XXL encoder | `test_text_encoder` (xfail - #4647 - single device), 
| `test_transformer.py` | CogVideoXTransformer3DModel   | `test_transformer` (xfail - #4646 - single device)
| `test_vae_decoder.py` | AutoencoderKLCogVideoX | `test_vae_decoder` (xfail — single chip — #4791  )

### Checklist
- [x] verify changes through local testing in Wormhole

### Logs
[cogvideox_may20_logs.zip](https://github.com/user-attachments/files/28047208/cogvideox_may20_logs.zip)