### PR TITLE
[wheel] Support bundling libtt-alchemist-lib.so into manylinux wheel

### DIFF
--- a/pjrt_implementation/src/api/module_builder/module_builder.cc
+++ b/pjrt_implementation/src/api/module_builder/module_builder.cc
@@ -162,16 +162,22 @@ TTAlchemistHandler::~TTAlchemistHandler() {
 }
 
 std::optional<std::string> TTAlchemistHandler::findTTAlchemistLibraryPath() {
-  const char *mlir_home = std::getenv("TT_MLIR_HOME");
-  if (mlir_home == nullptr) {
-    return std::nullopt;
+  // Wheel install: pjrt_plugin_tt/__init__.py exports TT_PJRT_PLUGIN_DIR,
+  // and the bundled library lives in <plugin_dir>/lib/.
+  if (const char *plugin_dir = std::getenv("TT_PJRT_PLUGIN_DIR")) {
+    std::string p = std::string(plugin_dir) + "/lib/libtt-alchemist-lib.so";
+    if (std::filesystem::exists(p)) {
+      return p;
+    }
   }
 
-  std::string alchemist_lib_path =
-      std::string(mlir_home) + "/build/lib/libtt-alchemist-lib.so";
-
-  if (std::filesystem::exists(alchemist_lib_path)) {
-    return alchemist_lib_path;
+  // Source build fallback: tt-mlir build tree.
+  if (const char *mlir_home = std::getenv("TT_MLIR_HOME")) {
+    std::string p =
+        std::string(mlir_home) + "/build/lib/libtt-alchemist-lib.so";
+    if (std::filesystem::exists(p)) {
+      return p;
+    }
   }
 
   return std::nullopt;

--- a/python_package/pyproject.toml
+++ b/python_package/pyproject.toml
@@ -8,4 +8,4 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-repair-wheel-command = "auditwheel repair --exclude libTTMLIRRuntime.so --exclude libTTMLIRCompiler.so --exclude libtt_metal.so --exclude libtt_stl.so --exclude libtt-umd.so.0 --exclude _ttnncpp.so --exclude _ttnn.so --exclude libdevice.so --exclude libtracy.so* -w {dest_dir} {wheel}"
+repair-wheel-command = "auditwheel repair --exclude libTTMLIRRuntime.so --exclude libTTMLIRCompiler.so --exclude libtt-alchemist-lib.so --exclude libtt_metal.so --exclude libtt_stl.so --exclude libtt-umd.so.0 --exclude _ttnncpp.so --exclude _ttnn.so --exclude libdevice.so --exclude libtracy.so* -w {dest_dir} {wheel}"


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/8257

### Problem description
Codegen lib (tt-alchemist) is not bundled into wheel(s).

### What's changed
https://github.com/tenstorrent/tt-mlir/pull/8685 adds cmake `install()` directives to copy the lib + `templates` dir, which then get packaged into wheel(s).

This change adds `TT_PJRT_PLUGIN_DIR` as another search path for the codegen lib. Together, these 2 changes allow codegen from wheels.

This is merge-able without the changes in tt-mlir - source path will still work until tt-mlir change is uplifted into tt-xla.

Total wheel footprint: +50 KB.

### Checklist
- [ ] New/Existing tests provide coverage for changes
