### PR TITLE
[WAN 2.2] Path for sp DiT sharding 

### DIFF
--- a/tests/torch/models/wan14b/monkey_patch.py
+++ b/tests/torch/models/wan14b/monkey_patch.py
@@ -70,12 +70,13 @@ def _patch_pad_seq_len_to_tile_aligned(tile: int = 32) -> None:
         if pad_amount > 0:
             # hidden_states: (B, S, D) — pad last-but-one dim on the right.
             hidden_states = F.pad(hidden_states, (0, 0, 0, pad_amount))
+            # NOTE: the rope freqs are padded to the same length by the SP rope
+            # hook (apply_dit_sp_activation_sharding._rope_hook), which pads them
+            # WHILE REPLICATED before sharding. Padding them here would happen
+            # after they're already SP-sharded and pile all padding onto the last
+            # shard (uneven shards). So we only carry the true (unpadded) length
+            # for K/V slicing in the attention processor.
             freqs_cos, freqs_sin = rotary_emb
-            # freqs: (1, S, 1, head_dim) — pad dim 1 on the right.
-            freqs_cos = F.pad(freqs_cos, (0, 0, 0, 0, 0, pad_amount))
-            freqs_sin = F.pad(freqs_sin, (0, 0, 0, 0, 0, pad_amount))
-            # Pack unpadded seq_len into the rotary_emb tuple so the patched
-            # attention processor can recover it without globals.
             rotary_emb = (freqs_cos, freqs_sin, unpadded_seq_len)
 
         # ----- everything below is unchanged from the original forward -----

--- a/tests/torch/models/wan14b/shared.py
+++ b/tests/torch/models/wan14b/shared.py
@@ -572,6 +572,20 @@ def apply_dit_sp_activation_sharding(dit, mesh: Mesh) -> None:
     """
     from tt_torch.sharding import sharding_constraint_hook, sharding_constraint_tensor
 
+    from .monkey_patch import _patch_pad_seq_len_to_tile_aligned
+
+    # SP shards the patchified sequence dim L. For the SP scatter (ttnn.mesh_partition)
+    # and the distributed reductions to stay tile-aligned, the padded L must be a
+    # multiple of SP*32, so each of the SP shards is a whole number of 32-row tiles.
+    # Pad to that target in two coordinated places, both keyed off `tile`:
+    #   - hidden_states: _patch_pad_seq_len_to_tile_aligned (model forward + K/V slice)
+    #   - rope freqs: the _rope_hook below (while replicated, before the SP shard)
+    # Both pads live here so the benchmark and the correctness suite get the fix
+    # purely by calling apply_dit_sp_activation_sharding (no per-test wiring).
+    sp = mesh.shape()[SP_AXIS]
+    tile = sp * 32
+    _patch_pad_seq_len_to_tile_aligned(tile=tile)
+
     def _block_entry_pre_hook(module, args):
         hidden_states = args[0]
         hidden_states = sharding_constraint_tensor(
@@ -585,13 +599,24 @@ def apply_dit_sp_activation_sharding(dit, mesh: Mesh) -> None:
     dit.blocks[0].register_forward_pre_hook(_block_entry_pre_hook)
 
     def _rope_hook(module, input, output):
+        import torch.nn.functional as F
+
         freqs_cos, freqs_sin = output
+        # Replicated anchor (terminates the reshape back-propagation).
         freqs_cos = sharding_constraint_tensor(
             freqs_cos, mesh, (None, None, None, None)
         )
         freqs_sin = sharding_constraint_tensor(
             freqs_sin, mesh, (None, None, None, None)
         )
+        # Pad L to `tile` (= SP*32) WHILE REPLICATED, so the SP shard below splits
+        # into whole 32-row tiles — same target as the hidden_states pad in
+        # _patch_pad_seq_len_to_tile_aligned. Padding a sharded dim would pile all
+        # padding on the last shard (uneven), so it must happen before the SP shard.
+        pad = (-freqs_cos.shape[1]) % tile
+        if pad:
+            freqs_cos = F.pad(freqs_cos, (0, 0, 0, 0, 0, pad))
+            freqs_sin = F.pad(freqs_sin, (0, 0, 0, 0, 0, pad))
         freqs_cos = sharding_constraint_tensor(
             freqs_cos, mesh, (None, SP_AXIS, None, None)
         )


### PR DESCRIPTION
### Problem description

On a 32-device Blackhole galaxy the WAN 2.2 DiT shards the token dim `L` across the 8-way SP axis. When `L`/`SP` isn't a multiple of the `32×32` tile size, the SP scatter (`ttnn.mesh_partition`) does a per-device local slice with a tile-unaligned begin and hits `TT_FATAL: Can only slice tilized tensor with height begin index aligned to tiles`. This blocks the 720p sharded DiT.

### What's changed

Pad the post-patchify sequence length to a multiple of `SP*32` so every SP shard is a whole number of tiles, then slice back before unpatchify. The padding is applied for both `hidden_states` (model forward) and the rope `freqs` (padded while replicated, before the SP shard), wired in one place (`apply_dit_sp_activation_sharding`) so both the `benchmark` and the `funcionality` tests can pick it up with no per-test changes.

This slows down the model, you can check more details [here](https://github.com/tenstorrent/tt-xla/discussions/5081#discussioncomment-17389509), but is necessary if we want to run 720p sharded on galaxy at all.
