### PR TITLE
[vLLM] Fix num_hidden_layers override for text-only models

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -19,7 +19,6 @@ import torch_xla.distributed.spmd as xs
 import torch_xla.runtime as xr
 import vllm.envs as envs
 from tt_torch.sharding import sharding_constraint_tensor
-from tt_torch.utils import torch_dynamo_tt_device_compatibility
 from vllm.compilation.wrapper import TorchCompileWithNoGuardsWrapper
 from vllm.config import (
     ParallelConfig,
@@ -1892,7 +1891,6 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         )
 
         with (
-            torch_dynamo_tt_device_compatibility(),
             self.maybe_select_dummy_loras(
                 self.lora_config, np.array([num_tokens], dtype=np.int32)
             ),
@@ -2058,8 +2056,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             if self.enable_tensor_parallel:
                 safe_mark_sharding(dummy_hidden, self.mesh, (None, None, "model"))
 
-            with torch_dynamo_tt_device_compatibility():
-                self.select_hidden_states(dummy_hidden, indices)
+            self.select_hidden_states(dummy_hidden, indices)
 
         xm.wait_device_ops()
         end = time.perf_counter()
@@ -2079,8 +2076,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         if self.enable_tensor_parallel and self.is_sharded_compute_logits:
             safe_mark_sharding(dummy_hidden, self.mesh, (None, None))
 
-        with torch_dynamo_tt_device_compatibility():
-            self.compute_logits(dummy_hidden)
+        self.compute_logits(dummy_hidden)
 
         xm.wait_device_ops()
         end = time.perf_counter()
@@ -2109,13 +2105,12 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # mark_dynamic because some operations in structured_decode require
         # them to be static.
         bitmasks = self.structured_decode_bitmasks.to(self.device)
-        with torch_dynamo_tt_device_compatibility():
-            self.structured_decode(
-                dummy_require_struct_decoding,
-                dummy_grammar_bitmask,
-                dummy_logits,
-                bitmasks,
-            )
+        self.structured_decode(
+            dummy_require_struct_decoding,
+            dummy_grammar_bitmask,
+            dummy_logits,
+            bitmasks,
+        )
 
         xm.wait_device_ops()
         end = time.perf_counter()
@@ -2148,7 +2143,6 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             )
             sampling_metadata.all_greedy = all_greedy
             with (
-                torch_dynamo_tt_device_compatibility(),
                 self.maybe_select_dummy_loras(
                     self.lora_config, np.array([self.max_num_reqs], dtype=np.int32)
                 ),
@@ -2182,7 +2176,6 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             self.device
         )
         with (
-            torch_dynamo_tt_device_compatibility(),
             self.maybe_select_dummy_loras(
                 self.lora_config, np.array([self.max_num_reqs], dtype=np.int32)
             ),

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -103,7 +103,11 @@ from .overrides import replace_modules
 from .platform import TTConfig
 from .sampler import Sampler
 from .vllm_distributed_utils import safe_mark_sharding, shard_model
-from .vllm_utils import determine_mesh_shape, prev_power_of_2
+from .vllm_utils import (
+    apply_hidden_layer_override,
+    determine_mesh_shape,
+    prev_power_of_2,
+)
 
 
 def add_kv_sharing_layers_to_kv_cache_groups(
@@ -538,22 +542,12 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self.mm_embed_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None
 
         # Override number of hidden layers if specified in TTConfig
-        self._original_num_layers = None
-        self._target_num_layers = None
-        target_num_layers = self.tt_config.num_hidden_layers
-        # Multimodal configs (e.g. Gemma 4) nest num_hidden_layers under text_config.
-        hf_config = vllm_config.model_config.hf_config
-        hf_text_config = getattr(hf_config, "text_config", hf_config)
-        original_num_layers = getattr(hf_text_config, "num_hidden_layers", 0)
-
-        if target_num_layers > 0 and target_num_layers < original_num_layers:
-            hf_text_config.num_hidden_layers = target_num_layers
-            logger.info(
-                f"Overriding num_hidden_layers from {original_num_layers} to {target_num_layers} for debugging and testing purposes."
+        self._original_num_layers, self._target_num_layers = (
+            apply_hidden_layer_override(
+                vllm_config.model_config.hf_config,
+                self.tt_config.num_hidden_layers,
             )
-            # Store original layer count for weight filtering
-            self._original_num_layers = original_num_layers
-            self._target_num_layers = target_num_layers
+        )
 
     def _filter_weights_for_layer_override(self, weights_iterator):
         """Filter weights to only include layers that exist in the modified model."""

--- a/integrations/vllm_plugin/vllm_tt/pooling_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/pooling_runner.py
@@ -97,7 +97,11 @@ from .logger import tt_init_logger
 from .overrides import replace_modules
 from .platform import TTConfig
 from .vllm_distributed_utils import shard_model
-from .vllm_utils import determine_mesh_shape, prev_power_of_2
+from .vllm_utils import (
+    apply_hidden_layer_override,
+    determine_mesh_shape,
+    prev_power_of_2,
+)
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
@@ -499,19 +503,12 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         )
 
         # Override number of hidden layers if specified in TTConfig
-        self._original_num_layers = None
-        self._target_num_layers = None
-        target_num_layers = self.tt_config.num_hidden_layers
-        original_num_layers = vllm_config.model_config.hf_config.num_hidden_layers
-
-        if target_num_layers > 0 and target_num_layers < original_num_layers:
-            vllm_config.model_config.hf_config.num_hidden_layers = target_num_layers
-            logger.info(
-                f"Overriding num_hidden_layers from {original_num_layers} to {target_num_layers} for debugging and testing purposes."
+        self._original_num_layers, self._target_num_layers = (
+            apply_hidden_layer_override(
+                vllm_config.model_config.hf_config,
+                self.tt_config.num_hidden_layers,
             )
-            # Store original layer count for weight filtering
-            self._original_num_layers = original_num_layers
-            self._target_num_layers = target_num_layers
+        )
 
     def _filter_weights_for_layer_override(self, weights_iterator):
         """Filter weights to only include layers that exist in the modified model."""

--- a/integrations/vllm_plugin/vllm_tt/vllm_utils.py
+++ b/integrations/vllm_plugin/vllm_tt/vllm_utils.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
+from typing import Any
+
 from .logger import tt_init_logger
 
 logger = tt_init_logger(__name__)
@@ -44,3 +46,53 @@ def determine_mesh_shape(num_devices: int, use_2d_mesh: bool) -> tuple[int, int]
 def prev_power_of_2(n: int) -> int:
     """The previous power of 2 (inclusive)"""
     return 0 if n <= 0 else 1 << (n.bit_length() - 1)
+
+
+def apply_hidden_layer_override(
+    hf_config: Any,
+    target_num_layers: int,
+) -> tuple[int | None, int | None]:
+    """Apply decoder hidden-layer override for root or text sub-config.
+
+    Plain LM configs expose num_hidden_layers attribute on the root config,
+    while multimodal model configs uses text_config for num_hidden_layers.
+    This helper resolves the right config object and applies the override only
+    when 0 < target_num_layers < original_num_layers.
+
+    Returns:
+        A tuple (original_num_layers, target_num_layers) when an override
+        is applied; otherwise (None, None).
+    """
+    if target_num_layers == 0:
+        return None, None
+
+    if target_num_layers < 0:
+        logger.warning(
+            "Ignoring num_hidden_layers override: expected non-negative value, got %d.",
+            target_num_layers,
+        )
+        return None, None
+
+    if hasattr(hf_config, "num_hidden_layers"):
+        original_num_layers = hf_config.num_hidden_layers
+        decoder_cfg = hf_config
+    else:
+        text_cfg = getattr(hf_config, "text_config", None)
+        if text_cfg is None or not hasattr(text_cfg, "num_hidden_layers"):
+            raise AttributeError(
+                f"{type(hf_config).__name__} has no decoder num_hidden_layers "
+                "(expected on config or text_config)"
+            )
+        original_num_layers = text_cfg.num_hidden_layers
+        decoder_cfg = text_cfg
+
+    if target_num_layers < original_num_layers:
+        decoder_cfg.num_hidden_layers = target_num_layers
+        logger.info(
+            "Overriding num_hidden_layers from %d to %d for debugging and testing purposes.",
+            original_num_layers,
+            target_num_layers,
+        )
+        return original_num_layers, target_num_layers
+
+    return None, None

--- a/tests/integrations/vllm_plugin/sampling/conftest.py
+++ b/tests/integrations/vllm_plugin/sampling/conftest.py
@@ -12,7 +12,7 @@ import gc
 import pytest
 import vllm
 
-TEST_TIMEOUT_SECONDS = 180
+TEST_TIMEOUT_SECONDS = 360
 
 _llm_cache: dict[str, vllm.LLM] = {}
 _needs_recreate = False


### PR DESCRIPTION
### Ticket
closes #5124

### Problem description
num_hidden_layers override is not being applied for text-only models

### What's changed
- Apply num_hidden_layers override for both text-only and multi-modal models
- Code refactoring and reusing shard override logic across both runners
- Remove locally applied torch_dynamo_tt_device_compatibility patch

### Checklist
- [X] Existing tests provide coverage for changes
