### PR TITLE
[vLLM] Add support for Rotary Embedding with Multimodal Sections

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/layers/__init__.py
+++ b/integrations/vllm_plugin/vllm_tt/layers/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Portions (c) 2026 Tenstorrent AI ULC
+
+from .mrope import override_mrope_module
+from .rmsnorm import TTRMSNorm, override_rmsnorm_module
+from .rotary_embedding import TTRotaryEmbedding, override_rotary_embedding_module
+
+__all__ = [
+    "TTRMSNorm",
+    "TTRotaryEmbedding",
+    "override_mrope_module",
+    "override_rmsnorm_module",
+    "override_rotary_embedding_module",
+]

--- a/integrations/vllm_plugin/vllm_tt/layers/mrope.py
+++ b/integrations/vllm_plugin/vllm_tt/layers/mrope.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Portions (c) 2026 Tenstorrent AI ULC
+
+from types import MethodType
+
+import torch
+from vllm.model_executor.layers.rotary_embedding.mrope import MRotaryEmbedding
+
+
+def _apply_interleaved_rope(x: torch.Tensor, mrope_section: list[int]) -> torch.Tensor:
+    """Reorganize chunked [T...H...W...] frequencies into interleaved layout."""
+    out = x[0].clone()
+    out[..., 1 : mrope_section[1] * 3 : 3] = x[1, ..., 1 : mrope_section[1] * 3 : 3]
+    out[..., 2 : mrope_section[2] * 3 : 3] = x[2, ..., 2 : mrope_section[2] * 3 : 3]
+    return out
+
+
+def _tt_mrope_forward(
+    self: MRotaryEmbedding,
+    positions: torch.Tensor,
+    query: torch.Tensor,
+    key: torch.Tensor | None = None,
+    offsets: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """TT-safe MRoPE forward path based on vLLM's native implementation.
+
+    Args:
+        positions:
+            [batch_size, num_tokens] (batched text inputs) or
+            [3, batch_size, num_tokens] (T/H/W positions with multimodal inputs)
+        query: [batch_size, num_tokens, num_heads * head_size]
+        key: [batch_size, num_tokens, num_kv_heads * head_size]
+    """
+
+    del offsets
+    assert positions.ndim in (2, 3)
+    assert key is not None
+
+    is_mrope_positions = positions.ndim == 3 and positions.shape[0] == 3
+    if is_mrope_positions:
+        batch_size, num_tokens = positions.shape[1], positions.shape[2]
+    else:
+        batch_size, num_tokens = positions.shape
+
+    assert query.shape[0] == batch_size and query.shape[1] == num_tokens
+    assert key.shape[0] == batch_size and key.shape[1] == num_tokens
+
+    cos_sin_cache = self._match_cos_sin_cache_dtype(query)
+    cos_sin = cos_sin_cache[positions]
+    cos, sin = cos_sin.chunk(2, dim=-1)
+
+    if is_mrope_positions:
+        assert self.mrope_section
+        if self.mrope_interleaved:
+            cos = _apply_interleaved_rope(cos, self.mrope_section)
+            sin = _apply_interleaved_rope(sin, self.mrope_section)
+        else:
+            cos = torch.cat(
+                [m[i] for i, m in enumerate(cos.split(self.mrope_section, dim=-1))],
+                dim=-1,
+            )
+            sin = torch.cat(
+                [m[i] for i, m in enumerate(sin.split(self.mrope_section, dim=-1))],
+                dim=-1,
+            )
+
+    query_shape = query.shape
+    query = query.view(batch_size, num_tokens, -1, self.head_size)
+    query_rot = query[..., : self.rotary_dim]
+    query_pass = query[..., self.rotary_dim :]
+    query_rot = self.apply_rotary_emb.forward_native(query_rot, cos, sin)
+    query = torch.cat((query_rot, query_pass), dim=-1).reshape(query_shape)
+
+    key_shape = key.shape
+    key = key.view(batch_size, num_tokens, -1, self.head_size)
+    key_rot = key[..., : self.rotary_dim]
+    key_pass = key[..., self.rotary_dim :]
+    key_rot = self.apply_rotary_emb.forward_native(key_rot, cos, sin)
+    key = torch.cat((key_rot, key_pass), dim=-1).reshape(key_shape)
+    return query, key
+
+
+def override_mrope_module(layer: torch.nn.Module) -> torch.nn.Module:
+    """Override MRoPE forward with TT local implementation.
+
+    This keeps the original module instance (and all its parameters/buffers)
+    while decoupling behavior from installed base vLLM.
+    """
+
+    assert isinstance(layer, MRotaryEmbedding)
+    layer.forward = MethodType(_tt_mrope_forward, layer)
+    return layer

--- a/integrations/vllm_plugin/vllm_tt/layers/rmsnorm.py
+++ b/integrations/vllm_plugin/vllm_tt/layers/rmsnorm.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Portions (c) 2026 Tenstorrent AI ULC
+
+import torch
+import torch.nn as nn
+from vllm.model_executor.layers.layernorm import RMSNorm
+
+
+class TTRMSNorm(nn.Module):
+    """TT-compatible RMSNorm replacement for vLLM's RMSNorm.
+
+    vLLM's RMSNorm.forward_native accesses `self.weight.data`, which causes an
+    AssertionError during torch.compile/torch.export tracing with FakeTensors.
+    Accessing `.data` on a FakeTensor lifts it out of the fake tensor context,
+    resulting in: "cannot call `.data` on a Tensor, the Tensor is a FakeTensor".
+
+    This class reimplements the RMSNorm forward pass using `self.weight` directly
+    (without `.data`), making it compatible with TT tracing and compilation.
+    """
+
+    def __init__(self, layer: nn.Module):
+        super().__init__()
+        assert isinstance(layer, RMSNorm)
+        self.hidden_size = layer.hidden_size
+        self.variance_epsilon = layer.variance_epsilon
+        self.variance_size_override = layer.variance_size_override
+        self.has_weight = layer.has_weight
+        self.weight = layer.weight
+
+        if hasattr(layer, "rocm_norm_func") and hasattr(
+            layer, "rocm_norm_func_with_add"
+        ):
+            self.rocm_norm_func = layer.rocm_norm_func
+            self.rocm_norm_func_with_add = layer.rocm_norm_func_with_add
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        residual: torch.Tensor | None = None,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+
+        orig_dtype = x.dtype
+        x = x.to(torch.float32)
+        if residual is not None:
+            # residual promoted f16->f32 automatically,
+            # otherwise Inductor eliminates the casts to and from f16,
+            # increasing memory usage (and complicating pattern matching)
+            x = x + residual
+            residual = x.to(orig_dtype)
+
+        if x.shape[-1] != self.hidden_size:
+            raise ValueError(
+                f"Expected hidden_size to be {self.hidden_size}, but found: {x.shape[-1]}"
+            )
+
+        if self.variance_size_override is None:
+            x_var = x
+        else:
+            if self.hidden_size < self.variance_size_override:
+                raise ValueError(
+                    "Expected hidden_size to be at least "
+                    f"{self.variance_size_override}, but found: {self.hidden_size}"
+                )
+
+            x_var = x[:, :, : self.variance_size_override]
+
+        variance = x_var.pow(2).mean(dim=-1, keepdim=True)
+
+        x = x * torch.rsqrt(variance + self.variance_epsilon)
+        x = x.to(orig_dtype)
+        if self.has_weight and self.weight is not None:
+            x = x * self.weight
+        if residual is None:
+            return x
+        return x, residual
+
+
+def override_rmsnorm_module(layer: torch.nn.Module) -> torch.nn.Module:
+    assert isinstance(layer, RMSNorm)
+    return TTRMSNorm(layer)

--- a/integrations/vllm_plugin/vllm_tt/layers/rotary_embedding.py
+++ b/integrations/vllm_plugin/vllm_tt/layers/rotary_embedding.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Portions (c) 2026 Tenstorrent AI ULC
+
+import torch
+import torch.nn as nn
+from vllm.model_executor.layers.rotary_embedding.base import RotaryEmbedding
+from vllm.model_executor.layers.rotary_embedding.common import ApplyRotaryEmb
+
+
+class TTRotaryEmbedding(nn.Module):
+    """TT-compatible RotaryEmbedding that computes cos/sin on-the-fly.
+
+    vLLM's RotaryEmbedding pre-builds a cos_sin_cache and uses index_select
+    (gather) with position_ids at runtime. This lowers to ttir.embedding which
+    requires indices on host via from_device, breaking metal trace mode.
+
+    This replacement computes cos/sin from inv_freq and positions using math
+    ops (outer product + cos/sin) that stay entirely on device.
+    """
+
+    def __init__(self, layer: nn.Module):
+        super().__init__()
+        assert isinstance(layer, RotaryEmbedding)
+        self.head_size = layer.head_size
+        self.rotary_dim = layer.rotary_dim
+        self.is_neox_style = layer.is_neox_style
+        # Delegates to the subclass implementation for correct frequency scaling
+        # (e.g. Llama3RotaryEmbedding applies frequency-dependent scaling)
+        inv_freq = layer._compute_inv_freq(layer.base)
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+
+    def _apply_rotary(
+        self,
+        x: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        num_tokens: int,
+    ) -> torch.Tensor:
+        orig_shape = x.shape
+        x = x.view(num_tokens, -1, self.head_size)
+        x_rot = ApplyRotaryEmb.forward_static(
+            x[..., : self.rotary_dim], cos, sin, self.is_neox_style
+        )
+        if self.rotary_dim == self.head_size:
+            return x_rot.reshape(orig_shape)
+        return torch.cat((x_rot, x[..., self.rotary_dim :]), dim=-1).reshape(orig_shape)
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        query: torch.Tensor,
+        key: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        positions_flat = positions.flatten().to(torch.float32)
+        num_tokens = positions_flat.shape[0]
+
+        freqs = torch.outer(positions_flat, self.inv_freq)
+        cos = freqs.cos().to(query.dtype)
+        sin = freqs.sin().to(query.dtype)
+
+        query = self._apply_rotary(query, cos, sin, num_tokens)
+        if key is not None:
+            key = self._apply_rotary(key, cos, sin, num_tokens)
+        return query, key
+
+
+def override_rotary_embedding_module(layer: torch.nn.Module) -> torch.nn.Module:
+    assert isinstance(layer, RotaryEmbedding)
+    return TTRotaryEmbedding(layer)

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -343,8 +343,6 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # self.supports_mm_inputs = self.mm_registry.supports_multimodal_inputs(
         #     model_config)
         self.supports_mm_inputs = False
-        # TODO: Support M-RoPE (e.g, Qwen2-VL)
-        assert not self.uses_mrope, "TPU does not support M-RoPE yet."
 
         self._num_slices_per_kv_cache_update_block = (
             _get_num_slices_per_kv_cache_update_block(
@@ -445,7 +443,14 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             for n in self.num_tokens_paddings
         }
         self._position_ids_dev = {
-            n: _alloc_dev((self.max_num_reqs, n), torch.int32)
+            n: _alloc_dev(
+                (
+                    (3, self.max_num_reqs, n)
+                    if self.uses_mrope
+                    else (self.max_num_reqs, n)
+                ),
+                torch.int32,
+            )
             for n in self.num_tokens_paddings
         }
         self._logits_indices_dev = _alloc_dev((self.max_num_reqs,), torch.int32)
@@ -507,8 +512,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         self.mm_budget = (
             MultiModalBudget(
-                self.model_config,
-                self.scheduler_config,
+                self.vllm_config,
                 self.mm_registry,
             )
             if self.supports_mm_inputs
@@ -1012,12 +1016,22 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             self.num_tokens_paddings, max_num_scheduled_tokens_all_reqs
         )
 
-        # Allocate a zero-initialized position tensor of shape
-        # [max_num_reqs, padded_total_num_scheduled_tokens]. Entries beyond the
-        # actual number of scheduled tokens per request remain zero (padding).
-        arange = torch.zeros(
-            (self.max_num_reqs, padded_total_num_scheduled_tokens), dtype=torch.int32
+        # Allocate a zero-initialized position tensor. For MRoPE models, keep
+        # three identical position planes [3, max_num_reqs, padded_tokens] to
+        # match the runtime input convention; otherwise use [max_num_reqs,
+        # padded_tokens]. Entries beyond the actual number of scheduled tokens
+        # per request remain zero (padding).
+        # NOTE: When M-RoPE is enabled, position ids are 3D regardless of the
+        # modality of inputs. For text-only inputs, each dimension has identical
+        # position IDs, making M-RoPE functionally equivalent to 1D-RoPE.
+        # See page 5 of https://arxiv.org/abs/2409.12191
+
+        arange_shape = (
+            (3, self.max_num_reqs, padded_total_num_scheduled_tokens)
+            if self.uses_mrope
+            else (self.max_num_reqs, padded_total_num_scheduled_tokens)
         )
+        arange = torch.zeros(arange_shape, dtype=torch.int32)
 
         # Populate position ids for each request.
         # For request i with n scheduled tokens, positions are computed as:
@@ -1040,10 +1054,14 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         #    [10,11,12,13,14],
         #    [5, 6, 7, 0, 0]]
         for i, n in enumerate(num_scheduled_tokens_per_req):
-            arange[i, :n] = (
+            positions = (
                 torch.arange(n, dtype=torch.int32)
                 + self.input_batch.num_computed_tokens_cpu[i]
             )
+            if self.uses_mrope:
+                arange[:, i, :n] = positions
+            else:
+                arange[i, :n] = positions
 
         # Allocate a zero-padded input_ids tensor of shape
         # [max_num_reqs, padded_total_num_scheduled_tokens].
@@ -1065,6 +1083,10 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # Move input_ids and position_ids to the target device for execution.
         # Reuse persistent device buffers and update in place via copy_ to
         # avoid issuing a fresh H2D transfer (and on-device alloc) per step.
+        # 'padded_total_num_scheduled_tokens' is used as the key into the
+        # preallocated buffer dictionaries (self._input_ids_dev and
+        # self._position_ids_dev) to select the buffer whose second dimension
+        # matches this step's padded token width.
         input_ids_dev = self._input_ids_dev[padded_total_num_scheduled_tokens]
         input_ids_dev.copy_(input_ids_cpu)
         self.input_ids = input_ids_dev
@@ -1885,6 +1907,8 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         per_layer_attn_metadata = dict.fromkeys(
             self._attention_layer_names, attn_metadata
         )
+        if self.uses_mrope:
+            position_ids = position_ids.unsqueeze(0).expand(3, -1, -1)
 
         with (
             torch_dynamo_tt_device_compatibility(),

--- a/integrations/vllm_plugin/vllm_tt/overrides.py
+++ b/integrations/vllm_plugin/vllm_tt/overrides.py
@@ -5,166 +5,32 @@
 from typing import OrderedDict
 
 import torch
-import torch.nn as nn
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.rotary_embedding.base import RotaryEmbedding
-from vllm.model_executor.layers.rotary_embedding.common import ApplyRotaryEmb
+from vllm.model_executor.layers.rotary_embedding.mrope import MRotaryEmbedding
 
+from .layers.mrope import override_mrope_module
+from .layers.rmsnorm import override_rmsnorm_module
+from .layers.rotary_embedding import override_rotary_embedding_module
 from .logger import tt_init_logger
 
 logger = tt_init_logger(__name__)
-
-
-class TTRMSNorm(nn.Module):
-    """TT-compatible RMSNorm replacement for vLLM's RMSNorm.
-
-    vLLM's RMSNorm.forward_native accesses `self.weight.data`, which causes an
-    AssertionError during torch.compile/torch.export tracing with FakeTensors.
-    Accessing `.data` on a FakeTensor lifts it out of the fake tensor context,
-    resulting in: "cannot call `.data` on a Tensor, the Tensor is a FakeTensor".
-
-    This class reimplements the RMSNorm forward pass using `self.weight` directly
-    (without `.data`), making it compatible with TT tracing and compilation.
-    """
-
-    def __init__(self, layer: nn.Module):
-        super().__init__()
-        assert isinstance(layer, RMSNorm)
-        self.hidden_size = layer.hidden_size
-        self.variance_epsilon = layer.variance_epsilon
-        self.variance_size_override = layer.variance_size_override
-        self.has_weight = layer.has_weight
-        self.weight = layer.weight
-
-        if hasattr(layer, "rocm_norm_func") and hasattr(
-            layer, "rocm_norm_func_with_add"
-        ):
-            self.rocm_norm_func = layer.rocm_norm_func
-            self.rocm_norm_func_with_add = layer.rocm_norm_func_with_add
-
-    def forward(
-        self,
-        x: torch.Tensor,
-        residual: torch.Tensor | None = None,
-    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-
-        orig_dtype = x.dtype
-        x = x.to(torch.float32)
-        if residual is not None:
-            # residual promoted f16->f32 automatically,
-            # otherwise Inductor eliminates the casts to and from f16,
-            # increasing memory usage (and complicating pattern matching)
-            x = x + residual
-            residual = x.to(orig_dtype)
-
-        if x.shape[-1] != self.hidden_size:
-            raise ValueError(
-                f"Expected hidden_size to be {self.hidden_size}, but found: {x.shape[-1]}"
-            )
-
-        if self.variance_size_override is None:
-            x_var = x
-        else:
-            if self.hidden_size < self.variance_size_override:
-                raise ValueError(
-                    "Expected hidden_size to be at least "
-                    f"{self.variance_size_override}, but found: {self.hidden_size}"
-                )
-
-            x_var = x[:, :, : self.variance_size_override]
-
-        variance = x_var.pow(2).mean(dim=-1, keepdim=True)
-
-        x = x * torch.rsqrt(variance + self.variance_epsilon)
-        x = x.to(orig_dtype)
-        if self.has_weight and self.weight is not None:
-            x = x * self.weight
-        if residual is None:
-            return x
-        else:
-            return x, residual
-
-
-class TTRotaryEmbedding(nn.Module):
-    """TT-compatible RotaryEmbedding that computes cos/sin on-the-fly.
-
-    vLLM's RotaryEmbedding pre-builds a cos_sin_cache and uses index_select
-    (gather) with position_ids at runtime. This lowers to ttir.embedding which
-    requires indices on host via from_device, breaking metal trace mode.
-
-    This replacement computes cos/sin from inv_freq and positions using math
-    ops (outer product + cos/sin) that stay entirely on device.
-    """
-
-    def __init__(self, layer: nn.Module):
-        super().__init__()
-        assert isinstance(layer, RotaryEmbedding)
-        self.head_size = layer.head_size
-        self.rotary_dim = layer.rotary_dim
-        self.is_neox_style = layer.is_neox_style
-        # Delegates to the subclass implementation for correct frequency scaling
-        # (e.g. Llama3RotaryEmbedding applies frequency-dependent scaling)
-        inv_freq = layer._compute_inv_freq(layer.base)
-        self.register_buffer("inv_freq", inv_freq, persistent=False)
-
-    def _apply_rotary(
-        self,
-        x: torch.Tensor,
-        cos: torch.Tensor,
-        sin: torch.Tensor,
-        num_tokens: int,
-    ) -> torch.Tensor:
-        orig_shape = x.shape
-        x = x.view(num_tokens, -1, self.head_size)
-        x_rot = ApplyRotaryEmb.forward_static(
-            x[..., : self.rotary_dim], cos, sin, self.is_neox_style
-        )
-        if self.rotary_dim == self.head_size:
-            return x_rot.reshape(orig_shape)
-        return torch.cat((x_rot, x[..., self.rotary_dim :]), dim=-1).reshape(orig_shape)
-
-    def forward(
-        self,
-        positions: torch.Tensor,
-        query: torch.Tensor,
-        key: torch.Tensor | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        positions_flat = positions.flatten().to(torch.float32)
-        num_tokens = positions_flat.shape[0]
-
-        freqs = torch.outer(positions_flat, self.inv_freq)
-        cos = freqs.cos().to(query.dtype)
-        sin = freqs.sin().to(query.dtype)
-
-        query = self._apply_rotary(query, cos, sin, num_tokens)
-        if key is not None:
-            key = self._apply_rotary(key, cos, sin, num_tokens)
-        return query, key
 
 
 def get_fqn(module):
     return module.__class__.__qualname__
 
 
-def tt_rmsnorm_module(layer: torch.nn.Module) -> torch.nn.Module:
-    assert isinstance(layer, RMSNorm)
-    return TTRMSNorm(layer)
-
-
-def tt_rotary_embedding_module(layer: torch.nn.Module) -> torch.nn.Module:
-    assert isinstance(layer, RotaryEmbedding)
-    return TTRotaryEmbedding(layer)
-
-
 MODULE_TYPE_TO_TT_OVERRIDE = OrderedDict(
     [
-        ("RMSNorm", tt_rmsnorm_module),
+        ("RMSNorm", override_rmsnorm_module),
     ]
 )
 
 # isinstance-based overrides for classes where subclasses need the same treatment
 ISINSTANCE_OVERRIDES = [
-    (RotaryEmbedding, tt_rotary_embedding_module),
+    (MRotaryEmbedding, override_mrope_module),
+    (RotaryEmbedding, override_rotary_embedding_module),
 ]
 
 

--- a/tests/integrations/vllm_plugin/generative/test_mrope.py
+++ b/tests/integrations/vllm_plugin/generative/test_mrope.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import vllm
+from conftest import assert_output_coherent, check_host_memory
+
+
+@pytest.mark.push
+@pytest.mark.single_device
+def test_mrope():
+    prompts = [
+        "Continue in English: I like taking walks in the",
+    ]
+    sampling_params = vllm.SamplingParams(temperature=0.8, top_p=0.95, max_tokens=32)
+    model_name = "Qwen/Qwen2-VL-2B-Instruct"
+
+    llm_args = {
+        "model": model_name,
+        "max_num_batched_tokens": 32,
+        "max_num_seqs": 1,
+        "max_model_len": 32,
+        "gpu_memory_utilization": 0.002,
+        "enforce_eager": True,
+        "limit_mm_per_prompt": {"image": 0, "video": 0, "audio": 0},
+        "additional_config": {
+            "min_context_len": 32,
+        },
+    }
+    llm = vllm.LLM(**llm_args)
+
+    output_text = llm.generate(prompts, sampling_params)[0].outputs[0].text
+    print(f"prompt: {prompts[0]}, output: {output_text}")
+    assert_output_coherent(output_text)
+
+    check_host_memory(model_name)


### PR DESCRIPTION
### Ticket
closes #5106 

### Problem description
vLLM M-RoPE layer is implemented for flattened inputs and causes failures for batched inputs.

### What's changed
- Add M-RoPE implementation for batched inputs required for TT vLLM plugin.
- Allocating preallocated position-id buffers as 3D ([3, max_num_reqs, num_tokens]) when M-RoPE is enabled and building runtime position tensors in matching 3D shape.
- Refactor TT compatible layers.

### Checklist
- [X] New tests provide coverage for changes
