### PR TITLE
[CI] Fix p150-perf shared runner name

### DIFF
--- a/.github/scripts/filter-test-matrix.py
+++ b/.github/scripts/filter-test-matrix.py
@@ -112,7 +112,9 @@ def filter_matrix_adv(matrix, adv_filter):
 
 def update_runners(matrix, sh_runner):
     """Update runner names based on shared runner flag."""
-    runner_map = {"p150": "p150b"} if sh_runner else {"n150": "n150-perf"}
+    runner_map = (
+        {"p150": "p150b", "p150-perf": "p150b"} if sh_runner else {"n150": "n150-perf"}
+    )
 
     for item in matrix:
         item["runs-on-original"] = item.get("runs-on")

--- a/.github/scripts/generate_test_matrix.py
+++ b/.github/scripts/generate_test_matrix.py
@@ -23,6 +23,7 @@ def map_runner_name(entry):
         "n300-high-memory": "tt-ubuntu-2204-n300-stable",
         "wormhole_b0": "tt-ubuntu-2204-n300-stable",
         "p150": "tt-ubuntu-2204-p150b-stable",
+        "p150-perf": "tt-ubuntu-2204-p150b-stable",
         "n300-llmbox": "tt-ubuntu-2204-n300-llmbox-stable",
         "cpu": "tt-ubuntu-2204-large-stable",
     }


### PR DESCRIPTION
### Ticket

### Problem description
When p150-perf and shared runner are select on Performance Benchmark, workflow is stuck.

### What's changed
p150-perf gets correct shared runner name now, so it is not stuck

### Checklist
- [ ] New/Existing tests provide coverage for changes
https://github.com/tenstorrent/tt-xla/actions/runs/27626847393