### PR TITLE
Add SDXL-Lightning component tests

### DIFF
--- a/tests/torch/models/sdxl_lightning/__init__.py
+++ b/tests/torch/models/sdxl_lightning/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/torch/models/sdxl_lightning/test_text_encoder.py
+++ b/tests/torch/models/sdxl_lightning/test_text_encoder.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""SDXL-Lightning — CLIPTextModel (text_encoder) component test."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+
+from third_party.tt_forge_models.sdxl_lightning.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.nightly
+@pytest.mark.model_test
+def test_text_encoder():
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.TEXT_ENCODER)
+    model = loader.load_model(dtype_override=torch.float32)
+    inputs = loader.load_inputs(dtype_override=torch.float32)
+
+    run_graph_test(
+        model,
+        inputs,
+        framework=Framework.TORCH,
+    )

--- a/tests/torch/models/sdxl_lightning/test_text_encoder_2.py
+++ b/tests/torch/models/sdxl_lightning/test_text_encoder_2.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""SDXL-Lightning — CLIPTextModelWithProjection (text_encoder_2) component test."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+
+from third_party.tt_forge_models.sdxl_lightning.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.xfail(
+    reason="AssertionError: Evaluation result 0 failed: PCC comparison failed. Calculated: pcc=0.9719658862052095. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/4727"
+)
+@pytest.mark.nightly
+@pytest.mark.model_test
+def test_text_encoder_2():
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.TEXT_ENCODER_2)
+    model = loader.load_model(dtype_override=torch.float32)
+    inputs = loader.load_inputs(dtype_override=torch.float32)
+
+    run_graph_test(
+        model,
+        inputs,
+        framework=Framework.TORCH,
+    )

--- a/tests/torch/models/sdxl_lightning/test_unet.py
+++ b/tests/torch/models/sdxl_lightning/test_unet.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""SDXL-Lightning — UNet2DConditionModel (unet) component test."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+
+from third_party.tt_forge_models.sdxl_lightning.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.nightly
+@pytest.mark.model_test
+def test_unet():
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.UNET)
+    model = loader.load_model(dtype_override=torch.float32)
+    inputs = loader.load_inputs(dtype_override=torch.float32)
+
+    run_graph_test(
+        model,
+        inputs,
+        framework=Framework.TORCH,
+    )

--- a/tests/torch/models/sdxl_lightning/test_vae_decoder.py
+++ b/tests/torch/models/sdxl_lightning/test_vae_decoder.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""SDXL-Lightning — AutoencoderKL (vae) decoder component test."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+
+from third_party.tt_forge_models.sdxl_lightning.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.xfail(
+    reason="Out of Memory: Not enough space to allocate 4294967296 B DRAM buffer across 12 banks, where each bank needs to store 357916672 B, but bank size is 1071821792 B  - https://github.com/tenstorrent/tt-xla/issues/4728"
+)
+@pytest.mark.nightly
+@pytest.mark.model_test
+def test_vae_decoder():
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.VAE)
+    model = loader.load_model(dtype_override=torch.float32)
+    inputs = loader.load_inputs(dtype_override=torch.float32)
+
+    run_graph_test(
+        model,
+        inputs,
+        framework=Framework.TORCH,
+    )


### PR DESCRIPTION
### Ticket

- closes https://github.com/tenstorrent/tt-xla/issues/4729

### Problem description

- Add initial bringup tests for each component of the SDXL-Lightning (4-step distilled SDXL) pipeline & test it in Wormhole.

### What's changed

| File | Component | Tests |
|------|-----------|-------|
| `test_text_encoder.py` | CLIPTextModel — CLIP ViT-L/14 (0.123B) | `test_text_encoder` (passed) |
| `test_text_encoder_2.py` | CLIPTextModelWithProjection — OpenCLIP ViT-bigG/14 (0.695B) | `test_text_encoder_2` (xfail - PCC drop 0.972 < 0.99 - #4727) |
| `test_unet.py` | UNet2DConditionModel — Lightning distilled weights (2.567B) | `test_unet` (passed) |
| `test_vae_decoder.py` | AutoencoderKL (0.084B) | `test_vae_decoder` (xfail - OOM - #4728) |

- Model loading, input generation, and wrapper modules are provided by https://github.com/tenstorrent/tt-forge-models/pull/662

### Checklist
- [x] Verify changes through local testing in Wormhole

### Logs

- [sdxl_lightning_component_logs.zip](https://github.com/user-attachments/files/27802616/sdxl_lightning_component_logs.zip)
