### PR TITLE
[vLLM plugin] Use [1, num_devices] shape for 1D mesh

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -1599,7 +1599,6 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         if (
             self.enable_tensor_parallel
-            and self.use_2d_mesh
             and self.model.lm_head is not None
             and isinstance(self.model.lm_head, ParallelLMHead)
         ):
@@ -1798,7 +1797,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             # Mark dummy inputs to match the generated hidden_states shardings
             # (during execution) to avoid re-compilation of select_hidden_states
             # graph later.
-            if self.enable_tensor_parallel and self.use_2d_mesh:
+            if self.enable_tensor_parallel:
                 xs.mark_sharding(dummy_hidden, self.mesh, (None, None, "model"))
 
             self.select_hidden_states(dummy_hidden, indices)
@@ -1818,6 +1817,8 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             (self.max_num_reqs, hsize), dtype=self._hidden_states_dtype
         )
         dummy_hidden = dummy_hidden.to(self.device)
+        if self.enable_tensor_parallel and self.is_sharded_compute_logits:
+            xs.mark_sharding(dummy_hidden, self.mesh, (None, None))
 
         self.compute_logits(dummy_hidden)
 
@@ -2184,7 +2185,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
     def select_hidden_states(self, hidden_states, indices_do_sample):
         batch_indices = torch.arange(indices_do_sample.shape[0], dtype=torch.int32)
         result = hidden_states[batch_indices, indices_do_sample, :]
-        if self.enable_tensor_parallel and self.use_2d_mesh:
+        if self.enable_tensor_parallel:
             result = sharding_constraint_tensor(result, self.mesh, (None, None))
         return result
 
@@ -2195,9 +2196,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # (quant_method.apply bypasses __call__) and all_gather is a
         # no-op (world_size=1). Must be inside the compiled graph —
         # external sharding_constraint between compiled functions breaks.
-        if self.enable_tensor_parallel and (
-            not self.use_2d_mesh or self.is_sharded_compute_logits
-        ):
+        if self.enable_tensor_parallel and self.is_sharded_compute_logits:
             logits = sharding_constraint_tensor(logits, self.mesh, (None, None))
         return logits
 

--- a/integrations/vllm_plugin/vllm_tt/pooling_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/pooling_runner.py
@@ -980,7 +980,7 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             is_causal = False
 
         if self.enable_data_parallel and attn_mask is not None:
-            xs.mark_sharding(attn_mask, self.mesh, ("batch", None, None, None))
+            xs.mark_sharding(attn_mask, self.mesh, ("model", None, None, None))
 
         attn_metadata = TTMetadata(
             attn_mask=attn_mask,
@@ -1221,8 +1221,8 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
             # Mark inputs for data parallel sharding.
             if self.enable_data_parallel:
-                xs.mark_sharding(input_ids, self.mesh, ("batch", None))
-                xs.mark_sharding(self.position_ids, self.mesh, ("batch", None))
+                xs.mark_sharding(input_ids, self.mesh, ("model", None))
+                xs.mark_sharding(self.position_ids, self.mesh, ("model", None))
 
             # Run the decoder
             with set_forward_context(
@@ -1440,8 +1440,8 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         # Mark inputs for data parallel sharding.
         if self.enable_data_parallel:
-            xs.mark_sharding(input_ids, self.mesh, ("batch", None))
-            xs.mark_sharding(position_ids, self.mesh, ("batch", None))
+            xs.mark_sharding(input_ids, self.mesh, ("model", None))
+            xs.mark_sharding(position_ids, self.mesh, ("model", None))
 
         # Default Configurations: valid for single input per batch.
         attn_mask = None
@@ -1462,7 +1462,7 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         # Mark attention mask for data parallel sharding.
         if self.enable_data_parallel and attn_mask is not None:
-            xs.mark_sharding(attn_mask, self.mesh, ("batch", None, None, None))
+            xs.mark_sharding(attn_mask, self.mesh, ("model", None, None, None))
 
         attn_metadata = TTMetadata(
             attn_mask=attn_mask,

--- a/integrations/vllm_plugin/vllm_tt/vllm_distributed_utils.py
+++ b/integrations/vllm_plugin/vllm_tt/vllm_distributed_utils.py
@@ -229,7 +229,7 @@ def partition_column_parallel_linear(
     layer: torch.nn.Module, mesh: xs.Mesh
 ) -> torch.nn.Module:
     assert isinstance(layer, ColumnParallelLinear)
-    xs.mark_sharding(layer.weight, mesh, ("batch", None))
+    xs.mark_sharding(layer.weight, mesh, ("model", None))
     logger.debug("Applied parallel sharding to %s", layer)
     return layer
 
@@ -248,7 +248,7 @@ def partition_parallel_lm_head(
 ) -> torch.nn.Module:
     assert isinstance(layer, ParallelLMHead)
     logger.debug("Applied parallel sharding to %s", layer)
-    xs.mark_sharding(layer.weight, mesh, ("batch", None))
+    xs.mark_sharding(layer.weight, mesh, ("model", None))
     return layer
 
 
@@ -257,7 +257,7 @@ def partition_vocab_parallel_embedding(
 ) -> torch.nn.Module:
     assert isinstance(layer, VocabParallelEmbedding)
     logger.debug("Applied parallel sharding to %s", layer)
-    xs.mark_sharding(layer.weight, mesh, (None, "batch"))
+    xs.mark_sharding(layer.weight, mesh, (None, "model"))
     # Apply sharding constraint to the output of the layer.
     hook_forward = sharding_constraint_hook(layer, mesh, (None, None, None))
     layer.register_forward_hook(hook_forward)

--- a/integrations/vllm_plugin/vllm_tt/vllm_utils.py
+++ b/integrations/vllm_plugin/vllm_tt/vllm_utils.py
@@ -10,7 +10,7 @@ def determine_mesh_shape(num_devices: int, use_2d_mesh: bool) -> tuple[int, int]
     if use_2d_mesh:
         # Use predefined mesh shapes based on number of devices
         mesh_shapes = {
-            2: (2, 1),
+            2: (1, 2),
             4: (2, 2),
             8: (2, 4),
             16: (4, 4),
@@ -36,7 +36,7 @@ def determine_mesh_shape(num_devices: int, use_2d_mesh: bool) -> tuple[int, int]
             return mesh_shape
     else:
         # For 1D mesh, all devices are in one dimension.
-        mesh_shape = (num_devices, 1)
+        mesh_shape = (1, num_devices)
         logger.info(f"Using 1D mesh shape for {num_devices} devices: {mesh_shape}")
         return mesh_shape
 

--- a/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
@@ -10,8 +10,7 @@ from conftest import assert_output_coherent, check_host_memory
 @pytest.mark.tensor_parallel
 @pytest.mark.dual_chip
 @pytest.mark.parametrize("model_name", ["meta-llama/Llama-3.2-3B"])
-@pytest.mark.parametrize("use_2d_mesh", [True, False])
-def test_tensor_parallel_generation_n300(model_name: str, use_2d_mesh: bool):
+def test_tensor_parallel_generation_n300(model_name: str):
     prompts = [
         "I like taking walks in the",
     ]
@@ -26,7 +25,6 @@ def test_tensor_parallel_generation_n300(model_name: str, use_2d_mesh: bool):
             "enable_const_eval": False,
             "min_context_len": 32,
             "enable_tensor_parallel": True,
-            "use_2d_mesh": use_2d_mesh,
         },
     }
     llm = vllm.LLM(**llm_args)
@@ -40,16 +38,14 @@ def test_tensor_parallel_generation_n300(model_name: str, use_2d_mesh: bool):
 @pytest.mark.tensor_parallel
 @pytest.mark.llmbox
 @pytest.mark.parametrize(
-    ["model_name", "enable_const_eval", "experimental_weight_dtype"],
+    ["model_name"],
     [
-        pytest.param("Qwen/Qwen3-0.6B", False, ""),
+        pytest.param("Qwen/Qwen3-0.6B"),
     ],
 )
 @pytest.mark.parametrize("use_2d_mesh", [True, False])
 def test_tensor_parallel_generation_llmbox_small(
     model_name: str,
-    enable_const_eval: bool,
-    experimental_weight_dtype: str,
     use_2d_mesh: bool,
 ):
     prompts = [
@@ -63,10 +59,8 @@ def test_tensor_parallel_generation_llmbox_small(
         "max_model_len": 32,
         "gpu_memory_utilization": 0.002,
         "additional_config": {
-            "enable_const_eval": enable_const_eval,
             "min_context_len": 32,
             "enable_tensor_parallel": True,
-            "experimental_weight_dtype": experimental_weight_dtype,
             "use_2d_mesh": use_2d_mesh,
         },
     }
@@ -86,7 +80,7 @@ def test_tensor_parallel_generation_llmbox_small(
     ["model_name", "enable_const_eval", "experimental_weight_dtype", "use_2d_mesh"],
     [
         pytest.param("Qwen/Qwen3-32B", False, "", True),
-        pytest.param("Qwen/Qwen2.5-32B", False, "", False),
+        pytest.param("Qwen/Qwen3-8B", False, "", False),
         pytest.param("meta-llama/Llama-3.1-70B", True, "bfp_bf8", True),
     ],
 )


### PR DESCRIPTION
### Ticket
closes #4590 

### Problem description
vLLM is using [num_devices, 1] as mesh shape for 1D mesh.

### What's changed
Use [1, num_devices] as mesh shape for 1D mesh

### Checklist
- [X] New/Existing tests provide coverage for changes
