### PR TITLE
Add model-test-emitpy preset to manual-test.yml

### DIFF
--- a/.github/workflows/manual-test.yml
+++ b/.github/workflows/manual-test.yml
@@ -30,6 +30,7 @@ on:
           - 'fusion-tests.json'
           - 'model-test-lb-blackhole-nightly.json'
           - 'model-test-lb-blackhole-weekly.json'
+          - 'model-test-emitpy.json'
           - 'Custom'
       test_suite_custom:
         description: 'Custom test suite json'


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`model-test-emitpy` doesn't exist as a preset in `manual-test.yml`. This makes it cumbersome to run - one needs to use the custom option and copy the json of `model-test-emitpy`.

### What's changed
Added the preset.

### Checklist
- [ ] New/Existing tests provide coverage for changes
