### PR TITLE
Bring up Stable Diffusion 3 Medium on single device

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -2170,6 +2170,9 @@ test_config:
     assert_pcc: false
     status: EXPECTED_PASSING
 
+  stable_diffusion/pytorch-3_Medium-single_device-inference:
+    status: EXCLUDE_MODEL  # stable_diffusion variants have a hand written test, don't run via test_models.py. TODO(@ppadjinTT): when pipeline becomes supported through test infra, enable this model again.
+
   stable_diffusion/pytorch-3.5_Medium-single_device-inference:
     status: EXCLUDE_MODEL  # stable_diffusion variants have a hand written test, don't run via test_models.py. TODO(@ppadjinTT): when pipeline becomes supported through test infra, enable this model again.
 

--- a/tests/torch/models/stable_diffusion_3_5/test_stable_diffusion_3_medium.py
+++ b/tests/torch/models/stable_diffusion_3_5/test_stable_diffusion_3_medium.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from infra import RunMode
+from utils import BringupStatus, Category, ModelGroup
+
+from third_party.tt_forge_models.config import Parallelism
+from third_party.tt_forge_models.stable_diffusion.pytorch import (
+    ModelLoader,
+    ModelVariant,
+)
+
+from .tester import StableDiffusion35Tester
+
+VARIANT_NAME = ModelVariant.STABLE_DIFFUSION_3_MEDIUM
+MODEL_INFO = ModelLoader._get_model_info(VARIANT_NAME)
+
+
+# ----- Fixtures -----
+
+
+@pytest.fixture
+def inference_tester() -> StableDiffusion35Tester:
+    return StableDiffusion35Tester(VARIANT_NAME)
+
+
+@pytest.fixture
+def training_tester() -> StableDiffusion35Tester:
+    return StableDiffusion35Tester(VARIANT_NAME, run_mode=RunMode.TRAINING)
+
+
+# ----- Tests -----
+
+
+@pytest.mark.single_device
+@pytest.mark.model_test
+@pytest.mark.record_test_properties(
+    category=Category.MODEL_TEST,
+    model_info=MODEL_INFO,
+    parallelism=Parallelism.SINGLE_DEVICE,
+    run_mode=RunMode.INFERENCE,
+    bringup_status=BringupStatus.FAILED_RUNTIME,
+)
+@pytest.mark.skip(
+    reason="RuntimeError: Bad StatusOr access: INTERNAL: Error code: 13 - DRAM buffer allocation failure in ttnn::eq during MMDiT forward (same family as SD 3.5 Medium OOM)"
+)
+def test_torch_stable_diffusion_3_medium_inference(
+    inference_tester: StableDiffusion35Tester,
+):
+    inference_tester.test()
+
+
+@pytest.mark.single_device
+@pytest.mark.record_test_properties(
+    category=Category.MODEL_TEST,
+    model_info=MODEL_INFO,
+    model_group=ModelGroup.GENERALITY,
+    run_mode=RunMode.TRAINING,
+)
+@pytest.mark.skip(reason="Support for training not implemented")
+def test_torch_stable_diffusion_3_medium_training(
+    training_tester: StableDiffusion35Tester,
+):
+    training_tester.test()


### PR DESCRIPTION
## Summary
- Uplifts `third_party/tt_forge_models` to pull in the new SD 3 Medium variant from tenstorrent/tt-forge-models#660.
- Adds a hand-written test `tests/torch/models/stable_diffusion_3_5/test_stable_diffusion_3_medium.py` mirroring the existing SD 3.5 Medium test.
- Registers a matching `EXCLUDE_MODEL` entry in the inference single-device runner YAML (matches the sibling SD 3.5 entries).

**Draft because it depends on tenstorrent/tt-forge-models#660. Will un-draft and rebase once that lands.**

## What runs on TT
A single MMDiT forward call through the `StableDiffusion3Pipeline` transformer. The CLIP/CLIP-2/T5-XXL text encoders, VAE and scheduler loop continue to run on CPU; this PR does not wire the full text-to-image pipeline through PJRT.

## Current bringup status
The test is marked `@pytest.mark.skip` with `BringupStatus.FAILED_RUNTIME`. The scaffolding works end-to-end (compile + load + execute reaches device), but execution fails inside `ttnn::eq` with a DRAM allocator error:

```
RuntimeError: Bad StatusOr access: INTERNAL: Error code: 13
```

This is the same family of failure as the existing `test_stable_diffusion_3_5_medium` `@pytest.mark.skip` (`Out of Memory: Not enough space to allocate ... DRAM buffer across 12 banks`). The skip allows the scaffolding to land while the underlying compiler/device issue is tracked separately.

## Test plan
- [x] Hand-written test compiles and reaches device execution.
- [x] Test collection is clean (the new test file collects without error).
- [ ] CI green on this PR after the submodule PR lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)