### PR TITLE
Add aten.histc decomposition (one_hot + sum)

### DIFF
--- a/python_package/tt_torch/backend/decompositions.py
+++ b/python_package/tt_torch/backend/decompositions.py
@@ -408,6 +408,27 @@ def _get_default_decomposition_ops() -> DecompositionOpsList:
     ]
 
 
+def histc(input, bins=100, min=0, max=0):
+    """Decomposition for aten.histc via one_hot + sum."""
+    # torch.histc: equal bounds (min == max, including the 0/0 default) mean "use the
+    # tensor's own range"; if that range is degenerate (constant input), widen by 1
+    # on each side -- matching aten's reference kernel:
+    # https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/cuda/SummaryOps.cu#L331
+    if min == max:
+        lo, hi = input.min(), input.max()
+        same = (lo == hi).to(input.dtype)
+        lo, hi = lo - same, hi + same
+    else:
+        lo, hi = min, max
+    x = input.flatten()
+    # bin index of each value; clamp pulls v == hi into the last bin.
+    idx = torch.floor((x - lo) / (hi - lo) * bins).to(torch.long).clamp(0, bins - 1)
+    # values outside [lo, hi] and NaN (compares False) are not counted.
+    valid = (x >= lo) & (x <= hi)
+    onehot = torch.nn.functional.one_hot(idx, bins).to(input.dtype)
+    return (onehot * valid.unsqueeze(-1).to(input.dtype)).sum(dim=0)
+
+
 def _get_custom_decompositions() -> DecompositionTable:
     aten = torch.ops.aten
     return {
@@ -445,6 +466,7 @@ def _get_custom_decompositions() -> DecompositionTable:
         torch.ops.aten.bitwise_or.Tensor: boolean_bitwise_or,
         aten.masked_scatter.default: masked_scatter,
         aten.sum.dim_IntList: sum_dim_IntList,
+        aten.histc.default: histc,
     }
 
 

--- a/tests/torch/ops/test_histc.py
+++ b/tests/torch/ops/test_histc.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Single-chip torch.histc op tests (histc is not sharded in DiffusionGemma)."""
+
+import pytest
+import torch
+from infra import ComparisonConfig, Framework, Workload
+from infra.testers.single_chip.op.op_tester import OpTester
+
+torch.manual_seed(0)
+
+
+class Histc(torch.nn.Module):
+    def __init__(self, bins, min, max):
+        super().__init__()
+        self.bins, self.min, self.max = bins, min, max
+
+    def forward(self, x):
+        return torch.histc(x, bins=self.bins, min=self.min, max=self.max)
+
+
+# (input, bins, min, max)
+CASES = [
+    (torch.randint(0, 128, (152,)).float(), 128, 0, 127),  # diffusion gemma case
+    (torch.randint(0, 128, (2048,)).float(), 128, 0, 127),  # diffusion gemma case
+    (torch.tensor([1.0, 2.0, 1.0]), 4, 0, 3),
+    (torch.linspace(0.0, 1.0, 50), 10, 0, 1),
+    (torch.tensor([-5.0, -0.1, 0.0, 1.5, 3.0, 4.0, 9.0]), 3, 0, 3),
+    (torch.tensor([0.0, 1.5, 3.0, 3.0]), 3, 0, 3),
+    (torch.tensor([0.0, float("nan"), 1.5, 3.0, 2.0]), 3, 0, 3),
+    (torch.linspace(-3.0, 3.0, 25), 6, -3, 3),
+    (torch.tensor([2.0]), 4, 0, 3),
+    (torch.rand(500) * 10.0, 256, 0, 10),
+    (torch.tensor([1.0, 5.0, 3.0, 9.0, 2.0, 8.0]), 5, 0, 0),
+    (torch.tensor([1.0, 5.0, 3.0, 9.0, 2.0, 8.0]), 5, 5, 5),
+    (torch.tensor([3.0, 3.0, 3.0]), 4, 0, 0),
+]
+
+
+@pytest.mark.parametrize("x, bins, min, max", CASES)
+def test_histc(x, bins, min, max):
+    tester = OpTester(comparison_config=ComparisonConfig(), framework=Framework.TORCH)
+    tester.test(
+        Workload(framework=Framework.TORCH, model=Histc(bins, min, max), args=[x])
+    )


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/5264

### Problem description

- `diffusiongemma-26B-A4B-it` crashes with `Fatal Python error: Segmentation fault`.
- `torch.histc` has no XLA/TTNN lowering, so torch_xla routes it to a CPU fallback. To move the op's inputs to CPU, the fallback force-materializes the in-flight (partial) XLA graph mid-stream, and compiling that partial graph segfaults inside torch_xla's `BuildStableHLOCompositePass` (in `_XLAC`). Full breakdown in the root-cause analysis of #5264.

### What's changed

- Added an `aten.histc` decomposition (`one_hot + sum`) in `python_package/tt_torch/backend/decompositions.py`, so `histc` lowers statically instead of falling back to CPU — this removes the mid-stream materialization and the segfault.
- Added `tests/torch/ops/test_histc.py` covering the model case plus histogram corner cases (fractional bins, out-of-range/NaN ignored, `value == max`, negative range, data-derived range).
- After this fix the model gets further and now fails with: `error: 'sdy.all_slice' op operates on axis "_axis_0" which is already bound by a parent sdy.manual_computation op`.


### Checklist
- [x] Verify the changes through local testing in n150

### Logs

- [jun17_diffgemma_before_fix.log](https://github.com/user-attachments/files/29102629/jun17_diffgemma_before_fix.log)
- [jun18_diffgemma_after_fix.log.zip](https://github.com/user-attachments/files/29102633/jun18_diffgemma_after_fix.log.zip)
- [jun22_histc_before_fix.log](https://github.com/user-attachments/files/29214089/jun22_histc_before_fix.log)
- [jun22_histc_after_fix.log](https://github.com/user-attachments/files/29214085/jun22_histc_after_fix.log)


