### PR TITLE
Add DiffusionGemma 26B to TP inference config via tt_moe backend

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -46,6 +46,12 @@ test_config:
     inject_custom_moe: true
     assert_pcc: false # https://github.com/tenstorrent/tt-xla/issues/3490
 
+  diffusiongemma/pytorch-26B-A4B-it-tensor_parallel-inference:
+    supported_archs: [n300-llmbox]
+    status: KNOWN_FAILURE_XFAIL
+    reason: "error: 'sdy.all_slice' op operates on axis '_axis_0' which is already bound by a parent sdy.manual_computation op - https://github.com/tenstorrent/tt-mlir/issues/8861"
+    inject_custom_moe: true
+
   falcon/pytorch-7B_Instruct-tensor_parallel-inference:
     supported_archs: [n300-llmbox, lb-blackhole]
     status: EXPECTED_PASSING

--- a/tests/torch/moe/test_hf_backends.py
+++ b/tests/torch/moe/test_hf_backends.py
@@ -5,8 +5,13 @@
 import pytest
 import torch
 import torch.nn as nn
+import torch_xla.core.xla_model as xm
+import torch_xla.distributed.spmd as xs
 import torch_xla.runtime as xr
-from tt_torch.moe_backend import tt_experts_forward
+from infra import ComparisonConfig
+from infra.evaluators.torch_comparison_evaluator import TorchComparisonEvaluator
+from infra.utilities.torch_multichip_utils import enable_spmd, get_mesh
+from tt_torch.moe_backend import register_tt_moe_backend, tt_experts_forward
 from utils import Category
 
 
@@ -69,3 +74,80 @@ def test_tt_experts_forward_cpu_fallback(is_transposed):
     out = tt_experts_forward(experts, hidden_states, top_k_index, top_k_weights)
     assert out.shape == (seq_len, hidden_dim)
     assert out.device.type == "cpu"
+
+
+@pytest.mark.nightly
+@pytest.mark.llmbox
+@pytest.mark.skip(reason="DiffusionGemma needs transformers==5.12.0")
+@pytest.mark.record_test_properties(category=Category.GRAPH_TEST)
+def test_diffusion_gemma_experts_grouped_cpu_vs_tt_moe():
+    """DiffusionGemma (26B-A4B) experts: grouped_mm (CPU golden) vs the multi-chip
+    expert-parallel tt_moe path. Experts are sharded on the expert dim; tt_moe reads
+    the global SPMD mesh to pick the EP cluster axis."""
+    # lazy import
+    from transformers.models.diffusion_gemma.configuration_diffusion_gemma import (
+        DiffusionGemmaTextConfig,
+    )
+    from transformers.models.diffusion_gemma.modeling_diffusion_gemma import (
+        DiffusionGemmaTextExperts,
+    )
+
+    torch.manual_seed(0)
+    register_tt_moe_backend()
+
+    # Real MoE-expert dims: fused gate_up, GELUTanh gate.
+    config = DiffusionGemmaTextConfig(
+        hidden_size=2816,
+        moe_intermediate_size=704,
+        num_experts=128,
+        top_k_experts=8,
+        hidden_activation="gelu_pytorch_tanh",
+    )
+    experts = DiffusionGemmaTextExperts(config)
+    with torch.no_grad():
+        for p in experts.parameters():
+            p.normal_(0, 0.02)  # gate_up_proj/down_proj are torch.empty -> initialize
+    experts = experts.to(torch.bfloat16).eval()
+    experts.config = config
+
+    # randn inputs with the model's shapes/dtypes. topk -> distinct experts per token
+    # (real top-k never repeats one); weights are normalized like the router output.
+    seq_len = 32
+    hidden_states = torch.randn(seq_len, config.hidden_size, dtype=torch.bfloat16)
+    top_k_index = (
+        torch.randn(seq_len, config.num_experts)
+        .topk(config.top_k_experts, dim=-1)
+        .indices
+    )
+    top_k_weights = torch.rand(seq_len, config.top_k_experts)
+    top_k_weights = (top_k_weights / top_k_weights.sum(-1, keepdim=True)).to(
+        torch.float32
+    )
+
+    # CPU golden -- grouped_mm
+    config._experts_implementation = "grouped_mm"
+    with torch.no_grad():
+        golden = experts(hidden_states, top_k_index, top_k_weights)
+
+    # TT run -- tt_moe (expert-parallel: sharded experts + global SPMD mesh)
+    config._experts_implementation = "tt_moe"
+    xr.set_device_type("TT")
+    enable_spmd()
+    device = xm.xla_device()
+    experts = experts.to(device)
+
+    num_devices = xr.global_runtime_device_count()
+    mesh = get_mesh((1, num_devices), ("batch", "model"))
+    xs.set_global_mesh(mesh)
+    xs.mark_sharding(experts.gate_up_proj, mesh, (("batch", "model"), None, None))
+    xs.mark_sharding(experts.down_proj, mesh, (("batch", "model"), None, None))
+
+    compiled = torch.compile(experts, backend="tt")
+    with torch.no_grad():
+        tt_out = compiled(
+            hidden_states.to(device),
+            top_k_index.to(device),
+            top_k_weights.to(device),
+        ).to("cpu")
+
+    TorchComparisonEvaluator(ComparisonConfig()).evaluate(tt_out, golden)


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-xla/issues/5264

### Problem description

- DiffusionGemma's MoE experts run through HuggingFace's default `grouped_mm` path, which has no TT lowering it falls back to CPU and segfaults (first in `histc`, then one op downstream in `torch._grouped_mm`). 
- For complete details, please  checkout the description and comment of attached ticket

### What's changed

Route the experts through tt_torch's `tt_moe` expert-parallel backend (#4988) via `inject_custom_moe`, which replaces them with `all_to_all_dispatch` / `sparse_matmul` / `all_to_all_combine` and never touches `histc` / `grouped_mm` — so the segfault is gone.

- Added the `diffusiongemma/pytorch-26B-A4B-it-tensor_parallel-inference` runner config entry (`inject_custom_moe: true`).
- Added an op-level parity test (`grouped_mm` CPU golden vs `tt_moe` TT, PCC ~0.999). It's `@pytest.mark.skip` in CI since it needs the DiffusionGemma `transformers==5.12.0` ; validated locally.
- Full TP run is `KNOWN_FAILURE_XFAIL` for now, on a separate Shardy sharding bug — tenstorrent/tt-mlir#8861.
- model also needes 5.12.0 but requitemtns.txt handler will install reuired verisona nd unistall it after run
- The full model run also needs `transformers==5.12.0`; the runner's `requirements.txt` handler installs it before the run and uninstalls it afterward, so the config entry runs in CI automatically (unlike the standalone test).

### Internal checks

- Ran the same parity test on the **actual captured MoE-expert inputs** (`grouped_mm` CPU golden vs `tt_moe` TT) → **PCC = 1.0**.

### Checklist
- [x] New/Existing tests provide coverage for changes

### Logs

- [jun22_diffusiongemma_before_fix.log](https://github.com/user-attachments/files/29214745/jun22_diffusiongemma_before_fix.log)
- [sanity.zip](https://github.com/user-attachments/files/29214860/sanity.zip)
- [jun22_diffusiongemma_after_fix.log.zip](https://github.com/user-attachments/files/29214865/jun22_diffusiongemma_after_fix.log.zip)


