### PR TITLE
Add vLLM Llama-3.1 TP benchmarks (n300-llmbox)

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -848,6 +848,26 @@
         "skip-ttnn-dump": true,
         "skip-device-perf": true,
         "runs-on": "n300-llmbox"
+      },
+      {
+        "name": "vllm_llama_3_1_8b_tp",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[llama-3.1-8b-tp]",
+        "vllm": true,
+        "skip-stablehlo-dump": true,
+        "skip-ttir-dump": true,
+        "skip-ttnn-dump": true,
+        "skip-device-perf": true,
+        "runs-on": "n300-llmbox"
+      },
+      {
+        "name": "vllm_llama_3_1_70b_tp",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[llama-3.1-70b-tp]",
+        "vllm": true,
+        "skip-stablehlo-dump": true,
+        "skip-ttir-dump": true,
+        "skip-ttnn-dump": true,
+        "skip-device-perf": true,
+        "runs-on": "n300-llmbox"
       }
     ]
   }

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -186,6 +186,19 @@ TP_CONFIGS = [
         _tp_config("mistralai/Mistral-Small-24B-Instruct-2501", 1),
         id="mistral-small-24b-instruct-2501-tp",
     ),
+    pytest.param(
+        _tp_config("meta-llama/Llama-3.1-8B-Instruct", 1),
+        id="llama-3.1-8b-tp",
+    ),
+    pytest.param(
+        _tp_config(
+            "meta-llama/Llama-3.1-70B-Instruct",
+            1,
+            enable_const_eval=True,
+            experimental_weight_dtype="bfp_bf8",
+        ),
+        id="llama-3.1-70b-tp",
+    ),
     # Verify fused decode_postprocess compiles to expected graph count (cpu_sampling=False path)
     pytest.param(
         _config("facebook/opt-125m", 1, gpu_memory_utilization=0.001),


### PR DESCRIPTION
### Ticket
Closes #5071.

### Problem description
Llama-3.1 TP benchmarks (8B and 70B) on n300-llmbox were not yet in CI. Single-chip n150 coverage was landed separately via #5056; this PR covers the remaining TP-only entries.

### What's changed
- Add `vllm_llama_3_1_8b_tp` and `vllm_llama_3_1_70b_tp` entries to `perf-bench-matrix.json` (n300-llmbox)
- Add corresponding `_tp_config()`-based parametrizations in `test_vllm_benchmarks.py`
- 70B-TP uses `enable_const_eval=True` + `experimental_weight_dtype="bfp_bf8"` (required to fit)

| Test | TTFT | Decode TPS |
|------|------|-----------|
| llama-3.1-8b-tp  | 111.5 ms | 16.0 tok/s |
| llama-3.1-70b-tp | 468.4 ms | 4.3 tok/s |

### Checklist
- [x] `test_vllm_tp_benchmark[llama-3.1-8b-tp]` passes locally on n300-llmbox
- [x] `test_vllm_tp_benchmark[llama-3.1-70b-tp]` passes locally on n300-llmbox
- [x] CI matrix picks up new entries and runs green — https://github.com/tenstorrent/tt-xla/actions/runs/27026933687