### PR TITLE
[Nightly][Galaxy] Force FABRIC_1D on WH galaxy and add per-job timeout

### DIFF
--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -372,23 +372,34 @@ jobs:
     - name: Collect Tests
       id: collect-tests
       shell: bash
+      env:
+        TIMEOUT_OVERRIDE: ${{ matrix.build.timeout }}
       run: |
         source venv/activate
         echo "Collecting tests for group ${{ matrix.build.group-id || 1}}..."
         python -m pytest --collect-only -q --disable-warnings ${{ env.BASE_PYTEST_CMD }} |& tee collected_tests.txt
 
-        # Check if any collected tests have notimeout marker
-        NOTIMEOUT_COUNT=$(python -m pytest --collect-only -q --disable-warnings -m notimeout $(grep "::" collected_tests.txt | tr '\n' ' ') 2>/dev/null | grep -c "::" || echo "0")
-        if [[ "$NOTIMEOUT_COUNT" -gt 0 ]]; then
-          echo "Found $NOTIMEOUT_COUNT tests with notimeout marker, using default timeout of 240 minutes"
-          ESTIMATED_DURATION=240
+        if [[ -n "$TIMEOUT_OVERRIDE" ]]; then
+          # Honor a per-job fixed timeout (minutes) from the test matrix preset,
+          # bypassing the duration-based estimate. Used when the duration-based
+          # estimate is unusable (e.g. tests missing from .test_durations, or a
+          # long outlier test that inflates the 3x safety margin).
+          echo "Using per-job timeout override of $TIMEOUT_OVERRIDE minutes"
+          ESTIMATED_DURATION=$TIMEOUT_OVERRIDE
         else
-          SCRIPT_OUTPUT=$(python .github/scripts/calculate_test_timeout.py \
-            --collected-output collected_tests.txt \
-            --durations-file .test_durations \
-            --default-timeout 240)
-          echo "$SCRIPT_OUTPUT"
-          ESTIMATED_DURATION=$(echo "$SCRIPT_OUTPUT" | tail -n 1)
+          # Check if any collected tests have notimeout marker
+          NOTIMEOUT_COUNT=$(python -m pytest --collect-only -q --disable-warnings -m notimeout $(grep "::" collected_tests.txt | tr '\n' ' ') 2>/dev/null | grep -c "::" || echo "0")
+          if [[ "$NOTIMEOUT_COUNT" -gt 0 ]]; then
+            echo "Found $NOTIMEOUT_COUNT tests with notimeout marker, using default timeout of 240 minutes"
+            ESTIMATED_DURATION=240
+          else
+            SCRIPT_OUTPUT=$(python .github/scripts/calculate_test_timeout.py \
+              --collected-output collected_tests.txt \
+              --durations-file .test_durations \
+              --default-timeout 240)
+            echo "$SCRIPT_OUTPUT"
+            ESTIMATED_DURATION=$(echo "$SCRIPT_OUTPUT" | tail -n 1)
+          fi
         fi
 
         echo "Estimated duration: $ESTIMATED_DURATION minutes"

--- a/.github/workflows/test-matrix-presets/basic-test-nightly-experimental.json
+++ b/.github/workflows/test-matrix-presets/basic-test-nightly-experimental.json
@@ -1,3 +1,3 @@
 [
-  { "runs-on": "galaxy-bh",           "name": "run_torch_bh_galaxy",   "dir": "./tests/torch",                            "test-mark": "nightly and bh_galaxy", "forked": true }
+  { "runs-on": "galaxy-bh",           "name": "run_torch_bh_galaxy",   "dir": "./tests/torch",                            "test-mark": "nightly and bh_galaxy", "forked": true, "timeout": 420 }
 ]

--- a/pjrt_implementation/src/api/client_instance.cc
+++ b/pjrt_implementation/src/api/client_instance.cc
@@ -521,18 +521,16 @@ ClientInstance::computeFabricConfig(const std::vector<uint32_t> &mesh_shape) {
                         : tt::runtime::FabricConfig::DISABLED;
     return tt::runtime::MeshFabricConfig{global, {}};
   }
-  // [Workaround] The Blackhole galaxy (UBB) lacks a both-axis wrap, so
-  // computeMeshFabricConfig's RING_RING is rejected as TORUS_XY by the
-  // TopologyMapper; force FABRIC_1D there. Other 32-device galaxies (e.g.
-  // Wormhole) have the wrap, so keep their auto-detected fabric.
-  bool is_blackhole = m_system_descriptor->chip_descs()->size() > 0 &&
-                      m_system_descriptor->chip_descs()->Get(0)->arch() ==
-                          ::tt::target::Arch::Blackhole;
-  if (is_blackhole && m_devices.size() == 32) {
+  // [Workaround] On a 32-device galaxy (UBB) the TopologyMapper rejects the
+  // auto-detected fabric: Blackhole lacks a both-axis wrap so RING_RING is
+  // rejected as TORUS_XY, and Wormhole fails with "Failed to add pinning
+  // constraints" (MGD vs physical topology). Force FABRIC_1D on both until the
+  // tt-metal topology mapper is fixed.
+  // See https://github.com/tenstorrent/tt-xla/issues/5210
+  if (m_devices.size() == 32) {
     LOG_F(WARNING,
-          "Auto-overriding fabric config to FABRIC_1D for the "
-          "32-device Blackhole galaxy (UBB); this is a workaround, not "
-          "expected behaviour.");
+          "Auto-overriding fabric config to FABRIC_1D for the 32-device galaxy "
+          "(UBB); this is a workaround, not expected behaviour.");
     return tt::runtime::MeshFabricConfig{tt::runtime::FabricConfig::FABRIC_1D,
                                          {}};
   }


### PR DESCRIPTION
### Ticket
1. [Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/5210#event-26800293987), 
2. [BlackHole Galaxy nightly experimental fail](https://github.com/tenstorrent/tt-xla/actions/runs/27597367074/job/81590486274)

### Problem description
1. it hits the same TopologyMapper pinning failure (#5210) that the Blackhole path already handles, and the (4,8) parent-mesh fix alone was not enough.
2. Also, since #5036, bh nightly fails due to timeout.

### What's changed
1. Extend the 32-device FABRIC_1D workaround to the Wormhole galaxy
2. Add a per-job 'timeout' (minutes) override in call-test.yml, honored by the bh_galaxy experimental preset (420). The duration-based estimate falls back to 240 because most bh_galaxy tests lack durations, and the deepseek e2e outlier would otherwise inflate the 3x margin.


### Checklist
- [ ] New/Existing tests provide coverage for changes
