### PR TITLE
[Benchmarks] Remove hardcoded `arch` report parameter 

### DIFF
--- a/.github/workflows/call-perf-test.yml
+++ b/.github/workflows/call-perf-test.yml
@@ -456,19 +456,7 @@ jobs:
           | jq -r '.workflow_runs[0].id')
         echo "last_nightly_workflow_id=$workflow_id" >> $GITHUB_OUTPUT
 
-        arch=""
-        if [[ "${{ matrix.build.runs-on }}" == *"qb2"* ]]; then
-          arch="qb2-blackhole"
-        elif [[ "${{ matrix.build.runs-on }}" == *"n150"* ]]; then
-          arch="wormhole"
-        elif [[ "${{ matrix.build.runs-on }}" == *"p150"* ]]; then
-          arch="blackhole"
-        elif [[ "${{ matrix.build.runs-on }}" == *"llmbox"* ]]; then
-          arch="wormhole_llmbox"
-        elif [[ "${{ matrix.build.runs-on }}" == *"galaxy"* ]]; then
-          arch="wormhole_galaxy"
-        fi
-        echo "arch=$arch" >> $GITHUB_OUTPUT
+        echo "device_type=${{ matrix.build.runs-on-original }}" >> $GITHUB_OUTPUT
 
     - name: Fetch previous perf results
       id: prev-perf
@@ -476,7 +464,7 @@ jobs:
       uses: ./.github/actions/superset-api
       with:
         query: 'benchmarks/last_measurement'
-        query_params: '{"project":"tt-forge/tt-xla","display_name":"${{ steps.set-query-strings.outputs.display_name }}","github_pipeline_id":"${{ steps.set-query-strings.outputs.last_nightly_workflow_id }}","arch":"${{ steps.set-query-strings.outputs.arch }}"}'
+        query_params: '{"project":"tt-forge/tt-xla","display_name":"${{ steps.set-query-strings.outputs.display_name }}","github_pipeline_id":"${{ steps.set-query-strings.outputs.last_nightly_workflow_id }}","device_type":"${{ steps.set-query-strings.outputs.device_type }}"}'
 
     - name: Check perf regression
       if: inputs.regression_check

--- a/tests/benchmark/benchmarks/llm_benchmark.py
+++ b/tests/benchmark/benchmarks/llm_benchmark.py
@@ -242,7 +242,6 @@ def benchmark_llm_torch_xla(
     read_logits_fn,
     mesh_config_fn,
     shard_spec_fn,
-    arch,
     required_pcc,
     fp32_dest_acc_en=None,
     experimental_kv_cache_dtype=None,
@@ -830,6 +829,7 @@ def benchmark_llm_torch_xla(
         )
 
     # Get device count and mesh info for metrics
+    arch = get_xla_device_arch()
     device_count = xr.global_runtime_device_count()
     mesh_shape = tuple(mesh.shape()) if mesh is not None else None
 
@@ -855,7 +855,7 @@ def benchmark_llm_torch_xla(
         torch_xla_enabled=True,
         backend="tt",
         device_name=socket.gethostname(),
-        arch=arch or get_xla_device_arch(),
+        arch=arch,
         input_is_image=False,
         input_sequence_length=input_sequence_length,
         device_count=device_count,

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -50,7 +50,6 @@ def test_llm(
     read_logits_fn=default_read_logits_fn,
     mesh_config_fn=None,
     shard_spec_fn=None,
-    arch=None,
     required_pcc=DEFAULT_REQUIRED_PCC,
     fp32_dest_acc_en=None,
     experimental_kv_cache_dtype=None,
@@ -150,7 +149,6 @@ def test_llm(
         read_logits_fn=read_logits_fn,
         mesh_config_fn=mesh_config_fn,
         shard_spec_fn=shard_spec_fn,
-        arch=arch,
         required_pcc=required_pcc,
         fp32_dest_acc_en=fp32_dest_acc_en,
         experimental_kv_cache_dtype=experimental_kv_cache_dtype,
@@ -227,7 +225,6 @@ def test_llm_tp(
     output_file,
     num_layers=None,
     request=None,
-    arch="wormhole_llmbox",
     decode_only=False,
     required_pcc=DEFAULT_REQUIRED_PCC,
     **kwargs,
@@ -251,7 +248,6 @@ def test_llm_tp(
         optimization_level=optimization_level,
         mesh_config_fn=mesh_config_fn,
         shard_spec_fn=shard_spec_fn,
-        arch=arch,
         num_layers=num_layers,
         request=request,
         decode_only=decode_only,
@@ -1861,7 +1857,6 @@ def test_llama_3_1_70b_tp_galaxy(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
-        arch="wormhole_galaxy",
         optimization_level=1,
     )
 
@@ -1894,7 +1889,6 @@ def test_gpt_oss_20b_tp_galaxy_batch_size_64(
         batch_size=(
             batch_size if batch_size is not None else 64
         ),  # 128 fails to compile - https://github.com/tenstorrent/tt-xla/issues/3907
-        arch="wormhole_galaxy",
         optimization_level=1,
     )
 
@@ -1967,7 +1961,6 @@ def test_gpt_oss_120b_tp_dp_galaxy_batch_size_128(
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
         batch_size=128,
-        arch="wormhole_galaxy",
         optimization_level=1,
         mesh_config_fn=_galaxy_mesh_config_fn,
         shard_spec_fn=_moe_throughput_galaxy_shard_spec_fn,
@@ -2003,7 +1996,6 @@ def test_gpt_oss_120b_tp_galaxy_batch_size_64(
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
         batch_size=batch_size if batch_size is not None else 64,
-        arch="wormhole_galaxy",
         optimization_level=1,
         mesh_config_fn=_galaxy_mesh_config_fn,
         shard_spec_fn=_moe_throughput_galaxy_shard_spec_fn,
@@ -2062,7 +2054,6 @@ def test_gpt_oss_120b_tp_qb2(
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
         batch_size=batch_size if batch_size is not None else 8,
-        arch="qb2-blackhole",
         optimization_level=1,
         trace_enabled=True,
         experimental_weight_dtype="bfp_bf8",
@@ -2106,7 +2097,6 @@ def test_kimi_k2_tp_galaxy_2_layers(
         decode_only=decode_only,
         input_output_sharding_spec=("batch", None),
         use_mla_cache=True,
-        arch="wormhole_galaxy",
         optimization_level=0,
         trace_enabled=False,
     )
@@ -2141,7 +2131,6 @@ def test_kimi_k2_5_tp_galaxy_2_layers(
         decode_only=decode_only,
         input_output_sharding_spec=("batch", None),
         use_mla_cache=True,
-        arch="wormhole_galaxy",
         optimization_level=0,
         trace_enabled=False,
     )
@@ -2176,7 +2165,6 @@ def test_deepseek_v3_2_exp_tp_galaxy_2_layers(
         input_output_sharding_spec=("batch", None),
         use_mla_cache=True,
         use_indexer_cache=True,
-        arch="wormhole_galaxy",
         optimization_level=0,
         trace_enabled=False,
         required_pcc=-0.92,

--- a/tests/benchmark/utils.py
+++ b/tests/benchmark/utils.py
@@ -374,7 +374,6 @@ def create_benchmark_result(
     torch_xla_enabled: bool = True,
     backend: str = "tt",
     device_name: str = "",
-    galaxy: bool = False,
     arch: str = "",
     input_is_image: bool = True,
     input_sequence_length: Optional[int] = -1,
@@ -474,7 +473,6 @@ def create_benchmark_result(
         "measurements": measurements,
         "device_info": {
             "device_name": device_name,
-            "galaxy": galaxy,
             "arch": arch,
             "device_count": device_count,
             "mesh_shape": mesh_shape,

--- a/tests/benchmark/utils.py
+++ b/tests/benchmark/utils.py
@@ -44,29 +44,6 @@ def get_xla_device_arch():
     return align_arch(arch_name)
 
 
-def get_device_type(arch: str, device_count: int) -> str:
-    """Determine device type string based on architecture and device count."""
-
-    if device_count == 32:
-        return "galaxy"
-    if device_count == 8:
-        return "llmbox"
-    if arch == "wormhole":
-        if device_count == 1:
-            return "n150"
-        if device_count == 2:
-            return "n300"
-    if arch == "blackhole":
-        if device_count == 1:
-            return "p150"
-        if device_count == 2:
-            return "p300"
-        if device_count == 4:
-            return "qb2-blackhole"
-
-    return "unknown"
-
-
 def sanitize_filename(name: str) -> str:
     """
     Sanitize a string to be safe for use in filenames.
@@ -476,7 +453,7 @@ def create_benchmark_result(
             "arch": arch,
             "device_count": device_count,
             "mesh_shape": mesh_shape,
-            "device_type": get_device_type(arch, device_count),
+            "device_type": None,
         },
     }
 


### PR DESCRIPTION
### Ticket
Closes #4940 

### Problem description
`arch` parameter was ambiguously used in llm benchmarks.
It should represent only the chip on which the model is run on - 'wormhole' or 'blackhole', while `device_type` should give more details on board type / runner type - 'n300-llmbox', 'galaxy-wh-6u', 'qb2-blackhole' etc.

Also, after this change landed https://github.com/tenstorrent/tt-xla/commit/aa65fd15a24cea2f8cf08c903bb8ed22ce248413, there is no need to generate `device_type` from within the benchmark script, since we have a job that patches it.

### What's changed
Removed `arch` parameter. `arch` is always derived from appropriate `get_*_device_arch` function.
Removed `galaxy` parameter since it is redundant.
Removed `get_device_type` since it can't be inferred from within the benchmark script, it is a pure CI report thing that is patched in the workflow.
Switched from `arch` to `device_type` in perf regression query string, for more fine-grained matching.

### Checklist
- [x] [n150 sanity check](https://github.com/tenstorrent/tt-xla/actions/runs/26568191467)
- [ ] [qb2-blackhole](https://github.com/tenstorrent/tt-xla/actions/runs/26633566947)
- [ ] [galaxy](https://github.com/tenstorrent/tt-xla/actions/runs/26633490808)
