### PR TITLE
[Tests] Xfail training PCC failures for phi1, phi1_lora, gemma_lora

### DIFF
--- a/tests/runner/test_config/torch_llm/test_config_training_single_device.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_training_single_device.yaml
@@ -27,13 +27,15 @@ test_config:
     status: EXPECTED_PASSING
 
   gemma_lora/pytorch-1.1_2B_IT-llm_prefill-seq_128-batch_1-single_device-mesh_default-training:
-    status: EXPECTED_PASSING
+    status: KNOWN_FAILURE_XFAIL
+    reason: "Gradient PCC comparison failed below threshold (pcc=0.99) - https://github.com/tenstorrent/tt-xla/issues/5024"
 
   gemma_lora/pytorch-1.1_2B_IT-llm_prefill-seq_128-batch_4-single_device-mesh_default-training:
     status: EXPECTED_PASSING
 
   phi1/causal_lm/pytorch-Phi_1-llm_prefill-seq_128-batch_1-single_device-mesh_default-training:
-    status: EXPECTED_PASSING
+    status: KNOWN_FAILURE_XFAIL
+    reason: "Gradient PCC comparison failed below threshold (pcc=0.99) - https://github.com/tenstorrent/tt-xla/issues/5024"
 
   phi1_lora/causal_lm/pytorch-Phi_1-llm_prefill-seq_128-batch_1-single_device-mesh_default-training:
     status: EXPECTED_PASSING
@@ -43,7 +45,8 @@ test_config:
     status: EXPECTED_PASSING
 
   phi1_lora/causal_lm/pytorch-Phi_1-llm_prefill-seq_128-batch_4-single_device-mesh_default-training:
-    status: EXPECTED_PASSING
+    status: KNOWN_FAILURE_XFAIL
+    reason: "Gradient PCC comparison failed below threshold (pcc=0.99) - https://github.com/tenstorrent/tt-xla/issues/5024"
 
   qwen_2_5/causal_lm/pytorch-1.5B-llm_prefill-seq_128-batch_1-single_device-mesh_default-training:
     status: EXPECTED_PASSING


### PR DESCRIPTION
## Problem description

The LLM torch training tests added in #4219 are marked `EXPECTED_PASSING`, but three of them fail the gradient PCC comparison (required `pcc=0.99`) on **p150** nightly, blocking the `test_forge_models_passing` pipeline:

- `phi1/causal_lm/...-batch_1-...-training` — worst pcc 0.9562 (14 params)
- `phi1_lora/causal_lm/...-batch_4-...-training` — worst pcc 0.9796 (48 params)
- `gemma_lora/...-batch_1-...-training` — worst pcc 0.7723 (36 params)

Failing nightly job: https://github.com/tenstorrent/tt-xla/actions/runs/26728987456/job/78815598509

## What's changed

Marks the three failing entries in `test_config_training_single_device.yaml` as `KNOWN_FAILURE_XFAIL` with a `reason:` linking the tracking issue, removing them from the expected-passing pipeline until the gradient PCC discrepancy is resolved.

Tracking issue: #5024

## Checklist
- [x] Linked to tracking issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
