### PR TITLE
[pjrt] fix prepare inputs for codegen

### DIFF
--- a/pjrt_implementation/inc/api/so_loaded_executable_instance.h
+++ b/pjrt_implementation/inc/api/so_loaded_executable_instance.h
@@ -48,8 +48,7 @@ public:
 private:
   // Returns an input tensor constructed from the provided buffer instances,
   // prepared for execution. The generated Python (SO) entrypoint expects host
-  // row-major inputs, so the tensor is moved to host (and untilized) before
-  // being returned.
+  // row-major inputs.
   std::optional<tt::runtime::Tensor>
   prepareInputTensor(const std::vector<BufferInstance *> &arg_buffers,
                      tt::runtime::Device device, size_t num_devices,

--- a/pjrt_implementation/src/api/so_loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/so_loaded_executable_instance.cc
@@ -199,8 +199,6 @@ SOLoadedExecutableInstance::prepareInputTensor(
 
   // SO (Python codegen) execution expects host row-major inputs; the generated
   // Python takes care of any device transfer and layout conversion itself.
-  tensor.move_to_host();
-
   return tensor.runtime_tensor();
 }
 

--- a/tests/torch/test_codegen_export_tensors_sharding.py
+++ b/tests/torch/test_codegen_export_tensors_sharding.py
@@ -49,17 +49,8 @@ class Model(torch.nn.Module):
         return x + self.w
 
 
-_XFAIL_REASON = (
-    "codegen with export_tensors=True does not preserve TP/EP sharding: "
-    "single shard is serialized to tensors/arg*.tensorbin instead of the "
-    "full distributed tensor, so a sharded tensor is silently replicated across the "
-    "mesh - https://github.com/tenstorrent/tt-xla/issues/5177"
-)
-
-
 @pytest.mark.push
 @pytest.mark.dual_chip
-@pytest.mark.xfail(reason=_XFAIL_REASON)
 def test_codegen_export_tensors_preserves_sharding():
     """Codegen export_tensors must serialize full sharded tensors, not one shard."""
     import ttnn
@@ -95,6 +86,10 @@ def test_codegen_export_tensors_preserves_sharding():
     with torch.no_grad():
         model(x)
 
+    # We need to sync here - in order for everything to be exported
+    # before we proceed with verifying the exported artifacts.
+    torch_xla.sync(wait=True)
+
     tensorbins = sorted(
         glob.glob(
             os.path.join(export_path, "**", "tensors", "arg*.tensorbin"),
@@ -106,20 +101,19 @@ def test_codegen_export_tensors_preserves_sharding():
         "codegen export_tensors produced nothing."
     )
 
-    # Both inputs (x and w) are sharded on dim 0 over the "model" axis, so
-    # every exported tensorbin must reassemble to the full global volume and
-    # carry one shard per device.
-    expected_volume = ROWS * COLS
     expected_nshards = num_devices
+    expected_per_shard_volume = (ROWS // num_devices) * COLS
 
     for path in tensorbins:
         tensor = ttnn.load_tensor(path)
         nshards = len(ttnn.get_device_tensors(tensor))
-        volume = tensor.volume()
-        assert nshards == expected_nshards and volume == expected_volume, (
-            f"{path}: expected full sharded tensor "
-            f"(volume={expected_volume}, nshards={expected_nshards}) but got "
-            f"shape={list(tensor.shape)}, volume={volume}, nshards={nshards}. "
-            "Only a single device shard was serialized "
-            "(see tenstorrent/tt-xla#5177)."
+        per_shard_volume = tensor.volume()
+        assert (
+            nshards == expected_nshards
+            and per_shard_volume == expected_per_shard_volume
+        ), (
+            f"{path}: expected full sharded tensor"
+            f"(per_shard_volume={expected_per_shard_volume}, "
+            f"nshards={expected_nshards}) but got shape={list(tensor.shape)}, "
+            f"per_shard_volume={per_shard_volume}, nshards={nshards}. "
         )


### PR DESCRIPTION
Python codegen expects the inputs to be host side in row-major layout. When we create a `PjrtTensor` from buffers we create a host tensor in row-major layout, so the `move_to_host()` call is not needed.

The reason why this call created problems when dealing with multi-chip tensors is that this method, besides pulling the data to host, is also reconstructing the buffer instances to each have their individual shard; i.e. it is splitting our one multi-chip `PjrtTensor` into multiple ones (to match the way xla represents the tensors as sets of buffer instances). So, `tensor.move_to_host(); return tensor.runtime_tensor()` will return the runtime tensor representing a single shard.

Removing the extra `move_to_host()` and updating the regression test. Regression test was expecting `tensor.volume()` to return global volume - which is wrong, it returns the per-shard volume. Also, adding explicit sync so that we make sure everything is exported before verifying the artifacts.

Closes #5177