### PR TITLE
vllm: Skip extract_nodes_info unless XLA_HLO_DEBUG=1 for compile time speedup

### DIFF
--- a/python_package/tt_torch/backend/backend.py
+++ b/python_package/tt_torch/backend/backend.py
@@ -103,8 +103,9 @@ def torch_pass_pipeline(
     # passes are reflected during execution.
     compiled_graph.recompile()
 
-    # Extract metadata from FX nodes in order to inject them into locs
-    node_info = extract_nodes_info(compiled_graph)
+    # Extract metadata from FX nodes in order to inject them into locs; only needed when XLA_HLO_DEBUG=1.
+    hlo_debug = os.environ.get("XLA_HLO_DEBUG", "0") == "1"
+    node_info = extract_nodes_info(compiled_graph) if hlo_debug else {}
 
     return compiled_graph, program.graph_signature, node_info
 


### PR DESCRIPTION
### Ticket
#5298 

### Problem description
- `torch_pass_pipeline` calls `extract_nodes_info()` on every compiled graph. That function does a per-FX-node AST walk — it opens and `ast.parse`s the enclosing source file (twice per `call_function` node, once in "simple" and once in "ast" mode) to build location metadata. The result (`node_info`) is only ever consumed by `MetadataInterpreter` in `XLAExecutor`, which runs solely when `XLA_HLO_DEBUG=1`. 
- With the flag unset (the default, and the production/benchmark path) the metadata is computed and then discarded, so it is pure wasted front-end compile time paid for every graph.

### What's changed
- `python_package/tt_torch/backend/backend.py`: gate the `extract_nodes_info()` call on `XLA_HLO_DEBUG=1`, returning an empty `node_info` otherwise. Matches the flag the sole consumer already keys off, so there is no behavior change when the flag is unset (`node_info` is inert there).

### Measured
Measured at commit `4fe5a22ce` (6/12) on a p150, warm cache, opt=1, trace=1, bfp8 KV:
- llama-3.1-8b @ 4096: engine init 868.8s → 799.3s (−8.0%).
- llama-3.2-1b @ 4096: backbone precompile 387.2s → 358.2s (−7.5%).
- Decode throughput and TTFT unchanged — the win is purely removing discarded front-end work.

### Checklist
- [x] Confirmed no behavior change with `XLA_HLO_DEBUG` unset (metadata is only consumed when the flag is set)
- [x] Spot-checked that `XLA_HLO_DEBUG=1` still produces location metadata in the HLO

