### PR TITLE
Add rotary embedding fusion validation to LLM benchmarks

### DIFF
--- a/tests/benchmark/benchmarks/llm_benchmark.py
+++ b/tests/benchmark/benchmarks/llm_benchmark.py
@@ -583,6 +583,10 @@ def benchmark_llm_torch_xla(
     # PCC/TOPK BENCHMARK
     # ========================================================
 
+    # Use a distinct export name for PCC/TOPK graphs to avoid confusion with perf graphs
+    options["export_model_name"] = export_model_name + "_pcc"
+    torch_xla.set_custom_compile_options(options)
+
     # Return logits to calculate PCC/TOPK
     logits_wrapper = LLMSamplingWrapper(
         model,
@@ -854,11 +858,12 @@ def benchmark_llm_torch_xla(
         mesh_shape=mesh_shape,
     )
 
-    if check_fusions_enabled and expected_ops:
-        check_fusions(
-            expected_ops=expected_ops,
-            export_model_name=export_model_name,
-            modules_dir=MODULE_EXPORT_PATH,
-        )
+    check_fusions(
+        expected_ops=expected_ops,
+        export_model_name=export_model_name,
+        modules_dir=MODULE_EXPORT_PATH,
+        num_layers=num_layers,
+        strict=check_fusions_enabled,
+    )
 
     return result

--- a/tests/benchmark/fusion_check.py
+++ b/tests/benchmark/fusion_check.py
@@ -5,9 +5,9 @@
 """
 Fusion-pattern verification for benchmark tests.
 
-Accepts a list of expected op strings (e.g. ["ttnn.rms_norm", "ttnn.scaled_dot_product_attention"]),
-globs the ttnn IR files produced by the current run, and searches for each op
-by simple string match. A pattern must appear in every graph file.
+Accepts a list of OpCount objects that specify expected per-layer op counts,
+globs the ttnn IR files produced by the current run, and verifies exact
+occurrence counts (per_layer_count * num_layers) in each graph file.
 
 The current run is identified by `export_model_name`, which embeds a unique
 `_run<hex>_` token, so files from previous runs are naturally excluded.
@@ -15,52 +15,139 @@ The current run is identified by `export_model_name`, which embeds a unique
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 
 
+@dataclass
+class OpCountPerLayer:
+    """Expected per-layer count for a TTNN op.
+
+    The total expected occurrences in an IR file is ``count * num_layers``.
+    """
+
+    op: str
+    count: int
+
+
+@dataclass
+class OpCountPerLayerBetween:
+    """Expected per-layer count range for a TTNN op.
+
+    The total expected occurrences must be between
+    ``min_count * num_layers`` and ``max_count * num_layers`` (inclusive).
+    """
+
+    op: str
+    min_count: int
+    max_count: int
+
+
+FusionCheck = OpCountPerLayer | OpCountPerLayerBetween
+
+# Ops that are commonly fused in TTNN IR. When no expected_ops are specified,
+# these are counted and printed for informational purposes.
+DISCOVERY_OPS = [
+    "ttnn.rotary_embedding",
+    "ttnn.scaled_dot_product_attention",
+    "ttnn.scaled_dot_product_attention_decode",
+]
+
+
+def _load_ir_files(
+    export_model_name: str, modules_dir: str | Path
+) -> list[tuple[Path, str]]:
+    irs_dir = Path(modules_dir) / "irs"
+    prefix = f"ttnn_{export_model_name}_g"
+    ir_files = sorted(irs_dir.glob(f"{prefix}*.mlir")) if irs_dir.is_dir() else []
+    return [(f, f.read_text()) for f in ir_files]
+
+
+def _count_op(ir_contents: list[tuple[Path, str]], op: str) -> int:
+    op_pattern = f'"{op}"'
+    return sum(text.count(op_pattern) for _, text in ir_contents)
+
+
 def check_fusions(
-    expected_ops: list[str],
+    expected_ops: list[FusionCheck],
     export_model_name: str,
     modules_dir: str | Path,
+    num_layers: int,
+    strict: bool = False,
 ) -> None:
     """
-    Verify that expected ops appear in the ttnn IR produced by this benchmark run.
+    Verify that expected ops appear the correct number of times in the ttnn IR.
 
-    Each op must be present in every matching ttnn graph file.
+    Always prints fusion stats. When ``strict=True``, raises on mismatches.
 
     Args:
-        expected_ops: List of op strings like "ttnn.rms_norm".
+        expected_ops: List of FusionCheck objects.
         export_model_name: Model export name used to glob IR file names.
-            Already unique per run via the `_run<hex>_` token it embeds.
         modules_dir: Directory containing the "irs/" subdirectory.
+        num_layers: Number of transformer layers in the model.
+        strict: If True, raise on mismatches. If False, only print stats.
 
     Raises:
-        AssertionError: if any op is absent from any graph file for this run,
-            or if no IR files can be found.
+        AssertionError: if strict=True and any check fails or no IR files are found.
     """
+    ir_contents = _load_ir_files(export_model_name, modules_dir)
+    if not ir_contents:
+        msg = (
+            f"Fusion check: no IR files found "
+            f"(looked for ttnn_{export_model_name}_g*.mlir under {modules_dir}/irs/)"
+        )
+        if strict:
+            raise AssertionError(msg)
+        print(f"WARNING: {msg}")
+        return
+
+    checked_ops = {check.op for check in expected_ops} if expected_ops else set()
+
+    # Print discovery stats for common fused ops not covered by explicit checks
+    uncovered = [op for op in DISCOVERY_OPS if op not in checked_ops]
+    if uncovered:
+        print(f"\nFusion discovery ({len(ir_contents)} IR files, {num_layers} layers):")
+        for op in uncovered:
+            count = _count_op(ir_contents, op)
+            if count > 0:
+                print(
+                    f"  INFO: '{op}' count={count} ({count / num_layers:.1f} per layer)"
+                )
+
     if not expected_ops:
         return
 
-    irs_dir = Path(modules_dir) / "irs"
-    prefix = f"ttnn_{export_model_name}_"
-    ir_files = sorted(irs_dir.glob(f"{prefix}*.mlir")) if irs_dir.is_dir() else []
-
-    if not ir_files:
-        raise AssertionError(
-            f"Fusion check failed: no IR files found "
-            f"(looked for {prefix}*.mlir under {modules_dir}/irs/)"
-        )
-
-    ir_contents = [(f, f.read_text()) for f in ir_files]
-
+    # Validate explicit checks
+    print(f"\nFusion check ({len(ir_contents)} IR files, {num_layers} layers):")
     failures: list[str] = []
-    for op in expected_ops:
-        missing_in = [f.name for f, text in ir_contents if op not in text]
-        if missing_in:
-            failures.append(
-                f"Op '{op}' missing in {len(missing_in)}/{len(ir_files)} "
-                f"ttnn graph file(s): {missing_in}"
-            )
+    for check in expected_ops:
+        actual_count = _count_op(ir_contents, check.op)
 
-    if failures:
+        if isinstance(check, OpCountPerLayerBetween):
+            min_expected = check.min_count * num_layers
+            max_expected = check.max_count * num_layers
+            passed = min_expected <= actual_count <= max_expected
+            status = "PASS" if passed else "FAIL"
+            msg = (
+                f"  {status}: '{check.op}' count={actual_count}, "
+                f"expected [{min_expected}..{max_expected}] "
+                f"([{check.min_count}..{check.max_count}] * {num_layers} layers)"
+            )
+            print(msg)
+            if not passed:
+                failures.append(msg.strip())
+        else:
+            expected_count = check.count * num_layers
+            passed = actual_count == expected_count
+            status = "PASS" if passed else "FAIL"
+            msg = (
+                f"  {status}: '{check.op}' count={actual_count}, "
+                f"expected {expected_count} "
+                f"({check.count} * {num_layers} layers)"
+            )
+            print(msg)
+            if not passed:
+                failures.append(msg.strip())
+
+    if failures and strict:
         raise AssertionError("Fusion check failed:\n" + "\n".join(failures))

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -8,6 +8,7 @@ import os
 import numpy as np
 import pytest
 from benchmarks.llm_benchmark import benchmark_llm_torch_xla
+from fusion_check import OpCountPerLayer, OpCountPerLayerBetween
 from llm_utils.token_accuracy import TokenAccuracy
 from loguru import logger
 from utils import create_model_loader, resolve_display_name
@@ -291,8 +292,8 @@ def test_llama_3_2_1b(
             else DEFAULT_OPTIMIZATION_LEVEL
         ),
         expected_ops=[
-            "ttnn.scaled_dot_product_attention",
-            "ttnn.rms_norm",
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+            OpCountPerLayer("ttnn.scaled_dot_product_attention_decode", 1),
         ],
         check_fusions=check_fusions,
     )
@@ -307,6 +308,7 @@ def test_llama_3_2_3b(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -329,6 +331,10 @@ def test_llama_3_2_3b(
             if optimization_level is not None
             else DEFAULT_OPTIMIZATION_LEVEL
         ),
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -341,6 +347,7 @@ def test_gemma_1_1_2b(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.gemma.pytorch.loader import (
         ModelLoader,
@@ -363,6 +370,10 @@ def test_gemma_1_1_2b(
             if optimization_level is not None
             else DEFAULT_OPTIMIZATION_LEVEL
         ),
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -375,6 +386,7 @@ def test_gemma_2_2b(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.gemma.pytorch.loader import (
         ModelLoader,
@@ -397,6 +409,10 @@ def test_gemma_2_2b(
             if optimization_level is not None
             else DEFAULT_OPTIMIZATION_LEVEL
         ),
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -409,6 +425,7 @@ def test_phi1(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.phi1.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -431,6 +448,10 @@ def test_phi1(
             if optimization_level is not None
             else DEFAULT_OPTIMIZATION_LEVEL
         ),
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -511,6 +532,7 @@ def test_falcon3_1b(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.falcon.pytorch.loader import (
         ModelLoader,
@@ -536,6 +558,10 @@ def test_falcon3_1b(
             if optimization_level is not None
             else DEFAULT_OPTIMIZATION_LEVEL
         ),
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -548,6 +574,7 @@ def test_falcon3_3b(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.falcon.pytorch.loader import (
         ModelLoader,
@@ -573,6 +600,10 @@ def test_falcon3_3b(
             if optimization_level is not None
             else DEFAULT_OPTIMIZATION_LEVEL
         ),
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -585,6 +616,7 @@ def test_qwen_2_5_0_5b(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.qwen_2_5.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -608,6 +640,10 @@ def test_qwen_2_5_0_5b(
             if optimization_level is not None
             else DEFAULT_OPTIMIZATION_LEVEL
         ),
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -620,6 +656,7 @@ def test_qwen_3_0_6b(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -642,6 +679,10 @@ def test_qwen_3_0_6b(
             if optimization_level is not None
             else DEFAULT_OPTIMIZATION_LEVEL
         ),
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -654,6 +695,7 @@ def test_qwen_3_1_7b(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -676,6 +718,10 @@ def test_qwen_3_1_7b(
             if optimization_level is not None
             else DEFAULT_OPTIMIZATION_LEVEL
         ),
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -688,6 +734,7 @@ def test_qwen_3_4b(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -710,6 +757,10 @@ def test_qwen_3_4b(
             if optimization_level is not None
             else DEFAULT_OPTIMIZATION_LEVEL
         ),
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -722,6 +773,7 @@ def test_qwen_2_5_1_5b(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.qwen_2_5.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -743,6 +795,10 @@ def test_qwen_2_5_1_5b(
             optimization_level if optimization_level is not None else 1
         ),
         required_pcc=0.90,
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -755,6 +811,7 @@ def test_qwen_2_5_3b(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.qwen_2_5.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -777,6 +834,10 @@ def test_qwen_2_5_3b(
             if optimization_level is not None
             else DEFAULT_OPTIMIZATION_LEVEL
         ),
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -789,6 +850,7 @@ def test_qwen_3_8b(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -811,6 +873,10 @@ def test_qwen_3_8b(
             if optimization_level is not None
             else DEFAULT_OPTIMIZATION_LEVEL
         ),
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -823,6 +889,7 @@ def test_qwen_2_5_7b(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.qwen_2_5.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -844,12 +911,21 @@ def test_qwen_2_5_7b(
             optimization_level if optimization_level is not None else 1
         ),
         required_pcc=0.90,
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
 # FAILED: KeyError: "L['self'].model.lifted_tensor_0"
 def test_gemma_1_1_7b(
-    output_file, num_layers, request, max_output_tokens, optimization_level
+    output_file,
+    num_layers,
+    request,
+    max_output_tokens,
+    optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.gemma.pytorch.loader import (
         ModelLoader,
@@ -869,12 +945,21 @@ def test_gemma_1_1_7b(
             if optimization_level is not None
             else DEFAULT_OPTIMIZATION_LEVEL
         ),
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
 # FAILED: TypeError: Phi3ForCausalLM.forward() got an unexpected keyword argument 'cache_position'
 def test_phi3_mini(
-    output_file, num_layers, request, max_output_tokens, optimization_level
+    output_file,
+    num_layers,
+    request,
+    max_output_tokens,
+    optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.phi3.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -894,12 +979,21 @@ def test_phi3_mini(
             if optimization_level is not None
             else DEFAULT_OPTIMIZATION_LEVEL
         ),
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
 # FAILED: KeyError: 'lifted_tensor_0'
 def test_phi3_5_mini(
-    output_file, num_layers, request, max_output_tokens, optimization_level
+    output_file,
+    num_layers,
+    request,
+    max_output_tokens,
+    optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.phi3.phi_3_5.pytorch.loader import (
         ModelLoader,
@@ -919,12 +1013,21 @@ def test_phi3_5_mini(
             if optimization_level is not None
             else DEFAULT_OPTIMIZATION_LEVEL
         ),
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
 # FAILED: AttributeError: 'MambaConfig' object has no attribute 'num_attention_heads'
 def test_mamba_2_8b(
-    output_file, num_layers, request, max_output_tokens, optimization_level
+    output_file,
+    num_layers,
+    request,
+    max_output_tokens,
+    optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.mamba.pytorch.loader import (
         ModelLoader,
@@ -944,6 +1047,10 @@ def test_mamba_2_8b(
             if optimization_level is not None
             else DEFAULT_OPTIMIZATION_LEVEL
         ),
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -956,6 +1063,7 @@ def test_falcon3_7b(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.falcon.pytorch.loader import (
         ModelLoader,
@@ -981,6 +1089,10 @@ def test_falcon3_7b(
             if optimization_level is not None
             else DEFAULT_OPTIMIZATION_LEVEL
         ),
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -993,6 +1105,7 @@ def test_mistral_7b(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.mistral.pytorch.loader import (
         ModelLoader,
@@ -1015,6 +1128,10 @@ def test_mistral_7b(
             if optimization_level is not None
             else DEFAULT_OPTIMIZATION_LEVEL
         ),
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -1028,6 +1145,7 @@ def test_ministral_8b(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.mistral.pytorch.loader import (
         ModelLoader,
@@ -1052,6 +1170,10 @@ def test_ministral_8b(
             if optimization_level is not None
             else DEFAULT_OPTIMIZATION_LEVEL
         ),
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -1064,6 +1186,7 @@ def test_llama_3_1_8b(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -1088,6 +1211,10 @@ def test_llama_3_1_8b(
             else DEFAULT_OPTIMIZATION_LEVEL
         ),
         required_pcc=0.90,
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -1100,6 +1227,7 @@ def test_falcon3_7b_tp(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.falcon.pytorch.loader import (
         ModelLoader,
@@ -1122,6 +1250,10 @@ def test_falcon3_7b_tp(
             if optimization_level is not None
             else DEFAULT_TP_OPTIMIZATION_LEVEL
         ),
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -1134,6 +1266,7 @@ def test_falcon3_10b_tp(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.falcon.pytorch.loader import (
         ModelLoader,
@@ -1156,6 +1289,10 @@ def test_falcon3_10b_tp(
             if optimization_level is not None
             else DEFAULT_TP_OPTIMIZATION_LEVEL
         ),
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -1168,6 +1305,7 @@ def test_llama_3_1_8b_instruct_tp(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -1190,6 +1328,10 @@ def test_llama_3_1_8b_instruct_tp(
             if optimization_level is not None
             else DEFAULT_TP_OPTIMIZATION_LEVEL
         ),
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -1202,6 +1344,7 @@ def test_mistral_7b_tp(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.mistral.pytorch.loader import (
         ModelLoader,
@@ -1224,6 +1367,10 @@ def test_mistral_7b_tp(
             if optimization_level is not None
             else DEFAULT_TP_OPTIMIZATION_LEVEL
         ),
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -1237,6 +1384,7 @@ def test_ministral_8b_tp(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.mistral.pytorch.loader import (
         ModelLoader,
@@ -1256,6 +1404,10 @@ def test_ministral_8b_tp(
         decode_only=decode_only,
         trace_enabled=False,
         optimization_level=1,
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -1268,6 +1420,7 @@ def test_mistral_nemo_instruct_2407_tp(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.mistral.pytorch.loader import (
         ModelLoader,
@@ -1286,6 +1439,10 @@ def test_mistral_nemo_instruct_2407_tp(
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
         optimization_level=1,
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -1298,6 +1455,7 @@ def test_mistral_small_24b_instruct_2501_tp(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.mistral.pytorch.loader import (
         ModelLoader,
@@ -1316,6 +1474,10 @@ def test_mistral_small_24b_instruct_2501_tp(
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
         optimization_level=1,  # flaky: occasionally hangs in CI with optimization_level=2
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -1328,6 +1490,7 @@ def test_qwen_2_5_14b_instruct_tp(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.qwen_2_5.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -1346,6 +1509,10 @@ def test_qwen_2_5_14b_instruct_tp(
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
         optimization_level=1,
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -1358,6 +1525,7 @@ def test_qwen_2_5_32b_instruct_tp(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.qwen_2_5.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -1380,6 +1548,10 @@ def test_qwen_2_5_32b_instruct_tp(
             if optimization_level is not None
             else DEFAULT_TP_OPTIMIZATION_LEVEL
         ),
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -1392,6 +1564,7 @@ def test_qwen_2_5_coder_32b_instruct_tp(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.qwen_2_5_coder.pytorch.loader import (
         ModelLoader,
@@ -1410,6 +1583,10 @@ def test_qwen_2_5_coder_32b_instruct_tp(
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
         optimization_level=1,
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -1422,6 +1599,7 @@ def test_qwen_3_0_6b_tp(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -1444,6 +1622,10 @@ def test_qwen_3_0_6b_tp(
             if optimization_level is not None
             else DEFAULT_TP_OPTIMIZATION_LEVEL
         ),
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -1456,6 +1638,7 @@ def test_qwen_3_1_7b_tp(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -1478,6 +1661,10 @@ def test_qwen_3_1_7b_tp(
             if optimization_level is not None
             else DEFAULT_TP_OPTIMIZATION_LEVEL
         ),
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -1490,6 +1677,7 @@ def test_qwen_3_8b_tp(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -1508,6 +1696,10 @@ def test_qwen_3_8b_tp(
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
         optimization_level=1,  # flaky: occasionally hangs in CI with optimization_level=2
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -1520,6 +1712,7 @@ def test_qwen_3_14b_tp(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -1538,6 +1731,10 @@ def test_qwen_3_14b_tp(
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
         optimization_level=1,
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -1550,6 +1747,7 @@ def test_qwen_3_32b_tp(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -1572,6 +1770,10 @@ def test_qwen_3_32b_tp(
             if optimization_level is not None
             else DEFAULT_TP_OPTIMIZATION_LEVEL
         ),
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -1584,6 +1786,7 @@ def test_llama_3_8b_instruct_tp(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -1606,6 +1809,10 @@ def test_llama_3_8b_instruct_tp(
             if optimization_level is not None
             else DEFAULT_TP_OPTIMIZATION_LEVEL
         ),
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -1618,6 +1825,7 @@ def test_llama_3_1_8b_tp(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -1640,6 +1848,10 @@ def test_llama_3_1_8b_tp(
             if optimization_level is not None
             else DEFAULT_TP_OPTIMIZATION_LEVEL
         ),
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -1652,6 +1864,7 @@ def test_llama_3_8b_tp(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -1674,6 +1887,10 @@ def test_llama_3_8b_tp(
             if optimization_level is not None
             else DEFAULT_TP_OPTIMIZATION_LEVEL
         ),
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -1686,6 +1903,7 @@ def test_llama_3_1_70b_tp(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -1708,6 +1926,10 @@ def test_llama_3_1_70b_tp(
             "model.layers.*.mlp.up_proj.weight": "bfp_bf4",
         },
         optimization_level=1,  # flaky: occasionally hangs in CI with optimization_level=2
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -1742,6 +1964,7 @@ def test_gpt_oss_20b_tp(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
         ModelLoader,
@@ -1763,6 +1986,10 @@ def test_gpt_oss_20b_tp(
         shard_spec_fn=_gpt_oss_20b_shard_spec_fn,
         trace_enabled=False,
         optimization_level=1,
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -1775,6 +2002,7 @@ def test_gpt_oss_20b_tp_batch_size_1(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
         ModelLoader,
@@ -1795,6 +2023,10 @@ def test_gpt_oss_20b_tp_batch_size_1(
         shard_spec_fn=_gpt_oss_20b_shard_spec_fn,
         batch_size=batch_size if batch_size is not None else 1,
         optimization_level=1,
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -1807,6 +2039,7 @@ def test_llama_3_1_70b_tp_galaxy(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
         ModelLoader,
@@ -1826,6 +2059,10 @@ def test_llama_3_1_70b_tp_galaxy(
         decode_only=decode_only,
         arch="wormhole_galaxy",
         optimization_level=1,
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -1838,6 +2075,7 @@ def test_gpt_oss_20b_tp_galaxy_batch_size_64(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
         ModelLoader,
@@ -1859,6 +2097,11 @@ def test_gpt_oss_20b_tp_galaxy_batch_size_64(
         ),  # 128 fails to compile - https://github.com/tenstorrent/tt-xla/issues/3907
         arch="wormhole_galaxy",
         optimization_level=1,
+        expected_ops=[
+            # TODO(sdjordjevic): Convert back to OpCount(4) once this is resolved https://github.com/tenstorrent/tt-mlir/issues/8415
+            OpCountPerLayerBetween("ttnn.rotary_embedding", 3, 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -1913,6 +2156,7 @@ def test_gpt_oss_120b_tp_dp_galaxy_batch_size_128(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
         ModelLoader,
@@ -1937,6 +2181,10 @@ def test_gpt_oss_120b_tp_dp_galaxy_batch_size_128(
         input_output_sharding_spec=("batch", None),
         kv_cache_sharding_spec=("batch", "model", None, None),
         trace_enabled=True,
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -1949,6 +2197,7 @@ def test_gpt_oss_120b_tp_galaxy_batch_size_64(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
         ModelLoader,
@@ -1973,6 +2222,11 @@ def test_gpt_oss_120b_tp_galaxy_batch_size_64(
         input_output_sharding_spec=("batch", None),
         kv_cache_sharding_spec=("batch", "model", None, None),
         trace_enabled=True,
+        expected_ops=[
+            # TODO(sdjordjevic): Convert back to OpCount(4) once this is resolved https://github.com/tenstorrent/tt-mlir/issues/8415
+            OpCountPerLayerBetween("ttnn.rotary_embedding", 3, 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -2008,6 +2262,7 @@ def test_gpt_oss_120b_tp_qb2(
     max_output_tokens,
     decode_only,
     optimization_level,
+    check_fusions,
 ):
     from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
         ModelLoader,
@@ -2037,6 +2292,10 @@ def test_gpt_oss_120b_tp_qb2(
         required_pcc=0.93,  # set for now as it's ~0.93 on test runs locally
         mesh_config_fn=_gpt_oss_120b_qb2_mesh_config_fn,
         # shard_spec_fn=_gpt_oss_120b_qb2_shard_spec_fn,
+        expected_ops=[
+            OpCountPerLayer("ttnn.rotary_embedding", 4),
+        ],
+        check_fusions=check_fusions,
     )
 
 
@@ -2050,6 +2309,7 @@ def test_kimi_k2_tp_galaxy_2_layers(
     batch_size,
     max_output_tokens,
     decode_only,
+    check_fusions,
 ):
     from third_party.tt_forge_models.kimi_k2.pytorch.loader import (
         ModelLoader,
@@ -2084,6 +2344,7 @@ def test_deepseek_v3_2_exp_tp_galaxy_2_layers(
     batch_size,
     max_output_tokens,
     decode_only,
+    check_fusions,
 ):
     from third_party.tt_forge_models.deepseek.deepseek_v3_2_exp.pytorch.loader import (
         ModelLoader,


### PR DESCRIPTION
### Ticket
N/A

### Summary
- Introduce OpCount and OpCountBetween dataclasses in fusion_check.py for structured, per-layer op count validation in compiled TTNN IR
- Add ttnn.rotary_embedding fusion checks to all LLM benchmark tests (4 per layer for most models, 3-4 range for gpt-oss models, skipped for phi1.5/phi2)
- Fusion stats are always printed; --check-fusions flag makes mismatches fail the test
- Rename PCC/TOPK graph exports with _pcc suffix to distinguish them from perf graphs

### Checklist
- [ ] New/Existing tests provide coverage for changes
