### PR TITLE
[CI] Add nightly run for vLLM QB2 tests

### DIFF
--- a/.github/workflows/test-matrix-presets/basic-test-nightly.json
+++ b/.github/workflows/test-matrix-presets/basic-test-nightly.json
@@ -13,6 +13,7 @@
   {"runs-on": "p150",                "name": "run_vllm_p150_tests",    "dir": "./tests/integrations/vllm_plugin",         "test-mark": "nightly and single_device",               "shared-runners": "true", "extra-wheel": "vllm"},
   {"runs-on": "n300",                "name": "run_vllm_n300_tests",    "dir": "./tests/integrations/vllm_plugin",         "test-mark": "nightly and data_parallel",               "shared-runners": "true", "extra-wheel": "vllm"},
   {"runs-on": "n300",                "name": "run_vllm_n300_tests",    "dir": "./tests/integrations/vllm_plugin",         "test-mark": "nightly and tensor_parallel and dual_chip", "shared-runners": "true", "extra-wheel": "vllm"},
+  {"runs-on": "qb2-blackhole",       "name": "run_vllm_bhqb_tests",    "dir": "./tests/integrations/vllm_plugin",         "test-mark": "nightly and bhqb",                        "extra-wheel": "vllm"},
   { "runs-on": "galaxy-wh-6u",       "name": "run_torch_galaxy",       "dir": "./tests/torch",                            "test-mark": "nightly and galaxy" },
   { "runs-on": "galaxy-wh-6u",        "name": "run_vllm_galaxy_wh_6u_tests", "dir": "./tests/integrations/vllm_plugin", "test-mark": "nightly and tensor_parallel and galaxy_wh_6u", "extra-wheel": "vllm" },
   { "runs-on": "galaxy-bh",           "name": "run_torch_bh_galaxy",   "dir": "./tests/torch",                            "test-mark": "nightly and bh_galaxy" }


### PR DESCRIPTION
### Ticket
closes #5054 

### Problem description
vLLM QB2 tests are added in manual vLLM nightly run but not added to basic nightly run which get triggered automatically every night.

### What's changed
Add vLLM QB2 tests to basic nightly tests to run.
