### PR TITLE
[pjrt] release host source after layout migration

### DIFF
--- a/pjrt_implementation/inc/api/buffer_instance.h
+++ b/pjrt_implementation/inc/api/buffer_instance.h
@@ -113,6 +113,21 @@ public:
   // Deletes the buffer data.
   void deleteData();
 
+  // Marks the host-buffer-done event ready, releasing the framework-side
+  // reference to the source host buffer.
+  //
+  // For host buffer semantics that require the plugin to keep the source
+  // alive until transfer completes (e.g. kImmutableUntilTransferCompletes),
+  // the on-done callback is registered at copyFromHost time but only fires
+  // when the BufferInstance is destroyed. Calling this method earlier --
+  // e.g. once the runtime has migrated the data to device and no longer
+  // needs the host source -- lets the framework release that source
+  // promptly instead of holding it for the BufferInstance's lifetime.
+  //
+  // Safe to call multiple times: no-op when the event is null
+  // (semantics that fire eagerly inside copyFromHost) or already ready.
+  void fireDoneWithHostBufferEvent();
+
   // This method should asynchronously copy data into device buffer from the
   // given host buffer. Currently our runtime expects all input buffers to be on
   // host and to be copied to device during execution, because it needs to read

--- a/pjrt_implementation/src/api/buffer_instance.cc
+++ b/pjrt_implementation/src/api/buffer_instance.cc
@@ -171,6 +171,35 @@ void BufferInstance::deleteData() {
   }
 }
 
+void BufferInstance::fireDoneWithHostBufferEvent() {
+  std::lock_guard<std::mutex> deleted_lock(m_data_deleted_mutex);
+  if (m_done_with_host_buffer_event == nullptr) {
+    return;
+  }
+  if (m_done_with_host_buffer_event->isReady()) {
+    m_done_with_host_buffer_event = nullptr;
+    return;
+  }
+  TT_FATAL(m_done_with_host_buffer_event->isIndestructible(),
+           "Expected done_with_host_buffer_event to be indestructible");
+
+  // Same cleanup-on-callback hack used by deleteData(): the callback
+  // deletes the EventInstance after the framework callback chain runs
+  // on a separate thread (see comment in deleteData).
+  m_done_with_host_buffer_event->onReady(
+      [](PJRT_Error *error, void *user_arg) {
+        delete reinterpret_cast<EventInstance *>(user_arg);
+      },
+      m_done_with_host_buffer_event);
+
+  EventInstance::markAsReadyAndCallback(m_done_with_host_buffer_event,
+                                        tt_pjrt_status::kSuccess);
+
+  // Null out so a later deleteData() does not try to fire it again
+  // (which would assert on isReady()).
+  m_done_with_host_buffer_event = nullptr;
+}
+
 // Constructing buffer instance for the first time.
 void BufferInstance::copyFromHost(
     const void *host_buffer, PJRT_Buffer_Type data_type,

--- a/pjrt_implementation/src/api/tensor.cc
+++ b/pjrt_implementation/src/api/tensor.cc
@@ -85,6 +85,16 @@ void PjrtTensor::ensure_layout(const tt::runtime::Device &device,
   const bool retain = tt::runtime::getTensorRetain(m_runtime_tensor);
   m_runtime_tensor =
       tt::runtime::toLayout(m_runtime_tensor, device, layout, retain);
+
+  // Notify each shard so the host-buffer-done event fires now and the
+  // framework releases its source reference, instead of holding it for
+  // the BufferInstance's full lifetime. No-op when the event was already
+  // fired or never set.
+  for (BufferInstance *shard : m_shards) {
+    if (shard != nullptr) {
+      shard->fireDoneWithHostBufferEvent();
+    }
+  }
 }
 
 // Moves pjrt tensor to host.


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/4592)

### Problem description
Under host buffer semantics where the plugin keeps the source alive until transfer completes (kImmutableUntilTransferCompletes), the on-done callback registered at copyFromHost time would otherwise only fire in deleteData(), i.e. when the BufferInstance is being destroyed. For workloads that issue many host->device transfers sharing one BufferInstance lifetime, that delays the framework-side(torch-xla) release until model teardown.


### What's changed
Adds BufferInstance::fireDoneWithHostBufferEvent() and calls it from PjrtTensor::ensure_layout right after toLayout migrates the runtime tensor to the requested (device) layout.
Firing the event right after toLayout completes lets the framework drop its source reference promptly. The helper is idempotent (no-op when the event was already fired or never set), so it is safe under both host buffer semantics.

### Checklist
- [ ] New/Existing tests provide coverage for changes
