### PR TITLE
Add deepseek v3.2 prefill and indexer tests to nightly

### DIFF
--- a/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_2_exp.py
+++ b/tests/torch/models/deepseek_v3_2_exp/test_deepseek_v3_2_exp.py
@@ -108,6 +108,7 @@ def test_deepseek_complex_rotary_emb():
     )
 
 
+@pytest.mark.nightly
 @pytest.mark.llmbox
 @pytest.mark.lb_blackhole
 @pytest.mark.parametrize("batch_size", [1, 4, 32, 64])
@@ -180,6 +181,7 @@ def test_deepseek_attention_prefill(batch_size):
     )
 
 
+@pytest.mark.nightly
 @pytest.mark.llmbox
 @pytest.mark.lb_blackhole
 @pytest.mark.parametrize("batch_size", [1, 4, 32, 64])


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`test_deepseek_attention_prefill` and `test_deepseek_indexer` are currently marked with `llmbox` but not `nightly` and so they are not being tested in nightly CI. Spoke with @hshahTT and confirmed these should be running in nightly.

### What's changed
Added `@pytest.mark.nightly` to both tests.

### Checklist
- [x] New/Existing tests provide coverage for changes
