### PR TITLE
pjrt+vllm_plugin: expose dram_size_bytes; use it for KV cache sizing

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/worker.py
+++ b/integrations/vllm_plugin/vllm_tt/worker.py
@@ -182,6 +182,31 @@ class TTWorker:
             # If usage stat is enabled, collect relevant info.
             report_usage_stats(self.vllm_config)
 
+    _DEFAULT_DEVICE_DRAM_BYTES = 12 * 1024**3  # n150-safe fallback
+
+    def _get_device_dram_bytes(self) -> int:
+        """Total on-device DRAM in bytes, queried from the PJRT plugin.
+
+        The plugin exposes ``dram_size_bytes`` as a device attribute, computed
+        from the tt-mlir SystemDesc (``num_dram_channels × dram_channel_size``)
+        at device-open time.  Returns the n150 default if the attribute is
+        missing or zero, which can happen with older plugin builds.
+        """
+        try:
+            attrs = xr.global_runtime_device_attributes()
+            bytes_val = int(attrs[self.local_rank].get("dram_size_bytes", 0))
+        except Exception as e:
+            logger.warning(
+                "Could not read dram_size_bytes from PJRT device attributes "
+                "(%s); falling back to %.0f GB",
+                e,
+                self._DEFAULT_DEVICE_DRAM_BYTES / 1024**3,
+            )
+            return self._DEFAULT_DEVICE_DRAM_BYTES
+        if bytes_val <= 0:
+            return self._DEFAULT_DEVICE_DRAM_BYTES
+        return bytes_val
+
     def determine_available_memory(self) -> int:
         if self.model_config.runner_type == "pooling":
             return int(11596411699)
@@ -237,7 +262,11 @@ class TTWorker:
         # total_memory_size = m["bytes_limit"]
         # current_mem = m["bytes_used"]
         # @LPanosTT: For now we will always report that no memory has been used.
-        total_memory_size = 12 * 1024**3  # m["bytes_limit"]
+        # TTXLA: query total device DRAM via the PJRT plugin's device attribute
+        # (sourced from the tt-mlir SystemDesc that the plugin already loads at
+        # startup).  Falls back to 12 GB if the attribute is absent (e.g. older
+        # plugin build).
+        total_memory_size = self._get_device_dram_bytes()
         current_mem = 0  # m["bytes_used"]
 
         # Ideally we would use profiled = m["peak_bytes_used"] to
@@ -262,6 +291,13 @@ class TTWorker:
             # We adjust the usable memory size for the KV cache to prevent OOM
             # errors, even after padding the head_size.
             tpu_kv_cache_bytes = tpu_kv_cache_bytes * head_size // padded_head_size
+        logger.info(
+            "KV cache sizing: device DRAM = %.2f GiB, gpu_memory_utilization = %.3f, "
+            "KV cache budget = %.2f GiB",
+            total_memory_size / 1024**3,
+            self.cache_config.gpu_memory_utilization,
+            tpu_kv_cache_bytes / 1024**3,
+        )
         return int(tpu_kv_cache_bytes)
 
     def sample_tokens(self, grammar_output: "GrammarOutput") -> ModelRunnerOutput:

--- a/pjrt_implementation/inc/api/device_description.h
+++ b/pjrt_implementation/inc/api/device_description.h
@@ -26,7 +26,8 @@ namespace tt::pjrt {
 class DeviceDescription {
 public:
   // Constructor.
-  DeviceDescription(int32_t device_id, tt::target::Arch arch);
+  DeviceDescription(int32_t device_id, tt::target::Arch arch,
+                    uint64_t dram_size_bytes = 0);
 
   // Binds PJRT API functions implementation related to PJRT_DeviceDescription
   // structure.
@@ -87,6 +88,7 @@ private:
   // This is to enure the attribute name persists for the lifetime of the
   // DeviceDescription
   std::string m_arch_attr_name = "device_arch"; // (eg. "Wormhole_b0")
+  std::string m_dram_size_attr_name = "dram_size_bytes";
 };
 
 namespace internal {

--- a/pjrt_implementation/inc/api/device_instance.h
+++ b/pjrt_implementation/inc/api/device_instance.h
@@ -29,11 +29,10 @@ class MemoryInstance;
 class DeviceInstance {
 public:
   // Creates new device instance.
-  static std::unique_ptr<DeviceInstance> createInstance(ClientInstance *client,
-                                                        int global_device_id,
-                                                        bool is_addressable,
-                                                        int local_device_id,
-                                                        tt::target::Arch arch);
+  static std::unique_ptr<DeviceInstance>
+  createInstance(ClientInstance *client, int global_device_id,
+                 bool is_addressable, int local_device_id,
+                 tt::target::Arch arch, uint64_t dram_size_bytes = 0);
 
   // Binds PJRT API functions implementation related to PJRT_Device structure.
   static void bindApi(PJRT_Api *api);
@@ -91,8 +90,9 @@ private:
   // Constructor.
   DeviceInstance(ClientInstance *client, int global_device_id,
                  bool is_addressable, int local_device_id,
-                 tt::target::Arch arch)
-      : m_client(client), m_description(global_device_id, arch),
+                 tt::target::Arch arch, uint64_t dram_size_bytes)
+      : m_client(client),
+        m_description(global_device_id, arch, dram_size_bytes),
         m_is_addressable(is_addressable), m_local_device_id(local_device_id),
         m_default_memory(nullptr) {}
 

--- a/pjrt_implementation/src/api/client_instance.cc
+++ b/pjrt_implementation/src/api/client_instance.cc
@@ -376,10 +376,18 @@ tt_pjrt_status ClientInstance::populateDevices() {
     // For now, just make all devices addressable.
     bool is_addressable = true;
 
+    const auto *chip_desc = m_system_descriptor->chip_descs()->Get(i);
+    // Total on-device DRAM = num_dram_channels * dram_channel_size.  Used
+    // by clients (e.g. vLLM) to size the KV cache without hardcoding a
+    // per-board number.
+    const uint64_t dram_size_bytes =
+        static_cast<uint64_t>(chip_desc->num_dram_channels()) *
+        chip_desc->dram_channel_size();
+
     std::unique_ptr<DeviceInstance> device_instance =
-        DeviceInstance::createInstance(
-            this, global_device_id, is_addressable, local_device_id,
-            m_system_descriptor->chip_descs()->Get(i)->arch());
+        DeviceInstance::createInstance(this, global_device_id, is_addressable,
+                                       local_device_id, chip_desc->arch(),
+                                       dram_size_bytes);
 
     m_devices_raw.push_back(device_instance.get());
     if (is_addressable) {

--- a/pjrt_implementation/src/api/device_description.cc
+++ b/pjrt_implementation/src/api/device_description.cc
@@ -35,7 +35,20 @@ PJRT_NamedValue createStringAttribute(const std::string &name,
   return attr;
 }
 
-DeviceDescription::DeviceDescription(int32_t device_id, tt::target::Arch arch)
+PJRT_NamedValue createInt64Attribute(const std::string &name, int64_t value) {
+  PJRT_NamedValue attr;
+  attr.struct_size = PJRT_NamedValue_STRUCT_SIZE;
+  attr.extension_start = nullptr;
+  attr.name = name.c_str();
+  attr.name_size = name.size();
+  attr.type = PJRT_NamedValue_kInt64;
+  attr.int64_value = value;
+  attr.value_size = 1;
+  return attr;
+}
+
+DeviceDescription::DeviceDescription(int32_t device_id, tt::target::Arch arch,
+                                     uint64_t dram_size_bytes)
     : m_device_id(device_id), m_process_index(0),
       m_device_kind(tt::target::EnumNameArch(arch)) {
   std::stringstream ss;
@@ -46,6 +59,11 @@ DeviceDescription::DeviceDescription(int32_t device_id, tt::target::Arch arch)
   m_attributes.push_back(createStringAttribute(
       m_arch_attr_name,
       m_device_kind)); // device arch attribute (e.g. "wormhole_b0")
+  // Total on-device DRAM in bytes, summed across all DRAM channels.  0 means
+  // "unknown" (e.g. when DeviceDescription is constructed outside of the
+  // client_instance flow, such as in unit tests).
+  m_attributes.push_back(createInt64Attribute(
+      m_dram_size_attr_name, static_cast<int64_t>(dram_size_bytes)));
 }
 
 void DeviceDescription::bindApi(PJRT_Api *api) {

--- a/pjrt_implementation/src/api/device_instance.cc
+++ b/pjrt_implementation/src/api/device_instance.cc
@@ -19,20 +19,20 @@
 
 namespace tt::pjrt {
 
-std::unique_ptr<DeviceInstance>
-DeviceInstance::createInstance(ClientInstance *client, int global_device_id,
-                               bool is_addressable, int local_device_id,
-                               tt::target::Arch arch) {
+std::unique_ptr<DeviceInstance> DeviceInstance::createInstance(
+    ClientInstance *client, int global_device_id, bool is_addressable,
+    int local_device_id, tt::target::Arch arch, uint64_t dram_size_bytes) {
   struct make_unique_enabler : public DeviceInstance {
     make_unique_enabler(ClientInstance *client, int global_device_id,
                         bool is_addressable, int local_device_id,
-                        tt::target::Arch arch)
+                        tt::target::Arch arch, uint64_t dram_size_bytes)
         : DeviceInstance(client, global_device_id, is_addressable,
-                         local_device_id, arch) {}
+                         local_device_id, arch, dram_size_bytes) {}
   };
 
-  return std::make_unique<make_unique_enabler>(
-      client, global_device_id, is_addressable, local_device_id, arch);
+  return std::make_unique<make_unique_enabler>(client, global_device_id,
+                                               is_addressable, local_device_id,
+                                               arch, dram_size_bytes);
 }
 
 void DeviceInstance::bindApi(PJRT_Api *api) {

--- a/pjrt_implementation/src/api/unit_tests/device_description_tests.cc
+++ b/pjrt_implementation/src/api/unit_tests/device_description_tests.cc
@@ -99,9 +99,10 @@ TEST(DeviceDescriptionUnitTests, API_PJRT_DeviceDescription_ProcessIndex) {
 }
 
 // Tests PJRT API for getting device attributes.
-// Currently there's one attribute: "device_arch" (e.g. "Wormhole_b0")
+// Exposed attributes: "device_arch" (string) and "dram_size_bytes" (int64).
 TEST(DeviceDescriptionUnitTests, API_PJRT_DeviceDescription_Attributes) {
-  DeviceDescription description(TT_DEVICE_HOST, TT_ARCH_WH);
+  constexpr uint64_t kFakeDramBytes = 32ULL * 1024 * 1024 * 1024;
+  DeviceDescription description(TT_DEVICE_HOST, TT_ARCH_WH, kFakeDramBytes);
 
   PJRT_DeviceDescription_Attributes_Args args;
   args.struct_size = PJRT_DeviceDescription_Attributes_Args_STRUCT_SIZE;
@@ -110,16 +111,31 @@ TEST(DeviceDescriptionUnitTests, API_PJRT_DeviceDescription_Attributes) {
   PJRT_Error *result = internal::onDeviceDescriptionAttributes(&args);
   ASSERT_EQ(result, nullptr);
 
-  EXPECT_EQ(args.num_attributes, 1);
+  EXPECT_EQ(args.num_attributes, 2);
   EXPECT_NE(args.attributes, nullptr);
 
-  // Ensure the attribute is "device_arch" (e.g. "Wormhole_b0")
-  const PJRT_NamedValue &attr = args.attributes[0];
-  EXPECT_EQ(attr.type, PJRT_NamedValue_kString);
-  EXPECT_EQ(std::string(attr.name, attr.name_size), "device_arch");
-  // Ensure the value is non-empty.
-  EXPECT_GT(attr.value_size, 0);
-  EXPECT_NE(attr.string_value, nullptr);
+  // Locate attributes by name; ordering is an implementation detail.
+  const PJRT_NamedValue *arch_attr = nullptr;
+  const PJRT_NamedValue *dram_attr = nullptr;
+  for (size_t i = 0; i < args.num_attributes; ++i) {
+    const std::string name(args.attributes[i].name,
+                           args.attributes[i].name_size);
+    if (name == "device_arch") {
+      arch_attr = &args.attributes[i];
+    } else if (name == "dram_size_bytes") {
+      dram_attr = &args.attributes[i];
+    }
+  }
+  ASSERT_NE(arch_attr, nullptr);
+  ASSERT_NE(dram_attr, nullptr);
+
+  EXPECT_EQ(arch_attr->type, PJRT_NamedValue_kString);
+  EXPECT_GT(arch_attr->value_size, 0);
+  EXPECT_NE(arch_attr->string_value, nullptr);
+
+  EXPECT_EQ(dram_attr->type, PJRT_NamedValue_kInt64);
+  EXPECT_EQ(dram_attr->value_size, 1);
+  EXPECT_EQ(static_cast<uint64_t>(dram_attr->int64_value), kFakeDramBytes);
 }
 
 // Tests PJRT API for getting the device kind.


### PR DESCRIPTION
### Ticket

Closes #4958. Related to #1414 (`PJRT_Device_MemoryStats`).

### Problem description

`worker.py:determine_available_memory()` hardcodes `total_memory_size = 12 * 1024**3` (n150 DRAM). On Blackhole (p100 = 28 GiB, p150 = 32 GiB) this caps the KV cache budget at a ~12 GiB ceiling regardless of physical DRAM — ~2.7× under-utilization on p150. The plugin already loads the tt-mlir SystemDesc at client init via `tt::runtime::getCurrentSystemDesc()`; previously every field except `arch` was discarded.

### What's changed

- `pjrt_implementation/inc/api/device_description.{h,cc}`: add `dram_size_bytes` (uint64) parameter to the constructor; add a `createInt64Attribute` helper; push the value as a PJRT device attribute alongside the existing `device_arch`.
- `pjrt_implementation/inc/api/device_instance.{h,cc}`: thread `dram_size_bytes` through `createInstance` and the private constructor.
- `pjrt_implementation/src/api/client_instance.cc`: at device populate time, compute `num_dram_channels × dram_channel_size` from the existing `chip_desc` flatbuffer entry and pass it to `DeviceInstance::createInstance`.
- `pjrt_implementation/src/api/unit_tests/device_description_tests.cc`: update `API_PJRT_DeviceDescription_Attributes` to expect 2 attributes, locate them by name (order is an implementation detail), and assert the int64 value matches.
- `integrations/vllm_plugin/vllm_tt/worker.py`: add `_get_device_dram_bytes()` helper that reads `dram_size_bytes` via `xr.global_runtime_device_attributes()` with the 12 GiB n150-safe fallback; use it for `total_memory_size` in `determine_available_memory()`; log the selected device DRAM, `gpu_memory_utilization`, and final KV cache budget at INFO so the chosen sizing is visible at engine init.

No new tt-metal/UMD queries — the SystemDesc was already loaded at startup; this just stops discarding the DRAM fields.

### Caveat

This raises `bytes_limit` to the real value but does not subtract model weights — that still needs `bytes_used` from #1414. On Blackhole + larger models, users may need to lower `gpu_memory_utilization` (e.g. from 0.9 → 0.45 for Llama-3.1-8B on p150) to avoid OOM at engine init. Strict improvement on the status quo, which under-reports in the other direction. See #4958 for the full discussion.

### Verification

Llama-3.2-3B b32, `max_model_len=128`, warmed up, p150 single device:

- `dram_size_bytes` attribute auto-detected as 34,225,520,640 bytes (31.88 GiB)
- KV cache budget rises from 10.8 GiB → 28.7 GiB at the vLLM-default `gpu_memory_utilization=0.9`
- Request 0 TTFT unchanged at 901 ms
- Benchmark PASS, no OOM
- n150 deployments see no change (their SystemDesc still reports 12 GiB)
- Example output on p150: `(EngineCore pid=246007) INFO:vllm_tt.worker:KV cache sizing: device DRAM = 31.88 GiB, gpu_memory_utilization = 0.001, KV cache budget = 0.03 GiB`

### Checklist

- [x] Tested locally on p150 (b32 PASS, no OOM at default `gpu_memory_utilization`)
- [x] No regression on n150 (SystemDesc unchanged → same budget)
- [x] Unit test updated for new 2-attribute expectation
- [x] vLLM Nightly CI run (passing) : https://github.com/tenstorrent/tt-xla/actions/runs/26494270090

