### PR TITLE
Playground v2.5: VAE on CPU until tenstorrent/tt-metal#46959 tracked by tt-xla

### DIFF
--- a/tests/benchmark/test_imagegen.py
+++ b/tests/benchmark/test_imagegen.py
@@ -92,14 +92,6 @@ def test_imagegen(
             json.dump(results, file, indent=2)
 
 
-@pytest.mark.xfail(
-    reason=(
-        "VAE compile TT_FATAL during warmup (cores harvested / device_hash mismatch), "
-        "possibly due to recent uplift — "
-        "https://github.com/tenstorrent/tt-xla/issues/5176"
-    ),
-    strict=False,
-)
 def test_playground_v2_5(output_file, request):
     from benchmarks.playground_v2_5_pipeline import (
         PlaygroundV25Config,
@@ -111,10 +103,13 @@ def test_playground_v2_5(output_file, request):
     height = width = 1024
 
     def build_pipeline_fn(compile_options):
-        # All 4 components on TT. compile_options forwarded into Config so the
-        # VAE-only opt_level switch can merge instead of clobbering.
+        # Text encoders + UNet on TT; VAE on CPU temporarily. Switching opt level
+        # mid-session (UNet opt 0 -> VAE opt 1) trips a device-hash mismatch
+        # (https://github.com/tenstorrent/tt-xla/issues/5176). Fixed in tt-metal
+        # https://github.com/tenstorrent/tt-metal/pull/46959.
+        # Keep the VAE on CPU until the fix is tracked by tt-xla.
         pipeline = PlaygroundV25Pipeline(
-            config=PlaygroundV25Config(compile_options=compile_options)
+            config=PlaygroundV25Config(vae_on_tt=False, compile_options=compile_options)
         )
         pipeline.setup()
 
@@ -139,9 +134,8 @@ def test_playground_v2_5(output_file, request):
         height=height,
         width=width,
         # opt_level=0 for text encoders + UNet (text_encoder 1 hits
-        # "Unsupported buffer type" at opt_level=1). VAE switches to
-        # opt_level=1 inline (and resets after) because GroupNorm
-        # decomposition at opt_level=0 OOMs the VAE.
+        # "Unsupported buffer type" at opt_level=1). VAE runs on CPU so no
+        # opt level switch is needed here.
         optimization_level=0,
         output_image_path="test_playground_v2_5_output.png",
     )
@@ -163,8 +157,9 @@ def test_sdxl_lightning(output_file, request):
         # decomposition at opt_level=0; opt_level=1 enables the composite
         # ttnn.group_norm which lets the VAE pass, but switching opt level
         # (UNet opt 0 -> VAE opt 1) trips a device-hash mismatch
-        # (https://github.com/tenstorrent/tt-xla/issues/5176). So keep the VAE on
-        # CPU until tt-metal https://github.com/tenstorrent/tt-metal/pull/46959 lands.
+        # (https://github.com/tenstorrent/tt-xla/issues/5176).
+        # Fixed in tt-metal https://github.com/tenstorrent/tt-metal/pull/46959.
+        # Keep the VAE on CPU until the fix is tracked by tt-xla.
         pipeline = SDXLLightningPipeline(
             config=SDXLLightningConfig(vae_on_tt=False, compile_options=compile_options)
         )

--- a/tests/torch/models/playground_v2_5/test_playground_v2_5_pipeline.py
+++ b/tests/torch/models/playground_v2_5/test_playground_v2_5_pipeline.py
@@ -374,7 +374,12 @@ def run_playground_v25_pipeline(
     num_inference_steps: int = 50,
 ):
     """Run Playground v2.5 pipeline and save output image."""
-    config = PlaygroundV25Config(device="cpu")
+    # Text encoders + UNet on TT; VAE on CPU temporarily. Switching opt level
+    # mid-session (UNet opt 0 -> VAE opt 1) trips a device-hash mismatch
+    # (https://github.com/tenstorrent/tt-xla/issues/5176).
+    # Fixed in tt-metal https://github.com/tenstorrent/tt-metal/pull/46959.
+    # Keep the VAE on CPU until the fix is tracked by tt-xla.
+    config = PlaygroundV25Config(device="cpu", vae_on_tt=False)
     pipeline = PlaygroundV25Pipeline(config=config)
     pipeline.setup()
 
@@ -390,14 +395,6 @@ def run_playground_v25_pipeline(
     return output_path
 
 
-@pytest.mark.xfail(
-    reason=(
-        "VAE compile TT_FATAL during warmup (cores harvested / device_hash mismatch), "
-        "possibly due to recent uplift — "
-        "https://github.com/tenstorrent/tt-xla/issues/5176"
-    ),
-    strict=False,
-)
 @pytest.mark.nightly
 @pytest.mark.model_test
 @pytest.mark.single_device


### PR DESCRIPTION
### Ticket

closes https://github.com/tenstorrent/tt-xla/issues/5284

### Problem description
Playground v2.5 e2e tests (benchmark + nightly) were xfailed because the VAE OOMs at opt_level=0 (GroupNorm decomposition) and switching opt_level mid-session (UNet opt 0 -> VAE opt 1) trips a device-hash mismatch in tt-metal's BuildEnvManager singleton (#5176). The tt-metal fix is merged (tenstorrent/tt-metal#46959) but the submodule bump isn't in tt-xla yet.`@pytest.mark.xfail` markers can be removed so the rest of the pipeline runs and passes until the fix is tracked in tt-xla.

### What's changed
Moved VAE to CPU in both Playground v2.5 e2e tests (benchmark + nightly), mirroring `sdxl_lightning_pipeline.py`. Text encoders + UNet still run on TT and produce real benchmark numbers / nightly signal; only the VAE decode falls back to CPU. Removed the `@pytest.mark.xfail` markers so the rest of the pipeline runs and passes until the fix is tracked in tt-xla.

### Checklist

- [x] Performance Benchmark - [n150](https://github.com/tenstorrent/tt-xla/actions/runs/27805299028/job/82287248167) , [p150-perf](https://github.com/tenstorrent/tt-xla/actions/runs/27805327547/job/82287298465)
- [x] Nightly test on Run Test single - [n150](https://github.com/tenstorrent/tt-xla/actions/runs/27805614953/job/82288337129)
