### PR TITLE
Fix runtime errors encountered due to transformers uplift.

### DIFF
--- a/examples/pytorch/gpt_oss_20b.py
+++ b/examples/pytorch/gpt_oss_20b.py
@@ -231,6 +231,11 @@ def construct_inputs(
     override_cache_sliding_window_layers(static_cache, max_cache_len, sliding_window)
 
     cache_position: torch.Tensor = torch.arange(0, inputs.input_ids.shape[1])
+    # Pass position_ids explicitly so gpt_oss's forward never enters the
+    # "position_ids is None" branch (which calls past_key_values.get_seq_length()
+    # and bakes a per-step Python int into the graph, causing dynamo to
+    # recompile on every decode step).
+    position_ids = cache_position.unsqueeze(0)
 
     # Attention mask is needed to ignore padding tokens in left-padded batches. The mask should match max_cache_len
     # to prevent recompilation or implicit padding by transformers, which can cause degenerate output.
@@ -244,6 +249,7 @@ def construct_inputs(
         "input_ids": inputs.input_ids,
         "past_key_values": static_cache,
         "cache_position": cache_position,
+        "position_ids": position_ids,
         "use_cache": True,
         "attention_mask": full_attention_mask,
     }
@@ -282,8 +288,19 @@ def transfer_to_device(
     for layer in input_args["past_key_values"].layers:
         layer.keys = layer.keys.to(device)
         layer.values = layer.values.to(device)
+        # StaticLayer.update builds a fresh `cache_position` each call as
+        # `torch.arange(kv_length, device=self.device) + self.cumulative_length`,
+        # then passes it to `self.keys.index_copy_(2, cache_position, ...)`.
+        # If `self.device` is still "cpu" or `cumulative_length` is a CPU tensor,
+        # the resulting index is CPU and `index_copy_` on an XLA `keys` tensor
+        # raises `Check failed: xtensor: Input tensor is not an XLA tensor`.
+        if isinstance(getattr(layer, "cumulative_length", None), torch.Tensor):
+            layer.cumulative_length = layer.cumulative_length.to(device)
+        if hasattr(layer, "device"):
+            layer.device = device
     input_args["input_ids"] = input_args["input_ids"].to(device)
     input_args["cache_position"] = input_args["cache_position"].to(device)
+    input_args["position_ids"] = input_args["position_ids"].to(device)
     input_args["attention_mask"] = input_args["attention_mask"].to(device)
 
     model = model.to(device)
@@ -398,6 +415,8 @@ def run_generate(
             host_cache_pos = input_args["cache_position"].to("cpu")
             host_cache_pos = torch.tensor([host_cache_pos[-1:] + 1])
             input_args["cache_position"] = host_cache_pos.to(device)
+            # keep position_ids in sync with cache_position (see construct_inputs)
+            input_args["position_ids"] = host_cache_pos.unsqueeze(0).to(device)
 
     print()
     if not is_interactive:

--- a/examples/pytorch/olmo3_1025_7b.py
+++ b/examples/pytorch/olmo3_1025_7b.py
@@ -49,6 +49,7 @@ def olmo3_1025_7b():
 
     input_args["input_ids"] = input_args["input_ids"].to(device)
     input_args["cache_position"] = input_args["cache_position"].to(device)
+    input_args["position_ids"] = input_args["position_ids"].to(device)
     input_args["attention_mask"] = input_args["attention_mask"].to(device)
     model = model.to(device)
 
@@ -77,6 +78,8 @@ def olmo3_1025_7b():
             host_cache_pos = input_args["cache_position"].to("cpu")
             host_cache_pos = torch.tensor([host_cache_pos[-1:] + 1])
             input_args["cache_position"] = host_cache_pos.to(device)
+            # keep position_ids in sync with cache_position (see _prepare_inputs)
+            input_args["position_ids"] = host_cache_pos.unsqueeze(0).to(device)
 
     print()
     for i in range(1):
@@ -172,11 +175,17 @@ def _prepare_inputs(
     full_attention_mask[:, :prompt_len] = inputs.attention_mask
 
     cache_position = torch.arange(0, seq_len)
+    # Pass position_ids explicitly so olmo3's forward never enters the
+    # "position_ids is None" branch (which calls past_key_values.get_seq_length()
+    # and bakes a per-step Python int into the graph, causing dynamo to
+    # recompile on every decode step).
+    position_ids = cache_position.unsqueeze(0)
 
     input_args = {
         "input_ids": inputs.input_ids,
         "past_key_values": static_cache,
         "cache_position": cache_position,
+        "position_ids": position_ids,
         "use_cache": True,
         "attention_mask": full_attention_mask,
     }

--- a/examples/pytorch/olmo3_1125_32b.py
+++ b/examples/pytorch/olmo3_1125_32b.py
@@ -98,6 +98,7 @@ def olmo3_1125_32b():
 
     input_args["input_ids"] = input_args["input_ids"].to(device)
     input_args["cache_position"] = input_args["cache_position"].to(device)
+    input_args["position_ids"] = input_args["position_ids"].to(device)
     input_args["attention_mask"] = input_args["attention_mask"].to(device)
     model = model.to(device)
 
@@ -129,6 +130,8 @@ def olmo3_1125_32b():
             host_cache_pos = input_args["cache_position"].to("cpu")
             host_cache_pos = torch.tensor([host_cache_pos[-1:] + 1])
             input_args["cache_position"] = host_cache_pos.to(device)
+            # keep position_ids in sync with cache_position (see _prepare_inputs)
+            input_args["position_ids"] = host_cache_pos.unsqueeze(0).to(device)
 
     print()
     for i in range(1):
@@ -218,11 +221,17 @@ def _prepare_inputs(
     full_attention_mask[:, :prompt_len] = inputs.attention_mask
 
     cache_position = torch.arange(0, seq_len)
+    # Pass position_ids explicitly so olmo3's forward never enters the
+    # "position_ids is None" branch (which calls past_key_values.get_seq_length()
+    # and bakes a per-step Python int into the graph, causing dynamo to
+    # recompile on every decode step).
+    position_ids = cache_position.unsqueeze(0)
 
     input_args = {
         "input_ids": inputs.input_ids,
         "past_key_values": static_cache,
         "cache_position": cache_position,
+        "position_ids": position_ids,
         "use_cache": True,
         "attention_mask": full_attention_mask,
     }

--- a/python_package/tt_torch/transformers_overrides.py
+++ b/python_package/tt_torch/transformers_overrides.py
@@ -77,9 +77,10 @@ def override_cache_sliding_window_layers(
 def tt_create_sliding_window_causal_mask(
     config,
     inputs_embeds: torch.Tensor,
-    attention_mask: Optional[torch.Tensor],
-    cache_position: torch.Tensor,
+    attention_mask: Optional[torch.Tensor] = None,
+    cache_position: Optional[torch.Tensor] = None,
     past_key_values=None,
+    position_ids: Optional[torch.Tensor] = None,
     **kwargs,
 ) -> torch.Tensor:
     """
@@ -89,15 +90,42 @@ def tt_create_sliding_window_causal_mask(
     only broadcasting tensor operations — no get_mask_sizes(),
     and no mutable Python state.  Designed to run with torch.compile on TT
     hardware as part of the model forward graph.
+
+    Accepts either ``cache_position`` (older HF call signature) or
+    ``position_ids`` (newer HF olmo3 / mistral / gpt_oss signature where
+    ``mask_kwargs`` no longer includes ``cache_position``). When only
+    ``position_ids`` is supplied, it is used as the cache position.
     """
+    if cache_position is None and position_ids is not None:
+        cache_position = position_ids[0] if position_ids.ndim == 2 else position_ids
+
     if past_key_values is None:
         return create_sliding_window_causal_mask(
             config,
             inputs_embeds,
             attention_mask,
             cache_position,
-            past_key_values,
+            past_key_values=past_key_values,
+            position_ids=position_ids,
             **kwargs,
+        )
+
+    # gpt_oss builds `mask_kwargs` without either `cache_position` or
+    # `position_ids`, so derive the absolute query position directly from
+    # `past_key_values.get_seq_length()` (the same primitive upstream relies on)
+    # offset by the query length implied by `inputs_embeds`. We can't simply
+    # call upstream `_preprocess_mask_arguments` instead: it is private, takes a
+    # `layer_idx`, returns a 7-tuple, and never returns `cache_position`, so we
+    # would still have to build the arange here anyway. Caches whose
+    # `get_seq_length()` returns a 0-D tensor stay graph-friendly; ones that
+    # return a Python int will specialize per decode step (recompile risk).
+    if cache_position is None:
+        q_length = inputs_embeds.shape[1]
+        past_seen_tokens = past_key_values.get_seq_length()
+        if isinstance(past_seen_tokens, torch.Tensor):
+            past_seen_tokens = past_seen_tokens.to(inputs_embeds.device)
+        cache_position = (
+            torch.arange(q_length, device=inputs_embeds.device) + past_seen_tokens
         )
 
     if isinstance(attention_mask, torch.Tensor) and attention_mask.ndim == 4:


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Fix runtime errors caused by the transformers uplift

The recent transformers uplift changed the HF call signatures and decode-time behavior for gpt_oss and olmo3, which surfaced two runtime problems in our PyTorch examples and the TT mask override

### What's changed
Updated the sliding-window mask override for the new HF signature. Newer transformers modeling code passes position_ids (instead of, or without, cache_position) when building attention masks. The override now accepts the new signature and gracefully derives the cache position when needed.


Log:
[mistral_8b.log](https://github.com/user-attachments/files/28341849/mistral_8b.log)
[olmo_7b.log](https://github.com/user-attachments/files/28341851/olmo_7b.log)
[olmo_32b.log](https://github.com/user-attachments/files/28341853/olmo_32b.log)
[gpt.log](https://github.com/user-attachments/files/28342749/gpt.log)



### Checklist
- [ ] New/Existing tests provide coverage for changes
