### PR TITLE
[CI] Re-enable t3k mutihost test

### DIFF
--- a/.github/workflows/test-matrix-presets/basic-multihost-test.json
+++ b/.github/workflows/test-matrix-presets/basic-multihost-test.json
@@ -1,3 +1,4 @@
 [
-    { "runs-on": "multi-host-bh-lb-2x",  "topology": "dual_bh_loudbox_1x16", "name": "multihost tests on dual bh loudbox 1x16", "test-mark": "push", "dir": "./tests/torch/multi_host/experimental",  "multihost": true }
+    { "runs-on": "multi-host-bh-lb-2x",  "topology": "dual_bh_loudbox_1x16", "name": "multihost tests on dual bh loudbox 1x16", "test-mark": "push", "dir": "./tests/torch/multi_host/experimental",  "multihost": true },
+    { "runs-on": "multi-host-t3000", "topology": "dual_t3k", "name": "multihost tests on dual t3k", "test-mark": "push", "dir": "./tests/torch/multi_host/experimental",  "multihost": true  }
 ]


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-forge/issues/964

### Problem description
Our multihost CI workflow solution doesn't work alongside tt-metal workflows on a shared multihost machines.

### What's changed
Multihost runner provisioning solution is fixed to work with (alongside) tt-metal workflows.
mulit-host-t3000 is available for testing now.

### Checklist
- [ ] New/Existing tests provide coverage for changes
