### PR TITLE
[PJRT] stop clearing program cache on executable destroy

### DIFF
--- a/pjrt_implementation/inc/api/loaded_executable_instance.h
+++ b/pjrt_implementation/inc/api/loaded_executable_instance.h
@@ -47,8 +47,7 @@ public:
   static void bindApi(PJRT_Api *api);
 
   // Virtual destructor for proper cleanup of derived classes
-  // Clears program cache on instance destroy.
-  virtual ~LoadedExecutableInstance();
+  virtual ~LoadedExecutableInstance() = default;
 
   // Casts this loaded executable instance to PJRT_LoadedExecutable pointer.
   operator PJRT_LoadedExecutable *() {

--- a/pjrt_implementation/src/api/loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/loaded_executable_instance.cc
@@ -9,7 +9,6 @@
 // https://llvm.org/LICENSE.txt
 
 #include "api/loaded_executable_instance.h"
-#include "tt/runtime/types.h"
 
 // c++ standard library includes
 #include <filesystem>
@@ -42,18 +41,6 @@
 #include "utils/logging.h"
 
 namespace tt::pjrt {
-
-// Clears program cache on instance destroy.
-LoadedExecutableInstance::~LoadedExecutableInstance() {
-  using namespace tt::runtime;
-
-  const std::optional<Device> &device = m_client_instance->parentMesh();
-  if (device && getCurrentHostRuntime() == HostRuntime::Local &&
-      isProgramCacheEnabled(*device)) {
-    DLOG_F(LOG_DEBUG, "Clearing program cache.");
-    clearProgramCache(*device);
-  }
-}
 
 void LoadedExecutableInstance::bindApi(PJRT_Api *api) {
   api->PJRT_LoadedExecutable_Destroy = internal::onLoadedExecutableDestroy;


### PR DESCRIPTION
### Ticket
Fixes: #4051

### Problem description
Described in issue.

### What's changed
- Program cache is no longer cleared on `LoadedExecutableInstance` destroy

### Checklist
- [x] Run locally llms to see `L1_SMALL` usage
- [x] Run nightly
- [x] Run perf benchmark
