### PR TITLE
[Test] Mark sana/1600M_1024px inference EXPECTED_PASSING

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -1207,6 +1207,12 @@ test_config:
   stable_diffusion_unet/pytorch-Base-single_device-inference:
     status: EXPECTED_PASSING
 
+  sana/pytorch-1600M_1024px-single_device-inference:
+    # ~30 min end-to-end (PCC ok). Wall-time is dominated by single-threaded
+    # TTNN conv2d host-side weight prep + the CPU golden reference, not compile.
+    # Covered by the 240-min default CI timeout (not yet in .test_durations).
+    status: EXPECTED_PASSING
+
   unet_for_conditional_generation/pytorch-Base-single_device-inference:
     status: EXPECTED_PASSING
     optimization_level: 1


### PR DESCRIPTION

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/4701)

### Problem description
In earlier main Sana model failed with value error,
but while testing in latest main, the model passes with runtime 30 mins

### What's changed
Updated yaml entry w.r.t latest main

### Checklist
- [x] New/Existing tests provide coverage for changes

### Logs
[run_fix.log](https://github.com/user-attachments/files/28854601/run_fix.log)
