### PR TITLE
Skip irrelevant test suites on PRs based on changed paths.

### DIFF
--- a/.github/workflows/call-inspect-changes.yml
+++ b/.github/workflows/call-inspect-changes.yml
@@ -15,6 +15,12 @@ on:
       only-run-forge-models:
         description: "True if only forge-models runner files changed."
         value: ${{ jobs.inspect-changes.outputs.only-run-forge-models }}
+      only-vllm-changes:
+        description: "True if every non-doc changed file is under vLLM paths (skip framework/forge-model tests)."
+        value: ${{ jobs.inspect-changes.outputs.only-vllm-changes }}
+      only-framework-changes:
+        description: "True if every non-doc changed file is under framework paths (skip vLLM tests)."
+        value: ${{ jobs.inspect-changes.outputs.only-framework-changes }}
       uplift-additional-test-suites:
         description: "Test suite presets for detected uplifts, colon-separated"
         value: ${{ jobs.inspect-changes.outputs.uplift-additional-test-suites }}
@@ -33,6 +39,8 @@ jobs:
       run-pr-tests: ${{ steps.inspect.outputs.run-pr-tests }}
       run-perf-tests: ${{ steps.inspect.outputs.run-perf-tests }}
       only-run-forge-models: ${{ steps.inspect.outputs.only-run-forge-models }}
+      only-vllm-changes: ${{ steps.inspect.outputs.only-vllm-changes }}
+      only-framework-changes: ${{ steps.inspect.outputs.only-framework-changes }}
       uplift-additional-test-suites: ${{ steps.inspect.outputs.uplift-additional-test-suites }}
       detected-uplifts: ${{ steps.inspect.outputs.detected-uplifts }}
       wheel-changes: ${{ steps.inspect.outputs.wheel-changes }}
@@ -53,6 +61,8 @@ jobs:
           run_pr_tests=false
           run_perf_tests=false
           only_run_forge_models=false
+          only_vllm_changes=false
+          only_framework_changes=false
           detected_uplifts=""
           uplift_additional_test_suites=""
           wheel_changes=false
@@ -170,6 +180,83 @@ jobs:
               done
             done
 
+            # Classify changed files into vLLM-only vs framework-only buckets.
+            # Anything that doesn't match either bucket (e.g. pjrt_implementation/,
+            # CMake, python_package/, src/) is treated as "shared" and forces the
+            # full test matrix to run. We only set the only-* flags when every
+            # non-skippable changed file falls into exactly one bucket.
+            if [[ "$skip_build_and_test" == "false" ]]; then
+              vllm_paths=(
+                "integrations/vllm_plugin/*"
+                "tests/integrations/vllm_plugin/*"
+                "examples/vllm/*"
+                "tests/benchmark/test_vllm_benchmarks.py"
+                "tests/benchmark/benchmarks/vllm_benchmark.py"
+              )
+              framework_paths=(
+                "tests/jax/*"
+                "tests/torch/*"
+                "tests/infra_tests/*"
+                "tests/runner/*"
+                "tests/op_by_op/*"
+                "tests/examples/*"
+                "third_party/tt_forge_models/*"
+              )
+
+              vllm_touched=false
+              framework_touched=false
+              shared_touched=false
+
+              for file in $CHANGED_FILES; do
+                file_is_skippable=false
+                for pattern in "${skip_patterns[@]}"; do
+                  if [[ $file == $pattern ]]; then
+                    file_is_skippable=true
+                    break
+                  fi
+                done
+                if [[ $file_is_skippable == true ]]; then
+                  continue
+                fi
+
+                matched=false
+                for pattern in "${vllm_paths[@]}"; do
+                  if [[ $file == $pattern ]]; then
+                    vllm_touched=true
+                    matched=true
+                    break
+                  fi
+                done
+                if [[ $matched == true ]]; then
+                  continue
+                fi
+
+                for pattern in "${framework_paths[@]}"; do
+                  if [[ $file == $pattern ]]; then
+                    framework_touched=true
+                    matched=true
+                    break
+                  fi
+                done
+                if [[ $matched == true ]]; then
+                  continue
+                fi
+
+                echo "Shared/core file changed (forces full matrix): $file"
+                shared_touched=true
+              done
+
+              if [[ $shared_touched == false ]]; then
+                if [[ $vllm_touched == true && $framework_touched == false ]]; then
+                  only_vllm_changes=true
+                  echo "Detected vLLM-only changes — framework + forge-model tests will be skipped."
+                elif [[ $framework_touched == true && $vllm_touched == false ]]; then
+                  only_framework_changes=true
+                  echo "Detected framework-only changes — vLLM tests will be skipped."
+                fi
+              fi
+            fi
+
           else
             skip_build_and_test=false
             run_pr_tests=true
@@ -179,12 +266,16 @@ jobs:
           echo "detected-uplifts=${detected_uplifts:-}"
           echo "uplift-additional-test-suites=${uplift_additional_test_suites:-}"
           echo "wheel-changes=$wheel_changes"
+          echo "only-vllm-changes=$only_vllm_changes"
+          echo "only-framework-changes=$only_framework_changes"
           echo "GITHUB_HEAD_REF=${GITHUB_HEAD_REF}"
 
           echo "skip-build-and-test=$skip_build_and_test" >> "$GITHUB_OUTPUT"
           echo "run-pr-tests=$run_pr_tests" >> "$GITHUB_OUTPUT"
           echo "run-perf-tests=$run_perf_tests" >> "$GITHUB_OUTPUT"
           echo "only-run-forge-models=$only_run_forge_models" >> "$GITHUB_OUTPUT"
+          echo "only-vllm-changes=$only_vllm_changes" >> "$GITHUB_OUTPUT"
+          echo "only-framework-changes=$only_framework_changes" >> "$GITHUB_OUTPUT"
           echo "uplift-additional-test-suites=${uplift_additional_test_suites:-}" >> "$GITHUB_OUTPUT"
           echo "detected-uplifts=${detected_uplifts:-}" >> "$GITHUB_OUTPUT"
           echo "wheel-changes=$wheel_changes" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/manual-test.yml
+++ b/.github/workflows/manual-test.yml
@@ -12,6 +12,7 @@ on:
         type: choice
         options:
           - 'basic-test.json'
+          - 'basic-test-vllm.json'
           - 'basic-test-nightly.json'
           - 'model-test-push.json'
           - 'model-test-full.json'

--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -55,11 +55,22 @@ jobs:
 
   test:
     needs: [ inspect-changes, build-image, build-ttxla ]
-    if: needs.inspect-changes.outputs.skip-build-and-test == 'false' && needs.inspect-changes.outputs.only-run-forge-models != 'true'
+    if: needs.inspect-changes.outputs.skip-build-and-test == 'false' && needs.inspect-changes.outputs.only-run-forge-models != 'true' && needs.inspect-changes.outputs.only-vllm-changes != 'true'
     uses: ./.github/workflows/call-test.yml
     secrets: inherit
     with:
       test_suite: basic-test.json
+      docker_image: ${{ needs.build-image.outputs.docker-image-base }}
+      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
+      artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
+
+  test_vllm:
+    needs: [ inspect-changes, build-image, build-ttxla ]
+    if: needs.inspect-changes.outputs.skip-build-and-test == 'false' && needs.inspect-changes.outputs.only-run-forge-models != 'true' && needs.inspect-changes.outputs.only-framework-changes != 'true'
+    uses: ./.github/workflows/call-test.yml
+    secrets: inherit
+    with:
+      test_suite: basic-test-vllm.json
       docker_image: ${{ needs.build-image.outputs.docker-image-base }}
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
@@ -100,7 +111,7 @@ jobs:
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
 
   test_forge_models_push:
-    if: needs.inspect-changes.outputs.skip-build-and-test == 'false'
+    if: needs.inspect-changes.outputs.skip-build-and-test == 'false' && needs.inspect-changes.outputs.only-vllm-changes != 'true'
     uses: ./.github/workflows/call-test.yml
     secrets: inherit
     needs: [ inspect-changes, build-image, build-ttxla ]
@@ -147,6 +158,7 @@ jobs:
       - build-ttxla
       - build-ttxla-debug
       - test
+      - test_vllm
       - test_forge_models_push
       - test-uplift-extended
       - test-tools
@@ -158,5 +170,5 @@ jobs:
     - name: Check if the needed jobs succeeded or failed
       uses: re-actors/alls-green@release/v1
       with:
-        allowed-skips: build-image, build-ttxla, build-ttxla-debug, test, test_forge_models_push, test-uplift-extended, test-tools, perf-benchmark, perf-benchmark-accuracy, build-docs
+        allowed-skips: build-image, build-ttxla, build-ttxla-debug, test, test_vllm, test_forge_models_push, test-uplift-extended, test-tools, perf-benchmark, perf-benchmark-accuracy, build-docs
         jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -53,6 +53,16 @@ jobs:
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
 
+  test_vllm:
+    needs: [ build-image, build-ttxla ]
+    uses: ./.github/workflows/call-test.yml
+    secrets: inherit
+    with:
+      test_suite: basic-test-vllm.json
+      docker_image: ${{ needs.build-image.outputs.docker-image-base }}
+      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
+      artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
+
   test_forge_models_push:
     uses: ./.github/workflows/call-test.yml
     secrets: inherit

--- a/.github/workflows/test-matrix-presets/basic-test-vllm.json
+++ b/.github/workflows/test-matrix-presets/basic-test-vllm.json
@@ -1,0 +1,7 @@
+[
+  {"runs-on": "n150",        "name": "run_vllm_n150_tests",    "dir": "./tests/integrations/vllm_plugin",        "test-mark": "push and single_device",                 "shared-runners": "true", "extra-wheel": "vllm"},
+  {"runs-on": "p150",        "name": "run_vllm_p150_tests",    "dir": "./tests/integrations/vllm_plugin",        "test-mark": "push and single_device",                 "shared-runners": "true", "extra-wheel": "vllm"},
+  {"runs-on": "n300",        "name": "run_vllm_n300_tests",    "dir": "./tests/integrations/vllm_plugin",        "test-mark": "push and data_parallel",                 "shared-runners": "true", "extra-wheel": "vllm"},
+  {"runs-on": "n300",        "name": "run_vllm_n300_tests",    "dir": "./tests/integrations/vllm_plugin",        "test-mark": "push and tensor_parallel and dual_chip", "shared-runners": "true", "extra-wheel": "vllm"},
+  {"runs-on": "n300-llmbox", "name": "run_vllm_llmbox_tests",  "dir": "./tests/integrations/vllm_plugin",        "test-mark": "push and tensor_parallel and llmbox",    "shared-runners": "true", "extra-wheel": "vllm"}
+]

--- a/.github/workflows/test-matrix-presets/basic-test.json
+++ b/.github/workflows/test-matrix-presets/basic-test.json
@@ -9,10 +9,5 @@
   {"runs-on": "n300-llmbox",        "name": "run_jax_4_devices",      "dir": "./tests/jax/multi_chip/llmbox/4_devices", "test-mark": "push",                    "shared-runners": "true" },
   {"runs-on": "n300-llmbox",        "name": "run_jax_8_devices",      "dir": "./tests/jax/multi_chip/llmbox/8_devices", "test-mark": "push",                    "shared-runners": "true" },
   {"runs-on": "n300-llmbox",        "name": "run_torch_multi_chip",   "dir": "./tests/torch",                           "test-mark": "push and llmbox",         "shared-runners": "true" },
-  {"runs-on": "n150",               "name": "run_vllm_n150_tests",    "dir": "./tests/integrations/vllm_plugin",        "test-mark": "push and single_device",  "shared-runners": "true", "extra-wheel": "vllm"},
-  {"runs-on": "p150",               "name": "run_vllm_p150_tests",    "dir": "./tests/integrations/vllm_plugin",        "test-mark": "push and single_device",  "shared-runners": "true", "extra-wheel": "vllm"},
-  {"runs-on": "n300",               "name": "run_vllm_n300_tests",    "dir": "./tests/integrations/vllm_plugin",        "test-mark": "push and data_parallel",  "shared-runners": "true", "extra-wheel": "vllm"},
-  {"runs-on": "n300",               "name": "run_vllm_n300_tests",    "dir": "./tests/integrations/vllm_plugin",        "test-mark": "push and tensor_parallel and dual_chip", "shared-runners": "true", "extra-wheel": "vllm"},
-  {"runs-on": "n300-llmbox",        "name": "run_vllm_llmbox_tests",  "dir": "./tests/integrations/vllm_plugin",        "test-mark": "push and tensor_parallel and llmbox", "shared-runners": "true", "extra-wheel": "vllm"},
   {"runs-on": "n300",               "name": "run_examples",           "dir": "./tests/examples",                        "test-mark": "push", "require":"alchemist", "parallel-groups": 3, "shared-runners": "true" }
 ]

--- a/.github/workflows/test-matrix-presets/full-mlir-uplift-qualification.json
+++ b/.github/workflows/test-matrix-presets/full-mlir-uplift-qualification.json
@@ -1,3 +1,3 @@
 [
-  { "include": ["basic-test.json", "model-test-push.json", "mlir-uplift-qualification.json"] }
+  { "include": ["basic-test.json", "basic-test-vllm.json", "model-test-push.json", "mlir-uplift-qualification.json"] }
 ]

--- a/.github/workflows/test-matrix-presets/on-pr.json
+++ b/.github/workflows/test-matrix-presets/on-pr.json
@@ -1,3 +1,3 @@
 [
-    { "include": ["basic-test.json", "model-test-push.json"] }
+    { "include": ["basic-test.json", "basic-test-vllm.json", "model-test-push.json"] }
 ]


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Today, **every PR** runs the full PR test matrix — JAX, PyTorch, infra, forge models, *and* vLLM — regardless of which area was actually touched. This has a few concrete downsides:
- **Wasted hardware time.** A one-line vLLM patch (e.g.`integrations/vllm_plugin/vllm_tt/sampler.py`) still triggers
  ~16 JAX/PyTorch jobs across `n150`, `p150`, `n300`, `wormhole_b0`, and `n300-llmbox` runners — none of which the change can affect. The symmetric problem holds for framework-only PRs (e.g. a `third_party/tt_forge_models/...` model update) which trigger vLLM tests that share no code with the change.
  
- **Hardware contention.** Tenstorrent runners (`n150`, `p150`, `n300`,  `n300-llmbox`, `wormhole_b0`) are finite. Unrelated test jobs sit in the queue and block other PRs from getting hardware time.

- **More flake exposure.** Every extra job is another roll of the flake-dice on a test that the PR couldn't have affected anyway.

### What's changed
`call-inspect-changes.yml` now classifies each changed file as **vLLM**, **framework**, or **shared/core**, and `pr-main.yml` skips the irrelevant test suites:
| PR touches | Runs |
|---|---|
| Only `integrations/vllm_plugin/**`, `tests/integrations/vllm_plugin/**`, `examples/vllm/**` | `test_vllm` only |
| Only `tests/jax/**`, `tests/torch/**`, `third_party/tt_forge_models/**`, … | `test` + `test_forge_models_push` |
| Anything "shared" (`pjrt_implementation/**`, CMake, `python_package/**`, `src/**`, …) | Full matrix (unchanged) |
| Both vLLM and framework files | Full matrix (safe default) |


Conservative by construction: **if any changed file doesn't match either bucket, the full matrix still runs.** `push-main.yml` is unaffected — every merge to `main` still runs everything.


### Checklist
- [ ] New/Existing tests provide coverage for changes
