### PR TITLE
Remove optimizer submesh device; let optimizer use mock device

### DIFF
--- a/pjrt_implementation/inc/api/client_instance.h
+++ b/pjrt_implementation/inc/api/client_instance.h
@@ -143,24 +143,11 @@ public:
     return m_parent_mesh;
   };
 
-  // Closes currently opened mesh device and submesh device, if any.
+  // Closes currently opened mesh device, if any.
   void closeMeshDevice();
-
-  // Returns the optimizer submesh device of the provided shape. If there is
-  // already opened optimizer submesh and its shape matches the provided shape,
-  // it is returned. Otherwise, we close any previously opened optimizer submesh
-  // and create a new one with the provided shape.
-  //
-  // NOTE: this method is not thread-safe and we will need to revisit this when
-  // adding support for parallel execution.
-  tt::runtime::Device
-  getOrCreateOptimizerSubmesh(const std::vector<uint32_t> &target_mesh_shape);
 
   // Closes currently opened parrent mesh device.
   void closeParentMesh();
-
-  // Closes currently opened optimizer submesh device, if any.
-  void closeOptimizerSubmesh();
 
   // Compiles given mlir program.
   tt_pjrt_status compileMlirProgram(
@@ -224,9 +211,6 @@ private:
 
   // Fabric config computed for the current mesh device.
   std::optional<tt::runtime::MeshFabricConfig> m_fabric_config;
-
-  // Optimizer submesh device (created from m_parent_mesh for optimizer passes).
-  std::optional<tt::runtime::Device> m_optimizer_submesh;
 
   // Used to identify the platform.
   const std::string m_platform_name = "tt";

--- a/pjrt_implementation/src/api/client_instance.cc
+++ b/pjrt_implementation/src/api/client_instance.cc
@@ -568,7 +568,6 @@ tt::runtime::Device ClientInstance::getOrCreateMeshDevice(
 }
 
 void ClientInstance::closeMeshDevice() {
-  closeOptimizerSubmesh();
   closeParentMesh();
   loguru::flush();
 }
@@ -622,44 +621,6 @@ void ClientInstance::closeParentMesh() {
     m_parent_mesh.reset();
     m_fabric_config.reset();
   }
-}
-
-void ClientInstance::closeOptimizerSubmesh() {
-  if (m_optimizer_submesh.has_value()) {
-    DLOG_F(LOG_DEBUG, "Closing optimizer submesh.");
-    tt::runtime::releaseSubMeshDevice(*m_optimizer_submesh);
-    m_optimizer_submesh.reset();
-  }
-}
-
-tt::runtime::Device ClientInstance::getOrCreateOptimizerSubmesh(
-    const std::vector<uint32_t> &target_mesh_shape) {
-
-  // Ensure parent mesh exists with the correct shape
-  tt::runtime::Device parent_mesh = getOrCreateMeshDevice(target_mesh_shape);
-
-  if (m_optimizer_submesh.has_value()) {
-    std::vector<uint32_t> optimizer_submesh_shape =
-        tt::runtime::getMeshShape(*m_optimizer_submesh);
-
-    if (optimizer_submesh_shape == target_mesh_shape) {
-      DLOG_F(LOG_DEBUG, "ClientInstance::getOrCreateOptimizerSubmesh - reusing "
-                        "already created optimizer submesh");
-      return *m_optimizer_submesh;
-    }
-
-    // If shape changed, parent mesh was closed and reopened in
-    // getOrCreateMeshDevice, which automatically closed the submesh.
-    // Clear the stale reference.
-    m_optimizer_submesh.reset();
-  }
-
-  DLOG_F(LOG_DEBUG, "ClientInstance::getOrCreateOptimizerSubmesh - "
-                    "creating optimizer submesh");
-  m_optimizer_submesh =
-      tt::runtime::createSubMeshDevice(parent_mesh, target_mesh_shape);
-
-  return *m_optimizer_submesh;
 }
 
 namespace internal {

--- a/pjrt_implementation/src/api/module_builder/module_builder.cc
+++ b/pjrt_implementation/src/api/module_builder/module_builder.cc
@@ -1027,9 +1027,6 @@ tt_pjrt_status ModuleBuilder::convertFromTTIRToTTNN(
   // Run the pass manager.
   mlir::LogicalResult mlir_result = ttir_to_ttnn_pm.run(mlir_module.get());
 
-  // Close the optimizer submesh now that the compilation is complete.
-  client_instance->closeOptimizerSubmesh();
-
   if (mlir::failed(mlir_result)) {
     LOG_F(ERROR, "Failed to run TTIRToTTNNCommon pipeline");
     return tt_pjrt_status::kInternal;


### PR DESCRIPTION
## What

Stops creating an "optimizer submesh" and passing its `MeshDevice` ptr to tt-mlir via `options.devicePtr`. Removes the supporting machinery from `ClientInstance`:
- `getOrCreateOptimizerSubmesh()`
- `closeOptimizerSubmesh()`
- `m_optimizer_submesh` member
- the `devicePtr` block + `closeOptimizerSubmesh()` call in `module_builder.cc`

## Why

With no external device passed, the optimizer falls back to the **mock device** — `DevicePassesWrapper`'s `else { ... openMockDevice(); }` branch, which tt-mlir already supports. The optimizer doesn't need a real on-silicon submesh to run op-model constraint queries.

This also removes the source of the `releaseSubMeshDevice` lifecycle crash that surfaces on multi-device (tensor-parallel) meshes once tt-metal is uplifted:
```
TT_THROW: MeshDevice cq ID 0 is in use by parent mesh ID 2 during close of mesh ID 4
 --- tt::runtime::releaseSubMeshDevice(...)
```
The optimizer submesh aliased the parent mesh's physical command queues; releasing it while the parent's CQ was in use tripped tt-metal's "one owner per CQ at teardown" guard.

## Notes

- The same functional change already landed on `uplift` (`21726fffc`); this brings `main` in line and additionally removes the now-dead helpers.
- The real-device path is preserved in tt-mlir (`if (externalDevice) ...` in `DevicePassesWrapper`), so it can be re-enabled from git history if the mock path ever regresses.