### PR TITLE
Move Training MoE Tests to QB2

### DIFF
--- a/.github/workflows/test-matrix-presets/model-test-push.json
+++ b/.github/workflows/test-matrix-presets/model-test-push.json
@@ -6,5 +6,5 @@
   {"runs-on": "n150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "n150 and expected_passing and push and large", "shared-runners": "true", "forge-models": true, "forked": true},
   {"runs-on": "p150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "p150 and expected_passing and push and large", "forge-models": true, "forked": true},
   { "runs-on": "n300-llmbox",   "name": "run_torch_multi_host",  "dir": "./tests/torch/multi_host/llmbox",                           "test-mark": "push and multi_host_cluster", "require": "release", "shared-runners": "true" },
-  { "runs-on": "qb2-blackhole",   "name": "run_torch_training",    "dir": "./tests/torch/training/test_moe.py",                        "test-mark": "push and training", "require": "release", "shared-runners": "true" }
+  { "runs-on": "qb2-blackhole",   "name": "run_torch_training",    "dir": "./tests/torch/training/test_moe.py",                        "test-mark": "push and training", "require": "release"}
 ]

--- a/.github/workflows/test-matrix-presets/model-test-push.json
+++ b/.github/workflows/test-matrix-presets/model-test-push.json
@@ -6,5 +6,5 @@
   {"runs-on": "n150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "n150 and expected_passing and push and large", "shared-runners": "true", "forge-models": true, "forked": true},
   {"runs-on": "p150", "name": "run_forge_models", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "p150 and expected_passing and push and large", "forge-models": true, "forked": true},
   { "runs-on": "n300-llmbox",   "name": "run_torch_multi_host",  "dir": "./tests/torch/multi_host/llmbox",                           "test-mark": "push and multi_host_cluster", "require": "release", "shared-runners": "true" },
-  { "runs-on": "n300-llmbox",   "name": "run_torch_training",    "dir": "./tests/torch/training/test_moe.py",                        "test-mark": "push and training", "require": "release", "shared-runners": "true" }
+  { "runs-on": "qb2-blackhole",   "name": "run_torch_training",    "dir": "./tests/torch/training/test_moe.py",                        "test-mark": "push and training", "require": "release", "shared-runners": "true" }
 ]

--- a/tests/torch/training/test_moe.py
+++ b/tests/torch/training/test_moe.py
@@ -51,7 +51,6 @@ def load_gpt_oss():
 
 
 @pytest.mark.push
-@pytest.mark.llmbox
 @pytest.mark.training
 def test_gpt_oss_moe_multichip_backward():
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
We are getting OOMs for MoE training tests. Needs further investigation but for now moving to better hardware.

### What's changed
- Move tests to QB2.

### Checklist
- [ ] New/Existing tests provide coverage for changes
