### PR TITLE
Remove some n300-llmbox models from benchmark CI

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -102,11 +102,6 @@
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b"
       },
       {
-        "name": "falcon3_7b_tp",
-        "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b_tp",
-        "runs-on": "n300-llmbox"
-      },
-      {
         "name": "falcon3_10b_tp",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_10b_tp",
         "runs-on": "n300-llmbox"
@@ -117,38 +112,8 @@
         "runs-on": "n300-llmbox"
       },
       {
-        "name": "ministral_8b_tp",
-        "pytest": "tests/benchmark/test_llms.py::test_ministral_8b_tp",
-        "runs-on": "n300-llmbox"
-      },
-      {
-        "name": "mistral_nemo_instruct_2407_tp",
-        "pytest": "tests/benchmark/test_llms.py::test_mistral_nemo_instruct_2407_tp",
-        "runs-on": "n300-llmbox"
-      },
-      {
         "name": "mistral_small_24b_instruct_2501_tp",
         "pytest": "tests/benchmark/test_llms.py::test_mistral_small_24b_instruct_2501_tp",
-        "runs-on": "n300-llmbox"
-      },
-      {
-        "name": "qwen_2_5_14b_instruct_tp",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_14b_instruct_tp",
-        "runs-on": "n300-llmbox"
-      },
-      {
-        "name": "qwen_2_5_coder_32b_instruct_tp",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_coder_32b_instruct_tp",
-        "runs-on": "n300-llmbox"
-      },
-      {
-        "name": "qwen_3_8b_tp",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_3_8b_tp",
-        "runs-on": "n300-llmbox"
-      },
-      {
-        "name": "qwen_3_14b_tp",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_3_14b_tp",
         "runs-on": "n300-llmbox"
       },
       {
@@ -169,11 +134,6 @@
       {
         "name": "gpt_oss_20b_tp",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp",
-        "runs-on": "n300-llmbox"
-      },
-      {
-        "name": "gpt_oss_20b_tp_batch_size_1",
-        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_batch_size_1",
         "runs-on": "n300-llmbox"
       },
       {


### PR DESCRIPTION
### Ticket
Addresses #4949

### Problem description
We should remove some n300-llmbox models from benchmark CI as we switch to qb2-blackhole machines.
Also, it will take some pressure of n300-llmbox CI machines mentioned here #4949.

### What's changed
Removed from regular n300-llmbox benchmarks:
- falcon3_7b_tp
- ministral_8b_tp
- mistral_nemo_instruct_2407_tp
- qwen_2_5_14b_instruct_tp
- qwen_2_5_coder_32b_instruct_tp
- qwen_3_8b_tp
- qwen_3_14b_tp
- gpt_oss_20b_tp_batch_size_1

We should consider switching to qb2-blackhole on vllm and accuracy (cc @dgolubovicTT ) benchmarks, and removing n300-llmbox models there as well.

### Checklist
- [ ] New/Existing tests provide coverage for changes
