### PR TITLE
Add missed torch tests to CI

### DIFF
--- a/tests/torch/graphs/test_contiguous_transposed_input.py
+++ b/tests/torch/graphs/test_contiguous_transposed_input.py
@@ -9,6 +9,7 @@ from utils import incorrect_result
 
 
 @pytest.mark.nightly
+@pytest.mark.single_device
 def test_contiguous_transposed_input():
     """
     Runs identity test with transposed input tensor (contiguous in memory).

--- a/tests/torch/graphs/test_mlp.py
+++ b/tests/torch/graphs/test_mlp.py
@@ -644,6 +644,7 @@ def test_gpt_oss_sparse_mlp_small_batch(decode_batch, decode_seq_len, arch):
 
 
 @pytest.mark.nightly
+@pytest.mark.single_device
 def test_a2a_sparse_mlp_cpu_parity():
     """Verify A2aSparseMLP produces the same results as the original MLP on CPU.
 

--- a/tests/torch/graphs/test_tensor_persistence.py
+++ b/tests/torch/graphs/test_tensor_persistence.py
@@ -505,6 +505,7 @@ def test_input_not_modified_reused_in_another_graph():
 
 @pytest.mark.push
 @pytest.mark.nightly
+@pytest.mark.single_device
 def test_concurrent_buffer_instance_transfer():
     """
     Test scenario: Input A participates in some graph, and is concurrently copied to host
@@ -544,6 +545,7 @@ def test_concurrent_buffer_instance_transfer():
 
 @pytest.mark.push
 @pytest.mark.nightly
+@pytest.mark.single_device
 def test_concurrent_multi_buffer_instance_transfer():
     """
     Test scenario: Inputs A and B participates in some graph, and are concurrently copied to host

--- a/tests/torch/models/HiDream_I1/test_text_encoder.py
+++ b/tests/torch/models/HiDream_I1/test_text_encoder.py
@@ -15,6 +15,7 @@ from third_party.tt_forge_models.hidream_i1.pytorch import ModelLoader, ModelVar
 
 @pytest.mark.nightly
 @pytest.mark.model_test
+@pytest.mark.single_device
 def test_text_encoder():
     xr.set_device_type("TT")
     torch.manual_seed(42)

--- a/tests/torch/models/HiDream_I1/test_text_encoder_2.py
+++ b/tests/torch/models/HiDream_I1/test_text_encoder_2.py
@@ -15,6 +15,7 @@ from third_party.tt_forge_models.hidream_i1.pytorch import ModelLoader, ModelVar
 
 @pytest.mark.nightly
 @pytest.mark.model_test
+@pytest.mark.single_device
 def test_text_encoder_2():
     xr.set_device_type("TT")
     torch.manual_seed(42)

--- a/tests/torch/models/HiDream_I1/test_text_encoder_3.py
+++ b/tests/torch/models/HiDream_I1/test_text_encoder_3.py
@@ -26,6 +26,7 @@ def test_text_encoder_3():
 )
 @pytest.mark.nightly
 @pytest.mark.model_test
+@pytest.mark.llmbox
 def test_text_encoder_3_sharded():
     _run(sharded=True)
 

--- a/tests/torch/models/HiDream_I1/test_text_encoder_3.py
+++ b/tests/torch/models/HiDream_I1/test_text_encoder_3.py
@@ -21,9 +21,6 @@ def test_text_encoder_3():
     _run(sharded=False)
 
 
-@pytest.mark.xfail(
-    reason="AssertionError: Evaluation result 0 failed: PCC comparison failed. Calculated: pcc=0.9873067700897922. Required: pcc=0.99. - https://github.com/tenstorrent/tt-xla/issues/4847"
-)
 @pytest.mark.nightly
 @pytest.mark.model_test
 @pytest.mark.llmbox

--- a/tests/torch/models/HiDream_I1/test_text_encoder_4.py
+++ b/tests/torch/models/HiDream_I1/test_text_encoder_4.py
@@ -28,6 +28,7 @@ def test_text_encoder_4():
 
 @pytest.mark.nightly
 @pytest.mark.model_test
+@pytest.mark.llmbox
 def test_text_encoder_4_sharded():
     _run(sharded=True)
 

--- a/tests/torch/models/HiDream_I1/test_transformer.py
+++ b/tests/torch/models/HiDream_I1/test_transformer.py
@@ -31,6 +31,7 @@ def test_transformer():
 )
 @pytest.mark.nightly
 @pytest.mark.model_test
+@pytest.mark.llmbox
 def test_transformer_sharded():
     _run(sharded=True)
 

--- a/tests/torch/models/HiDream_I1/test_vae_decoder.py
+++ b/tests/torch/models/HiDream_I1/test_vae_decoder.py
@@ -16,6 +16,7 @@ from third_party.tt_forge_models.hidream_i1.pytorch import ModelLoader, ModelVar
 
 @pytest.mark.nightly
 @pytest.mark.model_test
+@pytest.mark.single_device
 def test_vae_decoder():
     xr.set_device_type("TT")
     torch.manual_seed(42)

--- a/tests/torch/models/HunyuanImage_2_1/test_text_encoder.py
+++ b/tests/torch/models/HunyuanImage_2_1/test_text_encoder.py
@@ -24,9 +24,6 @@ def test_text_encoder():
     _run(sharded=False)
 
 
-@pytest.mark.xfail(
-    reason="Out of Memory: Not enough space to allocate 271581184 B DRAM buffer across 12 banks, where each bank needs to store 22657024 B, but bank size is 1071821792 B — https://github.com/tenstorrent/tt-xla/issues/4779"
-)
 @pytest.mark.nightly
 @pytest.mark.model_test
 @pytest.mark.llmbox

--- a/tests/torch/models/HunyuanImage_2_1/test_text_encoder.py
+++ b/tests/torch/models/HunyuanImage_2_1/test_text_encoder.py
@@ -29,6 +29,7 @@ def test_text_encoder():
 )
 @pytest.mark.nightly
 @pytest.mark.model_test
+@pytest.mark.llmbox
 def test_text_encoder_sharded():
     _run(sharded=True)
 

--- a/tests/torch/models/HunyuanImage_2_1/test_text_encoder_2.py
+++ b/tests/torch/models/HunyuanImage_2_1/test_text_encoder_2.py
@@ -21,6 +21,7 @@ from third_party.tt_forge_models.hunyuan_image_2_1.pytorch import (
 )
 @pytest.mark.nightly
 @pytest.mark.model_test
+@pytest.mark.single_device
 def test_text_encoder_2():
     xr.set_device_type("TT")
     torch.manual_seed(42)

--- a/tests/torch/models/HunyuanImage_2_1/test_transformer.py
+++ b/tests/torch/models/HunyuanImage_2_1/test_transformer.py
@@ -29,6 +29,7 @@ def test_transformer():
 )
 @pytest.mark.nightly
 @pytest.mark.model_test
+@pytest.mark.llmbox
 def test_transformer_sharded():
     _run(sharded=True)
 

--- a/tests/torch/models/Hunyuan_1_5/test_text_encoder.py
+++ b/tests/torch/models/Hunyuan_1_5/test_text_encoder.py
@@ -23,6 +23,7 @@ def test_text_encoder():
 
 @pytest.mark.nightly
 @pytest.mark.model_test
+@pytest.mark.llmbox
 def test_text_encoder_sharded():
     _run(sharded=True)
 

--- a/tests/torch/models/Hunyuan_1_5/test_text_encoder_2.py
+++ b/tests/torch/models/Hunyuan_1_5/test_text_encoder_2.py
@@ -18,6 +18,7 @@ from third_party.tt_forge_models.hunyuan_1_5.pytorch import ModelLoader, ModelVa
 )
 @pytest.mark.nightly
 @pytest.mark.model_test
+@pytest.mark.single_device
 def test_text_encoder_2():
     xr.set_device_type("TT")
     torch.manual_seed(42)

--- a/tests/torch/models/hunyuan_video/test_text_encoder.py
+++ b/tests/torch/models/hunyuan_video/test_text_encoder.py
@@ -22,6 +22,7 @@ def test_text_encoder():
 
 @pytest.mark.nightly
 @pytest.mark.model_test
+@pytest.mark.llmbox
 def test_text_encoder_sharded():
     _run(sharded=True)
 

--- a/tests/torch/models/hunyuan_video/test_text_encoder_2.py
+++ b/tests/torch/models/hunyuan_video/test_text_encoder_2.py
@@ -22,6 +22,7 @@ def test_text_encoder_2():
 
 @pytest.mark.nightly
 @pytest.mark.model_test
+@pytest.mark.llmbox
 def test_text_encoder_2_sharded():
     _run(sharded=True)
 

--- a/tests/torch/models/hunyuan_video/test_vae_decoder.py
+++ b/tests/torch/models/hunyuan_video/test_vae_decoder.py
@@ -25,6 +25,7 @@ def test_vae_decoder():
 )
 @pytest.mark.nightly
 @pytest.mark.model_test
+@pytest.mark.llmbox
 def test_vae_decoder_sharded():
     _run(sharded=True)
 

--- a/tests/torch/models/hunyuan_video/test_vae_decoder.py
+++ b/tests/torch/models/hunyuan_video/test_vae_decoder.py
@@ -20,9 +20,9 @@ def test_vae_decoder():
     _run(sharded=False)
 
 
-@pytest.mark.xfail(
-    reason="loc(gather.64): error: 'ttir.concat' op Output tensor dimension 2 does not match the sum of input tensor - https://github.com/tenstorrent/tt-xla/issues/4792"
-)
+@pytest.mark.skip(
+    reason="Takes over an hour to run"
+)  # "loc(gather.64): error: 'ttir.concat' op Output tensor dimension 2 does not match the sum of input tensor - https://github.com/tenstorrent/tt-xla/issues/4792"
 @pytest.mark.nightly
 @pytest.mark.model_test
 @pytest.mark.llmbox

--- a/tests/torch/models/krea_realtime/test_text_encoder.py
+++ b/tests/torch/models/krea_realtime/test_text_encoder.py
@@ -26,6 +26,7 @@ def test_text_encoder():
 
 @pytest.mark.nightly
 @pytest.mark.model_test
+@pytest.mark.llmbox
 def test_text_encoder_sharded():
     _run(sharded=True)
 

--- a/tests/torch/models/lumina_image/test_text_encoder.py
+++ b/tests/torch/models/lumina_image/test_text_encoder.py
@@ -27,6 +27,7 @@ def test_text_encoder():
 )
 @pytest.mark.nightly
 @pytest.mark.model_test
+@pytest.mark.llmbox
 def test_text_encoder_sharded():
     _run(sharded=True)
 

--- a/tests/torch/models/lumina_image/test_transformer.py
+++ b/tests/torch/models/lumina_image/test_transformer.py
@@ -25,6 +25,7 @@ def test_transformer():
 )
 @pytest.mark.nightly
 @pytest.mark.model_test
+@pytest.mark.llmbox
 def test_transformer_sharded():
     _run(sharded=True)
 

--- a/tests/torch/models/lumina_image/test_vae_decoder.py
+++ b/tests/torch/models/lumina_image/test_vae_decoder.py
@@ -20,6 +20,7 @@ def test_vae_decoder():
     _run(sharded=False)
 
 
+@pytest.mark.skip(reason="Timed out in CI")
 @pytest.mark.nightly
 @pytest.mark.model_test
 @pytest.mark.llmbox

--- a/tests/torch/models/lumina_image/test_vae_decoder.py
+++ b/tests/torch/models/lumina_image/test_vae_decoder.py
@@ -22,6 +22,7 @@ def test_vae_decoder():
 
 @pytest.mark.nightly
 @pytest.mark.model_test
+@pytest.mark.llmbox
 def test_vae_decoder_sharded():
     _run(sharded=True)
 

--- a/tests/torch/models/omnigen/test_vae_decoder.py
+++ b/tests/torch/models/omnigen/test_vae_decoder.py
@@ -20,6 +20,7 @@ def test_vae_decoder():
     _run(sharded=False)
 
 
+@pytest.mark.skip(reason="Test will likely time out in CI")
 @pytest.mark.nightly
 @pytest.mark.model_test
 @pytest.mark.llmbox

--- a/tests/torch/models/omnigen/test_vae_decoder.py
+++ b/tests/torch/models/omnigen/test_vae_decoder.py
@@ -22,6 +22,7 @@ def test_vae_decoder():
 
 @pytest.mark.nightly
 @pytest.mark.model_test
+@pytest.mark.llmbox
 def test_vae_decoder_sharded():
     _run(sharded=True)
 

--- a/tests/torch/models/omnigen/test_vae_encoder.py
+++ b/tests/torch/models/omnigen/test_vae_encoder.py
@@ -22,6 +22,7 @@ def test_vae_encoder():
 
 @pytest.mark.nightly
 @pytest.mark.model_test
+@pytest.mark.llmbox
 def test_vae_encoder_sharded():
     _run(sharded=True)
 

--- a/tests/torch/models/omnigen/test_vae_encoder.py
+++ b/tests/torch/models/omnigen/test_vae_encoder.py
@@ -20,6 +20,7 @@ def test_vae_encoder():
     _run(sharded=False)
 
 
+@pytest.mark.skip(reason="Timed out in CI")
 @pytest.mark.nightly
 @pytest.mark.model_test
 @pytest.mark.llmbox

--- a/tests/torch/models/playground_v2_5/test_text_encoder.py
+++ b/tests/torch/models/playground_v2_5/test_text_encoder.py
@@ -18,6 +18,7 @@ from third_party.tt_forge_models.playground_v2_5.pytorch import (
 
 @pytest.mark.nightly
 @pytest.mark.model_test
+@pytest.mark.single_device
 def test_text_encoder():
     xr.set_device_type("TT")
     torch.manual_seed(42)

--- a/tests/torch/models/playground_v2_5/test_text_encoder_2.py
+++ b/tests/torch/models/playground_v2_5/test_text_encoder_2.py
@@ -21,6 +21,7 @@ from third_party.tt_forge_models.playground_v2_5.pytorch import (
 )
 @pytest.mark.nightly
 @pytest.mark.model_test
+@pytest.mark.single_device
 def test_text_encoder_2():
     xr.set_device_type("TT")
     torch.manual_seed(42)

--- a/tests/torch/models/playground_v2_5/test_unet.py
+++ b/tests/torch/models/playground_v2_5/test_unet.py
@@ -18,6 +18,7 @@ from third_party.tt_forge_models.playground_v2_5.pytorch import (
 
 @pytest.mark.nightly
 @pytest.mark.model_test
+@pytest.mark.single_device
 def test_unet():
     xr.set_device_type("TT")
     torch.manual_seed(42)

--- a/tests/torch/models/playground_v2_5/test_vae_decoder.py
+++ b/tests/torch/models/playground_v2_5/test_vae_decoder.py
@@ -19,6 +19,7 @@ from third_party.tt_forge_models.playground_v2_5.pytorch import (
 
 @pytest.mark.nightly
 @pytest.mark.model_test
+@pytest.mark.single_device
 def test_vae_decoder():
     xr.set_device_type("TT")
     torch.manual_seed(42)

--- a/tests/torch/models/sdxl_lightning/test_text_encoder.py
+++ b/tests/torch/models/sdxl_lightning/test_text_encoder.py
@@ -15,6 +15,7 @@ from third_party.tt_forge_models.sdxl_lightning.pytorch import ModelLoader, Mode
 
 @pytest.mark.nightly
 @pytest.mark.model_test
+@pytest.mark.single_device
 def test_text_encoder():
     xr.set_device_type("TT")
     torch.manual_seed(42)

--- a/tests/torch/models/sdxl_lightning/test_text_encoder_2.py
+++ b/tests/torch/models/sdxl_lightning/test_text_encoder_2.py
@@ -18,6 +18,7 @@ from third_party.tt_forge_models.sdxl_lightning.pytorch import ModelLoader, Mode
 )
 @pytest.mark.nightly
 @pytest.mark.model_test
+@pytest.mark.single_device
 def test_text_encoder_2():
     xr.set_device_type("TT")
     torch.manual_seed(42)

--- a/tests/torch/models/sdxl_lightning/test_unet.py
+++ b/tests/torch/models/sdxl_lightning/test_unet.py
@@ -15,6 +15,7 @@ from third_party.tt_forge_models.sdxl_lightning.pytorch import ModelLoader, Mode
 
 @pytest.mark.nightly
 @pytest.mark.model_test
+@pytest.mark.single_device
 def test_unet():
     xr.set_device_type("TT")
     torch.manual_seed(42)

--- a/tests/torch/models/sdxl_lightning/test_vae_decoder.py
+++ b/tests/torch/models/sdxl_lightning/test_vae_decoder.py
@@ -16,6 +16,7 @@ from third_party.tt_forge_models.sdxl_lightning.pytorch import ModelLoader, Mode
 
 @pytest.mark.nightly
 @pytest.mark.model_test
+@pytest.mark.single_device
 def test_vae_decoder():
     xr.set_device_type("TT")
     torch.manual_seed(42)

--- a/tests/torch/models/surya_ocr/test_surya_ocr_text.py
+++ b/tests/torch/models/surya_ocr/test_surya_ocr_text.py
@@ -64,6 +64,7 @@ def test_torch_surya_ocr_text_inference():
     run_mode=RunMode.TRAINING,
 )
 @pytest.mark.skip(reason="Support for training not implemented")
+@pytest.mark.single_device
 def test_torch_surya_ocr_text_training():
     loader_path = inspect.getsourcefile(surya_loader)
     with RequirementsManager.for_loader(loader_path):

--- a/tests/torch/ops/test_call_method_composite_ops.py
+++ b/tests/torch/ops/test_call_method_composite_ops.py
@@ -35,6 +35,7 @@ class _TopKIndicesMethod(torch.nn.Module):
 
 
 @pytest.mark.push
+@pytest.mark.single_device
 def test_handle_composite_ops_method_selects_both():
     x = torch.randn(1, 10)
     gm = capture_gm_via_compile(_TopKBothMethod(), x)
@@ -47,6 +48,7 @@ def test_handle_composite_ops_method_selects_both():
 
 
 @pytest.mark.push
+@pytest.mark.single_device
 def test_handle_composite_ops_method_selects_values():
     x = torch.randn(1, 10)
     gm = capture_gm_via_compile(_TopKValuesMethod(), x)
@@ -59,6 +61,7 @@ def test_handle_composite_ops_method_selects_values():
 
 
 @pytest.mark.push
+@pytest.mark.single_device
 def test_handle_composite_ops_method_selects_indices():
     x = torch.randn(1, 10)
     gm = capture_gm_via_compile(_TopKIndicesMethod(), x)

--- a/tests/torch/ops/test_multi_output_composite_ops.py
+++ b/tests/torch/ops/test_multi_output_composite_ops.py
@@ -40,6 +40,7 @@ class _GeluModel(torch.nn.Module):
 
 
 @pytest.mark.push
+@pytest.mark.single_device
 def test_handle_composite_ops_gelu_no_multi_output():
     x = torch.randn(1, 10)
     gm = capture_gm_via_compile(_GeluModel(), x)
@@ -53,6 +54,7 @@ def test_handle_composite_ops_gelu_no_multi_output():
 
 
 @pytest.mark.push
+@pytest.mark.single_device
 def test_handle_composite_ops_selects_indices():
     x = torch.randn(1, 10)
     gm = capture_gm_via_compile(_TopKIndices(), x)
@@ -66,6 +68,7 @@ def test_handle_composite_ops_selects_indices():
 
 
 @pytest.mark.push
+@pytest.mark.single_device
 def test_handle_composite_ops_selects_values():
     x = torch.randn(1, 10)
     gm = capture_gm_via_compile(_TopKValues(), x)
@@ -78,6 +81,7 @@ def test_handle_composite_ops_selects_values():
 
 
 @pytest.mark.push
+@pytest.mark.single_device
 def test_handle_composite_ops_selects_both():
     x = torch.randn(1, 10)
     gm = capture_gm_via_compile(_TopKBoth(), x)

--- a/tests/torch/test_weight_dtype.py
+++ b/tests/torch/test_weight_dtype.py
@@ -63,6 +63,7 @@ class NestedModel(nn.Module):
 
 
 @pytest.mark.push
+@pytest.mark.single_device
 class TestWeightDtypeParametrization:
 
     def test_forward(self):
@@ -76,6 +77,7 @@ class TestWeightDtypeParametrization:
 
 
 @pytest.mark.push
+@pytest.mark.single_device
 class TestApplyWeightDtypeOverrides:
     def test_dict_config(self):
         model = SimpleModel()
@@ -129,6 +131,7 @@ class TestApplyWeightDtypeOverrides:
 
 
 @pytest.mark.push
+@pytest.mark.single_device
 class TestRemoveWeightDtypeOverrides:
     def test_remove(self):
         model = SimpleModel()
@@ -142,6 +145,7 @@ class TestRemoveWeightDtypeOverrides:
 
 
 @pytest.mark.push
+@pytest.mark.single_device
 class TestDumpWeightNames:
     def test_simple_model(self):
         model = SimpleModel()

--- a/tests/torch/test_weight_dtype.py
+++ b/tests/torch/test_weight_dtype.py
@@ -149,7 +149,7 @@ class TestRemoveWeightDtypeOverrides:
 class TestDumpWeightNames:
     def test_simple_model(self):
         model = SimpleModel()
-        result = dump_weight_names(model)
+        result = dump_weight_names(model, "test_model")
         assert "linear1.weight" in result
         assert "linear2.weight" in result
         assert len(result) == 2
@@ -157,7 +157,7 @@ class TestDumpWeightNames:
 
     def test_nested_model(self):
         model = NestedModel()
-        result = dump_weight_names(model, default_dtype="bfp_bf4")
+        result = dump_weight_names(model, "test_model", default_dtype="bfp_bf4")
         # 2 layers x (2 MLP + 2 attn) = 8 weight parameters
         assert len(result) == 8
         assert all(v == "bfp_bf4" for v in result.values())


### PR DESCRIPTION
### Ticket
N/A

### Problem description
There are currently multiple tests in tests/torch marked `nightly` or `push` but not running in CI since no device is specified. 49 missed tests found by: 

```
pytest tests/torch --collect-only -q \
  -m "(nightly or push) and not (single_device or dual_chip or llmbox or galaxy or bh_galaxy or multi_host_cluster)"
```

### What's changed
Added `@pytest.mark.single_device` for most tests and `@pytest.mark.llmbox` for sharded tests. 
- The `push` tests only take 40 seconds to run.
- The `nightly` tests take longer adding ~1 hour to n150, p150 and llmbox

TestDumpWeightNames tests were failing with 
```dump_weight_names() missing 1 required positional argument: 'model_name'```
so I passed in `"test_model"` as `model_name` and tests now pass.

Also made a devex request to ensure tests in /tests/torch have a device specified before they can be marked `nightly` or `push` to avoid this issue in the future.

### Checklist
- [x] New/Existing tests provide coverage for changes
