### PR TITLE
MoE backend from huggingface

### DIFF
--- a/python_package/tt_torch/__init__.py
+++ b/python_package/tt_torch/__init__.py
@@ -34,3 +34,24 @@ from .weight_dtype import (
     dump_weight_names,
     remove_weight_dtype_overrides,
 )
+
+_HF_BACKEND_EXPORTS = {
+    "TT_MOE_BACKEND_NAME": "moe_backend",
+    "TT_DENSE_EXPERTS_BACKEND_NAME": "moe_backend",
+    "get_tt_moe_shard_specs": "moe_backend",
+    "register_tt_moe_backend": "moe_backend",
+    "tt_experts_forward": "moe_backend",
+    "tt_dense_experts_forward": "moe_backend",
+}
+
+
+def __getattr__(name):
+    module_name = _HF_BACKEND_EXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    from importlib import import_module
+
+    value = getattr(import_module(f"{__name__}.{module_name}"), name)
+    globals()[name] = value
+    return value

--- a/python_package/tt_torch/custom_ops.py
+++ b/python_package/tt_torch/custom_ops.py
@@ -994,14 +994,24 @@ def sparse_matmul(
             if not is_input_a_sparse and is_input_b_sparse:
                 H = input_tensor_a.shape[-1]
                 split_seq = S % M == 0 and S >= M
+                # split_bd matches sparsity tile boundaries only when S=1
+                # (decode). For S>1, sparsity tiles cross BD boundaries since
+                # the flat token order is S-inner.
+                split_bd = S == 1 and BD % M == 0 and BD >= M
                 if split_seq:
                     input_tensor_a = input_tensor_a.reshape(BD, S // M, M, H)
                     sparsity = sparsity.reshape(BD, S // M, 1, E_experts)
-                else:
+                elif split_bd:
                     # Decode: tile on BD instead
                     input_tensor_a = input_tensor_a.reshape(BD // M, M, S, H)
                     input_tensor_a = input_tensor_a.permute(0, 2, 1, 3)
                     sparsity = sparsity.reshape(BD // M, S, 1, E_experts)
+                else:
+                    # Fall back to flat tiling of the BD*S token axis,
+                    # matching sparsity's natural [reduced, E] layout.
+                    AB = (BD * S) // M
+                    input_tensor_a = input_tensor_a.reshape(1, AB, M, H)
+                    sparsity = sparsity.reshape(1, AB, 1, E_experts)
 
         frontend_attributes = {
             "is_input_a_sparse": str(is_input_a_sparse),
@@ -1087,8 +1097,9 @@ def sparse_matmul(
                 out_e = torch.matmul(input_tensor_a, input_b_casted[0, e])
                 output[:, :, 0, e, :, :] = out_e * mask_e.unsqueeze(-1).unsqueeze(-1)
             if _tiled:
-                output = output.squeeze(2).permute(0, 1, 3, 2, 4).contiguous()
-                output = output.view(BD, S, E, N)
+                # Match XLA: 5D [A, B, E, M, N] so consumers can broadcast
+                # bias as [1, 1, E, 1, -1] uniformly across devices.
+                output = output.squeeze(2)
             return output.to(orig_dtype)
 
         elif is_input_a_sparse and not is_input_b_sparse:
@@ -1145,10 +1156,16 @@ def sparse_matmul_fake(
         reduced = sparsity.shape[2]
         M = (BD * S) // reduced
         if not is_input_a_sparse and is_input_b_sparse:
-            # Gate-up: tiled output [A, B, E, M, N] (5D)
+            # Gate-up: tiled output [A, B, E, M, N] (5D). Must mirror the
+            # real-op tiling exactly (see XLA branch).
             split_seq = S % M == 0 and S >= M
-            A = BD if split_seq else BD // M
-            B = S // M if split_seq else S
+            split_bd = S == 1 and BD % M == 0 and BD >= M
+            if split_seq:
+                A, B = BD, S // M
+            elif split_bd:
+                A, B = BD // M, S
+            else:
+                A, B = 1, (BD * S) // M
             output_shape = [A, B, E, M, N]
         else:
             output_shape = [BD, S, E, N]

--- a/python_package/tt_torch/moe_backend.py
+++ b/python_package/tt_torch/moe_backend.py
@@ -1,0 +1,577 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tenstorrent MoE experts backend for HuggingFace transformers.
+
+Registers two ``ExpertsInterface`` backends selectable via
+``experts_implementation=`` at ``from_pretrained`` time:
+
+  - ``tt_moe``   — multi-chip EP via all_to_all_dispatch / sparse_matmul / all_to_all_combine.
+  - ``tt_dense`` — dense bmm across all experts, single-device-friendly.
+
+Works with any ``@use_experts_implementation`` Experts module that exposes
+``gate_up_proj``, ``down_proj``, and ``_apply_gate``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Optional, Tuple
+
+import torch
+import torch.nn as nn
+from torch.nn import functional as F
+from transformers.integrations.moe import ALL_EXPERTS_FUNCTIONS, ExpertsInterface
+from transformers.modeling_utils import PreTrainedModel
+
+# Ensure torch.ops.tt.* are registered.
+from . import custom_ops  # noqa: F401
+
+TT_MOE_BACKEND_NAME = "tt_moe"
+TT_DENSE_EXPERTS_BACKEND_NAME = "tt_dense"
+REDUCTION_SIZE = 32
+
+# HF built-in backend keys — patched validator falls through for these.
+_HF_BUILTIN_EXPERTS_KEYS = frozenset({"eager", "grouped_mm", "batched_mm", "deepgemm"})
+
+# Module-level EP config; set by register_tt_moe_backend().
+_config: dict = {"cluster_axis": None}
+
+
+def _resolve_cluster_axis(mesh: Any) -> int:
+    configured_axis = _config["cluster_axis"]
+    if configured_axis is not None:
+        return int(configured_axis)
+
+    for axis, size in enumerate(tuple(int(d) for d in mesh.mesh_shape)):
+        if size > 1:
+            return axis
+    return 0
+
+
+def _mesh_info() -> Tuple[int, int, Tuple[int, ...], int]:
+    """Return (total_devices, dispatch_devices_on_cluster_axis, mesh_shape, axis).
+
+    Reads the currently-set torch_xla global SPMD mesh. Returns (1, 1, (1,), 0)
+    when no mesh is registered or torch_xla is unavailable.
+    """
+    try:
+        from torch_xla.distributed.spmd import get_global_mesh
+    except ImportError:
+        return 1, 1, (1,), 0
+    mesh = get_global_mesh()
+    if mesh is None:
+        return 1, 1, (1,), 0
+    mesh_shape = tuple(int(d) for d in mesh.mesh_shape)
+    total = 1
+    for d in mesh_shape:
+        total *= d
+    ax = _resolve_cluster_axis(mesh)
+    dispatch = mesh_shape[ax] if 0 <= ax < len(mesh_shape) else 1
+    return total, dispatch, mesh_shape, ax
+
+
+def _as_sparse_matmul_weight(weight: torch.Tensor, is_transposed: bool) -> torch.Tensor:
+    """Reshape weight to `[1, E, in, out]` for `sparse_matmul`."""
+    if is_transposed:
+        return weight.unsqueeze(0).contiguous()
+    return weight.transpose(-2, -1).unsqueeze(0).contiguous()
+
+
+class _ExpertAdapter:
+    """Normalize model-specific expert parameter names into semantic weights."""
+
+    def __init__(self, module: nn.Module):
+        self.module = module
+
+    @property
+    def num_experts(self) -> int:
+        return int(getattr(self.module, "num_experts"))
+
+    @property
+    def has_fused_gate_up(self) -> bool:
+        return False
+
+    def gate_up_weight(self) -> torch.Tensor:
+        raise RuntimeError("Adapter does not expose fused gate/up weights")
+
+    def gate_weight(self) -> torch.Tensor:
+        raise RuntimeError("Adapter does not expose separate gate weights")
+
+    def up_weight(self) -> torch.Tensor:
+        raise RuntimeError("Adapter does not expose separate up weights")
+
+    def down_weight(self) -> torch.Tensor:
+        raise NotImplementedError
+
+    def gate_up_bias(self) -> Optional[torch.Tensor]:
+        return None
+
+    def gate_bias(self) -> Optional[torch.Tensor]:
+        return None
+
+    def up_bias(self) -> Optional[torch.Tensor]:
+        return None
+
+    def down_bias(self) -> Optional[torch.Tensor]:
+        return None
+
+    def apply_gate(
+        self, gate_or_gate_up: torch.Tensor, up: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        if up is None:
+            raise RuntimeError("Separate gate/up adapter requires an up tensor")
+        return F.silu(gate_or_gate_up) * up
+
+
+class _FusedGateUpAdapter(_ExpertAdapter):
+    @property
+    def has_fused_gate_up(self) -> bool:
+        return True
+
+    def gate_up_weight(self) -> torch.Tensor:
+        return _as_sparse_matmul_weight(
+            self.module.gate_up_proj, bool(getattr(self.module, "is_transposed", False))
+        )
+
+    def down_weight(self) -> torch.Tensor:
+        return _as_sparse_matmul_weight(
+            self.module.down_proj, bool(getattr(self.module, "is_transposed", False))
+        )
+
+    def gate_up_bias(self) -> Optional[torch.Tensor]:
+        return getattr(self.module, "gate_up_proj_bias", None)
+
+    def down_bias(self) -> Optional[torch.Tensor]:
+        return getattr(self.module, "down_proj_bias", None)
+
+    def apply_gate(
+        self, gate_or_gate_up: torch.Tensor, up: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        return self.module._apply_gate(gate_or_gate_up)
+
+
+class _SeparateGateUpAdapter(_ExpertAdapter):
+    def _weight(self, name: str) -> torch.Tensor:
+        return _as_sparse_matmul_weight(
+            getattr(self.module, name),
+            bool(getattr(self.module, "is_transposed", False)),
+        )
+
+    def gate_weight(self) -> torch.Tensor:
+        return self._weight("gate_proj")
+
+    def up_weight(self) -> torch.Tensor:
+        return self._weight("up_proj")
+
+    def down_weight(self) -> torch.Tensor:
+        return self._weight("down_proj")
+
+    def gate_bias(self) -> Optional[torch.Tensor]:
+        return getattr(self.module, "gate_proj_bias", None)
+
+    def up_bias(self) -> Optional[torch.Tensor]:
+        return getattr(self.module, "up_proj_bias", None)
+
+    def down_bias(self) -> Optional[torch.Tensor]:
+        return getattr(self.module, "down_proj_bias", None)
+
+    def apply_gate(
+        self, gate_or_gate_up: torch.Tensor, up: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        if hasattr(self.module, "_apply_gate"):
+            return self.module._apply_gate(torch.cat((gate_or_gate_up, up), dim=-1))
+        return super().apply_gate(gate_or_gate_up, up)
+
+
+def _get_expert_adapter(module: nn.Module) -> _ExpertAdapter:
+    if hasattr(module, "gate_up_proj") and hasattr(module, "down_proj"):
+        return _FusedGateUpAdapter(module)
+    if (
+        hasattr(module, "gate_proj")
+        and hasattr(module, "up_proj")
+        and hasattr(module, "down_proj")
+    ):
+        return _SeparateGateUpAdapter(module)
+    raise RuntimeError(
+        f"tt_moe backend could not adapt Experts module {type(module).__name__}. "
+        "Expected fused gate_up/down or separate gate/up/down experts."
+    )
+
+
+def _expert_mapping(
+    num_experts: int,
+    num_devices: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """Build `[1, 1, E, D]` one-hot expert-to-device mapping."""
+    if num_experts % num_devices != 0:
+        raise ValueError(
+            f"num_experts ({num_experts}) must be divisible by num_devices "
+            f"({num_devices}) to build a one-hot expert-to-device mapping."
+        )
+
+    experts_per_device = num_experts // num_devices
+    device_ids = (
+        torch.arange(num_experts, device=device, dtype=torch.int64)
+        // experts_per_device
+    ).to(torch.uint16)
+
+    mapping = (
+        device_ids.unsqueeze(-1)
+        == torch.arange(num_devices, device=device, dtype=torch.int64).to(torch.uint16)
+    ).to(torch.uint16)
+    return mapping.view(1, 1, num_experts, num_devices)
+
+
+def _build_routing_scores(
+    top_k_index: torch.Tensor,
+    top_k_weights: torch.Tensor,
+    num_experts: int,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    """Expand top-k weights into a full `[T, E]` sparse router-scores tensor."""
+    one_hot = (
+        top_k_index.unsqueeze(-1) == torch.arange(num_experts, device=device)
+    ).to(dtype)
+    return torch.einsum("tk,tke->te", top_k_weights.to(dtype), one_hot)
+
+
+def _pad_moe_inputs(
+    hidden_states: torch.Tensor,
+    top_k_index: torch.Tensor,
+    top_k_weights: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]:
+    """Pad token axis to a multiple of REDUCTION_SIZE (32) for sparse_matmul."""
+    token_count, hidden_dim = hidden_states.shape
+    if token_count == 0:
+        return hidden_states, top_k_index, top_k_weights, token_count
+
+    token_multiple = REDUCTION_SIZE
+    padded_token_count = (
+        (token_count + token_multiple - 1) // token_multiple
+    ) * token_multiple
+    if padded_token_count == token_count:
+        return hidden_states, top_k_index, top_k_weights, token_count
+
+    pad_tokens = padded_token_count - token_count
+    hidden_pad = torch.zeros(
+        pad_tokens,
+        hidden_dim,
+        dtype=hidden_states.dtype,
+        device=hidden_states.device,
+    )
+    index_pad = torch.zeros(
+        pad_tokens,
+        top_k_index.shape[1],
+        dtype=top_k_index.dtype,
+        device=top_k_index.device,
+    )
+    weight_pad = torch.zeros(
+        pad_tokens,
+        top_k_weights.shape[1],
+        dtype=top_k_weights.dtype,
+        device=top_k_weights.device,
+    )
+    return (
+        torch.cat((hidden_states, hidden_pad), dim=0),
+        torch.cat((top_k_index, index_pad), dim=0),
+        torch.cat((top_k_weights, weight_pad), dim=0),
+        token_count,
+    )
+
+
+def _tt_experts_forward_ep(
+    self: torch.nn.Module,
+    hidden_states: torch.Tensor,
+    top_k_index: torch.Tensor,
+    top_k_weights: torch.Tensor,
+    total_devices: int,
+    dispatch_devices: int,
+    cluster_axis: int,
+) -> torch.Tensor:
+    """Expert-parallel compute: dispatch tokens to the devices holding their
+    selected experts, run the sparse_matmul chain on the dispatched layout,
+    then combine per-expert outputs back to original token positions.
+    """
+    hidden_states, top_k_index, top_k_weights, original_token_count = _pad_moe_inputs(
+        hidden_states, top_k_index, top_k_weights
+    )
+
+    experts = _get_expert_adapter(self)
+    T, H = hidden_states.shape
+    K = top_k_index.shape[-1]
+    E = experts.num_experts
+    dtype = hidden_states.dtype
+    device = hidden_states.device
+    routing_scores = _build_routing_scores(
+        top_k_index,
+        top_k_weights,
+        E,
+        dtype,
+        device,
+    )
+
+    expert_mapping = _expert_mapping(E, total_devices, device)  # [1, 1, E, D_total]
+
+    # num_devices = dispatch_devices (cluster_axis size), not total.
+    hidden_3d = hidden_states.view(1, T, H)
+    dispatched, metadata = torch.ops.tt.all_to_all_dispatch(
+        hidden_3d,
+        top_k_index,
+        expert_mapping,
+        num_devices=dispatch_devices,
+        cluster_axis=cluster_axis,
+    )  # dispatched: [1, BD, T, H];  metadata: [1, BD, T, K]
+    BD = dispatched.shape[1]
+    metadata = metadata.reshape(1, 1, BD * T, K)
+
+    # Sparsity from all-gathered metadata (not local router scores).
+    _, sparsity = torch.ops.tt.moe_expert_token_remap(
+        routing_scores,
+        expert_mapping,
+        metadata,
+        num_devices=dispatch_devices,
+    )  # sparsity: [1, 1, ceil(BD*T/32), E]
+
+    if experts.has_fused_gate_up:
+        gate_up_out = torch.ops.tt.sparse_matmul(
+            dispatched,
+            experts.gate_up_weight(),
+            sparsity,
+            nnz=0,
+            is_input_a_sparse=False,
+            is_input_b_sparse=True,
+        )
+        gate_up_bias = experts.gate_up_bias()
+        if gate_up_bias is not None:
+            gate_up_out = gate_up_out + gate_up_bias.view(1, 1, E, 1, -1)
+        activated = experts.apply_gate(gate_up_out)
+    else:
+        gate_out = torch.ops.tt.sparse_matmul(
+            dispatched,
+            experts.gate_weight(),
+            sparsity,
+            nnz=0,
+            is_input_a_sparse=False,
+            is_input_b_sparse=True,
+        )
+        up_out = torch.ops.tt.sparse_matmul(
+            dispatched,
+            experts.up_weight(),
+            sparsity,
+            nnz=0,
+            is_input_a_sparse=False,
+            is_input_b_sparse=True,
+        )
+        gate_bias = experts.gate_bias()
+        if gate_bias is not None:
+            gate_out = gate_out + gate_bias.view(1, 1, E, 1, -1)
+        up_bias = experts.up_bias()
+        if up_bias is not None:
+            up_out = up_out + up_bias.view(1, 1, E, 1, -1)
+        activated = experts.apply_gate(gate_out, up_out)
+
+    A, B, _, M_tile, I_dim = activated.shape  # 5D [A, B, E, M, N]
+    activated = activated.reshape(A * B, E, M_tile, I_dim)
+
+    down_out = torch.ops.tt.sparse_matmul(
+        activated,
+        experts.down_weight(),
+        sparsity,
+        nnz=0,
+        is_input_a_sparse=True,
+        is_input_b_sparse=False,
+    )  # [A*B, E, M, H]
+
+    down_bias = experts.down_bias()
+    if down_bias is not None:
+        down_out = down_out + down_bias.view(1, E, 1, -1)
+
+    down_out = down_out.permute(1, 0, 2, 3).reshape(E, 1, -1, H)  # [E, 1, BD*S, H]
+
+    combined = torch.ops.tt.all_to_all_combine(
+        down_out,
+        metadata,
+        expert_mapping,
+        num_devices=dispatch_devices,
+        cluster_axis=cluster_axis,
+        num_experts_per_tok=K,
+        output_shard_dim=2,
+    )  # [K, 1, T, H]
+
+    weights_k = top_k_weights.permute(1, 0).view(K, 1, T, 1).to(combined.dtype)
+    output = (combined * weights_k).sum(dim=0).view(T, H)
+    output = output[:original_token_count]
+    return output.to(dtype)
+
+
+def tt_experts_forward(
+    self: torch.nn.Module,
+    hidden_states: torch.Tensor,
+    top_k_index: torch.Tensor,
+    top_k_weights: torch.Tensor,
+) -> torch.Tensor:
+    """Multi-chip EP forward. CPU tensors fall back to HF `batched_mm`."""
+    if hidden_states.device.type == "cpu":
+        return ALL_EXPERTS_FUNCTIONS["batched_mm"](
+            self, hidden_states, top_k_index, top_k_weights
+        )
+
+    total_devices, dispatch_devices, mesh_shape, cluster_axis = _mesh_info()
+
+    if total_devices <= 1 or dispatch_devices <= 1:
+        raise RuntimeError(
+            f"{TT_MOE_BACKEND_NAME} requires a multi-chip SPMD mesh with an EP "
+            f"axis larger than 1, got mesh_shape={mesh_shape} and "
+            f"cluster_axis={cluster_axis}. Use a built-in HF experts backend "
+            "such as 'eager' or 'batched_mm' for single-device runs."
+        )
+
+    return _tt_experts_forward_ep(
+        self,
+        hidden_states,
+        top_k_index,
+        top_k_weights,
+        total_devices,
+        dispatch_devices,
+        cluster_axis,
+    )
+
+
+def tt_dense_experts_forward(
+    self: torch.nn.Module,
+    hidden_states: torch.Tensor,
+    top_k_index: torch.Tensor,
+    top_k_weights: torch.Tensor,
+) -> torch.Tensor:
+    """Dense-bmm forward over all experts, masked by routing weights.
+    Requires fused gate_up_proj / down_proj."""
+    if not (hasattr(self, "gate_up_proj") and hasattr(self, "down_proj")):
+        raise RuntimeError(
+            f"{TT_DENSE_EXPERTS_BACKEND_NAME} requires fused gate_up_proj/down_proj "
+            f"experts; got {type(self).__name__} which does not expose them. "
+            "Use a built-in HF backend (batched_mm/grouped_mm) for separate "
+            "gate/up experts."
+        )
+
+    T, H = hidden_states.shape
+    E = int(self.num_experts)
+    dtype = hidden_states.dtype
+    device = hidden_states.device
+
+    routing_weights = torch.zeros(T, E, dtype=dtype, device=device).scatter(
+        1, top_k_index, top_k_weights.to(dtype)
+    )
+
+    is_transposed = bool(getattr(self, "is_transposed", False))
+
+    h = hidden_states.repeat(E, 1).view(E, T, H)
+    gate_up_w = (
+        self.gate_up_proj if is_transposed else self.gate_up_proj.transpose(-1, -2)
+    )
+    gate_up = torch.bmm(h, gate_up_w)
+    gate_up_bias = getattr(self, "gate_up_proj_bias", None)
+    if gate_up_bias is not None:
+        gate_up = gate_up + gate_up_bias.unsqueeze(1)
+
+    activated = self._apply_gate(gate_up)
+
+    down_w = self.down_proj if is_transposed else self.down_proj.transpose(-1, -2)
+    down_out = torch.bmm(activated, down_w)
+    down_bias = getattr(self, "down_proj_bias", None)
+    if down_bias is not None:
+        down_out = down_out + down_bias.unsqueeze(1)
+
+    weighted = down_out * routing_weights.transpose(0, 1).unsqueeze(-1)
+    return weighted.sum(dim=0).to(dtype)
+
+
+_original_validator: Optional[Callable] = None
+
+
+def register_tt_moe_backend(cluster_axis: Optional[int] = None) -> None:
+    """Register tt_moe and tt_dense backends. Idempotent."""
+    global _original_validator
+
+    _config["cluster_axis"] = cluster_axis
+    ExpertsInterface.register(TT_MOE_BACKEND_NAME, tt_experts_forward)
+    if TT_MOE_BACKEND_NAME not in ALL_EXPERTS_FUNCTIONS:
+        raise RuntimeError(f"{TT_MOE_BACKEND_NAME} registration failed")
+    ExpertsInterface.register(TT_DENSE_EXPERTS_BACKEND_NAME, tt_dense_experts_forward)
+    if TT_DENSE_EXPERTS_BACKEND_NAME not in ALL_EXPERTS_FUNCTIONS:
+        raise RuntimeError(f"{TT_DENSE_EXPERTS_BACKEND_NAME} registration failed")
+
+    if _original_validator is not None:
+        return  # already patched
+
+    _original_validator = PreTrainedModel.get_correct_experts_implementation
+    original_validator = _original_validator
+
+    def patched_validator(self, requested_experts):
+        if (
+            requested_experts in ALL_EXPERTS_FUNCTIONS.valid_keys()
+            and requested_experts not in _HF_BUILTIN_EXPERTS_KEYS
+        ):
+            return requested_experts
+        return original_validator(self, requested_experts)
+
+    PreTrainedModel.get_correct_experts_implementation = patched_validator
+
+
+def get_tt_moe_shard_specs(
+    model: nn.Module,
+    original_spec_fn: Callable[[nn.Module], Dict[Any, Any]],
+    mesh_names: Tuple[str, ...],
+) -> Dict[Any, Any]:
+    """Add expert-dimension sharding to the upstream shard spec for MoE layers."""
+    shard_specs = original_spec_fn(model)
+    expert_axis: Any = tuple(mesh_names) if len(mesh_names) > 1 else mesh_names[0]
+
+    layers = getattr(getattr(model, "model", None), "layers", None)
+    if layers is None:
+        return shard_specs
+
+    for layer in layers:
+        mlp = getattr(layer, "mlp", None)
+        if mlp is None:
+            continue
+        experts = getattr(mlp, "experts", None)
+        if experts is None:
+            continue
+
+        # Shard only the expert dimension; compound axis for 2D meshes.
+        if hasattr(experts, "gate_up_proj") and hasattr(experts, "down_proj"):
+            shard_specs[experts.gate_up_proj] = (expert_axis, None, None)
+            gate_up_bias = getattr(experts, "gate_up_proj_bias", None)
+            if gate_up_bias is not None:
+                shard_specs[gate_up_bias] = (expert_axis, None)
+        elif all(
+            hasattr(experts, name) for name in ("gate_proj", "up_proj", "down_proj")
+        ):
+            shard_specs[experts.gate_proj] = (expert_axis, None, None)
+            shard_specs[experts.up_proj] = (expert_axis, None, None)
+            gate_bias = getattr(experts, "gate_proj_bias", None)
+            if gate_bias is not None:
+                shard_specs[gate_bias] = (expert_axis, None)
+            up_bias = getattr(experts, "up_proj_bias", None)
+            if up_bias is not None:
+                shard_specs[up_bias] = (expert_axis, None)
+        elif all(hasattr(experts, name) for name in ("w1", "w2", "w3")):
+            shard_specs[experts.w1] = (expert_axis, None, None)
+            shard_specs[experts.w3] = (expert_axis, None, None)
+        else:
+            continue
+
+        down = getattr(experts, "down_proj", getattr(experts, "w2", None))
+        if down is not None:
+            shard_specs[down] = (expert_axis, None, None)
+        down_bias = getattr(experts, "down_proj_bias", None)
+        if down_bias is not None:
+            shard_specs[down_bias] = (expert_axis, None)
+
+    return shard_specs
+
+
+register_tt_moe_backend()

--- a/python_package/tt_torch/sparse_mlp.py
+++ b/python_package/tt_torch/sparse_mlp.py
@@ -547,8 +547,13 @@ class A2aSparseMLP(nn.Module):
         router_input = hidden_states
         if not hasattr(self.router, "gate"):
             router_input = hidden_states.view(-1, hidden_size)
+        router_out = self.router(router_input, *extra_args, **extra_kwargs)
+        # Native router scores (matches HF GptOssMLP return contract) — used
+        # only as the second tuple element; internal sparse_matmul / dispatch
+        # use the [T, E] sparse form below.
+        native_router_scores = router_out[-2]
         router_scores, router_indices = _unpack_router_output(
-            self.router(router_input, *extra_args, **extra_kwargs), self.num_experts
+            router_out, self.num_experts
         )
 
         # Pad batch so (batch * seq_len) is a multiple of TILE (32). The
@@ -727,12 +732,12 @@ class A2aSparseMLP(nn.Module):
         output = (combined * topk_weights).sum(dim=0)  # [1, B*S, H]
         output = output.view(padded_batch, seq_len, hidden_size)
         if pad_batch > 0:
-            # Drop the padded batch entries (and matching router_scores rows)
-            # so callers see the original [batch_size, ...] shape.
+            # Drop the padded batch entries so callers see the original
+            # [batch_size, ...] shape. native_router_scores was computed
+            # pre-padding so it already has the correct row count.
             output = output[:batch_size]
-            router_scores = router_scores[: batch_size * seq_len]
 
-        return output.to(hidden_states.dtype), router_scores
+        return output.to(hidden_states.dtype), native_router_scores
 
 
 class DeepseekV3MoEToA2AAdapter(nn.Module):
@@ -1145,7 +1150,7 @@ def enable_sparse_mlp(
             should_replace = _is_moe_mlp(module)
 
         if not should_replace:
-            return False
+            return None
 
         if hasattr(module, "gate") and hasattr(module, "experts"):
             sparse_mlp = create_a2a_from_deepseek_v3_moe(
@@ -1155,13 +1160,14 @@ def enable_sparse_mlp(
                 cluster_axis=cluster_axis,
                 dispatch_devices=dispatch_devices,
             )
-            setattr(parent, name, sparse_mlp)
+            if name:
+                setattr(parent, name, sparse_mlp)
             replaced_count += 1
             if verbose:
                 print(
                     f"[SparseMLP] Replaced {name}: {type(module).__name__} -> DeepseekV3MoEToA2AAdapter"
                 )
-            return True
+            return sparse_mlp
 
         moe_config = _get_moe_config(module)
         if moe_config is None and config is not None:
@@ -1173,7 +1179,7 @@ def enable_sparse_mlp(
         if moe_config is None:
             if verbose:
                 print(f"[SparseMLP] Skipping {name}: could not determine MoE config")
-            return False
+            return None
 
         num_experts, num_experts_per_tok = moe_config
 
@@ -1201,7 +1207,8 @@ def enable_sparse_mlp(
             use_dense_matmul=use_dense_matmul,
         )
 
-        setattr(parent, name, sparse_mlp)
+        if name:
+            setattr(parent, name, sparse_mlp)
         replaced_count += 1
 
         if verbose:
@@ -1209,10 +1216,11 @@ def enable_sparse_mlp(
                 f"[SparseMLP] Replaced {name}: {type(module).__name__} -> A2aSparseMLP "
                 f"(experts={num_experts}, num_devices={num_devices})"
             )
-        return True
+        return sparse_mlp
 
     # Traverse and replace. Track replaced prefixes to skip their children.
     replaced_prefixes = set()
+    top_level_replacement = None
     for name, module in list(model.named_modules()):
         # Skip children of already-replaced modules
         if any(name.startswith(p + ".") or name == p for p in replaced_prefixes):
@@ -1229,13 +1237,19 @@ def enable_sparse_mlp(
             parent = model
             child_name = name
 
-        if replace_mlp(parent, child_name, module):
+        replacement = replace_mlp(parent, child_name, module)
+        if replacement is not None:
             replaced_prefixes.add(name)
+            # Top-level (name="") cannot be reassigned via setattr — return the
+            # replacement so callers like `mlp = enable_sparse_mlp(mlp, ...)`
+            # see the new module.
+            if name == "":
+                top_level_replacement = replacement
 
     if verbose:
         print(f"[SparseMLP] Total layers replaced: {replaced_count}")
 
-    return model
+    return top_level_replacement if top_level_replacement is not None else model
 
 
 def get_moe_shard_specs(

--- a/python_package/tt_torch/torch_overrides.py
+++ b/python_package/tt_torch/torch_overrides.py
@@ -164,21 +164,3 @@ def _sparse_mlp_forward(self, hidden_states):
         hidden_states, router_indices=router_indices, routing_weights=router_scores
     )
     return routed_out, router_scores
-
-
-# Monkey patch to restore 4.57.1 interfaces:
-# - Router returns full [T, E] sparse routing weights
-# - Experts has CPU per-expert loop + device dense bmm
-# - Bypasses @use_experts_implementation decorator dispatch
-try:
-    from transformers.models.gpt_oss.modeling_gpt_oss import (
-        GptOssExperts,
-        GptOssMLP,
-        GptOssTopKRouter,
-    )
-
-    GptOssTopKRouter.forward = _router_forward
-    GptOssExperts.forward = _experts_forward
-    GptOssMLP.forward = _sparse_mlp_forward
-except ImportError:
-    pass

--- a/tests/benchmark/benchmarks/llm_benchmark.py
+++ b/tests/benchmark/benchmarks/llm_benchmark.py
@@ -45,6 +45,7 @@ from utils import (
 xr.set_device_type("TT")
 
 MIN_STEPS = 16
+DEFAULT_EXPERTS_IMPLEMENTATION = "batched_mm"
 
 # Default input prompt
 DEFAULT_INPUT_PROMPT = (
@@ -55,7 +56,7 @@ MODULE_EXPORT_PATH = "modules"
 
 
 def setup_model_and_tokenizer(
-    model_loader, model_variant
+    model_loader, model_variant, experts_implementation: Optional[str] = None
 ) -> tuple[torch.nn.Module, PreTrainedTokenizer]:
     """
     Instantiate model and tokenizer.
@@ -69,13 +70,18 @@ def setup_model_and_tokenizer(
     """
     print(f"Loading model {model_loader.get_model_info(variant=model_variant).name}...")
 
-    model = model_loader.load_model(dtype_override=torch.bfloat16)
+    model_kwargs = {}
+    if experts_implementation is not None:
+        model_kwargs["experts_implementation"] = experts_implementation
+    model = model_loader.load_model(dtype_override=torch.bfloat16, **model_kwargs)
     if hasattr(model.config, "layer_types"):
         model.config.layer_types = ["full_attention"] * len(model.config.layer_types)
     # Use static dense experts forward to avoid graph breaks from data-dependent
     # loops in the original experts and _grouped_mm CPU crashes.
     if hasattr(model.config, "_experts_implementation"):
-        model.config._experts_implementation = "dense"
+        model.config._experts_implementation = (
+            experts_implementation or DEFAULT_EXPERTS_IMPLEMENTATION
+        )
     model = model.eval()
     tokenizer = model_loader.tokenizer
 
@@ -259,6 +265,7 @@ def benchmark_llm_torch_xla(
     check_fusions_enabled: bool = False,
     use_indexer_cache: bool = False,
     enable_create_d2m_subgraphs: bool = False,
+    experts_implementation: Optional[str] = None,
 ):
     """
     Benchmark an LLM (Large Language Model) using PyTorch and torch-xla.
@@ -348,7 +355,11 @@ def benchmark_llm_torch_xla(
     device: torch.device = torch_xla.device()
 
     # Instantiate model and tokenizer
-    model, tokenizer = setup_model_and_tokenizer(model_loader, model_variant)
+    model, tokenizer = setup_model_and_tokenizer(
+        model_loader,
+        model_variant,
+        experts_implementation=experts_implementation,
+    )
     full_model_name = model_loader.get_model_info(variant=model_variant).name
 
     # Initialize accuracy testing if enabled
@@ -389,7 +400,9 @@ def benchmark_llm_torch_xla(
     if max_output_tokens is None:
         max_output_tokens = max_cache_len - input_args["input_ids"].shape[1]
 
-    # Run CPU prefill (used as PCC baseline, or as decode-only prefill)
+    # Run CPU prefill (used as PCC baseline, or as decode-only prefill).
+    # tt_* experts/attention backends auto-fall-back to HF builtins for CPU
+    # tensors, so no backend swap is needed here.
     if not accuracy_testing:
         cpu_wrapper = LLMSamplingWrapper(model, read_logits_fn, return_logits=True)
         cpu_wrapper.eval()

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -4,6 +4,7 @@
 
 import json
 import os
+from typing import Optional
 
 import numpy as np
 import pytest
@@ -67,6 +68,7 @@ def test_llm(
     check_fusions: bool = False,
     use_indexer_cache: bool = False,
     enable_create_d2m_subgraphs: bool = False,
+    experts_implementation: Optional[str] = None,
 ):
     """Test LLM model with the given variant and optional configuration overrides.
 
@@ -166,6 +168,7 @@ def test_llm(
         check_fusions_enabled=check_fusions,
         use_indexer_cache=use_indexer_cache,
         enable_create_d2m_subgraphs=enable_create_d2m_subgraphs,
+        experts_implementation=experts_implementation,
     )
 
     if output_file:
@@ -1754,6 +1757,8 @@ def test_gpt_oss_20b_tp(
     decode_only,
     optimization_level,
 ):
+    from tt_torch import TT_DENSE_EXPERTS_BACKEND_NAME
+
     from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
         ModelLoader,
         ModelVariant,
@@ -1774,6 +1779,8 @@ def test_gpt_oss_20b_tp(
         shard_spec_fn=_gpt_oss_20b_shard_spec_fn,
         trace_enabled=False,
         optimization_level=1,
+        experts_implementation=TT_DENSE_EXPERTS_BACKEND_NAME,
+        required_pcc=0.94,
     )
 
 
@@ -1788,6 +1795,8 @@ def test_gpt_oss_20b_tp_d2m(
     decode_only,
     optimization_level,
 ):
+    from tt_torch import TT_DENSE_EXPERTS_BACKEND_NAME
+
     from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
         ModelLoader,
         ModelVariant,
@@ -1809,6 +1818,7 @@ def test_gpt_oss_20b_tp_d2m(
         trace_enabled=False,
         optimization_level=1,
         enable_create_d2m_subgraphs=True,
+        experts_implementation=TT_DENSE_EXPERTS_BACKEND_NAME,
     )
 
 
@@ -1822,6 +1832,8 @@ def test_gpt_oss_20b_tp_batch_size_1(
     decode_only,
     optimization_level,
 ):
+    from tt_torch import TT_DENSE_EXPERTS_BACKEND_NAME
+
     from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
         ModelLoader,
         ModelVariant,
@@ -1841,6 +1853,7 @@ def test_gpt_oss_20b_tp_batch_size_1(
         shard_spec_fn=_gpt_oss_20b_shard_spec_fn,
         batch_size=batch_size if batch_size is not None else 1,
         optimization_level=1,
+        experts_implementation=TT_DENSE_EXPERTS_BACKEND_NAME,
     )
 
 
@@ -1884,6 +1897,8 @@ def test_gpt_oss_20b_tp_galaxy_batch_size_64(
     decode_only,
     optimization_level,
 ):
+    from tt_torch import TT_DENSE_EXPERTS_BACKEND_NAME
+
     from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
         ModelLoader,
         ModelVariant,
@@ -1904,6 +1919,7 @@ def test_gpt_oss_20b_tp_galaxy_batch_size_64(
         ),  # 128 fails to compile - https://github.com/tenstorrent/tt-xla/issues/3907
         optimization_level=1,
         experimental_kv_cache_dtype=None,
+        experts_implementation=TT_DENSE_EXPERTS_BACKEND_NAME,
     )
 
 
@@ -1959,6 +1975,8 @@ def test_gpt_oss_120b_tp_dp_galaxy_batch_size_128(
     decode_only,
     optimization_level,
 ):
+    from tt_torch import TT_DENSE_EXPERTS_BACKEND_NAME
+
     from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
         ModelLoader,
         ModelVariant,
@@ -1982,6 +2000,7 @@ def test_gpt_oss_120b_tp_dp_galaxy_batch_size_128(
         kv_cache_sharding_spec=("batch", "model", None, None),
         trace_enabled=True,
         experimental_kv_cache_dtype=None,
+        experts_implementation=TT_DENSE_EXPERTS_BACKEND_NAME,
     )
 
 
@@ -1995,6 +2014,8 @@ def test_gpt_oss_120b_tp_galaxy_batch_size_64(
     decode_only,
     optimization_level,
 ):
+    from tt_torch import TT_DENSE_EXPERTS_BACKEND_NAME
+
     from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
         ModelLoader,
         ModelVariant,
@@ -2018,6 +2039,7 @@ def test_gpt_oss_120b_tp_galaxy_batch_size_64(
         kv_cache_sharding_spec=("batch", "model", None, None),
         trace_enabled=True,
         experimental_kv_cache_dtype=None,
+        experts_implementation=TT_DENSE_EXPERTS_BACKEND_NAME,
     )
 
 
@@ -2054,6 +2076,8 @@ def test_gpt_oss_120b_tp_qb2(
     decode_only,
     optimization_level,
 ):
+    from tt_torch import TT_DENSE_EXPERTS_BACKEND_NAME
+
     from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
         ModelLoader,
         ModelVariant,
@@ -2082,6 +2106,7 @@ def test_gpt_oss_120b_tp_qb2(
         required_pcc=0.93,  # set for now as it's ~0.93 on test runs locally
         mesh_config_fn=_gpt_oss_120b_qb2_mesh_config_fn,
         # shard_spec_fn=_gpt_oss_120b_qb2_shard_spec_fn,
+        experts_implementation=TT_DENSE_EXPERTS_BACKEND_NAME,
     )
 
 
@@ -2531,6 +2556,8 @@ def test_gpt_oss_20b_tp_qb2(
     decode_only,
     optimization_level,
 ):
+    from tt_torch import TT_DENSE_EXPERTS_BACKEND_NAME
+
     from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
         ModelLoader,
         ModelVariant,
@@ -2550,4 +2577,5 @@ def test_gpt_oss_20b_tp_qb2(
         mesh_config_fn=_gpt_oss_20b_mesh_config_fn,
         shard_spec_fn=_gpt_oss_20b_shard_spec_fn,
         optimization_level=2,
+        experts_implementation=TT_DENSE_EXPERTS_BACKEND_NAME,
     )

--- a/tests/runner/testers/torch/dynamic_torch_model_tester.py
+++ b/tests/runner/testers/torch/dynamic_torch_model_tester.py
@@ -8,13 +8,14 @@ import collections
 from typing import Any
 
 import torch
+import torch_xla.distributed.spmd as xs
 import torch_xla.runtime as xr
 from infra.evaluators import ComparisonConfig
 from infra.testers.compiler_config import CompilerConfig
 from infra.testers.single_chip.model import RunMode, TorchModelTester
 from infra.utilities.torch_multichip_utils import get_mesh
 from loguru import logger
-from tt_torch.sparse_mlp import enable_sparse_mlp, get_moe_shard_specs
+from tt_torch.moe_backend import TT_MOE_BACKEND_NAME, get_tt_moe_shard_specs
 
 from tests.runner.test_utils import RunPhase
 from tests.runner.utils import TorchDynamicLoader
@@ -254,7 +255,9 @@ class DynamicTorchModelTester(TorchModelTester):
             mesh_shape, mesh_names = self.dynamic_loader.get_mesh_config(num_devices)
 
         if mesh_shape and mesh_names:
-            return get_mesh(mesh_shape, mesh_names)
+            mesh = get_mesh(mesh_shape, mesh_names)
+            xs.set_global_mesh(mesh)
+            return mesh
         return None
 
     def _get_prefill_real_token_mask(self):
@@ -288,17 +291,27 @@ class DynamicTorchModelTester(TorchModelTester):
 
     def _inject_custom_moe(self, model):
         """Injects a custom MoE implementation into the model if specified in test metadata."""
-        logger.info(
-            "Custom MoE injection enabled for this test - using sparse_mlp.py implementation in tt_torch"
-        )
         mesh_info = self._workload.mesh.shape()
-        mesh_shape = tuple(mesh_info.values())
         mesh_names = tuple(mesh_info.keys())
-        enable_sparse_mlp(model, mesh=mesh_shape)
+
+        logger.info(
+            f"Custom MoE injection enabled for this test - using {TT_MOE_BACKEND_NAME} "
+            "experts backend"
+        )
+        if hasattr(model, "config"):
+            model.config._experts_implementation = TT_MOE_BACKEND_NAME
+        else:
+            logger.warning(
+                "Custom MoE injection requested but %s has no .config attribute; "
+                "%s backend will not be dispatched.",
+                type(model).__name__,
+                TT_MOE_BACKEND_NAME,
+            )
+
         shard_spec_fn = self._workload.shard_spec_fn
         if shard_spec_fn:
 
             def combined_shard_spec_fn(model, _fn=shard_spec_fn, _names=mesh_names):
-                return get_moe_shard_specs(model, _fn, _names)
+                return get_tt_moe_shard_specs(model, _fn, _names)
 
             self._workload.shard_spec_fn = combined_shard_spec_fn

--- a/tests/torch/graphs/test_mlp.py
+++ b/tests/torch/graphs/test_mlp.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 import torch
 import torch_xla
+import torch_xla.distributed.spmd as xs
 import torch_xla.runtime as xr
 from infra import Framework, run_graph_test
 from infra.evaluators import ComparisonConfig, PccConfig
@@ -19,6 +20,7 @@ from transformers.models.llama.modeling_llama import LlamaMLP
 from transformers.models.mistral.modeling_mistral import MistralMLP
 from transformers.models.qwen2.modeling_qwen2 import Qwen2MLP
 from transformers.models.qwen3.modeling_qwen3 import Qwen3MLP
+from tt_torch import TT_DENSE_EXPERTS_BACKEND_NAME, TT_MOE_BACKEND_NAME
 from tt_torch.sparse_mlp import (
     ACTIVATION_DEEPSEEK,
     A2aSparseMLP,
@@ -76,6 +78,7 @@ MODEL_LOADER_MAP = {
     "falcon": FalconModelLoader,
     "gpt_oss": GPTOSSModelLoader,
 }
+
 
 AVAILABLE_VARIANT_MAP = {
     "llama": [
@@ -480,7 +483,9 @@ def test_falcon_mlp(seq_len, variant, variant_config, arch):
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("mlp_type", ["standard", "sparse"])
+@pytest.mark.parametrize(
+    "mlp_type", [TT_DENSE_EXPERTS_BACKEND_NAME, TT_MOE_BACKEND_NAME]
+)
 @parametrize_arch(["single_device", "llmbox", "galaxy"])
 @pytest.mark.parametrize(
     "variant,variant_config",
@@ -488,12 +493,13 @@ def test_falcon_mlp(seq_len, variant, variant_config, arch):
     ids=[str(k) for k in get_available_variants("gpt_oss").keys()],
 )
 def test_gpt_oss_mlp(variant, variant_config, arch, mlp_type, request):
-    if mlp_type == "sparse" and arch != "llmbox":
-        # Cannot run sparse MLP on galaxy due to hang: https://github.com/tenstorrent/tt-xla/issues/3941
-        pytest.skip("Sparse MLP test only supported on llmbox arch")
+    if mlp_type == TT_MOE_BACKEND_NAME and arch != "llmbox":
+        # tt_moe requires a multi-chip SPMD mesh with an EP axis larger than 1;
+        # galaxy currently hangs (https://github.com/tenstorrent/tt-xla/issues/3941).
+        pytest.skip("tt_moe HF backend requires llmbox arch")
     if variant == GPTOSSModelVariant.GPT_OSS_120B and arch == "single_device":
         pytest.skip("120B model too large for single device")
-    if mlp_type != "sparse":
+    if mlp_type == TT_DENSE_EXPERTS_BACKEND_NAME:
         request.node.add_marker(
             pytest.mark.filecheck(["matmul_with_activation_silu.ttnn.mlir"])
         )
@@ -508,6 +514,9 @@ def test_gpt_oss_mlp(variant, variant_config, arch, mlp_type, request):
     model = AutoModelForCausalLM.from_config(
         config, trust_remote_code=True, torch_dtype=torch.bfloat16
     )
+    # Route GptOssExperts through the chosen HF backend. tt_dense replaces the
+    # legacy torch_overrides.py monkey patch; tt_moe replaces enable_sparse_mlp.
+    model.config._experts_implementation = mlp_type
     model.eval()
     mlp = model.model.layers[0].mlp
 
@@ -521,8 +530,10 @@ def test_gpt_oss_mlp(variant, variant_config, arch, mlp_type, request):
         mesh_shape = (batch_size, num_devices // batch_size)
         device_ids = np.array(range(num_devices))
         mesh = Mesh(device_ids, mesh_shape, ("batch", "model"))
-        if mlp_type == "sparse":
-            mlp = enable_sparse_mlp(mlp, mesh=mesh_shape, cluster_axis=0)
+        if mlp_type == TT_MOE_BACKEND_NAME:
+            # tt_moe HF backend reads the global SPMD mesh inside its forward to
+            # pick the EP cluster axis; run_graph_test doesn't set it for us.
+            xs.set_global_mesh(mesh)
 
         def get_shard_spec(mlp, args, kwargs):
             shard_specs = {}
@@ -532,12 +543,12 @@ def test_gpt_oss_mlp(variant, variant_config, arch, mlp_type, request):
             shard_specs[mlp.router.bias] = (None,)
 
             # Shard experts across devices.
-            if mlp_type == "standard":
+            if mlp_type == TT_DENSE_EXPERTS_BACKEND_NAME:
                 shard_specs[mlp.experts.gate_up_proj] = ("model", "batch", None)
                 shard_specs[mlp.experts.gate_up_proj_bias] = ("model", None)
                 shard_specs[mlp.experts.down_proj] = ("model", None, "batch")
                 shard_specs[mlp.experts.down_proj_bias] = ("model", "batch")
-            elif mlp_type == "sparse":
+            elif mlp_type == TT_MOE_BACKEND_NAME:
                 shard_specs[mlp.experts.gate_up_proj] = (("batch", "model"), None, None)
                 shard_specs[mlp.experts.gate_up_proj_bias] = (("batch", "model"), None)
                 shard_specs[mlp.experts.down_proj] = (("batch", "model"), None, None)
@@ -550,7 +561,11 @@ def test_gpt_oss_mlp(variant, variant_config, arch, mlp_type, request):
         get_shard_spec = None
 
     comparison_config = ComparisonConfig()
-    if variant == "120B" and arch == "single_device" and mlp_type == "standard":
+    if (
+        variant == "120B"
+        and arch == "single_device"
+        and mlp_type == TT_DENSE_EXPERTS_BACKEND_NAME
+    ):
         comparison_config = ComparisonConfig(pcc=PccConfig(required_pcc=0.985))
 
     run_graph_test(

--- a/tests/torch/moe/test_hf_backends.py
+++ b/tests/torch/moe/test_hf_backends.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import torch.nn as nn
+import torch_xla.runtime as xr
+from tt_torch.moe_backend import tt_experts_forward
+from utils import Category
+
+
+class DummyExperts(nn.Module):
+    def __init__(self, num_experts, hidden_dim, intermediate_dim, is_transposed=False):
+        super().__init__()
+        self.num_experts = num_experts
+        self.hidden_dim = hidden_dim
+        self.intermediate_dim = intermediate_dim
+        self.is_transposed = is_transposed
+        # Attrs read by HF `batched_mm` fallback when called on CPU tensors.
+        self.has_gate = True
+        self.has_bias = False
+
+        if is_transposed:
+            self.gate_up_proj = nn.Parameter(
+                torch.randn(num_experts, hidden_dim, 2 * intermediate_dim)
+            )
+            self.down_proj = nn.Parameter(
+                torch.randn(num_experts, intermediate_dim, hidden_dim)
+            )
+        else:
+            self.gate_up_proj = nn.Parameter(
+                torch.randn(num_experts, 2 * intermediate_dim, hidden_dim)
+            )
+            self.down_proj = nn.Parameter(
+                torch.randn(num_experts, hidden_dim, intermediate_dim)
+            )
+
+    def _apply_gate(self, gate_up_out):
+        # Simple GLU for testing
+        gate, up = gate_up_out.chunk(2, dim=-1)
+        return torch.nn.functional.silu(gate) * up
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.single_device
+@pytest.mark.record_test_properties(
+    category=Category.GRAPH_TEST,
+)
+@pytest.mark.parametrize("is_transposed", [False, True])
+def test_tt_experts_forward_cpu_fallback(is_transposed):
+    """CPU tensors should fall back to HF `batched_mm` instead of hitting the
+    multi-chip SPMD path."""
+    xr.set_device_type("TT")
+    num_experts = 4
+    hidden_dim = 64
+    intermediate_dim = 128
+    seq_len = 64  # Multiple of 32
+    num_experts_per_tok = 2
+
+    experts = DummyExperts(num_experts, hidden_dim, intermediate_dim, is_transposed)
+
+    hidden_states = torch.randn(seq_len, hidden_dim)
+    top_k_index = torch.randint(0, num_experts, (seq_len, num_experts_per_tok))
+    top_k_weights = torch.rand(seq_len, num_experts_per_tok)
+    top_k_weights = top_k_weights / top_k_weights.sum(dim=-1, keepdim=True)
+
+    out = tt_experts_forward(experts, hidden_states, top_k_index, top_k_weights)
+    assert out.shape == (seq_len, hidden_dim)
+    assert out.device.type == "cpu"


### PR DESCRIPTION
### Ticket
N/A

### Problem description
@sgligorijevicTT [introduced](https://github.com/tenstorrent/tt-xla/pull/4424) new MoE backend integration logic from HF, giving us a more generalized way to support MoE on our stack. The previous implementation was tightly coupled to our internal API.

### What's changed
**New HF backend modules (`tt_torch`)**
- `moe_backend.py`: registers `tt_moe` (multi-chip EP) and `tt_dense` (dense bmm) as HF `ExpertsInterface` backends.
- `attention_backend.py`: registers `tt_sdpa` as an HF attention backend.
- `__init__.py`: auto-registers on import; lazy exports.

**Legacy monkey patch removal**
- `torch_overrides.py`: drop `GptOssMLP/GptOssExperts/GptOssTopKRouter.forward`  overrides — they bypassed HF's `@use_experts_implementation` dispatcher,  so `tt_moe` could not take effect on GPT-OSS.

**Bug fixes exposed by removing the monkey patch**
- `sparse_mlp.py`: `enable_sparse_mlp(mlp, ...)` was a no-op for top-level MoE input (`setattr(parent, "", x)`). Return the replacement.
- `custom_ops.py` (sparse_matmul):
  - `split_bd` was only correct for `S == 1`; restrict it.
  - Add flat-tiling fallback for `BD < M` and `S < M`.
  - CPU gate-up returns 5D `[A, B, E, M, N]` to match XLA.

**Tests / examples**
- `test_gpt_oss_mlp` parametrised over `tt_dense` / `tt_moe`.
- New `tests/torch/moe/test_hf_backends.py`.
- Benchmarks plumb `experts_implementation`; GPT-OSS TP switched to `tt_dense`.
- New OLMoE / Trinity-Nano TP+EP demos.

### Checklist
- [ ] New/Existing tests provide coverage for changes
