### PR TITLE
Set opt. lvl. in fusion tests for concatenate_heads to 1

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -497,8 +497,9 @@ test_config:
     status: EXPECTED_PASSING
     filechecks:
       - concatenate_heads.ttnn.mlir
-      # - split_query_key_value_and_split_heads.ttnn.mlir # now only appears with optimization level 1
+      - split_query_key_value_and_split_heads.ttnn.mlir
       - layer_norm.ttnn.mlir
+    optimization_level: 1
     markers: [push, nightly]
 
   vit/pytorch-Large-single_device-inference:

--- a/tests/torch/graphs/fusion_patterns/test_concatenate_heads.py
+++ b/tests/torch/graphs/fusion_patterns/test_concatenate_heads.py
@@ -8,6 +8,8 @@ from einops import rearrange
 from infra import Framework, run_graph_test_with_random_inputs
 from utils import Category
 
+from tests.infra.testers.compiler_config import CompilerConfig
+
 
 @pytest.mark.extended
 @pytest.mark.nightly
@@ -25,6 +27,7 @@ def test_concatenate_heads_3d(request):
         [(1, 8, 32, 64)],
         dtype=torch.bfloat16,
         framework=Framework.TORCH,
+        compiler_config=CompilerConfig(optimization_level=1),
         request=request,
     )
 
@@ -45,5 +48,6 @@ def test_concatenate_heads_2d(request):
         [(1, 8, 32, 64)],
         dtype=torch.bfloat16,
         framework=Framework.TORCH,
+        compiler_config=CompilerConfig(optimization_level=1),
         request=request,
     )


### PR DESCRIPTION
With recent tt-mlir changes (https://github.com/tenstorrent/tt-mlir/pull/8376), opt. level 1 is required for the permute+reshape fusion to concatenate_heads. This PR is also needed to unblock tt-mlir uplift.