### PR TITLE
[CI] Move p150 perf benchmarks from experimental to main nightly

### DIFF
--- a/.github/workflows/schedule-benchmark-experimental.yml
+++ b/.github/workflows/schedule-benchmark-experimental.yml
@@ -25,16 +25,6 @@ jobs:
     with:
       docker_image: ${{ needs.build-image.outputs.docker-image }}
 
-  run-p150-perf-benchmarks:
-    needs: [build-image, build-ttxla]
-    secrets: inherit
-    uses: ./.github/workflows/call-filtered-perf-tests.yml
-    with:
-      adv_filter: '[ {"runs-on": "p150", "accuracy-testing": false} ]'
-      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
-      artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
-      regression_check: true
-
   run-n150-accuracy-benchmarks:
     needs: [build-image, build-ttxla]
     secrets: inherit
@@ -68,7 +58,6 @@ jobs:
 
   fail-notify:
     needs:
-      - run-p150-perf-benchmarks
       - run-n150-accuracy-benchmarks
       - run-llmbox-accuracy-benchmarks
       - run-galaxy-accuracy-benchmarks

--- a/.github/workflows/schedule-nightly.yml
+++ b/.github/workflows/schedule-nightly.yml
@@ -89,7 +89,7 @@ jobs:
       sh-runner: false
       skip-device-perf: true
       regression_check: true
-      adv_filter: '[ {"accuracy-testing": false}, {"runs-on": "n150"}, {"runs-on": "n300-llmbox"}, {"runs-on": "galaxy-wh-6u"} ]'
+      adv_filter: '[ {"accuracy-testing": false}, {"runs-on": "n150"}, {"runs-on": "p150"}, {"runs-on": "n300-llmbox"}, {"runs-on": "galaxy-wh-6u"} ]'
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
       wheel_build: manylinux


### PR DESCRIPTION
## Summary

- Add `{"runs-on": "p150"}` to the `perf-benchmark` adv_filter in `schedule-nightly.yml` so the **35 single-chip Blackhole perf tests** now run alongside n150 / n300-llmbox / galaxy-wh-6u in the main nightly.
- Delete the now-redundant `run-p150-perf-benchmarks` job from `schedule-benchmark-experimental.yml` (and its `fail-notify.needs` entry).

