### PR TITLE
Weekly maintance may9

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -36,7 +36,6 @@ test_config:
     status: EXPECTED_PASSING
 
   qwen_2_5/causal_lm/pytorch-1.5B-single_device-inference:
-    assert_pcc: false
     status: EXPECTED_PASSING
 
   clip/pytorch-Base_Patch16-single_device-inference:
@@ -905,10 +904,6 @@ test_config:
 
   qwen_2_5_coder/pytorch-1.5B-single_device-inference:
     status: EXPECTED_PASSING
-    arch_overrides:
-      n150:
-        required_pcc: 0.98
-        status: EXPECTED_PASSING
 
   retinanet/pytorch-ResNet34_Backbone_with_FPN-single_device-inference:
     assert_pcc: false


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Weekly maintance may9

### What's changed
```
test_all_models_torch[qwen_2_5/causal_lm/pytorch-1.5B-single_device-inference]                                                             language    generality  bfloat16       n150         PASSED                     PASSING       0.9949066931352669     0.99       PCC_DIS  single_device    92.545    ENABLE_PCC_099
test_all_models_torch[qwen_2_5/causal_lm/pytorch-1.5B-single_device-inference]                                                             language    generality  bfloat16       p150         PASSED                     PASSING       0.9969187721010916     0.99       PCC_DIS  single_device    63.418    ENABLE_PCC_099



test_all_models_torch[qwen_2_5_coder/pytorch-1.5B-single_device-inference]                                                                 language    generality  bfloat16       n150         PASSED                     PASSING       0.9951442077673819     0.98       PCC_EN   single_device    93.733    RAISE_PCC_099 
test_all_models_torch[qwen_2_5_coder/pytorch-1.5B-single_device-inference]                                                                 language    generality  bfloat16       p150         PASSED                     PASSING       0.9955273238903509     0.99       PCC_EN   single_device    59.955    N/A           
```


Since the model is now passing in weekly runs, I’ve updated the configuration file accordingly.


### Checklist
- [ ] New/Existing tests provide coverage for changes
