### PR TITLE
[CogVideoX] Add Sharded test for each model component

### DIFF
--- a/tests/torch/models/cog_videox/test_text_encoder.py
+++ b/tests/torch/models/cog_videox/test_text_encoder.py
@@ -9,23 +9,44 @@ import torch
 import torch_xla
 import torch_xla.runtime as xr
 from infra import Framework, run_graph_test
+from infra.testers.single_chip.model.torch_model_tester import _mask_jax_accelerator
+from infra.utilities.torch_multichip_utils import get_mesh
 
 from third_party.tt_forge_models.cog_videox.pytorch import ModelLoader, ModelVariant
 
 
 @pytest.mark.xfail(
-    reason="AssertionError: Evaluation result 0 failed: PCC comparison failed. Calculated: pcc=0.9685751315163685 - https://github.com/tenstorrent/tt-xla/issues/4647"
+    reason="AssertionError: Evaluation result 0 failed: PCC comparison failed. Calculated: pcc=0.9776592961517266 - https://github.com/tenstorrent/tt-xla/issues/4647"
 )
-def test_text_encoder():
+@pytest.mark.nightly
+@pytest.mark.llmbox
+@pytest.mark.model_test
+def test_text_encoder_sharded():
+    _run(sharded=True)
+
+
+def _run(sharded: bool):
     xr.set_device_type("TT")
     torch.manual_seed(42)
 
     loader = ModelLoader(ModelVariant.TEXT_ENCODER)
-    model = loader.load_model(dtype_override=torch.bfloat16)
+    encoder = loader.load_model(dtype_override=torch.bfloat16)
     inputs = loader.load_inputs(dtype_override=torch.bfloat16)
 
-    run_graph_test(
-        model,
-        inputs,
-        framework=Framework.TORCH,
-    )
+    mesh = None
+    shard_spec_fn = None
+    if sharded:
+        mesh_shape, mesh_names = loader.get_mesh_config(
+            xr.global_runtime_device_count()
+        )
+        mesh = get_mesh(mesh_shape, mesh_names)
+        shard_spec_fn = loader.load_shard_spec
+
+    with _mask_jax_accelerator():
+        run_graph_test(
+            encoder,
+            inputs,
+            framework=Framework.TORCH,
+            mesh=mesh,
+            shard_spec_fn=shard_spec_fn,
+        )

--- a/tests/torch/models/cog_videox/test_transformer.py
+++ b/tests/torch/models/cog_videox/test_transformer.py
@@ -9,14 +9,24 @@ import torch
 import torch_xla
 import torch_xla.runtime as xr
 from infra import Framework, run_graph_test
+from infra.testers.single_chip.model.torch_model_tester import _mask_jax_accelerator
+from infra.utilities.torch_multichip_utils import get_mesh
 
+from tests.infra.testers.compiler_config import CompilerConfig
 from third_party.tt_forge_models.cog_videox.pytorch import ModelLoader, ModelVariant
 
 
 @pytest.mark.xfail(
-    reason="Out of Memory: Not enough space to allocate 3183476736 B DRAM buffer across 12 bank - https://github.com/tenstorrent/tt-xla/issues/4646"
+    reason="AssertionError: Evaluation result 0 failed: PCC comparison failed. Calculated: pcc=0.9645380615162079 - https://github.com/tenstorrent/tt-xla/issues/5569"
 )
-def test_transformer():
+@pytest.mark.nightly
+@pytest.mark.llmbox
+@pytest.mark.model_test
+def test_transformer_sharded():
+    _run(sharded=True)
+
+
+def _run(sharded: bool):
     xr.set_device_type("TT")
     torch.manual_seed(42)
 
@@ -24,8 +34,20 @@ def test_transformer():
     model = loader.load_model(dtype_override=torch.bfloat16)
     inputs = loader.load_inputs(dtype_override=torch.bfloat16)
 
-    run_graph_test(
-        model,
-        inputs,
-        framework=Framework.TORCH,
-    )
+    mesh = None
+    shard_spec_fn = None
+    if sharded:
+        mesh_shape, mesh_names = loader.get_mesh_config(
+            xr.global_runtime_device_count()
+        )
+        mesh = get_mesh(mesh_shape, mesh_names)
+        shard_spec_fn = loader.load_shard_spec
+
+    with _mask_jax_accelerator():
+        run_graph_test(
+            model,
+            inputs,
+            framework=Framework.TORCH,
+            mesh=mesh,
+            shard_spec_fn=shard_spec_fn,
+        )

--- a/tests/torch/models/cog_videox/test_vae_decoder.py
+++ b/tests/torch/models/cog_videox/test_vae_decoder.py
@@ -9,14 +9,23 @@ import torch
 import torch_xla
 import torch_xla.runtime as xr
 from infra import Framework, run_graph_test
+from infra.testers.single_chip.model.torch_model_tester import _mask_jax_accelerator
+from infra.utilities.torch_multichip_utils import get_mesh
 
 from third_party.tt_forge_models.cog_videox.pytorch import ModelLoader, ModelVariant
 
 
 @pytest.mark.xfail(
-    reason="AssertionError: Evaluation result 0 failed: PCC comparison failed. Calculated: pcc=-0.7399767808716264 - https://github.com/tenstorrent/tt-xla/issues/4791"
+    reason="error: 'ttnn.group_norm' op flattened height must be tile-aligned - https://github.com/tenstorrent/tt-xla/issues/5479"
 )
-def test_vae_decoder():
+@pytest.mark.nightly
+@pytest.mark.llmbox
+@pytest.mark.model_test
+def test_vae_decoder_sharded():
+    _run(sharded=True)
+
+
+def _run(sharded: bool):
     xr.set_device_type("TT")
     torch.manual_seed(42)
 
@@ -24,8 +33,20 @@ def test_vae_decoder():
     model = loader.load_model(dtype_override=torch.bfloat16)
     inputs = loader.load_inputs(dtype_override=torch.bfloat16)
 
-    run_graph_test(
-        model,
-        inputs,
-        framework=Framework.TORCH,
-    )
+    mesh = None
+    shard_spec_fn = None
+    if sharded:
+        mesh_shape, mesh_names = loader.get_mesh_config(
+            xr.global_runtime_device_count()
+        )
+        mesh = get_mesh(mesh_shape, mesh_names)
+        shard_spec_fn = loader.load_shard_spec
+
+    with _mask_jax_accelerator():
+        run_graph_test(
+            model,
+            inputs,
+            framework=Framework.TORCH,
+            mesh=mesh,
+            shard_spec_fn=shard_spec_fn,
+        )


### PR DESCRIPTION
### Ticket

-  Fixes [#4976](https://github.com/tenstorrent/tt-xla/issues/4976)

### Problem description

- Add sharded tests for each component of the CogVideoX pipeline and  test in Wormhole.

### What's changed

| File | Component | Tests |
|------|-----------|-------|
| `test_text_encoder.py` | T5 v1.1-XXL encoder | `test_text_encoder` (xfail - #4647 - 8 devices), 
| `test_transformer.py` | CogVideoXTransformer3DModel   | `test_transformer` (xfail - #5114  - 8 devices)
| `test_vae_decoder.py` | AutoencoderKLCogVideoX | `test_vae_decoder` (xfail - #5479 - 8 devices)

### Checklist
- [x] verify changes through local testing in Wormhole

### Logs
[cogvideox_transformer_jun19.zip](https://github.com/user-attachments/files/29122009/cogvideox_transformer_jun19.zip)
[cogvideox_text_encoder_jun19.log](https://github.com/user-attachments/files/29122013/cogvideox_text_encoder_jun19.log)
[cogvideox_vae_decoder_jun19.log](https://github.com/user-attachments/files/29122017/cogvideox_vae_decoder_jun19.log)

