### PR TITLE
[vLLM]: skip wasted profile_run() in determine_available_memory

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/worker.py
+++ b/integrations/vllm_plugin/vllm_tt/worker.py
@@ -209,7 +209,11 @@ class TTWorker:
 
         # `max_num_tokens >= max_num_batched_tokens` due to padding.
         with self.model_runner.maybe_setup_dummy_loras(self.lora_config):
-            self.model_runner.profile_run(self.model_runner.max_num_tokens)
+            # TTXLA: skip until #1414 lands — profile_run()'s peak_bytes_used
+            # is discarded by the hardcoded `current_mem = 0` path below, so
+            # the forward pass is ~30-40 s of engine-init waste per server start.
+            # self.model_runner.profile_run(self.model_runner.max_num_tokens)
+            pass
 
         # Synchronize before measuring the memory usage.
         xm.wait_device_ops()


### PR DESCRIPTION
### Ticket

Closes #4892. Related to #1414 (PJRT_Device_MemoryStats).

### Problem description

`TTWorker.determine_available_memory()` runs a full forward pass via `self.model_runner.profile_run(...)` to measure peak device memory, then discards the result — `total_memory_size` and `current_mem` are hardcoded because `xm.get_memory_info()` is unimplemented (gated on #1414). The forward pass costs ~30-40 s per engine init for no functional benefit.

### What's changed

- `integrations/vllm_plugin/vllm_tt/worker.py`: comment out the `profile_run()` call, replace with `pass`. Surrounding KV-cache setup, `bind_kv_cache`, `wait_device_ops`, and `reset_dynamo_cache` are unchanged. No allocation behavior change — the function returns the same value it did before.

### Verification

- Llama-3.2-3B b32, p150 single device, `max_model_len=128`: engine init 127 s → 91 s. Benchmark PASS.
- Llama-3.2-3B b1, same setup: engine init 139 s → 88 s. Benchmark PASS.

### Checklist

- [x] Tested locally on p150 (b1 + b32, both PASS)
