### PR TITLE
[CI] Add QB2-Blackhole TP benchmarks to nightly

### DIFF
--- a/.github/workflows/call-perf-test.yml
+++ b/.github/workflows/call-perf-test.yml
@@ -458,7 +458,9 @@ jobs:
         echo "last_nightly_workflow_id=$workflow_id" >> $GITHUB_OUTPUT
 
         arch=""
-        if [[ "${{ matrix.build.runs-on }}" == *"n150"* ]]; then
+        if [[ "${{ matrix.build.runs-on }}" == *"qb2"* ]]; then
+          arch="qb2-blackhole"
+        elif [[ "${{ matrix.build.runs-on }}" == *"n150"* ]]; then
           arch="wormhole"
         elif [[ "${{ matrix.build.runs-on }}" == *"p150"* ]]; then
           arch="blackhole"

--- a/.github/workflows/manual-benchmark.yml
+++ b/.github/workflows/manual-benchmark.yml
@@ -26,6 +26,7 @@ on:
           - p150
           - n300-llmbox
           - galaxy-wh-6u
+          - qb2-blackhole
         default: n150
       skip-device-perf:
         description: "Skip device performance measurement"

--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -201,6 +201,78 @@
         "runs-on": "qb2-blackhole"
       },
       {
+        "name": "falcon3_7b_tp_qb2",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b_tp_qb2",
+        "runs-on": "qb2-blackhole"
+      },
+      {
+        "name": "falcon3_10b_tp_qb2",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pytest": "tests/benchmark/test_llms.py::test_falcon3_10b_tp_qb2",
+        "runs-on": "qb2-blackhole"
+      },
+      {
+        "name": "llama_3_1_8b_instruct_tp_qb2",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b_instruct_tp_qb2",
+        "runs-on": "qb2-blackhole"
+      },
+      {
+        "name": "ministral_8b_tp_qb2",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pytest": "tests/benchmark/test_llms.py::test_ministral_8b_tp_qb2",
+        "runs-on": "qb2-blackhole"
+      },
+      {
+        "name": "mistral_nemo_instruct_2407_tp_qb2",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pytest": "tests/benchmark/test_llms.py::test_mistral_nemo_instruct_2407_tp_qb2",
+        "runs-on": "qb2-blackhole"
+      },
+      {
+        "name": "mistral_small_24b_instruct_2501_tp_qb2",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pytest": "tests/benchmark/test_llms.py::test_mistral_small_24b_instruct_2501_tp_qb2",
+        "runs-on": "qb2-blackhole"
+      },
+      {
+        "name": "qwen_2_5_14b_instruct_tp_qb2",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_14b_instruct_tp_qb2",
+        "runs-on": "qb2-blackhole"
+      },
+      {
+        "name": "qwen_2_5_coder_32b_instruct_tp_qb2",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_coder_32b_instruct_tp_qb2",
+        "runs-on": "qb2-blackhole"
+      },
+      {
+        "name": "qwen_3_8b_tp_qb2",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pytest": "tests/benchmark/test_llms.py::test_qwen_3_8b_tp_qb2",
+        "runs-on": "qb2-blackhole"
+      },
+      {
+        "name": "qwen_3_14b_tp_qb2",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pytest": "tests/benchmark/test_llms.py::test_qwen_3_14b_tp_qb2",
+        "runs-on": "qb2-blackhole"
+      },
+      {
+        "name": "qwen_3_32b_tp_qb2",
+        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
+        "pytest": "tests/benchmark/test_llms.py::test_qwen_3_32b_tp_qb2",
+        "runs-on": "qb2-blackhole"
+      },
+      {
+        "name": "gpt_oss_20b_tp_qb2",
+        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.2.0",
+        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_qb2",
+        "runs-on": "qb2-blackhole"
+      },
+      {
         "name": "microsoft_phi-1",
         "pyreq": "datasets loguru pytest requests torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_phi1"

--- a/.github/workflows/schedule-nightly.yml
+++ b/.github/workflows/schedule-nightly.yml
@@ -89,7 +89,7 @@ jobs:
       sh-runner: false
       skip-device-perf: true
       regression_check: true
-      adv_filter: '[ {"accuracy-testing": false}, {"runs-on": "n150"}, {"runs-on": "p150"}, {"runs-on": "n300-llmbox"}, {"runs-on": "galaxy-wh-6u"} ]'
+      adv_filter: '[ {"accuracy-testing": false}, {"runs-on": "n150"}, {"runs-on": "p150"}, {"runs-on": "n300-llmbox"}, {"runs-on": "galaxy-wh-6u"}, {"runs-on": "qb2-blackhole"} ]'
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
       wheel_build: manylinux

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -2144,3 +2144,365 @@ def test_deepseek_v3_2_exp_tp_galaxy_2_layers(
         trace_enabled=False,
         required_pcc=-0.92,
     )
+
+
+def test_falcon3_7b_tp_qb2(
+    output_file,
+    num_layers,
+    request,
+    accuracy_testing,
+    batch_size,
+    max_output_tokens,
+    decode_only,
+    optimization_level,
+):
+    from third_party.tt_forge_models.falcon.pytorch.loader import (
+        ModelLoader,
+        ModelVariant,
+    )
+
+    variant = ModelVariant.FALCON_7B
+    test_llm_tp(
+        ModelLoader,
+        variant,
+        output_file,
+        num_layers=num_layers,
+        request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
+        max_output_tokens=max_output_tokens,
+        decode_only=decode_only,
+        optimization_level=2,
+    )
+
+
+def test_falcon3_10b_tp_qb2(
+    output_file,
+    num_layers,
+    request,
+    accuracy_testing,
+    batch_size,
+    max_output_tokens,
+    decode_only,
+    optimization_level,
+):
+    from third_party.tt_forge_models.falcon.pytorch.loader import (
+        ModelLoader,
+        ModelVariant,
+    )
+
+    variant = ModelVariant.FALCON_10B
+    test_llm_tp(
+        ModelLoader,
+        variant,
+        output_file,
+        num_layers=num_layers,
+        request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
+        max_output_tokens=max_output_tokens,
+        decode_only=decode_only,
+        optimization_level=2,
+    )
+
+
+def test_llama_3_1_8b_instruct_tp_qb2(
+    output_file,
+    num_layers,
+    request,
+    accuracy_testing,
+    batch_size,
+    max_output_tokens,
+    decode_only,
+    optimization_level,
+):
+    from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
+        ModelLoader,
+        ModelVariant,
+    )
+
+    variant = ModelVariant.LLAMA_3_1_8B_INSTRUCT
+    test_llm_tp(
+        ModelLoader,
+        variant,
+        output_file,
+        num_layers=num_layers,
+        request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
+        max_output_tokens=max_output_tokens,
+        decode_only=decode_only,
+        optimization_level=2,
+    )
+
+
+def test_ministral_8b_tp_qb2(
+    output_file,
+    num_layers,
+    request,
+    accuracy_testing,
+    batch_size,
+    max_output_tokens,
+    decode_only,
+    optimization_level,
+):
+    from third_party.tt_forge_models.mistral.pytorch.loader import (
+        ModelLoader,
+        ModelVariant,
+    )
+
+    variant = ModelVariant.MINISTRAL_8B
+    test_llm_tp(
+        ModelLoader,
+        variant,
+        output_file,
+        num_layers=num_layers,
+        request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
+        max_output_tokens=max_output_tokens,
+        decode_only=decode_only,
+        optimization_level=2,
+    )
+
+
+def test_mistral_nemo_instruct_2407_tp_qb2(
+    output_file,
+    num_layers,
+    request,
+    accuracy_testing,
+    batch_size,
+    max_output_tokens,
+    decode_only,
+    optimization_level,
+):
+    from third_party.tt_forge_models.mistral.pytorch.loader import (
+        ModelLoader,
+        ModelVariant,
+    )
+
+    variant = ModelVariant.MISTRAL_NEMO_INSTRUCT_2407
+    test_llm_tp(
+        ModelLoader,
+        variant,
+        output_file,
+        num_layers=num_layers,
+        request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
+        max_output_tokens=max_output_tokens,
+        decode_only=decode_only,
+        optimization_level=2,
+    )
+
+
+def test_mistral_small_24b_instruct_2501_tp_qb2(
+    output_file,
+    num_layers,
+    request,
+    accuracy_testing,
+    batch_size,
+    max_output_tokens,
+    decode_only,
+    optimization_level,
+):
+    from third_party.tt_forge_models.mistral.pytorch.loader import (
+        ModelLoader,
+        ModelVariant,
+    )
+
+    variant = ModelVariant.MISTRAL_SMALL_24B_INSTRUCT_2501
+    test_llm_tp(
+        ModelLoader,
+        variant,
+        output_file,
+        num_layers=num_layers,
+        request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
+        max_output_tokens=max_output_tokens,
+        decode_only=decode_only,
+        optimization_level=2,
+    )
+
+
+def test_qwen_2_5_14b_instruct_tp_qb2(
+    output_file,
+    num_layers,
+    request,
+    accuracy_testing,
+    batch_size,
+    max_output_tokens,
+    decode_only,
+    optimization_level,
+):
+    from third_party.tt_forge_models.qwen_2_5.causal_lm.pytorch.loader import (
+        ModelLoader,
+        ModelVariant,
+    )
+
+    variant = ModelVariant.QWEN_2_5_14B_INSTRUCT
+    test_llm_tp(
+        ModelLoader,
+        variant,
+        output_file,
+        num_layers=num_layers,
+        request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
+        max_output_tokens=max_output_tokens,
+        decode_only=decode_only,
+        optimization_level=2,
+    )
+
+
+def test_qwen_2_5_coder_32b_instruct_tp_qb2(
+    output_file,
+    num_layers,
+    request,
+    accuracy_testing,
+    batch_size,
+    max_output_tokens,
+    decode_only,
+    optimization_level,
+):
+    from third_party.tt_forge_models.qwen_2_5_coder.pytorch.loader import (
+        ModelLoader,
+        ModelVariant,
+    )
+
+    variant = ModelVariant.QWEN_2_5_CODER_32B_INSTRUCT
+    test_llm_tp(
+        ModelLoader,
+        variant,
+        output_file,
+        num_layers=num_layers,
+        request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
+        max_output_tokens=max_output_tokens,
+        decode_only=decode_only,
+        optimization_level=2,
+    )
+
+
+def test_qwen_3_8b_tp_qb2(
+    output_file,
+    num_layers,
+    request,
+    accuracy_testing,
+    batch_size,
+    max_output_tokens,
+    decode_only,
+    optimization_level,
+):
+    from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import (
+        ModelLoader,
+        ModelVariant,
+    )
+
+    variant = ModelVariant.QWEN_3_8B
+    test_llm_tp(
+        ModelLoader,
+        variant,
+        output_file,
+        num_layers=num_layers,
+        request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
+        max_output_tokens=max_output_tokens,
+        decode_only=decode_only,
+        optimization_level=2,
+    )
+
+
+def test_qwen_3_14b_tp_qb2(
+    output_file,
+    num_layers,
+    request,
+    accuracy_testing,
+    batch_size,
+    max_output_tokens,
+    decode_only,
+    optimization_level,
+):
+    from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import (
+        ModelLoader,
+        ModelVariant,
+    )
+
+    variant = ModelVariant.QWEN_3_14B
+    test_llm_tp(
+        ModelLoader,
+        variant,
+        output_file,
+        num_layers=num_layers,
+        request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
+        max_output_tokens=max_output_tokens,
+        decode_only=decode_only,
+        optimization_level=2,
+    )
+
+
+def test_qwen_3_32b_tp_qb2(
+    output_file,
+    num_layers,
+    request,
+    accuracy_testing,
+    batch_size,
+    max_output_tokens,
+    decode_only,
+    optimization_level,
+):
+    from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import (
+        ModelLoader,
+        ModelVariant,
+    )
+
+    variant = ModelVariant.QWEN_3_32B
+    test_llm_tp(
+        ModelLoader,
+        variant,
+        output_file,
+        num_layers=num_layers,
+        request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
+        max_output_tokens=max_output_tokens,
+        decode_only=decode_only,
+        optimization_level=2,
+    )
+
+
+def test_gpt_oss_20b_tp_qb2(
+    output_file,
+    num_layers,
+    request,
+    accuracy_testing,
+    batch_size,
+    max_output_tokens,
+    decode_only,
+    optimization_level,
+):
+    from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
+        ModelLoader,
+        ModelVariant,
+    )
+
+    variant = ModelVariant.GPT_OSS_20B
+    test_llm_tp(
+        ModelLoader,
+        variant,
+        output_file,
+        num_layers=num_layers,
+        request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
+        max_output_tokens=max_output_tokens,
+        decode_only=decode_only,
+        mesh_config_fn=_gpt_oss_20b_mesh_config_fn,
+        shard_spec_fn=_gpt_oss_20b_shard_spec_fn,
+        optimization_level=2,
+    )


### PR DESCRIPTION
### Problem description
QB2-Blackhole TP benchmarks aren't tracked in nightly. n300-llmbox has full coverage; QB2 has only one dormant test (`gpt_oss_120b_tp_qb2`, not picked up by the filter).

### What's changed
- Adds 12 `_qb2` TP variants mirroring the n300-llmbox roster (omits `gpt_oss_20b_tp_batch_size_1` and `llama_3_1_70b_tp` — both fail on QB2).
- Adds matrix entries and includes `qb2-blackhole` in the nightly perf filter.
- Adds `qb2-blackhole` to the runner→arch mapping so results land in their own Superset bucket.
- Adds `qb2-blackhole` to the `manual-benchmark.yml` runner choice list.
- New tests don't set `arch=`; CI patches `device_info.device_type` from the runner label (#3721).

Trace=ON for both `ministral_8b_tp_qb2` and `gpt_oss_20b_tp_qb2` — wormhole-specific trace issues (#3935, #4192) don't reproduce on Blackhole; prior local sweep showed 3.6× sps for ministral_8b and +6% for gpt_oss_20b.

### Checklist
- [x] All 12 tests passed locally on QB2 with `optimization_level=2`
- [x] Filter script verified: 13 qb2 entries resolve (12 new + existing 120b)
- [x] Branch CI run: https://github.com/tenstorrent/tt-xla/actions/runs/26597579965

### CI perf

<img width="758" height="482" alt="image" src="https://github.com/user-attachments/assets/fc0b33b9-0dfc-479a-8e4e-cbccb920dae7" />
