### PR TITLE
Remove model-specific install requirements from perf benchmarks

### DIFF
--- a/.github/workflows/call-perf-test.yml
+++ b/.github/workflows/call-perf-test.yml
@@ -169,10 +169,9 @@ jobs:
       shell: bash
       run: |
         source venv/activate
-        pip install ${{ matrix.build.pyreq }}
-        # Install correct torch-xla version from requirements.txt
-        pip install $(grep "torch-xla@" python_package/requirements.txt)
-        pip install torchvision==0.25.0+cpu --index-url https://download.pytorch.org/whl/cpu
+        if [ -n "${{ matrix.build.pyreq }}" ]; then
+          pip install ${{ matrix.build.pyreq }}
+        fi
 
     - name: Create perf report directory
       run: mkdir -p ${{ steps.strings.outputs.perf_report_path }}

--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -19,67 +19,56 @@
     "tests": [
       {
         "name": "resnet_jax",
-        "pyreq": "pytest tqdm loguru requests transformers==4.57.1 datasets flax==0.10.4 torch==2.10.0",
+        "pyreq": "transformers==4.57.1 flax==0.10.4",
         "pytest": "tests/benchmark/resnet_jax_benchmark.py::test_resnet_jax"
       },
       {
         "name": "mnist",
-        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_vision.py::test_mnist"
       },
       {
         "name": "resnet",
-        "pyreq": "datasets loguru pytest requests tabulate timm tqdm transformers==5.5.1 torch==2.10.0",
         "pytest": "tests/benchmark/test_vision.py::test_resnet50"
       },
       {
         "name": "mobilenetv2",
-        "pyreq": "datasets loguru pytest requests tabulate timm tqdm transformers==5.5.1 torch==2.10.0",
         "pytest": "tests/benchmark/test_vision.py::test_mobilenetv2"
       },
       {
         "name": "efficientnet",
-        "pyreq": "datasets loguru pytest requests tabulate timm tqdm transformers==5.5.1 torch==2.10.0",
         "pytest": "tests/benchmark/test_vision.py::test_efficientnet"
       },
       {
         "name": "segformer",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_vision.py::test_segformer"
       },
       {
         "name": "swin",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_vision.py::test_swin"
       },
       {
         "name": "ufld_v2",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_vision.py::test_ufld_v2"
       },
       {
         "name": "unet",
-        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_vision.py::test_unet"
       },
       {
         "name": "vit",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_vision.py::test_vit"
       },
       {
         "name": "vovnet",
-        "pyreq": "datasets loguru pytest pytorchcv requests tabulate timm tqdm transformers==5.5.1 torch==2.10.0",
         "pytest": "tests/benchmark/test_vision.py::test_vovnet"
       },
       {
         "name": "bge_m3_encode",
-        "pyreq": "datasets FlagEmbedding loguru pytest requests timm torch==2.10.0 tqdm transformers==4.57.1",
+        "pyreq": "transformers==4.57.1 FlagEmbedding",
         "pytest": "tests/benchmark/test_encoders.py::test_bge_m3"
       },
       {
         "name": "vllm_bge_m3_encode_batch1",
-        "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_bge_m3_batch1",
         "vllm": true,
         "skip-stablehlo-dump": true,
@@ -90,7 +79,6 @@
       },
       {
         "name": "vllm_bge_m3_encode_batch32",
-        "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_bge_m3_batch32",
         "vllm": true,
         "skip-stablehlo-dump": true,
@@ -101,226 +89,185 @@
       },
       {
         "name": "llama_3_2_1b_instruct",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_2_1b"
       },
       {
         "name": "llama_3_2_3b_instruct",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_2_3b"
       },
       {
         "name": "llama_3_1_8b_instruct",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b"
       },
       {
         "name": "falcon3_7b_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "falcon3_10b_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_10b_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "llama_3_1_8b_instruct_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b_instruct_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "ministral_8b_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_ministral_8b_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "mistral_nemo_instruct_2407_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_mistral_nemo_instruct_2407_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "mistral_small_24b_instruct_2501_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_mistral_small_24b_instruct_2501_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "qwen_2_5_14b_instruct_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_14b_instruct_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "qwen_2_5_coder_32b_instruct_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_coder_32b_instruct_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "qwen_3_8b_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_8b_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "qwen_3_14b_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_14b_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "qwen_3_32b_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_32b_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "test_llama_3_1_70b_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "llama_3_1_70b_tp_galaxy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp_galaxy",
         "runs-on": "galaxy-wh-6u"
       },
       {
         "name": "gpt_oss_20b_tp",
-        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "gpt_oss_20b_tp_d2m",
-        "pyreq": "datasets loguru pytest requests accelerate torch==2.9.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_d2m",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "gpt_oss_20b_tp_batch_size_1",
-        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_batch_size_1",
         "runs-on": "n300-llmbox"
       },
       {
         "name": "test_gpt_oss_20b_tp_galaxy_batch_size_64",
-        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_galaxy_batch_size_64",
         "runs-on": "galaxy-wh-6u"
       },
       {
         "name": "test_gpt_oss_120b_tp_dp_galaxy_batch_size_128",
-        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_120b_tp_dp_galaxy_batch_size_128",
         "runs-on": "galaxy-wh-6u"
       },
       {
         "name": "gpt_oss_120b_tp_qb2",
-        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_120b_tp_qb2",
         "runs-on": "qb2-blackhole"
       },
       {
         "name": "microsoft_phi-1",
-        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_phi1"
       },
       {
         "name": "microsoft_phi-1_5",
-        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_phi1_5"
       },
       {
         "name": "microsoft_phi-2",
-        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_phi2"
       },
       {
         "name": "google_gemma-1.1-2b-it",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_gemma_1_1_2b"
       },
       {
         "name": "tiiuae_falcon3-1b-base",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_1b"
       },
       {
         "name": "tiiuae_falcon3-3b-base",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_3b"
       },
       {
         "name": "tiiuae_falcon3-7b-base",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b"
       },
       {
         "name": "qwen_2_5_0_5b_instruct",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_0_5b"
       },
       {
         "name": "qwen_2_5_1_5b_instruct",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_1_5b"
       },
       {
         "name": "qwen_2_5_3b_instruct",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_3b"
       },
       {
         "name": "qwen_3_0_6b",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_0_6b"
       },
       {
         "name": "qwen_3_1_7b",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_1_7b"
       },
       {
         "name": "qwen_3_4b",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_4b"
       },
       {
         "name": "qwen_3_8b",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_8b"
       },
       {
         "name": "qwen_2_5_7b_instruct",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_7b"
       },
       {
         "name": "mistral_7b",
-        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.5.1 protobuf sentencepiece",
         "pytest": "tests/benchmark/test_llms.py::test_mistral_7b"
       },
       {
         "name": "ministral_8b",
-        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_ministral_8b"
       },
       {
         "name": "qwen_3_4b_embedding",
-        "pyreq": "datasets loguru pytest requests timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_encoders.py::test_qwen3_embedding_4b"
       },
       {
         "name": "vllm_qwen_3_4b_embedding_batch1",
-        "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_qwen3_embedding_4b_batch1",
         "vllm": true,
         "skip-stablehlo-dump": true,
@@ -331,238 +278,200 @@
       },
       {
         "name": "bert",
-        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_encoders.py::test_bert"
       },
       {
         "name": "unet_for_conditional_generation",
-        "pyreq": "accelerate datasets diffusers==0.36.0 loguru pytest requests torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_encoders.py::test_unet_for_conditional_generation"
       },
       {
         "name": "deepseek_v3_2_exp_tp_galaxy_2_layers",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_deepseek_v3_2_exp_tp_galaxy_2_layers",
         "runs-on": "galaxy-wh-6u"
       },
       {
         "name": "kimi_k2_tp_galaxy_2_layers",
-        "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==5.5.1 tiktoken",
         "pytest": "tests/benchmark/test_llms.py::test_kimi_k2_tp_galaxy_2_layers",
         "runs-on": "galaxy-wh-6u"
       },
       {
         "name": "kimi_k2_5_tp_galaxy_2_layers",
-        "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==5.5.1 tiktoken",
         "pytest": "tests/benchmark/test_llms.py::test_kimi_k2_5_tp_galaxy_2_layers",
         "runs-on": "galaxy-wh-6u"
       },
       {
         "name": "llama_3_2_1b_instruct_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_2_1b",
         "accuracy-testing": true
       },
       {
         "name": "llama_3_2_3b_instruct_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_2_3b",
         "accuracy-testing": true
       },
       {
         "name": "llama_3_1_8b_instruct_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b",
         "accuracy-testing": true
       },
       {
         "name": "mistral_7b_accuracy",
-        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.5.1 protobuf sentencepiece",
         "pytest": "tests/benchmark/test_llms.py::test_mistral_7b",
         "accuracy-testing": true
       },
       {
         "name": "qwen_2_5_7b_instruct_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_7b",
         "accuracy-testing": true
       },
       {
         "name": "google_gemma-1.1-2b-it_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_gemma_1_1_2b",
         "accuracy-testing": true
       },
       {
         "name": "google_gemma-2-2b-it_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_gemma_2_2b",
         "accuracy-testing": true
       },
       {
         "name": "microsoft_phi-1_accuracy",
-        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_phi1",
         "accuracy-testing": true
       },
       {
         "name": "microsoft_phi-1_5_accuracy",
-        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_phi1_5",
         "accuracy-testing": true
       },
       {
         "name": "microsoft_phi-2_accuracy",
-        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_phi2",
         "accuracy-testing": true
       },
       {
         "name": "tiiuae_falcon3-1b-base_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_1b",
         "accuracy-testing": true
       },
       {
         "name": "tiiuae_falcon3-3b-base_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_3b",
         "accuracy-testing": true
       },
       {
         "name": "tiiuae_falcon3-7b-base_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b",
         "accuracy-testing": true
       },
       {
         "name": "qwen_2_5_0_5b_instruct_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_0_5b",
         "accuracy-testing": true
       },
       {
         "name": "qwen_2_5_1_5b_instruct_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_1_5b",
         "accuracy-testing": true
       },
       {
         "name": "qwen_2_5_3b_instruct_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_3b",
         "accuracy-testing": true
       },
       {
         "name": "qwen_3_0_6b_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_0_6b",
         "accuracy-testing": true
       },
       {
         "name": "qwen_3_1_7b_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_1_7b",
         "accuracy-testing": true
       },
       {
         "name": "qwen_3_4b_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_4b",
         "accuracy-testing": true
       },
       {
         "name": "qwen_3_8b_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 torchvision==0.25.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_8b",
         "accuracy-testing": true
       },
       {
         "name": "ministral_8b_accuracy",
-        "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_ministral_8b",
         "accuracy-testing": true
       },
       {
         "name": "falcon3_7b_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "falcon3_10b_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_10b_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "llama_3_1_8b_instruct_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b_instruct_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "ministral_8b_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_ministral_8b_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "mistral_nemo_instruct_2407_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_mistral_nemo_instruct_2407_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "mistral_small_24b_instruct_2501_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_mistral_small_24b_instruct_2501_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "qwen_2_5_14b_instruct_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_14b_instruct_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "qwen_2_5_coder_32b_instruct_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_coder_32b_instruct_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "qwen_3_8b_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_8b_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "qwen_3_14b_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_14b_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "qwen_3_32b_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_32b_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "llama_3_1_70b_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true,
@@ -570,42 +479,36 @@
       },
       {
         "name": "gpt_oss_20b_tp_accuracy",
-        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp",
         "runs-on": "n300-llmbox",
         "accuracy-testing": true
       },
       {
         "name": "llama_3_1_70b_tp_galaxy_accuracy",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp_galaxy",
         "runs-on": "galaxy-wh-6u",
         "accuracy-testing": true
       },
       {
         "name": "gpt_oss_20b_tp_galaxy_accuracy",
-        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_galaxy_batch_size_64",
         "runs-on": "galaxy-wh-6u",
         "accuracy-testing": true
       },
       {
         "name": "gpt_oss_120b_tp_galaxy_accuracy",
-        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_120b_tp_galaxy_batch_size_64",
         "runs-on": "galaxy-wh-6u",
         "accuracy-testing": true
       },
       {
         "name": "gpt_oss_120b_tp_dp_galaxy_accuracy",
-        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.5.1",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_120b_tp_dp_galaxy_batch_size_128",
         "runs-on": "galaxy-wh-6u",
         "accuracy-testing": true
       },
       {
         "name": "vllm_llama_3_2_3b",
-        "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[llama-3.2-3b]",
         "vllm": true,
         "skip-stablehlo-dump": true,
@@ -616,7 +519,6 @@
       },
       {
         "name": "vllm_llama_3_2_3b_batch32",
-        "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[llama-3.2-3b-batch32]",
         "vllm": true,
         "skip-stablehlo-dump": true,
@@ -627,7 +529,6 @@
       },
       {
         "name": "vllm_opt_125m_opt1",
-        "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[opt-125m-opt1]",
         "vllm": true,
         "skip-stablehlo-dump": true,
@@ -638,7 +539,6 @@
       },
       {
         "name": "vllm_opt_125m_batch32_opt1",
-        "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[opt-125m-batch32-opt1]",
         "vllm": true,
         "skip-stablehlo-dump": true,
@@ -649,7 +549,6 @@
       },
       {
         "name": "vllm_llama_3_2_1b_instruct",
-        "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[llama-3.2-1b]",
         "vllm": true,
         "skip-stablehlo-dump": true,
@@ -660,7 +559,6 @@
       },
       {
         "name": "vllm_qwen2_5_0_5b_instruct",
-        "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen2.5-0.5b-instruct]",
         "vllm": true,
         "skip-stablehlo-dump": true,
@@ -671,7 +569,6 @@
       },
       {
         "name": "vllm_qwen2_5_1_5b_instruct",
-        "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen2.5-1.5b-instruct]",
         "vllm": true,
         "skip-stablehlo-dump": true,
@@ -682,7 +579,6 @@
       },
       {
         "name": "vllm_qwen2_5_3b_instruct",
-        "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen2.5-3b-instruct]",
         "vllm": true,
         "skip-stablehlo-dump": true,
@@ -693,7 +589,6 @@
       },
       {
         "name": "vllm_qwen3_0_6b",
-        "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen3-0.6b]",
         "vllm": true,
         "skip-stablehlo-dump": true,
@@ -704,7 +599,6 @@
       },
       {
         "name": "vllm_qwen3_1_7b",
-        "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen3-1.7b]",
         "vllm": true,
         "skip-stablehlo-dump": true,
@@ -715,7 +609,6 @@
       },
       {
         "name": "vllm_phi_1",
-        "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[phi-1]",
         "vllm": true,
         "skip-stablehlo-dump": true,
@@ -726,7 +619,6 @@
       },
       {
         "name": "vllm_phi_1_5",
-        "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[phi-1_5]",
         "vllm": true,
         "skip-stablehlo-dump": true,
@@ -737,7 +629,6 @@
       },
       {
         "name": "vllm_phi_2",
-        "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[phi-2]",
         "vllm": true,
         "skip-stablehlo-dump": true,
@@ -748,7 +639,6 @@
       },
       {
         "name": "vllm_falcon3_1b_base",
-        "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[falcon3-1b-base]",
         "vllm": true,
         "skip-stablehlo-dump": true,
@@ -759,7 +649,6 @@
       },
       {
         "name": "vllm_falcon3_1b_base_opt1",
-        "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[falcon3-1b-base-opt1]",
         "vllm": true,
         "skip-stablehlo-dump": true,
@@ -770,7 +659,6 @@
       },
       {
         "name": "vllm_falcon3_3b_base",
-        "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[falcon3-3b-base]",
         "vllm": true,
         "skip-stablehlo-dump": true,
@@ -781,7 +669,6 @@
       },
       {
         "name": "vllm_falcon3_7b_tp",
-        "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[falcon3-7b-tp]",
         "vllm": true,
         "skip-stablehlo-dump": true,
@@ -792,7 +679,6 @@
       },
       {
         "name": "vllm_falcon3_10b_tp",
-        "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[falcon3-10b-tp]",
         "vllm": true,
         "skip-stablehlo-dump": true,
@@ -803,7 +689,6 @@
       },
       {
         "name": "vllm_qwen3_8b_tp",
-        "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen3-8b-tp]",
         "vllm": true,
         "skip-stablehlo-dump": true,
@@ -814,7 +699,6 @@
       },
       {
         "name": "vllm_qwen3_14b_tp",
-        "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen3-14b-tp]",
         "vllm": true,
         "skip-stablehlo-dump": true,
@@ -825,7 +709,6 @@
       },
       {
         "name": "vllm_qwen3_32b_tp",
-        "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen3-32b-tp]",
         "vllm": true,
         "skip-stablehlo-dump": true,
@@ -836,7 +719,6 @@
       },
       {
         "name": "vllm_qwen2_5_14b_instruct_tp",
-        "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen2.5-14b-instruct-tp]",
         "vllm": true,
         "skip-stablehlo-dump": true,
@@ -847,7 +729,6 @@
       },
       {
         "name": "vllm_qwen2_5_coder_32b_instruct_tp",
-        "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen2.5-coder-32b-instruct-tp]",
         "vllm": true,
         "skip-stablehlo-dump": true,
@@ -858,7 +739,6 @@
       },
       {
         "name": "vllm_ministral_8b_tp",
-        "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[ministral-8b-tp]",
         "vllm": true,
         "skip-stablehlo-dump": true,
@@ -869,7 +749,6 @@
       },
       {
         "name": "vllm_mistral_nemo_instruct_2407_tp",
-        "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[mistral-nemo-instruct-2407-tp]",
         "vllm": true,
         "skip-stablehlo-dump": true,
@@ -880,7 +759,6 @@
       },
       {
         "name": "vllm_mistral_small_24b_instruct_2501_tp",
-        "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[mistral-small-24b-instruct-2501-tp]",
         "vllm": true,
         "skip-stablehlo-dump": true,

--- a/tests/benchmark/benchmarks/llm_benchmark.py
+++ b/tests/benchmark/benchmarks/llm_benchmark.py
@@ -15,7 +15,6 @@ import torch_xla.core.xla_model as xm
 import torch_xla.distributed.spmd as xs
 import torch_xla.runtime as xr
 import tracy
-import transformers
 from fusion_check import check_fusions
 from infra import MLACache, MLAStaticLayer
 from llm_utils import (
@@ -226,23 +225,6 @@ def _shard_kv_cache(past_key_values, mesh, kv_cache_sharding_spec):
             xs.mark_sharding(layer.values, mesh, kv_spec)
 
 
-def check_transformers_version():
-    """
-    Check that transformers version is = 5.5.1.
-    Raises RuntimeError if version is incompatible.
-    """
-    import packaging.version
-
-    current_version = packaging.version.parse(transformers.__version__)
-    max_version = packaging.version.parse("5.5.1")
-
-    if current_version != max_version:
-        raise RuntimeError(
-            f"Transformers version {transformers.__version__} is not supported. "
-            f"Please use version 5.5.1"
-        )
-
-
 def benchmark_llm_torch_xla(
     model_loader,
     model_variant,
@@ -344,9 +326,6 @@ def benchmark_llm_torch_xla(
             f"optimization_level must be >= 1 when enable_create_d2m_subgraphs "
             f"is enabled, got optimization_level={optimization_level}"
         )
-
-    # Check transformers version
-    check_transformers_version()
 
     xr.set_device_type("TT")
 


### PR DESCRIPTION
### Problem description
The perf benchmark workflow installs Python dependencies per-test via the `pyreq` field in `perf-bench-matrix.json`, and `llm_benchmark.py` enforces a hard-coded transformers version. With transformers now uplifted to 5.5.1 (and brought in via the wheel/docker image), the per-test installs and the version check are redundant and cause maintenance overhead.

### What's changed
- Drop `check_transformers_version()` (and its caller + the now-unused `import transformers`) from `tests/benchmark/benchmarks/llm_benchmark.py`.
- Remove the `pyreq` field from every test entry in `.github/workflows/perf-bench-matrix.json` (119 entries).
- Remove the entire `Install Python dependencies` step from `.github/workflows/call-perf-test.yml`; the wheel + docker image already provide what is needed.

### CI run
Single-chip shared-runner perf benchmark on this branch: https://github.com/tenstorrent/tt-xla/actions/runs/26410094134

### Test failures observed
Six jobs failed. Two are caused by this change, the rest are pre-existing / transient:

| Test | Cause | Caused by this PR? | Proposed solution |
| --- | --- | --- | --- |
| `resnet_jax` | `ImportError: cannot import name 'FlaxResNetForImageClassification' from 'transformers'` — Flax model classes were removed from transformers in versions >= 5.x. The original `pyreq` pinned `transformers==4.57.1` + `flax==0.10.4`. | Yes | Either rewrite the test to use a current Flax/JAX ResNet implementation (e.g., from `flax.linen` or a JAX-native model zoo), or move this test into a separate workflow that installs transformers 4.57.1 + flax. |
| `bge_m3_encode` | `ImportError: cannot import name 'is_torch_fx_available' from 'transformers.utils.import_utils'` — `FlagEmbedding` depends on this symbol which was moved/removed in newer transformers. Original `pyreq` pinned `transformers==4.57.1` + `FlagEmbedding`. | Yes | Wait for a `FlagEmbedding` release compatible with transformers 5.x, or run this test on a separate worker with the older pin. |
| `ufld_v2` | `ValueError: IRD_LF_CACHE environment variable is not set.` — the model loader downloads weights from the IRD LF cache; the env var is exported in `call-test.yml` (when `shared-runners` is true) but **not** in `call-perf-test.yml`. | No (pre-existing) | Add `IRD_LF_CACHE=${{ vars.IRD_LF_CACHE }}` to `call-perf-test.yml` for the shared-runner path, mirroring what `call-test.yml` already does. |
| `tiiuae_falcon3-7b-base` | `RuntimeError: Bad StatusOr access: INTERNAL: Error code: 13` — device-side runtime error. Same failure appears on `main` in the latest nightly. | No (pre-existing) | Track in an existing falcon3-7b issue; unrelated to dependency management. |
| `mistral_7b` | `error downloading xla-whl-release-2ef6fc3: error writing zip archive: unexpected EOF` during artifact download. | No (transient) | Retry the workflow; this is an artifact-server flake. |
| `vllm_llama_3_2_1b_instruct` | Same wheel artifact download EOF as above. | No (transient) | Retry the workflow. |

### Checklist
- [x] New/Existing tests provide coverage for changes (covered by the perf benchmark CI itself)