### PR TITLE
fix vllm perf's tokens / second value

### DIFF
--- a/.claude/skills/ci-benchmark-analyzer/SKILL.md
+++ b/.claude/skills/ci-benchmark-analyzer/SKILL.md
@@ -168,7 +168,7 @@ python <skill-path>/scripts/fetch_perf_reports.py <RUN_ID> --output-dir /tmp/per
 ```
 
 This produces `summary.json` with extracted metrics for all jobs. Key metrics per model:
-- **Samples/sec** = `total_samples / total_time`
+- **Samples/sec** = `samples_per_sec` measurement if present, else `total_samples / total_time`
 - **TTFT (ms)** = `ttft` value (LLM models only; absent for vision/encoder models)
 - **Device FW duration (s)** = `device_fw_duration` (only when device perf ran)
 - **Device type**: from `device_info.device_type`

--- a/.claude/skills/ci-benchmark-analyzer/scripts/compare_nightlies.py
+++ b/.claude/skills/ci-benchmark-analyzer/scripts/compare_nightlies.py
@@ -91,11 +91,17 @@ def extract_model_metrics(report: dict) -> dict:
     }
     total_samples = measurements.get("total_samples", 0)
     total_time = measurements.get("total_time", 0)
+    if "samples_per_sec" in measurements:
+        samples_per_sec = measurements["samples_per_sec"]
+    elif total_time > 0:
+        samples_per_sec = total_samples / total_time
+    else:
+        samples_per_sec = 0
 
     return {
         "display_name": report.get("config", {}).get("display_name", "unknown"),
         "device_type": report.get("device_info", {}).get("device_type", "unknown"),
-        "samples_per_sec": total_samples / total_time if total_time > 0 else 0,
+        "samples_per_sec": samples_per_sec,
         "ttft_ms": measurements.get("ttft"),
         "device_fw_duration_s": measurements.get("device_fw_duration"),
         "total_samples": total_samples,

--- a/.claude/skills/ci-benchmark-analyzer/scripts/fetch_perf_reports.py
+++ b/.claude/skills/ci-benchmark-analyzer/scripts/fetch_perf_reports.py
@@ -109,7 +109,12 @@ def extract_metrics(report: dict) -> dict:
 
     total_samples = measurements.get("total_samples", 0)
     total_time = measurements.get("total_time", 0)
-    samples_per_sec = total_samples / total_time if total_time > 0 else None
+    if "samples_per_sec" in measurements:
+        samples_per_sec = measurements["samples_per_sec"]
+    elif total_time > 0:
+        samples_per_sec = total_samples / total_time
+    else:
+        samples_per_sec = None
 
     return {
         "model": report.get("model", "unknown"),

--- a/tests/benchmark/benchmarks/vllm_benchmark.py
+++ b/tests/benchmark/benchmarks/vllm_benchmark.py
@@ -68,21 +68,18 @@ def _create_llm(config: VLLMBenchmarkConfig) -> vllm.LLM:
 
 def _extract_metrics(
     outputs: List[vllm.RequestOutput],
-    batch_size: int,
-) -> Tuple[float, int, float, float]:
+) -> Tuple[float, List[int], float, float]:
     """
     Extract per-request metrics and return aggregated per-user values.
 
     Returns:
-        (avg_ttft_ms, tokens_per_user, decode_total_time, tokens_per_sec_per_user)
+        (avg_ttft_ms, tokens_per_user, avg_decode_time_s, avg_tokens_per_sec)
     """
     ttft_values = []
-    total_gen_tokens = 0
 
     for i, output in enumerate(outputs):
         stats = output.metrics
         gen_tokens = len(output.outputs[0].token_ids)
-        total_gen_tokens += gen_tokens
 
         ttft_ms = stats.first_token_latency * 1000.0
         ttft_values.append(ttft_ms)
@@ -103,17 +100,33 @@ def _extract_metrics(
 
     avg_ttft_ms = sum(ttft_values) / len(ttft_values) if ttft_values else 0.0
 
-    decode_total_tokens = total_gen_tokens - batch_size
-    tokens_per_user = decode_total_tokens // batch_size
-
+    tokens_per_user = [len(o.outputs[0].token_ids) - 1 for o in outputs]
     first_token_times = [o.metrics.first_token_ts for o in outputs]
     last_token_times = [o.metrics.last_token_ts for o in outputs]
-    decode_total_time = max(last_token_times) - min(first_token_times)
-    tokens_per_sec_per_user = (
-        (tokens_per_user / decode_total_time) if decode_total_time > 0 else 0.0
+
+    decode_times_per_user = [
+        last_token_time - first_token_time
+        for last_token_time, first_token_time in zip(
+            last_token_times, first_token_times
+        )
+    ]
+    tokens_per_sec_per_user = [
+        tokens / decode_time if decode_time > 0 else 0.0
+        for tokens, decode_time in zip(tokens_per_user, decode_times_per_user)
+    ]
+    avg_tokens_per_sec = sum(tokens_per_sec_per_user) / len(tokens_per_sec_per_user)
+    avg_decode_time_s = (
+        sum(decode_times_per_user) / len(decode_times_per_user)
+        if decode_times_per_user
+        else 0.0
     )
 
-    return avg_ttft_ms, tokens_per_user, decode_total_time, tokens_per_sec_per_user
+    return (
+        avg_ttft_ms,
+        tokens_per_user,
+        avg_decode_time_s,
+        avg_tokens_per_sec,
+    )
 
 
 def _get_device_info(
@@ -197,9 +210,13 @@ def benchmark_vllm(
     _assert_token_counts(outputs, config.max_tokens, config.max_model_len)
     _assert_no_preemptions(llm)
 
-    avg_ttft_ms, tokens_per_user, decode_total_time, tokens_per_sec_per_user = (
-        _extract_metrics(outputs, config.batch_size)
-    )
+    (
+        avg_ttft_ms,
+        tokens_per_user,
+        avg_decode_time_s,
+        avg_tokens_per_sec,
+    ) = _extract_metrics(outputs)
+    total_samples = sum(tokens_per_user)
 
     metadata = get_benchmark_metadata()
     full_model_name = config.model
@@ -213,6 +230,11 @@ def benchmark_vllm(
             "value": avg_ttft_ms,
             "target": -1,
         },
+        {
+            "measurement_name": "samples_per_sec",
+            "value": avg_tokens_per_sec,
+            "target": -1,
+        },
     ]
 
     print_benchmark_results(
@@ -222,9 +244,9 @@ def benchmark_vllm(
         dataset_name=dataset_name,
         date=metadata["date"],
         machine_name=metadata["machine_name"],
-        total_time=decode_total_time,
-        total_samples=tokens_per_user,
-        samples_per_sec=tokens_per_sec_per_user,
+        total_time=avg_decode_time_s,
+        total_samples=total_samples,
+        samples_per_sec=avg_tokens_per_sec,
         evaluation_score=evaluation_score,
         batch_size=config.batch_size,
         data_format="bfloat16",
@@ -243,8 +265,8 @@ def benchmark_vllm(
         input_size=(config.max_model_len,),
         loop_count=1,
         data_format="bfloat16",
-        total_time=decode_total_time,
-        total_samples=tokens_per_user,
+        total_time=avg_decode_time_s,
+        total_samples=total_samples,
         evaluation_score=evaluation_score,
         custom_measurements=custom_measurements,
         optimization_level=config.additional_config.get("optimization_level", 0),

--- a/tests/benchmark/utils.py
+++ b/tests/benchmark/utils.py
@@ -293,9 +293,9 @@ def print_benchmark_results(
     print(f"| Dataset name: {dataset_name}")
     print(f"| Date: {date}")
     print(f"| Machine name: {machine_name}")
-    print(f"| Total execution time: {total_time}")
     print(f"| Total samples: {total_samples}")
-    print(f"| Sample per second: {samples_per_sec}")
+    print(f"| Avg. decode time: {total_time}")
+    print(f"| Avg. samples per second: {samples_per_sec}")
 
     if cpu_samples_per_sec is not None:
         print(f"| CPU samples per second: {cpu_samples_per_sec}")


### PR DESCRIPTION
### Ticket
#4491 

### Problem description
Current math for the tokens/second is missleading. When testing batch_size > 1, by just using `tokens_per_user / (max(last_token_times) - min(first_token_times))` you are mixing time windows from different users/requests. This is specifically an issue with vllm because the token gens don't seem to happen at the same exact time. We see a large delta between the time of the first token gen of the first user and the rest.
```
  Request 0: first_token_time=767.0ms
  Request 1: first_token_time=1534.0ms
  [ ... ]
  Request 31: first_token_time=1530.7ms
```
Instead for vllm I think it's better if we show avg tokens/second.

### What's changed
For vllm perf benchmark
1. Updated how we calculate the tokens/second data point and changed the name to `Avg. Sample per second` to clarify what we are displaying.
2. Added new var called `avg_decode _time` and renamed `decode_total_time` to `e2e_decode_time`
4. Added a custom measurements for `avg_decode _time` and `samples_per_sec`, and use them instead of `total_samples / total_time` (when they are part of the measuremnts) when we fetch/compare perf benchmarks.

### Checklist
- [x] New/Existing tests provide coverage for changes
