### PR TITLE
Set `--no-rosegment` linker flag in manylinux builds to mitigate `patchelf` corruption of binaries

### DIFF
--- a/.github/workflows/call-build-manylinux.yml
+++ b/.github/workflows/call-build-manylinux.yml
@@ -73,13 +73,6 @@ jobs:
       - name: Build ttxla  Wheel (manylinux)
         uses: pypa/cibuildwheel@v3.3
         env:
-          # LDFLAGS=-Wl,--no-rosegment: gcc-toolset-15's binutils (>= 2.44) defaults to
-          # --rosegment (single read-only segment => code segment first, no headroom), which
-          # makes patchelf relocate .init/.plt and corrupt DT_INIT during auditwheel repair ->
-          # SIGSEGV in the dynamic loader's call_init on dlopen. --no-rosegment restores the
-          # read-only-segment-first layout so patchelf edits RPATH in place. LDFLAGS is
-          # inherited by the tt-mlir and tt-metal ExternalProject sub-builds, so it covers
-          # every binary in the wheel (not just tt-xla's own extension).
           CIBW_ENVIRONMENT: >-
             CCACHE_REMOTE_ONLY=true
             CCACHE_TEMPDIR=/tmp/ccache

--- a/.github/workflows/call-build-manylinux.yml
+++ b/.github/workflows/call-build-manylinux.yml
@@ -73,11 +73,19 @@ jobs:
       - name: Build ttxla  Wheel (manylinux)
         uses: pypa/cibuildwheel@v3.3
         env:
+          # LDFLAGS=-Wl,--no-rosegment: gcc-toolset-15's binutils (>= 2.44) defaults to
+          # --rosegment (single read-only segment => code segment first, no headroom), which
+          # makes patchelf relocate .init/.plt and corrupt DT_INIT during auditwheel repair ->
+          # SIGSEGV in the dynamic loader's call_init on dlopen. --no-rosegment restores the
+          # read-only-segment-first layout so patchelf edits RPATH in place. LDFLAGS is
+          # inherited by the tt-mlir and tt-metal ExternalProject sub-builds, so it covers
+          # every binary in the wheel (not just tt-xla's own extension).
           CIBW_ENVIRONMENT: >-
             CCACHE_REMOTE_ONLY=true
             CCACHE_TEMPDIR=/tmp/ccache
             CCACHE_REMOTE_STORAGE="${{ env.CCACHE_REMOTE_STORAGE }}"
             IN_CIBW_ENV=ON
+            LDFLAGS="-Wl,--no-rosegment"
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ vars.HARBOR_PREFIX }}${{ inputs.docker-image }}
           CIBW_PROJECT_REQUIRES_PYTHON: "==3.12.*"
           CIBW_SKIP: "*-musllinux_*"

--- a/python_package/pyproject.toml
+++ b/python_package/pyproject.toml
@@ -8,12 +8,17 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-# DIAGNOSTIC (temporary): the /usr/bin/ld -z separate-code wrapper had zero effect on the
-# produced binaries, so either clang is not invoking /usr/bin/ld, or -z separate-code does
-# not control segment ordering on this image's binutils (GNU ld 2.35.2-72.el9; local repro
-# was 2.42). This prints (a) which linker clang actually invokes, and (b) the first LOAD
-# segment + .init address for a trivial .so linked with no flag / separate-code /
-# noseparate-code -- so we can see which (if any) flag yields the R-first/headroom layout on
-# the real toolchain. `|| true` keeps it from failing the build so we still get a wheel to inspect.
-before-all = "echo CLANG_LD:; /usr/bin/clang++ -print-prog-name=ld; echo CLANG_LD_LLD:; /usr/bin/clang++ -print-prog-name=ld.lld; echo LINK_INVOCATION:; /usr/bin/clang++ -### -shared -fPIC -o /tmp/t.so -xc /dev/null 2>&1 | tail -2; echo 'int g;void f(){g++;}' > /tmp/t.c; for m in none separate-code noseparate-code; do case $m in none) F= ;; *) F=-Wl,-z,$m ;; esac; /usr/bin/clang++ -shared -fPIC /tmp/t.c -o /tmp/m.so $F 2>/dev/null; echo MODE=$m; readelf -lW /tmp/m.so | grep -m1 LOAD; readelf -SW /tmp/m.so | grep -E '[.]init +PROGBITS'; done; true"
+# FIX: redirect clang's linker to the system el9 ld so the manylinux binaries get a
+# patchelf-safe layout. Root cause: the recent uplift pulled in gcc-toolset-15, and clang
+# invokes *its* ld (/opt/rh/gcc-toolset-15/.../bin/ld), whose newer binutils lays shared
+# objects out code-segment-first with .init/.plt jammed behind the program headers (no
+# headroom) -- and -z separate-code does NOT change that on this ld. `auditwheel repair`
+# then runs patchelf, which on that compact layout relocates .init/.plt into a non-exec
+# segment and leaves DT_INIT (and the init_array relocs) stale -> SIGSEGV in call_init on
+# dlopen. The system /usr/bin/ld (binutils 2.35.2-72.el9) instead defaults to a read-only
+# segment first (.init high, headroom), so patchelf edits RPATH in place and the binaries
+# stay valid (verified by extracting that exact ld and the older known-good wheels). We wrap
+# the gcc-toolset-15 ld that clang actually resolves so every sub-build (tt-metal, tt-mlir,
+# tt-xla) links through the safe system ld, with no per-repo CMake changes.
+before-all = "GT=$(readlink -f \"$(/usr/bin/clang++ -print-prog-name=ld)\"); if [ -n \"$GT\" ] && [ \"$GT\" != /usr/bin/ld ] && [ -e \"$GT\" ] && [ ! -e \"$GT.real\" ]; then cp -a \"$GT\" \"$GT.real\"; rm -f \"$GT\"; { echo '#!/bin/sh'; echo 'exec /usr/bin/ld \"$@\"'; } > \"$GT\"; chmod +x \"$GT\"; fi; echo \"clang ld wrapped at: $GT\"; cat \"$GT\"; echo 'system ld:'; /usr/bin/ld --version | head -1"
 repair-wheel-command = "auditwheel repair --exclude libTTMLIRRuntime.so --exclude libTTMLIRCompiler.so --exclude libtt-alchemist-lib.so --exclude libtt_metal.so --exclude libtt_stl.so --exclude libtt-umd.so.0 --exclude _ttnncpp.so --exclude _ttnn.so --exclude libdevice.so --exclude libtracy.so* -w {dest_dir} {wheel}"

--- a/python_package/pyproject.toml
+++ b/python_package/pyproject.toml
@@ -8,17 +8,10 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-# FIX: redirect clang's linker to the system el9 ld so the manylinux binaries get a
-# patchelf-safe layout. Root cause: the recent uplift pulled in gcc-toolset-15, and clang
-# invokes *its* ld (/opt/rh/gcc-toolset-15/.../bin/ld), whose newer binutils lays shared
-# objects out code-segment-first with .init/.plt jammed behind the program headers (no
-# headroom) -- and -z separate-code does NOT change that on this ld. `auditwheel repair`
-# then runs patchelf, which on that compact layout relocates .init/.plt into a non-exec
-# segment and leaves DT_INIT (and the init_array relocs) stale -> SIGSEGV in call_init on
-# dlopen. The system /usr/bin/ld (binutils 2.35.2-72.el9) instead defaults to a read-only
-# segment first (.init high, headroom), so patchelf edits RPATH in place and the binaries
-# stay valid (verified by extracting that exact ld and the older known-good wheels). We wrap
-# the gcc-toolset-15 ld that clang actually resolves so every sub-build (tt-metal, tt-mlir,
-# tt-xla) links through the safe system ld, with no per-repo CMake changes.
-before-all = "GT=$(readlink -f \"$(/usr/bin/clang++ -print-prog-name=ld)\"); if [ -n \"$GT\" ] && [ \"$GT\" != /usr/bin/ld ] && [ -e \"$GT\" ] && [ ! -e \"$GT.real\" ]; then cp -a \"$GT\" \"$GT.real\"; rm -f \"$GT\"; { echo '#!/bin/sh'; echo 'exec /usr/bin/ld \"$@\"'; } > \"$GT\"; chmod +x \"$GT\"; fi; echo \"clang ld wrapped at: $GT\"; cat \"$GT\"; echo 'system ld:'; /usr/bin/ld --version | head -1"
+# NOTE: the patchelf-safe linker layout is enforced via LDFLAGS=-Wl,--no-rosegment in the
+# manylinux build's CIBW_ENVIRONMENT (see .github/workflows/call-build-manylinux.yml), which
+# propagates to the tt-mlir and tt-metal ExternalProject sub-builds. gcc-toolset-15's binutils
+# (>= 2.44) defaults to --rosegment (single read-only segment => code-first, no headroom),
+# which makes patchelf relocate .init/.plt and corrupt DT_INIT during auditwheel repair;
+# --no-rosegment restores the read-only-segment-first layout so patchelf edits RPATH in place.
 repair-wheel-command = "auditwheel repair --exclude libTTMLIRRuntime.so --exclude libTTMLIRCompiler.so --exclude libtt-alchemist-lib.so --exclude libtt_metal.so --exclude libtt_stl.so --exclude libtt-umd.so.0 --exclude _ttnncpp.so --exclude _ttnn.so --exclude libdevice.so --exclude libtracy.so* -w {dest_dir} {wheel}"

--- a/python_package/pyproject.toml
+++ b/python_package/pyproject.toml
@@ -8,10 +8,4 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-# NOTE: the patchelf-safe linker layout is enforced via LDFLAGS=-Wl,--no-rosegment in the
-# manylinux build's CIBW_ENVIRONMENT (see .github/workflows/call-build-manylinux.yml), which
-# propagates to the tt-mlir and tt-metal ExternalProject sub-builds. gcc-toolset-15's binutils
-# (>= 2.44) defaults to --rosegment (single read-only segment => code-first, no headroom),
-# which makes patchelf relocate .init/.plt and corrupt DT_INIT during auditwheel repair;
-# --no-rosegment restores the read-only-segment-first layout so patchelf edits RPATH in place.
 repair-wheel-command = "auditwheel repair --exclude libTTMLIRRuntime.so --exclude libTTMLIRCompiler.so --exclude libtt-alchemist-lib.so --exclude libtt_metal.so --exclude libtt_stl.so --exclude libtt-umd.so.0 --exclude _ttnncpp.so --exclude _ttnn.so --exclude libdevice.so --exclude libtracy.so* -w {dest_dir} {wheel}"

--- a/python_package/pyproject.toml
+++ b/python_package/pyproject.toml
@@ -8,4 +8,16 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
+# TEMPORARY FIX: force the GNU ld `-z separate-code` layout for the whole manylinux build.
+# The manylinux toolchain regressed to emitting a `noseparate-code`-style layout (code
+# segment first at vaddr 0, with .init/.plt jammed right behind the program headers and no
+# headroom). `auditwheel repair` (and setup.py's RPATH pass) then run patchelf, which on that
+# compact layout must relocate .init/.plt into a non-executable segment and leaves DT_INIT
+# stale -> SIGSEGV in the dynamic loader's call_init on dlopen. `-z separate-code` puts a
+# read-only segment first, giving .init headroom, so patchelf edits RPATH in place and the
+# binaries stay valid (this is the layout older/good manylinux wheels and the linux_x86_64
+# wheel already have). We wrap /usr/bin/ld instead of passing a flag so every sub-build
+# (tt-metal, tt-mlir, tt-xla) is covered without per-repo CMake changes; the flag is appended
+# last so it overrides any earlier `-z noseparate-code`.
+before-all = "if [ ! -e /usr/bin/ld.real ]; then REAL=$(readlink -f /usr/bin/ld); cp -a \"$REAL\" /usr/bin/ld.real; rm -f /usr/bin/ld; { echo '#!/bin/sh'; echo 'exec /usr/bin/ld.real \"$@\" -z separate-code'; } > /usr/bin/ld; chmod +x /usr/bin/ld; fi; echo 'ld now forces -z separate-code:'; cat /usr/bin/ld; /usr/bin/ld --version | head -1"
 repair-wheel-command = "auditwheel repair --exclude libTTMLIRRuntime.so --exclude libTTMLIRCompiler.so --exclude libtt-alchemist-lib.so --exclude libtt_metal.so --exclude libtt_stl.so --exclude libtt-umd.so.0 --exclude _ttnncpp.so --exclude _ttnn.so --exclude libdevice.so --exclude libtracy.so* -w {dest_dir} {wheel}"

--- a/python_package/pyproject.toml
+++ b/python_package/pyproject.toml
@@ -8,16 +8,12 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-# TEMPORARY FIX: force the GNU ld `-z separate-code` layout for the whole manylinux build.
-# The manylinux toolchain regressed to emitting a `noseparate-code`-style layout (code
-# segment first at vaddr 0, with .init/.plt jammed right behind the program headers and no
-# headroom). `auditwheel repair` (and setup.py's RPATH pass) then run patchelf, which on that
-# compact layout must relocate .init/.plt into a non-executable segment and leaves DT_INIT
-# stale -> SIGSEGV in the dynamic loader's call_init on dlopen. `-z separate-code` puts a
-# read-only segment first, giving .init headroom, so patchelf edits RPATH in place and the
-# binaries stay valid (this is the layout older/good manylinux wheels and the linux_x86_64
-# wheel already have). We wrap /usr/bin/ld instead of passing a flag so every sub-build
-# (tt-metal, tt-mlir, tt-xla) is covered without per-repo CMake changes; the flag is appended
-# last so it overrides any earlier `-z noseparate-code`.
-before-all = "if [ ! -e /usr/bin/ld.real ]; then REAL=$(readlink -f /usr/bin/ld); cp -a \"$REAL\" /usr/bin/ld.real; rm -f /usr/bin/ld; { echo '#!/bin/sh'; echo 'exec /usr/bin/ld.real \"$@\" -z separate-code'; } > /usr/bin/ld; chmod +x /usr/bin/ld; fi; echo 'ld now forces -z separate-code:'; cat /usr/bin/ld; /usr/bin/ld --version | head -1"
+# DIAGNOSTIC (temporary): the /usr/bin/ld -z separate-code wrapper had zero effect on the
+# produced binaries, so either clang is not invoking /usr/bin/ld, or -z separate-code does
+# not control segment ordering on this image's binutils (GNU ld 2.35.2-72.el9; local repro
+# was 2.42). This prints (a) which linker clang actually invokes, and (b) the first LOAD
+# segment + .init address for a trivial .so linked with no flag / separate-code /
+# noseparate-code -- so we can see which (if any) flag yields the R-first/headroom layout on
+# the real toolchain. `|| true` keeps it from failing the build so we still get a wheel to inspect.
+before-all = "echo CLANG_LD:; /usr/bin/clang++ -print-prog-name=ld; echo CLANG_LD_LLD:; /usr/bin/clang++ -print-prog-name=ld.lld; echo LINK_INVOCATION:; /usr/bin/clang++ -### -shared -fPIC -o /tmp/t.so -xc /dev/null 2>&1 | tail -2; echo 'int g;void f(){g++;}' > /tmp/t.c; for m in none separate-code noseparate-code; do case $m in none) F= ;; *) F=-Wl,-z,$m ;; esac; /usr/bin/clang++ -shared -fPIC /tmp/t.c -o /tmp/m.so $F 2>/dev/null; echo MODE=$m; readelf -lW /tmp/m.so | grep -m1 LOAD; readelf -SW /tmp/m.so | grep -E '[.]init +PROGBITS'; done; true"
 repair-wheel-command = "auditwheel repair --exclude libTTMLIRRuntime.so --exclude libTTMLIRCompiler.so --exclude libtt-alchemist-lib.so --exclude libtt_metal.so --exclude libtt_stl.so --exclude libtt-umd.so.0 --exclude _ttnncpp.so --exclude _ttnn.so --exclude libdevice.so --exclude libtracy.so* -w {dest_dir} {wheel}"


### PR DESCRIPTION
### Ticket

https://github.com/tenstorrent/tt-xla/issues/5172

### Problem description

The issue linked above should have more information, but copying the key details here:

The manylinux wheel's tt-related shared libraries segfault on dlopen because the auditwheel/patchelf step corrupts them, and that corruption was triggered by a linker change pulled in by the recent tt-mlir/tt-metal toolchain [uplift](https://github.com/tenstorrent/tt-xla/commit/0d3d5c297fcd45a4f43b75a819cda4f7d756812e) (which pulled 3 weeks of metal commits because it was a very large and complicated uplift). The build's clang links through the active gcc-toolset's ld, and the manylinux toolchain bumped from gcc-toolset-14 to gcc-toolset-15 (confirmed by the embedded GCC version going 14.2.1 -> 15.2.1 in the binaries, when comparing an older valid build from the CI with the newest invalid one).

gcc-toolset-15's binutils ld defaults to a code-first layout, whereas gcc-toolset-14's produced the read-only-first layout - and that layout change is what makes patchelf relocate and corrupt the binaries. (The bump most likely arrived via the floating quay.io/pypa/manylinux_2_34 base image when the cibw image was rebuilt during the uplift, but the exact origin of the bump I did not investigate further.) Concretely, with gcc-toolset-15's ld the executable PT_LOAD starts at vaddr 0 and .init/.plt sections sit immediately behind the program headers (.init at ~0x25c), with no spare read-only page in front of the code. When auditwheel repair (and setup.py's own RPATH pass) then run patchelf to set RPATHs, patchelf cannot grow the dynamic info in place on that compact layout, so it relocates .init, .plt, .dynamic sections into a newly appended PT_LOAD segment - but it does this incorrectly: the new segment is marked non-executable, and patchelf updates neither DT_INIT (left pointing at the stale 0x25c, which is now inside the ELF header/phdr page = zero bytes) nor the DT_INIT_ARRAY constructor relocations. glibc's loader calls DT_INIT before DT_INIT_ARRAY during dlopen, jumps to 0x25c, executes header bytes as code, and segfaults in call_init. So patchelf is the direct corruptor, but the layout produced by gcc-toolset-15's ld is what makes patchelf relocate instead of edit in place. The fix is to make every sub-build link with a linker that produces the safe layout.
