### PR TITLE
Remove logical mapping of p150-perf -> qb2

### DIFF
--- a/.github/scripts/filter-test-matrix.py
+++ b/.github/scripts/filter-test-matrix.py
@@ -112,12 +112,7 @@ def filter_matrix_adv(matrix, adv_filter):
 
 def update_runners(matrix, sh_runner):
     """Update runner names based on shared runner flag."""
-    # "p150-perf" is a logical single-chip Blackhole perf label that always maps to
-    # the physical qb2-blackhole box (kept distinct from the multi-chip qb2-blackhole
-    # tests so the runs-on filter can separate them). The shared-runner-mode remap is
-    # layered on top.
-    runner_map = {"p150-perf": "qb2-blackhole"}
-    runner_map.update({"p150": "p150b"} if sh_runner else {"n150": "n150-perf"})
+    runner_map = {"p150": "p150b"} if sh_runner else {"n150": "n150-perf"}
 
     for item in matrix:
         item["runs-on-original"] = item.get("runs-on")


### PR DESCRIPTION
### Ticket
/

### Problem description
Logical mapping of runner labels that isn't conditional shouldn't be in workflows.

### What's changed
Remove the mapping from the code and add the labels to the actual qb2-blackhole runners.

### Checklist
Performance benchmark runs dispatched on the branch:
- only p150-perf tests -> [run](https://github.com/tenstorrent/tt-xla/actions/runs/27136573033)
- mixed tests group -> [run](https://github.com/tenstorrent/tt-xla/actions/runs/27138677838)
