### PR TITLE
[vLLM] Expose experimental_kv_cache_dtype + add xfailed BFP8 repro test

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -282,6 +282,17 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 self.kv_cache_dtype = model_dtype
         else:
             self.kv_cache_dtype = TPU_STR_DTYPE_TO_TORCH_DTYPE[cache_config.cache_dtype]
+        if self.tt_config.experimental_kv_cache_dtype == "bfp_bf8":
+            # uint8: a 1-byte stand-in so vLLM budgets blocks for the BFP8
+            # on-device footprint. The staged buffer stays bf16 (see below).
+            self.kv_cache_spec_dtype = torch.uint8
+        elif self.tt_config.experimental_kv_cache_dtype == "bfp_bf4":
+            raise NotImplementedError(
+                "experimental_kv_cache_dtype='bfp_bf4' is not yet supported; "
+                "see tt-xla #5011."
+            )
+        else:
+            self.kv_cache_spec_dtype = self.kv_cache_dtype
         self._hidden_states_dtype = self.dtype
 
         self.sliding_window = model_config.get_sliding_window()
@@ -851,7 +862,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                             block_size=block_size,
                             num_kv_heads=attn_module.num_kv_heads,
                             head_size=attn_module.head_size,
-                            dtype=self.kv_cache_dtype,
+                            dtype=self.kv_cache_spec_dtype,
                             sliding_window=attn_module.sliding_window,
                         )
                     else:
@@ -859,7 +870,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                             block_size=block_size,
                             num_kv_heads=attn_module.num_kv_heads,
                             head_size=attn_module.head_size,
-                            dtype=self.kv_cache_dtype,
+                            dtype=self.kv_cache_spec_dtype,
                         )
                 elif attn_module.attn_type in (
                     AttentionType.ENCODER,
@@ -879,7 +890,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     block_size=block_size,
                     num_kv_heads=1,
                     head_size=attn_module.head_size,
-                    dtype=self.kv_cache_dtype,
+                    dtype=self.kv_cache_spec_dtype,
                     cache_dtype_str=cache_dtype_str,
                 )
             else:
@@ -2464,7 +2475,9 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                         kv_cache_spec.num_kv_heads,
                         kv_cache_spec.head_size,
                     )
-                    dtype = kv_cache_spec.dtype
+                    # spec.dtype may be a 1-byte accounting dtype; the staged
+                    # buffer uses the real transfer dtype (converted on device).
+                    dtype = self.kv_cache_dtype
 
                     # Allocate separate K and V cache tensors to avoid
                     # slice/concat copies in the compiled decode graph.

--- a/integrations/vllm_plugin/vllm_tt/worker.py
+++ b/integrations/vllm_plugin/vllm_tt/worker.py
@@ -214,7 +214,9 @@ class TTWorker:
         kv_cache_spec = self.model_runner.get_kv_cache_spec()
         for layer_name, layer_spec in kv_cache_spec.items():
             if isinstance(layer_spec, AttentionSpec):
-                dtype = layer_spec.dtype
+                # spec dtype may be a 1-byte accounting dtype that isn't
+                # transferable; this placeholder uses the real cache dtype.
+                dtype = self.cache_dtype
 
                 # Use an empty tensor instead of `None`` to force Dynamo to pass
                 # it by reference, rather by specializing on the value ``None``.

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -20,6 +20,7 @@ from utils import resolve_display_name, sanitize_model_name
 #   TT_BENCHMARK_TEMPERATURE=<float>      default 0.0 (greedy)
 #   TT_BENCHMARK_CPU_SAMPLING=1           default 0 (device sampling)
 #   TT_BENCHMARK_MAX_MODEL_LEN=<int>      default 128
+#   TT_BENCHMARK_KV_CACHE_DTYPE=<str>     default "" (e.g. bfp_bf8, bfp_bf4)
 #   _BENCH_OPTIMIZATION_LEVEL=<int>       default 0 (overrides per-test opt level)
 #   TT_BENCHMARK_WEIGHT_DTYPE=<str>       e.g. "bfp_bf8"/"bfp_bf4"/"" (overrides per-test weight dtype)
 #   TT_BENCHMARK_WEIGHT_OVERRIDES=<path>  JSON file of {glob: dtype} per-tensor mixed-precision overrides
@@ -29,6 +30,7 @@ from utils import resolve_display_name, sanitize_model_name
 _BENCH_TEMPERATURE = float(os.environ.get("TT_BENCHMARK_TEMPERATURE", "0.0"))
 _BENCH_CPU_SAMPLING = os.environ.get("TT_BENCHMARK_CPU_SAMPLING", "0") == "1"
 _BENCH_MAX_MODEL_LEN = int(os.environ.get("TT_BENCHMARK_MAX_MODEL_LEN", "128"))
+_BENCH_KV_CACHE_DTYPE = os.environ.get("TT_BENCHMARK_KV_CACHE_DTYPE", "")
 _BENCH_OPTIMIZATION_LEVEL = os.environ.get("_BENCH_OPTIMIZATION_LEVEL")
 _BENCH_WEIGHT_DTYPE = os.environ.get("TT_BENCHMARK_WEIGHT_DTYPE")
 _BENCH_WEIGHT_OVERRIDES = os.environ.get("TT_BENCHMARK_WEIGHT_OVERRIDES")
@@ -64,6 +66,8 @@ def _config(
         additional["cpu_sampling"] = True
     if _BENCH_CPU_SAMPLING:
         additional["cpu_sampling"] = True
+    if _BENCH_KV_CACHE_DTYPE:
+        additional["experimental_kv_cache_dtype"] = _BENCH_KV_CACHE_DTYPE
     additional.update(additional_config_extra)
     if _BENCH_WEIGHT_DTYPE is not None:
         additional["experimental_weight_dtype"] = _BENCH_WEIGHT_DTYPE

--- a/tests/integrations/vllm_plugin/generative/test_opt_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_opt_generation.py
@@ -31,6 +31,39 @@ def test_opt_generation():
 
 @pytest.mark.push
 @pytest.mark.single_device
+@pytest.mark.xfail(
+    reason="experimental_kv_cache_dtype casts the KV cache to BFP8 but leaves the "
+    "query in bf16, and ttnn.paged_scaled_dot_product_attention_decode requires "
+    "Q/K/V to share an element type. See tt-xla #5006.",
+    strict=False,
+)
+def test_opt_generation_kv_cache_bfp8():
+    # Reproduces the experimental_kv_cache_dtype failure on the vLLM decode
+    # path; remove the xfail once tt-xla #5006 is fixed.
+    prompts = [
+        "Hello, my name is",
+    ]
+    sampling_params = vllm.SamplingParams(temperature=0.8, top_p=0.95, max_tokens=32)
+    llm_args = {
+        "model": "facebook/opt-125m",
+        "max_num_batched_tokens": 128,
+        "max_num_seqs": 1,
+        "max_model_len": 128,
+        "gpu_memory_utilization": 0.001,
+        "additional_config": {
+            "enable_const_eval": False,
+            "min_context_len": 32,
+            "experimental_kv_cache_dtype": "bfp_bf8",
+        },
+    }
+    llm = vllm.LLM(**llm_args)
+
+    output_text = llm.generate(prompts, sampling_params)[0].outputs[0].text
+    print(f"prompt: {prompts[0]}, output: {output_text}")
+
+
+@pytest.mark.push
+@pytest.mark.single_device
 def test_opt_generation_multibatch():
     prompts = [
         "Hello, my name is",


### PR DESCRIPTION
### Ticket

#5005 #5006

### Problem description

The tt-mlir `experimental-kv-cache-dtype` compile option (BFP8 KV cache) is now forwarded from `TTConfig`, but vLLM's KV-cache budgeting was unaware that the cache is a compile-time conversion to block-float — it still sized blocks as bf16. So the memory saving was invisible to the engine: longer contexts were rejected at init identically with and without the flag, delivering no benefit. The flag also had no test coverage on the vLLM path.

(There is also a tt-mlir-side decode compile failure — the cache is cast to BFP8 but the query stays bf16, and `ttnn.paged_scaled_dot_product_attention_decode` requires Q/K/V to share an element type. That fix isn't uplifting soon; the xfail test below guards it.)

### What's changed

- `integrations/vllm_plugin/vllm_tt/model_runner.py`: introduce `kv_cache_spec_dtype` — when the flag is set, vLLM's KV-cache spec/budgeting reports a 1-byte dtype (`uint8`) to match the real on-device BFP8 footprint, while the staged/transferred buffer stays bf16 (the dtype the compiler converts to block-float on device). Identity-preserving when the flag is unset. `bfp_bf4` is rejected pending sub-byte page accounting (#5011).
- `integrations/vllm_plugin/vllm_tt/worker.py`: the `determine_available_memory` placeholder tensor uses the real transferable cache dtype rather than the (now 1-byte) spec dtype.
- `tests/benchmark/test_vllm_benchmarks.py`: add a `TT_BENCHMARK_KV_CACHE_DTYPE` knob to exercise the flag and KV budget from the existing matrix.
- `tests/integrations/vllm_plugin/generative/test_opt_generation.py`: add `test_opt_generation_kv_cache_bfp8` (opt-125m, flag on), `xfail(strict=False)` against #5006. Kept non-strict so it won't churn the pipeline whenever the tt-mlir decode fix eventually lands.

### Result (the win)

Llama-3.1-8B, batch 1, single device, `gpu_memory_utilization=0.05` (KV budget 1.59 GiB):

| max_model_len | KV dtype | Result | KV capacity |
|--------------:|----------|--------|-------------|
| 16K | bf16 (default) | ❌ fails at init (needs 2.0 GiB > 1.59) | 13,056 tok |
| 16K | **bfp_bf8** | ✅ fits + runs, coherent output, no preemptions | 26,112 tok |

A 16K context that the bf16 cache rejects now serves end-to-end with the BFP8 cache — confirming the budgeting change makes the device-side saving visible to the engine.

### Checklist

- [x] Llama-3.1-8B 16K fits with bfp_bf8, fails with bf16 at the same budget
- [x] New opt-125m test reports `xfailed`; decode SDPA fix tracked in #5006

