### PR TITLE
Fix runner label mapping logic in perf tests

### DIFF
--- a/.github/scripts/filter-test-matrix.py
+++ b/.github/scripts/filter-test-matrix.py
@@ -112,23 +112,19 @@ def filter_matrix_adv(matrix, adv_filter):
     return filtered_matrix
 
 
-def update_runners(matrix):
-    """Update runner names based on shared runner flag."""
-    runner_map = {"p150-perf": "p150b", "n150-perf": "n150"}
+def update_runners(matrix, sh_runner):
+    """Resolve each test's final ``runs-on`` label and shared-runner flag."""
+    no_shared_runner = ("galaxy-wh-6u", "qb2-blackhole")
+    civ2_name_map = {"n150-perf": "n150", "p150-perf": "p150b"}
 
-    for item in list(matrix):
+    for item in matrix:
         runs_on = item.get("runs-on")
-        if runs_on in ("galaxy-wh-6u", "qb2-blackhole"):
-            print(
-                f"::warning::Requested runner '{runs_on}' is not available in the shared runners pool. Removing test '{item.get('name', 'unknown')}' from matrix.",
-                file=sys.stderr,
-            )
-            matrix.remove(item)
-            continue
-
         item["runs-on-original"] = runs_on
-        if runs_on in runner_map:
-            item["runs-on"] = runner_map[runs_on]
+        item["shared-runners"] = sh_runner and runs_on not in no_shared_runner
+        if item["shared-runners"]:
+            item["runs-on"] = (
+                f"tt-ubuntu-2204-{civ2_name_map.get(runs_on, runs_on)}-stable"
+            )
 
 
 def main():
@@ -150,8 +146,7 @@ def main():
         matrix = flatten_matrix(data)
         filtered = filter_matrix_adv(matrix, adv_filter)
 
-        if args.sh_runner:
-            update_runners(filtered)
+        update_runners(filtered, args.sh_runner)
 
         if not filtered:
             print("Error: No matching tests found", file=sys.stderr)

--- a/.github/scripts/filter-test-matrix.py
+++ b/.github/scripts/filter-test-matrix.py
@@ -112,18 +112,23 @@ def filter_matrix_adv(matrix, adv_filter):
     return filtered_matrix
 
 
-def update_runners(matrix, sh_runner):
+def update_runners(matrix):
     """Update runner names based on shared runner flag."""
-    runner_map = (
-        {"p150": "p150b", "p150-perf": "p150b"} if sh_runner else {"n150": "n150-perf"}
-    )
+    runner_map = {"p150-perf": "p150b", "n150-perf": "n150"}
 
-    for item in matrix:
-        item["runs-on-original"] = item.get("runs-on")
-        if item.get("runs-on") in runner_map:
-            item["runs-on"] = runner_map[item["runs-on"]]
+    for item in list(matrix):
+        runs_on = item.get("runs-on")
+        if runs_on in ("galaxy-wh-6u", "qb2-blackhole"):
+            print(
+                f"::warning::Requested runner '{runs_on}' is not available in the shared runners pool. Removing test '{item.get('name', 'unknown')}' from matrix.",
+                file=sys.stderr,
+            )
+            matrix.remove(item)
+            continue
 
-    return matrix
+        item["runs-on-original"] = runs_on
+        if runs_on in runner_map:
+            item["runs-on"] = runner_map[runs_on]
 
 
 def main():
@@ -145,7 +150,8 @@ def main():
         matrix = flatten_matrix(data)
         filtered = filter_matrix_adv(matrix, adv_filter)
 
-        update_runners(filtered, args.sh_runner)
+        if args.sh_runner:
+            update_runners(filtered)
 
         if not filtered:
             print("Error: No matching tests found", file=sys.stderr)

--- a/.github/workflows/call-filtered-perf-tests.yml
+++ b/.github/workflows/call-filtered-perf-tests.yml
@@ -105,5 +105,4 @@ jobs:
       torchxla_build_run_id: ${{ inputs.torchxla_build_run_id }}
       skip-device-perf: ${{ inputs.skip-device-perf || false }}
       regression_check: ${{ inputs.regression_check || false }}
-      sh-runner: ${{ inputs.sh-runner || false }}
       check_fusions: ${{ inputs.check_fusions }}

--- a/.github/workflows/call-perf-test.yml
+++ b/.github/workflows/call-perf-test.yml
@@ -39,11 +39,6 @@ on:
         required: false
         type: boolean
         default: false
-      sh-runner:
-        description: "Use shared runner"
-        required: false
-        type: boolean
-        default: false
       check_fusions:
         description: "Verify expected fusion ops are present in compiled IR"
         required: false
@@ -64,12 +59,12 @@ jobs:
       matrix:
         build: ${{ fromJson(inputs.matrix) }}
 
-    runs-on: ${{ !inputs.sh-runner && fromJson(format('["{0}", "in-service"]', matrix.build.runs-on)) || format('tt-ubuntu-2204-{0}-stable', matrix.build.runs-on) }}
+    runs-on: ${{ !matrix.build.shared-runners && fromJson(format('["{0}", "in-service"]', matrix.build.runs-on)) || matrix.build.runs-on }}
 
     name: "perf ${{ matrix.build.name }} (${{ matrix.build.runs-on-original || matrix.build.runs-on }})"
 
     container:
-      image: ${{ !inputs.sh-runner && inputs.docker_image || format('harbor.ci.tenstorrent.net/{0}', inputs.docker_image) }}
+      image: ${{ !matrix.build.shared-runners && inputs.docker_image || format('harbor.ci.tenstorrent.net/{0}', inputs.docker_image) }}
       options: --device /dev/tenstorrent
       volumes:
         - /dev/hugepages:/dev/hugepages
@@ -87,7 +82,7 @@ jobs:
     - name: Set caching env variables
       shell: bash
       run: |
-        if [[ "${{ inputs.sh-runner }}" == "false" || "${{ inputs.sh-runner }}" == "" ]]; then
+        if [[ "${{ matrix.build.shared-runners }}" != "true" ]]; then
           echo "DOCKER_CACHE_ROOT=/mnt/dockercache" >> $GITHUB_ENV
         fi
 

--- a/.github/workflows/manual-benchmark.yml
+++ b/.github/workflows/manual-benchmark.yml
@@ -17,7 +17,7 @@ on:
         type: choice
         options:
           - All
-          - n150
+          - n150-perf
           - p150-perf
           - n300-llmbox
           - galaxy-wh-6u

--- a/.github/workflows/manual-benchmark.yml
+++ b/.github/workflows/manual-benchmark.yml
@@ -22,7 +22,7 @@ on:
           - n300-llmbox
           - galaxy-wh-6u
           - qb2-blackhole
-        default: n150
+        default: n150-perf
       skip-device-perf:
         description: "Skip device performance measurement"
         required: false

--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -3,7 +3,7 @@
     "project": "tt-xla",
     "test-defaults": {
       "runs-on": [
-        "n150",
+        "n150-perf",
         "p150-perf"
       ],
       "dir": "",

--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -79,7 +79,7 @@ jobs:
       #   - vllm_llama_3_1_70b_tp (n300-llmbox): temporarily removed from On PR because flaky, tracked in issue #5294
       adv_filter: '[
         { "accuracy-testing": false },
-        { "runs-on": "n150", "filter": ["resnet","qwen_3_4b_embedding"] },
+        { "runs-on": "n150-perf", "filter": ["resnet","qwen_3_4b_embedding"] },
         { "runs-on": "n300-llmbox", "filter": ["test_llama_3_1_70b_tp"] } ]'
       sh-runner: false
       skip-device-perf: true

--- a/.github/workflows/schedule-benchmark-experimental.yml
+++ b/.github/workflows/schedule-benchmark-experimental.yml
@@ -30,7 +30,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/call-filtered-perf-tests.yml
     with:
-      adv_filter: '[ {"runs-on": "n150", "accuracy-testing": true} ]'
+      adv_filter: '[ {"runs-on": "n150-perf", "accuracy-testing": true} ]'
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
       sh-runner: true

--- a/.github/workflows/schedule-nightly.yml
+++ b/.github/workflows/schedule-nightly.yml
@@ -89,7 +89,7 @@ jobs:
       sh-runner: false
       skip-device-perf: true
       regression_check: true
-      adv_filter: '[ {"accuracy-testing": false}, {"runs-on": "n150"}, {"runs-on": "p150-perf"}, {"runs-on": "n300-llmbox"}, {"runs-on": "galaxy-wh-6u"}, {"runs-on": "qb2-blackhole"} ]'
+      adv_filter: '[ {"accuracy-testing": false}, {"runs-on": "n150-perf"}, {"runs-on": "p150-perf"}, {"runs-on": "n300-llmbox"}, {"runs-on": "galaxy-wh-6u"}, {"runs-on": "qb2-blackhole"} ]'
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
       wheel_build: manylinux


### PR DESCRIPTION
### Ticket
/

### Problem description
Users are allowed to choose an architecture for runners that don't exist in civ2. The job will wait for a runner that doesn't exist until it times out.

### What's changed
If perf benchmark test tries to be ran on qb2-blackhole or galaxy-wh-6u on shared runners, the job will throw a warning visible in the github UI and remove the tests that use that arch from the workflow (other jobs will execute normally).

### Checklist
Note:
Ran a few test runs but all are stuck waiting on cpu runners from civ2, will wait for them to finish and be successful before merging.
