### PR TITLE
Don't download weights in GPT OSS training test

### DIFF
--- a/tests/torch/training/test_moe.py
+++ b/tests/torch/training/test_moe.py
@@ -9,6 +9,7 @@ import torch_xla.distributed.spmd as xs
 import torch_xla.runtime as xr
 from infra.utilities.torch_multichip_utils import enable_spmd
 from torch_xla.distributed.spmd import Mesh
+from transformers import AutoModelForCausalLM
 
 from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
     ModelLoader as GptOssModelLoader,
@@ -18,7 +19,35 @@ from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
 )
 from third_party.tt_forge_models.gpt_oss.pytorch.overrides import (
     build_deinterleaved_shard_specs,
+    override_gpt_oss_modules,
 )
+
+
+def init_model(model):
+    for param in model.parameters():
+        if param.dim() > 1:
+            torch.nn.init.normal_(param, mean=0.0, std=0.02)
+        else:
+            torch.nn.init.zeros_(param)
+    return model
+
+
+def load_gpt_oss():
+    model_loader = GptOssModelLoader(GptOssModelVariant.GPT_OSS_20B, num_layers=8)
+    model_loader.load_config()
+    config = model_loader.config
+    dtype = getattr(config, "torch_dtype", None) or torch.bfloat16
+    model = AutoModelForCausalLM.from_config(
+        config=config,
+        trust_remote_code=True,
+        attn_implementation="eager",
+        torch_dtype=dtype,
+    )
+    init_model(model)
+
+    override_gpt_oss_modules(model)
+    model_loader.model = model
+    return model, model_loader
 
 
 @pytest.mark.push
@@ -26,8 +55,7 @@ from third_party.tt_forge_models.gpt_oss.pytorch.overrides import (
 @pytest.mark.training
 def test_gpt_oss_moe_multichip_backward():
 
-    model_loader = GptOssModelLoader(GptOssModelVariant.GPT_OSS_20B, num_layers=8)
-    model = model_loader.load_model(patch_modules=True)
+    model, model_loader = load_gpt_oss()
 
     enable_spmd()
     xr.set_device_type("TT")


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-xla/issues/4595

### Problem description
Model weights get loaded since weight caching doesn't work in CIv2. 

### What's changed
Randomly init weights.

### Checklist
- [ ] New/Existing tests provide coverage for changes
