### PR TITLE
[vLLM]: pad_attention_heads + Gemma-4-31B on n300_llmbox 1D 8-chip mesh

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -590,6 +590,18 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         if padded_q == orig_q and padded_kv == orig_kv:
             return None
 
+        # force_equal + padded_kv > orig_kv*c (i.e. c=k replication doesn't
+        # fill padded_kv and we'd zero-pad on top) hangs at first decode on
+        # llmbox; fail fast instead. See #5015.
+        if force_equal and padded_kv > orig_kv * best["c"]:
+            raise NotImplementedError(
+                f"pad_attention_heads_force_equal=True with orig_kv={orig_kv}, "
+                f"c={best['c']}, heads_axis={heads_axis} would zero-pad "
+                f"{padded_kv - orig_kv * best['c']} KV heads on top of c=k "
+                f"replication (padded_kv={padded_kv}). Known to hang at first "
+                f"decode on llmbox (#5015)."
+            )
+
         return {
             "orig_q": orig_q,
             "orig_kv": orig_kv,

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -17,9 +17,10 @@ import torch_xla
 import torch_xla.core.xla_model as xm
 import torch_xla.distributed.spmd as xs
 import torch_xla.runtime as xr
-import vllm.envs as envs
 from tt_torch.sharding import sharding_constraint_tensor
 from tt_torch.utils import torch_dynamo_tt_device_compatibility
+
+import vllm.envs as envs
 from vllm.compilation.wrapper import TorchCompileWithNoGuardsWrapper
 from vllm.config import (
     ParallelConfig,
@@ -261,7 +262,9 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             if self.use_2d_mesh and 1 in mesh_shape:
                 self.use_2d_mesh = False
 
-            self._maybe_pad_attention_heads(vllm_config, mesh_shape[0])
+            # QKV is sharded ("model", "batch"); heads land on the "model" axis.
+            heads_axis_size = mesh_shape[self.mesh.axis_names.index("model")]
+            self._maybe_pad_attention_heads(vllm_config, heads_axis_size)
 
         self.enforce_eager = model_config.enforce_eager
 
@@ -546,36 +549,18 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             self._original_num_layers = original_num_layers
             self._target_num_layers = target_num_layers
 
-    def _maybe_pad_attention_heads(self, vllm_config, batch_axis: int) -> None:
-        """Pad num_attention_heads / num_key_value_heads so that num_kv_heads
-        is a multiple of batch_axis. Two strategies are considered per padding
-        decision and the cheaper one (in qkv-projection size) is chosen:
-
-        - "Preserve ratio" (c=1): keep the original GQA ratio k, zero-pad both
-          Q and KV. pad_kv = next mult of batch_axis >= orig_kv. pad_q = pad_kv * k.
-        - "Replicate KV" (c>1): replicate each original KV head c times where
-          c divides k. New GQA ratio m = k / c. pad_kv = next mult of batch_axis
-          >= orig_kv * c. pad_q = pad_kv * m (typically much smaller than the
-          preserve-ratio case for MQA / small-ratio GQA models).
-
-        In both cases the original q->kv mapping is preserved for real q heads:
-        each q_idx in [0, orig_q) attends to (a copy of) the same orig kv head
-        it would have attended to without padding. Padded q heads attend to
-        zero-padded kv heads and produce zero outputs (zero-rows in o_proj).
+    @staticmethod
+    def _compute_head_pad_decision(
+        orig_q, orig_kv, head_dim, heads_axis, force_equal=False
+    ):
+        """Pick the cheapest pad_q / pad_kv such that pad_kv is a multiple of
+        heads_axis and the q->kv mapping is preserved for real heads. Returns
+        None if no padding is needed. ``force_equal=True`` restricts to c=k
+        (pad_q == pad_kv) — workaround for #5015.
         """
-        if not self.tt_config.pad_attention_heads:
-            return
-        if getattr(vllm_config.model_config, "use_mla", False):
-            return
-
-        hf_config = vllm_config.model_config.hf_config
-        orig_q = hf_config.num_attention_heads
-        orig_kv = getattr(hf_config, "num_key_value_heads", None) or orig_q
-
-        assert orig_q % orig_kv == 0, (
-            f"GQA ratio must be an integer: num_attention_heads={orig_q}, "
-            f"num_key_value_heads={orig_kv}"
-        )
+        assert (
+            orig_q % orig_kv == 0
+        ), f"GQA ratio must be an integer: q={orig_q}, kv={orig_kv}"
         k = orig_q // orig_kv
 
         best = None
@@ -583,8 +568,10 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             if k % m != 0:
                 continue
             c = k // m
+            if force_equal and c != k:
+                continue
             min_pad_kv = orig_kv * c
-            pad_kv_candidate = cdiv(min_pad_kv, batch_axis) * batch_axis
+            pad_kv_candidate = cdiv(min_pad_kv, heads_axis) * heads_axis
             pad_q_candidate = pad_kv_candidate * m
             if pad_q_candidate < orig_q:
                 continue
@@ -600,43 +587,90 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         padded_q = best["pad_q"]
         padded_kv = best["pad_kv"]
-        c = best["c"]
-        m = best["m"]
-
         if padded_q == orig_q and padded_kv == orig_kv:
-            return
+            return None
 
-        # NOTE: deliberately NOT mutating hf_config.num_attention_heads,
-        # num_key_value_heads, or head_dim. The model classes derive head_dim
-        # from hidden_size // num_heads (Qwen2.5) or from config.head_dim
-        # (Qwen3, Llama); leaving num_heads at orig means every derivation is
-        # correct and we don't need per-model patches. The padding is applied
-        # post-construction via _surgery_pad_attention_modules.
-        head_dim = getattr(hf_config, "head_dim", None) or (
-            hf_config.hidden_size // orig_q
-        )
-
-        hf_config._tt_head_pad = {
+        return {
             "orig_q": orig_q,
             "orig_kv": orig_kv,
             "padded_q": padded_q,
             "padded_kv": padded_kv,
             "head_dim": head_dim,
-            "kv_replication_factor": c,
+            "kv_replication_factor": best["c"],
+            "_gqa_ratio_post": best["m"],
         }
 
-        logger.info(
-            "[TT] Padding attention heads to align with batch_axis=%d: "
-            "num_attention_heads %d->%d, num_key_value_heads %d->%d "
-            "(kv_replication_factor=%d, new GQA ratio=%d)",
-            batch_axis,
-            orig_q,
-            padded_q,
-            orig_kv,
-            padded_kv,
-            c,
-            m,
+    def _maybe_pad_attention_heads(self, vllm_config, heads_axis: int) -> None:
+        """Pad num_attention_heads / num_key_value_heads so num_kv_heads is a
+        multiple of heads_axis. See _compute_head_pad_decision for the two
+        strategies and the cost function.
+
+        Models with two attention configurations (e.g. Gemma-4: sliding uses
+        num_key_value_heads/head_dim, full uses num_global_key_value_heads/
+        global_head_dim) get one spec per configuration, stored as a list on
+        hf_config._tt_head_pad_specs. Surgery picks the matching spec per
+        module by (attn.num_kv_heads, attn.head_size).
+
+        Does NOT mutate num_heads/num_kv_heads/head_dim on the HF config —
+        model classes derive head_dim from those, so we leave them at orig
+        and apply padding post-construction in _surgery_pad_attention_modules.
+        """
+        if not self.tt_config.pad_attention_heads:
+            return
+        if getattr(vllm_config.model_config, "use_mla", False):
+            return
+
+        hf_config = vllm_config.model_config.hf_config
+        # Multimodal models (e.g. Gemma-4) nest text-side attrs under text_config.
+        head_config = hf_config
+        if not hasattr(head_config, "num_attention_heads"):
+            head_config = getattr(head_config, "text_config", head_config)
+        orig_q = head_config.num_attention_heads
+        default_kv = getattr(head_config, "num_key_value_heads", None) or orig_q
+        default_hd = getattr(head_config, "head_dim", None) or (
+            head_config.hidden_size // orig_q
         )
+
+        # Each (kv-count attr, head-dim attr, log label) tuple defines a
+        # distinct attention configuration. Most models only expose the
+        # first; Gemma-4-style configs add the second for full-attention.
+        configurations = [
+            ("num_key_value_heads", "head_dim", ""),
+            ("num_global_key_value_heads", "global_head_dim", "GLOBAL "),
+        ]
+        force_equal = self.tt_config.pad_attention_heads_force_equal
+        specs = []
+        seen = set()
+        for kv_attr, hd_attr, label in configurations:
+            kv = getattr(head_config, kv_attr, None) or default_kv
+            hd = getattr(head_config, hd_attr, None) or default_hd
+            if (kv, hd) in seen:
+                continue
+            seen.add((kv, hd))
+            spec = self._compute_head_pad_decision(
+                orig_q, kv, hd, heads_axis, force_equal=force_equal
+            )
+            if spec is None:
+                continue
+            specs.append(spec)
+            logger.warning(
+                "[TT] Padding %sattention heads (heads_axis=%d, head_dim=%d): "
+                "%s %d->%d, num_attention_heads %d->%d "
+                "(kv_replication_factor=%d, new GQA ratio=%d)",
+                label,
+                heads_axis,
+                spec["head_dim"],
+                kv_attr,
+                spec["orig_kv"],
+                spec["padded_kv"],
+                spec["orig_q"],
+                spec["padded_q"],
+                spec["kv_replication_factor"],
+                spec["_gqa_ratio_post"],
+            )
+
+        if specs:
+            hf_config._tt_head_pad_specs = specs
 
     def _filter_weights_for_layer_override(self, weights_iterator):
         """Filter weights to only include layers that exist in the modified model."""
@@ -684,40 +718,73 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             f"Weight filtering complete: kept {kept_count} weights, skipped {skipped_count} weights"
         )
 
-    def _surgery_pad_attention_modules(self, model, pad_spec):
-        """Walk the loaded model and surgically pad each attention module's
-        qkv_proj, o_proj, and inner Attention.
+    def _surgery_pad_attention_modules(self, model, specs):
+        """Walk the loaded model and pad each attention module to its matching
+        spec (by attn.num_kv_heads + attn.head_size). Modules with no match
+        are left untouched.
 
-        Runs after the model has been constructed with the original head counts
-        (so each model class derives head_dim correctly) and after weights have
-        been loaded into the orig-shape Linears. For each parent that exposes
-        qkv_proj + o_proj + attn:Attention:
+        For each matched module: pad qkv_proj.weight/bias on the head dim
+        (Q zero-padded, K/V replicated c× then zero-padded), pad o_proj
+        weight on the input dim, then update head-count attrs on qkv_proj,
+        o_proj, parent, and the inner Attention/impl so SDPA + KV cache
+        spec see the padded counts. head_dim and scaling are unchanged.
+        """
+        from vllm.model_executor.layers.attention.attention import Attention
 
-        1. Pad qkv_proj.weight (and bias) on the head dim — Q is zero-padded,
-           K/V are per-head replicated c times then zero-padded if needed.
-        2. Pad o_proj.weight input dim with zero columns for the new q heads.
-        3. Update qkv_proj.output_sizes (read by XlaQKVParallelLinear at line
-           153 of vllm_distributed_utils.py to split into independent q/k/v).
-        4. Update parent attrs: num_heads, num_kv_heads, q_size, kv_size,
-           total_num_heads, total_num_kv_heads.
-        5. Update inner Attention attrs (num_heads, num_kv_heads) and its
-           impl's attrs so SDPA and the KV cache spec see padded counts.
+        if not specs:
+            return
 
-        head_dim and scaling are unchanged.
+        applied = {}
+        for _, parent in model.named_modules():
+            qkv_proj = getattr(parent, "qkv_proj", None)
+            o_proj = getattr(parent, "o_proj", None)
+            attn = getattr(parent, "attn", None)
+            if qkv_proj is None or o_proj is None or not isinstance(attn, Attention):
+                continue
+            spec = next(
+                (
+                    s
+                    for s in specs
+                    if s["orig_kv"] == attn.num_kv_heads
+                    and s["head_dim"] == attn.head_size
+                ),
+                None,
+            )
+            if spec is None:
+                continue
+            self._apply_head_pad_to_module(qkv_proj, o_proj, attn, parent, spec)
+            key = (spec["orig_kv"], spec["head_dim"])
+            applied[key] = applied.get(key, 0) + 1
+
+        for spec in specs:
+            count = applied.get((spec["orig_kv"], spec["head_dim"]), 0)
+            logger.warning(
+                "[TT] Surgery padded %d attention module(s) [head_dim=%d]: "
+                "num_attention_heads %d->%d, num_key_value_heads %d->%d "
+                "(kv_replication_factor=%d)",
+                count,
+                spec["head_dim"],
+                spec["orig_q"],
+                spec["padded_q"],
+                spec["orig_kv"],
+                spec["padded_kv"],
+                spec["kv_replication_factor"],
+            )
+
+    @staticmethod
+    def _apply_head_pad_to_module(qkv_proj, o_proj, attn, parent, spec):
+        """Apply ``spec`` to a single attention module — pad weights/biases
+        and update head-count attributes. Pure tensor surgery; no XLA/SPMD
+        annotations (those happen later in shard_model).
         """
         import torch.nn.functional as F
 
-        from vllm.model_executor.layers.attention.attention import Attention
-
-        orig_q = pad_spec["orig_q"]
-        orig_kv = pad_spec["orig_kv"]
-        padded_q = pad_spec["padded_q"]
-        padded_kv = pad_spec["padded_kv"]
-        head_dim = pad_spec["head_dim"]
-        c = pad_spec.get("kv_replication_factor", 1)
-
-        if padded_q == orig_q and padded_kv == orig_kv:
-            return
+        orig_q = spec["orig_q"]
+        orig_kv = spec["orig_kv"]
+        padded_q = spec["padded_q"]
+        padded_kv = spec["padded_kv"]
+        head_dim = spec["head_dim"]
+        c = spec["kv_replication_factor"]
 
         pad_q_rows = (padded_q - orig_q) * head_dim
         q_size_orig = orig_q * head_dim
@@ -728,116 +795,73 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         def pad_dim0(t, amount):
             if amount == 0:
                 return t
-            if t.ndim == 1:
-                return F.pad(t, (0, amount))
-            return F.pad(t, (0, 0, 0, amount))
+            return F.pad(t, (0, amount) if t.ndim == 1 else (0, 0, 0, amount))
 
-        def pad_dim1(t, amount):
-            if amount == 0:
-                return t
-            return F.pad(t, (0, amount, 0, 0))
-
-        def replicate_then_zero_pad_kv(t):
-            expected_rows = orig_kv * head_dim
-            if t.shape[0] != expected_rows:
+        def pad_kv(t):
+            # Replicate each original KV head c× then zero-pad to padded_kv.
+            # Falls back to plain zero-pad if shape doesn't match (defensive
+            # for biases of unexpected shape).
+            if t.shape[0] != kv_size_orig:
                 return pad_dim0(t, (padded_kv - orig_kv) * head_dim)
             per_head = t.view(orig_kv, head_dim, *t.shape[1:])
             if c > 1:
                 per_head = per_head.repeat_interleave(c, dim=0)
             flat = per_head.reshape(orig_kv * c * head_dim, *t.shape[1:])
-            zero_rows = (padded_kv - orig_kv * c) * head_dim
-            return pad_dim0(flat, zero_rows)
+            return pad_dim0(flat, (padded_kv - orig_kv * c) * head_dim)
 
         def pad_qkv_packed(t):
-            q_part = t[:q_size_orig]
-            k_part = t[q_size_orig : q_size_orig + kv_size_orig]
-            v_part = t[q_size_orig + kv_size_orig : q_size_orig + 2 * kv_size_orig]
-            return torch.cat(
-                [
-                    pad_dim0(q_part, pad_q_rows),
-                    replicate_then_zero_pad_kv(k_part),
-                    replicate_then_zero_pad_kv(v_part),
-                ],
-                dim=0,
-            )
+            q = t[:q_size_orig]
+            k = t[q_size_orig : q_size_orig + kv_size_orig]
+            v = t[q_size_orig + kv_size_orig : q_size_orig + 2 * kv_size_orig]
+            return torch.cat([pad_dim0(q, pad_q_rows), pad_kv(k), pad_kv(v)], dim=0)
 
-        found = 0
-        for name, parent in model.named_modules():
-            qkv_proj = getattr(parent, "qkv_proj", None)
-            o_proj = getattr(parent, "o_proj", None)
-            attn = getattr(parent, "attn", None)
-            if qkv_proj is None or o_proj is None:
-                continue
-            if not isinstance(attn, Attention):
-                continue
-
-            # Pad qkv_proj.weight and bias.
-            qkv_proj.weight = nn.Parameter(
-                pad_qkv_packed(qkv_proj.weight.data), requires_grad=False
-            )
-            if qkv_proj.bias is not None:
-                qkv_proj.bias = nn.Parameter(
-                    pad_qkv_packed(qkv_proj.bias.data), requires_grad=False
-                )
-
-            # Update qkv_proj split metadata. output_sizes is what
-            # XlaQKVParallelLinear reads at vllm_distributed_utils.py:153.
-            qkv_proj.output_sizes = [padded_q_size, padded_kv_size, padded_kv_size]
-            new_total_out = sum(qkv_proj.output_sizes)
-            if hasattr(qkv_proj, "output_size"):
-                qkv_proj.output_size = new_total_out
-            if hasattr(qkv_proj, "output_size_per_partition"):
-                qkv_proj.output_size_per_partition = new_total_out
-
-            # Pad o_proj.weight on the input dim (the head-concat side).
-            o_proj.weight = nn.Parameter(
-                pad_dim1(o_proj.weight.data, pad_q_rows), requires_grad=False
-            )
-            if hasattr(o_proj, "input_size"):
-                o_proj.input_size = padded_q_size
-            if hasattr(o_proj, "input_size_per_partition"):
-                o_proj.input_size_per_partition = padded_q_size
-
-            # Update parent attrs used by forward (split sizes, view shapes).
-            parent.num_heads = padded_q
-            parent.num_kv_heads = padded_kv
-            if hasattr(parent, "total_num_heads"):
-                parent.total_num_heads = padded_q
-            if hasattr(parent, "total_num_kv_heads"):
-                parent.total_num_kv_heads = padded_kv
-            if hasattr(parent, "q_size"):
-                parent.q_size = padded_q_size
-            if hasattr(parent, "kv_size"):
-                parent.kv_size = padded_kv_size
-
-            # Update Attention and its impl so SDPA and KV cache spec see the
-            # padded counts. head_size and scaling are unchanged.
-            attn.num_heads = padded_q
-            attn.num_kv_heads = padded_kv
-            impl = getattr(attn, "impl", None)
-            if impl is not None:
-                impl.num_heads = padded_q
-                impl.num_kv_heads = padded_kv
-                if hasattr(impl, "num_queries_per_kv"):
-                    impl.num_queries_per_kv = padded_q // padded_kv
-                # Pad sinks on impl if present.
-                sinks = getattr(impl, "sinks", None)
-                if sinks is not None and sinks.shape[0] == orig_q:
-                    impl.sinks = pad_dim0(sinks, padded_q - orig_q)
-
-            found += 1
-
-        logger.info(
-            "[TT] Surgery padded %d attention module(s): "
-            "num_attention_heads %d->%d, num_key_value_heads %d->%d "
-            "(kv_replication_factor=%d)",
-            found,
-            orig_q,
-            padded_q,
-            orig_kv,
-            padded_kv,
-            c,
+        qkv_proj.weight = nn.Parameter(
+            pad_qkv_packed(qkv_proj.weight.data), requires_grad=False
         )
+        if qkv_proj.bias is not None:
+            qkv_proj.bias = nn.Parameter(
+                pad_qkv_packed(qkv_proj.bias.data), requires_grad=False
+            )
+        # qkv_proj.output_sizes is read by XlaQKVParallelLinear (line 153 of
+        # vllm_distributed_utils.py) to split into independent q/k/v.
+        qkv_proj.output_sizes = [padded_q_size, padded_kv_size, padded_kv_size]
+        new_total = sum(qkv_proj.output_sizes)
+        for attr in ("output_size", "output_size_per_partition"):
+            if hasattr(qkv_proj, attr):
+                setattr(qkv_proj, attr, new_total)
+
+        # o_proj.weight is [hidden, num_heads*head_dim]; pad the input dim.
+        if pad_q_rows:
+            o_proj.weight = nn.Parameter(
+                F.pad(o_proj.weight.data, (0, pad_q_rows, 0, 0)),
+                requires_grad=False,
+            )
+        for attr in ("input_size", "input_size_per_partition"):
+            if hasattr(o_proj, attr):
+                setattr(o_proj, attr, padded_q_size)
+
+        # Parent / Attention / impl attrs used by forward, SDPA, KV cache spec.
+        parent.num_heads = padded_q
+        parent.num_kv_heads = padded_kv
+        for attr, val in (
+            ("total_num_heads", padded_q),
+            ("total_num_kv_heads", padded_kv),
+            ("q_size", padded_q_size),
+            ("kv_size", padded_kv_size),
+        ):
+            if hasattr(parent, attr):
+                setattr(parent, attr, val)
+        attn.num_heads = padded_q
+        attn.num_kv_heads = padded_kv
+        impl = getattr(attn, "impl", None)
+        if impl is not None:
+            impl.num_heads = padded_q
+            impl.num_kv_heads = padded_kv
+            if hasattr(impl, "num_queries_per_kv"):
+                impl.num_queries_per_kv = padded_q // padded_kv
+            sinks = getattr(impl, "sinks", None)
+            if sinks is not None and sinks.shape[0] == orig_q:
+                impl.sinks = pad_dim0(sinks, padded_q - orig_q)
 
     def reset_mm_cache(self) -> None:
         if self.mm_budget:
@@ -2001,13 +2025,13 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             try:
                 model_loader = get_model_loader(self.load_config)
 
-                # The model is constructed with the ORIGINAL num_heads /
-                # num_kv_heads (we do not mutate hf_config), so every model
-                # class derives head_dim correctly. Head padding is applied
-                # post-load via _surgery_pad_attention_modules below.
-                pad_spec = getattr(
+                # Head padding (if any) is applied post-load via surgery —
+                # _maybe_pad_attention_heads has stashed the spec list on
+                # hf_config but left num_heads/num_kv_heads at orig so model
+                # classes derive head_dim correctly during construction.
+                pad_specs = getattr(
                     self.vllm_config.model_config.hf_config,
-                    "_tt_head_pad",
+                    "_tt_head_pad_specs",
                     None,
                 )
                 layer_override_active = (
@@ -2028,8 +2052,8 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                         vllm_config=self.vllm_config, model_config=self.model_config
                     ).eval()
 
-                if pad_spec is not None:
-                    self._surgery_pad_attention_modules(model, pad_spec)
+                if pad_specs is not None:
+                    self._surgery_pad_attention_modules(model, pad_specs)
 
                 replace_modules(model)
                 model = model.to(self.device)
@@ -2711,6 +2735,10 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         if self.enable_tensor_parallel:
             # Shard KV Cache — each entry is [k_cache, v_cache].
+            # NOTE: QKV weight is sharded ("model", "batch") in
+            # vllm_distributed_utils, so K/V projection outputs land on the
+            # "model" axis. Cache heads-axis must match to avoid emitting
+            # sdy.CollectivePermute (tt-mlir #3370, unsupported lowering).
             for kv_pair in self.kv_caches:
                 for cache in kv_pair:
                     assert cache.ndim == 4, "KV cache tensor must be 4D."

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -261,6 +261,8 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             if self.use_2d_mesh and 1 in mesh_shape:
                 self.use_2d_mesh = False
 
+            self._maybe_pad_attention_heads(vllm_config, mesh_shape[0])
+
         self.enforce_eager = model_config.enforce_eager
 
         self.num_xla_graphs = 0
@@ -544,6 +546,98 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             self._original_num_layers = original_num_layers
             self._target_num_layers = target_num_layers
 
+    def _maybe_pad_attention_heads(self, vllm_config, batch_axis: int) -> None:
+        """Pad num_attention_heads / num_key_value_heads so that num_kv_heads
+        is a multiple of batch_axis. Two strategies are considered per padding
+        decision and the cheaper one (in qkv-projection size) is chosen:
+
+        - "Preserve ratio" (c=1): keep the original GQA ratio k, zero-pad both
+          Q and KV. pad_kv = next mult of batch_axis >= orig_kv. pad_q = pad_kv * k.
+        - "Replicate KV" (c>1): replicate each original KV head c times where
+          c divides k. New GQA ratio m = k / c. pad_kv = next mult of batch_axis
+          >= orig_kv * c. pad_q = pad_kv * m (typically much smaller than the
+          preserve-ratio case for MQA / small-ratio GQA models).
+
+        In both cases the original q->kv mapping is preserved for real q heads:
+        each q_idx in [0, orig_q) attends to (a copy of) the same orig kv head
+        it would have attended to without padding. Padded q heads attend to
+        zero-padded kv heads and produce zero outputs (zero-rows in o_proj).
+        """
+        if not self.tt_config.pad_attention_heads:
+            return
+        if getattr(vllm_config.model_config, "use_mla", False):
+            return
+
+        hf_config = vllm_config.model_config.hf_config
+        orig_q = hf_config.num_attention_heads
+        orig_kv = getattr(hf_config, "num_key_value_heads", None) or orig_q
+
+        assert orig_q % orig_kv == 0, (
+            f"GQA ratio must be an integer: num_attention_heads={orig_q}, "
+            f"num_key_value_heads={orig_kv}"
+        )
+        k = orig_q // orig_kv
+
+        best = None
+        for m in range(1, k + 1):
+            if k % m != 0:
+                continue
+            c = k // m
+            min_pad_kv = orig_kv * c
+            pad_kv_candidate = cdiv(min_pad_kv, batch_axis) * batch_axis
+            pad_q_candidate = pad_kv_candidate * m
+            if pad_q_candidate < orig_q:
+                continue
+            cost = pad_q_candidate + 2 * pad_kv_candidate
+            if best is None or cost < best["cost"]:
+                best = {
+                    "pad_q": pad_q_candidate,
+                    "pad_kv": pad_kv_candidate,
+                    "c": c,
+                    "m": m,
+                    "cost": cost,
+                }
+
+        padded_q = best["pad_q"]
+        padded_kv = best["pad_kv"]
+        c = best["c"]
+        m = best["m"]
+
+        if padded_q == orig_q and padded_kv == orig_kv:
+            return
+
+        # NOTE: deliberately NOT mutating hf_config.num_attention_heads,
+        # num_key_value_heads, or head_dim. The model classes derive head_dim
+        # from hidden_size // num_heads (Qwen2.5) or from config.head_dim
+        # (Qwen3, Llama); leaving num_heads at orig means every derivation is
+        # correct and we don't need per-model patches. The padding is applied
+        # post-construction via _surgery_pad_attention_modules.
+        head_dim = getattr(hf_config, "head_dim", None) or (
+            hf_config.hidden_size // orig_q
+        )
+
+        hf_config._tt_head_pad = {
+            "orig_q": orig_q,
+            "orig_kv": orig_kv,
+            "padded_q": padded_q,
+            "padded_kv": padded_kv,
+            "head_dim": head_dim,
+            "kv_replication_factor": c,
+        }
+
+        logger.info(
+            "[TT] Padding attention heads to align with batch_axis=%d: "
+            "num_attention_heads %d->%d, num_key_value_heads %d->%d "
+            "(kv_replication_factor=%d, new GQA ratio=%d)",
+            batch_axis,
+            orig_q,
+            padded_q,
+            orig_kv,
+            padded_kv,
+            c,
+            m,
+        )
+
     def _filter_weights_for_layer_override(self, weights_iterator):
         """Filter weights to only include layers that exist in the modified model."""
         if self._original_num_layers is None or self._target_num_layers is None:
@@ -588,6 +682,161 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         logger.info(
             f"Weight filtering complete: kept {kept_count} weights, skipped {skipped_count} weights"
+        )
+
+    def _surgery_pad_attention_modules(self, model, pad_spec):
+        """Walk the loaded model and surgically pad each attention module's
+        qkv_proj, o_proj, and inner Attention.
+
+        Runs after the model has been constructed with the original head counts
+        (so each model class derives head_dim correctly) and after weights have
+        been loaded into the orig-shape Linears. For each parent that exposes
+        qkv_proj + o_proj + attn:Attention:
+
+        1. Pad qkv_proj.weight (and bias) on the head dim — Q is zero-padded,
+           K/V are per-head replicated c times then zero-padded if needed.
+        2. Pad o_proj.weight input dim with zero columns for the new q heads.
+        3. Update qkv_proj.output_sizes (read by XlaQKVParallelLinear at line
+           153 of vllm_distributed_utils.py to split into independent q/k/v).
+        4. Update parent attrs: num_heads, num_kv_heads, q_size, kv_size,
+           total_num_heads, total_num_kv_heads.
+        5. Update inner Attention attrs (num_heads, num_kv_heads) and its
+           impl's attrs so SDPA and the KV cache spec see padded counts.
+
+        head_dim and scaling are unchanged.
+        """
+        import torch.nn.functional as F
+
+        from vllm.model_executor.layers.attention.attention import Attention
+
+        orig_q = pad_spec["orig_q"]
+        orig_kv = pad_spec["orig_kv"]
+        padded_q = pad_spec["padded_q"]
+        padded_kv = pad_spec["padded_kv"]
+        head_dim = pad_spec["head_dim"]
+        c = pad_spec.get("kv_replication_factor", 1)
+
+        if padded_q == orig_q and padded_kv == orig_kv:
+            return
+
+        pad_q_rows = (padded_q - orig_q) * head_dim
+        q_size_orig = orig_q * head_dim
+        kv_size_orig = orig_kv * head_dim
+        padded_q_size = padded_q * head_dim
+        padded_kv_size = padded_kv * head_dim
+
+        def pad_dim0(t, amount):
+            if amount == 0:
+                return t
+            if t.ndim == 1:
+                return F.pad(t, (0, amount))
+            return F.pad(t, (0, 0, 0, amount))
+
+        def pad_dim1(t, amount):
+            if amount == 0:
+                return t
+            return F.pad(t, (0, amount, 0, 0))
+
+        def replicate_then_zero_pad_kv(t):
+            expected_rows = orig_kv * head_dim
+            if t.shape[0] != expected_rows:
+                return pad_dim0(t, (padded_kv - orig_kv) * head_dim)
+            per_head = t.view(orig_kv, head_dim, *t.shape[1:])
+            if c > 1:
+                per_head = per_head.repeat_interleave(c, dim=0)
+            flat = per_head.reshape(orig_kv * c * head_dim, *t.shape[1:])
+            zero_rows = (padded_kv - orig_kv * c) * head_dim
+            return pad_dim0(flat, zero_rows)
+
+        def pad_qkv_packed(t):
+            q_part = t[:q_size_orig]
+            k_part = t[q_size_orig : q_size_orig + kv_size_orig]
+            v_part = t[q_size_orig + kv_size_orig : q_size_orig + 2 * kv_size_orig]
+            return torch.cat(
+                [
+                    pad_dim0(q_part, pad_q_rows),
+                    replicate_then_zero_pad_kv(k_part),
+                    replicate_then_zero_pad_kv(v_part),
+                ],
+                dim=0,
+            )
+
+        found = 0
+        for name, parent in model.named_modules():
+            qkv_proj = getattr(parent, "qkv_proj", None)
+            o_proj = getattr(parent, "o_proj", None)
+            attn = getattr(parent, "attn", None)
+            if qkv_proj is None or o_proj is None:
+                continue
+            if not isinstance(attn, Attention):
+                continue
+
+            # Pad qkv_proj.weight and bias.
+            qkv_proj.weight = nn.Parameter(
+                pad_qkv_packed(qkv_proj.weight.data), requires_grad=False
+            )
+            if qkv_proj.bias is not None:
+                qkv_proj.bias = nn.Parameter(
+                    pad_qkv_packed(qkv_proj.bias.data), requires_grad=False
+                )
+
+            # Update qkv_proj split metadata. output_sizes is what
+            # XlaQKVParallelLinear reads at vllm_distributed_utils.py:153.
+            qkv_proj.output_sizes = [padded_q_size, padded_kv_size, padded_kv_size]
+            new_total_out = sum(qkv_proj.output_sizes)
+            if hasattr(qkv_proj, "output_size"):
+                qkv_proj.output_size = new_total_out
+            if hasattr(qkv_proj, "output_size_per_partition"):
+                qkv_proj.output_size_per_partition = new_total_out
+
+            # Pad o_proj.weight on the input dim (the head-concat side).
+            o_proj.weight = nn.Parameter(
+                pad_dim1(o_proj.weight.data, pad_q_rows), requires_grad=False
+            )
+            if hasattr(o_proj, "input_size"):
+                o_proj.input_size = padded_q_size
+            if hasattr(o_proj, "input_size_per_partition"):
+                o_proj.input_size_per_partition = padded_q_size
+
+            # Update parent attrs used by forward (split sizes, view shapes).
+            parent.num_heads = padded_q
+            parent.num_kv_heads = padded_kv
+            if hasattr(parent, "total_num_heads"):
+                parent.total_num_heads = padded_q
+            if hasattr(parent, "total_num_kv_heads"):
+                parent.total_num_kv_heads = padded_kv
+            if hasattr(parent, "q_size"):
+                parent.q_size = padded_q_size
+            if hasattr(parent, "kv_size"):
+                parent.kv_size = padded_kv_size
+
+            # Update Attention and its impl so SDPA and KV cache spec see the
+            # padded counts. head_size and scaling are unchanged.
+            attn.num_heads = padded_q
+            attn.num_kv_heads = padded_kv
+            impl = getattr(attn, "impl", None)
+            if impl is not None:
+                impl.num_heads = padded_q
+                impl.num_kv_heads = padded_kv
+                if hasattr(impl, "num_queries_per_kv"):
+                    impl.num_queries_per_kv = padded_q // padded_kv
+                # Pad sinks on impl if present.
+                sinks = getattr(impl, "sinks", None)
+                if sinks is not None and sinks.shape[0] == orig_q:
+                    impl.sinks = pad_dim0(sinks, padded_q - orig_q)
+
+            found += 1
+
+        logger.info(
+            "[TT] Surgery padded %d attention module(s): "
+            "num_attention_heads %d->%d, num_key_value_heads %d->%d "
+            "(kv_replication_factor=%d)",
+            found,
+            orig_q,
+            padded_q,
+            orig_kv,
+            padded_kv,
+            c,
         )
 
     def reset_mm_cache(self) -> None:
@@ -1752,27 +2001,36 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             try:
                 model_loader = get_model_loader(self.load_config)
 
-                # If layer override is active, patch the weight loading process
-                if (
+                # The model is constructed with the ORIGINAL num_heads /
+                # num_kv_heads (we do not mutate hf_config), so every model
+                # class derives head_dim correctly. Head padding is applied
+                # post-load via _surgery_pad_attention_modules below.
+                pad_spec = getattr(
+                    self.vllm_config.model_config.hf_config,
+                    "_tt_head_pad",
+                    None,
+                )
+                layer_override_active = (
                     self._original_num_layers is not None
                     and self._target_num_layers is not None
-                ):
-                    # Store reference to original get_all_weights method
+                )
+                if layer_override_active:
                     original_get_all_weights = model_loader.get_all_weights
 
-                    def filtered_get_all_weights(model_config, model):
-                        # Get all weights using the original method
-                        all_weights = original_get_all_weights(model_config, model)
-                        # Filter out weights for non-existent layers
-                        return self._filter_weights_for_layer_override(all_weights)
+                    def transformed_get_all_weights(model_config, model):
+                        weights = original_get_all_weights(model_config, model)
+                        return self._filter_weights_for_layer_override(weights)
 
-                    # Temporarily replace the method
-                    model_loader.get_all_weights = filtered_get_all_weights
+                    model_loader.get_all_weights = transformed_get_all_weights
 
                 with set_current_vllm_config(self.vllm_config):
                     model = model_loader.load_model(
                         vllm_config=self.vllm_config, model_config=self.model_config
                     ).eval()
+
+                if pad_spec is not None:
+                    self._surgery_pad_attention_modules(model, pad_spec)
+
                 replace_modules(model)
                 model = model.to(self.device)
 
@@ -2416,11 +2674,14 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     if self.enable_tensor_parallel:
                         num_kv_heads = kv_cache_spec.num_kv_heads
                         assert self.original_parallel_config is not None
-                        tp_size = self.original_parallel_config.tensor_parallel_size
+                        # KV cache is sharded along the "batch" mesh axis only
+                        # (see mark_sharding call below), so num_kv_heads only
+                        # needs to divide mesh_shape[0], not the full TP product.
+                        batch_axis = self.mesh.mesh_shape[0]
                         # TODO: Handle kv cache duplication under SPMD mode.
-                        assert num_kv_heads % tp_size == 0, (
+                        assert num_kv_heads % batch_axis == 0, (
                             f"num_kv_heads {num_kv_heads} must be divisible by "
-                            f"tp_size {tp_size} under SPMD mode"
+                            f"batch mesh axis {batch_axis} under SPMD mode"
                         )
                     kv_cache_shape = TTAttentionBackend.get_kv_cache_shape(
                         num_blocks,

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -17,10 +17,9 @@ import torch_xla
 import torch_xla.core.xla_model as xm
 import torch_xla.distributed.spmd as xs
 import torch_xla.runtime as xr
+import vllm.envs as envs
 from tt_torch.sharding import sharding_constraint_tensor
 from tt_torch.utils import torch_dynamo_tt_device_compatibility
-
-import vllm.envs as envs
 from vllm.compilation.wrapper import TorchCompileWithNoGuardsWrapper
 from vllm.config import (
     ParallelConfig,

--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional, Union, cast
 
 import torch
-
 from vllm.platforms.interface import Platform, PlatformEnum
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 

--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional, Union, cast
 
 import torch
+
 from vllm.platforms.interface import Platform, PlatformEnum
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
@@ -106,6 +107,12 @@ class TTConfig:
     # PJRT IR export — when set, MLIR is dumped to `export_path` keyed by `export_model_name`.
     export_path: Optional[str] = None
     export_model_name: Optional[str] = None
+
+    # Pad num_attention_heads / num_key_value_heads up to the next multiple of
+    # the "batch" mesh axis size, so models with awkward head counts can be
+    # sharded cleanly. GQA ratio is preserved; padded heads are zero-projected
+    # and contribute nothing to the output.
+    pad_attention_heads: bool = False
 
     def __post_init__(self):
         # tt::sampling + enable_trace + optimization_level >= 1 hits a

--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -109,10 +109,15 @@ class TTConfig:
     export_model_name: Optional[str] = None
 
     # Pad num_attention_heads / num_key_value_heads up to the next multiple of
-    # the "batch" mesh axis size, so models with awkward head counts can be
-    # sharded cleanly. GQA ratio is preserved; padded heads are zero-projected
-    # and contribute nothing to the output.
+    # the heads-sharding mesh axis, so models with awkward head counts can be
+    # sharded cleanly. Padded q heads are zero-projected and contribute nothing
+    # to the output.
     pad_attention_heads: bool = False
+
+    # Force c=k (padded_q == padded_kv) instead of the default min-cost
+    # strategy. Workaround for #5015 (tt-metal concat bug on unequal Q/K/V).
+    # Gemma-4-31B on llmbox 1D 8-chip needs this.
+    pad_attention_heads_force_equal: bool = False
 
     def __post_init__(self):
         # tt::sampling + enable_trace + optimization_level >= 1 hits a

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -89,6 +89,9 @@ def _gemma4_tp_config(model: str, batch_size: int):
         gpu_memory_utilization=0.1,
         enable_tensor_parallel=True,
         use_2d_mesh=False,
+        pad_attention_heads=True,
+        # Workaround for #5015 (drop once the tt-metal concat fix lands).
+        pad_attention_heads_force_equal=True,
         min_context_len=32,
         enable_const_eval=True,
         experimental_weight_dtype="",

--- a/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
@@ -3,8 +3,34 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 from conftest import assert_output_coherent, check_host_memory
+from vllm_tt.model_runner import TTModelRunner
 
 import vllm
+
+
+@pytest.mark.push
+def test_pad_decision_gates_force_equal_with_zero_pad():
+    """force_equal with padded_kv > orig_kv*c is gated (#5015)."""
+    # Qwen2.5-7B + force_equal → gated (orig_kv=4, c=7 → 28 + 4 zero-pad).
+    with pytest.raises(NotImplementedError, match="force_equal"):
+        TTModelRunner._compute_head_pad_decision(
+            orig_q=28, orig_kv=4, head_dim=128, heads_axis=8, force_equal=True
+        )
+    # Qwen2.5-7B without force_equal → min-cost spec.
+    spec = TTModelRunner._compute_head_pad_decision(
+        orig_q=28, orig_kv=4, head_dim=128, heads_axis=8, force_equal=False
+    )
+    assert spec["padded_kv"] == 8 and spec["padded_q"] == 56
+    # Gemma-4-31B sliding (orig_kv=16, c=2) — padded_kv == orig_kv*c, fine.
+    spec = TTModelRunner._compute_head_pad_decision(
+        orig_q=32, orig_kv=16, head_dim=256, heads_axis=8, force_equal=True
+    )
+    assert spec["padded_kv"] == 32 and spec["kv_replication_factor"] == 2
+    # Gemma-4-31B global (orig_kv=4, c=8) — padded_kv == orig_kv*c, fine.
+    spec = TTModelRunner._compute_head_pad_decision(
+        orig_q=32, orig_kv=4, head_dim=512, heads_axis=8, force_equal=True
+    )
+    assert spec["padded_kv"] == 32 and spec["kv_replication_factor"] == 8
 
 
 @pytest.mark.push
@@ -47,12 +73,15 @@ def test_tensor_parallel_generation_n300(model_name: str):
         pytest.param("meta-llama/Llama-3.2-3B", False, id="llama-3.2-3b"),
         # Qwen2.5-7B: min-cost path (k=7, padded_kv 4->8, padded_q 28->56).
         pytest.param("Qwen/Qwen2.5-7B", False, id="qwen2.5-7b"),
-        # Qwen2.5-7B + force_equal hangs at first decode on llmbox (#5015).
+        # Qwen2.5-7B + force_equal hits the NotImplementedError gate (#5015)
+        # at decision time. Skipped (not xfailed) because the gate raises in
+        # the engine subprocess and gets wrapped in RuntimeError; the gate
+        # itself is covered by test_pad_decision_gates_force_equal_with_zero_pad.
         pytest.param(
             "Qwen/Qwen2.5-7B",
             True,
             id="qwen2.5-7b-force-equal",
-            marks=pytest.mark.skip(reason="hangs at first decode (#5015)"),
+            marks=pytest.mark.skip(reason="gated by #5015"),
         ),
     ],
 )

--- a/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
@@ -2,10 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import pytest
+import vllm
 from conftest import assert_output_coherent, check_host_memory
 from vllm_tt.model_runner import TTModelRunner
-
-import vllm
 
 
 @pytest.mark.push

--- a/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
@@ -38,8 +38,26 @@ def test_tensor_parallel_generation_n300(model_name: str):
 @pytest.mark.push
 @pytest.mark.tensor_parallel
 @pytest.mark.llmbox
-@pytest.mark.parametrize("model_name", ["meta-llama/Llama-3.2-3B", "Qwen/Qwen2.5-7B"])
-def test_tensor_parallel_generation_n300(model_name: str, use_2d_mesh: bool):
+@pytest.mark.parametrize(
+    ["model_name", "force_equal"],
+    [
+        # Llama-3.2-3B: num_kv_heads=8 divides 8 → padding is a no-op,
+        # covers the "pad_attention_heads=True on a model that doesn't
+        # need it" path.
+        pytest.param("meta-llama/Llama-3.2-3B", False, id="llama-3.2-3b"),
+        # Qwen2.5-7B: min-cost path (k=7, padded_kv 4->8, padded_q 28->56).
+        pytest.param("Qwen/Qwen2.5-7B", False, id="qwen2.5-7b"),
+        # Qwen2.5-7B + force_equal hangs at first decode on llmbox (#5015).
+        pytest.param(
+            "Qwen/Qwen2.5-7B",
+            True,
+            id="qwen2.5-7b-force-equal",
+            marks=pytest.mark.skip(reason="hangs at first decode (#5015)"),
+        ),
+    ],
+)
+def test_tensor_parallel_generation_llmbox_pad(model_name: str, force_equal: bool):
+    """pad_attention_heads smoke test on llmbox 1D 8-chip mesh."""
     prompts = [
         "Continue in English: I like taking walks in the",
     ]
@@ -55,8 +73,8 @@ def test_tensor_parallel_generation_n300(model_name: str, use_2d_mesh: bool):
             "min_context_len": 32,
             "enable_tensor_parallel": True,
             "use_2d_mesh": False,
-            "num_hidden_layers": 1,
             "pad_attention_heads": True,
+            "pad_attention_heads_force_equal": force_equal,
         },
     }
     llm = vllm.LLM(**llm_args)
@@ -235,6 +253,53 @@ def test_tensor_parallel_generation_bhqb_gemma4_31b(
             "enable_tensor_parallel": True,
             "experimental_weight_dtype": experimental_weight_dtype,
             "use_2d_mesh": use_2d_mesh,
+            "cpu_sampling": False,
+            "flat_model_io": True,
+        },
+    }
+    llm = vllm.LLM(**llm_args)
+
+    output_text = llm.chat(messages, sampling_params)[0].outputs[0].text
+    print(f"output: {output_text}")
+    assert_output_coherent(output_text)
+
+    check_host_memory(model_name)
+
+
+@pytest.mark.nightly
+@pytest.mark.tensor_parallel
+@pytest.mark.llmbox
+def test_tensor_parallel_generation_llmbox_gemma4_31b():
+    """Gemma-4-31B on n300_llmbox 1D 8-chip mesh.
+
+    End-to-end coverage of the full pad_attention_heads stack:
+    force_equal (#5015), per-layer-type spec dispatch (sliding vs
+    full attention configs), and the text_config fallback for
+    multimodal HF configs. Sister of the BHQB 2D-mesh test.
+    """
+    model_name = "google/gemma-4-31B-it"
+
+    messages = [[{"role": "user", "content": "Describe Tenstorrent in one sentence."}]]
+    sampling_params = vllm.SamplingParams(temperature=0.0, top_p=1.0, max_tokens=32)
+    llm_args = {
+        "model": model_name,
+        # Text-only path on a multimodal model: zero every modality so the
+        # mm-encoder graph doesn't compile the vision tower at all.
+        "limit_mm_per_prompt": {"image": 0, "video": 0, "audio": 0},
+        # Gemma-4 mm enforces a floor from MultiModalBudget regardless of
+        # limit_mm_per_prompt; 2560 clears the video-frame floor of 2496.
+        "max_num_batched_tokens": 2560,
+        "max_num_seqs": 1,
+        "max_model_len": 128,
+        "gpu_memory_utilization": 0.1,
+        "additional_config": {
+            "enable_const_eval": True,
+            "min_context_len": 32,
+            "enable_tensor_parallel": True,
+            "experimental_weight_dtype": "",
+            "use_2d_mesh": False,
+            "pad_attention_heads": True,
+            "pad_attention_heads_force_equal": True,
             "cpu_sampling": False,
             "flat_model_io": True,
         },

--- a/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
@@ -2,8 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import pytest
-import vllm
 from conftest import assert_output_coherent, check_host_memory
+
+import vllm
 
 
 @pytest.mark.push
@@ -25,6 +26,37 @@ def test_tensor_parallel_generation_n300(model_name: str):
             "enable_const_eval": False,
             "min_context_len": 32,
             "enable_tensor_parallel": True,
+        },
+    }
+    llm = vllm.LLM(**llm_args)
+
+    output_text = llm.generate(prompts, sampling_params)[0].outputs[0].text
+    print(f"prompt: {prompts[0]}, output: {output_text}")
+    assert_output_coherent(output_text)
+
+
+@pytest.mark.push
+@pytest.mark.tensor_parallel
+@pytest.mark.llmbox
+@pytest.mark.parametrize("model_name", ["meta-llama/Llama-3.2-3B", "Qwen/Qwen2.5-7B"])
+def test_tensor_parallel_generation_n300(model_name: str, use_2d_mesh: bool):
+    prompts = [
+        "Continue in English: I like taking walks in the",
+    ]
+    sampling_params = vllm.SamplingParams(temperature=0.8, top_p=0.95, max_tokens=32)
+    llm_args = {
+        "model": model_name,
+        "max_num_batched_tokens": 32,
+        "max_num_seqs": 1,
+        "max_model_len": 32,
+        "gpu_memory_utilization": 0.002,
+        "additional_config": {
+            "enable_const_eval": False,
+            "min_context_len": 32,
+            "enable_tensor_parallel": True,
+            "use_2d_mesh": False,
+            "num_hidden_layers": 1,
+            "pad_attention_heads": True,
         },
     }
     llm = vllm.LLM(**llm_args)


### PR DESCRIPTION
### Ticket
Closes #5003. Continues from #4881 Initial PR.

### Problem description
Gemma-4-31B requires attention-head padding to run on n300_llmbox's 1D 8-chip TP mesh: its `num_global_key_value_heads=4` doesn't divide the 8-way model axis, and Shardy asserts on the non-divisible factor. Aleks's initial `pad_attention_heads` work (#4881) handles single-config models like Qwen2.5-7B but doesn't cover Gemma-4's two distinct attention configurations (sliding vs full layers) or its multimodal `text_config` nesting. A tt-metal concat program-cache bug also surfaces along the way when padded `[Q;K;V]` are unequal-sized on the sharded axis.

### What's changed

Three commits:

1. **`pad_attention_heads` (Aleks's original).** Pad `num_attention_heads` / `num_key_value_heads` so `num_kv_heads` is a multiple of the TP axis size. Two strategies (min-cost zero-pad and c=k replication); cost function picks the cheapest. Surgery patches `qkv_proj`/`o_proj`/`Attention` post-load.
2. **Extend for Gemma-4-31B on llmbox.** Per-attention-configuration spec dispatch (Gemma-4 has both sliding and full layers with different `num_kv_heads`/`head_dim`), `text_config` fallback for multimodal HF configs, new `pad_attention_heads_force_equal` flag that forces `c=k` to sidestep the tt-metal concat bug on unequal-sized `[Q;K;V]` (tracked in #5015), and a refactor pass on the surgery code (-70 lines, no behavior change).
3. **Gate hang-prone `force_equal` configs (#5015).** Raise `NotImplementedError` at engine init when `force_equal=True` would zero-pad on top of c=k replication (`padded_kv > orig_kv * c`). The only known instance is Qwen2.5-7B, which hangs at first decode on llmbox without the gate. Gemma-4-31B stays clear because both its configs have `padded_kv == orig_kv * c`.

Padding is opt-in via `pad_attention_heads` (default `False`); models that don't use it see zero behavior change.

### Known limitations

- `pad_attention_heads_force_equal` is a workaround for the tt-metal concat bug (#5015), not the final state. It costs extra memory/compute on the zero-padded heads. The real fix is upstream in tt-metal; the flag is meant to be deleted once that lands.
- `qwen2.5-7b-force-equal` push parametrization is `pytest.mark.skip`'d (gated by #5015). The gate is exercised via a fast unit test instead. Skip rather than xfail because `NotImplementedError` gets wrapped as `RuntimeError` in the engine subprocess and doesn't compose cleanly with strict xfail.
- The extension targets the specific shape of Gemma-4-31B on llmbox; other multi-attention-config or multimodal models may surface adjacent issues that aren't covered here.

### Testing

- **Push**:
  - `test_tensor_parallel_generation_llmbox_pad[llama-3.2-3b]` — pad-is-no-op path.
  - `test_tensor_parallel_generation_llmbox_pad[qwen2.5-7b]` — min-cost pad path.
  - `test_pad_decision_gates_force_equal_with_zero_pad` — fast unit test on the gate (~3s, no hardware).
- **Nightly**:
  - `test_tensor_parallel_generation_llmbox_gemma4_31b` — Gemma-4-31B end-to-end on n300_llmbox 1D 8-chip.
- **Benchmark**:
  - `test_vllm_tp_benchmark[gemma4-31b-it-tp]` — runs at ~5 tok/sec, ~10 min compile.
- **Branch CI runs**:
  - vLLM Push (passing): https://github.com/tenstorrent/tt-xla/actions/runs/26730172197
  - vLLM Nightly (passing): https://github.com/tenstorrent/tt-xla/actions/runs/26734989772

### Checklist
- [x] New/Existing tests provide coverage for changes