### PR TITLE
Refactor Sliding Attention Overrides with Generic Model Rewrite Support

### DIFF
--- a/examples/pytorch/gpt_oss_20b.py
+++ b/examples/pytorch/gpt_oss_20b.py
@@ -27,7 +27,7 @@ from transformers.modeling_outputs import CausalLMOutputWithPast
 from tt_torch.sharding import sharding_constraint_hook
 from tt_torch.transformers_overrides import (
     override_cache_sliding_window_layers,
-    override_gpt_oss_sliding_window_causal_mask,
+    override_model_sliding_window_causal_mask,
 )
 
 DEFAULT_PROMPTS = ["Explain quantum mechanics."]
@@ -152,7 +152,7 @@ def setup_model_and_tokenizer(
         attn_implementation="eager",
     )
     # Override the gpt_oss model to use the TT-friendly sliding window causal mask
-    override_gpt_oss_sliding_window_causal_mask()
+    override_model_sliding_window_causal_mask(model)
     model = model.eval()
 
     tokenizer: PreTrainedTokenizer = AutoTokenizer.from_pretrained(model_name)

--- a/examples/pytorch/mistral_8b.py
+++ b/examples/pytorch/mistral_8b.py
@@ -14,7 +14,7 @@ from transformers.cache_utils import StaticCache
 from transformers.configuration_utils import PretrainedConfig
 from tt_torch.transformers_overrides import (
     override_cache_sliding_window_layers,
-    override_ministral_sliding_window_causal_mask,
+    override_model_sliding_window_causal_mask,
 )
 
 MODEL_NAME = "mistralai/Ministral-8B-Instruct-2410"
@@ -94,7 +94,7 @@ def mistral_8b():
 
 def _load_model_and_tokenizer(model_name: str):
     model = AutoModelForCausalLM.from_pretrained(model_name, dtype=torch.bfloat16)
-    override_ministral_sliding_window_causal_mask()
+    override_model_sliding_window_causal_mask(model)
     model = model.eval()
     tokenizer = AutoTokenizer.from_pretrained(model_name)
     if tokenizer.pad_token is None:

--- a/examples/pytorch/olmo3_1025_7b.py
+++ b/examples/pytorch/olmo3_1025_7b.py
@@ -14,7 +14,7 @@ from transformers.cache_utils import StaticCache
 from transformers.configuration_utils import PretrainedConfig
 from tt_torch.transformers_overrides import (
     override_cache_sliding_window_layers,
-    override_olmo3_sliding_window_causal_mask,
+    override_model_sliding_window_causal_mask,
 )
 
 MODEL_NAME = "allenai/Olmo-3-1025-7B"
@@ -97,7 +97,7 @@ def olmo3_1025_7b():
 
 def _load_model_and_tokenizer(model_name: str):
     model = AutoModelForCausalLM.from_pretrained(model_name, dtype=torch.bfloat16)
-    override_olmo3_sliding_window_causal_mask()
+    override_model_sliding_window_causal_mask(model)
     model = model.eval()
     tokenizer = AutoTokenizer.from_pretrained(model_name)
     if tokenizer.pad_token is None:

--- a/examples/pytorch/olmo3_1125_32b.py
+++ b/examples/pytorch/olmo3_1125_32b.py
@@ -16,7 +16,7 @@ from transformers.cache_utils import StaticCache
 from transformers.configuration_utils import PretrainedConfig
 from tt_torch.transformers_overrides import (
     override_cache_sliding_window_layers,
-    override_olmo3_sliding_window_causal_mask,
+    override_model_sliding_window_causal_mask,
 )
 
 MODEL_NAME = "allenai/Olmo-3-1125-32B"
@@ -149,7 +149,7 @@ def olmo3_1125_32b():
 
 def _load_model_and_tokenizer(model_name: str):
     model = AutoModelForCausalLM.from_pretrained(model_name, dtype=torch.bfloat16)
-    override_olmo3_sliding_window_causal_mask()
+    override_model_sliding_window_causal_mask(model)
     model = model.eval()
     tokenizer = AutoTokenizer.from_pretrained(model_name)
     if tokenizer.pad_token is None:

--- a/python_package/tt_torch/transformers_overrides.py
+++ b/python_package/tt_torch/transformers_overrides.py
@@ -8,43 +8,21 @@ from transformers.cache_utils import StaticCache, StaticLayer, StaticSlidingWind
 from transformers.masking_utils import create_sliding_window_causal_mask
 
 
-def override_gpt_oss_sliding_window_causal_mask():
+def override_model_sliding_window_causal_mask(model):
+    """Apply TT-friendly in-place rewrites to a HuggingFace model's modeling module.
+
+    Generic replacement for the per-model ``override_<name>_sliding_window_causal_mask``
+    helpers: the modeling module is resolved from ``type(model).__module__``
+    and its ``create_sliding_window_causal_mask`` is rebound to the
+    compile-friendly TT variant.
+
+    Args:
+        model: A HuggingFace ``PreTrainedModel`` instance.
     """
-    Override gpt_oss's modeling so that its
-    create_sliding_window_causal_mask points to the TT-friendly version.
+    import importlib
 
-    Call this before torch.compile so that dynamo traces through the
-    patched function.
-    """
-    import transformers.models.gpt_oss.modeling_gpt_oss as gpt_oss_mod
-
-    gpt_oss_mod.create_sliding_window_causal_mask = tt_create_sliding_window_causal_mask
-
-
-def override_olmo3_sliding_window_causal_mask():
-    """
-    Override olmo3's modeling so that its
-    create_sliding_window_causal_mask points to the TT-friendly version.
-    """
-    import transformers.models.olmo3.modeling_olmo3 as olmo3_mod
-
-    olmo3_mod.create_sliding_window_causal_mask = tt_create_sliding_window_causal_mask
-
-
-def override_ministral_sliding_window_causal_mask():
-    """
-    Override ministral's modeling so that its
-    create_sliding_window_causal_mask points to the TT-friendly version.
-
-    Note: ministral (mistralai/Ministral-*) uses a separate module
-    transformers.models.ministral.modeling_ministral, distinct from
-    transformers.models.mistral.modeling_mistral.
-    """
-    import transformers.models.ministral.modeling_ministral as ministral_mod
-
-    ministral_mod.create_sliding_window_causal_mask = (
-        tt_create_sliding_window_causal_mask
-    )
+    mod = importlib.import_module(type(model).__module__)
+    mod.create_sliding_window_causal_mask = tt_create_sliding_window_causal_mask
 
 
 def override_cache_sliding_window_layers(

--- a/tests/runner/testers/torch/dynamic_torch_model_tester.py
+++ b/tests/runner/testers/torch/dynamic_torch_model_tester.py
@@ -148,6 +148,16 @@ class DynamicTorchModelTester(TorchModelTester):
             batch_size=batch_size,
         )
 
+        # Loaders expose `requires_model_rewrites` to request TT-friendly
+        # in-place model rewrites (e.g. sliding-window mask patches). Querying
+        # the loader property keeps the inputs dict free of non-model keys.
+        if getattr(self.dynamic_loader.loader, "requires_model_rewrites", False):
+            from tt_torch.transformers_overrides import (
+                override_model_sliding_window_causal_mask,
+            )
+
+            override_model_sliding_window_causal_mask(self._model)
+
         if self.parallelism == Parallelism.DATA_PARALLEL:
             num_devices = xr.global_runtime_device_count()
             if isinstance(inputs, collections.abc.Mapping):


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/4171

### Problem description
The goal of this refactoring is to streamline the execution flow for sliding attention by introducing two main functions: `override_model_sliding_window_causal_mask`, which will reside in **tt-xla**, and input generation, which will reside in **tt-forge-models**. Previously, each model had its own dedicated override function, leading to duplicated logic across implementations. As part of this refactor, we plan to replace these model-specific override functions with a single generalized implementation that can support all models uniformly, while keeping only the input generation logic model-specific within **tt-forge-models**.


### What's changed
Previously, we maintained separate functions for each model, namely `override_gpt_oss_sliding_window_causal_mask`, `override_olmo3_sliding_window_causal_mask`, and `override_ministral_sliding_window_causal_mask`. As part of the refactoring effort, these model-specific implementations have been consolidated into a single generalized function, `**override_model_sliding_window_causal_mask**`, which provides a unified solution across all supported models.

To achieve the second goal, I introduced a new property **requires_model_rewrites** on the base loader in tt-forge-models (base.py) and propagate it to tt-xla. In tt-xla (dynamic_torch_model_tester.py), this flag is checked before compilation, and if it is set to true, the override_model_sliding_window_causal_mask function is invoked.




logs:
[mistral_8b.log](https://github.com/user-attachments/files/28341849/mistral_8b.log)
[olmo_7b.log](https://github.com/user-attachments/files/28341851/olmo_7b.log)
[olmo_32b.log](https://github.com/user-attachments/files/28341853/olmo_32b.log)
[gpt.log](https://github.com/user-attachments/files/28342749/gpt.log)


### Checklist
- [ ] New/Existing tests provide coverage for changes
