### PR TITLE
[vLLM] Pin FastAPI in deps to avoid route-tree regression

### DIFF
--- a/integrations/vllm_plugin/requirements-vllm-plugin.txt
+++ b/integrations/vllm_plugin/requirements-vllm-plugin.txt
@@ -1,2 +1,3 @@
 vllm==0.19.1
 transformers==5.5.1
+fastapi[standard] >= 0.133.0, < 0.137.0 # First version supporting Starlette 1.0; < 0.137.0 avoids route-tree change that breaks model-hosting-container-standards handler overrides.

--- a/integrations/vllm_plugin/setup.py
+++ b/integrations/vllm_plugin/setup.py
@@ -53,6 +53,7 @@ setup(
     install_requires=[
         "vllm==0.19.1",
         "transformers==5.5.1",
+        "fastapi[standard] >= 0.133.0, < 0.137.0",
     ],
     python_requires=">=3.12, <3.13",
     license="Apache-2.0",


### PR DESCRIPTION
### Ticket
closes #5334 

### Problem description
Responses API test fails on /health with FastAPI 0.137.1 (latest release)

### What's changed
Pin FastAPI in deps to avoid route-tree regression.

### Checklist
- [X] New/Existing tests provide coverage for changes
