### PR TITLE
[vLLM] batch paged_fill_cache across users in prefill (compile/perf improvement)

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/attention.py
+++ b/integrations/vllm_plugin/vllm_tt/attention.py
@@ -483,27 +483,27 @@ class TTAttentionBackendImpl(AttentionImpl):
                 attn_metadata.page_table,
             )
         else:
-            # Prefill: fill multiple tokens at once
+            # Prefill: batched across users via N-element batch_idx_tensor.
             key_for_update = inputs.key.transpose(1, 2)
             value_for_update = inputs.value.transpose(1, 2)
 
-            for batch_idx in range(inputs.users):
-                k_cache = torch.ops.tt.paged_fill_cache(
-                    k_cache,
-                    key_for_update[batch_idx : batch_idx + 1],
-                    attn_metadata.fill_page_table,
-                    batch_idx=torch.tensor(
-                        [batch_idx], dtype=torch.int32, device=k_cache.device
-                    ),
-                )
-                v_cache = torch.ops.tt.paged_fill_cache(
-                    v_cache,
-                    value_for_update[batch_idx : batch_idx + 1],
-                    attn_metadata.fill_page_table,
-                    batch_idx=torch.tensor(
-                        [batch_idx], dtype=torch.int32, device=v_cache.device
-                    ),
-                )
+            batch_idxs = torch.arange(
+                key_for_update.shape[0],
+                dtype=torch.int32,
+                device=k_cache.device,
+            )
+            k_cache = torch.ops.tt.paged_fill_cache(
+                k_cache,
+                key_for_update,
+                attn_metadata.fill_page_table,
+                batch_idx=batch_idxs,
+            )
+            v_cache = torch.ops.tt.paged_fill_cache(
+                v_cache,
+                value_for_update,
+                attn_metadata.fill_page_table,
+                batch_idx=batch_idxs,
+            )
 
         # Preserve tensor identity so XLA reuses the traced graph.
         kv_cache[0].copy_(k_cache)

--- a/integrations/vllm_plugin/vllm_tt/attention.py
+++ b/integrations/vllm_plugin/vllm_tt/attention.py
@@ -487,6 +487,8 @@ class TTAttentionBackendImpl(AttentionImpl):
             key_for_update = inputs.key.transpose(1, 2)
             value_for_update = inputs.value.transpose(1, 2)
 
+            # TODO(#5154): hoist to a setup-time metadata input built on CPU
+            # instead of an in-graph device constructor rebuilt per call.
             batch_idxs = torch.arange(
                 key_for_update.shape[0],
                 dtype=torch.int32,


### PR DESCRIPTION
### Ticket

- Closes/relates to [#4880](https://github.com/tenstorrent/tt-xla/issues/4880)
- Depends on [tt-mlir #8613](https://github.com/tenstorrent/tt-mlir/pull/8613) (verifier relaxation) and [tt-metal #45117](https://github.com/tenstorrent/tt-metal/pull/45117) (kernel relaxation); both arrive via regular tt-metal -> tt-mlir -> tt-xla uplift.

### Problem

- Motivated by **compile time and prefill performance**. `_handle_paged_attention`'s prefill branch ran a Python `for batch_idx in range(inputs.users):` loop, calling `paged_fill_cache` once per user per K/V per layer. At trace time the loop unrolls into the graph, so b32 with 32 layers produced 2048 `paged_fill_cache` ops plus ~7000 supporting `slice` / `to_device` / `get_device` ops in the compiled prefill graph (vs. 64 at b1), driving both engine init and per-prefill latency.

### What's changed

- Single hunk in `integrations/vllm_plugin/vllm_tt/attention.py` (+18 / -18). The per-user loop is replaced with one batched call per K/V: `batch_idxs = torch.arange(key_for_update.shape[0], dtype=int32, ...)` produces an N-element `batch_idx_tensor` and the op is invoked once with the full batched K/V instead of N times with per-row slices.

- b1 behavior is unchanged (`arange(1)` collapses to the same single-row call the old loop produced). Multi-user prefill is what changes.

### Testing

End-to-end coverage is unchanged:
- `tests/integrations/vllm_plugin/generative/test_kv_cache_bleed.py` exercises 4-way concurrent prefill (`max_num_seqs=4`) on TinyLlama and asserts no cross-user contamination.
- `tests/benchmark/test_vllm_benchmarks.py` Llama-3.2-3B b32 sweep is the perf source of truth.

Headlines from the b32 sweep on p150 (full numbers and raw logs in the follow-up comment):

- **Wall-clock 2–3x faster**: seq128 153 s -> 70 s, seq1024 476 s -> 147 s, seq2048 610 s -> 196 s.
- **Samples/sec is now flat across seq_len**: was 16.3 / 17.1 / 18.5 at seq 2048 / 1024 / 128 (dropping with longer seq because the compiled graph grew with `seq_len`-dependent fan-out); now ~19.0–19.3 at all three.
- Most of the wall-clock win is engine init (compile + warmup); residual scaling with `max_model_len` comes from the unrelated exponential bucket compile (`[1, 32, 64, ..., max]`).

### Checklist

- [x] Existing tests provide coverage for changes
- [x] [tt-mlir #8613](https://github.com/tenstorrent/tt-mlir/pull/8613) + [tt-metal #45117](https://github.com/tenstorrent/tt-metal/pull/45117) merged and uplifted to tt-xla before this lands. Will hold off from merging this until changes arrive here.
- [ ] vLLM Nightly: https://github.com/tenstorrent/tt-xla/actions/runs/27310498979
