### PR TITLE
[Benchmark] Fix GLM4.7 and Deepseek-v3.1 MoE shard specs

### DIFF
--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -2768,5 +2768,5 @@ def test_glm_4_7_tp_galaxy_4_layers(
         shard_spec_fn=_glm_4_7_shard_spec_fn,
         input_output_sharding_spec=("batch", None),
         kv_cache_sharding_spec=("batch", "model", None, None),
-        required_pcc=0.99, # Since this is only a 4 layer test, pcc lower than 0.99 likely indicates a larger full model regression
+        required_pcc=0.99,
     )

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -2588,7 +2588,7 @@ def test_gpt_oss_20b_tp_qb2(
 def _deepseek_v3_1_shard_spec_fn(model_loader, model):
     """Sharding specs for DeepSeek V3.1 on 4x8 galaxy mesh with TP 8, DP 4, EP 32."""
     from tt_torch.sparse_mlp import A2aSparseMLPWithSharedExperts
-    
+
     shard_specs = {}
 
     shard_specs[model.model.embed_tokens.weight] = (None, "model")

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -2587,6 +2587,8 @@ def test_gpt_oss_20b_tp_qb2(
 
 def _deepseek_v3_1_shard_spec_fn(model_loader, model):
     """Sharding specs for DeepSeek V3.1 on 4x8 galaxy mesh with TP 8, DP 4, EP 32."""
+    from tt_torch.sparse_mlp import A2aSparseMLPWithSharedExperts
+    
     shard_specs = {}
 
     shard_specs[model.model.embed_tokens.weight] = (None, "model")
@@ -2766,5 +2768,5 @@ def test_glm_4_7_tp_galaxy_4_layers(
         shard_spec_fn=_glm_4_7_shard_spec_fn,
         input_output_sharding_spec=("batch", None),
         kv_cache_sharding_spec=("batch", "model", None, None),
-        required_pcc=0.86,
+        required_pcc=0.99, # Since this is only a 4 layer test, pcc lower than 0.99 likely indicates a larger full model regression
     )

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -2216,7 +2216,7 @@ def test_deepseek_v3_2_exp_tp_galaxy_2_layers(
         experimental_kv_cache_dtype=None,
         optimization_level=0,
         trace_enabled=False,
-        required_pcc=-0.92,
+        required_pcc=0.92,
     )
 
 

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -2585,6 +2585,62 @@ def test_gpt_oss_20b_tp_qb2(
     )
 
 
+def _deepseek_v3_1_shard_spec_fn(model_loader, model):
+    """Sharding specs for DeepSeek V3.1 on 4x8 galaxy mesh with TP 8, DP 4, EP 32."""
+    shard_specs = {}
+
+    shard_specs[model.model.embed_tokens.weight] = (None, "model")
+    shard_specs[model.model.norm.weight] = ("model",)
+    shard_specs[model.lm_head.weight] = (None, "model")
+
+    for layer in model.model.layers:
+        sa = layer.self_attn
+        shard_specs[sa.q_a_proj.weight] = (None, "model")
+        shard_specs[sa.q_b_proj.weight] = ("model", None)
+        shard_specs[sa.kv_a_proj_with_mqa.weight] = (None, "model")
+        shard_specs[sa.kv_b_proj.weight] = ("model", None)
+        shard_specs[sa.o_proj.weight] = (None, "model")
+
+        shard_specs[layer.input_layernorm.weight] = ("model",)
+        shard_specs[layer.post_attention_layernorm.weight] = ("model",)
+
+        mlp = layer.mlp
+        if isinstance(mlp, A2aSparseMLPWithSharedExperts):
+            inner = mlp.mlp if hasattr(mlp, "mlp") else mlp
+            shard_specs[inner.router.gate.weight] = (None, "model")
+            shard_specs[inner.experts.gate_proj] = (
+                ("batch", "model"),
+                None,
+                None,
+            )
+            shard_specs[inner.experts.up_proj] = (
+                ("batch", "model"),
+                None,
+                None,
+            )
+            shard_specs[inner.experts.down_proj] = (
+                ("batch", "model"),
+                None,
+                None,
+            )
+            for bias_name in ("gate_proj_bias", "up_proj_bias", "down_proj_bias"):
+                b = getattr(inner.experts, bias_name, None)
+                if b is not None:
+                    shard_specs[b] = (("batch", "model"), None)
+
+            shared = getattr(mlp, "shared_experts", None)
+            if shared is not None:
+                shard_specs[shared.gate_proj.weight] = (None, "model")
+                shard_specs[shared.up_proj.weight] = (None, "model")
+                shard_specs[shared.down_proj.weight] = ("model", None)
+        else:
+            shard_specs[mlp.gate_proj.weight] = ("batch", "model")
+            shard_specs[mlp.up_proj.weight] = ("batch", "model")
+            shard_specs[mlp.down_proj.weight] = ("model", "batch")
+
+    return shard_specs
+
+
 # This test only runs 4 layers so we expect to see incoherent output
 def test_deepseek_v3_1_tp_galaxy_4_layers(
     output_file,
@@ -2615,6 +2671,7 @@ def test_deepseek_v3_1_tp_galaxy_4_layers(
         use_mla_cache=True,
         optimization_level=0,
         trace_enabled=False,
+        shard_spec_fn=_deepseek_v3_1_shard_spec_fn,
         required_pcc=0.96,
         experimental_kv_cache_dtype=None,
     )
@@ -2659,9 +2716,9 @@ def _glm_4_7_shard_spec_fn(model_loader, model):
         if isinstance(mlp, A2aSparseMLPWithSharedExperts):
             inner = mlp.mlp
             shard_specs[inner.router.gate.weight] = (None, None)
-            shard_specs[inner.experts.gate_proj] = (("model", "batch"), None, None)
-            shard_specs[inner.experts.up_proj] = (("model", "batch"), None, None)
-            shard_specs[inner.experts.down_proj] = (("model", "batch"), None, None)
+            shard_specs[inner.experts.gate_proj] = (("batch", "model"), None, None)
+            shard_specs[inner.experts.up_proj] = (("batch", "model"), None, None)
+            shard_specs[inner.experts.down_proj] = (("batch", "model"), None, None)
 
             shared = getattr(mlp, "shared_experts", None)
             if shared is not None:
@@ -2708,6 +2765,6 @@ def test_glm_4_7_tp_galaxy_4_layers(
         trace_enabled=False,
         shard_spec_fn=_glm_4_7_shard_spec_fn,
         input_output_sharding_spec=("batch", None),
-        kv_cache_sharding_spec=("batch", None, None, None),
+        kv_cache_sharding_spec=("batch", "model", None, None),
         required_pcc=0.86,
     )


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/5096

### Problem description
These models were both seeing low pcc for 4 layers that dropped significantly as more layers (4 -> 6) were run. Also, the graph for GLM4.7 contains a lot of `point_to_point` ops which is usually an indication of improper sharding.

### What's changed
Both models see a PCC improvement when the expert sharding switches from `("model", "batch")`  to `("batch", "model")`. 

**Deepseek-v3.1** with this change (before the regression tracked in https://github.com/tenstorrent/tt-xla/issues/5209) sees:
- 4 layers - `0.978 -> 0.998` prefill and `0.965 -> 0.999` decode
- 6 layers - `0.886 -> 0.992` prefill and `XX -> 0.996` decode

**GLM4.7** with this change compared to nightly:
- 4 layers - `0.935 -> 0.997` prefill and `0.859 -> 0.993` decode

I set `required_pcc=0.99`. Since this is only a 4 layer test, pcc lower than 0.99 usually indicates a larger full model regression.

Changing `kv_cache_sharding_spec=("batch", None, None, None)` to `kv_cache_sharding_spec=("batch", "model", None, None)` for GLM reduced the number of `point_to_points` from `2688` in prefill to `0` but had no effect on PCC.

**Deepseek-v3.2-exp** - fixed a typo in `required_pcc`. Nightly pcc is still above `0.92`.

### Checklist
- [x] New/Existing tests provide coverage for changes
