### PR TITLE
[vLLM] Skip KV cache initialization

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -2384,6 +2384,16 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 "supported yet."
             )
 
+        # This may be a valid config if full model is not being compiled; for
+        # example, using num_hidden_layers override to compile only a subset of
+        # layers. In that case, we should not raise an error but just skip the
+        # KV cache initialization.
+        if len(kv_cache_config.kv_cache_groups) == 0:
+            logger.warning(
+                "No KV cache group found in the config. Skipping KV cache initialization."
+            )
+            return
+
         if (
             kv_cache_config.kv_cache_groups[0].kv_cache_spec.block_size
             != self.block_size


### PR DESCRIPTION
### Problem description
KV cache initialization crashes if no layer requires kv cache. This may occur if we are running model partially by setting num_hidden_layers.

### What's changed
Skip KV cache initialization if not required.