### PR TITLE
[fix] tt_torch dynamo: patch wrap_values NameError in NNModuleVariable.call_method

### DIFF
--- a/python_package/tt_torch/utils.py
+++ b/python_package/tt_torch/utils.py
@@ -31,6 +31,139 @@ def apply_dynamo_compatibility_patches():
     """Apply TorchDynamo compatibility patches for TT devices."""
     torch._C._accelerator_getDeviceIndex = cpu_device_index
     torch._C._accelerator_getStream = cpu_stream
+    apply_dynamo_nn_module_wrap_values_patch()
+
+
+# TODO: https://github.com/tenstorrent/tt-xla/issues/4806
+_DYNAMO_WRAP_VALUES_BUG_TORCH_VERSION = "2.10.0"
+
+
+def _wrap_values_patch_warn(msg: str) -> None:
+    """
+    Emit a warning about the ``wrap_values`` Dynamo patch.
+
+    Prefers the project's ``ttxla_tools`` logger (matches the convention in
+    the rest of ``tt_torch``), but lazily imported so this module stays
+    importable even if ``ttxla_tools`` is not on the path yet. Falls back to
+    the stdlib ``warnings`` module so the message is never silently dropped.
+    """
+    full_msg = f"[tt_torch] dynamo wrap_values patch: {msg}"
+    try:
+        from ttxla_tools.logging import logger
+
+        logger.warning(full_msg)
+    except Exception:
+        import warnings
+
+        warnings.warn(full_msg, RuntimeWarning, stacklevel=3)
+
+
+def apply_dynamo_nn_module_wrap_values_patch() -> None:
+    """
+    Patch a bug in torch._dynamo's ``NNModuleVariable.call_method`` where the
+    local helper ``wrap_values`` references an undefined ``named_children``
+    free variable instead of its local ``result`` list. This raises
+    ``InternalTorchDynamoError: NameError: cannot access free variable
+    'named_children' ...`` whenever Dynamo traces ``nn.Module`` methods like
+    ``.parameters()``, ``.children()``, ``.modules()`` or ``.buffers()`` (e.g.
+    via transformers' ``invert_attention_mask`` -> ``self.dtype``).
+
+    Introduced in pytorch/pytorch#167342, fixed upstream in
+    pytorch/pytorch#174399. Only applied on the exact torch release that
+    contains the bug (see ``_DYNAMO_WRAP_VALUES_BUG_TORCH_VERSION``); remove
+    this patch once we move to a torch release containing the upstream fix.
+
+    Safe to call multiple times (no-op after the first successful apply, or
+    when running on a torch version that no longer contains the bug). Any
+    unexpected failure inside this routine is surfaced as a warning rather
+    than silently swallowed -- if the patch fails to apply on a torch
+    version that *should* contain the bug, downstream Dynamo compilation
+    errors would otherwise be hard to attribute.
+    """
+    # Strip any local-version suffix, e.g. "2.10.0+cpu" / "2.10.0+cu121".
+    torch_version = torch.__version__.split("+", 1)[0]
+    if torch_version != _DYNAMO_WRAP_VALUES_BUG_TORCH_VERSION:
+        return
+
+    try:
+        from torch._dynamo.variables import nn_module as _nn_module_mod
+        from torch._dynamo.variables.nn_module import NNModuleVariable
+    except ImportError as exc:
+        _wrap_values_patch_warn(
+            f"could not import torch._dynamo.variables.nn_module ({exc!r}); "
+            "patch not applied"
+        )
+        return
+
+    if getattr(
+        NNModuleVariable.call_method, "_tt_xla_wrap_values_patch_applied", False
+    ):
+        return
+
+    import inspect
+    import re
+    import textwrap
+
+    try:
+        src = textwrap.dedent(inspect.getsource(NNModuleVariable.call_method))
+    except (OSError, TypeError) as exc:
+        _wrap_values_patch_warn(
+            f"inspect.getsource(NNModuleVariable.call_method) failed "
+            f"({exc!r}); patch not applied"
+        )
+        return
+
+    # Anchor the rewrite on the `wrap_values` helper specifically rather than
+    # on the bare ``named_children, mutation_type=...`` string. The helper is
+    # the only place in ``call_method`` that mistakenly references
+    # ``named_children`` (its local accumulator is called ``result``); every
+    # other branch -- including the legitimate ``name == "named_children"``
+    # branch and the ``name == "named_parameters"`` etc. branches -- builds
+    # and returns a correctly-named list. Matching on ``def wrap_values(...
+    # return ListIteratorVariable(named_children, ...)`` therefore stays
+    # correct even if upstream later adds a third occurrence of the bare
+    # marker above the buggy site.
+    wrap_values_bug_re = re.compile(
+        r"(def\s+wrap_values\s*\([^)]*\)[^:]*:"  # def wrap_values(items: ...) -> ...:
+        r".*?"  # function body (non-greedy)
+        r"return\s+ListIteratorVariable\(\s*)"  # return ListIteratorVariable(
+        r"named_children"  # the misnamed free variable
+        r"(\s*,\s*mutation_type\s*=\s*"  # , mutation_type=
+        r"ValueMutationNew\(\)\s*\))",  # ValueMutationNew())
+        flags=re.DOTALL,
+    )
+    match = wrap_values_bug_re.search(src)
+    if match is None:
+        _wrap_values_patch_warn(
+            "could not locate the buggy `wrap_values` return in "
+            f"NNModuleVariable.call_method source on torch {torch_version}; "
+            "source layout likely changed, patch not applied"
+        )
+        return
+    new_src = wrap_values_bug_re.sub(r"\1result\2", src, count=1)
+
+    namespace: dict = {}
+    try:
+        exec(
+            compile(new_src, _nn_module_mod.__file__, "exec"),
+            _nn_module_mod.__dict__,
+            namespace,
+        )
+    except Exception as exc:
+        _wrap_values_patch_warn(
+            f"failed to compile/exec rewritten call_method ({exc!r}); patch "
+            "not applied"
+        )
+        return
+
+    patched = namespace.get("call_method")
+    if patched is None:
+        _wrap_values_patch_warn(
+            "rewritten module did not define `call_method`; patch not applied"
+        )
+        return
+    patched._tt_xla_wrap_values_patch_applied = True
+    NNModuleVariable.call_method = patched
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/4738

### Problem description
On torch==2.10.0, Dynamo's `NNModuleVariable.call_method` has a bug where the `wrap_values` helper returns `ListIteratorVariable(named_children, ...)` instead of its local `result` list, raising `NameError: cannot access free
variable 'named_children' ...` whenever a traced `forward` calls`.parameters()`, `.children()`, `.modules()` or `.buffers()`. The bug is only reachable when `inline_inbuilt_nn_modules = False`, which `torch_plugin_tt` sets globally, so every such model is broken on tt-xla today (perceiver/Language_Perceiver).Fixed upstream in pytorch/pytorch#174399 (post-2.10), so this PR installs an
equivalent runtime patch until we bump torch.

### What's changed
- Add `apply_dynamo_nn_module_wrap_values_patch()` in `python_package/tt_torch/utils.py` and call it from
  `apply_dynamo_compatibility_patches()` (already runs at `import tt_torch`).
- The patch sources `NNModuleVariable.call_method` via `inspect.getsource`, rewrites the single buggy `named_children` reference inside `wrap_values` to `result` (`count=1`; the legitimate use in the `name == "named_children"`  branch is left untouched), and `exec`s it in the original module's globals.
- Idempotent and self-disables when the upstream source no longer contains the buggy pattern, so the helper becomes a no-op (and can be deleted) once we move to a torch release containing pytorch/pytorch#174399.


Before fix:
```
test_all_models_torch[perceiver/pytorch-Language_Perceiver-single_device-inference]                                                        language    generality  bfloat16       n150         FAILED_FE_COMPILATION      PASSING       N/A                    0.99       PCC_EN   single_device    14.253    N/A           
test_all_models_torch[perceiver/pytorch-Language_Perceiver-single_device-inference]                                                        language    generality  bfloat16       p150         FAILED_FE_COMPILATION      PASSING       N/A                    0.99       PCC_EN   single_device    10.429    N/A           

```
After fix:(models are passing)
https://github.com/tenstorrent/tt-xla/actions/runs/25987835900
https://github.com/tenstorrent/tt-xla/actions/runs/25987856765


### Checklist
- [ ] New/Existing tests provide coverage for changes
