### PR TITLE
Clamp out-of-range negative aten.slice starts to -dim_size (#5199)

### DIFF
--- a/python_package/tt_torch/backend/backend.py
+++ b/python_package/tt_torch/backend/backend.py
@@ -29,6 +29,7 @@ from .passes import (
     bypass_assert_tensor_metadata,
     bypass_dtype_promotion_and_redundant_cast,
     bypass_redundant_getitem,
+    clamp_neg_slice_bounds,
     handle_composite_ops,
     insert_argument_type_markers,
     rewrite_adaptive_avgpool_to_mean,
@@ -71,6 +72,13 @@ def torch_pass_pipeline(
         strict=False,
     )
     program = program.run_decompositions(decompositions)
+
+    # Clamp out-of-range negative slice start/end bounds to -dim_size (CPU
+    # __getitem__ semantics) on the exported graph, where nodes still carry shape
+    # meta (program.module() drops it). XLA's strict aten.slice otherwise rejects
+    # them. In torch_pass_pipeline so both legacy and experimental paths get it.
+    # Refs: tt-xla #5199.
+    clamp_neg_slice_bounds(program.graph_module)
 
     compiled_graph = program.module()
     # When torch.compile traces a model, it flattens the module hierarchy and

--- a/python_package/tt_torch/backend/passes.py
+++ b/python_package/tt_torch/backend/passes.py
@@ -327,6 +327,58 @@ def run_shape_prop(gm, example_inputs):
     shape_prop.run(*fake_args)
 
 
+def clamp_neg_slice_bounds(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
+    """Clamp out-of-range negative ``aten.slice.Tensor`` start/end bounds to ``-dim_size``.
+
+    CPU's ``Tensor.__getitem__`` clamps a bound ``< -dim_size`` to ``-dim_size``;
+    XLA's strict ``aten.slice.Tensor`` instead raises "Value out of range". Only a
+    constant negative start/end on a statically known dim is rewritten, so valid
+    slices are untouched. Refs: tt-xla #5199.
+    """
+    changed = False
+    for node in gm.graph.nodes:
+        if node.op != "call_function" or node.target is not torch.ops.aten.slice.Tensor:
+            continue
+        # aten.slice.Tensor(input, dim, start, end=None, step=1)
+        if len(node.args) < 3:
+            continue
+        inp, dim = node.args[0], node.args[1]
+        if not isinstance(inp, torch.fx.Node) or not isinstance(dim, int):
+            continue
+        shape = getattr(inp.meta.get("val"), "shape", None)
+        if shape is None:
+            shape = getattr(inp.meta.get("tensor_meta"), "shape", None)
+        if shape is None:
+            continue
+        ndim = len(shape)
+        d = dim + ndim if dim < 0 else dim
+        if not (0 <= d < ndim):
+            continue
+        dim_size = shape[d]
+        if not isinstance(dim_size, int):  # skip symbolic / dynamic dims
+            continue
+        # Clamp the start (args[2]) and end (args[3]) bounds independently.
+        new_args = list(node.args)
+        node_changed = False
+        for i in (2, 3):
+            bound = new_args[i] if i < len(new_args) else None
+            if isinstance(bound, int) and bound < -dim_size:
+                new_args[i] = -dim_size
+                node_changed = True
+        if node_changed:
+            logger.debug(
+                f"clamp_neg_slice_bounds: clamped {node.name} start/end "
+                f"{tuple(node.args[2:4])} -> {tuple(new_args[2:4])} "
+                f"(dim {dim}, size {dim_size})"
+            )
+            node.args = tuple(new_args)
+            changed = True
+    if changed:
+        gm.graph.lint()
+        gm.recompile()
+    return gm
+
+
 def bypass_dtype_promotion_and_redundant_cast(gm, example_inputs):
     """
     Removes casting of nodes to float32 unless they were explicitly set by the user.

--- a/tests/torch/ops/test_slice.py
+++ b/tests/torch/ops/test_slice.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Out-of-range slice bounds. Origin: DiffusionGemma's sliding-window KV-cache update
+(transformers cache_utils) does ``x[:, :, -sliding_window + 1 :, :]`` -> start -1023
+on a dim of size 19. CPU's ``__getitem__`` clamps any out-of-range bound; XLA's
+strict ``aten.slice.Tensor`` rejects the negative ones ("Value out of range"), which
+``clamp_neg_slice_bounds`` fixes by clamping them to ``-dim_size``.
+
+Covers the four out-of-range corners (start/end x too-negative/too-positive):
+non-empty results (neg start, pos end) compare via PCC; empty results
+(neg end, pos start) assert shape. (refs: tt-xla #5199)
+"""
+
+import pytest
+import torch
+import torch_xla.core.xla_model as xm
+import torch_xla.runtime as xr
+from infra.utilities.types import Framework
+from utils import Category
+
+from tests.infra.testers.single_chip.op.op_tester import run_op_test_with_random_inputs
+
+SHAPE = (1, 8, 19, 256)  # [batch, kv_heads, seq, head_dim]; dim 2 (seq) = 19
+
+
+@pytest.mark.single_device
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    torch_op_name="torch.ops.aten.slice.Tensor",
+)
+@pytest.mark.parametrize(
+    ["start", "end"],
+    [
+        (-1023, None),  # neg_start: x[:, :, -1023:, :]  (DiffusionGemma cache slice)
+        (None, 1023),  # pos_end:   x[:, :, :1023, :]
+    ],
+    ids=["neg_start", "pos_end"],
+)
+def test_slice_oob_full(start, end, request):
+    """Out-of-range bound with a non-empty result -> compared against CPU via PCC."""
+
+    def slice_op(x: torch.Tensor) -> torch.Tensor:
+        return x[:, :, start:end, :]
+
+    run_op_test_with_random_inputs(
+        slice_op,
+        [SHAPE],
+        dtype=torch.bfloat16,
+        framework=Framework.TORCH,
+        request=request,
+    )
+
+
+@pytest.mark.single_device
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    torch_op_name="torch.ops.aten.slice.Tensor",
+)
+@pytest.mark.parametrize(
+    ["start", "end"],
+    [
+        (None, -1023),  # neg_end:   x[:, :, :-1023, :]
+        (1023, None),  # pos_start: x[:, :, 1023:, :]
+    ],
+    ids=["neg_end", "pos_start"],
+)
+def test_slice_oob_empty(start, end):
+    """Out-of-range bound with an empty result -> assert shape (PCC can't compare 0 elements)."""
+
+    def slice_op(x):
+        return x[:, :, start:end, :]
+
+    expected = torch.empty(SHAPE)[
+        :, :, start:end, :
+    ].shape  # CPU clamp -> (1, 8, 0, 256)
+
+    xr.set_device_type("TT")
+    model = torch.compile(slice_op, backend="tt")
+    x = torch.randn(SHAPE, dtype=torch.bfloat16).to(xm.xla_device())
+    with torch.no_grad():
+        out = model(x).to("cpu")
+
+    assert out.shape == expected


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-xla/issues/5199

### Problem description

- Models with a sliding-window KV cache on a short sequence (e.g. DiffusionGemma) fail at compile with `RuntimeError: Value out of range`. The cache slice `x[:, :, -sliding_window + 1:, :]` lowers to `aten.slice.Tensor(..., start=-1023)` on a dim of size 19 — CPU's `__getitem__` silently clamps an out-of-range negative start, but XLA's strict `aten.slice.Tensor` rejects it. (#5199)

### What's changed

- Implemented as a torch FX pass, per @jameszianxuTT's suggestion in https://github.com/tenstorrent/tt-xla/pull/4552#issuecomment-4413007441.
- Add `clamp_neg_slice_bounds`: rewrites a constant negative slice `start`/`end` `< -dim_size` to `-dim_size` (CPU eager semantics), only on statically-known dims — valid slices are untouched.
- Wire it into `torch_pass_pipeline` (on the exported graph, before `program.module()`) so both the legacy and experimental compile paths get it 
- Generalized from start-only to also clamp negative `end` (per the review on #5211). A four-corner check (start/end × negative/positive) confirmed only the two **negative** bounds are rejected by XLA; positive bounds are already clamped natively, so they're left untouched.
- Add `tests/torch/ops/test_slice.py` covering all four out-of-range corners — non-empty results (neg start, pos end) compared via PCC, empty results (neg end, pos start) via shape assert.
- **DiffusionGemma:** this clears the slice error — the model now traces past it and fails further downstream with a **segfault** (separate blocker, to be handled next). This PR only unblocks the slice issue.
- **krea VAE not fixed:** its failing slice (`x[:, :, -CACHE_T:, :, :]`, `autoencoder_kl_wan.py:883`) takes a different path — it runs via `__torch_function__` (eager, from a Dynamo graph break in the frame-by-frame decode loop) instead of becoming an `aten.slice.Tensor` node in the exported FX graph this pass rewrites, so the FX pass can't reach it. Handled separately.


### Checklist
- [x] Verify the changes through local testing in WH

### Logs

- [jun16_slice_4_cases_before_fix.log](https://github.com/user-attachments/files/28987725/jun16_slice_4_cases_before_fix.log)
- [jun16_slice_4_cases_after_fix.log](https://github.com/user-attachments/files/28998699/jun16_z_slice_4_cases_after_fix.log)
- [jun15_diffusiongemma4_8_chips_before_fix.log](https://github.com/user-attachments/files/28955060/jun15_diffusongemma4_8_chips_3.log)
- [jun16_diffusiongemma4_8_chips_after_fix.log](https://github.com/user-attachments/files/28998694/jun16_z_diffusongemma4_8_chips_after_fix.log)







