### PR TITLE
Skip gpt_oss_20b_tp perf test on n300-llmbox

### DIFF
--- a/.github/scripts/filter-test-matrix.py
+++ b/.github/scripts/filter-test-matrix.py
@@ -13,6 +13,8 @@ def flatten_matrix(data):
     for proj in data:
         test_defaults = proj.get("test-defaults", {})
         for test in proj.get("tests", []):
+            if test.get("skip"):
+                continue
             merged_test = {**test_defaults, **test, "project": proj["project"]}
 
             runs_on = merged_test.get("runs-on", [])

--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -143,7 +143,8 @@
       {
         "name": "gpt_oss_20b_tp",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp",
-        "runs-on": "n300-llmbox"
+        "runs-on": "n300-llmbox",
+        "skip": true
       },
       {
         "name": "gpt_oss_20b_tp_batch_size_1",


### PR DESCRIPTION
## What

Disable the `gpt_oss_20b_tp` perf benchmark on `n300-llmbox` as it causing 6h hangs and blocking the CI.

Example
https://github.com/tenstorrent/tt-xla/actions/runs/27728913468/job/82031418298
