### PR TITLE
Fix Ministral-8B single-device inference by removing optimization_level:2

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -1708,7 +1708,6 @@ test_config:
         bringup_status: FAILED_RUNTIME
 
   mistral/pytorch-Ministral_8B_Instruct-single_device-inference:
-    optimization_level: 2
     arch_overrides:
       p150:
         status: EXPECTED_PASSING


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
After the sliding-attention refactor in tt-forge-models (#604 / #4975), Ministral-8B now runs through the StaticCache + sliding-window-mask graph. On that graph, optimization_level: 2 triggers a tile-alignment failure at runtime:

TT_FATAL ... Physical shard shape (1, 30) must be tile {32, 32} sized!
ttnn::to_layout(...)
At opt level 2 the sharding/layout pass emits a (1, N) shard whose leading dim can't meet the {32, 32} tile requirement. Running the same model at optimization_level: 0 (the default) compiles and passes cleanly — this also matches the olmo3 sliding-window configs and the standalone examples/pytorch/mistral_8b.py, which both run at the default level and pass.

### What's changed
Removed optimization_level=2 from the test configuration file.

Logs:
with the optimization_level-2:
[mist_sd.log](https://github.com/user-attachments/files/28676734/mist_sd.log)

After removing thr optimization_level:
[mist_sd_1.log](https://github.com/user-attachments/files/28676742/mist_sd_1.log)


### Checklist
- [ ] New/Existing tests provide coverage for changes
