### PR TITLE
[vLLM] Add Gemma 4-31B Blackhole Galaxy test through vLLM

### DIFF
--- a/.github/workflows/test-matrix-presets/basic-test-nightly-experimental.json
+++ b/.github/workflows/test-matrix-presets/basic-test-nightly-experimental.json
@@ -1,3 +1,4 @@
 [
-  { "runs-on": "galaxy-bh",           "name": "run_torch_bh_galaxy",   "dir": "./tests/torch",                            "test-mark": "nightly and bh_galaxy", "forked": true }
+  { "runs-on": "galaxy-bh",           "name": "run_torch_bh_galaxy",   "dir": "./tests/torch",                            "test-mark": "nightly and bh_galaxy", "forked": true },
+  { "runs-on": "galaxy-bh",           "name": "run_vllm_bh_galaxy",    "dir": "./tests/integrations/vllm_plugin",         "test-mark": "nightly and tensor_parallel and bh_galaxy", "extra-wheel": "vllm" }
 ]

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -257,12 +257,14 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         if self.enable_tensor_parallel:
             num_devices = xr.global_runtime_device_count()
-            mesh_shape = determine_mesh_shape(num_devices, use_2d_mesh=self.use_2d_mesh)
+            mesh_shape = determine_mesh_shape(
+                num_devices, self.tt_config.use_2d_mesh, self.tt_config.mesh_shape
+            )
             device_ids = np.array(range(num_devices))
             self.mesh = xs.Mesh(device_ids, mesh_shape, ("batch", "model"))
-            # Updating the config to reflect the actual mesh shape used.
-            if self.use_2d_mesh and 1 in mesh_shape:
-                self.use_2d_mesh = False
+            # A mesh with a size-1 axis is effectively 1D; downstream sharding
+            # treats only genuinely 2D meshes as 2D.
+            self.use_2d_mesh = 1 not in mesh_shape
 
         self.enforce_eager = model_config.enforce_eager
 

--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -111,6 +111,11 @@ class TTConfig:
     # Flag to enable 2D mesh for tensor parallel execution.
     use_2d_mesh: bool = True
 
+    # Explicit (batch, model) SPMD mesh shape for tensor/data parallel
+    # execution. When None, use_2d_mesh is used to determine the mesh shape.
+    # When set, it overrides use_2d_mesh.
+    mesh_shape: Optional[list[int]] = None
+
     # Flatten model I/O to a flat token stream at the model-call boundary
     # (needed by HF forwards like Gemma-4's PLE path).
     flat_model_io: bool = False

--- a/integrations/vllm_plugin/vllm_tt/pooling_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/pooling_runner.py
@@ -273,7 +273,6 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 self.enable_data_parallel = False
 
         self.enable_tensor_parallel = self.tt_config.enable_tensor_parallel
-        self.use_2d_mesh = self.tt_config.use_2d_mesh
 
         model_config = self.model_config
         cache_config = self.cache_config
@@ -289,7 +288,7 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # Setup for parallel execution.
         if self.enable_tensor_parallel or self.enable_data_parallel:
             mesh_shape = determine_mesh_shape(
-                self.num_devices, use_2d_mesh=self.use_2d_mesh
+                self.num_devices, self.tt_config.use_2d_mesh, self.tt_config.mesh_shape
             )
             device_ids = np.array(range(self.num_devices))
             self.mesh = xs.Mesh(device_ids, mesh_shape, ("batch", "model"))

--- a/integrations/vllm_plugin/vllm_tt/vllm_utils.py
+++ b/integrations/vllm_plugin/vllm_tt/vllm_utils.py
@@ -8,9 +8,39 @@ from .logger import tt_init_logger
 logger = tt_init_logger(__name__)
 
 
-def determine_mesh_shape(num_devices: int, use_2d_mesh: bool) -> tuple[int, int]:
+def determine_mesh_shape(
+    num_devices: int,
+    use_2d_mesh: bool | None = None,
+    mesh_shape: tuple[int, int] | list[int] | None = None,
+) -> tuple[int, int]:
+    """Resolve the (batch, model) SPMD mesh shape against the device count.
+
+    'mesh_shape' is given priority over 'use_2d_mesh'.
+    If 'mesh_shape' is None and 'use_2d_mesh' is True, a pre-defined 2D mesh is used.
+    If 'mesh_shape' is None and 'use_2d_mesh' is False, [1, num_devices] is used.
+    """
+    # 1. If mesh_shape is provided, use it.
+    if mesh_shape is not None:
+        dims = list(mesh_shape)
+        if len(dims) != 2:
+            raise ValueError(
+                f"mesh_shape must have exactly 2 dimensions (batch, model); got {mesh_shape}"
+            )
+        if any(d <= 0 for d in dims):
+            raise ValueError(
+                f"mesh_shape dimensions must be positive; got {mesh_shape}"
+            )
+        if dims[0] * dims[1] != num_devices:
+            raise ValueError(
+                f"mesh_shape {tuple(dims)} has product {dims[0] * dims[1]}, "
+                f"which does not match the device count {num_devices}"
+            )
+        resolved = (dims[0], dims[1])
+        logger.info(f"Using mesh shape for {num_devices} devices: {resolved}")
+        return resolved
+
+    # 2. If use_2d_mesh is True, use a pre-defined 2D mesh.
     if use_2d_mesh:
-        # Use predefined mesh shapes based on number of devices
         mesh_shapes = {
             2: (1, 2),
             4: (2, 2),
@@ -18,12 +48,12 @@ def determine_mesh_shape(num_devices: int, use_2d_mesh: bool) -> tuple[int, int]
             16: (4, 4),
             32: (4, 8),
         }
+
         if num_devices in mesh_shapes:
-            mesh_shape = mesh_shapes[num_devices]
             logger.info(
-                f"Using predefined mesh shape for {num_devices} devices: {mesh_shape}"
+                f"Using predefined mesh shape for {num_devices} devices: {mesh_shapes[num_devices]}"
             )
-            return mesh_shape
+            return mesh_shapes[num_devices]
         else:
             # Fallback to computation for unsupported device counts
             logger.warning(
@@ -36,11 +66,13 @@ def determine_mesh_shape(num_devices: int, use_2d_mesh: bool) -> tuple[int, int]
             mesh_shape = (mesh_dim1, mesh_dim2)
             logger.info(f"Computed mesh shape: {mesh_shape}")
             return mesh_shape
+    # 3. If use_2d_mesh is False, use a 1D mesh.
     else:
-        # For 1D mesh, all devices are in one dimension.
-        mesh_shape = (1, num_devices)
-        logger.info(f"Using 1D mesh shape for {num_devices} devices: {mesh_shape}")
-        return mesh_shape
+        resolved = (1, num_devices)
+        logger.info(
+            f"Using default 1D mesh shape for {num_devices} devices: {resolved}"
+        )
+        return resolved
 
 
 def prev_power_of_2(n: int) -> int:

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -96,7 +96,10 @@ def _tp_config(
 ):
     tp_defaults = {
         "enable_tensor_parallel": True,
-        "use_2d_mesh": True,
+        "use_2d_mesh": False,
+        # Default to a 1D mesh (1, num_devices); each TP config passes an
+        # explicit mesh_shape for its target machine.
+        "mesh_shape": None,
         "min_context_len": 32,
     }
     tp_defaults.update(additional_config_extra)
@@ -119,16 +122,16 @@ def _tp_config(
 def _gemma4_tp_config(model: str, batch_size: int):
     # Gemma-4 is a multimodal model run text-only on a TP mesh. Mirrors
     # tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
-    # ::test_tensor_parallel_generation_bhqb_gemma4_31b:
+    # ::test_tensor_parallel_generation_gemma4_31b:
     #   - limit_mm_per_prompt zeroed so the vision/audio tower never compiles
     #   - max_num_batched_tokens floored at 2560 (MultiModalBudget video floor)
-    #   - flat_model_io for Gemma-4's PLE forward; use_2d_mesh=False -> 1D mesh
+    #   - flat_model_io for Gemma-4's PLE forward; default mesh_shape=None ->
+    #     1D mesh (gemma4 TP runs on qb2-blackhole)
     cfg = _config(
         model,
         batch_size,
         gpu_memory_utilization=0.1,
         enable_tensor_parallel=True,
-        use_2d_mesh=False,
         min_context_len=32,
         enable_const_eval=True,
         experimental_weight_dtype="",
@@ -180,46 +183,54 @@ SINGLE_DEVICE_CONFIGS = [
 ]
 
 
+# All _tp_config benchmarks below run on n300-llmbox (8 devices): a (2, 4) 2D
+# mesh. The qb2-blackhole config (qwen3-32b-qb2) uses a 1D mesh (mesh_shape=None).
 TP_CONFIGS = [
-    pytest.param(_tp_config("tiiuae/Falcon3-7B-Base", 1), id="falcon3-7b-tp"),
-    pytest.param(_tp_config("tiiuae/Falcon3-10B-Base", 1), id="falcon3-10b-tp"),
-    pytest.param(_tp_config("Qwen/Qwen3-8B", 1), id="qwen3-8b-tp"),
     pytest.param(
-        _tp_config("Qwen/Qwen3-8B", 1, optimization_level=1),
+        _tp_config("tiiuae/Falcon3-7B-Base", 1, mesh_shape=[2, 4]), id="falcon3-7b-tp"
+    ),
+    pytest.param(
+        _tp_config("tiiuae/Falcon3-10B-Base", 1, mesh_shape=[2, 4]),
+        id="falcon3-10b-tp",
+    ),
+    pytest.param(_tp_config("Qwen/Qwen3-8B", 1, mesh_shape=[2, 4]), id="qwen3-8b-tp"),
+    pytest.param(
+        _tp_config("Qwen/Qwen3-8B", 1, mesh_shape=[2, 4], optimization_level=1),
         id="qwen3-8b-tp-opt1",
     ),
-    pytest.param(_tp_config("Qwen/Qwen3-14B", 1), id="qwen3-14b-tp"),
-    pytest.param(_tp_config("Qwen/Qwen3-32B", 1), id="qwen3-32b-tp"),
+    pytest.param(_tp_config("Qwen/Qwen3-14B", 1, mesh_shape=[2, 4]), id="qwen3-14b-tp"),
+    pytest.param(_tp_config("Qwen/Qwen3-32B", 1, mesh_shape=[2, 4]), id="qwen3-32b-tp"),
     pytest.param(_gemma4_tp_config("google/gemma-4-31B-it", 1), id="gemma4-31b-it-tp"),
+    pytest.param(_tp_config("Qwen/Qwen3-32B", 1), id="qwen3-32b-qb2-tp"),
     pytest.param(
-        _tp_config("Qwen/Qwen3-32B", 1, use_2d_mesh=False), id="qwen3-32b-qb2-tp"
+        _tp_config("Qwen/Qwen2.5-14B-Instruct", 1, mesh_shape=[2, 4]),
+        id="qwen2.5-14b-instruct-tp",
     ),
     pytest.param(
-        _tp_config("Qwen/Qwen2.5-14B-Instruct", 1), id="qwen2.5-14b-instruct-tp"
-    ),
-    pytest.param(
-        _tp_config("Qwen/Qwen2.5-Coder-32B-Instruct", 1),
+        _tp_config("Qwen/Qwen2.5-Coder-32B-Instruct", 1, mesh_shape=[2, 4]),
         id="qwen2.5-coder-32b-instruct-tp",
     ),
     pytest.param(
-        _tp_config("mistralai/Ministral-8B-Instruct-2410", 1), id="ministral-8b-tp"
+        _tp_config("mistralai/Ministral-8B-Instruct-2410", 1, mesh_shape=[2, 4]),
+        id="ministral-8b-tp",
     ),
     pytest.param(
-        _tp_config("mistralai/Mistral-Nemo-Instruct-2407", 1),
+        _tp_config("mistralai/Mistral-Nemo-Instruct-2407", 1, mesh_shape=[2, 4]),
         id="mistral-nemo-instruct-2407-tp",
     ),
     pytest.param(
-        _tp_config("mistralai/Mistral-Small-24B-Instruct-2501", 1),
+        _tp_config("mistralai/Mistral-Small-24B-Instruct-2501", 1, mesh_shape=[2, 4]),
         id="mistral-small-24b-instruct-2501-tp",
     ),
     pytest.param(
-        _tp_config("meta-llama/Llama-3.1-8B-Instruct", 1),
+        _tp_config("meta-llama/Llama-3.1-8B-Instruct", 1, mesh_shape=[2, 4]),
         id="llama-3.1-8b-tp",
     ),
     pytest.param(
         _tp_config(
             "meta-llama/Llama-3.1-70B-Instruct",
             1,
+            mesh_shape=[2, 4],
             enable_const_eval=True,
             experimental_weight_dtype="bfp_bf8",
         ),

--- a/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
@@ -77,18 +77,18 @@ def test_tensor_parallel_generation_llmbox_small(
 @pytest.mark.tensor_parallel
 @pytest.mark.llmbox
 @pytest.mark.parametrize(
-    ["model_name", "enable_const_eval", "experimental_weight_dtype", "use_2d_mesh"],
+    ["model_name", "enable_const_eval", "experimental_weight_dtype", "mesh_shape"],
     [
-        pytest.param("Qwen/Qwen3-32B", False, "", True),
-        pytest.param("Qwen/Qwen3-8B", False, "", False),
-        pytest.param("meta-llama/Llama-3.1-70B", True, "bfp_bf8", True),
+        pytest.param("Qwen/Qwen3-32B", False, "", [2, 4]),
+        pytest.param("Qwen/Qwen3-8B", False, "", [1, 8]),
+        pytest.param("meta-llama/Llama-3.1-70B", True, "bfp_bf8", [2, 4]),
     ],
 )
 def test_tensor_parallel_generation_llmbox_large(
     model_name: str,
     enable_const_eval: bool,
     experimental_weight_dtype: str,
-    use_2d_mesh: bool,
+    mesh_shape: list[int],
 ):
     prompts = [
         "I like taking walks in the",
@@ -105,7 +105,7 @@ def test_tensor_parallel_generation_llmbox_large(
             "min_context_len": 32,
             "enable_tensor_parallel": True,
             "experimental_weight_dtype": experimental_weight_dtype,
-            "use_2d_mesh": use_2d_mesh,
+            "mesh_shape": mesh_shape,
         },
     }
     llm = vllm.LLM(**llm_args)
@@ -121,14 +121,14 @@ def test_tensor_parallel_generation_llmbox_large(
 @pytest.mark.tensor_parallel
 @pytest.mark.galaxy_wh_6u
 @pytest.mark.parametrize(
-    ["model_name", "enable_const_eval", "experimental_weight_dtype", "use_2d_mesh"],
-    [pytest.param("mistralai/Mistral-Large-Instruct-2411", True, "bfp_bf8", True)],
+    ["model_name", "enable_const_eval", "experimental_weight_dtype", "mesh_shape"],
+    [pytest.param("mistralai/Mistral-Large-Instruct-2411", True, "bfp_bf8", [4, 8])],
 )
 def test_tensor_parallel_generation_galaxy_wh_6u_large(
     model_name: str,
     enable_const_eval: bool,
     experimental_weight_dtype: str,
-    use_2d_mesh: bool,
+    mesh_shape: list[int],
 ):
     inputs = ["How many days ago was Mistral founded?"]
 
@@ -144,7 +144,7 @@ def test_tensor_parallel_generation_galaxy_wh_6u_large(
             "min_context_len": 64,
             "enable_tensor_parallel": True,
             "experimental_weight_dtype": experimental_weight_dtype,
-            "use_2d_mesh": use_2d_mesh,
+            "mesh_shape": mesh_shape,
         },
     }
     llm = vllm.LLM(**llm_args)
@@ -158,18 +158,25 @@ def test_tensor_parallel_generation_galaxy_wh_6u_large(
 
 @pytest.mark.nightly
 @pytest.mark.tensor_parallel
-@pytest.mark.bhqb
 @pytest.mark.parametrize(
-    ["enable_const_eval", "experimental_weight_dtype", "use_2d_mesh"],
+    ["enable_const_eval", "experimental_weight_dtype"],
     [
-        pytest.param(True, "", False),
+        pytest.param(True, ""),
     ],
 )
-def test_tensor_parallel_generation_bhqb_gemma4_31b(
+@pytest.mark.parametrize(
+    "mesh_shape",
+    [
+        pytest.param([1, 4], marks=pytest.mark.bhqb),
+        pytest.param([8, 4], marks=pytest.mark.bh_galaxy),
+    ],
+)
+def test_tensor_parallel_generation_gemma4_31b(
+    mesh_shape: list[int],
     enable_const_eval: bool,
     experimental_weight_dtype: str,
-    use_2d_mesh: bool,
 ):
+
     model_name = "google/gemma-4-31B-it"
 
     messages = [[{"role": "user", "content": "Describe Tenstorrent in one sentence."}]]
@@ -190,7 +197,7 @@ def test_tensor_parallel_generation_bhqb_gemma4_31b(
             "min_context_len": 32,
             "enable_tensor_parallel": True,
             "experimental_weight_dtype": experimental_weight_dtype,
-            "use_2d_mesh": use_2d_mesh,
+            "mesh_shape": mesh_shape,
             "cpu_sampling": False,
             "flat_model_io": True,
         },

--- a/tests/integrations/vllm_plugin/pooling/utils.py
+++ b/tests/integrations/vllm_plugin/pooling/utils.py
@@ -21,6 +21,7 @@ def run_pooling_test(
     max_num_batched_tokens: int = 128,
     optimization_level: int = 0,
     use_2d_mesh: bool = False,
+    mesh_shape: list[int] | None = None,
 ):
     path = os.path.join(os.path.dirname(__file__), baseline_path)
     loaded_data = torch.load(path)
@@ -46,6 +47,7 @@ def run_pooling_test(
             "enable_const_eval": enable_const_eval,
             "optimization_level": optimization_level,
             "use_2d_mesh": use_2d_mesh,
+            "mesh_shape": mesh_shape,
         },
     }
     model = vllm.LLM(**llm_args)


### PR DESCRIPTION
### Ticket
#5223 

### Problem description
We want Gemma 4-31B through vLLM.

### What's changed
- Parameterized mesh shape
    - Mesh shapes were pre-defined, and for Galaxy it was `[4,8]`. This resulted in sharding across dim indivisible by 8. Now, mesh shape is parameterized and using `[8,4]` for Gemma 4.
- Parameterized test_tensor_parallel_generation_gemma4_31b to run on bhqh and bh galaxy

### Checklist
- [x] vLLM Model Test Nightly: https://github.com/tenstorrent/tt-xla/actions/runs/27699193354
- [x] Gemma 4 blackhole galaxy (basic test nightly experimental): https://github.com/tenstorrent/tt-xla/actions/runs/27699850119
