### PR TITLE
Fix tiktoken pyreq for kimi benchmarks

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -291,11 +291,13 @@
       },
       {
         "name": "kimi_k2_tp_galaxy_2_layers",
+        "pyreq": "tiktoken",
         "pytest": "tests/benchmark/test_llms.py::test_kimi_k2_tp_galaxy_2_layers",
         "runs-on": "galaxy-wh-6u"
       },
       {
         "name": "kimi_k2_5_tp_galaxy_2_layers",
+        "pyreq": "tiktoken",
         "pytest": "tests/benchmark/test_llms.py::test_kimi_k2_5_tp_galaxy_2_layers",
         "runs-on": "galaxy-wh-6u"
       },


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Model specific install requirements were removed from the perf benchmarks (https://github.com/tenstorrent/tt-xla/pull/4939) however kimi-k2 tests will fail without `tiktoken`as a pyreq.

```
E   ImportError: This modeling file requires the following packages that were not found in your environment: tiktoken. Run `pip install tiktoken`
```

### What's changed
Added ` "pyreq": "tiktoken",` for both kimi benchmarks.

### Checklist
- [x] New/Existing tests provide coverage for changes
