### PR TITLE
Add example for stable diffusion 1 5 model

### DIFF
--- a/examples/pytorch/sd_v1_5_pipeline.py
+++ b/examples/pytorch/sd_v1_5_pipeline.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Runnable Stable Diffusion 1.5 text-to-image example on Tenstorrent.
+
+The reusable pipeline implementation is shared with the image-gen benchmark
+(``tests/benchmark/test_imagegen.py``) and the nightly test, and lives in
+``tt_forge_models`` — this script is just a thin runnable demo so the
+implementation isn't duplicated in ``examples/``.
+
+The UNet (the heavy net) runs on the Tenstorrent backend via
+``torch.compile(backend="tt")``; the precision-sensitive CLIP text encoder, the
+scheduler and the VAE run on CPU.
+"""
+
+from third_party.tt_forge_models.stable_diffusion_1_5.pytorch.pipeline import (
+    SD15Config,
+    SD15Pipeline,
+    save_image,
+)
+
+PROMPT = "a photo of a cat"
+NEGATIVE_PROMPT = ""
+CFG_SCALE = 7.5
+NUM_INFERENCE_STEPS = 50
+SEED = 42
+OUTPUT_PATH = "sd_v1_5_output.png"
+
+
+def main():
+    pipeline = SD15Pipeline(config=SD15Config())
+    pipeline.setup()
+
+    image = pipeline.generate(
+        prompt=PROMPT,
+        negative_prompt=NEGATIVE_PROMPT,
+        cfg_scale=CFG_SCALE,
+        num_inference_steps=NUM_INFERENCE_STEPS,
+        seed=SEED,
+    )
+
+    save_image(image, OUTPUT_PATH)
+    print(f"Saved output image to {OUTPUT_PATH}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-xla/issues/5042

### Problem description
Stable diffusion 1 5 model is passing e2e so we need to add example for this model 

### What's changed
- Adds `examples/pytorch/sd_v1_5_pipeline.py` for Stable Diffusion 1.5 (`stable-diffusion-v1-5/stable-diffusion-v1-5`), mirroring the existing `sd_v1_4_pipeline.py`.
- UNet runs on the TT backend; VAE + PNDM scheduler on CPU; CFG denoising loop; 512x512 output.

### Checklist
- [x] New/Existing tests provide coverage for changes

I have attached the log for your reference:
[sd_v1_5.log](https://github.com/user-attachments/files/28495121/sd_v1_5.log)

output image:
<img width="512" height="512" alt="test_sd15_output" src="https://github.com/user-attachments/assets/ba07f475-43ad-4455-b19f-bb26a88aaae7" />