### PR TITLE
[vLLM] Fix runner to use correct sampling graph for cpu sampling

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -2068,7 +2068,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     bitmasks,
                 )
 
-            selected_token_ids = self.sample_from_logits(logits, sampling_metadata)
+            selected_token_ids = self.sample_from_logits_cpu(logits, sampling_metadata)
 
         return hidden_states, logits, selected_token_ids, kv_connector_output
 

--- a/tests/integrations/vllm_plugin/sampling/test_cpu_sampling.py
+++ b/tests/integrations/vllm_plugin/sampling/test_cpu_sampling.py
@@ -56,7 +56,7 @@ def test_cpu_sampling_greedy():
 
 
 @pytest.mark.single_device
-@pytest.mark.nightly
+@pytest.mark.push
 def test_cpu_sampling_temperature():
     """Non-greedy temperature sampling produces coherent output."""
     params = vllm.SamplingParams(temperature=0.6, max_tokens=32)


### PR DESCRIPTION
### Ticket
closes #5315 

### Problem description
Incorrect sampling graph is utilized for cpu sampling. This bug was introduced in https://github.com/tenstorrent/tt-xla/pull/5316

### What's changed
- Use correct sampling graph for cpu sampling.
- Run one cpu sampling test on Push.

### Checklist
- [X] New/Existing tests provide coverage for changes
