### PR TITLE
Add `--force-run` option to pytest for debugging skipped tests

### DIFF
--- a/tests/runner/conftest.py
+++ b/tests/runner/conftest.py
@@ -109,6 +109,12 @@ def pytest_addoption(parser):
         default=False,
         help="Run EmitPy verification: re-run models via codegen_py backend and compare against flatbuffer result",
     )
+    parser.addoption(
+        "--force-run",
+        action="store_true",
+        default=False,
+        help="Run tests marked NOT_SUPPORTED_SKIP instead of skipping them (for local debugging)",
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/runner/test_models.py
+++ b/tests/runner/test_models.py
@@ -112,10 +112,11 @@ def _run_model_test_impl(
 
         comparison_config = test_metadata.to_comparison_config()
 
+        force_run = request.config.getoption("--force-run", default=False)
         try:
             # Only run the actual model test if not marked for skip. The record properties
             # function in finally block will always be called and handles the pytest.skip.
-            if test_metadata.status != ModelTestStatus.NOT_SUPPORTED_SKIP:
+            if test_metadata.status != ModelTestStatus.NOT_SUPPORTED_SKIP or force_run:
                 # Framework-specific tester creation
                 if framework == Framework.TORCH:
                     tester = DynamicTorchModelTester(

--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -743,7 +743,8 @@ def record_model_test_properties(
         record_property("group", str(model_info.group))
 
     # Control flow for skipped and xfailed tests is handled by pytest.
-    if test_metadata.status == ModelTestStatus.NOT_SUPPORTED_SKIP:
+    force_run = request.config.getoption("--force-run", default=False)
+    if test_metadata.status == ModelTestStatus.NOT_SUPPORTED_SKIP and not force_run:
         pytest.skip(reason)
     elif test_metadata.status == ModelTestStatus.KNOWN_FAILURE_XFAIL:
         pytest.xfail(reason)


### PR DESCRIPTION
### Ticket
N/A — local debugging convenience.

### Problem description
Model tests in `tests/runner/test_config/torch/*.yaml` marked `NOT_SUPPORTED_SKIP` are skipped at collection time by `tests/runner/test_models.py:118` and again inside `tests/runner/test_utils.py:746` via `pytest.skip(reason)`. There's no way to force one of these tests to actually run without editing the YAML, which is awkward when re-triaging an entry whose listed reason has gone stale (e.g. an upstream fix landed and the original failure no longer reproduces — you want to see the new failure mode).

### What's changed
Adds a `--force-run` pytest CLI flag that bypasses the `NOT_SUPPORTED_SKIP` gate so the test executes for real. `KNOWN_FAILURE_XFAIL` behavior is unchanged (use the existing `--runxfail` for that).

- `tests/runner/conftest.py` — registers `--force-run` (off by default).
- `tests/runner/test_models.py:118` — `if test_metadata.status != ModelTestStatus.NOT_SUPPORTED_SKIP or force_run:` lets the test body execute.
- `tests/runner/test_utils.py:746` — `pytest.skip(reason)` only fires when `not force_run`.

Default behavior (no flag) is preserved: skipped tests still skip.

Verified locally on `centernet/pytorch-ResNet18_Backbone_COCO-single_device-training` (currently `NOT_SUPPORTED_SKIP`):
- Without flag → `1 skipped`.
- With `--force-run` → test executes, hits the actual TT-MLIR `UNREACHABLE` assertion (which is what you'd want to see during retriage).

### Checklist
- [x] New/Existing tests provide coverage for changes