### PR TITLE
Add relative L2 error similarity metric to op-tests and benchmarks

### DIFF
--- a/tests/benchmark/benchmarks/llm_benchmark.py
+++ b/tests/benchmark/benchmarks/llm_benchmark.py
@@ -36,6 +36,7 @@ from tt_torch.weight_dtype import apply_weight_dtype_overrides
 from utils import (
     build_xla_export_name,
     compute_pcc,
+    compute_rel_l2,
     create_benchmark_result,
     get_benchmark_metadata,
     get_xla_device_arch,
@@ -751,32 +752,43 @@ def benchmark_llm_torch_xla(
         )
     elif decode_only:
         decode_pcc_value = compute_pcc(output_logits[0][0], cpu_output_logits[1][0])
+        decode_rel_l2_value = compute_rel_l2(
+            cpu_output_logits[1][0], output_logits[0][0]
+        )
         assert (
             decode_pcc_value >= required_pcc
         ), f"First decode PCC failed. PCC={decode_pcc_value:.6f}, Required={required_pcc}"
         print(
-            "First decode PCC verification passed with PCC={:.6f}".format(
-                decode_pcc_value
+            "First decode PCC verification passed with PCC={:.6f}, rel_l2={:.6e}".format(
+                decode_pcc_value, decode_rel_l2_value
             )
         )
     else:
         # Check PCC for prefill
         pcc_value = compute_pcc(output_logits[0][0], cpu_output_logits[0][0])
+        rel_l2_value = compute_rel_l2(cpu_output_logits[0][0], output_logits[0][0])
         assert (
             pcc_value >= required_pcc
         ), f"Prefill PCC failed. PCC={pcc_value:.6f}, Required={required_pcc}"
-        print("Prefill PCC verification passed with PCC={:.6f}".format(pcc_value))
+        print(
+            "Prefill PCC verification passed with PCC={:.6f}, rel_l2={:.6e}".format(
+                pcc_value, rel_l2_value
+            )
+        )
         # Check PCC for first decode token
         assert (
             len(output_logits) > 1 and len(cpu_output_logits) > 1
         ), "Not enough logits to check PCC"
         decode_pcc_value = compute_pcc(output_logits[1][0], cpu_output_logits[1][0])
+        decode_rel_l2_value = compute_rel_l2(
+            cpu_output_logits[1][0], output_logits[1][0]
+        )
         assert (
             decode_pcc_value >= required_pcc
         ), f"First decode PCC failed. PCC={decode_pcc_value:.6f}, Required={required_pcc}"
         print(
-            "First decode PCC verification passed with PCC={:.6f}".format(
-                decode_pcc_value
+            "First decode PCC verification passed with PCC={:.6f}, rel_l2={:.6e}".format(
+                decode_pcc_value, decode_rel_l2_value
             )
         )
 

--- a/tests/benchmark/benchmarks/llm_benchmark.py
+++ b/tests/benchmark/benchmarks/llm_benchmark.py
@@ -35,6 +35,7 @@ from tt_torch.weight_dtype import apply_weight_dtype_overrides
 from utils import (
     build_xla_export_name,
     compute_pcc,
+    compute_rel_l2,
     create_benchmark_result,
     get_benchmark_metadata,
     get_xla_device_arch,
@@ -799,32 +800,43 @@ def benchmark_llm_torch_xla(
         )
     elif decode_only:
         decode_pcc_value = compute_pcc(output_logits[0][0], cpu_output_logits[1][0])
+        decode_rel_l2_value = compute_rel_l2(
+            cpu_output_logits[1][0], output_logits[0][0]
+        )
         assert (
             decode_pcc_value >= required_pcc
         ), f"First decode PCC failed. PCC={decode_pcc_value:.6f}, Required={required_pcc}"
         print(
-            "First decode PCC verification passed with PCC={:.6f}".format(
-                decode_pcc_value
+            "First decode PCC verification passed with PCC={:.6f}, rel_l2={:.6e}".format(
+                decode_pcc_value, decode_rel_l2_value
             )
         )
     else:
         # Check PCC for prefill
         pcc_value = compute_pcc(output_logits[0][0], cpu_output_logits[0][0])
+        rel_l2_value = compute_rel_l2(cpu_output_logits[0][0], output_logits[0][0])
         assert (
             pcc_value >= required_pcc
         ), f"Prefill PCC failed. PCC={pcc_value:.6f}, Required={required_pcc}"
-        print("Prefill PCC verification passed with PCC={:.6f}".format(pcc_value))
+        print(
+            "Prefill PCC verification passed with PCC={:.6f}, rel_l2={:.6e}".format(
+                pcc_value, rel_l2_value
+            )
+        )
         # Check PCC for first decode token
         assert (
             len(output_logits) > 1 and len(cpu_output_logits) > 1
         ), "Not enough logits to check PCC"
         decode_pcc_value = compute_pcc(output_logits[1][0], cpu_output_logits[1][0])
+        decode_rel_l2_value = compute_rel_l2(
+            cpu_output_logits[1][0], output_logits[1][0]
+        )
         assert (
             decode_pcc_value >= required_pcc
         ), f"First decode PCC failed. PCC={decode_pcc_value:.6f}, Required={required_pcc}"
         print(
-            "First decode PCC verification passed with PCC={:.6f}".format(
-                decode_pcc_value
+            "First decode PCC verification passed with PCC={:.6f}, rel_l2={:.6e}".format(
+                decode_pcc_value, decode_rel_l2_value
             )
         )
 

--- a/tests/benchmark/utils.py
+++ b/tests/benchmark/utils.py
@@ -219,9 +219,7 @@ def compute_pcc(golden_output: torch.Tensor, device_output: torch.Tensor) -> flo
     return max(-1.0, min(1.0, pcc))
 
 
-def compute_rel_l2(
-    golden_output: torch.Tensor, device_output: torch.Tensor
-) -> float:
+def compute_rel_l2(golden_output: torch.Tensor, device_output: torch.Tensor) -> float:
     """Compute relative L2 error between two tensors.
 
     rel_l2 = ||device_output - golden_output||_2 / ||golden_output||_2

--- a/tests/benchmark/utils.py
+++ b/tests/benchmark/utils.py
@@ -237,9 +237,7 @@ def compute_pcc(golden_output: torch.Tensor, device_output: torch.Tensor) -> flo
     return max(-1.0, min(1.0, pcc))
 
 
-def compute_rel_l2(
-    golden_output: torch.Tensor, device_output: torch.Tensor
-) -> float:
+def compute_rel_l2(golden_output: torch.Tensor, device_output: torch.Tensor) -> float:
     """Compute relative L2 error between two tensors.
 
     rel_l2 = ||device_output - golden_output||_2 / ||golden_output||_2

--- a/tests/benchmark/utils.py
+++ b/tests/benchmark/utils.py
@@ -237,6 +237,43 @@ def compute_pcc(golden_output: torch.Tensor, device_output: torch.Tensor) -> flo
     return max(-1.0, min(1.0, pcc))
 
 
+def compute_rel_l2(
+    golden_output: torch.Tensor, device_output: torch.Tensor
+) -> float:
+    """Compute relative L2 error between two tensors.
+
+    rel_l2 = ||device_output - golden_output||_2 / ||golden_output||_2
+
+    Computed in float64 to avoid norm underflow in bf16/fp32. Complements PCC:
+    PCC is scale-blind, max-atol is dominated by a single outlier, max-rtol
+    blows up near zero. rel_l2 is scale-sensitive, stable near zero globally
+    (denominator is the golden norm, not per-element |y|), and captures
+    distributed degradation rather than one bad element.
+
+    Args:
+        golden_output: Golden reference tensor.
+        device_output: Device output tensor.
+
+    Returns:
+        Non-negative float. 0.0 if both tensors are exactly zero, inf if the
+        golden norm is zero but the difference norm is non-zero, NaN
+        propagated through if either tensor contains NaN.
+    """
+    golden_flat = golden_output.to(torch.float64).flatten()
+    device_flat = device_output.to(torch.float64).flatten()
+
+    diff_norm = torch.linalg.vector_norm(device_flat - golden_flat)
+    golden_norm = torch.linalg.vector_norm(golden_flat)
+
+    if torch.isnan(diff_norm) or torch.isnan(golden_norm):
+        return float("nan")
+
+    if golden_norm.item() == 0.0:
+        return 0.0 if diff_norm.item() == 0.0 else float("inf")
+
+    return (diff_norm / golden_norm).item()
+
+
 def get_benchmark_metadata() -> Dict[str, str]:
     """Get common benchmark metadata."""
     return {

--- a/tests/benchmark/utils.py
+++ b/tests/benchmark/utils.py
@@ -219,6 +219,43 @@ def compute_pcc(golden_output: torch.Tensor, device_output: torch.Tensor) -> flo
     return max(-1.0, min(1.0, pcc))
 
 
+def compute_rel_l2(
+    golden_output: torch.Tensor, device_output: torch.Tensor
+) -> float:
+    """Compute relative L2 error between two tensors.
+
+    rel_l2 = ||device_output - golden_output||_2 / ||golden_output||_2
+
+    Computed in float64 to avoid norm underflow in bf16/fp32. Complements PCC:
+    PCC is scale-blind, max-atol is dominated by a single outlier, max-rtol
+    blows up near zero. rel_l2 is scale-sensitive, stable near zero globally
+    (denominator is the golden norm, not per-element |y|), and captures
+    distributed degradation rather than one bad element.
+
+    Args:
+        golden_output: Golden reference tensor.
+        device_output: Device output tensor.
+
+    Returns:
+        Non-negative float. 0.0 if both tensors are exactly zero, inf if the
+        golden norm is zero but the difference norm is non-zero, NaN
+        propagated through if either tensor contains NaN.
+    """
+    golden_flat = golden_output.to(torch.float64).flatten()
+    device_flat = device_output.to(torch.float64).flatten()
+
+    diff_norm = torch.linalg.vector_norm(device_flat - golden_flat)
+    golden_norm = torch.linalg.vector_norm(golden_flat)
+
+    if torch.isnan(diff_norm) or torch.isnan(golden_norm):
+        return float("nan")
+
+    if golden_norm.item() == 0.0:
+        return 0.0 if diff_norm.item() == 0.0 else float("inf")
+
+    return (diff_norm / golden_norm).item()
+
+
 def get_benchmark_metadata() -> Dict[str, str]:
     """Get common benchmark metadata."""
     return {

--- a/tests/infra/evaluators/__init__.py
+++ b/tests/infra/evaluators/__init__.py
@@ -10,6 +10,7 @@ from .evaluation_config import (
     ImageGenQualityConfig,
     PccConfig,
     QualityConfig,
+    RelL2Config,
 )
 from .evaluator import ComparisonResult, EvaluationResult, Evaluator, QualityResult
 from .evaluator_factory import EvaluatorFactory
@@ -38,4 +39,5 @@ __all__ = [
     "PccConfig",
     "AtolConfig",
     "AllcloseConfig",
+    "RelL2Config",
 ]

--- a/tests/infra/evaluators/comparison_evaluator.py
+++ b/tests/infra/evaluators/comparison_evaluator.py
@@ -8,7 +8,13 @@ from typing import Tuple
 
 from infra.utilities import PyTree, Tensor
 
-from .evaluation_config import AllcloseConfig, AtolConfig, ComparisonConfig, PccConfig
+from .evaluation_config import (
+    AllcloseConfig,
+    AtolConfig,
+    ComparisonConfig,
+    PccConfig,
+    RelL2Config,
+)
 from .evaluator import ComparisonResult, Evaluator
 
 
@@ -43,6 +49,7 @@ class ComparisonEvaluator(Evaluator):
             atol=None,
             allclose=None,
             equal=None,
+            rel_l2=None,
             error_message=None,
         )
 
@@ -58,6 +65,12 @@ class ComparisonEvaluator(Evaluator):
         )
         _comparison_result.allclose = self._compare_allclose(
             device_output, golden_output, self._comparison_config.allclose
+        )
+        _comparison_result.rel_l2 = self._compare_rel_l2(
+            device_output,
+            golden_output,
+            self._comparison_config.rel_l2,
+            pcc_mask=pcc_mask,
         )
 
         # Check if output is single-element (PCC undefined, force atol check)
@@ -146,6 +159,29 @@ class ComparisonEvaluator(Evaluator):
                 f"Required: atol={allclose_config.atol}, rtol={allclose_config.rtol}."
             )
 
+        if (
+            self._comparison_config.rel_l2.enabled
+            and comparison_result.rel_l2 is not None
+        ):
+            required_rel_l2 = self._comparison_config.rel_l2.required_rel_l2
+            # rel_l2 is an error metric: larger is worse. Guard nan/inf first.
+            if math.isnan(comparison_result.rel_l2) or math.isinf(
+                comparison_result.rel_l2
+            ):
+                passed = False
+                error_messages.append(
+                    f"RelL2 comparison failed. "
+                    f"Calculated: rel_l2={comparison_result.rel_l2} (invalid value). "
+                    f"Required: rel_l2<={required_rel_l2}."
+                )
+            elif comparison_result.rel_l2 > required_rel_l2:
+                passed = False
+                error_messages.append(
+                    f"RelL2 comparison failed. "
+                    f"Calculated: rel_l2={comparison_result.rel_l2}. "
+                    f"Required: rel_l2<={required_rel_l2}."
+                )
+
         # Combine all error messages if any failures occurred
         combined_error_message = None
         if error_messages:
@@ -188,6 +224,22 @@ class ComparisonEvaluator(Evaluator):
         Compares PCC metric between device and golden output, with optional
         masking for padded tokens.
         Returns the calculated PCC value.
+        """
+        raise NotImplementedError("Subclasses must implement this method")
+
+    @abstractmethod
+    def _compare_rel_l2(
+        self,
+        device_output: PyTree,
+        golden_output: PyTree,
+        rel_l2_config: RelL2Config,
+        pcc_mask: Tensor | None = None,
+    ) -> float:
+        """
+        Computes relative L2 error ||device - golden||_2 / ||golden||_2 over a
+        pytree of tensors. Aggregated as max across leaves (larger is worse).
+        Computed in float64. Returns the calculated value (>= 0; inf if golden
+        norm is zero and tensors differ; 0 if both are exactly equal).
         """
         raise NotImplementedError("Subclasses must implement this method")
 

--- a/tests/infra/evaluators/comparison_evaluator.py
+++ b/tests/infra/evaluators/comparison_evaluator.py
@@ -28,7 +28,11 @@ class ComparisonEvaluator(Evaluator):
         self._comparison_config = comparison_config
 
     def evaluate(
-        self, device_out: Tensor, golden_out: Tensor, *, pcc_mask: Tensor | None = None
+        self,
+        device_out: Tensor,
+        golden_out: Tensor,
+        *,
+        real_token_mask: Tensor | None = None,
     ) -> ComparisonResult:
         """
         Compares device output with golden output based on ComparisonConfig provided
@@ -61,7 +65,7 @@ class ComparisonEvaluator(Evaluator):
             device_output,
             golden_output,
             self._comparison_config.pcc,
-            pcc_mask=pcc_mask,
+            real_token_mask=real_token_mask,
         )
         _comparison_result.allclose = self._compare_allclose(
             device_output, golden_output, self._comparison_config.allclose
@@ -70,7 +74,7 @@ class ComparisonEvaluator(Evaluator):
             device_output,
             golden_output,
             self._comparison_config.rel_l2,
-            pcc_mask=pcc_mask,
+            real_token_mask=real_token_mask,
         )
 
         # Check if output is single-element (PCC undefined, force atol check)
@@ -218,11 +222,13 @@ class ComparisonEvaluator(Evaluator):
         device_output: PyTree,
         golden_output: PyTree,
         pcc_config: PccConfig,
-        pcc_mask: Tensor | None = None,
+        real_token_mask: Tensor | None = None,
     ) -> float:
         """
-        Compares PCC metric between device and golden output, with optional
-        masking for padded tokens.
+        Compares PCC metric between device and golden output. If
+        `real_token_mask` is provided (the LLM attention mask, supplied by
+        callers like the dynamic torch tester during LLM prefill), padded
+        positions are excluded before computing PCC.
         Returns the calculated PCC value.
         """
         raise NotImplementedError("Subclasses must implement this method")
@@ -233,13 +239,15 @@ class ComparisonEvaluator(Evaluator):
         device_output: PyTree,
         golden_output: PyTree,
         rel_l2_config: RelL2Config,
-        pcc_mask: Tensor | None = None,
+        real_token_mask: Tensor | None = None,
     ) -> float:
         """
         Computes relative L2 error ||device - golden||_2 / ||golden||_2 over a
         pytree of tensors. Aggregated as max across leaves (larger is worse).
         Computed in float64. Returns the calculated value (>= 0; inf if golden
         norm is zero and tensors differ; 0 if both are exactly equal).
+        If `real_token_mask` is provided, padded positions are excluded before
+        computing the metric (same convention as `_compare_pcc`).
         """
         raise NotImplementedError("Subclasses must implement this method")
 

--- a/tests/infra/evaluators/evaluation_config.py
+++ b/tests/infra/evaluators/evaluation_config.py
@@ -49,11 +49,22 @@ class PccConfig(ConfigBase):
 
 
 @dataclass
+class RelL2Config(ConfigBase):
+    # Relative L2 error: ||device - golden||_2 / ||golden||_2.
+    # Computed in float64 to avoid norm underflow.
+    # Pytree aggregation is max-across-leaves (larger = worse).
+    # Threshold defaults to 1.0 (very loose) so this metric is effectively
+    # observability-only until per-model tuning lands.
+    required_rel_l2: float = 1.0
+
+
+@dataclass
 class ComparisonConfig:
     equal: EqualConfig = field(default_factory=lambda: EqualConfig(False))
     atol: AtolConfig = field(default_factory=lambda: AtolConfig(False))
     pcc: PccConfig = field(default_factory=PccConfig)
     allclose: AllcloseConfig = field(default_factory=lambda: AllcloseConfig(False))
+    rel_l2: RelL2Config = field(default_factory=lambda: RelL2Config(False))
     assert_on_failure: bool = True  # Default to True for backwards compatibility
 
     def __post_init__(self):
@@ -67,12 +78,14 @@ class ComparisonConfig:
         self.atol.enable()
         self.allclose.enable()
         self.pcc.enable()
+        self.rel_l2.enable()
 
     def disable_all(self) -> None:
         self.equal.disable()
         self.atol.disable()
         self.allclose.disable()
         self.pcc.disable()
+        self.rel_l2.disable()
 
     def all_disabled(self) -> bool:
         return not any(
@@ -81,6 +94,7 @@ class ComparisonConfig:
                 self.atol.enabled,
                 self.allclose.enabled,
                 self.pcc.enabled,
+                self.rel_l2.enabled,
             ]
         )
 

--- a/tests/infra/evaluators/evaluation_config.py
+++ b/tests/infra/evaluators/evaluation_config.py
@@ -54,7 +54,7 @@ class RelL2Config(ConfigBase):
     # Computed in float64 to avoid norm underflow.
     # Pytree aggregation is max-across-leaves (larger = worse).
     # Threshold defaults to 1.0 (very loose) so this metric is effectively
-    # observability-only until per-model tuning lands.
+    # observability-only for now.
     required_rel_l2: float = 1.0
 
 

--- a/tests/infra/evaluators/evaluator.py
+++ b/tests/infra/evaluators/evaluator.py
@@ -23,6 +23,7 @@ class ComparisonResult(EvaluationResult):
     atol: float | None = None
     allclose: bool | None = None
     equal: bool | None = None
+    rel_l2: float | None = None
 
 
 @dataclass

--- a/tests/infra/evaluators/jax_comparison_evaluator.py
+++ b/tests/infra/evaluators/jax_comparison_evaluator.py
@@ -11,7 +11,7 @@ from infra.utilities import Framework, PyTree
 from jax.tree import map as tree_map
 
 from .comparison_evaluator import ComparisonEvaluator
-from .evaluation_config import AllcloseConfig, AtolConfig, PccConfig
+from .evaluation_config import AllcloseConfig, AtolConfig, PccConfig, RelL2Config
 
 
 class JaxComparisonEvaluator(ComparisonEvaluator):
@@ -114,3 +114,33 @@ class JaxComparisonEvaluator(ComparisonEvaluator):
         )
         passed = jax.tree.reduce(lambda x, y: x and y, all_close)
         return bool(passed)
+
+    # @override
+    @run_on_cpu(Framework.JAX)
+    def _compare_rel_l2(
+        self,
+        device_output: PyTree,
+        golden_output: PyTree,
+        rel_l2_config: RelL2Config,
+        pcc_mask: PyTree | None = None,
+    ) -> float:
+        # TODO: Once https://github.com/tenstorrent/tt-xla/issues/3641 is fixed, add support for pcc_mask, as done in TorchComparisonEvaluator.
+        if pcc_mask is not None:
+            warnings.warn(
+                "pcc_mask was provided to JaxComparisonEvaluator but will be ignored.",
+            )
+
+        def compute_rel_l2(x: jax.Array, y: jax.Array):
+            x64 = x.astype("float64").flatten()
+            y64 = y.astype("float64").flatten()
+            diff_norm = jnp.linalg.norm(x64 - y64)
+            golden_norm = jnp.linalg.norm(y64)
+            if float(golden_norm) == 0.0:
+                return 0.0 if float(diff_norm) == 0.0 else float("inf")
+            return float(diff_norm / golden_norm)
+
+        leaf_rel_l2s = jax.tree.map(compute_rel_l2, device_output, golden_output)
+        flat_rel_l2s, _ = jax.tree_util.tree_flatten(leaf_rel_l2s)
+        if not flat_rel_l2s:
+            return 0.0
+        return float(max(flat_rel_l2s))

--- a/tests/infra/evaluators/jax_comparison_evaluator.py
+++ b/tests/infra/evaluators/jax_comparison_evaluator.py
@@ -67,13 +67,13 @@ class JaxComparisonEvaluator(ComparisonEvaluator):
         device_output: PyTree,
         golden_output: PyTree,
         pcc_config: PccConfig,
-        pcc_mask: PyTree | None = None,
+        real_token_mask: PyTree | None = None,
     ) -> float:
 
-        # TODO: Once https://github.com/tenstorrent/tt-xla/issues/3641 is fixed, add support for pcc_mask, as done in TorchComparisonEvaluator.
-        if pcc_mask is not None:
+        # TODO: Once https://github.com/tenstorrent/tt-xla/issues/3641 is fixed, add support for real_token_mask, as done in TorchComparisonEvaluator.
+        if real_token_mask is not None:
             warnings.warn(
-                "pcc_mask was provided to JaxComparisonEvaluator but will be ignored.",
+                "real_token_mask was provided to JaxComparisonEvaluator but will be ignored.",
             )
 
         def compute_pcc(x: jax.Array, y: jax.Array):
@@ -122,19 +122,21 @@ class JaxComparisonEvaluator(ComparisonEvaluator):
         device_output: PyTree,
         golden_output: PyTree,
         rel_l2_config: RelL2Config,
-        pcc_mask: PyTree | None = None,
+        real_token_mask: PyTree | None = None,
     ) -> float:
-        # TODO: Once https://github.com/tenstorrent/tt-xla/issues/3641 is fixed, add support for pcc_mask, as done in TorchComparisonEvaluator.
-        if pcc_mask is not None:
+        # TODO: Once https://github.com/tenstorrent/tt-xla/issues/3641 is fixed, add support for real_token_mask, as done in TorchComparisonEvaluator.
+        if real_token_mask is not None:
             warnings.warn(
-                "pcc_mask was provided to JaxComparisonEvaluator but will be ignored.",
+                "real_token_mask was provided to JaxComparisonEvaluator but will be ignored.",
             )
 
+        # Nested so the closure can be passed directly to jax.tree.map as a
+        # binary `(x, y) -> float` function. Same pattern as `_compare_pcc`.
         def compute_rel_l2(x: jax.Array, y: jax.Array):
-            x64 = x.astype("float64").flatten()
-            y64 = y.astype("float64").flatten()
-            diff_norm = jnp.linalg.norm(x64 - y64)
-            golden_norm = jnp.linalg.norm(y64)
+            device_flat = x.astype("float64").flatten()
+            golden_flat = y.astype("float64").flatten()
+            diff_norm = jnp.linalg.norm(device_flat - golden_flat)
+            golden_norm = jnp.linalg.norm(golden_flat)
             if float(golden_norm) == 0.0:
                 return 0.0 if float(diff_norm) == 0.0 else float("inf")
             return float(diff_norm / golden_norm)

--- a/tests/infra/evaluators/torch_comparison_evaluator.py
+++ b/tests/infra/evaluators/torch_comparison_evaluator.py
@@ -108,16 +108,16 @@ class TorchComparisonEvaluator(ComparisonEvaluator):
         device_output: PyTree,
         golden_output: PyTree,
         pcc_config: PccConfig,
-        pcc_mask: torch.Tensor | None = None,
+        real_token_mask: torch.Tensor | None = None,
     ) -> float:
         def apply_real_token_mask(x: torch.Tensor, y: torch.Tensor):
-            if pcc_mask is None:
+            if real_token_mask is None:
                 return x, y
 
             assert (
-                pcc_mask.ndim == 2
-            ), f"Expected pcc_mask to have shape [batch, seq], got {tuple(pcc_mask.shape)}"
-            batch_size, seq_len = pcc_mask.shape
+                real_token_mask.ndim == 2
+            ), f"Expected real_token_mask to have shape [batch, seq], got {tuple(real_token_mask.shape)}"
+            batch_size, seq_len = real_token_mask.shape
 
             if x.dim() < 2 or y.dim() < 2:
                 return x, y
@@ -129,11 +129,11 @@ class TorchComparisonEvaluator(ComparisonEvaluator):
             # - rank-4 tensors (e.g. KV [B, H, S, D]) -> sequence dim is -2
             assert (
                 x.shape == y.shape
-            ), f"pcc_mask requires matching shapes, got {x.shape} vs {y.shape}"
+            ), f"real_token_mask requires matching shapes, got {x.shape} vs {y.shape}"
             assert x.dim() in (
                 3,
                 4,
-            ), f"pcc_mask only supports rank-3 (logits) or rank-4 (KV) tensors, got rank {x.dim()} with shape {x.shape}"
+            ), f"real_token_mask only supports rank-3 (logits) or rank-4 (KV) tensors, got rank {x.dim()} with shape {x.shape}"
             assert (
                 x.shape[-2] == seq_len
             ), f"dim -2 should be seq_len ({seq_len}), got {x.shape[-2]} in shape {x.shape}"
@@ -141,9 +141,12 @@ class TorchComparisonEvaluator(ComparisonEvaluator):
             x_seq_first = x.movedim(-2, 1)
             y_seq_first = y.movedim(-2, 1)
 
-            x, y = x_seq_first[pcc_mask], y_seq_first[pcc_mask]
+            x, y = x_seq_first[real_token_mask], y_seq_first[real_token_mask]
             return x, y
 
+        # Nested so the closure can capture `apply_real_token_mask` (and through
+        # it `real_token_mask`); also lets us pass a clean `(x, y) -> float` to
+        # tree_map without functools.partial.
         def compute_pcc(x: torch.Tensor, y: torch.Tensor):
             if x is None and y is None:
                 return None
@@ -195,16 +198,16 @@ class TorchComparisonEvaluator(ComparisonEvaluator):
         device_output: PyTree,
         golden_output: PyTree,
         rel_l2_config: RelL2Config,
-        pcc_mask: torch.Tensor | None = None,
+        real_token_mask: torch.Tensor | None = None,
     ) -> float:
         def apply_real_token_mask(x: torch.Tensor, y: torch.Tensor):
-            if pcc_mask is None:
+            if real_token_mask is None:
                 return x, y
 
             assert (
-                pcc_mask.ndim == 2
-            ), f"Expected pcc_mask to have shape [batch, seq], got {tuple(pcc_mask.shape)}"
-            batch_size, seq_len = pcc_mask.shape
+                real_token_mask.ndim == 2
+            ), f"Expected real_token_mask to have shape [batch, seq], got {tuple(real_token_mask.shape)}"
+            batch_size, seq_len = real_token_mask.shape
 
             if x.dim() < 2 or y.dim() < 2:
                 return x, y
@@ -213,28 +216,31 @@ class TorchComparisonEvaluator(ComparisonEvaluator):
 
             assert (
                 x.shape == y.shape
-            ), f"pcc_mask requires matching shapes, got {x.shape} vs {y.shape}"
+            ), f"real_token_mask requires matching shapes, got {x.shape} vs {y.shape}"
             assert x.dim() in (
                 3,
                 4,
-            ), f"pcc_mask only supports rank-3 (logits) or rank-4 (KV) tensors, got rank {x.dim()} with shape {x.shape}"
+            ), f"real_token_mask only supports rank-3 (logits) or rank-4 (KV) tensors, got rank {x.dim()} with shape {x.shape}"
             assert (
                 x.shape[-2] == seq_len
             ), f"dim -2 should be seq_len ({seq_len}), got {x.shape[-2]} in shape {x.shape}"
 
             x_seq_first = x.movedim(-2, 1)
             y_seq_first = y.movedim(-2, 1)
-            return x_seq_first[pcc_mask], y_seq_first[pcc_mask]
+            return x_seq_first[real_token_mask], y_seq_first[real_token_mask]
 
+        # Nested so the closure can capture `apply_real_token_mask` (and through
+        # it `real_token_mask`); also lets us pass a clean `(x, y) -> float` to
+        # tree_map without functools.partial. Same pattern as `_compare_pcc`.
         def compute_rel_l2(x: torch.Tensor, y: torch.Tensor):
             if x is None and y is None:
                 return None
             x, y = apply_real_token_mask(x, y)
             # _match_data_types already casted to float64; redundant cast kept for safety.
-            x64 = x.to(torch.float64).flatten()
-            y64 = y.to(torch.float64).flatten()
-            diff_norm = torch.linalg.vector_norm(x64 - y64)
-            golden_norm = torch.linalg.vector_norm(y64)
+            device_flat = x.to(torch.float64).flatten()
+            golden_flat = y.to(torch.float64).flatten()
+            diff_norm = torch.linalg.vector_norm(device_flat - golden_flat)
+            golden_norm = torch.linalg.vector_norm(golden_flat)
             if golden_norm.item() == 0.0:
                 # Both exactly zero -> perfect match; otherwise undefined (inf).
                 return 0.0 if diff_norm.item() == 0.0 else float("inf")

--- a/tests/infra/evaluators/torch_comparison_evaluator.py
+++ b/tests/infra/evaluators/torch_comparison_evaluator.py
@@ -9,7 +9,7 @@ from torch.utils._pytree import tree_flatten, tree_map
 from transformers import Cache, DynamicCache, EncoderDecoderCache
 
 from .comparison_evaluator import ComparisonEvaluator
-from .evaluation_config import AllcloseConfig, AtolConfig, PccConfig
+from .evaluation_config import AllcloseConfig, AtolConfig, PccConfig, RelL2Config
 
 
 class TorchComparisonEvaluator(ComparisonEvaluator):
@@ -190,3 +190,62 @@ class TorchComparisonEvaluator(ComparisonEvaluator):
         all_close = tree_map(_allclose_leaf, device_output, golden_output)
         flat_close, _ = tree_flatten(all_close)
         return all(flat_close)
+
+    # @override
+    @run_on_cpu(Framework.TORCH)
+    def _compare_rel_l2(
+        self,
+        device_output: PyTree,
+        golden_output: PyTree,
+        rel_l2_config: RelL2Config,
+        pcc_mask: torch.Tensor | None = None,
+    ) -> float:
+        def apply_real_token_mask(x: torch.Tensor, y: torch.Tensor):
+            if pcc_mask is None:
+                return x, y
+
+            assert (
+                pcc_mask.ndim == 2
+            ), f"Expected pcc_mask to have shape [batch, seq], got {tuple(pcc_mask.shape)}"
+            batch_size, seq_len = pcc_mask.shape
+
+            if x.dim() < 2 or y.dim() < 2:
+                return x, y
+            if x.shape[0] != batch_size or y.shape[0] != batch_size:
+                return x, y
+
+            assert (
+                x.shape == y.shape
+            ), f"pcc_mask requires matching shapes, got {x.shape} vs {y.shape}"
+            assert x.dim() in (
+                3,
+                4,
+            ), f"pcc_mask only supports rank-3 (logits) or rank-4 (KV) tensors, got rank {x.dim()} with shape {x.shape}"
+            assert (
+                x.shape[-2] == seq_len
+            ), f"dim -2 should be seq_len ({seq_len}), got {x.shape[-2]} in shape {x.shape}"
+
+            x_seq_first = x.movedim(-2, 1)
+            y_seq_first = y.movedim(-2, 1)
+            return x_seq_first[pcc_mask], y_seq_first[pcc_mask]
+
+        def compute_rel_l2(x: torch.Tensor, y: torch.Tensor):
+            if x is None and y is None:
+                return None
+            x, y = apply_real_token_mask(x, y)
+            # _match_data_types already casted to float64; redundant cast kept for safety.
+            x64 = x.to(torch.float64).flatten()
+            y64 = y.to(torch.float64).flatten()
+            diff_norm = torch.linalg.vector_norm(x64 - y64)
+            golden_norm = torch.linalg.vector_norm(y64)
+            if golden_norm.item() == 0.0:
+                # Both exactly zero -> perfect match; otherwise undefined (inf).
+                return 0.0 if diff_norm.item() == 0.0 else float("inf")
+            return float(diff_norm / golden_norm)
+
+        leaf_rel_l2s = tree_map(compute_rel_l2, device_output, golden_output)
+        flat_rel_l2s, _ = tree_flatten(leaf_rel_l2s)
+        filtered = [v for v in flat_rel_l2s if v is not None]
+        if not filtered:
+            return 0.0
+        return float(max(filtered))

--- a/tests/infra/evaluators/torch_comparison_evaluator.py
+++ b/tests/infra/evaluators/torch_comparison_evaluator.py
@@ -108,16 +108,16 @@ class TorchComparisonEvaluator(ComparisonEvaluator):
         device_output: PyTree,
         golden_output: PyTree,
         pcc_config: PccConfig,
-        pcc_mask: torch.Tensor | None = None,
+        real_token_mask: torch.Tensor | None = None,
     ) -> float:
         def apply_real_token_mask(x: torch.Tensor, y: torch.Tensor):
-            if pcc_mask is None:
+            if real_token_mask is None:
                 return x, y
 
             assert (
-                pcc_mask.ndim == 2
-            ), f"Expected pcc_mask to have shape [batch, seq], got {tuple(pcc_mask.shape)}"
-            batch_size, seq_len = pcc_mask.shape
+                real_token_mask.ndim == 2
+            ), f"Expected real_token_mask to have shape [batch, seq], got {tuple(real_token_mask.shape)}"
+            batch_size, seq_len = real_token_mask.shape
 
             # Mask only applies to rank-3/4 tensors (logits [B,S,V] or KV [B,H,S,D]).
             # Rank-1/2 tensors (e.g. 2D gradient matrices in training) have no sequence
@@ -132,11 +132,11 @@ class TorchComparisonEvaluator(ComparisonEvaluator):
             # - rank-4 tensors (e.g. KV [B, H, S, D]) -> sequence dim is -2
             assert (
                 x.shape == y.shape
-            ), f"pcc_mask requires matching shapes, got {x.shape} vs {y.shape}"
+            ), f"real_token_mask requires matching shapes, got {x.shape} vs {y.shape}"
             assert x.dim() in (
                 3,
                 4,
-            ), f"pcc_mask only supports rank-3 (logits) or rank-4 (KV) tensors, got rank {x.dim()} with shape {x.shape}"
+            ), f"real_token_mask only supports rank-3 (logits) or rank-4 (KV) tensors, got rank {x.dim()} with shape {x.shape}"
             assert (
                 x.shape[-2] == seq_len
             ), f"dim -2 should be seq_len ({seq_len}), got {x.shape[-2]} in shape {x.shape}"
@@ -144,9 +144,12 @@ class TorchComparisonEvaluator(ComparisonEvaluator):
             x_seq_first = x.movedim(-2, 1)
             y_seq_first = y.movedim(-2, 1)
 
-            x, y = x_seq_first[pcc_mask], y_seq_first[pcc_mask]
+            x, y = x_seq_first[real_token_mask], y_seq_first[real_token_mask]
             return x, y
 
+        # Nested so the closure can capture `apply_real_token_mask` (and through
+        # it `real_token_mask`); also lets us pass a clean `(x, y) -> float` to
+        # tree_map without functools.partial.
         def compute_pcc(x: torch.Tensor, y: torch.Tensor):
             if x is None and y is None:
                 return None
@@ -198,16 +201,16 @@ class TorchComparisonEvaluator(ComparisonEvaluator):
         device_output: PyTree,
         golden_output: PyTree,
         rel_l2_config: RelL2Config,
-        pcc_mask: torch.Tensor | None = None,
+        real_token_mask: torch.Tensor | None = None,
     ) -> float:
         def apply_real_token_mask(x: torch.Tensor, y: torch.Tensor):
-            if pcc_mask is None:
+            if real_token_mask is None:
                 return x, y
 
             assert (
-                pcc_mask.ndim == 2
-            ), f"Expected pcc_mask to have shape [batch, seq], got {tuple(pcc_mask.shape)}"
-            batch_size, seq_len = pcc_mask.shape
+                real_token_mask.ndim == 2
+            ), f"Expected real_token_mask to have shape [batch, seq], got {tuple(real_token_mask.shape)}"
+            batch_size, seq_len = real_token_mask.shape
 
             if x.dim() < 2 or y.dim() < 2:
                 return x, y
@@ -216,28 +219,31 @@ class TorchComparisonEvaluator(ComparisonEvaluator):
 
             assert (
                 x.shape == y.shape
-            ), f"pcc_mask requires matching shapes, got {x.shape} vs {y.shape}"
+            ), f"real_token_mask requires matching shapes, got {x.shape} vs {y.shape}"
             assert x.dim() in (
                 3,
                 4,
-            ), f"pcc_mask only supports rank-3 (logits) or rank-4 (KV) tensors, got rank {x.dim()} with shape {x.shape}"
+            ), f"real_token_mask only supports rank-3 (logits) or rank-4 (KV) tensors, got rank {x.dim()} with shape {x.shape}"
             assert (
                 x.shape[-2] == seq_len
             ), f"dim -2 should be seq_len ({seq_len}), got {x.shape[-2]} in shape {x.shape}"
 
             x_seq_first = x.movedim(-2, 1)
             y_seq_first = y.movedim(-2, 1)
-            return x_seq_first[pcc_mask], y_seq_first[pcc_mask]
+            return x_seq_first[real_token_mask], y_seq_first[real_token_mask]
 
+        # Nested so the closure can capture `apply_real_token_mask` (and through
+        # it `real_token_mask`); also lets us pass a clean `(x, y) -> float` to
+        # tree_map without functools.partial. Same pattern as `_compare_pcc`.
         def compute_rel_l2(x: torch.Tensor, y: torch.Tensor):
             if x is None and y is None:
                 return None
             x, y = apply_real_token_mask(x, y)
             # _match_data_types already casted to float64; redundant cast kept for safety.
-            x64 = x.to(torch.float64).flatten()
-            y64 = y.to(torch.float64).flatten()
-            diff_norm = torch.linalg.vector_norm(x64 - y64)
-            golden_norm = torch.linalg.vector_norm(y64)
+            device_flat = x.to(torch.float64).flatten()
+            golden_flat = y.to(torch.float64).flatten()
+            diff_norm = torch.linalg.vector_norm(device_flat - golden_flat)
+            golden_norm = torch.linalg.vector_norm(golden_flat)
             if golden_norm.item() == 0.0:
                 # Both exactly zero -> perfect match; otherwise undefined (inf).
                 return 0.0 if diff_norm.item() == 0.0 else float("inf")

--- a/tests/infra/evaluators/torch_comparison_evaluator.py
+++ b/tests/infra/evaluators/torch_comparison_evaluator.py
@@ -9,7 +9,7 @@ from torch.utils._pytree import tree_flatten, tree_map
 from transformers import Cache, DynamicCache, EncoderDecoderCache
 
 from .comparison_evaluator import ComparisonEvaluator
-from .evaluation_config import AllcloseConfig, AtolConfig, PccConfig
+from .evaluation_config import AllcloseConfig, AtolConfig, PccConfig, RelL2Config
 
 
 class TorchComparisonEvaluator(ComparisonEvaluator):
@@ -187,3 +187,62 @@ class TorchComparisonEvaluator(ComparisonEvaluator):
         all_close = tree_map(_allclose_leaf, device_output, golden_output)
         flat_close, _ = tree_flatten(all_close)
         return all(flat_close)
+
+    # @override
+    @run_on_cpu(Framework.TORCH)
+    def _compare_rel_l2(
+        self,
+        device_output: PyTree,
+        golden_output: PyTree,
+        rel_l2_config: RelL2Config,
+        pcc_mask: torch.Tensor | None = None,
+    ) -> float:
+        def apply_real_token_mask(x: torch.Tensor, y: torch.Tensor):
+            if pcc_mask is None:
+                return x, y
+
+            assert (
+                pcc_mask.ndim == 2
+            ), f"Expected pcc_mask to have shape [batch, seq], got {tuple(pcc_mask.shape)}"
+            batch_size, seq_len = pcc_mask.shape
+
+            if x.dim() < 2 or y.dim() < 2:
+                return x, y
+            if x.shape[0] != batch_size or y.shape[0] != batch_size:
+                return x, y
+
+            assert (
+                x.shape == y.shape
+            ), f"pcc_mask requires matching shapes, got {x.shape} vs {y.shape}"
+            assert x.dim() in (
+                3,
+                4,
+            ), f"pcc_mask only supports rank-3 (logits) or rank-4 (KV) tensors, got rank {x.dim()} with shape {x.shape}"
+            assert (
+                x.shape[-2] == seq_len
+            ), f"dim -2 should be seq_len ({seq_len}), got {x.shape[-2]} in shape {x.shape}"
+
+            x_seq_first = x.movedim(-2, 1)
+            y_seq_first = y.movedim(-2, 1)
+            return x_seq_first[pcc_mask], y_seq_first[pcc_mask]
+
+        def compute_rel_l2(x: torch.Tensor, y: torch.Tensor):
+            if x is None and y is None:
+                return None
+            x, y = apply_real_token_mask(x, y)
+            # _match_data_types already casted to float64; redundant cast kept for safety.
+            x64 = x.to(torch.float64).flatten()
+            y64 = y.to(torch.float64).flatten()
+            diff_norm = torch.linalg.vector_norm(x64 - y64)
+            golden_norm = torch.linalg.vector_norm(y64)
+            if golden_norm.item() == 0.0:
+                # Both exactly zero -> perfect match; otherwise undefined (inf).
+                return 0.0 if diff_norm.item() == 0.0 else float("inf")
+            return float(diff_norm / golden_norm)
+
+        leaf_rel_l2s = tree_map(compute_rel_l2, device_output, golden_output)
+        flat_rel_l2s, _ = tree_flatten(leaf_rel_l2s)
+        filtered = [v for v in flat_rel_l2s if v is not None]
+        if not filtered:
+            return 0.0
+        return float(max(filtered))

--- a/tests/infra_tests/single_chip/test_result_assertion.py
+++ b/tests/infra_tests/single_chip/test_result_assertion.py
@@ -7,7 +7,7 @@
 import jax.numpy as jnp
 import pytest
 import torch
-from infra.evaluators import AtolConfig, ComparisonConfig, PccConfig
+from infra.evaluators import AtolConfig, ComparisonConfig, PccConfig, RelL2Config
 
 from tests.infra.evaluators import (
     Evaluator,
@@ -378,3 +378,71 @@ def test_invalid_pcc_triggers_assertion(framework_setup, invalid_value):
     # Should raise AssertionError because PCC will be invalid
     with pytest.raises(AssertionError, match="PCC comparison failed"):
         comparator.evaluate(device_output, golden_output)
+
+
+@pytest.mark.push
+def test_rel_l2_zero_for_identical_tensors(framework_setup):
+    """rel_l2 must be exactly 0 for identical tensors."""
+    create_tensor = framework_setup["create_tensor"]
+    comparator_class = framework_setup["comparator_class"]
+
+    config = ComparisonConfig(
+        pcc=PccConfig(enabled=False),
+        atol=AtolConfig(enabled=False),
+        rel_l2=RelL2Config(enabled=True, required_rel_l2=0.0),
+    )
+    comparator = comparator_class(config)
+
+    x = create_tensor([1.0, 2.0, 3.0, 4.0])
+    y = create_tensor([1.0, 2.0, 3.0, 4.0])
+
+    result = comparator.evaluate(x, y)
+    assert result.passed is True
+    assert result.rel_l2 == 0.0
+
+
+@pytest.mark.push
+def test_rel_l2_small_for_close_tensors(framework_setup):
+    """rel_l2 must be near 0 for almost-matching tensors and pass a 1e-2 threshold."""
+    create_tensor = framework_setup["create_tensor"]
+    comparator_class = framework_setup["comparator_class"]
+
+    config = ComparisonConfig(
+        pcc=PccConfig(enabled=False),
+        atol=AtolConfig(enabled=False),
+        rel_l2=RelL2Config(enabled=True, required_rel_l2=1e-2),
+    )
+    comparator = comparator_class(config)
+
+    x = create_tensor([1.0, 2.0, 3.0, 4.0])
+    y = create_tensor([1.0001, 2.0001, 3.0001, 4.0001])
+
+    result = comparator.evaluate(x, y)
+    assert result.passed is True
+    assert result.rel_l2 is not None
+    assert 0.0 < result.rel_l2 < 1e-2
+
+
+@pytest.mark.push
+def test_rel_l2_fail_for_clearly_different_tensors(framework_setup):
+    """rel_l2 must exceed a strict threshold for clearly different tensors."""
+    create_tensor = framework_setup["create_tensor"]
+    comparator_class = framework_setup["comparator_class"]
+
+    config = ComparisonConfig(
+        pcc=PccConfig(enabled=False),
+        atol=AtolConfig(enabled=False),
+        rel_l2=RelL2Config(enabled=True, required_rel_l2=1e-2),
+        assert_on_failure=False,
+    )
+    comparator = comparator_class(config)
+
+    x = create_tensor([1.0, 2.0, 3.0, 4.0])
+    y = create_tensor([5.0, 1.0, 4.0, 2.0])
+
+    result = comparator.evaluate(x, y)
+    assert result.passed is False
+    assert result.rel_l2 is not None
+    assert result.rel_l2 > 1e-2
+    assert result.error_message is not None
+    assert "RelL2 comparison failed" in result.error_message

--- a/tests/runner/testers/torch/dynamic_torch_model_tester.py
+++ b/tests/runner/testers/torch/dynamic_torch_model_tester.py
@@ -257,8 +257,12 @@ class DynamicTorchModelTester(TorchModelTester):
             return get_mesh(mesh_shape, mesh_names)
         return None
 
-    def _get_prefill_pcc_mask(self):
-        """Return boolean token mask for LLM prefill PCC filtering."""
+    def _get_prefill_real_token_mask(self):
+        """Return boolean real-token mask for LLM prefill metric filtering.
+
+        Excludes padded positions from PCC, rel_l2, and any other
+        sequence-aware metric that consumes the mask.
+        """
         if self.run_phase != RunPhase.LLM_PREFILL:
             return None
 
@@ -268,11 +272,11 @@ class DynamicTorchModelTester(TorchModelTester):
         return attention_mask.to(dtype=torch.bool)
 
     def _compare(self, device_out, golden_out):
-        """Compare outputs, masking padded prefill tokens for PCC only."""
+        """Compare outputs, masking padded prefill tokens for mask-aware metrics."""
         return self._evaluator.evaluate(
             device_out,
             golden_out,
-            pcc_mask=self._get_prefill_pcc_mask(),
+            real_token_mask=self._get_prefill_real_token_mask(),
         )
 
     def _unpack_forward_output(self, output: Any) -> torch.Tensor:


### PR DESCRIPTION
## Summary

  Adds `rel_l2 = ||device - golden||_2 / ||golden||_2` as a new similarity metric, alongside the existing PCC / atol / allclose checks.
  
  **Motivation — every metric we use today has a known failure mode:**
  
  - **PCC** is alignment/shape-only and scale-blind: scaling a tensor by some factor still yields PCC = 1.0.
  - **max atol** is dominated by a single outlier element, hiding the overall quality of the tensor.
  - **max rtol** blows up wherever the golden tensor is near zero (e.g. LLM logits routinely hit `|y| ~ 1e-7`, sending rtol to `~1e5` even when the result is numerically fine).

  `rel_l2` is the standard numerical-linear-algebra / HPC validation metric:
  
  - **Scale-sensitive** (catches drift that PCC misses).
  - **Stable near zero globally** (denominator is `||y||_2`, not per-element `|y_i|`).
  - **Captures distributed degradation** rather than one bad element.
  - **Smooth, robust, well-conditioned.**

  All norms are computed in float64 to avoid bf16/fp32 underflow.
  
  ### What changes


  - **Test infra evaluators** (`tests/infra/evaluators/`): new `RelL2Config` (disabled by default, threshold `1.0`), `rel_l2` field on the comparison result, and Torch + JAX implementations. Integrated into the existing comparison pipeline alongside PCC / atol / allclose.
  - **Benchmark utilities** (`tests/benchmark/`): standalone `compute_rel_l2` helper, and rel_l2 is printed next to PCC at each verification point in the LLM benchmark. Observability-only — no new asserts.
  - Rename `pcc_mask` to `real_token_mask` since the mask is now consumed by both PCC and rel_l2 (and any future sequence-aware metric). Also renames the corresponding helper in `tests/runner/testers/torch/dynamic_torch_model_tester.py`.

  ### Defaults
  
  `RelL2Config` defaults to `enabled=False` with a permissive threshold of `1.0`. Observability-only: no existing test changes pass/fail status. Tightening thresholds per-model is a follow-up.
  
  ## Tests
`pytest -v tests/infra_tests/single_chip/test_result_assertion.py` passes (pre-existing + new rel_l2 tests).