### PR TITLE
[Playground v2.5] Wire e2e pipeline into nightly and benchmark CI

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -63,6 +63,10 @@
         "pytest": "tests/benchmark/test_vision.py::test_vovnet"
       },
       {
+        "name": "playground_v2_5",
+        "pytest": "tests/benchmark/test_imagegen.py::test_playground_v2_5"
+      },
+      {
         "name": "bge_m3_encode",
         "pyreq": "transformers==4.57.1 FlagEmbedding",
         "pytest": "tests/benchmark/test_encoders.py::test_bge_m3"

--- a/tests/benchmark/benchmarks/imagegen_benchmark.py
+++ b/tests/benchmark/benchmarks/imagegen_benchmark.py
@@ -1,0 +1,198 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generic text-to-image (diffusion) benchmark harness for torch-xla / TT.
+
+Mirrors the structure of ``vision_benchmark.py``: the per-model configuration
+lives in ``test_imagegen.py`` and this module owns the reusable measurement
+logic. Diffusion pipelines don't fit the single-forward vision harness — each
+generation is a multi-step denoising loop — so this harness uses a two-pass
+scheme:
+
+  - Pass 1 (warmup): a single-step ``generate()`` call — enough to trigger
+    the first-forward compile of every component.
+  - Pass 2 (steady-state): a full ``generate(num_inference_steps)`` call;
+    every forward is a cache hit. This is the pass whose image is saved and
+    whose latency drives the reported throughput.
+
+Per-model wiring provides a ``build_pipeline_fn`` that returns
+``(pipeline, generate_fn)``; this module sets the XLA compile options,
+builds the pipeline (which compiles the heavy net for TT), runs the two passes
+and emits a standardized benchmark result.
+"""
+
+import socket
+import time
+
+import torch_xla
+import torch_xla.runtime as xr
+from utils import (
+    build_xla_export_name,
+    create_benchmark_result,
+    get_benchmark_metadata,
+    get_xla_device_arch,
+    print_benchmark_results,
+    save_image,
+)
+
+xr.set_device_type("TT")
+
+MODULE_EXPORT_PATH = "modules"
+
+
+def benchmark_imagegen_torch_xla(
+    build_pipeline_fn,
+    model_info_name,
+    prompt,
+    num_inference_steps,
+    height,
+    width,
+    optimization_level,
+    trace_enabled,
+    ttnn_perf_metrics_output_file,
+    display_name=None,
+    output_image_path=None,
+):
+    """Benchmark a text-to-image diffusion pipeline on the TT backend.
+
+    Args:
+        build_pipeline_fn: ``build_pipeline_fn(compile_options) -> (pipeline, generate_fn)``.
+            ``compile_options`` is forwarded so the pipeline can merge instead
+            of overwriting if it needs to switch any option inline.
+            ``generate_fn(prompt, num_inference_steps) -> image tensor (B, 3, H, W)``
+            runs one full text-to-image generation.
+        model_info_name: Model name for identification and reporting.
+        prompt: Text prompt to generate from.
+        num_inference_steps: Number of denoising steps per generation.
+        height, width: Output image dimensions.
+        optimization_level: tt-mlir optimization level for compilation.
+        trace_enabled: Whether to enable tracing.
+        ttnn_perf_metrics_output_file: Base path for TTNN perf metrics files.
+        display_name: Display name used for export naming / dashboard.
+        output_image_path: If set, the steady-state image is saved here.
+
+    Returns:
+        Standardized benchmark result dict (see ``create_benchmark_result``).
+    """
+    export_model_name = build_xla_export_name(
+        model_name=display_name or model_info_name,
+        num_layers=None,
+        batch_size=1,
+        input_sequence_length=None,
+    )
+
+    options = {
+        "optimization_level": optimization_level,
+        "export_path": MODULE_EXPORT_PATH,
+        "export_model_name": export_model_name,
+        "ttnn_perf_metrics_enabled": True,
+        "ttnn_perf_metrics_output_file": ttnn_perf_metrics_output_file,
+        "enable_trace": trace_enabled,
+    }
+    torch_xla.set_custom_compile_options(options)
+
+    # Build + compile the pipeline (heavy net registers the "tt" backend and is
+    # moved to the XLA device here; actual kernel compilation happens lazily on
+    # the first forward, i.e. during the warmup pass below).
+    pipeline, generate_fn = build_pipeline_fn(options)
+
+    # Pass 1 (warmup): 1 step is enough to trigger the first-forward compile
+    # of every component.
+    print("Starting warmup pass (includes compile)...")
+    warmup_start = time.perf_counter()
+    generate_fn(prompt, 1)
+    warmup_time = time.perf_counter() - warmup_start
+    print(f"Warmup pass: {warmup_time:.3f}s")
+
+    # Pass 2 (steady-state): steady-state generation; this image is the saved one.
+    print("Starting steady-state pass...")
+    steady_state_start = time.perf_counter()
+    steady_state_image = generate_fn(prompt, num_inference_steps)
+    steady_state_time = time.perf_counter() - steady_state_start
+    print(f"Steady-state pass: {steady_state_time:.3f}s")
+
+    if output_image_path is not None:
+        save_image(steady_state_image, output_image_path)
+        print(f"Saved output image to {output_image_path}")
+
+    # Throughput is reported on the steady-state pass. One image per run.
+    total_samples = 1
+    samples_per_sec = total_samples / steady_state_time
+
+    # Per-component forward+sync times from the pipeline's own instrumentation
+    # (steady-state pass).
+    perf = pipeline._perf
+    unet_steps = perf["unet_steps"]
+    unet_step_mean_s = sum(unet_steps) / len(unet_steps)
+    tt_components_total = perf["te1"] + perf["te2"] + sum(unet_steps) + perf["vae"]
+    cpu_overhead = max(0.0, perf["total"] - tt_components_total)
+
+    metadata = get_benchmark_metadata()
+    full_model_name = model_info_name
+    model_type = "Image Generation, Text-to-Image"
+    dataset_name = "Text Prompt"
+    input_size = (3, height, width)
+
+    print_benchmark_results(
+        model_title=full_model_name,
+        full_model_name=full_model_name,
+        model_type=model_type,
+        dataset_name=dataset_name,
+        date=metadata["date"],
+        machine_name=metadata["machine_name"],
+        total_time=steady_state_time,
+        total_samples=total_samples,
+        samples_per_sec=samples_per_sec,
+        evaluation_score=0.0,
+        batch_size=1,
+        data_format="bfloat16",
+        input_size=input_size,
+    )
+    print(
+        f"| Num inference steps: {num_inference_steps}\n"
+        f"| Steady-state:\n"
+        f"|   Text encoder 1 (s):  {perf['te1']:.3f}\n"
+        f"|   Text encoder 2 (s):  {perf['te2']:.3f}\n"
+        f"|   UNet step mean (s):  {unet_step_mean_s:.3f}\n"
+        f"|   VAE (s):             {perf['vae']:.3f}\n"
+        f"|   CPU overhead (s):    {cpu_overhead:.3f}"
+    )
+
+    custom_measurements = [
+        {"measurement_name": "images_per_second", "value": samples_per_sec},
+        {"measurement_name": "e2e_latency", "value": steady_state_time},
+        {"measurement_name": "text_encoder_1_s", "value": perf["te1"]},
+        {"measurement_name": "text_encoder_2_s", "value": perf["te2"]},
+        {"measurement_name": "unet_step_mean_s", "value": unet_step_mean_s},
+        {"measurement_name": "vae_s", "value": perf["vae"]},
+        {"measurement_name": "cpu_overhead_s", "value": cpu_overhead},
+    ]
+
+    result = create_benchmark_result(
+        full_model_name=full_model_name,
+        model_type=model_type,
+        dataset_name=dataset_name,
+        num_layers=-1,
+        batch_size=1,
+        input_size=input_size,
+        loop_count=num_inference_steps,
+        data_format="bfloat16",
+        total_time=steady_state_time,
+        total_samples=total_samples,
+        evaluation_score=0.0,
+        custom_measurements=custom_measurements,
+        optimization_level=optimization_level,
+        program_cache_enabled=True,
+        trace_enabled=trace_enabled,
+        model_info=model_info_name,
+        display_name=display_name,
+        torch_xla_enabled=True,
+        backend="tt",
+        device_name=socket.gethostname(),
+        arch=get_xla_device_arch(),
+        device_count=xr.global_runtime_device_count(),
+        input_is_image=True,
+    )
+
+    return result

--- a/tests/benchmark/benchmarks/playground_v2_5_pipeline.py
+++ b/tests/benchmark/benchmarks/playground_v2_5_pipeline.py
@@ -2,25 +2,24 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Playground v2.5 — end-to-end TT pipeline example.
+"""Playground v2.5 — benchmark-side pipeline for the imagegen harness.
 
 Each nn.Module component (text_encoder, text_encoder_2, unet, vae) can be
 independently moved to Tenstorrent via
 `model.compile(backend="tt") + model.to(xla_device())`. Tokenizer and
 scheduler always stay on CPU. CPU→TT→CPU device switching is done inline at
-the call site of each nn component.
+the call site of each nn component. Per-component forward+sync times are
+collected into `self._perf` for the harness to read after each generate() call.
 """
 
-from pathlib import Path
+import time
 from typing import Optional
 
 import torch
 import torch_xla
 import torch_xla.core.xla_model as xm
-import torch_xla.runtime as xr
 from diffusers import EDMDPMSolverMultistepScheduler
 from loguru import logger
-from PIL import Image
 from transformers import CLIPTokenizer
 
 from third_party.tt_forge_models.playground_v2_5.pytorch import (
@@ -29,10 +28,6 @@ from third_party.tt_forge_models.playground_v2_5.pytorch import (
 )
 
 MODEL_ID = "playgroundai/playground-v2.5-1024px-aesthetic"
-PROMPT = "Astronaut in a jungle, cold color palette, muted colors, detailed, 8k"
-NEGATIVE_PROMPT = None
-SEED = 42
-GUIDANCE_SCALE = 3.0
 HEIGHT = 1024
 WIDTH = 1024
 
@@ -40,11 +35,11 @@ WIDTH = 1024
 class PlaygroundV25Config:
     def __init__(
         self,
-        device: str = "cpu",
         text_encoder_on_tt: bool = True,
         text_encoder_2_on_tt: bool = True,
         unet_on_tt: bool = True,
         vae_on_tt: bool = True,
+        compile_options: Optional[dict] = None,
     ):
         self.model_id = MODEL_ID
         self.width = WIDTH
@@ -52,11 +47,13 @@ class PlaygroundV25Config:
         self.vae_scale_factor = 8
         self.latents_width = self.width // self.vae_scale_factor
         self.latents_height = self.height // self.vae_scale_factor
-        self.device = device
         self.text_encoder_on_tt = text_encoder_on_tt
         self.text_encoder_2_on_tt = text_encoder_2_on_tt
         self.unet_on_tt = unet_on_tt
         self.vae_on_tt = vae_on_tt
+        # Harness-set compile options; used to preserve them around the
+        # VAE-only opt_level switch in generate().
+        self.compile_options = compile_options or {}
 
 
 class PlaygroundV25Pipeline:
@@ -64,8 +61,6 @@ class PlaygroundV25Pipeline:
 
     def __init__(self, config: PlaygroundV25Config):
         self.config = config
-        self.device = config.device
-        self.model_id = config.model_id
 
     def setup(self):
         self.load_models()
@@ -104,15 +99,15 @@ class PlaygroundV25Pipeline:
 
     def load_scheduler(self):
         self.scheduler = EDMDPMSolverMultistepScheduler.from_pretrained(
-            self.model_id, subfolder="scheduler"
+            self.config.model_id, subfolder="scheduler"
         )
 
     def load_tokenizers(self):
         self.tokenizer = CLIPTokenizer.from_pretrained(
-            self.model_id, subfolder="tokenizer"
+            self.config.model_id, subfolder="tokenizer"
         )
         self.tokenizer_2 = CLIPTokenizer.from_pretrained(
-            self.model_id, subfolder="tokenizer_2"
+            self.config.model_id, subfolder="tokenizer_2"
         )
 
     def _get_add_time_ids(self, dtype):
@@ -130,10 +125,21 @@ class PlaygroundV25Pipeline:
         num_inference_steps: int = 50,
         seed: Optional[int] = None,
     ) -> torch.Tensor:
+        assert isinstance(
+            prompt, str
+        ), "Only single-prompt generation (batch_size=1) is tested for now"
         batch_size = 1
 
-        tt_cast = lambda x: x.to(device=xm.xla_device())
-        cpu_cast = lambda x: x.to("cpu")
+        device = xm.xla_device()
+        # Per-component forward+sync times (reset every generate() call).
+        self._perf = {
+            "te1": None,
+            "te2": None,
+            "unet_steps": [],
+            "vae": None,
+            "total": None,
+        }
+        t_total_start = time.perf_counter()
 
         with torch.no_grad():
             generator = torch.Generator(device="cpu")
@@ -150,18 +156,19 @@ class PlaygroundV25Pipeline:
                 max_length=self.tokenizer.model_max_length,
                 truncation=True,
                 return_tensors="pt",
-            ).input_ids.to(device=self.device)
+            ).input_ids.to(device="cpu")
 
             # CPU → TT
             if self.config.text_encoder_on_tt:
-                self.text_encoder = self.text_encoder.to(xm.xla_device())
-                tokens_1 = tokens_1.to(device=xm.xla_device())
+                self.text_encoder = self.text_encoder.to(device)
+                tokens_1 = tokens_1.to(device=device)
 
+            t0 = time.perf_counter()
             prompt_embeds_1 = self.text_encoder(tokens_1)
-
-            # TT → CPU
+            # TT → CPU (cpu cast forces sync — timer ends after this)
             if self.config.text_encoder_on_tt:
-                prompt_embeds_1 = cpu_cast(prompt_embeds_1)
+                prompt_embeds_1 = prompt_embeds_1.to("cpu")
+            self._perf["te1"] = time.perf_counter() - t0
 
             if self.config.text_encoder_on_tt:
                 self.text_encoder = self.text_encoder.to("cpu")
@@ -176,19 +183,20 @@ class PlaygroundV25Pipeline:
                 max_length=self.tokenizer_2.model_max_length,
                 truncation=True,
                 return_tensors="pt",
-            ).input_ids.to(device=self.device)
+            ).input_ids.to(device="cpu")
 
             # CPU → TT
             if self.config.text_encoder_2_on_tt:
-                self.text_encoder_2 = self.text_encoder_2.to(xm.xla_device())
-                tokens_2 = tokens_2.to(device=xm.xla_device())
+                self.text_encoder_2 = self.text_encoder_2.to(device)
+                tokens_2 = tokens_2.to(device=device)
 
+            t0 = time.perf_counter()
             prompt_embeds_2, pooled_prompt_embeds = self.text_encoder_2(tokens_2)
-
-            # TT → CPU
+            # TT → CPU (cpu cast forces sync — timer ends after this)
             if self.config.text_encoder_2_on_tt:
-                prompt_embeds_2 = cpu_cast(prompt_embeds_2)
-                pooled_prompt_embeds = cpu_cast(pooled_prompt_embeds)
+                prompt_embeds_2 = prompt_embeds_2.to("cpu")
+                pooled_prompt_embeds = pooled_prompt_embeds.to("cpu")
+            self._perf["te2"] = time.perf_counter() - t0
 
             if self.config.text_encoder_2_on_tt:
                 self.text_encoder_2 = self.text_encoder_2.to("cpu")
@@ -212,12 +220,12 @@ class PlaygroundV25Pipeline:
                     max_length=self.tokenizer.model_max_length,
                     truncation=True,
                     return_tensors="pt",
-                ).input_ids.to(device=self.device)
+                ).input_ids.to(device="cpu")
                 if self.config.text_encoder_on_tt:
-                    neg_tokens_1 = neg_tokens_1.to(device=xm.xla_device())
+                    neg_tokens_1 = neg_tokens_1.to(device=device)
                 negative_prompt_embeds_1 = self.text_encoder(neg_tokens_1)
                 if self.config.text_encoder_on_tt:
-                    negative_prompt_embeds_1 = cpu_cast(negative_prompt_embeds_1)
+                    negative_prompt_embeds_1 = negative_prompt_embeds_1.to("cpu")
 
                 neg_tokens_2 = self.tokenizer_2(
                     [negative_prompt],
@@ -225,16 +233,16 @@ class PlaygroundV25Pipeline:
                     max_length=self.tokenizer_2.model_max_length,
                     truncation=True,
                     return_tensors="pt",
-                ).input_ids.to(device=self.device)
+                ).input_ids.to(device="cpu")
                 if self.config.text_encoder_2_on_tt:
-                    neg_tokens_2 = neg_tokens_2.to(device=xm.xla_device())
+                    neg_tokens_2 = neg_tokens_2.to(device=device)
                 negative_prompt_embeds_2, negative_pooled_prompt_embeds = (
                     self.text_encoder_2(neg_tokens_2)
                 )
                 if self.config.text_encoder_2_on_tt:
-                    negative_prompt_embeds_2 = cpu_cast(negative_prompt_embeds_2)
-                    negative_pooled_prompt_embeds = cpu_cast(
-                        negative_pooled_prompt_embeds
+                    negative_prompt_embeds_2 = negative_prompt_embeds_2.to("cpu")
+                    negative_pooled_prompt_embeds = negative_pooled_prompt_embeds.to(
+                        "cpu"
                     )
 
                 negative_prompt_embeds = torch.cat(
@@ -248,12 +256,10 @@ class PlaygroundV25Pipeline:
             )
 
             add_time_ids = self._get_add_time_ids(prompt_embeds.dtype)
-            add_time_ids = torch.cat([add_time_ids, add_time_ids], dim=0).to(
-                self.device
-            )
+            add_time_ids = torch.cat([add_time_ids, add_time_ids], dim=0).to("cpu")
 
             # ── Timesteps ─────────────────────────────────────────────────
-            self.scheduler.set_timesteps(num_inference_steps, device=self.device)
+            self.scheduler.set_timesteps(num_inference_steps, device="cpu")
             timesteps = self.scheduler.timesteps
 
             # ── Latents ───────────────────────────────────────────────────
@@ -265,7 +271,7 @@ class PlaygroundV25Pipeline:
             )
             latents = torch.randn(
                 latent_shape, generator=generator, dtype=torch.float32
-            ).to(device=self.device)
+            ).to(device="cpu")
             latents = latents * self.scheduler.init_noise_sigma
 
             # ── Denoising loop (UNet) ─────────────────────────────────────
@@ -274,7 +280,18 @@ class PlaygroundV25Pipeline:
             )
             # Move UNet to TT once before the loop; evict after.
             if self.config.unet_on_tt:
-                self.unet = self.unet.to(xm.xla_device())
+                self.unet = self.unet.to(device)
+
+            # Loop-invariant inputs: convert once, reuse across all 50 steps.
+            if self.config.unet_on_tt:
+                unet_eh = prompt_embeds.to(torch.bfloat16).to(device)
+                unet_te = add_text_embeds.to(torch.bfloat16).to(device)
+                unet_ti = add_time_ids.to(torch.bfloat16).to(device)
+            else:
+                unet_eh = prompt_embeds
+                unet_te = add_text_embeds
+                unet_ti = add_time_ids
+
             for i, t in enumerate(timesteps):
                 logger.info(f"[STEP] UNet step {i + 1}/{num_inference_steps}")
 
@@ -283,25 +300,21 @@ class PlaygroundV25Pipeline:
                     latent_model_input, t
                 )
 
-                # CPU → TT (UNet runs in bf16 on TT)
+                # CPU → TT (UNet runs in bf16 on TT). Only sample + timestep
+                # change per step; embeds/time_ids are hoisted above.
                 if self.config.unet_on_tt:
-                    unet_sample = tt_cast(latent_model_input.to(torch.bfloat16))
-                    unet_t = tt_cast(t.to(torch.bfloat16))
-                    unet_eh = tt_cast(prompt_embeds.to(torch.bfloat16))
-                    unet_te = tt_cast(add_text_embeds.to(torch.bfloat16))
-                    unet_ti = tt_cast(add_time_ids.to(torch.bfloat16))
+                    unet_sample = latent_model_input.to(torch.bfloat16).to(device)
+                    unet_t = t.to(torch.bfloat16).to(device)
                 else:
                     unet_sample = latent_model_input
                     unet_t = t
-                    unet_eh = prompt_embeds
-                    unet_te = add_text_embeds
-                    unet_ti = add_time_ids
 
+                t0 = time.perf_counter()
                 noise_pred = self.unet(unet_sample, unet_t, unet_eh, unet_te, unet_ti)
-
-                # TT → CPU
+                # TT → CPU (cpu cast forces sync — timer ends after this)
                 if self.config.unet_on_tt:
-                    noise_pred = cpu_cast(noise_pred).to(torch.float32)
+                    noise_pred = noise_pred.to("cpu").to(torch.float32)
+                self._perf["unet_steps"].append(time.perf_counter() - t0)
 
                 # CFG + scheduler step
                 uncond, text = noise_pred.chunk(2)
@@ -331,85 +344,30 @@ class PlaygroundV25Pipeline:
             latents = latents * latents_std / scaling_factor + latents_mean
 
             # opt_level=1 keeps ttir.group_norm -> ttnn.group_norm; opt_level=0
-            # decomposes GroupNorm which can OOM on the VAE.
-            # See: https://github.com/tenstorrent/tt-xla/issues/4710
+            # decomposes GroupNorm which OOMs the VAE (issue #4710).
             if self.config.vae_on_tt:
-                torch_xla.set_custom_compile_options({"optimization_level": 1})
+                torch_xla.set_custom_compile_options(
+                    {**self.config.compile_options, "optimization_level": 1}
+                )
 
             # CPU → TT
             if self.config.vae_on_tt:
-                self.vae = self.vae.to(xm.xla_device())
-                latents = tt_cast(latents)
+                self.vae = self.vae.to(device)
+                latents = latents.to(device)
 
+            t0 = time.perf_counter()
             image = self.vae(latents)
-
-            # TT → CPU
+            # TT → CPU (cpu cast forces sync — timer ends after this)
             if self.config.vae_on_tt:
-                image = cpu_cast(image)
+                image = image.to("cpu")
+            self._perf["vae"] = time.perf_counter() - t0
 
             if self.config.vae_on_tt:
                 self.vae = self.vae.to("cpu")
+                # Restore harness-set options (un-merge the VAE opt_level bump).
+                torch_xla.set_custom_compile_options(self.config.compile_options)
 
             logger.info("[STAGE] VAE decode: done")
+            self._perf["total"] = time.perf_counter() - t_total_start
 
             return image
-
-
-def save_image(image: torch.Tensor, filepath: str = "output.png"):
-    image = (
-        (torch.clamp(image / 2 + 0.5, 0.0, 1.0) * 255.0).round().to(dtype=torch.uint8)
-    )
-    image_np = image.cpu().squeeze().numpy()
-    assert image_np.ndim == 3, "Image must be 3D"
-    if image_np.shape[0] == 3:
-        image_np = image_np.transpose(1, 2, 0)
-    Image.fromarray(image_np).save(filepath)
-
-
-def run_playground_v25_pipeline(
-    output_path: str = "playground_v25_output.png",
-    num_inference_steps: int = 50,
-):
-    """Run Playground v2.5 pipeline and save output image."""
-    config = PlaygroundV25Config(device="cpu")
-    pipeline = PlaygroundV25Pipeline(config=config)
-    pipeline.setup()
-
-    img = pipeline.generate(
-        prompt=PROMPT,
-        negative_prompt=NEGATIVE_PROMPT,
-        cfg_scale=GUIDANCE_SCALE,
-        num_inference_steps=num_inference_steps,
-        seed=SEED,
-    )
-
-    save_image(img, output_path)
-    return output_path
-
-
-def test_playground_v25_pipeline():
-    """Run the full Playground v2.5 pipeline with all components on TT."""
-    xr.set_device_type("TT")
-
-    output_path = "playground_v2_5_output.png"
-    output_file = Path(output_path)
-    if output_file.exists():
-        output_file.unlink()
-
-    run_playground_v25_pipeline(
-        output_path=output_path,
-        num_inference_steps=50,
-    )
-
-    assert output_file.exists(), f"Output image {output_path} was not created"
-
-    with Image.open(output_path) as img:
-        width, height = img.size
-        assert width == WIDTH, f"Expected width {WIDTH}, got {width}"
-        assert height == HEIGHT, f"Expected height {HEIGHT}, got {height}"
-
-    logger.info(f"Output image saved to {output_path} ({width}x{height})")
-
-
-if __name__ == "__main__":
-    test_playground_v25_pipeline()

--- a/tests/benchmark/test_imagegen.py
+++ b/tests/benchmark/test_imagegen.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Text-to-image (diffusion) benchmarks.
+
+Config-driven entry points (one ``test_<model>`` per model) that drive
+per-model pipelines through the shared harness in
+``benchmarks/imagegen_benchmark.py``. This mirrors the ``test_vision.py`` /
+``vision_benchmark.py`` split: model-specific config lives here, the reusable
+measurement logic lives in ``benchmarks/``.
+"""
+
+import json
+
+import pytest
+from benchmarks.imagegen_benchmark import benchmark_imagegen_torch_xla
+from utils import aggregate_ttnn_perf_metrics, resolve_display_name
+
+# Defaults shared by all image-gen models.
+DEFAULT_OPTIMIZATION_LEVEL = 1
+DEFAULT_TRACE_ENABLED = False
+DEFAULT_SEED = 42
+
+
+def test_imagegen(
+    build_pipeline_fn,
+    model_info_name,
+    output_file,
+    prompt,
+    num_inference_steps,
+    height,
+    width,
+    request=None,
+    optimization_level=DEFAULT_OPTIMIZATION_LEVEL,
+    trace_enabled=DEFAULT_TRACE_ENABLED,
+    output_image_path=None,
+):
+    """Run a text-to-image benchmark with the given configuration.
+
+    Args:
+        build_pipeline_fn: Callable returning ``(pipeline, generate_fn, save_fn)``;
+            see ``benchmark_imagegen_torch_xla``.
+        model_info_name: Model name for identification and reporting.
+        output_file: Path to save benchmark results as JSON.
+        prompt: Text prompt to generate from.
+        num_inference_steps: Number of denoising steps.
+        height, width: Output image dimensions.
+        optimization_level: Optimization level (0, 1, or 2).
+        trace_enabled: Enable trace.
+        output_image_path: If set, the steady-state image is saved here.
+    """
+    resolved_display_name = resolve_display_name(
+        request=request, fallback=model_info_name
+    )
+    ttnn_perf_metrics_output_file = f"tt_xla_{resolved_display_name}_perf_metrics"
+
+    print(f"Running image-gen benchmark for model: {model_info_name}")
+    print(
+        f"""Configuration:
+    optimization_level={optimization_level}
+    trace_enabled={trace_enabled}
+    prompt={prompt!r}
+    num_inference_steps={num_inference_steps}
+    height={height}
+    width={width}
+    ttnn_perf_metrics_output_file={ttnn_perf_metrics_output_file}
+    """
+    )
+
+    results = benchmark_imagegen_torch_xla(
+        build_pipeline_fn=build_pipeline_fn,
+        model_info_name=model_info_name,
+        display_name=resolved_display_name,
+        prompt=prompt,
+        num_inference_steps=num_inference_steps,
+        height=height,
+        width=width,
+        optimization_level=optimization_level,
+        trace_enabled=trace_enabled,
+        ttnn_perf_metrics_output_file=ttnn_perf_metrics_output_file,
+        output_image_path=output_image_path,
+    )
+
+    if output_file:
+        results["project"] = "tt-forge/tt-xla"
+        results["model_rawname"] = model_info_name
+
+        aggregate_ttnn_perf_metrics(ttnn_perf_metrics_output_file, results)
+
+        with open(output_file, "w") as file:
+            json.dump(results, file, indent=2)
+
+
+@pytest.mark.xfail(
+    reason=(
+        "VAE compile TT_FATAL during warmup (cores harvested / device_hash mismatch), "
+        "possibly due to recent uplift — "
+        "https://github.com/tenstorrent/tt-xla/issues/5176"
+    ),
+    strict=False,
+)
+def test_playground_v2_5(output_file, request):
+    from benchmarks.playground_v2_5_pipeline import (
+        PlaygroundV25Config,
+        PlaygroundV25Pipeline,
+    )
+
+    prompt = "Astronaut in a jungle, cold color palette, muted colors, detailed, 8k"
+    num_inference_steps = 50
+    height = width = 1024
+
+    def build_pipeline_fn(compile_options):
+        # All 4 components on TT. compile_options forwarded into Config so the
+        # VAE-only opt_level switch can merge instead of clobbering.
+        pipeline = PlaygroundV25Pipeline(
+            config=PlaygroundV25Config(compile_options=compile_options)
+        )
+        pipeline.setup()
+
+        def generate_fn(prompt, steps):
+            return pipeline.generate(
+                prompt=prompt,
+                negative_prompt=None,
+                cfg_scale=3.0,
+                num_inference_steps=steps,
+                seed=DEFAULT_SEED,
+            )
+
+        return pipeline, generate_fn
+
+    test_imagegen(
+        build_pipeline_fn=build_pipeline_fn,
+        model_info_name="playground-v2.5",
+        output_file=output_file,
+        request=request,
+        prompt=prompt,
+        num_inference_steps=num_inference_steps,
+        height=height,
+        width=width,
+        # opt_level=0 for text encoders + UNet (text_encoder 1 hits
+        # "Unsupported buffer type" at opt_level=1). VAE switches to
+        # opt_level=1 inline (and resets after) because GroupNorm
+        # decomposition at opt_level=0 OOMs the VAE.
+        optimization_level=0,
+        output_image_path="test_playground_v2_5_output.png",
+    )

--- a/tests/benchmark/utils.py
+++ b/tests/benchmark/utils.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
 import torch
+from PIL import Image
 
 
 def align_arch(arch: str):
@@ -568,3 +569,15 @@ def move_to_cpu(data):
         moved = [move_to_cpu(item) for item in data]
         return type(data)(moved)
     return data
+
+
+def save_image(image: torch.Tensor, filepath: str = "output.png"):
+    """Save a diffusion-model output tensor (range [-1, 1], CHW or BCHW) as a PNG."""
+    image = (
+        (torch.clamp(image / 2 + 0.5, 0.0, 1.0) * 255.0).round().to(dtype=torch.uint8)
+    )
+    image_np = image.cpu().squeeze().numpy()
+    assert image_np.ndim == 3, "Image must be 3D"
+    if image_np.shape[0] == 3:
+        image_np = image_np.transpose(1, 2, 0)
+    Image.fromarray(image_np).save(filepath)

--- a/tests/torch/models/playground_v2_5/test_playground_v2_5_pipeline.py
+++ b/tests/torch/models/playground_v2_5/test_playground_v2_5_pipeline.py
@@ -1,0 +1,433 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Playground v2.5 — nightly e2e pipeline test.
+
+Each nn.Module component (text_encoder, text_encoder_2, unet, vae) can be
+independently moved to Tenstorrent via
+`model.compile(backend="tt") + model.to(xla_device())`. Tokenizer and
+scheduler always stay on CPU. CPU→TT→CPU device switching is done inline at
+the call site of each nn component.
+"""
+
+from pathlib import Path
+from typing import Optional
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.core.xla_model as xm
+import torch_xla.runtime as xr
+from diffusers import EDMDPMSolverMultistepScheduler
+from infra import RunMode
+from loguru import logger
+from PIL import Image
+from transformers import CLIPTokenizer
+from utils import BringupStatus, Category, ModelGroup
+
+from third_party.tt_forge_models.playground_v2_5.pytorch import (
+    ModelLoader,
+    ModelVariant,
+)
+
+MODEL_ID = "playgroundai/playground-v2.5-1024px-aesthetic"
+PROMPT = "Astronaut in a jungle, cold color palette, muted colors, detailed, 8k"
+NEGATIVE_PROMPT = None
+SEED = 42
+GUIDANCE_SCALE = 3.0
+HEIGHT = 1024
+WIDTH = 1024
+
+
+class PlaygroundV25Config:
+    def __init__(
+        self,
+        device: str = "cpu",
+        text_encoder_on_tt: bool = True,
+        text_encoder_2_on_tt: bool = True,
+        unet_on_tt: bool = True,
+        vae_on_tt: bool = True,
+    ):
+        self.model_id = MODEL_ID
+        self.width = WIDTH
+        self.height = HEIGHT
+        self.vae_scale_factor = 8
+        self.latents_width = self.width // self.vae_scale_factor
+        self.latents_height = self.height // self.vae_scale_factor
+        self.device = device
+        self.text_encoder_on_tt = text_encoder_on_tt
+        self.text_encoder_2_on_tt = text_encoder_2_on_tt
+        self.unet_on_tt = unet_on_tt
+        self.vae_on_tt = vae_on_tt
+
+
+class PlaygroundV25Pipeline:
+    """Playground v2.5 pipeline with per-component TT toggles."""
+
+    def __init__(self, config: PlaygroundV25Config):
+        self.config = config
+        self.device = config.device
+        self.model_id = config.model_id
+
+    def setup(self):
+        self.load_models()
+        self.load_scheduler()
+        self.load_tokenizers()
+
+    def load_models(self):
+        # Load all models on CPU. For TT-bound components we only register the
+        # `tt` dynamo backend here; the actual move to xla_device happens in
+        # generate() right before the forward, and we evict back to CPU after.
+        # This keeps at most one model resident on TT DRAM at a time.
+        self.text_encoder = ModelLoader(ModelVariant.TEXT_ENCODER).load_model(
+            dtype_override=torch.float32
+        )
+        if self.config.text_encoder_on_tt:
+            self.text_encoder.compile(backend="tt")
+
+        self.text_encoder_2 = ModelLoader(ModelVariant.TEXT_ENCODER_2).load_model(
+            dtype_override=torch.float32
+        )
+        if self.config.text_encoder_2_on_tt:
+            self.text_encoder_2.compile(backend="tt")
+
+        # UNet on fp32 throws OOM on the second iteration of the denoising loop,
+        # so UNet runs in bf16.
+        unet_dtype = torch.bfloat16 if self.config.unet_on_tt else torch.float32
+        self.unet = ModelLoader(ModelVariant.UNET).load_model(dtype_override=unet_dtype)
+        if self.config.unet_on_tt:
+            self.unet.compile(backend="tt")
+
+        self.vae = ModelLoader(ModelVariant.VAE).load_model(
+            dtype_override=torch.float32
+        )
+        if self.config.vae_on_tt:
+            self.vae.compile(backend="tt")
+
+    def load_scheduler(self):
+        self.scheduler = EDMDPMSolverMultistepScheduler.from_pretrained(
+            self.model_id, subfolder="scheduler"
+        )
+
+    def load_tokenizers(self):
+        self.tokenizer = CLIPTokenizer.from_pretrained(
+            self.model_id, subfolder="tokenizer"
+        )
+        self.tokenizer_2 = CLIPTokenizer.from_pretrained(
+            self.model_id, subfolder="tokenizer_2"
+        )
+
+    def _get_add_time_ids(self, dtype):
+        original_size = (self.config.height, self.config.width)
+        crops_coords_top_left = (0, 0)
+        target_size = (self.config.height, self.config.width)
+        add_time_ids = list(original_size + crops_coords_top_left + target_size)
+        return torch.tensor([add_time_ids], dtype=dtype)
+
+    def generate(
+        self,
+        prompt: str,
+        negative_prompt: Optional[str] = None,
+        cfg_scale: float = 3.0,
+        num_inference_steps: int = 50,
+        seed: Optional[int] = None,
+    ) -> torch.Tensor:
+        batch_size = 1
+
+        tt_cast = lambda x: x.to(device=xm.xla_device())
+        cpu_cast = lambda x: x.to("cpu")
+
+        with torch.no_grad():
+            generator = torch.Generator(device="cpu")
+            if seed is not None:
+                generator.manual_seed(seed)
+            else:
+                generator.seed()
+
+            # ── Text encoder 1 (CLIPTextModel) ────────────────────────────
+            logger.info("[STAGE] Text encoder 1: start")
+            tokens_1 = self.tokenizer(
+                [prompt],
+                padding="max_length",
+                max_length=self.tokenizer.model_max_length,
+                truncation=True,
+                return_tensors="pt",
+            ).input_ids.to(device=self.device)
+
+            # CPU → TT
+            if self.config.text_encoder_on_tt:
+                self.text_encoder = self.text_encoder.to(xm.xla_device())
+                tokens_1 = tokens_1.to(device=xm.xla_device())
+
+            prompt_embeds_1 = self.text_encoder(tokens_1)
+
+            # TT → CPU
+            if self.config.text_encoder_on_tt:
+                prompt_embeds_1 = cpu_cast(prompt_embeds_1)
+
+            if self.config.text_encoder_on_tt:
+                self.text_encoder = self.text_encoder.to("cpu")
+
+            logger.info("[STAGE] Text encoder 1: done")
+
+            # ── Text encoder 2 (CLIPTextModelWithProjection) ──────────────
+            logger.info("[STAGE] Text encoder 2: start")
+            tokens_2 = self.tokenizer_2(
+                [prompt],
+                padding="max_length",
+                max_length=self.tokenizer_2.model_max_length,
+                truncation=True,
+                return_tensors="pt",
+            ).input_ids.to(device=self.device)
+
+            # CPU → TT
+            if self.config.text_encoder_2_on_tt:
+                self.text_encoder_2 = self.text_encoder_2.to(xm.xla_device())
+                tokens_2 = tokens_2.to(device=xm.xla_device())
+
+            prompt_embeds_2, pooled_prompt_embeds = self.text_encoder_2(tokens_2)
+
+            # TT → CPU
+            if self.config.text_encoder_2_on_tt:
+                prompt_embeds_2 = cpu_cast(prompt_embeds_2)
+                pooled_prompt_embeds = cpu_cast(pooled_prompt_embeds)
+
+            if self.config.text_encoder_2_on_tt:
+                self.text_encoder_2 = self.text_encoder_2.to("cpu")
+
+            logger.info("[STAGE] Text encoder 2: done")
+
+            # Concat the two encoders' hidden states
+            prompt_embeds = torch.cat([prompt_embeds_1, prompt_embeds_2], dim=-1)
+
+            # force_zeros_for_empty_prompt=True for playground-v2.5: zero path
+            # only when negative_prompt is None.
+            if negative_prompt is None:
+                negative_prompt_embeds = torch.zeros_like(prompt_embeds)
+                negative_pooled_prompt_embeds = torch.zeros_like(pooled_prompt_embeds)
+            else:
+                # Encode negative prompt through both text encoders (mirrors
+                # the positive flow above).
+                neg_tokens_1 = self.tokenizer(
+                    [negative_prompt],
+                    padding="max_length",
+                    max_length=self.tokenizer.model_max_length,
+                    truncation=True,
+                    return_tensors="pt",
+                ).input_ids.to(device=self.device)
+                if self.config.text_encoder_on_tt:
+                    neg_tokens_1 = neg_tokens_1.to(device=xm.xla_device())
+                negative_prompt_embeds_1 = self.text_encoder(neg_tokens_1)
+                if self.config.text_encoder_on_tt:
+                    negative_prompt_embeds_1 = cpu_cast(negative_prompt_embeds_1)
+
+                neg_tokens_2 = self.tokenizer_2(
+                    [negative_prompt],
+                    padding="max_length",
+                    max_length=self.tokenizer_2.model_max_length,
+                    truncation=True,
+                    return_tensors="pt",
+                ).input_ids.to(device=self.device)
+                if self.config.text_encoder_2_on_tt:
+                    neg_tokens_2 = neg_tokens_2.to(device=xm.xla_device())
+                negative_prompt_embeds_2, negative_pooled_prompt_embeds = (
+                    self.text_encoder_2(neg_tokens_2)
+                )
+                if self.config.text_encoder_2_on_tt:
+                    negative_prompt_embeds_2 = cpu_cast(negative_prompt_embeds_2)
+                    negative_pooled_prompt_embeds = cpu_cast(
+                        negative_pooled_prompt_embeds
+                    )
+
+                negative_prompt_embeds = torch.cat(
+                    [negative_prompt_embeds_1, negative_prompt_embeds_2], dim=-1
+                )
+
+            # CFG concat (uncond first)
+            prompt_embeds = torch.cat([negative_prompt_embeds, prompt_embeds], dim=0)
+            add_text_embeds = torch.cat(
+                [negative_pooled_prompt_embeds, pooled_prompt_embeds], dim=0
+            )
+
+            add_time_ids = self._get_add_time_ids(prompt_embeds.dtype)
+            add_time_ids = torch.cat([add_time_ids, add_time_ids], dim=0).to(
+                self.device
+            )
+
+            # ── Timesteps ─────────────────────────────────────────────────
+            self.scheduler.set_timesteps(num_inference_steps, device=self.device)
+            timesteps = self.scheduler.timesteps
+
+            # ── Latents ───────────────────────────────────────────────────
+            latent_shape = (
+                batch_size,
+                4,
+                self.config.latents_height,
+                self.config.latents_width,
+            )
+            latents = torch.randn(
+                latent_shape, generator=generator, dtype=torch.float32
+            ).to(device=self.device)
+            latents = latents * self.scheduler.init_noise_sigma
+
+            # ── Denoising loop (UNet) ─────────────────────────────────────
+            logger.info(
+                f"[STAGE] UNet denoising loop: start ({num_inference_steps} steps)"
+            )
+            # Move UNet to TT once before the loop; evict after.
+            if self.config.unet_on_tt:
+                self.unet = self.unet.to(xm.xla_device())
+            for i, t in enumerate(timesteps):
+                logger.info(f"[STEP] UNet step {i + 1}/{num_inference_steps}")
+
+                latent_model_input = torch.cat([latents] * 2)
+                latent_model_input = self.scheduler.scale_model_input(
+                    latent_model_input, t
+                )
+
+                # CPU → TT (UNet runs in bf16 on TT)
+                if self.config.unet_on_tt:
+                    unet_sample = tt_cast(latent_model_input.to(torch.bfloat16))
+                    unet_t = tt_cast(t.to(torch.bfloat16))
+                    unet_eh = tt_cast(prompt_embeds.to(torch.bfloat16))
+                    unet_te = tt_cast(add_text_embeds.to(torch.bfloat16))
+                    unet_ti = tt_cast(add_time_ids.to(torch.bfloat16))
+                else:
+                    unet_sample = latent_model_input
+                    unet_t = t
+                    unet_eh = prompt_embeds
+                    unet_te = add_text_embeds
+                    unet_ti = add_time_ids
+
+                noise_pred = self.unet(unet_sample, unet_t, unet_eh, unet_te, unet_ti)
+
+                # TT → CPU
+                if self.config.unet_on_tt:
+                    noise_pred = cpu_cast(noise_pred).to(torch.float32)
+
+                # CFG + scheduler step
+                uncond, text = noise_pred.chunk(2)
+                noise_pred = uncond + cfg_scale * (text - uncond)
+
+                latents = self.scheduler.step(
+                    noise_pred, t, latents, return_dict=False
+                )[0]
+            # Evict UNet from TT before VAE comes onto the device.
+            if self.config.unet_on_tt:
+                self.unet = self.unet.to("cpu")
+            logger.info("[STAGE] UNet denoising loop: done")
+
+            # ── VAE decode ────────────────────────────────────────────────
+            logger.info("[STAGE] VAE decode: start")
+            latents_mean = (
+                torch.tensor(self.vae.vae.config.latents_mean)
+                .view(1, 4, 1, 1)
+                .to(latents.device, latents.dtype)
+            )
+            latents_std = (
+                torch.tensor(self.vae.vae.config.latents_std)
+                .view(1, 4, 1, 1)
+                .to(latents.device, latents.dtype)
+            )
+            scaling_factor = self.vae.vae.config.scaling_factor
+            latents = latents * latents_std / scaling_factor + latents_mean
+
+            # opt_level=1 keeps ttir.group_norm -> ttnn.group_norm; opt_level=0
+            # decomposes GroupNorm which can OOM on the VAE.
+            # See: https://github.com/tenstorrent/tt-xla/issues/4710
+            if self.config.vae_on_tt:
+                torch_xla.set_custom_compile_options({"optimization_level": 1})
+
+            # CPU → TT
+            if self.config.vae_on_tt:
+                self.vae = self.vae.to(xm.xla_device())
+                latents = tt_cast(latents)
+
+            image = self.vae(latents)
+
+            # TT → CPU
+            if self.config.vae_on_tt:
+                image = cpu_cast(image)
+
+            if self.config.vae_on_tt:
+                self.vae = self.vae.to("cpu")
+
+            logger.info("[STAGE] VAE decode: done")
+
+            return image
+
+
+def save_image(image: torch.Tensor, filepath: str = "output.png"):
+    image = (
+        (torch.clamp(image / 2 + 0.5, 0.0, 1.0) * 255.0).round().to(dtype=torch.uint8)
+    )
+    image_np = image.cpu().squeeze().numpy()
+    assert image_np.ndim == 3, "Image must be 3D"
+    if image_np.shape[0] == 3:
+        image_np = image_np.transpose(1, 2, 0)
+    Image.fromarray(image_np).save(filepath)
+
+
+def run_playground_v25_pipeline(
+    output_path: str = "playground_v25_output.png",
+    num_inference_steps: int = 50,
+):
+    """Run Playground v2.5 pipeline and save output image."""
+    config = PlaygroundV25Config(device="cpu")
+    pipeline = PlaygroundV25Pipeline(config=config)
+    pipeline.setup()
+
+    img = pipeline.generate(
+        prompt=PROMPT,
+        negative_prompt=NEGATIVE_PROMPT,
+        cfg_scale=GUIDANCE_SCALE,
+        num_inference_steps=num_inference_steps,
+        seed=SEED,
+    )
+
+    save_image(img, output_path)
+    return output_path
+
+
+@pytest.mark.xfail(
+    reason=(
+        "VAE compile TT_FATAL during warmup (cores harvested / device_hash mismatch), "
+        "possibly due to recent uplift — "
+        "https://github.com/tenstorrent/tt-xla/issues/5176"
+    ),
+    strict=False,
+)
+@pytest.mark.nightly
+@pytest.mark.model_test
+@pytest.mark.single_device
+@pytest.mark.large
+@pytest.mark.record_test_properties(
+    category=Category.MODEL_TEST,
+    model_name="PlaygroundV2_5_Pipeline",
+    model_group=ModelGroup.RED,
+    run_mode=RunMode.INFERENCE,
+    bringup_status=BringupStatus.PASSED,
+)
+def test_playground_v25_pipeline():
+    """Run the full Playground v2.5 pipeline with all components on TT."""
+    xr.set_device_type("TT")
+
+    output_path = "playground_v2_5_output.png"
+    output_file = Path(output_path)
+    if output_file.exists():
+        output_file.unlink()
+
+    run_playground_v25_pipeline(
+        output_path=output_path,
+        num_inference_steps=50,
+    )
+
+    assert output_file.exists(), f"Output image {output_path} was not created"
+
+    with Image.open(output_path) as img:
+        width, height = img.size
+        assert width == WIDTH, f"Expected width {WIDTH}, got {width}"
+        assert height == HEIGHT, f"Expected height {HEIGHT}, got {height}"
+
+    logger.info(f"Output image saved to {output_path} ({width}x{height})")


### PR DESCRIPTION
### Ticket

- closes https://github.com/tenstorrent/tt-xla/issues/5047

### Problem description

Image-gen Model that passes bringup should be added to nightly + benchmark CI. Playground v2.5's all 4 components are passing but the e2e pipeline is still a manually-invoked example with no CI coverage.

### What's changed

Benchmark structure mirrors the `imagegen_benchmark` pattern introduced in https://github.com/tenstorrent/tt-xla/pull/5085 (per @VladanKovacevic's review): shared harness in `benchmarks/`, per-model config in `test_imagegen.py`.

- **Nightly** (`tests/torch/models/playground_v2_5/test_playground_v2_5_pipeline.py`): self-contained — pipeline class + `run_playground_v25_pipeline` helper + test function all inline (no import from `examples/`). Markers: `nightly`, `model_test`, `single_device`, `large`, `record_test_properties`.
- **Benchmark** (`tests/benchmark/test_imagegen.py::test_playground_v2_5`): config-driven entry; all 4 components on TT; `optimization_level=0` (with VAE switching to 1 inline, **merged with harness options** instead of overwriting). Two-pass harness: warmup (1 step — triggers compile of every component) + steady-state (full 50 steps, all cache hits). Emits per-component steady-state measurements: `text_encoder_1_s`, `text_encoder_2_s`, `unet_step_mean_s`, `vae_s`, `cpu_overhead_s`, `e2e_latency`, `images_per_second`.
- **Benchmark pipeline class** (`tests/benchmark/benchmarks/playground_v2_5_pipeline.py`): per @VladanKovacevic's review, the benchmark has its own pipeline (no import from `examples/`). The same self-contained pattern is applied to the nightly test; the previous `examples/pytorch/playground_v2_5_pipeline.py` demo file is removed since neither test path imports from it anymore.
- **Matrix entry** added to `.github/workflows/perf-bench-matrix.json`.
- **xfail marker** (both nightly + benchmark) for https://github.com/tenstorrent/tt-xla/issues/5176 — VAE compile TT_FATAL on current main after the recent uplift. PR code verified correct on a pre-uplift commit: https://github.com/tenstorrent/tt-xla/actions/runs/27344277516/job/80792035664.

### Checklist
- [x] Validate benchmark test on N150 — https://github.com/tenstorrent/tt-xla/actions/runs/27337975698
