### PR TITLE
Add HunyuanImage 2.1 component tests (text_encoder, text_encoder_2, transformer, vae)

### DIFF
--- a/tests/torch/models/HunyuanImage_2_1/__init__.py
+++ b/tests/torch/models/HunyuanImage_2_1/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/torch/models/HunyuanImage_2_1/test_text_encoder.py
+++ b/tests/torch/models/HunyuanImage_2_1/test_text_encoder.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""HunyuanImage 2.1 — Qwen2.5-VL-7B-Instruct text encoder component test."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+from infra.utilities.torch_multichip_utils import get_mesh
+
+from third_party.tt_forge_models.hunyuan_image_2_1.pytorch import (
+    ModelLoader,
+    ModelVariant,
+)
+
+
+@pytest.mark.skip(
+    reason="model size > 8B — won't fit on a single chip; sharded variant runs"
+)
+def test_text_encoder():
+    _run(sharded=False)
+
+
+@pytest.mark.xfail(
+    reason="Out of Memory: Not enough space to allocate 271581184 B DRAM buffer across 12 banks, where each bank needs to store 22657024 B, but bank size is 1071821792 B — https://github.com/tenstorrent/tt-xla/issues/4779"
+)
+@pytest.mark.nightly
+@pytest.mark.model_test
+def test_text_encoder_sharded():
+    _run(sharded=True)
+
+
+def _run(sharded: bool):
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.TEXT_ENCODER)
+    encoder = loader.load_model(dtype_override=torch.float32)
+    inputs = loader.load_inputs(dtype_override=torch.float32)
+
+    mesh = None
+    shard_spec_fn = None
+    if sharded:
+        mesh_shape, mesh_names = loader.get_mesh_config(
+            xr.global_runtime_device_count()
+        )
+        mesh = get_mesh(mesh_shape, mesh_names)
+        shard_spec_fn = loader.load_shard_spec
+
+    run_graph_test(
+        encoder,
+        inputs,
+        framework=Framework.TORCH,
+        mesh=mesh,
+        shard_spec_fn=shard_spec_fn,
+    )

--- a/tests/torch/models/HunyuanImage_2_1/test_text_encoder_2.py
+++ b/tests/torch/models/HunyuanImage_2_1/test_text_encoder_2.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""HunyuanImage 2.1 — ByT5 text encoder component test (text_encoder_2)."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+
+from third_party.tt_forge_models.hunyuan_image_2_1.pytorch import (
+    ModelLoader,
+    ModelVariant,
+)
+
+
+@pytest.mark.xfail(
+    reason="AssertionError: Evaluation result 0 failed: PCC comparison failed. Calculated: pcc=0.9827067647730205. Required: pcc=0.99. — https://github.com/tenstorrent/tt-xla/issues/4784"
+)
+@pytest.mark.nightly
+@pytest.mark.model_test
+def test_text_encoder_2():
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.TEXT_ENCODER_2)
+    encoder = loader.load_model(dtype_override=torch.float32)
+    inputs = loader.load_inputs(dtype_override=torch.float32)
+
+    run_graph_test(
+        encoder,
+        inputs,
+        framework=Framework.TORCH,
+    )

--- a/tests/torch/models/HunyuanImage_2_1/test_transformer.py
+++ b/tests/torch/models/HunyuanImage_2_1/test_transformer.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""HunyuanImage 2.1 — HunyuanImageTransformer2DModel (MMDiT) component test."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+from infra.utilities.torch_multichip_utils import get_mesh
+
+from third_party.tt_forge_models.hunyuan_image_2_1.pytorch import (
+    ModelLoader,
+    ModelVariant,
+)
+
+
+@pytest.mark.skip(
+    reason="model size 17.45B — won't fit on a single chip; sharded variant runs"
+)
+def test_transformer():
+    _run(sharded=False)
+
+
+@pytest.mark.xfail(
+    reason="Out of Memory: Not enough space to allocate 234881024 B DRAM buffer across 12 banks, where each bank needs to store 19574784 B, but bank size is 1071821792 B - https://github.com/tenstorrent/tt-xla/issues/4780"
+)
+@pytest.mark.nightly
+@pytest.mark.model_test
+def test_transformer_sharded():
+    _run(sharded=True)
+
+
+def _run(sharded: bool):
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.TRANSFORMER)
+    model = loader.load_model(dtype_override=torch.float32)
+    inputs = loader.load_inputs(dtype_override=torch.float32)
+
+    mesh = None
+    shard_spec_fn = None
+    if sharded:
+        mesh_shape, mesh_names = loader.get_mesh_config(
+            xr.global_runtime_device_count()
+        )
+        mesh = get_mesh(mesh_shape, mesh_names)
+        shard_spec_fn = loader.load_shard_spec
+
+    run_graph_test(
+        model,
+        inputs,
+        framework=Framework.TORCH,
+        mesh=mesh,
+        shard_spec_fn=shard_spec_fn,
+    )

--- a/tests/torch/models/HunyuanImage_2_1/test_vae_decoder.py
+++ b/tests/torch/models/HunyuanImage_2_1/test_vae_decoder.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""HunyuanImage 2.1 — AutoencoderKLHunyuanImage decoder component test."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+
+from third_party.tt_forge_models.hunyuan_image_2_1.pytorch import (
+    ModelLoader,
+    ModelVariant,
+)
+
+
+@pytest.mark.xfail(
+    reason="Out of Memory: Not enough space to allocate 8589934592 B DRAM buffer across 12 banks, where each bank needs to store 715829248 B, but bank size is 1071821792 B  - https://github.com/tenstorrent/tt-xla/issues/4781"
+)
+def test_vae_decoder():
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.VAE)
+    model = loader.load_model(dtype_override=torch.float32)
+    inputs = loader.load_inputs(dtype_override=torch.float32)
+
+    run_graph_test(
+        model,
+        inputs,
+        framework=Framework.TORCH,
+    )


### PR DESCRIPTION
### Ticket

- closes https://github.com/tenstorrent/tt-xla/issues/4774

### Problem description

- Add initial bringup tests for each component of the HunyuanImage-2.1-Distilled text-to-image pipeline & test it in Wormhole.

### What's changed

| File | Component | Tests |
|------|-----------|-------|
| `test_text_encoder.py` | Qwen2_5_VLForConditionalGeneration — Qwen2.5-VL-7B-Instruct (8.29B) | `test_text_encoder` (skip - OOM on single chip), `test_text_encoder_sharded` (OOM on 2 chips - xfail - https://github.com/tenstorrent/tt-xla/issues/4779) |
| `test_text_encoder_2.py` | T5EncoderModel — ByT5 glyph encoder (0.22B) | `test_text_encoder_2` (PCC drop - xfail - https://github.com/tenstorrent/tt-xla/issues/4784) |
| `test_transformer.py` | HunyuanImageTransformer2DModel — hybrid MM-DiT (dual-stream + single-stream blocks) (17.45B) | `test_transformer` (skip - OOM on single chip), `test_transformer_sharded` (OOM on 4 chips - xfail - https://github.com/tenstorrent/tt-xla/issues/4780) |
| `test_vae_decoder.py` | AutoencoderKLHunyuanImage — 32× spatial-compression image VAE (0.41B) | `test_vae_decoder` (OOM - xfail - https://github.com/tenstorrent/tt-xla/issues/4781) |

- Model loading, input generation, wrapper modules, and shard specs are provided by https://github.com/tenstorrent/tt-forge-models/pull/672

### Checklist
- [x] Verify changes through local testing in Wormhole

### Logs

- [hunyuanimage_2_1_tt.zip](https://github.com/user-attachments/files/28021002/hunyuanimage_2_1_tt.zip)
