### PR TITLE
Add Gemma-4 26B-A4B MoE support for vLLM on 2D mesh

### DIFF
--- a/integrations/vllm_plugin/setup.py
+++ b/integrations/vllm_plugin/setup.py
@@ -56,5 +56,8 @@ setup(
     ],
     python_requires=">=3.12, <3.13",
     license="Apache-2.0",
-    entry_points={"vllm.platform_plugins": ["tt = vllm_tt:register"]},
+    entry_points={
+        "vllm.platform_plugins": ["tt = vllm_tt:register"],
+        "vllm.general_plugins": ["tt_moe = vllm_tt:register_moe_oot_layer"],
+    },
 )

--- a/integrations/vllm_plugin/vllm_tt/__init__.py
+++ b/integrations/vllm_plugin/vllm_tt/__init__.py
@@ -17,3 +17,10 @@ def register():
     # Setting worker multiprocessing method to spawn to avoid hangs in consecutive vllm pytest runs
     os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
     return "vllm_tt.platform.TTPlatform"
+
+
+def register_moe_oot_layer():
+    # OOT-registers TTFusedMoE (CustomOp.register_oot) so Gemma-4's FusedMoE
+    # uses our dense / expert-parallel routing path under XLA SPMD. Mirrors the
+    # MLA backend's register_*_oot_layer + vllm.general_plugins pattern.
+    from .layers.fused_moe import TTFusedMoE  # noqa: F401

--- a/integrations/vllm_plugin/vllm_tt/layers/fused_moe.py
+++ b/integrations/vllm_plugin/vllm_tt/layers/fused_moe.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""TT FusedMoE OOT layer for vLLM.
+
+``TTFusedMoE`` (OOT-registered for ``FusedMoE``) replaces the upstream fused
+expert kernel — which doesn't lower cleanly through the TT compiler — with a
+TT-friendly expert dispatch delegated to ``tt_torch.moe_backend``:
+
+* genuine 2D mesh (both axes > 1): expert-parallel ``tt_experts_forward``
+  (experts are sharded across the mesh by ``partition_fused_moe``);
+* otherwise (1D / degenerate / single chip): dense-bmm
+  ``tt_dense_experts_forward`` (route every token through every expert, then
+  mask by the routing weights).
+
+Routing uses the model's own ``custom_routing_function`` when present, else
+standard softmax / top_k / renormalize. Registered at import time via
+``@CustomOp.register_oot``; the import is fired from ``register_moe_oot_layer``
+(the ``vllm.general_plugins`` entry point), mirroring the MLA backend.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+from vllm.model_executor.custom_op import CustomOp
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.layer import FusedMoE
+
+
+@CustomOp.register_oot(name="FusedMoE")
+class TTFusedMoE(FusedMoE):
+    """OOT FusedMoE specialised for the TT compile pipeline (see module docstring)."""
+
+    # vLLM FusedMoE → tt_torch.moe_backend expert-module interface adapter.
+    @property
+    def num_experts(self):
+        return self.global_num_experts
+
+    @property
+    def gate_up_proj(self):
+        return self.w13_weight
+
+    @property
+    def down_proj(self):
+        return self.w2_weight
+
+    @property
+    def is_transposed(self):
+        # vLLM stores w13 / w2 already in row-major [E, out, in] orientation,
+        # matching tt_dense_experts_forward's "not transposed" expectation
+        # (it will transpose(-1, -2) before the bmm).
+        return False
+
+    def _apply_gate(self, gate_up):
+        gate, up = gate_up.chunk(2, dim=-1)
+        if self.activation == MoEActivation.SILU:
+            return F.silu(gate) * up
+        if self.activation == MoEActivation.GELU:
+            # HF Gemma-4 uses tanh-approximated GELU; vLLM's "gelu" maps here.
+            return F.gelu(gate, approximate="tanh") * up
+        raise NotImplementedError(
+            f"TTFusedMoE: activation {self.activation} not supported"
+        )
+
+    def forward_native(self, hidden_states, router_logits):
+        # Lazy import keeps tt_torch.moe_backend out of the import-time cycle.
+        from tt_torch import tt_dense_experts_forward, tt_experts_forward
+        from tt_torch.moe_backend import _mesh_info
+
+        orig_shape = hidden_states.shape
+        h_flat = hidden_states.view(-1, orig_shape[-1])
+        # Routing operates on [T, E]; flatten any leading dims of the logits.
+        logits_flat = router_logits.view(-1, router_logits.shape[-1])
+
+        if self.custom_routing_function is not None:
+            # Model supplied its own routing (e.g. Gemma-4 folds
+            # per_expert_scale into the top-k weights here).
+            topk_weights, topk_ids = self.custom_routing_function(
+                h_flat, logits_flat, self.top_k, self.renormalize
+            )
+        else:
+            scores = F.softmax(logits_flat.float(), dim=-1)
+            topk_weights, topk_ids = torch.topk(scores, self.top_k, dim=-1)
+            if self.renormalize:
+                renorm = topk_weights.sum(dim=-1, keepdim=True).clamp(min=1e-9)
+                topk_weights = topk_weights / renorm
+
+        topk_weights = topk_weights.to(h_flat.dtype)
+        # Expert-parallel tt-moe is only valid on a genuine 2D mesh (both axes
+        # > 1), where partition_fused_moe shards the experts across the mesh.
+        # On 1D / degenerate (1, N) / single-chip meshes, use dense bmm.
+        _, _, mesh_shape, _ = _mesh_info()
+        is_2d_mesh = len(mesh_shape) == 2 and all(d > 1 for d in mesh_shape)
+        if is_2d_mesh:
+            out_flat = tt_experts_forward(self, h_flat, topk_ids, topk_weights)
+        else:
+            out_flat = tt_dense_experts_forward(self, h_flat, topk_ids, topk_weights)
+        return out_flat.view(orig_shape)

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -268,6 +268,10 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             # A mesh with a size-1 axis is effectively 1D; downstream sharding
             # treats only genuinely 2D meshes as 2D.
             self.use_2d_mesh = 1 not in mesh_shape
+            # Register as the global SPMD mesh so tt_torch.moe_backend's
+            # _mesh_info() can resolve the expert-parallel cluster axis (the
+            # tt_moe EP path reads get_global_mesh()).
+            xs.set_global_mesh(self.mesh)
 
         self.enforce_eager = model_config.enforce_eager
 
@@ -1879,6 +1883,12 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         if not hasattr(self, "model"):
             self.model = model
 
+        # Repair MoE routing closures that captured CPU tensors before
+        # model.to(device). Must run after the model is on device.
+        from .overrides import repair_stale_moe_closures
+
+        repair_stale_moe_closures(self.model)
+
         # Multimodal configs (e.g. Gemma-4) nest the language model and
         # don't expose lm_head on the top-level module. Walk the module
         # tree to find any ParallelLMHead instance.
@@ -2530,11 +2540,11 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 hsize,
                 self.max_num_reqs,
             )
-            # Mark dummy inputs to match the generated hidden_states shardings
-            # (during execution) to avoid re-compilation of select_hidden_states
-            # graph later.
+            # Match model.forward's hidden_states sharding ("batch" axis,
+            # from RowParallel down_proj). A mismatched axis here silently
+            # corrupts the select output on (2,2) 2D mesh.
             if self.enable_tensor_parallel:
-                safe_mark_sharding(dummy_hidden, self.mesh, (None, None, "model"))
+                safe_mark_sharding(dummy_hidden, self.mesh, (None, None, "batch"))
 
             self.select_hidden_states_compiled(dummy_hidden, indices)
 

--- a/integrations/vllm_plugin/vllm_tt/overrides.py
+++ b/integrations/vllm_plugin/vllm_tt/overrides.py
@@ -62,3 +62,31 @@ def replace_modules(model: torch.nn.Module) -> None:
             _process_module(child_module, child_name, module)
 
     _process_module(model)
+
+
+def repair_stale_moe_closures(model: torch.nn.Module) -> None:
+    """Move CPU tensors captured by MoE ``custom_routing_function`` closures
+    onto the model's device.
+
+    Models that build ``custom_routing_function`` as a closure over a parameter
+    (e.g. Gemma-4's ``per_expert_scale``) keep the original CPU tensor in the
+    closure cell after ``model.to(device)``, so routing later mixes cpu/xla
+    tensors and fails to trace. Rewrite any such cell to the device tensor —
+    name- and model-agnostic. Runs unconditionally after load, independent of TP.
+    """
+    device = next((p.device for p in model.parameters()), None)
+    if device is None or device.type == "cpu":
+        return
+
+    for module in model.modules():
+        fn = getattr(module, "custom_routing_function", None)
+        closure = getattr(fn, "__closure__", None)
+        if not closure:
+            continue
+        for cell in closure:
+            try:
+                val = cell.cell_contents
+            except ValueError:
+                continue  # empty cell
+            if isinstance(val, torch.Tensor) and val.device != device:
+                cell.cell_contents = val.to(device)

--- a/integrations/vllm_plugin/vllm_tt/vllm_distributed_utils.py
+++ b/integrations/vllm_plugin/vllm_tt/vllm_distributed_utils.py
@@ -38,12 +38,25 @@ def safe_mark_sharding(tensor, mesh, partition_spec, strict=False):
     else:
         axis_sizes = mesh.shape()
 
+    def _axis_size(axis):
+        # Compound axis (tuple of names) shards a single tensor dim across
+        # multiple mesh axes; its effective size is the product.
+        if isinstance(axis, (tuple, list)):
+            size = 1
+            for a in axis:
+                s = axis_sizes.get(a)
+                if s is None:
+                    return None
+                size *= s
+            return size
+        return axis_sizes.get(axis)
+
     safe_spec = []
     for i, axis in enumerate(partition_spec):
         if axis is None or i >= tensor.ndim:
             safe_spec.append(None)
             continue
-        mesh_axis_size = axis_sizes.get(axis)
+        mesh_axis_size = _axis_size(axis)
         if mesh_axis_size is None or tensor.shape[i] % mesh_axis_size != 0:
             msg = (
                 f"safe_mark_sharding: dim {i} (size {tensor.shape[i]}) "
@@ -312,6 +325,30 @@ def partition_vocab_parallel_embedding(
     return layer
 
 
+def partition_fused_moe(layer: torch.nn.Module, mesh: xs.Mesh) -> torch.nn.Module:
+    """Fully shard FusedMoE expert weights along the expert dimension (dim 0).
+
+    vLLM stacks experts as ``w13_weight`` [E, 2*I, H] and ``w2_weight``
+    [E, H, I]. TTFusedMoE only takes the expert-parallel (tt_experts_forward)
+    path on a genuine 2D mesh (both axes > 1), where experts are distributed
+    across *all* devices via a compound sharding over both axes (e.g. (2,2) ->
+    4-way split of E). On a 1D / degenerate / single-chip mesh TTFusedMoE uses
+    the dense bmm path, which needs the full expert set on every device, so
+    leave the expert weights replicated (mirrors the is_2d guard in
+    layers/fused_moe.py)."""
+    mesh_shape = tuple(int(d) for d in mesh.mesh_shape)
+    if not (len(mesh_shape) == 2 and all(d > 1 for d in mesh_shape)):
+        logger.debug("Skipping expert sharding for %s on non-2D mesh", layer)
+        return layer
+    expert_axis = tuple(mesh.axis_names)
+    for name in ("w13_weight", "w2_weight"):
+        w = getattr(layer, name, None)
+        if w is not None:
+            safe_mark_sharding(w, mesh, (expert_axis, None, None))
+    logger.debug("Applied compound expert-dim sharding to %s", layer)
+    return layer
+
+
 MODULE_TYPE_TO_WRAPPING_FUNC = OrderedDict(
     [
         ("MergedColumnParallelLinear", partition_merged_column_parallel_linear),
@@ -324,6 +361,7 @@ MODULE_TYPE_TO_WRAPPING_FUNC = OrderedDict(
         # that are not wrapped in vLLM's parallel linear types). Must come last
         # so the more specific vLLM types above always take priority.
         ("Linear", partition_linear),
+        ("TTFusedMoE", partition_fused_moe),
     ]
 )
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -28,6 +28,7 @@ markers =
     llmbox: marks test for llmbox (llmbox)
     galaxy: marks test for galaxy (galaxy)
     bh_galaxy: marks test for blackhole galaxy (galaxy-bh)
+    bhqb: marks test for blackhole quietbox (4-chip p300c)
     # Multi-host Configuration
     multi_host_cluster: marks test for multi-host setups (llmbox)
     # FileCheck

--- a/tests/integrations/vllm_plugin/generative/conftest.py
+++ b/tests/integrations/vllm_plugin/generative/conftest.py
@@ -59,6 +59,8 @@ def check_host_memory(model_name: str) -> float:
     model_rss_limits_gb = {
         "Qwen/Qwen3-0.6B": 5,
         "Qwen/Qwen3-32B": 150,
+        # 26B-A4B measured ~57 GB host RSS; ~50% headroom.
+        "google/gemma-4-26B-A4B-it": 85,
     }
 
     # Measures max RSS across child processes; assumes one engine at a time.

--- a/tests/integrations/vllm_plugin/generative/test_gemma4_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_gemma4_generation.py
@@ -39,3 +39,32 @@ def test_generation_single_device_gemma4_e4b():
     assert_output_coherent(output_text)
 
     check_host_memory(model_name)
+
+
+@pytest.mark.nightly
+@pytest.mark.bhqb
+def test_generation_bhqb_gemma4_26b_a4b():
+    model_name = "google/gemma-4-26B-A4B-it"
+    messages = [[{"role": "user", "content": "Describe Tenstorrent in one sentence."}]]
+    sampling_params = vllm.SamplingParams(temperature=0.0, top_p=1.0, max_tokens=32)
+    llm_args = {
+        "model": model_name,
+        "limit_mm_per_prompt": {"image": 0, "video": 0, "audio": 0},
+        "max_num_batched_tokens": 2560,
+        "max_num_seqs": 1,
+        "max_model_len": 128,
+        "gpu_memory_utilization": 0.1,
+        "additional_config": {
+            "enable_const_eval": True,
+            "min_context_len": 32,
+            "enable_tensor_parallel": True,
+            "use_2d_mesh": True,
+        },
+    }
+    llm = vllm.LLM(**llm_args)
+
+    output_text = llm.chat(messages, sampling_params)[0].outputs[0].text
+    print(f"output: {output_text}")
+    assert_output_coherent(output_text)
+
+    check_host_memory(model_name)


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/3097)

### Problem description
There was no good way to support TT MoE backend from vLLM, that blocks our stacks support MoE models.

### What's changed
- TTFusedMoE (OOT layer in layers/fused_moe.py, registered via the vllm.general_plugins entry point) routes expert dispatch through tt_torch.moe_backend: expert-parallel tt_experts_forward on a genuine 2D mesh, dense tt_dense_experts_forward otherwise. Routing uses the model's custom_routing_function when present.
- partition_fused_moe shards FusedMoE expert weights along the expert dim with a compound (batch, model) axis on a 2D mesh (replicated otherwise, matching the dense path); safe_mark_sharding now supports compound axes.
- Register the SPMD mesh globally (set_global_mesh) so moe_backend can resolve the expert-parallel cluster axis.
- repair_stale_moe_closures (overrides.py) rewrites MoE routing closures that captured CPU tensors before model.to(device) (e.g. Gemma-4 per_expert_scale).
- Precompile select_hidden_states and the fused decode_postprocess (including its runtime prefill re-mark) with the 'batch'-axis hidden sharding to match model.forward output on a 2x2 mesh. A mismatched 'model' axis silently corrupted the selected hidden states / produced token-soup output.
- Add bhqb 26B-A4B generation test (and register the bhqb pytest marker).

### Checklist
- [ ] New/Existing tests provide coverage for changes
