### PR TITLE
Update Forge version in inference server when releasing monthly

### DIFF
--- a/.github/workflows/call-update-inference-server-version.yml
+++ b/.github/workflows/call-update-inference-server-version.yml
@@ -98,6 +98,7 @@ jobs:
           set -euo pipefail
 
           models=(efficientnet mobilenetv2 resnet-50 segformer vit vovnet)
+          models=(resnet-50)
 
           checklist="$RUNNER_TEMP/checklist.md"
           : > "$checklist"

--- a/.github/workflows/call-update-inference-server-version.yml
+++ b/.github/workflows/call-update-inference-server-version.yml
@@ -57,7 +57,7 @@ jobs:
 
           # Persist the base PR body; the dispatch step will append a checklist.
           cat > "$RUNNER_TEMP/pr_body.md" <<EOF
-          Automated version bump of \`tt-forge\` to \`${new_version}\` in \`${REQ_FILE}\`, triggered by the tt-xla \`Stable version release\` workflow.
+          Automated version bump of \`tt-forge\` to \`${new_version}\` \`tt-media-server/Dockerfile.forge\`.
           EOF
 
           existing_pr="$(gh pr list \
@@ -98,7 +98,7 @@ jobs:
           set -euo pipefail
 
           models=(efficientnet mobilenetv2 resnet-50 segformer vit vovnet)
-          models=(resnet-50)
+          models=(resnet-50 segformer)
 
           checklist="$RUNNER_TEMP/checklist.md"
           : > "$checklist"

--- a/.github/workflows/call-update-inference-server-version.yml
+++ b/.github/workflows/call-update-inference-server-version.yml
@@ -1,0 +1,160 @@
+name: Update tt-forge version in tt-inference-server (call)
+
+on:
+  workflow_call:
+    inputs:
+      release_tag:
+        description: "tt-forge release version to pin in tt-inference-server"
+        type: string
+        required: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  open-version-bump-pr:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.TT_FORGE_RELEASER }}
+      TARGET_REPO: tenstorrent/tt-inference-server
+      REQ_FILE: tt-media-server/tt_model_runners/forge_runners/requirements.txt
+    steps:
+      - name: Checkout tt-inference-server
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ env.TARGET_REPO }}
+          token: ${{ secrets.TT_FORGE_RELEASER }}
+
+      - name: Bump tt-forge version and open PR
+        id: bump
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          new_version="${{ inputs.release_tag }}"
+          branch="bump-tt-forge-${new_version}"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          echo "new_version=$new_version" >> "$GITHUB_OUTPUT"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git checkout -B "$branch"
+
+          sed -i -E "s/^tt-forge==.*/tt-forge==${new_version}/" "$REQ_FILE"
+
+          if git diff --quiet -- "$REQ_FILE"; then
+            echo "tt-forge already pinned to ${new_version} in ${REQ_FILE}; nothing to push."
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git add "$REQ_FILE"
+          git commit -m "Bump tt-forge to ${new_version}"
+          git push -u origin "$branch" --force
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
+
+          # Persist the base PR body; the dispatch step will append a checklist.
+          cat > "$RUNNER_TEMP/pr_body.md" <<EOF
+          Automated version bump of \`tt-forge\` to \`${new_version}\` in \`${REQ_FILE}\`, triggered by the tt-xla \`Stable version release\` workflow.
+          EOF
+
+          existing_pr="$(gh pr list \
+            --repo "$TARGET_REPO" \
+            --head "$branch" \
+            --base main \
+            --state open \
+            --json number -q '.[0].number' || true)"
+
+          if [ -z "$existing_pr" ]; then
+            gh pr create \
+              --repo "$TARGET_REPO" \
+              --head "$branch" \
+              --base main \
+              --draft \
+              --title "Bump tt-forge to ${new_version}" \
+              --body-file "$RUNNER_TEMP/pr_body.md"
+            existing_pr="$(gh pr list \
+              --repo "$TARGET_REPO" \
+              --head "$branch" \
+              --base main \
+              --state open \
+              --json number -q '.[0].number')"
+          else
+            echo "PR already open: #$existing_pr"
+          fi
+
+          echo "pr_number=$existing_pr" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch tt-shield on-dispatch.yml for each model and update PR checklist
+        if: steps.bump.outputs.pushed == 'true'
+        shell: bash
+        env:
+          BRANCH: ${{ steps.bump.outputs.branch }}
+          PR_NUMBER: ${{ steps.bump.outputs.pr_number }}
+          SHIELD_REPO: tenstorrent/tt-shield
+        run: |
+          set -euo pipefail
+
+          models=(efficientnet mobilenetv2 resnet-50 segformer vit vovnet)
+
+          checklist="$RUNNER_TEMP/checklist.md"
+          : > "$checklist"
+
+          for model in "${models[@]}"; do
+            prev_id="$(gh run list \
+              --repo "$SHIELD_REPO" \
+              --workflow on-dispatch.yml \
+              --event workflow_dispatch \
+              --limit 1 \
+              --json databaseId -q '.[0].databaseId' 2>/dev/null || echo '')"
+
+            echo "Dispatching ${SHIELD_REPO} on-dispatch.yml for model=${model} inference-server-git-ref=${BRANCH}"
+            gh workflow run on-dispatch.yml \
+              --repo "$SHIELD_REPO" \
+              --ref main \
+              -f model="${model}" \
+              -f runner-label=n150 \
+              -f device-type=n150 \
+              -f tt-metal-git-ref=main \
+              -f inference-server-git-ref="${BRANCH}" \
+              -f vllm-git-ref=dev \
+              -f workflow=release \
+              -f throttle-perf=0 \
+              -f impl-of-model=default \
+              -f run-full-evals=false \
+              -f run-ai-summary=false
+
+            # Poll for the newly-registered run by watching for a databaseId change.
+            run_url=""
+            for attempt in $(seq 1 20); do
+              sleep 3
+              new_id="$(gh run list \
+                --repo "$SHIELD_REPO" \
+                --workflow on-dispatch.yml \
+                --event workflow_dispatch \
+                --limit 1 \
+                --json databaseId -q '.[0].databaseId' 2>/dev/null || echo '')"
+              if [ -n "$new_id" ] && [ "$new_id" != "$prev_id" ]; then
+                run_url="$(gh run view "$new_id" --repo "$SHIELD_REPO" --json url -q '.url')"
+                break
+              fi
+            done
+
+            if [ -n "$run_url" ]; then
+              echo "- [ ] \`${model}\`: ${run_url}" >> "$checklist"
+            else
+              echo "- [ ] \`${model}\`: (dispatch succeeded but run URL was not resolved in time)" >> "$checklist"
+            fi
+          done
+
+          # Rebuild PR body = original body + checklist section, then update.
+          full_body="$RUNNER_TEMP/pr_body_full.md"
+          {
+            cat "$RUNNER_TEMP/pr_body.md"
+            printf '\n### Checklist\n\n'
+            cat "$checklist"
+          } > "$full_body"
+
+          gh pr edit "$PR_NUMBER" --repo "$TARGET_REPO" --body-file "$full_body"

--- a/.github/workflows/call-update-inference-server-version.yml
+++ b/.github/workflows/call-update-inference-server-version.yml
@@ -16,7 +16,7 @@ jobs:
   open-version-bump-pr:
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ secrets.TT_FORGE_RELEASER }}
+      GH_TOKEN: ${{ secrets.TT_INFERENCE_SERVER_RELEASE }}
       TARGET_REPO: tenstorrent/tt-inference-server
       REQ_FILE: tt-media-server/tt_model_runners/forge_runners/requirements.txt
     steps:
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: ${{ env.TARGET_REPO }}
-          token: ${{ secrets.TT_FORGE_RELEASER }}
+          token: ${{ secrets.TT_INFERENCE_SERVER_RELEASE }}
 
       - name: Bump tt-forge version and open PR
         id: bump

--- a/.github/workflows/call-update-inference-server-version.yml
+++ b/.github/workflows/call-update-inference-server-version.yml
@@ -57,7 +57,7 @@ jobs:
 
           # Persist the base PR body; the dispatch step will append a checklist.
           cat > "$RUNNER_TEMP/pr_body.md" <<EOF
-          Automated version bump of \`tt-forge\` to \`${new_version}\` \`tt-media-server/Dockerfile.forge\`.
+          Automated version bump of \`tt-forge\` to \`${new_version}\` in \`tt-media-server/Dockerfile.forge\`.
           EOF
 
           existing_pr="$(gh pr list \
@@ -72,7 +72,6 @@ jobs:
               --repo "$TARGET_REPO" \
               --head "$branch" \
               --base main \
-              --draft \
               --title "Bump tt-forge to ${new_version}" \
               --body-file "$RUNNER_TEMP/pr_body.md"
             existing_pr="$(gh pr list \
@@ -98,7 +97,6 @@ jobs:
           set -euo pipefail
 
           models=(efficientnet mobilenetv2 resnet-50 segformer vit vovnet)
-          models=(resnet-50 segformer)
 
           checklist="$RUNNER_TEMP/checklist.md"
           : > "$checklist"

--- a/.github/workflows/manual-stable-release.yml
+++ b/.github/workflows/manual-stable-release.yml
@@ -71,4 +71,4 @@ jobs:
     uses: ./.github/workflows/call-update-inference-server-version.yml
     secrets: inherit
     with:
-      release_tag: "1.2.0.dev20260524002812"
+      release_tag: "1.2.0.dev20260525002812"

--- a/.github/workflows/manual-stable-release.yml
+++ b/.github/workflows/manual-stable-release.yml
@@ -71,4 +71,4 @@ jobs:
     uses: ./.github/workflows/call-update-inference-server-version.yml
     secrets: inherit
     with:
-      release_tag: "1.2.0.dev20260526002843"
+      release_tag: "1.2.0.dev20260524002812"

--- a/.github/workflows/manual-stable-release.yml
+++ b/.github/workflows/manual-stable-release.yml
@@ -2,16 +2,6 @@ name: Stable version release
 
 on:
   workflow_dispatch:
-    inputs:
-      xla_sha_override:
-        description: 'Git SHA of commit in tenstorrent/tt-xla or branch name'
-        required: true
-        type: string
-      should_overwrite_release:
-        description: 'Should we overwrite an existing pypi wheel'
-        type: boolean
-        required: false
-        default: false
 
 permissions:
   contents: write
@@ -21,58 +11,64 @@ permissions:
   checks: write
 
 jobs:
-  build-image:
-    uses: ./.github/workflows/call-build-docker.yml
-    secrets: inherit
-    with:
-      xla_sha_override: ${{ inputs.xla_sha_override }}
+  # build-image:
+  #   uses: ./.github/workflows/call-build-docker.yml
+  #   secrets: inherit
+  #   with:
+  #     xla_sha_override: ${{ inputs.xla_sha_override }}
 
-  build-ttxla:
-    uses: ./.github/workflows/call-build.yml
-    name: "Build tt-xla"
-    secrets: inherit
-    needs: build-image
-    with:
-      docker_image: ${{ needs.build-image.outputs.docker-image }}
-      docker_image_manylinux: ${{ needs.build-image.outputs.docker-image-manylinux }}
-      build_types: release,manylinux
-      xla_sha_override: ${{ inputs.xla_sha_override }}
+  # build-ttxla:
+  #   uses: ./.github/workflows/call-build.yml
+  #   name: "Build tt-xla"
+  #   secrets: inherit
+  #   needs: build-image
+  #   with:
+  #     docker_image: ${{ needs.build-image.outputs.docker-image }}
+  #     docker_image_manylinux: ${{ needs.build-image.outputs.docker-image-manylinux }}
+  #     build_types: release,manylinux
+  #     xla_sha_override: ${{ inputs.xla_sha_override }}
 
-  release:
-    uses: ./.github/workflows/call-release.yml
-    needs: [ build-ttxla ]
-    secrets: inherit
-    with:
-      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
-      wheel_release_artifact_name: xla-whl-manylinux${{ needs.build-ttxla.outputs.artifact_suffix }}
-      wheel_release_vllm_tt_artifact_name: vllm-tt-whl-release${{ needs.build-ttxla.outputs.artifact_suffix }}
-      is_nightly_release: false
-      xla_sha_override: ${{ inputs.xla_sha_override }}
-      should_overwrite_release: ${{ inputs.should_overwrite_release }}
+  # release:
+  #   uses: ./.github/workflows/call-release.yml
+  #   needs: [ build-ttxla ]
+  #   secrets: inherit
+  #   with:
+  #     artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
+  #     wheel_release_artifact_name: xla-whl-manylinux${{ needs.build-ttxla.outputs.artifact_suffix }}
+  #     wheel_release_vllm_tt_artifact_name: vllm-tt-whl-release${{ needs.build-ttxla.outputs.artifact_suffix }}
+  #     is_nightly_release: false
+  #     xla_sha_override: ${{ inputs.xla_sha_override }}
+  #     should_overwrite_release: ${{ inputs.should_overwrite_release }}
 
-  release-forge:
-    uses: ./.github/workflows/call-forge-release.yml
-    needs: [ release ]
-    secrets: inherit
-    with:
-      release_tag: ${{ needs.release.outputs.release_tag }}
-      xla_sha_override: ${{ inputs.xla_sha_override }}
-      should_overwrite_release: ${{ inputs.should_overwrite_release }}
+  # release-forge:
+  #   uses: ./.github/workflows/call-forge-release.yml
+  #   needs: [ release ]
+  #   secrets: inherit
+  #   with:
+  #     release_tag: ${{ needs.release.outputs.release_tag }}
+  #     xla_sha_override: ${{ inputs.xla_sha_override }}
+  #     should_overwrite_release: ${{ inputs.should_overwrite_release }}
 
-  update-release-notes-tt-xla:
-    needs: [ release-forge, release ]
-    uses: ./.github/workflows/manual-update-release-notes.yml
-    secrets: inherit
-    with:
-      tag_name: ${{ needs.release.outputs.release_tag }}
-      is_nightly: false
-      target_repo: tenstorrent/tt-xla
+  # update-release-notes-tt-xla:
+  #   needs: [ release-forge, release ]
+  #   uses: ./.github/workflows/manual-update-release-notes.yml
+  #   secrets: inherit
+  #   with:
+  #     tag_name: ${{ needs.release.outputs.release_tag }}
+  #     is_nightly: false
+  #     target_repo: tenstorrent/tt-xla
 
-  update-release-notes-tt-forge:
-    needs: [ release-forge, release ]
-    uses: ./.github/workflows/manual-update-release-notes.yml
+  # update-release-notes-tt-forge:
+  #   needs: [ release-forge, release ]
+  #   uses: ./.github/workflows/manual-update-release-notes.yml
+  #   secrets: inherit
+  #   with:
+  #     tag_name: ${{ needs.release.outputs.release_tag }}
+  #     is_nightly: false
+  #     target_repo: tenstorrent/tt-forge
+
+  update-version-in-inference-server:
+    uses: ./.github/workflows/call-update-inference-server-version.yml
     secrets: inherit
     with:
-      tag_name: ${{ needs.release.outputs.release_tag }}
-      is_nightly: false
-      target_repo: tenstorrent/tt-forge
+      release_tag: "1.2.0.dev20260526002843"

--- a/.github/workflows/manual-stable-release.yml
+++ b/.github/workflows/manual-stable-release.yml
@@ -2,6 +2,16 @@ name: Stable version release
 
 on:
   workflow_dispatch:
+    inputs:
+      xla_sha_override:
+        description: 'Git SHA of commit in tenstorrent/tt-xla or branch name'
+        required: true
+        type: string
+      should_overwrite_release:
+        description: 'Should we overwrite an existing pypi wheel'
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: write
@@ -11,64 +21,65 @@ permissions:
   checks: write
 
 jobs:
-  # build-image:
-  #   uses: ./.github/workflows/call-build-docker.yml
-  #   secrets: inherit
-  #   with:
-  #     xla_sha_override: ${{ inputs.xla_sha_override }}
+  build-image:
+    uses: ./.github/workflows/call-build-docker.yml
+    secrets: inherit
+    with:
+      xla_sha_override: ${{ inputs.xla_sha_override }}
 
-  # build-ttxla:
-  #   uses: ./.github/workflows/call-build.yml
-  #   name: "Build tt-xla"
-  #   secrets: inherit
-  #   needs: build-image
-  #   with:
-  #     docker_image: ${{ needs.build-image.outputs.docker-image }}
-  #     docker_image_manylinux: ${{ needs.build-image.outputs.docker-image-manylinux }}
-  #     build_types: release,manylinux
-  #     xla_sha_override: ${{ inputs.xla_sha_override }}
+  build-ttxla:
+    uses: ./.github/workflows/call-build.yml
+    name: "Build tt-xla"
+    secrets: inherit
+    needs: build-image
+    with:
+      docker_image: ${{ needs.build-image.outputs.docker-image }}
+      docker_image_manylinux: ${{ needs.build-image.outputs.docker-image-manylinux }}
+      build_types: release,manylinux
+      xla_sha_override: ${{ inputs.xla_sha_override }}
 
-  # release:
-  #   uses: ./.github/workflows/call-release.yml
-  #   needs: [ build-ttxla ]
-  #   secrets: inherit
-  #   with:
-  #     artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
-  #     wheel_release_artifact_name: xla-whl-manylinux${{ needs.build-ttxla.outputs.artifact_suffix }}
-  #     wheel_release_vllm_tt_artifact_name: vllm-tt-whl-release${{ needs.build-ttxla.outputs.artifact_suffix }}
-  #     is_nightly_release: false
-  #     xla_sha_override: ${{ inputs.xla_sha_override }}
-  #     should_overwrite_release: ${{ inputs.should_overwrite_release }}
+  release:
+    uses: ./.github/workflows/call-release.yml
+    needs: [ build-ttxla ]
+    secrets: inherit
+    with:
+      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
+      wheel_release_artifact_name: xla-whl-manylinux${{ needs.build-ttxla.outputs.artifact_suffix }}
+      wheel_release_vllm_tt_artifact_name: vllm-tt-whl-release${{ needs.build-ttxla.outputs.artifact_suffix }}
+      is_nightly_release: false
+      xla_sha_override: ${{ inputs.xla_sha_override }}
+      should_overwrite_release: ${{ inputs.should_overwrite_release }}
 
-  # release-forge:
-  #   uses: ./.github/workflows/call-forge-release.yml
-  #   needs: [ release ]
-  #   secrets: inherit
-  #   with:
-  #     release_tag: ${{ needs.release.outputs.release_tag }}
-  #     xla_sha_override: ${{ inputs.xla_sha_override }}
-  #     should_overwrite_release: ${{ inputs.should_overwrite_release }}
+  release-forge:
+    uses: ./.github/workflows/call-forge-release.yml
+    needs: [ release ]
+    secrets: inherit
+    with:
+      release_tag: ${{ needs.release.outputs.release_tag }}
+      xla_sha_override: ${{ inputs.xla_sha_override }}
+      should_overwrite_release: ${{ inputs.should_overwrite_release }}
 
-  # update-release-notes-tt-xla:
-  #   needs: [ release-forge, release ]
-  #   uses: ./.github/workflows/manual-update-release-notes.yml
-  #   secrets: inherit
-  #   with:
-  #     tag_name: ${{ needs.release.outputs.release_tag }}
-  #     is_nightly: false
-  #     target_repo: tenstorrent/tt-xla
+  update-release-notes-tt-xla:
+    needs: [ release-forge, release ]
+    uses: ./.github/workflows/manual-update-release-notes.yml
+    secrets: inherit
+    with:
+      tag_name: ${{ needs.release.outputs.release_tag }}
+      is_nightly: false
+      target_repo: tenstorrent/tt-xla
 
-  # update-release-notes-tt-forge:
-  #   needs: [ release-forge, release ]
-  #   uses: ./.github/workflows/manual-update-release-notes.yml
-  #   secrets: inherit
-  #   with:
-  #     tag_name: ${{ needs.release.outputs.release_tag }}
-  #     is_nightly: false
-  #     target_repo: tenstorrent/tt-forge
+  update-release-notes-tt-forge:
+    needs: [ release-forge, release ]
+    uses: ./.github/workflows/manual-update-release-notes.yml
+    secrets: inherit
+    with:
+      tag_name: ${{ needs.release.outputs.release_tag }}
+      is_nightly: false
+      target_repo: tenstorrent/tt-forge
 
   update-version-in-inference-server:
+    needs: [ release-forge, release ]
     uses: ./.github/workflows/call-update-inference-server-version.yml
     secrets: inherit
     with:
-      release_tag: "1.2.0.dev20260525002812"
+      release_tag: ${{ needs.release.outputs.release_tag }}

--- a/.github/workflows/manual-update-durations.yml
+++ b/.github/workflows/manual-update-durations.yml
@@ -8,71 +8,105 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: write
-  actions: write
-  id-token: write
-  packages: write
-  checks: write
+  issues: write
+  pull-requests: write
 
 jobs:
-  # build-image:
-  #   uses: ./.github/workflows/call-build-docker.yml
-  #   secrets: inherit
-  #   with:
-  #     xla_sha_override: ${{ inputs.xla_sha_override }}
+  update_test_durations:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          # ref: main
+      - uses: actions/setup-python@v6
+      - name: Process test durations from latest workflows
+        id: get-test-durations
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          repo="tenstorrent/tt-xla"
 
-  # build-ttxla:
-  #   uses: ./.github/workflows/call-build.yml
-  #   name: "Build tt-xla"
-  #   secrets: inherit
-  #   needs: build-image
-  #   with:
-  #     docker_image: ${{ needs.build-image.outputs.docker-image }}
-  #     docker_image_manylinux: ${{ needs.build-image.outputs.docker-image-manylinux }}
-  #     build_types: release,manylinux
-  #     xla_sha_override: ${{ inputs.xla_sha_override }}
+          get_test_results_from_wf() {
+            local wf_name="$1"
+            local conclusions="$2"
+            local num=5
 
-  # release:
-  #   uses: ./.github/workflows/call-release.yml
-  #   needs: [ build-ttxla ]
-  #   secrets: inherit
-  #   with:
-  #     artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
-  #     wheel_release_artifact_name: xla-whl-manylinux${{ needs.build-ttxla.outputs.artifact_suffix }}
-  #     wheel_release_vllm_tt_artifact_name: vllm-tt-whl-release${{ needs.build-ttxla.outputs.artifact_suffix }}
-  #     is_nightly_release: false
-  #     xla_sha_override: ${{ inputs.xla_sha_override }}
-  #     should_overwrite_release: ${{ inputs.should_overwrite_release }}
+            # get json of the last $num workflow runs
+            gh run list --workflow $wf_name -R $repo -b main -L $num --status completed --json attempt,conclusion,databaseId >runs.json
 
-  # release-forge:
-  #   uses: ./.github/workflows/call-forge-release.yml
-  #   needs: [ release ]
-  #   secrets: inherit
-  #   with:
-  #     release_tag: ${{ needs.release.outputs.release_tag }}
-  #     xla_sha_override: ${{ inputs.xla_sha_override }}
-  #     should_overwrite_release: ${{ inputs.should_overwrite_release }}
+            counter=0
+            while true; do
+              # Check the status of 'conclusion'
+              conclusion=$(jq -r ".[$counter].conclusion" runs.json)
 
-  # update-release-notes-tt-xla:
-  #   needs: [ release-forge, release ]
-  #   uses: ./.github/workflows/manual-update-release-notes.yml
-  #   secrets: inherit
-  #   with:
-  #     tag_name: ${{ needs.release.outputs.release_tag }}
-  #     is_nightly: false
-  #     target_repo: tenstorrent/tt-xla
+              if echo "$conclusions" | grep -q -w "$conclusion"; then
+                break
+              else
+                ((++counter))
 
-  # update-release-notes-tt-forge:
-  #   needs: [ release-forge, release ]
-  #   uses: ./.github/workflows/manual-update-release-notes.yml
-  #   secrets: inherit
-  #   with:
-  #     tag_name: ${{ needs.release.outputs.release_tag }}
-  #     is_nightly: false
-  #     target_repo: tenstorrent/tt-forge
+                # Exit if the counter reaches $num
+                if [ $counter -ge $num ]; then
+                  echo "ERROR: Did not found good workflow within last $num. Exiting."
+                  exit 1
+                fi
+              fi
+            done
+            curr_wf_id=$(jq -r ".[$counter].databaseId" runs.json)
+            curr_wf_att=$(jq -r ".[$counter].attempt" runs.json)
+            echo "curr_$3_wf_link=\"https://github.com/$repo/actions/runs/$curr_wf_id/attempts/$curr_wf_att\"" >> "$GITHUB_OUTPUT"
+            rm -f runs.json
 
-  update-version-in-inference-server:
-    uses: ./.github/workflows/call-update-inference-server-version.yml
-    secrets: inherit
-    with:
-      release_tag: "1.2.0.dev20260526002843"
+            gh run download $curr_wf_id --pattern "test-reports-*" -R $repo -D ${{runner.temp}}/reports
+          }
+
+          # get test results from the last nightly that was success or failure
+          get_test_results_from_wf "schedule-nightly.yml" "success,failure" "nightly"
+
+          # get test results from the last successful push
+          get_test_results_from_wf "push-main.yml" "success" "push"
+
+          # get test results from the last weekly that was success or failure
+          get_test_results_from_wf "schedule-weekly.yml" "success,failure" "weekly"
+
+          # get test results from the last weekly training that was success or failure
+          get_test_results_from_wf "schedule-weekly-training.yml" "success,failure" "weekly-training"
+
+          python .github/scripts/get_test_duration_from_junit_xmls.py ${{runner.temp}}/reports .test_durations
+          echo "" >> .test_durations
+          echo "----- NEW DURATIONS"
+          cat .test_durations
+
+          echo "TODAY=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v8
+        id: create-pr
+        with:
+          branch: test-durations-update
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
+          base: main
+          commit-message: "Update test durations based on latest workflows ${{ steps.get-test-durations.outputs.TODAY }}"
+          title: "Update test durations based on latest workflows ${{ steps.get-test-durations.outputs.TODAY }}"
+          body: "This PR updates test durations based on latest nightly (${{ steps.get-test-durations.outputs.curr_nightly_wf_link }}), latest weekly (${{ steps.get-test-durations.outputs.curr_weekly_wf_link }}), latest weekly training (${{ steps.get-test-durations.outputs.curr_weekly_training_wf_link }}) and latest push (${{ steps.get-test-durations.outputs.curr_push_wf_link }})"
+          labels: tooling
+          delete-branch: true
+          token: ${{ github.token }}
+
+      - name: Enable Pull Request Automerge
+        if: ${{ steps.create-pr.outputs.pull-request-number }}
+        run: gh pr merge --squash --auto "${{ steps.create-pr.outputs.pull-request-number }}"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Generate Summary
+        run: |
+          echo "## Test duration report" >> $GITHUB_STEP_SUMMARY
+          echo "Used [Nightly](${{ steps.get-test-durations.outputs.curr_nightly_wf_link }})" >> $GITHUB_STEP_SUMMARY
+          echo "And [Push](${{ steps.get-test-durations.outputs.curr_push_wf_link }})" >> $GITHUB_STEP_SUMMARY
+          echo "And [Weekly](${{ steps.get-test-durations.outputs.curr_weekly_wf_link }})" >> $GITHUB_STEP_SUMMARY
+          echo "And [Weekly Training](${{ steps.get-test-durations.outputs.curr_weekly_training_wf_link }})" >> $GITHUB_STEP_SUMMARY
+          echo "Generated test durations in [Pull Request](${{ steps.create-pr.outputs.pull-request-url }})" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/manual-update-durations.yml
+++ b/.github/workflows/manual-update-durations.yml
@@ -8,105 +8,71 @@ on:
   workflow_dispatch:
 
 permissions:
-  actions: read
   contents: write
-  issues: write
-  pull-requests: write
+  actions: write
+  id-token: write
+  packages: write
+  checks: write
 
 jobs:
-  update_test_durations:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          # ref: main
-      - uses: actions/setup-python@v6
-      - name: Process test durations from latest workflows
-        id: get-test-durations
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          repo="tenstorrent/tt-xla"
+  # build-image:
+  #   uses: ./.github/workflows/call-build-docker.yml
+  #   secrets: inherit
+  #   with:
+  #     xla_sha_override: ${{ inputs.xla_sha_override }}
 
-          get_test_results_from_wf() {
-            local wf_name="$1"
-            local conclusions="$2"
-            local num=5
+  # build-ttxla:
+  #   uses: ./.github/workflows/call-build.yml
+  #   name: "Build tt-xla"
+  #   secrets: inherit
+  #   needs: build-image
+  #   with:
+  #     docker_image: ${{ needs.build-image.outputs.docker-image }}
+  #     docker_image_manylinux: ${{ needs.build-image.outputs.docker-image-manylinux }}
+  #     build_types: release,manylinux
+  #     xla_sha_override: ${{ inputs.xla_sha_override }}
 
-            # get json of the last $num workflow runs
-            gh run list --workflow $wf_name -R $repo -b main -L $num --status completed --json attempt,conclusion,databaseId >runs.json
+  # release:
+  #   uses: ./.github/workflows/call-release.yml
+  #   needs: [ build-ttxla ]
+  #   secrets: inherit
+  #   with:
+  #     artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
+  #     wheel_release_artifact_name: xla-whl-manylinux${{ needs.build-ttxla.outputs.artifact_suffix }}
+  #     wheel_release_vllm_tt_artifact_name: vllm-tt-whl-release${{ needs.build-ttxla.outputs.artifact_suffix }}
+  #     is_nightly_release: false
+  #     xla_sha_override: ${{ inputs.xla_sha_override }}
+  #     should_overwrite_release: ${{ inputs.should_overwrite_release }}
 
-            counter=0
-            while true; do
-              # Check the status of 'conclusion'
-              conclusion=$(jq -r ".[$counter].conclusion" runs.json)
+  # release-forge:
+  #   uses: ./.github/workflows/call-forge-release.yml
+  #   needs: [ release ]
+  #   secrets: inherit
+  #   with:
+  #     release_tag: ${{ needs.release.outputs.release_tag }}
+  #     xla_sha_override: ${{ inputs.xla_sha_override }}
+  #     should_overwrite_release: ${{ inputs.should_overwrite_release }}
 
-              if echo "$conclusions" | grep -q -w "$conclusion"; then
-                break
-              else
-                ((++counter))
+  # update-release-notes-tt-xla:
+  #   needs: [ release-forge, release ]
+  #   uses: ./.github/workflows/manual-update-release-notes.yml
+  #   secrets: inherit
+  #   with:
+  #     tag_name: ${{ needs.release.outputs.release_tag }}
+  #     is_nightly: false
+  #     target_repo: tenstorrent/tt-xla
 
-                # Exit if the counter reaches $num
-                if [ $counter -ge $num ]; then
-                  echo "ERROR: Did not found good workflow within last $num. Exiting."
-                  exit 1
-                fi
-              fi
-            done
-            curr_wf_id=$(jq -r ".[$counter].databaseId" runs.json)
-            curr_wf_att=$(jq -r ".[$counter].attempt" runs.json)
-            echo "curr_$3_wf_link=\"https://github.com/$repo/actions/runs/$curr_wf_id/attempts/$curr_wf_att\"" >> "$GITHUB_OUTPUT"
-            rm -f runs.json
+  # update-release-notes-tt-forge:
+  #   needs: [ release-forge, release ]
+  #   uses: ./.github/workflows/manual-update-release-notes.yml
+  #   secrets: inherit
+  #   with:
+  #     tag_name: ${{ needs.release.outputs.release_tag }}
+  #     is_nightly: false
+  #     target_repo: tenstorrent/tt-forge
 
-            gh run download $curr_wf_id --pattern "test-reports-*" -R $repo -D ${{runner.temp}}/reports
-          }
-
-          # get test results from the last nightly that was success or failure
-          get_test_results_from_wf "schedule-nightly.yml" "success,failure" "nightly"
-
-          # get test results from the last successful push
-          get_test_results_from_wf "push-main.yml" "success" "push"
-
-          # get test results from the last weekly that was success or failure
-          get_test_results_from_wf "schedule-weekly.yml" "success,failure" "weekly"
-
-          # get test results from the last weekly training that was success or failure
-          get_test_results_from_wf "schedule-weekly-training.yml" "success,failure" "weekly-training"
-
-          python .github/scripts/get_test_duration_from_junit_xmls.py ${{runner.temp}}/reports .test_durations
-          echo "" >> .test_durations
-          echo "----- NEW DURATIONS"
-          cat .test_durations
-
-          echo "TODAY=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
-
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
-        id: create-pr
-        with:
-          branch: test-durations-update
-          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-          author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
-          base: main
-          commit-message: "Update test durations based on latest workflows ${{ steps.get-test-durations.outputs.TODAY }}"
-          title: "Update test durations based on latest workflows ${{ steps.get-test-durations.outputs.TODAY }}"
-          body: "This PR updates test durations based on latest nightly (${{ steps.get-test-durations.outputs.curr_nightly_wf_link }}), latest weekly (${{ steps.get-test-durations.outputs.curr_weekly_wf_link }}), latest weekly training (${{ steps.get-test-durations.outputs.curr_weekly_training_wf_link }}) and latest push (${{ steps.get-test-durations.outputs.curr_push_wf_link }})"
-          labels: tooling
-          delete-branch: true
-          token: ${{ github.token }}
-
-      - name: Enable Pull Request Automerge
-        if: ${{ steps.create-pr.outputs.pull-request-number }}
-        run: gh pr merge --squash --auto "${{ steps.create-pr.outputs.pull-request-number }}"
-        env:
-          GH_TOKEN: ${{ github.token }}
-
-      - name: Generate Summary
-        run: |
-          echo "## Test duration report" >> $GITHUB_STEP_SUMMARY
-          echo "Used [Nightly](${{ steps.get-test-durations.outputs.curr_nightly_wf_link }})" >> $GITHUB_STEP_SUMMARY
-          echo "And [Push](${{ steps.get-test-durations.outputs.curr_push_wf_link }})" >> $GITHUB_STEP_SUMMARY
-          echo "And [Weekly](${{ steps.get-test-durations.outputs.curr_weekly_wf_link }})" >> $GITHUB_STEP_SUMMARY
-          echo "And [Weekly Training](${{ steps.get-test-durations.outputs.curr_weekly_training_wf_link }})" >> $GITHUB_STEP_SUMMARY
-          echo "Generated test durations in [Pull Request](${{ steps.create-pr.outputs.pull-request-url }})" >> $GITHUB_STEP_SUMMARY
+  update-version-in-inference-server:
+    uses: ./.github/workflows/call-update-inference-server-version.yml
+    secrets: inherit
+    with:
+      release_tag: "1.2.0.dev20260526002843"


### PR DESCRIPTION
### Ticket
/

### Problem description
/

### What's changed
When a monthly tt-forge version is released we want to update tt-inference-server's Forge Docker image to contain the newest version.
6 Forge tests from tt-shield will also get triggered and mentioned in the PR to validate that the version bump was not breaking.

### Checklist
- [ ] Example of the PR on tt-inference-server -> [PR](https://github.com/tenstorrent/tt-inference-server/pull/3766)
