### PR TITLE
Fix: correct image path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 </h1>
 <picture>
-  <img alt="Logo" src="docs/src/imgs/tt_xla_logo.png" height="250">
+  <img alt="Logo" src="docs/source/imgs/tt_xla_logo.png" height="250">
 </picture>
 
 </div>
@@ -20,7 +20,7 @@ TT-XLA leverages a PJRT interface to integrate JAX (and in the future other fram
 
 -----
 # Quick Links
-- [Getting Started / How to Run a Model](docs/src/getting_started.md)
+- [Getting Started / How to Run a Model](docs/source/getting_started.md)
 
 -----
 # What is This Repo?
@@ -34,7 +34,7 @@ The TT-XLA repository is primarily used to enable running PyTorch and JAX models
 
 - [TT-Forge-ONNX](https://github.com/tenstorrent/tt-forge-onnx)
   - A TVM based graph compiler designed to optimize and transform computational graphs for deep learning models. Supports ingestion of ONNX, TensorFlow, PaddlePaddle and similar ML frameworks via TVM ([TT-TVM](https://github.com/tenstorrent/tt-tvm)). It also supports ingestion of PyTorch, however it is recommended that you use TT-XLA. TT-Forge-ONNX does not support multi-chip configurations; it is for single-chip projects only.
-  - See the [TT-Forge-ONNX docs pages](https://docs.tenstorrent.com/tt-forge-onnx/getting-started.html) for an overview and getting started guide.
+  - See the [TT-Forge-ONNX docs pages](https://docs.tenstorrent.com/tt-forge-onnx/getting_started.html) for an overview and getting started guide.
 
 - [TT-Torch](https://github.com/tenstorrent/tt-torch) - (deprecated)
   - A MLIR-native, open-source, PyTorch 2.X and torch-mlir based front-end. It provides stableHLO (SHLO) graphs to TT-MLIR. Supports ingestion of PyTorch models via PT2.X compile and ONNX models via torch-mlir (ONNX->SHLO)


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
In the latest main branch, the TT image is not visible due to commit de9197eb3fec8bacac6117787c87824ef8ee770c:
https://github.com/tenstorrent/tt-xla/pull/4686

In this commit, the image path was changed, but the README file was not updated accordingly. As a result, the image is not being displayed.

### What's changed

- Corrected the logo in the README file to match the new image path.
- Updated the Quick Links in the README file to point to the correct destinations.
- Corrected the TT-Forge-ONNX documentation pages.

latest main:
<img width="1517" height="920" alt="image" src="https://github.com/user-attachments/assets/76e14d5d-dad6-46fb-8004-965ff12dc8d4" />

after my change:

<img width="1517" height="920" alt="image" src="https://github.com/user-attachments/assets/b480103d-a9f4-4adc-9c51-5e703717569d" />

### Checklist
- [ ] New/Existing tests provide coverage for changes
