### PR TITLE
Fix libtt-alchemist-lib.so bundling into manylinux wheel

### DIFF
--- a/pjrt_implementation/src/api/module_builder/module_builder.cc
+++ b/pjrt_implementation/src/api/module_builder/module_builder.cc
@@ -175,21 +175,30 @@ TTAlchemistHandler::~TTAlchemistHandler() {
 }
 
 std::optional<std::string> TTAlchemistHandler::findTTAlchemistLibraryPath() {
+  // The library lands in `lib/` on Debian-style builds (e.g. the release wheel)
+  // and in `lib64/` on RHEL-style builds (e.g. the manylinux wheel, where CMake
+  // GNUInstallDirs defaults CMAKE_INSTALL_LIBDIR to lib64). Check both.
+  static constexpr const char *kLibSubdirs[] = {"/lib/", "/lib64/"};
+  static constexpr const char *kLibName = "libtt-alchemist-lib.so";
+
   // Wheel install: pjrt_plugin_tt/__init__.py exports TT_PJRT_PLUGIN_DIR,
-  // and the bundled library lives in <plugin_dir>/lib/.
+  // and the bundled library lives in <plugin_dir>/lib/ or <plugin_dir>/lib64/.
   if (const char *plugin_dir = std::getenv("TT_PJRT_PLUGIN_DIR")) {
-    std::string p = std::string(plugin_dir) + "/lib/libtt-alchemist-lib.so";
-    if (std::filesystem::exists(p)) {
-      return p;
+    for (const char *subdir : kLibSubdirs) {
+      std::string p = std::string(plugin_dir) + subdir + kLibName;
+      if (std::filesystem::exists(p)) {
+        return p;
+      }
     }
   }
 
-  // Source build fallback: tt-mlir build tree.
+  // Source build fallback: tt-mlir build tree (lib/ or lib64/).
   if (const char *mlir_home = std::getenv("TT_MLIR_HOME")) {
-    std::string p =
-        std::string(mlir_home) + "/build/lib/libtt-alchemist-lib.so";
-    if (std::filesystem::exists(p)) {
-      return p;
+    for (const char *subdir : kLibSubdirs) {
+      std::string p = std::string(mlir_home) + "/build" + subdir + kLibName;
+      if (std::filesystem::exists(p)) {
+        return p;
+      }
     }
   }
 


### PR DESCRIPTION
### Ticket
N/A
### Problem description
On push is currently broken with `tests/torch/test_torch_xla_basic.py::test_spmd_sharding[fully_replicated-input_shape0-axis_names0]` failing in **`test push and dual_chip (n300, torch_multichip, 14)`**. The failure is actually caused by the codegen regression test added in this [commit](https://github.com/tenstorrent/tt-xla/commit/a0ba4ca3266475f441f3d326d612d5659c5845ae). That codegen test requires the alchemist lib to run, but `findTTAlchemistLibraryPath` fails to find the lib because it only searches `<plugin_dir>/lib/`. That is wrong for the manylinux wheel, which is built on a RHEL-style base where CMake's GNUInstallDirs defaults `CMAKE_INSTALL_LIBDIR` to `lib64/`, so the lib is actually inside `<plugin_dir>/lib64`. Because the codegen test is marked `XFAIL` (until the bug it guards is fixed), the resulting mid-step codegen abort is swallowed, leaving unmaterialized tensors behind. The `torch_multichip` job runs as a single, unforked process, so that leaked state persists into the next test in collection order (`tests/torch/test_torch_xla_basic.py::test_spmd_sharding[fully_replicated-input_shape0-axis_names0]` fails with `RuntimeError: Check failed: tensor_data`).

[On PR](https://github.com/tenstorrent/tt-xla/actions/runs/27561966226) passed because the pipeline uses default release wheel which is Ubuntu based, so `CMAKE_INSTALL_LIBDIR` defaults to `lib/` and lookup works fine. However, [on push](https://github.com/tenstorrent/tt-xla/actions/runs/27754728802/attempts/1) pipeline which uses manylinux build failed. 

This wasn't exposed earlier by the codegen tests in the `examples` folder because they run in a job that explicitly sets `require: alchemist`, which forces the release wheel. Nothing was running codegen on a manylinux wheel until this test landed in a job that doesn't set `require: alchemist`.

### What's changed
Fixed `findTTAlchemistLibraryPath` to search both `lib/` (Debian-style, used by release wheel) and `lib64/` (RHEL-style, used by manylinux wheel).

### Checklist
- [ ] New/Existing tests provide coverage for changes
