### PR TITLE
Add Gemma-4-31B-it to vLLM benchmarks on QB2 Blackhole

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -792,6 +792,16 @@
         "runs-on": "n300-llmbox"
       },
       {
+        "name": "vllm_gemma4_31b_it_tp",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[gemma4-31b-it-tp]",
+        "vllm": true,
+        "skip-stablehlo-dump": true,
+        "skip-ttir-dump": true,
+        "skip-ttnn-dump": true,
+        "skip-device-perf": true,
+        "runs-on": "qb2-blackhole"
+      },
+      {
         "name": "vllm_qwen2_5_14b_instruct_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen2.5-14b-instruct-tp]",
         "vllm": true,

--- a/tests/benchmark/benchmarks/vllm_benchmark.py
+++ b/tests/benchmark/benchmarks/vllm_benchmark.py
@@ -28,6 +28,15 @@ class VLLMBenchmarkConfig:
     max_model_len: int = 128
     gpu_memory_utilization: float = 0.002
 
+    # Per-modality input caps; zero them (e.g. {"image": 0, "video": 0,
+    # "audio": 0}) to run a multimodal model text-only so its encoder never compiles.
+    limit_mm_per_prompt: Optional[Dict[str, int]] = None
+
+    # Floor for max_num_batched_tokens (effective = max(batch * len, this)).
+    # Some multimodal models need a higher floor (Gemma-4: >= 2560 for the
+    # MultiModalBudget video-frame floor).
+    min_num_batched_tokens: int = 0
+
     # TT compile options passed directly to vLLM's additional_config (TTConfig).
     additional_config: Dict[str, Any] = field(default_factory=dict)
 
@@ -36,6 +45,10 @@ class VLLMBenchmarkConfig:
     max_tokens: int = 128
     warmup_iterations: int = 1
     prompt: str = DEFAULT_PROMPT
+
+    # When True, send `prompt` as a chat message via llm.chat() so the chat
+    # template is applied; instruct models (e.g. Gemma-4-it) degenerate without it.
+    use_chat_template: bool = False
 
     # Sampling params (temperature=0.0 -> greedy)
     temperature: float = 0.0
@@ -62,15 +75,21 @@ def _create_llm(config: VLLMBenchmarkConfig) -> vllm.LLM:
     # tests/benchmark/test_vllm_benchmarks.py).
     additional_config.setdefault("cpu_sampling", False)
 
+    max_num_batched_tokens = max(
+        config.batch_size * config.max_model_len, config.min_num_batched_tokens
+    )
+
     llm_args: Dict[str, Any] = {
         "model": config.model,
         "max_model_len": config.max_model_len,
         "max_num_seqs": config.batch_size,
-        "max_num_batched_tokens": config.batch_size * config.max_model_len,
+        "max_num_batched_tokens": max_num_batched_tokens,
         "gpu_memory_utilization": config.gpu_memory_utilization,
         "disable_log_stats": False,
         "additional_config": additional_config,
     }
+    if config.limit_mm_per_prompt is not None:
+        llm_args["limit_mm_per_prompt"] = config.limit_mm_per_prompt
 
     print(f"Creating vLLM engine for {config.model} ...")
     print(f"  LLM args: {llm_args}")
@@ -185,7 +204,6 @@ def benchmark_vllm(
     display_name: str,
 ) -> Dict[str, Any]:
     """Run a vLLM benchmark and return a standardised result dict."""
-    prompts = [config.prompt] * config.batch_size
     sampling_params = vllm.SamplingParams(
         max_tokens=config.max_tokens,
         ignore_eos=True,
@@ -194,14 +212,29 @@ def benchmark_vllm(
 
     llm = _create_llm(config)
 
+    # chat() applies the model's chat template; generate() feeds the raw
+    # prompt. Same (inputs, sampling_params) -> List[RequestOutput] signature.
+    if config.use_chat_template:
+        inputs = [
+            [{"role": "user", "content": config.prompt}]
+            for _ in range(config.batch_size)
+        ]
+        run_fn = llm.chat
+    else:
+        inputs = [config.prompt] * config.batch_size
+        run_fn = llm.generate
+
+    def _run() -> List[vllm.RequestOutput]:
+        return run_fn(inputs, sampling_params)
+
     if config.warmup_iterations > 0:
         print(f"\nWarming up ({config.warmup_iterations} iteration(s)) ...")
         for _ in range(config.warmup_iterations):
-            llm.generate(prompts, sampling_params)
+            _run()
         print("Warmup complete.")
 
     print(f"\nStarting benchmark ({config.max_tokens} tokens) ...")
-    outputs: List[vllm.RequestOutput] = llm.generate(prompts, sampling_params)
+    outputs: List[vllm.RequestOutput] = _run()
 
     # Print generated text for output-quality inspection.
     for i, output in enumerate(outputs):

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -76,6 +76,33 @@ def _tp_config(
     )
 
 
+def _gemma4_tp_config(model: str, batch_size: int):
+    # Gemma-4 is a multimodal model run text-only on a TP mesh. Mirrors
+    # tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
+    # ::test_tensor_parallel_generation_bhqb_gemma4_31b:
+    #   - limit_mm_per_prompt zeroed so the vision/audio tower never compiles
+    #   - max_num_batched_tokens floored at 2560 (MultiModalBudget video floor)
+    #   - flat_model_io for Gemma-4's PLE forward; use_2d_mesh=False -> 1D mesh
+    cfg = _config(
+        model,
+        batch_size,
+        gpu_memory_utilization=0.1,
+        enable_tensor_parallel=True,
+        use_2d_mesh=False,
+        min_context_len=32,
+        enable_const_eval=True,
+        experimental_weight_dtype="",
+        cpu_sampling=False,
+        flat_model_io=True,
+    )
+    cfg.limit_mm_per_prompt = {"image": 0, "video": 0, "audio": 0}
+    cfg.min_num_batched_tokens = 2560
+    # Gemma-4-it is instruct-tuned; drive via the chat template so it
+    # produces coherent output instead of a degenerate completion loop.
+    cfg.use_chat_template = True
+    return cfg
+
+
 SINGLE_DEVICE_CONFIGS = [
     pytest.param(_config("meta-llama/Llama-3.2-3B", 1), id="llama-3.2-3b"),
     pytest.param(
@@ -137,6 +164,7 @@ TP_CONFIGS = [
     ),
     pytest.param(_tp_config("Qwen/Qwen3-14B", 1), id="qwen3-14b-tp"),
     pytest.param(_tp_config("Qwen/Qwen3-32B", 1), id="qwen3-32b-tp"),
+    pytest.param(_gemma4_tp_config("google/gemma-4-31B-it", 1), id="gemma4-31b-it-tp"),
     pytest.param(
         _tp_config("Qwen/Qwen2.5-14B-Instruct", 1), id="qwen2.5-14b-instruct-tp"
     ),


### PR DESCRIPTION
### Ticket
#4596

### Problem description
- Gemma-4 vLLM support merged today in #4889 but only had generative integration-test coverage. This adds the (passing) Gemma-4-31B model to the vLLM benchmark suite so we get perf/TTFT tracking for it.

### What's changed
- `vllm_benchmark.py`: three opt-in `VLLMBenchmarkConfig` fields — `limit_mm_per_prompt` (run a multimodal model text-only), `min_num_batched_tokens` (floor for `max_num_batched_tokens`; Gemma-4 needs ≥2560 for the `MultiModalBudget`), and `use_chat_template` (drive via `llm.chat()` so instruct models get their chat template — Gemma-4-it degenerates without it).
- `test_vllm_benchmarks.py`: added `_gemma4_tp_config()` mirroring `test_tensor_parallel_generation_bhqb_gemma4_31b` from #4889 (text-only TP, `flat_model_io`, 1D mesh, chat template) plus one `TP_CONFIGS` param, `gemma4-31b-it-tp`.
- `perf-bench-matrix.json`: wired in as `vllm_gemma4_31b_it_tp` on `qb2-blackhole` (TP=4 over a 1x4 mesh); the other vLLM TP benchmarks run on `n300-llmbox`.
- No behavior change for existing models: all three new fields default to off, so every other benchmark resolves to the same engine args and the same `generate()` call as before; the test/matrix edits are purely additive.
- Batch-1 only, like every other TP config in the suite (batched TP currently hits a tt-mlir ingest limit, not specific to Gemma-4).
- Helper kept Gemma-4-specific rather than a generic `_text_only_mm_tp_config`: `flat_model_io` and the 2560 floor are model-specific, and with one caller a generic name would hide that — worth generalizing when a second multimodal model lands.

### Test results
- `gemma4-31b-it-tp` (b1) passes on a 4-chip board (1x4 TP mesh): ~9.1 tok/s/user, ~530 ms TTFT, and with the chat template the output is coherent (vs. the pre-fix `"writing clean code: writing clean code: ..."` loop).

### Checklist
- [x] Passes locally on QB2 Blackhole
- [x] Perf Benchmark for gemma4-31b-it passing on QB2: https://github.com/tenstorrent/tt-xla/actions/runs/26733746882
