### PR TITLE
[CI] Use manylinux wheel for testing on push event

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -52,6 +52,7 @@ jobs:
       docker_image: ${{ needs.build-image.outputs.docker-image-base }}
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
+      wheel_build: manylinux
 
   test_forge_models_push:
     uses: ./.github/workflows/call-test.yml
@@ -62,6 +63,7 @@ jobs:
       docker_image: ${{ needs.build-image.outputs.docker-image }}
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
+      wheel_build: manylinux
 
   deploy-docs:
     needs: [ build-image, build-ttxla ]


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/5189

### Problem description
Testing with manylinux wheel is done only on nightly workflows so it is hard to catch regressions 

### What's changed
Use. manylinux wheel for testing in on push event

### Checklist
- [ ] New/Existing tests provide coverage for changes
