### PR TITLE
Add QB2 to weekly runs

### DIFF
--- a/.github/workflows/test-matrix-presets/model-test-passing-weekly.json
+++ b/.github/workflows/test-matrix-presets/model-test-passing-weekly.json
@@ -9,5 +9,6 @@
   {"runs-on": "p150", "name": "run_forge_models_jax", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "p150 and training and weekly and expected_passing and not large", "parallel-groups": 1, "forge-models": true},
   {"runs-on": "n300-llmbox", "name": "run_forge_models_multichip_torch", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "n300-llmbox and weekly and tensor_parallel and expected_passing", "parallel-groups": 1, "forge-models": true},
   {"runs-on": "n300", "name": "run_forge_models_multichip_torch", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "n300 and weekly and data_parallel and expected_passing", "parallel-groups": 8, "forge-models": true},
-  {"runs-on": "n300-llmbox", "name": "run_forge_models_multichip_jax", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "n300-llmbox and weekly and tensor_parallel and expected_passing", "parallel-groups": 1, "forge-models": true}
+  {"runs-on": "n300-llmbox", "name": "run_forge_models_multichip_jax", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "n300-llmbox and weekly and tensor_parallel and expected_passing", "parallel-groups": 1, "forge-models": true},
+  {"runs-on": "qb2-blackhole", "name": "run_forge_models_multichip_torch", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "qb2-blackhole and weekly and tensor_parallel and expected_passing", "parallel-groups": 2, "forge-models": true}
 ]

--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -258,3 +258,13 @@ test_config:
     supported_archs: [galaxy-wh-6u]
     status: EXPECTED_PASSING
     enable_weight_bfp8_conversion: true
+
+  deepseek/llama/pytorch-DeepSeek-R1-Distill-Llama-70B-tensor_parallel-inference:
+    supported_archs: [qb2-blackhole]
+    status: EXPECTED_PASSING
+    enable_weight_bfp8_conversion: true
+
+  deepseek/qwen/pytorch-R1_Distill_32B-tensor_parallel-inference:
+    supported_archs: [qb2-blackhole]
+    status: EXPECTED_PASSING
+    enable_weight_bfp8_conversion: true


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Add QB2 to weekly runs
Since some generality models require QB2 to run, I added an entry to the model-test-passing-weekly.json file so the test runs in the weekly CI.

### What's changed
The following models were added to tt-forge-models quite some time ago, but we didn’t have available machines to test them. Since QB2 machines are now available in CI, I re-tested the models and added them to the config file.

deepseek/llama/pytorch-DeepSeek-R1-Distill-Llama-70B-tensor_parallel-inference:
https://github.com/tenstorrent/tt-xla/actions/runs/26436754029/job/77822515401

deepseek/qwen/pytorch-R1_Distill_32B-tensor_parallel-inference:
https://github.com/tenstorrent/tt-xla/actions/runs/26437932000/job/77825111173

### Checklist
- [ ] New/Existing tests provide coverage for changes
