### PR TITLE
Add Qwen3-32B vLLM perf benchmark for QuietBox2 (batch 1)

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -802,6 +802,16 @@
         "runs-on": "qb2-blackhole"
       },
       {
+        "name": "vllm_qwen3_32b_qb2_tp",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen3-32b-qb2-tp]",
+        "vllm": true,
+        "skip-stablehlo-dump": true,
+        "skip-ttir-dump": true,
+        "skip-ttnn-dump": true,
+        "skip-device-perf": true,
+        "runs-on": "qb2-blackhole"
+      },
+      {
         "name": "vllm_qwen2_5_14b_instruct_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen2.5-14b-instruct-tp]",
         "vllm": true,

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -166,6 +166,9 @@ TP_CONFIGS = [
     pytest.param(_tp_config("Qwen/Qwen3-32B", 1), id="qwen3-32b-tp"),
     pytest.param(_gemma4_tp_config("google/gemma-4-31B-it", 1), id="gemma4-31b-it-tp"),
     pytest.param(
+        _tp_config("Qwen/Qwen3-32B", 1, use_2d_mesh=False), id="qwen3-32b-qb2-tp"
+    ),
+    pytest.param(
         _tp_config("Qwen/Qwen2.5-14B-Instruct", 1), id="qwen2.5-14b-instruct-tp"
     ),
     pytest.param(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/4894

### Problem Description
P1 model request from Forge Productize Models: add `Qwen/Qwen3-32B` through the vLLM benchmark on QuietBox2.

### What's Changed
- Adds the `qwen3-32b-qb2-tp` entry to `TP_CONFIGS` in `tests/benchmark/test_vllm_benchmarks.py` (Qwen3-32B, tensor-parallel, `use_2d_mesh=False` → 1×4 mesh).
- Adds the matching `vllm_qwen3_32b_qb2_tp` perf entry to `.github/workflows/perf-bench-matrix.json`, running on `qb2-blackhole`.

**Note:** We want to eventually run this at batch 32, but we're adding batch 1 for now to align with the vLLM benchmark tests already added.

### Checklist
- [x] Perf benchmark run: https://github.com/tenstorrent/tt-xla/actions/runs/26772621474