### PR TITLE
Update test config statuses for YOLOv9, YOLOS, and OLM OCR

### DIFF
--- a/tests/runner/test_config/torch/test_config_training_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_training_single_device.yaml
@@ -397,9 +397,9 @@ test_config:
   #   bringup_status: FAILED_FE_COMPILATION
   #   reason: "tt-forge-models doesn't implement unpack_forward_output for this model."
   yolov9/pytorch-T-single_device-training:
-    status: KNOWN_FAILURE_XFAIL
-    bringup_status: FAILED_TTMLIR_COMPILATION
-    reason: "ElementsAttr::getValues UNREACHABLE on dense<4294967295> : tensor<ui32> (mlir BuiltinAttributeInterfaces.h:313)"
+    status: NOT_SUPPORTED_SKIP
+    bringup_status: FAILED_RUNTIME
+    reason: "crashed with signal 6"
   yolov9/pytorch-S-single_device-training:
     status: KNOWN_FAILURE_XFAIL
     bringup_status: FAILED_TTMLIR_COMPILATION
@@ -1661,7 +1661,7 @@ test_config:
     bringup_status: FAILED_RUNTIME
     reason: "ElementsAttr does not provide iteration facilities for type `int` (https://github.com/tenstorrent/tt-xla/issues/3109)"
   olm_ocr/image_text_generation/pytorch-olmOCR-7B-0225-preview-single_device-training:
-    status: KNOWN_FAILURE_XFAIL
+    status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION
     reason: "TorchDynamo NameError: cannot access free variable 'named_children' (transformers qwen2_vl get_image_features modeling_utils.dtype generator)"
   olm_ocr/image_text_generation/pytorch-olmOCR-7B-0825-single_device-training:
@@ -1777,7 +1777,7 @@ test_config:
     bringup_status: FAILED_FE_COMPILATION
     reason: "RuntimeError: function '_has_torch_function' already has a docstring"
   yolos_small/pytorch-Small-single_device-training:
-    status: EXPECTED_PASSING
+    status: KNOWN_FAILURE_XFAIL
     assert_pcc: false
   yolov7/pytorch-Default-single_device-training:
     status: NOT_SUPPORTED_SKIP

--- a/tests/runner/test_config/torch/test_config_training_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_training_single_device.yaml
@@ -1777,8 +1777,13 @@ test_config:
     bringup_status: FAILED_FE_COMPILATION
     reason: "RuntimeError: function '_has_torch_function' already has a docstring"
   yolos_small/pytorch-Small-single_device-training:
-    status: KNOWN_FAILURE_XFAIL
-    assert_pcc: false
+    arch_overrides:
+      n150:
+        status: KNOWN_FAILURE_XFAIL
+        assert_pcc: false
+      p150:
+        status: EXPECTED_PASSING
+        assert_pcc: false
   yolov7/pytorch-Default-single_device-training:
     status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_FE_COMPILATION

--- a/tests/runner/test_config/torch/test_config_training_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_training_single_device.yaml
@@ -542,7 +542,7 @@ test_config:
     bringup_status: FAILED_RUNTIME
     reason: "Statically allocated circular buffers on core range [(x=7,y=6) - (x=7,y=6)] grow to 2371840 B which is beyond max L1 size of 1499136 B (assert.hpp:103)"
   detr/object_detection/pytorch-ResNet50_Backbone-single_device-training:
-    status: KNOWN_FAILURE_XFAIL
+    status: NOT_SUPPORTED_SKIP
     bringup_status: FAILED_RUNTIME
     reason: "Fatal Python error: Aborted during torch_xla.sync after forward pass."
   detr/segmentation/pytorch-ResNet50_Backbone_Panoptic-single_device-training:


### PR DESCRIPTION
### Ticket
Closes #4719

### Problem description
Several training model tests had stale or incorrect statuses in the test config.

### What's changed

All changes are in `tests/runner/test_config/torch/test_config_training_single_device.yaml`.

- **yolov9/pytorch-T**: `KNOWN_FAILURE_XFAIL` → `NOT_SUPPORTED_SKIP`; bringup status updated from `FAILED_TTMLIR_COMPILATION` to `FAILED_RUNTIME` (crashes with signal 6)
- **detr/object_detection/pytorch-ResNet50_Backbone**: `KNOWN_FAILURE_XFAIL` → `NOT_SUPPORTED_SKIP` (aborts during `torch_xla.sync` after forward pass)
- **olm_ocr/pytorch-olmOCR-7B-0225-preview**: `KNOWN_FAILURE_XFAIL` → `NOT_SUPPORTED_SKIP` (TorchDynamo `NameError` during FE compilation)
- **yolos_small/pytorch-Small**: replaced global `EXPECTED_PASSING` with per-arch overrides — `KNOWN_FAILURE_XFAIL` on n150, `EXPECTED_PASSING` on p150

### Checklist
- [ ] New/Existing tests provide coverage for changes