### PR TITLE
Temporarily disable gpt_oss_20b_tp_d2m test from llm benchmarks

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -168,11 +168,6 @@
         "runs-on": "n300-llmbox"
       },
       {
-        "name": "gpt_oss_20b_tp_d2m",
-        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_d2m",
-        "runs-on": "n300-llmbox"
-      },
-      {
         "name": "gpt_oss_20b_tp_batch_size_1",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_batch_size_1",
         "runs-on": "n300-llmbox"

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -1785,7 +1785,7 @@ def test_gpt_oss_20b_tp(
 
 
 # Test with D2M fusion enabled (enable-create-d2m-subgraphs=true).
-# FAILED: SIGSEGV in TTNNRowMajorLayoutPropagation (https://github.com/tenstorrent/tt-xla/issues/5052)
+# FAILED: SIGSEGV in TTNNRowMajorLayoutPropagation (https://github.com/tenstorrent/tt-xla/issues/5121)
 def test_gpt_oss_20b_tp_d2m(
     output_file,
     num_layers,

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -1785,6 +1785,7 @@ def test_gpt_oss_20b_tp(
 
 
 # Test with D2M fusion enabled (enable-create-d2m-subgraphs=true).
+# FAILED: SIGSEGV in TTNNRowMajorLayoutPropagation (https://github.com/tenstorrent/tt-xla/issues/5052)
 def test_gpt_oss_20b_tp_d2m(
     output_file,
     num_layers,


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/5121)

### Problem description
gpt oss 20b w/ d2m crashes with a segfault. This is blocking tt-mlir uplift.

### What's changed
Temporarily disable the test to unblock uplift. There is a [PR](https://github.com/tenstorrent/tt-mlir/pull/8741) for a fix on tt-mlir, after the fix lands the test can be re-enabled. 

