### PR TITLE
Set opt. lvl. to 1 for SDXL-Lightning, HiDreamI1 and Playground v2.5 VAE decoder tests

### DIFF
--- a/tests/torch/models/HiDream_I1/test_vae_decoder.py
+++ b/tests/torch/models/HiDream_I1/test_vae_decoder.py
@@ -10,12 +10,10 @@ import torch_xla
 import torch_xla.runtime as xr
 from infra import Framework, run_graph_test
 
+from tests.infra.testers.compiler_config import CompilerConfig
 from third_party.tt_forge_models.hidream_i1.pytorch import ModelLoader, ModelVariant
 
 
-@pytest.mark.xfail(
-    reason=" Out of Memory: Not enough space to allocate 4294967296 B DRAM buffer across 12 banks, where each bank needs to store 357916672 B, but bank size is 1071821792 B - https://github.com/tenstorrent/tt-xla/issues/4762"
-)
 @pytest.mark.nightly
 @pytest.mark.model_test
 def test_vae_decoder():
@@ -26,8 +24,14 @@ def test_vae_decoder():
     model = loader.load_model(dtype_override=torch.float32)
     inputs = loader.load_inputs(dtype_override=torch.float32)
 
+    # opt_level=1 keeps ttir.group_norm -> ttnn.group_norm; opt_level=0 triggers
+    # GroupNorm decomposition (reshape+mean+sub) which triggers OOM
+    # https://github.com/tenstorrent/tt-xla/issues/4710
+    compiler_config = CompilerConfig(optimization_level=1)
+
     run_graph_test(
         model,
         inputs,
         framework=Framework.TORCH,
+        compiler_config=compiler_config,
     )

--- a/tests/torch/models/playground_v2_5/test_vae_decoder.py
+++ b/tests/torch/models/playground_v2_5/test_vae_decoder.py
@@ -10,15 +10,13 @@ import torch_xla
 import torch_xla.runtime as xr
 from infra import Framework, run_graph_test
 
+from tests.infra.testers.compiler_config import CompilerConfig
 from third_party.tt_forge_models.playground_v2_5.pytorch import (
     ModelLoader,
     ModelVariant,
 )
 
 
-@pytest.mark.xfail(
-    reason="Out of Memory: Not enough space to allocate 4294967296 B DRAM buffer across 12 banks, where each bank needs to store 357916672 B, but bank size is 1071821792 B — https://github.com/tenstorrent/tt-xla/issues/4710"
-)
 @pytest.mark.nightly
 @pytest.mark.model_test
 def test_vae_decoder():
@@ -29,8 +27,14 @@ def test_vae_decoder():
     model = loader.load_model(dtype_override=torch.float32)
     inputs = loader.load_inputs(dtype_override=torch.float32)
 
+    # opt_level=1 keeps ttir.group_norm -> ttnn.group_norm; opt_level=0 triggers
+    # GroupNorm decomposition (reshape+mean+sub) which triggers OOM
+    # https://github.com/tenstorrent/tt-xla/issues/4710
+    compiler_config = CompilerConfig(optimization_level=1)
+
     run_graph_test(
         model,
         inputs,
         framework=Framework.TORCH,
+        compiler_config=compiler_config,
     )

--- a/tests/torch/models/sdxl_lightning/test_vae_decoder.py
+++ b/tests/torch/models/sdxl_lightning/test_vae_decoder.py
@@ -10,12 +10,10 @@ import torch_xla
 import torch_xla.runtime as xr
 from infra import Framework, run_graph_test
 
+from tests.infra.testers.compiler_config import CompilerConfig
 from third_party.tt_forge_models.sdxl_lightning.pytorch import ModelLoader, ModelVariant
 
 
-@pytest.mark.xfail(
-    reason="Out of Memory: Not enough space to allocate 4294967296 B DRAM buffer across 12 banks, where each bank needs to store 357916672 B, but bank size is 1071821792 B  - https://github.com/tenstorrent/tt-xla/issues/4728"
-)
 @pytest.mark.nightly
 @pytest.mark.model_test
 def test_vae_decoder():
@@ -26,8 +24,14 @@ def test_vae_decoder():
     model = loader.load_model(dtype_override=torch.float32)
     inputs = loader.load_inputs(dtype_override=torch.float32)
 
+    # opt_level=1 keeps ttir.group_norm -> ttnn.group_norm; opt_level=0 triggers
+    # GroupNorm decomposition (reshape+mean+sub) which triggers OOM
+    # https://github.com/tenstorrent/tt-xla/issues/4710
+    compiler_config = CompilerConfig(optimization_level=1)
+
     run_graph_test(
         model,
         inputs,
         framework=Framework.TORCH,
+        compiler_config=compiler_config,
     )


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-xla/issues/4710
- fixes https://github.com/tenstorrent/tt-xla/issues/4728
- fixes https://github.com/tenstorrent/tt-xla/issues/4762

### Problem description

- VAE decoders of SDXL-Lightning, HiDreamI1 and Playground v2.5 fail with OOM from the decomposition of `group_norm`. For full context see [#4710](https://github.com/tenstorrent/tt-xla/issues/4710).
- `group_norm` composite was enabled in tt-xla via [#4868](https://github.com/tenstorrent/tt-xla/pull/4868)
- However, [#8447](https://github.com/tenstorrent/tt-mlir/pull/8447) (*Group norm decomposition*) makes the `ttir.group_norm` → `ttnn.group_norm` mapping unavailable at `opt_level=0`: when the optimizer is disabled, the pass unconditionally rewrites `ttir.group_norm` into a reshape + mean + variance + subtract chain, and the `ttnn::mean` over the tile-padded intermediate is what triggers the 4 GiB OOM.
- Setting `opt_level=1` keeps `ttir.group_norm` → `ttnn.group_norm` and avoids the decomposition path.


### What's changed

- Set `optimization_level=1` in the SDXL-Lightning, HiDreamI1 and Playground v2.5 VAE decoder tests.

### Checklist
- [x] Verified the changes through local testing

### Logs

- [may26_playground_v2_5_vae_decoder_opt1.log](https://github.com/user-attachments/files/28260609/may26_playground_v2_5_vae_decoder_opt1.log)
- [may26_playground_v2_5_vae_decoder_opt0.log](https://github.com/user-attachments/files/28260612/may26_playground_v2_5_vae_decoder.log)
- [may26_sdxl_lightning_vae_decoder_opt1.log](https://github.com/user-attachments/files/28260613/may26_sdxl_lightning_vae_decoder_opt1.log)
- [may26_sdxl_lightning_vae_decoder_opt0.log](https://github.com/user-attachments/files/28260614/may26_sdxl_lightning_vae_decoder.log)
- [may26_hidream_vae_decoder_opt0.log](https://github.com/user-attachments/files/28264542/may26_hidream_vae_decoder_opt0.log)
- [may26_hidream_vae_decoder_opt1.log](https://github.com/user-attachments/files/28264543/may26_hidream_vae_decoder_opt1.log)

