### PR TITLE
[Test Infra] Enable FIBO tensor-parallel inference

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -17,6 +17,10 @@ test_config:
     status: KNOWN_FAILURE_XFAIL
     reason: " Error: loc('compare.1209'): error: Compare operation is not supported in stablehlo-pipeline for meshes not 1x1 - https://github.com/tenstorrent/tt-mlir/issues/3497"
 
+  fibo/pytorch-Base-tensor_parallel-inference:
+    supported_archs: [n300-llmbox]
+    status: EXPECTED_PASSING
+
   gemma/pytorch-1.1_7B_IT-tensor_parallel-inference:
     supported_archs: [n300-llmbox, lb-blackhole]
     status: EXPECTED_PASSING


### PR DESCRIPTION
## Problem

FIBO (`briaai/FIBO`, ~12B-param DiT) runs out of DRAM on a single device —
`test_all_models_torch[fibo/pytorch-Base-single_device-inference]` fails with
`TT_FATAL: Out of Memory` on an ~8 GB DRAM buffer allocation.

## What's changed

Bring FIBO up across the n300-llmbox mesh with tensor parallelism:

- Add `fibo/pytorch-Base-tensor_parallel-inference` (`EXPECTED_PASSING`,
  `supported_archs: [n300-llmbox]`) to
  `tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml`.
- Uplift `third_party/tt_forge_models` to pick up the FIBO loader's
  `get_mesh_config` + `load_shard_spec` (Megatron-1D shard spec).

## Dependency

> ⚠️ Depends on **tenstorrent/tt-forge-models#739** (the FIBO shard spec).
> The submodule pointer here references that PR's branch commit. **Before
> merge**, re-point the uplift to the squashed/merged tt-forge-models SHA.

## Test

```
pytest -svv tests/runner/test_models.py::test_all_models_torch[fibo/pytorch-Base-tensor_parallel-inference] --arch n300-llmbox
# 1 passed in 927.36s on 8-chip n300-llmbox; PCC asserted vs CPU golden.
```
