### PR TITLE
[Claude] Skill for model sharding

### DIFF
--- a/.claude/skills/sharding-model-analysis/SKILL.md
+++ b/.claude/skills/sharding-model-analysis/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: sharding-model-analysis
+description: Analyze a PyTorch model, then design and implement an optimal multi-device sharding strategy for Tenstorrent hardware that minimizes collective-communication (CCL) ops. A strategy is both which parallelism to use (tensor / sequence / data) and how to shard under it - e.g. Megatron column→row is one of several tensor-parallel schemes. Use whenever the user asks to shard a model, distribute it across devices, write Shardy annotations, reduce CCLs, or analyze a model for tensor/sequence parallelism. Trigger even when the user only says "sharding strategy" or names a model with a device count, without asking for a full plan.
+---
+
+# Sharding Model Analysis
+
+Shard a model across Tenstorrent devices to make **inference as fast as possible**. Speed comes from splitting compute across devices so they run in parallel - but every split that crosses a tensor boundary forces a collective-communication (CCL) op, and each CCL is a cross-device sync that stalls every device until it finishes. So the goal is to **parallelize as much compute as possible while paying the fewest CCL ops for it** (and the fewest bytes per CCL). Memory balance is **not** an objective: shard for speed first, and shard to save DRAM only when the speed-optimal layout can't fit on the hardware.
+
+## Core rules
+
+- **Optimize for speed, not memory.** The objective is fast inference - parallelize compute across devices and pay the minimum CCL cost for that parallelism. How evenly DRAM is balanced is irrelevant *unless* the model doesn't otherwise fit.
+- **Minimize CCLs or their size.** Among the layouts that parallelize the compute, pick the one with the fewest CCLs/ fewest bytes moved, pay attention that sometimes several small CCLs can beat one large one.
+- **Only shard for memory as a loud fallback.** If the speed-optimal sharding can't fit in DRAM, *then* switch to a memory-saving layout (e.g. activation/sequence-parallel) and flag the speed trade-off explicitly. Never silently pick a high-CCL or memory-first strategy.
+- **One mesh shape per pipeline.** When a pipeline chains several models, they all share one mesh shape. Pick the shape that's optimal for the slowest (longest-running) model and make the rest adopt it; if some model can't run under that shape, fall back to a shape every model supports.
+- **Cite every non-trivial decision** - Megatron paper section, an internal PR/discussion, or prior work - so the user can verify it.
+- **Never write Shardy syntax from memory.** Read [references/shardy_sharding.md](references/shardy_sharding.md) first.
+- **Run `source venv/activate`** before any repo command or test.
+
+## Reference map - read on demand
+
+| Need | Read |
+|---|---|
+| Enumerate a model's modules + param shapes | [references/run_analysis.md](references/run_analysis.md) |
+| Standard mesh shapes per device count | [references/mesh_shapes.md](references/mesh_shapes.md) |
+| Megatron / ZeRO background | [references/general_sharding.md](references/general_sharding.md) |
+| Which collective each sharding pattern emits (CCL accounting) | [references/ccl_cheatsheet.md](references/ccl_cheatsheet.md) |
+| Shardy annotation syntax | [references/shardy_sharding.md](references/shardy_sharding.md) |
+| Video-gen VAE sharding (what the compiler supports today) | [references/video_vae.md](references/video_vae.md) |
+| Video-gen DiT sharding (what the compiler supports today) | [references/video_dit.md](references/video_dit.md) |
+| Known unsupported patterns / open compiler issues | [references/compiler_support.md](references/compiler_support.md) |
+| Report skeleton to fill in | [assets/sharding_analysis_template.md](assets/sharding_analysis_template.md) |
+| Live device count | run `scripts/num_devices.py` |
+
+## Output
+
+Maintain a single evolving report, **`sharding_analysis.md`**, in the user's working directory, started from [assets/sharding_analysis_template.md](assets/sharding_analysis_template.md). It grows phase by phase and ends as the clean final deliverable. It must contain:
+
+- Model architecture (components and submodules)
+- Recommended strategy, plus the rejected alternatives and why
+- Per-component CCL accounting (count and approximate transfer size) and the model total
+- Bottlenecks and any compiler limitations hit
+
+Second deliverable: the user's model script with the sharding implemented.
+
+## Workflow
+
+Track these phases with `TodoWrite` and keep the user updated. Finish each phase before starting the next; pause for the user where noted or if you are unsure on how to continue.
+
+**1 - Identify the model.** Get the user's load script and read it to pin down the exact model and variant. If you can't find it, ask. Do not proceed while the model is uncertain.
+
+**2 - Map the architecture.** Enumerate every submodule and parameter shape using the recipes in [references/run_analysis.md](references/run_analysis.md) (`print`, `named_modules`, `named_parameters`). Research unfamiliar blocks in source or online. Record the architecture in `sharding_analysis.md`.
+
+**3 - Fix the mesh shapes.** Run `scripts/num_devices.py` for the device count and map it to [references/mesh_shapes.md](references/mesh_shapes.md). Confirm with the user. A sharded dim must divide cleanly by its mesh-axis size, so keep every target mesh in mind - aim for one strategy that holds across all of them.
+
+**4 - Design per-component sharding.** For each component, pick the layout that minimizes CCLs, then minimizes CCL bytes. Default to Megatron-style column→row pairs ([references/general_sharding.md](references/general_sharding.md)): one all-reduce per pair, intermediate never gathered. Use [references/ccl_cheatsheet.md](references/ccl_cheatsheet.md) to count the collective each choice emits, and check [references/compiler_support.md](references/compiler_support.md) before committing - don't design around a pattern that can't lower yet. For video models, start from [references/video_vae.md](references/video_vae.md) and [references/video_dit.md](references/video_dit.md) - they record current compiler support. After per-component choices, re-evaluate the whole model: components must compose without forcing extra reshards.
+
+**5 - Write the plan and get sign-off.** Fill in `sharding_analysis.md`: the recommendation, per-component reasoning with rejected alternatives, per-component and total CCL count/size, and bottlenecks, all cited. **Then ask the user to approve before implementing.**
+
+**6 - Implement with Shardy.** Read [references/shardy_sharding.md](references/shardy_sharding.md), then implement exactly the plan from `sharding_analysis.md`. Verify the code. Ask the user to add IR-export options and run the test:
+```
+export_path="path/to/model",
+export_model_name="model_name"
+```
+Have them tell you when the run finishes so you can inspect the logs.
+
+**7 - Verify against the IR.** Inspect both **TTIR** and **TTNN**; confirm the emitted sharding matches the plan. On a mismatch, isolate the offending module into a minimal test and repeat phases 6–7 on it to find the root cause; record findings in `sharding_analysis.md` and tell the user what's needed to enable it. If the model *runs* slowly (long compile is fine), a CCL op may be hanging - ask the user to enable debug logging:
+```
+export TTMLIR_RUNTIME_LOGGER_LEVEL=DEBUG
+export TT_RUNTIME_MEMORY_LOG_LEVEL=operation
+```
+and build tt-xla in debug mode:
+```
+cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=Debug && cmake --build build
+```
+A stuck CCL means the op hangs: ask a user whether to open an issue for it and choose an alternative strategy (also note it inside the `sharding_analysis.md`).
+
+**8 - Finalize the report.** Once everything works, clean up `sharding_analysis.md` into the final deliverable: architecture, per-module sharding, CCL count/size analysis, and the trade-offs that justify the chosen strategy.

--- a/.claude/skills/sharding-model-analysis/assets/sharding_analysis_template.md
+++ b/.claude/skills/sharding-model-analysis/assets/sharding_analysis_template.md
@@ -1,0 +1,38 @@
+# Sharding analysis - <MODEL NAME>
+
+> Living document. Built up across the skill's phases, finalized in phase 8.
+
+## 1. Model & target
+- Model / variant:
+- Load script:
+- dtype:
+- Device count and target mesh shape(s): <e.g. (1, 4) on qb2 - see references/mesh_shapes.md>
+
+## 2. Architecture
+<Module tree with parameter shapes - see references/run_analysis.md. Mark which
+consecutive layers form Megatron column→row pairs.>
+
+## 3. Recommended strategy (summary)
+<One paragraph: which parallelism (tensor / sequence / data) and which scheme under it
+(e.g. Megatron column→row), plus the headline CCL total.>
+
+## 4. Per-component design
+Repeat per component:
+
+### <component name>
+- **Chosen sharding:** <e.g. `to_q/k/v ("tp", None)` column-parallel; `to_out (None, "tp")` row-parallel>
+- **Why:** <rationale; cite a source - Megatron §, a PR, references/video_*.md>
+- **Rejected alternatives:** <option → why worse: more/larger CCLs, or unsupported per references/compiler_support.md>
+- **CCLs:** <count + approximate size, per references/ccl_cheatsheet.md>
+
+## 5. CCL budget
+| Component | Collective | Count | Approx size |
+|---|---|---|---|
+|  |  |  |  |
+| **Total** |  |  |  |
+
+## 6. Bottlenecks & compiler limitations
+<Largest CCLs; anything hitting references/compiler_support.md; fallbacks taken and why.>
+
+## 7. Sources
+<Papers, GitHub issues/PRs, discussions, and code references cited above.>

--- a/.claude/skills/sharding-model-analysis/references/ccl_cheatsheet.md
+++ b/.claude/skills/sharding-model-analysis/references/ccl_cheatsheet.md
@@ -1,0 +1,34 @@
+# CCL cheat-sheet - which collective each sharding pattern emits
+
+Use this for the CCL accounting in your analysis. It maps a sharding pattern to the
+collective the Shardy partitioner inserts, at the *logical* level (all-reduce /
+all-gather / reduce-scatter).
+
+> **This can change.** Partitioner behavior and tt-mlir lowering evolve. Treat this as
+> a starting point and confirm against the exported IR (phase 7) and current tt-mlir -
+> not as a fixed contract.
+
+## Pattern → collective
+
+| Sharding pattern | Collective inserted | Source |
+|---|---|---|
+| Column-parallel matmul (shard weight *output* dim) | none - output stays sharded | Megatron §3 (arxiv 1909.08053); [video_dit.md](video_dit.md), [video_vae.md](video_vae.md) |
+| Row-parallel matmul (shard weight *input*/contraction dim) | **1 all-reduce** (local output is a partial sum) | Megatron §3; [video_vae.md](video_vae.md), [video_dit.md](video_dit.md) |
+| Reduction (norm / softmax stats) over a sharded axis | **1 all-reduce** of the reduced stats (small - the axis is collapsed before the exchange) | [video_vae.md](video_vae.md) ("norm2"), [video_dit.md](video_dit.md) ("norm_q/k stats AR") |
+| Attention over a sequence-sharded activation needing full K/V | **all-gather** K and V along the sequence axis | [video_dit.md](video_dit.md) ("AG of K, V along SP") |
+| Resharding sharded → replicated | **all-gather** | [video_dit.md](video_dit.md) (exit at `proj_out`) |
+
+## One decomposition identity
+
+`all_reduce ≡ reduce_scatter + all_gather` - 2 collectives. This is the standard
+all-reduce decomposition and is stated in [video_vae.md](video_vae.md)
+("all_reduce, which decomposes as reduce_scatter + all_gather - 2 ccls"). Handy when
+weighing a row-parallel all-reduce against a column-parallel result that only needs a
+single all-gather downstream.
+
+## Verifying op names in the IR
+
+The only collective op name confirmed in this repo's IR tests is `ttir.all_gather`
+(`tests/filecheck/sharding_constraints.ttir.mlir`). Do **not** assume other TTIR/TTNN
+op spellings - read the exported TTIR/TTNN for your model to see exactly what was
+emitted.

--- a/.claude/skills/sharding-model-analysis/references/compiler_support.md
+++ b/.claude/skills/sharding-model-analysis/references/compiler_support.md
@@ -1,0 +1,30 @@
+# Compiler support - known limitations and open issues
+
+A living list of sharding patterns the tt-mlir / tt-metal stack does **not** support
+yet, so you don't design a strategy around something that can't lower.
+
+> Support changes over time. **Verify each item against current tt-mlir before ruling a
+> strategy out**, and append new findings here if you hit them.
+
+## Known limitations
+
+### Spatial sharding of convolutions (halo exchange)
+Sharding a Conv3D/Conv2D on spatial dims (D/H/W) requires neighboring devices to
+exchange kernel-sized "halo" border strips (`neighbor_pad` / `slice_reshard`). This is
+**not yet exposed through TTIR/TTNN MLIR**, so it can't be driven from the compiler
+side today.
+- Tracking issue: tt-mlir #8216 - https://github.com/tenstorrent/tt-mlir/issues/8216
+- Fallback: for conv-heavy models (e.g. VAE), shard channels (C_in/C_out) instead of
+  spatial dims. See [video_vae.md](video_vae.md).
+
+### Shardy back-propagating a shard through a reshape
+A single `sharding_constraint` placed after a reshape lets Shardy propagate the shard
+*back into* the reshape; tt-mlir then fails to update the reshape's static result type
+→ "number of elements doesn't match".
+- Workaround: apply two constraints back-to-back downstream of the reshape - a
+  replicated anchor first, then the sharded spec. See [video_dit.md](video_dit.md) and
+  [shardy_sharding.md](shardy_sharding.md).
+
+## Adding an entry
+When you hit a new limitation, record it as:
+**pattern → symptom → tracking issue/PR → workaround or fallback**, with a source link.

--- a/.claude/skills/sharding-model-analysis/references/general_sharding.md
+++ b/.claude/skills/sharding-model-analysis/references/general_sharding.md
@@ -1,0 +1,38 @@
+# General sharding strategies
+
+Consult these before designing a strategy:
+- Megatron-style tensor parallelism - https://arxiv.org/abs/1909.08053
+- ZeRO sharding - https://arxiv.org/abs/1910.02054
+
+Short summary so you know which to reach for; read the papers for the full picture.
+
+## Megatron-style tensor parallelism (the default here)
+
+Split the *weights* of a matmul pair across devices so the activation between them is
+never gathered - **one all-reduce per pair**.
+
+- **Column-parallel** (first matmul): shard the weight's *output* dim. Each device
+  computes a slice of the output. No collective.
+- **Row-parallel** (second matmul): shard the weight's *input* dim. Each device
+  consumes its matching activation slice and produces a partial sum → **one all-reduce**
+  to combine.
+
+Example - an MLP `up` then `down` (PyTorch `nn.Linear` weight is `[out, in]`):
+```
+up.weight    ("model", None)   # column-parallel: shard output dim, no CCL
+down.weight  (None, "model")   # row-parallel:    shard input dim → all-reduce after
+```
+Attention is the same template: `to_q/k/v` column-parallel, `to_out` row-parallel.
+See [shardy_sharding.md](shardy_sharding.md) for the exact annotation syntax and
+[ccl_cheatsheet.md](ccl_cheatsheet.md) for the collective each side emits.
+
+## ZeRO sharding
+
+A *data-parallel* memory optimization (primarily training-time): replicate compute
+across ranks but shard what each rank *stores* - optimizer states (stage 1),
++ gradients (stage 2), + parameters (stage 3). It cuts per-device memory without
+changing the math, paying an all-gather to reassemble parameters when needed.
+
+Reach for it when the bottleneck is **memory under data parallelism**, not when you
+need to split a single large layer's compute - that's Megatron's job. The two compose
+(Megatron TP within a node, ZeRO/DP across nodes).

--- a/.claude/skills/sharding-model-analysis/references/mesh_shapes.md
+++ b/.claude/skills/sharding-model-analysis/references/mesh_shapes.md
@@ -1,0 +1,12 @@
+
+Usual mesh shapes for different number of devices are:
+
+```
+{
+    32: (8, 4), # galaxy
+    8: (2, 4)/(1, 8), # loudbox
+    4: (1, 4), # qb, qb 2
+    2: (1, 2), # p300, n300 (card with 2 chips)
+    1: (1, 1) # p150, n150 (single chip card)
+}
+```

--- a/.claude/skills/sharding-model-analysis/references/run_analysis.md
+++ b/.claude/skills/sharding-model-analysis/references/run_analysis.md
@@ -1,0 +1,79 @@
+# Getting model architecture
+
+Let this be example of our model:
+```python
+import torch
+import torch.nn as nn
+
+class Block(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.fc = nn.Linear(dim, dim)
+        self.act = nn.ReLU()
+    def forward(self, x):
+        return self.act(self.fc(x))
+
+class TinyNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.embed = nn.Linear(4, 8)
+        self.blocks = nn.ModuleList([Block(8) for _ in range(2)])
+        self.head = nn.Linear(8, 2)
+    def forward(self, x):
+        x = self.embed(x)
+        for b in self.blocks:
+            x = b(x)
+        return self.head(x)
+
+model = TinyNet()
+```
+
+
+## 1.  `print()`
+
+You can get model by simply using print functionality and you would get something like this:
+
+```
+TinyNet(
+  (embed): Linear(in_features=4, out_features=8, bias=True)
+  (blocks): ModuleList(
+    (0-1): 2 x Block(
+      (fc): Linear(in_features=8, out_features=8, bias=True)
+      (act): ReLU()
+    )
+  )
+  (head): Linear(in_features=8, out_features=2, bias=True)
+)
+```
+
+## 2. `named_modules()`
+
+```
+             TinyNet
+embed        Linear
+blocks       ModuleList
+blocks.0     Block
+blocks.0.fc  Linear
+blocks.0.act ReLU
+blocks.1     Block
+blocks.1.fc  Linear
+blocks.1.act ReLU
+head         Linear
+```
+
+## 3. `named_parameters()`
+
+Note ReLU never appears - no params - and bias rows show up separately:
+
+```
+embed.weight        (8, 4)   32
+embed.bias          (8,)      8
+blocks.0.fc.weight  (8, 8)   64
+blocks.0.fc.bias    (8,)      8
+blocks.1.fc.weight  (8, 8)   64
+blocks.1.fc.bias    (8,)      8
+head.weight         (2, 8)   16
+head.bias           (2,)      2
+
+Total: 202
+```

--- a/.claude/skills/sharding-model-analysis/references/shardy_sharding.md
+++ b/.claude/skills/sharding-model-analysis/references/shardy_sharding.md
@@ -1,0 +1,133 @@
+# Shardy sharding examples (PyTorch / PyTorch-XLA)
+
+We shard via **PyTorch-XLA SPMD**: annotate tensors with `xs.mark_sharding(...)` (and
+the `tt_torch` helpers for intermediates); torch-xla emits StableHLO with those
+annotations, and `CONVERT_SHLO_TO_SHARDY=1` converts them into the **Shardy** dialect
+that tt-mlir consumes.
+
+The decision is whether we shard model **weights** (tensor / Megatron parallelism) or
+**activation / input tensors** (data / sequence parallelism). The API is the same -
+what changes is *which* tensor you annotate.
+
+> **PyTorch gotcha.** `torch.nn.Linear` stores its weight as `[out_features,
+> in_features]` and computes `x @ W.T`, so:
+> - **column-parallel** (split *output* features) → shard weight **dim 0** → `("model", None)`
+> - **row-parallel** (split *input* features) → shard weight **dim 1** → `(None, "model")`
+>
+> Matches `examples/pytorch/llama.py` (`up_proj`/`gate_proj` → `("model", None)`,
+> `down_proj` → `(None, "model")`).
+
+## 0. Common setup
+
+```python
+import os, numpy as np, torch, torch_xla
+import torch_xla.runtime as xr
+import torch_xla.distributed.spmd as xs
+from torch_xla.distributed.spmd import Mesh
+
+# Required once per process; CANNOT be undone in-process.
+os.environ["CONVERT_SHLO_TO_SHARDY"] = "1"
+xr.use_spmd()
+device = torch_xla.device()
+
+# Mesh(device_ids, mesh_shape, axis_names) - axis names are referenced in the specs.
+N = xr.global_runtime_device_count()        # e.g. 2 chips on an p300
+mesh = Mesh(np.arange(N), (N,), ("x",))
+
+class MLP(torch.nn.Module):
+    """Minimal 2-layer MLP used for both scenarios below:  y = gelu(x @ fc1) @ fc2"""
+    def __init__(self, hidden=256, ff=1024):
+        super().__init__()
+        self.fc1 = torch.nn.Linear(hidden, ff, bias=False)   # weight: [ff,  hidden]
+        self.fc2 = torch.nn.Linear(ff, hidden, bias=False)   # weight: [hidden, ff]
+    def forward(self, x):
+        return self.fc2(torch.nn.functional.gelu(self.fc1(x)))
+```
+
+`partition_spec` is a tuple, one entry per tensor dim: `None` = replicated, `"x"` =
+sharded on mesh axis `"x"`, `("a","b")` = sharded on two axes; *not* calling
+`mark_sharding` leaves the tensor replicated. The sharded dim must divide cleanly by
+the axis size (`safe_mark_sharding` in `vllm_tt/vllm_distributed_utils.py` falls back
+to replication otherwise).
+
+## 1. Sharding weights (tensor parallelism, Megatron)
+
+Activations replicated, weight matrices split: `fc1` column-parallel, `fc2`
+row-parallel → Shardy inserts exactly **one all-reduce**.
+
+```python
+mesh = Mesh(np.arange(N), (N,), ("model",))
+model = MLP().to(device)
+
+# fc1.weight [ff, hidden]: shard OUTPUT features (dim 0) -> column-parallel
+# fc2.weight [hidden, ff]: shard INPUT  features (dim 1) -> row-parallel
+xs.mark_sharding(model.fc1.weight, mesh, ("model", None))
+xs.mark_sharding(model.fc2.weight, mesh, (None, "model"))
+
+x = torch.randn(8, 256).to(device)          # not marked => replicated
+y = torch.compile(model, backend="tt")(x)
+```
+
+Emitted Shardy annotation (`_partition_spec_to_sdy_sharding` in
+`python_package/tt_torch/sharding.py`); `mesh_idx_0` is a placeholder tt-mlir swaps
+for the real axis name:
+
+```mlir
+// fc1.weight : #sdy.sharding_per_value<[<@mesh, [{"mesh_idx_0"}, {}]>]>   (shard dim0)
+// fc2.weight : #sdy.sharding_per_value<[<@mesh, [{}, {"mesh_idx_0"}]>]>   (shard dim1)
+```
+
+## 2. Sharding activations (data / sequence parallelism)
+
+Weights replicated (unmarked); split the activation along one dim. Sharding the
+**input** is enough for data parallelism - fully local, no collectives:
+
+```python
+mesh = Mesh(np.arange(N), (N,), ("batch",))
+model = MLP().to(device)
+compiled = torch.compile(model, backend="tt")
+
+x = torch.randn(32, 256).to(device)
+xs.mark_sharding(x, mesh, ("batch", None))   # shard batch dim
+y = compiled(x)
+```
+
+### Sharding an *intermediate* activation
+
+For a tensor *inside* the graph, register a **forward pre-hook** that applies
+`sharding_constraint_tensor` as a **back-to-back pair**: a replicated anchor first,
+then the sharded spec. The anchor stops Shardy from back-propagating the sharding
+through upstream reshapes/ops. (Pattern from `tests/torch/models/wan14b/shared.py`'s
+`apply_dit_sp_activation_sharding`.)
+
+```python
+from tt_torch.sharding import sharding_constraint_tensor
+
+def apply_activation_sharding(model, mesh):
+    def _pre_hook(module, args):
+        h = args[0]
+        h = sharding_constraint_tensor(h, mesh, (None, None))      # replicated anchor
+        h = sharding_constraint_tensor(h, mesh, ("batch", None))   # then shard
+        return (h,) + args[1:]
+    model.fc2.register_forward_pre_hook(_pre_hook)                 # pin fc2's input
+
+apply_activation_sharding(model, mesh)
+```
+
+`sharding_constraint_tensor` also takes `unreduced=[...]` to mark a tensor as holding
+partial sums on an axis; Shardy inserts the all-reduce when it is next consumed.
+
+## Summary
+
+| | **Weights** | **Activations** |
+|---|---|---|
+| Parallelism | Tensor (Megatron) | Data / sequence |
+| Annotated tensor | `fc1.weight`, `fc2.weight` | input `x` / intermediate `h` |
+| Spec | `("model", None)`, `(None, "model")` | `("batch", None)` (weights unmarked) |
+| Collectives | 1× all-reduce | none |
+
+Steps: (1) `CONVERT_SHLO_TO_SHARDY=1` + `xr.use_spmd()`; (2) build the `Mesh`;
+(3) `xs.mark_sharding(...)` for weights/inputs, or a forward pre-hook with the
+back-to-back `sharding_constraint_tensor` pair for intermediates; (4)
+`torch.compile(model, backend="tt")`. "Weight" vs "activation" sharding is purely
+which tensor you attach the spec to.

--- a/.claude/skills/sharding-model-analysis/references/video_dit.md
+++ b/.claude/skills/sharding-model-analysis/references/video_dit.md
@@ -1,0 +1,236 @@
+Here we walk through how we shard the **Wan 2.2 14B DiT** (`WanTransformer3DModel`) - the dual-expert transformer that runs every denoising step in the Wan 2.2 A14B pipeline. This is the DiT counterpart to the [VAE sharding discussion](https://github.com/tenstorrent/tt-xla/discussions/4664). Implementation lives in `shared.py::shard_dit_specs` and `apply_dit_sp_activation_sharding`.
+
+---
+
+## DiT structure - what we're sharding
+
+```
+WanTransformer3DModel  (~14B params per expert, 2 experts in A14B)
+├── rope                  WanRotaryPosEmbed  (buffers, no params)
+├── patch_embedding       Conv3d(C_in → D, k=(1,2,2), s=(1,2,2))      ← entry, replicated
+├── condition_embedder    WanTimeTextImageEmbedding
+│   ├── time_embedder     Linear + SiLU + Linear  (→ D)               ← Megatron pair
+│   ├── time_proj         Linear(D → 6·D)                             ← replicated
+│   └── text_embedder     Linear + GELU + Linear  (→ D)               ← Megatron pair
+├── blocks[0..N-1]        WanTransformerBlock × 40                    ← the bulk
+│   each block:
+│     ├── norm1, norm3    FP32LayerNorm  (non-affine)
+│     ├── attn1           WanAttention (self, with RoPE)              ← Megatron pair
+│     ├── attn2           WanAttention (cross, K/V from prompt)       ← Megatron pair
+│     ├── norm2           FP32LayerNorm  (affine)
+│     ├── ffn             FeedForward (D → ffn_dim → D, gelu-approximate) ← Megatron pair
+│     └── scale_shift_table  Parameter (1, 6, D)                      ← replicated
+├── norm_out              FP32LayerNorm  (non-affine)
+├── proj_out              Linear(D → out_channels · prod(patch_size)) ← exit, replicated
+└── scale_shift_table     Parameter (1, 2, D)                         ← replicated
+```
+
+The model has `num_heads = 40` attention heads and `num_layers = 40` blocks. Per forward, the activation enters the block stack flat as `(B, L, D)` where `L = F'·H'·W'` is the number of patchified video tokens.
+
+---
+
+## Two sharding axes
+
+Following tt-metal's terminology:
+
+| Role | What it shards | Size on (2, 4) mesh | Size on (8, 4) mesh |
+|---|---|:---:|:---:|
+| **TP** (tensor-parallel) | hidden dim `D` and FFN inner dim - head-aligned | **4** | **4** |
+| **SP** (sequence-parallel) | flat token dim `L` of activations | **2** | **8** |
+
+We fix TP=4 on every production mesh because `num_heads = 40 = 10 × 4` divides cleanly and each device ends up with a whole number of attention heads. SP scales with whatever's left over after pinning TP.
+
+`shard_dit_specs` handles **TP via weight annotations**. `apply_dit_sp_activation_sharding` handles **SP via `sharding_constraint` ops on intermediate activations** - since SP shards a dim (L) that has no analog in any parameter.
+
+
+---
+
+## Why Megatron is right for the DiT
+
+A DiT block is textbook [Megatron-LM](https://arxiv.org/abs/1909.08053): two column→row matmul pairs (attention QKV+O, FFN up+down) with a non-linearity between. Same template the VAE residual block uses, just at transformer scale:
+
+- **Column-parallel** (`to_q/k/v`, `ff1`): split the output dim. The output is head-aligned (40 heads split 4 ways → 10 heads per device), so each device naturally owns a contiguous head group. No CCL.
+- **Row-parallel** (`to_out`, `ff2`): split the input dim. Consumes the partitioned activation directly; the matmul output is a partial sum that needs **one all-reduce** to materialize.
+
+Three such pairs per block give us 3 all-reduces per block at minimum (`attn1.to_out`, `attn2.to_out`, `ffn.ff2`). No `all_gather` between the column and row sides - the activation stays sharded across the non-linearity. The norms inside attention (`norm_q/k`) reduce over the full hidden dim, which is sharded, so each one needs a small stats AR.
+
+---
+
+## Block-level sharding strategy
+
+Inside the block, the activation flips between two sharding states depending on whether we're inside or outside a Megatron pair:
+
+```
+STATE A - between Megatron pairs   :  TP-replicated D, SP-sharded L
+   per-device shape: (B, L/sp, D)
+
+STATE B - inside a Megatron pair   :  TP-sharded D, SP-sharded L
+   per-device shape: (B, L/sp, D/tp)
+```
+
+The transitions are baked into the matmul shapes:
+- **STATE A → STATE B** at every column-parallel projection (`to_q/k/v`, `ff1`) - pure local matmul, no CCL.
+- **STATE B → STATE A** at every row-parallel projection (`to_out`, `ff2`) - emits a partial sum, AR materializes the full D.
+
+The block's entry and exit both sit in STATE A, so the 40 blocks chain transparently.
+
+---
+
+## One block, end to end
+
+```
+                  spatial : STATE A
+                      │
+                      ▼
+              ┌── norm1 ─────────────────────────────────────────────┐
+              │  non-affine LN + adaLN (scale_msa, shift_msa)        │
+              │  no params, fully local                              │ 0 CCL
+              └──────────────────────────────────────────────────────┘
+                      │
+              ┌── attn1 (self-attention) ────────────────────────────┐
+              │  to_q/k/v   col-parallel  STATE A → STATE B          │
+              │  norm_q/k   RMSNorm across full D, γ TP-sharded      │ 2 small stats AR
+              │  head split + RoPE apply (local)                     │
+              │  AG of K, V along SP axis on L                       │ 2 large SP-AG
+              │  SDPA       per-device on local Q × full K, V        │
+              │  to_out     row-parallel  STATE B → STATE A          │ 1 large TP-AR
+              └──────────────────────────────────────────────────────┘
+                      │
+                      + gate_msa * attn1_out  (STATE A + STATE A)
+                      ▼
+              ┌── norm2 ─────────────────────────────────────────────┐
+              │  affine LN, γ/β replicated, fully local              │ 0 CCL
+              └──────────────────────────────────────────────────────┘
+                      │
+              ┌── attn2 (cross-attention to prompt) ─────────────────┐
+              │  to_q       col-parallel on spatial                  │
+              │  to_k/v     col-parallel on prompt (already SP-rep)  │ no K/V AG needed
+              │  norm_q/k   stats AR                                 │ 2 small stats AR
+              │  SDPA       per-device, no ring                      │
+              │  to_out     row-parallel + AR  STATE B → STATE A     │ 1 large TP-AR
+              └──────────────────────────────────────────────────────┘
+                      │
+                      + attn2_out  (STATE A + STATE A)
+                      ▼
+              ┌── norm3 + adaLN ─────────────────────────────────────┐ 0 CCL
+              └──────────────────────────────────────────────────────┘
+                      │
+              ┌── ffn ───────────────────────────────────────────────┐
+              │  net[0].proj  col-parallel  STATE A → inner-sharded  │
+              │  GELU         local on inner-sharded                 │
+              │  net[2]       row-parallel + AR                      │ 1 large TP-AR
+              └──────────────────────────────────────────────────────┘
+                      │
+                      + c_gate_msa * ffn_out  (STATE A + STATE A)
+                      ▼
+                  spatial : STATE A
+```
+
+Per-block CCL bill at the largest mesh we care about (Galaxy 8×4, sp=8, tp=4):
+
+| Op | Count | Size |
+|---|:---:|:---:|
+| `attn1` K and V SP-AGs | 2 | big |
+| `attn1.to_out` AR | 1 | big |
+| `attn2.to_out` AR | 1 | big |
+| `ffn.net[2]` AR | 1 | big |
+| norm_q/k stats ARs (× 2 attns) | 4 | small |
+| **Total** | **5 big + 4 small** | |
+
+On the 1×4 mesh, SP collapses to a no-op so the two K/V SP-AGs disappear - that block costs just **3 big + 4 small** CCLs.
+
+---
+
+## Why cross-attention is "free" on the SP axis
+
+In `attn1` (self-attention), K and V are derived from `spatial` so they share its SP-sharded L axis. Each device only sees its own slice of L tokens, but SDPA needs every Q token to attend against the full K, V - so we **all-gather K and V along SP** before the dot-product.
+
+`attn2` (cross-attention) is different. K and V come from the prompt, which has its own L_prompt axis that's unrelated to the video's L. The prompt is replicated on the SP axis to start with, so `attn2`'s K and V are already SP-replicated and no SP-AG is needed. That's why cross-attention costs half the CCL of self-attention.
+
+---
+
+## Sequence parallelism - sharding the L axis of activations
+
+SP shards the activation's L axis across `sp_factor` devices. Since no weight has an L axis, we can't express SP via `shard_dit_specs` - we annotate intermediate activations directly with `sharding_constraint` ops.
+
+The dataflow at runtime:
+
+```
+input (5D, replicated on all axes)
+       ↓ patch_embedding (replicated weight) → 5D (B, D, F', H', W') replicated
+       ↓ flatten(2).transpose(1, 2)          → 3D (B, L, D) replicated
+       ↓  ★ sharding_constraint "replicated"   ★ sharding_constraint "L on SP"   ← introduce SP here
+       ↓
+       (B, L/sp, D)  ← STATE A
+       ↓ block 0
+       ↓ ...
+       ↓ block 39 → (B, L/sp, D) ← STATE A
+       ↓ proj_out (replicated weight)        → (B, L/sp, 64)
+       ↓  ★ sharding_constraint "replicated"  ← AG L back to full before unpatchify
+       ↓ reshape → permute → flatten ×3
+       output (replicated)
+```
+
+The interesting part is the **double constraint at the block-stack entry** (and an analogous one inside `rope.forward`). It's there to work around a tt-mlir lowering issue with reshape:
+
+```
+What we want:                            What happens with a single constraint:
+
+    5D replicated                            5D replicated
+        ↓                                       ↓
+    reshape (5D → 3D)                       reshape (5D → 3D)
+        ↓                                       ↓
+    sharding_constraint("L on SP")          sharding_constraint("L on SP")
+        ↓                                       ↑ ← Shardy back-propagates
+    block stack ...                              │   the shard INTO the
+                                                 │   reshape, partitions one
+                                                 │   of (F', H', W'), and
+                                                 │   tt-mlir fails to update
+                                                 │   the reshape's static
+                                                 │   result type to per-device
+                                                 │   shape → "number of elements
+                                                 │   doesn't match" error
+```
+
+The fix is two constraints back to back, both downstream of the reshape:
+
+```
+    reshape (5D → 3D)
+        ↓
+    sharding_constraint(replicated)   ← terminates back-propagation here
+        ↓
+    sharding_constraint(L on SP)      ← shard requested between two non-reshape ops
+        ↓                                  → Shardy inserts a clean scatter
+    block stack ...                         (reshape is never partitioned)
+```
+
+We apply this pattern in two places: at the block-stack entry (after `flatten+transpose`) and on the rope output (rope's body ends in a similar reshape). The exit at `proj_out` only needs a **single** constraint because the direction is reversed there - we're going sharded → replicated *upstream* of the unpatchify reshape, which doesn't trigger the bug; the all-gather lands cleanly before the reshape.
+
+
+---
+
+## Full DiT layout - what's sharded where
+
+```
+WanTransformer3DModel
+├── rope                  buffers, replicated; output marked SP-on-L via forward hook
+├── patch_embedding       weight replicated, output stays replicated
+├── condition_embedder
+│   ├── time_embedder     Megatron col→row pair (TP on D)
+│   ├── time_proj         replicated  (lone col-par would cost an AG every block)
+│   └── text_embedder     Megatron col→row pair (TP on D)
+├── blocks[0..39]
+│   ├── norm1, norm3      no params (non-affine LN)
+│   ├── norm2.weight/bias replicated  (matches STATE A)
+│   ├── attn1, attn2
+│   │   ├── to_q/k/v      ("tp", None)        col-parallel on D
+│   │   ├── norm_q/k      ("tp",)             gamma matches sharded act
+│   │   └── to_out[0]     (None, "tp")        row-parallel + AR → STATE A
+│   ├── ffn
+│   │   ├── net[0].proj   ("tp", None)        col-parallel on inner
+│   │   └── net[2]        (None, "tp")        row-parallel + AR
+│   └── scale_shift_table replicated
+├── norm_out              no params
+├── proj_out              replicated  (one explicit AG hook to force replicated output)
+└── scale_shift_table     replicated  (final-layer adaLN)
+```

--- a/.claude/skills/sharding-model-analysis/references/video_vae.md
+++ b/.claude/skills/sharding-model-analysis/references/video_vae.md
@@ -1,0 +1,153 @@
+## Conv3D Sharding Strategy
+
+### Available Sharding Dimensions
+
+For a Conv3D with input `[B, C_in, D, H, W]`, weight `[C_out, C_in, kD, kH, kW]`, output `[B, C_out, D', H', W']`:
+
+| Strategy | What gets split | Communication needed |
+|----------|----------------|---------------------|
+| **C_out** (weight dim 0) | Weight split on output filters, bias split | **None** - each output channel is independent |
+| **C_in** (weight dim 1) | Input + weight split on input channels | **all_reduce** to sum partial convolutions |
+| **D/H/W** (spatial) | Input split along spatial dims | **halo exchange** - neighboring tiles need overlapping kernel-sized borders |
+| **B** (batch) | Input split along batch | **None** - pure data parallelism |
+
+### Why depth sharding is not beneficial
+
+The WAN VAE decoder uses **streaming decode** - it processes one temporal frame at a time, feeding `[1, C, 1, H, W]` through the decoder in a loop of 32 iterations, with a `feat_cache` holding the last 1-2 frames of intermediate activations per `CausalConv3d` layer for temporal context. This means **D is always 1 during computation** - there's no depth dimension to shard.
+
+### Spatial sharding
+
+Convolution with a kernel of size k requires each spatial tile to have access to `(k-1)/2` extra elements from its neighbors on each boundary - this is called the **halo**. Before each `conv` layer, devices must exchange these halo strips with their neighbors via collective communication ops (`neighbour_pad`, `slice_reshard`).
+
+Currently we don't support it and we have open [issue](https://github.com/tenstorrent/tt-mlir/issues/8216) in `tt-mlir` (check out issue for more details about spatial sharding and ccls).
+
+The tt-metal takes *this* approach: it shards **activations** along `H` and `W`, and keeps **all weights replicated**. This makes sense for a VAE specifically - the decoder weights are small but activations are large, so the bigger win is splitting the *data* rather than the *parameters*. For each 3×3×3 causal `Conv3d`, neighboring devices exchange 1-pixel halo strips on H and W via a custom `ttnn.experimental.neighbor_pad_async` collective; the only all-gather appears around the single mid-block attention (to materialize a full spatial extent for SDPA) and there are **no all-reduces** in the entire decoder. The halo primitive they rely on is exactly what [issue](https://github.com/tenstorrent/tt-mlir/issues/8216) is tracking - until it's exposed through TTIR/TTNN MLIR, we can't take this route from the compiler side, which is why we fall back to channel sharding below.
+
+
+### Channel sharding (in Megatron style)
+
+That leaves us with only thing we can shard currently -> channels (`C_in` and `C_out`), so let's see what we can do with it.
+
+The VAE's `ResidualBlock` has this structure:
+```python
+residual = Sequential(
+    RMS_norm(in_dim),
+    SiLU(),
+    CausalConv3d(in_dim, out_dim, 3),   # Conv A
+    RMS_norm(out_dim),
+    SiLU(),
+    CausalConv3d(out_dim, out_dim, 3),  # Conv B
+)
+shortcut = CausalConv3d(in_dim, out_dim, 1)
+return residual + shortcut
+```
+
+The ResidualBlock naturally pairs two consecutive `conv3D` layers - this is a good example of **[Megatron-style tensor parallelism](https://arxiv.org/abs/1909.08053)** for Transformer layers). The idea is to alternate between two complementary sharding strategies across consecutive layers:
+- The **first layer** shards its output (column-parallel) - splitting work across devices with no communication
+- The **second layer** shards its input (row-parallel) - consuming the already-partitioned output directly, then doing a single all_reduce at the end
+
+This way, only one collective operation (all_reduce) is needed per pair of layers, and the intermediate tensor between the two layers is never gathered - it stays partitioned (given that we know how to deal with `RMS_norm` and `SiLU` in the middle, which we do :).
+
+**Conv A → C_out sharding (column-parallel):**
+- Input is replicated across all devices: full `[B, in_dim, 1, H, W]`
+- Weight `[out_dim, in_dim, 3, 3, 3]` is sharded on dim 0 (output channels) → each device gets `[out_dim/N, in_dim, 3, 3, 3]`
+- Each device independently convolves the full input with its weight slice, producing its portion of output channels
+- Output is `[B, out_dim/N, 1, H, W]` - **no communication needed**
+
+**Conv B → C_in sharding (row-parallel):**
+- Input comes from Conv A's output, already partitioned: `[B, out_dim/N, 1, H, W]` on each device
+- This naturally matches C_in sharding - **no all_gather needed** between Conv A and Conv B
+- Weight `[out_dim_b, out_dim, 3, 3, 3]` is sharded on dim 1 (input channels) → each device gets `[out_dim_b, out_dim/N, 3, 3, 3]`
+- Each device convolves its `out_dim/N` input channels with its corresponding weight slice. The output has **all** `out_dim` output channels (since weight dim 0 is not split), but each device only computed a **partial sum** over its slice of input channels
+- **all_reduce** sums the N partial outputs → correct full result `[B, out_dim_b, 1, H', W']`
+
+The shortcut path (`CausalConv3d(in_dim, out_dim, 1)` or `Identity`) operates on the original replicated input, producing a full `[B, out_dim, 1, H, W]` tensor. The residual add `x + h` works directly since both sides are full after the all_reduce.
+
+**Per ResidualBlock cost: only 1 all_reduce** (at Conv B's output). No all_gather between Conv A→B.
+
+---
+
+## `WanResidualBlock` op sequence under Megatron `(col, row)` C-sharding
+
+> Numbers below are calculated for **480p** at the first **`mid_block.resnets[0]`** (the very first `WanResidualBlock` the decoder hits). At this position the activation has `C = 384` channels and spatial shape `(T, H, W) = (1, 60, 104)` which gives us `[1, 384, 1, 60, 104]` tensor on input. With a 4-device mesh, each device holds `C / N = 96` channels of the C-sharded activation.
+
+
+> **NOTE**
+This only shows us that in Megatron-style sharding we also have to pay attention on what lays between 2 convs that we are sharding, if there wasn't `rms_norm`, we could've gotten away with just one `all_reduce` op per block (one after `conv2`).
+```
+                              x_in  (replicated)
+                                    │
+                ┌───────────────────┼───────────────────┐
+                │                                       │
+                ▼                                       ▼
+              norm1                              conv_shortcut
+                │                                 (Identity when
+                ▼                                  in_dim == out_dim)
+              silu                                      │
+                │                                       │
+                ▼                                       │
+              conv1  ── column-parallel                 │
+                │       (weight sharded on C_out)       │
+                │                                       │
+                ▼  ◀── activation is now C-sharded      │
+        ┏━━━━━━━━━━━━━━━━━━┓                            │
+        ┃     norm2        ┃ ◀── ★ all_reduce  (small)  │
+        ┃                  ┃     on (B, 1, T, H, W)     │
+        ┗━━━━━━━━━━━━━━━━━━┛                            │
+                │                                       │
+                ▼                                       │
+              silu                                      │
+                │                                       │
+                ▼                                       │
+        ┏━━━━━━━━━━━━━━━━━━┓                            │
+        ┃     conv2        ┃ ◀── ★ all_reduce  (big)    │
+        ┃ row-parallel     ┃     on (B, C, T, H, W)     │
+        ┃ (weight on C_in) ┃                            │
+        ┗━━━━━━━━━━━━━━━━━━┛                            │
+                │                                       │
+                ▼  ◀── back to replicated               │
+                │                                       ▼
+                └──────────────────► + ◄────────────────┘
+                                     │
+                                     ▼
+                                  x_out  (replicated)
+```
+
+### Why the extra small AR inside `norm2`
+
+`norm1` and `norm2` are both **RMS-norms over the channel axis** - they compute `Σ_c x_c²` along C. After `conv1` (column-parallel), the activation is C-sharded, so each device only has `C/N` of the channels and its local sum is just a partial. We need an `all_reduce` to combine the partials into the full sum. (`norm1`'s input is replicated, so its sum is already complete - no AR needed there.)
+
+This AR is small because the channel sum collapses C to 1 *before* the cross-device step. So we're not all-reducing the full activation `(B, C, T, H, W)` - we're all-reducing the per-spatial-position scalar `(B, 1, T, H, W)`, which is `C` times smaller. The activation itself stays C-sharded, gets divided locally by the now-globally-consistent norm, and flows straight into `conv2` as the row-parallel input it expects.
+
+
+---
+
+For context, here's how the decoder is currently sharded - Megatron col→row pair on every `WanResidualBlock`, everything else replicated:
+
+```
+AutoencoderKLWan
+├── post_quant_conv      WanCausalConv3d(16 → 16, k=(1,1,1))                            [replicated]
+└── decoder              WanDecoder3d
+    ├── conv_in          WanCausalConv3d(16 → 384, k=(3,3,3))                           [replicated]
+    ├── mid_block        WanMidBlock(dim=384, num_layers=1)
+    │   ├── resnets[0]   WanResidualBlock(384 → 384)                                    [SHARDED - Megatron col→row]
+    │   ├── attentions[0] WanAttentionBlock(384)                                        [replicated]
+    │   └── resnets[1]   WanResidualBlock(384 → 384)                                    [SHARDED - Megatron col→row]
+    ├── up_blocks[0]     WanUpBlock(384 → 384, 3 resnets, upsample3d)                   [resnets SHARDED, upsampler replicated]
+    ├── up_blocks[1]     WanUpBlock(192 → 384, 3 resnets, upsample3d)                   [resnets SHARDED, upsampler replicated]
+    ├── up_blocks[2]     WanUpBlock(192 → 192, 3 resnets, upsample2d)                   [resnets SHARDED, upsampler replicated]
+    ├── up_blocks[3]     WanUpBlock(96  → 96,  3 resnets, no upsampler)                 [resnets SHARDED]
+    ├── norm_out         WanRMS_norm(96, channel_first=True)                            [replicated]
+    └── conv_out         WanCausalConv3d(96 → 3, k=(3,3,3))                             [replicated]
+```
+
+## Further sharding consideration: WanResample (upsamplers / downsamplers)
+
+There is additional compute parallelism we leave on the table by keeping `WanResample` replicated. The natural way to shard it is **col-parallel on `resample[1].weight` (split `C_out`)** rather than row-parallel (split `C_in`):
+
+- **Row-parallel (`C_in`)** produces a partial-sum output that needs an `all_reduce`, which decomposes as `reduce_scatter` + `all_gather` - 2 ccls.
+- **Col-parallel (`C_out`)** produces a clean C-sharded output that only needs **one `all_gather`** to materialize replicated downstream - 1 ccl.
+
+We don't apply this today because we want every block to be **self-contained: replicated in, replicated out**. If we shard `resample[1]` col-parallel, the C-sharded output leaks into the next downstream block and overrides the sharding strategy we set for it - Shardy re-derives a different (worse) layout for that block, which costs us perf. The way to stop the leak is to explicitly mark the resample output as replicated via `xs.mark_sharding(x, mesh, (None,) * x.ndim)` on the intermediate tensor inside `WanResample.forward`, which we'd rather avoid for now.
+
+If profiling later shows the resample conv is the bottleneck, we can revisit this again.

--- a/.claude/skills/sharding-model-analysis/scripts/num_devices.py
+++ b/.claude/skills/sharding-model-analysis/scripts/num_devices.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import torch_xla.runtime as xr
+
+
+# Get number of devices
+# NOTE: first activate environment by running `source venv/activate`
+def get_num_devices() -> int:
+    return xr.global_runtime_device_count()
+
+
+if __name__ == "__main__":
+    print(f"Number of devices: {get_num_devices()}")


### PR DESCRIPTION
### Ticket
Closes #4038

### Problem description
Adds a Claude Code skill (`sharding-model-analysis`) for sharding a PyTorch model
across Tenstorrent devices. Given a model, the skill analyzes its architecture,
designs a sharding strategy that minimizes collective-communication (CCL) ops,
writes the reasoning and plan to `sharding_analysis.md`, and implements the sharding
in the user's model script using Shardy annotations.

The skill lives under `.claude/skills/sharding-model-analysis/` and ships with
reference docs (Shardy syntax, CCL cheat-sheet, mesh shapes, compiler-support
limitations, video VAE/DiT notes) and a report template.