### PR TITLE
Fix '_has_torch_function already has a docstring' across 25 training tests

### DIFF
--- a/tests/runner/requirements.py
+++ b/tests/runner/requirements.py
@@ -40,6 +40,19 @@ class RequirementsManager:
     # compared against resolved import names in _purge_stale_modules.
     _JAX_PURGE_SKIP = frozenset({"flax"})
 
+    # C-extension packages that cannot be safely re-imported in the same
+    # process. Re-executing torch/overrides.py raises
+    # "RuntimeError: function '_has_torch_function' already has a docstring"
+    # because torch._C._add_docstr refuses to re-document a C function whose
+    # docstring is already set on the live module object. Purging only the
+    # Python wrappers from sys.modules does not reset the C-extension state,
+    # so the second import always fails. The same hazard applies to torch's
+    # sibling extensions (torchvision, torchaudio, etc.) and to tt_torch,
+    # which monkey-patches torch at import time (see tt_torch/torch_overrides.py).
+    _TORCH_PURGE_SKIP = frozenset(
+        {"torch", "torchvision", "torchaudio", "torch_xla", "tt_torch"}
+    )
+
     # Top-level directory names in RECORD that are not importable packages.
     _RECORD_SKIP = frozenset({"__pycache__", "bin", "share"})
 
@@ -414,6 +427,12 @@ class RequirementsManager:
         Purging it would create a mismatch between the old class objects held
         by module-level variables (e.g. ``nnx.Module``) and the freshly loaded
         ones, breaking ``isinstance`` checks.
+
+        ``torch`` and its sibling C-extension packages are also excluded: their
+        ``.py`` modules cannot be safely re-executed because they call
+        ``torch._C._add_docstr`` on C-level functions whose docstrings have
+        already been set in the live process, raising ``RuntimeError: function
+        '<name>' already has a docstring``.
         """
         affected_normalized: Set[str] = set()
         for name in self._newly_installed | set(self._changed_versions.keys()):
@@ -430,6 +449,13 @@ class RequirementsManager:
                     f"[Requirements] JAX framework: skipping purge for {sorted(skipped)}"
                 )
             affected_normalized = affected_normalized - skip
+
+        torch_skipped = affected_normalized & self._TORCH_PURGE_SKIP
+        if torch_skipped:
+            _dbg(
+                f"[Requirements] skipping purge for torch C-extensions: {sorted(torch_skipped)}"
+            )
+            affected_normalized = affected_normalized - self._TORCH_PURGE_SKIP
 
         if not affected_normalized:
             return

--- a/tests/runner/test_config/torch/test_config_training_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_training_single_device.yaml
@@ -1568,22 +1568,22 @@ test_config:
     markers: [notimeout]
   allam/causal_lm/pytorch-7B_Instruct-single_device-training:
     status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_FE_COMPILATION
-    reason: "RuntimeError: function '_has_torch_function' already has a docstring"
+    bringup_status: FAILED_RUNTIME
+    reason: "Out of Memory: Not enough space to allocate 33554432 B DRAM buffer across 8 banks, where each bank needs to store 4194304 B"
   arcee/text_generation/pytorch-arcee_Spark-single_device-training:
     status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_FE_COMPILATION
-    reason: "RuntimeError: function '_has_torch_function' already has a docstring"
+    bringup_status: FAILED_RUNTIME
+    reason: "Out of Memory: Not enough space to allocate 135790592 B DRAM buffer across 8 banks, where each bank needs to store 16973824 B"
   attention_denseunet/pytorch-Base-single_device-training:
     status: NOT_SUPPORTED_SKIP
   bevformer/pytorch-v2_R50_T1-single_device-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
-    reason: "RuntimeError: function '_has_torch_function' already has a docstring"
+    reason: "AssertionError: Torch not compiled with CUDA enabled"
   bevformer/pytorch-v2_R50_T1_Base-single_device-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
-    reason: "RuntimeError: function '_has_torch_function' already has a docstring"
+    reason: "tt-forge-models doesn't implement unpack_forward_output for this model."
   boltz2/pytorch-Default-single_device-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
@@ -1595,19 +1595,19 @@ test_config:
   deepseek/deepseek_math/pytorch-7B_Instruct-single_device-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
-    reason: "RuntimeError: function '_has_torch_function' already has a docstring"
+    reason: "AttributeError raised from transformers/tokenization_utils_base.py:__getattr__"
   deepseek/qwen/pytorch-R1_Distill_32B-single_device-training:
     status: KNOWN_FAILURE_XFAIL
     markers: [notimeout]
     reason: "Out of Memory: Not enough space to allocate 8589934592 B DRAM buffer across 8 banks, where each bank needs to store 1073741824 B, but bank size is 4273390016 B"
   dinov2/image_classification/pytorch-Large-single_device-training:
     status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_FE_COMPILATION
-    reason: "RuntimeError: function '_has_torch_function' already has a docstring"
+    bringup_status: INCORRECT_RESULT
+    reason: "PCC comparison failed. Calculated: pcc=nan (invalid value). Required: pcc=0.99."
   dinov2/image_classification/pytorch-Small-single_device-training:
     status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_FE_COMPILATION
-    reason: "RuntimeError: function '_has_torch_function' already has a docstring"
+    bringup_status: INCORRECT_RESULT
+    reason: "PCC comparison failed. Calculated: pcc=nan (invalid value). Required: pcc=0.99."
   efficientdet/pytorch-D0-single_device-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
@@ -1618,19 +1618,19 @@ test_config:
     reason: "PCC comparison failed. Calculated: pcc=nan (invalid value). Required: pcc=0.99."
   falcon/pytorch-3_10B_Base-single_device-training:
     status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_FE_COMPILATION
-    reason: "RuntimeError: function '_has_torch_function' already has a docstring"
+    bringup_status: FAILED_RUNTIME
+    reason: "Out of Memory: Not enough space to allocate 141557760 B DRAM buffer across 8 banks, where each bank needs to store 17694720 B"
   falcon/pytorch-3_7B_Base-single_device-training:
     status: NOT_SUPPORTED_SKIP
   gemma/pytorch-2_27B_IT-single_device-training:
     status: NOT_SUPPORTED_SKIP
   gemma/pytorch-2_9B_IT-single_device-training:
-    bringup_status: FAILED_FE_COMPILATION
-    reason: "RuntimeError: function '_has_torch_function' already has a docstring"
+    bringup_status: FAILED_RUNTIME
+    reason: "Out of Memory: Not enough space to allocate 102760448 B DRAM buffer across 8 banks, where each bank needs to store 12845056 B"
   gemma/text_extraction_and_translation/pytorch-Translategemma_4B_IT-single_device-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
-    reason: "RuntimeError: function '_has_torch_function' already has a docstring"
+    reason: "tt-forge-models doesn't implement unpack_forward_output for this model."
   glm/causal_lm/pytorch-4.5_Air-single_device-training:
     status: NOT_SUPPORTED_SKIP
   gpt_neo/sequence_classification/pytorch-2_7B-single_device-training:
@@ -1644,7 +1644,7 @@ test_config:
   issac_groot/pytorch-Gr00t_N1.5_3B-single_device-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
-    reason: "RuntimeError: function '_has_torch_function' already has a docstring"
+    reason: "RuntimeError: element 0 of tensors does not require grad and does not have a grad_fn"
   llama/causal_lm/pytorch-3.2_3B-single_device-training:
     status: NOT_SUPPORTED_SKIP
   llama/llama_3_2_vision/pytorch-3.2_11B_Vision_Instruct-single_device-training:
@@ -1656,8 +1656,8 @@ test_config:
     markers: [large, notimeout]
   llama/sequence_classification/pytorch-3.1_8B-single_device-training:
     status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_FE_COMPILATION
-    reason: "RuntimeError: function '_has_torch_function' already has a docstring"
+    bringup_status: FAILED_RUNTIME
+    reason: "Out of Memory: Not enough space to allocate 33554432 B DRAM buffer across 8 banks, where each bank needs to store 4194304 B"
   maskformer_swin_b/pytorch-Swin_Base_Ade-single_device-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
@@ -1665,11 +1665,11 @@ test_config:
   minicpm_o_2_6/pytorch-Default-single_device-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
-    reason: "RuntimeError: function '_has_torch_function' already has a docstring"
+    reason: "OSError: Could not load this library: venv/lib/python3.12/site-packages/torchaudio/lib/libtorchaudio.so"
   mistral/pixtral/pytorch-single_device-training:
     status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_FE_COMPILATION
-    reason: "RuntimeError: function '_has_torch_function' already has a docstring"
+    bringup_status: FAILED_RUNTIME
+    reason: "Out of Memory: Not enough space to allocate 146800640 B DRAM buffer across 8 banks, where each bank needs to store 18350080 B"
   mistral/pytorch-Ministral_8B_Instruct-single_device-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_RUNTIME
@@ -1681,7 +1681,7 @@ test_config:
   olm_ocr/image_text_generation/pytorch-olmOCR-7B-0825-single_device-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
-    reason: "RuntimeError: function '_has_torch_function' already has a docstring"
+    reason: "tt-forge-models doesn't implement unpack_forward_output for this model."
   olmo3/causal_lm/pytorch-3_1025_7b-single_device-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_RUNTIME
@@ -1693,11 +1693,11 @@ test_config:
   openvla_oft/pytorch-Finetuned_Libero_Goal-single_device-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
-    reason: "RuntimeError: function '_has_torch_function' already has a docstring"
+    reason: "tt-forge-models doesn't implement unpack_forward_output for this model."
   openvla_oft/pytorch-Finetuned_Libero_Object-single_device-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
-    reason: "RuntimeError: function '_has_torch_function' already has a docstring"
+    reason: "tt-forge-models doesn't implement unpack_forward_output for this model."
   panoptic_segmentation/pytorch-ResNet101_Backbone_3x_COCO-single_device-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
@@ -1705,11 +1705,11 @@ test_config:
   petr/pytorch-Vovnet_Gridmask_P4_800x320-single_device-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
-    reason: "RuntimeError: function '_has_torch_function' already has a docstring"
+    reason: "NameError: name 'Image' is not defined"
   phi2/token_classification/pytorch-Phi_2-single_device-training:
     status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_FE_COMPILATION
-    reason: "RuntimeError: function '_has_torch_function' already has a docstring"
+    bringup_status: INCORRECT_RESULT
+    reason: "PCC comparison failed. Calculated: pcc=nan (invalid value). Required: pcc=0.99."
   phi3/phi_3_5/pytorch-Mini_Instruct-single_device-training:
     status: KNOWN_FAILURE_XFAIL
     markers: [notimeout]
@@ -1720,8 +1720,8 @@ test_config:
     reason: "Out of Memory: Not enough space to allocate 52428800 B DRAM buffer"
   phi4/token_cls/pytorch-Phi_4-single_device-training:
     status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_FE_COMPILATION
-    reason: "RuntimeError: function '_has_torch_function' already has a docstring"
+    bringup_status: FAILED_RUNTIME
+    reason: "Out of Memory: Not enough space to allocate 78643200 B DRAM buffer across 8 banks, where each bank needs to store 9830400 B"
   pi_0/pytorch-lerobot_pi0_libero_base-single_device-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
@@ -1730,12 +1730,12 @@ test_config:
     status: NOT_SUPPORTED_SKIP
   qwen_2_5/causal_lm/pytorch-7B_Instruct-single_device-training:
     status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_FE_COMPILATION
-    reason: "RuntimeError: function '_has_torch_function' already has a docstring"
+    bringup_status: FAILED_RUNTIME
+    reason: "Out of Memory: Not enough space to allocate 135790592 B DRAM buffer across 8 banks, where each bank needs to store 16973824 B"
   qwen_2_5/causal_lm/pytorch-7B_Instruct_1M-single_device-training:
     status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_FE_COMPILATION
-    reason: "RuntimeError: function '_has_torch_function' already has a docstring"
+    bringup_status: FAILED_RUNTIME
+    reason: "Out of Memory: Not enough space to allocate 135790592 B DRAM buffer across 8 banks, where each bank needs to store 16973824 B"
   qwen_2_5_coder/pytorch-7B-single_device-training:
     arch_overrides:
       n150:
@@ -1749,11 +1749,11 @@ test_config:
     status: NOT_SUPPORTED_SKIP
   qwen_3/causal_lm/pytorch-8B-single_device-training:
     status: NOT_SUPPORTED_SKIP
-    bringup_status: FAILED_FE_COMPILATION
-    reason: "RuntimeError: function '_has_torch_function' already has a docstring"
+    bringup_status: FAILED_RUNTIME
+    reason: "Out of Memory: Not enough space to allocate 100663296 B DRAM buffer across 8 banks, where each bank needs to store 12582912 B"
   qwen_3/causal_lm/pytorch-14B-single_device-training:
-    bringup_status: FAILED_FE_COMPILATION
-    reason: "RuntimeError: function '_has_torch_function' already has a docstring"
+    bringup_status: FAILED_RUNTIME
+    reason: "Out of Memory: Not enough space to allocate 178257920 B DRAM buffer across 8 banks, where each bank needs to store 22282240 B"
   rt_detr/pytorch-R34vd-single_device-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
@@ -1761,7 +1761,7 @@ test_config:
   rt_detr/pytorch-R50vd-single_device-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
-    reason: "RuntimeError: function '_has_torch_function' already has a docstring"
+    reason: "tt-forge-models doesn't implement unpack_forward_output for this model."
   seamless_m4t/pytorch-Large-single_device-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
@@ -1797,7 +1797,7 @@ test_config:
   yolov7/pytorch-Default-single_device-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
-    reason: "RuntimeError: function '_has_torch_function' already has a docstring"
+    reason: "tt-forge-models doesn't implement unpack_forward_output for this model."
   yolov7/pytorch-E6-single_device-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION


### PR DESCRIPTION
### Ticket
N/A — discovered while triaging training-test failures on `agobeljicTT/4923-2-dtype-skill`.

### Problem description
38 training tests in `test_config_training_single_device.yaml` were failing with the misleading
`RuntimeError: function '_has_torch_function' already has a docstring`. Zero inference tests had
the same signature.

Root cause: `tests/runner/requirements.py:_purge_stale_modules` deletes `sys.modules` entries for
any package whose freeze line changed during a per-model `pip install`. Some model `requirements.txt`
files (e.g. `seamless_m4t/.../requirements.txt → torchaudio==2.9.0`,
`pi_0/.../requirements.txt → torchcodec==0.10.0`) downgrade `torch`. When the purge then evicts
`torch.*` from `sys.modules`, the next `import torch.overrides` re-executes
`overrides.py`, which calls `torch._C._add_docstr(_has_torch_function, …)` on a C function whose
docstring was already set in this process — boom. The same hazard exists for any sibling C-extension
loaded at import time (`torchvision`, `torchaudio`, `torch_xla`) and for `tt_torch.torch_overrides`,
which monkey-patches torch globally on import.

### What's changed
1. `tests/runner/requirements.py`: added a `_TORCH_PURGE_SKIP` frozenset (`torch`, `torchvision`,
   `torchaudio`, `torch_xla`, `tt_torch`) that mirrors the existing `_JAX_PURGE_SKIP` for `flax`,
   and subtracted it from the purge set in `_purge_stale_modules` (with a `_dbg` line for visibility).
   This prevents re-execution of those modules' `.py` files inside the live process while still
   allowing pip rollback to update them on disk.
2. `tests/runner/test_config/torch/test_config_training_single_device.yaml`: re-ran every test that
   was failing with the docstring error and updated 25 entries to reflect the *real* underlying
   failure that the docstring error was previously masking:
   - **11× OOM** (large LLMs: allam-7B, arcee-Spark, falcon-3.10B, gemma-9B, llama-3.1-8B,
     mistral-pixtral, phi4, qwen_2_5-7B/1M, qwen_3-8B/14B) → `bringup_status: FAILED_RUNTIME` +
     specific DRAM-allocation reason matching the existing OOM convention.
   - **6× missing `unpack_forward_output` handler** (bevformer-Base, gemma-translate, olm_ocr,
     openvla_oft Goal/Object, rt_detr, yolov7-Default).
   - **3× PCC=nan** (dinov2-Large/Small, phi2) → `bringup_status: INCORRECT_RESULT`.
   - 1× CUDA-only model code (bevformer-T1).
   - 1× NO_GRAD on forward output (issac_groot).
   - 1× transformers tokenizer `AttributeError` (deepseek-7B).
   - 1× `NameError: 'Image' is not defined` loader bug (petr).
   - 1× `OSError: Could not load libtorchaudio.so` (minicpm_o_2_6 — its own pip install).

   8 entries are intentionally left as the docstring-error reason — a separate `seamless_m4t`-driven
   bug downgraded `torch` on disk (2.10.0+cpu → 2.9.0+cpu), and every test that ran after it died
   with `_XLAC undefined symbol: _ZNK3c1010TensorImpl19try_incref_pyobjectEv`. That is a real venv
   corruption, separate from this fix and out of scope here. Affected: seamless_m4t, siglip,
   smolvla, ultra_fast_lane_detection (both), yolov7-E6, yoloworld, llama_3_2_vision.

### Checklist
- [x] New/Existing tests provide coverage for changes — the 25 updated YAML entries are themselves
  the regression test surface; the next nightly will verify the docstring error doesn't reappear.