### PR TITLE
[GLM Image] Add initial tests for each part of the pipeline

### DIFF
--- a/tests/torch/models/glm_image/__init__.py
+++ b/tests/torch/models/glm_image/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/torch/models/glm_image/test_text_encoder.py
+++ b/tests/torch/models/glm_image/test_text_encoder.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""GLM-Image — T5EncoderModel component test."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+from infra.utilities.torch_multichip_utils import get_mesh
+
+from third_party.tt_forge_models.glm_image.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.nightly
+@pytest.mark.model_test
+def test_text_encoder_sharded():
+    _run(sharded=True)
+
+
+def _run(sharded: bool):
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.TEXT_ENCODER)
+    encoder = loader.load_model(dtype_override=torch.bfloat16)
+    inputs = loader.load_inputs(dtype_override=torch.bfloat16)
+
+    mesh = None
+    shard_spec_fn = None
+    if sharded:
+        mesh_shape, mesh_names = loader.get_mesh_config(
+            xr.global_runtime_device_count()
+        )
+        mesh = get_mesh(mesh_shape, mesh_names)
+        shard_spec_fn = loader.load_shard_spec
+
+    run_graph_test(
+        encoder,
+        inputs,
+        framework=Framework.TORCH,
+        mesh=mesh,
+        shard_spec_fn=shard_spec_fn,
+    )

--- a/tests/torch/models/glm_image/test_transformer.py
+++ b/tests/torch/models/glm_image/test_transformer.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""GLM-Image — GlmImageTransformer2DModel component test."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+from infra.utilities.torch_multichip_utils import get_mesh
+
+from third_party.tt_forge_models.glm_image.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.xfail(
+    reason="IndexError: index 4023 is out of bounds for dimension 0 with size 1 - https://github.com/tenstorrent/tt-xla/issues/4804"
+)
+@pytest.mark.nightly
+@pytest.mark.model_test
+def test_transformer_sharded():
+    _run(sharded=True)
+
+
+def _run(sharded: bool):
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.TRANSFORMER)
+    model = loader.load_model(dtype_override=torch.bfloat16)
+    inputs = loader.load_inputs(dtype_override=torch.bfloat16)
+
+    mesh = None
+    shard_spec_fn = None
+    if sharded:
+        mesh_shape, mesh_names = loader.get_mesh_config(
+            xr.global_runtime_device_count()
+        )
+        mesh = get_mesh(mesh_shape, mesh_names)
+        shard_spec_fn = loader.load_shard_spec
+
+    run_graph_test(
+        model,
+        inputs,
+        framework=Framework.TORCH,
+        mesh=mesh,
+        shard_spec_fn=shard_spec_fn,
+    )

--- a/tests/torch/models/glm_image/test_vae_decoder.py
+++ b/tests/torch/models/glm_image/test_vae_decoder.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""GLM-Image — AutoencoderKL decoder component test."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+from infra.utilities.torch_multichip_utils import get_mesh
+
+from third_party.tt_forge_models.glm_image.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.nightly
+@pytest.mark.model_test
+def test_vae_decoder_sharded():
+    _run(sharded=True)
+
+
+def _run(sharded: bool):
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.VAE)
+    model = loader.load_model(dtype_override=torch.bfloat16)
+    inputs = loader.load_inputs(dtype_override=torch.bfloat16)
+
+    mesh = None
+    shard_spec_fn = None
+    if sharded:
+        mesh_shape, mesh_names = loader.get_mesh_config(
+            xr.global_runtime_device_count()
+        )
+        mesh = get_mesh(mesh_shape, mesh_names)
+        shard_spec_fn = loader.load_shard_spec
+
+    run_graph_test(
+        model,
+        inputs,
+        framework=Framework.TORCH,
+        mesh=mesh,
+        shard_spec_fn=shard_spec_fn,
+    )

--- a/tests/torch/models/glm_image/test_vision_language_encoder.py
+++ b/tests/torch/models/glm_image/test_vision_language_encoder.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""GLM-Image — GlmImageForConditionalGeneration component test."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+from infra.utilities.torch_multichip_utils import get_mesh
+
+from third_party.tt_forge_models.glm_image.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.xfail(
+    reason="ttir.repeat op Input tensor shape (394,1) at index 0 does not repeat to output (3,394) using repeat value 3 - https://github.com/tenstorrent/tt-xla/issues/4803"
+)
+@pytest.mark.nightly
+@pytest.mark.model_test
+def test_vision_language_encoder_sharded():
+    _run(sharded=True)
+
+
+def _run(sharded: bool):
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.VISION_LANGUAGE_ENCODER)
+    model = loader.load_model(dtype_override=torch.bfloat16)
+    inputs = loader.load_inputs(dtype_override=torch.bfloat16)
+
+    mesh = None
+    shard_spec_fn = None
+    if sharded:
+        mesh_shape, mesh_names = loader.get_mesh_config(
+            xr.global_runtime_device_count()
+        )
+        mesh = get_mesh(mesh_shape, mesh_names)
+        shard_spec_fn = loader.load_shard_spec
+
+    run_graph_test(
+        model,
+        inputs,
+        framework=Framework.TORCH,
+        mesh=mesh,
+        shard_spec_fn=shard_spec_fn,
+    )


### PR DESCRIPTION
### Ticket

- fixes #4805 

### Problem description

- Add initial bringup tests for each component of the GLM Image pipeline and  test in Wormhole.

### What's changed

| File | Component | Tests |
|------|-----------|-------|
| `test_text_encoder.py` | T5 encoder | `test_text_encoder` (`test_text_encoder_sharded` (passes — 2 devices) |
| `test_vision_languange_encoder.py` | VisionLanguageEncoder | `test_vision_languange_encoder_sharded` (xfail - #4803 - 2 devices) |
| `test_transformer.py` | GlmImageTransformer2DModel   | `test_transformer_sharded` (`test_transformer_sharded` (xfail - #4804   - 2 devices) |
| `test_vae_decoder.py` | AutoencoderKL | `test_vae_decoder` ( ` test_vae_decoder_sharded`  (passes - 2 devices) |

### Checklist
- [x] verify changes through local testing in Wormhole

### Logs
[glm_image_text_encoder.log](https://github.com/user-attachments/files/28064969/glm_image_text_encoder.log)
[glm_image_transformer.log](https://github.com/user-attachments/files/28064978/glm_image_transformer.log)
[glm_image_vae_decoder.log](https://github.com/user-attachments/files/28064979/glm_image_vae_decoder.log)
[glm_image_vision_text_encoder.log](https://github.com/user-attachments/files/28064985/glm_image_vision_text_encoder.log)