### PR TITLE
Enable const eval for sampling and pooling vllm tests

### DIFF
--- a/tests/integrations/vllm_plugin/generative/test_decode.py
+++ b/tests/integrations/vllm_plugin/generative/test_decode.py
@@ -15,7 +15,7 @@ def test_decode():
         "max_model_len": 16,
         "gpu_memory_utilization": 0.002,
         "additional_config": {
-            "enable_const_eval": False,
+            "enable_const_eval": True,
             "min_context_len": 1,
             "num_hidden_layers": 1,
             "decode_only": True,

--- a/tests/integrations/vllm_plugin/generative/test_kv_cache_bleed.py
+++ b/tests/integrations/vllm_plugin/generative/test_kv_cache_bleed.py
@@ -159,7 +159,7 @@ def vllm_server():
         "--chat-template",
         template_path,
         "--additional-config",
-        json.dumps({"enable_const_eval": False, "min_context_len": 32}),
+        json.dumps({"enable_const_eval": True, "min_context_len": 32}),
     ]
 
     proc = None

--- a/tests/integrations/vllm_plugin/generative/test_llama3_3b_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_llama3_3b_generation.py
@@ -19,7 +19,7 @@ def test_llama3_3b_generation():
         "max_model_len": 128,
         "gpu_memory_utilization": 0.002,
         "additional_config": {
-            "enable_const_eval": False,
+            "enable_const_eval": True,
             "min_context_len": 32,
         },
     }

--- a/tests/integrations/vllm_plugin/generative/test_opt_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_opt_generation.py
@@ -19,7 +19,7 @@ def test_opt_generation():
         "max_model_len": 128,
         "gpu_memory_utilization": 0.001,
         "additional_config": {
-            "enable_const_eval": False,
+            "enable_const_eval": True,
             "min_context_len": 32,
         },
     }
@@ -43,7 +43,7 @@ def test_opt_generation_kv_cache_bfp8():
         "max_model_len": 128,
         "gpu_memory_utilization": 0.001,
         "additional_config": {
-            "enable_const_eval": False,
+            "enable_const_eval": True,
             "min_context_len": 32,
             "experimental_kv_cache_dtype": "bfp_bf8",
         },
@@ -69,7 +69,7 @@ def test_opt_generation_multibatch():
         "max_model_len": 128,
         "gpu_memory_utilization": 0.001,
         "additional_config": {
-            "enable_const_eval": False,
+            "enable_const_eval": True,
             "min_context_len": 32,
         },
     }
@@ -97,7 +97,7 @@ def test_opt_generation_large_batch(batch_size):
         "max_model_len": 32,
         "gpu_memory_utilization": 0.001,
         "additional_config": {
-            "enable_const_eval": False,
+            "enable_const_eval": True,
             "min_context_len": 32,
         },
     }

--- a/tests/integrations/vllm_plugin/generative/test_responses_api.py
+++ b/tests/integrations/vllm_plugin/generative/test_responses_api.py
@@ -95,7 +95,7 @@ def vllm_server():
         "--additional-config",
         json.dumps(
             {
-                "enable_const_eval": False,
+                "enable_const_eval": True,
                 "min_context_len": 32,
             }
         ),

--- a/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
@@ -22,7 +22,7 @@ def test_tensor_parallel_generation_n300(model_name: str):
         "max_model_len": 32,
         "gpu_memory_utilization": 0.002,
         "additional_config": {
-            "enable_const_eval": False,
+            "enable_const_eval": True,
             "min_context_len": 32,
             "enable_tensor_parallel": True,
         },


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Enable const eval for sampling and pooling vllm tests

### What's changed
Regarding **enable_const_eval**, the backend default is True. If a test case does not explicitly specify this parameter, it will be treated as True. If the test case sets it to False, then enable_const_eval will be False for that case.

In some examples, the value was set to False, so I updated it to True and compared the runtime across several examples based on the enable_const_eval parameter.

ex: 
meta-llama/Llama-3.2-3B  (enable_const_eval)false  (exec)218 sec
meta-llama/Llama-3.2-3B  (enable_const_eval)true  (exec)80 sec

decode.py
meta-llama/Llama-3.2-3B (enable_const_eval)false (exec)22.27 sec
meta-llama/Llama-3.2-3B (enable_const_eval)true (exec)22.23 sec

### Checklist
- [ ] New/Existing tests provide coverage for changes
