### PR TITLE
[PJRT] Basic PP and D2D activation transfer over sockets

### DIFF
--- a/pjrt_implementation/inc/api/buffer_instance.h
+++ b/pjrt_implementation/inc/api/buffer_instance.h
@@ -69,6 +69,13 @@ public:
   // Binds PJRT API functions implementation related to PJRT_Buffer structure.
   static void bindApi(PJRT_Api *api);
 
+  // Pipeline-parallel: releases any device tensors stashed by copyToHost that
+  // were never consumed by a matching copyFromHost (e.g. a genuine device->host
+  // readout to numpy). MUST be called while the mesh device is still open
+  // (before teardown), otherwise the retained tensors destruct after the device
+  // is gone and crash.
+  static void clearPendingDevicePulls();
+
   // Casts this buffer instance to PJRT_Buffer pointer.
   operator PJRT_Buffer *() { return reinterpret_cast<PJRT_Buffer *>(this); }
 
@@ -200,6 +207,21 @@ private:
   // Currently only used for device to device transfer in copy construction
   // of new buffer instance.
   void copyFromBuffer(BufferInstance *src_buffer);
+
+  // Pipeline-parallel: if `host_buffer` matches a device tensor stashed by a
+  // prior copyToHost (a cross-device host roundtrip reusing the same host
+  // pointer) for a genuine cross-device activation hop, moves the activation
+  // device-to-device over a fabric socket, attaches the result to this buffer,
+  // signals the host-buffer-done event, and returns true.
+  //
+  // Returns false only when this is NOT a pipeline hop and the caller should
+  // use the normal host upload: no stash for this pointer, a shape mismatch
+  // (coincidental host-pointer reuse), or a same-device roundtrip. Once a
+  // genuine cross-device hop is identified, an inability to socket it (fabric
+  // disabled, source not on device, or a socket failure) is fatal rather than
+  // a silent host fallback.
+  bool trySocketTransferFromHostPull(
+      const void *host_buffer, EventInstance **out_done_with_host_buffer_event);
 
   // Calculates required tensor shape.
   static std::vector<std::uint32_t> calculateShape(const std::int64_t *dims,

--- a/pjrt_implementation/inc/api/client_instance.h
+++ b/pjrt_implementation/inc/api/client_instance.h
@@ -15,6 +15,7 @@
 
 // c++ standard library includes
 #include <cstdlib>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -143,11 +144,55 @@ public:
     return m_parent_mesh;
   };
 
+  // Returns the shape of the live parent mesh (row-major), or empty if none is
+  // open. Used by pipeline-parallel routing to map a device id to a submesh
+  // offset within whatever shape the parent was actually opened as.
+  std::vector<uint32_t> getParentMeshShape() const {
+    return m_parent_mesh.has_value() ? tt::runtime::getMeshShape(*m_parent_mesh)
+                                     : std::vector<uint32_t>{};
+  }
+
   // Closes currently opened mesh device, if any.
   void closeMeshDevice();
 
   // Closes currently opened parrent mesh device.
   void closeParentMesh();
+
+  // Pipeline-parallel: returns a live submesh of submesh_shape at
+  // submesh_offset within the already-open parent mesh, creating and caching it
+  // on first use. Carves directly from the parent (no getOrCreateMeshDevice /
+  // reshape), so multiple submeshes stay open concurrently and cached handles
+  // never go stale.
+  //
+  // NOTE: not thread-safe (sequential execution only for now).
+  tt::runtime::Device
+  getOrCreateSubmesh(const std::vector<uint32_t> &submesh_shape,
+                     const std::vector<uint32_t> &submesh_offset);
+
+  // Releases all live pipeline submeshes (before closing the parent mesh).
+  void closeLiveSubmeshes();
+
+  // Pipeline-parallel: returns the live {1,1} submesh that device `global_id`
+  // belongs to within the open parent mesh (row-major offset {id/C, id%C}).
+  // Reuses the submesh cached during that stage's execute.
+  tt::runtime::Device getSubmeshForDeviceId(uint32_t global_device_id);
+
+  // Returns the cached sender/receiver socket pair connecting the submesh at
+  // src_offset to the one at dst_offset, creating it on first use. Endpoints
+  // are worker core {0,0} on each 1x1 submesh.
+  std::pair<tt::runtime::MeshSocketHandle, tt::runtime::MeshSocketHandle> &
+  getOrCreateSocketPair(const std::vector<uint32_t> &src_offset,
+                        const std::vector<uint32_t> &dst_offset,
+                        tt::runtime::Device src_submesh,
+                        tt::runtime::Device dst_submesh);
+
+  // Pure predicate: is a copy from src_id to dst_id a socket-eligible
+  // intra-parent TT submesh hop? True if fabric is on, the parent is open,
+  // ids differ, and both ids index into the parent. Static for unit testing.
+  static bool
+  isSocketTransferEligible(uint32_t src_id, uint32_t dst_id,
+                           const std::vector<uint32_t> &parent_shape,
+                           bool fabric_enabled);
 
   // Compiles given mlir program.
   tt_pjrt_status compileMlirProgram(
@@ -211,6 +256,23 @@ private:
 
   // Fabric config computed for the current mesh device.
   std::optional<tt::runtime::MeshFabricConfig> m_fabric_config;
+
+  // Live pipeline-parallel submeshes carved from m_parent_mesh, keyed by offset
+  // within the parent (row-major). Kept open concurrently for multi-stage
+  // execution.
+  std::map<std::vector<uint32_t>, tt::runtime::Device> m_live_submeshes;
+
+  // Pipeline-parallel: socket pairs keyed by {src_offset, dst_offset} within
+  // the parent. Created lazily on the first cross-submesh transfer and reused
+  // across runs/microbatches. Released in closeLiveSubmeshes() before the
+  // submeshes close.
+  std::map<
+      std::pair<std::vector<uint32_t>, std::vector<uint32_t>>,
+      std::pair<tt::runtime::MeshSocketHandle, tt::runtime::MeshSocketHandle>>
+      m_socket_pairs;
+
+  // Default socket FIFO size in bytes (tunable).
+  static constexpr uint32_t kSocketFifoSize = 16 * 1024;
 
   // Used to identify the platform.
   const std::string m_platform_name = "tt";

--- a/pjrt_implementation/src/api/buffer_instance.cc
+++ b/pjrt_implementation/src/api/buffer_instance.cc
@@ -13,6 +13,7 @@
 // c++ standard library includes
 #include <cstddef>
 #include <cstring>
+#include <map>
 #include <memory>
 #include <numeric>
 #include <optional>
@@ -46,6 +47,44 @@
 namespace tt::pjrt {
 
 std::mutex BufferInstance::s_copy_to_host_internal_mutex;
+
+// Pipeline-parallel device-to-device sockets.
+//
+// torch-xla never calls PJRT_Buffer_CopyToDevice; a cross-device tensor move is
+// a host roundtrip: copyToHost(srcBuf, host_ptr) then copyFromHost(dstBuf,
+// host_ptr) reusing the SAME host pointer. We exploit
+// that: copyToHost stashes a copy of the source's still-on-device tensor handle
+// (its refcount alone keeps the device buffer alive across move_to_host's
+// readback) keyed by the host pointer; copyFromHost, on a matching pointer for
+// a TT->TT submesh hop, sockets the activation device-to-device and skips the
+// upload.
+//
+// Lifetime: the map holds one device-tensor handle per pending readout. It
+// self-bounds because torch-xla pools/reuses host pointers (a reused pointer
+// overwrites and releases the prior handle), matched entries are erased on
+// consumption, and clearPendingDevicePulls() drains the rest before the mesh
+// device is torn down (a handle outliving the device would crash on destruct).
+namespace {
+struct HostPullEntry {
+  uint32_t src_device_id;
+  // Source buffer dimensions, used to reject a coincidental host-pointer reuse:
+  // torch-xla pools host buffers, so a pointer stashed by one readout can later
+  // be handed to an unrelated upload. A shape mismatch means this is not the
+  // activation that was stashed, so we must not socket it.
+  std::vector<std::int64_t> src_dims;
+  tt::runtime::Tensor device_tensor;
+};
+std::mutex g_pending_pulls_mutex;
+std::map<const void *, HostPullEntry> g_pending_device_pulls;
+} // namespace
+
+void BufferInstance::clearPendingDevicePulls() {
+  const std::lock_guard<std::mutex> lock(g_pending_pulls_mutex);
+  // Dropping the handles here (while the device is still open) lets their
+  // backing device buffers deallocate cleanly; doing it at process teardown
+  // (after the device is gone) would crash in the tensor destructor.
+  g_pending_device_pulls.clear();
+}
 
 std::unique_ptr<BufferInstance> BufferInstance::createInputBufferInstance(
     PJRT_Buffer_Type data_type, const std::int64_t *dims, size_t num_dims,
@@ -225,6 +264,95 @@ bool isDenseRowMajor(const std::int64_t *dims, size_t num_dims,
 
 } // namespace
 
+bool BufferInstance::trySocketTransferFromHostPull(
+    const void *host_buffer, EventInstance **out_done_with_host_buffer_event) {
+  // Claim the stashed source device tensor for this host pointer, if any.
+  std::optional<HostPullEntry> pull;
+  {
+    const std::lock_guard<std::mutex> lock(g_pending_pulls_mutex);
+    auto it = g_pending_device_pulls.find(host_buffer);
+    if (it != g_pending_device_pulls.end()) {
+      pull = std::move(it->second);
+      g_pending_device_pulls.erase(it);
+    }
+  }
+  // No stash for this host pointer: an ordinary host->device upload (weights,
+  // inputs, ...), not a pipeline activation hop. Use the normal host path.
+  if (!pull.has_value()) {
+    return false;
+  }
+
+  // Coincidental host-pointer reuse: torch-xla pooled this pointer for a
+  // different (differently-shaped) buffer than the one we stashed. Not the
+  // stashed activation -> normal host path (and do NOT socket stale data).
+  if (pull->src_dims != m_dimensions) {
+    return false;
+  }
+
+  ClientInstance *client = getDevice()->getClient();
+  uint32_t src_id = pull->src_device_id;
+  uint32_t dst_id = static_cast<uint32_t>(getDevice()->getGlobalDeviceId());
+
+  // device->host->same-device roundtrip (e.g. a layout change), not a
+  // cross-device transfer. Nothing to socket; use the normal host path.
+  if (src_id == dst_id) {
+    return false;
+  }
+
+  // From here this IS an intended cross-device activation hop. If it cannot be
+  // socketed, fail loudly rather than silently degrading to a host roundtrip.
+  std::vector<uint32_t> parent_shape = client->getParentMeshShape();
+  bool fabric_on = client->getFabricConfig().has_value();
+  TT_FATAL(ClientInstance::isSocketTransferEligible(src_id, dst_id,
+                                                    parent_shape, fabric_on),
+           "Pipeline-parallel activation hop device {} -> {} is not "
+           "socket-eligible (fabric_enabled={}, parent_open={}); enable "
+           "FABRIC_2D and keep the parent mesh multi-device.",
+           src_id, dst_id, fabric_on, !parent_shape.empty());
+  TT_FATAL(tt::runtime::isTensorAllocated(pull->device_tensor),
+           "Pipeline-parallel source tensor for device {} -> {} is not "
+           "allocated on device; cannot socket the activation.",
+           src_id, dst_id);
+
+  try {
+    uint32_t cols = parent_shape.back();
+    std::vector<uint32_t> src_off = {src_id / cols, src_id % cols};
+    std::vector<uint32_t> dst_off = {dst_id / cols, dst_id % cols};
+
+    tt::runtime::Device src_submesh = client->getSubmeshForDeviceId(src_id);
+    tt::runtime::Device dst_submesh = client->getSubmeshForDeviceId(dst_id);
+    auto &sockets = client->getOrCreateSocketPair(src_off, dst_off, src_submesh,
+                                                  dst_submesh);
+
+    tt::runtime::Tensor recv_tensor =
+        tt::runtime::createEmptyTensorLike(dst_submesh, pull->device_tensor);
+    tt::runtime::socketSend(sockets.first, pull->device_tensor);
+    tt::runtime::socketRecv(sockets.second, recv_tensor);
+    tt::runtime::synchronizeDevice(src_submesh);
+    tt::runtime::synchronizeDevice(dst_submesh);
+
+    m_pjrt_tensor.reset();
+    PjrtTensor::from_runtime_tensor({this}, std::move(recv_tensor));
+    markAsDataReady();
+
+    // We never aliased the host buffer (data came over the socket), so the
+    // framework may free it immediately.
+    std::unique_ptr<EventInstance> done_event = EventInstance::createInstance();
+    EventInstance::markAsReadyAndCallback(done_event.get(),
+                                          tt_pjrt_status::kSuccess);
+    *out_done_with_host_buffer_event = done_event.release();
+
+    DLOG_F(LOG_DEBUG, "Socket D2D transfer (host-pull) device %u -> %u", src_id,
+           dst_id);
+    return true;
+  } catch (const std::exception &e) {
+    // An intended cross-device socket hop failed mid-transfer. Fail loudly
+    // instead of silently degrading to a host roundtrip.
+    TT_THROW("Pipeline-parallel socket transfer device {} -> {} failed: {}",
+             src_id, dst_id, e.what());
+  }
+}
+
 // Constructing buffer instance for the first time.
 void BufferInstance::copyFromHost(
     const void *host_buffer, PJRT_Buffer_Type data_type,
@@ -237,6 +365,15 @@ void BufferInstance::copyFromHost(
       "m_data_type and data_type do not match: m_data_type={}, data_type={}",
       data_type_utils::getPJRTBufferTypeString(m_data_type),
       data_type_utils::getPJRTBufferTypeString(data_type));
+
+  // Pipeline-parallel: if this upload's host pointer matches a device tensor
+  // that copyToHost stashed (a device->host->device hop), and it is a
+  // socket-eligible TT->TT submesh hop, transfer the activation
+  // device-to-device over a fabric socket and skip the host upload entirely.
+  if (trySocketTransferFromHostPull(host_buffer,
+                                    out_done_with_host_buffer_event)) {
+    return;
+  }
 
   m_pjrt_tensor.reset();
 
@@ -439,6 +576,27 @@ tt_pjrt_status BufferInstance::copyToHost(void *host_buffer,
                                           size_t host_buffer_size,
                                           EventInstance **out_copy_done_event) {
   ZoneScoped;
+
+  // Pipeline-parallel: if this buffer is a device-resident TT tensor, stash a
+  // copy of its device-tensor handle keyed by the destination host pointer, so
+  // a subsequent copyFromHost reusing that pointer can socket the data
+  // device-to-device instead of re-uploading from host. The handle's refcount
+  // alone keeps the device buffer alive across the move_to_host readback below
+  // (no setTensorRetain: retaining every readout's output tensor would corrupt
+  // the runtime's normal tensor lifecycle).
+  //
+  // The stash aliases the same device tensor the readback thread is about to
+  // pull; that is safe only because the framework waits on this op's completion
+  // event before issuing the partner copyFromHost (so the socketSend that reads
+  // the handle never races the readback).
+  if (m_pjrt_tensor && m_pjrt_tensor->has_runtime_tensor() &&
+      tt::runtime::isTensorAllocated(runtimeTensor())) {
+    tt::runtime::Tensor device_tensor = runtimeTensor();
+    const std::lock_guard<std::mutex> lock(g_pending_pulls_mutex);
+    g_pending_device_pulls[host_buffer] =
+        HostPullEntry{static_cast<uint32_t>(getDevice()->getGlobalDeviceId()),
+                      m_dimensions, std::move(device_tensor)};
+  }
 
   // In compile-only mode, output buffers have no associated tensor (no
   // hardware to compute on). Zero-fill the host buffer and signal success.

--- a/pjrt_implementation/src/api/client_instance.cc
+++ b/pjrt_implementation/src/api/client_instance.cc
@@ -16,7 +16,9 @@
 #include <cstring>
 #include <filesystem>
 #include <map>
+#include <numeric>
 #include <optional>
+#include <utility>
 
 // system includes
 #include <unistd.h>
@@ -667,6 +669,11 @@ ClientInstance::openMeshDevice(const std::vector<uint32_t> &mesh_shape) {
 
 void ClientInstance::closeParentMesh() {
   if (m_parent_mesh.has_value()) {
+    // Release any device tensors stashed for pipeline-parallel socket transfers
+    // while the submeshes/parent are still open, so their handles don't
+    // destruct after the device is gone.
+    BufferInstance::clearPendingDevicePulls();
+    closeLiveSubmeshes();
     DLOG_F(LOG_DEBUG, "Closing parent mesh.");
     tt::runtime::closeMeshDevice(*m_parent_mesh);
     m_parent_mesh.reset();
@@ -674,6 +681,88 @@ void ClientInstance::closeParentMesh() {
   }
 }
 
+tt::runtime::Device ClientInstance::getOrCreateSubmesh(
+    const std::vector<uint32_t> &submesh_shape,
+    const std::vector<uint32_t> &submesh_offset) {
+  // The parent mesh is opened once in populateDevices and stays open; we carve
+  // submeshes from it WITHOUT going through getOrCreateMeshDevice, so we never
+  // risk a reshape (close+reopen) that would invalidate already-cached submesh
+  // handles in m_live_submeshes.
+  TT_FATAL(m_parent_mesh.has_value(),
+           "Parent mesh must be open before carving a submesh");
+
+  auto it = m_live_submeshes.find(submesh_offset);
+  if (it != m_live_submeshes.end()) {
+    DLOG_F(LOG_DEBUG,
+           "ClientInstance::getOrCreateSubmesh - reusing submesh at offset %s",
+           utils::to_string(submesh_offset).c_str());
+    return it->second;
+  }
+
+  DLOG_F(
+      LOG_DEBUG,
+      "ClientInstance::getOrCreateSubmesh - creating submesh %s at offset %s",
+      utils::to_string(submesh_shape).c_str(),
+      utils::to_string(submesh_offset).c_str());
+  tt::runtime::Device submesh = tt::runtime::createSubMeshDevice(
+      *m_parent_mesh, submesh_shape, submesh_offset);
+  m_live_submeshes.emplace(submesh_offset, submesh);
+  return submesh;
+}
+
+bool ClientInstance::isSocketTransferEligible(
+    uint32_t src_id, uint32_t dst_id, const std::vector<uint32_t> &parent_shape,
+    bool fabric_enabled) {
+  if (!fabric_enabled || parent_shape.empty() || src_id == dst_id) {
+    return false;
+  }
+  size_t parent_devices =
+      std::accumulate(parent_shape.begin(), parent_shape.end(),
+                      static_cast<size_t>(1), std::multiplies<size_t>{});
+  return src_id < parent_devices && dst_id < parent_devices;
+}
+
+tt::runtime::Device
+ClientInstance::getSubmeshForDeviceId(uint32_t global_device_id) {
+  std::vector<uint32_t> parent_shape = getParentMeshShape();
+  TT_FATAL(!parent_shape.empty(),
+           "getSubmeshForDeviceId requires an open parent mesh");
+  uint32_t parent_cols = parent_shape.back();
+  std::vector<uint32_t> offset = {global_device_id / parent_cols,
+                                  global_device_id % parent_cols};
+  return getOrCreateSubmesh(/*submesh_shape=*/{1, 1}, offset);
+}
+
+std::pair<tt::runtime::MeshSocketHandle, tt::runtime::MeshSocketHandle> &
+ClientInstance::getOrCreateSocketPair(const std::vector<uint32_t> &src_offset,
+                                      const std::vector<uint32_t> &dst_offset,
+                                      tt::runtime::Device src_submesh,
+                                      tt::runtime::Device dst_submesh) {
+  auto key = std::make_pair(src_offset, dst_offset);
+  auto it = m_socket_pairs.find(key);
+  if (it == m_socket_pairs.end()) {
+    // Worker core {0,0} on each 1x1 submesh.
+    auto pair = tt::runtime::createSocketPair(
+        src_submesh, dst_submesh, /*senderCore=*/{0, 0},
+        /*receiverCore=*/{0, 0}, kSocketFifoSize);
+    it = m_socket_pairs.emplace(std::move(key), std::move(pair)).first;
+  }
+  return it->second;
+}
+
+void ClientInstance::closeLiveSubmeshes() {
+  // Release socket pairs first: they reference the submeshes below.
+  for (auto &entry : m_socket_pairs) {
+    tt::runtime::closeSocket(entry.second.first);
+    tt::runtime::closeSocket(entry.second.second);
+  }
+  m_socket_pairs.clear();
+
+  for (auto &entry : m_live_submeshes) {
+    tt::runtime::releaseSubMeshDevice(entry.second);
+  }
+  m_live_submeshes.clear();
+}
 namespace internal {
 
 PJRT_Error *onClientCreate(PJRT_Client_Create_Args *args) {

--- a/pjrt_implementation/src/api/loaded_executable_instance.cc
+++ b/pjrt_implementation/src/api/loaded_executable_instance.cc
@@ -11,6 +11,7 @@
 #include "api/loaded_executable_instance.h"
 
 // c++ standard library includes
+#include <algorithm>
 #include <filesystem>
 #include <mutex>
 #include <numeric>
@@ -131,6 +132,30 @@ LoadedExecutableInstance::getOrCreateMeshDevice(
   // offset. We need to keep track of opened devices in Client and map the
   // buffers devices to these devices.
   // https://github.com/tenstorrent/tt-xla/issues/502
+
+  // Pipeline-parallel: when this executable targets a strict subset of the
+  // client's devices (a stage), carve/keep a live submesh of the parent instead
+  // of reshaping the parent mesh (which would close any other stage's submesh).
+  // Offsets are computed against the parent's ACTUAL shape (row-major), so this
+  // works whether the parent was opened as [1, N] or 2D (e.g. {4, 8}).
+  // NOTE: assumes the stage's devices are contiguous within the parent (the
+  // runtime can only open contiguous submeshes - tt-xla #502).
+  std::vector<uint32_t> parent_shape = m_client_instance->getParentMeshShape();
+  size_t parent_devices =
+      parent_shape.empty()
+          ? 0
+          : std::accumulate(parent_shape.begin(), parent_shape.end(),
+                            static_cast<size_t>(1), std::multiplies<size_t>{});
+  if (parent_devices > 0 && mesh_shape_num_devices < parent_devices) {
+    uint32_t parent_cols = parent_shape.back();
+    uint32_t min_device_id = static_cast<uint32_t>(
+        *std::min_element(device_ids.begin(), device_ids.end()));
+    // Row-major: device d in an [R, C] parent is at coord {d / C, d % C}.
+    std::vector<uint32_t> submesh_offset = {min_device_id / parent_cols,
+                                            min_device_id % parent_cols};
+    return m_client_instance->getOrCreateSubmesh(devices_mesh_shape,
+                                                 submesh_offset);
+  }
 
   return m_client_instance->getOrCreateMeshDevice(devices_mesh_shape);
 }

--- a/pjrt_implementation/src/api/module_builder/module_builder.cc
+++ b/pjrt_implementation/src/api/module_builder/module_builder.cc
@@ -427,7 +427,20 @@ ModuleBuilder::buildModule(
   // compiler determined mesh shape.
   if (current_mesh_shape.has_value() &&
       current_mesh_shape.value() != mesh_shape) {
-    client_instance->getOrCreateMeshDevice(mesh_shape);
+    auto product = [](const std::vector<uint32_t> &s) {
+      return std::accumulate(s.begin(), s.end(), static_cast<size_t>(1),
+                             std::multiplies<size_t>{});
+    };
+    // Pipeline-parallel: if the compiled graph uses strictly FEWER devices than
+    // the current parent mesh, KEEP the parent open and let execution carve a
+    // submesh for it, instead of collapsing the parent to the graph's shape
+    // (which would close any other stage's device and make device-to-device
+    // sockets impossible). Still reshape when the graph needs more devices
+    // (grow) OR the same device count in a different topology (e.g. {2,2} vs
+    // {1,4}), since a submesh can't re-topologise.
+    if (product(mesh_shape) >= product(current_mesh_shape.value())) {
+      client_instance->getOrCreateMeshDevice(mesh_shape);
+    }
   }
 
   // TODO(mrakita): Use the VHLO module name from the module builder, if it has

--- a/pjrt_implementation/src/api/unit_tests/buffer_instance_tests.cc
+++ b/pjrt_implementation/src/api/unit_tests/buffer_instance_tests.cc
@@ -265,4 +265,20 @@ TEST_F(BufferInstanceUnitTests, API_PJRT_Buffer_Destroy) {
   ASSERT_EQ(error, nullptr);
 }
 
+// Tests the pure predicate that decides whether a device-to-device copy is a
+// socket-eligible intra-parent TT submesh hop. See
+// plans/pipeline-parallel-basic.
+TEST(SocketTransferEligibility, BasicCases) {
+  // Parent [1,2]: device 0 -> device 1 is eligible when fabric is on.
+  EXPECT_TRUE(ClientInstance::isSocketTransferEligible(0, 1, {1, 2}, true));
+  // Fabric off -> not eligible.
+  EXPECT_FALSE(ClientInstance::isSocketTransferEligible(0, 1, {1, 2}, false));
+  // Same device -> not eligible.
+  EXPECT_FALSE(ClientInstance::isSocketTransferEligible(0, 0, {1, 2}, true));
+  // No parent open -> not eligible.
+  EXPECT_FALSE(ClientInstance::isSocketTransferEligible(0, 1, {}, true));
+  // Id out of range of the parent -> not eligible.
+  EXPECT_FALSE(ClientInstance::isSocketTransferEligible(0, 5, {1, 2}, true));
+}
+
 } // namespace tt::pjrt::tests

--- a/python_package/torch_plugin_tt/experimental/__init__.py
+++ b/python_package/torch_plugin_tt/experimental/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from torch_plugin_tt.experimental.pipeline import PipelineParallel, pipeline
+
+__all__ = ["PipelineParallel", "pipeline"]

--- a/python_package/torch_plugin_tt/experimental/pipeline.py
+++ b/python_package/torch_plugin_tt/experimental/pipeline.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Explicit layer-split pipeline parallelism across TT devices.
+
+The user declares the split by passing one ``nn.Module`` per stage; stage ``i``
+runs on ``torch_xla.device(i)``. The activation crosses each boundary with
+``h.to(next_device)``, which the tt-xla plugin performs as a device-to-device
+socket transfer (TT-Metal MeshSocket) when both endpoints are TT submeshes of
+the same parent mesh.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch_xla
+
+
+class PipelineParallel(nn.Module):
+    """N stages, one per TT device. Forward threads the activation across
+    devices: x -> xla:0 [stage0] -> xla:1 [stage1] -> ... -> cpu."""
+
+    def __init__(self, stages: list[nn.Module]):
+        super().__init__()
+        if len(stages) < 2:
+            raise ValueError("pipeline needs at least 2 stages")
+        self.devices = [torch_xla.device(i) for i in range(len(stages))]
+        self.stages = nn.ModuleList(
+            stage.to(self.devices[i]) for i, stage in enumerate(stages)
+        )
+
+    def stage_param_devices(self) -> list[str]:
+        """Device each stage's weights permanently live on (proves placement)."""
+        return [str(next(s.parameters()).device) for s in self.stages]
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        h = x.to(self.devices[0])
+        for i, stage in enumerate(self.stages):
+            h = stage(h)
+            if i + 1 < len(self.stages):
+                h = h.to(self.devices[i + 1])  # cross-device activation transfer
+        return h.to("cpu")
+
+
+def pipeline(stages: list[nn.Module]) -> PipelineParallel:
+    """Factory: build a PipelineParallel from a list of per-stage modules."""
+    return PipelineParallel(stages)

--- a/tests/torch/pipeline_parallel/__init__.py
+++ b/tests/torch/pipeline_parallel/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/torch/pipeline_parallel/test_socket_pipeline.py
+++ b/tests/torch/pipeline_parallel/test_socket_pipeline.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""2-stage pipeline with device-to-device socket activation transfer.
+
+The stage-0 -> stage-1 boundary crosses over a TT-Metal MeshSocket path.
+"""
+
+import pytest
+import torch
+import torch.nn as nn
+import torch_xla
+import torch_xla.core.xla_model as xm
+import torch_xla.runtime as xr
+from torch_plugin_tt.experimental import pipeline
+from utils import Category
+
+LAYER_DIMS = [256, 512, 128]  # 2 Linear layers -> 2 stages
+DTYPE = torch.bfloat16
+BATCH = 32
+
+
+def _pcc(a: torch.Tensor, b: torch.Tensor) -> float:
+    a = a.flatten().float() - a.flatten().float().mean()
+    b = b.flatten().float() - b.flatten().float().mean()
+    denom = a.norm() * b.norm()
+    return 1.0 if denom == 0 else float((a @ b) / denom)
+
+
+def _build_stages(seed: int = 0) -> tuple[list[nn.Module], nn.Module]:
+    torch.manual_seed(seed)
+    l0 = nn.Sequential(nn.Linear(LAYER_DIMS[0], LAYER_DIMS[1], dtype=DTYPE), nn.ReLU())
+    l1 = nn.Linear(LAYER_DIMS[1], LAYER_DIMS[2], dtype=DTYPE)
+    golden = nn.Sequential(l0, l1)
+    return [l0, l1], golden
+
+
+@pytest.mark.nightly
+@pytest.mark.dual_chip
+@pytest.mark.record_test_properties(category=Category.OTHER)
+def test_two_stage_socket_pipeline():
+    if xr.global_runtime_device_count() < 2:
+        pytest.skip("needs >= 2 devices")
+
+    stages, golden_model = _build_stages()
+    x = torch.randn(BATCH, LAYER_DIMS[0], dtype=DTYPE)
+    golden = golden_model(x)  # CPU golden BEFORE moving layers to device
+
+    model = pipeline(stages)
+    assert model.stage_param_devices() == ["xla:0", "xla:1"]
+
+    out = model(x)
+    xm.mark_step()
+
+    assert out.shape == (BATCH, LAYER_DIMS[-1])
+    measured = _pcc(out, golden)
+    assert measured >= 0.99, f"PCC too low: {measured:.5f}"

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -7,7 +7,7 @@ option(USE_CUSTOM_TT_MLIR_VERSION "Flag to use TT_MLIR_VERSION set by the user" 
 if (NOT DEFINED TT_MLIR_VERSION OR NOT USE_CUSTOM_TT_MLIR_VERSION)
     # Pinned to the tt-mlir pipeline-parallel feature branch so this tt-xla
     # branch builds against the runtime socket API.
-    set(TT_MLIR_VERSION "pp-basic")
+    set(TT_MLIR_VERSION "pp-basic-socket-d2d")
 endif()
 
 set(LOGURU_VERSION "4adaa185883e3c04da25913579c451d3c32cfac1")

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -5,7 +5,11 @@
 option(USE_CUSTOM_TT_MLIR_VERSION "Flag to use TT_MLIR_VERSION set by the user" OFF)
 
 if (NOT DEFINED TT_MLIR_VERSION OR NOT USE_CUSTOM_TT_MLIR_VERSION)
-    set(TT_MLIR_VERSION "70ff200c7d2fa8d8401f316a0a0b35ee88cbfb72")
+    # Pinned to the tt-mlir pipeline-parallel feature branch so this tt-xla
+    # branch builds against the runtime socket API. Bare branch name (NOT
+    # "origin/...") so tt-xla setup.py's raw.githubusercontent version fetch
+    # resolves. See plans/pipeline-parallel-basic.
+    set(TT_MLIR_VERSION "pp-basic")
 endif()
 
 set(LOGURU_VERSION "4adaa185883e3c04da25913579c451d3c32cfac1")

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -6,9 +6,7 @@ option(USE_CUSTOM_TT_MLIR_VERSION "Flag to use TT_MLIR_VERSION set by the user" 
 
 if (NOT DEFINED TT_MLIR_VERSION OR NOT USE_CUSTOM_TT_MLIR_VERSION)
     # Pinned to the tt-mlir pipeline-parallel feature branch so this tt-xla
-    # branch builds against the runtime socket API. Bare branch name (NOT
-    # "origin/...") so tt-xla setup.py's raw.githubusercontent version fetch
-    # resolves. See plans/pipeline-parallel-basic.
+    # branch builds against the runtime socket API.
     set(TT_MLIR_VERSION "pp-basic")
 endif()
 


### PR DESCRIPTION
### Ticket
#2831

### Problem description
We don't have a pipeline-parallel path running end-to-end through the
tt-xla / tt-mlir stack today. We need an initial plan + PoC

### What's changed
This PR establishes the mechanism (activations move D2D over the fabric, all stages devices stay open) and proves it correct. The scheduling (async submit, microbatching, removing the per-hop device syncs, thread-safe resource management) is what's left to turn sequential placement into genuinely concurrent pipelining.

This whole mechanism is built on explicit per-device addressing, which SPMD takes away (has one virtual device and sends same program to all devices). We cant be in SPMD regime because:

- `PipelineParallel` places stage `i` on physical device `i` and crosses each boundary with `h.to(next_device)`. This requires each physical chip to be an individually addressable PJRT device.
- The socket transfer is triggered by a single source buffer on a known device being read back to a host pointer, then re-uploaded to a single destination buffer on another known device. The plugin reads `src_device_id` and `dst_device_id` off those individual buffers to compute the submesh offsets.

Main things this PR contains:

**1. `experimental/pipeline.py`**

This is the user-facing API and the *only* way to express the pipeline. It places stage `i` on `torch_xla.device(i)` and, in `forward`, threads the activation with `h.to(next_device)`.

**2. Intercepting the host round-trip in `buffer_instance.cc`**

A cross-device move is expressed as `copyToHost(src, host_ptr)` followed by `copyFromHost(dst, host_ptr)` **reusing the same host pointer**. So:

- `copyToHost` **stashes** the source's still-on-device tensor handle, keyed by the host pointer (its refcount alone keeps the device buffer alive across the readback).
- `copyFromHost` (`trySocketTransferFromHostPull`) checks whether the incoming host pointer matches a stash and if it's a genuine cross-device hop, it sends the activation D2D over a socket and skips the host upload entirely.

`clearPendingDevicePulls()` is needed because a stashed device-tensor handle that outlives the mesh device would crash in its destructor at teardown.

**3. Keeping all stages devices open at once: `client_instance.cc` + `module_builder.cc` + `loaded_executable_instance.cc`**

A socket needs *both* endpoints alive simultaneously. The pre-existing code reshaped the single mesh device per executable (close + reopen), which would tear down any other stage's device and make sockets impossible. So:

- `getOrCreateSubmesh` carves each stage's device as a **live submesh** out of one long-lived parent mesh, cached by offset, multiple stages stay open concurrently and cached handles never go stale.
- `module_builder.cc` now only reshapes the parent when the graph needs **≥** the current device count. If a stage uses *fewer* devices, it keeps the parent open and lets execution carve a submesh.
- `loaded_executable_instance.cc` detects "this executable targets a strict subset of devices" and routes it to a submesh at the right offset instead of reshaping.
- `getOrCreateSocketPair` / `closeLiveSubmeshes` manage the socket lifecycle (created lazily on first cross-submesh transfer, reused across runs, released before the submeshes close).

### Checklist
- [ ] Wait for tt-mlir uplift of sockets API
