### PR TITLE
xfail olmo and mistral_8b examples added in #4287

### DIFF
--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -25,6 +25,8 @@ XFAIL_FILES: dict[str, str] = {
     "pytorch/olmo3_1125_32b.py": "Olmo3 32B example requires n300-llmbox",
     "jax/codegen/cpp/resnet.py": "FlaxResNetModel removed in transformers 5.x",
     "jax/codegen/python/resnet.py": "FlaxResNetModel removed in transformers 5.x",
+    "pytorch/olmo3_1025_7b.py": "Failing with Device count mismatch: 1 vs 2 - Related #4624",
+    "pytorch/mistral_8b.py": "Failing with Device count mismatch: 1 vs 2 - Related #4624",
 }
 
 


### PR DESCRIPTION
### Ticket
Likely merge conflict to #4624 

### Problem description
Examples added in #4287 do not pass, due to a recent uncaught regression introduced by #4624 that prevents execution of singledevice tests (which these are) on multichip environments (which examples are run on).

Thanks to @kmabeeTT and @mmanzoorTT for bisect information to open #4624.

### What's changed
Xfail affected tests.

### Checklist
- [x] New/Existing tests provide coverage for changes
