### PR TITLE
Add kimi-k2.5 benchmark

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -313,6 +313,12 @@
         "runs-on": "galaxy-wh-6u"
       },
       {
+        "name": "kimi_k2_5_tp_galaxy_2_layers",
+        "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==5.2.0 tiktoken",
+        "pytest": "tests/benchmark/test_llms.py::test_kimi_k2_5_tp_galaxy_2_layers",
+        "runs-on": "galaxy-wh-6u"
+      },
+      {
         "name": "llama_3_2_1b_instruct_accuracy",
         "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_2_1b",

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -2066,7 +2066,7 @@ def test_kimi_k2_tp_galaxy_2_layers(
         accuracy_testing=accuracy_testing,
         batch_size=64,  # Test hangs for a batch size of 128 - Issue: https://github.com/tenstorrent/tt-xla/issues/4565
         max_output_tokens=max_output_tokens,
-        decode_only=decode_only,  # This test fails prefill + decode with low decode pcc = Issue: https://github.com/tenstorrent/tt-xla/issues/4614
+        decode_only=decode_only,
         input_output_sharding_spec=("batch", None),
         use_mla_cache=True,
         arch="wormhole_galaxy",
@@ -2101,7 +2101,7 @@ def test_kimi_k2_5_tp_galaxy_2_layers(
         accuracy_testing=accuracy_testing,
         batch_size=64,  # Test hangs for a batch size of 128 - Issue: https://github.com/tenstorrent/tt-xla/issues/4565
         max_output_tokens=max_output_tokens,
-        decode_only=decode_only,  # This test fails prefill + decode with low decode pcc = Issue: https://github.com/tenstorrent/tt-xla/issues/4614
+        decode_only=decode_only,
         input_output_sharding_spec=("batch", None),
         use_mla_cache=True,
         arch="wormhole_galaxy",

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -2107,7 +2107,6 @@ def test_kimi_k2_5_tp_galaxy_2_layers(
         arch="wormhole_galaxy",
         optimization_level=0,
         trace_enabled=False,
-        required_pcc=0.94,
     )
 
 

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -2107,7 +2107,7 @@ def test_kimi_k2_5_tp_galaxy_2_layers(
         arch="wormhole_galaxy",
         optimization_level=0,
         trace_enabled=False,
-        required_pcc=0.90,
+        required_pcc=0.94,
     )
 
 

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -2075,6 +2075,42 @@ def test_kimi_k2_tp_galaxy_2_layers(
     )
 
 
+# Trace disabled: topk i64 indices can't reside in device DRAM inside capture_or_execute_trace
+# This test only runs 2 layers so we expect to see incoherent output
+def test_kimi_k2_5_tp_galaxy_2_layers(
+    output_file,
+    num_layers,
+    request,
+    accuracy_testing,
+    batch_size,
+    max_output_tokens,
+    decode_only,
+):
+    from third_party.tt_forge_models.kimi_k2.k2_5.pytorch.loader import (
+        ModelLoader,
+        ModelVariant,
+    )
+
+    variant = ModelVariant.KIMI_K2_5_MODIFIED
+    test_llm_tp(
+        ModelLoader,
+        variant,
+        output_file,
+        num_layers=2,
+        request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=64,  # Test hangs for a batch size of 128 - Issue: https://github.com/tenstorrent/tt-xla/issues/4565
+        max_output_tokens=max_output_tokens,
+        decode_only=decode_only,  # This test fails prefill + decode with low decode pcc = Issue: https://github.com/tenstorrent/tt-xla/issues/4614
+        input_output_sharding_spec=("batch", None),
+        use_mla_cache=True,
+        arch="wormhole_galaxy",
+        optimization_level=0,
+        trace_enabled=False,
+        required_pcc=0.90,
+    )
+
+
 # This test only runs 2 layers so we expect to see incoherent output
 def test_deepseek_v3_2_exp_tp_galaxy_2_layers(
     output_file,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/4351

### Problem description
We want to bringup kimi-k2.6. Since kimi-k2.5 is passing as a two layer benchmark we can start by adding this. 

### What's changed
Added a 2 layer benchmark for kimi-k2.5 (with trace disabled). This test sees the same hang as kimi-k2 for `batch_size=128` so `batch_size=64` for now.

Also removed comment about resolved issue for kimi-k2 pcc.

### Checklist
- [x] New/Existing tests provide coverage for changes
