### PR TITLE
decompositions: fix scales passed as exact in upsample_nearest callers

### DIFF
--- a/python_package/tt_torch/backend/decompositions.py
+++ b/python_package/tt_torch/backend/decompositions.py
@@ -162,8 +162,7 @@ def upsample_nearest_vec(
     scales = (
         scale_factors if scale_factors else [None] * len(osize)  # type: ignore[list-item]
     )
-    return upsample_nearest(input, osize, scales, scales)
-
+    return upsample_nearest(input, osize, scales)
 
 def upsample_nearest_default(
     input: torch.Tensor,
@@ -179,8 +178,7 @@ def upsample_nearest_default(
     scales = (
         scale_factors if scale_factors else [None] * len(osize)  # type: ignore[list-item]
     )
-    return upsample_nearest(input, osize, scales, scales)
-
+    return upsample_nearest(input, osize, scales)
 
 # TODO: Remove this decomposition when we can lower a stablehlo.reduce_window which is equivalent to a sum-pool
 # to ttir

--- a/python_package/tt_torch/backend/decompositions.py
+++ b/python_package/tt_torch/backend/decompositions.py
@@ -164,6 +164,7 @@ def upsample_nearest_vec(
     )
     return upsample_nearest(input, osize, scales)
 
+
 def upsample_nearest_default(
     input: torch.Tensor,
     output_size: list[int],
@@ -179,6 +180,7 @@ def upsample_nearest_default(
         scale_factors if scale_factors else [None] * len(osize)  # type: ignore[list-item]
     )
     return upsample_nearest(input, osize, scales)
+
 
 # TODO: Remove this decomposition when we can lower a stablehlo.reduce_window which is equivalent to a sum-pool
 # to ttir


### PR DESCRIPTION
### Ticket
N/A — bug found by code review (no linked issue)

### Problem description
`upsample_nearest_vec` and `upsample_nearest_default` both call the
internal `upsample_nearest` helper with `scales` passed twice:

    return upsample_nearest(input, osize, scales, scales)

The function signature is:

    def upsample_nearest(input, output_size, scales, exact: bool = False)

The 4th positional argument maps to `exact: bool`, not a second copy of
`scales`. A non-empty list coerces to `True` in boolean context, so
`exact` is silently set to `True` on every call instead of the intended
default `False`. This is a copy-paste error present in both the `.vec`
and `.default` dispatch paths.

### What's changed
Removed the extraneous 4th argument (`scales`) from both call sites in
`upsample_nearest_vec` (line 165) and `upsample_nearest_default`
(line 182) in `python_package/tt_torch/backend/decompositions.py`.

`exact` defaults to `False` and is not yet read inside `upsample_nearest`'s
body, so runtime behaviour is unchanged. The fix aligns the calls with
the declared interface and prevents silent misbehaviour the moment
`exact` is wired up for floor-vs-round nearest-neighbor semantics.

### Checklist
- [ ] New/Existing tests provide coverage for changes