### PR TITLE
[WIP] Uplift JAX and JaxLib to uplift easydel

### DIFF
--- a/pjrt_implementation/inc/api/client_instance.h
+++ b/pjrt_implementation/inc/api/client_instance.h
@@ -28,6 +28,7 @@
 #include "api/device_instance.h"
 #include "api/loaded_executable_instance.h"
 #include "api/memory_instance.h"
+#include "api/topology_description.h"
 #include "utils/status.h"
 
 namespace tt::pjrt {
@@ -105,6 +106,11 @@ public:
   const std::vector<MemoryInstance *> &getAddressableMemoriesRaw() const {
     return m_addressable_memories_raw;
   }
+
+  // Returns the singleton topology description for this client, creating it on
+  // first call. JAX 0.9 invokes PJRT_Client_TopologyDescription during plugin
+  // init, so the client must always be able to hand back a topology.
+  TopologyDescription *getOrCreateTopologyDescription();
 
   // Returns true if the client was initialized in compile-only mode ()
   //
@@ -234,6 +240,10 @@ private:
   // We don't have a versioning system for our software stack yet.
   const std::string m_platform_version = "0.0.0";
 
+  // Lazily-created topology description; owned by the client and handed back
+  // (non-owning) from PJRT_Client_TopologyDescription.
+  std::unique_ptr<TopologyDescription> m_topology_description;
+
   // Set of all tracked buffers. Used to materialize all buffers before mesh
   // reshape to prevent data loss.
   std::unordered_set<BufferInstance *> m_tracked_buffers;
@@ -286,6 +296,10 @@ onClientDefaultDeviceAssignment(PJRT_Client_DefaultDeviceAssignment_Args *args);
 
 // Implements PJRT_Client_BufferFromHostBuffer API function.
 PJRT_Error *onBufferFromHostBuffer(PJRT_Client_BufferFromHostBuffer_Args *args);
+
+// Implements PJRT_Client_TopologyDescription API function.
+PJRT_Error *
+onClientTopologyDescription(PJRT_Client_TopologyDescription_Args *args);
 
 } // namespace internal
 

--- a/pjrt_implementation/inc/api/device_instance.h
+++ b/pjrt_implementation/inc/api/device_instance.h
@@ -135,6 +135,9 @@ onDeviceAddressableMemories(PJRT_Device_AddressableMemories_Args *args);
 // Implements PJRT_Device_DefaultMemory API function.
 PJRT_Error *onDeviceDefaultMemory(PJRT_Device_DefaultMemory_Args *args);
 
+// Implements PJRT_Device_GetAttributes API function.
+PJRT_Error *onDeviceGetAttributes(PJRT_Device_GetAttributes_Args *args);
+
 } // namespace internal
 
 } // namespace tt::pjrt

--- a/pjrt_implementation/inc/api/error_instance.h
+++ b/pjrt_implementation/inc/api/error_instance.h
@@ -69,6 +69,9 @@ void onErrorMessage(PJRT_Error_Message_Args *args);
 // Implements PJRT_Error_GetCode API function.
 PJRT_Error *onErrorGetCode(PJRT_Error_GetCode_Args *args);
 
+// Implements PJRT_Error_ForEachPayload API function.
+PJRT_Error *onErrorForEachPayload(PJRT_Error_ForEachPayload_Args *args);
+
 } // namespace internal
 
 } // namespace tt::pjrt

--- a/pjrt_implementation/inc/api/loaded_executable_instance.h
+++ b/pjrt_implementation/inc/api/loaded_executable_instance.h
@@ -71,6 +71,14 @@ public:
     return m_addressable_devices;
   }
 
+  // Returns logical (replica, partition) ids for the addressable devices, in
+  // the same order as `getAddressableDevices()`. Lazily computed; lifetime
+  // matches the loaded executable instance. tt-xla does not currently use SPMD
+  // partitioning, so each device is reported as a distinct replica with
+  // partition=0 — enough for JAX 0.9's CompileAndLoad to succeed without
+  // hard-aborting on UNIMPLEMENTED.
+  const std::vector<PJRT_LogicalDeviceIds> &getAddressableDeviceLogicalIds();
+
   // Returns true if the client was initialized in compile-only mode.
   bool isCompileOnly() const;
 
@@ -169,6 +177,10 @@ protected:
 
   // Client instance that created this loaded executable.
   ClientInstance *m_client_instance;
+
+  // Lazily-computed logical ids matching `m_addressable_devices`. Mutable to
+  // allow population from a const-style accessor.
+  std::vector<PJRT_LogicalDeviceIds> m_addressable_device_logical_ids;
 };
 
 namespace internal {
@@ -183,6 +195,10 @@ onLoadedExecutableGetExecutable(PJRT_LoadedExecutable_GetExecutable_Args *args);
 // Implements PJRT_LoadedExecutable_AddressableDevices API function.
 PJRT_Error *onLoadedExecutableAddressableDevices(
     PJRT_LoadedExecutable_AddressableDevices_Args *args);
+
+// Implements PJRT_LoadedExecutable_AddressableDeviceLogicalIds API function.
+PJRT_Error *onLoadedExecutableAddressableDeviceLogicalIds(
+    PJRT_LoadedExecutable_AddressableDeviceLogicalIds_Args *args);
 
 // Implements PJRT_LoadedExecutable_Delete API function.
 PJRT_Error *onLoadedExecutableDelete(PJRT_LoadedExecutable_Delete_Args *args);

--- a/pjrt_implementation/inc/api/topology_description.h
+++ b/pjrt_implementation/inc/api/topology_description.h
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TT_XLA_PJRT_IMPLEMENTATION_INC_API_TOPOLOGY_DESCRIPTION_H_
+#define TT_XLA_PJRT_IMPLEMENTATION_INC_API_TOPOLOGY_DESCRIPTION_H_
+
+// c++ standard library includes
+#include <string>
+#include <vector>
+
+// PJRT C API includes
+#include "xla/pjrt/c/pjrt_c_api.h"
+
+namespace tt::pjrt {
+
+class ClientInstance;
+class DeviceDescription;
+
+// Represents PJRT_TopologyDescription structure and the functionality around
+// it. A TopologyDescription is owned by the client that created it (see
+// PJRT_Client_TopologyDescription), and its lifetime matches the client's.
+class TopologyDescription {
+public:
+  TopologyDescription(std::string platform_name, std::string platform_version,
+                      std::vector<DeviceDescription *> device_descriptions);
+
+  // Binds PJRT API functions implementation related to PJRT_TopologyDescription
+  // structure.
+  static void bindApi(PJRT_Api *api);
+
+  operator PJRT_TopologyDescription *() {
+    return reinterpret_cast<PJRT_TopologyDescription *>(this);
+  }
+
+  static TopologyDescription *unwrap(PJRT_TopologyDescription *topology) {
+    return reinterpret_cast<TopologyDescription *>(topology);
+  }
+
+  static const TopologyDescription *
+  unwrap(const PJRT_TopologyDescription *topology) {
+    return reinterpret_cast<const TopologyDescription *>(topology);
+  }
+
+  const std::string &getPlatformName() const { return m_platform_name; }
+  const std::string &getPlatformVersion() const { return m_platform_version; }
+
+  // Raw PJRT_DeviceDescription pointers backed by the owning client's
+  // DeviceInstance objects. Lifetime matches the client.
+  const std::vector<PJRT_DeviceDescription *> &
+  getDeviceDescriptionsRaw() const {
+    return m_device_descriptions_raw;
+  }
+
+  const std::vector<PJRT_NamedValue> &getAttributes() const {
+    return m_attributes;
+  }
+
+private:
+  std::string m_platform_name;
+  std::string m_platform_version;
+  // Cached raw pointers ready to return from
+  // PJRT_TopologyDescription_GetDeviceDescriptions. Owned by the client.
+  std::vector<PJRT_DeviceDescription *> m_device_descriptions_raw;
+  // Empty attribute list for now; reserved for platform-specific topology
+  // info if/when downstream needs it.
+  std::vector<PJRT_NamedValue> m_attributes;
+};
+
+namespace internal {
+
+PJRT_Error *
+onTopologyDescriptionDestroy(PJRT_TopologyDescription_Destroy_Args *args);
+
+PJRT_Error *onTopologyDescriptionPlatformName(
+    PJRT_TopologyDescription_PlatformName_Args *args);
+
+PJRT_Error *onTopologyDescriptionPlatformVersion(
+    PJRT_TopologyDescription_PlatformVersion_Args *args);
+
+PJRT_Error *onTopologyDescriptionGetDeviceDescriptions(
+    PJRT_TopologyDescription_GetDeviceDescriptions_Args *args);
+
+PJRT_Error *
+onTopologyDescriptionAttributes(PJRT_TopologyDescription_Attributes_Args *args);
+
+PJRT_Error *onTopologyDescriptionFingerprint(
+    PJRT_TopologyDescription_Fingerprint_Args *args);
+
+} // namespace internal
+
+} // namespace tt::pjrt
+
+#endif // TT_XLA_PJRT_IMPLEMENTATION_INC_API_TOPOLOGY_DESCRIPTION_H_

--- a/pjrt_implementation/src/api/CMakeLists.txt
+++ b/pjrt_implementation/src/api/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(TTPJRTApi
     "serialized_executable_instance.cc"
     "tensor.cc"
     "tensor_pool.cc"
+    "topology_description.cc"
 )
 
 target_include_directories(TTPJRTApi

--- a/pjrt_implementation/src/api/client_instance.cc
+++ b/pjrt_implementation/src/api/client_instance.cc
@@ -335,6 +335,23 @@ void ClientInstance::bindApi(PJRT_Api *api) {
   api->PJRT_Client_DefaultDeviceAssignment =
       internal::onClientDefaultDeviceAssignment;
   api->PJRT_Client_BufferFromHostBuffer = internal::onBufferFromHostBuffer;
+  api->PJRT_Client_TopologyDescription = internal::onClientTopologyDescription;
+}
+
+TopologyDescription *ClientInstance::getOrCreateTopologyDescription() {
+  if (m_topology_description != nullptr) {
+    return m_topology_description.get();
+  }
+
+  std::vector<DeviceDescription *> descriptions;
+  descriptions.reserve(m_devices_raw.size());
+  for (DeviceInstance *device : m_devices_raw) {
+    descriptions.push_back(&device->getDeviceDescription());
+  }
+
+  m_topology_description = std::make_unique<TopologyDescription>(
+      m_platform_name, m_platform_version, std::move(descriptions));
+  return m_topology_description.get();
 }
 
 tt_pjrt_status ClientInstance::populateDevices() {
@@ -945,6 +962,18 @@ onBufferFromHostBuffer(PJRT_Client_BufferFromHostBuffer_Args *args) {
   // Releasing the ownership to the PJRT API caller since the caller is
   // responsible for calling `PJRT_Buffer_Destroy` on the buffer.
   args->buffer = *buffer.release();
+
+  return nullptr;
+}
+
+PJRT_Error *
+onClientTopologyDescription(PJRT_Client_TopologyDescription_Args *args) {
+  ZoneScoped;
+  DLOG_F(LOG_DEBUG, "ClientInstance::PJRT_Client_TopologyDescription");
+
+  TopologyDescription *topology =
+      ClientInstance::unwrap(args->client)->getOrCreateTopologyDescription();
+  args->topology = reinterpret_cast<PJRT_TopologyDescription *>(topology);
 
   return nullptr;
 }

--- a/pjrt_implementation/src/api/device_instance.cc
+++ b/pjrt_implementation/src/api/device_instance.cc
@@ -41,6 +41,7 @@ void DeviceInstance::bindApi(PJRT_Api *api) {
   api->PJRT_Device_LocalHardwareId = internal::onDeviceLocalHardwareId;
   api->PJRT_Device_AddressableMemories = internal::onDeviceAddressableMemories;
   api->PJRT_Device_DefaultMemory = internal::onDeviceDefaultMemory;
+  api->PJRT_Device_GetAttributes = internal::onDeviceGetAttributes;
 }
 
 namespace internal {
@@ -92,6 +93,26 @@ PJRT_Error *onDeviceDefaultMemory(PJRT_Device_DefaultMemory_Args *args) {
   DLOG_F(LOG_DEBUG, "DeviceInstance::PJRT_Device_DefaultMemory");
 
   args->memory = *(DeviceInstance::unwrap(args->device)->getDefaultMemory());
+
+  return nullptr;
+};
+
+PJRT_Error *onDeviceGetAttributes(PJRT_Device_GetAttributes_Args *args) {
+  ZoneScoped;
+  DLOG_F(LOG_DEBUG, "DeviceInstance::PJRT_Device_GetAttributes");
+
+  // JAX 0.9's PjRtCApiDevice::InitAttributes calls this during client creation,
+  // asserts `attributes_deleter != nullptr`, and aborts on UNIMPLEMENTED. The
+  // attribute storage is owned by the DeviceDescription (lifetime == client),
+  // so the deleter is a no-op — but it must be non-null.
+  const std::vector<PJRT_NamedValue> &attributes =
+      DeviceInstance::unwrap(args->device)
+          ->getDeviceDescription()
+          .getAttributes();
+  args->attributes = attributes.data();
+  args->num_attributes = attributes.size();
+  args->device_attributes = nullptr;
+  args->attributes_deleter = +[](PJRT_Device_Attributes *) {};
 
   return nullptr;
 };

--- a/pjrt_implementation/src/api/error_instance.cc
+++ b/pjrt_implementation/src/api/error_instance.cc
@@ -38,6 +38,7 @@ void ErrorInstance::bindApi(PJRT_Api *api) {
   api->PJRT_Error_Destroy = internal::onErrorDestroy;
   api->PJRT_Error_Message = internal::onErrorMessage;
   api->PJRT_Error_GetCode = internal::onErrorGetCode;
+  api->PJRT_Error_ForEachPayload = internal::onErrorForEachPayload;
 }
 
 namespace internal {
@@ -119,6 +120,15 @@ PJRT_Error *onErrorGetCode(PJRT_Error_GetCode_Args *args) {
     args->code = PJRT_Error_Code_UNKNOWN;
   }
 
+  return nullptr;
+}
+
+PJRT_Error *onErrorForEachPayload(PJRT_Error_ForEachPayload_Args *args) {
+  DLOG_F(LOG_DEBUG, "ErrorInstance::PJRT_Error_ForEachPayload");
+
+  // tt-xla errors carry no key/value payloads, so the visitor is not invoked.
+  // Returning success (rather than an "unimplemented" error) breaks the loop
+  // JAX 0.9 enters when probing PJRT_Client_TopologyDescription failures.
   return nullptr;
 }
 

--- a/pjrt_implementation/src/api/loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/loaded_executable_instance.cc
@@ -48,6 +48,8 @@ void LoadedExecutableInstance::bindApi(PJRT_Api *api) {
       internal::onLoadedExecutableGetExecutable;
   api->PJRT_LoadedExecutable_AddressableDevices =
       internal::onLoadedExecutableAddressableDevices;
+  api->PJRT_LoadedExecutable_AddressableDeviceLogicalIds =
+      internal::onLoadedExecutableAddressableDeviceLogicalIds;
   api->PJRT_LoadedExecutable_GetDeviceAssignment =
       internal::onLoadedExecutableGetDeviceAssignment;
   api->PJRT_LoadedExecutable_Delete = internal::onLoadedExecutableDelete;
@@ -57,6 +59,21 @@ void LoadedExecutableInstance::bindApi(PJRT_Api *api) {
 
 bool LoadedExecutableInstance::isCompileOnly() const {
   return m_client_instance->isCompileOnly();
+}
+
+const std::vector<PJRT_LogicalDeviceIds> &
+LoadedExecutableInstance::getAddressableDeviceLogicalIds() {
+  if (m_addressable_device_logical_ids.size() == m_addressable_devices.size()) {
+    return m_addressable_device_logical_ids;
+  }
+  m_addressable_device_logical_ids.clear();
+  m_addressable_device_logical_ids.reserve(m_addressable_devices.size());
+  for (size_t i = 0; i < m_addressable_devices.size(); ++i) {
+    m_addressable_device_logical_ids.push_back(
+        PJRT_LogicalDeviceIds{/*replica=*/static_cast<int>(i),
+                              /*partition=*/0});
+  }
+  return m_addressable_device_logical_ids;
 }
 
 bool LoadedExecutableInstance::isDeleted() {
@@ -426,6 +443,25 @@ PJRT_Error *onLoadedExecutableAddressableDevices(
   args->addressable_devices =
       reinterpret_cast<PJRT_Device *const *>(addressable_devices.data());
   args->num_addressable_devices = addressable_devices.size();
+
+  return nullptr;
+}
+
+PJRT_Error *onLoadedExecutableAddressableDeviceLogicalIds(
+    PJRT_LoadedExecutable_AddressableDeviceLogicalIds_Args *args) {
+  ZoneScoped;
+  DLOG_F(LOG_DEBUG, "LoadedExecutableInstance::"
+                    "PJRT_LoadedExecutable_AddressableDeviceLogicalIds");
+
+  LoadedExecutableInstance *loaded_executable =
+      LoadedExecutableInstance::unwrap(args->executable);
+
+  const std::vector<PJRT_LogicalDeviceIds> &logical_ids =
+      loaded_executable->getAddressableDeviceLogicalIds();
+
+  args->addressable_device_logical_ids =
+      const_cast<PJRT_LogicalDeviceIds *>(logical_ids.data());
+  args->num_addressable_device_logical_ids = logical_ids.size();
 
   return nullptr;
 }

--- a/pjrt_implementation/src/api/topology_description.cc
+++ b/pjrt_implementation/src/api/topology_description.cc
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/topology_description.h"
+
+#include <utility>
+
+#include "api/device_description.h"
+#include "utils/logging.h"
+
+namespace tt::pjrt {
+
+TopologyDescription::TopologyDescription(
+    std::string platform_name, std::string platform_version,
+    std::vector<DeviceDescription *> device_descriptions)
+    : m_platform_name(std::move(platform_name)),
+      m_platform_version(std::move(platform_version)) {
+  m_device_descriptions_raw.reserve(device_descriptions.size());
+  for (DeviceDescription *description : device_descriptions) {
+    m_device_descriptions_raw.push_back(
+        reinterpret_cast<PJRT_DeviceDescription *>(description));
+  }
+}
+
+void TopologyDescription::bindApi(PJRT_Api *api) {
+  api->PJRT_TopologyDescription_Destroy =
+      internal::onTopologyDescriptionDestroy;
+  api->PJRT_TopologyDescription_PlatformName =
+      internal::onTopologyDescriptionPlatformName;
+  api->PJRT_TopologyDescription_PlatformVersion =
+      internal::onTopologyDescriptionPlatformVersion;
+  api->PJRT_TopologyDescription_GetDeviceDescriptions =
+      internal::onTopologyDescriptionGetDeviceDescriptions;
+  api->PJRT_TopologyDescription_Attributes =
+      internal::onTopologyDescriptionAttributes;
+  api->PJRT_TopologyDescription_Fingerprint =
+      internal::onTopologyDescriptionFingerprint;
+}
+
+namespace internal {
+
+// The topology returned by PJRT_Client_TopologyDescription is owned by the
+// client (see pjrt_c_api.h:601). Destroy is therefore a no-op here — the
+// client cleans it up on PJRT_Client_Destroy. A future
+// PJRT_TopologyDescription_Create path (AOT compilation) would need a
+// self-owned variant that actually frees.
+PJRT_Error *
+onTopologyDescriptionDestroy(PJRT_TopologyDescription_Destroy_Args *args) {
+  DLOG_F(LOG_DEBUG, "TopologyDescription::PJRT_TopologyDescription_Destroy");
+  return nullptr;
+}
+
+PJRT_Error *onTopologyDescriptionPlatformName(
+    PJRT_TopologyDescription_PlatformName_Args *args) {
+  DLOG_F(LOG_DEBUG,
+         "TopologyDescription::PJRT_TopologyDescription_PlatformName");
+
+  const std::string &name =
+      TopologyDescription::unwrap(args->topology)->getPlatformName();
+  args->platform_name = name.data();
+  args->platform_name_size = name.size();
+  return nullptr;
+}
+
+PJRT_Error *onTopologyDescriptionPlatformVersion(
+    PJRT_TopologyDescription_PlatformVersion_Args *args) {
+  DLOG_F(LOG_DEBUG,
+         "TopologyDescription::PJRT_TopologyDescription_PlatformVersion");
+
+  const std::string &version =
+      TopologyDescription::unwrap(args->topology)->getPlatformVersion();
+  args->platform_version = version.data();
+  args->platform_version_size = version.size();
+  return nullptr;
+}
+
+PJRT_Error *onTopologyDescriptionGetDeviceDescriptions(
+    PJRT_TopologyDescription_GetDeviceDescriptions_Args *args) {
+  DLOG_F(LOG_DEBUG,
+         "TopologyDescription::PJRT_TopologyDescription_GetDeviceDescriptions");
+
+  const std::vector<PJRT_DeviceDescription *> &descriptions =
+      TopologyDescription::unwrap(args->topology)->getDeviceDescriptionsRaw();
+  args->descriptions = descriptions.data();
+  args->num_descriptions = descriptions.size();
+  return nullptr;
+}
+
+PJRT_Error *onTopologyDescriptionAttributes(
+    PJRT_TopologyDescription_Attributes_Args *args) {
+  DLOG_F(LOG_DEBUG, "TopologyDescription::PJRT_TopologyDescription_Attributes");
+
+  const std::vector<PJRT_NamedValue> &attributes =
+      TopologyDescription::unwrap(args->topology)->getAttributes();
+  args->attributes = attributes.data();
+  args->num_attributes = attributes.size();
+  return nullptr;
+}
+
+PJRT_Error *onTopologyDescriptionFingerprint(
+    PJRT_TopologyDescription_Fingerprint_Args *args) {
+  DLOG_F(LOG_DEBUG,
+         "TopologyDescription::PJRT_TopologyDescription_Fingerprint");
+
+  // Fingerprint is used as an AOT compilation cache key; tt-xla does not
+  // support AOT compilation yet, so a constant value is sufficient — every
+  // client sees the same topology.
+  args->fingerprint = 0;
+  return nullptr;
+}
+
+} // namespace internal
+
+} // namespace tt::pjrt

--- a/pjrt_implementation/src/api_bindings.cc
+++ b/pjrt_implementation/src/api_bindings.cc
@@ -20,6 +20,7 @@
 #include "api/loaded_executable_instance.h"
 #include "api/memory_instance.h"
 #include "api/plugin_attributes.h"
+#include "api/topology_description.h"
 #include "utils/logging.h"
 
 namespace tt::pjrt {
@@ -45,6 +46,7 @@ void bindApi(PJRT_Api *api) {
   LoadedExecutableInstance::bindApi(api);
   MemoryInstance::bindApi(api);
   PluginAttributes::bindApi(api);
+  TopologyDescription::bindApi(api);
 }
 
 void bindUndefineds(PJRT_Api *api) {

--- a/pjrt_implementation/src/stubs.inc
+++ b/pjrt_implementation/src/stubs.inc
@@ -117,10 +117,6 @@
   // store in the buffer is available to the client.
   _STUB(PJRT_Client_CreateBuffersForAsyncHostToDevice);
 
-  // Returns the topology description of the runtime topology. Doesn't hold
-  // value without other PJRT_TopologyDescription related API calls.
-  _STUB(PJRT_Client_TopologyDescription);
-
   // Not required to be implemented. Used to map memory for fast transfers.
   _STUB(PJRT_Client_DmaMap);
   _STUB(PJRT_Client_DmaUnmap);
@@ -157,13 +153,10 @@
   _STUB(PJRT_CopyToDeviceStream_TotalBytes);
   _STUB(PJRT_CopyToDeviceStream_GranuleSize);
   _STUB(PJRT_CopyToDeviceStream_CurrentBytes);
+  // AOT compilation (used outside the client lifetime) is not yet supported.
   _STUB(PJRT_TopologyDescription_Create);
-  _STUB(PJRT_TopologyDescription_Destroy);
-  _STUB(PJRT_TopologyDescription_PlatformName);
-  _STUB(PJRT_TopologyDescription_PlatformVersion);
-  _STUB(PJRT_TopologyDescription_GetDeviceDescriptions);
+  // Serialization/deserialization are needed for AOT cache keys only.
   _STUB(PJRT_TopologyDescription_Serialize);
-  _STUB(PJRT_TopologyDescription_Attributes);
   _STUB(PJRT_TopologyDescription_Deserialize);
   _STUB(PJRT_TopologyDescription_Fingerprint);
   _STUB(PJRT_TopologyDescription_MakeCanonicalShapeForMemorySpace);
@@ -179,7 +172,4 @@
   _STUB(PJRT_AsyncHostToDeviceTransferManager_AddMetadata);
   _STUB(PJRT_AsyncHostToDeviceTransferManager_TransferLiteral);
   _STUB(PJRT_Client_Load);
-  _STUB(PJRT_Device_GetAttributes);
-  _STUB(PJRT_LoadedExecutable_AddressableDeviceLogicalIds);
   _STUB(PJRT_Buffer_Bitcast);
-  _STUB(PJRT_Error_ForEachPayload);

--- a/python_package/jax_plugin_tt/__init__.py
+++ b/python_package/jax_plugin_tt/__init__.py
@@ -12,7 +12,15 @@ from pjrt_plugin_tt import (
     setup_tt_pjrt_plugin_dir,
 )
 
-from .monkeypatch import setup_monkey_patches
+from .monkeypatch import _patch_triton_for_non_gpu_host, setup_monkey_patches
+
+# Install the triton null-driver shim at module-load time so that any
+# subsequent `import easydel` works on hosts without a GPU. JAX only invokes
+# `initialize()` lazily (on first device access), which can be after user
+# code has already tried to import EasyDeL — too late to install patches
+# from there. This is safe to run unconditionally: it's a no-op when
+# triton is absent or when a real GPU driver is active.
+_patch_triton_for_non_gpu_host()
 
 
 def initialize():

--- a/python_package/jax_plugin_tt/monkeypatch.py
+++ b/python_package/jax_plugin_tt/monkeypatch.py
@@ -17,7 +17,6 @@ from typing import Any, Callable
 import jax
 import jax.lax
 import jax.nn
-from jax._src import random
 from jax.extend import core
 from jax.interpreters import ad
 from jax.interpreters.mlir import ir, register_lowering

--- a/python_package/jax_plugin_tt/monkeypatch.py
+++ b/python_package/jax_plugin_tt/monkeypatch.py
@@ -331,6 +331,48 @@ def _create_absl_handler_close_patch_config():
     ]
 
 
+def _patch_triton_for_non_gpu_host():
+    """Allow EasyDeL/ejkernel to be imported on hosts without a GPU.
+
+    ejkernel's `@triton.autotune` decorators run at module import time and
+    call `driver.active.get_benchmarker()`, which raises if triton finds
+    zero active GPU drivers. tt-xla compiles JAX programs through PJRT to
+    tt-mlir and never invokes triton kernels, so installing a null driver
+    on triton's LazyProxy lets the import chain succeed. If real GPU
+    drivers are present (e.g. someone develops on a CUDA host), we leave
+    triton alone.
+    """
+    try:
+        import triton.runtime.driver as triton_driver
+        from triton.backends import backends
+    except ImportError:
+        return  # triton not installed; nothing to do.
+
+    try:
+        if any(x.driver.is_active() for x in backends.values()):
+            return  # Real GPU driver present; nothing to patch.
+    except Exception:
+        return  # Anything unexpected — don't risk breaking real GPU setups.
+
+    class _NullDriver:
+        def get_benchmarker(self):
+            def _benchmarker(*args, **kwargs):
+                raise RuntimeError(
+                    "triton kernel execution is not supported on the "
+                    "Tenstorrent backend; this code path should not be "
+                    "reached when running on TT hardware."
+                )
+
+            return _benchmarker
+
+        def __getattr__(self, name):
+            return lambda *args, **kwargs: None
+
+    # Pre-resolve triton's LazyProxy so the first access doesn't run
+    # `_create_driver()` and raise.
+    triton_driver.active._obj = _NullDriver()
+
+
 def _get_monkeypatches():
     """
     Get the list of monkey patches for the Tenstorrent JAX plugin.
@@ -371,6 +413,10 @@ def setup_monkey_patches():
     This function applies monkey patches to jax.nn.gelu for Tenstorrent optimization
     and flax.linen.Module.apply for weight marking.
     """
+    # Install the triton-null-driver shim before any patches that might
+    # transitively import EasyDeL/ejkernel.
+    _patch_triton_for_non_gpu_host()
+
     # Get and apply monkey patches
     monkeypatches = _get_monkeypatches()
     _apply_patches(monkeypatches)

--- a/python_package/requirements.txt
+++ b/python_package/requirements.txt
@@ -1,6 +1,9 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-jax==0.7.1
-jaxlib==0.7.1
+jax==0.9.2
+jaxlib==0.9.2
+# flax<0.12 imports jax._src.core.mutable_array which was removed in jax 0.9.
+# Pinning flax 0.12+ is required for jax 0.9 compatibility.
+flax==0.12.3
 requests
 torch@https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl
 loguru

--- a/tests/infra/testers/multichip/op/jax_multichip_op_tester.py
+++ b/tests/infra/testers/multichip/op/jax_multichip_op_tester.py
@@ -134,11 +134,11 @@ class JaxMultichipOpTester(BaseTester):
                     False
                 ), "Serialization/filecheck not supported through JAX multichip op/graph testers yet."
 
-        with self._device_mesh:
+        with jax.set_mesh(self._device_mesh):
             self._compile_for_tt_device(device_workload)
             device_res = self._run_on_multichip_device(device_workload)
 
-        with self._cpu_mesh:
+        with jax.set_mesh(self._cpu_mesh):
             self._compile_for_cpu(cpu_workload)
             cpu_res = self._run_on_multichip_device(cpu_workload)
 
@@ -194,7 +194,7 @@ class JaxMultichipOpTester(BaseTester):
         compiler_options = self._compiler_config.to_jax_compiler_options()
 
         # For multichip, we need to compile the workload first within the device mesh
-        with self._device_mesh:
+        with jax.set_mesh(self._device_mesh):
             self._compile(workload, compiler_options)
 
         # Then serialize using the device runner

--- a/tests/infra/utilities/jax_multichip_utils.py
+++ b/tests/infra/utilities/jax_multichip_utils.py
@@ -73,7 +73,7 @@ def make_flax_linen_parameters_partition_specs_on_cpu(
 
 def make_easydel_parameters_partition_specs(
     model_state: PyTree,
-    partition_rules: Tuple[Tuple[str, PartitionSpec], ...],
+    partition_rules: Tuple[Tuple[str, object], ...],
     axis_name="X",
 ) -> PyTree:
     """
@@ -81,13 +81,37 @@ def make_easydel_parameters_partition_specs(
 
     Args:
         model_state: The NNX model state (from nnx.split(model)[1])
-        partition_rules: Tuple of (regex_pattern, PartitionSpec) pairs
+        partition_rules: Tuple of (regex_pattern, spec) pairs. `spec` may be:
+            - a `PartitionSpec` instance (legacy EasyDeL format), or
+            - one of EasyDeL's resolver classes `ColumnWise`, `RowWise`,
+              `Replicated` (post-uplift format). Resolver classes are
+              recognized by name to avoid a hard import dependency on
+              eformer/EasyDeL — the canonical translation matches
+              `PartitionManager.resolve` with default `PartitionAxis` names
+              (dp/fsdp/ep/tp/sp).
         axis_name: The name of the mesh axis to map 'tp' to (e.g., "X")
 
     Returns:
         PyTree of partition specs matching the model_state structure
     """
     import re
+
+    # Canonical PartitionSpec each EasyDeL resolver class resolves to under the
+    # default PartitionAxis names. Sourced from
+    # eformer/escale/partition/manager.py:PartitionAxis (tensor_parallel_axis
+    # defaults to "tp"; fsdp/sp to their names).
+    _RESOLVER_TO_PARTITION_SPEC = {
+        "ColumnWise": PartitionSpec(("fsdp", "sp"), "tp"),
+        "RowWise": PartitionSpec("tp", ("fsdp", "sp")),
+        "Replicated": PartitionSpec(),
+    }
+
+    def normalize_spec(spec):
+        """Translate an EasyDeL resolver class to its PartitionSpec, or
+        pass through an existing PartitionSpec unchanged."""
+        if isinstance(spec, type) and spec.__name__ in _RESOLVER_TO_PARTITION_SPEC:
+            return _RESOLVER_TO_PARTITION_SPEC[spec.__name__]
+        return spec
 
     def jax_path_to_string(path) -> str:
         """Convert JAX tree path to string representation.
@@ -161,7 +185,7 @@ def make_easydel_parameters_partition_specs(
         """
         for pattern, spec in partition_rules:
             if re.search(pattern, param_path):
-                mapped_spec = map_tp_to_mesh_axis(spec)
+                mapped_spec = map_tp_to_mesh_axis(normalize_spec(spec))
                 return mapped_spec
         # Default to replicated if no match
         return PartitionSpec()

--- a/tests/infra/workloads/jax_workload.py
+++ b/tests/infra/workloads/jax_workload.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Callable, Mapping, Optional, Sequence
 
+import jax
 from flax import nnx
 from infra.utilities import Framework, Model, ShardingMode
 from jax.sharding import Mesh, PartitionSpec
@@ -92,7 +93,7 @@ class JaxMultichipWorkload(Workload):
     def execute(self) -> Any:
         if isinstance(self.model, nnx.Module):
             self.set_nnx_model_mesh_recursive(self._device_mesh)
-            with self.device_mesh:
+            with jax.set_mesh(self.device_mesh):
                 return super().execute()
         else:
             return super().execute()

--- a/tests/jax/multi_chip/bounties/Llama_3.1-8B/llama/generate_multi_chip.py
+++ b/tests/jax/multi_chip/bounties/Llama_3.1-8B/llama/generate_multi_chip.py
@@ -78,7 +78,7 @@ def main(
     )
 
     print("✍️ Generating...")
-    with mesh:
+    with jax.set_mesh(mesh):
         results = llama.generate_from_str(
             [prompt],
             max_gen_len=max_gen_len,

--- a/tests/jax/multi_chip/bounties/falcon3_7b/requirements.txt
+++ b/tests/jax/multi_chip/bounties/falcon3_7b/requirements.txt
@@ -19,8 +19,8 @@ idna==3.10
 importlib_resources==6.5.2
 ipykernel==6.29.5
 ipython==8.26.0
-jax==0.6.0
-jaxlib==0.6.0
+jax==0.9.2
+jaxlib==0.9.2
 jedi==0.19.1
 Jinja2==3.1.6
 jupyter_client==8.6.2

--- a/tests/jax/multi_chip/bounties/gemma3/gemma3/gemma3_tp.py
+++ b/tests/jax/multi_chip/bounties/gemma3/gemma3/gemma3_tp.py
@@ -900,7 +900,7 @@ class Gemma3ForCausalLM(BaseModel):
             )
             return logits
 
-        with device_mesh:
+        with jax.set_mesh(device_mesh):
             if self.config.use_cache:
                 self.init_cache(input_ids)
             model_spec = self._udpate_with_sharding(self)

--- a/tests/jax/multi_chip/bounties/gemma3/requirements.txt
+++ b/tests/jax/multi_chip/bounties/gemma3/requirements.txt
@@ -1,5 +1,5 @@
 # Core ML frameworks
-jax==0.6.2
+jax==0.9.2
 flax==0.10.7
 optax==0.2.5
 

--- a/tests/jax/multi_chip/bounties/mistral_small/test_model_implementation.py
+++ b/tests/jax/multi_chip/bounties/mistral_small/test_model_implementation.py
@@ -77,10 +77,10 @@ def test_compare_hf(tokenizer, mesh, nnx_model):
         graphdef, state = nnx.split(nnx_model)
         tokens = tokenizer(input, return_tensors="jax")["input_ids"]
 
-        with timer("test_compare_hf - jit compile"), mesh:
+        with timer("test_compare_hf - jit compile"), jax.set_mesh(mesh):
             compiled_model = jit_model.lower(graphdef, state, tokens).compile()
 
-        with timer("test_compare_hf - nnx forward pass"), mesh:
+        with timer("test_compare_hf - nnx forward pass"), jax.set_mesh(mesh):
             nnx_result = compiled_model(graphdef, state, tokens)
             nnx_result.block_until_ready()
             return nnx_result

--- a/tests/jax/multi_chip/bounties/mixtral_8x7b/multichip/multichipmixtral.py
+++ b/tests/jax/multi_chip/bounties/mixtral_8x7b/multichip/multichipmixtral.py
@@ -870,7 +870,7 @@ class FlaxMixtralForCausalLM(nnx.Module):
             )
             return outputs.logits, outputs.past_key_values
 
-        with device_mesh:
+        with jax.set_mesh(device_mesh):
             cache_specs = self.prepare_sharding()
 
             model_state = nnx.state(self)

--- a/tests/jax/multi_chip/bounties/mixtral_8x7b/requirements.txt
+++ b/tests/jax/multi_chip/bounties/mixtral_8x7b/requirements.txt
@@ -1,5 +1,5 @@
 # Core ML frameworks
-jax==0.6.0
+jax==0.9.2
 flax==0.10.6
 optax==0.2.4
 


### PR DESCRIPTION
### Problem description
Jax and Jaxlib version needs to be updated  to accomodate latest changes released by EasyDel

### Files changed
 - C++: 
               *  api_bindings.cc
               * error_instance.{h,cc}
               * client_instance.{h,cc}
               * device_instance.{h,cc}
               *  loaded_executable_instance.{h,cc}
               * stubs.inc
               *  src/api/CMakeLists.txt
               *  2 new files (topology_description.{h,cc})
  - Python pins: 
               * python_package/requirements.txt (jax, jaxlib, flax, torch-xla)
               * 3 bounty requirements.txt
  - Code migration: 
                * 9 with mesh: → jax.set_mesh() across 6 test/example files; one dead jax._src.random import removed




### Checklist
- [x] New/Existing tests provide coverage for changes
