### PR TITLE
Update the inference test config of d_fine variants based on latest main results

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -1832,29 +1832,49 @@ test_config:
         status: EXCLUDE_MODEL # This model is run as tensor_parallel already.
 
   d_fine/pytorch-Nano-single_device-inference:
-    status: NOT_SUPPORTED_SKIP
-    reason: "d_fine nano hangs forever, removing all of them."
-    bringup_status: FAILED_RUNTIME
+    arch_overrides:
+      n150:
+        status: KNOWN_FAILURE_XFAIL
+        reason: "AssertionError: Evaluation result 0 failed: PCC comparison failed. Calculated: pcc=nan (invalid value). Required: pcc=0.99. - https://github.com/tenstorrent/tt-xla/issues/4714"
+      p150:
+        status: KNOWN_FAILURE_XFAIL
+        reason: "AssertionError: Evaluation result 0 failed: PCC comparison failed. Calculated: pcc=0.004327041538509983. Required: pcc=0.99. - https://github.com/tenstorrent/tt-xla/issues/4714"
 
   d_fine/pytorch-Small-single_device-inference:
-    status: NOT_SUPPORTED_SKIP
-    reason: "d_fine small hangs forever, removing all of them."
-    bringup_status: FAILED_RUNTIME
+    arch_overrides:
+      n150:
+        status: KNOWN_FAILURE_XFAIL
+        reason: "AssertionError: Evaluation result 0 failed: PCC comparison failed. Calculated: pcc=nan (invalid value). Required: pcc=0.99. - https://github.com/tenstorrent/tt-xla/issues/4714"
+      p150:
+        status: KNOWN_FAILURE_XFAIL
+        reason: "AssertionError: Evaluation result 0 failed: PCC comparison failed. Calculated: pcc=nan (invalid value). Required: pcc=0.99. - https://github.com/tenstorrent/tt-xla/issues/4714"
 
   d_fine/pytorch-Medium-single_device-inference:
-    status: NOT_SUPPORTED_SKIP
-    reason: "d_fine medium hangs forever, removing all of them."
-    bringup_status: FAILED_RUNTIME
+    arch_overrides:
+      n150:
+        status: KNOWN_FAILURE_XFAIL
+        reason: "AssertionError: Evaluation result 0 failed: PCC comparison failed. Calculated: pcc=0.20286665988748961. Required: pcc=0.99. - https://github.com/tenstorrent/tt-xla/issues/4714"
+      p150:
+        status: KNOWN_FAILURE_XFAIL
+        reason: "AssertionError: Evaluation result 0 failed: PCC comparison failed. Calculated: pcc=nan (invalid value). Required: pcc=0.99. - https://github.com/tenstorrent/tt-xla/issues/4714"
 
   d_fine/pytorch-Large-single_device-inference:
-    status: NOT_SUPPORTED_SKIP
-    reason: "d_fine large hangs forever, removing all of them."
-    bringup_status: FAILED_RUNTIME
+    arch_overrides:
+      n150:
+        status: KNOWN_FAILURE_XFAIL
+        reason: "AssertionError: Evaluation result 0 failed: PCC comparison failed. Calculated: pcc=nan (invalid value). Required: pcc=0.99. - https://github.com/tenstorrent/tt-xla/issues/4714"
+      p150:
+        status: KNOWN_FAILURE_XFAIL
+        reason: "AssertionError: Evaluation result 0 failed: PCC comparison failed. Calculated: pcc=0.3777558992205605. Required: pcc=0.99. - https://github.com/tenstorrent/tt-xla/issues/4714"
 
   d_fine/pytorch-Xlarge-single_device-inference:
-    status: NOT_SUPPORTED_SKIP
-    reason: "d_fine xlarge hangs forever, removing all of them."
-    bringup_status: FAILED_RUNTIME
+    arch_overrides:
+      n150:
+        status: KNOWN_FAILURE_XFAIL
+        reason: "AssertionError: Evaluation result 0 failed: PCC comparison failed. Calculated: pcc=nan (invalid value). Required: pcc=0.99. - https://github.com/tenstorrent/tt-xla/issues/4714"
+      p150:
+        status: KNOWN_FAILURE_XFAIL
+        reason: "AssertionError: Evaluation result 0 failed: PCC comparison failed. Calculated: pcc=nan (invalid value). Required: pcc=0.99. - https://github.com/tenstorrent/tt-xla/issues/4714"
 
   hrnet/pytorch-v2_W48_Osmr-single_device-inference:
     required_pcc: 0.985  # https://github.com/tenstorrent/tt-xla/issues/1491


### PR DESCRIPTION
### Problem description

- `d_fine` variants were skipped because of a hang ([#3736](https://github.com/tenstorrent/tt-xla/issues/3736)). The required [Metal fix](https://github.com/tenstorrent/tt-metal/pull/43055) is now tracked by tt-xla main, and the variants no longer hang.
- On current main, inference still fails on n150/p150 with PCC below threshold (or nan); tracked in [#4714](https://github.com/tenstorrent/tt-xla/issues/4714).

### What's changed

- Updated the config based on latest main results 

### Checklist
- [x] Verify the changes using Run Test single

### Logs/Runs

- N150- https://github.com/tenstorrent/tt-xla/actions/runs/25876389741/job/76047634193
- P150 - https://github.com/tenstorrent/tt-xla/actions/runs/25876439526/job/76046780167