### PR TITLE
Add Gemma4 e4b, 31b support for vLLM

### DIFF
--- a/.github/workflows/test-matrix-presets/vllm-model-tests-nightly.json
+++ b/.github/workflows/test-matrix-presets/vllm-model-tests-nightly.json
@@ -4,5 +4,6 @@
     {"runs-on": "n300", "name": "run_vllm_n300_tests", "dir": "./tests/integrations/vllm_plugin", "test-mark": "nightly and data_parallel", "shared-runners": "true", "extra-wheel": "vllm"},
     {"runs-on": "n300", "name": "run_vllm_n300_tests", "dir": "./tests/integrations/vllm_plugin", "test-mark": "nightly and tensor_parallel and dual_chip", "shared-runners": "true", "extra-wheel": "vllm"},
     {"runs-on": "n300-llmbox", "name": "run_vllm_llmbox_tests", "dir": "./tests/integrations/vllm_plugin", "test-mark": "nightly and tensor_parallel and llmbox", "shared-runners": "true", "extra-wheel": "vllm"},
-    { "runs-on": "galaxy-wh-6u",        "name": "run_vllm_galaxy_wh_6u_tests", "dir": "./tests/integrations/vllm_plugin", "test-mark": "nightly and tensor_parallel and galaxy_wh_6u", "extra-wheel": "vllm" }
+    { "runs-on": "galaxy-wh-6u",        "name": "run_vllm_galaxy_wh_6u_tests", "dir": "./tests/integrations/vllm_plugin", "test-mark": "nightly and tensor_parallel and galaxy_wh_6u", "extra-wheel": "vllm" },
+    {"runs-on": "qb2-blackhole", "name": "run_vllm_bhqb_tests", "dir": "./tests/integrations/vllm_plugin", "test-mark": "nightly and bhqb", "extra-wheel": "vllm"}
 ]

--- a/integrations/vllm_plugin/vllm_tt/attention.py
+++ b/integrations/vllm_plugin/vllm_tt/attention.py
@@ -284,7 +284,13 @@ class TTAttentionBackendImpl(AttentionImpl):
 
         # kv_cache is [k_cache, v_cache] after init, but a scalar placeholder
         # during profiling — isinstance distinguishes the two cases.
-        if isinstance(kv_cache, (list, tuple)) and kv_cache[0].numel() > 0:
+        # Skip cache update when sharing KV cache with another layer — the
+        # target layer already wrote to the shared cache.
+        if (
+            isinstance(kv_cache, (list, tuple))
+            and kv_cache[0].numel() > 0
+            and self.kv_sharing_target_layer_name is None
+        ):
             self._handle_paged_attention(inputs, kv_cache, attn_metadata)
 
         # Compute attention based on mode:
@@ -293,7 +299,9 @@ class TTAttentionBackendImpl(AttentionImpl):
         # - is_prefill=False: Paged decode attention (generative models only)
         if inputs.is_prefill:
             assert self.sinks is None, "Attention sink is unsupported in SDPA prefill"
-            output = self._compute_full_attention(inputs, attn_metadata)
+            # Pass kv_cache so shared-KV layers can gather K/V from the target
+            # layer's paged cache (see ``_compute_full_attention`` docstring).
+            output = self._compute_full_attention(inputs, kv_cache, attn_metadata)
         else:
             output = self._compute_decode_attention(inputs, kv_cache, attn_metadata)
 
@@ -502,7 +510,10 @@ class TTAttentionBackendImpl(AttentionImpl):
         kv_cache[1].copy_(v_cache)
 
     def _compute_full_attention(
-        self, inputs, attn_metadata: TTMetadata
+        self,
+        inputs,
+        kv_cache,
+        attn_metadata: TTMetadata,
     ) -> torch.Tensor:
         """Compute full attention using scaled dot-product attention (non-paged).
 
@@ -512,22 +523,84 @@ class TTAttentionBackendImpl(AttentionImpl):
         2. Pooling models: For the entire attention computation, as these models
            process all tokens in a single pass without a decode phase or KV cache.
         """
-        # scaled_dot_product_attention expects [B, N_tokens, N_heads, H]
-        query_for_sdpa = inputs.query.transpose(-3, -2)
-        key_for_sdpa = inputs.key.transpose(-3, -2)
-        value_for_sdpa = inputs.value.transpose(-3, -2)
+        shared_kv_mode = (
+            self.kv_sharing_target_layer_name is not None
+            and isinstance(kv_cache, (list, tuple))
+            and len(kv_cache) >= 2
+            and kv_cache[0].numel() > 0
+        )
+
+        if shared_kv_mode:
+            # Gather dense [users, num_kv_heads, kv_num_tokens, head_size]
+            # from the target layer's paged cache (kv_cache is already the
+            # target's tensor via vLLM's alias).
+            key_for_sdpa = self._gather_paged_to_dense(
+                kv_cache[0], attn_metadata.page_table, inputs.kv_num_tokens
+            )
+            value_for_sdpa = self._gather_paged_to_dense(
+                kv_cache[1], attn_metadata.page_table, inputs.kv_num_tokens
+            )
+            # SDPA expects [users, num_heads, tokens, head]. The gather helper
+            # already returns that layout, only Q needs the transpose.
+            query_for_sdpa = inputs.query.transpose(-3, -2)
+        else:
+            # scaled_dot_product_attention expects [B, N_tokens, N_heads, H]
+            query_for_sdpa = inputs.query.transpose(-3, -2)
+            key_for_sdpa = inputs.key.transpose(-3, -2)
+            value_for_sdpa = inputs.value.transpose(-3, -2)
+
+        sdpa_kwargs = {
+            "is_causal": attn_metadata.is_causal,
+            "attn_mask": attn_metadata.attn_mask,
+            "scale": self.scale,
+        }
+        if self.sliding_window is not None:
+            sdpa_kwargs["sliding_window_size"] = self.sliding_window
 
         output = torch.ops.tt.scaled_dot_product_attention(
             query_for_sdpa,
             key_for_sdpa,
             value_for_sdpa,
-            is_causal=attn_metadata.is_causal,
-            attn_mask=attn_metadata.attn_mask,
+            **sdpa_kwargs,
         ).transpose(
             -3, -2
         )  # Back to [users, tokens, num_heads, head_size]
 
         return output
+
+    def _gather_paged_to_dense(
+        self,
+        cache: torch.Tensor,
+        page_table: torch.Tensor,
+        num_tokens: int,
+    ) -> torch.Tensor:
+        """Gather a dense K/V tensor from a paged cache buffer.
+
+        Paged layout is ``[num_blocks, num_kv_heads, block_size, head_size]``
+        as declared by ``TTAttentionBackend.get_kv_cache_shape``. The
+        ``page_table`` gives the block ids per user. We index the blocks,
+        re-order dims so the token axis is flattened across blocks, and trim
+        to the logical prompt length so downstream SDPA sees a dense tensor
+        matching the self-K/V path's shape.
+        """
+        num_blocks_per_user = page_table.shape[1]
+        num_kv_heads = cache.shape[1]
+        block_size = cache.shape[2]
+        head_size = cache.shape[3]
+        users = page_table.shape[0]
+
+        flat_indices = page_table.reshape(-1)
+        gathered = torch.index_select(cache, 0, flat_indices)
+        # [users * num_blocks_per_user, num_kv_heads, block_size, head_size]
+        gathered = gathered.view(
+            users, num_blocks_per_user, num_kv_heads, block_size, head_size
+        )
+        # [users, num_kv_heads, num_blocks_per_user, block_size, head_size]
+        gathered = gathered.permute(0, 2, 1, 3, 4).contiguous()
+        # [users, num_kv_heads, num_blocks_per_user * block_size, head_size]
+        gathered = gathered.reshape(users, num_kv_heads, -1, head_size)
+        # Trim padding past the logical prompt length.
+        return gathered[:, :, :num_tokens, :]
 
     def _compute_decode_attention(
         self, inputs, kv_cache: list[torch.Tensor], attn_metadata: TTMetadata
@@ -541,15 +614,24 @@ class TTAttentionBackendImpl(AttentionImpl):
         # In decode, query_num_tokens == 1 is normal
         query_for_decode = inputs.query.transpose(0, 1)
 
+        decode_kwargs = {
+            "cur_pos_tensor": attn_metadata.cache_position,
+            "is_causal": attn_metadata.is_causal,
+            "attn_mask": attn_metadata.attn_mask,
+            "attention_sink": self.sinks,
+            "scale": self.scale,
+        }
+        # Mirror the prefill path: sliding-window layers (e.g. Gemma-4) need
+        # the kwarg threaded through, otherwise decode looks at the full KV.
+        if self.sliding_window is not None:
+            decode_kwargs["sliding_window_size"] = self.sliding_window
+
         out = torch.ops.tt.paged_scaled_dot_product_attention_decode(
             query_for_decode,
             k_cache,
             v_cache,
             attn_metadata.page_table,
-            cur_pos_tensor=attn_metadata.cache_position,
-            is_causal=attn_metadata.is_causal,
-            attn_mask=attn_metadata.attn_mask,
-            attention_sink=self.sinks,
+            **decode_kwargs,
         )
         # out: [query_num_tokens, users, num_heads, head_size]
         out = out.transpose(0, 1)  # [users, query_num_tokens, num_heads, head_size]

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -19,6 +19,7 @@ import torch_xla.distributed.spmd as xs
 import torch_xla.runtime as xr
 import vllm.envs as envs
 from tt_torch.sharding import sharding_constraint_tensor
+from tt_torch.utils import torch_dynamo_tt_device_compatibility
 from vllm.compilation.wrapper import TorchCompileWithNoGuardsWrapper
 from vllm.config import (
     ParallelConfig,
@@ -70,6 +71,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheSpec,
     MLAAttentionSpec,
     SlidingWindowSpec,
+    UniformTypeKVCacheSpecs,
 )
 from vllm.v1.outputs import (
     EMPTY_MODEL_RUNNER_OUTPUT,
@@ -100,7 +102,7 @@ from .metadata import XLASupportedSamplingMetadata
 from .overrides import replace_modules
 from .platform import TTConfig
 from .sampler import Sampler
-from .vllm_distributed_utils import shard_model
+from .vllm_distributed_utils import safe_mark_sharding, shard_model
 from .vllm_utils import determine_mesh_shape, prev_power_of_2
 
 
@@ -133,6 +135,14 @@ def add_kv_sharing_layers_to_kv_cache_groups(
 
         if runner_only_attn_layers is not None:
             runner_only_attn_layers.add(layer_name)
+
+
+def _get_layer_kv_cache_spec(
+    kv_cache_spec: KVCacheSpec, layer_name: str
+) -> KVCacheSpec:
+    if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
+        return kv_cache_spec.kv_cache_specs[layer_name]
+    return kv_cache_spec
 
 
 if TYPE_CHECKING:
@@ -235,6 +245,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         parallel_config = self.parallel_config
         self.device = device
         self.check_recompilation = envs.VLLM_XLA_CHECK_RECOMPILATION
+        self.use_flat_model_io = self.tt_config.flat_model_io
 
         # SPMD Related
         self.enable_tensor_parallel = self.tt_config.enable_tensor_parallel
@@ -418,6 +429,46 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # Keep in int64 to avoid overflow with long context
         self.arange_np = np.arange(self.max_num_tokens, dtype=np.int64)
 
+        # Persistent device-side scratch buffers for `_prepare_inputs`,
+        # reused via copy_ each step to avoid per-step H2D broadcasts under SPMD.
+        def _alloc_dev(shape, dtype):
+            return torch.zeros(shape, dtype=dtype, device="cpu").to(self.device)
+
+        self._input_ids_dev = {
+            n: _alloc_dev((self.max_num_reqs, n), torch.int32)
+            for n in self.num_tokens_paddings
+        }
+        self._position_ids_dev = {
+            n: _alloc_dev((self.max_num_reqs, n), torch.int32)
+            for n in self.num_tokens_paddings
+        }
+        self._logits_indices_dev = _alloc_dev((self.max_num_reqs,), torch.int32)
+        self._page_table_dev_max = _alloc_dev(
+            (self.num_reqs_max_model_len, self.max_num_blocks_per_req),
+            self.block_table_cpu.dtype,
+        )
+        self._fill_page_table_dev_max = _alloc_dev(
+            (self.num_reqs_max_model_len, self.max_num_blocks_per_req),
+            self.block_table_cpu.dtype,
+        )
+        self._cache_position_dev_max = _alloc_dev(
+            (self.num_reqs_max_model_len,), self.seq_lens_cpu.dtype
+        )
+        if self.most_model_len is not None:
+            assert self.num_reqs_most_model_len is not None
+            assert self.num_blocks_per_most_len_req is not None
+            self._page_table_dev_most = _alloc_dev(
+                (self.num_reqs_most_model_len, self.num_blocks_per_most_len_req),
+                self.block_table_cpu.dtype,
+            )
+            self._fill_page_table_dev_most = _alloc_dev(
+                (self.num_reqs_most_model_len, self.num_blocks_per_most_len_req),
+                self.block_table_cpu.dtype,
+            )
+            self._cache_position_dev_most = _alloc_dev(
+                (self.num_reqs_most_model_len,), self.seq_lens_cpu.dtype
+            )
+
         # Layer pairings for cross-layer KV sharing.
         # If an Attention layer `layer_name` is in the keys of this dict, it
         # means this layer will perform attention using the keys and values
@@ -473,10 +524,13 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self._original_num_layers = None
         self._target_num_layers = None
         target_num_layers = self.tt_config.num_hidden_layers
-        original_num_layers = vllm_config.model_config.hf_config.num_hidden_layers
+        # Multimodal configs (e.g. Gemma 4) nest num_hidden_layers under text_config.
+        hf_config = vllm_config.model_config.hf_config
+        hf_text_config = getattr(hf_config, "text_config", hf_config)
+        original_num_layers = getattr(hf_text_config, "num_hidden_layers", 0)
 
         if target_num_layers > 0 and target_num_layers < original_num_layers:
-            vllm_config.model_config.hf_config.num_hidden_layers = target_num_layers
+            hf_text_config.num_hidden_layers = target_num_layers
             logger.info(
                 f"Overriding num_hidden_layers from {original_num_layers} to {target_num_layers} for debugging and testing purposes."
             )
@@ -993,8 +1047,14 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             ]
 
         # Move input_ids and position_ids to the target device for execution.
-        self.input_ids = input_ids_cpu.to(self.device)
-        self.position_ids = arange.to(self.device)
+        # Reuse persistent device buffers and update in place via copy_ to
+        # avoid issuing a fresh H2D transfer (and on-device alloc) per step.
+        input_ids_dev = self._input_ids_dev[padded_total_num_scheduled_tokens]
+        input_ids_dev.copy_(input_ids_cpu)
+        self.input_ids = input_ids_dev
+        position_ids_dev = self._position_ids_dev[padded_total_num_scheduled_tokens]
+        position_ids_dev.copy_(arange)
+        self.position_ids = position_ids_dev
 
         # Prepare the attention metadata.
         self.query_start_loc_np[0] = 0
@@ -1054,13 +1114,33 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         else:
             fill_page_table = page_table
 
-        cache_position = cache_position.to(self.device)
-        page_table = page_table.to(self.device)
-        fill_page_table = (
-            fill_page_table.to(self.device)
-            if fill_page_table is not page_table
-            else page_table
-        )
+        if use_max_model_len:
+            cache_position_dev = self._cache_position_dev_max
+            page_table_dev = self._page_table_dev_max
+            fill_page_table_dev_buf = self._fill_page_table_dev_max
+        else:
+            cache_position_dev = self._cache_position_dev_most
+            page_table_dev = self._page_table_dev_most
+            fill_page_table_dev_buf = self._fill_page_table_dev_most
+
+        # Clear unused rows so persistent device buffers don't keep stale
+        # block indices from a previous call (would surface as KV bleed).
+        cache_position[num_reqs:] = -1
+        page_table[num_reqs:, :] = 0
+        if fill_page_table is not page_table:
+            fill_page_table[num_reqs:, :] = 0
+
+        cache_position_dev.copy_(cache_position)
+        page_table_dev.copy_(page_table)
+        if fill_page_table is page_table:
+            fill_page_table_dev = page_table_dev
+        else:
+            fill_page_table_dev_buf.copy_(fill_page_table)
+            fill_page_table_dev = fill_page_table_dev_buf
+
+        cache_position = cache_position_dev
+        page_table = page_table_dev
+        fill_page_table = fill_page_table_dev
 
         if self.lora_config is not None:
             # We need to respect padding when activating LoRA adapters
@@ -1089,7 +1169,8 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         logits_indices[: len(num_scheduled_tokens_per_req)] = (
             torch.from_numpy(num_scheduled_tokens_per_req) - 1
         )
-        logits_indices = logits_indices.to(self.device)
+        self._logits_indices_dev.copy_(logits_indices)
+        logits_indices = self._logits_indices_dev
 
         if self.lora_config is not None:
             # We need to respect padding when activating LoRA adapters
@@ -1102,10 +1183,9 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
             self.set_active_loras(self.input_batch, padded_num_scheduled_tokens_per_req)
 
-        layer_names = get_layers_from_vllm_config(self.vllm_config, Attention).keys()
-        per_layer_attn_metadata = {
-            layer_name: attn_metadata for layer_name in layer_names
-        }
+        per_layer_attn_metadata = dict.fromkeys(
+            self._attention_layer_names, attn_metadata
+        )
         return (
             per_layer_attn_metadata,
             logits_indices,
@@ -1272,6 +1352,48 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             # then the embedding layer is not included in the CUDA graph.
             return input_ids, None
 
+    def _prepare_model_call_tensors(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        inputs_embeds: torch.Tensor | None,
+    ) -> tuple[
+        torch.Tensor | None,
+        torch.Tensor,
+        torch.Tensor | None,
+        Optional[torch.Size],
+    ]:
+        if not self.use_flat_model_io:
+            return input_ids, positions, inputs_embeds, None
+
+        restore_shape: Optional[torch.Size] = None
+
+        if input_ids is not None and input_ids.ndim > 1:
+            restore_shape = input_ids.shape
+            input_ids = input_ids.reshape(-1)
+
+        if inputs_embeds is not None and inputs_embeds.ndim > 2:
+            if restore_shape is None:
+                restore_shape = torch.Size(inputs_embeds.shape[:-1])
+            inputs_embeds = inputs_embeds.reshape(-1, inputs_embeds.shape[-1])
+
+        if positions.ndim > 1:
+            if restore_shape is None:
+                restore_shape = positions.shape
+            positions = positions.reshape(-1)
+
+        return input_ids, positions, inputs_embeds, restore_shape
+
+    def _restore_model_hidden_states(
+        self,
+        hidden_states: torch.Tensor,
+        restore_shape: Optional[torch.Size],
+    ) -> torch.Tensor:
+        if restore_shape is None or hidden_states.ndim != 2:
+            return hidden_states
+
+        return hidden_states.reshape(*restore_shape, hidden_states.shape[-1])
+
     @torch.no_grad()
     def execute_model(
         self,
@@ -1336,6 +1458,14 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             input_ids, inputs_embeds = self._get_model_inputs(
                 self.input_ids, mm_embed_inputs
             )
+            (
+                model_input_ids,
+                model_positions,
+                model_inputs_embeds,
+                hidden_state_shape,
+            ) = self._prepare_model_call_tensors(
+                input_ids, self.position_ids, inputs_embeds
+            )
             torch_xla.sync(wait=False)
             # Run the decoder
             with (
@@ -1349,10 +1479,13 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 ) as kv_connector_output,
             ):
                 hidden_states = self.model(
-                    input_ids=input_ids,
-                    positions=self.position_ids,
-                    inputs_embeds=inputs_embeds,
+                    input_ids=model_input_ids,
+                    positions=model_positions,
+                    inputs_embeds=model_inputs_embeds,
                 )
+            hidden_states = self._restore_model_hidden_states(
+                hidden_states, hidden_state_shape
+            )
 
             # Save hidden states (before position selection) for prompt
             # logprobs.  Only extract rows for requests that actually need
@@ -1367,6 +1500,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
             hidden_states = self.select_hidden_states(hidden_states, logits_indices)
             logits = self.compute_logits(hidden_states)
+
             sampling_device = (
                 torch.device("cpu") if self.tt_config.cpu_sampling else self.device
             )
@@ -1597,16 +1731,22 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         if not hasattr(self, "model"):
             self.model = model
 
-        if (
-            self.enable_tensor_parallel
-            and self.model.lm_head is not None
-            and isinstance(self.model.lm_head, ParallelLMHead)
-        ):
-            self.is_sharded_compute_logits = True
+        # Multimodal configs (e.g. Gemma-4) nest the language model and
+        # don't expose lm_head on the top-level module. Walk the module
+        # tree to find any ParallelLMHead instance.
+        self.is_sharded_compute_logits = self.enable_tensor_parallel and any(
+            isinstance(m, ParallelLMHead) for m in self.model.modules()
+        )
 
         self.model.compile(backend="tt", dynamic=False)
         self.sampler = Sampler()
         logger.info(f"Compiled model: \n{self.model}")
+
+        # Cache attention layer names so we don't rebuild the per-layer
+        # attn_metadata dict every step.
+        self._attention_layer_names = tuple(
+            get_layers_from_vllm_config(self.vllm_config, Attention).keys()
+        )
 
     def reload_weights(self) -> None:
         assert (
@@ -1618,18 +1758,11 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
     @torch.no_grad()
     def _dummy_run(self, num_tokens: int, num_reqs: int, num_blocks: int) -> None:
-        if self.supports_mm_inputs:
-            input_ids = None
-            inputs_embeds = torch.zeros(
-                (num_tokens, self.inputs_embeds_size),
-                dtype=self.dtype,
-                device=self.device,
-            )
-        else:
-            input_ids = torch.zeros(
-                (self.max_num_reqs, num_tokens), dtype=torch.int32
-            ).to(self.device)
-            inputs_embeds = None
+        # Start with token ids so _get_model_inputs runs embed_input_ids and the
+        # XLA graph structure matches the real execution path.
+        input_ids = torch.zeros((self.max_num_reqs, num_tokens), dtype=torch.int32).to(
+            self.device
+        )
 
         position_ids = torch.zeros(
             (self.max_num_reqs, num_tokens), dtype=torch.int32
@@ -1646,20 +1779,47 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             attn_mask=None,
         )
 
-        layer_names = get_layers_from_vllm_config(self.vllm_config, Attention).keys()
-        per_layer_attn_metadata = {
-            layer_name: attn_metadata for layer_name in layer_names
-        }
+        per_layer_attn_metadata = dict.fromkeys(
+            self._attention_layer_names, attn_metadata
+        )
 
         with (
+            torch_dynamo_tt_device_compatibility(),
             self.maybe_select_dummy_loras(
                 self.lora_config, np.array([num_tokens], dtype=np.int32)
             ),
             set_forward_context(per_layer_attn_metadata, self.vllm_config, 0),
         ):
-            out = self.model(
-                input_ids=input_ids, positions=position_ids, inputs_embeds=inputs_embeds
+            input_ids, inputs_embeds = self._get_model_inputs(
+                input_ids, mm_embed_inputs=None
             )
+            # Pin pre-flatten sharding hints; without this, large prefill traces
+            # split into a secondary sync that drops mhlo.spmd_output_sharding
+            # and trips shlo_clean_for_xla_ingestion.
+            if self.enable_tensor_parallel:
+                # 2D mesh: model batch dim -> "batch" axis (data-parallel).
+                # 1D mesh (1, N): "batch" axis is size 1, fall back to "model".
+                batch_axis = "batch" if self.use_2d_mesh else "model"
+                if input_ids is not None:
+                    safe_mark_sharding(input_ids, self.mesh, (batch_axis, None))
+                safe_mark_sharding(position_ids, self.mesh, (batch_axis, None))
+                if inputs_embeds is not None:
+                    safe_mark_sharding(
+                        inputs_embeds, self.mesh, (batch_axis, None, None)
+                    )
+            (
+                model_input_ids,
+                model_positions,
+                model_inputs_embeds,
+                hidden_state_shape,
+            ) = self._prepare_model_call_tensors(input_ids, position_ids, inputs_embeds)
+            torch_xla.sync(wait=False)
+            out = self.model(
+                input_ids=model_input_ids,
+                positions=model_positions,
+                inputs_embeds=model_inputs_embeds,
+            )
+            out = self._restore_model_hidden_states(out, hidden_state_shape)
 
         self._hidden_states_dtype = out.dtype
 
@@ -1764,12 +1924,15 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             self._dummy_run(
                 num_tokens, self.num_reqs_max_model_len, self.max_num_blocks_per_req
             )
+            # Sync per token count so prefill and decode graphs stay separate.
+            torch_xla.sync()
             if self.most_model_len is not None:
                 self._dummy_run(
                     num_tokens,
                     self.num_reqs_most_model_len,
                     self.num_blocks_per_most_len_req,
                 )
+                torch_xla.sync()
         xm.wait_device_ops()
         end = time.perf_counter()
         logger.info("Compilation finished in %.2f [secs].", end - start)
@@ -1798,9 +1961,10 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             # (during execution) to avoid re-compilation of select_hidden_states
             # graph later.
             if self.enable_tensor_parallel:
-                xs.mark_sharding(dummy_hidden, self.mesh, (None, None, "model"))
+                safe_mark_sharding(dummy_hidden, self.mesh, (None, None, "model"))
 
-            self.select_hidden_states(dummy_hidden, indices)
+            with torch_dynamo_tt_device_compatibility():
+                self.select_hidden_states(dummy_hidden, indices)
 
         xm.wait_device_ops()
         end = time.perf_counter()
@@ -1818,9 +1982,10 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         )
         dummy_hidden = dummy_hidden.to(self.device)
         if self.enable_tensor_parallel and self.is_sharded_compute_logits:
-            xs.mark_sharding(dummy_hidden, self.mesh, (None, None))
+            safe_mark_sharding(dummy_hidden, self.mesh, (None, None))
 
-        self.compute_logits(dummy_hidden)
+        with torch_dynamo_tt_device_compatibility():
+            self.compute_logits(dummy_hidden)
 
         xm.wait_device_ops()
         end = time.perf_counter()
@@ -1849,12 +2014,13 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # mark_dynamic because some operations in structured_decode require
         # them to be static.
         bitmasks = self.structured_decode_bitmasks.to(self.device)
-        self.structured_decode(
-            dummy_require_struct_decoding,
-            dummy_grammar_bitmask,
-            dummy_logits,
-            bitmasks,
-        )
+        with torch_dynamo_tt_device_compatibility():
+            self.structured_decode(
+                dummy_require_struct_decoding,
+                dummy_grammar_bitmask,
+                dummy_logits,
+                bitmasks,
+            )
 
         xm.wait_device_ops()
         end = time.perf_counter()
@@ -1887,6 +2053,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             )
             sampling_metadata.all_greedy = all_greedy
             with (
+                torch_dynamo_tt_device_compatibility(),
                 self.maybe_select_dummy_loras(
                     self.lora_config, np.array([self.max_num_reqs], dtype=np.int32)
                 ),
@@ -1920,6 +2087,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             self.device
         )
         with (
+            torch_dynamo_tt_device_compatibility(),
             self.maybe_select_dummy_loras(
                 self.lora_config, np.array([self.max_num_reqs], dtype=np.int32)
             ),
@@ -2030,15 +2198,14 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self._dummy_run(
             num_tokens, self.num_reqs_max_model_len, self.max_num_blocks_per_req
         )
+        torch_xla.sync()
         if self.most_model_len is not None:
             self._dummy_run(
                 num_tokens,
                 self.num_reqs_most_model_len,
                 self.num_blocks_per_most_len_req,
             )
-
         torch_xla.sync(wait=False)
-        xm.wait_device_ops()
         self.encoder_cache.clear()
         gc.collect()
         logger.info(f"Profiling run with num_tokens={num_tokens} finished.")
@@ -2112,8 +2279,10 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         kv_caches: dict[str, torch.Tensor] = {}
         for kv_cache_group in kv_cache_config.kv_cache_groups:
-            kv_cache_spec = kv_cache_group.kv_cache_spec
             for layer_name in kv_cache_group.layer_names:
+                kv_cache_spec = _get_layer_kv_cache_spec(
+                    kv_cache_group.kv_cache_spec, layer_name
+                )
                 tensor_size = kv_cache_sizes[layer_name]
                 assert tensor_size % kv_cache_spec.page_size_bytes == 0
                 num_blocks = tensor_size // kv_cache_spec.page_size_bytes  # noqa
@@ -2154,11 +2323,11 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         )
 
         if self.enable_tensor_parallel:
-            # Shard KV Cache — each entry is [k_cache, v_cache]
+            # Shard KV Cache — each entry is [k_cache, v_cache].
             for kv_pair in self.kv_caches:
                 for cache in kv_pair:
                     assert cache.ndim == 4, "KV cache tensor must be 4D."
-                    xs.mark_sharding(cache, self.mesh, (None, "batch", None, None))
+                    safe_mark_sharding(cache, self.mesh, (None, "model", None, None))
 
         if has_kv_transfer_group():
             get_kv_transfer_group().register_kv_caches(kv_caches)
@@ -2185,7 +2354,11 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
     def select_hidden_states(self, hidden_states, indices_do_sample):
         batch_indices = torch.arange(indices_do_sample.shape[0], dtype=torch.int32)
         result = hidden_states[batch_indices, indices_do_sample, :]
-        if self.enable_tensor_parallel:
+        # Only emit the sharding constraint on 2D mesh — under 1D mesh the
+        # `tt.sharding_constraint @mesh` op lands in a sub-graph that doesn't
+        # otherwise reference @mesh, which trips "unknown mesh: @mesh" in
+        # shlo_compiler.
+        if self.enable_tensor_parallel and self.use_2d_mesh:
             result = sharding_constraint_tensor(result, self.mesh, (None, None))
         return result
 

--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -68,6 +68,10 @@ class TTConfig:
     # Target dtype for weight conversion (e.g. "bfp_bf8", "bfp_bf4"). Empty disables.
     experimental_weight_dtype: str = ""
 
+    # Toggle the tt-mlir permute+matmul fusion optimization. Mirrors the PJRT
+    # compile option; defaults to True to match the PJRT default.
+    experimental_enable_permute_matmul_fusion: bool = True
+
     # Perform token sampling on CPU instead of compiling a sampling graph for device
     cpu_sampling: bool = False
 
@@ -93,7 +97,15 @@ class TTConfig:
     # Flag to enable 2D mesh for tensor parallel execution.
     use_2d_mesh: bool = True
 
+    # Flatten model I/O to a flat token stream at the model-call boundary
+    # (needed by HF forwards like Gemma-4's PLE path).
+    flat_model_io: bool = False
+
     enable_trace: bool = False
+
+    # PJRT IR export — when set, MLIR is dumped to `export_path` keyed by `export_model_name`.
+    export_path: Optional[str] = None
+    export_model_name: Optional[str] = None
 
     def __post_init__(self):
         # tt::sampling + enable_trace + optimization_level >= 1 hits a
@@ -112,13 +124,22 @@ class TTConfig:
             )
 
     def get_pjrt_compile_config(self) -> dict:
-        return {
+        cfg = {
             "enable_const_eval": self.enable_const_eval,
             "enable_const_eval_on_cpu": self.enable_const_eval_on_cpu,
             "optimization_level": self.optimization_level,
             "experimental_weight_dtype": self.experimental_weight_dtype,
             "enable_trace": "true" if self.enable_trace else "false",
+            "experimental_enable_permute_matmul_fusion": self.experimental_enable_permute_matmul_fusion,
         }
+        if self.export_path:
+            cfg["export_path"] = self.export_path
+        if self.export_model_name:
+            name = self.export_model_name
+            if self.enable_tensor_parallel:
+                name = f"{name}_g{xrt.global_ordinal()}"
+            cfg["export_model_name"] = name
+        return cfg
 
 
 class TTPlatform(Platform):

--- a/integrations/vllm_plugin/vllm_tt/vllm_distributed_utils.py
+++ b/integrations/vllm_plugin/vllm_tt/vllm_distributed_utils.py
@@ -28,6 +28,36 @@ from .logger import tt_init_logger
 logger = tt_init_logger(__name__)
 
 
+def safe_mark_sharding(tensor, mesh, partition_spec, strict=False):
+    """xs.mark_sharding that replicates any dim whose size is not divisible
+    by the mesh axis it would be sharded on. When ``strict`` is True, raise
+    instead of falling back to replication — use this from call sites where
+    silent replication would mask a perf regression."""
+    if not hasattr(mesh, "shape"):
+        axis_sizes = dict(zip(mesh.axis_names, mesh.mesh_shape))
+    else:
+        axis_sizes = mesh.shape()
+
+    safe_spec = []
+    for i, axis in enumerate(partition_spec):
+        if axis is None or i >= tensor.ndim:
+            safe_spec.append(None)
+            continue
+        mesh_axis_size = axis_sizes.get(axis)
+        if mesh_axis_size is None or tensor.shape[i] % mesh_axis_size != 0:
+            msg = (
+                f"safe_mark_sharding: dim {i} (size {tensor.shape[i]}) "
+                f"not divisible by mesh axis {axis!r} (size {mesh_axis_size})"
+            )
+            if strict:
+                raise ValueError(msg + "; strict=True")
+            logger.warning("%s; replicating instead", msg)
+            safe_spec.append(None)
+        else:
+            safe_spec.append(axis)
+    xs.mark_sharding(tensor, mesh, tuple(safe_spec))
+
+
 class XlaMergedColumnParallelLinear(nn.Module):
 
     def __init__(self, merged_column_parallel_linear: nn.Module, mesh: "xs.Mesh"):
@@ -50,13 +80,13 @@ class XlaMergedColumnParallelLinear(nn.Module):
     def _shard_weight(self, mesh: "xs.Mesh"):
         for i in range(self.num_outputs):
             self.weights[i] = Parameter(self.weights[i].to("xla"), requires_grad=False)
-            xs.mark_sharding(self.weights[i], mesh, ("batch", "model"))
+            safe_mark_sharding(self.weights[i], mesh, ("model", "batch"))
 
             if self.biases[i] is not None:
                 self.biases[i] = Parameter(
                     self.biases[i].to("xla"), requires_grad=False
                 )
-                xs.mark_sharding(self.biases[i], mesh, ("batch",))
+                safe_mark_sharding(self.biases[i], mesh, ("model",))
 
     def _load_weights_from_merged_column_parallel_linear(
         self, merged_column_parallel_linear: nn.Module
@@ -135,19 +165,19 @@ class XlaQKVParallelLinear(nn.Module):
         self.q_weight = Parameter(self.q_weight.to("xla"), requires_grad=False)
         self.k_weight = Parameter(self.k_weight.to("xla"), requires_grad=False)
         self.v_weight = Parameter(self.v_weight.to("xla"), requires_grad=False)
-        xs.mark_sharding(self.q_weight, mesh, ("batch", "model"))
-        xs.mark_sharding(self.k_weight, mesh, ("batch", "model"))
-        xs.mark_sharding(self.v_weight, mesh, ("batch", "model"))
+        safe_mark_sharding(self.q_weight, mesh, ("model", "batch"))
+        safe_mark_sharding(self.k_weight, mesh, ("model", "batch"))
+        safe_mark_sharding(self.v_weight, mesh, ("model", "batch"))
         if self.q_bias is not None:
             assert (
                 self.k_bias is not None and self.v_bias is not None
             ), "QKVParallelLinear should have q, k, and v biases together."
             self.q_bias = Parameter(self.q_bias.to("xla"), requires_grad=False)
-            xs.mark_sharding(self.q_bias, mesh, ("batch",))
+            safe_mark_sharding(self.q_bias, mesh, ("model",))
             self.k_bias = Parameter(self.k_bias.to("xla"), requires_grad=False)
-            xs.mark_sharding(self.k_bias, mesh, ("batch",))
+            safe_mark_sharding(self.k_bias, mesh, ("model",))
             self.v_bias = Parameter(self.v_bias.to("xla"), requires_grad=False)
-            xs.mark_sharding(self.v_bias, mesh, ("batch",))
+            safe_mark_sharding(self.v_bias, mesh, ("model",))
 
     def _load_weights_from_qkv_linear(self, qkv_linear: nn.Module):
         q_proj_size, k_proj_size, _ = qkv_linear.output_sizes
@@ -229,7 +259,7 @@ def partition_column_parallel_linear(
     layer: torch.nn.Module, mesh: xs.Mesh
 ) -> torch.nn.Module:
     assert isinstance(layer, ColumnParallelLinear)
-    xs.mark_sharding(layer.weight, mesh, ("model", None))
+    safe_mark_sharding(layer.weight, mesh, ("model", None))
     logger.debug("Applied parallel sharding to %s", layer)
     return layer
 
@@ -238,7 +268,7 @@ def partition_row_parallel_linear(
     layer: torch.nn.Module, mesh: xs.Mesh
 ) -> torch.nn.Module:
     assert isinstance(layer, RowParallelLinear)
-    xs.mark_sharding(layer.weight, mesh, ("model", "batch"))
+    safe_mark_sharding(layer.weight, mesh, ("batch", "model"))
     logger.debug("Applied parallel sharding to %s", layer)
     return layer
 
@@ -256,11 +286,11 @@ def partition_vocab_parallel_embedding(
     layer: torch.nn.Module, mesh: xs.Mesh
 ) -> torch.nn.Module:
     assert isinstance(layer, VocabParallelEmbedding)
-    logger.debug("Applied parallel sharding to %s", layer)
-    xs.mark_sharding(layer.weight, mesh, (None, "model"))
+    safe_mark_sharding(layer.weight, mesh, (None, "model"))
     # Apply sharding constraint to the output of the layer.
     hook_forward = sharding_constraint_hook(layer, mesh, (None, None, None))
     layer.register_forward_hook(hook_forward)
+    logger.debug("Applied parallel sharding to %s", layer)
     return layer
 
 

--- a/python_package/tt_torch/custom_ops.py
+++ b/python_package/tt_torch/custom_ops.py
@@ -798,6 +798,7 @@ def paged_scaled_dot_product_attention_decode(
     cur_pos_tensor: torch.Tensor = None,
     attention_sink: torch.Tensor = None,
     scale: float = None,
+    sliding_window_size: int = None,
 ) -> torch.Tensor:
     device = query.device
 
@@ -819,6 +820,8 @@ def paged_scaled_dot_product_attention_decode(
 
         if scale is not None:
             attrs["scale"] = str(scale)
+        if sliding_window_size is not None:
+            attrs["sliding_window_size"] = str(sliding_window_size)
 
         inputs = [query, key, value, page_table]
         if attn_mask is not None:
@@ -911,6 +914,7 @@ def paged_scaled_dot_product_attention_decode_fake(
     cur_pos_tensor: torch.Tensor = None,
     attention_sink: torch.Tensor = None,
     scale: float = None,
+    sliding_window_size: int = None,
 ) -> torch.Tensor:
     return torch.zeros_like(query)
 

--- a/python_package/tt_torch/sharding.py
+++ b/python_package/tt_torch/sharding.py
@@ -19,6 +19,29 @@ import torch
 _MESH_IDX_PREFIX = "mesh_idx_"
 
 
+def _normalize_partition_spec_for_rank(partition_spec, tensor_rank: int) -> tuple:
+    """Normalize a partition spec to match the runtime tensor rank.
+
+    Only fully-replicated specs (all ``None``) may be resized: any non-``None``
+    entry implies a specific tensor dim is sharded, and a silent rank shift
+    would map that axis to a different dim. Callers needing rank flexibility
+    for a sharded spec must pass an exact-rank spec themselves.
+    """
+    normalized_partition_spec = tuple(partition_spec)
+
+    if len(normalized_partition_spec) == tensor_rank:
+        return normalized_partition_spec
+
+    if any(axis is not None for axis in normalized_partition_spec):
+        raise ValueError(
+            f"partition_spec rank ({len(normalized_partition_spec)}) does not "
+            f"match tensor rank ({tensor_rank}); cannot resize a spec with "
+            f"non-replicated dims: {normalized_partition_spec}"
+        )
+
+    return (None,) * tensor_rank
+
+
 def _partition_spec_to_sdy_sharding(mesh, partition_spec, unreduced=None) -> str:
     """
     Convert a partition_spec to an sdy.sharding string.
@@ -134,10 +157,17 @@ def sharding_constraint_hook(module, mesh, partition_spec):
     if not hasattr(mesh, "axis_names"):
         raise ValueError("mesh must have 'axis_names' attribute")
 
-    # Convert to sdy.sharding string at hook creation time
-    sdy_sharding = _partition_spec_to_sdy_sharding(mesh, partition_spec)
-
     def hook(mod, input, output):
+        if not isinstance(output, torch.Tensor):
+            raise TypeError(
+                "sharding_constraint_hook expects a Tensor output, got "
+                f"{type(output).__name__}"
+            )
+
+        normalized_partition_spec = _normalize_partition_spec_for_rank(
+            partition_spec, output.ndim
+        )
+        sdy_sharding = _partition_spec_to_sdy_sharding(mesh, normalized_partition_spec)
         return torch.ops.tt.sharding_constraint(output, sdy_sharding)
 
     return hook
@@ -187,7 +217,11 @@ def sharding_constraint_tensor(input, mesh, partition_spec, unreduced=None):
     if not hasattr(mesh, "axis_names"):
         raise ValueError("mesh must have 'axis_names' attribute")
 
-    # Convert to sdy.sharding string
-    sdy_sharding = _partition_spec_to_sdy_sharding(mesh, partition_spec, unreduced)
+    normalized_partition_spec = _normalize_partition_spec_for_rank(
+        partition_spec, input.ndim
+    )
+    sdy_sharding = _partition_spec_to_sdy_sharding(
+        mesh, normalized_partition_spec, unreduced
+    )
 
     return torch.ops.tt.sharding_constraint(input, sdy_sharding)

--- a/python_package/tt_torch/torch_overrides.py
+++ b/python_package/tt_torch/torch_overrides.py
@@ -5,8 +5,52 @@ import torch
 from torch.overrides import TorchFunctionMode
 
 
+def _unflatten_to_shape(
+    input_shape: torch.Size, dim: int, sizes: tuple[int, ...] | list[int] | torch.Size
+) -> tuple:
+    dim = dim if dim >= 0 else len(input_shape) + dim
+    if dim < 0 or dim >= len(input_shape):
+        raise IndexError(f"Dimension out of range: dim={dim}, rank={len(input_shape)}")
+
+    sizes = tuple(sizes)
+    inferred_index = None
+    known_product = 1
+    normalized_sizes = []
+
+    for index, size in enumerate(sizes):
+        if size == -1:
+            if inferred_index is not None:
+                raise ValueError("Only one dimension can be inferred in unflatten")
+            inferred_index = index
+            normalized_sizes.append(size)
+        else:
+            normalized_sizes.append(size)
+            known_product *= size
+
+    if inferred_index is not None:
+        normalized_sizes[inferred_index] = input_shape[dim] // known_product
+
+    return (
+        *input_shape[:dim],
+        *normalized_sizes,
+        *input_shape[dim + 1 :],
+    )
+
+
 class TorchFunctionOverride(TorchFunctionMode):
     def __torch_function__(self, func, types, args, kwargs=None):
+        kwargs = kwargs or {}
+
+        if func.__name__ == "unflatten":
+            tensor = args[0]
+            dim = kwargs.get("dim", args[1])
+            sizes = kwargs.get("sizes", args[2])
+            # Bypass Tensor.unflatten -> super().unflatten(), which Dynamo
+            # cannot trace in fullgraph mode under TorchFunctionMode.
+            return torch.ops.aten.reshape.default(
+                tensor, _unflatten_to_shape(tensor.shape, dim, sizes)
+            )
+
         if (
             func.__name__ == "matmul" or func.__name__ == "linear"
         ) and not torch.compiler.is_compiling():

--- a/tests/integrations/vllm_plugin/generative/test_gemma4_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_gemma4_generation.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import vllm
+from conftest import assert_output_coherent, check_host_memory
+
+
+@pytest.mark.nightly
+@pytest.mark.bhqb
+def test_generation_single_device_gemma4_e4b():
+    model_name = "google/gemma-4-E4B-it"
+    messages = [[{"role": "user", "content": "Describe Tenstorrent in one sentence."}]]
+    sampling_params = vllm.SamplingParams(temperature=0.0, top_p=1.0, max_tokens=32)
+    llm_args = {
+        "model": model_name,
+        # Text-only path on a multimodal model: zero every modality so the
+        # mm-encoder graph doesn't compile the vision tower at all.
+        "limit_mm_per_prompt": {"image": 0, "video": 0, "audio": 0},
+        # Gemma-4 mm enforces a floor from MultiModalBudget regardless of
+        # limit_mm_per_prompt; 2560 clears the video-frame floor of 2496.
+        "max_num_batched_tokens": 2560,
+        "max_num_seqs": 1,
+        "max_model_len": 128,
+        "gpu_memory_utilization": 0.002,
+        "additional_config": {
+            "enable_const_eval": True,
+            "min_context_len": 32,
+            "enable_tensor_parallel": False,
+            "use_2d_mesh": False,
+            "cpu_sampling": False,
+            "flat_model_io": True,
+        },
+    }
+    llm = vllm.LLM(**llm_args)
+
+    output_text = llm.chat(messages, sampling_params)[0].outputs[0].text
+    print(f"output: {output_text}")
+    assert_output_coherent(output_text)
+
+    check_host_memory(model_name)

--- a/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
@@ -120,6 +120,18 @@ def test_tensor_parallel_generation_llmbox_large(
 @pytest.mark.nightly
 @pytest.mark.tensor_parallel
 @pytest.mark.galaxy_wh_6u
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "sdpa_decode tree-reduction limit (max 64 cores/head) exceeded after the "
+        "QKV sharding axis swap to ('model', 'batch') in this PR. With kv_heads=8 "
+        "split 8-way on galaxy_wh_6u's (4, 8) mesh model axis, each device gets "
+        "1 KV head and the kernel allocates the full 72-core grid to it. Fixed "
+        "in tt-metal by #44617 (L1-safe defaults for paged SDPA decode, "
+        "max_cores_per_head_batch=1). Remove this xfail once tt-mlir uplifts "
+        "past tt-metal 5cd3b7a (open uplift PRs: tt-mlir #8484, #8597)."
+    ),
+)
 @pytest.mark.parametrize(
     ["model_name", "enable_const_eval", "experimental_weight_dtype", "use_2d_mesh"],
     [pytest.param("mistralai/Mistral-Large-Instruct-2411", True, "bfp_bf8", True)],
@@ -151,6 +163,54 @@ def test_tensor_parallel_generation_galaxy_wh_6u_large(
 
     output_text = llm.generate(inputs, sampling_params)[0].outputs[0].text
     print("output: ", output_text)
+    assert_output_coherent(output_text)
+
+    check_host_memory(model_name)
+
+
+@pytest.mark.nightly
+@pytest.mark.tensor_parallel
+@pytest.mark.bhqb
+@pytest.mark.parametrize(
+    ["enable_const_eval", "experimental_weight_dtype", "use_2d_mesh"],
+    [
+        pytest.param(True, "", False),
+    ],
+)
+def test_tensor_parallel_generation_bhqb_gemma4_31b(
+    enable_const_eval: bool,
+    experimental_weight_dtype: str,
+    use_2d_mesh: bool,
+):
+    model_name = "google/gemma-4-31B-it"
+
+    messages = [[{"role": "user", "content": "Describe Tenstorrent in one sentence."}]]
+    sampling_params = vllm.SamplingParams(temperature=0.0, top_p=1.0, max_tokens=32)
+    llm_args = {
+        "model": model_name,
+        # Text-only path on a multimodal model: zero every modality so the
+        # mm-encoder graph doesn't compile the vision tower at all.
+        "limit_mm_per_prompt": {"image": 0, "video": 0, "audio": 0},
+        # Gemma-4 mm enforces a floor from MultiModalBudget regardless of
+        # limit_mm_per_prompt; 2560 clears the video-frame floor of 2496.
+        "max_num_batched_tokens": 2560,
+        "max_num_seqs": 1,
+        "max_model_len": 128,
+        "gpu_memory_utilization": 0.1,
+        "additional_config": {
+            "enable_const_eval": enable_const_eval,
+            "min_context_len": 32,
+            "enable_tensor_parallel": True,
+            "experimental_weight_dtype": experimental_weight_dtype,
+            "use_2d_mesh": use_2d_mesh,
+            "cpu_sampling": False,
+            "flat_model_io": True,
+        },
+    }
+    llm = vllm.LLM(**llm_args)
+
+    output_text = llm.chat(messages, sampling_params)[0].outputs[0].text
+    print(f"output: {output_text}")
     assert_output_coherent(output_text)
 
     check_host_memory(model_name)


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/4596)

### Problem description
There is a working branch that supports Gemma4 (origin/kmabee/aknezevic/gemma4), need to be mainlined

### What's changed
- Enables Gemma-4 text-only inference (E4B single-device, 31B BHQB TP=4): cross-layer KV sharing, sliding-window SDPA, mesh-aware KV cache axis selection.
- Detects nested `ParallelLMHead` for Gemma-4 multimodal config so the sharded `compute_logits` path fires.
- Adds `flat_model_io` TTConfig option for HF forwards needing a flat token stream (Gemma-4 PLE).

### Checklist
- [ ] New/Existing tests provide coverage for changes
