### PR TITLE
Reduce DeepSeek-V4 e2e PCC test to 10 layers on BH Galaxy

### DIFF
--- a/tests/torch/models/deepseek_v4/test_deepseek_v4_e2e.py
+++ b/tests/torch/models/deepseek_v4/test_deepseek_v4_e2e.py
@@ -166,9 +166,12 @@ def transformer_shard_spec(model: mdo.Transformer):
 @pytest.mark.bh_galaxy
 @pytest.mark.parametrize("model_name", ["deepseek-ai/DeepSeek-V4-Flash"])
 @pytest.mark.parametrize("num_iterations", [10])
+@pytest.mark.parametrize("num_layers", [10])
 @pytest.mark.parametrize("use_cpu_decode_inputs", [True])
 @torch.inference_mode()
-def test_prefill_and_decode_pcc_e2e(model_name, num_iterations, use_cpu_decode_inputs):
+def test_prefill_and_decode_pcc_e2e(
+    model_name, num_iterations, num_layers, use_cpu_decode_inputs
+):
     enable_spmd()
     xr.set_device_type("TT")
 
@@ -178,6 +181,12 @@ def test_prefill_and_decode_pcc_e2e(model_name, num_iterations, use_cpu_decode_i
     assert bsz == 32, "Batch size must be 32 (restriction comes from enable_sparse_mlp)"
 
     args = weight_loader.load_config_args(model_name, False)
+
+    # Run only the first `num_layers` blocks. The full 43-layer model takes
+    # ~4.5hr on BH Galaxy CI, blowing past the job timeout; the reduced depth
+    # keeps wall time under an hour while still exercising the e2e path.
+    # Revert to the full layer count once BH Galaxy CI is stabilized.
+    args.n_layers = num_layers
 
     args.n_mtp_layers = 0  # Disable multi-token prediction
     args.max_batch_size = bsz


### PR DESCRIPTION
### Problem description
Bh glx CI is [failed](https://github.com/tenstorrent/tt-xla/actions/runs/27808093755/job/82295382992) due to timeout.

### What's changed
The full 43-layer test_prefill_and_decode_pcc_e2e run takes ~4.5hr on BH Galaxy CI, which is the main driver of the nightly job timing out. Restricting it to the first 10 layers brings the wall time under an hour while still covering the prefill+decode e2e path. The full-model functional coverage remains in test_deepseek_v4_e2e_streaming.

This is a temporary reduction; revert to the full layer count once BH Galaxy CI is stabilized.

### Checklist
- [ ] New/Existing tests provide coverage for changes
