### PR TITLE
Implement deferred transfer of host tensor data to multihost workers

### DIFF
--- a/pjrt_implementation/inc/api/buffer_instance.h
+++ b/pjrt_implementation/inc/api/buffer_instance.h
@@ -109,16 +109,6 @@ public:
     return m_borrowed_host_base_ptr;
   }
 
-  // True when both buffers borrow host memory with the same client base
-  // address (typical JAX aliasing of the same array).
-  bool aliasesSameBorrowedHostBase(const BufferInstance &other) const;
-
-  // True when both buffers borrow host memory and their naive contiguous spans
-  // [base, base + logicalTensorSize()) overlap. Exact for dense layout; custom
-  // byte_strides may reference bytes outside that span.
-  static bool borrowedHostByteRangesOverlap(const BufferInstance &a,
-                                            const BufferInstance &b);
-
   // Returns a string representation of the buffer's shape in the format
   // [d1,d2,d3,...].
   std::string toShapeStr() const;

--- a/pjrt_implementation/inc/api/buffer_instance.h
+++ b/pjrt_implementation/inc/api/buffer_instance.h
@@ -102,6 +102,23 @@ public:
   // the buffer's dimensions and data type.
   size_t logicalTensorSize() const;
 
+  // Base host pointer from PJRT_BufferFromHostBuffer when this buffer uses a
+  // borrowed host tensor (see copyFromHost). Null if the runtime owns a copy
+  // (owned tensor), or if the buffer was not created from a host submission.
+  const void *borrowedHostBasePointer() const {
+    return m_borrowed_host_base_ptr;
+  }
+
+  // True when both buffers borrow host memory with the same client base
+  // address (typical JAX aliasing of the same array).
+  bool aliasesSameBorrowedHostBase(const BufferInstance &other) const;
+
+  // True when both buffers borrow host memory and their naive contiguous spans
+  // [base, base + logicalTensorSize()) overlap. Exact for dense layout; custom
+  // byte_strides may reference bytes outside that span.
+  static bool borrowedHostByteRangesOverlap(const BufferInstance &a,
+                                            const BufferInstance &b);
+
   // Returns a string representation of the buffer's shape in the format
   // [d1,d2,d3,...].
   std::string toShapeStr() const;
@@ -211,6 +228,10 @@ private:
 
   // Unique identifier for this buffer instance.
   const uint64_t m_uid;
+
+  // PJRT client pointer for borrowed host tensors only; see
+  // borrowedHostBasePointer().
+  const void *m_borrowed_host_base_ptr = nullptr;
 
   // Buffer's data type.
   PJRT_Buffer_Type m_data_type;

--- a/pjrt_implementation/inc/api/buffer_instance.h
+++ b/pjrt_implementation/inc/api/buffer_instance.h
@@ -102,13 +102,6 @@ public:
   // the buffer's dimensions and data type.
   size_t logicalTensorSize() const;
 
-  // Base host pointer from PJRT_BufferFromHostBuffer when this buffer uses a
-  // borrowed host tensor (see copyFromHost). Null if the runtime owns a copy
-  // (owned tensor), or if the buffer was not created from a host submission.
-  const void *borrowedHostBasePointer() const {
-    return m_borrowed_host_base_ptr;
-  }
-
   // Returns a string representation of the buffer's shape in the format
   // [d1,d2,d3,...].
   std::string toShapeStr() const;
@@ -218,10 +211,6 @@ private:
 
   // Unique identifier for this buffer instance.
   const uint64_t m_uid;
-
-  // PJRT client pointer for borrowed host tensors only; see
-  // borrowedHostBasePointer().
-  const void *m_borrowed_host_base_ptr = nullptr;
 
   // Buffer's data type.
   PJRT_Buffer_Type m_data_type;

--- a/pjrt_implementation/inc/api/flatbuffer_loaded_executable_instance.h
+++ b/pjrt_implementation/inc/api/flatbuffer_loaded_executable_instance.h
@@ -56,6 +56,14 @@ private:
                      tt::runtime::Device device, size_t num_devices,
                      std::uint32_t program_index, size_t arg_index) override;
 
+  // In distributed runtime, runtime inputs from BufferFromHostBuffer are not
+  // pushed to device until prepareInputTensor. See issue #4011, due to a
+  // fundamental lack of information from PJRT API that would let us safely
+  // share memory on workers. This function actually pushes controller host
+  // "shell" runtime tensors to workers and discards the shells.
+  void
+  materializeShellTensors(const std::vector<BufferInstance *> &arg_buffers);
+
   // Creates flatbuffer loaded executable instance from the executable image.
   FlatbufferLoadedExecutableInstance(
       std::shared_ptr<FlatbufferExecutableImage> executable_image,

--- a/pjrt_implementation/inc/api/tensor.h
+++ b/pjrt_implementation/inc/api/tensor.h
@@ -73,8 +73,7 @@ public:
   // tensor.
   static PjrtTensor &
   from_runtime_tensor(std::vector<BufferInstance *> shards,
-                      tt::runtime::Tensor device_tensor,
-                      std::optional<HostTensorShell> shell = std::nullopt);
+                      tt::runtime::Tensor device_tensor);
   static PjrtTensor &
   from_host_tensor_shell(std::vector<BufferInstance *> shards,
                          HostTensorShell shell);

--- a/pjrt_implementation/inc/api/tensor.h
+++ b/pjrt_implementation/inc/api/tensor.h
@@ -71,12 +71,13 @@ public:
 
   // Creates new pjrt tensor for provided shards from an existing runtime
   // tensor.
-  static PjrtTensor &from_runtime_tensor(std::vector<BufferInstance *> shards,
-                                         tt::runtime::Tensor device_tensor,
-                                         std::optional<HostTensorShell> shell =
-                                             std::nullopt);
-  static PjrtTensor &from_host_tensor_shell(
-      std::vector<BufferInstance *> shards, HostTensorShell shell);
+  static PjrtTensor &
+  from_runtime_tensor(std::vector<BufferInstance *> shards,
+                      tt::runtime::Tensor device_tensor,
+                      std::optional<HostTensorShell> shell = std::nullopt);
+  static PjrtTensor &
+  from_host_tensor_shell(std::vector<BufferInstance *> shards,
+                         HostTensorShell shell);
 
 public: // Constructors needs to be public for std::shared_ptr.
   PjrtTensor(Private, std::vector<BufferInstance *> shards,
@@ -103,7 +104,9 @@ public: // Constructors needs to be public for std::shared_ptr.
              "Accessing runtime tensor on shell-only PjrtTensor");
     return *m_runtime_tensor;
   }
-  bool has_runtime_tensor() const noexcept { return m_runtime_tensor.has_value(); }
+  bool has_runtime_tensor() const noexcept {
+    return m_runtime_tensor.has_value();
+  }
   const std::optional<HostTensorShell> &host_tensor_shell() const {
     return m_host_tensor_shell;
   }

--- a/pjrt_implementation/inc/api/tensor.h
+++ b/pjrt_implementation/inc/api/tensor.h
@@ -13,6 +13,7 @@
 
 // c++ standard library includes
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -50,6 +51,14 @@ class PjrtTensor {
   };
 
 public:
+  struct HostTensorShell {
+    const void *host_buffer;
+    std::vector<std::uint32_t> shape;
+    std::vector<std::uint32_t> strides;
+    std::uint32_t element_size;
+    ::tt::target::DataType runtime_data_type;
+  };
+
   // Initializes pjrt tensor from pjrt buffers.
   //
   // If tensor already exists (shards already share same tensor) tensor will be
@@ -63,11 +72,15 @@ public:
   // Creates new pjrt tensor for provided shards from an existing runtime
   // tensor.
   static PjrtTensor &from_runtime_tensor(std::vector<BufferInstance *> shards,
-                                         tt::runtime::Tensor device_tensor);
+                                         tt::runtime::Tensor device_tensor,
+                                         std::optional<HostTensorShell> shell =
+                                             std::nullopt);
+  static PjrtTensor &from_host_tensor_shell(
+      std::vector<BufferInstance *> shards, HostTensorShell shell);
 
 public: // Constructors needs to be public for std::shared_ptr.
   PjrtTensor(Private, std::vector<BufferInstance *> shards,
-             tt::runtime::Tensor tensor);
+             std::optional<tt::runtime::Tensor> tensor);
 
   ~PjrtTensor();
 
@@ -80,8 +93,20 @@ public: // Constructors needs to be public for std::shared_ptr.
   std::vector<BufferInstance *> &shards() { return m_shards; };
   const std::vector<BufferInstance *> &shards() const { return m_shards; };
 
-  tt::runtime::Tensor &runtime_tensor() { return m_runtime_tensor; }
-  const tt::runtime::Tensor &runtime_tensor() const { return m_runtime_tensor; }
+  tt::runtime::Tensor &runtime_tensor() {
+    TT_FATAL(m_runtime_tensor.has_value(),
+             "Accessing runtime tensor on shell-only PjrtTensor");
+    return *m_runtime_tensor;
+  }
+  const tt::runtime::Tensor &runtime_tensor() const {
+    TT_FATAL(m_runtime_tensor.has_value(),
+             "Accessing runtime tensor on shell-only PjrtTensor");
+    return *m_runtime_tensor;
+  }
+  bool has_runtime_tensor() const noexcept { return m_runtime_tensor.has_value(); }
+  const std::optional<HostTensorShell> &host_tensor_shell() const {
+    return m_host_tensor_shell;
+  }
 
   uint64_t uid() const noexcept { return m_uid; }
 
@@ -120,8 +145,13 @@ private:
   // Tensor shards. Each shard hold pjrt tensor reference to this pjrt tensor.
   std::vector<BufferInstance *> m_shards;
 
-  // Underlying runtime tensor.
-  tt::runtime::Tensor m_runtime_tensor;
+  // Underlying runtime tensor. May be absent for shell-only host tensors until
+  // runtime materialization in prepareInputTensor.
+  std::optional<tt::runtime::Tensor> m_runtime_tensor;
+
+  // Optional metadata for host-submitted tensors used to recreate worker-local
+  // runtime tensors without depending on the initial runtime tensor descriptor.
+  std::optional<HostTensorShell> m_host_tensor_shell;
 };
 
 // Shared pointer to pjrt tensor used by all shards that holds tensor.

--- a/pjrt_implementation/inc/api/tensor.h
+++ b/pjrt_implementation/inc/api/tensor.h
@@ -71,9 +71,8 @@ public:
 
   // Creates new pjrt tensor for provided shards from an existing runtime
   // tensor.
-  static PjrtTensor &
-  from_runtime_tensor(std::vector<BufferInstance *> shards,
-                      tt::runtime::Tensor device_tensor);
+  static PjrtTensor &from_runtime_tensor(std::vector<BufferInstance *> shards,
+                                         tt::runtime::Tensor device_tensor);
   static PjrtTensor &
   from_host_tensor_shell(std::vector<BufferInstance *> shards,
                          HostTensorShell shell);

--- a/pjrt_implementation/inc/api/tensor.h
+++ b/pjrt_implementation/inc/api/tensor.h
@@ -57,6 +57,12 @@ public:
     std::vector<std::uint32_t> strides;
     std::uint32_t element_size;
     ::tt::target::DataType runtime_data_type;
+
+    bool operator==(const HostTensorShell &other) const {
+      return host_buffer == other.host_buffer && shape == other.shape &&
+             strides == other.strides && element_size == other.element_size &&
+             runtime_data_type == other.runtime_data_type;
+    }
   };
 
   // Initializes pjrt tensor from pjrt buffers.

--- a/pjrt_implementation/src/api/buffer_instance.cc
+++ b/pjrt_implementation/src/api/buffer_instance.cc
@@ -12,6 +12,7 @@
 
 // c++ standard library includes
 #include <cstring>
+#include <cstddef>
 #include <memory>
 #include <numeric>
 #include <optional>
@@ -125,6 +126,27 @@ size_t BufferInstance::logicalTensorSize() const {
                          });
 }
 
+bool BufferInstance::aliasesSameBorrowedHostBase(
+    const BufferInstance &other) const {
+  const void *a = m_borrowed_host_base_ptr;
+  const void *b = other.m_borrowed_host_base_ptr;
+  return a != nullptr && a == b;
+}
+
+bool BufferInstance::borrowedHostByteRangesOverlap(const BufferInstance &a,
+                                                   const BufferInstance &b) {
+  const void *pa = a.m_borrowed_host_base_ptr;
+  const void *pb = b.m_borrowed_host_base_ptr;
+  if (pa == nullptr || pb == nullptr) {
+    return false;
+  }
+  const auto *ba = static_cast<const std::byte *>(pa);
+  const auto *bb = static_cast<const std::byte *>(pb);
+  const size_t sa = a.logicalTensorSize();
+  const size_t sb = b.logicalTensorSize();
+  return ba < bb + sb && bb < ba + sa;
+}
+
 std::string BufferInstance::toShapeStr() const {
   return tt::pjrt::utils::to_string(m_dimensions);
 }
@@ -214,6 +236,7 @@ void BufferInstance::copyFromHost(
       data_type_utils::getPJRTBufferTypeString(data_type));
 
   m_pjrt_tensor.reset();
+  m_borrowed_host_base_ptr = nullptr;
 
   ::tt::target::DataType runtime_data_type =
       tt::pjrt::data_type_utils::convertPJRTToRuntimeDataType(m_data_type);
@@ -269,6 +292,8 @@ void BufferInstance::copyFromHost(
         const_cast<void *>(host_buffer), shape, strides, element_size,
         runtime_data_type);
 
+    m_borrowed_host_base_ptr = host_buffer;
+
     // Memory is aliased, we need to hold on to host buffer until this buffer is
     // deleted.
     m_done_with_host_buffer_event = done_with_host_buffer_event.get();
@@ -291,6 +316,8 @@ void BufferInstance::copyFromHost(
 void BufferInstance::copyFromBuffer(BufferInstance *src_buffer) {
   DLOG_F(LOG_DEBUG, "BufferInstance::copyFromBuffer");
   TT_FATAL(src_buffer->getPjrtTensor(), "Source buffer has no data.");
+
+  m_borrowed_host_base_ptr = nullptr;
 
   ::tt::target::DataType runtime_data_type =
       tt::pjrt::data_type_utils::convertPJRTToRuntimeDataType(

--- a/pjrt_implementation/src/api/buffer_instance.cc
+++ b/pjrt_implementation/src/api/buffer_instance.cc
@@ -259,7 +259,7 @@ void BufferInstance::copyFromHost(
         host_buffer, shape, strides, element_size, runtime_data_type};
     m_done_with_host_buffer_event = done_with_host_buffer_event.get();
     m_done_with_host_buffer_event->setIndestructible();
-    PjrtTensor::from_host_tensor_shell({this}, std::move(*host_tensor_shell));
+    PjrtTensor::from_host_tensor_shell({this}, std::move(host_tensor_shell));
   } else {
     if (cannot_borrow_host_buffer) {
       runtime_tensor = tt::runtime::createOwnedHostTensor(

--- a/pjrt_implementation/src/api/buffer_instance.cc
+++ b/pjrt_implementation/src/api/buffer_instance.cc
@@ -230,21 +230,17 @@ void BufferInstance::copyFromHost(
 
   tt::runtime::Tensor runtime_tensor;
 
-  // In distributed runtime, for ImmutableOnlyDuringCall semantics, or for
-  // unsupported runtime dtypes, we defer host tensor materialization until
+  // In distributed runtime, we defer host tensor materialization until
   // prepareInputTensor and keep only shell metadata in PjrtTensor.
   //
-  // In case when input host buffer has a semantic `ImmutableOnlyDuringCall`
-  // we are not allowed to alias it directly, so we have to create owned host
-  // tensor which copies buffer data. In JAX this semantic is used only for
-  // copying scalars and numpy arrays, so the copy shouldn't take long. We can
-  // mark the event as ready since we don't need the original host buffer
-  // anymore.
-  //
-  // If the runtime data type which has been inferred from m_data_type is not
-  // supported by runtime/ttnn, then we must create an owned tensor as runtime
-  // must case the data inside the host buffer into a supported data type. Thus,
-  // the buffer cannot be borrowed.
+  // In non-distributed runtime:
+  // - For `ImmutableOnlyDuringCall` semantics we are not allowed to alias the
+  //   host buffer directly, so we create an owned host tensor which copies
+  //   buffer data. In JAX this semantic is used only for copying scalars and
+  //   numpy arrays, so the copy shouldn't take long.
+  // - For unsupported runtime dtypes, we must create an owned tensor as runtime
+  //   must cast the data into a supported data type; the buffer cannot be
+  //   borrowed.
 
   bool is_distributed = ::tt::runtime::getCurrentHostRuntime() ==
                         tt::runtime::HostRuntime::Distributed;

--- a/pjrt_implementation/src/api/buffer_instance.cc
+++ b/pjrt_implementation/src/api/buffer_instance.cc
@@ -11,8 +11,8 @@
 #include "api/buffer_instance.h"
 
 // c++ standard library includes
-#include <cstring>
 #include <cstddef>
+#include <cstring>
 #include <memory>
 #include <numeric>
 #include <optional>
@@ -228,6 +228,8 @@ void BufferInstance::copyFromHost(
   std::unique_ptr<EventInstance> done_with_host_buffer_event =
       EventInstance::createInstance();
 
+  tt::runtime::Tensor runtime_tensor;
+
   std::optional<PjrtTensor::HostTensorShell> host_tensor_shell;
 
   // In distributed runtime, for ImmutableOnlyDuringCall semantics, or for
@@ -245,16 +247,26 @@ void BufferInstance::copyFromHost(
   // supported by runtime/ttnn, then we must create an owned tensor as runtime
   // must case the data inside the host buffer into a supported data type. Thus,
   // the buffer cannot be borrowed.
-  if (::tt::runtime::getCurrentHostRuntime() ==
-          tt::runtime::HostRuntime::Distributed ||
-      host_buffer_semantics ==
+  if (host_buffer_semantics ==
           PJRT_HostBufferSemantics_kImmutableOnlyDuringCall ||
       !::tt::runtime::utils::isSupportedDataType(runtime_data_type)) {
-    host_tensor_shell = PjrtTensor::HostTensorShell{
-        host_buffer, shape, strides, element_size, runtime_data_type};
-    m_done_with_host_buffer_event = done_with_host_buffer_event.get();
-    m_done_with_host_buffer_event->setIndestructible();
-    PjrtTensor::from_host_tensor_shell({this}, std::move(*host_tensor_shell));
+
+    if (::tt::runtime::getCurrentHostRuntime() ==
+        tt::runtime::HostRuntime::Distributed) {
+      host_tensor_shell = PjrtTensor::HostTensorShell{
+          host_buffer, shape, strides, element_size, runtime_data_type};
+      m_done_with_host_buffer_event = done_with_host_buffer_event.get();
+      m_done_with_host_buffer_event->setIndestructible();
+      PjrtTensor::from_host_tensor_shell({this}, std::move(*host_tensor_shell));
+    } else {
+      runtime_tensor = tt::runtime::createOwnedHostTensor(
+          host_buffer, shape, strides, element_size, runtime_data_type);
+      // Memory is copied, we don't need host buffer anymore.
+      EventInstance::markAsReadyAndCallback(done_with_host_buffer_event.get(),
+                                            tt_pjrt_status::kSuccess);
+      PjrtTensor::from_runtime_tensor({this}, std::move(runtime_tensor));
+    }
+
   }
   // Otherwise when input host buffer has other semantic we are allowed to alias
   // it, so we can create borrowed host which doesn't copy any data and instead
@@ -265,7 +277,7 @@ void BufferInstance::copyFromHost(
     // TODO(mrakita): Metal doesn't have a read-only version of borrowed buffer
     // so we have to const cast here.
     // https://github.com/tenstorrent/tt-metal/issues/20622
-    tt::runtime::Tensor runtime_tensor = tt::runtime::createBorrowedHostTensor(
+    runtime_tensor = tt::runtime::createBorrowedHostTensor(
         const_cast<void *>(host_buffer), shape, strides, element_size,
         runtime_data_type);
     host_tensor_shell = PjrtTensor::HostTensorShell{

--- a/pjrt_implementation/src/api/buffer_instance.cc
+++ b/pjrt_implementation/src/api/buffer_instance.cc
@@ -250,10 +250,11 @@ void BufferInstance::copyFromHost(
   std::unique_ptr<EventInstance> done_with_host_buffer_event =
       EventInstance::createInstance();
 
-  tt::runtime::Tensor runtime_tensor;
+  std::optional<PjrtTensor::HostTensorShell> host_tensor_shell;
 
-  // In distributed runtime, we always create owned host tensor because we
-  // cannot alias the host buffer.
+  // In distributed runtime, for ImmutableOnlyDuringCall semantics, or for
+  // unsupported runtime dtypes, we defer host tensor materialization until
+  // prepareInputTensor and keep only shell metadata in PjrtTensor.
   //
   // In case when input host buffer has a semantic `ImmutableOnlyDuringCall`
   // we are not allowed to alias it directly, so we have to create owned host
@@ -271,19 +272,13 @@ void BufferInstance::copyFromHost(
       host_buffer_semantics ==
           PJRT_HostBufferSemantics_kImmutableOnlyDuringCall ||
       !::tt::runtime::utils::isSupportedDataType(runtime_data_type)) {
-
-    // runtime_tensor = tt::runtime::createOwnedHostTensor(
-    //     host_buffer, shape, strides, element_size, runtime_data_type);
-
-    // // Memory is copied, we don't need host buffer anymore.
-    // EventInstance::markAsReadyAndCallback(done_with_host_buffer_event.get(),
-    //                                       tt_pjrt_status::kSuccess);
     m_borrowed_host_base_ptr = host_buffer;
 
-    runtime_tensor = tt::runtime::createBorrowedHostTensorOnController(const_cast<void *>(host_buffer), shape, strides, element_size, runtime_data_type);
+    host_tensor_shell = PjrtTensor::HostTensorShell{
+        host_buffer, shape, strides, element_size, runtime_data_type};
     m_done_with_host_buffer_event = done_with_host_buffer_event.get();
     m_done_with_host_buffer_event->setIndestructible();
-    
+    PjrtTensor::from_host_tensor_shell({this}, std::move(*host_tensor_shell));
   }
   // Otherwise when input host buffer has other semantic we are allowed to alias
   // it, so we can create borrowed host which doesn't copy any data and instead
@@ -294,9 +289,11 @@ void BufferInstance::copyFromHost(
     // TODO(mrakita): Metal doesn't have a read-only version of borrowed buffer
     // so we have to const cast here.
     // https://github.com/tenstorrent/tt-metal/issues/20622
-    runtime_tensor = tt::runtime::createBorrowedHostTensor(
+    tt::runtime::Tensor runtime_tensor = tt::runtime::createBorrowedHostTensor(
         const_cast<void *>(host_buffer), shape, strides, element_size,
         runtime_data_type);
+    host_tensor_shell = PjrtTensor::HostTensorShell{
+        host_buffer, shape, strides, element_size, runtime_data_type};
 
     m_borrowed_host_base_ptr = host_buffer;
 
@@ -308,9 +305,10 @@ void BufferInstance::copyFromHost(
     // XLA PJRT client destroys event immediately after it sets callback on it.
     // https://github.com/openxla/xla/issues/25172
     m_done_with_host_buffer_event->setIndestructible();
-  }
 
-  PjrtTensor::from_runtime_tensor({this}, runtime_tensor);
+    PjrtTensor::from_runtime_tensor({this}, std::move(runtime_tensor),
+                                    std::move(host_tensor_shell));
+  }
 
   markAsDataReady();
 

--- a/pjrt_implementation/src/api/buffer_instance.cc
+++ b/pjrt_implementation/src/api/buffer_instance.cc
@@ -251,6 +251,11 @@ void BufferInstance::copyFromHost(
       !::tt::runtime::utils::isSupportedDataType(runtime_data_type);
 
   if (is_distributed) {
+    TT_ASSERT(host_buffer_semantics !=
+                  PJRT_HostBufferSemantics_kImmutableOnlyDuringCall,
+              "In distributed mode we unsafely borrow data from host_buffer; "
+              "this is okay iff caller guarantees that host_buffer lifetime is "
+              "safe until execution.");
     PjrtTensor::HostTensorShell host_tensor_shell = PjrtTensor::HostTensorShell{
         host_buffer, shape, strides, element_size, runtime_data_type};
     m_done_with_host_buffer_event = done_with_host_buffer_event.get();

--- a/pjrt_implementation/src/api/buffer_instance.cc
+++ b/pjrt_implementation/src/api/buffer_instance.cc
@@ -247,54 +247,54 @@ void BufferInstance::copyFromHost(
   // the buffer cannot be borrowed.
 
   bool is_distributed = ::tt::runtime::getCurrentHostRuntime() ==
-        tt::runtime::HostRuntime::Distributed;
-  
-  bool cannot_borrow_host_buffer = host_buffer_semantics ==
+                        tt::runtime::HostRuntime::Distributed;
+
+  bool cannot_borrow_host_buffer =
+      host_buffer_semantics ==
           PJRT_HostBufferSemantics_kImmutableOnlyDuringCall ||
       !::tt::runtime::utils::isSupportedDataType(runtime_data_type);
 
-  if (is_distributed){
+  if (is_distributed) {
     PjrtTensor::HostTensorShell host_tensor_shell = PjrtTensor::HostTensorShell{
-      host_buffer, shape, strides, element_size, runtime_data_type};
+        host_buffer, shape, strides, element_size, runtime_data_type};
     m_done_with_host_buffer_event = done_with_host_buffer_event.get();
     m_done_with_host_buffer_event->setIndestructible();
-    PjrtTensor::from_host_tensor_shell({this}, std::move(host_tensor_shell));
-  }
-  else{
-    if(cannot_borrow_host_buffer){
+    PjrtTensor::from_host_tensor_shell({this}, std::move(*host_tensor_shell));
+  } else {
+    if (cannot_borrow_host_buffer) {
       runtime_tensor = tt::runtime::createOwnedHostTensor(
-        host_buffer, shape, strides, element_size, runtime_data_type);
+          host_buffer, shape, strides, element_size, runtime_data_type);
       // Memory is copied, we don't need host buffer anymore.
       EventInstance::markAsReadyAndCallback(done_with_host_buffer_event.get(),
                                             tt_pjrt_status::kSuccess);
       PjrtTensor::from_runtime_tensor({this}, std::move(runtime_tensor));
     }
 
-    // Otherwise when input host buffer has other semantic we are allowed to alias
-    // it, so we can create borrowed host which doesn't copy any data and instead
-    // uses direct pointer to existing data. Since we are holding a pointer to the
-    // original data we can't mark the event as ready yet, so we remember it and
-    // mark it as ready once the buffer is destroyed.
-    else{
-    // TODO(mrakita): Metal doesn't have a read-only version of borrowed buffer
-    // so we have to const cast here.
-    // https://github.com/tenstorrent/tt-metal/issues/20622
-    runtime_tensor = tt::runtime::createBorrowedHostTensor(
-      const_cast<void *>(host_buffer), shape, strides, element_size,
-      runtime_data_type);
+    // Otherwise when input host buffer has other semantic we are allowed to
+    // alias it, so we can create borrowed host which doesn't copy any data and
+    // instead uses direct pointer to existing data. Since we are holding a
+    // pointer to the original data we can't mark the event as ready yet, so we
+    // remember it and mark it as ready once the buffer is destroyed.
+    else {
+      // TODO(mrakita): Metal doesn't have a read-only version of borrowed
+      // buffer so we have to const cast here.
+      // https://github.com/tenstorrent/tt-metal/issues/20622
+      runtime_tensor = tt::runtime::createBorrowedHostTensor(
+          const_cast<void *>(host_buffer), shape, strides, element_size,
+          runtime_data_type);
 
-    // Memory is aliased, we need to hold on to host buffer until this buffer is
-    // deleted.
-    m_done_with_host_buffer_event = done_with_host_buffer_event.get();
+      // Memory is aliased, we need to hold on to host buffer until this buffer
+      // is deleted.
+      m_done_with_host_buffer_event = done_with_host_buffer_event.get();
 
-    // TODO(mrakita): This is a major hack that we currently have to do because
-    // XLA PJRT client destroys event immediately after it sets callback on it.
-    // https://github.com/openxla/xla/issues/25172
-    m_done_with_host_buffer_event->setIndestructible();
+      // TODO(mrakita): This is a major hack that we currently have to do
+      // because XLA PJRT client destroys event immediately after it sets
+      // callback on it. https://github.com/openxla/xla/issues/25172
+      m_done_with_host_buffer_event->setIndestructible();
 
-    PjrtTensor::from_runtime_tensor({this}, std::move(runtime_tensor));
+      PjrtTensor::from_runtime_tensor({this}, std::move(runtime_tensor));
     }
-  }    
+  }
 
   markAsDataReady();
 

--- a/pjrt_implementation/src/api/buffer_instance.cc
+++ b/pjrt_implementation/src/api/buffer_instance.cc
@@ -272,12 +272,18 @@ void BufferInstance::copyFromHost(
           PJRT_HostBufferSemantics_kImmutableOnlyDuringCall ||
       !::tt::runtime::utils::isSupportedDataType(runtime_data_type)) {
 
-    runtime_tensor = tt::runtime::createOwnedHostTensor(
-        host_buffer, shape, strides, element_size, runtime_data_type);
+    // runtime_tensor = tt::runtime::createOwnedHostTensor(
+    //     host_buffer, shape, strides, element_size, runtime_data_type);
 
-    // Memory is copied, we don't need host buffer anymore.
-    EventInstance::markAsReadyAndCallback(done_with_host_buffer_event.get(),
-                                          tt_pjrt_status::kSuccess);
+    // // Memory is copied, we don't need host buffer anymore.
+    // EventInstance::markAsReadyAndCallback(done_with_host_buffer_event.get(),
+    //                                       tt_pjrt_status::kSuccess);
+    m_borrowed_host_base_ptr = host_buffer;
+
+    runtime_tensor = tt::runtime::createBorrowedHostTensorOnController(const_cast<void *>(host_buffer), shape, strides, element_size, runtime_data_type);
+    m_done_with_host_buffer_event = done_with_host_buffer_event.get();
+    m_done_with_host_buffer_event->setIndestructible();
+    
   }
   // Otherwise when input host buffer has other semantic we are allowed to alias
   // it, so we can create borrowed host which doesn't copy any data and instead

--- a/pjrt_implementation/src/api/buffer_instance.cc
+++ b/pjrt_implementation/src/api/buffer_instance.cc
@@ -126,27 +126,6 @@ size_t BufferInstance::logicalTensorSize() const {
                          });
 }
 
-bool BufferInstance::aliasesSameBorrowedHostBase(
-    const BufferInstance &other) const {
-  const void *a = m_borrowed_host_base_ptr;
-  const void *b = other.m_borrowed_host_base_ptr;
-  return a != nullptr && a == b;
-}
-
-bool BufferInstance::borrowedHostByteRangesOverlap(const BufferInstance &a,
-                                                   const BufferInstance &b) {
-  const void *pa = a.m_borrowed_host_base_ptr;
-  const void *pb = b.m_borrowed_host_base_ptr;
-  if (pa == nullptr || pb == nullptr) {
-    return false;
-  }
-  const auto *ba = static_cast<const std::byte *>(pa);
-  const auto *bb = static_cast<const std::byte *>(pb);
-  const size_t sa = a.logicalTensorSize();
-  const size_t sb = b.logicalTensorSize();
-  return ba < bb + sb && bb < ba + sa;
-}
-
 std::string BufferInstance::toShapeStr() const {
   return tt::pjrt::utils::to_string(m_dimensions);
 }

--- a/pjrt_implementation/src/api/buffer_instance.cc
+++ b/pjrt_implementation/src/api/buffer_instance.cc
@@ -215,7 +215,6 @@ void BufferInstance::copyFromHost(
       data_type_utils::getPJRTBufferTypeString(data_type));
 
   m_pjrt_tensor.reset();
-  m_borrowed_host_base_ptr = nullptr;
 
   ::tt::target::DataType runtime_data_type =
       tt::pjrt::data_type_utils::convertPJRTToRuntimeDataType(m_data_type);
@@ -251,8 +250,6 @@ void BufferInstance::copyFromHost(
       host_buffer_semantics ==
           PJRT_HostBufferSemantics_kImmutableOnlyDuringCall ||
       !::tt::runtime::utils::isSupportedDataType(runtime_data_type)) {
-    m_borrowed_host_base_ptr = host_buffer;
-
     host_tensor_shell = PjrtTensor::HostTensorShell{
         host_buffer, shape, strides, element_size, runtime_data_type};
     m_done_with_host_buffer_event = done_with_host_buffer_event.get();
@@ -273,8 +270,6 @@ void BufferInstance::copyFromHost(
         runtime_data_type);
     host_tensor_shell = PjrtTensor::HostTensorShell{
         host_buffer, shape, strides, element_size, runtime_data_type};
-
-    m_borrowed_host_base_ptr = host_buffer;
 
     // Memory is aliased, we need to hold on to host buffer until this buffer is
     // deleted.
@@ -299,8 +294,6 @@ void BufferInstance::copyFromHost(
 void BufferInstance::copyFromBuffer(BufferInstance *src_buffer) {
   DLOG_F(LOG_DEBUG, "BufferInstance::copyFromBuffer");
   TT_FATAL(src_buffer->getPjrtTensor(), "Source buffer has no data.");
-
-  m_borrowed_host_base_ptr = nullptr;
 
   ::tt::target::DataType runtime_data_type =
       tt::pjrt::data_type_utils::convertPJRTToRuntimeDataType(

--- a/pjrt_implementation/src/api/buffer_instance.cc
+++ b/pjrt_implementation/src/api/buffer_instance.cc
@@ -230,8 +230,6 @@ void BufferInstance::copyFromHost(
 
   tt::runtime::Tensor runtime_tensor;
 
-  std::optional<PjrtTensor::HostTensorShell> host_tensor_shell;
-
   // In distributed runtime, for ImmutableOnlyDuringCall semantics, or for
   // unsupported runtime dtypes, we defer host tensor materialization until
   // prepareInputTensor and keep only shell metadata in PjrtTensor.
@@ -247,41 +245,43 @@ void BufferInstance::copyFromHost(
   // supported by runtime/ttnn, then we must create an owned tensor as runtime
   // must case the data inside the host buffer into a supported data type. Thus,
   // the buffer cannot be borrowed.
-  if (host_buffer_semantics ==
-          PJRT_HostBufferSemantics_kImmutableOnlyDuringCall ||
-      !::tt::runtime::utils::isSupportedDataType(runtime_data_type)) {
 
-    if (::tt::runtime::getCurrentHostRuntime() ==
-        tt::runtime::HostRuntime::Distributed) {
-      host_tensor_shell = PjrtTensor::HostTensorShell{
-          host_buffer, shape, strides, element_size, runtime_data_type};
-      m_done_with_host_buffer_event = done_with_host_buffer_event.get();
-      m_done_with_host_buffer_event->setIndestructible();
-      PjrtTensor::from_host_tensor_shell({this}, std::move(*host_tensor_shell));
-    } else {
+  bool is_distributed = ::tt::runtime::getCurrentHostRuntime() ==
+        tt::runtime::HostRuntime::Distributed;
+  
+  bool cannot_borrow_host_buffer = host_buffer_semantics ==
+          PJRT_HostBufferSemantics_kImmutableOnlyDuringCall ||
+      !::tt::runtime::utils::isSupportedDataType(runtime_data_type);
+
+  if (is_distributed){
+    PjrtTensor::HostTensorShell host_tensor_shell = PjrtTensor::HostTensorShell{
+      host_buffer, shape, strides, element_size, runtime_data_type};
+    m_done_with_host_buffer_event = done_with_host_buffer_event.get();
+    m_done_with_host_buffer_event->setIndestructible();
+    PjrtTensor::from_host_tensor_shell({this}, std::move(host_tensor_shell));
+  }
+  else{
+    if(cannot_borrow_host_buffer){
       runtime_tensor = tt::runtime::createOwnedHostTensor(
-          host_buffer, shape, strides, element_size, runtime_data_type);
+        host_buffer, shape, strides, element_size, runtime_data_type);
       // Memory is copied, we don't need host buffer anymore.
       EventInstance::markAsReadyAndCallback(done_with_host_buffer_event.get(),
                                             tt_pjrt_status::kSuccess);
       PjrtTensor::from_runtime_tensor({this}, std::move(runtime_tensor));
     }
 
-  }
-  // Otherwise when input host buffer has other semantic we are allowed to alias
-  // it, so we can create borrowed host which doesn't copy any data and instead
-  // uses direct pointer to existing data. Since we are holding a pointer to the
-  // original data we can't mark the event as ready yet, so we remember it and
-  // mark it as ready once the buffer is destroyed.
-  else {
+    // Otherwise when input host buffer has other semantic we are allowed to alias
+    // it, so we can create borrowed host which doesn't copy any data and instead
+    // uses direct pointer to existing data. Since we are holding a pointer to the
+    // original data we can't mark the event as ready yet, so we remember it and
+    // mark it as ready once the buffer is destroyed.
+    else{
     // TODO(mrakita): Metal doesn't have a read-only version of borrowed buffer
     // so we have to const cast here.
     // https://github.com/tenstorrent/tt-metal/issues/20622
     runtime_tensor = tt::runtime::createBorrowedHostTensor(
-        const_cast<void *>(host_buffer), shape, strides, element_size,
-        runtime_data_type);
-    host_tensor_shell = PjrtTensor::HostTensorShell{
-        host_buffer, shape, strides, element_size, runtime_data_type};
+      const_cast<void *>(host_buffer), shape, strides, element_size,
+      runtime_data_type);
 
     // Memory is aliased, we need to hold on to host buffer until this buffer is
     // deleted.
@@ -292,9 +292,9 @@ void BufferInstance::copyFromHost(
     // https://github.com/openxla/xla/issues/25172
     m_done_with_host_buffer_event->setIndestructible();
 
-    PjrtTensor::from_runtime_tensor({this}, std::move(runtime_tensor),
-                                    std::move(host_tensor_shell));
-  }
+    PjrtTensor::from_runtime_tensor({this}, std::move(runtime_tensor));
+    }
+  }    
 
   markAsDataReady();
 

--- a/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
@@ -119,7 +119,11 @@ FlatbufferLoadedExecutableInstance::prepareInputTensor(
       continue;
     }
     const void *host_base = buf->borrowedHostBasePointer();
-    if (host_base != nullptr) {
+    // Skip buffers that already have a runtime tensor - they've already been
+    // transferred in a previous execution. The shell metadata is discarded
+    // after the first transfer since we no longer need to copy from the
+    // client's host buffer.
+    if (host_base != nullptr && !buf->getPjrtTensor()->has_runtime_tensor()) {
       borrowed_host_base_ptr_to_buffers[host_base].push_back(buf);
     }
   }

--- a/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
@@ -71,6 +71,22 @@ FlatbufferLoadedExecutableInstance::prepareInputTensor(
     return std::nullopt;
   }
 
+  bool is_distributed = ::tt::runtime::getCurrentHostRuntime() ==
+                        tt::runtime::HostRuntime::Distributed;
+  if (is_distributed) {
+    materializeShellTensors(arg_buffers);
+  }
+
+  PjrtTensor &tensor = PjrtTensor::from_pjrt_buffers(
+      arg_buffers, m_executable_image->getDevicesMeshShape(), *strategy);
+
+  tensor.ensure_layout(runtime_device, expected_layout);
+
+  return tensor.runtime_tensor();
+}
+
+void FlatbufferLoadedExecutableInstance::materializeShellTensors(
+    const std::vector<BufferInstance *> &arg_buffers) {
   // Group arg buffers by their borrowed host base pointer. Buffers that do
   // not borrow host memory (i.e. own their host tensor) are skipped.
   std::unordered_map<const void *, std::vector<BufferInstance *>>
@@ -97,13 +113,11 @@ FlatbufferLoadedExecutableInstance::prepareInputTensor(
     }
 
     const auto &shell = buffers.front()->getPjrtTensor()->host_tensor_shell();
-    if (!shell.has_value()) {
-      LOG_F(ERROR,
-            "Missing host tensor shell metadata for buffer uid=%lu ptr=%p",
-            buffers.front()->getUID(),
-            static_cast<const void *>(buffers.front()));
-      return std::nullopt;
-    }
+
+    TT_FATAL(shell.has_value(),
+             "Missing host tensor shell metadata for buffer uid=%lu ptr=%p",
+             buffers.front()->getUID(),
+             static_cast<const void *>(buffers.front()));
 
     // First buffer gets a newly-allocated owned host tensor that actually
     // copies the bytes from the client's host_base pointer. Subsequent
@@ -128,16 +142,6 @@ FlatbufferLoadedExecutableInstance::prepareInputTensor(
                                       std::move(worker_runtime_tensor));
     }
   }
-
-  // from runtime tensor will create a multidevice host tensor from shards here,
-  // if necessary (strategy != identity) at this point, we should swap out the
-  // shards with the new worker local tensors
-  PjrtTensor &tensor = PjrtTensor::from_pjrt_buffers(
-      arg_buffers, m_executable_image->getDevicesMeshShape(), *strategy);
-
-  tensor.ensure_layout(runtime_device, expected_layout);
-
-  return tensor.runtime_tensor();
 }
 
 std::shared_ptr<FlatbufferExecutableImage>

--- a/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
@@ -65,6 +65,43 @@ FlatbufferLoadedExecutableInstance::prepareInputTensor(
       fillStrategyMapFromSharding(
           m_executable_image->getInputSharding(arg_index), num_devices);
 
+  // Log the buffers being introduced for debugging
+  {
+    std::ostringstream log_stream;
+    log_stream << "Arg buffers introduced for arg_index=" << arg_index << ": ";
+    for (size_t i = 0; i < arg_buffers.size(); ++i) {
+      const BufferInstance* buf = arg_buffers[i];
+      log_stream << "[i=" << i;
+      if (buf) {
+        log_stream << " ptr=" << buf
+                   << " data_ptr=" << buf->runtimeTensor().data
+                   << " shape=(";
+        const std::string shape = buf->toShapeStr();
+        log_stream << shape;
+        log_stream << ")";
+      } else {
+        log_stream << " null";
+      }
+      log_stream << "] ";
+    }
+
+    log_stream << " | Strategy {";
+    if (mlir::succeeded(strategy)) {
+      const auto& strat_map = *strategy;
+      size_t n = 0;
+      for (const auto& [k, v] : strat_map) {
+        log_stream << k << "=" << v;
+        if (++n < strat_map.size()) log_stream << ", ";
+      }
+    } else {
+      log_stream << "FAILED strategy";
+    }
+    log_stream << "}";
+
+    LOG_F(INFO, "%s", log_stream.str().c_str());
+  }
+
+          
   if (mlir::failed(strategy)) {
     LOG_F(ERROR, "Failed to fill strategy map from sharding");
     return std::nullopt;

--- a/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
@@ -150,6 +150,7 @@ FlatbufferLoadedExecutableInstance::prepareInputTensor(
     LOG_F(INFO, "%s", log_stream.str().c_str());
   }
   
+  size_t group_idx = 0;
   for (const auto &[host_base, buffers] : borrowed_host_base_ptr_to_buffers) {
     if (buffers.empty()) {
       continue;
@@ -168,13 +169,25 @@ FlatbufferLoadedExecutableInstance::prepareInputTensor(
     // tensor, so we only hold one copy of the data on the worker side.
     tt::runtime::Tensor owned_tensor =
         tt::runtime::createOwnedHostTensor(host_base, desc);
+    LOG_F(INFO,
+          "Group %zu: created owned host tensor (copied from host_base=%p)",
+          group_idx, host_base);
 
     for (size_t i = 0; i < buffers.size(); ++i) {
       BufferInstance *buffer = buffers[i];
 
+      const bool is_first = (i == 0);
       tt::runtime::Tensor worker_runtime_tensor =
-          (i == 0) ? owned_tensor
+          is_first ? owned_tensor
                    : tt::runtime::createUnsafeBorrowedHostTensor(owned_tensor);
+
+      LOG_F(INFO,
+            "Group %zu: replacing runtime tensor for buffer uid=%lu ptr=%p "
+            "shape=(%s) with %s tensor (i=%zu/%zu)",
+            group_idx, buffer->getUID(),
+            static_cast<const void *>(buffer),
+            buffer->toShapeStr().c_str(),
+            is_first ? "owned" : "unsafe-borrowed", i, buffers.size());
 
       // Inplace replacement: rebuilds the BufferInstance's PjrtTensor around
       // the new runtime tensor and updates m_pjrt_tensor via setPjrtTensor.
@@ -182,6 +195,8 @@ FlatbufferLoadedExecutableInstance::prepareInputTensor(
       PjrtTensor::from_runtime_tensor({buffer},
                                       std::move(worker_runtime_tensor));
     }
+
+    ++group_idx;
   }
 
 

--- a/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
@@ -101,10 +101,52 @@ FlatbufferLoadedExecutableInstance::prepareInputTensor(
     LOG_F(INFO, "%s", log_stream.str().c_str());
   }
 
-          
+         
   if (mlir::failed(strategy)) {
     LOG_F(ERROR, "Failed to fill strategy map from sharding");
     return std::nullopt;
+  }
+
+  // Group arg buffers by their borrowed host base pointer. Buffers that do
+  // not borrow host memory (i.e. own their host tensor) are skipped.
+  std::unordered_map<const void *, std::vector<BufferInstance *>>
+      borrowed_host_base_ptr_to_buffers;
+  borrowed_host_base_ptr_to_buffers.reserve(arg_buffers.size());
+
+  for (BufferInstance *buf : arg_buffers) {
+    if (buf == nullptr) {
+      continue;
+    }
+    const void *host_base = buf->borrowedHostBasePointer();
+    if (host_base != nullptr) {
+      borrowed_host_base_ptr_to_buffers[host_base].push_back(buf);
+    }
+  }
+
+  // map population
+  {
+    std::ostringstream log_stream;
+    log_stream << "borrowed_host_base_ptr_to_buffers for arg_index="
+               << arg_index << " (entries=" << borrowed_host_base_ptr_to_buffers.size()
+               << "): ";
+    size_t entry_idx = 0;
+    for (const auto &[host_base, buffers] : borrowed_host_base_ptr_to_buffers) {
+      log_stream << "{host_base=" << host_base
+                 << " count=" << buffers.size() << " buffers=[";
+      for (size_t i = 0; i < buffers.size(); ++i) {
+        const BufferInstance *b = buffers[i];
+        log_stream << "(uid=" << b->getUID() << " ptr=" << b
+                   << " shape=(" << b->toShapeStr() << "))";
+        if (i + 1 < buffers.size()) {
+          log_stream << ", ";
+        }
+      }
+      log_stream << "]}";
+      if (++entry_idx < borrowed_host_base_ptr_to_buffers.size()) {
+        log_stream << ", ";
+      }
+    }
+    LOG_F(INFO, "%s", log_stream.str().c_str());
   }
 
   PjrtTensor &tensor = PjrtTensor::from_pjrt_buffers(

--- a/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
@@ -87,31 +87,19 @@ FlatbufferLoadedExecutableInstance::prepareInputTensor(
 
 void FlatbufferLoadedExecutableInstance::materializeShellTensors(
     const std::vector<BufferInstance *> &arg_buffers) {
-  // Group arg buffers by their borrowed host base pointer. Buffers that do
-  // not borrow host memory (i.e. own their host tensor) are skipped.
+  // Group arg buffers by their borrowed host base pointer for grouped transfer
   std::unordered_map<const void *, std::vector<BufferInstance *>>
       borrowed_host_base_ptr_to_buffers;
-  borrowed_host_base_ptr_to_buffers.reserve(arg_buffers.size());
 
   for (BufferInstance *buf : arg_buffers) {
-    if (buf == nullptr) {
-      continue;
-    }
+    // Buffers without a shell have already been materialized
     const auto &shell = buf->getPjrtTensor()->host_tensor_shell();
-    // Skip buffers that already have a runtime tensor - they've already been
-    // transferred in a previous execution. The shell metadata is discarded
-    // after the first transfer since we no longer need to copy from the
-    // client's host buffer.
-    if (shell.has_value() && !buf->getPjrtTensor()->has_runtime_tensor()) {
+    if (shell.has_value()) {
       borrowed_host_base_ptr_to_buffers[shell->host_buffer].push_back(buf);
     }
   }
 
   for (const auto &[host_base, buffers] : borrowed_host_base_ptr_to_buffers) {
-    if (buffers.empty()) {
-      continue;
-    }
-
     const auto &shell = buffers.front()->getPjrtTensor()->host_tensor_shell();
 
     TT_FATAL(shell.has_value(),

--- a/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
@@ -7,6 +7,7 @@
 
 // tracy includes
 #include "tracy/Tracy.hpp"
+#include "tt/runtime/runtime.h"
 
 // tt-mlir includes
 #include "tt/runtime/types.h"
@@ -148,9 +149,49 @@ FlatbufferLoadedExecutableInstance::prepareInputTensor(
     }
     LOG_F(INFO, "%s", log_stream.str().c_str());
   }
+  
+  for (const auto &[host_base, buffers] : borrowed_host_base_ptr_to_buffers) {
+    if (buffers.empty()) {
+      continue;
+    }
 
+    // Use the first buffer's existing (borrowed) runtime tensor to recover the
+    // shape/stride/itemsize/dtype metadata needed to materialize an owned
+    // host copy. All buffers that share this host_base are expected to have
+    // identical TensorDesc since they alias the same client host array.
+    const tt::runtime::TensorDesc desc =
+        tt::runtime::getTensorDesc(buffers.front()->runtimeTensor());
+
+    // First buffer gets a newly-allocated owned host tensor that actually
+    // copies the bytes from the client's host_base pointer. Subsequent
+    // buffers in the group get unsafe-borrowed tensors aliasing that owned
+    // tensor, so we only hold one copy of the data on the worker side.
+    tt::runtime::Tensor owned_tensor =
+        tt::runtime::createOwnedHostTensor(host_base, desc);
+
+    for (size_t i = 0; i < buffers.size(); ++i) {
+      BufferInstance *buffer = buffers[i];
+
+      tt::runtime::Tensor worker_runtime_tensor =
+          (i == 0) ? owned_tensor
+                   : tt::runtime::createUnsafeBorrowedHostTensor(owned_tensor);
+
+      // Inplace replacement: rebuilds the BufferInstance's PjrtTensor around
+      // the new runtime tensor and updates m_pjrt_tensor via setPjrtTensor.
+      // This releases the old (borrowed-from-client) runtime tensor.
+      PjrtTensor::from_runtime_tensor({buffer},
+                                      std::move(worker_runtime_tensor));
+    }
+  }
+
+
+  
+  // from runtime tensor will create a multidevice host tensor from shards here, if necessary (strategy != identity)
+  // at this point, we should swap out the shards with the new worker local tensors
   PjrtTensor &tensor = PjrtTensor::from_pjrt_buffers(
       arg_buffers, m_executable_image->getDevicesMeshShape(), *strategy);
+
+  
 
   tensor.ensure_layout(runtime_device, expected_layout);
 

--- a/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
@@ -74,7 +74,7 @@ FlatbufferLoadedExecutableInstance::prepareInputTensor(
       log_stream << "[i=" << i;
       if (buf) {
         log_stream << " ptr=" << buf
-                   << " data_ptr=" << buf->runtimeTensor().data
+                   << " borrowed_host_base=" << buf->borrowedHostBasePointer()
                    << " shape=(";
         const std::string shape = buf->toShapeStr();
         log_stream << shape;

--- a/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
@@ -71,13 +71,12 @@ FlatbufferLoadedExecutableInstance::prepareInputTensor(
     std::ostringstream log_stream;
     log_stream << "Arg buffers introduced for arg_index=" << arg_index << ": ";
     for (size_t i = 0; i < arg_buffers.size(); ++i) {
-      const BufferInstance* buf = arg_buffers[i];
+      const BufferInstance *buf = arg_buffers[i];
       log_stream << "[i=" << i;
       if (buf) {
         const auto &shell = buf->getPjrtTensor()->host_tensor_shell();
-        log_stream << " ptr=" << buf
-                   << " shell_host_buffer=" << (shell ? shell->host_buffer : nullptr)
-                   << " shape=(";
+        log_stream << " ptr=" << buf << " shell_host_buffer="
+                   << (shell ? shell->host_buffer : nullptr) << " shape=(";
         const std::string shape = buf->toShapeStr();
         log_stream << shape;
         log_stream << ")";
@@ -89,11 +88,12 @@ FlatbufferLoadedExecutableInstance::prepareInputTensor(
 
     log_stream << " | Strategy {";
     if (mlir::succeeded(strategy)) {
-      const auto& strat_map = *strategy;
+      const auto &strat_map = *strategy;
       size_t n = 0;
-      for (const auto& [k, v] : strat_map) {
+      for (const auto &[k, v] : strat_map) {
         log_stream << k << "=" << v;
-        if (++n < strat_map.size()) log_stream << ", ";
+        if (++n < strat_map.size())
+          log_stream << ", ";
       }
     } else {
       log_stream << "FAILED strategy";
@@ -103,7 +103,6 @@ FlatbufferLoadedExecutableInstance::prepareInputTensor(
     LOG_F(INFO, "%s", log_stream.str().c_str());
   }
 
-         
   if (mlir::failed(strategy)) {
     LOG_F(ERROR, "Failed to fill strategy map from sharding");
     return std::nullopt;
@@ -133,16 +132,17 @@ FlatbufferLoadedExecutableInstance::prepareInputTensor(
   {
     std::ostringstream log_stream;
     log_stream << "borrowed_host_base_ptr_to_buffers for arg_index="
-               << arg_index << " (entries=" << borrowed_host_base_ptr_to_buffers.size()
+               << arg_index
+               << " (entries=" << borrowed_host_base_ptr_to_buffers.size()
                << "): ";
     size_t entry_idx = 0;
     for (const auto &[host_base, buffers] : borrowed_host_base_ptr_to_buffers) {
-      log_stream << "{host_base=" << host_base
-                 << " count=" << buffers.size() << " buffers=[";
+      log_stream << "{host_base=" << host_base << " count=" << buffers.size()
+                 << " buffers=[";
       for (size_t i = 0; i < buffers.size(); ++i) {
         const BufferInstance *b = buffers[i];
-        log_stream << "(uid=" << b->getUID() << " ptr=" << b
-                   << " shape=(" << b->toShapeStr() << "))";
+        log_stream << "(uid=" << b->getUID() << " ptr=" << b << " shape=("
+                   << b->toShapeStr() << "))";
         if (i + 1 < buffers.size()) {
           log_stream << ", ";
         }
@@ -154,7 +154,7 @@ FlatbufferLoadedExecutableInstance::prepareInputTensor(
     }
     LOG_F(INFO, "%s", log_stream.str().c_str());
   }
-  
+
   size_t group_idx = 0;
   for (const auto &[host_base, buffers] : borrowed_host_base_ptr_to_buffers) {
     if (buffers.empty()) {
@@ -174,10 +174,9 @@ FlatbufferLoadedExecutableInstance::prepareInputTensor(
     // copies the bytes from the client's host_base pointer. Subsequent
     // buffers in the group get unsafe-borrowed tensors aliasing that owned
     // tensor, so we only hold one copy of the data on the worker side.
-    tt::runtime::Tensor owned_tensor =
-        tt::runtime::createOwnedHostTensor(
-            const_cast<void *>(shell->host_buffer), shell->shape, shell->strides,
-            shell->element_size, shell->runtime_data_type);
+    tt::runtime::Tensor owned_tensor = tt::runtime::createOwnedHostTensor(
+        const_cast<void *>(shell->host_buffer), shell->shape, shell->strides,
+        shell->element_size, shell->runtime_data_type);
     LOG_F(INFO,
           "Group %zu: created owned host tensor (copied from host_base=%p)",
           group_idx, host_base);
@@ -193,8 +192,7 @@ FlatbufferLoadedExecutableInstance::prepareInputTensor(
       LOG_F(INFO,
             "Group %zu: replacing runtime tensor for buffer uid=%lu ptr=%p "
             "shape=(%s) with %s tensor (i=%zu/%zu)",
-            group_idx, buffer->getUID(),
-            static_cast<const void *>(buffer),
+            group_idx, buffer->getUID(), static_cast<const void *>(buffer),
             buffer->toShapeStr().c_str(),
             is_first ? "owned" : "unsafe-borrowed", i, buffers.size());
 
@@ -208,14 +206,11 @@ FlatbufferLoadedExecutableInstance::prepareInputTensor(
     ++group_idx;
   }
 
-
-  
-  // from runtime tensor will create a multidevice host tensor from shards here, if necessary (strategy != identity)
-  // at this point, we should swap out the shards with the new worker local tensors
+  // from runtime tensor will create a multidevice host tensor from shards here,
+  // if necessary (strategy != identity) at this point, we should swap out the
+  // shards with the new worker local tensors
   PjrtTensor &tensor = PjrtTensor::from_pjrt_buffers(
       arg_buffers, m_executable_image->getDevicesMeshShape(), *strategy);
-
-  
 
   tensor.ensure_layout(runtime_device, expected_layout);
 

--- a/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
@@ -66,43 +66,6 @@ FlatbufferLoadedExecutableInstance::prepareInputTensor(
       fillStrategyMapFromSharding(
           m_executable_image->getInputSharding(arg_index), num_devices);
 
-  // Log the buffers being introduced for debugging
-  {
-    std::ostringstream log_stream;
-    log_stream << "Arg buffers introduced for arg_index=" << arg_index << ": ";
-    for (size_t i = 0; i < arg_buffers.size(); ++i) {
-      const BufferInstance *buf = arg_buffers[i];
-      log_stream << "[i=" << i;
-      if (buf) {
-        const auto &shell = buf->getPjrtTensor()->host_tensor_shell();
-        log_stream << " ptr=" << buf << " shell_host_buffer="
-                   << (shell ? shell->host_buffer : nullptr) << " shape=(";
-        const std::string shape = buf->toShapeStr();
-        log_stream << shape;
-        log_stream << ")";
-      } else {
-        log_stream << " null";
-      }
-      log_stream << "] ";
-    }
-
-    log_stream << " | Strategy {";
-    if (mlir::succeeded(strategy)) {
-      const auto &strat_map = *strategy;
-      size_t n = 0;
-      for (const auto &[k, v] : strat_map) {
-        log_stream << k << "=" << v;
-        if (++n < strat_map.size())
-          log_stream << ", ";
-      }
-    } else {
-      log_stream << "FAILED strategy";
-    }
-    log_stream << "}";
-
-    LOG_F(INFO, "%s", log_stream.str().c_str());
-  }
-
   if (mlir::failed(strategy)) {
     LOG_F(ERROR, "Failed to fill strategy map from sharding");
     return std::nullopt;
@@ -128,34 +91,6 @@ FlatbufferLoadedExecutableInstance::prepareInputTensor(
     }
   }
 
-  // map population
-  {
-    std::ostringstream log_stream;
-    log_stream << "borrowed_host_base_ptr_to_buffers for arg_index="
-               << arg_index
-               << " (entries=" << borrowed_host_base_ptr_to_buffers.size()
-               << "): ";
-    size_t entry_idx = 0;
-    for (const auto &[host_base, buffers] : borrowed_host_base_ptr_to_buffers) {
-      log_stream << "{host_base=" << host_base << " count=" << buffers.size()
-                 << " buffers=[";
-      for (size_t i = 0; i < buffers.size(); ++i) {
-        const BufferInstance *b = buffers[i];
-        log_stream << "(uid=" << b->getUID() << " ptr=" << b << " shape=("
-                   << b->toShapeStr() << "))";
-        if (i + 1 < buffers.size()) {
-          log_stream << ", ";
-        }
-      }
-      log_stream << "]}";
-      if (++entry_idx < borrowed_host_base_ptr_to_buffers.size()) {
-        log_stream << ", ";
-      }
-    }
-    LOG_F(INFO, "%s", log_stream.str().c_str());
-  }
-
-  size_t group_idx = 0;
   for (const auto &[host_base, buffers] : borrowed_host_base_ptr_to_buffers) {
     if (buffers.empty()) {
       continue;
@@ -177,9 +112,6 @@ FlatbufferLoadedExecutableInstance::prepareInputTensor(
     tt::runtime::Tensor owned_tensor = tt::runtime::createOwnedHostTensor(
         const_cast<void *>(shell->host_buffer), shell->shape, shell->strides,
         shell->element_size, shell->runtime_data_type);
-    LOG_F(INFO,
-          "Group %zu: created owned host tensor (copied from host_base=%p)",
-          group_idx, host_base);
 
     for (size_t i = 0; i < buffers.size(); ++i) {
       BufferInstance *buffer = buffers[i];
@@ -189,21 +121,12 @@ FlatbufferLoadedExecutableInstance::prepareInputTensor(
           is_first ? owned_tensor
                    : tt::runtime::createUnsafeBorrowedHostTensor(owned_tensor);
 
-      LOG_F(INFO,
-            "Group %zu: replacing runtime tensor for buffer uid=%lu ptr=%p "
-            "shape=(%s) with %s tensor (i=%zu/%zu)",
-            group_idx, buffer->getUID(), static_cast<const void *>(buffer),
-            buffer->toShapeStr().c_str(),
-            is_first ? "owned" : "unsafe-borrowed", i, buffers.size());
-
       // Inplace replacement: rebuilds the BufferInstance's PjrtTensor around
       // the new runtime tensor and updates m_pjrt_tensor via setPjrtTensor.
       // This releases the old (borrowed-from-client) runtime tensor.
       PjrtTensor::from_runtime_tensor({buffer},
                                       std::move(worker_runtime_tensor));
     }
-
-    ++group_idx;
   }
 
   // from runtime tensor will create a multidevice host tensor from shards here,

--- a/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
@@ -107,6 +107,14 @@ void FlatbufferLoadedExecutableInstance::materializeShellTensors(
              buffers.front()->getUID(),
              static_cast<const void *>(buffers.front()));
 
+    for (size_t i = 1; i < buffers.size(); ++i) {
+      const auto &other = buffers[i]->getPjrtTensor()->host_tensor_shell();
+      TT_FATAL(other.has_value() && *other == *shell,
+               "Shell metadata mismatch for buffers sharing host_buffer %p: "
+               "buffer uid=%lu vs uid=%lu",
+               host_base, buffers[i]->getUID(), buffers.front()->getUID());
+    }
+
     // First buffer gets a newly-allocated owned host tensor that actually
     // copies the bytes from the client's host_base pointer. Subsequent
     // buffers in the group get unsafe-borrowed tensors aliasing that owned

--- a/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
@@ -74,8 +74,9 @@ FlatbufferLoadedExecutableInstance::prepareInputTensor(
       const BufferInstance* buf = arg_buffers[i];
       log_stream << "[i=" << i;
       if (buf) {
+        const auto &shell = buf->getPjrtTensor()->host_tensor_shell();
         log_stream << " ptr=" << buf
-                   << " borrowed_host_base=" << buf->borrowedHostBasePointer()
+                   << " shell_host_buffer=" << (shell ? shell->host_buffer : nullptr)
                    << " shape=(";
         const std::string shape = buf->toShapeStr();
         log_stream << shape;
@@ -118,13 +119,13 @@ FlatbufferLoadedExecutableInstance::prepareInputTensor(
     if (buf == nullptr) {
       continue;
     }
-    const void *host_base = buf->borrowedHostBasePointer();
+    const auto &shell = buf->getPjrtTensor()->host_tensor_shell();
     // Skip buffers that already have a runtime tensor - they've already been
     // transferred in a previous execution. The shell metadata is discarded
     // after the first transfer since we no longer need to copy from the
     // client's host buffer.
-    if (host_base != nullptr && !buf->getPjrtTensor()->has_runtime_tensor()) {
-      borrowed_host_base_ptr_to_buffers[host_base].push_back(buf);
+    if (shell.has_value() && !buf->getPjrtTensor()->has_runtime_tensor()) {
+      borrowed_host_base_ptr_to_buffers[shell->host_buffer].push_back(buf);
     }
   }
 

--- a/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/flatbuffer_loaded_executable_instance.cc
@@ -156,19 +156,23 @@ FlatbufferLoadedExecutableInstance::prepareInputTensor(
       continue;
     }
 
-    // Use the first buffer's existing (borrowed) runtime tensor to recover the
-    // shape/stride/itemsize/dtype metadata needed to materialize an owned
-    // host copy. All buffers that share this host_base are expected to have
-    // identical TensorDesc since they alias the same client host array.
-    const tt::runtime::TensorDesc desc =
-        tt::runtime::getTensorDesc(buffers.front()->runtimeTensor());
+    const auto &shell = buffers.front()->getPjrtTensor()->host_tensor_shell();
+    if (!shell.has_value()) {
+      LOG_F(ERROR,
+            "Missing host tensor shell metadata for buffer uid=%lu ptr=%p",
+            buffers.front()->getUID(),
+            static_cast<const void *>(buffers.front()));
+      return std::nullopt;
+    }
 
     // First buffer gets a newly-allocated owned host tensor that actually
     // copies the bytes from the client's host_base pointer. Subsequent
     // buffers in the group get unsafe-borrowed tensors aliasing that owned
     // tensor, so we only hold one copy of the data on the worker side.
     tt::runtime::Tensor owned_tensor =
-        tt::runtime::createOwnedHostTensor(host_base, desc);
+        tt::runtime::createOwnedHostTensor(
+            const_cast<void *>(shell->host_buffer), shell->shape, shell->strides,
+            shell->element_size, shell->runtime_data_type);
     LOG_F(INFO,
           "Group %zu: created owned host tensor (copied from host_base=%p)",
           group_idx, host_base);

--- a/pjrt_implementation/src/api/tensor.cc
+++ b/pjrt_implementation/src/api/tensor.cc
@@ -52,12 +52,27 @@ PjrtTensor &PjrtTensor::from_pjrt_buffers(
 // Creates new pjrt tensor for provided shards from an existing runtime tensor.
 PjrtTensor &
 PjrtTensor::from_runtime_tensor(std::vector<BufferInstance *> shards,
-                                tt::runtime::Tensor rt_tensor) {
+                                tt::runtime::Tensor rt_tensor,
+                                std::optional<HostTensorShell> shell) {
 
   tt::runtime::setTensorRetain(rt_tensor, true);
 
   auto tensor = std::make_shared<PjrtTensor>(Private{}, std::move(shards),
                                              std::move(rt_tensor));
+  tensor->m_host_tensor_shell = std::move(shell);
+
+  for (BufferInstance *shard : tensor->shards()) {
+    shard->setPjrtTensor(tensor);
+  }
+
+  return *tensor;
+}
+
+PjrtTensor &PjrtTensor::from_host_tensor_shell(
+    std::vector<BufferInstance *> shards, HostTensorShell shell) {
+  auto tensor = std::make_shared<PjrtTensor>(Private{}, std::move(shards),
+                                             std::nullopt);
+  tensor->m_host_tensor_shell = std::move(shell);
 
   for (BufferInstance *shard : tensor->shards()) {
     shard->setPjrtTensor(tensor);
@@ -67,7 +82,7 @@ PjrtTensor::from_runtime_tensor(std::vector<BufferInstance *> shards,
 }
 
 PjrtTensor::PjrtTensor(Private, std::vector<BufferInstance *> shards,
-                       tt::runtime::Tensor rt_tensor)
+                       std::optional<tt::runtime::Tensor> rt_tensor)
     : m_uid{next_uid()}, m_shards{std::move(shards)},
       m_runtime_tensor{std::move(rt_tensor)} {
 
@@ -78,13 +93,15 @@ PjrtTensor::~PjrtTensor() { TensorPool::erase(this); }
 
 void PjrtTensor::ensure_layout(const tt::runtime::Device &device,
                                const tt::runtime::Layout &layout) {
+  TT_FATAL(m_runtime_tensor.has_value(),
+           "Cannot ensure layout for shell-only PjrtTensor");
 
-  if (tt::runtime::hasLayout(m_runtime_tensor, layout))
+  if (tt::runtime::hasLayout(*m_runtime_tensor, layout))
     return;
 
-  const bool retain = tt::runtime::getTensorRetain(m_runtime_tensor);
+  const bool retain = tt::runtime::getTensorRetain(*m_runtime_tensor);
   m_runtime_tensor =
-      tt::runtime::toLayout(m_runtime_tensor, device, layout, retain);
+      tt::runtime::toLayout(*m_runtime_tensor, device, layout, retain);
 
   // Notify each shard so the host-buffer-done event fires now and the
   // framework releases its source reference, instead of holding it for
@@ -123,8 +140,10 @@ void PjrtTensor::ensure_layout(const tt::runtime::Device &device,
 // remove_shard().
 void PjrtTensor::move_to_host() noexcept {
   ZoneScoped;
+  TT_FATAL(m_runtime_tensor.has_value(),
+           "Cannot move shell-only PjrtTensor to host");
   std::vector<tt::runtime::Tensor> tensors =
-      tt::runtime::toHost(m_runtime_tensor, /*untilize=*/true);
+      tt::runtime::toHost(*m_runtime_tensor, /*untilize=*/true);
 
   TT_FATAL(tensors.size() == m_shards.size() || tensors.size() == 1,
            "Unexpected number of tensors after move to host: "
@@ -139,7 +158,7 @@ void PjrtTensor::move_to_host() noexcept {
     }
 
     tt::runtime::Tensor rt_tensor =
-        tensors.size() == 1 ? m_runtime_tensor : std::move(tensors[i]);
+        tensors.size() == 1 ? *m_runtime_tensor : std::move(tensors[i]);
     PjrtTensor::from_runtime_tensor({m_shards[i]}, std::move(rt_tensor));
   }
 

--- a/pjrt_implementation/src/api/tensor.cc
+++ b/pjrt_implementation/src/api/tensor.cc
@@ -52,14 +52,12 @@ PjrtTensor &PjrtTensor::from_pjrt_buffers(
 // Creates new pjrt tensor for provided shards from an existing runtime tensor.
 PjrtTensor &
 PjrtTensor::from_runtime_tensor(std::vector<BufferInstance *> shards,
-                                tt::runtime::Tensor rt_tensor,
-                                std::optional<HostTensorShell> shell) {
+                                tt::runtime::Tensor rt_tensor) {
 
   tt::runtime::setTensorRetain(rt_tensor, true);
 
   auto tensor = std::make_shared<PjrtTensor>(Private{}, std::move(shards),
                                              std::move(rt_tensor));
-  tensor->m_host_tensor_shell = std::move(shell);
 
   for (BufferInstance *shard : tensor->shards()) {
     shard->setPjrtTensor(tensor);

--- a/pjrt_implementation/src/api/tensor.cc
+++ b/pjrt_implementation/src/api/tensor.cc
@@ -140,8 +140,14 @@ void PjrtTensor::ensure_layout(const tt::runtime::Device &device,
 // remove_shard().
 void PjrtTensor::move_to_host() noexcept {
   ZoneScoped;
-  TT_FATAL(m_runtime_tensor.has_value(),
-           "Cannot move shell-only PjrtTensor to host");
+  // TT_FATAL(m_runtime_tensor.has_value(),
+  //          "Cannot move shell-only PjrtTensor to host");
+
+  if (!m_runtime_tensor.has_value() && m_host_tensor_shell.has_value()) {
+    // A shell-only PJRT tensor is already on host.
+    return;
+  }
+
   std::vector<tt::runtime::Tensor> tensors =
       tt::runtime::toHost(*m_runtime_tensor, /*untilize=*/true);
 

--- a/pjrt_implementation/src/api/tensor.cc
+++ b/pjrt_implementation/src/api/tensor.cc
@@ -68,10 +68,11 @@ PjrtTensor::from_runtime_tensor(std::vector<BufferInstance *> shards,
   return *tensor;
 }
 
-PjrtTensor &PjrtTensor::from_host_tensor_shell(
-    std::vector<BufferInstance *> shards, HostTensorShell shell) {
-  auto tensor = std::make_shared<PjrtTensor>(Private{}, std::move(shards),
-                                             std::nullopt);
+PjrtTensor &
+PjrtTensor::from_host_tensor_shell(std::vector<BufferInstance *> shards,
+                                   HostTensorShell shell) {
+  auto tensor =
+      std::make_shared<PjrtTensor>(Private{}, std::move(shards), std::nullopt);
   tensor->m_host_tensor_shell = std::move(shell);
 
   for (BufferInstance *shard : tensor->shards()) {

--- a/pjrt_implementation/src/api/tensor.cc
+++ b/pjrt_implementation/src/api/tensor.cc
@@ -139,11 +139,12 @@ void PjrtTensor::ensure_layout(const tt::runtime::Device &device,
 // remove_shard().
 void PjrtTensor::move_to_host() noexcept {
   ZoneScoped;
-  // TT_FATAL(m_runtime_tensor.has_value(),
-  //          "Cannot move shell-only PjrtTensor to host");
 
+  // Shell-only tensors (deferred in distributed runtime) have no device-side
+  // data to move. This can happen legitimately if the runtime mesh is different
+  // from The ClientInstance default (1xN_DEVICES) which induces a mesh reshape
+  // prior to first execution. Early return since there's nothing to move.
   if (!m_runtime_tensor.has_value() && m_host_tensor_shell.has_value()) {
-    // A shell-only PJRT tensor is already on host.
     return;
   }
 


### PR DESCRIPTION
### Ticket
Closes #4011 

### Problem description
Multihost workers currently lack a mechanism for buffer data aliasing. While the host controller has a shared ownership model (borrowing allocations from caller) workers materialize every shard and replica as an independent allocation leading to extreme host memory waste scaling with device count.

The root issue: at the current copyFromHost callsite, torch_xla doesn't provide enough information to identify which BufferInstances share the same source data.

### What's changed
1. Introduce HostTensorShell: A struct that captures copyFromHost arguments (host buffer pointer, shape, strides, dtype) without materializing a runtime tensor. Acts as deferred metadata until execution time, as a member of PJRTTensor
2. Deduplicate at execution time: In prepareInputTensor, group BufferInstances by their host buffer pointer address.
For each group:
- First buffer gets an owned tensor (actual copy from host)
- Subsequent buffers get createUnsafeBorrowedHostTensor aliasing the first, avoiding redundant copies
3. Multihost-only codepath: This behavior is gated on getCurrentHostRuntime() == Distributed. Single-host runtime is unchanged.

Discussion and comparison of alternative approaches was made in [this RFC.](https://docs.google.com/document/d/1n-_KaQo9yVHLazT8HPJaHyIbDufTe5OqroLEnAME_rc/edit?tab=t.0)

### Checklist
- [x] New/Existing tests provide coverage for changes
- [x] Existing multihost tests passing https://github.com/tenstorrent/tt-xla/actions/runs/25684369837
