### PR TITLE
Isolate codegen regression test

### DIFF
--- a/.github/workflows/manual-test.yml
+++ b/.github/workflows/manual-test.yml
@@ -32,6 +32,7 @@ on:
           - 'model-test-lb-blackhole-nightly.json'
           - 'model-test-lb-blackhole-weekly.json'
           - 'model-test-emitpy.json'
+          - 'codegen-regression-tests.json'
           - 'basic-multihost-test.json'
           - 'Custom'
       test_suite_custom:

--- a/.github/workflows/schedule-nightly.yml
+++ b/.github/workflows/schedule-nightly.yml
@@ -80,6 +80,20 @@ jobs:
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
       wheel_build: manylinux
 
+  # Dedicated job for standalone codegen (currently EmitPy only) regression guards (require alchemist).
+  test_codegen_regression:
+    uses: ./.github/workflows/call-test.yml
+    secrets: inherit
+    needs: [ build-image, build-ttxla ]
+    # This ensures the job runs regardless of success or failure of `nightly_tests`:
+    if: success() || failure()
+    with:
+      test_suite: codegen-regression-tests.json
+      docker_image: ${{ needs.build-image.outputs.docker-image-base }}
+      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
+      artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
+      wheel_build: manylinux
+
   perf-benchmark:
     uses: ./.github/workflows/call-filtered-perf-tests.yml
     needs: [ build-image, build-ttxla ]
@@ -207,6 +221,7 @@ jobs:
       - test_full_model
       - test_forge_models_passing
       - test_forge_models_xfail
+      - test_codegen_regression
       - build-image
       - build-ttxla
       - perf-benchmark

--- a/.github/workflows/test-matrix-presets/codegen-regression-tests.json
+++ b/.github/workflows/test-matrix-presets/codegen-regression-tests.json
@@ -1,0 +1,3 @@
+[
+  {"runs-on": "n300", "name": "run_codegen_tensor_parallel", "dir": "./tests/torch/codegen", "test-mark": "tensor_parallel and dual_chip", "require": "alchemist", "forked": true}
+]

--- a/tests/torch/codegen/test_codegen_regression.py
+++ b/tests/torch/codegen/test_codegen_regression.py
@@ -57,10 +57,11 @@ _XFAIL_REASON = (
 )
 
 
-@pytest.mark.push
+# Requires tt-alchemist; runs only via the dedicated codegen-regression-tests.json preset, not the generic push/nightly tests/torch jobs (which lack alchemist).
+@pytest.mark.tensor_parallel
 @pytest.mark.dual_chip
-@pytest.mark.xfail(reason=_XFAIL_REASON)
-def test_codegen_export_tensors_preserves_sharding():
+@pytest.mark.xfail(strict=True, reason=_XFAIL_REASON)
+def test_codegen_export_tensors_sharding():
     """Codegen export_tensors must serialize full sharded tensors, not one shard."""
     import ttnn
 


### PR DESCRIPTION
### Ticket
N/A
### Problem description
The codegen regression test is currently marked `push/dual_chip` and is the only codegen test in `test push and dual_chip (n300, torch_multichip, 14)`. 

### What's changed
- Moved the test to a dedicated `tests/torch/codegen/` group and renamed the
  file to `test_codegen_regression.py` (test func `test_codegen_export_tensors_sharding`)
- Re-marked the test to `tensor_parallel/dual_chip` so the generic `tests/torch` jobs (all gated on `push/nightly`) never collect it 
- Made the `XFAIL` strict, so removal of the marker is forced once #5177 is fixed
- Added preset `codegen-regression-tests.json` (require: alchemist, forked, n300, dir-scoped to `tests/torch/codegen`)
- Wired it into `schedule-nightly.yml` for automatic nightly runs, and into the `manual-test.yml` dropdown for on-demand runs
### Checklist
- [ ] New/Existing tests provide coverage for changes
