### PR TITLE
Fix GPT-OSS 20B example segfault by selecting tt_dense experts backend

### DIFF
--- a/examples/pytorch/gpt_oss_20b.py
+++ b/examples/pytorch/gpt_oss_20b.py
@@ -24,6 +24,10 @@ from transformers import (
 from transformers.cache_utils import StaticCache
 from transformers.configuration_utils import PretrainedConfig
 from transformers.modeling_outputs import CausalLMOutputWithPast
+
+# Importing this name also imports tt_torch.moe_backend, which registers the
+# "tt_dense"/"tt_moe" HF experts backends via register_tt_moe_backend().
+from tt_torch import TT_DENSE_EXPERTS_BACKEND_NAME
 from tt_torch.sharding import sharding_constraint_hook
 from tt_torch.transformers_overrides import (
     override_cache_sliding_window_layers,
@@ -144,13 +148,21 @@ def setup_model_and_tokenizer(
     Returns:
         Tuple of (model, tokenizer)
     """
+    # Use the static dense experts forward (tt_dense) instead of HF's default
+    # experts path. The default path has data-dependent loops and falls back to
+    # CPU ops (e.g. _grouped_mm) that crash during StableHLO conversion. The
+    # #4988 MoE-backend change removed the GptOss forward monkey-patches, so the
+    # backend must now be selected explicitly here (the benchmark does the same).
     model: torch.nn.Module = AutoModelForCausalLM.from_pretrained(
         model_name,
         dtype=torch.bfloat16,
         low_cpu_mem_usage=True,
         trust_remote_code=True,
         attn_implementation="eager",
+        experts_implementation=TT_DENSE_EXPERTS_BACKEND_NAME,
     )
+    if hasattr(model.config, "_experts_implementation"):
+        model.config._experts_implementation = TT_DENSE_EXPERTS_BACKEND_NAME
     # Override the gpt_oss model to use the TT-friendly sliding window causal mask
     override_model_sliding_window_causal_mask(model)
     model = model.eval()


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Running the `examples/pytorch/gpt_oss_20b.py` example segfaults during compilation.

This regressed in #4988 ("MoE backend from huggingface"), which removed the
`GptOssMLP/GptOssExperts/GptOssTopKRouter.forward` monkey-patches from
`torch_overrides.py`. Those patches were what previously forced GPT-OSS onto the
TT-friendly sparse MLP path. After #4988, the experts backend must be selected
explicitly via `experts_implementation=`.
The benchmark (`tests/benchmark/test_llms.py`) was updated to pass
`experts_implementation="tt_dense"`, but the example was not, so it fell through
to HF's default experts implementation — the path the benchmark explicitly
avoids ("data-dependent loops in the original experts and _grouped_mm CPU
crashes"). An unsupported op there hits `cpu_fallback` → `_to_cpu` → graph
compile → StableHLO conversion crash.


### What's changed

- Pass `experts_implementation=TT_DENSE_EXPERTS_BACKEND_NAME` to `from_pretrained` and set `model.config._experts_implementation`, mirroring the benchmark.

-  Import `TT_DENSE_EXPERTS_BACKEND_NAME` from `tt_torch` (this import also registers th `tt_dense`/`tt_moe` HF backends via `register_tt_moe_backend()`).

Logs:
On #4988 (current):
[gpt.log](https://github.com/user-attachments/files/28663960/gpt.log)

ommit below #4988 (last good)
[gpt_1.log](https://github.com/user-attachments/files/28663969/gpt_1.log)

#4988 + this fix 
[gpt_2.log](https://github.com/user-attachments/files/28663972/gpt_2.log)

### Checklist
- [ ] New/Existing tests provide coverage for changes
