### PR TITLE
 Fix JAX optimization_level not reaching PJRT plugin

### DIFF
--- a/pjrt_implementation/inc/api/compile_options.h
+++ b/pjrt_implementation/inc/api/compile_options.h
@@ -26,6 +26,10 @@ enum class BackendRuntime {
 
 // POD struct containing various options used to customize module compilation.
 struct CompileOptions {
+
+  // Map the key used to store and retrieve the optimization level
+  static inline const std::string optimization_level_key = "optimization_level";
+
   // Optimization level (0, 1, or 2) that controls multiple optimization passes.
   // See documentation for details on what each level enables.
   // Level 0 (default): All optimizations disabled

--- a/pjrt_implementation/src/api/compile_options.cc
+++ b/pjrt_implementation/src/api/compile_options.cc
@@ -18,7 +18,7 @@ CompileOptions CompileOptions::parse(
   CompileOptions options;
 
   options.optimization_level =
-      internal::parseIntOption(compile_options, "optimization_level")
+      internal::parseIntOption(compile_options, optimization_level_key)
           .value_or(options.optimization_level);
   options.experimental_weight_dtype =
       internal::parseStringOption(compile_options, "experimental_weight_dtype")

--- a/pjrt_implementation/src/api/compile_options_parser.cc
+++ b/pjrt_implementation/src/api/compile_options_parser.cc
@@ -4,6 +4,9 @@
 
 #include "api/compile_options_parser.h"
 
+// PJRT implementation headers
+#include "api/compile_options.h"
+
 // third-party includes
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/io/zero_copy_stream_impl_lite.h>
@@ -209,7 +212,7 @@ tt_pjrt_status CompileOptionsParser::extractCustomProtobufFields(
           if (exec_field.number() == kOptimizationLevelFieldNumber &&
               exec_field.type() ==
                   google::protobuf::UnknownField::TYPE_VARINT) {
-            out_compile_options.emplace("optimization_level",
+            out_compile_options.emplace(CompileOptions::optimization_level_key,
                                         std::to_string(exec_field.varint()));
           }
         }

--- a/pjrt_implementation/src/api/compile_options_parser.cc
+++ b/pjrt_implementation/src/api/compile_options_parser.cc
@@ -191,13 +191,32 @@ tt_pjrt_status CompileOptionsParser::extractCustomProtobufFields(
   // options map entry.
   constexpr int kMapValueFieldNumber = 2;
 
+  // ExecutableBuildOptionsProto is field #3 in CompileOptionsProto.
+  constexpr int kExecutableBuildOptionsFieldNumber = 3;
+
+  // Optimization level is field #24 inside ExecutableBuildOptionsProto.
+  constexpr int kOptimizationLevelFieldNumber = 24;
+
   for (int i = 0; i < unknown_fields.field_count(); ++i) {
     const google::protobuf::UnknownField &field = unknown_fields.field(i);
 
-    // Currently, we only support custom compiler options serialized in the
-    // `kCustomCompilerOptionsFieldNumber` field. In case we encounter
-    // options being serialized into some other field we will need to update
-    // this to support them.
+    if (field.number() == kExecutableBuildOptionsFieldNumber) {
+      google::protobuf::UnknownFieldSet exec_build_fields;
+      if (parseNestedProtobufField(field, exec_build_fields)) {
+        for (int j = 0; j < exec_build_fields.field_count(); ++j) {
+          const google::protobuf::UnknownField &exec_field =
+              exec_build_fields.field(j);
+          if (exec_field.number() == kOptimizationLevelFieldNumber &&
+              exec_field.type() ==
+                  google::protobuf::UnknownField::TYPE_VARINT) {
+            out_compile_options.emplace("optimization_level",
+                                        std::to_string(exec_field.varint()));
+          }
+        }
+      }
+      continue;
+    }
+
     if (field.number() != kCustomCompilerOptionsFieldNumber ||
         field.type() != google::protobuf::UnknownField::TYPE_LENGTH_DELIMITED) {
       continue;

--- a/pjrt_implementation/src/api/unit_tests/compile_options_parser_tests.cc
+++ b/pjrt_implementation/src/api/unit_tests/compile_options_parser_tests.cc
@@ -37,7 +37,6 @@ static constexpr uint32_t kWireTypeVarint = 0;
 // Protobuf field for length
 static constexpr uint32_t kWireTypeLengthDelimited = 2;
 
-
 // Helper to encode a varint field into wire-format bytes.
 static std::string encodeVarint(int field_number, uint64_t value) {
   std::string output;
@@ -52,8 +51,7 @@ static std::string encodeVarint(int field_number, uint64_t value) {
 }
 
 // Helper to encode a length field wrapping inner bytes.
-static std::string encodeLength(int field_number,
-                                              const std::string &data) {
+static std::string encodeLength(int field_number, const std::string &data) {
   std::string output;
   google::protobuf::io::StringOutputStream sos(&output);
   google::protobuf::io::CodedOutputStream cos(&sos);
@@ -88,9 +86,8 @@ TEST(CompileOptionsParserUnitTests,
   ASSERT_TRUE(parseToFieldSet(data, fields));
 
   std::unordered_map<std::string, std::string> compile_options;
-  tt_pjrt_status status =
-      CompileOptionsParser::extractCustomProtobufFields(fields,
-                                                        compile_options);
+  tt_pjrt_status status = CompileOptionsParser::extractCustomProtobufFields(
+      fields, compile_options);
   ASSERT_TRUE(tt_pjrt_status_is_ok(status));
   ASSERT_NE(compile_options.find("optimization_level"), compile_options.end());
   EXPECT_EQ(compile_options["optimization_level"], "0");
@@ -104,9 +101,8 @@ TEST(CompileOptionsParserUnitTests,
   ASSERT_TRUE(parseToFieldSet(data, fields));
 
   std::unordered_map<std::string, std::string> compile_options;
-  tt_pjrt_status status =
-      CompileOptionsParser::extractCustomProtobufFields(fields,
-                                                        compile_options);
+  tt_pjrt_status status = CompileOptionsParser::extractCustomProtobufFields(
+      fields, compile_options);
   ASSERT_TRUE(tt_pjrt_status_is_ok(status));
   ASSERT_NE(compile_options.find("optimization_level"), compile_options.end());
   EXPECT_EQ(compile_options["optimization_level"], "1");
@@ -120,9 +116,8 @@ TEST(CompileOptionsParserUnitTests,
   ASSERT_TRUE(parseToFieldSet(data, fields));
 
   std::unordered_map<std::string, std::string> compile_options;
-  tt_pjrt_status status =
-      CompileOptionsParser::extractCustomProtobufFields(fields,
-                                                        compile_options);
+  tt_pjrt_status status = CompileOptionsParser::extractCustomProtobufFields(
+      fields, compile_options);
   ASSERT_TRUE(tt_pjrt_status_is_ok(status));
   ASSERT_NE(compile_options.find("optimization_level"), compile_options.end());
   EXPECT_EQ(compile_options["optimization_level"], "2");
@@ -133,9 +128,8 @@ TEST(CompileOptionsParserUnitTests,
   google::protobuf::UnknownFieldSet fields;
 
   std::unordered_map<std::string, std::string> compile_options;
-  tt_pjrt_status status =
-      CompileOptionsParser::extractCustomProtobufFields(fields,
-                                                        compile_options);
+  tt_pjrt_status status = CompileOptionsParser::extractCustomProtobufFields(
+      fields, compile_options);
   ASSERT_TRUE(tt_pjrt_status_is_ok(status));
   EXPECT_EQ(compile_options.find("optimization_level"), compile_options.end());
 }
@@ -150,9 +144,8 @@ TEST(CompileOptionsParserUnitTests,
   ASSERT_TRUE(parseToFieldSet(unrelated, fields));
 
   std::unordered_map<std::string, std::string> compile_options;
-  tt_pjrt_status status =
-      CompileOptionsParser::extractCustomProtobufFields(fields,
-                                                        compile_options);
+  tt_pjrt_status status = CompileOptionsParser::extractCustomProtobufFields(
+      fields, compile_options);
   ASSERT_TRUE(tt_pjrt_status_is_ok(status));
   EXPECT_TRUE(compile_options.empty());
 }

--- a/pjrt_implementation/src/api/unit_tests/compile_options_parser_tests.cc
+++ b/pjrt_implementation/src/api/unit_tests/compile_options_parser_tests.cc
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+// SPDX-FileCopyrightText: Copyright 2023 The IREE Authors
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// https://llvm.org/LICENSE.txt
+
+// C++ standard library headers
+#include <string>
+#include <unordered_map>
+
+// GTest headers
+#include "gtest/gtest.h"
+
+// Protobuf headers
+#include <google/protobuf/io/coded_stream.h>
+#include <google/protobuf/io/zero_copy_stream_impl_lite.h>
+#include <google/protobuf/unknown_field_set.h>
+
+// PJRT implementation headers
+#include "api/compile_options_parser.h"
+
+namespace tt::pjrt::tests {
+
+// ExecutableBuildOptionsProto is field #3 in CompileOptionsProto.
+constexpr int kExecutableBuildOptionsFieldNumber = 3;
+
+// Optimization level is field #24 inside ExecutableBuildOptionsProto.
+constexpr int kOptimizationLevelFieldNumber = 24;
+
+// Protobuf field for varint
+static constexpr uint32_t kWireTypeVarint = 0;
+
+// Protobuf field for length
+static constexpr uint32_t kWireTypeLengthDelimited = 2;
+
+
+// Helper to encode a varint field into wire-format bytes.
+static std::string encodeVarint(int field_number, uint64_t value) {
+  std::string output;
+  google::protobuf::io::StringOutputStream sos(&output);
+  google::protobuf::io::CodedOutputStream cos(&sos);
+
+  // Shifting by 3 since protobuf has only 6 different types
+  cos.WriteTag((field_number << 3) | kWireTypeVarint);
+  cos.WriteVarint64(value);
+
+  return output;
+}
+
+// Helper to encode a length field wrapping inner bytes.
+static std::string encodeLength(int field_number,
+                                              const std::string &data) {
+  std::string output;
+  google::protobuf::io::StringOutputStream sos(&output);
+  google::protobuf::io::CodedOutputStream cos(&sos);
+
+  cos.WriteTag((field_number << 3) | kWireTypeLengthDelimited);
+  cos.WriteVarint32(data.size());
+  cos.WriteRaw(data.data(), data.size());
+
+  return output;
+}
+
+static std::string
+buildCompileOptionsWithOptLevel(uint64_t optimization_level) {
+  std::string inner =
+      encodeVarint(kOptimizationLevelFieldNumber, optimization_level);
+  return encodeLength(kExecutableBuildOptionsFieldNumber, inner);
+}
+
+// Helper to parse raw bytes into an UnknownFieldSet.
+static bool parseToFieldSet(const std::string &data,
+                            google::protobuf::UnknownFieldSet &fields) {
+  google::protobuf::io::CodedInputStream cis(
+      reinterpret_cast<const uint8_t *>(data.data()), data.size());
+  return fields.MergeFromCodedStream(&cis);
+}
+
+TEST(CompileOptionsParserUnitTests,
+     extractCustomProtobufFields_optimizationLevelZero) {
+  std::string data = buildCompileOptionsWithOptLevel(0);
+
+  google::protobuf::UnknownFieldSet fields;
+  ASSERT_TRUE(parseToFieldSet(data, fields));
+
+  std::unordered_map<std::string, std::string> compile_options;
+  tt_pjrt_status status =
+      CompileOptionsParser::extractCustomProtobufFields(fields,
+                                                        compile_options);
+  ASSERT_TRUE(tt_pjrt_status_is_ok(status));
+  ASSERT_NE(compile_options.find("optimization_level"), compile_options.end());
+  EXPECT_EQ(compile_options["optimization_level"], "0");
+}
+
+TEST(CompileOptionsParserUnitTests,
+     extractCustomProtobufFields_optimizationLevelOne) {
+  std::string data = buildCompileOptionsWithOptLevel(1);
+
+  google::protobuf::UnknownFieldSet fields;
+  ASSERT_TRUE(parseToFieldSet(data, fields));
+
+  std::unordered_map<std::string, std::string> compile_options;
+  tt_pjrt_status status =
+      CompileOptionsParser::extractCustomProtobufFields(fields,
+                                                        compile_options);
+  ASSERT_TRUE(tt_pjrt_status_is_ok(status));
+  ASSERT_NE(compile_options.find("optimization_level"), compile_options.end());
+  EXPECT_EQ(compile_options["optimization_level"], "1");
+}
+
+TEST(CompileOptionsParserUnitTests,
+     extractCustomProtobufFields_optimizationLevelPresent) {
+  std::string data = buildCompileOptionsWithOptLevel(2);
+
+  google::protobuf::UnknownFieldSet fields;
+  ASSERT_TRUE(parseToFieldSet(data, fields));
+
+  std::unordered_map<std::string, std::string> compile_options;
+  tt_pjrt_status status =
+      CompileOptionsParser::extractCustomProtobufFields(fields,
+                                                        compile_options);
+  ASSERT_TRUE(tt_pjrt_status_is_ok(status));
+  ASSERT_NE(compile_options.find("optimization_level"), compile_options.end());
+  EXPECT_EQ(compile_options["optimization_level"], "2");
+}
+
+TEST(CompileOptionsParserUnitTests,
+     extractCustomProtobufFields_optimizationLevelAbsent) {
+  google::protobuf::UnknownFieldSet fields;
+
+  std::unordered_map<std::string, std::string> compile_options;
+  tt_pjrt_status status =
+      CompileOptionsParser::extractCustomProtobufFields(fields,
+                                                        compile_options);
+  ASSERT_TRUE(tt_pjrt_status_is_ok(status));
+  EXPECT_EQ(compile_options.find("optimization_level"), compile_options.end());
+}
+
+TEST(CompileOptionsParserUnitTests,
+     extractCustomProtobufFields_unrelatedFieldsIgnored) {
+
+  // Field #5 should be ignored entirely.
+  std::string unrelated = encodeVarint(5, 42);
+
+  google::protobuf::UnknownFieldSet fields;
+  ASSERT_TRUE(parseToFieldSet(unrelated, fields));
+
+  std::unordered_map<std::string, std::string> compile_options;
+  tt_pjrt_status status =
+      CompileOptionsParser::extractCustomProtobufFields(fields,
+                                                        compile_options);
+  ASSERT_TRUE(tt_pjrt_status_is_ok(status));
+  EXPECT_TRUE(compile_options.empty());
+}
+
+} // namespace tt::pjrt::tests

--- a/pjrt_implementation/src/api/unit_tests/compile_options_parser_tests.cc
+++ b/pjrt_implementation/src/api/unit_tests/compile_options_parser_tests.cc
@@ -21,6 +21,7 @@
 #include <google/protobuf/unknown_field_set.h>
 
 // PJRT implementation headers
+#include "api/compile_options.h"
 #include "api/compile_options_parser.h"
 
 namespace tt::pjrt::tests {
@@ -79,36 +80,6 @@ static bool parseToFieldSet(const std::string &data,
 }
 
 TEST(CompileOptionsParserUnitTests,
-     extractCustomProtobufFields_optimizationLevelZero) {
-  std::string data = buildCompileOptionsWithOptLevel(0);
-
-  google::protobuf::UnknownFieldSet fields;
-  ASSERT_TRUE(parseToFieldSet(data, fields));
-
-  std::unordered_map<std::string, std::string> compile_options;
-  tt_pjrt_status status = CompileOptionsParser::extractCustomProtobufFields(
-      fields, compile_options);
-  ASSERT_TRUE(tt_pjrt_status_is_ok(status));
-  ASSERT_NE(compile_options.find("optimization_level"), compile_options.end());
-  EXPECT_EQ(compile_options["optimization_level"], "0");
-}
-
-TEST(CompileOptionsParserUnitTests,
-     extractCustomProtobufFields_optimizationLevelOne) {
-  std::string data = buildCompileOptionsWithOptLevel(1);
-
-  google::protobuf::UnknownFieldSet fields;
-  ASSERT_TRUE(parseToFieldSet(data, fields));
-
-  std::unordered_map<std::string, std::string> compile_options;
-  tt_pjrt_status status = CompileOptionsParser::extractCustomProtobufFields(
-      fields, compile_options);
-  ASSERT_TRUE(tt_pjrt_status_is_ok(status));
-  ASSERT_NE(compile_options.find("optimization_level"), compile_options.end());
-  EXPECT_EQ(compile_options["optimization_level"], "1");
-}
-
-TEST(CompileOptionsParserUnitTests,
      extractCustomProtobufFields_optimizationLevelPresent) {
   std::string data = buildCompileOptionsWithOptLevel(2);
 
@@ -119,8 +90,9 @@ TEST(CompileOptionsParserUnitTests,
   tt_pjrt_status status = CompileOptionsParser::extractCustomProtobufFields(
       fields, compile_options);
   ASSERT_TRUE(tt_pjrt_status_is_ok(status));
-  ASSERT_NE(compile_options.find("optimization_level"), compile_options.end());
-  EXPECT_EQ(compile_options["optimization_level"], "2");
+  ASSERT_NE(compile_options.find(CompileOptions::optimization_level_key),
+            compile_options.end());
+  EXPECT_EQ(compile_options[CompileOptions::optimization_level_key], "2");
 }
 
 TEST(CompileOptionsParserUnitTests,
@@ -131,13 +103,14 @@ TEST(CompileOptionsParserUnitTests,
   tt_pjrt_status status = CompileOptionsParser::extractCustomProtobufFields(
       fields, compile_options);
   ASSERT_TRUE(tt_pjrt_status_is_ok(status));
-  EXPECT_EQ(compile_options.find("optimization_level"), compile_options.end());
+  EXPECT_EQ(compile_options.find(CompileOptions::optimization_level_key),
+            compile_options.end());
 }
 
+// Sanity check that unrelated fields are ignored.
 TEST(CompileOptionsParserUnitTests,
      extractCustomProtobufFields_unrelatedFieldsIgnored) {
 
-  // Field #5 should be ignored entirely.
   std::string unrelated = encodeVarint(5, 42);
 
   google::protobuf::UnknownFieldSet fields;


### PR DESCRIPTION
### Ticket
Fixes #5072 

### Problem description
- Fix a naming collision where JAX intercepts optimization_level from compiler_options before it reaches the TT PJRT plugin
- JAX treats optimization_level as a built-in XLA ExecutableBuildOptions field, ([code](https://github.com/jax-ml/jax/blob/main/jax/_src/compiler.py#L207)) it pops it from env_option_overrides (protobuf field 7) and places it on ExecutableBuildOptionsProto (protobuf field 3). Since tt-xla only read field 7, the value was silently lost and always defaulted to 0.

### What's changed
- The fix extracts optimization_level from field 3 as a fallback. Values from field 7 (e.g. from torch_xla.set_custom_compile_options()) still take precedence via overwrite.


### Checklist
- [x] New/Existing tests provide coverage for changes
