### PR TITLE
Add vibevoice/pytorch-1.5B single-device inference test config

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -22,6 +22,10 @@ test_config:
   gpt_neo/causal_lm/pytorch-2_7B-single_device-inference:
     status: EXPECTED_PASSING
 
+  vibevoice/pytorch-1.5B-single_device-inference:
+    supported_archs: ["n150"]
+    status: EXPECTED_PASSING
+
   vovnet/pytorch-27s-single_device-inference:
     status: EXPECTED_PASSING
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/5217)

### Problem description

`microsoft/VibeVoice-1.5B` was brought up single-device on n150 (inference), but it is not registered in the inference test config, so it is not exercised by the test suite. The loader for it is added in a companion tt-forge-models PR (branch `sai_arthi_raguram/vibe_voice`), which must land and be uplifted before this entry resolves.

### What's changed

Registers VibeVoice-1.5B for single-device inference testing:

```yaml
vibevoice/pytorch-1.5B-single_device-inference:
  supported_archs: ["n150"]
  status: EXPECTED_PASSING
```

- **`supported_archs: ["n150"]`** — bringup was verified on n150 only; restrict to that arch (matches the single-arch convention used by e.g. `falcon/pytorch-3_*`).
- **`status: EXPECTED_PASSING`** — the registry-driven `test_all_models_torch` run passes with the **default** PCC comparison.
- **No `assert_pcc` / `required_pcc` override** — default PCC assertion already passes, so there's nothing to mask.
- **No test-fixture change** — this model runs through the registry-driven `tests/runner/test_models.py::test_all_models_torch[...]` path; there is no per-model `test_*.py`, and the loader's `ModelInfo` carries no `bringup_status` field. The YAML `status` is the single source of truth.

**Impact:** VibeVoice-1.5B is now covered by single-device inference CI on n150.

Provenance: tt-xla `cb89a724b`; tt-forge-models `f96d6a82a0` at bringup.

### Checklist
- [x] New/Existing tests provide coverage for changes — `test_all_models_torch[vibevoice/pytorch-1.5B-single_device-inference]` → **`1 passed in 210.41s`** on n150.

##  Logs
[bringup_steps.txt](https://github.com/user-attachments/files/29241208/bringup_steps.txt)
[iter_2_run.log](https://github.com/user-attachments/files/29241212/iter_2_run.log)
[model_overview.md](https://github.com/user-attachments/files/29241214/model_overview.md)

