### PR TITLE
Add example for stable diffusion 3 model

### DIFF
--- a/examples/pytorch/sd_v3_pipeline.py
+++ b/examples/pytorch/sd_v3_pipeline.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Runnable Stable Diffusion 3 Medium text-to-image example on Tenstorrent.
+
+The reusable pipeline implementation is shared with the image-gen benchmark
+(``tests/benchmark/test_imagegen.py``) and the nightly test, and lives in
+``tt_forge_models`` — this script is just a thin runnable demo so the
+implementation isn't duplicated in ``examples/``.
+
+The MMDiT transformer (the heavy net) runs on the Tenstorrent backend via
+``torch.compile(backend="tt")``; the three text encoders (two CLIP + T5), the
+scheduler and the VAE run on CPU.
+"""
+
+from third_party.tt_forge_models.stable_diffusion_3.pytorch.pipeline import (
+    SD3Config,
+    SD3Pipeline,
+    save_image,
+)
+
+PROMPT = "An astronaut riding a green horse"
+NEGATIVE_PROMPT = ""
+GUIDANCE_SCALE = 7.0
+NUM_INFERENCE_STEPS = 28
+SEED = 42
+OUTPUT_PATH = "sd_v3_output.png"
+
+
+def main():
+    pipeline = SD3Pipeline(config=SD3Config())
+    pipeline.setup()
+
+    image = pipeline.generate(
+        prompt=PROMPT,
+        negative_prompt=NEGATIVE_PROMPT,
+        guidance_scale=GUIDANCE_SCALE,
+        num_inference_steps=NUM_INFERENCE_STEPS,
+        seed=SEED,
+    )
+
+    save_image(image, OUTPUT_PATH)
+    print(f"Saved output image to {OUTPUT_PATH}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-xla/issues/5076

### Problem description
Stable Diffusion 3 Medium (`stabilityai/stable-diffusion-3-medium-diffusers`)
runs e2e on TT, so we add an example for it (analogous to the SD 1.5 / SDXL
examples). Model code reference: tenstorrent/tt-forge-models#667.

### What's changed
- Adds `examples/pytorch/sd_v3_pipeline.py` for Stable Diffusion 3 Medium.
- The MMDiT transformer (the heavy net) runs on the TT backend via
  `torch.compile(backend="tt")`; the three text encoders (two CLIP + T5),
  the scheduler and the VAE run on CPU.
- CFG denoising loop with flow-matching scheduler + dynamic shifting
  (`guidance_scale=7.0`, 28 steps), 1024x1024 output.
- Prompt encoding / latent prep / timestep retrieval / VAE decode reuse the
  diffusers `StableDiffusion3Pipeline` helper methods so numerics match upstream;
  only the per-step transformer call is redirected to TT.

### Checklist
- [x] New/Existing tests provide coverage for changes

I have attached the logs for your reference:
[sd3_output.log](https://github.com/user-attachments/files/28585995/sd3_output.log)

I have attached the output image for your reference:
<img width="1024" height="1024" alt="sd3_output" src="https://github.com/user-attachments/assets/06ee94e6-5908-4cc3-b562-c0d434e40096" />
