### PR TITLE
Nightly Maintance may21

### DIFF
--- a/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
@@ -110,8 +110,7 @@ test_config:
 
   llama/causal_lm/pytorch-3.2_3B-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     status: EXPECTED_PASSING
-    assert_pcc: false
-    required_pcc: 0.97
+    required_pcc: 0.98
 
   llama/causal_lm/pytorch-Tinyllama_v1.1-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     status: EXPECTED_PASSING

--- a/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
@@ -125,17 +125,17 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox", "lb-blackhole"]
-    required_pcc: 0.95
+    required_pcc: 0.96
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_4-fsdp-no_dp-tensor_parallel-mesh_4x8-inference:
     supported_archs: ["galaxy-wh-6u"]
-    required_pcc: 0.95
+    required_pcc: 0.96
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-fsdp-no_dp-tensor_parallel-mesh_4x8-inference:
     supported_archs: ["galaxy-wh-6u"]
-    required_pcc: 0.90
+    required_pcc: 0.91
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_4-fsdp-no_dp-tensor_parallel-mesh_4x8-inference:
@@ -178,7 +178,7 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox", "lb-blackhole"]
-    required_pcc: 0.90
+    required_pcc: 0.91
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_4-fsdp-dp-tensor_parallel-mesh_4x8-inference:
@@ -220,17 +220,17 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox", "lb-blackhole"]
-    required_pcc: 0.95
+    required_pcc: 0.96
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_4-megatron-no_dp-tensor_parallel-mesh_4x8-inference:
     supported_archs: ["galaxy-wh-6u"]
-    required_pcc: 0.95
+    required_pcc: 0.96
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox", "lb-blackhole"]
-    required_pcc: 0.90
+    required_pcc: 0.91
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_4-megatron-no_dp-tensor_parallel-mesh_4x8-inference:
@@ -272,7 +272,7 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox", "lb-blackhole"]
-    required_pcc: 0.95
+    required_pcc: 0.96
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_4-megatron-dp-tensor_parallel-mesh_4x8-inference:


### PR DESCRIPTION
## Summary

Nightly maintenance updates for the may21 nightly run ([26250613769](https://github.com/tenstorrent/tt-xla/actions/runs/26250613769)). Updates `required_pcc` overrides for inference tests that now consistently pass at a higher threshold than previously configured.

## Changes (status: true rows from `final_report.log`)

- `llama/causal_lm/pytorch-3.2_3B-llm_decode-seq_1-batch_1-single_device-mesh_default-inference` (`tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml`): drop `assert_pcc: false`; raise `required_pcc` 0.97 -> 0.98 (n150 pcc=0.9943, p150 pcc=0.9865, min floor = 0.98).
- `llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference` (`tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml`): raise `required_pcc` 0.95 -> 0.96 (n300-llmbox pcc=0.9642).
- `llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference` (same YAML): raise `required_pcc` 0.95 -> 0.96 (n300-llmbox pcc=0.9646).
- `llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference` (same YAML): raise `required_pcc` 0.95 -> 0.96 (n300-llmbox pcc=0.9641).
- `llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_4-fsdp-no_dp-tensor_parallel-mesh_4x8-inference` (same YAML): raise `required_pcc` 0.95 -> 0.96 (galaxy-wh-6u pcc=0.9675).
- `llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_4-megatron-no_dp-tensor_parallel-mesh_4x8-inference` (same YAML): raise `required_pcc` 0.95 -> 0.96 (galaxy-wh-6u pcc=0.9670).
- `llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference` (same YAML): raise `required_pcc` 0.90 -> 0.91 (n300-llmbox pcc=0.9147).
- `llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-fsdp-no_dp-tensor_parallel-mesh_4x8-inference` (same YAML): raise `required_pcc` 0.90 -> 0.91 (galaxy-wh-6u pcc=0.9154).
- `llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference` (same YAML): raise `required_pcc` 0.90 -> 0.91 (n300-llmbox pcc=0.9156).

The `phi3/phi_3_5/pytorch-Mini_Instruct-single_device-inference` entry resolved to `set_required_pcc=0.97`, which already matches the current YAML value — no edit applied.

Training-mode rows (13 of them) were intentionally skipped per the skill's training-out-of-scope rule. Tensor-parallel inference rows with `pcc < pcc_thres` were skipped via `status: false`.