### PR TITLE
Sharded topk composite op investigation

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -78,6 +78,16 @@
         "pytest": "tests/benchmark/test_encoders.py::test_bge_m3"
       },
       {
+        "name": "bge_m3_encode_batch1",
+        "pyreq": "datasets FlagEmbedding loguru pytest requests timm torch==2.10.0 tqdm transformers==4.57.1",
+        "pytest": "tests/benchmark/test_encoders.py::test_bge_m3_batch1"
+      },
+      {
+        "name": "bge_m3_encode_batch32",
+        "pyreq": "datasets FlagEmbedding loguru pytest requests timm torch==2.10.0 tqdm transformers==4.57.1",
+        "pytest": "tests/benchmark/test_encoders.py::test_bge_m3_batch32"
+      },
+      {
         "name": "llama_3_2_1b_instruct",
         "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_2_1b"
@@ -289,6 +299,11 @@
         "name": "qwen_3_4b_embedding",
         "pyreq": "datasets loguru pytest requests timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_encoders.py::test_qwen3_embedding_4b"
+      },
+      {
+        "name": "qwen_3_4b_embedding_batch1",
+        "pyreq": "datasets loguru pytest requests timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pytest": "tests/benchmark/test_encoders.py::test_qwen3_embedding_4b_batch1"
       },
       {
         "name": "bert",

--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -79,13 +79,25 @@
       },
       {
         "name": "bge_m3_encode_batch1",
-        "pyreq": "datasets FlagEmbedding loguru pytest requests timm torch==2.10.0 tqdm transformers==4.57.1",
-        "pytest": "tests/benchmark/test_encoders.py::test_bge_m3_batch1"
+        "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_bge_m3_batch1",
+        "vllm": true,
+        "skip-stablehlo-dump": true,
+        "skip-ttir-dump": true,
+        "skip-ttnn-dump": true,
+        "skip-device-perf": true,
+        "runs-on": "n150"
       },
       {
         "name": "bge_m3_encode_batch32",
-        "pyreq": "datasets FlagEmbedding loguru pytest requests timm torch==2.10.0 tqdm transformers==4.57.1",
-        "pytest": "tests/benchmark/test_encoders.py::test_bge_m3_batch32"
+        "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_bge_m3_batch32",
+        "vllm": true,
+        "skip-stablehlo-dump": true,
+        "skip-ttir-dump": true,
+        "skip-ttnn-dump": true,
+        "skip-device-perf": true,
+        "runs-on": "n150"
       },
       {
         "name": "llama_3_2_1b_instruct",
@@ -302,8 +314,14 @@
       },
       {
         "name": "qwen_3_4b_embedding_batch1",
-        "pyreq": "datasets loguru pytest requests timm torch==2.10.0 tqdm transformers==5.2.0",
-        "pytest": "tests/benchmark/test_encoders.py::test_qwen3_embedding_4b_batch1"
+        "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_qwen3_embedding_4b_batch1",
+        "vllm": true,
+        "skip-stablehlo-dump": true,
+        "skip-ttir-dump": true,
+        "skip-ttnn-dump": true,
+        "skip-device-perf": true,
+        "runs-on": "n150"
       },
       {
         "name": "bert",

--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -78,7 +78,7 @@
         "pytest": "tests/benchmark/test_encoders.py::test_bge_m3"
       },
       {
-        "name": "bge_m3_encode_batch1",
+        "name": "vllm_bge_m3_encode_batch1",
         "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_bge_m3_batch1",
         "vllm": true,
@@ -89,7 +89,7 @@
         "runs-on": "n150"
       },
       {
-        "name": "bge_m3_encode_batch32",
+        "name": "vllm_bge_m3_encode_batch32",
         "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_bge_m3_batch32",
         "vllm": true,
@@ -313,7 +313,7 @@
         "pytest": "tests/benchmark/test_encoders.py::test_qwen3_embedding_4b"
       },
       {
-        "name": "qwen_3_4b_embedding_batch1",
+        "name": "vllm_qwen_3_4b_embedding_batch1",
         "pyreq": "loguru pytest torch==2.10.0 transformers==5.5.1 vllm==0.19.1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_qwen3_embedding_4b_batch1",
         "vllm": true,

--- a/tests/benchmark/benchmarks/vllm_benchmark.py
+++ b/tests/benchmark/benchmarks/vllm_benchmark.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import socket
+import time
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -38,6 +39,19 @@ class VLLMBenchmarkConfig:
 
     # Sampling params (temperature=0.0 -> greedy)
     temperature: float = 0.0
+
+
+@dataclass
+class VLLMEmbeddingBenchmarkConfig:
+    """Configuration for a vLLM embedding benchmark run."""
+
+    model: str = "BAAI/bge-m3"
+    max_model_len: int = 512
+    gpu_memory_utilization: float = 0.05
+    additional_config: Dict[str, Any] = field(default_factory=dict)
+    batch_size: int = 1
+    warmup_iterations: int = 1
+    loop_count: int = 32
 
 
 def _create_llm(config: VLLMBenchmarkConfig) -> vllm.LLM:
@@ -267,5 +281,91 @@ def benchmark_vllm(
         input_sequence_length=config.max_model_len,
         device_count=device_count,
         mesh_shape=mesh_shape,
+        vllm=True,
+    )
+
+
+def benchmark_vllm_embedding(
+    config: VLLMEmbeddingBenchmarkConfig,
+    display_name: str,
+) -> Dict[str, Any]:
+    """Run a vLLM embedding benchmark and return a standardised result dict."""
+    prompts = [DEFAULT_PROMPT] * config.batch_size
+
+    llm_args: Dict[str, Any] = {
+        "model": config.model,
+        "task": "embed",
+        "max_model_len": config.max_model_len,
+        "max_num_seqs": config.batch_size,
+        "max_num_batched_tokens": config.batch_size * config.max_model_len,
+        "gpu_memory_utilization": config.gpu_memory_utilization,
+        "disable_log_stats": False,
+        "additional_config": dict(config.additional_config),
+    }
+    print(f"Creating vLLM embedding engine for {config.model} ...")
+    print(f"  LLM args: {llm_args}")
+    llm = vllm.LLM(**llm_args)
+
+    if config.warmup_iterations > 0:
+        print(f"\nWarming up ({config.warmup_iterations} iteration(s)) ...")
+        for _ in range(config.warmup_iterations):
+            llm.encode(prompts)
+        print("Warmup complete.")
+
+    print(f"\nStarting benchmark ({config.loop_count} iterations) ...")
+    total_time = 0.0
+    for _ in range(config.loop_count):
+        t0 = time.perf_counter()
+        llm.encode(prompts)
+        total_time += time.perf_counter() - t0
+
+    avg_time = total_time / config.loop_count
+    samples_per_sec = config.batch_size / avg_time
+
+    metadata = get_benchmark_metadata()
+    full_model_name = config.model
+    model_type = "text-embedding"
+    dataset_name = "Random Data"
+    evaluation_score = 0.0
+
+    print_benchmark_results(
+        model_title=full_model_name,
+        full_model_name=full_model_name,
+        model_type=model_type,
+        dataset_name=dataset_name,
+        date=metadata["date"],
+        machine_name=metadata["machine_name"],
+        total_time=avg_time,
+        total_samples=config.batch_size,
+        samples_per_sec=samples_per_sec,
+        evaluation_score=evaluation_score,
+        batch_size=config.batch_size,
+        input_sequence_length=config.max_model_len,
+    )
+
+    return create_benchmark_result(
+        full_model_name=full_model_name,
+        model_type=model_type,
+        dataset_name=dataset_name,
+        num_layers=-1,
+        batch_size=config.batch_size,
+        input_size=(config.max_model_len,),
+        loop_count=config.loop_count,
+        data_format="bfloat16",
+        total_time=avg_time,
+        total_samples=config.batch_size,
+        evaluation_score=evaluation_score,
+        optimization_level=config.additional_config.get("optimization_level", 0),
+        program_cache_enabled=True,
+        trace_enabled=config.additional_config.get("enable_trace", True),
+        model_info=full_model_name,
+        display_name=display_name,
+        torch_xla_enabled=True,
+        backend="tt",
+        device_name=socket.gethostname(),
+        arch="wormhole",
+        input_is_image=False,
+        input_sequence_length=config.max_model_len,
+        device_count=1,
         vllm=True,
     )

--- a/tests/benchmark/test_encoders.py
+++ b/tests/benchmark/test_encoders.py
@@ -499,6 +499,7 @@ def _run_bge_m3(output_file, request, batch_size: int):
 
 
 def test_bge_m3(output_file, request):
+    """BGE-M3 encoder benchmark (batch_size=4)."""
     _run_bge_m3(output_file=output_file, request=request, batch_size=4)
 
 

--- a/tests/benchmark/test_encoders.py
+++ b/tests/benchmark/test_encoders.py
@@ -274,6 +274,63 @@ def test_qwen3_embedding_4b(output_file, num_layers, request):
     )
 
 
+# Trace disabled: host/device tensor shape mismatch (https://github.com/tenstorrent/tt-xla/issues/3936)
+def test_qwen3_embedding_4b_batch1(output_file, num_layers, request):
+    from third_party.tt_forge_models.qwen_3.embedding.pytorch.loader import (
+        ModelLoader,
+        ModelVariant,
+    )
+
+    data_format = "bfloat16"
+    input_sequence_length = 128
+
+    variant = ModelVariant.QWEN_3_EMBEDDING_4B
+    loader = create_model_loader(ModelLoader, num_layers=num_layers, variant=variant)
+    if num_layers is not None and loader is None:
+        pytest.fail(
+            "num_layers override requested but ModelLoader does not support it."
+        )
+    model_info_name = loader.get_model_info(variant=variant).name
+    print(f"\nLoading model {model_info_name}...")
+    model = loader.load_model(dtype_override=DTYPE_MAP[data_format])
+
+    load_inputs_fn = get_default_inputs
+
+    tokenizer = loader.tokenizer
+    preprocess_fn = lambda sentences, device: {
+        k: v.to(device)
+        for k, v in tokenizer(
+            sentences,
+            padding=True,
+            truncation=True,
+            max_length=input_sequence_length,
+            return_tensors="pt",
+        ).items()
+    }
+
+    output_processor_fn = lambda out, inputs: apply_last_token_pooling(
+        out.last_hidden_state, inputs["attention_mask"]
+    )
+
+    test_encoder(
+        model=model,
+        model_info_name=model_info_name,
+        output_file=output_file,
+        display_name=variant.name,
+        request=request,
+        load_inputs_fn=load_inputs_fn,
+        preprocess_fn=preprocess_fn,
+        output_processor_fn=output_processor_fn,
+        data_format=data_format,
+        num_layers=num_layers,
+        batch_size=1,
+        input_sequence_length=input_sequence_length,
+        loop_count=32,
+        optimization_level=0,
+        trace_enabled=False,
+    )
+
+
 # [pytest.skip] Too large for single chip
 def test_qwen3_embedding_8b(output_file, num_layers, request):
     from third_party.tt_forge_models.qwen_3.embedding.pytorch.loader import (
@@ -335,11 +392,11 @@ def test_qwen3_embedding_8b(output_file, num_layers, request):
     )
 
 
-def test_bge_m3(output_file, request):
-    """Test BGE-M3 encoder model with custom postprocessing.
+def _run_bge_m3(output_file, request, batch_size: int):
+    """Shared BGE-M3 benchmark helper.
 
     BGE-M3 has a unique architecture that produces dense, sparse, and colbert embeddings.
-    This test includes all the necessary postprocessing but returns only dense_vecs for PCC calculation.
+    Returns only dense_vecs for PCC calculation.
     """
     from collections import defaultdict
 
@@ -490,12 +547,27 @@ def test_bge_m3(output_file, request):
         preprocess_fn=bge_m3_preprocess,
         output_processor_fn=bge_m3_output_processor,
         data_format=data_format,
-        batch_size=4,
+        batch_size=batch_size,
         input_sequence_length=input_sequence_length,
         loop_count=32,
         optimization_level=0,
         required_pcc=0.97,
     )
+
+
+def test_bge_m3(output_file, request):
+    """BGE-M3 encoder benchmark (batch_size=4)."""
+    _run_bge_m3(output_file=output_file, request=request, batch_size=4)
+
+
+def test_bge_m3_batch1(output_file, request):
+    """BGE-M3 encoder benchmark with batch_size=1."""
+    _run_bge_m3(output_file=output_file, request=request, batch_size=1)
+
+
+def test_bge_m3_batch32(output_file, request):
+    """BGE-M3 encoder benchmark with batch_size=32."""
+    _run_bge_m3(output_file=output_file, request=request, batch_size=32)
 
 
 # Trace disabled: output tensor not on device (https://github.com/tenstorrent/tt-xla/issues/3937)

--- a/tests/benchmark/test_encoders.py
+++ b/tests/benchmark/test_encoders.py
@@ -274,63 +274,6 @@ def test_qwen3_embedding_4b(output_file, num_layers, request):
     )
 
 
-# Trace disabled: host/device tensor shape mismatch (https://github.com/tenstorrent/tt-xla/issues/3936)
-def test_qwen3_embedding_4b_batch1(output_file, num_layers, request):
-    from third_party.tt_forge_models.qwen_3.embedding.pytorch.loader import (
-        ModelLoader,
-        ModelVariant,
-    )
-
-    data_format = "bfloat16"
-    input_sequence_length = 128
-
-    variant = ModelVariant.QWEN_3_EMBEDDING_4B
-    loader = create_model_loader(ModelLoader, num_layers=num_layers, variant=variant)
-    if num_layers is not None and loader is None:
-        pytest.fail(
-            "num_layers override requested but ModelLoader does not support it."
-        )
-    model_info_name = loader.get_model_info(variant=variant).name
-    print(f"\nLoading model {model_info_name}...")
-    model = loader.load_model(dtype_override=DTYPE_MAP[data_format])
-
-    load_inputs_fn = get_default_inputs
-
-    tokenizer = loader.tokenizer
-    preprocess_fn = lambda sentences, device: {
-        k: v.to(device)
-        for k, v in tokenizer(
-            sentences,
-            padding=True,
-            truncation=True,
-            max_length=input_sequence_length,
-            return_tensors="pt",
-        ).items()
-    }
-
-    output_processor_fn = lambda out, inputs: apply_last_token_pooling(
-        out.last_hidden_state, inputs["attention_mask"]
-    )
-
-    test_encoder(
-        model=model,
-        model_info_name=model_info_name,
-        output_file=output_file,
-        display_name=variant.name,
-        request=request,
-        load_inputs_fn=load_inputs_fn,
-        preprocess_fn=preprocess_fn,
-        output_processor_fn=output_processor_fn,
-        data_format=data_format,
-        num_layers=num_layers,
-        batch_size=1,
-        input_sequence_length=input_sequence_length,
-        loop_count=32,
-        optimization_level=0,
-        trace_enabled=False,
-    )
-
-
 # [pytest.skip] Too large for single chip
 def test_qwen3_embedding_8b(output_file, num_layers, request):
     from third_party.tt_forge_models.qwen_3.embedding.pytorch.loader import (
@@ -556,18 +499,7 @@ def _run_bge_m3(output_file, request, batch_size: int):
 
 
 def test_bge_m3(output_file, request):
-    """BGE-M3 encoder benchmark (batch_size=4)."""
     _run_bge_m3(output_file=output_file, request=request, batch_size=4)
-
-
-def test_bge_m3_batch1(output_file, request):
-    """BGE-M3 encoder benchmark with batch_size=1."""
-    _run_bge_m3(output_file=output_file, request=request, batch_size=1)
-
-
-def test_bge_m3_batch32(output_file, request):
-    """BGE-M3 encoder benchmark with batch_size=32."""
-    _run_bge_m3(output_file=output_file, request=request, batch_size=32)
 
 
 # Trace disabled: output tensor not on device (https://github.com/tenstorrent/tt-xla/issues/3937)

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -6,7 +6,12 @@ import json
 import os
 
 import pytest
-from benchmarks.vllm_benchmark import VLLMBenchmarkConfig, benchmark_vllm
+from benchmarks.vllm_benchmark import (
+    VLLMBenchmarkConfig,
+    VLLMEmbeddingBenchmarkConfig,
+    benchmark_vllm,
+    benchmark_vllm_embedding,
+)
 from utils import resolve_display_name
 
 # Sampling overrides — keep SINGLE_DEVICE_CONFIGS focused on (model,
@@ -170,6 +175,65 @@ def _run_vllm_benchmark(config, output_file, request):
         with open(output_file, "w") as f:
             json.dump(results, f, indent=2)
         print(f"Results written to {output_file}")
+
+
+def _embedding_config(
+    model: str,
+    batch_size: int,
+    *,
+    max_model_len: int = 512,
+    gpu_memory_utilization: float = 0.05,
+    **additional_config_extra,
+):
+    additional = {"enable_trace": True}
+    additional.update(additional_config_extra)
+    return VLLMEmbeddingBenchmarkConfig(
+        model=model,
+        batch_size=batch_size,
+        max_model_len=max_model_len,
+        gpu_memory_utilization=gpu_memory_utilization,
+        additional_config=additional,
+    )
+
+
+def _run_vllm_embedding_benchmark(config, output_file, request):
+    display_name = "vllm_" + resolve_display_name(
+        request=request, fallback=config.model
+    )
+    results = benchmark_vllm_embedding(config, display_name)
+    if output_file:
+        results["project"] = "tt-xla"
+        results["model_rawname"] = config.model
+        with open(output_file, "w") as f:
+            json.dump(results, f, indent=2)
+        print(f"Results written to {output_file}")
+
+
+# Trace disabled: host/device tensor shape mismatch (https://github.com/tenstorrent/tt-xla/issues/3936)
+def test_vllm_qwen3_embedding_4b_batch1(output_file, request):
+    _run_vllm_embedding_benchmark(
+        _embedding_config(
+            "Qwen/Qwen3-Embedding-4B", 1, max_model_len=128, enable_trace=False
+        ),
+        output_file,
+        request,
+    )
+
+
+def test_vllm_bge_m3_batch1(output_file, request):
+    _run_vllm_embedding_benchmark(
+        _embedding_config("BAAI/bge-m3", 1),
+        output_file,
+        request,
+    )
+
+
+def test_vllm_bge_m3_batch32(output_file, request):
+    _run_vllm_embedding_benchmark(
+        _embedding_config("BAAI/bge-m3", 32),
+        output_file,
+        request,
+    )
 
 
 @pytest.mark.parametrize("config", SINGLE_DEVICE_CONFIGS)

--- a/tests/torch/ops/test_topk.py
+++ b/tests/torch/ops/test_topk.py
@@ -282,6 +282,7 @@ def test_topk_vllm_sampling_shapes(input_shape: tuple, k: int):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.push
 @pytest.mark.nightly
 @pytest.mark.dual_chip
 @pytest.mark.record_test_properties(

--- a/tests/torch/ops/test_topk.py
+++ b/tests/torch/ops/test_topk.py
@@ -4,8 +4,10 @@
 
 import pytest
 import torch
+import torch_xla.runtime as xr
 from benchmark.utils import compute_pcc
-from infra import Framework, run_op_test, run_op_test_with_random_inputs
+from infra import Framework, run_graph_test, run_op_test, run_op_test_with_random_inputs
+from torch_xla.distributed.spmd import Mesh
 from utils import Category
 
 
@@ -262,5 +264,58 @@ def test_topk_vllm_sampling_shapes(input_shape: tuple, k: int):
         TopKBoth(k),
         [torch.randn(*input_shape, dtype=torch.float32)],
         framework=Framework.TORCH,
+        custom_comparator=_topk_vllm_comparator,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sharded topk: verify composite op survives shardy reoutlining
+#
+# The composite op path works by: flatten composite decomp into main graph →
+# propagate shardings through each op → reoutline back to the original
+# composite. If shardy inserts a CCL in the middle of the flattened decomp,
+# reoutlining fails. This test checks whether that happens with sharded vocab.
+#
+# Run with TTXLA_LOGGER_LEVEL=VERBOSE and inspect the dump after the
+# reoutlining pass — if tenstorrent.topk is still present, composite survived
+# and no custom op is needed.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.nightly
+@pytest.mark.multi_device
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    torch_op_name="torch.topk",
+)
+def test_topk_sharded_vocab():
+    """Verify composite topk works end-to-end with vocab-sharded input (TP).
+
+    Each device holds vocab_per_shard logits. Shardy should propagate the
+    shard annotation through the composite topk decomp and reoutline back
+    to the original composite op without inserting an unneeded CCL.
+    """
+    num_devices = xr.global_runtime_device_count()
+    device_ids = list(range(num_devices))
+    mesh = Mesh(device_ids, (1, num_devices), ("batch", "model"))
+
+    k = 32
+    vocab_per_shard = 32768
+    batch = 1
+
+    class ShardedTopK(torch.nn.Module):
+        def forward(self, x):
+            return torch.topk(x, k, dim=-1)
+
+    def get_shard_spec(model, args, kwargs):
+        # input is sharded along vocab dim across model axis
+        return {args[0]: (None, "model")}
+
+    run_graph_test(
+        ShardedTopK(),
+        [torch.randn(batch, vocab_per_shard * num_devices, dtype=torch.float32)],
+        framework=Framework.TORCH,
+        mesh=mesh,
+        shard_spec_fn=get_shard_spec,
         custom_comparator=_topk_vllm_comparator,
     )

--- a/tests/torch/ops/test_topk.py
+++ b/tests/torch/ops/test_topk.py
@@ -283,7 +283,7 @@ def test_topk_vllm_sampling_shapes(input_shape: tuple, k: int):
 
 
 @pytest.mark.nightly
-@pytest.mark.multi_device
+@pytest.mark.dual_chip
 @pytest.mark.record_test_properties(
     category=Category.OP_TEST,
     torch_op_name="torch.topk",


### PR DESCRIPTION
## Summary
- Adds `test_topk_sharded_vocab` to `tests/torch/ops/test_topk.py` to check whether the composite topk op survives shardy reoutlining with a vocab-sharded input (tensor parallel setup)
- This is an investigation test for the tt-mlir PR #8601 discussion about avoiding a custom op for sharded topk

## What to check
Run with `TTXLA_LOGGER_LEVEL=VERBOSE` on n300 and inspect the dump after the reoutlining pass:
- If `tenstorrent.topk` is present → composite survived, no custom op needed
- If `all_gather`/`all_reduce` inserted mid-decomp → shardy CCL bug confirmed (per Het Shah's hypothesis)

## Test plan
- [ ] `tests/torch/ops/test_topk.py::test_topk_sharded_vocab` passes on n300

🤖 Generated with [Claude Code](https://claude.com/claude-code)