### PR TITLE
[Benchmark] Run single-chip benchmark models through vllm benchmark

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -71,21 +71,15 @@
         "name": "vllm_bge_m3_encode_batch1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_bge_m3_batch1",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
-        "skip-device-perf": true,
-        "runs-on": "n150"
+
+        "skip-device-perf": true
       },
       {
         "name": "vllm_bge_m3_encode_batch32",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_bge_m3_batch32",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
-        "skip-device-perf": true,
-        "runs-on": "n150"
+
+        "skip-device-perf": true
       },
       {
         "name": "llama_3_2_1b_instruct",
@@ -330,11 +324,8 @@
         "name": "vllm_qwen_3_4b_embedding_batch1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_qwen3_embedding_4b_batch1",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
-        "skip-device-perf": true,
-        "runs-on": "n150"
+
+        "skip-device-perf": true
       },
       {
         "name": "bert",
@@ -573,209 +564,147 @@
         "name": "vllm_llama_3_2_3b",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[llama-3.2-3b]",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
-        "skip-device-perf": true,
-        "runs-on": "n150"
+
+        "skip-device-perf": true
       },
       {
         "name": "vllm_llama_3_2_1b_instruct",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[llama-3.2-1b]",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
-        "skip-device-perf": true,
-        "runs-on": "n150"
+
+        "skip-device-perf": true
       },
       {
         "name": "vllm_llama_3_1_8b",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[llama-3.1-8b]",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
-        "skip-device-perf": true,
-        "runs-on": "n150"
+
+        "skip-device-perf": true
       },
       {
         "name": "vllm_qwen2_5_0_5b_instruct",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen2.5-0.5b-instruct]",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
-        "skip-device-perf": true,
-        "runs-on": "n150"
+
+        "skip-device-perf": true
       },
       {
         "name": "vllm_qwen2_5_1_5b_instruct",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen2.5-1.5b-instruct]",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
-        "skip-device-perf": true,
-        "runs-on": "n150"
+
+        "skip-device-perf": true
       },
       {
         "name": "vllm_qwen2_5_3b_instruct",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen2.5-3b-instruct]",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
-        "skip-device-perf": true,
-        "runs-on": "n150"
+
+        "skip-device-perf": true
       },
       {
         "name": "vllm_qwen2_5_7b_instruct",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen2.5-7b-instruct]",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
-        "skip-device-perf": true,
-        "runs-on": "n150"
+
+        "skip-device-perf": true
       },
       {
         "name": "vllm_qwen3_0_6b",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen3-0.6b]",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
-        "skip-device-perf": true,
-        "runs-on": "n150"
+
+        "skip-device-perf": true
       },
       {
         "name": "vllm_qwen3_1_7b",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen3-1.7b]",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
-        "skip-device-perf": true,
-        "runs-on": "n150"
+
+        "skip-device-perf": true
       },
       {
         "name": "vllm_qwen3_4b",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen3-4b]",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
-        "skip-device-perf": true,
-        "runs-on": "n150"
+
+        "skip-device-perf": true
       },
       {
         "name": "vllm_qwen3_8b",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen3-8b]",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
-        "skip-device-perf": true,
-        "runs-on": "n150"
+
+        "skip-device-perf": true
       },
       {
         "name": "vllm_gemma_1_1_2b_it",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[gemma-1.1-2b-it]",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
-        "skip-device-perf": true,
-        "runs-on": "n150"
+
+        "skip-device-perf": true
       },
       {
         "name": "vllm_phi_1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[phi-1]",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
-        "skip-device-perf": true,
-        "runs-on": "n150"
+
+        "skip-device-perf": true
       },
       {
         "name": "vllm_phi_1_5",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[phi-1_5]",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
-        "skip-device-perf": true,
-        "runs-on": "n150"
+
+        "skip-device-perf": true
       },
       {
         "name": "vllm_phi_2",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[phi-2]",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
-        "skip-device-perf": true,
-        "runs-on": "n150"
+
+        "skip-device-perf": true
       },
       {
         "name": "vllm_falcon3_1b_base",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[falcon3-1b-base]",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
-        "skip-device-perf": true,
-        "runs-on": "n150"
+
+        "skip-device-perf": true
       },
       {
         "name": "vllm_falcon3_3b_base",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[falcon3-3b-base]",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
-        "skip-device-perf": true,
-        "runs-on": "n150"
+
+        "skip-device-perf": true
       },
       {
         "name": "vllm_falcon3_7b_base",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[falcon3-7b-base]",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
-        "skip-device-perf": true,
-        "runs-on": "n150"
+
+        "skip-device-perf": true
       },
       {
         "name": "vllm_mistral_7b_instruct",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[mistral-7b-instruct]",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
-        "skip-device-perf": true,
-        "runs-on": "n150"
+
+        "skip-device-perf": true
       },
       {
         "name": "vllm_ministral_8b",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[ministral-8b]",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
-        "skip-device-perf": true,
-        "runs-on": "n150"
+
+        "skip-device-perf": true
       },
       {
         "name": "vllm_falcon3_7b_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[falcon3-7b-tp]",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
+
         "skip-device-perf": true,
         "runs-on": "n300-llmbox"
       },
@@ -783,9 +712,7 @@
         "name": "vllm_falcon3_10b_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[falcon3-10b-tp]",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
+
         "skip-device-perf": true,
         "runs-on": "n300-llmbox"
       },
@@ -793,9 +720,7 @@
         "name": "vllm_qwen3_8b_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen3-8b-tp]",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
+
         "skip-device-perf": true,
         "runs-on": "n300-llmbox"
       },
@@ -803,9 +728,7 @@
         "name": "vllm_qwen3_14b_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen3-14b-tp]",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
+
         "skip-device-perf": true,
         "runs-on": "n300-llmbox"
       },
@@ -813,9 +736,7 @@
         "name": "vllm_qwen3_32b_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen3-32b-tp]",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
+
         "skip-device-perf": true,
         "runs-on": "n300-llmbox"
       },
@@ -823,9 +744,7 @@
         "name": "vllm_gemma4_31b_it_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[gemma4-31b-it-tp]",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
+
         "skip-device-perf": true,
         "runs-on": "qb2-blackhole"
       },
@@ -833,9 +752,7 @@
         "name": "vllm_qwen3_32b_qb2_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen3-32b-qb2-tp]",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
+
         "skip-device-perf": true,
         "runs-on": "qb2-blackhole"
       },
@@ -843,9 +760,7 @@
         "name": "vllm_qwen2_5_14b_instruct_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen2.5-14b-instruct-tp]",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
+
         "skip-device-perf": true,
         "runs-on": "n300-llmbox"
       },
@@ -853,9 +768,7 @@
         "name": "vllm_qwen2_5_coder_32b_instruct_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen2.5-coder-32b-instruct-tp]",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
+
         "skip-device-perf": true,
         "runs-on": "n300-llmbox"
       },
@@ -863,9 +776,7 @@
         "name": "vllm_ministral_8b_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[ministral-8b-tp]",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
+
         "skip-device-perf": true,
         "runs-on": "n300-llmbox"
       },
@@ -873,9 +784,7 @@
         "name": "vllm_mistral_nemo_instruct_2407_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[mistral-nemo-instruct-2407-tp]",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
+
         "skip-device-perf": true,
         "runs-on": "n300-llmbox"
       },
@@ -883,9 +792,7 @@
         "name": "vllm_mistral_small_24b_instruct_2501_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[mistral-small-24b-instruct-2501-tp]",
         "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
+
         "skip-device-perf": true,
         "runs-on": "n300-llmbox"
       }

--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -71,14 +71,18 @@
         "name": "vllm_bge_m3_encode_batch1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_bge_m3_batch1",
         "vllm": true,
-
+        "skip-stablehlo-dump": true,
+        "skip-ttir-dump": true,
+        "skip-ttnn-dump": true,
         "skip-device-perf": true
       },
       {
         "name": "vllm_bge_m3_encode_batch32",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_bge_m3_batch32",
         "vllm": true,
-
+        "skip-stablehlo-dump": true,
+        "skip-ttir-dump": true,
+        "skip-ttnn-dump": true,
         "skip-device-perf": true
       },
       {
@@ -324,7 +328,9 @@
         "name": "vllm_qwen_3_4b_embedding_batch1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_qwen3_embedding_4b_batch1",
         "vllm": true,
-
+        "skip-stablehlo-dump": true,
+        "skip-ttir-dump": true,
+        "skip-ttnn-dump": true,
         "skip-device-perf": true
       },
       {
@@ -564,147 +570,126 @@
         "name": "vllm_llama_3_2_3b",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[llama-3.2-3b]",
         "vllm": true,
-
         "skip-device-perf": true
       },
       {
         "name": "vllm_llama_3_2_1b_instruct",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[llama-3.2-1b]",
         "vllm": true,
-
         "skip-device-perf": true
       },
       {
         "name": "vllm_llama_3_1_8b",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[llama-3.1-8b]",
         "vllm": true,
-
         "skip-device-perf": true
       },
       {
         "name": "vllm_qwen2_5_0_5b_instruct",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen2.5-0.5b-instruct]",
         "vllm": true,
-
         "skip-device-perf": true
       },
       {
         "name": "vllm_qwen2_5_1_5b_instruct",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen2.5-1.5b-instruct]",
         "vllm": true,
-
         "skip-device-perf": true
       },
       {
         "name": "vllm_qwen2_5_3b_instruct",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen2.5-3b-instruct]",
         "vllm": true,
-
         "skip-device-perf": true
       },
       {
         "name": "vllm_qwen2_5_7b_instruct",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen2.5-7b-instruct]",
         "vllm": true,
-
         "skip-device-perf": true
       },
       {
         "name": "vllm_qwen3_0_6b",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen3-0.6b]",
         "vllm": true,
-
         "skip-device-perf": true
       },
       {
         "name": "vllm_qwen3_1_7b",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen3-1.7b]",
         "vllm": true,
-
         "skip-device-perf": true
       },
       {
         "name": "vllm_qwen3_4b",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen3-4b]",
         "vllm": true,
-
         "skip-device-perf": true
       },
       {
         "name": "vllm_qwen3_8b",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen3-8b]",
         "vllm": true,
-
         "skip-device-perf": true
       },
       {
         "name": "vllm_gemma_1_1_2b_it",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[gemma-1.1-2b-it]",
         "vllm": true,
-
         "skip-device-perf": true
       },
       {
         "name": "vllm_phi_1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[phi-1]",
         "vllm": true,
-
         "skip-device-perf": true
       },
       {
         "name": "vllm_phi_1_5",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[phi-1_5]",
         "vllm": true,
-
         "skip-device-perf": true
       },
       {
         "name": "vllm_phi_2",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[phi-2]",
         "vllm": true,
-
         "skip-device-perf": true
       },
       {
         "name": "vllm_falcon3_1b_base",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[falcon3-1b-base]",
         "vllm": true,
-
         "skip-device-perf": true
       },
       {
         "name": "vllm_falcon3_3b_base",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[falcon3-3b-base]",
         "vllm": true,
-
         "skip-device-perf": true
       },
       {
         "name": "vllm_falcon3_7b_base",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[falcon3-7b-base]",
         "vllm": true,
-
         "skip-device-perf": true
       },
       {
         "name": "vllm_mistral_7b_instruct",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[mistral-7b-instruct]",
         "vllm": true,
-
         "skip-device-perf": true
       },
       {
         "name": "vllm_ministral_8b",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[ministral-8b]",
         "vllm": true,
-
         "skip-device-perf": true
       },
       {
         "name": "vllm_falcon3_7b_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[falcon3-7b-tp]",
         "vllm": true,
-
         "skip-device-perf": true,
         "runs-on": "n300-llmbox"
       },
@@ -712,7 +697,6 @@
         "name": "vllm_falcon3_10b_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[falcon3-10b-tp]",
         "vllm": true,
-
         "skip-device-perf": true,
         "runs-on": "n300-llmbox"
       },
@@ -720,7 +704,6 @@
         "name": "vllm_qwen3_8b_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen3-8b-tp]",
         "vllm": true,
-
         "skip-device-perf": true,
         "runs-on": "n300-llmbox"
       },
@@ -728,7 +711,6 @@
         "name": "vllm_qwen3_14b_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen3-14b-tp]",
         "vllm": true,
-
         "skip-device-perf": true,
         "runs-on": "n300-llmbox"
       },
@@ -736,7 +718,6 @@
         "name": "vllm_qwen3_32b_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen3-32b-tp]",
         "vllm": true,
-
         "skip-device-perf": true,
         "runs-on": "n300-llmbox"
       },
@@ -744,7 +725,6 @@
         "name": "vllm_gemma4_31b_it_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[gemma4-31b-it-tp]",
         "vllm": true,
-
         "skip-device-perf": true,
         "runs-on": "qb2-blackhole"
       },
@@ -752,7 +732,6 @@
         "name": "vllm_qwen3_32b_qb2_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen3-32b-qb2-tp]",
         "vllm": true,
-
         "skip-device-perf": true,
         "runs-on": "qb2-blackhole"
       },
@@ -760,7 +739,6 @@
         "name": "vllm_qwen2_5_14b_instruct_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen2.5-14b-instruct-tp]",
         "vllm": true,
-
         "skip-device-perf": true,
         "runs-on": "n300-llmbox"
       },
@@ -768,7 +746,6 @@
         "name": "vllm_qwen2_5_coder_32b_instruct_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen2.5-coder-32b-instruct-tp]",
         "vllm": true,
-
         "skip-device-perf": true,
         "runs-on": "n300-llmbox"
       },
@@ -776,7 +753,6 @@
         "name": "vllm_ministral_8b_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[ministral-8b-tp]",
         "vllm": true,
-
         "skip-device-perf": true,
         "runs-on": "n300-llmbox"
       },
@@ -784,7 +760,6 @@
         "name": "vllm_mistral_nemo_instruct_2407_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[mistral-nemo-instruct-2407-tp]",
         "vllm": true,
-
         "skip-device-perf": true,
         "runs-on": "n300-llmbox"
       },
@@ -792,7 +767,6 @@
         "name": "vllm_mistral_small_24b_instruct_2501_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[mistral-small-24b-instruct-2501-tp]",
         "vllm": true,
-
         "skip-device-perf": true,
         "runs-on": "n300-llmbox"
       }

--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -580,38 +580,18 @@
         "runs-on": "n150"
       },
       {
-        "name": "vllm_llama_3_2_3b_batch32",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[llama-3.2-3b-batch32]",
-        "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
-        "skip-device-perf": true,
-        "runs-on": "n150"
-      },
-      {
-        "name": "vllm_opt_125m_opt1",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[opt-125m-opt1]",
-        "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
-        "skip-device-perf": true,
-        "runs-on": "n150"
-      },
-      {
-        "name": "vllm_opt_125m_batch32_opt1",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[opt-125m-batch32-opt1]",
-        "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
-        "skip-device-perf": true,
-        "runs-on": "n150"
-      },
-      {
         "name": "vllm_llama_3_2_1b_instruct",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[llama-3.2-1b]",
+        "vllm": true,
+        "skip-stablehlo-dump": true,
+        "skip-ttir-dump": true,
+        "skip-ttnn-dump": true,
+        "skip-device-perf": true,
+        "runs-on": "n150"
+      },
+      {
+        "name": "vllm_llama_3_1_8b",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[llama-3.1-8b]",
         "vllm": true,
         "skip-stablehlo-dump": true,
         "skip-ttir-dump": true,
@@ -650,6 +630,16 @@
         "runs-on": "n150"
       },
       {
+        "name": "vllm_qwen2_5_7b_instruct",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen2.5-7b-instruct]",
+        "vllm": true,
+        "skip-stablehlo-dump": true,
+        "skip-ttir-dump": true,
+        "skip-ttnn-dump": true,
+        "skip-device-perf": true,
+        "runs-on": "n150"
+      },
+      {
         "name": "vllm_qwen3_0_6b",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen3-0.6b]",
         "vllm": true,
@@ -662,6 +652,36 @@
       {
         "name": "vllm_qwen3_1_7b",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen3-1.7b]",
+        "vllm": true,
+        "skip-stablehlo-dump": true,
+        "skip-ttir-dump": true,
+        "skip-ttnn-dump": true,
+        "skip-device-perf": true,
+        "runs-on": "n150"
+      },
+      {
+        "name": "vllm_qwen3_4b",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen3-4b]",
+        "vllm": true,
+        "skip-stablehlo-dump": true,
+        "skip-ttir-dump": true,
+        "skip-ttnn-dump": true,
+        "skip-device-perf": true,
+        "runs-on": "n150"
+      },
+      {
+        "name": "vllm_qwen3_8b",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen3-8b]",
+        "vllm": true,
+        "skip-stablehlo-dump": true,
+        "skip-ttir-dump": true,
+        "skip-ttnn-dump": true,
+        "skip-device-perf": true,
+        "runs-on": "n150"
+      },
+      {
+        "name": "vllm_gemma_1_1_2b_it",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[gemma-1.1-2b-it]",
         "vllm": true,
         "skip-stablehlo-dump": true,
         "skip-ttir-dump": true,
@@ -710,8 +730,8 @@
         "runs-on": "n150"
       },
       {
-        "name": "vllm_falcon3_1b_base_opt1",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[falcon3-1b-base-opt1]",
+        "name": "vllm_falcon3_3b_base",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[falcon3-3b-base]",
         "vllm": true,
         "skip-stablehlo-dump": true,
         "skip-ttir-dump": true,
@@ -720,8 +740,28 @@
         "runs-on": "n150"
       },
       {
-        "name": "vllm_falcon3_3b_base",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[falcon3-3b-base]",
+        "name": "vllm_falcon3_7b_base",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[falcon3-7b-base]",
+        "vllm": true,
+        "skip-stablehlo-dump": true,
+        "skip-ttir-dump": true,
+        "skip-ttnn-dump": true,
+        "skip-device-perf": true,
+        "runs-on": "n150"
+      },
+      {
+        "name": "vllm_mistral_7b_instruct",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[mistral-7b-instruct]",
+        "vllm": true,
+        "skip-stablehlo-dump": true,
+        "skip-ttir-dump": true,
+        "skip-ttnn-dump": true,
+        "skip-device-perf": true,
+        "runs-on": "n150"
+      },
+      {
+        "name": "vllm_ministral_8b",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[ministral-8b]",
         "vllm": true,
         "skip-stablehlo-dump": true,
         "skip-ttir-dump": true,

--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -633,12 +633,6 @@
         "skip-device-perf": true
       },
       {
-        "name": "vllm_gemma_1_1_2b_it",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[gemma-1.1-2b-it]",
-        "vllm": true,
-        "skip-device-perf": true
-      },
-      {
         "name": "vllm_phi_1",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[phi-1]",
         "vllm": true,

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -1828,6 +1828,19 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             isinstance(m, ParallelLMHead) for m in self.model.modules()
         )
 
+        # Per-tensor weight dtype overrides (mixed precision), mirroring the
+        # torch-xla benchmark's apply_weight_dtype_overrides. Registered after
+        # weight load and before compile so the tt.weight_dtype_override custom
+        # call is captured in the traced graph. Patterns must match vLLM's
+        # (often fused) parameter names, e.g. "*.mlp.down_proj.weight".
+        if self.tt_config.weight_dtype_overrides is not None:
+            from tt_torch.weight_dtype import apply_weight_dtype_overrides
+
+            applied = apply_weight_dtype_overrides(
+                self.model, self.tt_config.weight_dtype_overrides
+            )
+            logger.info("Applied %d per-tensor weight dtype override(s)", len(applied))
+
         self.model.compile(backend="tt", dynamic=False)
         self.sampler = Sampler()
         logger.info(f"Compiled model: \n{self.model}")

--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -68,6 +68,16 @@ class TTConfig:
     # Target dtype for weight conversion (e.g. "bfp_bf8", "bfp_bf4"). Empty disables.
     experimental_weight_dtype: str = ""
 
+    # Per-tensor weight dtype overrides for mixed precision. Either a dict
+    # mapping fnmatch globs over (vLLM) parameter names to dtype strings
+    # ("bfp_bf4"/"bfp_bf8"/"bf16"), with an optional "default" key for
+    # unmatched weights, or a path to a JSON file of the same shape. Applied
+    # via tt_torch.weight_dtype.apply_weight_dtype_overrides at load time,
+    # mirroring the torch-xla benchmark's weight_dtype_overrides. Takes
+    # precedence over experimental_weight_dtype for matched tensors. None
+    # disables.
+    weight_dtype_overrides: Optional[Union[dict, str]] = None
+
     # Toggle the tt-mlir permute+matmul fusion optimization. Mirrors the PJRT
     # compile option; defaults to True to match the PJRT default.
     experimental_enable_permute_matmul_fusion: bool = True

--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -72,6 +72,17 @@ class TTConfig:
     # compile option; defaults to True to match the PJRT default.
     experimental_enable_permute_matmul_fusion: bool = True
 
+    # Enable fp32 destination accumulation in matmul/reduction kernels. None
+    # leaves the tt-mlir default; some models (e.g. Llama-3.1-8B, Ministral)
+    # set this False in the torch-xla benchmark. Mirrors that fp32_dest_acc_en
+    # knob.
+    fp32_dest_acc_en: Optional[bool] = None
+
+    # Override the on-device KV cache element dtype (e.g. "bfp8"). None leaves
+    # the tt-mlir default. Emitted as the "experimental-kv-cache-dtype" PJRT
+    # compile option (note the hyphenated key, matching the torch-xla bench).
+    experimental_kv_cache_dtype: Optional[str] = None
+
     # Perform token sampling on CPU instead of compiling a sampling graph for device
     cpu_sampling: bool = False
 
@@ -132,6 +143,12 @@ class TTConfig:
             "enable_trace": "true" if self.enable_trace else "false",
             "experimental_enable_permute_matmul_fusion": self.experimental_enable_permute_matmul_fusion,
         }
+        # Conditionally-emitted options (omitted when None to leave the tt-mlir
+        # defaults), matching how the torch-xla benchmark builds its options.
+        if self.fp32_dest_acc_en is not None:
+            cfg["fp32_dest_acc_en"] = self.fp32_dest_acc_en
+        if self.experimental_kv_cache_dtype is not None:
+            cfg["experimental-kv-cache-dtype"] = self.experimental_kv_cache_dtype
         if self.export_path:
             cfg["export_path"] = self.export_path
         if self.export_model_name:

--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -71,9 +71,7 @@ class TTConfig:
     # Per-tensor weight dtype overrides for mixed precision. Either a dict
     # mapping fnmatch globs over (vLLM) parameter names to dtype strings
     # ("bfp_bf4"/"bfp_bf8"/"bf16"), with an optional "default" key for
-    # unmatched weights, or a path to a JSON file of the same shape. Applied
-    # via tt_torch.weight_dtype.apply_weight_dtype_overrides at load time,
-    # mirroring the torch-xla benchmark's weight_dtype_overrides. Takes
+    # unmatched weights, or a path to a JSON file of the same shape. Takes
     # precedence over experimental_weight_dtype for matched tensors. None
     # disables.
     weight_dtype_overrides: Optional[Union[dict, str]] = None
@@ -82,15 +80,10 @@ class TTConfig:
     # compile option; defaults to True to match the PJRT default.
     experimental_enable_permute_matmul_fusion: bool = True
 
-    # Enable fp32 destination accumulation in matmul/reduction kernels. None
-    # leaves the tt-mlir default; some models (e.g. Llama-3.1-8B, Ministral)
-    # set this False in the torch-xla benchmark. Mirrors that fp32_dest_acc_en
-    # knob.
+    # Enable fp32 destination accumulation in matmul/reduction kernels.
     fp32_dest_acc_en: Optional[bool] = None
 
-    # Override the on-device KV cache element dtype (e.g. "bfp8"). None leaves
-    # the tt-mlir default. Emitted as the "experimental-kv-cache-dtype" PJRT
-    # compile option (note the hyphenated key, matching the torch-xla bench).
+    # Override the on-device KV cache element dtype.
     experimental_kv_cache_dtype: Optional[str] = None
 
     # Perform token sampling on CPU instead of compiling a sampling graph for device
@@ -153,8 +146,6 @@ class TTConfig:
             "enable_trace": "true" if self.enable_trace else "false",
             "experimental_enable_permute_matmul_fusion": self.experimental_enable_permute_matmul_fusion,
         }
-        # Conditionally-emitted options (omitted when None to leave the tt-mlir
-        # defaults), matching how the torch-xla benchmark builds its options.
         if self.fp32_dest_acc_en is not None:
             cfg["fp32_dest_acc_en"] = self.fp32_dest_acc_en
         if self.experimental_kv_cache_dtype is not None:

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -12,7 +12,7 @@ from benchmarks.vllm_benchmark import (
     benchmark_vllm,
     benchmark_vllm_embedding,
 )
-from utils import resolve_display_name
+from utils import resolve_display_name, sanitize_model_name
 
 # Sampling overrides — keep SINGLE_DEVICE_CONFIGS focused on (model,
 # batch_size). CI re-runs the same matrix with different sampling
@@ -242,6 +242,15 @@ def _run_vllm_benchmark(config, output_file, request):
     print(f"\n{'='*60}")
     print(f"vLLM Benchmark: {display_name}")
     print(f"{'='*60}")
+
+    # Dump compiler IR (StableHLO + TTNN) to modules/irs/ by default, keyed by a
+    # filename-safe display name, mirroring the torch-xla benchmark
+    # (export_path="modules"). An explicit export_path / export_model_name in
+    # additional_config still wins.
+    config.additional_config.setdefault("export_path", "modules")
+    config.additional_config.setdefault(
+        "export_model_name", sanitize_model_name(display_name)
+    )
 
     results = benchmark_vllm(config, display_name)
 

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -153,8 +153,10 @@ SINGLE_DEVICE_CONFIGS = [
     # Gemma
     pytest.param(_config("google/gemma-1.1-2b-it"), id="gemma-1.1-2b-it"),
     # Phi
-    pytest.param(_config("microsoft/phi-1"), id="phi-1"),
-    pytest.param(_config("microsoft/phi-1_5"), id="phi-1_5"),
+    pytest.param(_config("microsoft/phi-1", gpu_memory_utilization=0.30), id="phi-1"),
+    pytest.param(
+        _config("microsoft/phi-1_5", gpu_memory_utilization=0.30), id="phi-1_5"
+    ),
     pytest.param(_config("microsoft/phi-2", gpu_memory_utilization=0.30), id="phi-2"),
     # Falcon 3
     pytest.param(_config("tiiuae/Falcon3-1B-Base"), id="falcon3-1b-base"),

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -23,12 +23,18 @@ from utils import resolve_display_name, sanitize_model_name
 #   _BENCH_OPTIMIZATION_LEVEL=<int>       default 0 (overrides per-test opt level)
 #   TT_BENCHMARK_WEIGHT_DTYPE=<str>       e.g. "bfp_bf8"/"bfp_bf4"/"" (overrides per-test weight dtype)
 #   TT_BENCHMARK_WEIGHT_OVERRIDES=<path>  JSON file of {glob: dtype} per-tensor mixed-precision overrides
+#   TT_BENCHMARK_GMU=<float>              overrides per-test gpu_memory_utilization
+#   TT_BENCHMARK_BATCH_SIZE=<int>         overrides per-test batch_size
+#   TT_BENCHMARK_TRACE=0|1                overrides per-test enable_trace
 _BENCH_TEMPERATURE = float(os.environ.get("TT_BENCHMARK_TEMPERATURE", "0.0"))
 _BENCH_CPU_SAMPLING = os.environ.get("TT_BENCHMARK_CPU_SAMPLING", "0") == "1"
 _BENCH_MAX_MODEL_LEN = int(os.environ.get("TT_BENCHMARK_MAX_MODEL_LEN", "128"))
 _BENCH_OPTIMIZATION_LEVEL = os.environ.get("_BENCH_OPTIMIZATION_LEVEL")
 _BENCH_WEIGHT_DTYPE = os.environ.get("TT_BENCHMARK_WEIGHT_DTYPE")
 _BENCH_WEIGHT_OVERRIDES = os.environ.get("TT_BENCHMARK_WEIGHT_OVERRIDES")
+_BENCH_GMU = os.environ.get("TT_BENCHMARK_GMU")
+_BENCH_BATCH_SIZE = os.environ.get("TT_BENCHMARK_BATCH_SIZE")
+_BENCH_TRACE = os.environ.get("TT_BENCHMARK_TRACE")
 
 
 def _config(
@@ -50,6 +56,10 @@ def _config(
 ):
     if _BENCH_OPTIMIZATION_LEVEL is not None:
         optimization_level = int(_BENCH_OPTIMIZATION_LEVEL)
+    if _BENCH_BATCH_SIZE is not None:
+        batch_size = int(_BENCH_BATCH_SIZE)
+    if _BENCH_GMU is not None:
+        gpu_memory_utilization = float(_BENCH_GMU)
     additional = {"enable_trace": True}
     if experimental_weight_dtype:
         additional["experimental_weight_dtype"] = experimental_weight_dtype
@@ -70,6 +80,8 @@ def _config(
         # Path to a JSON {glob: dtype} file; loaded plugin-side by
         # apply_weight_dtype_overrides. Takes precedence over the uniform dtype.
         additional["weight_dtype_overrides"] = _BENCH_WEIGHT_OVERRIDES
+    if _BENCH_TRACE is not None:
+        additional["enable_trace"] = _BENCH_TRACE == "1"
     return VLLMBenchmarkConfig(
         model=model,
         batch_size=batch_size,

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -21,10 +21,12 @@ from utils import resolve_display_name
 #   TT_BENCHMARK_CPU_SAMPLING=1           default 0 (device sampling)
 #   TT_BENCHMARK_MAX_MODEL_LEN=<int>      default 128
 #   _BENCH_OPTIMIZATION_LEVEL=<int>       default 0 (overrides per-test opt level)
+#   TT_BENCHMARK_WEIGHT_DTYPE=<str>       e.g. "bfp_bf8"/"bfp_bf4"/"" (overrides per-test weight dtype)
 _BENCH_TEMPERATURE = float(os.environ.get("TT_BENCHMARK_TEMPERATURE", "0.0"))
 _BENCH_CPU_SAMPLING = os.environ.get("TT_BENCHMARK_CPU_SAMPLING", "0") == "1"
 _BENCH_MAX_MODEL_LEN = int(os.environ.get("TT_BENCHMARK_MAX_MODEL_LEN", "128"))
 _BENCH_OPTIMIZATION_LEVEL = os.environ.get("_BENCH_OPTIMIZATION_LEVEL")
+_BENCH_WEIGHT_DTYPE = os.environ.get("TT_BENCHMARK_WEIGHT_DTYPE")
 
 
 def _config(
@@ -45,6 +47,10 @@ def _config(
     if _BENCH_CPU_SAMPLING:
         additional["cpu_sampling"] = True
     additional.update(additional_config_extra)
+    # Env override wins over per-config value so CI can sweep weight dtype
+    # one knob per re-run (mirrors _BENCH_OPTIMIZATION_LEVEL/CPU_SAMPLING).
+    if _BENCH_WEIGHT_DTYPE is not None:
+        additional["experimental_weight_dtype"] = _BENCH_WEIGHT_DTYPE
     return VLLMBenchmarkConfig(
         model=model,
         batch_size=batch_size,
@@ -109,14 +115,35 @@ SINGLE_DEVICE_CONFIGS = [
         _config("meta-llama/Llama-3.2-3B", 32, gpu_memory_utilization=0.037),
         id="llama-3.2-3b-batch32",
     ),
-    pytest.param(_config("meta-llama/Llama-3.2-1B-Instruct", 1), id="llama-3.2-1b"),
+    # bfp_bf8 weights match the torch-xla benchmark default and are a large
+    # decode win (~+30% at b=1, ~+15% at b=32). For Llama-3.1-8B they are also
+    # *required* to fit on a single Wormhole (bf16 ~16GB > 12GB DRAM -> OOM).
+    # optimization_level stays 0 for both shapes: opt2 fails to compile the
+    # vLLM Llama graph (b=1 -> select_hidden_states INTERNAL error; b=32 ->
+    # tt-mlir #4569 BeamCandidate assert), and opt1 also hits #4569 at b=32.
+    # (opt1 does compile at b=1 for a marginal ~+2%, left off for uniformity.)
     pytest.param(
-        _config("meta-llama/Llama-3.2-1B-Instruct", 32),
+        _config(
+            "meta-llama/Llama-3.2-1B-Instruct", 1, experimental_weight_dtype="bfp_bf8"
+        ),
+        id="llama-3.2-1b",
+    ),
+    pytest.param(
+        _config(
+            "meta-llama/Llama-3.2-1B-Instruct", 32, experimental_weight_dtype="bfp_bf8"
+        ),
         id="llama-3.2-1b-batch32",
     ),
-    pytest.param(_config("meta-llama/Llama-3.1-8B-Instruct", 1), id="llama-3.1-8b"),
     pytest.param(
-        _config("meta-llama/Llama-3.1-8B-Instruct", 32),
+        _config(
+            "meta-llama/Llama-3.1-8B-Instruct", 1, experimental_weight_dtype="bfp_bf8"
+        ),
+        id="llama-3.1-8b",
+    ),
+    pytest.param(
+        _config(
+            "meta-llama/Llama-3.1-8B-Instruct", 32, experimental_weight_dtype="bfp_bf8"
+        ),
         id="llama-3.1-8b-batch32",
     ),
     pytest.param(

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -134,15 +134,22 @@ SINGLE_DEVICE_CONFIGS = [
         ),
         id="llama-3.2-1b-batch32",
     ),
+    # fp32_dest_acc_en=False matches the torch-xla Llama-3.1-8B benchmark.
     pytest.param(
         _config(
-            "meta-llama/Llama-3.1-8B-Instruct", 1, experimental_weight_dtype="bfp_bf8"
+            "meta-llama/Llama-3.1-8B-Instruct",
+            1,
+            experimental_weight_dtype="bfp_bf8",
+            fp32_dest_acc_en=False,
         ),
         id="llama-3.1-8b",
     ),
     pytest.param(
         _config(
-            "meta-llama/Llama-3.1-8B-Instruct", 32, experimental_weight_dtype="bfp_bf8"
+            "meta-llama/Llama-3.1-8B-Instruct",
+            32,
+            experimental_weight_dtype="bfp_bf8",
+            fp32_dest_acc_en=False,
         ),
         id="llama-3.1-8b-batch32",
     ),

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -33,15 +33,28 @@ _BENCH_WEIGHT_OVERRIDES = os.environ.get("TT_BENCHMARK_WEIGHT_OVERRIDES")
 
 def _config(
     model: str,
-    batch_size: int,
+    batch_size: int = 32,
     *,
     gpu_memory_utilization: float = 0.05,
     optimization_level: int = 0,
+    # Defaults aligned with the torch-xla LLM benchmark: bfp_bf8 weights (a
+    # large decode win, and required for 8B-class models to fit on one
+    # Wormhole) and fp32_dest_acc_en=False. optimization_level stays 0 --
+    # opt>=1 currently fails to compile the vLLM Llama graph at b=32 (tt-mlir
+    # #4569 BeamCandidate) and opt2 fails at b=1 (select_hidden_states
+    # INTERNAL). Pass experimental_weight_dtype="" / fp32_dest_acc_en=None to
+    # opt out (see _tp_config).
+    experimental_weight_dtype: str = "bfp_bf8",
+    fp32_dest_acc_en: bool | None = False,
     **additional_config_extra,
 ):
     if _BENCH_OPTIMIZATION_LEVEL is not None:
         optimization_level = int(_BENCH_OPTIMIZATION_LEVEL)
     additional = {"enable_trace": True}
+    if experimental_weight_dtype:
+        additional["experimental_weight_dtype"] = experimental_weight_dtype
+    if fp32_dest_acc_en is not None:
+        additional["fp32_dest_acc_en"] = fp32_dest_acc_en
     if optimization_level > 0:
         additional["optimization_level"] = optimization_level
         # TTConfig raises if enable_trace=True AND opt>=1 AND cpu_sampling=False
@@ -84,6 +97,10 @@ def _tp_config(
         model,
         batch_size,
         gpu_memory_utilization=gpu_memory_utilization,
+        # Keep TP configs as-is: the single-device alignment defaults
+        # (bfp_bf8, fp32_dest_acc_en=False) do not apply here.
+        experimental_weight_dtype="",
+        fp32_dest_acc_en=None,
         **tp_defaults,
     )
 
@@ -115,82 +132,48 @@ def _gemma4_tp_config(model: str, batch_size: int):
     return cfg
 
 
+# Single-device LLMs mirror the torch-xla llm benchmark (tests/benchmark/
+# test_llms.py) at batch_size=32 with the aligned _config defaults (bfp_bf8
+# weights, fp32_dest_acc_en=False, optimization_level=0, trace on). Models the
+# vLLM plugin can't run on a single device are intentionally omitted: Mamba
+# (arch unsupported), all tensor-parallel models (need >1 device; see
+# TP_CONFIGS), and the galaxy/qb2 MoE + DeepSeek/Kimi MLA tests.
 SINGLE_DEVICE_CONFIGS = [
-    pytest.param(_config("meta-llama/Llama-3.2-3B", 1), id="llama-3.2-3b"),
+    # Llama
+    pytest.param(_config("meta-llama/Llama-3.2-1B-Instruct"), id="llama-3.2-1b"),
+    pytest.param(_config("meta-llama/Llama-3.2-3B-Instruct"), id="llama-3.2-3b"),
+    pytest.param(_config("meta-llama/Llama-3.1-8B-Instruct"), id="llama-3.1-8b"),
+    # Qwen 2.5
+    pytest.param(_config("Qwen/Qwen2.5-0.5B-Instruct"), id="qwen2.5-0.5b-instruct"),
+    pytest.param(_config("Qwen/Qwen2.5-1.5B-Instruct"), id="qwen2.5-1.5b-instruct"),
+    pytest.param(_config("Qwen/Qwen2.5-3B-Instruct"), id="qwen2.5-3b-instruct"),
+    pytest.param(_config("Qwen/Qwen2.5-7B-Instruct"), id="qwen2.5-7b-instruct"),
+    # Qwen 3
+    pytest.param(_config("Qwen/Qwen3-0.6B"), id="qwen3-0.6b"),
+    pytest.param(_config("Qwen/Qwen3-1.7B"), id="qwen3-1.7b"),
+    pytest.param(_config("Qwen/Qwen3-4B"), id="qwen3-4b"),
+    pytest.param(_config("Qwen/Qwen3-8B"), id="qwen3-8b"),
+    # Gemma
+    pytest.param(_config("google/gemma-1.1-2b-it"), id="gemma-1.1-2b-it"),
+    pytest.param(_config("google/gemma-2-2b-it"), id="gemma-2-2b-it"),
+    pytest.param(_config("google/gemma-1.1-7b-it"), id="gemma-1.1-7b-it"),
+    # Phi
+    pytest.param(_config("microsoft/phi-1"), id="phi-1"),
+    pytest.param(_config("microsoft/phi-1_5"), id="phi-1_5"),
+    pytest.param(_config("microsoft/phi-2"), id="phi-2"),
+    pytest.param(_config("microsoft/Phi-3-mini-4k-instruct"), id="phi-3-mini-4k"),
+    pytest.param(_config("microsoft/Phi-3.5-mini-instruct"), id="phi-3.5-mini"),
+    # Falcon 3
+    pytest.param(_config("tiiuae/Falcon3-1B-Base"), id="falcon3-1b-base"),
+    pytest.param(_config("tiiuae/Falcon3-3B-Base"), id="falcon3-3b-base"),
+    pytest.param(_config("tiiuae/Falcon3-7B-Base"), id="falcon3-7b-base"),
+    # Mistral
     pytest.param(
-        _config("meta-llama/Llama-3.2-3B", 32, gpu_memory_utilization=0.037),
-        id="llama-3.2-3b-batch32",
+        _config("mistralai/Mistral-7B-Instruct-v0.3"), id="mistral-7b-instruct"
     ),
-    # bfp_bf8 weights match the torch-xla benchmark default and are a large
-    # decode win (~+30% at b=1, ~+15% at b=32). For Llama-3.1-8B they are also
-    # *required* to fit on a single Wormhole (bf16 ~16GB > 12GB DRAM -> OOM).
-    # optimization_level stays 0 for both shapes: opt2 fails to compile the
-    # vLLM Llama graph (b=1 -> select_hidden_states INTERNAL error; b=32 ->
-    # tt-mlir #4569 BeamCandidate assert), and opt1 also hits #4569 at b=32.
-    # (opt1 does compile at b=1 for a marginal ~+2%, left off for uniformity.)
-    pytest.param(
-        _config(
-            "meta-llama/Llama-3.2-1B-Instruct", 1, experimental_weight_dtype="bfp_bf8"
-        ),
-        id="llama-3.2-1b",
-    ),
-    pytest.param(
-        _config(
-            "meta-llama/Llama-3.2-1B-Instruct", 32, experimental_weight_dtype="bfp_bf8"
-        ),
-        id="llama-3.2-1b-batch32",
-    ),
-    # fp32_dest_acc_en=False matches the torch-xla Llama-3.1-8B benchmark.
-    pytest.param(
-        _config(
-            "meta-llama/Llama-3.1-8B-Instruct",
-            1,
-            experimental_weight_dtype="bfp_bf8",
-            fp32_dest_acc_en=False,
-        ),
-        id="llama-3.1-8b",
-    ),
-    pytest.param(
-        _config(
-            "meta-llama/Llama-3.1-8B-Instruct",
-            32,
-            experimental_weight_dtype="bfp_bf8",
-            fp32_dest_acc_en=False,
-        ),
-        id="llama-3.1-8b-batch32",
-    ),
-    pytest.param(
-        _config(
-            "facebook/opt-125m", 1, gpu_memory_utilization=0.001, optimization_level=1
-        ),
-        id="opt-125m-opt1",
-    ),
-    pytest.param(
-        _config(
-            "facebook/opt-125m", 32, gpu_memory_utilization=0.02, optimization_level=1
-        ),
-        id="opt-125m-batch32-opt1",
-        marks=pytest.mark.xfail(
-            reason="tt-mlir MemoryLayoutPropagation::consolidateBeam assert "
-            "(regression from tt-mlir uplift #4569); see tt-mlir issue TODO",
-            strict=False,
-            run=True,
-        ),
-    ),
-    pytest.param(_config("Qwen/Qwen2.5-0.5B-Instruct", 1), id="qwen2.5-0.5b-instruct"),
-    pytest.param(_config("Qwen/Qwen2.5-1.5B-Instruct", 1), id="qwen2.5-1.5b-instruct"),
-    pytest.param(_config("Qwen/Qwen2.5-3B-Instruct", 1), id="qwen2.5-3b-instruct"),
-    pytest.param(_config("Qwen/Qwen3-0.6B", 1), id="qwen3-0.6b"),
-    pytest.param(_config("Qwen/Qwen3-1.7B", 1), id="qwen3-1.7b"),
-    pytest.param(_config("microsoft/phi-1", 1), id="phi-1"),
-    pytest.param(_config("microsoft/phi-1_5", 1), id="phi-1_5"),
-    pytest.param(_config("microsoft/phi-2", 1), id="phi-2"),
-    pytest.param(_config("tiiuae/Falcon3-1B-Base", 1), id="falcon3-1b-base"),
-    pytest.param(
-        _config("tiiuae/Falcon3-1B-Base", 1, optimization_level=1),
-        id="falcon3-1b-base-opt1",
-    ),
-    pytest.param(_config("tiiuae/Falcon3-3B-Base", 1), id="falcon3-3b-base"),
+    pytest.param(_config("mistralai/Ministral-8B-Instruct-2410"), id="ministral-8b"),
+    # OPT (vLLM-only fast canary; not part of the torch-xla matrix)
+    pytest.param(_config("facebook/opt-125m"), id="opt-125m"),
 ]
 
 

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -22,11 +22,13 @@ from utils import resolve_display_name
 #   TT_BENCHMARK_MAX_MODEL_LEN=<int>      default 128
 #   _BENCH_OPTIMIZATION_LEVEL=<int>       default 0 (overrides per-test opt level)
 #   TT_BENCHMARK_WEIGHT_DTYPE=<str>       e.g. "bfp_bf8"/"bfp_bf4"/"" (overrides per-test weight dtype)
+#   TT_BENCHMARK_WEIGHT_OVERRIDES=<path>  JSON file of {glob: dtype} per-tensor mixed-precision overrides
 _BENCH_TEMPERATURE = float(os.environ.get("TT_BENCHMARK_TEMPERATURE", "0.0"))
 _BENCH_CPU_SAMPLING = os.environ.get("TT_BENCHMARK_CPU_SAMPLING", "0") == "1"
 _BENCH_MAX_MODEL_LEN = int(os.environ.get("TT_BENCHMARK_MAX_MODEL_LEN", "128"))
 _BENCH_OPTIMIZATION_LEVEL = os.environ.get("_BENCH_OPTIMIZATION_LEVEL")
 _BENCH_WEIGHT_DTYPE = os.environ.get("TT_BENCHMARK_WEIGHT_DTYPE")
+_BENCH_WEIGHT_OVERRIDES = os.environ.get("TT_BENCHMARK_WEIGHT_OVERRIDES")
 
 
 def _config(
@@ -51,6 +53,10 @@ def _config(
     # one knob per re-run (mirrors _BENCH_OPTIMIZATION_LEVEL/CPU_SAMPLING).
     if _BENCH_WEIGHT_DTYPE is not None:
         additional["experimental_weight_dtype"] = _BENCH_WEIGHT_DTYPE
+    if _BENCH_WEIGHT_OVERRIDES is not None:
+        # Path to a JSON {glob: dtype} file; loaded plugin-side by
+        # apply_weight_dtype_overrides. Takes precedence over the uniform dtype.
+        additional["weight_dtype_overrides"] = _BENCH_WEIGHT_OVERRIDES
     return VLLMBenchmarkConfig(
         model=model,
         batch_size=batch_size,

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -155,7 +155,7 @@ SINGLE_DEVICE_CONFIGS = [
     # Phi
     pytest.param(_config("microsoft/phi-1"), id="phi-1"),
     pytest.param(_config("microsoft/phi-1_5"), id="phi-1_5"),
-    pytest.param(_config("microsoft/phi-2"), id="phi-2"),
+    pytest.param(_config("microsoft/phi-2", gpu_memory_utilization=0.30), id="phi-2"),
     # Falcon 3
     pytest.param(_config("tiiuae/Falcon3-1B-Base"), id="falcon3-1b-base"),
     pytest.param(_config("tiiuae/Falcon3-3B-Base"), id="falcon3-3b-base"),

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -43,13 +43,6 @@ def _config(
     *,
     gpu_memory_utilization: float = 0.05,
     optimization_level: int = 0,
-    # Defaults aligned with the torch-xla LLM benchmark: bfp_bf8 weights (a
-    # large decode win, and required for 8B-class models to fit on one
-    # Wormhole) and fp32_dest_acc_en=False. optimization_level stays 0 --
-    # opt>=1 currently fails to compile the vLLM Llama graph at b=32 (tt-mlir
-    # #4569 BeamCandidate) and opt2 fails at b=1 (select_hidden_states
-    # INTERNAL). Pass experimental_weight_dtype="" / fp32_dest_acc_en=None to
-    # opt out (see _tp_config).
     experimental_weight_dtype: str = "bfp_bf8",
     fp32_dest_acc_en: bool | None = False,
     **additional_config_extra,
@@ -72,8 +65,6 @@ def _config(
     if _BENCH_CPU_SAMPLING:
         additional["cpu_sampling"] = True
     additional.update(additional_config_extra)
-    # Env override wins over per-config value so CI can sweep weight dtype
-    # one knob per re-run (mirrors _BENCH_OPTIMIZATION_LEVEL/CPU_SAMPLING).
     if _BENCH_WEIGHT_DTYPE is not None:
         additional["experimental_weight_dtype"] = _BENCH_WEIGHT_DTYPE
     if _BENCH_WEIGHT_OVERRIDES is not None:
@@ -144,12 +135,6 @@ def _gemma4_tp_config(model: str, batch_size: int):
     return cfg
 
 
-# Single-device LLMs mirror the torch-xla llm benchmark (tests/benchmark/
-# test_llms.py) at batch_size=32 with the aligned _config defaults (bfp_bf8
-# weights, fp32_dest_acc_en=False, optimization_level=0, trace on). Models the
-# vLLM plugin can't run on a single device are intentionally omitted: Mamba
-# (arch unsupported), all tensor-parallel models (need >1 device; see
-# TP_CONFIGS), and the galaxy/qb2 MoE + DeepSeek/Kimi MLA tests.
 SINGLE_DEVICE_CONFIGS = [
     # Llama
     pytest.param(_config("meta-llama/Llama-3.2-1B-Instruct"), id="llama-3.2-1b"),
@@ -167,14 +152,10 @@ SINGLE_DEVICE_CONFIGS = [
     pytest.param(_config("Qwen/Qwen3-8B"), id="qwen3-8b"),
     # Gemma
     pytest.param(_config("google/gemma-1.1-2b-it"), id="gemma-1.1-2b-it"),
-    pytest.param(_config("google/gemma-2-2b-it"), id="gemma-2-2b-it"),
-    pytest.param(_config("google/gemma-1.1-7b-it"), id="gemma-1.1-7b-it"),
     # Phi
     pytest.param(_config("microsoft/phi-1"), id="phi-1"),
     pytest.param(_config("microsoft/phi-1_5"), id="phi-1_5"),
     pytest.param(_config("microsoft/phi-2"), id="phi-2"),
-    pytest.param(_config("microsoft/Phi-3-mini-4k-instruct"), id="phi-3-mini-4k"),
-    pytest.param(_config("microsoft/Phi-3.5-mini-instruct"), id="phi-3.5-mini"),
     # Falcon 3
     pytest.param(_config("tiiuae/Falcon3-1B-Base"), id="falcon3-1b-base"),
     pytest.param(_config("tiiuae/Falcon3-3B-Base"), id="falcon3-3b-base"),
@@ -238,10 +219,7 @@ def _run_vllm_benchmark(config, output_file, request):
     print(f"vLLM Benchmark: {display_name}")
     print(f"{'='*60}")
 
-    # Dump compiler IR (StableHLO + TTNN) to modules/irs/ by default, keyed by a
-    # filename-safe display name, mirroring the torch-xla benchmark
-    # (export_path="modules"). An explicit export_path / export_model_name in
-    # additional_config still wins.
+    # Dump compiler IR modules.
     config.additional_config.setdefault("export_path", "modules")
     config.additional_config.setdefault(
         "export_model_name", sanitize_model_name(display_name)


### PR DESCRIPTION
### Ticket
Part of https://github.com/tenstorrent/tt-xla/issues/5051

### Problem description
This PR is a part of a bigger effort to align perf benchmark with vllm benchmark.

### What's changed
- Run n150 and p150 benchmark LLMs in vLLM benchmark.
- Use batch_size=32.
- Enabled `experimental_weight_dtype` and set it to "bfp_bf8" by default, `weight_dtype_overrides` (mixed precision), `experimental_kv_cache_dtype`, `fp32_dest_acc`.

### Checklist
- [x] [n150 vLLM benchmark](https://github.com/tenstorrent/tt-xla/actions/runs/26847531491)
    - [x] [phi1 and phi1.5 rerun after preemption fix](https://github.com/tenstorrent/tt-xla/actions/runs/26853231053)
    - gemma-1.1-2b fails, disabled and opened an issue: https://github.com/tenstorrent/tt-xla/issues/5084
- [x] [p150 vLLM benchmark](https://github.com/tenstorrent/tt-xla/actions/runs/26848296072)
    - gemma-1.1-2b fails, disabled and opened an issue: https://github.com/tenstorrent/tt-xla/issues/5084
    - disabled IR dump for failing encoders
