### PR TITLE
Bring back gpt_oss_20b_tp_batch_size_1 and qwen_2_5_coder_32b_instruct_tp to benchmark CI

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -117,6 +117,11 @@
         "runs-on": "n300-llmbox"
       },
       {
+        "name": "qwen_2_5_coder_32b_instruct_tp",
+        "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_coder_32b_instruct_tp",
+        "runs-on": "n300-llmbox"
+      },
+      {
         "name": "qwen_3_32b_tp",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_32b_tp",
         "runs-on": "n300-llmbox"
@@ -134,6 +139,11 @@
       {
         "name": "gpt_oss_20b_tp",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp",
+        "runs-on": "n300-llmbox"
+      },
+      {
+        "name": "gpt_oss_20b_tp_batch_size_1",
+        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_batch_size_1",
         "runs-on": "n300-llmbox"
       },
       {


### PR DESCRIPTION
### Problem description
Some n300-llmbox models have been recently removed due to qb2-blackhole transition https://github.com/tenstorrent/tt-xla/commit/04310ef034808d3ddff598681eaf535fb07320ea

`gpt_oss_20b_tp_batch_size_1` and `qwen_2_5_coder_32b_instruct_tp` failed on n300-llmbox https://github.com/tenstorrent/tt-xla/issues/5207 and qb2-blackhole models will not be working until UMD fix gets uplifted https://github.com/tenstorrent/tt-xla/issues/5204.
This might take a lot of time, and it is likely these errors would be present on qb2-blackhole as well, so we should bring back these two models on n300-llmbox and continue our efforts on fixing them.

### What's changed

Added mentioned 2 models back to n300-llmbox benchmark CI.

### Checklist
- [ ] New/Existing tests provide coverage for changes
