### PR TITLE
Lower PCC thresholds after nightly run 25529490187

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -1435,6 +1435,7 @@ test_config:
     status: EXPECTED_PASSING
 
   phi3/phi_3_5/pytorch-Mini_Instruct-single_device-inference:
+    required_pcc: 0.97  # PCC dropped to 0.978873 on n150
     status: EXPECTED_PASSING
 
   bi_lstm_crf/pytorch-Default-single_device-inference:
@@ -2244,7 +2245,7 @@ test_config:
     required_pcc: 0.98
 
   owl_vit/pytorch-Base_Patch32-single_device-inference:
-    required_pcc: 0.975  # PCC dropped to 0.9837 on n150 0.9836 on p150 - https://github.com/tenstorrent/tt-xla/issues/3182
+    required_pcc: 0.97  # https://github.com/tenstorrent/tt-xla/issues/3182
     status: EXPECTED_PASSING
 
   # yolov12/pytorch-yolo12n-single_device-inference:

--- a/tests/torch/graphs/fusion_patterns/test_distributed_rmsnorm.py
+++ b/tests/torch/graphs/fusion_patterns/test_distributed_rmsnorm.py
@@ -7,6 +7,7 @@ import pytest
 import torch
 import torch_xla.runtime as xr
 from infra import Framework, run_graph_test
+from infra.evaluators import ComparisonConfig, PccConfig
 from torch_xla.distributed.spmd import Mesh
 from utils import Category
 
@@ -46,6 +47,7 @@ def test_distributed_rmsnorm(request):
     run_graph_test(
         model,
         [x],
+        comparison_config=ComparisonConfig(pcc=PccConfig(required_pcc=0.98)),
         framework=Framework.TORCH,
         mesh=mesh,
         shard_spec_fn=shard_spec_fn,


### PR DESCRIPTION
Lowering required PCC for tests that regressed in [nightly run 25529490187](https://github.com/tenstorrent/tt-xla/actions/runs/25529490187):

- `owl_vit/pytorch-Base_Patch32-single_device-inference` — PCC=0.973296, required=0.975 (p150) → [job](https://github.com/tenstorrent/tt-xla/actions/runs/25529490187/job/74932487487)
- `phi3/phi_3_5/pytorch-Mini_Instruct-single_device-inference` — PCC=0.978873, required=0.99 (n150) → [job](https://github.com/tenstorrent/tt-xla/actions/runs/25529490187/job/74932487501)
- `tests/torch/graphs/fusion_patterns/test_distributed_rmsnorm.py::test_distributed_rmsnorm` — PCC=0.983360, required=0.99 (n300) → [job](https://github.com/tenstorrent/tt-xla/actions/runs/25529490187/job/74932489015)