### PR TITLE
[perf] Run single-chip benchmarks on stable qb2-blackhole via p150-perf label

### DIFF
--- a/.github/scripts/filter-test-matrix.py
+++ b/.github/scripts/filter-test-matrix.py
@@ -112,7 +112,12 @@ def filter_matrix_adv(matrix, adv_filter):
 
 def update_runners(matrix, sh_runner):
     """Update runner names based on shared runner flag."""
-    runner_map = {"p150": "p150b"} if sh_runner else {"n150": "n150-perf"}
+    # "p150-perf" is a logical single-chip Blackhole perf label that always maps to
+    # the physical qb2-blackhole box (kept distinct from the multi-chip qb2-blackhole
+    # tests so the runs-on filter can separate them). The shared-runner-mode remap is
+    # layered on top.
+    runner_map = {"p150-perf": "qb2-blackhole"}
+    runner_map.update({"p150": "p150b"} if sh_runner else {"n150": "n150-perf"})
 
     for item in matrix:
         item["runs-on-original"] = item.get("runs-on")

--- a/.github/workflows/call-perf-test.yml
+++ b/.github/workflows/call-perf-test.yml
@@ -61,7 +61,7 @@ jobs:
 
     runs-on: ${{ !inputs.sh-runner && fromJson(format('["{0}", "in-service"]', matrix.build.runs-on)) || format('tt-ubuntu-2204-{0}-stable', matrix.build.runs-on) }}
 
-    name: "perf ${{ matrix.build.name }} (${{ matrix.build.runs-on }})"
+    name: "perf ${{ matrix.build.name }} (${{ matrix.build.runs-on-original || matrix.build.runs-on }})"
 
     container:
       image: ${{ !inputs.sh-runner && inputs.docker_image || format('harbor.ci.tenstorrent.net/{0}', inputs.docker_image) }}

--- a/.github/workflows/manual-benchmark.yml
+++ b/.github/workflows/manual-benchmark.yml
@@ -18,7 +18,7 @@ on:
         options:
           - All
           - n150
-          - p150
+          - p150-perf
           - n300-llmbox
           - galaxy-wh-6u
           - qb2-blackhole

--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -4,7 +4,7 @@
     "test-defaults": {
       "runs-on": [
         "n150",
-        "p150"
+        "p150-perf"
       ],
       "dir": "",
       "bs": 12,

--- a/.github/workflows/schedule-nightly.yml
+++ b/.github/workflows/schedule-nightly.yml
@@ -89,7 +89,7 @@ jobs:
       sh-runner: false
       skip-device-perf: true
       regression_check: true
-      adv_filter: '[ {"accuracy-testing": false}, {"runs-on": "n150"}, {"runs-on": "p150"}, {"runs-on": "n300-llmbox"}, {"runs-on": "galaxy-wh-6u"}, {"runs-on": "qb2-blackhole"} ]'
+      adv_filter: '[ {"accuracy-testing": false}, {"runs-on": "n150"}, {"runs-on": "p150-perf"}, {"runs-on": "n300-llmbox"}, {"runs-on": "galaxy-wh-6u"}, {"runs-on": "qb2-blackhole"} ]'
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
       wheel_build: manylinux


### PR DESCRIPTION
## What

Introduce a logical **`p150-perf`** `runs-on` label for single-chip Blackhole perf workloads and make it the default single-chip runner (`n150` + `p150-perf`), retiring the flaky standalone `p150` from the perf matrix. `p150-perf` is aliased to the physical **`qb2-blackhole`** runner, so single-chip perf runs on a stable QB2 host while staying cleanly separable from the multi-chip tensor-parallel (`qb2-blackhole`) tests.

## Why

CI single-chip perf on the standalone `p150` runners was unstable (flaky/queueing nodes, weaker hosts → noisy, ~2× lower numbers). QB2 boxes are stable and faster. But QB2 is a *multi-chip* system, so we needed a way to designate "single-chip workload on QB2" that is distinct from the multi-chip `_tp_qb2` tests **without** name-substring hacks or per-test duplication.

The clean solution is the existing `runs-on` filter dimension: single-chip tests use the logical label `p150-perf`, TP tests use `qb2-blackhole`, and both map to the same physical box.

## How

- **`perf-bench-matrix.json`** — default `runs-on`: `["n150", "p150-perf"]` (drops the flaky standalone `p150`).
- **`filter-test-matrix.py`** — `update_runners` gains an unconditional alias `p150-perf → qb2-blackhole`. Filtering runs *before* the remap, so `runs-on-filter=p150-perf` selects exactly the single-chip tests and `=qb2-blackhole` selects exactly the TP tests; both execute on QB2.
- **`call-perf-test.yml`** — job name uses `runs-on-original`, so single-chip jobs display as `(p150-perf)` and TP as `(qb2-blackhole)`.
- **`manual-benchmark.yml` / `schedule-nightly.yml`** — `p150` → `p150-perf` in the runner filters.

TP/galaxy/vllm tests keep their explicit `runs-on` and are unaffected. Other workflows' `p150` usage (model-test presets) is untouched.

## Validation (on QB2 hardware)

- Filter dry-run: `p150-perf` → single-chip jobs, all routed to physical `qb2-blackhole`, labeled `(p150-perf)`; `qb2-blackhole` → only the `_tp_qb2`/vllm tests. No collisions, no duplication.
- Live runs on QB2: jobs show `(p150-perf)` on `120-qb2-*` runners. **Vision** is genuinely single-chip (`torch_xla.device()`); confirmed via compiled IR (`meshShape=1x1, chipIds=[0]`). **Single-chip LLMs** also run single-chip and pass (e.g. qwen_3_8b IR `meshShape=1x1`).

## Known QB2 failures (follow-ups, not caused by this change)

- **`google_gemma-1.1-2b-it`** — `Device count mismatch: 1 vs 4` on multi-device boxes (its `sqrt(hidden_size)` scalar graph carries a spurious identity 1×4 mesh). Root-caused and tracked in **#5102**.
- **`ufld_v2`** — known Blackhole quirk (needs `IRD_LF_CACHE`).
- **`bge_m3_encode`** — pre-existing QB2 failure (needs triage).

Reviewers may want to `xfail`/exclude these from `p150-perf` before this lands in nightly.

## Note on load

This routes all single-chip perf tests (~57 jobs) onto QB2 hardware per nightly. Flag if QB2 runner capacity is a concern — we can scope the set down.
