### PR TITLE
[vLLM] Warmup phase optimization

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -251,6 +251,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self.device = device
         self.check_recompilation = envs.VLLM_XLA_CHECK_RECOMPILATION
         self.use_flat_model_io = self.tt_config.flat_model_io
+        self.enable_decode_fused_graphs = self.tt_config.enable_decode_fused_graphs
 
         # SPMD Related
         self.enable_tensor_parallel = self.tt_config.enable_tensor_parallel
@@ -1496,6 +1497,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
     def sample_tokens(
         self, grammar_output: "GrammarOutput | None"
     ) -> ModelRunnerOutput:
+        logger.info(f"sample_tokens called with grammar_output")
         if self.scheduler_output is None:
             # Nothing to do (PP non-final rank case), output isn't used.
             return None  # type: ignore[return-value]
@@ -1572,7 +1574,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     )
                 )
             else:
-                if self.position_ids.shape[-1] == 1:
+                if self.position_ids.shape[-1] == 1 and self.enable_decode_fused_graphs:
                     hidden_states, logits, selected_token_ids, kv_connector_output = (
                         self._model_decode(
                             input_ids,
@@ -2122,7 +2124,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 dummy_grammar_bitmask,
                 dummy_bitmasks,
             ) = self._get_dummy_inputs(config)
-            if config["num_tokens"] == 1:
+            if config["num_tokens"] == 1 and self.enable_decode_fused_graphs:
                 _, _, _, _ = self._model_decode(
                     dummy_inputs,
                     dummy_positions,

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -1548,7 +1548,9 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     require_struct_decoding,
                     grammar_bitmask_padded,
                     bitmask_arange,
-                ) = self.prepare_structured_decoding_input(grammar_output, num_reqs)
+                ) = self.prepare_structured_decoding_input(
+                    grammar_output, self.max_num_reqs
+                )
             torch_xla.sync(wait=False)
 
             # Decode path
@@ -1570,7 +1572,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     )
                 )
             else:
-                if input_ids is not None and input_ids.shape[1] == 1:
+                if self.position_ids.shape[-1] == 1:
                     hidden_states, logits, selected_token_ids, kv_connector_output = (
                         self._model_decode(
                             input_ids,
@@ -2610,17 +2612,23 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             if not self.tt_config.cpu_sampling:
                 logger.info("Warmup mode: fused runtime path")
                 self._precompile_model_fused()
+                if self.tt_config.decode_only:
+                    logger.info(
+                        "decode_only=True: skipping remaining graphs compilation."
+                    )
+                    return
             else:
                 logger.info("Warmup mode: unfused runtime path (cpu_sampling=True)")
                 self._precompile_backbone()
                 if self.tt_config.decode_only:
                     logger.info(
-                        "decode_only=True: skipping unfused postprocessing warmup"
+                        "decode_only=True: skipping remaining graphs compilation."
                     )
                     return
                 self._precompile_select_hidden_states()
                 self._precompile_compute_logits()
                 self._precompile_structured_decoding()
+
             self._precompile_mm_encoder()
             # TODO(#4387): precompile fails trace-insertion at opt_level=1;
             # skip when trace is on. Paired with the CPU fallback at the

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -1497,7 +1497,6 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
     def sample_tokens(
         self, grammar_output: "GrammarOutput | None"
     ) -> ModelRunnerOutput:
-        logger.info(f"sample_tokens called with grammar_output")
         if self.scheduler_output is None:
             # Nothing to do (PP non-final rank case), output isn't used.
             return None  # type: ignore[return-value]
@@ -1555,7 +1554,6 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 )
             torch_xla.sync(wait=False)
 
-            # Decode path
             if self.tt_config.cpu_sampling:
                 hidden_states, logits, selected_token_ids, kv_connector_output = (
                     self._model_unfused(
@@ -2113,6 +2111,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         ]
 
         for config in configs:
+            logger.info(f"Compiling graph for config={config}")
             (
                 dummy_inputs,
                 dummy_positions,
@@ -2141,7 +2140,6 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 )
                 self._update_num_xla_graphs("_model_decode")
             else:
-                logger.info(f"Compiling prefill path with config={config}")
                 _, _, _, _ = self._model_prefill(
                     dummy_inputs,
                     dummy_positions,
@@ -2346,9 +2344,11 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         and postprocessing is compiled separately.
         This will produce 1 model forward graph and 4 postprocessing graphs
         (for each combination of greedy/non-greedy sampling and grammar/no-grammar)
-         for each input tokens.
+        for each input lenght.
         Separate compilation is used because compiling combined graphs significantly
         increase the warmup time.
+        This path is always used for prefill and is also used for decode if
+        enable_decode_fused_graphs=False.
         """
         with (
             set_forward_context(

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -3,8 +3,10 @@
 # SPDX-FileCopyrightText: Portions (c) 2025 Tenstorrent AI ULC
 
 import bisect
+import contextlib
 import gc
 import time
+from itertools import product
 from typing import TYPE_CHECKING, Any, Literal, Optional, Union, cast
 from unittest.mock import patch
 
@@ -534,12 +536,6 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             if self.supports_mm_inputs
             else None
         )
-
-        if self.tt_config.cpu_sampling:
-            logger.warning("cpu_sampling=True: using CPU sampling path")
-            self.sample_from_logits_func = self.sample_from_logits_cpu
-        else:
-            self.sample_from_logits_func = self.sample_from_logits
 
         # For passing scheduler_output between successive
         # execute_model() and sample_tokens() calls.
@@ -1528,45 +1524,6 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 self.input_ids, mm_embed_inputs
             )
             self._pin_input_shardings(input_ids, self.position_ids, inputs_embeds)
-            (
-                model_input_ids,
-                model_positions,
-                model_inputs_embeds,
-                hidden_state_shape,
-            ) = self._prepare_model_call_tensors(
-                input_ids, self.position_ids, inputs_embeds
-            )
-            torch_xla.sync(wait=False)
-            # Run the decoder
-            with (
-                set_forward_context(
-                    attn_metadata,
-                    self.vllm_config,
-                    num_tokens=scheduler_output.total_num_scheduled_tokens,
-                ),
-                self.maybe_get_kv_connector_output(
-                    scheduler_output
-                ) as kv_connector_output,
-            ):
-                hidden_states = self.model(
-                    input_ids=model_input_ids,
-                    positions=model_positions,
-                    inputs_embeds=model_inputs_embeds,
-                )
-            hidden_states = self._restore_model_hidden_states(
-                hidden_states, hidden_state_shape
-            )
-
-            # Save hidden states (before position selection) for prompt
-            # logprobs.  Only extract rows for requests that actually need
-            # them, keyed by batch index, so we never copy the full
-            # [max_num_reqs, padded_seq_len, H] tensor to CPU.
-            if self.num_prompt_logprobs:
-                for i in range(start_index, end_index):
-                    req_id = self.input_batch.req_ids[i]
-                    if req_id in self.num_prompt_logprobs:
-                        local_idx = i - start_index
-                        prompt_lp_hs[i] = hidden_states[local_idx].cpu()
 
             sampling_device = (
                 torch.device("cpu") if self.tt_config.cpu_sampling else self.device
@@ -1582,68 +1539,83 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 sampling_device,
                 vocab_size=self.vocab_size,
             )
+            apply_grammar = grammar_output is not None
+            require_struct_decoding = None
+            grammar_bitmask_padded = None
+            bitmask_arange = None
+            if apply_grammar == True:
+                (
+                    require_struct_decoding,
+                    grammar_bitmask_padded,
+                    bitmask_arange,
+                ) = self.prepare_structured_decoding_input(grammar_output, num_reqs)
+            torch_xla.sync(wait=False)
+
+            # Decode path
             if self.tt_config.cpu_sampling:
-                # cpu_sampling path: select + compute on device, sample on CPU
-                hidden_states = self.select_hidden_states(hidden_states, logits_indices)
-                logits = self.compute_logits(hidden_states)
-                if grammar_output is not None:
-                    (
+                hidden_states, logits, selected_token_ids, kv_connector_output = (
+                    self._model_unfused(
+                        input_ids,
+                        self.position_ids,
+                        inputs_embeds,
+                        logits_indices,
+                        sampling_metadata,
+                        attn_metadata,
+                        apply_grammar,
                         require_struct_decoding,
                         grammar_bitmask_padded,
-                        arange,
-                    ) = self.prepare_structured_decoding_input(logits, grammar_output)
-                    logits = self.structured_decode(
-                        require_struct_decoding, grammar_bitmask_padded, logits, arange
+                        bitmask_arange,
+                        scheduler_output.total_num_scheduled_tokens,
+                        scheduler_output,
                     )
-                selected_token_ids = self.sample_from_logits_func(
-                    logits, sampling_metadata
                 )
             else:
-                # fused path: decode_postprocess is compiled only for num_tokens=1.
-                # For prefill (num_tokens > 1), eagerly select the last token per
-                # request outside the compiled function so the shape is always
-                # (max_num_reqs, 1, hsize) — no extra compiled graphs needed.
-                if hidden_states.shape[1] != 1:
-                    batch_idx = torch.arange(
-                        self.max_num_reqs, dtype=torch.int32, device=self.device
-                    )
-                    hidden_states = hidden_states[
-                        batch_idx, logits_indices, :
-                    ].unsqueeze(1)
-                    if self.enable_tensor_parallel and self.use_2d_mesh:
-                        xs.mark_sharding(
-                            hidden_states, self.mesh, (None, None, "model")
-                        )
-                    logits_indices = torch.zeros(
-                        self.max_num_reqs, dtype=torch.int32, device=self.device
-                    )
-                if grammar_output is not None:
-                    # prepare_structured_decoding_input only uses logits for shape/device
-                    _shape_proxy = hidden_states.new_empty(
-                        self.max_num_reqs, self.vocab_size
-                    )
-                    require_struct_decoding, grammar_bitmask_padded, bitmasks = (
-                        self.prepare_structured_decoding_input(
-                            _shape_proxy, grammar_output
+                if input_ids is not None and input_ids.shape[1] == 1:
+                    hidden_states, logits, selected_token_ids, kv_connector_output = (
+                        self._model_decode(
+                            input_ids,
+                            self.position_ids,
+                            inputs_embeds,
+                            logits_indices,
+                            sampling_metadata,
+                            attn_metadata,
+                            apply_grammar,
+                            require_struct_decoding,
+                            grammar_bitmask_padded,
+                            bitmask_arange,
+                            scheduler_output.total_num_scheduled_tokens,
+                            scheduler_output,
                         )
                     )
                 else:
-                    self.require_structured_out_cpu.zero_()
-                    require_struct_decoding = self.require_structured_out_cpu[
-                        : self.max_num_reqs
-                    ].to(self.device)
-                    grammar_bitmask_padded = self.grammar_bitmask_cpu[
-                        : self.max_num_reqs
-                    ].to(self.device)
-                    bitmasks = self.structured_decode_bitmasks.to(self.device)
-                selected_token_ids, logits = self.decode_postprocess(
-                    hidden_states,
-                    logits_indices,
-                    sampling_metadata,
-                    require_struct_decoding,
-                    grammar_bitmask_padded,
-                    bitmasks,
-                )
+                    hidden_states, logits, selected_token_ids, kv_connector_output = (
+                        self._model_prefill(
+                            input_ids,
+                            self.position_ids,
+                            inputs_embeds,
+                            logits_indices,
+                            sampling_metadata,
+                            attn_metadata,
+                            apply_grammar,
+                            require_struct_decoding,
+                            grammar_bitmask_padded,
+                            bitmask_arange,
+                            scheduler_output.total_num_scheduled_tokens,
+                            scheduler_output,
+                        )
+                    )
+
+            # Save hidden states (before position selection) for prompt
+            # logprobs.  Only extract rows for requests that actually need
+            # them, keyed by batch index, so we never copy the full
+            # [max_num_reqs, padded_seq_len, H] tensor to CPU.
+            if self.num_prompt_logprobs:
+                for i in range(start_index, end_index):
+                    req_id = self.input_batch.req_ids[i]
+                    if req_id in self.num_prompt_logprobs:
+                        local_idx = i - start_index
+                        prompt_lp_hs[i] = hidden_states[local_idx].cpu()
+
             # NOTE (NickLucche) Use the original logits (before any penalties or
             # temperature scaling) for the top-k logprobs. We can't enforce it
             # due to recompilations outside torch.compiled code, so just make
@@ -2035,6 +2007,422 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 end - start,
             )
 
+    def _model_unfused(
+        self,
+        inputs,
+        positions,
+        input_embeds,
+        logits_indices,
+        sampling_metadata,
+        attn_metadata,
+        apply_grammar,
+        require_struct_decoding,
+        grammar_bitmask,
+        bitmasks,
+        num_tokens: int,
+        scheduler_output: "SchedulerOutput | None",
+    ):
+        """
+        Compile and run model forward and postprocessing steps as separate graphs.
+
+        This is used for the non-fused runtime flow (for example cpu_sampling)
+        so the model/backbone and postprocessing graphs are compiled separately.
+        """
+        with (
+            set_forward_context(
+                attn_metadata,
+                self.vllm_config,
+                num_tokens=num_tokens,
+            ),
+            (
+                self.maybe_get_kv_connector_output(scheduler_output)
+                if scheduler_output is not None
+                else contextlib.nullcontext(None)
+            ) as kv_connector_output,
+        ):
+            (
+                model_input_ids,
+                model_positions,
+                model_inputs_embeds,
+                hidden_state_shape,
+            ) = self._prepare_model_call_tensors(inputs, positions, input_embeds)
+
+            hidden_states = self.model(
+                input_ids=model_input_ids,
+                positions=model_positions,
+                inputs_embeds=model_inputs_embeds,
+            )
+            hidden_states = self._restore_model_hidden_states(
+                hidden_states, hidden_state_shape
+            )
+
+            selected_states = self.select_hidden_states(hidden_states, logits_indices)
+            logits = self.compute_logits(selected_states)
+
+            if apply_grammar:
+                logits = self.structured_decode(
+                    require_struct_decoding,
+                    grammar_bitmask,
+                    logits,
+                    bitmasks,
+                )
+
+            selected_token_ids = self.sample_from_logits(logits, sampling_metadata)
+
+        return hidden_states, logits, selected_token_ids, kv_connector_output
+
+    def _precompile_model_fused(self) -> None:
+        """
+        Warm up the fused decode and prefill runtime paths.
+
+        Compiles the combined runtime entrypoints across token-count and
+        sampling/grammar variants so serving can reuse cached graphs.
+        """
+        logger.info(
+            "Compiling model decode and prefill paths with different input shapes."
+        )
+        start = time.perf_counter()
+        all_greedy_options = [True, False]
+        apply_grammar_options = [True, False]
+        num_tokens_paddings = self.num_tokens_paddings
+        if self.tt_config.decode_only:
+            num_tokens_paddings = [1]  # Only compile the decode path
+            logger.info(
+                f"decode_only is set, only compiling decode path with num_tokens=1"
+            )
+
+        configs = [
+            {
+                "num_tokens": num_tokens,
+                "all_greedy": all_greedy,
+                "apply_grammar": apply_grammar,
+            }
+            for (
+                num_tokens,
+                all_greedy,
+                apply_grammar,
+            ) in product(
+                num_tokens_paddings,
+                all_greedy_options,
+                apply_grammar_options,
+            )
+        ]
+
+        for config in configs:
+            (
+                dummy_inputs,
+                dummy_positions,
+                dummy_input_embeds,
+                dummy_indices,
+                dummy_sampling_metadata,
+                dummy_attn_metadata,
+                dummy_require_struct_decoding,
+                dummy_grammar_bitmask,
+                dummy_bitmasks,
+            ) = self._get_dummy_inputs(config)
+            if config["num_tokens"] == 1:
+                _, _, _, _ = self._model_decode(
+                    dummy_inputs,
+                    dummy_positions,
+                    dummy_input_embeds,
+                    dummy_indices,
+                    dummy_sampling_metadata,
+                    dummy_attn_metadata,
+                    config["apply_grammar"],
+                    dummy_require_struct_decoding,
+                    dummy_grammar_bitmask,
+                    dummy_bitmasks,
+                    config["num_tokens"],
+                    None,
+                )
+                self._update_num_xla_graphs("_model_decode")
+            else:
+                logger.info(f"Compiling prefill path with config={config}")
+                _, _, _, _ = self._model_prefill(
+                    dummy_inputs,
+                    dummy_positions,
+                    dummy_input_embeds,
+                    dummy_indices,
+                    dummy_sampling_metadata,
+                    dummy_attn_metadata,
+                    config["apply_grammar"],
+                    dummy_require_struct_decoding,
+                    dummy_grammar_bitmask,
+                    dummy_bitmasks,
+                    config["num_tokens"],
+                    None,
+                )
+                self._update_num_xla_graphs("_model_prefill")
+
+        xm.wait_device_ops()
+        end = time.perf_counter()
+        logger.info("Compilation finished in %.2f [secs].", end - start)
+
+    def _get_dummy_inputs(self, config: dict):
+        """
+        Build dummy tensors and metadata for fused-path warmup.
+        """
+        num_tokens = config["num_tokens"]
+        all_greedy = config["all_greedy"]
+        apply_grammar = config["apply_grammar"]
+        hsize = self.model_config.get_hidden_size()
+
+        dummy_inputs = torch.zeros(
+            (self.max_num_reqs, num_tokens), dtype=torch.int32
+        ).to(self.device)
+        dummy_positions = torch.zeros(
+            (self.max_num_reqs, num_tokens), dtype=torch.int32
+        ).to(self.device)
+        dummy_inputs_embeds = torch.zeros(
+            (self.max_num_reqs, num_tokens, hsize), dtype=self._hidden_states_dtype
+        ).to(self.device)
+        page_table = torch.zeros(
+            (self.num_reqs_max_model_len, self.max_num_blocks_per_req),
+            dtype=torch.int32,
+        ).to(self.device)
+        cache_position = torch.ones(
+            (self.num_reqs_max_model_len,), dtype=torch.int32
+        ).to(self.device)
+
+        attn_metadata = TTMetadata(
+            page_table=page_table,
+            cache_position=cache_position,
+            is_causal=True,
+            attn_mask=None,
+            fill_page_table=page_table,
+        )
+        per_layer_attn_metadata = dict.fromkeys(
+            self._attention_layer_names, attn_metadata
+        )
+
+        dummy_inputs, dummy_inputs_embeds = self._get_model_inputs(
+            dummy_inputs, mm_embed_inputs=None
+        )
+        self._pin_input_shardings(dummy_inputs, dummy_positions, dummy_inputs_embeds)
+
+        dummy_indices = torch.zeros(self.max_num_reqs, dtype=torch.int32).to(
+            self.device
+        )
+
+        generate_params_if_all_greedy = not all_greedy
+        dummy_sampling_metadata = XLASupportedSamplingMetadata.from_input_batch(
+            self.input_batch,
+            self.max_num_reqs,
+            self.device,
+            generate_params_if_all_greedy,
+            vocab_size=self.vocab_size,
+        )
+        dummy_sampling_metadata.all_greedy = all_greedy
+
+        dummy_require_struct_decoding = None
+        dummy_grammar_bitmask = None
+        dummy_bitmasks = None
+        if apply_grammar:
+            dummy_require_struct_decoding = self.require_structured_out_cpu[
+                : self.max_num_reqs
+            ].to(self.device)
+            dummy_grammar_bitmask = self.grammar_bitmask_cpu[: self.max_num_reqs].to(
+                self.device
+            )
+            dummy_bitmasks = self.structured_decode_bitmasks.to(self.device)
+
+        return (
+            dummy_inputs,
+            dummy_positions,
+            dummy_inputs_embeds,
+            dummy_indices,
+            dummy_sampling_metadata,
+            per_layer_attn_metadata,
+            dummy_require_struct_decoding,
+            dummy_grammar_bitmask,
+            dummy_bitmasks,
+        )
+
+    def _model_decode(
+        self,
+        inputs,
+        positions,
+        input_embeds,
+        logits_indices,
+        sampling_metadata,
+        attn_metadata,
+        apply_grammar,
+        require_struct_decoding,
+        grammar_bitmask,
+        bitmasks,
+        num_tokens: int,
+        scheduler_output: "SchedulerOutput | None",
+    ):
+        """Run the fused decode path under the forward context."""
+        with (
+            set_forward_context(
+                attn_metadata,
+                self.vllm_config,
+                num_tokens=num_tokens,
+            ),
+            (
+                self.maybe_get_kv_connector_output(scheduler_output)
+                if scheduler_output is not None
+                else contextlib.nullcontext(None)
+            ) as kv_connector_output,
+        ):
+            hidden_states, logits, selected_token_ids = self._model_decode_compiled(
+                inputs,
+                positions,
+                input_embeds,
+                logits_indices,
+                sampling_metadata,
+                apply_grammar,
+                require_struct_decoding,
+                grammar_bitmask,
+                bitmasks,
+            )
+
+        return hidden_states, logits, selected_token_ids, kv_connector_output
+
+    @torch.compile(backend="tt", fullgraph=True, dynamic=False)
+    def _model_decode_compiled(
+        self,
+        inputs,
+        positions,
+        input_embeds,
+        logits_indices,
+        sampling_metadata,
+        apply_grammar,
+        require_struct_decoding,
+        grammar_bitmask,
+        bitmasks,
+    ):
+        """Compile model forward, logits selection, and sampling for decode."""
+
+        (
+            model_input_ids,
+            model_positions,
+            model_inputs_embeds,
+            hidden_state_shape,
+        ) = self._prepare_model_call_tensors(inputs, positions, input_embeds)
+
+        hidden_states = self.model(
+            input_ids=model_input_ids,
+            positions=model_positions,
+            inputs_embeds=model_inputs_embeds,
+        )
+        hidden_states = self._restore_model_hidden_states(
+            hidden_states, hidden_state_shape
+        )
+
+        selected_states = self.select_hidden_states(hidden_states, logits_indices)
+        logits = self.compute_logits(selected_states)
+
+        if apply_grammar == True:
+            logits = self.structured_decode(
+                require_struct_decoding, grammar_bitmask, logits, bitmasks
+            )
+        selected_token_ids = self.sample_from_logits(logits, sampling_metadata)
+
+        return hidden_states, logits, selected_token_ids
+
+    def _model_prefill(
+        self,
+        inputs,
+        positions,
+        input_embeds,
+        logits_indices,
+        sampling_metadata,
+        attn_metadata,
+        apply_grammar,
+        require_struct_decoding,
+        grammar_bitmask,
+        bitmasks,
+        num_tokens: int,
+        scheduler_output: "SchedulerOutput | None",
+    ):
+        """
+        Run the split prefill path. Model forward is compiled as separate graph
+        and postprocessing is compiled separately.
+        This will produce 1 model forward graph and 4 postprocessing graphs
+        (for each combination of greedy/non-greedy sampling and grammar/no-grammar)
+         for each input tokens.
+        Separate compilation is used because compiling combined graphs significantly
+        increase the warmup time.
+        """
+        with (
+            set_forward_context(
+                attn_metadata,
+                self.vllm_config,
+                num_tokens=num_tokens,
+            ),
+            (
+                self.maybe_get_kv_connector_output(scheduler_output)
+                if scheduler_output is not None
+                else contextlib.nullcontext(None)
+            ) as kv_connector_output,
+        ):
+            hidden_states = self._model_prefill_model_compiled(
+                inputs,
+                positions,
+                input_embeds,
+            )
+            logits, selected_token_ids = self._model_prefill_postprocess_compiled(
+                hidden_states,
+                logits_indices,
+                sampling_metadata,
+                apply_grammar,
+                require_struct_decoding,
+                grammar_bitmask,
+                bitmasks,
+            )
+
+        return hidden_states, logits, selected_token_ids, kv_connector_output
+
+    @torch.compile(backend="tt", fullgraph=True, dynamic=False)
+    def _model_prefill_model_compiled(
+        self,
+        inputs,
+        positions,
+        input_embeds,
+    ):
+        """Compile the model-forward portion of the prefill path."""
+        (
+            model_input_ids,
+            model_positions,
+            model_inputs_embeds,
+            hidden_state_shape,
+        ) = self._prepare_model_call_tensors(inputs, positions, input_embeds)
+
+        hidden_states = self.model(
+            input_ids=model_input_ids,
+            positions=model_positions,
+            inputs_embeds=model_inputs_embeds,
+        )
+        return self._restore_model_hidden_states(hidden_states, hidden_state_shape)
+
+    @torch.compile(backend="tt", fullgraph=True, dynamic=False)
+    def _model_prefill_postprocess_compiled(
+        self,
+        hidden_states,
+        logits_indices,
+        sampling_metadata,
+        apply_grammar,
+        require_struct_decoding,
+        grammar_bitmask,
+        bitmasks,
+    ):
+        """Compile the logits and sampling postprocessing for prefill."""
+        selected_states = self.select_hidden_states(hidden_states, logits_indices)
+        logits = self.compute_logits(selected_states)
+
+        if apply_grammar:
+            logits = self.structured_decode(
+                require_struct_decoding,
+                grammar_bitmask,
+                logits,
+                bitmasks,
+            )
+
+        selected_token_ids = self.sample_from_logits(logits, sampling_metadata)
+        return logits, selected_token_ids
+
     def _precompile_backbone(self) -> None:
         logger.info("Compiling the model with different input shapes.")
         start = time.perf_counter()
@@ -2082,7 +2470,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             if self.enable_tensor_parallel:
                 safe_mark_sharding(dummy_hidden, self.mesh, (None, None, "model"))
 
-            self.select_hidden_states(dummy_hidden, indices)
+            self.select_hidden_states_compiled(dummy_hidden, indices)
 
         xm.wait_device_ops()
         end = time.perf_counter()
@@ -2102,7 +2490,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         if self.enable_tensor_parallel and self.is_sharded_compute_logits:
             safe_mark_sharding(dummy_hidden, self.mesh, (None, None))
 
-        self.compute_logits(dummy_hidden)
+        self.compute_logits_compiled(dummy_hidden)
 
         xm.wait_device_ops()
         end = time.perf_counter()
@@ -2131,7 +2519,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # mark_dynamic because some operations in structured_decode require
         # them to be static.
         bitmasks = self.structured_decode_bitmasks.to(self.device)
-        self.structured_decode(
+        self.structured_decode_compiled(
             dummy_require_struct_decoding,
             dummy_grammar_bitmask,
             dummy_logits,
@@ -2173,7 +2561,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     self.lora_config, np.array([self.max_num_reqs], dtype=np.int32)
                 ),
             ):
-                self.sample_from_logits(dummy_logits, sampling_metadata)
+                self.sample_from_logits_compiled(dummy_logits, sampling_metadata)
 
         # NOTE: the seeded sampling path (no_generators=False, q_samples
         # present) compiles a separate graph variant due to the q_samples
@@ -2206,70 +2594,12 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 self.lora_config, np.array([self.max_num_reqs], dtype=np.int32)
             ),
         ):
-            self.gather_logprobs(dummy_logits, dummy_tokens)
+            self.gather_logprobs_compiled(dummy_logits, dummy_tokens)
 
         xm.wait_device_ops()
         end = time.perf_counter()
         logger.info("Compilation finished in %.2f [secs].", end - start)
         self._update_num_xla_graphs("gather_logprobs")
-
-    def _precompile_decode_postprocess(self) -> None:
-        torch._dynamo.config.dynamic_shapes = False
-        logger.info("Compiling decode_postprocess with different input shapes.")
-        start = time.perf_counter()
-        hsize = self.model_config.get_hidden_size()
-        # decode always processes exactly 1 token per request, so only num_tokens=1
-        # is needed here. Prefill batches (num_tokens > 1) use the cpu-sample fallback.
-        for num_tokens in [1]:
-            for all_greedy in [False, True]:
-                logger.info(
-                    "  -- num_tokens: %d, all_greedy: %s", num_tokens, all_greedy
-                )
-                # Fresh tensors per iteration — reusing across SPMD compilations
-                # causes stale tensor IDs that misclassify inputs as constants
-                # (#3672). For decode_postprocess this previously caused the
-                # structured-decode masking branch to be elided on the second
-                # compile, so real grammar bitmasks were ignored at runtime.
-                dummy_require = self.require_structured_out_cpu[: self.max_num_reqs].to(
-                    self.device
-                )
-                dummy_bitmask = self.grammar_bitmask_cpu[: self.max_num_reqs].to(
-                    self.device
-                )
-                bitmasks = self.structured_decode_bitmasks.to(self.device)
-                indices = torch.zeros(self.max_num_reqs, dtype=torch.int32).to(
-                    self.device
-                )
-                dummy_hidden = torch.zeros(
-                    (self.max_num_reqs, num_tokens, hsize),
-                    dtype=self._hidden_states_dtype,
-                ).to(self.device)
-                if self.enable_tensor_parallel and self.use_2d_mesh:
-                    xs.mark_sharding(dummy_hidden, self.mesh, (None, None, "model"))
-                sampling_metadata = XLASupportedSamplingMetadata.from_input_batch(
-                    self.input_batch,
-                    self.max_num_reqs,
-                    self.device,
-                    not all_greedy,
-                    vocab_size=self.vocab_size,
-                )
-                sampling_metadata.all_greedy = all_greedy
-                with self.maybe_select_dummy_loras(
-                    self.lora_config, np.array([self.max_num_reqs], dtype=np.int32)
-                ):
-                    _, _ = self.decode_postprocess(
-                        dummy_hidden,
-                        indices,
-                        sampling_metadata,
-                        dummy_require,
-                        dummy_bitmask,
-                        bitmasks,
-                    )
-
-        xm.wait_device_ops()
-        end = time.perf_counter()
-        logger.info("Compilation finished in %.2f [secs].", end - start)
-        self._update_num_xla_graphs("decode_postprocess")
 
     def capture_model(self) -> None:
         """
@@ -2277,26 +2607,25 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         """
         torch._dynamo.config.dynamic_shapes = False
         with self.maybe_setup_dummy_loras(self.lora_config):
-            self._precompile_backbone()
-            if self.tt_config.decode_only:
-                return
-            self._precompile_mm_encoder()
             if not self.tt_config.cpu_sampling:
-                # decode_postprocess handles both decode (num_tokens=1) and
-                # prefill (last token pre-selected eagerly before the call).
-                self._precompile_decode_postprocess()
+                logger.info("Warmup mode: fused runtime path")
+                self._precompile_model_fused()
             else:
-                # cpu_sampling: fused decode_postprocess skipped (sampling on CPU);
-                # precompile the device-side graphs separately instead.
-                logger.warning(
-                    "cpu_sampling=True: using separate precompile for select/compute/structured"
-                )
+                logger.info("Warmup mode: unfused runtime path (cpu_sampling=True)")
+                self._precompile_backbone()
+                if self.tt_config.decode_only:
+                    logger.info(
+                        "decode_only=True: skipping unfused postprocessing warmup"
+                    )
+                    return
                 self._precompile_select_hidden_states()
                 self._precompile_compute_logits()
                 self._precompile_structured_decoding()
+            self._precompile_mm_encoder()
             # TODO(#4387): precompile fails trace-insertion at opt_level=1;
             # skip when trace is on. Paired with the CPU fallback at the
             # runtime call site. Remove both once the compiler bug is fixed.
+            # TODO: Move it to the fused precompile path once the bug is fixed.
             if not self.tt_config.enable_trace:
                 self._precompile_gather_logprobs()
 
@@ -2539,7 +2868,13 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             TorchCompileWithNoGuardsWrapper.__init__(compiled_model)
 
     @torch.compile(backend="tt", fullgraph=True, dynamic=False)
-    def select_hidden_states(self, hidden_states, indices_do_sample):
+    def select_hidden_states_compiled(
+        self, hidden_states, indices_do_sample
+    ) -> torch.Tensor:
+        """Compiled wrapper for hidden-state selection warmup and reuse."""
+        return self.select_hidden_states(hidden_states, indices_do_sample)
+
+    def select_hidden_states(self, hidden_states, indices_do_sample) -> torch.Tensor:
         batch_indices = torch.arange(indices_do_sample.shape[0], dtype=torch.int32)
         result = hidden_states[batch_indices, indices_do_sample, :]
         # Only emit the sharding constraint on 2D mesh — under 1D mesh the
@@ -2551,6 +2886,12 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         return result
 
     @torch.compile(backend="tt", fullgraph=True, dynamic=False)
+    def compute_logits_compiled(
+        self, sample_hidden_states: torch.Tensor
+    ) -> torch.Tensor:
+        """Compiled wrapper for vocab-logit computation warmup and reuse."""
+        return self.compute_logits(sample_hidden_states)
+
     def compute_logits(self, sample_hidden_states: torch.Tensor) -> torch.Tensor:
         logits = self.model.compute_logits(sample_hidden_states)
         # Replicate logits for SPMD. Hooks can't reach ParallelLMHead
@@ -2561,7 +2902,6 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             logits = sharding_constraint_tensor(logits, self.mesh, (None, None))
         return logits
 
-    @torch.compile(backend="tt", fullgraph=True, dynamic=False)
     def sample_from_logits(
         self, logits: torch.Tensor, sampling_metadata: XLASupportedSamplingMetadata
     ) -> torch.Tensor:
@@ -2582,61 +2922,6 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         else:
             out_tokens = self.sampler(logits, sampling_metadata).sampled_token_ids
         return out_tokens
-
-    @torch.compile(backend="tt", fullgraph=True, dynamic=False)
-    def decode_postprocess(
-        self,
-        hidden_states: torch.Tensor,
-        logits_indices: torch.Tensor,
-        sampling_metadata: XLASupportedSamplingMetadata,
-        require_struct_decoding: torch.Tensor,
-        grammar_bitmask: torch.Tensor,
-        bitmasks: torch.Tensor,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Fused select_hidden_states → compute_logits → structured_decode → sample.
-
-        Returns (selected_token_ids, logits). The logits are post-structured-decode
-        (matching the cpu_sampling path) and pre-penalty/temperature, so callers
-        that need logprobs can use them directly without recomputation.
-
-        NOTE: This method inlines the logic of select_hidden_states, compute_logits,
-        structured_decode (via apply_grammar_bitmask), and sample_from_logits.
-        The cpu_sampling=True path calls those methods separately. If you fix a bug
-        in any of them, mirror the change here too.
-        """
-        # select_hidden_states
-        batch_indices = torch.arange(logits_indices.shape[0], dtype=torch.int32)
-        hidden = hidden_states[batch_indices, logits_indices, :]
-        if self.enable_tensor_parallel and self.use_2d_mesh:
-            hidden = sharding_constraint_tensor(hidden, self.mesh, (None, None))
-        # compute_logits
-        logits = self.model.compute_logits(hidden)
-        if self.enable_tensor_parallel and (
-            not self.use_2d_mesh or self.is_sharded_compute_logits
-        ):
-            logits = sharding_constraint_tensor(logits, self.mesh, (None, None))
-        # structured_decode (always applied; require_struct_decoding masks inactive reqs)
-        bits = grammar_bitmask.unsqueeze(-1) & bitmasks
-        allowed = (bits != 0).reshape(logits.shape[0], -1)[:, : self.vocab_size]
-        logits = torch.where(
-            require_struct_decoding,
-            torch.where(allowed, logits, torch.full_like(logits, float("-inf"))),
-            logits,
-        )
-        # sample_from_logits
-        if (
-            sampling_metadata.all_greedy
-            and sampling_metadata.no_penalties
-            and sampling_metadata.no_logit_bias
-            and sampling_metadata.no_bad_words
-            and sampling_metadata.no_allowed_token_ids
-            and sampling_metadata.no_min_tokens
-            and sampling_metadata.no_generators
-        ):
-            selected = torch.argmax(logits, dim=-1, keepdim=True)
-        else:
-            selected = self.sampler(logits, sampling_metadata).sampled_token_ids
-        return selected, logits
 
     def sample_from_logits_cpu(
         self, logits: torch.Tensor, sampling_metadata: XLASupportedSamplingMetadata
@@ -2736,6 +3021,11 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             return torch.where(temp < 1e-6, greedy, random).unsqueeze(-1)
 
     @torch.compile(backend="tt", fullgraph=True, dynamic=False)
+    def gather_logprobs_compiled(
+        self, logits: torch.Tensor, sampled_tokens: torch.Tensor
+    ) -> LogprobsTensors:
+        return self.gather_logprobs(logits, sampled_tokens)
+
     def gather_logprobs(
         self, logits: torch.Tensor, sampled_tokens: torch.Tensor
     ) -> LogprobsTensors:
@@ -2879,6 +3169,18 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         return result
 
     @torch.compile(backend="tt", fullgraph=True, dynamic=False)
+    def structured_decode_compiled(
+        self,
+        require_struct_decoding: torch.Tensor,
+        grammar_bitmask: torch.Tensor,
+        logits: torch.Tensor,
+        bitmasks: torch.Tensor,
+    ) -> torch.Tensor:
+        """Compiled wrapper for grammar-constrained logits masking."""
+        return self.structured_decode(
+            require_struct_decoding, grammar_bitmask, logits, bitmasks
+        )
+
     def structured_decode(
         self,
         require_struct_decoding: torch.Tensor,
@@ -2913,10 +3215,9 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         return self.model.embed_input_ids(*args, **kwargs)
 
     def prepare_structured_decoding_input(
-        self, logits: torch.Tensor, grammar_output: "GrammarOutput"
+        self, grammar_output: "GrammarOutput", num_reqs: int
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         grammar_bitmask = grammar_output.grammar_bitmask
-        num_reqs, _ = logits.shape
 
         # Reset pre-allocated tensors
         self.grammar_bitmask_cpu.zero_()
@@ -2937,9 +3238,9 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             cumulative_mask_idx += 1
 
         return (
-            self.require_structured_out_cpu[:num_reqs].to(logits.device),
-            self.grammar_bitmask_cpu[:num_reqs].to(logits.device),
-            self.structured_decode_bitmasks.to(logits.device),
+            self.require_structured_out_cpu[:num_reqs].to(self.device),
+            self.grammar_bitmask_cpu[:num_reqs].to(self.device),
+            self.structured_decode_bitmasks.to(self.device),
         )
 
     def _get_mm_dummy_batch(

--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -100,6 +100,12 @@ class TTConfig:
     # (e.g. local debugging of decode-only tests).
     decode_only: bool = False
 
+    # Generate fused decode graphs containing both the model forward and post-processing
+    # (e.g. sampling, compute_logits, applying grammar constraints) in a single
+    # graph. This will generate 4 graphs capturing greedy/non-greedy sampling
+    # with and without grammar constraints.
+    enable_decode_fused_graphs: bool = False
+
     # Override number of hidden layers (0 = use model default)
     # For debugging and testing purposes, we allow overriding the number of hidden
     # layers in the model config to enable testing with smaller models or to

--- a/tests/integrations/vllm_plugin/generative/test_prefill_recompile.py
+++ b/tests/integrations/vllm_plugin/generative/test_prefill_recompile.py
@@ -6,16 +6,20 @@
 Warms up, then sweeps prompt lengths across every prefill token-bucket of a 4K
 context and asserts the XLA cached-graph count does not grow — i.e. all prefill
 graphs were precompiled at init. A single transformer layer keeps compile fast.
+
+Reading the (process-local) graph counter requires the engine to run in-process
+(VLLM_ENABLE_V1_MULTIPROCESSING=0), which initializes the XLA computation cache
+in this process. That cache is a once-only process singleton, so doing this in
+the shared pytest worker poisons every subsequent vLLM test ("Computation cache
+has already been initialized"). To isolate it, the pytest test re-execs this
+file as a worker in a throwaway child process; the env var and the cache init
+live and die with the child.
 """
 import os
+import subprocess
+import sys
 
 import pytest
-import torch_xla.runtime as xr
-import vllm
-
-# Run in-process so the (process-local) graph counter sees the engine's compiles
-# (vLLM reads this lazily at engine creation, so setting it after import is fine).
-os.environ.setdefault("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
 
 # Non-gated and small; only 1 layer is compiled below, so init stays fast.
 MODEL = "Qwen/Qwen3-0.6B"
@@ -27,10 +31,44 @@ MAX_TOKENS = 4
 #   128->128, 200->256, 512->512, 1000->1024, 2048->2048, 3000->4096, 4000->4096
 SWEEP_ISLS = (128, 200, 512, 1000, 2048, 3000, 4000)
 
+WORKER_TIMEOUT = 1800
+
 
 @pytest.mark.push
 @pytest.mark.single_device
 def test_no_prefill_recompile():
+    # Isolate the in-process engine in a fresh child (see module docstring). A
+    # clean subprocess — not os.fork()/pytest-forked — is required: the parent
+    # pytest worker has already loaded the PJRT plugin, so a forked child would
+    # not guarantee the pristine XLA cache this test depends on.
+    env = {**os.environ, "VLLM_ENABLE_V1_MULTIPROCESSING": "0"}
+    try:
+        proc = subprocess.run(
+            [sys.executable, __file__],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=WORKER_TIMEOUT,
+        )
+        stdout, stderr, rc = proc.stdout, proc.stderr, proc.returncode
+    except subprocess.TimeoutExpired as e:
+        stdout, stderr, rc = e.stdout or "", e.stderr or "", None
+
+    # Surface the worker's [recompile-test] trace for debugging either way.
+    print(stdout, flush=True)
+    if stderr:
+        print(stderr, file=sys.stderr, flush=True)
+    assert rc == 0, (
+        f"prefill-recompile worker failed (exit={rc}) — prefill graphs recompiled "
+        "at runtime or the worker timed out; see output above."
+    )
+
+
+def _run_sweep():
+    """Worker body (runs in the isolated child process). Returns exit code."""
+    import torch_xla.runtime as xr
+    import vllm
+
     llm = vllm.LLM(
         model=MODEL,
         max_model_len=MAX_LEN,
@@ -49,9 +87,15 @@ def test_no_prefill_recompile():
     baseline = xr.get_num_cached_compilation_graph()
     print(f"\n[recompile-test] warmup done; cached XLA graphs = {baseline}", flush=True)
     # If this is 0 the engine ran out-of-process and recompiles can't be seen.
-    assert baseline > 0, "graph counter is 0 — need VLLM_ENABLE_V1_MULTIPROCESSING=0"
+    if baseline <= 0:
+        print(
+            "[recompile-test] FAIL: graph counter is 0 — engine did not run "
+            "in-process (VLLM_ENABLE_V1_MULTIPROCESSING=0 not honored).",
+            flush=True,
+        )
+        return 1
 
-    # Sweep each ISL and assert no new graphs were compiled
+    # Sweep each ISL and assert no new graphs were compiled.
     print(f"[recompile-test] sweeping {len(SWEEP_ISLS)} ISLs: {SWEEP_ISLS}", flush=True)
     prev = baseline
     for n in SWEEP_ISLS:
@@ -65,7 +109,15 @@ def test_no_prefill_recompile():
 
     total = prev - baseline
     print(f"[recompile-test] total new graphs during sweep: {total}", flush=True)
-    assert total == 0, (
-        f"{total} XLA graph(s) compiled during the ISL sweep — prefill graphs are "
-        "recompiling at runtime instead of being precompiled at engine init."
-    )
+    if total != 0:
+        print(
+            f"[recompile-test] FAIL: {total} XLA graph(s) compiled during the ISL "
+            "sweep — prefill graphs are recompiling at runtime.",
+            flush=True,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_sweep())

--- a/tests/integrations/vllm_plugin/generative/test_prefill_recompile.py
+++ b/tests/integrations/vllm_plugin/generative/test_prefill_recompile.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Regression test: no XLA graph recompiles after warmup across an ISL sweep.
+
+Warms up, then sweeps prompt lengths across every prefill token-bucket of a 4K
+context and asserts the XLA cached-graph count does not grow — i.e. all prefill
+graphs were precompiled at init. A single transformer layer keeps compile fast.
+"""
+import os
+
+import pytest
+import torch_xla.runtime as xr
+import vllm
+
+# Run in-process so the (process-local) graph counter sees the engine's compiles
+# (vLLM reads this lazily at engine creation, so setting it after import is fine).
+os.environ.setdefault("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+
+# Non-gated and small; only 1 layer is compiled below, so init stays fast.
+MODEL = "Qwen/Qwen3-0.6B"
+MAX_LEN = 4096
+MAX_TOKENS = 4
+
+# ISLs covering each prefill bucket (128/256/512/1024/2048/4096), mixing power-of-
+# two (aligned) and non-power-of-two (padded up) lengths:
+#   128->128, 200->256, 512->512, 1000->1024, 2048->2048, 3000->4096, 4000->4096
+SWEEP_ISLS = (128, 200, 512, 1000, 2048, 3000, 4000)
+
+
+@pytest.mark.push
+@pytest.mark.single_device
+def test_no_prefill_recompile():
+    llm = vllm.LLM(
+        model=MODEL,
+        max_model_len=MAX_LEN,
+        max_num_seqs=1,
+        max_num_batched_tokens=MAX_LEN,
+        gpu_memory_utilization=0.1,
+        enable_prefix_caching=False,  # each ISL fully prefills its own bucket
+        additional_config={"num_hidden_layers": 1, "min_context_len": 128},
+    )
+    sp = vllm.SamplingParams(temperature=0.0, max_tokens=MAX_TOKENS)
+
+    def gen(n):
+        llm.generate({"prompt_token_ids": [100] * n}, sp, use_tqdm=False)
+
+    gen(64)  # one warmup request absorbs the one-time decode/sampling graphs
+    baseline = xr.get_num_cached_compilation_graph()
+    print(f"\n[recompile-test] warmup done; cached XLA graphs = {baseline}", flush=True)
+    # If this is 0 the engine ran out-of-process and recompiles can't be seen.
+    assert baseline > 0, "graph counter is 0 — need VLLM_ENABLE_V1_MULTIPROCESSING=0"
+
+    # Sweep each ISL and assert no new graphs were compiled
+    print(f"[recompile-test] sweeping {len(SWEEP_ISLS)} ISLs: {SWEEP_ISLS}", flush=True)
+    prev = baseline
+    for n in SWEEP_ISLS:
+        gen(n)
+        cur = xr.get_num_cached_compilation_graph()
+        flag = "  <-- RECOMPILE" if cur > prev else ""
+        print(
+            f"[recompile-test] ISL={n:5d} -> +{cur - prev} graph(s){flag}", flush=True
+        )
+        prev = cur
+
+    total = prev - baseline
+    print(f"[recompile-test] total new graphs during sweep: {total}", flush=True)
+    assert total == 0, (
+        f"{total} XLA graph(s) compiled during the ISL sweep — prefill graphs are "
+        "recompiling at runtime instead of being precompiled at engine init."
+    )

--- a/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
@@ -25,8 +25,6 @@ def test_tensor_parallel_generation_n300(model_name: str):
             "enable_const_eval": False,
             "min_context_len": 32,
             "enable_tensor_parallel": True,
-            "num_hidden_layers": 1,
-            "enable_decode_fused_graphs": True,
         },
     }
     llm = vllm.LLM(**llm_args)

--- a/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
@@ -25,6 +25,8 @@ def test_tensor_parallel_generation_n300(model_name: str):
             "enable_const_eval": False,
             "min_context_len": 32,
             "enable_tensor_parallel": True,
+            "num_hidden_layers": 1,
+            "enable_decode_fused_graphs": True,
         },
     }
     llm = vllm.LLM(**llm_args)


### PR DESCRIPTION
### Ticket
closes #5267 

### Problem description
Graphs are JIT-compiled at inference time outside of warmup phase and multiple implementations for post-processing tasks.

### What's changed
- Uses the same post-processing code/implementation for fused and unfused paths.
- Fused Decode graphs: Creates 4 fused decode graphs (model backbone + 4 variations of greedy/non-greedy sampling and grammar/no-grammar combinations).
- Fused Prefill graphs: Creates 1 model backbone and 4 post-processing graphs for each input prefill length.
- Flag 'enable_decode_fused_graphs' [Default: False]: Whether to follow fused decode graphs path (4 graphs; combined model forward and post-processing graphs) or fused prefill graphs path (5 graphs; separate model forward and post-processing graphs).
- Unfused graphs. All graphs are separate and this path is activated when cpu_sampling is True.
- Avoid graph creation/compilation during inference. Prefill graphs are generated during inference currently. 
- Add test asserting no graph recompiles at inference/serve time.

### Checklist
- [X] New/Existing tests provide coverage for changes
