### PR TITLE
Add fusion detection catalog and MLIR fusion-enablement skill

### DIFF
--- a/.claude/skills/enabling-fusions/SKILL.md
+++ b/.claude/skills/enabling-fusions/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: enabling-fusions
+description: Use when turning a missed-fusion candidate into a real tt-mlir MLIR-level fusing pattern — implementing (or un-gating/fixing) a TTIR or TTNN OpRewritePattern so the compiler fuses ops it currently leaves separate. Pairs with the finding-missed-fusions skill, which produces the fusion_todo.yml this skill consumes. Targets tt-mlir MLIR passes only (not the Torch FX path).
+allowed-tools: Bash Read Grep Glob Write Edit Task
+---
+
+# Enabling Fusions (tt-mlir MLIR level)
+
+## Overview
+
+This skill takes a missed-fusion candidate (from `finding-missed-fusions`' `fusion_todo.yml`) and **enables the fusion in tt-mlir** by adding, un-gating, or fixing an MLIR pattern rewrite. It is the "enable them if easy/possible" counterpart to the detection skill.
+
+Scope is deliberately narrow: **tt-mlir MLIR-level fusing only** — the `ttir-fusing` and `ttnn-fusing` passes. The Torch FX `FusionProvider` / composite path in tt-xla is explicitly out of scope.
+
+The deliverable for a successful run is: pattern code (new or modified) + a FileCheck lit test + a built `ttmlir-opt` that passes that test, plus a short summary. **If the candidate is not cheaply doable in MLIR (e.g. it needs a brand-new tt-metal kernel), record why and stop** — don't force it.
+
+## When to Use
+
+- User asks to "enable this fusion", "implement the missed fusion", "fix the fusion that isn't firing", or hands you a `fusion_todo.yml`.
+- After running `finding-missed-fusions`, to act on the highest-priority entries.
+
+When NOT to use:
+- The fusion belongs to the Torch FX / composite path (use `docs/source/fusing_and_composite_ops.md` instead).
+- The candidate's `source` is `torch`/`triton`/`cuda` with no existing TTNN/TTIR target op — that is a kernel feature request, not an MLIR fusing pattern. Record it and stop.
+
+## Inputs
+
+- A `fusion_todo.yml` (whole file or a single `missed_fusions` entry). Each entry already carries the fields this skill branches on:
+  - `dialect_level` — `ttir` or `ttnn` (which pass to extend).
+  - `pass_status` — `no_pass`, `pass_exists_not_fired`, or `gated_off`.
+  - `owning_pass` / `existing_pattern` — present when a catalog pattern already targets this `fused_op`.
+  - `fused_op`, `component_ops`, and per-instance `ttir_segment` / `ttnn_segment` (verbatim IR — reuse directly as FileCheck test input).
+- The tt-mlir source tree at `third_party/tt-mlir/src/tt-mlir/` (pinned commit in `third_party/CMakeLists.txt`).
+- The fusing catalog at [`../finding-missed-fusions/references/ttmlir-fusing-catalog.md`](../finding-missed-fusions/references/ttmlir-fusing-catalog.md) — the same catalog the detection skill uses. Read it first.
+
+## Process
+
+### 1. Triage by `pass_status`
+
+Branch on `pass_status` before writing any code:
+
+| `pass_status` | What it means | Action |
+|---------------|---------------|--------|
+| `gated_off` | A catalog pattern (`existing_pattern`) exists but is behind a disabled build/flag | **Easiest.** Re-run with the gating flag on and confirm it fires. No new code. See step 2a. |
+| `pass_exists_not_fired` | A catalog pattern targets this `fused_op`, but it didn't match this IR | Reproduce, find why the match guard rejected it, and relax/extend the existing pattern. See step 2b. |
+| `no_pass` | No catalog pattern targets this `fused_op` | Scaffold a new `OpRewritePattern`. See step 3. |
+
+Always confirm the candidate isn't already handled by the composite path (catalog "Composite path" section) before doing anything.
+
+### 2a. `gated_off`: flip the flag and verify
+
+The op-model-validated TTNN patterns (SDPA, NLP head ops, split-QKV, TTNN RoPE) need a `TTMLIR_ENABLE_OPMODEL` build plus pass options. Verify the pattern fires once enabled rather than writing code:
+
+```bash
+cd third_party/tt-mlir/src/tt-mlir
+# TTNN-level, op-model-gated pattern (e.g. SDPAFusing):
+build/bin/ttmlir-opt \
+  --ttir-to-ttnn-backend-pipeline="enable-fusing-pass=true" \
+  --mlir-print-local-scope <repro>.mlir | FileCheck <repro>.mlir
+# Or run the standalone pass with explicit options:
+build/bin/ttmlir-opt --ttnn-fusing="enable-op-constraints=true" <repro.ttnn>.mlir
+```
+
+For TTIR gated patterns use the matching options (`ttir-fusing="ttnn-enable-conv2d-with-multiply-pattern=true"` or `enable-permute-matmul-fusion=true`). If it fires, the "fix" is a configuration/pipeline-default change — document which flag is needed and where it should be enabled. If it still doesn't fire, reclassify as `pass_exists_not_fired` and go to 2b.
+
+### 2b. `pass_exists_not_fired`: fix the existing pattern
+
+1. Build a minimal repro `.mlir` from the entry's `ttir_segment` / `ttnn_segment` (verbatim).
+2. Run the owning pass on it (see commands in step 5) and confirm the fusion does *not* happen.
+3. Open the `existing_pattern` class in the owning pass's source (catalog gives the file) and read its `matchAndRewrite` / match guards. Common rejection causes: `hasOneUse()` checks, rank/shape constraints, dtype mismatch, an unexpected intervening op (typecast/reshape) the matcher doesn't look through.
+4. Relax/extend the guard *narrowly* so it accepts this case without over-matching. Add a `lookThrough<...>` for benign intervening ops where the existing code already uses that helper (see `SDPAFusingPattern.cpp`).
+5. Add a positive FileCheck case (step 4) for the newly-covered shape and keep all existing tests green.
+
+### 3. `no_pass`: scaffold a new pattern
+
+1. **Pick the level** using `dialect_level` and the catalog rule of thumb:
+   - **TTIR** (`lib/Dialect/TTIR/Transforms/TTIRFusing.cpp`) for framework-shape fusions (matmul+bias→linear, norms, activations, reductions, RoPE, topk, softmax).
+   - **TTNN** (`lib/Dialect/TTNN/Transforms/TTNNFusing.cpp`) for hardware-op fusions that depend on TTNN ops/layouts/op-model constraints (conv/matmul+activation, SDPA, NLP head ops, split-QKV).
+2. **Choose the anchor op** — the op that terminates the pattern (the one whose result feeds the rest of the graph). Examples from the repo: `AddOp` for conv+bias / matmul+bias, `MultiplyOp` for RMSNorm/SiLU, `DivOp` for softmax, `ReshapeOp` for concat-heads, `MatmulOp` for SDPA. The `OpRewritePattern<AnchorOp>` matches on this type.
+3. **Write the pattern class.** Mirror an existing pattern of similar complexity:
+   - Simple, single-file pattern → add the class directly in the pass `.cpp` next to siblings (see `ConvAddBias`, `TTNNMatmulAndLinearWithActivation`).
+   - Non-trivial pattern (helpers, multi-op walk, op-model validation) → put it in its own `lib/Dialect/TT{IR,NN}/Transforms/Fusing/<Name>Pattern.cpp` with a header under `include/ttmlir/Dialect/TT{IR,NN}/Transforms/Fusing/<Name>Pattern.h` (see `SDPAFusingPattern`, `RoPEFusingPattern`, `SplitQKVFusingPatterns`).
+   - Structure: `matchAndRewrite(AnchorOp srcOp, PatternRewriter &rewriter)` → validate guards (return `failure()` early), build the fused op via `rewriter.create<FusedOp>(...)`, then `rewriter.replaceOp(srcOp, ...)`. Let DCE remove the now-dead component ops.
+   - For TTNN ops with hardware constraints, validate the candidate fused op before committing, exactly as `SDPAFusing`/`NLPConcatHeadsDecodeFusing` do (`IsolatedIRValidationWrapper` / `op_constraint_validation::validateOperation`), and guard the registration with `#ifdef TTMLIR_ENABLE_OPMODEL` + `enableOpConstraints`.
+4. **Register the pattern** in the owning pass's `runOnOperation()`:
+   - TTIR: add `patterns.add<MyFusionPattern>(&getContext());` in `TTIRFusing.cpp` (alongside the existing `patterns.add<...>` block). If it should be optional, add a pass `Option<...>` in `include/ttmlir/Dialect/TTIR/Transforms/Passes.td` and guard the `add` with it.
+   - TTNN: add `patterns.add<MyFusing>(&getContext());` (or `(&getContext(), validationConfig)` for op-model patterns) in `TTNNFusing.cpp`, inside the `#ifdef TTMLIR_ENABLE_OPMODEL` / `enableOpConstraints` block if it needs validation.
+   - Add the new `.cpp` to the dialect's transforms `CMakeLists.txt` if you created a new file.
+
+### 4. Add a FileCheck lit test
+
+Create `test/ttmlir/Dialect/TT{IR,NN}/fusing/<name>.mlir` following the existing tests in those directories:
+
+```mlir
+// RUN: ttmlir-opt -ttir-fusing -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+module {
+  func.func @my_case(%arg0: ..., ...) -> ... {
+    // CHECK-LABEL: func.func @my_case
+    // CHECK: "ttir.<fused_op>"
+    // CHECK-NOT: "ttir.<component_op_a>"
+    // CHECK-NOT: "ttir.<component_op_b>"
+    <verbatim component IR from the fusion_todo.yml ttir_segment/ttnn_segment>
+    return ...
+  }
+}
+```
+
+- Use the entry's verbatim `ttir_segment` / `ttnn_segment` as the function body so the test reflects the real model shape.
+- TTNN-level tests typically run through the backend pipeline: `// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-fusing-pass=true" ...` (see `test/ttmlir/Dialect/TTNN/fusing/resnet_pattern_fusing.mlir`). Add `enable-fusing-conv2d-with-multiply-pattern=true` or other options as the pattern requires.
+- Include at least one **negative** case (a near-miss that must NOT fuse) when the match guards are non-trivial — see `matmul_with_bias_negative.mlir`, `split_query_key_values_and_split_heads_negative.mlir`.
+
+### 5. Build and verify
+
+```bash
+cd third_party/tt-mlir/src/tt-mlir
+# Build just the opt tool (fast iteration):
+cmake --build build --target ttmlir-opt
+
+# Run your new pattern directly on the repro:
+build/bin/ttmlir-opt -ttir-fusing -o /tmp/out.mlir /tmp/repro.mlir   # TTIR
+build/bin/ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-fusing-pass=true" \
+  -o /tmp/out.mlir /tmp/repro.mlir                                    # TTNN pipeline
+FileCheck test/ttmlir/Dialect/TTIR/fusing/<name>.mlir --input-file=/tmp/out.mlir
+
+# Run the lit test suite (or just the fusing dir):
+cmake --build build --target check-ttmlir
+# Targeted: llvm-lit -v build/test/ttmlir/Dialect/TTIR/fusing/<name>.mlir
+```
+
+Op-model-gated TTNN patterns require the build to be configured with `TTMLIR_ENABLE_OPMODEL`; if the current `build/` was not, note that the verification needs an op-model-enabled build.
+
+### 6. Confirm with the detection skill
+
+Regenerate fresh IR for the affected model (or re-dump the repro through the full pipeline) and re-run `finding-missed-fusions`. The fixed candidate should no longer appear in `fusion_todo.yml` — that silence is the success signal, end to end.
+
+## Deliverables
+
+For each enabled fusion, report:
+- The `fused_op`, `dialect_level`, and which path was taken (`gated_off` flag flip / `pass_exists_not_fired` fix / `no_pass` new pattern).
+- Files touched: pattern `.cpp`/`.h`, pass registration, `CMakeLists.txt`, and the FileCheck test path.
+- Number of report `instances` this covers.
+- The exact `ttmlir-opt` + `FileCheck` command used to verify, and whether an op-model build was needed.
+
+If a candidate could not be enabled cheaply (needs a new tt-metal kernel, or the guard relaxation would over-match), say so explicitly and leave the entry for kernel/feature work — do not write a speculative pattern.
+
+## Common Mistakes
+
+- **Writing a new pattern when one already exists.** Always honor `pass_status`: `gated_off` and `pass_exists_not_fired` must reuse `existing_pattern`, not duplicate it.
+- **Choosing the wrong dialect level.** Hardware-op fusions (SDPA, conv/matmul+activation, NLP head ops) belong at TTNN; framework-shape fusions belong at TTIR. The catalog's rule of thumb is authoritative.
+- **Over-matching.** Relaxing a guard so it fuses cases the hardware op can't handle produces silent miscompiles. Add a negative FileCheck case to pin the boundary.
+- **Skipping op-model validation on TTNN patterns.** Constraint-sensitive TTNN ops must be validated before commit (as `SDPAFusing` does) and gated under `TTMLIR_ENABLE_OPMODEL`.
+- **Paraphrasing the test IR.** Use the verbatim `ttir_segment` / `ttnn_segment` from the report so the test reflects a real model shape.
+- **Forcing a theoretical fusion.** A `source: torch|triton|cuda` candidate with no existing target op is a kernel request — record and stop, don't invent a pattern.
+- **Forgetting the CMake entry.** A new `Fusing/<Name>Pattern.cpp` won't compile until it's added to the dialect transforms `CMakeLists.txt`.

--- a/.claude/skills/enabling-fusions/references/ttmlir-fusing-catalog.md
+++ b/.claude/skills/enabling-fusions/references/ttmlir-fusing-catalog.md
@@ -1,0 +1,7 @@
+# tt-mlir Fusing Catalog (shared)
+
+This skill reuses the **single canonical** fusing catalog maintained by the detection skill, to avoid divergence between detect and enable:
+
+[`../../finding-missed-fusions/references/ttmlir-fusing-catalog.md`](../../finding-missed-fusions/references/ttmlir-fusing-catalog.md)
+
+Read that file for the full list of TTIR (`ttir-fusing`) and TTNN (`ttnn-fusing`) patterns, the op each fuses to, the owning pass, source files, gating flags, and the TTIR-vs-TTNN level rule of thumb. Do not duplicate the catalog here — update the canonical copy and refresh it when the pinned tt-mlir commit (`third_party/CMakeLists.txt`) changes.

--- a/.claude/skills/finding-missed-fusions/SKILL.md
+++ b/.claude/skills/finding-missed-fusions/SKILL.md
@@ -42,13 +42,22 @@ Either may arrive as its own `.mlir` file or as a section inside an execution lo
    - Is it a standalone `.mlir`, or a log with embedded IR (locate the `module { ... }` block)?
    - Does it contain TTIR (`ttir.*` ops) or TTNN (`ttnn.*` ops)? The dialect prefix is the tell.
 2. **Fetch the TTNN op reference**: https://docs.tenstorrent.com/tt-metal/latest/ttnn/_sources/ttnn/api.rst.txt — this is the source of truth for what fused ops exist.
-3. **Scan for direct fusions**: walk the IR for op sequences that match a fused TTNN op (e.g., separate `mean → sub → mul → rsqrt → add` collapsing to `ttnn.layer_norm`). Scan TTIR for the same patterns at the higher level.
-4. **Scan for theoretical fusions**: identify patterns that map to single kernels in torch/triton/cuda (e.g., `matmul → softmax → matmul` → `scaled_dot_product_attention`).
-5. **Cross-reference TTIR ↔ TTNN** when both are available: line up matching `loc(#locNNNN)` references so each `instance` in the report can carry both representations.
-6. **Fan out subagents** for parallel scans across large IR dumps — split by line ranges or by op family. Each subagent returns a partial list of `missed_fusions` entries which you merge.
-7. **Decide**:
-   - Nothing found → return without writing a file. Do nothing.
-   - Found candidates → write `fusion_todo.yml` in the schema below.
+3. **Load the tt-mlir fusing catalog**: read [`references/ttmlir-fusing-catalog.md`](references/ttmlir-fusing-catalog.md). It enumerates every fusion tt-mlir **already implements** at the MLIR level (`ttir-fusing` / `ttnn-fusing`), the op each collapses to, the owning pass, and any gating flag. This is what lets you classify each candidate (see step 7) and avoid reporting fusions the compiler already does.
+4. **Scan for direct fusions**: walk the IR for op sequences that match a fused TTNN op (e.g., separate `mean → sub → mul → rsqrt → add` collapsing to `ttnn.layer_norm`). Scan TTIR for the same patterns at the higher level.
+5. **Scan for theoretical fusions**: identify patterns that map to single kernels in torch/triton/cuda (e.g., `matmul → softmax → matmul` → `scaled_dot_product_attention`).
+6. **Cross-reference TTIR ↔ TTNN** when both are available: line up matching `loc(#locNNNN)` references so each `instance` in the report can carry both representations.
+7. **Classify each candidate against the catalog** to populate the actionability fields (`dialect_level`, `pass_status`, `owning_pass`, `existing_pattern`):
+   - Decide `dialect_level` (`ttir` vs `ttnn`) per the catalog's rule of thumb — framework-shape fusions at TTIR, hardware-op fusions at TTNN.
+   - Match the candidate's `component_ops` / motif against the catalog. Set `pass_status` to:
+     - `no_pass` — no catalog pattern targets this `fused_op` → a new MLIR pattern is needed.
+     - `pass_exists_not_fired` — a catalog pattern targets this `fused_op` and the IR shape looks eligible, yet the ops are still separate → an existing-pattern gap/bug.
+     - `gated_off` — a catalog pattern exists but is behind a disabled flag/build (e.g. the op-model-gated TTNN patterns, or `conv2dWithMultiplyEnabled` / `permuteMatmulEnabled` / `enableRoPEFusion`).
+   - When `pass_status != no_pass`, record `owning_pass` (`ttir-fusing` / `ttnn-fusing`) and `existing_pattern` (the catalog pattern class name).
+8. **Fan out subagents** for parallel scans across large IR dumps — split by line ranges or by op family. Each subagent returns a partial list of `missed_fusions` entries which you merge.
+9. **Prioritize**: sort `missed_fusions` by number of `instances` (descending) so the highest-impact gaps appear first. The count drives whether a fusion is worth implementing.
+10. **Decide**:
+    - Nothing found → return without writing a file. Do nothing.
+    - Found candidates → write `fusion_todo.yml` in the schema below.
 
 ## Output Schema: `fusion_todo.yml`
 
@@ -62,6 +71,10 @@ input:
 missed_fusions:
   - fused_op: ttnn.linear
     source: ttnn                    # one of: ttnn | torch | triton | cuda
+    dialect_level: ttir             # ttir | ttnn — where the fusion should be implemented
+    pass_status: pass_exists_not_fired  # no_pass | pass_exists_not_fired | gated_off
+    owning_pass: ttir-fusing        # required when pass_status != no_pass
+    existing_pattern: MatmulWithBiasFusionPattern  # catalog pattern class; required when pass_status != no_pass
     component_ops:
       - ttnn.matmul
       - ttnn.add
@@ -81,6 +94,9 @@ missed_fusions:
 
   - fused_op: ttnn.layer_norm        # with weight/bias operands
     source: ttnn
+    dialect_level: ttir
+    pass_status: no_pass             # no ttir-fusing pattern for affine adaLN; handled via composite path
+    # owning_pass / existing_pattern omitted because pass_status == no_pass
     component_ops:
       - ttnn.layer_norm              # currently called with operandSegmentSizes = [1, 0, 0]
       - ttnn.add
@@ -107,6 +123,10 @@ missed_fusions:
 
   - fused_op: torch.scaled_dot_product_attention
     source: torch
+    dialect_level: ttnn
+    pass_status: gated_off           # ttnn-fusing SDPAFusing exists but needs TTMLIR_ENABLE_OPMODEL + enableOpConstraints
+    owning_pass: ttnn-fusing
+    existing_pattern: SDPAFusing
     component_ops:
       - ttnn.matmul
       - ttnn.multiply
@@ -140,6 +160,10 @@ missed_fusions:
 | `missed_fusions` | yes | Top-level list of fusion candidates |
 | `fused_op` | yes | Fully qualified target op (e.g., `ttnn.layer_norm`, `torch.scaled_dot_product_attention`) |
 | `source` | yes | `ttnn` (direct fusion) or `torch` / `triton` / `cuda` (theoretical) |
+| `dialect_level` | yes | `ttir` or `ttnn` — the dialect level where this fusion should be implemented. Drives which tt-mlir pass the enable skill extends. Use the catalog's rule of thumb. |
+| `pass_status` | yes | `no_pass` (no tt-mlir pattern exists), `pass_exists_not_fired` (a catalog pattern targets this `fused_op` but didn't fire), or `gated_off` (pattern exists but is behind a disabled build/flag). Set by cross-referencing `references/ttmlir-fusing-catalog.md`. |
+| `owning_pass` | when `pass_status != no_pass` | The catalog pass that owns/should own this fusion: `ttir-fusing` or `ttnn-fusing`. |
+| `existing_pattern` | when `pass_status != no_pass` | The catalog pattern class name (e.g. `SDPAFusing`, `MatmulWithBiasFusionPattern`) that already targets this `fused_op`. |
 | `component_ops` | yes | Ops that should collapse into `fused_op` |
 | `instances` | yes | Every concrete site the pattern was found — count drives prioritization |
 | `instances[].ir_loc` | optional | The MLIR `#loc...` ref(s) covering the segment, comma-separated. Use these to align TTIR ↔ TTNN. |
@@ -150,7 +174,8 @@ missed_fusions:
 ## Common Mistakes
 
 - **Reporting when nothing is missed.** Silence is the success signal. Do not produce an empty `missed_fusions: []` file — produce nothing.
-- **Including fusions the compiler already does.** Verify the IR really shows separate ops, not a fused op printed as its components. For example, a `ttnn.layer_norm` with `operandSegmentSizes = [1, 1, 1]` *already* has weight and bias fused — don't flag it.
+- **Including fusions the compiler already does.** Verify the IR really shows separate ops, not a fused op printed as its components. For example, a `ttnn.layer_norm` with `operandSegmentSizes = [1, 1, 1]` *already* has weight and bias fused — don't flag it. Also cross-check `references/ttmlir-fusing-catalog.md`: if a candidate appears already collapsed via a catalog pattern or the composite path (`tenstorrent.*`), don't report it.
+- **Skipping the catalog classification.** Every entry must carry `dialect_level` and `pass_status`. An entry without these is not actionable by the enable skill. Don't guess — look the `fused_op` up in the catalog.
 - **Skipping the theoretical class.** Even when no TTNN fused op exists, surfacing torch/triton/cuda equivalents prioritizes kernel work.
 - **Free-form output.** No `- start yaml` markers, no prose-only values, no markdown headings inside the file. The YAML must `yaml.safe_load`.
 - **Reporting only one occurrence per pattern.** List *every* instance — the count is what tells the reader whether it's worth fixing.

--- a/.claude/skills/finding-missed-fusions/references/ttmlir-fusing-catalog.md
+++ b/.claude/skills/finding-missed-fusions/references/ttmlir-fusing-catalog.md
@@ -1,0 +1,100 @@
+# tt-mlir Fusing Catalog
+
+Source of truth for **which fusions tt-mlir already implements at the MLIR level**. Use this to decide, for each missed-fusion candidate, whether it needs a brand-new pattern (`no_pass`), an existing pattern that did not fire (`pass_exists_not_fired`), or an existing pattern that is compiled/configured off (`gated_off`).
+
+Paths are relative to the checked-out tt-mlir source at `third_party/tt-mlir/src/tt-mlir/`. The pinned tt-mlir commit lives in `third_party/CMakeLists.txt` (`set(TT_MLIR_VERSION "...")`) — re-derive this catalog if that commit changes substantially.
+
+There are **two MLIR fusing passes**, one per dialect level:
+
+| Pass (pipeline flag) | Dialect level | Source file | When it runs |
+|----------------------|---------------|-------------|--------------|
+| `ttir-fusing` | TTIR (framework-shaped ops, pre-backend) | `lib/Dialect/TTIR/Transforms/TTIRFusing.cpp` | After StableHLO→TTIR conversion |
+| `ttnn-fusing` | TTNN (backend ops, post-lowering, HW-aware) | `lib/Dialect/TTNN/Transforms/TTNNFusing.cpp` | After TTIR→TTNN lowering |
+
+Rule of thumb: framework-shape fusions (matmul+bias→linear, layer/rms norm, activations, RoPE, topk, softmax) live at **TTIR**; hardware-op fusions that depend on TTNN ops/layouts/op-model constraints (conv/matmul + activation, SDPA, NLP head ops, split-QKV) live at **TTNN**.
+
+---
+
+## TTIR-level patterns (`ttir-fusing`)
+
+All registered in `TTIRFusing.cpp` `runOnOperation()`. "Anchor op" = the op type the `OpRewritePattern` matches on (the rewrite's entry point).
+
+| Pattern class | Fuses to (`fused_op`) | Anchor op | Gating | Notes |
+|---------------|----------------------|-----------|--------|-------|
+| `MatmulWithBiasFusionPattern` | `ttir.linear` | `ttir.add` | always on | matmul + bias add → linear with bias operand |
+| `ConvAddBias<Conv2dOp \| ConvTranspose2dOp \| Conv3dOp>` | conv with bias operand | `ttir.add` | always on | folds bias add into conv (sums with existing bias if present) |
+| `ConvTagWeights<Conv2dOp \| Conv3dOp>` | (weight tagging, prep) | conv op | always on | not a fusion per se; tags constant weights |
+| `ReductionWithReshapePattern<Sum \| Mean \| Max \| Min \| Prod \| ReduceAnd \| ReduceOr \| ArgMax>` | keep-dim reduction | the reduction op | always on | reduction + reshape → reduction with `keep_dim` |
+| `SoftmaxFusionPattern` | `ttir.softmax` | `ttir.div` | always on | `div(exp(x), sum(exp(x)))` → softmax |
+| `NumericStableSoftmaxFusionPattern` | `ttir.softmax` | `ttir.div` | always on | numerically-stable (max-subtract) softmax variant |
+| `RMSNormFusionPattern` | `ttir.rms_norm` | `ttir.multiply` | always on | RMSNorm decomposition → rms_norm |
+| `GeluFusionPattern` | `ttir.gelu` | (gelu decomp) | always on | erf/tanh gelu decomposition |
+| `Relu6FusionPattern` | `ttir.relu6` | min/max clamp | always on | clamp(0,6) → relu6 |
+| `SiluFusionPattern` | `ttir.silu` | `ttir.multiply` | always on | `x * sigmoid(x)` → silu |
+| `HardsigmoidFusionPattern` | `ttir.hardsigmoid` | clamp pattern | always on | |
+| `MishFusingPattern` | `ttir.mish` | mish decomp | always on | |
+| `ReluFusionPattern` | `ttir.relu` | `ttir.maximum` | always on | `maximum(x, 0)` → relu |
+| `ScaledSumToMeanPattern` | `ttir.mean` | `ttir.multiply` | always on | `sum(x) * (1/N)` → mean |
+| `SpatialMeanOptimizationPattern` | optimized `ttir.mean` | `ttir.mean` | always on | rank-4 spatial (HxW) mean optimization |
+| `ConcatenateHeadsUpdatePattern` | concatenate-heads form | `ttir.reshape` | always on | attention head concat reshape |
+| `RepVGGConvSumFusionPattern` | fused conv sum | sum/add | always on | RepVGG conv-branch sum |
+| `SharedLHSMatmulFusion<MatmulOp \| LinearOp>` | shared-LHS matmul | matmul/linear | always on | merges matmuls that share an LHS operand |
+| `ReshapeBroadcastReshapeToRepeatPattern` | `ttir.repeat` | `ttir.reshape` | always on | reshape→broadcast→reshape → repeat |
+| `fusing::RoPERotateHalfFusingPattern` | `ttir.rotary_embedding` (RoPE) | rotate-half motif | always on | rotate_half RoPE |
+| `fusing::RoPEComplexRotationFusingPattern` | RoPE | complex-rotation motif | always on | complex-multiply RoPE variant |
+| `fusing::TopKFusingPattern` | `ttir.topk` | topk motif | always on | (header `Transforms/Fusing/TopKFusingPattern.h`) |
+| `ConvWithMultiply<Conv2dOp \| ConvTranspose2dOp>` | conv with scale | `ttir.multiply` | **gated**: `conv2dWithMultiplyEnabled` (default **false**) | fold scale into conv |
+| `BatchNormDecomposition` | decomposed BN | batch_norm | **gated**: `conv2dWithMultiplyEnabled` (default **false**) | |
+| `PermuteMatmulFusionPattern<MatmulOp \| LinearOp>` | matmul w/ transpose attr | `ttir.permute` | **gated**: `permuteMatmulEnabled` (default **false**) | fold permute into matmul transpose_a/b |
+
+RoPE / TopK pattern bodies live in `lib/Dialect/TTIR/Transforms/Fusing/{RoPEFusingPattern,TopKFusingPattern}.cpp` with headers under `include/ttmlir/Dialect/TTIR/Transforms/Fusing/`.
+
+Pass options (from `include/ttmlir/Dialect/TTIR/Transforms/Passes.td`):
+- `ttnn-enable-conv2d-with-multiply-pattern` (`conv2dWithMultiplyEnabled`, default false)
+- `enable-permute-matmul-fusion` (`permuteMatmulEnabled`, default false)
+
+---
+
+## TTNN-level patterns (`ttnn-fusing`)
+
+Registered in `TTNNFusing.cpp` `runOnOperation()`.
+
+| Pattern class | Fuses to (`fused_op`) | Anchor op | Gating | Notes |
+|---------------|----------------------|-----------|--------|-------|
+| `TTNNConv2dWithActivation<ReluOp \| Relu6Op \| SiluOp \| SigmoidOp>` | `ttnn.conv2d` w/ activation in `Conv2dConfig` | `ttnn.conv2d` | always on | folds following activation (and optional reshape) into conv config |
+| `TTNNMatmulAndLinearWithActivation<{Matmul,Linear} × {Sigmoid,Silu,Gelu}>` | `ttnn.matmul`/`ttnn.linear` w/ `activation` attr | matmul/linear | always on | folds following activation into the op's `activation` attribute |
+| `fusing::SDPAFusing` | `ttnn.scaled_dot_product_attention` / `...attention_decode` | `ttnn.matmul` (the AV matmul) | **gated**: `TTMLIR_ENABLE_OPMODEL` build + `enableOpConstraints` | matmul→(scale)→softmax→matmul → SDPA; validates via op-model. Source: `Transforms/Fusing/SDPAFusingPattern.cpp` |
+| `NLPConcatHeadsDecodeFusing` | `ttnn.nlp_concat_heads_decode` | `ttnn.reshape` | **gated**: `TTMLIR_ENABLE_OPMODEL` + `enableOpConstraints` | decode-phase permute+reshape head concat (seq_len==1, tile-aligned) |
+| `fusing::SplitQueryKeyValueAndSplitHeadsFusing<MatmulOp \| LinearOp>` | `ttnn.split_query_key_value_and_split_heads` | matmul/linear | **gated**: `TTMLIR_ENABLE_OPMODEL` + `enableOpConstraints` | fused QKV projection + head split. Source: `Transforms/Fusing/SplitQKVFusingPatterns.cpp` |
+| `fusing::NLPCreateQKVHeadsDecodeFusing` | `ttnn.nlp_create_qkv_heads_decode` | (QKV head create motif) | **gated**: `TTMLIR_ENABLE_OPMODEL` + `enableOpConstraints` | decode-phase QKV head creation |
+| `fusing::RoPERotateHalfFusing` / `RoPEExpandedFusing` / `RoPEDecodeFusing` | RoPE ttnn op | RoPE motifs | **gated**: `TTMLIR_ENABLE_OPMODEL` + `enableOpConstraints` + `enableRoPEFusion` (default **false**; RoPE normally done at TTIR) | Source: `Transforms/Fusing/RoPEFusingPattern.cpp` |
+| `TypecastOp::getCanonicalizationPatterns` | (cleanup) | `ttnn.typecast` | always on | folds consecutive typecasts so other patterns match cleanly |
+
+Pass options (from `include/ttmlir/Dialect/TTNN/Transforms/Passes.td`):
+- `enable-op-constraints` (`enableOpConstraints`, default false) — required for the op-model-validated patterns above; only effective in a `TTMLIR_ENABLE_OPMODEL` build.
+- `max-fallback-attempts` (`maxFallbackAttempts`, default 10000)
+- `enable-rope-fusion` (`enableRoPEFusion`, default false)
+
+The op-model-gated TTNN patterns are wrapped in `#ifdef TTMLIR_ENABLE_OPMODEL ... if (enableOpConstraints) { ... }`. If a candidate matches one of these but is not firing, the most likely cause is `gated_off` (build/pass not configured with op constraints), not a missing pattern.
+
+---
+
+## Composite path (not `ttir-fusing`)
+
+Some high-level ops reach TTIR as **StableHLO composites** (`tenstorrent.<op>`), wrapped on the tt-xla side and legalized by `lib/Conversion/StableHLOToTTIR/StableHLOLegalizeCompositePass.cpp` (and `StableHLOToTTIRPatterns.cpp`), **not** by `ttir-fusing`. Known composite names include `tenstorrent.gelu`, `tenstorrent.rms_norm`, `tenstorrent.layer_norm`, `tenstorrent.topk`, `tenstorrent.scaled_dot_product_attention`.
+
+Implication for detection: if the IR shows these ops already collapsed (or shows the `tenstorrent.*` composite), the fusion is already handled via the composite path — do **not** report it. A `layer_norm` that appears as separate `mean/sub/mul/rsqrt/add` with no composite marker and no `ttir.layer_norm` is still a real candidate, but its owner is the composite/Torch-FX path rather than `ttir-fusing` (note this in the report; it is out of scope for the MLIR enable skill).
+
+---
+
+## How to refresh this catalog
+
+```bash
+cd third_party/tt-mlir/src/tt-mlir
+# TTIR pattern registrations:
+rg -n "patterns\.add<" lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+# TTNN pattern registrations:
+rg -n "patterns\.add<" lib/Dialect/TTNN/Transforms/TTNNFusing.cpp
+# Pass options / gating flags:
+rg -n "def TTIRFusing|def TTNNFusing" -A40 include/ttmlir/Dialect/TTIR/Transforms/Passes.td include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+```


### PR DESCRIPTION
### Problem description
No systematic way to find a model's missed op fusions or tell whether each needs a flag, a pattern tweak, a new MLIR pattern, or a kernel.

### What's changed
- `finding-missed-fusions` (improved): audits TTIR/TTNN, writes `fusion_todo.yml`, classifies each candidate (`dialect_level` / `pass_status` / `owning_pass` / `existing_pattern`).
- `ttmlir-fusing-catalog.md` (new): source of truth for fusions tt-mlir already does — powers the classification.
- `enabling-fusions` (new): turns an actionable entry into a real tt-mlir pattern (scaffold, register, FileCheck, re-verify).

### Validation
Exercised end-to-end on YOLOv4: found the where-form LeakyReLU the old matcher missed, enabled it (70 `ttnn.leaky_relu` fired), **+37% throughput** (13.82 → 18.97 samples/s); correctly punted conv+mish/leaky_relu to kernel requests.

### Checklist
- [x] New/Existing tests provide coverage for changes


I have attached the logs for your reference:
[yolov4_after_clean.log](https://github.com/user-attachments/files/28451880/yolov4_after_clean.log)
[yolov4_before_clean.log](https://github.com/user-attachments/files/28451881/yolov4_before_clean.log)
