### PR TITLE
Add Gemma-4 multimodal image input for vLLM

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/layers/__init__.py
+++ b/integrations/vllm_plugin/vllm_tt/layers/__init__.py
@@ -1,14 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Portions (c) 2026 Tenstorrent AI ULC
 
+from .mm_embeddings import install_static_shape_merge_multimodal_embeddings
 from .mrope import override_mrope_module
+from .multimodal_attention import override_vision_attention
 from .rmsnorm import TTRMSNorm, override_rmsnorm_module
 from .rotary_embedding import TTRotaryEmbedding, override_rotary_embedding_module
 
 __all__ = [
     "TTRMSNorm",
     "TTRotaryEmbedding",
+    "install_static_shape_merge_multimodal_embeddings",
     "override_mrope_module",
     "override_rmsnorm_module",
     "override_rotary_embedding_module",
+    "override_vision_attention",
 ]

--- a/integrations/vllm_plugin/vllm_tt/layers/mm_embeddings.py
+++ b/integrations/vllm_plugin/vllm_tt/layers/mm_embeddings.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Portions (c) 2026 Tenstorrent AI ULC
+
+import torch
+
+from ..logger import tt_init_logger
+
+logger = tt_init_logger(__name__)
+
+
+def install_static_shape_merge_multimodal_embeddings() -> None:
+    """Replace vLLM's masked_scatter_-based _merge_multimodal_embeddings: the
+    boolean-mask scatter lowers to a dynamic-dim (set_dimension_size) tensor
+    that tt-mlir's Shardy pass rejects. cumsum+gather+where gives the same
+    result with static shapes. Idempotent (attribute-flag guarded)."""
+    import vllm.model_executor.models.utils as _vllm_utils
+
+    if getattr(_vllm_utils, "_tt_static_shape_merge_installed", False):
+        return
+
+    def _tt_merge_multimodal_embeddings(
+        inputs_embeds: torch.Tensor,
+        multimodal_embeddings,
+        is_multimodal: torch.Tensor,
+    ) -> torch.Tensor:
+        if len(multimodal_embeddings) == 0:
+            return inputs_embeds
+        mm_embeds_flat = _vllm_utils._flatten_embeddings(multimodal_embeddings).to(
+            dtype=inputs_embeds.dtype
+        )
+        # Zero-based positional index of each mm token among the mm tokens
+        # (0, 0, 1, 1, 2, ... where ascents happen at mm positions). Subtract 1
+        # so non-mm positions point to index -1 (clamped to 0 below for safety).
+        mm_indices = is_multimodal.to(torch.int64).cumsum(dim=0) - 1
+        mm_indices = mm_indices.clamp(min=0)
+        # Gather mm embeddings at those indices for every position. Non-mm
+        # positions read garbage which torch.where then discards.
+        mm_padded = mm_embeds_flat[mm_indices]
+        merged = torch.where(is_multimodal.unsqueeze(-1), mm_padded, inputs_embeds)
+        return merged
+
+    _vllm_utils._merge_multimodal_embeddings = _tt_merge_multimodal_embeddings
+    _vllm_utils._tt_static_shape_merge_installed = True
+    logger.info(
+        "Installed static-shape _merge_multimodal_embeddings (replaces "
+        "masked_scatter_-based default that emits dynamic shapes)."
+    )

--- a/integrations/vllm_plugin/vllm_tt/layers/multimodal_attention.py
+++ b/integrations/vllm_plugin/vllm_tt/layers/multimodal_attention.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Portions (c) 2026 Tenstorrent AI ULC
+
+import torch
+import torch.nn as nn
+from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+
+from ..logger import tt_init_logger
+
+logger = tt_init_logger(__name__)
+
+
+def tt_sdpa_attention_forward(
+    module: nn.Module,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attention_mask: torch.Tensor | None,
+    dropout: float = 0.0,
+    scaling: float | None = None,
+    is_causal: bool | None = None,
+    **kwargs,
+) -> tuple[torch.Tensor, None]:
+    """Fused TT SDPA attention for an HF vision tower.
+
+    vLLM has no API to route a HF-instantiated vision tower's attention to a
+    device backend, so we register this into HF's ALL_ATTENTION_FUNCTIONS and
+    point the tower's _attn_implementation at it.
+
+    Q/K/V: [batch, heads, seq, head_dim]; returns (attn_output, None) with
+    attn_output [batch, seq, heads, head_dim] (the sdpa_attention_forward
+    contract).
+    """
+    n_rep = getattr(module, "num_key_value_groups", 1) or 1
+    if n_rep > 1:
+        key = key.repeat_interleave(n_rep, dim=1)
+        value = value.repeat_interleave(n_rep, dim=1)
+
+    is_causal = (
+        is_causal if is_causal is not None else getattr(module, "is_causal", False)
+    )
+    if scaling is None:
+        scaling = float(query.shape[-1]) ** -0.5
+
+    # The TT SDPA op asserts query/key seq length is tile-aligned (multiple of
+    # 32). Vision encoders typically produce non-aligned patch counts. Pad
+    # Q/K/V along the seq dim with zeros and add an additive mask to zero out
+    # softmax contributions from padded K positions. Trim padded Q rows from
+    # the output afterwards.
+    _TILE = 32
+    seq_q = query.shape[2]
+    seq_k = key.shape[2]
+    pad_q = (-seq_q) % _TILE
+    pad_k = (-seq_k) % _TILE
+
+    if pad_q > 0:
+        query = torch.nn.functional.pad(query, (0, 0, 0, pad_q))
+    if pad_k > 0:
+        key = torch.nn.functional.pad(key, (0, 0, 0, pad_k))
+        value = torch.nn.functional.pad(value, (0, 0, 0, pad_k))
+        masked_value = torch.finfo(query.dtype).min
+        # TTIR SDPA op requires the mask's dim 2 to equal the (padded) query
+        # sequence length — broadcast-shaped [B, 1, 1, K] is rejected. Use the
+        # explicit [B, 1, Q_pad, K_pad] layout. Since masking only depends on
+        # the key position, every query row is identical.
+        if attention_mask is None:
+            attention_mask = torch.zeros(
+                (query.shape[0], 1, seq_q + pad_q, seq_k + pad_k),
+                dtype=query.dtype,
+                device=query.device,
+            )
+            attention_mask[..., seq_k:] = masked_value
+        else:
+            attention_mask = torch.nn.functional.pad(
+                attention_mask, (0, pad_k), value=masked_value
+            )
+        # The TT SDPA op disallows is_causal=True when attn_mask is set.
+        is_causal = False
+
+    attn_output = torch.ops.tt.scaled_dot_product_attention(
+        query,
+        key,
+        value,
+        is_causal=is_causal,
+        attn_mask=attention_mask,
+        scale=scaling,
+    )
+
+    if pad_q > 0:
+        attn_output = attn_output[:, :, :seq_q, :]
+
+    attn_output = attn_output.transpose(1, 2).contiguous()
+    return attn_output, None
+
+
+# Idempotently register so reloads (e.g. pytest reruns) don't raise.
+if "tt" not in ALL_ATTENTION_FUNCTIONS:
+    ALL_ATTENTION_FUNCTIONS.register("tt", tt_sdpa_attention_forward)
+
+
+def override_vision_attention(model: torch.nn.Module) -> None:
+    """Point the HF vision/audio tower's _attn_implementation at the registered
+    "tt" attention so its forward dispatches to tt_sdpa_attention_forward.
+    No-op on towers without an HF config (getattr-guarded)."""
+    for tower_attr in ("vision_tower", "audio_tower"):
+        tower = getattr(model, tower_attr, None)
+        if tower is None:
+            continue
+        cfg = getattr(tower, "config", None)
+        if cfg is None:
+            continue
+        prev = getattr(cfg, "_attn_implementation", None)
+        cfg._attn_implementation = "tt"
+        logger.info("Routed %s attention through TT SDPA (was %r)", tower_attr, prev)

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -2036,7 +2036,18 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                             num_tokens, dtype=torch.int32, device="cpu"
                         )
                         # Align placeholders and actual num mm_embeddings.
-                        placeholders_ids[:items_size] = hf_config.image_token_index
+                        # `image_token_id` was renamed from `image_token_index`;
+                        # fall back to the old name for configs that use it.
+                        image_token_id = getattr(
+                            hf_config,
+                            "image_token_id",
+                            getattr(hf_config, "image_token_index", None),
+                        )
+                        assert image_token_id is not None, (
+                            "hf_config has neither image_token_id nor "
+                            "image_token_index"
+                        )
+                        placeholders_ids[:items_size] = image_token_id
 
                         placeholders_ids = placeholders_ids.to(self.device)
 

--- a/integrations/vllm_plugin/vllm_tt/overrides.py
+++ b/integrations/vllm_plugin/vllm_tt/overrides.py
@@ -5,16 +5,20 @@
 from typing import OrderedDict
 
 import torch
-from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.rotary_embedding.base import RotaryEmbedding
 from vllm.model_executor.layers.rotary_embedding.mrope import MRotaryEmbedding
 
+from .layers.mm_embeddings import install_static_shape_merge_multimodal_embeddings
 from .layers.mrope import override_mrope_module
+from .layers.multimodal_attention import override_vision_attention
 from .layers.rmsnorm import override_rmsnorm_module
 from .layers.rotary_embedding import override_rotary_embedding_module
 from .logger import tt_init_logger
 
 logger = tt_init_logger(__name__)
+
+# Patch vLLM's multimodal embedding merge to a static-shape impl at import time.
+install_static_shape_merge_multimodal_embeddings()
 
 
 def get_fqn(module):
@@ -32,6 +36,29 @@ ISINSTANCE_OVERRIDES = [
     (MRotaryEmbedding, override_mrope_module),
     (RotaryEmbedding, override_rotary_embedding_module),
 ]
+
+
+def _promote_pre_allocated_attrs_to_buffers(model: torch.nn.Module) -> None:
+    """Re-register plain torch.Tensor attributes as buffers so .to() moves them.
+
+    Some multimodal models pre-allocate ``self.per_layer_embeddings`` as a
+    plain attribute (not a registered buffer) on CPU. ``model.to(device)``
+    only relocates parameters and registered buffers, leaving it stranded on
+    CPU; a later add against an XLA tensor then trips dynamo's mixed-device
+    check. Promote such attributes to non-persistent buffers so .to() follows
+    them.
+    """
+    pre_allocated_attrs = ("per_layer_embeddings",)
+    for attr in pre_allocated_attrs:
+        if not hasattr(model, attr):
+            continue
+        t = getattr(model, attr)
+        if not isinstance(t, torch.Tensor):
+            continue
+        if attr in dict(model.named_buffers(recurse=False)):
+            continue
+        delattr(model, attr)
+        model.register_buffer(attr, t, persistent=False)
 
 
 def replace_modules(model: torch.nn.Module) -> None:
@@ -62,6 +89,8 @@ def replace_modules(model: torch.nn.Module) -> None:
             _process_module(child_module, child_name, module)
 
     _process_module(model)
+    override_vision_attention(model)
+    _promote_pre_allocated_attrs_to_buffers(model)
 
 
 def repair_stale_moe_closures(model: torch.nn.Module) -> None:

--- a/tests/integrations/vllm_plugin/generative/test_gemma4_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_gemma4_generation.py
@@ -1,9 +1,13 @@
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
+import base64
+import io
+
 import pytest
 import vllm
 from conftest import assert_output_coherent, check_host_memory
+from PIL import Image, ImageDraw
 
 
 @pytest.mark.nightly
@@ -61,6 +65,113 @@ def test_generation_bhqb_gemma4_26b_a4b():
             "enable_tensor_parallel": True,
             "use_2d_mesh": True,
             "optimization_level": 0,
+        },
+    }
+    llm = vllm.LLM(**llm_args)
+
+    output_text = llm.chat(messages, sampling_params)[0].outputs[0].text
+    print(f"output: {output_text}")
+    assert_output_coherent(output_text)
+
+    check_host_memory(model_name)
+
+
+@pytest.mark.nightly
+@pytest.mark.bhqb
+def test_generation_single_device_gemma4_e4b_image():
+    model_name = "google/gemma-4-E4B-it"
+
+    # Synthetic image: a red square on a blue background.
+    image = Image.new("RGB", (256, 256), (20, 80, 200))
+    ImageDraw.Draw(image).rectangle([64, 64, 192, 192], fill=(220, 40, 40))
+    buf = io.BytesIO()
+    image.save(buf, format="PNG")
+    image_url = f"data:image/png;base64,{base64.b64encode(buf.getvalue()).decode()}"
+
+    messages = [
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": image_url}},
+                    {"type": "text", "text": "Describe this image in one sentence."},
+                ],
+            }
+        ]
+    ]
+    sampling_params = vllm.SamplingParams(temperature=0.0, top_p=1.0, max_tokens=32)
+    llm_args = {
+        "model": model_name,
+        "limit_mm_per_prompt": {"image": 1, "video": 0, "audio": 0},
+        # KV-sharing layers gather K/V from the cache (sized by max_model_len),
+        # and the prefill bucket rounds max_model_len up to a power of two; keep
+        # max_model_len a power of two >= the image token count so q == kv.
+        "max_num_batched_tokens": 512,
+        "max_num_seqs": 1,
+        "max_model_len": 512,
+        "gpu_memory_utilization": 0.002,
+        "additional_config": {
+            "enable_const_eval": True,
+            "min_context_len": 32,
+            "enable_tensor_parallel": False,
+            "use_2d_mesh": False,
+            "cpu_sampling": True,
+            "flat_model_io": True,
+        },
+    }
+    llm = vllm.LLM(**llm_args)
+
+    output_text = llm.chat(messages, sampling_params)[0].outputs[0].text
+    print(f"output: {output_text}")
+    assert_output_coherent(output_text)
+
+    check_host_memory(model_name)
+
+
+@pytest.mark.nightly
+@pytest.mark.tensor_parallel
+@pytest.mark.bhqb
+@pytest.mark.parametrize(
+    "model_name, use_2d_mesh",
+    [
+        pytest.param("google/gemma-4-31B-it", False, id="31b"),
+        pytest.param("google/gemma-4-26B-A4B-it", True, id="26b_a4b"),
+    ],
+)
+def test_generation_bhqb_gemma4_image(model_name, use_2d_mesh):
+    # Synthetic image: a red square on a blue background.
+    image = Image.new("RGB", (256, 256), (20, 80, 200))
+    ImageDraw.Draw(image).rectangle([64, 64, 192, 192], fill=(220, 40, 40))
+    buf = io.BytesIO()
+    image.save(buf, format="PNG")
+    image_url = f"data:image/png;base64,{base64.b64encode(buf.getvalue()).decode()}"
+
+    messages = [
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": image_url}},
+                    {"type": "text", "text": "Describe this image in one sentence."},
+                ],
+            }
+        ]
+    ]
+    sampling_params = vllm.SamplingParams(temperature=0.0, top_p=1.0, max_tokens=32)
+    llm_args = {
+        "model": model_name,
+        "limit_mm_per_prompt": {"image": 1, "video": 0, "audio": 0},
+        "max_num_batched_tokens": 2560,
+        "max_num_seqs": 1,
+        "max_model_len": 1024,
+        "gpu_memory_utilization": 0.1,
+        "additional_config": {
+            "enable_const_eval": True,
+            "min_context_len": 32,
+            "enable_tensor_parallel": True,
+            "use_2d_mesh": use_2d_mesh,
+            "cpu_sampling": False,
+            "flat_model_io": True,
         },
     }
     llm = vllm.LLM(**llm_args)


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/4702)

### Problem description
There's not yet support for multimodal model in vLLM

### What's changed
Enable the multimodal encoder path in the TT model runner: activate supports_mm_inputs, execute/gather the mm encoder (handle the is_embed mask for models that interleave marker tokens), precompile embed_input_ids, and build the dummy mm batch via the current vLLM API.

overrides: route HF vision/audio tower attention through the fused TT SDPA op (eager attention can't lower over the device mesh); replace vLLM's masked_scatter_-based _merge_multimodal_embeddings with a static-shape cumsum+gather+where impl (the dynamic mask scatter is rejected by tt-mlir's Shardy pass); promote pre-allocated plain-tensor attrs to non-persistent  buffers so model.to(device) relocates them.

ascend_scheduler: schedule multimodal encoder inputs (the base scheduler does this inline with KV allocation; do it post-hoc to stay close to AscendScheduler.schedule()).

Add a BHQB 31B image-input test.

### Checklist
- [ ] New/Existing tests provide coverage for changes
