### PR TITLE
Add Mochi-1 component tests at original resolution (text encoder, DiT, VAE decoder)

### DIFF
--- a/tests/torch/models/mochi/test_text_encoder.py
+++ b/tests/torch/models/mochi/test_text_encoder.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Mochi — T5-XXL text encoder component test (4.76B)."""
+
+import pytest
+import torch
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+
+from third_party.tt_forge_models.mochi.pytorch import ModelLoader, ModelVariant
+from third_party.tt_forge_models.mochi.pytorch.src.utils import (
+    load_text_encoder_inputs_full_res,
+)
+
+
+@pytest.mark.xfail(
+    reason="AssertionError: Evaluation result 0 failed: PCC comparison failed. Calculated: pcc=0.9651207601058263. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/4652 "
+)
+def test_text_encoder():
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.MOCHI, subfolder="text_encoder")
+    encoder = loader.load_model(dtype_override=torch.bfloat16)
+    inputs = load_text_encoder_inputs_full_res(dtype=torch.bfloat16)
+
+    run_graph_test(encoder, inputs, framework=Framework.TORCH)

--- a/tests/torch/models/mochi/test_transformer.py
+++ b/tests/torch/models/mochi/test_transformer.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Mochi — MochiTransformer3DModel (DiT) component test (10.03B)."""
+
+import os
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.core.xla_model as xm
+import torch_xla.distributed.spmd as xs
+import torch_xla.runtime as xr
+from infra.utilities.torch_multichip_utils import get_mesh
+
+from third_party.tt_forge_models.mochi.pytorch import ModelLoader, ModelVariant
+from third_party.tt_forge_models.mochi.pytorch.src.utils import (
+    load_transformer_inputs_full_res,
+)
+
+
+@pytest.mark.xfail(
+    reason="Out of Memory: Not enough space to allocate 32463388672 B DRAM buffer "
+    "across 12 banks, where each bank needs to store 2705283072 B, but bank size "
+    "is 1071821792 B — https://github.com/tenstorrent/tt-xla/issues/4651"
+)
+def test_transformer_sharded():
+    # Not using run_graph_test: it runs the model on CPU as a golden reference
+    # first, and the 10B transformer CPU pass takes ~12 min at full resolution.
+    # TT-only for now.
+    # TODO: re-enable CPU golden + PCC check via run_graph_test once the TT
+    # path is passing - https://github.com/tenstorrent/tt-xla/issues/4884
+    torch_xla.set_custom_compile_options(
+        {"experimental-enable-dram-space-saving-optimization": "true"}
+    )
+    xr.set_device_type("TT")
+    os.environ["CONVERT_SHLO_TO_SHARDY"] = "1"
+    xr.use_spmd()
+    torch.manual_seed(42)
+
+    device = xm.xla_device()
+
+    loader = ModelLoader(ModelVariant.MOCHI, subfolder="transformer")
+    model = loader.load_model(dtype_override=torch.bfloat16).eval().to(device)
+
+    compiled = torch.compile(model, backend="tt")
+
+    mesh_shape, mesh_names = loader.get_mesh_config(xr.global_runtime_device_count())
+    mesh = get_mesh(mesh_shape, mesh_names)
+    shard_spec = loader.load_shard_spec(model)
+    for tensor, partition_spec in shard_spec.items():
+        xs.mark_sharding(tensor, mesh, partition_spec)
+
+    hidden_states, encoder_hidden_states, timestep, encoder_attention_mask = (
+        load_transformer_inputs_full_res(dtype=torch.bfloat16)
+    )
+    hidden_states = hidden_states.to(device)
+    encoder_hidden_states = encoder_hidden_states.to(device)
+    timestep = timestep.to(device)
+    encoder_attention_mask = encoder_attention_mask.to(device)
+
+    with torch.no_grad():
+        tt_out = compiled(
+            hidden_states=hidden_states,
+            encoder_hidden_states=encoder_hidden_states,
+            timestep=timestep,
+            encoder_attention_mask=encoder_attention_mask,
+        )

--- a/tests/torch/models/mochi/test_vae_decoder.py
+++ b/tests/torch/models/mochi/test_vae_decoder.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Mochi VAE decoder component test at original Mochi-1 resolution (0.36B)."""
+
+import os
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.core.xla_model as xm
+import torch_xla.distributed.spmd as xs
+import torch_xla.runtime as xr
+from infra.utilities.torch_multichip_utils import get_mesh
+
+from third_party.tt_forge_models.mochi.pytorch import ModelLoader, ModelVariant
+from third_party.tt_forge_models.mochi.pytorch.src.utils import (
+    load_vae_decoder_inputs_full_res,
+)
+
+
+@pytest.mark.xfail(
+    reason="DRAM OOM during sharded decoder pixel-shuffle intermediate — "
+    "https://github.com/tenstorrent/tt-xla/issues/4252"
+)
+def test_torch_mochi_vae_decoder_inference():
+    # Not using run_graph_test: it runs the model on CPU as a golden
+    # reference first, and the Mochi VAE decoder CPU pass takes > 50 min at
+    # full resolution. TT-only for now.
+    # TODO: re-enable CPU golden + PCC check via run_graph_test once the
+    # TT path is passing - https://github.com/tenstorrent/tt-xla/issues/4885
+    # SPMD setup must come before any tensor lands on the XLA device.
+    torch_xla.set_custom_compile_options(
+        {"experimental-enable-dram-space-saving-optimization": "true"}
+    )
+    xr.set_device_type("TT")
+    os.environ["CONVERT_SHLO_TO_SHARDY"] = "1"
+    xr.use_spmd()
+    torch.manual_seed(42)
+
+    device = xm.xla_device()
+
+    loader = ModelLoader(ModelVariant.MOCHI, subfolder="vae")
+    vae = loader.load_model(dtype_override=torch.bfloat16)
+    decoder = vae.decoder.eval().to(device)
+
+    compiled = torch.compile(decoder, backend="tt")
+
+    # Megatron-style sharding applied after weights are on the XLA device.
+    mesh_shape, mesh_names = loader.get_mesh_config(xr.global_runtime_device_count())
+    mesh = get_mesh(mesh_shape, mesh_names)
+    shard_spec = loader.load_shard_spec(decoder)
+    for tensor, partition_spec in shard_spec.items():
+        xs.mark_sharding(tensor, mesh, partition_spec)
+
+    [latent] = load_vae_decoder_inputs_full_res(dtype=torch.bfloat16)
+    tt_latent = latent.to(device)
+
+    with torch.no_grad():
+        tt_out = compiled(tt_latent)


### PR DESCRIPTION
### Ticket

- closes https://github.com/tenstorrent/tt-xla/issues/4640

### Problem description

- There were no tt-xla component tests for Mochi-1 at its original inference resolution (480×848, 84 frames). 

### What's changed

- Companion [PR](https://github.com/tenstorrent/tt-forge-models/pull/647) adds the full-resolution input helpers, mesh config, `shard_transformer_specs`, and `shard_vae_decoder_specs`. This PR consumes them and adds three new component tests under `tests/torch/models/mochi/`:

- `test_text_encoder.py` — T5-XXL (~4.76B) on a single chip via `run_graph_test`. Xfailed with a PCC drop (#4652).

- `test_transformer.py` — `MochiTransformer3DModel` DiT (~10.03B) sharded via `loader.get_mesh_config()` + `loader.load_shard_spec`. Xfailed with DRAM OOM (#4651).

- `test_vae_decoder.py` — `AutoencoderKLMochi.decoder` (~0.36B) at full res, sharded via the same mesh and Megatron column–row strategy on the ResBlock convs. Xfailed with DRAM OOM during the pixel-shuffle intermediate (#4252).

### Checklist
- [x] Verify the changes through local testing in WH

### Logs

- [may12_mochi_encoder.log](https://github.com/user-attachments/files/27654716/may12_mochi_encoder.log)
- [may23_mochi_transformer_8_chips.log](https://github.com/user-attachments/files/28176543/may23_mochi_transformer_8_chips_re.log)
- [may23_mochi_vae_decoder_8_chips.log](https://github.com/user-attachments/files/28176546/may23_mochi_vae_decoder_8_chips_re.log)