### PR TITLE
[pjrt] Route non-contiguous host buffers through the owned-tensor path

### DIFF
--- a/pjrt_implementation/src/api/buffer_instance.cc
+++ b/pjrt_implementation/src/api/buffer_instance.cc
@@ -253,13 +253,12 @@ void BufferInstance::copyFromHost(
   // path so the runtime gathers the data into a contiguous tensor: the
   // borrowed/zero-copy path cannot alias non-contiguous memory, and the runtime
   // would otherwise read the buffer linearly and corrupt it.
-  // Complex dtypes are left to the existing path: their `shape` carries an extra
-  // trailing dim that has no corresponding entry in `byte_strides`.
-  bool is_non_contiguous =
-      host_buffer != nullptr &&
-      !data_type_utils::isComplexPJRTType(m_data_type) &&
-      !isDenseRowMajor(dims, num_dims, byte_strides, num_byte_strides,
-                       element_size);
+  // Complex dtypes are left to the existing path: their `shape` carries an
+  // extra trailing dim that has no corresponding entry in `byte_strides`.
+  bool is_non_contiguous = host_buffer != nullptr &&
+                           !data_type_utils::isComplexPJRTType(m_data_type) &&
+                           !isDenseRowMajor(dims, num_dims, byte_strides,
+                                            num_byte_strides, element_size);
 
   std::unique_ptr<EventInstance> done_with_host_buffer_event =
       EventInstance::createInstance();

--- a/pjrt_implementation/src/api/buffer_instance.cc
+++ b/pjrt_implementation/src/api/buffer_instance.cc
@@ -201,6 +201,30 @@ void BufferInstance::fireDoneWithHostBufferEvent() {
   m_done_with_host_buffer_event = nullptr;
 }
 
+namespace {
+
+// Returns true if `byte_strides` describe a dense, row-major (C-contiguous)
+// layout for `dims`. `num_byte_strides == 0` is the PJRT sentinel meaning
+// "dense". Dimensions of size <= 1 are ignored, since their stride is
+// irrelevant to the memory layout.
+bool isDenseRowMajor(const std::int64_t *dims, size_t num_dims,
+                     const std::int64_t *byte_strides, size_t num_byte_strides,
+                     std::uint32_t element_size) {
+  if (num_byte_strides == 0) {
+    return true;
+  }
+  std::int64_t expected = static_cast<std::int64_t>(element_size);
+  for (size_t d = num_dims; d-- > 0;) {
+    if (dims[d] > 1 && byte_strides[d] != expected) {
+      return false;
+    }
+    expected *= dims[d];
+  }
+  return true;
+}
+
+} // namespace
+
 // Constructing buffer instance for the first time.
 void BufferInstance::copyFromHost(
     const void *host_buffer, PJRT_Buffer_Type data_type,
@@ -225,6 +249,18 @@ void BufferInstance::copyFromHost(
   std::vector<std::int64_t> strides =
       calculateStrides(num_dims, byte_strides, num_byte_strides, element_size);
 
+  // For a non-contiguous (e.g. transposed/sliced) host buffer, force the owned
+  // path so the runtime gathers the data into a contiguous tensor: the
+  // borrowed/zero-copy path cannot alias non-contiguous memory, and the runtime
+  // would otherwise read the buffer linearly and corrupt it.
+  // Complex dtypes are left to the existing path: their `shape` carries an extra
+  // trailing dim that has no corresponding entry in `byte_strides`.
+  bool is_non_contiguous =
+      host_buffer != nullptr &&
+      !data_type_utils::isComplexPJRTType(m_data_type) &&
+      !isDenseRowMajor(dims, num_dims, byte_strides, num_byte_strides,
+                       element_size);
+
   std::unique_ptr<EventInstance> done_with_host_buffer_event =
       EventInstance::createInstance();
 
@@ -248,7 +284,8 @@ void BufferInstance::copyFromHost(
   bool cannot_borrow_host_buffer =
       host_buffer_semantics ==
           PJRT_HostBufferSemantics_kImmutableOnlyDuringCall ||
-      !::tt::runtime::utils::isSupportedDataType(runtime_data_type);
+      !::tt::runtime::utils::isSupportedDataType(runtime_data_type) ||
+      is_non_contiguous;
 
   if (is_distributed) {
     TT_ASSERT(host_buffer_semantics !=

--- a/pjrt_implementation/src/api/buffer_instance.cc
+++ b/pjrt_implementation/src/api/buffer_instance.cc
@@ -249,16 +249,15 @@ void BufferInstance::copyFromHost(
   std::vector<std::int64_t> strides =
       calculateStrides(num_dims, byte_strides, num_byte_strides, element_size);
 
-  // For a non-contiguous (e.g. transposed/sliced) host buffer, force the owned
-  // path so the runtime gathers the data into a contiguous tensor: the
-  // borrowed/zero-copy path cannot alias non-contiguous memory, and the runtime
-  // would otherwise read the buffer linearly and corrupt it.
-  // Complex dtypes are left to the existing path: their `shape` carries an
-  // extra trailing dim that has no corresponding entry in `byte_strides`.
-  bool is_non_contiguous = host_buffer != nullptr &&
-                           !data_type_utils::isComplexPJRTType(m_data_type) &&
-                           !isDenseRowMajor(dims, num_dims, byte_strides,
-                                            num_byte_strides, element_size);
+  // A buffer is treated as contiguous if it is a complex dtype (its `shape`
+  // carries an extra trailing dim with no matching `byte_strides` entry) or
+  // genuinely dense row-major. A non-contiguous (e.g. transposed/sliced) buffer
+  // is forced onto the owned path below so the runtime gathers it into a
+  // contiguous tensor: the borrowed/zero-copy path cannot alias non-contiguous
+  // memory and would read it linearly, corrupting the data.
+  bool is_contiguous = data_type_utils::isComplexPJRTType(m_data_type) ||
+                       isDenseRowMajor(dims, num_dims, byte_strides,
+                                       num_byte_strides, element_size);
 
   std::unique_ptr<EventInstance> done_with_host_buffer_event =
       EventInstance::createInstance();
@@ -284,7 +283,7 @@ void BufferInstance::copyFromHost(
       host_buffer_semantics ==
           PJRT_HostBufferSemantics_kImmutableOnlyDuringCall ||
       !::tt::runtime::utils::isSupportedDataType(runtime_data_type) ||
-      is_non_contiguous;
+      !is_contiguous;
 
   if (is_distributed) {
     TT_ASSERT(host_buffer_semantics !=

--- a/pjrt_implementation/src/api/loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/loaded_executable_instance.cc
@@ -263,8 +263,7 @@ tt_pjrt_status LoadedExecutableInstance::createDefaultOutputBuffers(
     // product of all following dimension sizes.
     std::vector<std::int64_t> strides(output_shape->size());
     std::exclusive_scan(output_shape->rbegin(), output_shape->rend(),
-                        strides.rbegin(), std::uint32_t(1),
-                        std::multiplies<>());
+                        strides.rbegin(), std::int64_t(1), std::multiplies<>());
 
     // Only create host tensor when not in compile-only mode
     std::optional<tt::runtime::Tensor> host_tensor;

--- a/tests/jax/single_chip/graphs/test_strided_tensors.py
+++ b/tests/jax/single_chip/graphs/test_strided_tensors.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import jax
+import numpy as np
+import pytest
+from utils import Category
+
+# ---------- Fixtures ----------
+
+
+@pytest.fixture
+def cpu() -> jax.Device:
+    return jax.devices("cpu")[0]
+
+
+@pytest.fixture
+def tt_device() -> jax.Device:
+    return jax.devices("tt")[0]
+
+
+# ---------- Helpers ----------
+
+
+def _make_views() -> dict:
+    """NumPy views exercising different (non-)contiguous memory layouts."""
+    base = np.arange(32 * 16, dtype=np.float32).reshape(32, 16)
+    return {
+        "contiguous": base,
+        "transpose": base.T,  # swapped strides
+        "row_slice": base[::2],  # strided outer dim
+        "col_slice": base[:, ::2],  # gap in inner dim
+        "block": base[1:5, 2:7],  # offset sub-block
+        "reversed": base[::-1],  # negative outer stride
+    }
+
+
+# ---------- Tests ----------
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.record_test_properties(category=Category.GRAPH_TEST)
+@pytest.mark.parametrize("view_name", list(_make_views().keys()))
+def test_strided_host_buffer_roundtrip(
+    view_name: str, cpu: jax.Device, tt_device: jax.Device
+):
+    """
+    Transferring a non-contiguous host buffer to the device and back must
+    preserve its logical contents: the PJRT plugin has to gather the strided
+    buffer into a contiguous tensor rather than reading it linearly.
+    """
+    view = _make_views()[view_name]
+    expected = np.ascontiguousarray(view)
+
+    on_device = jax.device_put(view, tt_device)
+    got = np.asarray(jax.device_put(on_device, cpu))
+
+    assert np.array_equal(got, expected), (
+        f"'{view_name}' view was not reconstructed correctly:\n"
+        f"expected:\n{expected}\n"
+        f"got:\n{got}"
+    )


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/8622

### Problem description
Described in issue.

### What's changed
Detect whether the incoming host buffer is C-contiguous from its `byte_strides` (`isDenseRowMajor`) and, when it is not (and it's not a complex dtype), force the owned path

### Checklist
- [x] tt-mlir uplift where [createOwnedHostTensor honors the stride argument](https://github.com/tenstorrent/tt-mlir/pull/8697)
