### PR TITLE
[Lumina Image] Add initial tests for each part of the pipeline

### DIFF
--- a/tests/torch/models/lumina_image/__init__.py
+++ b/tests/torch/models/lumina_image/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/torch/models/lumina_image/test_text_encoder.py
+++ b/tests/torch/models/lumina_image/test_text_encoder.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Lumina-Image-2.0 — Gemma-2 text encoder component test."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+from infra.testers.single_chip.model.torch_model_tester import _mask_jax_accelerator
+from infra.utilities.torch_multichip_utils import get_mesh
+
+from third_party.tt_forge_models.lumina_image.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.xfail(
+    reason="RuntimeError: Value out of range (expected to be in range of [-256, 255], but got -4095) - https://github.com/tenstorrent/tt-xla/issues/4900"
+)
+def test_text_encoder():
+    _run(sharded=False)
+
+
+@pytest.mark.xfail(
+    reason="RuntimeError: Value out of range (expected to be in range of [-256, 255], but got -4095) - https://github.com/tenstorrent/tt-xla/issues/4900"
+)
+@pytest.mark.nightly
+@pytest.mark.model_test
+def test_text_encoder_sharded():
+    _run(sharded=True)
+
+
+def _run(sharded: bool):
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.TEXT_ENCODER)
+    encoder = loader.load_model(dtype_override=torch.bfloat16)
+    inputs = loader.load_inputs(dtype_override=torch.bfloat16)
+
+    mesh = None
+    shard_spec_fn = None
+    if sharded:
+        mesh_shape, mesh_names = loader.get_mesh_config(
+            xr.global_runtime_device_count()
+        )
+        mesh = get_mesh(mesh_shape, mesh_names)
+        shard_spec_fn = loader.load_shard_spec
+
+    with _mask_jax_accelerator():
+        run_graph_test(
+            encoder,
+            inputs,
+            framework=Framework.TORCH,
+            mesh=mesh,
+            shard_spec_fn=shard_spec_fn,
+        )

--- a/tests/torch/models/lumina_image/test_transformer.py
+++ b/tests/torch/models/lumina_image/test_transformer.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Lumina-Image-2.0 — Lumina2Transformer2DModel (DiT) component test."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+from infra.testers.single_chip.model.torch_model_tester import _mask_jax_accelerator
+from infra.utilities.torch_multichip_utils import get_mesh
+
+from third_party.tt_forge_models.lumina_image.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.skip
+def test_transformer():
+    _run(sharded=False)
+
+
+@pytest.mark.xfail(
+    reason="loc(concatenate.459): error: failed to legalize unresolved materialization - https://github.com/tenstorrent/tt-xla/issues/4901"
+)
+@pytest.mark.nightly
+@pytest.mark.model_test
+def test_transformer_sharded():
+    _run(sharded=True)
+
+
+def _run(sharded: bool):
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.TRANSFORMER)
+    model = loader.load_model(dtype_override=torch.bfloat16)
+    inputs = loader.load_inputs(dtype_override=torch.bfloat16)
+
+    mesh = None
+    shard_spec_fn = None
+    if sharded:
+        mesh_shape, mesh_names = loader.get_mesh_config(
+            xr.global_runtime_device_count()
+        )
+        mesh = get_mesh(mesh_shape, mesh_names)
+        shard_spec_fn = loader.load_shard_spec
+
+    with _mask_jax_accelerator():
+        run_graph_test(
+            model,
+            inputs,
+            framework=Framework.TORCH,
+            mesh=mesh,
+            shard_spec_fn=shard_spec_fn,
+        )

--- a/tests/torch/models/lumina_image/test_vae_decoder.py
+++ b/tests/torch/models/lumina_image/test_vae_decoder.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Lumina-Image-2.0 — AutoencoderKL decoder component test."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+from infra.testers.single_chip.model.torch_model_tester import _mask_jax_accelerator
+from infra.utilities.torch_multichip_utils import get_mesh
+
+from third_party.tt_forge_models.lumina_image.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.skip
+def test_vae_decoder():
+    _run(sharded=False)
+
+
+@pytest.mark.nightly
+@pytest.mark.model_test
+def test_vae_decoder_sharded():
+    _run(sharded=True)
+
+
+def _run(sharded: bool):
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.VAE)
+    model = loader.load_model(dtype_override=torch.bfloat16)
+    inputs = loader.load_inputs(dtype_override=torch.bfloat16)
+
+    mesh = None
+    shard_spec_fn = None
+    if sharded:
+        mesh_shape, mesh_names = loader.get_mesh_config(
+            xr.global_runtime_device_count()
+        )
+        mesh = get_mesh(mesh_shape, mesh_names)
+        shard_spec_fn = loader.load_shard_spec
+
+    with _mask_jax_accelerator():
+        run_graph_test(
+            model,
+            inputs,
+            framework=Framework.TORCH,
+            mesh=mesh,
+            shard_spec_fn=shard_spec_fn,
+        )


### PR DESCRIPTION
### Ticket

- fixes #4768 

### Problem description

- Add initial bringup tests for each component of the Lumina Image pipeline and  test in Wormhole.

### What's changed

| File | Component | Tests |
|------|-----------|-------|
| `test_text_encoder.py` | Lumina2Transformer2DModel | `test_text_encoder` (xfail - #4900  - 2 chips), 
| `test_transformer.py` | HunyuanVideoTransformer3DModel   | `test_transformer` (xfail - #4901 - 2 chips)
| `test_vae_decoder.py` | AutoencoderKL | `test_vae_decoder` (passes - 2 chips )

### Checklist
- [x] verify changes through local testing in Wormhole

### Logs
[lumina_text_encoder.log](https://github.com/user-attachments/files/28012624/lumina_text_encoder.log)
[lumina_transformer.log](https://github.com/user-attachments/files/28012627/lumina_transformer.log)
[lumina_vae_decoder.log](https://github.com/user-attachments/files/28012629/lumina_vae_decoder.log)

