### PR TITLE
Fix TT_RUNTIME_DEBUG compile-time variable propagation to PJRT callers 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ option(TTXLA_ENABLE_PJRT_TESTS "Enable PJRT tests" OFF)
 option(TTXLA_ENABLE_EWHEEL_INSTALL "Enable editable wheel install" ON)
 option(TTXLA_ENABLE_TOOLS "Enable building tools" ON)
 option(TTXLA_ENABLE_EMITPY_EXECUTION "Enable EmitPy execution via PythonModelRunner" ON)
+option(TT_RUNTIME_DEBUG "Enable ttmlir runtime debugging" OFF)
 option(TT_USE_SYSTEM_SFPI "Use system SFPI" OFF)
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(TTXLA_ENABLE_PJRT_TESTS ON)
@@ -60,6 +61,7 @@ set_property(CACHE TTMLIR_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "RelWith
 
 if(TTXLA_ENABLE_EXPLORER)
     set(TTMLIR_ENABLE_BINDINGS_PYTHON ON)
+    set(TT_RUNTIME_DEBUG ON)
 endif()
 
 option(TTXLA_TRACY_ZONES "Enable PJRT tracy zones" OFF)

--- a/pjrt_implementation/src/api/CMakeLists.txt
+++ b/pjrt_implementation/src/api/CMakeLists.txt
@@ -68,7 +68,10 @@ if(TTXLA_ENABLE_EMITPY_EXECUTION)
     target_link_libraries(TTPJRTApi PRIVATE tt-alchemist-python-runner)
 endif()
 
-target_compile_definitions(TTPJRTApi PRIVATE TTXLA_ENABLE_EMITPY_EXECUTION=$<BOOL:${TTXLA_ENABLE_EMITPY_EXECUTION}>)
+target_compile_definitions(TTPJRTApi PRIVATE
+    TTXLA_ENABLE_EMITPY_EXECUTION=$<BOOL:${TTXLA_ENABLE_EMITPY_EXECUTION}>
+    TT_RUNTIME_DEBUG=$<BOOL:${TT_RUNTIME_DEBUG}>
+)
 
 # Enable Tracy profiling if requested
 if(TTXLA_TRACY_ZONES)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -86,11 +86,6 @@ else()
     if(NOT DEFINED ENV{TT_METAL_RUNTIME_ROOT})
         set(WITH_METAL_RUNTIME_ROOT_SET "TT_METAL_RUNTIME_ROOT=${TTPJRT_SOURCE_DIR}/third_party/tt-mlir/src/tt-mlir/third_party/tt-metal/src/tt-metal")
     endif()
-    set(TT_RUNTIME_DEBUG ${TT_RUNTIME_DEBUG} CACHE BOOL "Enable ttmlir runtime debugging")
-    if(TTXLA_ENABLE_EXPLORER)
-        set(TT_RUNTIME_DEBUG ON)
-    endif()
-
     message(STATUS "ttmlir runtime debugging is set to: ${TT_RUNTIME_DEBUG}")
 
     ExternalProject_Add(


### PR DESCRIPTION
### Ticket
Related: Instrumentation for #3791 

### Problem description
1. TT_RUNTIME_DEBUG is a cmake variable set at compile time for the relevant TUs, it is consumed by users of tt/runtime/debug.h header. 

2. This header is used by two entities: 
  - libTTMLIRRuntime.so - mlir runtime dylib / callee
  - pjrt_plugin_tt.so - Specifically in PJRTApi cmake target / caller (in future)

3. The header has a compile time flag that will compile some debug APIs into stubs based on the setting of TT_RUNTIME_DEBUG. 

4. TT_RUNTIME_DEBUG was only set for the callee lib, not a potential PJRT caller, so PJRT will get stubs for some runtime debug functions while mlir lib internal calls will get the non-stubbed functions, which is very confusing differential behaviour. In particular on multihost, it results in the multihost workers being able to log to debug stats but the multihost controller getting empty debug stats.

### What's changed
Promote TT_RUNTIME_DEBUG to top-level cmake variable and propagate it to all users of debug headers. (In the future, `flatbuffer_loaded_executable_instance.cc` but this PR adds it to anything in PJRTApi target)

### Checklist
- [ ] New/Existing tests provide coverage for changes
