### PR TITLE
Fix off by 1 in accuracy benchmark loop

### DIFF
--- a/tests/benchmark/benchmarks/llm_benchmark.py
+++ b/tests/benchmark/benchmarks/llm_benchmark.py
@@ -653,17 +653,19 @@ def benchmark_llm_torch_xla(
 
     # The prefill call above already consumed gt[0] as teacher-forced input for
     # the first decode step, so the decode call must start its ground-truth
-    # window at gt[1] to stay aligned.
+    # window at gt[1] to stay aligned. It also consumed one of the logits_steps
+    # total iterations, so decode runs logits_steps-1 steps (not logits_steps).
     decode_ground_truth = (
         ground_truth_for_benchmark[1:]
         if ground_truth_for_benchmark is not None and not decode_only
         else ground_truth_for_benchmark
     )
+    decode_steps = logits_steps if decode_only else logits_steps - 1
     device_decode_logits, _ = generate_and_benchmark(
         compiled_logits,
         input_args,
         device,
-        logits_steps,
+        decode_steps,
         verbose=False,
         ground_truth_tokens=decode_ground_truth,
         collect_logits=True,


### PR DESCRIPTION
### Ticket
#4758

### Problem description
The accuracy benchmark loop in `tests/benchmark/benchmarks/llm_benchmark.py` ran one decode iteration too many. The prefill call already consumes one of the `logits_steps` total iterations (and one ground-truth token at `gt[0]`), but the subsequent decode loop was still configured for the full `logits_steps`, leading to an off-by-one in the total number of steps executed.

### What's changed
- Decode now runs `logits_steps - 1` steps when not in `decode_only` mode, so the total number of iterations across prefill + decode matches `logits_steps`.
- `decode_only` path is unchanged (still runs the full `logits_steps`).
- Updated the comment to explain both the ground-truth window shift and the step-count adjustment.

### Benchmark runs (llama_3_2_1b)
- Perf (single chip, n150): https://github.com/tenstorrent/tt-xla/actions/runs/26175651870
- Accuracy (experimental workflow, includes `llama_3_2_1b_instruct_accuracy` on n150): https://github.com/tenstorrent/tt-xla/actions/runs/26175656084

### Checklist
- [x] New/Existing tests provide coverage for changes