### PR TITLE
vLLM Falcon3-7B removing num_hidden_layers config from test

### DIFF
--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -188,7 +188,9 @@ SINGLE_DEVICE_CONFIGS = [
 TP_CONFIGS = [
     pytest.param(
         _tp_config(
-            "tiiuae/Falcon3-7B-Base", 32, mesh_shape=[2, 4],
+            "tiiuae/Falcon3-7B-Base",
+            32,
+            mesh_shape=[2, 4],
         ),
         id="falcon3-7b-tp",
     ),

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -188,7 +188,7 @@ SINGLE_DEVICE_CONFIGS = [
 TP_CONFIGS = [
     pytest.param(
         _tp_config(
-            "tiiuae/Falcon3-7B-Base", 32, mesh_shape=[2, 4], num_hidden_layers=4
+            "tiiuae/Falcon3-7B-Base", 32, mesh_shape=[2, 4],
         ),
         id="falcon3-7b-tp",
     ),


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Previous PR #5159 accidentally set `num_hidden_layers=4` for `falcon-3-7b` in `test_vllm_benchmarks.py`. Didn't get caught in reviews.

### What's changed
Removed the config from the test.

### Checklist
- [x] vllm perf test for falcon3 7b: https://github.com/tenstorrent/tt-xla/actions/runs/27852497445
