### PR TITLE
Nightly Maintance may19

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -1471,7 +1471,6 @@ test_config:
   gemma/pytorch-1.1_7B_IT-single_device-inference:
     supported_archs: ["p150"]
     status: EXPECTED_PASSING
-    assert_pcc: false # ComputeConfig math_fidelity/fp32_dest_acc_en - https://github.com/tenstorrent/tt-xla/issues/2861
     optimization_level: 2
 
   stable_diffusion_xl/pytorch-Base_1.0-single_device-inference:


### PR DESCRIPTION
## Ticket
https://github.com/tenstorrent/tt-xla/issues/2861

## Summary

Sync test_config YAMLs based on nightly CI run [26068607651](https://github.com/tenstorrent/tt-xla/actions/runs/26068607651) (2026-05-19), filtered to `language` model-type.

## Changes (status: true rows)

- `gemma/pytorch-1.1_7B_IT-single_device-inference` — `tests/runner/test_config/torch/test_config_inference_single_device.yaml` — removed `assert_pcc: false` (and its trailing comment) per `ENABLE_PCC_099` guidance; row now passing on p150 at pcc=0.9967 against default 0.99 threshold.

## Status: true rows already at target state (no edit required)

- `bi_lstm_crf/pytorch-Default-single_device-inference` — `tests/runner/test_config/torch/test_config_inference_single_device.yaml` — entry was already `EXPECTED_PASSING` with no XFAIL/required_pcc/assert_pcc fields to remove.
- `qwen_2_5/causal_lm/pytorch-1.5B_Instruct-llm_decode-seq_1-batch_1-single_device-mesh_default-inference` — `tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml` — entry was already `EXPECTED_PASSING` with no override to remove.
