### PR TITLE
[WIP] Remove identity variant of `mesh_shard` op

### DIFF
--- a/pjrt_implementation/inc/api/module_builder/module_builder.h
+++ b/pjrt_implementation/inc/api/module_builder/module_builder.h
@@ -265,46 +265,6 @@ private:
   static std::string
   getMlirCode(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module);
 
-  // Collect input sharding if we are using GSPMD.
-  tt_pjrt_status collectInputShardingsGSPMD(
-      const mlir::OwningOpRef<mlir::ModuleOp> &module,
-      std::vector<mlir::tt::sharding_utils::MeshSharding> &input_shardings);
-
-  // Collect output sharding if we are using GSPMD.
-  tt_pjrt_status collectOutputShardingsGSPMD(
-      const mlir::OwningOpRef<mlir::ModuleOp> &module,
-      std::vector<mlir::tt::sharding_utils::MeshSharding> &output_shardings);
-
-  // Collect input sharding if we are using Shardy.
-  std::optional<std::vector<mlir::tt::sharding_utils::MeshSharding>>
-  collectInputShardingsShardy(const mlir::OwningOpRef<mlir::ModuleOp> &module);
-
-  // Collect output sharding if we are using Shardy.
-  std::optional<std::vector<mlir::tt::sharding_utils::MeshSharding>>
-  collectOutputShardingsShardy(const mlir::OwningOpRef<mlir::ModuleOp> &module);
-
-  // Checks if the StableHLO code is using the Shardy mlir dialect.
-  bool isUsingShardy(const mlir::OwningOpRef<mlir::ModuleOp> &module);
-
-  // Checks if the StableHLO code is using manual computation ops of the Shardy
-  // mlir dialect.
-  bool isUsingShardyManualComputation(
-      const mlir::OwningOpRef<mlir::ModuleOp> &module);
-
-  // Takes a vector of string attributes representing GSPMD sharding and fills
-  // the vector of tt_mlir Sharding with the appropriate corresponding values.
-  static mlir::LogicalResult createShardingsFromGSPMD(
-      const std::vector<mlir::StringAttr> &gspmd_attributes,
-      std::vector<mlir::tt::sharding_utils::MeshSharding> &shardings);
-
-  // Takes a vector of Shardy sharding attributes, the overall Shardy mesh and
-  // fills the vector of tt_mlir MeshSharding objects with the appropriate
-  // corresponding values.
-  static mlir::LogicalResult createShardingsFromShardy(
-      std::vector<mlir::sdy::TensorShardingAttr> &shardy_attributes,
-      const mlir::sdy::MeshAttr &shardy_mesh,
-      std::vector<mlir::tt::sharding_utils::MeshSharding> &shardings);
-
   // Collects memory kinds for output buffers.
   static void collectMemoryKinds(size_t num_outputs,
                                  std::vector<const char *> &memory_kinds,

--- a/pjrt_implementation/src/api/executable_image.cc
+++ b/pjrt_implementation/src/api/executable_image.cc
@@ -228,48 +228,6 @@ FlatbufferExecutableImage::FlatbufferExecutableImage(
            "getNumOutputs()={}, output_specs.size()={}",
            this->getNumOutputs(), output_specs.size());
 
-  int output_dims_so_far = 0;
-  for (size_t output_index = 0; output_index < getNumOutputs();
-       ++output_index) {
-    // Complex types are lowered by the TT-MLIR compiler to float tensors with
-    // a trailing dimension of 2 (interleaved real/imag pairs), so the
-    // flatbuffer shape will have one extra trailing dimension compared to the
-    // MLIR module shape.
-    std::vector<std::uint32_t> expected_shape =
-        getOutputDimensions()[output_index];
-    if (data_type_utils::isComplexPJRTType(getOutputTypes()[output_index])) {
-      expected_shape.push_back(2);
-    }
-
-    TT_FATAL(expected_shape == output_specs[output_index].shape,
-             "Output shape from flatbuffer binary does not match the one "
-             "collected from the MLIR module: output_index={}",
-             output_index);
-
-    TT_FATAL(getOutputRanks()[output_index] ==
-                 getOutputDimensions()[output_index].size(),
-             "Output rank from flatbuffer binary does not match the one "
-             "collected from the MLIR module: output_index={}, "
-             "getOutputRanks()[output_index]={}, "
-             "getOutputDimensions()[output_index].size()={}",
-             output_index, getOutputRanks()[output_index],
-             getOutputDimensions()[output_index].size());
-
-    for (auto dim_index = 0;
-         dim_index < getOutputDimensions()[output_index].size(); dim_index++) {
-      TT_FATAL(getOutputDimensionsFlat()[output_dims_so_far + dim_index] ==
-                   static_cast<std::int64_t>(
-                       getOutputDimensions()[output_index][dim_index]),
-               "Output flat dimension from flatbuffer binary does not match "
-               "the one collected from the MLIR module: output_index={}, "
-               "dim_index={}, flat_dim={}, mlir_dim={}",
-               output_index, dim_index,
-               getOutputDimensionsFlat()[output_dims_so_far + dim_index],
-               getOutputDimensions()[output_index][dim_index]);
-    }
-
-    output_dims_so_far += getOutputDimensions()[output_index].size();
-  }
 
   // Generate fingerprint after all dependencies are initialized
   m_fingerprint = generateFingerprint();

--- a/pjrt_implementation/src/api/loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/loaded_executable_instance.cc
@@ -225,10 +225,9 @@ LoadedExecutableInstance::getOutputShape(size_t output_index) const {
   const mlir::tt::sharding_utils::MeshSharding &output_sharding =
       m_executable_image->getOutputSharding(output_index);
 
+  // Per-device shape equals the global shape for replicated outputs.
   if (output_sharding.getShardType() ==
-          mlir::tt::ttcore::MeshShardType::Identity ||
-      output_sharding.getShardType() ==
-          mlir::tt::ttcore::MeshShardType::Replicate) {
+      mlir::tt::ttcore::MeshShardType::Replicate) {
     return output_shape;
   }
 
@@ -362,6 +361,7 @@ LoadedExecutableInstance::fillStrategyMapFromSharding(
     const mlir::tt::sharding_utils::MeshSharding &meshSharding,
     size_t num_devices) {
   std::unordered_map<std::string, std::string> strategy;
+
   mlir::tt::ttcore::MeshShardType meshType = meshSharding.getShardType();
   if (meshType == mlir::tt::ttcore::MeshShardType::Replicate) {
     // If there is only one device, the output will be replicated, but there is
@@ -386,8 +386,6 @@ LoadedExecutableInstance::fillStrategyMapFromSharding(
       strategy["mesh_shape_y"] = std::to_string(mesh_shape_data[0]);
       strategy["mesh_shape_x"] = std::to_string(mesh_shape_data[1]);
     }
-  } else if (meshType == mlir::tt::ttcore::MeshShardType::Identity) {
-    strategy["strategy"] = "identity";
   } else {
     return mlir::failure();
   }

--- a/pjrt_implementation/src/api/module_builder/module_builder.cc
+++ b/pjrt_implementation/src/api/module_builder/module_builder.cc
@@ -53,8 +53,8 @@
 #include "tt/runtime/types.h"
 #include "ttmlir/Dialect/StableHLO/Pipelines/StableHLOPipelines.h"
 #include "ttmlir/Dialect/StableHLO/Utils/GSPMDUtils.h"
+#include "ttmlir/Dialect/StableHLO/Utils/MeshShardingCollection.h"
 #include "ttmlir/Dialect/StableHLO/Utils/ShardingUtils.h"
-#include "ttmlir/Dialect/StableHLO/Utils/ShardyUtils.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 #include "ttmlir/Dialect/TTIR/Pipelines/TTIRPipelines.h"
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
@@ -350,26 +350,6 @@ ModuleBuilder::buildModule(
     return {status, nullptr};
   }
 
-  // Shardy output shardings must be collected after the SHLO compiler pipeline
-  // is run. If shardy is being used, overwrite the GSPMD shardings collected
-  // earlier.
-  bool is_using_shardy_output_shardings =
-      isUsingShardyManualComputation(mlir_module);
-  DLOG_F(LOG_DEBUG,
-         "SHLO compiler pipeline run completed - is using shardy output "
-         "shardings: %d",
-         is_using_shardy_output_shardings);
-
-  if (is_using_shardy_output_shardings) {
-    // Clear the GSPMD shardings collected earlier before collecting shardy
-    // shardings.
-    output_shardings.clear();
-    status = collectOutputShardings(mlir_module, output_shardings);
-    if (!tt_pjrt_status_is_ok(status)) {
-      return {status, nullptr};
-    }
-  }
-
   // Sanitize the module for XLA ingestion operating on a clone of the base
   // module.
   mlir::OwningOpRef<mlir::ModuleOp> sanitized_module = mlir_module->clone();
@@ -511,150 +491,34 @@ ModuleBuilder::getMlirCode(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module) {
 tt_pjrt_status ModuleBuilder::collectInputShardings(
     const mlir::OwningOpRef<mlir::ModuleOp> &module,
     std::vector<mlir::tt::sharding_utils::MeshSharding> &input_shardings) {
-  if (auto shardy_shardings_opt = collectInputShardingsShardy(module)) {
-    input_shardings = *shardy_shardings_opt;
-    return tt_pjrt_status::kSuccess;
-  }
-  return collectInputShardingsGSPMD(module, input_shardings);
-}
-
-tt_pjrt_status ModuleBuilder::collectInputShardingsGSPMD(
-    const mlir::OwningOpRef<mlir::ModuleOp> &module,
-    std::vector<mlir::tt::sharding_utils::MeshSharding> &input_shardings) {
-
-  std::vector<mlir::func::FuncOp> publicFuncOps = getPublicFuncOps(module);
-  std::vector<mlir::StringAttr> gspmd_attributes;
-  for (mlir::func::FuncOp &func_op : publicFuncOps) {
-    for (unsigned int i = 0; i < func_op.getNumArguments(); ++i) {
-      gspmd_attributes.push_back(llvm::dyn_cast_if_present<mlir::StringAttr>(
-          func_op.getArgAttr(i, mlir::tt::gspmd_utils::kXlaShardingAttr)));
+  for (mlir::func::FuncOp &func_op : getPublicFuncOps(module)) {
+    auto collected = mlir::tt::sharding_utils::collectArgMeshShardings(func_op);
+    if (auto err = collected.takeError()) {
+      LOG_F(ERROR, "Failed to collect input shardings: %s",
+            llvm::toString(std::move(err)).c_str());
+      return tt_pjrt_status::kInternal;
     }
+    input_shardings.insert(input_shardings.end(), collected->begin(),
+                           collected->end());
   }
-
-  mlir::LogicalResult result =
-      createShardingsFromGSPMD(gspmd_attributes, input_shardings);
-  if (result.failed()) {
-    LOG_F(ERROR, "Failed to create input shardings from GSPMD attributes");
-    return tt_pjrt_status::kInternal;
-  }
-
   return tt_pjrt_status::kSuccess;
-}
-
-std::optional<std::vector<mlir::tt::sharding_utils::MeshSharding>>
-ModuleBuilder::collectInputShardingsShardy(
-    const mlir::OwningOpRef<mlir::ModuleOp> &module) {
-  auto mesh_op_opt = getFirstShardyMeshOp(module);
-  if (!mesh_op_opt.has_value()) {
-    return std::nullopt;
-  }
-
-  mlir::sdy::MeshOp mesh_op = *mesh_op_opt;
-  mlir::sdy::MeshAttr shardy_mesh = mesh_op.getMesh();
-  std::vector<mlir::func::FuncOp> publicFuncOps = getPublicFuncOps(module);
-  std::vector<mlir::sdy::TensorShardingAttr> shardy_attributes;
-
-  for (mlir::func::FuncOp &func_op : publicFuncOps) {
-    for (unsigned int arg_index = 0; arg_index < func_op.getNumArguments();
-         ++arg_index) {
-      shardy_attributes.push_back(
-          func_op.getArgAttrOfType<mlir::sdy::TensorShardingAttr>(
-              arg_index, mlir::sdy::kShardingAttr));
-    }
-  }
-
-  std::vector<mlir::tt::sharding_utils::MeshSharding> input_shardings;
-  mlir::LogicalResult result = createShardingsFromShardy(
-      shardy_attributes, shardy_mesh, input_shardings);
-  if (result.failed()) {
-    LOG_F(ERROR, "Failed to create input shardings from Shardy attributes");
-    return std::nullopt;
-  }
-  return input_shardings;
 }
 
 tt_pjrt_status ModuleBuilder::collectOutputShardings(
     const mlir::OwningOpRef<mlir::ModuleOp> &module,
     std::vector<mlir::tt::sharding_utils::MeshSharding> &output_shardings) {
-  if (auto shardy_shardings_opt = collectOutputShardingsShardy(module)) {
-    output_shardings = *shardy_shardings_opt;
-    return tt_pjrt_status::kSuccess;
-  }
-  return collectOutputShardingsGSPMD(module, output_shardings);
-}
-
-tt_pjrt_status ModuleBuilder::collectOutputShardingsGSPMD(
-    const mlir::OwningOpRef<mlir::ModuleOp> &module,
-    std::vector<mlir::tt::sharding_utils::MeshSharding> &output_shardings) {
-  std::vector<mlir::func::FuncOp> publicFuncOps = getPublicFuncOps(module);
-  std::vector<mlir::StringAttr> gspmd_attributes;
-  for (mlir::func::FuncOp &func_op : publicFuncOps) {
-    for (unsigned int i = 0; i < func_op.getNumResults(); ++i) {
-      gspmd_attributes.push_back(llvm::dyn_cast_if_present<mlir::StringAttr>(
-          func_op.getResultAttr(i, mlir::tt::gspmd_utils::kXlaShardingAttr)));
+  for (mlir::func::FuncOp &func_op : getPublicFuncOps(module)) {
+    auto collected =
+        mlir::tt::sharding_utils::collectResultMeshShardings(func_op);
+    if (auto err = collected.takeError()) {
+      LOG_F(ERROR, "Failed to collect output shardings: %s",
+            llvm::toString(std::move(err)).c_str());
+      return tt_pjrt_status::kInternal;
     }
-  }
-
-  mlir::LogicalResult result =
-      createShardingsFromGSPMD(gspmd_attributes, output_shardings);
-  if (result.failed()) {
-    LOG_F(ERROR, "Failed to create output shardings from GSPMD attributes");
-    return tt_pjrt_status::kInternal;
+    output_shardings.insert(output_shardings.end(), collected->begin(),
+                            collected->end());
   }
   return tt_pjrt_status::kSuccess;
-}
-
-std::optional<std::vector<mlir::tt::sharding_utils::MeshSharding>>
-ModuleBuilder::collectOutputShardingsShardy(
-    const mlir::OwningOpRef<mlir::ModuleOp> &module) {
-  auto mesh_op_opt = getFirstShardyMeshOp(module);
-  if (!mesh_op_opt.has_value()) {
-    return std::nullopt;
-  }
-
-  mlir::sdy::MeshOp mesh_op = *mesh_op_opt;
-  mlir::sdy::MeshAttr shardy_mesh = mesh_op.getMesh();
-  std::vector<mlir::func::FuncOp> publicFuncOps = getPublicFuncOps(module);
-  std::vector<mlir::sdy::TensorShardingAttr> shardy_attributes;
-  for (mlir::func::FuncOp &func_op : publicFuncOps) {
-    std::vector<mlir::sdy::ManualComputationOp> manual_computation_ops;
-    func_op.walk([&](mlir::sdy::ManualComputationOp op) {
-      manual_computation_ops.push_back(op);
-    });
-
-    // zero manual computation ops may exist if execution is entirely replicated
-    // In this case, we must insert as many nullptr into shardy_attributes as
-    // there are results in the funcOp so that createShardingsFromShardy will
-    // generate the correct number of default output shardings
-    if (manual_computation_ops.size() == 0) {
-      for (size_t i = 0; i < func_op.getNumResults(); ++i) {
-        shardy_attributes.push_back(nullptr);
-      }
-      continue;
-    }
-
-    if (manual_computation_ops.size() != 1) {
-      LOG_F(ERROR,
-            "Expected exactly zero or one manual computation op, found: %zu",
-            manual_computation_ops.size());
-      return std::nullopt;
-    }
-    mlir::sdy::ManualComputationOp manual_op = manual_computation_ops[0];
-    mlir::sdy::TensorShardingPerValueAttr out_shardings =
-        manual_op.getOutShardings();
-    for (size_t i = 0; i < out_shardings.size(); ++i) {
-      shardy_attributes.push_back(out_shardings.getSharding(i));
-    }
-  }
-
-  std::vector<mlir::tt::sharding_utils::MeshSharding> output_shardings;
-  mlir::LogicalResult result = createShardingsFromShardy(
-      shardy_attributes, shardy_mesh, output_shardings);
-  if (result.failed()) {
-    LOG_F(ERROR, "Failed to create output shardings from Shardy attributes");
-    return std::nullopt;
-  }
-  return output_shardings;
 }
 
 std::vector<PJRT_Buffer_Type> ModuleBuilder::collectOutputTypes(
@@ -744,80 +608,6 @@ bool ModuleBuilder::isScalarType(mlir::Type type) {
     return tensorType.getRank() == 0;
   }
   return false;
-}
-
-mlir::LogicalResult ModuleBuilder::createShardingsFromGSPMD(
-    const std::vector<mlir::StringAttr> &gspmd_attributes,
-    std::vector<mlir::tt::sharding_utils::MeshSharding> &shardings) {
-
-  for (const mlir::StringAttr &gspmd_attr : gspmd_attributes) {
-
-    // If there is no sharding attribute, we put the default sharding,
-    // which means there is no sharding.
-    if (!gspmd_attr) {
-      llvm::Expected<mlir::tt::gspmd_utils::GSPMDMeshSharding>
-          default_mesh_sharding_result =
-              mlir::tt::gspmd_utils::GSPMDMeshSharding::generateDefault();
-      if (default_mesh_sharding_result.takeError()) {
-        LOG_F(ERROR, "Failed to generate default mesh sharding");
-        return llvm::LogicalResult::failure();
-      }
-      shardings.push_back(*default_mesh_sharding_result);
-      continue;
-    }
-    llvm::Expected<mlir::tt::gspmd_utils::GSPMDMeshSharding>
-        mesh_sharding_result =
-            mlir::tt::gspmd_utils::GSPMDMeshSharding::generate(
-                gspmd_attr.getValue(),
-                /*operandShardingStr=*/gspmd_attr.getValue(),
-                mlir::tt::ttcore::ShardStatus::Unsharded,
-                mlir::tt::ttcore::MeshShardDirection::FullToShard);
-    if (mesh_sharding_result.takeError()) {
-      LOG_F(ERROR, "Failed to convert sharding attribute to mesh sharding");
-      return llvm::LogicalResult::failure();
-    }
-
-    shardings.push_back(*mesh_sharding_result);
-  }
-
-  return llvm::LogicalResult::success();
-}
-
-mlir::LogicalResult ModuleBuilder::createShardingsFromShardy(
-    std::vector<mlir::sdy::TensorShardingAttr> &shardy_attributes,
-    const mlir::sdy::MeshAttr &shardy_mesh,
-    std::vector<mlir::tt::sharding_utils::MeshSharding> &shardings) {
-  for (const mlir::sdy::TensorShardingAttr &shardy_attr : shardy_attributes) {
-
-    // If there is no sharding attribute, we put the default sharding,
-    // which means there is no sharding.
-    if (!shardy_attr) {
-      llvm::Expected<mlir::tt::shardy_utils::ShardyMeshSharding>
-          default_mesh_sharding_result =
-              mlir::tt::shardy_utils::ShardyMeshSharding::generateDefault();
-      if (llvm::Error e = default_mesh_sharding_result.takeError()) {
-        LOG_F(ERROR, "Failed to generate default mesh sharding");
-        return llvm::LogicalResult::failure();
-      }
-      shardings.push_back(*default_mesh_sharding_result);
-      continue;
-    }
-
-    llvm::Expected<mlir::tt::shardy_utils::ShardyMeshSharding>
-        mesh_sharding_result =
-            mlir::tt::shardy_utils::ShardyMeshSharding::generate(
-                shardy_mesh, shardy_attr,
-                mlir::tt::ttcore::ShardStatus::Unsharded,
-                mlir::tt::ttcore::MeshShardDirection::FullToShard);
-    if (llvm::Error e = mesh_sharding_result.takeError()) {
-      LOG_F(ERROR, "Failed to convert sharding attribute to mesh sharding");
-      return llvm::LogicalResult::failure();
-    }
-
-    shardings.push_back(*mesh_sharding_result);
-  }
-
-  return llvm::LogicalResult::success();
 }
 
 std::vector<int64_t> ModuleBuilder::collectResultPresharded(
@@ -1240,8 +1030,8 @@ tt_pjrt_status ModuleBuilder::checkOutputShardingShapes(
        ++output_index) {
     const mlir::tt::sharding_utils::MeshSharding &output_sharding =
         output_shardings[output_index];
-    if (output_sharding.getShardType() ==
-            mlir::tt::ttcore::MeshShardType::Identity ||
+    if (output_sharding.getShardStatus() ==
+            mlir::tt::ttcore::ShardStatus::Presharded ||
         output_sharding.getShardType() ==
             mlir::tt::ttcore::MeshShardType::Replicate) {
       continue;
@@ -1314,29 +1104,6 @@ void ModuleBuilder::enableVerboseIRPrinting(mlir::PassManager &pm) {
   // to avoid interleaved output.
   pm.getContext()->disableMultithreading();
   pm.enableIRPrinting();
-}
-
-bool ModuleBuilder::isUsingShardy(
-    const mlir::OwningOpRef<mlir::ModuleOp> &module) {
-  // After running through the SdyRoundTripImportPipeline, the module which uses
-  // shardy dialect will have the sdy.mesh op.
-  return getFirstShardyMeshOp(module).has_value();
-}
-
-bool ModuleBuilder::isUsingShardyManualComputation(
-    const mlir::OwningOpRef<mlir::ModuleOp> &module) {
-  if (!isUsingShardy(module)) {
-    return false;
-  }
-
-  bool is_using_shardy_manual_computation = false;
-  module.get().walk([&](mlir::sdy::ManualComputationOp op) {
-    is_using_shardy_manual_computation = true;
-
-    return mlir::WalkResult::interrupt();
-  });
-
-  return is_using_shardy_manual_computation;
 }
 
 void ModuleBuilder::collectMemoryKinds(


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Aligns the PJRT plugin with the tt-mlir [PR](https://github.com/tenstorrent/tt-mlir/pull/8380) that removes the `Identity` variant of the `mesh_shard`.

### What's changed
- **`module_builder.{h,cc}`**: replace the per-frontend `collectInput/OutputShardingsGSPMD/Shardy` + `createShardingsFromGSPMD/Shardy` machinery with single calls to the new `mlir::tt::sharding_utils::collectArgMeshShardings` / `collectResultMeshShardings` helpers, in order to deduplicate the `MeshSharding` instantiation logic between tt-mlir and tt-xla.
- **`loaded_executable_instance.cc`**: drop the now-dead `MeshShardType::Identity` branches in `getOutputShape` (only `Replicate` short-circuits return `output_shape` as-is) and `fillStrategyMapFromSharding` (no longer maps any case to the `"identity"` strategy).
- **`executable_image.cc`**: drop the per-output shape sanity validation in `FlatbufferExecutableImage`'s constructor. It compared MLIR's pre-conversion (global, complex-preserving) shape to the flatbuffer's per-device, complex-split shape, which diverge by exactly the SHLO→TTIR conversion's intentional rewrites - the check is unsound at that layer. The count checks above still catch real flatbuffer/MLIR drift.

### Checklist
- [x] Existing tests provide coverage