### PR TITLE
Update the inference test config of panoptic segmentation variants w.r.t current main

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -2182,16 +2182,27 @@ test_config:
     reason: "Out of Memory: Not enough space to allocate 5468979200 B DRAM buffer across 12 banks, where each bank needs to store 455749632 B, but bank size is only 1073741792 B - https://github.com/tenstorrent/tt-xla/issues/1722"
 
   panoptic_segmentation/pytorch-ResNet101_Backbone_3x_COCO-single_device-inference:
-    status: NOT_SUPPORTED_SKIP
-    reason: "Copy to host buffer failed with error: Buffer pointers must not be null (https://github.com/tenstorrent/tt-xla/issues/3722)"
+    arch_overrides:
+      n150:
+        status: KNOWN_FAILURE_XFAIL
+        reason: "ValueError: Node arity mismatch; expected 13, but got 16. - https://github.com/tenstorrent/tt-xla/issues/4794"
+      p150:
+        status: KNOWN_FAILURE_XFAIL
+        reason: "ValueError: Node arity mismatch; expected 15, but got 16. - https://github.com/tenstorrent/tt-xla/issues/4794"
 
   panoptic_segmentation/pytorch-ResNet50_Backbone_1x_COCO-single_device-inference:
-    status: NOT_SUPPORTED_SKIP
-    reason: "Copy to host buffer failed with error: Buffer pointers must not be null (https://github.com/tenstorrent/tt-xla/issues/3722)"
+    arch_overrides:
+      n150:
+        status: KNOWN_FAILURE_XFAIL
+        reason: "ValueError: Node arity mismatch; expected 14, but got 15. - https://github.com/tenstorrent/tt-xla/issues/4794"
+      p150:
+        status: KNOWN_FAILURE_XFAIL
+        reason: "ValueError: Node arity mismatch; expected 13, but got 15. - https://github.com/tenstorrent/tt-xla/issues/4794"
+
 
   panoptic_segmentation/pytorch-ResNet50_Backbone_3x_COCO-single_device-inference:
-    status: NOT_SUPPORTED_SKIP
-    reason: "Copy to host buffer failed with error: Buffer pointers must not be null (https://github.com/tenstorrent/tt-xla/issues/3722)"
+    status: KNOWN_FAILURE_XFAIL
+    reason: "ValueError: Node arity mismatch; expected 14, but got 17. - https://github.com/tenstorrent/tt-xla/issues/4794"
 
   sam/pytorch-Vit_Huge-single_device-inference:
     status: EXPECTED_PASSING


### PR DESCRIPTION
### Problem description

- On current main, panoptic segmentation variants fails with https://github.com/tenstorrent/tt-xla/issues/4794
- It's configs need to be updated.

### What's changed

- Updated the inference test config based on current failure.

### Checklist
- [x] Verify the changes via Run Test Single 

### Logs/Runs

- N150 - https://github.com/tenstorrent/tt-xla/actions/runs/26146836844
- P150 - https://github.com/tenstorrent/tt-xla/actions/runs/26146881276
