### PR TITLE
Set default kv cache dtype to bfp_bf8

### DIFF
--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -328,6 +328,7 @@ def test_llama_3_2_3b(
             if optimization_level is not None
             else DEFAULT_OPTIMIZATION_LEVEL
         ),
+        experimental_kv_cache_dtype=None,
     )
 
 
@@ -396,6 +397,7 @@ def test_gemma_2_2b(
             if optimization_level is not None
             else DEFAULT_OPTIMIZATION_LEVEL
         ),
+        experimental_kv_cache_dtype=None,
     )
 
 
@@ -430,6 +432,7 @@ def test_phi1(
             if optimization_level is not None
             else DEFAULT_OPTIMIZATION_LEVEL
         ),
+        experimental_kv_cache_dtype=None,
     )
 
 
@@ -464,6 +467,7 @@ def test_phi1_5(
             if optimization_level is not None
             else DEFAULT_OPTIMIZATION_LEVEL
         ),
+        experimental_kv_cache_dtype=None,
     )
 
 
@@ -498,6 +502,7 @@ def test_phi2(
             if optimization_level is not None
             else DEFAULT_OPTIMIZATION_LEVEL
         ),
+        experimental_kv_cache_dtype=None,
     )
 
 
@@ -607,6 +612,7 @@ def test_qwen_2_5_0_5b(
             if optimization_level is not None
             else DEFAULT_OPTIMIZATION_LEVEL
         ),
+        experimental_kv_cache_dtype=None,
     )
 
 
@@ -675,6 +681,7 @@ def test_qwen_3_1_7b(
             if optimization_level is not None
             else DEFAULT_OPTIMIZATION_LEVEL
         ),
+        experimental_kv_cache_dtype=None,
     )
 
 
@@ -709,6 +716,7 @@ def test_qwen_3_4b(
             if optimization_level is not None
             else DEFAULT_OPTIMIZATION_LEVEL
         ),
+        experimental_kv_cache_dtype=None,
     )
 
 
@@ -742,6 +750,7 @@ def test_qwen_2_5_1_5b(
             optimization_level if optimization_level is not None else 1
         ),
         required_pcc=0.90,
+        experimental_kv_cache_dtype=None,
     )
 
 
@@ -776,6 +785,7 @@ def test_qwen_2_5_3b(
             if optimization_level is not None
             else DEFAULT_OPTIMIZATION_LEVEL
         ),
+        experimental_kv_cache_dtype=None,
     )
 
 
@@ -1121,6 +1131,7 @@ def test_falcon3_7b_tp(
             if optimization_level is not None
             else DEFAULT_TP_OPTIMIZATION_LEVEL
         ),
+        experimental_kv_cache_dtype=None,
     )
 
 
@@ -1155,6 +1166,7 @@ def test_falcon3_10b_tp(
             if optimization_level is not None
             else DEFAULT_TP_OPTIMIZATION_LEVEL
         ),
+        experimental_kv_cache_dtype=None,
     )
 
 
@@ -1891,6 +1903,7 @@ def test_gpt_oss_20b_tp_galaxy_batch_size_64(
             batch_size if batch_size is not None else 64
         ),  # 128 fails to compile - https://github.com/tenstorrent/tt-xla/issues/3907
         optimization_level=1,
+        experimental_kv_cache_dtype=None,
     )
 
 
@@ -1968,6 +1981,7 @@ def test_gpt_oss_120b_tp_dp_galaxy_batch_size_128(
         input_output_sharding_spec=("batch", None),
         kv_cache_sharding_spec=("batch", "model", None, None),
         trace_enabled=True,
+        experimental_kv_cache_dtype=None,
     )
 
 
@@ -2003,6 +2017,7 @@ def test_gpt_oss_120b_tp_galaxy_batch_size_64(
         input_output_sharding_spec=("batch", None),
         kv_cache_sharding_spec=("batch", "model", None, None),
         trace_enabled=True,
+        experimental_kv_cache_dtype=None,
     )
 
 
@@ -2058,6 +2073,7 @@ def test_gpt_oss_120b_tp_qb2(
         optimization_level=1,
         trace_enabled=True,
         experimental_weight_dtype="bfp_bf8",
+        experimental_kv_cache_dtype=None,
         weight_dtype_overrides={
             "default": "bfp_bf8",
             "model.layers.*.mlp.experts.gate_up_proj": "bfp_bf4",

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -26,6 +26,7 @@ DEFAULT_INPUT_SEQUENCE_LENGTH = 128
 DEFAULT_DATA_FORMAT = "bfloat16"
 DEFAULT_TASK = "text-generation"
 DEFAULT_EXPERIMENTAL_WEIGHT_DTYPE = "bfp_bf8"
+DEFAULT_EXPERIMENTAL_KV_CACHE_DTYPE = "bfp_bf8"
 DEFAULT_EXPERIMENTAL_ENABLE_PERMUTE_MATMUL_FUSION = False
 DEFAULT_REQUIRED_PCC = 0.94
 
@@ -52,7 +53,7 @@ def test_llm(
     shard_spec_fn=None,
     required_pcc=DEFAULT_REQUIRED_PCC,
     fp32_dest_acc_en=None,
-    experimental_kv_cache_dtype=None,
+    experimental_kv_cache_dtype=DEFAULT_EXPERIMENTAL_KV_CACHE_DTYPE,
     num_layers=None,
     request=None,
     accuracy_testing: bool = False,


### PR DESCRIPTION
### Ticket

Closes #4343 
### Problem description
`experimental_kv_cache_dtype` currently must be set manually. It should be set to bfp_bf8 by default.

### What's changed

Sets `DEFAULT_EXPERIMENTAL_KV_CACHE_DTYPE="bfp_bf8"` so benchmark tests use bfp_bf8 KV cache by default.  39/55 tests use the default bfp_bf8 kv cache.     

### Excluded tests                       
Some models still use bfloat16 KV cache (`experimental_kv_cache_dtype=None`). Reasons: 
- There are pre-existing failures unrelated to this change (crashes or timeouts on both dtypes)
- Accuracy regression ≥5% with bfp_bf8 KV cache

[Performance benchmark experimental #135](https://github.com/tenstorrent/tt-xla/actions/runs/26401006322/job/77715017936)