### PR TITLE
[pjrt] expose const-eval-inputs-to-system-memory pipeline option

### DIFF
--- a/pjrt_implementation/inc/api/compile_options.h
+++ b/pjrt_implementation/inc/api/compile_options.h
@@ -92,6 +92,22 @@ struct CompileOptions {
   // precision for all operations, which can improve accuracy for some models.
   bool enable_const_eval_on_cpu = true;
 
+  // Forces const-eval function inputs to be annotated as system memory in
+  // the executable's expected layout.
+  //
+  // ON  (default): consteval inputs stay on host RAM, cached outputs on
+  //                device DRAM. The host-side staging is held for the
+  //                BufferInstance's full lifetime (ensure_layout sees the
+  //                source already on host and skips migration).
+  //
+  // OFF:           consteval inputs migrate to device DRAM on first use,
+  //                so the host-side staging can be released between
+  //                stages. Useful for staged-load workloads (e.g. layer-
+  //                by-layer ship) where host data must be freed between
+  //                stages, at the cost of holding both inputs and cached
+  //                outputs on device DRAM.
+  bool enable_const_eval_inputs_to_system_memory = true;
+
   // Enables transpose + matmul and transpose + linear ops fusion.
   // This controls fusing of transpose + matmul and transpose + linear ops.
   // When disabled, transpose is kept as a separate op which can be constevaled,

--- a/pjrt_implementation/src/api/compile_options.cc
+++ b/pjrt_implementation/src/api/compile_options.cc
@@ -51,6 +51,10 @@ CompileOptions CompileOptions::parse(
   options.enable_const_eval_on_cpu =
       internal::parseBoolOption(compile_options, "enable_const_eval_on_cpu")
           .value_or(options.enable_const_eval_on_cpu);
+  options.enable_const_eval_inputs_to_system_memory =
+      internal::parseBoolOption(compile_options,
+                                "enable_const_eval_inputs_to_system_memory")
+          .value_or(options.enable_const_eval_inputs_to_system_memory);
   options.experimental_enable_permute_matmul_fusion =
       internal::parseBoolOption(compile_options,
                                 "experimental_enable_permute_matmul_fusion")

--- a/pjrt_implementation/src/api/module_builder/module_builder.cc
+++ b/pjrt_implementation/src/api/module_builder/module_builder.cc
@@ -1083,6 +1083,8 @@ tt_pjrt_status ModuleBuilder::convertFromTTIRToTTNN(
   options.systemDescPath = system_descriptor_path.data();
   options.enableConstEval = compile_options.enable_const_eval;
   options.enableCPUHoistedConstEval = compile_options.enable_const_eval_on_cpu;
+  options.enableConstEvalInputsToSystemMemory =
+      compile_options.enable_const_eval_inputs_to_system_memory;
   options.dramSpaceSavingOptimizationEnabled =
       compile_options.experimental_enable_dram_space_saving_optimization;
   options.ttnnPerfMetricsEnabled = compile_options.ttnn_perf_metrics_enabled;


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/4592)

### Problem description
We are not able to use existing ttnn option `enable_const_eval_inputs_to_system_memory`

### What's changed
Adds a PJRT compile option `enable_const_eval_inputs_to_system_memory` that forwards to the TTIRToTTNNCommonPipelineOptions field of the same name.

By default the compiler annotates const-eval function inputs as system memory in the executable's expected layout, which keeps their host-side copies alive for the lifetime of the model. For workloads that do not need the host copies after the first execute (e.g. when host RAM headroom is tight), exposing this option lets the caller opt out so the runtime migrates the inputs to device on first use and the host-side copy is released.

Default mirrors the compiler default (true), so existing behavior is unchanged.

### Checklist
- [ ] New/Existing tests provide coverage for changes
