### PR TITLE
[Test] Mark kokoro/Kokoro-82M single-device inference KNOWN_FAILURE_X…

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -351,6 +351,10 @@ test_config:
     required_pcc: 0.98  # AssertionError: PCC comparison failed. Calculated: pcc=0.988092303276062. Required: pcc=0.99. Exposed by removal of consteval on host: https://github.com/tenstorrent/tt-xla/issues/1242
     status: EXPECTED_PASSING
 
+  kokoro/pytorch-hexgrad/Kokoro-82M-single_device-inference:
+    status: KNOWN_FAILURE_XFAIL
+    reason: "INCORRECT_RESULT: bf16 waveform-PCC precision wall. Compiles + runs E2E on n150 with trained weights and produces a finite, sane-magnitude waveform, but waveform PCC tops out at ~0.14 (need 0.99). The iSTFTNet vocoder (sine-phase cumsum + STFT/iSTFT over a long 1-D waveform) is catastrophically sensitive to bf16 *tensor storage*: decoder output PCC is already 0.948 and the vocoder collapses it to 0.138. fp32_dest_acc_en+hifi4 is bit-identical (storage-bound, not accumulation-bound). See https://github.com/tenstorrent/tt-xla/issues/5332."
+
   mamba/pytorch-1.4b_HF-single_device-inference:
     status: EXPECTED_PASSING
 


### PR DESCRIPTION
### Ticket
[Github Issue](https://github.com/tenstorrent/tt-xla/issues/5215)
### Problem description
Bring up `hexgrad/Kokoro-82M` (StyleTTS2 TTS / iSTFTNet vocoder) on the tt-xla
PyTorch runner. The model now has a tt-forge-models loader (companion PR:
tenstorrent/tt-forge-models#<NN>); this PR wires it into the tt-xla single-device
inference suite and records its status.

The model compiles and runs end-to-end on n150 with trained weights and produces
a finite, sane-magnitude waveform, but waveform PCC tops out at ~0.14 (need
0.99): the iSTFTNet vocoder (sine-phase `cumsum` + STFT/iSTFT over a long 1-D
waveform) is sensitive to bf16 tensor **storage**. Decoder output PCC is already
0.948 and the vocoder collapses it to 0.138; `fp32_dest_acc_en`+hifi4 is
bit-identical (storage-bound, not accumulation-bound). Root cause and the full
device-vs-CPU bisect are in tenstorrent/tt-xla#5332.

### What's changed
- **`third_party/tt_forge_models`** — submodule pointer bumped to include the
  Kokoro loader (companion tt-forge-models PR). *(Apply after that PR merges.)*
- **`tests/runner/test_config/torch/test_config_inference_single_device.yaml`** —
  new `kokoro/pytorch-hexgrad/Kokoro-82M-single_device-inference` entry,
  `KNOWN_FAILURE_XFAIL`, reason documenting the bf16 waveform-PCC wall and
  linking #5332.
- **`python_package/tt_torch/utils.py`** — Dynamo guard-repr patch fix:
  `self.get(guard)` → `self.get(guard.name)` (a prerequisite that unblocked
  compilation during bringup). *(Drop this hunk if it has already landed on
  main from another change.)*
- **`tests/torch/ops/kokoro/`** — two self-contained single-device op sanities
  reproducing the underlying device numerical-robustness gap (bf16
  `InstanceNorm1d` variance catastrophic-cancellation on a near-constant input
  → `rsqrt` → inf/FLT_MAX/nan): `test_adain_sanity.py` (minimal bare op) and
  `test_adain_chain_sanity.py` (Conv1d → AdaIN1d, the Kokoro structure). Both
  `xfail(strict=False)`, [#5332](https://github.com/tenstorrent/tt-xla/issues/5332). *(Currently staged on branch
  `sai_arthi_raguram/kokoro-instancenorm-bf16-repro`)

### Checklist
- [x] New/Existing tests provide coverage for changes — model node runs E2E on
  n150 (xfail on PCC); op sanities reproduce the root-cause gap in isolation.

### Logs
[debug_report.md](https://github.com/user-attachments/files/29249497/debug_report.md)
[iter_n150_13_fp32acc_realw_run.log](https://github.com/user-attachments/files/29249500/iter_n150_13_fp32acc_realw_run.log)
