### PR TITLE
weight_dtype: make model_name optional in dump_weight_names

### DIFF
--- a/python_package/tt_torch/weight_dtype.py
+++ b/python_package/tt_torch/weight_dtype.py
@@ -136,7 +136,7 @@ def remove_weight_dtype_overrides(model: torch.nn.Module) -> int:
 
 def dump_weight_names(
     model: torch.nn.Module,
-    model_name: str,
+    model_name: Optional[str] = None,
     output_dir: Optional[str] = None,
     default_dtype: str = "bfp_bf8",
 ) -> dict:
@@ -149,8 +149,9 @@ def dump_weight_names(
 
     Args:
         model: The model to inspect.
-        model_name: HuggingFace model name (e.g. "mistralai/Mistral-7B-Instruct-v0.3").
-            The part after '/' is used as the JSON filename.
+        model_name: Optional HuggingFace model name (e.g. "mistralai/Mistral-7B-Instruct-v0.3").
+            The part after '/' is used as the JSON filename when output_dir is set.
+            Required when output_dir is provided.
         output_dir: Optional directory to write the JSON file to.
             The filename is derived from model_name automatically.
         default_dtype: Default dtype string to use for all entries.
@@ -165,6 +166,10 @@ def dump_weight_names(
             result[key] = default_dtype
 
     if output_dir is not None:
+        if model_name is None:
+            raise ValueError(
+                "model_name must be provided when output_dir is set."
+            )
         filename = model_name.split("/")[-1] + ".json"
         output_path = os.path.join(output_dir, filename)
         os.makedirs(output_dir, exist_ok=True)

--- a/tests/torch/test_weight_dtype.py
+++ b/tests/torch/test_weight_dtype.py
@@ -159,3 +159,17 @@ class TestDumpWeightNames:
         assert all(v == "bfp_bf4" for v in result.values())
         assert "model.layers.0.mlp.fc1.weight" in result
         assert "model.layers.1.self_attn.q_proj.weight" in result
+
+    def test_no_model_name_no_output_dir(self):
+        # model_name is optional when output_dir is not set
+        model = SimpleModel()
+        result = dump_weight_names(model)
+        assert "linear1.weight" in result
+        assert "linear2.weight" in result
+
+    def test_output_dir_without_model_name_raises(self):
+        # output_dir without model_name must raise a clear ValueError
+        model = SimpleModel()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with pytest.raises(ValueError, match="model_name must be provided"):
+                dump_weight_names(model, output_dir=tmpdir)


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`dump_weight_names` declared `model_name: str` as a required positional
argument, but the parameter is only used inside the `if output_dir is not None`
branch to derive the output filename. The existing tests in
`TestDumpWeightNames` call `dump_weight_names(model)` and
`dump_weight_names(model, default_dtype="bfp_bf4")` without providing
`model_name`, causing both tests to fail unconditionally with:
`TypeError: dump_weight_names() missing 1 required positional argument: 'model_name'`

### What's changed
- Changed `model_name: str` to `model_name: Optional[str] = None` in
  `dump_weight_names` so it can be called without a model name when no file
  output is needed.
- Added an explicit `ValueError` guard: if `output_dir` is provided but
  `model_name` is `None`, a clear error is raised immediately. All existing
  callers that pass both arguments are unaffected.
- Added two new tests to `TestDumpWeightNames`:
  - `test_no_model_name_no_output_dir`: confirms the function returns a correct
    dict when called with only a model.
  - `test_output_dir_without_model_name_raises`: confirms a `ValueError` is
    raised when `output_dir` is set but `model_name` is omitted.

### Checklist
- [x] New/Existing tests provide coverage for changes