### PR TITLE
HiDream_I1: add sharded test for text_encoder_3

### DIFF
--- a/tests/torch/models/HiDream_I1/test_text_encoder_3.py
+++ b/tests/torch/models/HiDream_I1/test_text_encoder_3.py
@@ -9,16 +9,28 @@ import torch
 import torch_xla
 import torch_xla.runtime as xr
 from infra import Framework, run_graph_test
+from infra.utilities.torch_multichip_utils import get_mesh
 
 from third_party.tt_forge_models.hidream_i1.pytorch import ModelLoader, ModelVariant
 
 
+@pytest.mark.skip(
+    reason="OOM on single device - https://github.com/tenstorrent/tt-xla/issues/4760 , sharded variant runs"
+)
+def test_text_encoder_3():
+    _run(sharded=False)
+
+
 @pytest.mark.xfail(
-    reason="Out of Memory: Not enough space to allocate 167772160 B DRAM buffer across 12 banks, where each bank needs to store 13983744 B, but bank size is 1071821792 B — https://github.com/tenstorrent/tt-xla/issues/4760"
+    reason="AssertionError: Evaluation result 0 failed: PCC comparison failed. Calculated: pcc=0.9873067700897922. Required: pcc=0.99. - https://github.com/tenstorrent/tt-xla/issues/4847"
 )
 @pytest.mark.nightly
 @pytest.mark.model_test
-def test_text_encoder_3():
+def test_text_encoder_3_sharded():
+    _run(sharded=True)
+
+
+def _run(sharded: bool):
     xr.set_device_type("TT")
     torch.manual_seed(42)
 
@@ -26,8 +38,19 @@ def test_text_encoder_3():
     model = loader.load_model(dtype_override=torch.float32)
     inputs = loader.load_inputs(dtype_override=torch.float32)
 
+    mesh = None
+    shard_spec_fn = None
+    if sharded:
+        mesh_shape, mesh_names = loader.get_mesh_config(
+            xr.global_runtime_device_count()
+        )
+        mesh = get_mesh(mesh_shape, mesh_names)
+        shard_spec_fn = loader.load_shard_spec
+
     run_graph_test(
         model,
         inputs,
         framework=Framework.TORCH,
+        mesh=mesh,
+        shard_spec_fn=shard_spec_fn,
     )


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/4760

### Problem description

- `test_text_encoder_3` (HiDream-I1-Fast T5 v1.1 XXL encoder, ~4.6 B params) OOMs on a single chip — the model is too big to fit in ~1 GB of DRAM. See the linked issue for the full root-cause analysis.

### What's changed

-  Added sharded test for text_encoder_3
- Depends on the tt-forge-models change that adds `shard_t5_encoder_specs` and wires it through `ModelLoader.load_shard_spec` for `TEXT_ENCODER_3`. - https://github.com/tenstorrent/tt-forge-models/pull/692

### Checklist
- [x]  Verify the changes through local testing in WH

### Logs

- [may22_hidream_text_encoder3_1_chip.log](https://github.com/user-attachments/files/28142211/may22_hidream_text_encoder3.log)
- [may22_hidream_text_encoder3_2_chips.log](https://github.com/user-attachments/files/28142207/may22_hidream_text_encoder3_2_chips.log)
