### PR TITLE
[HunyuanVideo-1.5-Diffusers-480p_t2v_distilled] Add tiled VAE decoder test

### DIFF
--- a/tests/torch/models/Hunyuan_1_5/test_vae_decoder.py
+++ b/tests/torch/models/Hunyuan_1_5/test_vae_decoder.py
@@ -13,14 +13,32 @@ from infra import Framework, run_graph_test
 from third_party.tt_forge_models.hunyuan_1_5.pytorch import ModelLoader, ModelVariant
 
 
-@pytest.mark.skip(
-    reason="hang on TT — investigation pending — https://github.com/tenstorrent/tt-xla/issues/4485"
+@pytest.mark.parametrize(
+    "variant",
+    [
+        pytest.param(
+            ModelVariant.VAE,
+            marks=pytest.mark.xfail(
+                reason="hang on TT — https://github.com/tenstorrent/tt-xla/issues/4485",
+                strict=False,
+            ),
+            id="non_tiled",
+        ),
+        pytest.param(
+            ModelVariant.VAE_TILED,
+            marks=pytest.mark.xfail(
+                reason="ttir.scaled_dot_product_attention rejects 3D mask — https://github.com/tenstorrent/tt-mlir/issues/8362",
+                strict=False,
+            ),
+            id="tiled",
+        ),
+    ],
 )
-def test_vae_decoder():
+def test_vae_decoder(variant):
     xr.set_device_type("TT")
     torch.manual_seed(42)
 
-    loader = ModelLoader(ModelVariant.VAE)
+    loader = ModelLoader(variant)
     model = loader.load_model(dtype_override=torch.bfloat16)
     inputs = loader.load_inputs(dtype_override=torch.bfloat16)
 


### PR DESCRIPTION
### Ticket

- closes https://github.com/tenstorrent/tt-xla/issues/4619

### Problem description

- Non tiled vae decoder hangs ([#4485](https://github.com/tenstorrent/tt-xla/issues/4485)). As a quick workaround, bringup tiled variant.

### What's changed

- Added test for the tiled variant.

### Checklist
- [x] verified the changes through local testing in N150

### Logs

- [may11_vae_decoder_tiled.log](https://github.com/user-attachments/files/27603836/may11_h_vae_decoder_tiled.log)