### PR TITLE
[Benchmark] Add custom sharding for glm_4_7

### DIFF
--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -2620,6 +2620,69 @@ def test_deepseek_v3_1_tp_galaxy_4_layers(
     )
 
 
+def _glm_4_7_shard_spec_fn(model_loader, model):
+    """Hidden-replicated sharding spec for GLM-4 on the 4x8 galaxy mesh.
+    TP - 8 : DP - 4 : EP - 32
+    The residual hidden dim is kept replicated along the model axis so the RMS norms reduce locally instead of lowering to a distributed all_gather norm.
+    Embedding is replicated, lm_head is vocab-parallel, and attention / dense MLP / shared experts are col->row parallel along model axis TP - 8.
+    Routed expert weights are sharded across both model and batch axes EP - 32, matching DeepSeek V3.x / Kimi K2.
+
+    NOTE: this spec duplicates the GLM-4 ModelLoader.load_shard_spec on the
+    tt-forge-models branch mvasiljevic/glm_sharding_testing
+    (https://github.com/tenstorrent/tt-forge-models/tree/mvasiljevic/glm_sharding_testing).
+    The loader's default should be updated/refactored to match so the spec
+    lives in one place and we avoid confusion between the two.
+    """
+    from tt_torch.sparse_mlp import A2aSparseMLPWithSharedExperts
+
+    shard_specs = {}
+
+    shard_specs[model.model.embed_tokens.weight] = (None, None)
+    shard_specs[model.model.norm.weight] = (None,)
+    shard_specs[model.lm_head.weight] = ("model", None)
+
+    for layer in model.model.layers:
+        shard_specs[layer.input_layernorm.weight] = (None,)
+        shard_specs[layer.post_attention_layernorm.weight] = (None,)
+
+        attn = layer.self_attn
+        shard_specs[attn.q_proj.weight] = ("model", None)
+        shard_specs[attn.k_proj.weight] = ("model", None)
+        shard_specs[attn.v_proj.weight] = ("model", None)
+        shard_specs[attn.o_proj.weight] = (None, "model")
+
+        if attn.q_proj.bias is not None:
+            shard_specs[attn.q_proj.bias] = ("model",)
+            shard_specs[attn.k_proj.bias] = ("model",)
+            shard_specs[attn.v_proj.bias] = ("model",)
+
+        if hasattr(attn, "q_norm"):
+            shard_specs[attn.q_norm.weight] = (None,)
+            shard_specs[attn.k_norm.weight] = (None,)
+
+        mlp = layer.mlp
+
+        if isinstance(mlp, A2aSparseMLPWithSharedExperts):
+            inner = mlp.mlp
+            shard_specs[inner.router.gate.weight] = (None, None)
+            shard_specs[inner.experts.gate_proj] = (("model", "batch"), None, None)
+            shard_specs[inner.experts.up_proj] = (("model", "batch"), None, None)
+            shard_specs[inner.experts.down_proj] = (("model", "batch"), None, None)
+
+            shared = getattr(mlp, "shared_experts", None)
+            if shared is not None:
+                shard_specs[shared.gate_proj.weight] = ("model", None)
+                shard_specs[shared.up_proj.weight] = ("model", None)
+                shard_specs[shared.down_proj.weight] = (None, "model")
+
+        else:
+            shard_specs[mlp.gate_proj.weight] = ("model", None)
+            shard_specs[mlp.up_proj.weight] = ("model", None)
+            shard_specs[mlp.down_proj.weight] = (None, "model")
+
+    return shard_specs
+
+
 # This test only runs 4 layers so we expect to see incoherent output
 def test_glm_4_7_tp_galaxy_4_layers(
     output_file,
@@ -2649,6 +2712,7 @@ def test_glm_4_7_tp_galaxy_4_layers(
         decode_only=decode_only,
         optimization_level=0,
         trace_enabled=False,
+        shard_spec_fn=_glm_4_7_shard_spec_fn,
         input_output_sharding_spec=("batch", None),
         kv_cache_sharding_spec=("batch", None, None, None),
         required_pcc=0.86,

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -2626,12 +2626,6 @@ def _glm_4_7_shard_spec_fn(model_loader, model):
     The residual hidden dim is kept replicated along the model axis so the RMS norms reduce locally instead of lowering to a distributed all_gather norm.
     Embedding is replicated, lm_head is vocab-parallel, and attention / dense MLP / shared experts are col->row parallel along model axis TP - 8.
     Routed expert weights are sharded across both model and batch axes EP - 32, matching DeepSeek V3.x / Kimi K2.
-
-    NOTE: this spec duplicates the GLM-4 ModelLoader.load_shard_spec on the
-    tt-forge-models branch mvasiljevic/glm_sharding_testing
-    (https://github.com/tenstorrent/tt-forge-models/tree/mvasiljevic/glm_sharding_testing).
-    The loader's default should be updated/refactored to match so the spec
-    lives in one place and we avoid confusion between the two.
     """
     from tt_torch.sparse_mlp import A2aSparseMLPWithSharedExperts
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The GLM-4 galaxy benchmark (`test_glm_4_7_tp_galaxy_4_layers`) used a shard spec that sharded the residual hidden dim across the `model` axis, which forces every RMS norm to lower to a distributed all_gather norm.

### What's changed
Add a custom `_glm_4_7_shard_spec_fn` for the test (wired in via `shard_spec_fn`) that keeps the hidden dim replicated along the `model` axis, so the RMS norms reduce locally instead of all_gathering:
- embedding replicated, `lm_head` vocab-parallel
- attention / dense MLP / shared experts col->row parallel along `model` (TP)
- routed experts use compound EP (`model` x `batch`) on the expert dim, matching DeepSeek V3.x / Kimi K2

Because the hidden dim is replicated, the RMS norms reduce locally and the **distributed RMS norm is no longer needed**. This should also unblock `batch_size=128` (previously hanging, see [#5097](https://github.com/tenstorrent/tt-xla/pull/5097)), but bs128 still randomly dies — both locally and on CI — so it is not enabled here.

The spec is defined entirely in the test (no tt_forge_models submodule bump). It duplicates the GLM-4 `ModelLoader.load_shard_spec` on the tt-forge-models branch [mvasiljevic/glm_sharding_testing](https://github.com/tenstorrent/tt-forge-models/tree/mvasiljevic/glm_sharding_testing), which should be updated/refactored to match so the spec lives in one place and we avoid confusion between the two.

### Perf
Samples/sec on galaxy-wh-6u (bs64, isl128, 4 layers), vs the nightly baseline [run 27175829468](https://github.com/tenstorrent/tt-xla/actions/runs/27175829468/job/80224459020) (5.49 samples/sec):

| Config | Samples/sec | Boost |
|--------|-------------|-------|
| baseline (nightly) | 5.49 | — |
| new sharding, opt level 0 | 6.55 | +19.3% |
| new sharding, opt level 1 (+ tt-mlir MoE ROW_MAJOR workaround) | 7.14 | +30.1% |

### CI
Performance Benchmark CI (galaxy-wh-6u, filter=glm, dedicated runner):
- opt level 0 (default tt-mlir, no pin needed): https://github.com/tenstorrent/tt-xla/actions/runs/27224440003
- opt level 1 (needs pinned tt-mlir MoE ROW_MAJOR workaround):
  - bs64:  https://github.com/tenstorrent/tt-xla/actions/runs/27225233959
  - bs128 (randomly dies): https://github.com/tenstorrent/tt-xla/actions/runs/27225235879

### Checklist
- [x] New/Existing tests provide coverage for changes
