### PR TITLE
[Benchmark] Fix multichip arch, perf regression check and qb2 transformers pin failures

### DIFF
--- a/.github/workflows/call-perf-test.yml
+++ b/.github/workflows/call-perf-test.yml
@@ -457,6 +457,7 @@ jobs:
         echo "last_nightly_workflow_id=$workflow_id" >> $GITHUB_OUTPUT
 
         echo "device_type=${{ matrix.build.runs-on-original }}" >> $GITHUB_OUTPUT
+        echo "arch=$(jq -r '.device_info.arch // ""' ${{ steps.strings.outputs.perf_report_json_file }})" >> $GITHUB_OUTPUT
 
     - name: Fetch previous perf results
       id: prev-perf
@@ -464,7 +465,7 @@ jobs:
       uses: ./.github/actions/superset-api
       with:
         query: 'benchmarks/last_measurement'
-        query_params: '{"project":"tt-forge/tt-xla","display_name":"${{ steps.set-query-strings.outputs.display_name }}","github_pipeline_id":"${{ steps.set-query-strings.outputs.last_nightly_workflow_id }}","device_type":"${{ steps.set-query-strings.outputs.device_type }}"}'
+        query_params: '{"project":"tt-forge/tt-xla","display_name":"${{ steps.set-query-strings.outputs.display_name }}","github_pipeline_id":"${{ steps.set-query-strings.outputs.last_nightly_workflow_id }}","arch":"${{ steps.set-query-strings.outputs.arch }}","device_type":"${{ steps.set-query-strings.outputs.device_type }}"}'
 
     - name: Check perf regression
       if: inputs.regression_check

--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -196,73 +196,61 @@
       },
       {
         "name": "falcon3_7b_tp_qb2",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b_tp_qb2",
         "runs-on": "qb2-blackhole"
       },
       {
         "name": "falcon3_10b_tp_qb2",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_10b_tp_qb2",
         "runs-on": "qb2-blackhole"
       },
       {
         "name": "llama_3_1_8b_instruct_tp_qb2",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b_instruct_tp_qb2",
         "runs-on": "qb2-blackhole"
       },
       {
         "name": "ministral_8b_tp_qb2",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_ministral_8b_tp_qb2",
         "runs-on": "qb2-blackhole"
       },
       {
         "name": "mistral_nemo_instruct_2407_tp_qb2",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_mistral_nemo_instruct_2407_tp_qb2",
         "runs-on": "qb2-blackhole"
       },
       {
         "name": "mistral_small_24b_instruct_2501_tp_qb2",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_mistral_small_24b_instruct_2501_tp_qb2",
         "runs-on": "qb2-blackhole"
       },
       {
         "name": "qwen_2_5_14b_instruct_tp_qb2",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_14b_instruct_tp_qb2",
         "runs-on": "qb2-blackhole"
       },
       {
         "name": "qwen_2_5_coder_32b_instruct_tp_qb2",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_coder_32b_instruct_tp_qb2",
         "runs-on": "qb2-blackhole"
       },
       {
         "name": "qwen_3_8b_tp_qb2",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_8b_tp_qb2",
         "runs-on": "qb2-blackhole"
       },
       {
         "name": "qwen_3_14b_tp_qb2",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_14b_tp_qb2",
         "runs-on": "qb2-blackhole"
       },
       {
         "name": "qwen_3_32b_tp_qb2",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_32b_tp_qb2",
         "runs-on": "qb2-blackhole"
       },
       {
         "name": "gpt_oss_20b_tp_qb2",
-        "pyreq": "datasets loguru pytest requests accelerate torch==2.10.0 tqdm transformers==5.2.0",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_qb2",
         "runs-on": "qb2-blackhole"
       },

--- a/tests/benchmark/utils.py
+++ b/tests/benchmark/utils.py
@@ -39,6 +39,11 @@ def get_xla_device_arch():
     import torch_xla.core.xla_model as xm
 
     device = xm.xla_device()
+    # In SPMD mode xm.xla_device() returns a virtual "SPMD:N" device which
+    # xm.xla_device_kind() cannot resolve. All chips in the mesh share the
+    # same arch so querying xla:0 is sufficient.
+    if str(device).startswith("SPMD:"):
+        device = "xla:0"
     device = xm.xla_device_kind(device)
     arch_name = str(device).lower()
     return align_arch(arch_name)

--- a/tests/benchmark/utils.py
+++ b/tests/benchmark/utils.py
@@ -36,17 +36,16 @@ def get_jax_device_arch():
 
 def get_xla_device_arch():
     """Get the architecture of the XLA device."""
-    import torch_xla.core.xla_model as xm
+    import torch_xla.runtime as xr
 
-    device = xm.xla_device()
-    try:
-        device = xm.xla_device_kind(device)
-    except RuntimeError:
-        # In SPMD/multi-device mode xm.xla_device() returns a virtual device
-        # (e.g. "spmd:0") that xla_device_kind() cannot resolve. All chips in
-        # the mesh share the same arch so xla:0 is sufficient.
-        device = xm.xla_device_kind("xla:0")
-    arch_name = str(device).lower()
+    # Query the physical runtime devices directly. This works in both regular
+    # and SPMD modes. xm.xla_device_kind() cannot be used because in SPMD mode
+    # (e.g. tensor-parallel benchmarks) xm.xla_device() resolves to a virtual
+    # "SPMD:0" device that the device-kind lookup cannot find.
+    attrs = xr.global_runtime_device_attributes()
+    if not attrs:
+        return ""
+    arch_name = str(attrs[0]["device_arch"]).lower()
     return align_arch(arch_name)
 
 

--- a/tests/benchmark/utils.py
+++ b/tests/benchmark/utils.py
@@ -39,12 +39,13 @@ def get_xla_device_arch():
     import torch_xla.core.xla_model as xm
 
     device = xm.xla_device()
-    # In SPMD mode xm.xla_device() returns a virtual "SPMD:N" device which
-    # xm.xla_device_kind() cannot resolve. All chips in the mesh share the
-    # same arch so querying xla:0 is sufficient.
-    if str(device).startswith("SPMD:"):
-        device = "xla:0"
-    device = xm.xla_device_kind(device)
+    try:
+        device = xm.xla_device_kind(device)
+    except RuntimeError:
+        # In SPMD/multi-device mode xm.xla_device() returns a virtual device
+        # (e.g. "spmd:0") that xla_device_kind() cannot resolve. All chips in
+        # the mesh share the same arch so xla:0 is sufficient.
+        device = xm.xla_device_kind("xla:0")
     arch_name = str(device).lower()
     return align_arch(arch_name)
 


### PR DESCRIPTION
### Problem description

Recent change https://github.com/tenstorrent/tt-xla/commit/e875a19671ab539b88d6667f8e60556b15fd0cb9 introduced two failures:
- `get_xla_device_arch()` [failed](https://github.com/tenstorrent/tt-xla/actions/runs/26728987456/job/78815598920) on multi-chip devices
- "Check perf regression" job [compared n150 with previous p150 perf numbers](https://github.com/tenstorrent/tt-xla/actions/runs/26728987456/job/78815597341), probably because `device_type` check failed in query (UPDATE: [device_type isn't handled](https://github.com/tenstorrent/data_iac/blob/f4bc74a95a1ccb4ec3fd4198f61bf69079b9feda/terraform/resources/api_gateway_data_db_main/routes/last_measurement.py#L48))

Additionally, newly added QB2 models https://github.com/tenstorrent/tt-xla/commit/0e0d21261e8cff9203efffe605c01d0f57dfb3e0 retained `pyreq` pin for `transformers`, which is removed in https://github.com/tenstorrent/tt-xla/commit/51d5a10fa303f9df0d38eb15bd1a5bd76e2ffceb, resulting in [benchmark CI failure](https://github.com/tenstorrent/tt-xla/actions/runs/26698947366/job/78688175432).

### What's changed

Modified `get_xla_device_arch()` to work in multi-chip case.
Reintroduced arch in query string to differentiate wormhole and blackhole job runs.
Removed hardcoded qb2 `pyreq`.

### Checklist
- [x] [n150 vit "Check perf regression" validation](https://github.com/tenstorrent/tt-xla/actions/runs/26749568924/job/78835528132)
- [x] [n150 llama_3_2_1b `get_xla_device_arch()` sanity check](https://github.com/tenstorrent/tt-xla/actions/runs/26755602230)
- [x] [n300-llmbox ministral_8b_tp `get_xla_device_arch()` validation](https://github.com/tenstorrent/tt-xla/actions/runs/26755552271)
- [ ] [qb2 ministral_8b transformers pin fix](https://github.com/tenstorrent/tt-xla/actions/runs/26755658229)
