### PR TITLE
[vLLM] Fix qwen3-32b batch-32 TP prefill sharding collapse; enable bs32 benchmark

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/attention.py
+++ b/integrations/vllm_plugin/vllm_tt/attention.py
@@ -487,22 +487,35 @@ class TTAttentionBackendImpl(AttentionImpl):
             key_for_update = inputs.key.transpose(1, 2)
             value_for_update = inputs.value.transpose(1, 2)
 
+            # Hoist the per-user batch index into a single tensor and
+            # static-slice it per iteration, instead of materializing a fresh
+            # torch.tensor([batch_idx]) constant each loop. torch.export unrolls
+            # this loop, so the old form lifted (batch_size * 2) scalar int32
+            # constants per layer as graph params (batch_size * 2 * num_layers
+            # total). At batch 32 / 64 layers that is ~4096 extra params, which
+            # trips torch_xla's parameter-wrapping threshold: the prefill graph
+            # is then emitted as a @main wrapper forwarding to an inner function,
+            # and the inliner drops the per-arg sdy.sharding, so already-mesh-
+            # distributed inputs get a spurious replicate distribute_tensor
+            # ("single buffer from host storage" fatal, trace off) or trip the
+            # TTNNLayout assertion (trace on). See issue #5032. The static slice
+            # fill_batch_idx[i:i+1] lowers to compile-time slice attributes, not
+            # lifted operands, so the prefill graph stays flat.
+            fill_batch_idx = torch.arange(
+                inputs.users, dtype=torch.int32, device=k_cache.device
+            )
             for batch_idx in range(inputs.users):
                 k_cache = torch.ops.tt.paged_fill_cache(
                     k_cache,
                     key_for_update[batch_idx : batch_idx + 1],
                     attn_metadata.fill_page_table,
-                    batch_idx=torch.tensor(
-                        [batch_idx], dtype=torch.int32, device=k_cache.device
-                    ),
+                    batch_idx=fill_batch_idx[batch_idx : batch_idx + 1],
                 )
                 v_cache = torch.ops.tt.paged_fill_cache(
                     v_cache,
                     value_for_update[batch_idx : batch_idx + 1],
                     attn_metadata.fill_page_table,
-                    batch_idx=torch.tensor(
-                        [batch_idx], dtype=torch.int32, device=v_cache.device
-                    ),
+                    batch_idx=fill_batch_idx[batch_idx : batch_idx + 1],
                 )
 
         # Preserve tensor identity so XLA reuses the traced graph.

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -188,7 +188,10 @@ TP_CONFIGS = [
     pytest.param(_tp_config("Qwen/Qwen3-32B", 1), id="qwen3-32b-tp"),
     pytest.param(_gemma4_tp_config("google/gemma-4-31B-it", 1), id="gemma4-31b-it-tp"),
     pytest.param(
-        _tp_config("Qwen/Qwen3-32B", 1, use_2d_mesh=False), id="qwen3-32b-qb2-tp"
+        _tp_config(
+            "Qwen/Qwen3-32B", 32, use_2d_mesh=False, gpu_memory_utilization=0.1
+        ),
+        id="qwen3-32b-qb2-tp",
     ),
     pytest.param(
         _tp_config("Qwen/Qwen2.5-14B-Instruct", 1), id="qwen2.5-14b-instruct-tp"

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -188,9 +188,7 @@ TP_CONFIGS = [
     pytest.param(_tp_config("Qwen/Qwen3-32B", 1), id="qwen3-32b-tp"),
     pytest.param(_gemma4_tp_config("google/gemma-4-31B-it", 1), id="gemma4-31b-it-tp"),
     pytest.param(
-        _tp_config(
-            "Qwen/Qwen3-32B", 32, use_2d_mesh=False, gpu_memory_utilization=0.1
-        ),
+        _tp_config("Qwen/Qwen3-32B", 32, use_2d_mesh=False, gpu_memory_utilization=0.1),
         id="qwen3-32b-qb2-tp",
     ),
     pytest.param(


### PR DESCRIPTION
### Ticket
#5032

### Problem description
The qwen3-32b vLLM benchmark fails at **batch 32** on a 1×4 tensor-parallel mesh (QB2 / 4× Blackhole).

The prefill KV-cache fill loop materializes a fresh `torch.tensor([batch_idx])` per batch, per K/V, per layer. `torch` unrolls this Python loop, lifting `batch_size × 2 × num_layers` scalar `int32` constants as graph parameters, which is ~4096 for batch 32 / 64 layers. That pushes the prefill graph's parameter count over torch_xla's parameter-wrapping threshold, so it is emitted as a thin public `@main` wrapper forwarding to a private inner function. The compiler inlines that callee but does not copy the per-argument `sdy.sharding` up to `@main`, so every entry argument is treated as `Unsharded`. The compiler then inserts a replicate `distribute_tensor` on inputs that are already mesh-distributed:

- **trace off:** runtime fatal `Can't get a single buffer from host storage distributed over mesh shape MeshShape([1,4])`
- **trace on:** `TTNNLayoutAttr` `Memory layout is required for non-SystemMemory buffer type` assertion

(decode is unaffected - at batch 1 these scalars are limited as it scales based on batch_size from my tests, hence the bs1 test has not been failing on CI.)

### What's changed
- `integrations/vllm_plugin/vllm_tt/attention.py`: hoist the per-user fill batch index into a single `torch.arrange(inputs.users)` and static-slice it (`fill_batch_idx[i:i+1]`) instead of building a `torch.tensor([batch_idx])` each iteration. A static slice lowers to compile-time slice attributes, not lifted operands, so no per-user constants are added to the graph. Prefill drops back under the parameter-wrapping threshold, the graph stays flat, `sdy.sharding` survives, and both failure modes above are resolved. `paged_fill_cache` is still single-user per call; this is purely about how the index is passed.
- `tests/benchmark/test_vllm_benchmarks.py`: convert `qwen3-32b-qb2-tp` from batch 1 to batch 32 (`use_2d_mesh=False`, `gpu_memory_utilization=0.1`) so the bs32 path is exercised.

Validated on QB2 (1×4 Blackhole) locally, will add CI test.

### Checklist
- [x] qb2 w/ 1x4 mesh benchmark: https://github.com/tenstorrent/tt-xla/actions/runs/27039167668
- [ ] n300-llmbox w/ 1x8 mesh benchmark: https://github.com/tenstorrent/tt-xla/actions/runs/27039142903
- [ ] Ensure falcon 3 7B and 10B is fixed from above llmbox test.

_Note: the branch used for the tests was a custom branch with the fix but with all tests set to `use_2d_mesh=False` for illustrative purposes to show proof of support. If needed we can set them in a later PR._