### PR TITLE
[Benchmark] Add kv_cache PCC check

### DIFF
--- a/tests/benchmark/benchmarks/llm_benchmark.py
+++ b/tests/benchmark/benchmarks/llm_benchmark.py
@@ -406,18 +406,26 @@ def benchmark_llm_torch_xla(
     cpu_output_logits: list = []
     cpu_output_tokens: Optional[torch.Tensor] = None
     if not accuracy_testing:
-        cpu_wrapper = LLMSamplingWrapper(model, read_logits_fn, return_logits=True)
+        cpu_wrapper = LLMSamplingWrapper(
+            model, read_logits_fn, return_logits=True, return_kv_cache=True
+        )
         cpu_wrapper.eval()
 
         # Iter 0: prefill. After this, input_args holds the post-prefill decode
         # state (input_ids=next_token_0, cache_position=[prompt_len]).
-        cpu_prefill_logits, cpu_prefill_tokens, _ = generate_and_benchmark(
+        (
+            cpu_prefill_logits,
+            cpu_prefill_tokens,
+            cpu_prefill_kv,
+            _,
+        ) = generate_and_benchmark(
             cpu_wrapper,
             input_args,
             torch.device("cpu"),
             1,
             verbose=False,
             collect_logits=True,
+            collect_kv_cache=True,
         )
 
         # Snapshot first-decode inputs before CPU iter 1 advances them.
@@ -425,16 +433,23 @@ def benchmark_llm_torch_xla(
         decode_only_cache_position = input_args["cache_position"].clone()
         decode_only_cache = input_args["past_key_values"]
 
-        cpu_decode_logits, cpu_decode_tokens, _ = generate_and_benchmark(
+        (
+            cpu_decode_logits,
+            cpu_decode_tokens,
+            cpu_decode_kv,
+            _,
+        ) = generate_and_benchmark(
             cpu_wrapper,
             input_args,
             torch.device("cpu"),
             NUM_PCC_DECODE_STEPS,
             verbose=False,
             collect_logits=True,
+            collect_kv_cache=True,
         )
 
         cpu_output_logits = cpu_prefill_logits + cpu_decode_logits
+        cpu_output_kv_cache = cpu_prefill_kv + cpu_decode_kv
 
         # CPU output tokens, used to teacher-force the device PCC run for the
         # first len(cpu_output_logits) steps.
@@ -539,7 +554,7 @@ def benchmark_llm_torch_xla(
                 )
         print("Warming up...")
         warmup_tokens = min(MIN_STEPS, max_output_tokens)
-        _, _, _ = generate_and_benchmark(
+        _, _, _, _ = generate_and_benchmark(
             compiled_perf_model,
             input_args,
             device,
@@ -582,7 +597,7 @@ def benchmark_llm_torch_xla(
 
     # Run perf benchmark
     print(f"\nStarting performance benchmark...")
-    _, _, iteration_times = generate_and_benchmark(
+    _, _, _, iteration_times = generate_and_benchmark(
         compiled_perf_model,
         input_args,
         device,
@@ -603,6 +618,7 @@ def benchmark_llm_torch_xla(
         model,
         read_logits_fn,
         return_logits=True,
+        return_kv_cache=True,
         mesh=mesh,
         output_sharding_spec=input_output_sharding_spec,
     )
@@ -648,7 +664,7 @@ def benchmark_llm_torch_xla(
     # logits_steps counts prefill (when present) as one of the total iterations,
     # so the unified call runs exactly logits_steps iters in both decode_only
     # and prefill+decode modes.
-    output_logits, _, _ = generate_and_benchmark(
+    output_logits, _, output_kv_cache, _ = generate_and_benchmark(
         compiled_logits,
         input_args,
         device,
@@ -656,6 +672,7 @@ def benchmark_llm_torch_xla(
         verbose=False,
         ground_truth_tokens=device_gt,
         collect_logits=True,
+        collect_kv_cache=True,
     )
 
     print("\nPCC/TOPK benchmark complete")
@@ -793,14 +810,9 @@ def benchmark_llm_torch_xla(
         assert (
             len(output_logits) >= 1 + NUM_PCC_DECODE_STEPS
             and len(cpu_output_logits) >= 1 + NUM_PCC_DECODE_STEPS
-        ), "Not enough logits to check PCC"
-
-        # Pre-transfer device KV cache to CPU once.
-        cpu_pkv = decode_only_cache
-        device_layers_cpu = [
-            (layer.keys.to("cpu"), layer.values.to("cpu"))
-            for layer in input_args["past_key_values"].layers
-        ]
+            and len(output_kv_cache) >= 1 + NUM_PCC_DECODE_STEPS
+            and len(cpu_output_kv_cache) >= 1 + NUM_PCC_DECODE_STEPS
+        ), "Not enough logits/kv-cache snapshots to check PCC"
 
         # Logit PCC + KV-cache PCC.
         for step in range(1 + NUM_PCC_DECODE_STEPS):
@@ -818,13 +830,16 @@ def benchmark_llm_torch_xla(
             print(f"{label} PCC verification passed with PCC={pcc_value:.6f}")
 
             end_position = prompt_len + step
-            for layer_idx, (cpu_layer, (dev_keys, dev_values)) in enumerate(
-                zip(cpu_pkv.layers, device_layers_cpu)
-            ):
-                cpu_k = cpu_layer.keys[:, :, :end_position, :]
-                cpu_v = cpu_layer.values[:, :, :end_position, :]
-                dev_k = dev_keys[:, :, :end_position, :]
-                dev_v = dev_values[:, :, :end_position, :]
+            dev_layers = output_kv_cache[step]
+            cpu_layers = cpu_output_kv_cache[step]
+            for layer_idx, (
+                (cpu_k_full, cpu_v_full),
+                (dev_k_full, dev_v_full),
+            ) in enumerate(zip(cpu_layers, dev_layers)):
+                cpu_k = cpu_k_full[:, :, :end_position, :]
+                cpu_v = cpu_v_full[:, :, :end_position, :]
+                dev_k = dev_k_full[:, :, :end_position, :]
+                dev_v = dev_v_full[:, :, :end_position, :]
                 pcc_k = compute_pcc(cpu_k, dev_k)
                 pcc_v = compute_pcc(cpu_v, dev_v)
                 assert pcc_k >= required_pcc, (
@@ -837,7 +852,7 @@ def benchmark_llm_torch_xla(
                 )
             print(
                 f"KV cache PCC after {label} passed for all "
-                f"{len(cpu_pkv.layers)} layers"
+                f"{len(cpu_layers)} layers"
             )
 
     # Get device count and mesh info for metrics

--- a/tests/benchmark/benchmarks/llm_benchmark.py
+++ b/tests/benchmark/benchmarks/llm_benchmark.py
@@ -46,6 +46,10 @@ xr.set_device_type("TT")
 
 MIN_STEPS = 16
 
+# Number of decode steps to PCC-check on top of the prefill. So the total number
+# of PCC checkpoints (logit PCC + KV-cache PCC) is 1 + NUM_PCC_DECODE_STEPS.
+NUM_PCC_DECODE_STEPS = 1
+
 # Default input prompt
 DEFAULT_INPUT_PROMPT = (
     "Here is an exaustive list of the best practices for writing clean code:"
@@ -392,11 +396,15 @@ def benchmark_llm_torch_xla(
             dtype=torch.bfloat16,
         )
 
+    prompt_len = input_args["input_ids"].shape[1]
+
     # Limit maximum generation count to fit within preallocated static cache
     if max_output_tokens is None:
-        max_output_tokens = max_cache_len - input_args["input_ids"].shape[1]
+        max_output_tokens = max_cache_len - prompt_len
 
     # Run CPU prefill (used as PCC baseline, or as decode-only prefill)
+    cpu_output_logits: list = []
+    cpu_output_tokens: Optional[torch.Tensor] = None
     if not accuracy_testing:
         cpu_wrapper = LLMSamplingWrapper(model, read_logits_fn, return_logits=True)
         cpu_wrapper.eval()
@@ -417,17 +425,29 @@ def benchmark_llm_torch_xla(
         decode_only_cache_position = input_args["cache_position"].clone()
         decode_only_cache = input_args["past_key_values"]
 
-        # Iter 1: first decode. Provides the PCC reference for device first decode.
-        cpu_decode_logits, _ = generate_and_benchmark(
-            cpu_wrapper,
-            input_args,
-            torch.device("cpu"),
-            1,
-            verbose=False,
-            collect_logits=True,
-        )
+        # Run NUM_PCC_DECODE_STEPS decode steps.
+        cpu_decode_logits: list = []
+        if NUM_PCC_DECODE_STEPS > 0:
+            cpu_decode_logits, _ = generate_and_benchmark(
+                cpu_wrapper,
+                input_args,
+                torch.device("cpu"),
+                NUM_PCC_DECODE_STEPS,
+                verbose=False,
+                collect_logits=True,
+            )
 
         cpu_output_logits = cpu_prefill_logits + cpu_decode_logits
+
+        # CPU output tokens, used to teacher-force the device PCC run
+        # for the first len(cpu_output_logits) steps.
+        cpu_output_tokens = torch.tensor(
+            [
+                int(logits[0, -1, :].argmax(dim=-1).item())
+                for logits in cpu_output_logits
+            ],
+            dtype=torch.long,
+        )
 
     # Transfer model to device
     model = model.to(device, dtype=torch.bfloat16)
@@ -621,57 +641,25 @@ def benchmark_llm_torch_xla(
 
     print("\nStarting PCC/TOPK benchmark...")
 
-    device_prefill_logits = []
-    if not decode_only:
-        device_prefill_logits, _ = generate_and_benchmark(
-            compiled_logits,
-            input_args,
-            device,
-            1,
-            verbose=False,
-            ground_truth_tokens=ground_truth_for_benchmark,
-            collect_logits=True,
-        )
+    # Teacher-force device decode steps with the grpund truth CPU output tokens
+    # (or reference tokens for accuracy testing).
+    if accuracy_testing:
+        device_gt = ground_truth_for_benchmark
+    elif decode_only:
+        device_gt = None
+    else:
+        device_gt = cpu_output_tokens
 
-        device_prefill_output_ids = input_args["input_ids"].to("cpu")
-
-        # Override device's first-decode input with CPU's prefill output when they
-        # diverge, so the decode PCC reference is comparing apples to apples
-        # (otherwise a poor prefill PCC compounds into the decode PCC — see #4614).
-        if not accuracy_testing and not torch.equal(
-            device_prefill_output_ids, first_decode_input_ids.cpu()
-        ):
-            logger.warning(
-                "Device prefill produced different tokens than CPU prefill; "
-                "using CPU prefill output as decode PCC reference."
-            )
-            input_args["input_ids"] = first_decode_input_ids.to(device)
-            if input_output_sharding_spec:
-                xs.mark_sharding(
-                    input_args["input_ids"], mesh, input_output_sharding_spec
-                )
-
-    # The prefill call above already consumed gt[0] as teacher-forced input for
-    # the first decode step, so the decode call must start its ground-truth
-    # window at gt[1] to stay aligned. It also consumed one of the logits_steps
-    # total iterations, so decode runs logits_steps-1 steps (not logits_steps).
-    decode_ground_truth = (
-        ground_truth_for_benchmark[1:]
-        if ground_truth_for_benchmark is not None and not decode_only
-        else ground_truth_for_benchmark
-    )
-    decode_steps = logits_steps if decode_only else logits_steps - 1
-    device_decode_logits, _ = generate_and_benchmark(
+    total_steps = logits_steps if decode_only else 1 + logits_steps
+    output_logits, _ = generate_and_benchmark(
         compiled_logits,
         input_args,
         device,
-        decode_steps,
+        total_steps,
         verbose=False,
-        ground_truth_tokens=decode_ground_truth,
+        ground_truth_tokens=device_gt,
         collect_logits=True,
     )
-
-    output_logits = device_prefill_logits + device_decode_logits
 
     print("\nPCC/TOPK benchmark complete")
 
@@ -793,35 +781,67 @@ def benchmark_llm_torch_xla(
             ]
         )
     elif decode_only:
-        decode_pcc_value = compute_pcc(output_logits[0][0], cpu_output_logits[1][0])
-        assert (
-            decode_pcc_value >= required_pcc
-        ), f"First decode PCC failed. PCC={decode_pcc_value:.6f}, Required={required_pcc}"
-        print(
-            "First decode PCC verification passed with PCC={:.6f}".format(
-                decode_pcc_value
+        # decode_only skips device prefill, so device step k matches CPU step k+1.
+        for step in range(NUM_PCC_DECODE_STEPS):
+            label = "First decode" if step == 0 else f"Decode step {step + 1}"
+            decode_pcc_value = compute_pcc(
+                output_logits[step][0], cpu_output_logits[step + 1][0]
             )
-        )
+            assert decode_pcc_value >= required_pcc, (
+                f"{label} PCC failed. PCC={decode_pcc_value:.6f}, "
+                f"Required={required_pcc}"
+            )
+            print(f"{label} PCC verification passed with PCC={decode_pcc_value:.6f}")
     else:
-        # Check PCC for prefill
-        pcc_value = compute_pcc(output_logits[0][0], cpu_output_logits[0][0])
         assert (
-            pcc_value >= required_pcc
-        ), f"Prefill PCC failed. PCC={pcc_value:.6f}, Required={required_pcc}"
-        print("Prefill PCC verification passed with PCC={:.6f}".format(pcc_value))
-        # Check PCC for first decode token
-        assert (
-            len(output_logits) > 1 and len(cpu_output_logits) > 1
+            len(output_logits) >= 1 + NUM_PCC_DECODE_STEPS
+            and len(cpu_output_logits) >= 1 + NUM_PCC_DECODE_STEPS
         ), "Not enough logits to check PCC"
-        decode_pcc_value = compute_pcc(output_logits[1][0], cpu_output_logits[1][0])
-        assert (
-            decode_pcc_value >= required_pcc
-        ), f"First decode PCC failed. PCC={decode_pcc_value:.6f}, Required={required_pcc}"
-        print(
-            "First decode PCC verification passed with PCC={:.6f}".format(
-                decode_pcc_value
+
+        # Pre-transfer device KV cache to CPU once.
+        cpu_pkv = decode_only_cache
+        device_layers_cpu = [
+            (layer.keys.to("cpu"), layer.values.to("cpu"))
+            for layer in input_args["past_key_values"].layers
+        ]
+
+        # Logit PCC + KV-cache PCC.
+        for step in range(1 + NUM_PCC_DECODE_STEPS):
+            if step == 0:
+                label = "Prefill"
+            elif step == 1:
+                label = "First decode"
+            else:
+                label = f"Decode step {step}"
+
+            pcc_value = compute_pcc(output_logits[step][0], cpu_output_logits[step][0])
+            assert pcc_value >= required_pcc, (
+                f"{label} PCC failed. PCC={pcc_value:.6f}, " f"Required={required_pcc}"
             )
-        )
+            print(f"{label} PCC verification passed with PCC={pcc_value:.6f}")
+
+            end_position = prompt_len + step
+            for layer_idx, (cpu_layer, (dev_keys, dev_values)) in enumerate(
+                zip(cpu_pkv.layers, device_layers_cpu)
+            ):
+                cpu_k = cpu_layer.keys[:, :, :end_position, :]
+                cpu_v = cpu_layer.values[:, :, :end_position, :]
+                dev_k = dev_keys[:, :, :end_position, :]
+                dev_v = dev_values[:, :, :end_position, :]
+                pcc_k = compute_pcc(cpu_k, dev_k)
+                pcc_v = compute_pcc(cpu_v, dev_v)
+                assert pcc_k >= required_pcc, (
+                    f"KV cache keys PCC failed at {label} layer {layer_idx}: "
+                    f"PCC={pcc_k:.6f}, Required={required_pcc}"
+                )
+                assert pcc_v >= required_pcc, (
+                    f"KV cache values PCC failed at {label} layer {layer_idx}: "
+                    f"PCC={pcc_v:.6f}, Required={required_pcc}"
+                )
+            print(
+                f"KV cache PCC after {label} passed for all "
+                f"{len(cpu_pkv.layers)} layers"
+            )
 
     # Get device count and mesh info for metrics
     device_count = xr.global_runtime_device_count()

--- a/tests/benchmark/benchmarks/llm_benchmark.py
+++ b/tests/benchmark/benchmarks/llm_benchmark.py
@@ -650,12 +650,14 @@ def benchmark_llm_torch_xla(
     else:
         device_gt = cpu_output_tokens
 
-    total_steps = logits_steps if decode_only else 1 + logits_steps
+    # logits_steps counts prefill (when present) as one of the total iterations,
+    # so the unified call runs exactly logits_steps iters in both decode_only
+    # and prefill+decode modes.
     output_logits, _ = generate_and_benchmark(
         compiled_logits,
         input_args,
         device,
-        total_steps,
+        logits_steps,
         verbose=False,
         ground_truth_tokens=device_gt,
         collect_logits=True,

--- a/tests/benchmark/benchmarks/llm_benchmark.py
+++ b/tests/benchmark/benchmarks/llm_benchmark.py
@@ -411,7 +411,7 @@ def benchmark_llm_torch_xla(
 
         # Iter 0: prefill. After this, input_args holds the post-prefill decode
         # state (input_ids=next_token_0, cache_position=[prompt_len]).
-        cpu_prefill_logits, _ = generate_and_benchmark(
+        cpu_prefill_logits, cpu_prefill_tokens, _ = generate_and_benchmark(
             cpu_wrapper,
             input_args,
             torch.device("cpu"),
@@ -425,27 +425,22 @@ def benchmark_llm_torch_xla(
         decode_only_cache_position = input_args["cache_position"].clone()
         decode_only_cache = input_args["past_key_values"]
 
-        # Run NUM_PCC_DECODE_STEPS decode steps.
-        cpu_decode_logits: list = []
-        if NUM_PCC_DECODE_STEPS > 0:
-            cpu_decode_logits, _ = generate_and_benchmark(
-                cpu_wrapper,
-                input_args,
-                torch.device("cpu"),
-                NUM_PCC_DECODE_STEPS,
-                verbose=False,
-                collect_logits=True,
-            )
+        cpu_decode_logits, cpu_decode_tokens, _ = generate_and_benchmark(
+            cpu_wrapper,
+            input_args,
+            torch.device("cpu"),
+            NUM_PCC_DECODE_STEPS,
+            verbose=False,
+            collect_logits=True,
+        )
 
         cpu_output_logits = cpu_prefill_logits + cpu_decode_logits
 
-        # CPU output tokens, used to teacher-force the device PCC run
-        # for the first len(cpu_output_logits) steps.
+        # CPU output tokens, used to teacher-force the device PCC run for the
+        # first len(cpu_output_logits) steps.
+        cpu_output_token_tensors = cpu_prefill_tokens + cpu_decode_tokens
         cpu_output_tokens = torch.tensor(
-            [
-                int(logits[0, -1, :].argmax(dim=-1).item())
-                for logits in cpu_output_logits
-            ],
+            [int(t[0, 0]) for t in cpu_output_token_tensors],
             dtype=torch.long,
         )
 
@@ -544,7 +539,7 @@ def benchmark_llm_torch_xla(
                 )
         print("Warming up...")
         warmup_tokens = min(MIN_STEPS, max_output_tokens)
-        _, _ = generate_and_benchmark(
+        _, _, _ = generate_and_benchmark(
             compiled_perf_model,
             input_args,
             device,
@@ -587,7 +582,7 @@ def benchmark_llm_torch_xla(
 
     # Run perf benchmark
     print(f"\nStarting performance benchmark...")
-    _, iteration_times = generate_and_benchmark(
+    _, _, iteration_times = generate_and_benchmark(
         compiled_perf_model,
         input_args,
         device,
@@ -653,7 +648,7 @@ def benchmark_llm_torch_xla(
     # logits_steps counts prefill (when present) as one of the total iterations,
     # so the unified call runs exactly logits_steps iters in both decode_only
     # and prefill+decode modes.
-    output_logits, _ = generate_and_benchmark(
+    output_logits, _, _ = generate_and_benchmark(
         compiled_logits,
         input_args,
         device,

--- a/tests/benchmark/llm_utils/decode_utils.py
+++ b/tests/benchmark/llm_utils/decode_utils.py
@@ -276,7 +276,9 @@ def generate_and_benchmark(
         max_tokens_to_generate: Number of decode steps to run
         verbose: Print per-iteration timing
         ground_truth_tokens: 1D tensor of ground truth token IDs for teacher forcing.
-                           None = autoregressive mode.
+                           None = autoregressive mode. If shorter than
+                           max_tokens_to_generate, the loop teacher-forces while
+                           the gt window has tokens and autoregresses afterward.
         collect_logits: Whether to collect logits.
             True: Model must return (next_token_ids, next_cache_position, logits)
                   and logits are moved to CPU each step (for PCC/accuracy).
@@ -332,7 +334,7 @@ def generate_and_benchmark(
             else:
                 next_token_ids, next_token_ids_replicated, next_cache_position = output
 
-            if ground_truth_tokens is not None:
+            if gt_cpu is not None and step < gt_cpu.shape[0]:
                 input_args["input_ids"] = gt_cpu[step].to(device)
             else:
                 input_args["input_ids"] = next_token_ids

--- a/tests/benchmark/llm_utils/decode_utils.py
+++ b/tests/benchmark/llm_utils/decode_utils.py
@@ -33,6 +33,9 @@ class LLMSamplingWrapper(torch.nn.Module):
         read_logits_fn: Function to extract logits from model output.
         return_logits: If True, forward() returns (next_token_ids, next_cache_position, logits).
             If False, returns (next_token_ids, next_cache_position) only.
+        return_kv_cache: If True, forward() additionally returns per-layer
+            (keys, values) tensors extracted from model output.past_key_values.
+            Requires return_logits=True.
         mesh: Optional SPMD mesh for sharding constraints.
         output_sharding_spec: Optional sharding spec for output token ids.
             When both mesh and output_sharding_spec are provided, applies a
@@ -44,13 +47,17 @@ class LLMSamplingWrapper(torch.nn.Module):
         model: torch.nn.Module,
         read_logits_fn,
         return_logits: bool = True,
+        return_kv_cache: bool = False,
         mesh=None,
         output_sharding_spec=None,
     ):
         super().__init__()
+        if return_kv_cache and not return_logits:
+            raise ValueError("return_kv_cache=True requires return_logits=True")
         self.model = model
         self.read_logits_fn = read_logits_fn
         self.return_logits = return_logits
+        self.return_kv_cache = return_kv_cache
         self.mesh = mesh
         self.output_sharding_spec = output_sharding_spec
 
@@ -87,6 +94,25 @@ class LLMSamplingWrapper(torch.nn.Module):
                 replicate_spec = tuple(None for _ in range(logits_out.dim()))
                 logits_out = sharding_constraint_tensor(
                     logits, self.mesh, replicate_spec
+                )
+            if self.return_kv_cache:
+                # Surface per-layer K/V from model output. Replicate when sharded
+                # so the consumer can transfer to CPU.
+                kv_cache_out = []
+                for layer in output.past_key_values.layers:
+                    k, v = layer.keys, layer.values
+                    if self.mesh and self.output_sharding_spec:
+                        k_replicate = tuple(None for _ in range(k.dim()))
+                        v_replicate = tuple(None for _ in range(v.dim()))
+                        k = sharding_constraint_tensor(k, self.mesh, k_replicate)
+                        v = sharding_constraint_tensor(v, self.mesh, v_replicate)
+                    kv_cache_out.append((k, v))
+                return (
+                    next_token_ids,
+                    next_token_ids_replicated,
+                    next_cache_position,
+                    logits_out,
+                    kv_cache_out,
                 )
             return (
                 next_token_ids,
@@ -265,8 +291,14 @@ def generate_and_benchmark(
     verbose: bool = True,
     ground_truth_tokens: Optional[torch.Tensor] = None,
     collect_logits: bool = True,
+    collect_kv_cache: bool = False,
     tokenizer=None,
-) -> tuple[list[torch.Tensor], list[torch.Tensor], list[int]]:
+) -> tuple[
+    list[torch.Tensor],
+    list[torch.Tensor],
+    list[list[tuple[torch.Tensor, torch.Tensor]]],
+    list[int],
+]:
     """On-device decode loop for benchmarks and accuracy testing.
 
     Args:
@@ -280,19 +312,26 @@ def generate_and_benchmark(
                            max_tokens_to_generate, the loop teacher-forces while
                            the gt window has tokens and autoregresses afterward.
         collect_logits: Whether to collect logits.
-            True: Model must return (next_token_ids, next_cache_position, logits)
+            True: Model must return (next_token_ids, next_cache_position, logits[, kv_cache])
                   and logits are moved to CPU each step (for PCC/accuracy).
             False: Model must return (next_token_ids, next_cache_position) only
                   (for performance benchmarking without OOM risk).
+        collect_kv_cache: If True, also collect per-step per-layer (keys, values)
+            tensors surfaced by the wrapper. Requires collect_logits=True and a
+            wrapper built with return_kv_cache=True.
         tokenizer: Optional tokenizer for decoding generated token IDs to text.
 
     Returns:
-        (output_logits, output_tokens, iteration_times)
+        (output_logits, output_tokens, output_kv_cache, iteration_times)
         - output_logits: List of logit tensors per step (empty if collect_logits=False)
         - output_tokens: List of per-step next_token_ids tensors (shape [batch_size, 1])
                          moved to CPU.
+        - output_kv_cache: List per step of [(keys_cpu, values_cpu)] per layer
+                           (empty if collect_kv_cache=False).
         - iteration_times: List of iteration times in nanoseconds
     """
+    if collect_kv_cache and not collect_logits:
+        raise ValueError("collect_kv_cache=True requires collect_logits=True")
 
     if ground_truth_tokens is not None:
         assert (
@@ -305,6 +344,7 @@ def generate_and_benchmark(
 
     output_logits: list[torch.Tensor] = []
     output_tokens: list[torch.Tensor] = []
+    output_kv_cache: list[list[tuple[torch.Tensor, torch.Tensor]]] = []
     iteration_times: list[int] = []
     generated_texts: list[str] = [""] * batch_size
 
@@ -327,12 +367,24 @@ def generate_and_benchmark(
             output = model(**input_args)
 
             if collect_logits:
-                (
-                    next_token_ids,
-                    next_token_ids_replicated,
-                    next_cache_position,
-                    logits,
-                ) = output
+                if collect_kv_cache:
+                    (
+                        next_token_ids,
+                        next_token_ids_replicated,
+                        next_cache_position,
+                        logits,
+                        kv_cache,
+                    ) = output
+                    output_kv_cache.append(
+                        [(k.to("cpu"), v.to("cpu")) for k, v in kv_cache]
+                    )
+                else:
+                    (
+                        next_token_ids,
+                        next_token_ids_replicated,
+                        next_cache_position,
+                        logits,
+                    ) = output
                 output_logits.append(logits.to("cpu"))
                 output_tokens.append(next_token_ids_replicated.to("cpu"))
             else:
@@ -363,7 +415,7 @@ def generate_and_benchmark(
         for i in range(batch_size):
             print(f"User {i}: {generated_texts[i]}")
 
-    return output_logits, output_tokens, iteration_times
+    return output_logits, output_tokens, output_kv_cache, iteration_times
 
 
 def init_accuracy_testing(

--- a/tests/benchmark/llm_utils/decode_utils.py
+++ b/tests/benchmark/llm_utils/decode_utils.py
@@ -266,7 +266,7 @@ def generate_and_benchmark(
     ground_truth_tokens: Optional[torch.Tensor] = None,
     collect_logits: bool = True,
     tokenizer=None,
-) -> tuple[list[torch.Tensor], list[int]]:
+) -> tuple[list[torch.Tensor], list[torch.Tensor], list[int]]:
     """On-device decode loop for benchmarks and accuracy testing.
 
     Args:
@@ -287,8 +287,10 @@ def generate_and_benchmark(
         tokenizer: Optional tokenizer for decoding generated token IDs to text.
 
     Returns:
-        (output_logits, iteration_times)
+        (output_logits, output_tokens, iteration_times)
         - output_logits: List of logit tensors per step (empty if collect_logits=False)
+        - output_tokens: List of per-step next_token_ids tensors (shape [batch_size, 1])
+                         moved to CPU.
         - iteration_times: List of iteration times in nanoseconds
     """
 
@@ -302,6 +304,7 @@ def generate_and_benchmark(
     batch_size = input_args["input_ids"].shape[0]
 
     output_logits: list[torch.Tensor] = []
+    output_tokens: list[torch.Tensor] = []
     iteration_times: list[int] = []
     generated_texts: list[str] = [""] * batch_size
 
@@ -331,6 +334,7 @@ def generate_and_benchmark(
                     logits,
                 ) = output
                 output_logits.append(logits.to("cpu"))
+                output_tokens.append(next_token_ids_replicated.to("cpu"))
             else:
                 next_token_ids, next_token_ids_replicated, next_cache_position = output
 
@@ -359,7 +363,7 @@ def generate_and_benchmark(
         for i in range(batch_size):
             print(f"User {i}: {generated_texts[i]}")
 
-    return output_logits, iteration_times
+    return output_logits, output_tokens, iteration_times
 
 
 def init_accuracy_testing(


### PR DESCRIPTION
### Ticket
Closes #4783 

### Problem description
Currently we measure PCC only for first user's prefill and first decode logits.
As a next step in extending PCC check, we want to add PCC check for KV cache.

### What's changed
- Added KV cache PCC check, for same number of steps as output logits PCC check.
- Modified `generate_and_benchmark` teacher-forcing logic so it can teacher-force a smaller window of ground truth tokens, and then continue autoregressivelly to full length of decode steps. This removes the need to split prefill and decode calls introduced in https://github.com/tenstorrent/tt-xla/commit/392e200b9ff69edcea01568330ed1ac09ca8b016

### Notes
We expect many models to fail because of this issue: #4785 

### Checklist
- [ ] [n150 LLMs](https://github.com/tenstorrent/tt-xla/actions/runs/26224737758)
- [ ] [LLMBOX LLMs](https://github.com/tenstorrent/tt-xla/actions/runs/26224756956)
- [ ] [Galaxy LLMs](https://github.com/tenstorrent/tt-xla/actions/runs/26224777626)
- [ ] [n150 LLMs on Marina's fix](https://github.com/tenstorrent/tt-xla/actions/runs/26505643781)
- [ ] [falcon3_10b_tp on Marina's fix](https://github.com/tenstorrent/tt-xla/actions/runs/26505570056)
