### PR TITLE
Add example for BRIA 2.3 model

### DIFF
--- a/examples/pytorch/bria_2_3_pipeline.py
+++ b/examples/pytorch/bria_2_3_pipeline.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Runnable BRIA 2.3 text-to-image example on Tenstorrent.
+
+The reusable pipeline implementation is shared with the image-gen benchmark and
+lives in ``tt_forge_models`` — this script is just a thin runnable demo so the
+implementation isn't duplicated in ``examples/``.
+
+BRIA 2.3 is an SDXL-class model: the UNet (the heavy net) runs on the
+Tenstorrent backend via ``torch.compile(backend="tt")``; the two CLIP text
+encoders, the scheduler and the VAE run on CPU.
+
+Note: ``briaai/BRIA-2.3`` is a gated Hugging Face repo — accept its terms and
+authenticate (``huggingface-cli login``) before running.
+"""
+
+from third_party.tt_forge_models.bria_2_3.pytorch.pipeline import (
+    Bria23Config,
+    Bria23Pipeline,
+    save_image,
+)
+
+PROMPT = (
+    "A portrait of a Beautiful and playful ethereal singer, "
+    "golden designs, highly detailed, blurry background"
+)
+NEGATIVE_PROMPT = ""
+GUIDANCE_SCALE = 5.0
+NUM_INFERENCE_STEPS = 50
+SEED = 42
+OUTPUT_PATH = "bria_2_3_output.png"
+
+
+def main():
+    pipeline = Bria23Pipeline(config=Bria23Config())
+    pipeline.setup()
+
+    image = pipeline.generate(
+        prompt=PROMPT,
+        negative_prompt=NEGATIVE_PROMPT,
+        guidance_scale=GUIDANCE_SCALE,
+        num_inference_steps=NUM_INFERENCE_STEPS,
+        seed=SEED,
+    )
+
+    save_image(image, OUTPUT_PATH)
+    print(f"Saved output image to {OUTPUT_PATH}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-xla/issues/5077

### Problem description
BRIA 2.3 (`briaai/BRIA-2.3`) is an SDXL-class text-to-image model that runs e2e
on TT, so we add an example for it (analogous to the Stable Diffusion 1.5 /
SDXL examples). Model code reference: tenstorrent/tt-forge-models#661.

### What's changed
- Adds `examples/pytorch/bria_2_3_pipeline.py` for BRIA 2.3 (`briaai/BRIA-2.3`).
- The SDXL UNet (the heavy net) runs on the TT backend via `torch.compile(backend="tt")`;
  the two CLIP text encoders, the scheduler and the VAE run on CPU.
- CFG denoising loop (`guidance_scale=5.0`, 50 steps), 1024x1024 output.
- Prompt encoding / latent prep / scheduler step / VAE decode reuse the diffusers
  pipeline helper methods so numerics match upstream; only the per-step UNet call
  is redirected to TT. Applies the BRIA-specific `force_zeros_for_empty_prompt = False`.

### Checklist
- [x] New/Existing tests provide coverage for changes

I have attached the logs for your reference:
[bria_2_3_output.log](https://github.com/user-attachments/files/28585916/bria_2_3_output.log)

I have attached the output image for your reference:
<img width="1024" height="1024" alt="bria_2_3_output" src="https://github.com/user-attachments/assets/b6724f2c-a105-438c-864d-421ba19f1f0a" />
