### PR TITLE
Refactoring the sliding attention using generics and flags.

### DIFF
--- a/examples/pytorch/gpt_oss_20b.py
+++ b/examples/pytorch/gpt_oss_20b.py
@@ -27,7 +27,7 @@ from transformers.modeling_outputs import CausalLMOutputWithPast
 from tt_torch.sharding import sharding_constraint_hook
 from tt_torch.transformers_overrides import (
     override_cache_sliding_window_layers,
-    override_gpt_oss_sliding_window_causal_mask,
+    override_sliding_window_causal_mask,
 )
 
 DEFAULT_PROMPTS = ["Explain quantum mechanics."]
@@ -152,7 +152,7 @@ def setup_model_and_tokenizer(
         attn_implementation="eager",
     )
     # Override the gpt_oss model to use the TT-friendly sliding window causal mask
-    override_gpt_oss_sliding_window_causal_mask()
+    override_sliding_window_causal_mask(model)
     model = model.eval()
 
     tokenizer: PreTrainedTokenizer = AutoTokenizer.from_pretrained(model_name)

--- a/examples/pytorch/mistral_8b.py
+++ b/examples/pytorch/mistral_8b.py
@@ -14,7 +14,7 @@ from transformers.cache_utils import StaticCache
 from transformers.configuration_utils import PretrainedConfig
 from tt_torch.transformers_overrides import (
     override_cache_sliding_window_layers,
-    override_ministral_sliding_window_causal_mask,
+    override_sliding_window_causal_mask,
 )
 
 MODEL_NAME = "mistralai/Ministral-8B-Instruct-2410"
@@ -94,7 +94,7 @@ def mistral_8b():
 
 def _load_model_and_tokenizer(model_name: str):
     model = AutoModelForCausalLM.from_pretrained(model_name, dtype=torch.bfloat16)
-    override_ministral_sliding_window_causal_mask()
+    override_sliding_window_causal_mask(model)
     model = model.eval()
     tokenizer = AutoTokenizer.from_pretrained(model_name)
     if tokenizer.pad_token is None:

--- a/examples/pytorch/olmo3_1025_7b.py
+++ b/examples/pytorch/olmo3_1025_7b.py
@@ -14,7 +14,7 @@ from transformers.cache_utils import StaticCache
 from transformers.configuration_utils import PretrainedConfig
 from tt_torch.transformers_overrides import (
     override_cache_sliding_window_layers,
-    override_olmo3_sliding_window_causal_mask,
+    override_sliding_window_causal_mask,
 )
 
 MODEL_NAME = "allenai/Olmo-3-1025-7B"
@@ -94,7 +94,7 @@ def olmo3_1025_7b():
 
 def _load_model_and_tokenizer(model_name: str):
     model = AutoModelForCausalLM.from_pretrained(model_name, dtype=torch.bfloat16)
-    override_olmo3_sliding_window_causal_mask()
+    override_sliding_window_causal_mask(model)
     model = model.eval()
     tokenizer = AutoTokenizer.from_pretrained(model_name)
     if tokenizer.pad_token is None:

--- a/examples/pytorch/olmo3_1125_32b.py
+++ b/examples/pytorch/olmo3_1125_32b.py
@@ -16,7 +16,7 @@ from transformers.cache_utils import StaticCache
 from transformers.configuration_utils import PretrainedConfig
 from tt_torch.transformers_overrides import (
     override_cache_sliding_window_layers,
-    override_olmo3_sliding_window_causal_mask,
+    override_sliding_window_causal_mask,
 )
 
 MODEL_NAME = "allenai/Olmo-3-1125-32B"
@@ -146,7 +146,7 @@ def olmo3_1125_32b():
 
 def _load_model_and_tokenizer(model_name: str):
     model = AutoModelForCausalLM.from_pretrained(model_name, dtype=torch.bfloat16)
-    override_olmo3_sliding_window_causal_mask()
+    override_sliding_window_causal_mask(model)
     model = model.eval()
     tokenizer = AutoTokenizer.from_pretrained(model_name)
     if tokenizer.pad_token is None:

--- a/python_package/tt_torch/transformers_overrides.py
+++ b/python_package/tt_torch/transformers_overrides.py
@@ -8,43 +8,20 @@ from transformers.cache_utils import StaticCache, StaticLayer, StaticSlidingWind
 from transformers.masking_utils import create_sliding_window_causal_mask
 
 
-def override_gpt_oss_sliding_window_causal_mask():
+def override_sliding_window_causal_mask(model):
+    """Monkey-patch the create_sliding_window_causal_mask function of the
+    transformers modeling module that backs ``model`` with the TT-friendly
+    compile-safe version.
+
+    Call this AFTER ``from_pretrained`` and BEFORE ``torch.compile`` so that
+    dynamo traces through the patched function.
     """
-    Override gpt_oss's modeling so that its
-    create_sliding_window_causal_mask points to the TT-friendly version.
+    import importlib
 
-    Call this before torch.compile so that dynamo traces through the
-    patched function.
-    """
-    import transformers.models.gpt_oss.modeling_gpt_oss as gpt_oss_mod
-
-    gpt_oss_mod.create_sliding_window_causal_mask = tt_create_sliding_window_causal_mask
-
-
-def override_olmo3_sliding_window_causal_mask():
-    """
-    Override olmo3's modeling so that its
-    create_sliding_window_causal_mask points to the TT-friendly version.
-    """
-    import transformers.models.olmo3.modeling_olmo3 as olmo3_mod
-
-    olmo3_mod.create_sliding_window_causal_mask = tt_create_sliding_window_causal_mask
-
-
-def override_ministral_sliding_window_causal_mask():
-    """
-    Override ministral's modeling so that its
-    create_sliding_window_causal_mask points to the TT-friendly version.
-
-    Note: ministral (mistralai/Ministral-*) uses a separate module
-    transformers.models.ministral.modeling_ministral, distinct from
-    transformers.models.mistral.modeling_mistral.
-    """
-    import transformers.models.ministral.modeling_ministral as ministral_mod
-
-    ministral_mod.create_sliding_window_causal_mask = (
-        tt_create_sliding_window_causal_mask
-    )
+    model_type = model.config.model_type
+    module_name = f"transformers.models.{model_type}.modeling_{model_type}"
+    mod = importlib.import_module(module_name)
+    mod.create_sliding_window_causal_mask = tt_create_sliding_window_causal_mask
 
 
 def override_cache_sliding_window_layers(

--- a/tests/runner/test_config/constants.py
+++ b/tests/runner/test_config/constants.py
@@ -44,6 +44,10 @@ ALLOWED_FIELDS = {
     "inject_custom_moe",
     # EmitPy verification: assert exact match between emitpy and flatbuffer results
     "emitpy_assert_exact",
+    # Whether to apply the TT-friendly sliding-window causal-mask override to the
+    # transformers module before compile/forward. Used by sliding-window LLMs
+    # (olmo3, gpt_oss, ministral, ...) that need a compile-safe mask function.
+    "overrides_sliding_attention",
 }
 
 # Single source of truth for the placeholders YAML filename

--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -1684,6 +1684,7 @@ test_config:
     arch_overrides:
       p150:
         status: EXPECTED_PASSING
+        overrides_sliding_attention: true
 
       n150:
         status: NOT_SUPPORTED_SKIP
@@ -2557,6 +2558,7 @@ test_config:
         reason: "Out of Memory: Not enough space to allocate 52428800 B L1 buffer across 64 banks, where each bank needs to store 819200 B, but bank size is only 1331936 B"
       p150:
         status: EXPECTED_PASSING
+        overrides_sliding_attention: true
 
   olm_ocr/image_text_generation/pytorch-olmOCR-7B-0225-preview-single_device-inference:
     supported_archs: ["p150"]

--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -99,6 +99,7 @@ test_config:
   mistral/pytorch-Ministral_8B_Instruct-tensor_parallel-inference:
     supported_archs: [n300-llmbox, lb-blackhole]
     status: EXPECTED_PASSING
+    overrides_sliding_attention: true
 
   mistral/pytorch-Small_24B_INSTRUCT_2501-tensor_parallel-inference:
     supported_archs: [n300-llmbox, lb-blackhole]
@@ -205,6 +206,7 @@ test_config:
     supported_archs: [n300-llmbox, lb-blackhole]
     assert_pcc: True
     status: EXPECTED_PASSING
+    overrides_sliding_attention: true
 
   mistral/pytorch-mistral_small_3.1_24b_instruct_2503-tensor_parallel-inference:
     supported_archs: [n300-llmbox, lb-blackhole]

--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -207,6 +207,14 @@ class ModelTestConfig:
         # Set to false in YAML config for models with known minor differences.
         self.emitpy_assert_exact = self._resolve("emitpy_assert_exact", default=True)
 
+        # Whether to apply the TT-friendly sliding-window causal-mask override
+        # to the loaded transformers module before compile/forward. Generic
+        # replacement for the per-model override_<model>_sliding_window_causal_mask
+        # helpers in tt_torch.transformers_overrides; opt-in via YAML per model.
+        self.overrides_sliding_attention = self._resolve(
+            "overrides_sliding_attention", default=False
+        )
+
     def _resolve(self, key, default=None):
         overrides = self.data.get("arch_overrides", {})
         if self.arch in overrides and key in overrides[self.arch]:

--- a/tests/runner/testers/torch/dynamic_torch_model_tester.py
+++ b/tests/runner/testers/torch/dynamic_torch_model_tester.py
@@ -70,6 +70,17 @@ class DynamicTorchModelTester(TorchModelTester):
         if test_metadata and getattr(test_metadata, "inject_custom_moe", False):
             self._inject_custom_moe(self._model)
 
+        # Monkey-patch transformers' create_sliding_window_causal_mask with the
+        # TT-friendly compile-safe version when the YAML config asks for it.
+        # Generic replacement for the per-model override_<model>_sliding_window_
+        # causal_mask helpers previously called inside tt-forge-models loaders.
+        # Patching happens after model construction but before torch.compile so
+        # dynamo traces through the patched function.
+        if test_metadata and getattr(
+            test_metadata, "overrides_sliding_attention", False
+        ):
+            self._apply_sliding_window_mask_override(self._model)
+
     def _compile_for_tt_device(self, workload, options=None):
         """Apply per-variant weight dtype overrides before compiling for TT device."""
         self._apply_weight_dtype_overrides()
@@ -146,6 +157,15 @@ class DynamicTorchModelTester(TorchModelTester):
             seq_len=seq_len,
             batch_size=batch_size,
         )
+
+        # Build TT-friendly sliding-window input_args (StaticCache with
+        # TTStaticSlidingWindowLayer, full attention mask, cache_position) when
+        # the YAML config asks for it. Generic replacement for the sliding-window
+        # input-construction block previously embedded in tt-forge-models loaders.
+        if self._test_metadata and getattr(
+            self._test_metadata, "overrides_sliding_attention", False
+        ):
+            inputs = self._build_sliding_window_input_args(inputs)
 
         if self.parallelism == Parallelism.DATA_PARALLEL:
             num_devices = xr.global_runtime_device_count()
@@ -298,3 +318,112 @@ class DynamicTorchModelTester(TorchModelTester):
                 return get_moe_shard_specs(model, _fn, _names)
 
             self._workload.shard_spec_fn = combined_shard_spec_fn
+
+    def _build_sliding_window_input_args(self, inputs):
+        """Build a full sliding-window input_args dict (with a TT-friendly
+        StaticCache) from the raw tokenizer output returned by the loader.
+
+        Generic replacement for the sliding-window input-construction block
+        previously embedded in tt-forge-models loaders. Constructs a
+        StaticCache sized to the loader's variant max_length, runs
+        ``early_initialization``, swaps every StaticSlidingWindowLayer for
+        the TT-friendly TTStaticSlidingWindowLayer, and pads the attention
+        mask to ``max_cache_len`` so torch.compile sees static shapes.
+        """
+        from transformers.cache_utils import StaticCache
+        from tt_torch.transformers_overrides import override_cache_sliding_window_layers
+
+        # Inputs from the loader may be a HF BatchEncoding or a plain dict.
+        if isinstance(inputs, collections.abc.Mapping):
+            input_ids = inputs["input_ids"]
+            attention_mask = inputs["attention_mask"]
+        else:
+            input_ids = inputs.input_ids
+            attention_mask = inputs.attention_mask
+
+        batch_size, seq_len = input_ids.shape[0], input_ids.shape[1]
+
+        # max_cache_len comes from the loader's variant config (e.g. olmo3
+        # uses max_length=256). Fall back to seq_len if the loader does not
+        # expose a variant config.
+        variant_config = getattr(self.dynamic_loader.loader, "_variant_config", None)
+        max_cache_len = getattr(variant_config, "max_length", seq_len)
+
+        text_config = self._model.config.get_text_config(decoder=True)
+        head_dim = getattr(text_config, "head_dim", None) or (
+            text_config.hidden_size // text_config.num_attention_heads
+        )
+        cache_dtype = next(self._model.parameters()).dtype
+
+        static_cache = StaticCache(
+            config=self._model.config,
+            max_cache_len=max_cache_len,
+        )
+        static_cache.early_initialization(
+            batch_size=batch_size,
+            num_heads=text_config.num_key_value_heads,
+            head_dim=head_dim,
+            dtype=cache_dtype,
+            device="cpu",
+        )
+
+        sliding_window = getattr(text_config, "sliding_window", max_cache_len)
+        override_cache_sliding_window_layers(
+            static_cache, max_cache_len, sliding_window
+        )
+
+        # Attention mask must match max_cache_len to prevent recompilation or
+        # implicit padding by transformers, which can cause degenerate output.
+        full_attention_mask = torch.ones(
+            (batch_size, max_cache_len), dtype=attention_mask.dtype
+        )
+        full_attention_mask[:, :seq_len] = attention_mask
+
+        cache_position = torch.arange(0, seq_len)
+
+        logger.info(
+            f"Built sliding-window input_args "
+            f"(batch_size={batch_size}, seq_len={seq_len}, "
+            f"max_cache_len={max_cache_len}, sliding_window={sliding_window})"
+        )
+
+        return {
+            "input_ids": input_ids,
+            "past_key_values": static_cache,
+            "cache_position": cache_position,
+            "use_cache": True,
+            "attention_mask": full_attention_mask,
+        }
+
+    @staticmethod
+    def _apply_sliding_window_mask_override(model):
+        """Apply the generic TT sliding-window causal-mask override to ``model``.
+
+        Thin wrapper around ``tt_torch.transformers_overrides
+        .override_sliding_window_causal_mask`` that adds defensive logging so
+        a misconfigured ``overrides_sliding_attention: true`` YAML entry on a
+        model that doesn't actually use sliding-window attention emits a
+        warning instead of crashing the test.
+        """
+        from tt_torch.transformers_overrides import override_sliding_window_causal_mask
+
+        model_type = getattr(getattr(model, "config", None), "model_type", None)
+        if not model_type:
+            logger.warning(
+                "Skipping sliding-window mask override: model has no "
+                "config.model_type"
+            )
+            return
+
+        try:
+            override_sliding_window_causal_mask(model)
+        except (ImportError, AttributeError) as e:
+            logger.warning(
+                f"Skipping sliding-window mask override for model_type="
+                f"{model_type!r}: {e}"
+            )
+            return
+
+        logger.info(
+            f"Applied TT sliding-window mask override " f"(model_type={model_type})"
+        )


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/4171

### Problem description
Move sliding-window attention overrides out of tt-forge-models loaders into generic tt-xla test infrastructure


### What's changed

overrides_sliding_attention is an opt-in boolean YAML flag (default false) that tells the test runner to apply tt-xla's TT-friendly sliding-window logic — swap HF's StaticSlidingWindowLayer for the compile-safe TTStaticSlidingWindowLayer in the input cache, and monkey-patch the model's create_sliding_window_causal_mask with the compile-safe version. Set it to true for sliding-window LLMs (olmo3, gpt_oss, ministral, …) that need a torch.compile-friendly attention path on TT hardware.

Note: No code dependencies in the tt-forge-models repository.

```
YAML:  overrides_sliding_attention: true   (per test row)
  │
  ▼ config_loader.py validates against ALLOWED_FIELDS
  ▼ conftest.py builds ModelTestConfig and attaches to item._test_meta
  ▼ test_metadata fixture returns it
  │
  ▼ test_models.py forwards test_metadata to DynamicTorchModelTester
  │
  ▼ DynamicTorchModelTester.__init__:
       │
       ├─ super().__init__() (loads model, builds inputs)
       │    └─ _get_input_activations:
       │         ├─ inputs = loader.load_inputs()         # tokenizer output only
       │         └─ if flag: inputs = self._build_sliding_window_input_args(inputs)
       │                ├─ build HF StaticCache
       │                ├─ early_initialization
       │                ├─ override_cache_sliding_window_layers (TT cache layer swap)
       │                ├─ pad attention_mask to max_cache_len
       │                └─ return input_args dict
       │
       └─ Post-super hooks:
            └─ if flag: self._apply_sliding_window_mask_override(self._model)
                   └─ override_sliding_window_causal_mask(model)
                          ├─ resolve transformers.models.<type>.modeling_<type>
                          └─ patch create_sliding_window_causal_mask
  │
  ▼ tester.test() → torch.compile traces forward with TT-friendly mask
                    and TT-friendly StaticCache layers
```
logs:
[gpt_ooss.log](https://github.com/user-attachments/files/27631214/gpt_ooss.log)
[olmo3_1125_32b.log](https://github.com/user-attachments/files/27631218/olmo3_1125_32b.log)

### Checklist
- [ ] New/Existing tests provide coverage for changes
