### PR TITLE
 [vLLM] Remove xfails for fixed bugs (#4570, #5006); re-point logprobs xfail

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -121,22 +121,6 @@ class TTConfig:
     export_path: Optional[str] = None
     export_model_name: Optional[str] = None
 
-    def __post_init__(self):
-        # tt::sampling + enable_trace + optimization_level >= 1 hits a
-        # tt-mlir compile bug: TTNNGreedyMemoryLayoutPropagation falls
-        # back to system_memory on the sampling op's output, breaking
-        # ttnn.capture_or_execute_trace. Tracked in tt-xla #4570.
-        # Workarounds: optimization_level=0, cpu_sampling=True, or
-        # enable_trace=False.
-        if self.enable_trace and self.optimization_level >= 1 and not self.cpu_sampling:
-            raise ValueError(
-                "tt::sampling + enable_trace=True + optimization_level>=1 "
-                "triggers a tt-mlir compile-time bug (tt-xla #4570). Set "
-                "additional_config={'cpu_sampling': True}, or "
-                "{'optimization_level': 0}, or {'enable_trace': False}. "
-                "Remove this guard once the kernel-side OpModel fix lands."
-            )
-
     def get_pjrt_compile_config(self) -> dict:
         cfg = {
             "enable_const_eval": self.enable_const_eval,

--- a/tests/integrations/vllm_plugin/generative/test_llama3_3b_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_llama3_3b_generation.py
@@ -31,16 +31,6 @@ def test_llama3_3b_generation():
 
 @pytest.mark.nightly
 @pytest.mark.single_device
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "tt::sampling + enable_trace=True + optimization_level>=1 "
-        "triggers a tt-mlir compile-time bug (tt-xla #4570) — rejected by "
-        "TTConfig.__post_init__. See test_llama3_3b_generation_trace_opt0 "
-        "for the workaround variant. Remove this xfail once the kernel-side "
-        "OpModel fix lands and the TTConfig guard is removed."
-    ),
-)
 def test_llama3_3b_generation_trace():
     """Trace variant: greedy + device sampling so the metal-trace path is exercised."""
     prompts = [

--- a/tests/integrations/vllm_plugin/generative/test_opt_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_opt_generation.py
@@ -31,15 +31,7 @@ def test_opt_generation():
 
 @pytest.mark.push
 @pytest.mark.single_device
-@pytest.mark.xfail(
-    reason="experimental_kv_cache_dtype casts the KV cache to BFP8 but leaves the "
-    "query in bf16, and ttnn.paged_scaled_dot_product_attention_decode requires "
-    "Q/K/V to share an element type. See tt-xla #5006.",
-    strict=False,
-)
 def test_opt_generation_kv_cache_bfp8():
-    # Reproduces the experimental_kv_cache_dtype failure on the vLLM decode
-    # path; remove the xfail once tt-xla #5006 is fixed.
     prompts = [
         "Hello, my name is",
     ]

--- a/tests/integrations/vllm_plugin/sampling/test_trace_logprobs.py
+++ b/tests/integrations/vllm_plugin/sampling/test_trace_logprobs.py
@@ -20,17 +20,23 @@ import vllm
 @pytest.mark.nightly
 @pytest.mark.single_device
 @pytest.mark.xfail(
-    strict=True,
+    strict=False,
     reason=(
-        "tt::sampling + enable_trace=True + optimization_level>=1 "
-        "triggers a tt-mlir compile-time bug (tt-xla #4570) — rejected by "
-        "TTConfig.__post_init__. The combination is exactly what this test "
-        "exercises by design; xfail until the OpModel fix lands and the "
-        "TTConfig guard is removed."
+        "opt-125m + enable_trace + enable_const_eval + optimization_level=1 + "
+        "logprobs fails on Blackhole in two stages (both distinct from the "
+        "now-fixed #4570 layout bug — the Llama-3.2-3B trace variant passes): "
+        "(1) a tt-metal pinned-write command-sequence-size assert "
+        "(dispatch.cpp:989) during the const-eval cache load — tt-xla #5184, "
+        "fixed upstream by tt-metal #46539, pending tt-mlir uplift; and after "
+        "that, (2) a ttnn.sampling output dtype mismatch where the graph "
+        "declares UINT32 but the kernel returns INT32 — tt-xla #5185. Both "
+        "asserts are debug-gated (TT_RUNTIME_DEBUG/TT_ASSERT), so non-strict: a "
+        "release build may pass silently (values are preserved). Remove once "
+        "both land."
     ),
 )
 def test_opt125m_trace_logprobs():
-    """Logprobs + trace at opt_level=1: exercised via CPU fallback."""
+    """Logprobs + trace at opt_level=1 on the device sampler."""
     llm = vllm.LLM(
         model="facebook/opt-125m",
         max_num_batched_tokens=128,


### PR DESCRIPTION
## Ticket

Closes #4570 #5006
Refs #5184 #5185

## Problem description

The tt-mlir fixes for the trace + `optimization_level>=1` sampling compile bug and the BFP8 KV-cache decode SDPA element-type mismatch have landed, so those xfails/guards are now dead. Verified on Blackhole single_device: `test_llama3_3b_generation_trace` and `test_opt_generation_kv_cache_bfp8` pass. `test_opt125m_trace_logprobs` still fails on two further bugs (tracked separately) and stays xfailed.

## What's changed

- `integrations/vllm_plugin/vllm_tt/platform.py`: drop the `TTConfig.__post_init__` `ValueError` that rejected `enable_trace=True + optimization_level>=1`. Seed-rejection logic untouched.
- generative tests: un-xfail `test_llama3_3b_generation_trace` and `test_opt_generation_kv_cache_bfp8`.
- `tests/integrations/vllm_plugin/sampling/test_trace_logprobs.py`: re-point `test_opt125m_trace_logprobs` from the now-fixed compile bug to the two newly-tracked blockers (a tt-metal pinned-write command-sequence-size assert, fixed upstream and pending uplift; and a ttnn.sampling UINT32/INT32 output dtype mismatch). Switched to non-strict since both asserts are debug-gated and a release build may pass silently; docstring corrected.

## Checklist

- [x] `test_llama3_3b_generation_trace` and `test_opt_generation_kv_cache_bfp8` pass on Blackhole single_device
