### PR TITLE
Bring up Stable Diffusion 1.5 UNet on single device

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -1189,6 +1189,9 @@ test_config:
   stable_diffusion_unet/pytorch-Base-single_device-inference:
     status: EXPECTED_PASSING
 
+  stable_diffusion_unet/pytorch-V1_5-single_device-inference:
+    status: EXPECTED_PASSING
+
   unet_for_conditional_generation/pytorch-Base-single_device-inference:
     status: EXPECTED_PASSING
 


### PR DESCRIPTION
## Summary
- Uplifts `third_party/tt_forge_models` to pull in the new `V1_5` variant of `stable_diffusion_unet` from tenstorrent/tt-forge-models#659.
- Registers `stable_diffusion_unet/pytorch-V1_5-single_device-inference` as `EXPECTED_PASSING` in the inference single-device runner YAML.

**Draft because it depends on tenstorrent/tt-forge-models#659. Will un-draft and rebase once that lands so the submodule pointer references a commit on `main`.**

## What runs on TT
Same scope as the existing `stable_diffusion_unet/pytorch-Base` (SD 1.4) test — a single forward pass through the SD 1.5 `UNet2DConditionModel`. The CLIP text encoder, VAE and scheduler loop continue to run on CPU; this PR does not wire the full text-to-image pipeline through PJRT.

## Test plan
- [x] `pytest -vv tests/runner/test_models.py::test_all_models_torch[stable_diffusion_unet/pytorch-V1_5-single_device-inference]` — passed in ~163 s on a single device (PCC ≥ 0.99 vs CPU bf16).
- [ ] CI green on this PR after the submodule PR lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)