### PR TITLE
Nightly Maintenance may24

### DIFF
--- a/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml
@@ -110,8 +110,7 @@ test_config:
 
   llama/causal_lm/pytorch-3.2_3B-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     status: EXPECTED_PASSING
-    assert_pcc: false
-    required_pcc: 0.97
+    required_pcc: 0.98
 
   llama/causal_lm/pytorch-Tinyllama_v1.1-llm_decode-seq_1-batch_1-single_device-mesh_default-inference:
     status: EXPECTED_PASSING

--- a/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml
@@ -125,17 +125,17 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox", "lb-blackhole"]
-    required_pcc: 0.95
+    required_pcc: 0.96
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_4-fsdp-no_dp-tensor_parallel-mesh_4x8-inference:
     supported_archs: ["galaxy-wh-6u"]
-    required_pcc: 0.95
+    required_pcc: 0.96
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-fsdp-no_dp-tensor_parallel-mesh_4x8-inference:
     supported_archs: ["galaxy-wh-6u"]
-    required_pcc: 0.90
+    required_pcc: 0.91
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_4-fsdp-no_dp-tensor_parallel-mesh_4x8-inference:
@@ -178,7 +178,7 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox", "lb-blackhole"]
-    required_pcc: 0.90
+    required_pcc: 0.91
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_4-fsdp-dp-tensor_parallel-mesh_4x8-inference:
@@ -220,17 +220,17 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox", "lb-blackhole"]
-    required_pcc: 0.95
+    required_pcc: 0.96
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_4-megatron-no_dp-tensor_parallel-mesh_4x8-inference:
     supported_archs: ["galaxy-wh-6u"]
-    required_pcc: 0.95
+    required_pcc: 0.96
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox", "lb-blackhole"]
-    required_pcc: 0.90
+    required_pcc: 0.91
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_4-megatron-no_dp-tensor_parallel-mesh_4x8-inference:
@@ -272,7 +272,7 @@ test_config:
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference:
     supported_archs: ["n300-llmbox", "lb-blackhole"]
-    required_pcc: 0.95
+    required_pcc: 0.96
     status: EXPECTED_PASSING
     markers: [nightly]
   llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_4-megatron-dp-tensor_parallel-mesh_4x8-inference:


### PR DESCRIPTION
## Summary

Updates `tests/runner/test_config/torch_llm/` YAMLs based on the nightly CI run [26347444481](https://github.com/tenstorrent/tt-xla/actions/runs/26347444481) for `language` torch models.

## Changes

### `tests/runner/test_config/torch_llm/test_config_inference_single_device.yaml`
- `llama/causal_lm/pytorch-3.2_3B-llm_decode-seq_1-batch_1-single_device-mesh_default-inference` — removed `assert_pcc: false`; bumped `required_pcc` 0.97 -> 0.98 (n150 pcc=0.9943, p150 pcc=0.9866; floor of min).

### `tests/runner/test_config/torch_llm/test_config_inference_tensor_parallel.yaml`
- `llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-fsdp-no_dp-tensor_parallel-mesh_2x4-inference` — `required_pcc` 0.95 -> 0.96 (n300-llmbox pcc=0.9642).
- `llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron-dp-tensor_parallel-mesh_2x4-inference` — `required_pcc` 0.95 -> 0.96 (n300-llmbox pcc=0.9646).
- `llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference` — `required_pcc` 0.95 -> 0.96 (n300-llmbox pcc=0.9641).
- `llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_4-fsdp-no_dp-tensor_parallel-mesh_4x8-inference` — `required_pcc` 0.95 -> 0.96 (galaxy-wh-6u pcc=0.9675).
- `llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_4096-batch_4-megatron-no_dp-tensor_parallel-mesh_4x8-inference` — `required_pcc` 0.95 -> 0.96 (galaxy-wh-6u pcc=0.9670).
- `llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-fsdp-dp-tensor_parallel-mesh_2x4-inference` — `required_pcc` 0.90 -> 0.91 (n300-llmbox pcc=0.9147).
- `llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-fsdp-no_dp-tensor_parallel-mesh_4x8-inference` — `required_pcc` 0.90 -> 0.91 (galaxy-wh-6u pcc=0.9154).
- `llama/causal_lm/pytorch-3.1_8B_Instruct-llm_prefill-seq_8192-batch_1-megatron-no_dp-tensor_parallel-mesh_2x4-inference` — `required_pcc` 0.90 -> 0.91 (n300-llmbox pcc=0.9156).