### PR TITLE
Fix inflated number of devices when no tensors are sharded

### DIFF
--- a/pjrt_implementation/inc/api/module_builder/module_builder.h
+++ b/pjrt_implementation/inc/api/module_builder/module_builder.h
@@ -200,6 +200,8 @@ private:
   tt_pjrt_status runCompilerStableHLOPipeline(
       mlir::OwningOpRef<mlir::ModuleOp> &mlir_module,
       const std::vector<int64_t> &result_presharded,
+      const std::vector<mlir::tt::sharding_utils::MeshSharding>
+          &output_shardings,
       const std::optional<std::string> &export_path,
       const std::string &model_name = "",
       const std::optional<std::vector<uint32_t>> &current_mesh_shape =

--- a/pjrt_implementation/src/api/module_builder/module_builder.cc
+++ b/pjrt_implementation/src/api/module_builder/module_builder.cc
@@ -98,6 +98,19 @@ moduleHasAnyFuncArguments(const mlir::OwningOpRef<mlir::ModuleOp> &m) {
   return public_func_ops[0].getNumArguments() > 0;
 }
 
+// Returns true if any sharding genuinely partitions a tensor across devices
+// (`MeshShardType::Devices`). Replicate / presharded-replicate shardings do not
+// count, since they do not require a multi-device mesh.
+static bool anyShardedAcrossDevices(
+    const std::vector<mlir::tt::sharding_utils::MeshSharding> &shardings) {
+  return std::any_of(
+      shardings.begin(), shardings.end(),
+      [](const mlir::tt::sharding_utils::MeshSharding &sharding) {
+        return sharding.getShardType() ==
+               mlir::tt::ttcore::MeshShardType::Devices;
+      });
+}
+
 // Maps per-axis fabric config to TTNN mesh topology for CCL operations.
 static std::vector<mlir::tt::ttcore::Topology>
 fabricConfigToMeshTopology(const tt::runtime::MeshFabricConfig &fabricConfig) {
@@ -350,8 +363,9 @@ ModuleBuilder::buildModule(
                   : std::nullopt;
 
   status = runCompilerStableHLOPipeline(
-      mlir_module, result_presharded, compile_options.export_path,
-      compile_options.export_model_name, current_mesh_shape);
+      mlir_module, result_presharded, output_shardings,
+      compile_options.export_path, compile_options.export_model_name,
+      current_mesh_shape);
   if (!tt_pjrt_status_is_ok(status)) {
     return {status, nullptr};
   }
@@ -726,6 +740,7 @@ std::vector<int64_t> ModuleBuilder::collectResultPresharded(
 tt_pjrt_status ModuleBuilder::runCompilerStableHLOPipeline(
     mlir::OwningOpRef<mlir::ModuleOp> &mlir_module,
     const std::vector<int64_t> &result_presharded,
+    const std::vector<mlir::tt::sharding_utils::MeshSharding> &output_shardings,
     const std::optional<std::string> &export_path,
     const std::string &model_name,
     const std::optional<std::vector<uint32_t>> &current_mesh_shape) {
@@ -734,8 +749,18 @@ tt_pjrt_status ModuleBuilder::runCompilerStableHLOPipeline(
   mlir::tt::stablehlo::StableHLOPipelineOptions stablehlo_pipeline_options;
   stablehlo_pipeline_options.resultPresharded = result_presharded;
 
+  // A graph with no inputs inherits the full device mesh so that a genuinely
+  // distributed result lands on all devices (see #4439). But that is only
+  // correct when something is actually sharded across devices: a no-input graph
+  // that merely produces a replicated value (e.g. gemma's standalone
+  // `sqrt(hidden_size)` scalar normalizer) is executed on a single device, so
+  // stamping it with the full mesh inflates the device count and breaks
+  // execution with a "Device count mismatch" error. Only adopt the full mesh
+  // when a result is genuinely device-sharded; otherwise let it default to a
+  // single device.
   if (current_mesh_shape.has_value() && current_mesh_shape->size() == 2 &&
-      !moduleHasAnyFuncArguments(mlir_module)) {
+      !moduleHasAnyFuncArguments(mlir_module) &&
+      anyShardedAcrossDevices(output_shardings)) {
     stablehlo_pipeline_options.meshShape = {
         static_cast<int64_t>((*current_mesh_shape)[0]),
         static_cast<int64_t>((*current_mesh_shape)[1])};


### PR DESCRIPTION
Fixes https://github.com/tenstorrent/tt-xla/issues/5102.

On multi-device systems a class of single-device models (most single-device vLLM inference models such as phi, qwen, falcon, llama, mistral, and the bge_m3 embeddings) failed with "Device count mismatch: 1 vs N" and Error code 13. The root cause is PR #4439, which made any graph with no inputs inherit the full device mesh so a genuinely distributed no-input result would land on all devices; that is wrong for a no-input graph that merely produces a replicated value (for example gemma's standalone sqrt(hidden_size) embedding-normalizer scalar), which is executed on a single device, so stamping it with the full mesh inflated num_devices_to_utilize (for example to 4) while execution used 1 device. This change refines that behavior in runCompilerStableHLOPipeline (module_builder): a no-argument graph only adopts the full mesh shape when one of its results is genuinely sharded across devices, otherwise it defaults to a single device, which keeps the module mesh attribute consistent with the device count and avoids the mismatch.

Verified in CI that the single-device inference models which fail with this signature on current main pass on this branch on identical p150-perf hardware.