### PR TITLE
[CI] Replace custom job_id action with built-in job.check_run_id

### DIFF
--- a/.github/workflows/call-build-debug.yml
+++ b/.github/workflows/call-build-debug.yml
@@ -33,12 +33,6 @@ jobs:
             submodules: recursive
             repository: 'tenstorrent/tt-xla'
 
-      - name: Fetch job ID
-        id: fetch-job-id
-        uses: tenstorrent/tt-github-actions/.github/actions/job_id@main
-        with:
-          job_name: "Build tt-xla (debug)"
-
       - name: Override tt-mlir SHA if mlir_override is set
         if: ${{ inputs.mlir_override }}
         shell: bash
@@ -52,7 +46,7 @@ jobs:
         run: |
             echo "work-dir=$(pwd)" >> "$GITHUB_OUTPUT"
             echo "build-output-dir=$(pwd)/build" >> "$GITHUB_OUTPUT"
-            echo "test-report-name=report_${{ steps.fetch-job-id.outputs.job_id }}.xml" >> "$GITHUB_OUTPUT"
+            echo "test-report-name=report_${{ job.check_run_id }}.xml" >> "$GITHUB_OUTPUT"
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.22
@@ -82,14 +76,14 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@v6
         with:
-          name: test-log-pjrt-unit-tests-${{ github.run_attempt }}-${{ steps.fetch-job-id.outputs.job_id }}
+          name: test-log-pjrt-unit-tests-${{ github.run_attempt }}-${{ job.check_run_id }}
           path: ${{ steps.strings.outputs.build-output-dir }}/ctest.log
 
       - name: Upload test report
         if: success() || failure()
         uses: actions/upload-artifact@v6
         with:
-            name: test-reports-pjrt-unit-tests-${{ github.run_attempt }}-${{ steps.fetch-job-id.outputs.job_id }}
+            name: test-reports-pjrt-unit-tests-${{ github.run_attempt }}-${{ job.check_run_id }}
             path: ${{ steps.strings.outputs.build-output-dir }}/${{ steps.strings.outputs.test-report-name }}
 
       - name: Show unit test report

--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -79,7 +79,6 @@ jobs:
 
     runs-on: ${{ !matrix.build.shared-runners && fromJson(format('["{0}", "in-service"]', matrix.build.runs-on)) || matrix.build.runs-on  }}
 
-    # Keep this name in sync with the fetch-job-id step
     name: "test ${{ matrix.build.test-mark }} (${{ matrix.build.runs-on }}, ${{ matrix.build.name }}, ${{ strategy.job-index }})"
 
     container:
@@ -100,12 +99,6 @@ jobs:
         SSH_AUTH_SOCK: /var/run/mpirun/id_rsa_multihost_ssh_agent_sock
 
     steps:
-
-    - name: Fetch job id
-      id: fetch-job-id
-      uses: tenstorrent/tt-github-actions/.github/actions/job_id@main
-      with:
-        job_name: "test ${{ matrix.build.test-mark }} (${{ matrix.build.runs-on }}, ${{ matrix.build.name }}, ${{ strategy.job-index }})"
 
     - name: Mark repo as safe for git
       run: |
@@ -161,7 +154,7 @@ jobs:
       id: strings
       shell: bash
       env:
-        JOB_ID: ${{ steps.fetch-job-id.outputs.job_id }}
+        JOB_ID: ${{ job.check_run_id }}
       run: |
         echo "work-dir=$(pwd)" >> "$GITHUB_OUTPUT"
         echo "build-output-dir=$(pwd)/build" >> "$GITHUB_OUTPUT"
@@ -409,7 +402,7 @@ jobs:
         python -m pytest ${{ env.VERBOSITY }} ${{ env.BASE_PYTEST_CMD }} \
           --junitxml=${{ steps.strings.outputs.test_report_path }} \
           --perf-report-dir=${{ steps.strings.outputs.perf_report_dir }} \
-          --perf-id=${{ steps.fetch-job-id.outputs.job_id }} \
+          --perf-id=${{ job.check_run_id }} \
           2>&1 | tee pytest.log
 
     # produce_cicd_data silently drops artifacts with spaces in the name, must replace spaces with underscores
@@ -425,7 +418,7 @@ jobs:
       uses: actions/upload-artifact@v6
       if: success() || failure()
       with:
-        name: test-log-${{ matrix.build.runs-on }}-${{ steps.sanitize.outputs.test_mark }}-${{ steps.fetch-job-id.outputs.job_id }}
+        name: test-log-${{ matrix.build.runs-on }}-${{ steps.sanitize.outputs.test_mark }}-${{ job.check_run_id }}
         path: pytest.log
         if-no-files-found: ignore
 
@@ -433,7 +426,7 @@ jobs:
       uses: actions/upload-artifact@v6
       if: success() || failure()
       with:
-        name: test-reports-${{ needs.generate-matrix-test.outputs.test_matrix_hash }}-${{ github.run_attempt }}.${{ strategy.job-index }}-${{ matrix.build.runs-on }}-${{ steps.sanitize.outputs.test_mark }}-${{ steps.fetch-job-id.outputs.job_id }}
+        name: test-reports-${{ needs.generate-matrix-test.outputs.test_matrix_hash }}-${{ github.run_attempt }}.${{ strategy.job-index }}-${{ matrix.build.runs-on }}-${{ steps.sanitize.outputs.test_mark }}-${{ job.check_run_id }}
         path: ${{ steps.strings.outputs.test_report_path }}
         if-no-files-found: ignore
 
@@ -442,7 +435,7 @@ jobs:
       uses: actions/upload-artifact@v6
       if: success() || failure()
       with:
-        name: perf-reports-${{ needs.generate-matrix-test.outputs.test_matrix_hash }}-${{ github.run_attempt }}.${{ strategy.job-index }}-${{ matrix.build.runs-on }}-${{ steps.sanitize.outputs.test_mark }}-${{ steps.fetch-job-id.outputs.job_id }}
+        name: perf-reports-${{ needs.generate-matrix-test.outputs.test_matrix_hash }}-${{ github.run_attempt }}.${{ strategy.job-index }}-${{ matrix.build.runs-on }}-${{ steps.sanitize.outputs.test_mark }}-${{ job.check_run_id }}
         path: ${{ steps.strings.outputs.perf_report_dir }}
         # If --perf-report-dir is not given, no files will be generated so this ignore is needed to avoid failing the job.
         if-no-files-found: 'ignore'
@@ -473,7 +466,7 @@ jobs:
       if: inputs.dump_irs && (success() || failure())
       uses: actions/upload-artifact@v6
       with:
-        name: ir-dumps-${{ needs.generate-matrix-test.outputs.test_matrix_hash }}-${{ github.run_attempt }}.${{ strategy.job-index }}-${{ matrix.build.runs-on }}-${{ steps.sanitize.outputs.test_mark }}-${{ steps.fetch-job-id.outputs.job_id }}
+        name: ir-dumps-${{ needs.generate-matrix-test.outputs.test_matrix_hash }}-${{ github.run_attempt }}.${{ strategy.job-index }}-${{ matrix.build.runs-on }}-${{ steps.sanitize.outputs.test_mark }}-${{ job.check_run_id }}
         path: collected_irs/
         if-no-files-found: ignore
 


### PR DESCRIPTION
## Summary
- Replace `tenstorrent/tt-github-actions/.github/actions/job_id@main` with the built-in `${{ job.check_run_id }}` context property in `call-test.yml` and `call-build-debug.yml`.
- Removes the dedicated `Fetch job id` step and the extra GitHub API lookup it performed — the check run ID is now read directly from the job context.

## Test plan
- [ ] Verify CI workflows succeed and that artifact / report names still include the expected numeric job ID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)