### PR TITLE
[CI] Add CPU only tests

### DIFF
--- a/.github/scripts/generate_test_matrix.py
+++ b/.github/scripts/generate_test_matrix.py
@@ -24,6 +24,7 @@ def map_runner_name(entry):
         "wormhole_b0": "tt-ubuntu-2204-n300-stable",
         "p150": "tt-ubuntu-2204-p150b-stable",
         "n300-llmbox": "tt-ubuntu-2204-n300-llmbox-stable",
+        "cpu": "tt-ubuntu-2204-large-stable",
     }
 
     if entry.get("shared-runners") == "true" or entry.get("shared-runners") is True:

--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -84,7 +84,7 @@ jobs:
 
     container:
       image: ${{ !matrix.build.shared-runners && inputs.docker_image || format('harbor.ci.tenstorrent.net/{0}', inputs.docker_image) }}
-      options: ${{ (matrix.build.runs-on-original == 'cpu' || matrix.build.runs-on == 'cpu') && '' || '--device /dev/tenstorrent' }}
+      options: ${{ (matrix.build.runs-on-original == 'cpu' || matrix.build.runs-on == 'cpu') && ' ' || '--device /dev/tenstorrent' }}
       volumes:
         - /dev/hugepages:/dev/hugepages
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -84,7 +84,7 @@ jobs:
 
     container:
       image: ${{ !matrix.build.shared-runners && inputs.docker_image || format('harbor.ci.tenstorrent.net/{0}', inputs.docker_image) }}
-      options: --device /dev/tenstorrent
+      options: ${{ (matrix.build.runs-on-original == 'cpu' || matrix.build.runs-on == 'cpu') && '' || '--device /dev/tenstorrent' }}
       volumes:
         - /dev/hugepages:/dev/hugepages
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/manual-test-single.yml
+++ b/.github/workflows/manual-test-single.yml
@@ -32,6 +32,7 @@ on:
           - 'llmbox-2'
           - 'galaxy-wh-6u'
           - 'qb2-blackhole'
+          - 'cpu'
       shared_runners:
         description: 'Run test on the CIv2 runner'
         required: false


### PR DESCRIPTION
### Ticket
Slack issue

### Problem description
There is no option to run tests on CPU only runners in `call-test.yml`.

### What's changed
Add an option to run tests on CPU only runners.

### Checklist
- [ ] New/Existing tests provide coverage for changes
