### PR TITLE
[vLLM tests] Fix INTERNALERROR in cleanup hook; relax `test_seed_mixed_batch` xfail to strict=False (onPR Flaky Fail)

### DIFF
--- a/tests/integrations/vllm_plugin/conftest.py
+++ b/tests/integrations/vllm_plugin/conftest.py
@@ -23,8 +23,14 @@ def pytest_runtest_makereport(item, call):
     if report.when != "call" or not report.failed:
         return
     for obj in gc.get_objects():
-        if isinstance(obj, vllm.LLM):
-            try:
-                obj.llm_engine.engine_core.shutdown()
-            except Exception:
-                pass
+        try:
+            is_llm = isinstance(obj, vllm.LLM)
+        except ReferenceError:
+            # Dead weakref proxies in gc.get_objects() raise here.
+            continue
+        if not is_llm:
+            continue
+        try:
+            obj.llm_engine.engine_core.shutdown()
+        except Exception:
+            pass

--- a/tests/integrations/vllm_plugin/sampling/test_sampling_params_synthetic.py
+++ b/tests/integrations/vllm_plugin/sampling/test_sampling_params_synthetic.py
@@ -606,7 +606,7 @@ def test_gather_logprobs_topk_indices_exact_on_device(device):
 @pytest.mark.single_device
 @pytest.mark.parametrize("vocab_size", VOCAB_SIZES)
 @pytest.mark.xfail(
-    strict=True,
+    strict=False,
     reason=(
         "Device sampler does not honor per-row seeds: the tt::sampling "
         "kernel uses a single shared seed across all 32 cores and ignores "


### PR DESCRIPTION
### Ticket

Fixes #4735
Related: #4539

### Problem description

- A flaky test failure in onPR reported yesterday
- On p150b CI, `test_seed_mixed_batch[qwen3_32b]` aborts the test session with pytest `INTERNALERROR` (exit code 3), preventing subsequent variants from running. Two interacting issues: (1) `strict=True` xfail converts an accidental XPASS into a failed report — same flake mechanism documented in #4539 for the sister test; (2) the cleanup hook then hits `ReferenceError` on a dead `weakref.proxy` returned by `gc.get_objects()`.

### What's changed

- **`tests/integrations/vllm_plugin/sampling/test_sampling_params_synthetic.py`**: relax `test_seed_mixed_batch` from `strict=True` to `strict=False`, matching the precedent set for `test_seed_precomputed_noise` in #4539.
- **`tests/integrations/vllm_plugin/conftest.py`**: wrap `isinstance(obj, vllm.LLM)` with `try/except ReferenceError` to skip dead weakref proxies in `gc.get_objects()`. Matches the existing pattern at `tests/conftest.py:534`.

### Checklist

- [x] Reproduced original INTERNALERROR via synthetic pytest harness and confirmed the fix resolves it
- [x] Ran 8/8 seed-test variants on p150b — all XFAIL, no INTERNALERROR
- [x] vLLM Nightly: https://github.com/tenstorrent/tt-xla/actions/runs/25964007998