### PR TITLE
[fix] tt_torch dynamo guard: pass guard.name (str) to GuardBuilder.get()

### DIFF
--- a/python_package/tt_torch/utils.py
+++ b/python_package/tt_torch/utils.py
@@ -96,7 +96,7 @@ def apply_xla_dynamo_guard_repr_patch() -> None:
             )
 
         ref = self.arg_ref(guard)
-        val = self.get(guard)
+        val = self.get(guard.name)
         id_val = self.id_ref(val, guard.name)
 
         # Generate safe string representation without materializing XLA tensors


### PR DESCRIPTION
### Problem description
Fixes `InternalTorchDynamoError: TypeError: eval() arg 1 must be a string, bytes or code object` raised from python_package/tt_torch/utils.py:99 in the patched id_match_unchecked.

GuardBuilder.get(name: str, ...) eval()s `name` against self.scope, so it requires a string. The override was passing the Guard object itself, unlike PyTorch's own id_match_unchecked (torch/_dynamo/guards.py:1985) and unlike the next line of our own code which correctly uses `self.id_ref(val, guard.name)`.

### What's changed
This regression was introduced in 7daaa094d ("PyTorch and vLLM uplift") when this file was created as part of the PyTorch 2.9.1 -> 2.10.0 bump. Because apply_xla_dynamo_guard_repr_patch() runs unconditionally at `import tt_torch`, every torch test that hits an ID_MATCH guard on a non-TypeSource source was masking its real failure behind this TypeError. Confirmed with bi_lstm_crf: pre-fix the test fails with the TypeError above; post-fix it fails with its original recorded reason ("RuntimeError: tensor has a non-zero number of elements ..."), which matches the existing YAML entry, so no YAML change is needed for that entry.

### Checklist
- [ ] New/Existing tests provide coverage for changes
