### PR TITLE
Align vllm_benchmark with llm_benchmark and add opt-125m tests

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -579,6 +579,28 @@
         "skip-ttnn-dump": true,
         "skip-device-perf": true,
         "runs-on": "n150"
+      },
+      {
+        "name": "vllm_opt_125m_opt1",
+        "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[opt-125m-opt1]",
+        "vllm": true,
+        "skip-stablehlo-dump": true,
+        "skip-ttir-dump": true,
+        "skip-ttnn-dump": true,
+        "skip-device-perf": true,
+        "runs-on": "n150"
+      },
+      {
+        "name": "vllm_opt_125m_batch32_opt1",
+        "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[opt-125m-batch32-opt1]",
+        "vllm": true,
+        "skip-stablehlo-dump": true,
+        "skip-ttir-dump": true,
+        "skip-ttnn-dump": true,
+        "skip-device-perf": true,
+        "runs-on": "n150"
       }
     ]
   }

--- a/tests/benchmark/benchmarks/vllm_benchmark.py
+++ b/tests/benchmark/benchmarks/vllm_benchmark.py
@@ -249,7 +249,7 @@ def benchmark_vllm(
         custom_measurements=custom_measurements,
         optimization_level=config.additional_config.get("optimization_level", 0),
         program_cache_enabled=True,
-        trace_enabled=False,
+        trace_enabled=config.additional_config.get("enable_trace", False),
         experimental_weight_dtype=(
             "bfp_bf8"
             if config.additional_config.get(

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -12,16 +12,30 @@ from utils import resolve_display_name
 # Sampling overrides — keep SINGLE_DEVICE_CONFIGS focused on (model,
 # batch_size). CI re-runs the same matrix with different sampling
 # configs by setting these env vars (one knob per re-run):
-#   TT_BENCHMARK_TEMPERATURE=<float>  default 0.0 (greedy)
-#   TT_BENCHMARK_CPU_SAMPLING=1       default 0 (device sampling)
-#   TT_BENCHMARK_MAX_MODEL_LEN=<int>  default 128
+#   TT_BENCHMARK_TEMPERATURE=<float>      default 0.0 (greedy)
+#   TT_BENCHMARK_CPU_SAMPLING=1           default 0 (device sampling)
+#   TT_BENCHMARK_MAX_MODEL_LEN=<int>      default 128
+#   _BENCH_OPTIMIZATION_LEVEL=<int>       default 0 (overrides per-test opt level)
 _BENCH_TEMPERATURE = float(os.environ.get("TT_BENCHMARK_TEMPERATURE", "0.0"))
 _BENCH_CPU_SAMPLING = os.environ.get("TT_BENCHMARK_CPU_SAMPLING", "0") == "1"
 _BENCH_MAX_MODEL_LEN = int(os.environ.get("TT_BENCHMARK_MAX_MODEL_LEN", "128"))
+_BENCH_OPTIMIZATION_LEVEL = os.environ.get("_BENCH_OPTIMIZATION_LEVEL")
 
 
-def _config(model: str, batch_size: int, *, gpu_memory_utilization: float = 0.05):
+def _config(
+    model: str,
+    batch_size: int,
+    *,
+    gpu_memory_utilization: float = 0.05,
+    optimization_level: int = 0,
+):
+    if _BENCH_OPTIMIZATION_LEVEL is not None:
+        optimization_level = int(_BENCH_OPTIMIZATION_LEVEL)
     additional = {"enable_trace": True}
+    if optimization_level > 0:
+        additional["optimization_level"] = optimization_level
+        # TTConfig raises if enable_trace=True AND opt>=1 AND cpu_sampling=False
+        additional["cpu_sampling"] = True
     if _BENCH_CPU_SAMPLING:
         additional["cpu_sampling"] = True
     return VLLMBenchmarkConfig(
@@ -49,6 +63,18 @@ SINGLE_DEVICE_CONFIGS = [
     pytest.param(
         _config("meta-llama/Llama-3.1-8B-Instruct", 32),
         id="llama-3.1-8b-batch32",
+    ),
+    pytest.param(
+        _config(
+            "facebook/opt-125m", 1, gpu_memory_utilization=0.001, optimization_level=1
+        ),
+        id="opt-125m-opt1",
+    ),
+    pytest.param(
+        _config(
+            "facebook/opt-125m", 32, gpu_memory_utilization=0.02, optimization_level=1
+        ),
+        id="opt-125m-batch32-opt1",
     ),
 ]
 


### PR DESCRIPTION
### Ticket
closes #4319

### Problem description
`vllm_benchmark.py` and `test_vllm_benchmarks.py` weren't aligned with the corresponding `llm_benchmark.py` / `test_llms.py` interface. `optimization_level` and `trace_enabled` were buried inside `additional_config`, and `trace_enabled` was hardcoded to `False` when writing the benchmark result. There was also no env var override for optimization level like the llm tests have.

### What's changed
- Expose `optimization_level` as a first-class parameter of `_config` in `test_vllm_benchmarks.py`
- Fix hardcoded `trace_enabled=False` in `create_benchmark_result` call so it reflects actual config
- Add `_BENCH_OPTIMIZATION_LEVEL` env var to match `test_llms.py` behavior
- Add `opt-125m` benchmark entries at batch 1 and batch 32 with opt level 1
- Add matching opt-125m rows to the CI perf matrix

### Checklist
- [X] Existing tests provide coverage for changes
