### PR TITLE
Fix main build break - Make host tensor shell represent strides as i64

### DIFF
--- a/pjrt_implementation/inc/api/tensor.h
+++ b/pjrt_implementation/inc/api/tensor.h
@@ -54,7 +54,7 @@ public:
   struct HostTensorShell {
     const void *host_buffer;
     std::vector<std::uint32_t> shape;
-    std::vector<std::uint32_t> strides;
+    std::vector<std::int64_t> strides;
     std::uint32_t element_size;
     ::tt::target::DataType runtime_data_type;
 


### PR DESCRIPTION
### Ticket
Closes #5155 

### Problem description
Simultaneous merge timing is causing build failure in tt-xla main due to slight API change. mlir runtime now accepts strides as i64 instead of ui32.

Thanks to @kmabeeTT  for the fix

### What's changed
From caller side change stride representation in host tensor shell (mocking runtime tensor in multihost) to i64.

### Checklist
- [ ] New/Existing tests provide coverage for changes
