### PR TITLE
[CI] Fix wheel build selector

### DIFF
--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -169,11 +169,11 @@ jobs:
         echo "perf_report_dir=$(pwd)/benchmark_reports" >> "$GITHUB_OUTPUT"
         # Override wheel_build to release if matrix.build.require is 'release' or 'alchemist'
         if [[ "${{ matrix.build.require }}" == "release" || "${{ matrix.build.require }}" == "alchemist" || "${{ matrix.build.multihost }}" == "true" ]]; then
-          echo "wheel_build=release" >> "$GITHUB_OUTPUT"
+          wheel_build=release
         else
-          echo "wheel_build=${{ inputs.wheel_build }}" >> "$GITHUB_OUTPUT"
+          wheel_build="${{ inputs.wheel_build }}"
         fi
-        echo "wheel_artifact_name=xla-whl-${{ inputs.wheel_build }}${{ inputs.artifact_suffix }}" >> "$GITHUB_OUTPUT"
+        echo "wheel_artifact_name=xla-whl-$wheel_build${{ inputs.artifact_suffix }}" >> "$GITHUB_OUTPUT"
         echo "wheel_release_vllm_tt_artifact_name=vllm-tt-whl-release${{inputs.artifact_suffix}}" >> "$GITHUB_OUTPUT"
         echo "alchemist_artifact_name=alchemist-lib-release${{ inputs.artifact_suffix }}" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
### Ticket

### Problem description
Wheel build selector was not functioning, it was set as gh output variable instead of bash variable.

### What's changed
Set it as bash variable and use it when selecting wheel for download.

### Checklist
- [ ] New/Existing tests provide coverage for changes
