### PR TITLE
[Composite OPs] Register autograd for `xla::mark_tensor`

### DIFF
--- a/python_package/tt_torch/custom_ops.py
+++ b/python_package/tt_torch/custom_ops.py
@@ -76,6 +76,23 @@ def _(ctx, grad_output):
     return grad_output, None, None
 
 
+def _xla_mark_tensor_setup_context(ctx, inputs, output):
+    pass
+
+
+def _xla_mark_tensor_backward(ctx, grad_output):
+    # xla::mark_tensor(Tensor x, str name, int pos, str id, bool is_input, Any? attr)
+    # Only ``x`` is a differentiable Tensor, the rest are metadata so we return None for them.
+    return grad_output, None, None, None, None, None
+
+
+torch.library.register_autograd(
+    "xla::mark_tensor",
+    _xla_mark_tensor_backward,
+    setup_context=_xla_mark_tensor_setup_context,
+)
+
+
 @torch.library.custom_op(
     "tt::sharding_constraint", mutates_args=[], device_types=["cpu", "xla"]
 )


### PR DESCRIPTION
### Ticket
None

### Problem description
During Gemma4 E2B fine-tuning it was noted that backward of `gelu` was missing in IR, with silent fallback that sets grads to 0. 
We register `gelu` op as composite op, which is handled via `StableHLOCompositeBuilder` which calls `xla::mark_tensor` on inputs&outputs of op. Given that `xla::mark_tensor` had no registered autograd, backward pass was executed incorrectly through them, propagating error through rest of the model and training steps.

### What's changed
Registered autograd for `xla::mark_tensor`, with pass-through backward.

### Checklist
- [ ] New/Existing tests provide coverage for changes
