### PR TITLE
Fix mesh-shape inference for no-input graphs on multichip hosts

### DIFF
--- a/pjrt_implementation/inc/api/client_instance.h
+++ b/pjrt_implementation/inc/api/client_instance.h
@@ -25,6 +25,7 @@
 #include "tt/runtime/runtime.h"
 
 // tt-xla includes
+#include "api/compile_options_parser.h"
 #include "api/device_instance.h"
 #include "api/loaded_executable_instance.h"
 #include "api/memory_instance.h"
@@ -167,7 +168,8 @@ public:
       const PJRT_Program *mlir_program,
       LoadedExecutableInstance **out_executable,
       const std::unordered_map<std::string, std::string> &compile_options,
-      const std::optional<std::vector<int64_t>> &replica_device_ids);
+      const std::optional<std::vector<int64_t>> &replica_device_ids,
+      const ExecutableDeviceShape &device_shape);
 
 private:
   tt_pjrt_status populateDevices();

--- a/pjrt_implementation/inc/api/compile_options_parser.h
+++ b/pjrt_implementation/inc/api/compile_options_parser.h
@@ -31,6 +31,14 @@ namespace tt::pjrt {
 //
 // The protobuf layout is defined in:
 // https://github.com/openxla/xla/blob/main/xla/pjrt/proto/compile_options.proto
+struct ExecutableDeviceShape {
+  std::optional<int64_t> num_partitions;
+  std::optional<int64_t> num_replicas;
+
+  // Number of devices the executable will distribute its computation across.
+  int64_t targetNumDevices() const { return num_partitions.value_or(1); }
+};
+
 class CompileOptionsParser {
 public:
   // Parses compile options protobuf and extracts both custom compile options
@@ -38,7 +46,8 @@ public:
   static tt_pjrt_status parseCompileOptions(
       const char *compile_options_data, size_t compile_options_size,
       std::unordered_map<std::string, std::string> &out_compile_options,
-      std::optional<std::vector<int64_t>> &out_replica_device_ids);
+      std::optional<std::vector<int64_t>> &out_replica_device_ids,
+      ExecutableDeviceShape &out_device_shape);
 
   // Parses compile options protobuf data into UnknownFieldSet.
   // Returns true if parsing succeeded, false otherwise.
@@ -57,6 +66,11 @@ public:
   static tt_pjrt_status extractReplicaDeviceIds(
       const google::protobuf::UnknownFieldSet &unknown_fields,
       std::optional<std::vector<int64_t>> &out_replica_device_ids);
+
+  // Extracts num_partitions and num_replicas from ExecutableBuildOptionsProto.
+  static tt_pjrt_status
+  extractDeviceShape(const google::protobuf::UnknownFieldSet &unknown_fields,
+                     ExecutableDeviceShape &out_device_shape);
 
   // Helper function to parse a length-delimited protobuf field into an
   // UnknownFieldSet. Returns true if parsing succeeds, false otherwise.

--- a/pjrt_implementation/inc/api/module_builder/module_builder.h
+++ b/pjrt_implementation/inc/api/module_builder/module_builder.h
@@ -33,6 +33,7 @@
 
 // tt-xla includes
 #include "api/compile_options.h"
+#include "api/compile_options_parser.h"
 #include "utils/status.h"
 
 namespace tt::pjrt {
@@ -129,7 +130,8 @@ public:
       const std::string_view &mlir_code,
       const std::string &system_descriptor_path,
       const std::unordered_map<std::string, std::string> &compile_options,
-      tt::pjrt::ClientInstance *client_instance);
+      tt::pjrt::ClientInstance *client_instance,
+      const ExecutableDeviceShape &device_shape = {});
 
   // Gets the first sdy.Mesh op of a mlir module with shardy dialect enbaled.
   // Could be used to extract mesh attribute from the module so we can use it as
@@ -190,7 +192,8 @@ private:
       const std::optional<std::string> &export_path,
       const std::string &model_name = "",
       const std::optional<std::vector<uint32_t>> &current_mesh_shape =
-          std::nullopt);
+          std::nullopt,
+      size_t target_num_devices = 1);
 
   // Converts StableHLO module to TTIR module.
   tt_pjrt_status

--- a/pjrt_implementation/src/api/client_instance.cc
+++ b/pjrt_implementation/src/api/client_instance.cc
@@ -432,13 +432,14 @@ tt_pjrt_status ClientInstance::populateMemories() {
 tt_pjrt_status ClientInstance::compileMlirProgram(
     const PJRT_Program *mlir_program, LoadedExecutableInstance **out_executable,
     const std::unordered_map<std::string, std::string> &compile_options,
-    const std::optional<std::vector<int64_t>> &replica_device_ids) {
+    const std::optional<std::vector<int64_t>> &replica_device_ids,
+    const ExecutableDeviceShape &device_shape) {
 
   std::string_view mlir_code(mlir_program->code, mlir_program->code_size);
 
   std::tuple<tt_pjrt_status, std::shared_ptr<ExecutableImage>> compile_result =
       m_module_builder->buildModule(mlir_code, m_cached_system_descriptor_path,
-                                    compile_options, this);
+                                    compile_options, this, device_shape);
   tt_pjrt_status status = std::get<tt_pjrt_status>(compile_result);
   if (!tt_pjrt_status_is_ok(status)) {
     return status;
@@ -810,14 +811,15 @@ PJRT_Error *onClientCompile(PJRT_Client_Compile_Args *args) {
   ZoneScoped;
   DLOG_F(LOG_DEBUG, "ClientInstance::PJRT_Client_Compile");
 
-  // Parse compile options and extract both custom options and replica device
-  // IDs
+  // Parse compile options: custom options, replica device IDs, and the
+  // executable device shape (num_partitions x num_replicas).
   std::unordered_map<std::string, std::string> compile_options_map;
   std::optional<std::vector<int64_t>> replica_device_ids;
+  ExecutableDeviceShape device_shape;
   tt_pjrt_status compile_options_status =
       CompileOptionsParser::parseCompileOptions(
           args->compile_options, args->compile_options_size,
-          compile_options_map, replica_device_ids);
+          compile_options_map, replica_device_ids, device_shape);
   if (!tt_pjrt_status_is_ok(compile_options_status)) {
     return *ErrorInstance::makeError(compile_options_status).release();
   }
@@ -837,7 +839,7 @@ PJRT_Error *onClientCompile(PJRT_Client_Compile_Args *args) {
   tt_pjrt_status compile_status = client_instance->compileMlirProgram(
       args->program,
       reinterpret_cast<LoadedExecutableInstance **>(&args->executable),
-      compile_options_map, replica_device_ids);
+      compile_options_map, replica_device_ids, device_shape);
 
   return *ErrorInstance::makeError(compile_status).release();
 }

--- a/pjrt_implementation/src/api/compile_options_parser.cc
+++ b/pjrt_implementation/src/api/compile_options_parser.cc
@@ -16,7 +16,8 @@ namespace tt::pjrt {
 tt_pjrt_status CompileOptionsParser::parseCompileOptions(
     const char *compile_options_data, size_t compile_options_size,
     std::unordered_map<std::string, std::string> &out_compile_options,
-    std::optional<std::vector<int64_t>> &out_replica_device_ids) {
+    std::optional<std::vector<int64_t>> &out_replica_device_ids,
+    ExecutableDeviceShape &out_device_shape) {
 
   google::protobuf::UnknownFieldSet unknown_fields;
 
@@ -37,6 +38,13 @@ tt_pjrt_status CompileOptionsParser::parseCompileOptions(
       extractReplicaDeviceIds(unknown_fields, out_replica_device_ids);
   if (!tt_pjrt_status_is_ok(replica_ids_status)) {
     return replica_ids_status;
+  }
+
+  // Extract num_partitions / num_replicas (target device shape).
+  tt_pjrt_status shape_status =
+      extractDeviceShape(unknown_fields, out_device_shape);
+  if (!tt_pjrt_status_is_ok(shape_status)) {
+    return shape_status;
   }
 
   return tt_pjrt_status::kSuccess;
@@ -169,6 +177,45 @@ tt_pjrt_status CompileOptionsParser::extractReplicaDeviceIds(
     out_replica_device_ids = std::vector<int64_t>(unique_device_ids.begin(),
                                                   unique_device_ids.end());
   }
+  return tt_pjrt_status::kSuccess;
+}
+
+tt_pjrt_status CompileOptionsParser::extractDeviceShape(
+    const google::protobuf::UnknownFieldSet &unknown_fields,
+    ExecutableDeviceShape &out_device_shape) {
+  out_device_shape = {};
+
+  constexpr int kExecutableBuildOptionsProtoFieldNumber = 3;
+  constexpr int kNumReplicasFieldNumber = 4;
+  constexpr int kNumPartitionsFieldNumber = 5;
+
+  for (int i = 0; i < unknown_fields.field_count(); ++i) {
+    const google::protobuf::UnknownField &field = unknown_fields.field(i);
+    if (field.number() != kExecutableBuildOptionsProtoFieldNumber) {
+      continue;
+    }
+
+    google::protobuf::UnknownFieldSet exec_build_fields;
+    if (!parseNestedProtobufField(field, exec_build_fields)) {
+      continue;
+    }
+
+    for (int j = 0; j < exec_build_fields.field_count(); ++j) {
+      const google::protobuf::UnknownField &exec_field =
+          exec_build_fields.field(j);
+      if (exec_field.type() != google::protobuf::UnknownField::TYPE_VARINT) {
+        continue;
+      }
+      if (exec_field.number() == kNumReplicasFieldNumber) {
+        out_device_shape.num_replicas =
+            static_cast<int64_t>(exec_field.varint());
+      } else if (exec_field.number() == kNumPartitionsFieldNumber) {
+        out_device_shape.num_partitions =
+            static_cast<int64_t>(exec_field.varint());
+      }
+    }
+  }
+
   return tt_pjrt_status::kSuccess;
 }
 

--- a/pjrt_implementation/src/api/module_builder/module_builder.cc
+++ b/pjrt_implementation/src/api/module_builder/module_builder.cc
@@ -271,10 +271,16 @@ ModuleBuilder::buildModule(
     const std::string_view &mlir_code,
     const std::string &system_descriptor_path,
     const std::unordered_map<std::string, std::string> &compile_options_map,
-    ClientInstance *client_instance) {
+    ClientInstance *client_instance,
+    const ExecutableDeviceShape &device_shape) {
   DLOG_F(LOG_DEBUG, "ModuleBuilder::buildModule");
 
   auto compile_options = CompileOptions::parse(compile_options_map);
+
+  const size_t target_num_devices =
+      static_cast<size_t>(device_shape.targetNumDevices());
+  DLOG_F(LOG_DEBUG, "ModuleBuilder::buildModule - target_num_devices=%zu",
+         target_num_devices);
 
   // Construct full name: {model_name}_g{N}
   // e.g., 1lyr_phi1_bs32_g0
@@ -343,9 +349,10 @@ ModuleBuilder::buildModule(
       parent_mesh ? std::make_optional(tt::runtime::getMeshShape(*parent_mesh))
                   : std::nullopt;
 
-  status = runCompilerStableHLOPipeline(
-      mlir_module, result_presharded, compile_options.export_path,
-      compile_options.export_model_name, current_mesh_shape);
+  status = runCompilerStableHLOPipeline(mlir_module, result_presharded,
+                                        compile_options.export_path,
+                                        compile_options.export_model_name,
+                                        current_mesh_shape, target_num_devices);
   if (!tt_pjrt_status_is_ok(status)) {
     return {status, nullptr};
   }
@@ -857,17 +864,34 @@ tt_pjrt_status ModuleBuilder::runCompilerStableHLOPipeline(
     const std::vector<int64_t> &result_presharded,
     const std::optional<std::string> &export_path,
     const std::string &model_name,
-    const std::optional<std::vector<uint32_t>> &current_mesh_shape) {
+    const std::optional<std::vector<uint32_t>> &current_mesh_shape,
+    size_t target_num_devices) {
   mlir::PassManager stablehlo_pipeline_pm(mlir_module.get()->getName(),
                                           mlir::PassManager::Nesting::Implicit);
   mlir::tt::stablehlo::StableHLOPipelineOptions stablehlo_pipeline_options;
   stablehlo_pipeline_options.resultPresharded = result_presharded;
 
-  if (current_mesh_shape.has_value() && current_mesh_shape->size() == 2 &&
-      !moduleHasAnyFuncArguments(mlir_module)) {
-    stablehlo_pipeline_options.meshShape = {
-        static_cast<int64_t>((*current_mesh_shape)[0]),
-        static_cast<int64_t>((*current_mesh_shape)[1])};
+  // No-input graphs:
+  //  - single-chip target -> leave meshShape unset; AnalyzeMesh defaults to
+  //    {1,1} and the parent mesh is reshaped to {1,1} downstream.
+  //  - multichip target -> pass parent mesh shape when it matches the target
+  //    device count; otherwise synthesize {1, target_num_devices}.
+  if (!moduleHasAnyFuncArguments(mlir_module) && target_num_devices > 1) {
+    const size_t parent_mesh_num_devices =
+        current_mesh_shape.has_value()
+            ? std::accumulate(current_mesh_shape->begin(),
+                              current_mesh_shape->end(), size_t{1},
+                              std::multiplies<>())
+            : size_t{0};
+    if (current_mesh_shape.has_value() && current_mesh_shape->size() == 2 &&
+        parent_mesh_num_devices == target_num_devices) {
+      stablehlo_pipeline_options.meshShape = {
+          static_cast<int64_t>((*current_mesh_shape)[0]),
+          static_cast<int64_t>((*current_mesh_shape)[1])};
+    } else {
+      stablehlo_pipeline_options.meshShape = {
+          1, static_cast<int64_t>(target_num_devices)};
+    }
   }
   mlir::tt::stablehlo::createStableHLOPipeline(stablehlo_pipeline_pm,
                                                stablehlo_pipeline_options);

--- a/tests/torch/graphs/test_mesh_shapes.py
+++ b/tests/torch/graphs/test_mesh_shapes.py
@@ -19,11 +19,6 @@ class _WithInput(torch.nn.Module):
         return x @ x.T + 1.0
 
 
-class _Identity(torch.nn.Module):
-    def forward(self, a):
-        return a + 0.0
-
-
 class _NoInput(torch.nn.Module):
     def forward(self):
         # All operands are constants -> StableHLO module has no func args.
@@ -50,7 +45,7 @@ def test_no_input_single_device():
 
     model = torch.compile(_NoInput().to(device), backend="tt")
     out = model()
-    torch_xla.sync()
+    torch_xla.sync(wait=True)
     assert torch.allclose(out.cpu(), torch.full((4,), 2.0))
 
 
@@ -65,13 +60,15 @@ def test_with_input_multichip_sharded():
     n = xr.global_runtime_device_count()
     mesh = Mesh(np.array(range(n)), (1, n), ("batch", "model"))
 
-    a = torch.randn(32, 32 * n, dtype=torch.float32).to(device)
-    xs.mark_sharding(a, mesh, (None, "model"))
+    a = torch.randn(32, 32 * n, dtype=torch.float32)
+    a_dev = a.to(device)
+    xs.mark_sharding(a_dev, mesh, (None, "model"))
 
-    model = torch.compile(_Identity(), backend="tt").to(device)
-    out = model(a)
-    torch_xla.sync()
-    assert torch.allclose(out.cpu(), a.cpu())
+    model = torch.compile(_WithInput(), backend="tt").to(device)
+    out = model(a_dev)
+    torch_xla.sync(wait=True)
+    expected = a @ a.T + 1.0
+    assert torch.allclose(out.cpu(), expected, rtol=5e-2, atol=1e-1)
 
 
 # Case 4: multichip target, module has no args.
@@ -88,7 +85,7 @@ def test_no_input_multichip_sharded_output():
     t = torch.ones(8, 32 * n, device=xm.xla_device(), dtype=torch.float32)
     xs.mark_sharding(t, mesh, (None, "model"))
     u = t + 1.0
-    torch_xla.sync()
+    torch_xla.sync(wait=True)
     assert torch.allclose(u.cpu(), torch.full((8, 32 * n), 2.0))
 
 
@@ -102,13 +99,13 @@ def test_single_device_sequential_no_input_then_with_input():
 
     no_input = torch.compile(_NoInput().to(device), backend="tt")
     out_a = no_input()
-    torch_xla.sync()
+    torch_xla.sync(wait=True)
     assert torch.allclose(out_a.cpu(), torch.full((4,), 2.0))
 
     with_input = torch.compile(_WithInput().to(device), backend="tt")
     x = torch.randn(3, 3).to(device)
     out_b = with_input(x)
-    torch_xla.sync()
+    torch_xla.sync(wait=True)
     assert out_b.cpu().shape == (3, 3)
 
 
@@ -123,12 +120,12 @@ def test_single_device_sequential_with_input_then_no_input():
     with_input = torch.compile(_WithInput().to(device), backend="tt")
     x = torch.randn(3, 3).to(device)
     out_a = with_input(x)
-    torch_xla.sync()
+    torch_xla.sync(wait=True)
     assert out_a.cpu().shape == (3, 3)
 
     no_input = torch.compile(_NoInput().to(device), backend="tt")
     out_b = no_input()
-    torch_xla.sync()
+    torch_xla.sync(wait=True)
     assert torch.allclose(out_b.cpu(), torch.full((4,), 2.0))
 
 
@@ -143,10 +140,31 @@ def test_with_input_multichip_replicated():
     n = xr.global_runtime_device_count()
     mesh = Mesh(np.array(range(n)), (1, n), ("batch", "model"))
 
-    a = torch.randn(32, 32, dtype=torch.float32).to(device)
-    xs.mark_sharding(a, mesh, (None, None))  # fully replicated
+    a = torch.randn(32, 32, dtype=torch.float32)
+    a_dev = a.to(device)
+    xs.mark_sharding(a_dev, mesh, (None, None))  # fully replicated
 
-    model = torch.compile(_Identity(), backend="tt").to(device)
-    out = model(a)
-    torch_xla.sync()
-    assert torch.allclose(out.cpu(), a.cpu())
+    model = torch.compile(_WithInput(), backend="tt").to(device)
+    out = model(a_dev)
+    torch_xla.sync(wait=True)
+    expected = a @ a.T + 1.0
+    assert torch.allclose(out.cpu(), expected, rtol=1e-2, atol=1e-2)
+
+
+# Case 8: Multichip no mesh.
+@pytest.mark.push
+@pytest.mark.multi_chip
+@pytest.mark.record_test_properties(category=Category.GRAPH_TEST)
+def test_with_input_multichip_no_mesh():
+    enable_spmd()
+    xr.set_device_type("TT")
+    device = torch_xla.device()
+
+    a = torch.randn(32, 32, dtype=torch.float32)
+    a_dev = a.to(device)
+
+    model = torch.compile(_WithInput(), backend="tt").to(device)
+    out = model(a_dev)
+    torch_xla.sync(wait=True)
+    expected = a @ a.T + 1.0
+    assert torch.allclose(out.cpu(), expected, rtol=1e-2, atol=1e-2)

--- a/tests/torch/graphs/test_mesh_shapes.py
+++ b/tests/torch/graphs/test_mesh_shapes.py
@@ -32,7 +32,6 @@ class _NoInput(torch.nn.Module):
 
 # Case 1: single-device target, module has args.
 @pytest.mark.push
-@pytest.mark.nightly
 @pytest.mark.single_device
 @pytest.mark.record_test_properties(category=Category.GRAPH_TEST)
 def test_with_input_single_device():
@@ -43,7 +42,6 @@ def test_with_input_single_device():
 
 # Case 2: single-device target, module has no args.
 @pytest.mark.push
-@pytest.mark.nightly
 @pytest.mark.single_device
 @pytest.mark.record_test_properties(category=Category.GRAPH_TEST)
 def test_no_input_single_device():
@@ -58,7 +56,6 @@ def test_no_input_single_device():
 
 # Case 3: multichip target, sharded inputs.
 @pytest.mark.push
-@pytest.mark.nightly
 @pytest.mark.multi_chip
 @pytest.mark.record_test_properties(category=Category.GRAPH_TEST)
 def test_with_input_multichip_sharded():
@@ -79,7 +76,6 @@ def test_with_input_multichip_sharded():
 
 # Case 4: multichip target, module has no args.
 @pytest.mark.push
-@pytest.mark.nightly
 @pytest.mark.multi_chip
 @pytest.mark.record_test_properties(category=Category.GRAPH_TEST)
 def test_no_input_multichip_sharded_output():
@@ -98,7 +94,6 @@ def test_no_input_multichip_sharded_output():
 
 # Case 5: sequential single-device compiles, no-input first.
 @pytest.mark.push
-@pytest.mark.nightly
 @pytest.mark.single_device
 @pytest.mark.record_test_properties(category=Category.GRAPH_TEST)
 def test_single_device_sequential_no_input_then_with_input():
@@ -119,7 +114,6 @@ def test_single_device_sequential_no_input_then_with_input():
 
 # Case 6: sequential single-device compiles, with-input first.
 @pytest.mark.push
-@pytest.mark.nightly
 @pytest.mark.single_device
 @pytest.mark.record_test_properties(category=Category.GRAPH_TEST)
 def test_single_device_sequential_with_input_then_no_input():
@@ -140,7 +134,6 @@ def test_single_device_sequential_with_input_then_no_input():
 
 # Case 7: SPMD enabled but input fully replicated.
 @pytest.mark.push
-@pytest.mark.nightly
 @pytest.mark.multi_chip
 @pytest.mark.record_test_properties(category=Category.GRAPH_TEST)
 def test_with_input_multichip_replicated():

--- a/tests/torch/graphs/test_mesh_shapes.py
+++ b/tests/torch/graphs/test_mesh_shapes.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import numpy as np
+import pytest
+import torch
+import torch_xla
+import torch_xla.core.xla_model as xm
+import torch_xla.distributed.spmd as xs
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test_with_random_inputs
+from infra.utilities.torch_multichip_utils import enable_spmd
+from torch_xla.distributed.spmd import Mesh
+from utils import Category
+
+
+class _WithInput(torch.nn.Module):
+    def forward(self, x):
+        return x @ x.T + 1.0
+
+
+class _Identity(torch.nn.Module):
+    def forward(self, a):
+        return a + 0.0
+
+
+class _NoInput(torch.nn.Module):
+    def forward(self):
+        # All operands are constants -> StableHLO module has no func args.
+        return torch.ones(4, device=xm.xla_device(), dtype=torch.float32) + 1.0
+
+
+# Case 1: single-device target, module has args.
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.single_device
+@pytest.mark.record_test_properties(category=Category.GRAPH_TEST)
+def test_with_input_single_device():
+    run_graph_test_with_random_inputs(
+        _WithInput(), [(3, 3)], dtype=torch.float32, framework=Framework.TORCH
+    )
+
+
+# Case 2: single-device target, module has no args.
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.single_device
+@pytest.mark.record_test_properties(category=Category.GRAPH_TEST)
+def test_no_input_single_device():
+    xr.set_device_type("TT")
+    device = torch_xla.device()
+
+    model = torch.compile(_NoInput().to(device), backend="tt")
+    out = model()
+    torch_xla.sync()
+    assert torch.allclose(out.cpu(), torch.full((4,), 2.0))
+
+
+# Case 3: multichip target, sharded inputs.
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.multi_chip
+@pytest.mark.record_test_properties(category=Category.GRAPH_TEST)
+def test_with_input_multichip_sharded():
+    enable_spmd()
+    xr.set_device_type("TT")
+    device = torch_xla.device()
+    n = xr.global_runtime_device_count()
+    mesh = Mesh(np.array(range(n)), (1, n), ("batch", "model"))
+
+    a = torch.randn(32, 32 * n, dtype=torch.float32).to(device)
+    xs.mark_sharding(a, mesh, (None, "model"))
+
+    model = torch.compile(_Identity(), backend="tt").to(device)
+    out = model(a)
+    torch_xla.sync()
+    assert torch.allclose(out.cpu(), a.cpu())
+
+
+# Case 4: multichip target, module has no args.
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.multi_chip
+@pytest.mark.record_test_properties(category=Category.GRAPH_TEST)
+def test_no_input_multichip_sharded_output():
+    enable_spmd()
+    xr.set_device_type("TT")
+    n = xr.global_runtime_device_count()
+    mesh = Mesh(np.array(range(n)), (1, n), ("batch", "model"))
+
+    # Constant tensor with a sharded output, HLO module has no func args.
+    t = torch.ones(8, 32 * n, device=xm.xla_device(), dtype=torch.float32)
+    xs.mark_sharding(t, mesh, (None, "model"))
+    u = t + 1.0
+    torch_xla.sync()
+    assert torch.allclose(u.cpu(), torch.full((8, 32 * n), 2.0))
+
+
+# Case 5: sequential single-device compiles, no-input first.
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.single_device
+@pytest.mark.record_test_properties(category=Category.GRAPH_TEST)
+def test_single_device_sequential_no_input_then_with_input():
+    xr.set_device_type("TT")
+    device = torch_xla.device()
+
+    no_input = torch.compile(_NoInput().to(device), backend="tt")
+    out_a = no_input()
+    torch_xla.sync()
+    assert torch.allclose(out_a.cpu(), torch.full((4,), 2.0))
+
+    with_input = torch.compile(_WithInput().to(device), backend="tt")
+    x = torch.randn(3, 3).to(device)
+    out_b = with_input(x)
+    torch_xla.sync()
+    assert out_b.cpu().shape == (3, 3)
+
+
+# Case 6: sequential single-device compiles, with-input first.
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.single_device
+@pytest.mark.record_test_properties(category=Category.GRAPH_TEST)
+def test_single_device_sequential_with_input_then_no_input():
+    xr.set_device_type("TT")
+    device = torch_xla.device()
+
+    with_input = torch.compile(_WithInput().to(device), backend="tt")
+    x = torch.randn(3, 3).to(device)
+    out_a = with_input(x)
+    torch_xla.sync()
+    assert out_a.cpu().shape == (3, 3)
+
+    no_input = torch.compile(_NoInput().to(device), backend="tt")
+    out_b = no_input()
+    torch_xla.sync()
+    assert torch.allclose(out_b.cpu(), torch.full((4,), 2.0))
+
+
+# Case 7: SPMD enabled but input fully replicated.
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.multi_chip
+@pytest.mark.record_test_properties(category=Category.GRAPH_TEST)
+def test_with_input_multichip_replicated():
+    enable_spmd()
+    xr.set_device_type("TT")
+    device = torch_xla.device()
+    n = xr.global_runtime_device_count()
+    mesh = Mesh(np.array(range(n)), (1, n), ("batch", "model"))
+
+    a = torch.randn(32, 32, dtype=torch.float32).to(device)
+    xs.mark_sharding(a, mesh, (None, None))  # fully replicated
+
+    model = torch.compile(_Identity(), backend="tt").to(device)
+    out = model(a)
+    torch_xla.sync()
+    assert torch.allclose(out.cpu(), a.cpu())


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-xla/issues/4624

### Problem description
Single-chip tests need to be able to run on multichip machines.
This can be achieved by checking the `num_partitions` field [passed by torch-xla](https://github.com/tenstorrent/pytorch-xla/blob/5c82b1034208844b584e6088b2e043838935e875/torch_xla/csrc/runtime/pjrt_computation_client.cpp#L584).

 `num_partitions` is the right discriminator because torch-xla only sets it to `device_count()` on the SPMD branch, the non-SPMD branch keeps `num_partitions=1` and instead sets `num_replicas=device_count()` (each replica is dispatched as its own 1-device `ExecuteSharded` call), so using the product `num_partitions x num_replicas` would mis-classify single-device compiles as multichip.

### What's changed
  - Read `num_partitions` / `num_replicas` from `ExecutableBuildOptionsProto`.
  - Use `target_num_devices` into `runCompilerStableHLOPipeline`.
  - In the no-input branch of `runCompilerStableHLOPipeline`, only pass the parent mesh shape into `AnalyzeMesh` when `target_num_devices > 1`. Single-chip compiles fall back to AnalyzeMesh's default `{1,1}` and the existing reshape path reshapes the parent mesh downstream.
  - Added `tests/torch/graphs/test_mesh_shapes.py` covering 7 cases: single/multi chip x with/without args, sharded vs replicated inputs, and sequential single-device compiles.
  
###  Known Limitation!
Changing mode mid execution is faulty. Tests with different modes (single and multichip) fail when they are ran subsequently. Will need further discussion.

### Checklist
- [ ] New/Existing tests provide coverage for changes
