### PR TITLE
Nightly Maintance may16

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -1434,8 +1434,8 @@ test_config:
     status: EXPECTED_PASSING
 
   bi_lstm_crf/pytorch-Default-single_device-inference:
-    status: KNOWN_FAILURE_XFAIL
-    reason: "RuntimeError: The tensor has a non-zero number of elements, but its data is not allocated yet."
+    status: EXPECTED_PASSING
+
 
   flux/pytorch-Schnell-single_device-inference:
     supported_archs: ["p150"]

--- a/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
@@ -27,7 +27,6 @@ test_config:
 
   qwen_2_5/causal_lm/pytorch-1.5B_Instruct-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     status: EXPECTED_PASSING
-    required_pcc: 0.98
 
   qwen_2_5/causal_lm/pytorch-3B_Instruct-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     status: EXPECTED_PASSING


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Nightly Maintance may16

### What's changed
Since the model is now passing in nightly runs, I’ve updated the configuration file accordingly.


```
test_all_models_torch[bi_lstm_crf/pytorch-Default-single_device-inference]                                                                  language    red         bfloat16       n150          PASSED                     XFAIL         1.0                     0.99       PCC_EN   single_device    21.503    RM_XFAIL                
test_all_models_torch[bi_lstm_crf/pytorch-Default-single_device-inference]                                                                  language    red         bfloat16       p150          PASSED                     XFAIL         1.0                     0.99       PCC_EN   single_device    14.453    RM_XFAIL                

test_llms_torch[qwen_2_5/causal_lm/pytorch-1.5B_Instruct-llm_decode-seq_1-batch_1-single_device-mesh_default-inference]                     language    red         bfloat16       n150          PASSED                     PASSING       0.9996338345407176      0.98       PCC_EN   single_device    82.115    RAISE_PCC_099           
test_llms_torch[qwen_2_5/causal_lm/pytorch-1.5B_Instruct-llm_decode-seq_1-batch_1-single_device-mesh_default-inference]                     language    red         bfloat16       p150          PASSED                     PASSING       0.9995970004658922      0.98       PCC_EN   single_device    64.594    RAISE_PCC_099           


```
### Checklist
- [ ] New/Existing tests provide coverage for changes
