### PR TITLE
Bringup initial component tests for Qwen-Image

### DIFF
--- a/tests/torch/models/qwen_image/__init__.py
+++ b/tests/torch/models/qwen_image/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/torch/models/qwen_image/test_text_encoder.py
+++ b/tests/torch/models/qwen_image/test_text_encoder.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Qwen-Image — Qwen2_5_VLForConditionalGeneration (text_encoder, ~7.6B) tensor-parallel component test."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+from infra.utilities.torch_multichip_utils import get_mesh
+
+from third_party.tt_forge_models.qwen_image.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.nightly
+@pytest.mark.model_test
+@pytest.mark.llmbox
+@pytest.mark.tensor_parallel
+def test_text_encoder_sharded():
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.QWEN_IMAGE_TEXT_ENCODER)
+    model = loader.load_model(dtype_override=torch.bfloat16)
+    inputs = loader.load_inputs(dtype_override=torch.bfloat16)
+
+    mesh_shape, mesh_names = loader.get_mesh_config(xr.global_runtime_device_count())
+    mesh = get_mesh(mesh_shape, mesh_names)
+
+    run_graph_test(
+        model,
+        inputs,
+        framework=Framework.TORCH,
+        mesh=mesh,
+        shard_spec_fn=loader.load_shard_spec,
+    )

--- a/tests/torch/models/qwen_image/test_transformer.py
+++ b/tests/torch/models/qwen_image/test_transformer.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Qwen-Image — QwenImageTransformer2DModel (transformer, ~20B) tensor-parallel component test.
+
+The 40.9 GiB (bf16) MMDiT transformer exceeds every single TT chip, so it runs
+Megatron 1D tensor-parallel on the llmbox fabric. 24 attention heads and 60
+blocks divide cleanly across 2/3/4/6/8 devices.
+"""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+from infra.utilities.torch_multichip_utils import get_mesh
+
+from third_party.tt_forge_models.qwen_image.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.nightly
+@pytest.mark.model_test
+@pytest.mark.llmbox
+@pytest.mark.tensor_parallel
+def test_transformer_sharded():
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.QWEN_IMAGE_TRANSFORMER)
+    model = loader.load_model(dtype_override=torch.bfloat16)
+    inputs = loader.load_inputs(dtype_override=torch.bfloat16)
+
+    mesh_shape, mesh_names = loader.get_mesh_config(xr.global_runtime_device_count())
+    mesh = get_mesh(mesh_shape, mesh_names)
+
+    run_graph_test(
+        model,
+        inputs,
+        framework=Framework.TORCH,
+        mesh=mesh,
+        shard_spec_fn=loader.load_shard_spec,
+    )

--- a/tests/torch/models/qwen_image/test_vae.py
+++ b/tests/torch/models/qwen_image/test_vae.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Qwen-Image — AutoencoderKLQwenImage (vae) decoder component test. Params: ~0.25 B."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+
+from third_party.tt_forge_models.qwen_image.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.nightly
+@pytest.mark.model_test
+@pytest.mark.single_device
+def test_vae():
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.QWEN_IMAGE_VAE)
+    model = loader.load_model(dtype_override=torch.float32)
+    inputs = loader.load_inputs(dtype_override=torch.float32)
+
+    run_graph_test(model, inputs, framework=Framework.TORCH)


### PR DESCRIPTION
### Github Issue
[Issue Link](https://github.com/tenstorrent/tt-xla/issues/4696)

### Problem description

Add initial bringup tests for each component of the Qwen/Qwen-Image pipeline
(`QwenImagePipeline`, a text-to-image MMDiT, ~28B aggregate) and test them on a
single Wormhole device.

### What's changed

| File | Component | Tests |
|------|-----------|-------|
| `test_text_encoder.py` | `Qwen2_5_VLForConditionalGeneration` — Qwen2.5-VL 7B (~7.7B) | `test_text_encoder` (passed) |
| `test_transformer.py` | `QwenImageTransformer2DModel` — 60-block MMDiT (~20B) | `test_transformer` (xfail — OOM, single device cannot fit 20B; needs multi-chip — #TBD-TRANSFORMER) |
| `test_vae_decoder.py` | `AutoencoderKLQwenImage` (~0.2B) | `test_vae_decoder` (passed) |

Model loading, input generation, and wrapper modules are provided by the
per-component Qwen-Image loader in tt-forge-models
(`qwen_image/pytorch/loader.py` — TextEncoder / Transformer / Vae variants).

The text encoder and transformer OOM on a single device (DRAM ~99% full before
the failing allocation) — a capacity limit, not fragmentation. Both are the
expected multi-chip components; the loader already ships tensor-parallel shard
specs (mesh `[1,3]` n150 / `[1,2]` p150). They are tracked as `xfail` here until
the multi-chip bringup verifies them.

### Checklist

- [x] Verify changes through local testing in Wormhole
  - VAE decoder: PASSED locally (single device, 574s)
  - TextEncoder / Transformer: Earlier OOM reproduced locally (xfail), but now fixed and passing in latest commits
- [x] File tracking issues for the two OOM xfails 
https://github.com/tenstorrent/tt-xla/issues/5064  - added fix in latest commit 
https://github.com/tenstorrent/tt-xla/issues/5065
  references in the test `xfail` reasons

### Logs
[text_encoder.log](https://github.com/user-attachments/files/28550075/text_encoder.log)
[transformer.log](https://github.com/user-attachments/files/28550076/transformer.log)
[vae_decoder.log](https://github.com/user-attachments/files/28550077/vae_decoder.log)
