### PR TITLE
Add HiDream-I1-Fast component tests

### DIFF
--- a/tests/torch/models/HiDream_I1/__init__.py
+++ b/tests/torch/models/HiDream_I1/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/torch/models/HiDream_I1/test_text_encoder.py
+++ b/tests/torch/models/HiDream_I1/test_text_encoder.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""HiDream-I1-Fast — CLIP-L (text_encoder) component test. Params: ~0.123 B."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+
+from third_party.tt_forge_models.hidream_i1.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.nightly
+@pytest.mark.model_test
+def test_text_encoder():
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.TEXT_ENCODER)
+    model = loader.load_model(dtype_override=torch.float32)
+    inputs = loader.load_inputs(dtype_override=torch.float32)
+
+    run_graph_test(
+        model,
+        inputs,
+        framework=Framework.TORCH,
+    )

--- a/tests/torch/models/HiDream_I1/test_text_encoder_2.py
+++ b/tests/torch/models/HiDream_I1/test_text_encoder_2.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""HiDream-I1-Fast — CLIP-G (text_encoder_2) component test. Params: ~0.695 B."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+
+from third_party.tt_forge_models.hidream_i1.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.nightly
+@pytest.mark.model_test
+def test_text_encoder_2():
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.TEXT_ENCODER_2)
+    model = loader.load_model(dtype_override=torch.float32)
+    inputs = loader.load_inputs(dtype_override=torch.float32)
+
+    run_graph_test(
+        model,
+        inputs,
+        framework=Framework.TORCH,
+    )

--- a/tests/torch/models/HiDream_I1/test_text_encoder_3.py
+++ b/tests/torch/models/HiDream_I1/test_text_encoder_3.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""HiDream-I1-Fast — T5-XXL encoder (text_encoder_3) component test. Params: ~4.6 B."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+
+from third_party.tt_forge_models.hidream_i1.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.xfail(
+    reason="Out of Memory: Not enough space to allocate 167772160 B DRAM buffer across 12 banks, where each bank needs to store 13983744 B, but bank size is 1071821792 B — https://github.com/tenstorrent/tt-xla/issues/4760"
+)
+@pytest.mark.nightly
+@pytest.mark.model_test
+def test_text_encoder_3():
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.TEXT_ENCODER_3)
+    model = loader.load_model(dtype_override=torch.float32)
+    inputs = loader.load_inputs(dtype_override=torch.float32)
+
+    run_graph_test(
+        model,
+        inputs,
+        framework=Framework.TORCH,
+    )

--- a/tests/torch/models/HiDream_I1/test_text_encoder_4.py
+++ b/tests/torch/models/HiDream_I1/test_text_encoder_4.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""HiDream-I1-Fast — Llama-3.1-8B-Instruct (text_encoder_4) component test. Params: ~8.0 B.
+
+Llama-3.1-8B exceeds single-chip memory; only the sharded variant is expected
+to run. The unsharded test stays in the file for reference and is skipped by
+default.
+"""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+from infra.utilities.torch_multichip_utils import get_mesh
+
+from third_party.tt_forge_models.hidream_i1.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.skip(
+    reason="OOM on single device — Llama-3.1-8B exceeds single-chip memory; sharded variant runs"
+)
+def test_text_encoder_4():
+    _run(sharded=False)
+
+
+@pytest.mark.nightly
+@pytest.mark.model_test
+def test_text_encoder_4_sharded():
+    _run(sharded=True)
+
+
+def _run(sharded: bool):
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.TEXT_ENCODER_4)
+    model = loader.load_model(dtype_override=torch.float32)
+    inputs = loader.load_inputs(dtype_override=torch.float32)
+
+    mesh = None
+    shard_spec_fn = None
+    if sharded:
+        mesh_shape, mesh_names = loader.get_mesh_config(
+            xr.global_runtime_device_count()
+        )
+        mesh = get_mesh(mesh_shape, mesh_names)
+        shard_spec_fn = loader.load_shard_spec
+
+    run_graph_test(
+        model,
+        inputs,
+        framework=Framework.TORCH,
+        mesh=mesh,
+        shard_spec_fn=shard_spec_fn,
+    )

--- a/tests/torch/models/HiDream_I1/test_transformer.py
+++ b/tests/torch/models/HiDream_I1/test_transformer.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""HiDream-I1-Fast — HiDreamImageTransformer2DModel (Sparse-MoE MM-DiT) component test. Params: ~17 B static, ~14 B activated per token (top-2-of-4 MoE).
+
+The transformer's 17 B parameters exceed single-chip memory; only the sharded
+variant is expected to run. The unsharded test stays in the file for reference
+and is skipped by default.
+"""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+from infra.utilities.torch_multichip_utils import get_mesh
+
+from third_party.tt_forge_models.hidream_i1.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.skip(
+    reason="OOM on single device — HiDream DiT (17 B) exceeds single-chip memory; sharded variant runs"
+)
+def test_transformer():
+    _run(sharded=False)
+
+
+@pytest.mark.xfail(
+    reason="Out of Memory: Not enough space to allocate 10737418240 B DRAM buffer across 12 banks, where each bank needs to store 894787584 B, but bank size is 1071821792 B - https://github.com/tenstorrent/tt-xla/issues/4761"
+)
+@pytest.mark.nightly
+@pytest.mark.model_test
+def test_transformer_sharded():
+    _run(sharded=True)
+
+
+def _run(sharded: bool):
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.TRANSFORMER)
+    model = loader.load_model(dtype_override=torch.float32)
+    inputs = loader.load_inputs(dtype_override=torch.float32)
+
+    mesh = None
+    shard_spec_fn = None
+    if sharded:
+        mesh_shape, mesh_names = loader.get_mesh_config(
+            xr.global_runtime_device_count()
+        )
+        mesh = get_mesh(mesh_shape, mesh_names)
+        shard_spec_fn = loader.load_shard_spec
+
+    run_graph_test(
+        model,
+        inputs,
+        framework=Framework.TORCH,
+        mesh=mesh,
+        shard_spec_fn=shard_spec_fn,
+    )

--- a/tests/torch/models/HiDream_I1/test_vae_decoder.py
+++ b/tests/torch/models/HiDream_I1/test_vae_decoder.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""HiDream-I1-Fast — AutoencoderKL (vae) decoder component test. Params: ~0.084 B."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+
+from third_party.tt_forge_models.hidream_i1.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.xfail(
+    reason=" Out of Memory: Not enough space to allocate 4294967296 B DRAM buffer across 12 banks, where each bank needs to store 357916672 B, but bank size is 1071821792 B - https://github.com/tenstorrent/tt-xla/issues/4762"
+)
+@pytest.mark.nightly
+@pytest.mark.model_test
+def test_vae_decoder():
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.VAE)
+    model = loader.load_model(dtype_override=torch.float32)
+    inputs = loader.load_inputs(dtype_override=torch.float32)
+
+    run_graph_test(
+        model,
+        inputs,
+        framework=Framework.TORCH,
+    )


### PR DESCRIPTION
### Ticket

- closes https://github.com/tenstorrent/tt-xla/issues/4752

### Problem description

- Add initial bringup tests for each component of the HiDream-I1-Fast text-to-image pipeline & test it in Wormhole.

### What's changed

| File | Component | Tests |
|------|-----------|-------|
| `test_text_encoder.py` | CLIPTextModelWithProjection — CLIP ViT-L/14 (0.123B) | `test_text_encoder` (passed) |
| `test_text_encoder_2.py` | CLIPTextModelWithProjection — OpenCLIP ViT-bigG/14 (0.695B) | `test_text_encoder_2` (passed) |
| `test_text_encoder_3.py` | T5EncoderModel — T5 v1.1 XXL encoder (4.6B) | `test_text_encoder_3` (OOM - xfail - single chip) |
| `test_text_encoder_4.py` | LlamaForCausalLM — Llama-3.1-8B-Instruct (8.0B) | `test_text_encoder_4` (skip - OOM on single chip), `test_text_encoder_4_sharded` (OOM - xfail - 2 chips) |
| `test_transformer.py` | HiDreamImageTransformer2DModel — Sparse-MoE MM-DiT (17B static / 14B activated per token) | `test_transformer` (skip - OOM on single device), `test_transformer_sharded` (OOM - xfail - 4 chips) |
| `test_vae_decoder.py` | AutoencoderKL — FLUX-derived 16-channel latent VAE (0.084B) | `test_vae_decoder` (OOM - xfail - single chip) |

- Model loading, input generation, wrapper modules, and shard specs are provided by https://github.com/tenstorrent/tt-forge-models/pull/666

### Checklist
- [x] Verify changes through local testing in Wormhole

### Logs

- [components_tt_run.zip](https://github.com/user-attachments/files/27965419/tt.zip)
