### PR TITLE
[vLLM] Add prefill request-count bucketing via min_num_seqs

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -1722,9 +1722,6 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                         )
                     )
 
-            logger.info(f"hidden_states: {hidden_states.shape} {hidden_states}")
-            logger.info(f"logits: {logits.shape} {logits}")
-            logger.info(f"selected_token_ids: {selected_token_ids}")
             # Save hidden states (before position selection) for prompt
             # logprobs.  Only extract rows for requests that actually need
             # them, keyed by batch index, so we never copy the full

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -2236,6 +2236,12 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         ]
 
         for config in configs:
+            if config["num_tokens"] == 1 and config["num_reqs"] != self.max_num_reqs:
+                logger.debug(
+                    f"Skipping config={config} because decode path only supports max_num_reqs={self.max_num_reqs}"
+                )
+                continue
+
             logger.info(f"Compiling graph for config={config}")
             (
                 dummy_inputs,

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -482,50 +482,45 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             num_reqs: _alloc_dev((num_reqs,), torch.int32)
             for num_reqs in {self.min_num_reqs, self.max_num_reqs}
         }
-        self._page_table_dev_max = _alloc_dev(
-            (self.num_reqs_max_model_len, self.max_num_blocks_per_req),
-            self.block_table_cpu.dtype,
-        )
-        self._page_table_dev_min = _alloc_dev(
-            (self.min_num_reqs, self.max_num_blocks_per_req),
-            self.block_table_cpu.dtype,
-        )
-        self._fill_page_table_dev_max = _alloc_dev(
-            (self.num_reqs_max_model_len, self.max_num_blocks_per_req),
-            self.block_table_cpu.dtype,
-        )
-        self._fill_page_table_dev_min = _alloc_dev(
-            (self.min_num_reqs, self.max_num_blocks_per_req),
-            self.block_table_cpu.dtype,
-        )
-        self._cache_position_dev_max = _alloc_dev(
-            (self.num_reqs_max_model_len,), self.seq_lens_cpu.dtype
-        )
-        self._cache_position_dev_min = _alloc_dev(
-            (self.min_num_reqs,), self.seq_lens_cpu.dtype
-        )
+        self._page_table_dev_max = {
+            num_reqs: _alloc_dev(
+                (num_reqs, self.max_num_blocks_per_req),
+                self.block_table_cpu.dtype,
+            )
+            for num_reqs in {self.min_num_reqs, self.num_reqs_max_model_len}
+        }
+        self._fill_page_table_dev_max = {
+            num_reqs: _alloc_dev(
+                (num_reqs, self.max_num_blocks_per_req),
+                self.block_table_cpu.dtype,
+            )
+            for num_reqs in {self.min_num_reqs, self.num_reqs_max_model_len}
+        }
+        self._cache_position_dev_max = {
+            num_reqs: _alloc_dev((num_reqs,), self.seq_lens_cpu.dtype)
+            for num_reqs in {self.min_num_reqs, self.num_reqs_max_model_len}
+        }
         if self.most_model_len is not None:
             assert self.num_reqs_most_model_len is not None
             assert self.num_blocks_per_most_len_req is not None
-            self._page_table_dev_most = _alloc_dev(
-                (self.num_reqs_most_model_len, self.num_blocks_per_most_len_req),
-                self.block_table_cpu.dtype,
-            )
-            self._page_table_dev_most_min = _alloc_dev(
-                (self.min_num_reqs, self.num_blocks_per_most_len_req),
-                self.block_table_cpu.dtype,
-            )
-            self._fill_page_table_dev_most = _alloc_dev(
-                (self.num_reqs_most_model_len, self.num_blocks_per_most_len_req),
-                self.block_table_cpu.dtype,
-            )
-            self._fill_page_table_dev_most_min = _alloc_dev(
-                (self.min_num_reqs, self.num_blocks_per_most_len_req),
-                self.block_table_cpu.dtype,
-            )
-            self._cache_position_dev_most = _alloc_dev(
-                (self.num_reqs_most_model_len,), self.seq_lens_cpu.dtype
-            )
+            self._page_table_dev_most = {
+                num_reqs: _alloc_dev(
+                    (num_reqs, self.num_blocks_per_most_len_req),
+                    self.block_table_cpu.dtype,
+                )
+                for num_reqs in {self.min_num_reqs, self.num_reqs_most_model_len}
+            }
+            self._fill_page_table_dev_most = {
+                num_reqs: _alloc_dev(
+                    (num_reqs, self.num_blocks_per_most_len_req),
+                    self.block_table_cpu.dtype,
+                )
+                for num_reqs in {self.min_num_reqs, self.num_reqs_most_model_len}
+            }
+            self._cache_position_dev_most = {
+                num_reqs: _alloc_dev((num_reqs,), self.seq_lens_cpu.dtype)
+                for num_reqs in {self.min_num_reqs, self.num_reqs_most_model_len}
+            }
 
         # Layer pairings for cross-layer KV sharing.
         # If an Attention layer `layer_name` is in the keys of this dict, it
@@ -1212,37 +1207,13 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             fill_page_table = page_table
 
         if use_max_model_len:
-            cache_position_dev = (
-                self._cache_position_dev_min
-                if target_num_reqs == self.min_num_reqs
-                else self._cache_position_dev_max
-            )
-            page_table_dev = (
-                self._page_table_dev_min
-                if target_num_reqs == self.min_num_reqs
-                else self._page_table_dev_max
-            )
-            fill_page_table_dev_buf = (
-                self._fill_page_table_dev_min
-                if target_num_reqs == self.min_num_reqs
-                else self._fill_page_table_dev_max
-            )
+            cache_position_dev = self._cache_position_dev_max[target_num_reqs]
+            page_table_dev = self._page_table_dev_max[target_num_reqs]
+            fill_page_table_dev_buf = self._fill_page_table_dev_max[target_num_reqs]
         else:
-            cache_position_dev = (
-                self._cache_position_dev_min
-                if target_num_reqs == self.min_num_reqs
-                else self._cache_position_dev_most
-            )
-            page_table_dev = (
-                self._page_table_dev_most_min
-                if target_num_reqs == self.min_num_reqs
-                else self._page_table_dev_most
-            )
-            fill_page_table_dev_buf = (
-                self._fill_page_table_dev_most_min
-                if target_num_reqs == self.min_num_reqs
-                else self._fill_page_table_dev_most
-            )
+            cache_position_dev = self._cache_position_dev_most[target_num_reqs]
+            page_table_dev = self._page_table_dev_most[target_num_reqs]
+            fill_page_table_dev_buf = self._fill_page_table_dev_most[target_num_reqs]
 
         # Clear unused rows so persistent device buffers don't keep stale
         # block indices from a previous call (would surface as KV bleed).

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -1051,14 +1051,6 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 else self.max_num_reqs
             )
 
-        # Respect backend row limits for the selected KV path.
-        if use_max_model_len:
-            assert self.num_reqs_max_model_len is not None
-            target_num_reqs = min(target_num_reqs, self.num_reqs_max_model_len)
-        else:
-            assert self.num_reqs_most_model_len is not None
-            target_num_reqs = min(target_num_reqs, self.num_reqs_most_model_len)
-
         # Compute the padded total number of scheduled tokens so that all requests
         # in the batch share a common, hardware-compatible sequence length.
         padded_total_num_scheduled_tokens = _get_padded_token_len(

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -156,8 +156,6 @@ if TYPE_CHECKING:
 logger = tt_init_logger(__name__)
 
 INVALID_TOKEN_ID = -1
-# Smallest output size
-MIN_NUM_SEQS = 1
 
 
 def generate_attn_mask(
@@ -321,9 +319,11 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             if self.most_model_len is not None
             else None
         )
-        # InputBatch needs to work with sampling tensors greater than padding
-        # to avoid dynamic shapes. Also, avoid suboptimal alignment.
-        self.max_num_reqs = max(scheduler_config.max_num_seqs, MIN_NUM_SEQS)
+        self.max_num_reqs = scheduler_config.max_num_seqs
+        resolved_min_num_reqs = self.tt_config.min_num_seqs
+        if resolved_min_num_reqs is None:
+            resolved_min_num_reqs = self.max_num_reqs
+        self.min_num_reqs = resolved_min_num_reqs
         if scheduler_config.max_num_batched_tokens < self.tt_config.min_context_len:
             logger.warning(
                 f"max_num_batched_tokens {scheduler_config.max_num_batched_tokens} is less than min_context_len {self.tt_config.min_context_len}, setting min_context_len to max_num_batched_tokens"
@@ -462,31 +462,47 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             return torch.zeros(shape, dtype=dtype, device="cpu").to(self.device)
 
         self._input_ids_dev = {
-            n: _alloc_dev((self.max_num_reqs, n), torch.int32)
-            for n in self.num_tokens_paddings
+            (num_reqs, num_tokens): _alloc_dev((num_reqs, num_tokens), torch.int32)
+            for num_reqs in {self.min_num_reqs, self.max_num_reqs}
+            for num_tokens in self.num_tokens_paddings
         }
         self._position_ids_dev = {
-            n: _alloc_dev(
+            (num_reqs, num_tokens): _alloc_dev(
                 (
-                    (3, self.max_num_reqs, n)
+                    (3, num_reqs, num_tokens)
                     if self.uses_mrope
-                    else (self.max_num_reqs, n)
+                    else (num_reqs, num_tokens)
                 ),
                 torch.int32,
             )
-            for n in self.num_tokens_paddings
+            for num_reqs in {self.min_num_reqs, self.max_num_reqs}
+            for num_tokens in self.num_tokens_paddings
         }
-        self._logits_indices_dev = _alloc_dev((self.max_num_reqs,), torch.int32)
+        self._logits_indices_dev = {
+            num_reqs: _alloc_dev((num_reqs,), torch.int32)
+            for num_reqs in {self.min_num_reqs, self.max_num_reqs}
+        }
         self._page_table_dev_max = _alloc_dev(
             (self.num_reqs_max_model_len, self.max_num_blocks_per_req),
+            self.block_table_cpu.dtype,
+        )
+        self._page_table_dev_min = _alloc_dev(
+            (self.min_num_reqs, self.max_num_blocks_per_req),
             self.block_table_cpu.dtype,
         )
         self._fill_page_table_dev_max = _alloc_dev(
             (self.num_reqs_max_model_len, self.max_num_blocks_per_req),
             self.block_table_cpu.dtype,
         )
+        self._fill_page_table_dev_min = _alloc_dev(
+            (self.min_num_reqs, self.max_num_blocks_per_req),
+            self.block_table_cpu.dtype,
+        )
         self._cache_position_dev_max = _alloc_dev(
             (self.num_reqs_max_model_len,), self.seq_lens_cpu.dtype
+        )
+        self._cache_position_dev_min = _alloc_dev(
+            (self.min_num_reqs,), self.seq_lens_cpu.dtype
         )
         if self.most_model_len is not None:
             assert self.num_reqs_most_model_len is not None
@@ -495,8 +511,16 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 (self.num_reqs_most_model_len, self.num_blocks_per_most_len_req),
                 self.block_table_cpu.dtype,
             )
+            self._page_table_dev_most_min = _alloc_dev(
+                (self.min_num_reqs, self.num_blocks_per_most_len_req),
+                self.block_table_cpu.dtype,
+            )
             self._fill_page_table_dev_most = _alloc_dev(
                 (self.num_reqs_most_model_len, self.num_blocks_per_most_len_req),
+                self.block_table_cpu.dtype,
+            )
+            self._fill_page_table_dev_most_min = _alloc_dev(
+                (self.min_num_reqs, self.num_blocks_per_most_len_req),
                 self.block_table_cpu.dtype,
             )
             self._cache_position_dev_most = _alloc_dev(
@@ -1018,6 +1042,27 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         assert max_num_scheduled_tokens_all_reqs > 0
 
         num_reqs = len(num_scheduled_tokens_per_req)
+        actual_num_reqs = num_reqs
+
+        # Decode always runs with max request shape. For prefill, keep runtime
+        # request shape aligned with warmup by selecting min or max bucket.
+        is_decode_step = max_num_scheduled_tokens_all_reqs == 1
+        if is_decode_step:
+            target_num_reqs = self.max_num_reqs
+        else:
+            target_num_reqs = (
+                self.min_num_reqs
+                if actual_num_reqs <= self.min_num_reqs
+                else self.max_num_reqs
+            )
+
+        # Respect backend row limits for the selected KV path.
+        if use_max_model_len:
+            assert self.num_reqs_max_model_len is not None
+            target_num_reqs = min(target_num_reqs, self.num_reqs_max_model_len)
+        else:
+            assert self.num_reqs_most_model_len is not None
+            target_num_reqs = min(target_num_reqs, self.num_reqs_most_model_len)
 
         # Compute the padded total number of scheduled tokens so that all requests
         # in the batch share a common, hardware-compatible sequence length.
@@ -1026,8 +1071,8 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         )
 
         # Allocate a zero-initialized position tensor. For MRoPE models, keep
-        # three identical position planes [3, max_num_reqs, padded_tokens] to
-        # match the runtime input convention; otherwise use [max_num_reqs,
+        # three identical position planes [3, target_num_reqs, padded_tokens] to
+        # match the runtime input convention; otherwise use [target_num_reqs,
         # padded_tokens]. Entries beyond the actual number of scheduled tokens
         # per request remain zero (padding).
         # NOTE: When M-RoPE is enabled, position ids are 3D regardless of the
@@ -1036,9 +1081,9 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # See page 5 of https://arxiv.org/abs/2409.12191
 
         arange_shape = (
-            (3, self.max_num_reqs, padded_total_num_scheduled_tokens)
+            (3, target_num_reqs, padded_total_num_scheduled_tokens)
             if self.uses_mrope
-            else (self.max_num_reqs, padded_total_num_scheduled_tokens)
+            else (target_num_reqs, padded_total_num_scheduled_tokens)
         )
         arange = torch.zeros(arange_shape, dtype=torch.int32)
 
@@ -1073,10 +1118,10 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 arange[i, :n] = positions
 
         # Allocate a zero-padded input_ids tensor of shape
-        # [max_num_reqs, padded_total_num_scheduled_tokens].
+        # [target_num_reqs, padded_total_num_scheduled_tokens].
         # Only the first n tokens per request are populated; the rest are padding.
         input_ids_cpu = torch.zeros(
-            (self.max_num_reqs, padded_total_num_scheduled_tokens),
+            (target_num_reqs, padded_total_num_scheduled_tokens),
             dtype=torch.int32,
             device="cpu",
         )
@@ -1092,14 +1137,16 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # Move input_ids and position_ids to the target device for execution.
         # Reuse persistent device buffers and update in place via copy_ to
         # avoid issuing a fresh H2D transfer (and on-device alloc) per step.
-        # 'padded_total_num_scheduled_tokens' is used as the key into the
-        # preallocated buffer dictionaries (self._input_ids_dev and
-        # self._position_ids_dev) to select the buffer whose second dimension
-        # matches this step's padded token width.
-        input_ids_dev = self._input_ids_dev[padded_total_num_scheduled_tokens]
+        # The tuple key captures both runtime dimensions so the cached buffer
+        # matches this batch exactly instead of slicing a larger one.
+        input_ids_dev = self._input_ids_dev[
+            (target_num_reqs, padded_total_num_scheduled_tokens)
+        ]
         input_ids_dev.copy_(input_ids_cpu)
         self.input_ids = input_ids_dev
-        position_ids_dev = self._position_ids_dev[padded_total_num_scheduled_tokens]
+        position_ids_dev = self._position_ids_dev[
+            (target_num_reqs, padded_total_num_scheduled_tokens)
+        ]
         position_ids_dev.copy_(arange)
         self.position_ids = position_ids_dev
 
@@ -1118,26 +1165,28 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         if use_max_model_len:
             assert self.num_reqs_max_model_len is not None
             page_table = self.block_table_cpu[
-                : self.num_reqs_max_model_len, : self.max_num_blocks_per_req
+                :target_num_reqs, : self.max_num_blocks_per_req
             ]
-            page_table[:num_reqs, : self.max_num_blocks_per_req] = (
-                self.input_batch.block_table[0].get_cpu_tensor()[:num_reqs]
+            page_table[:actual_num_reqs, : self.max_num_blocks_per_req] = (
+                self.input_batch.block_table[0].get_cpu_tensor()[:actual_num_reqs]
             )
             seq_lens = self.seq_lens_cpu[: self.num_reqs_max_model_len]
         else:
+            assert self.num_reqs_most_model_len is not None
             page_table = self.block_table_cpu[
-                : self.num_reqs_most_model_len, : self.num_blocks_per_most_len_req
+                :target_num_reqs, : self.num_blocks_per_most_len_req
             ]
-            page_table[:num_reqs, : self.num_blocks_per_most_len_req] = (
+            page_table[:actual_num_reqs, : self.num_blocks_per_most_len_req] = (
                 self.input_batch.block_table[0].get_cpu_tensor()[
-                    :num_reqs, : self.num_blocks_per_most_len_req
+                    :actual_num_reqs, : self.num_blocks_per_most_len_req
                 ]
             )
             seq_lens = self.seq_lens_cpu[: self.num_reqs_most_model_len]
 
         cache_position = seq_lens - 1
+        cache_position = cache_position[:target_num_reqs]
 
-        if num_reqs == 1:
+        if actual_num_reqs == 1:
             cache_position[1:] = -1
             page_table[1:, :] = 0
 
@@ -1147,13 +1196,14 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # different prefix length, so we roll per-row. Done outside the
         # compiled graph to avoid shape-change recompilation.
         offsets = (
-            self.input_batch.num_computed_tokens_cpu[:num_reqs] // self.block_size
-            if num_reqs > 0
+            self.input_batch.num_computed_tokens_cpu[:actual_num_reqs]
+            // self.block_size
+            if actual_num_reqs > 0
             else np.array([], dtype=np.int64)
         )
         if np.any(offsets > 0):
             fill_page_table = page_table.clone()
-            for i in range(num_reqs):
+            for i in range(actual_num_reqs):
                 if offsets[i] > 0:
                     fill_page_table[i] = torch.roll(
                         page_table[i], shifts=-int(offsets[i])
@@ -1162,20 +1212,44 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             fill_page_table = page_table
 
         if use_max_model_len:
-            cache_position_dev = self._cache_position_dev_max
-            page_table_dev = self._page_table_dev_max
-            fill_page_table_dev_buf = self._fill_page_table_dev_max
+            cache_position_dev = (
+                self._cache_position_dev_min
+                if target_num_reqs == self.min_num_reqs
+                else self._cache_position_dev_max
+            )
+            page_table_dev = (
+                self._page_table_dev_min
+                if target_num_reqs == self.min_num_reqs
+                else self._page_table_dev_max
+            )
+            fill_page_table_dev_buf = (
+                self._fill_page_table_dev_min
+                if target_num_reqs == self.min_num_reqs
+                else self._fill_page_table_dev_max
+            )
         else:
-            cache_position_dev = self._cache_position_dev_most
-            page_table_dev = self._page_table_dev_most
-            fill_page_table_dev_buf = self._fill_page_table_dev_most
+            cache_position_dev = (
+                self._cache_position_dev_min
+                if target_num_reqs == self.min_num_reqs
+                else self._cache_position_dev_most
+            )
+            page_table_dev = (
+                self._page_table_dev_most_min
+                if target_num_reqs == self.min_num_reqs
+                else self._page_table_dev_most
+            )
+            fill_page_table_dev_buf = (
+                self._fill_page_table_dev_most_min
+                if target_num_reqs == self.min_num_reqs
+                else self._fill_page_table_dev_most
+            )
 
         # Clear unused rows so persistent device buffers don't keep stale
         # block indices from a previous call (would surface as KV bleed).
-        cache_position[num_reqs:] = -1
-        page_table[num_reqs:, :] = 0
+        cache_position[actual_num_reqs:] = -1
+        page_table[actual_num_reqs:, :] = 0
         if fill_page_table is not page_table:
-            fill_page_table[num_reqs:, :] = 0
+            fill_page_table[actual_num_reqs:, :] = 0
 
         cache_position_dev.copy_(cache_position)
         page_table_dev.copy_(page_table)
@@ -1212,12 +1286,13 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # partial request, we do so for simplicity. We will ignore the sampled
         # token from the partial request.
         # Per-user last-token index within each padded slot.
-        logits_indices = torch.zeros(self.max_num_reqs, dtype=torch.int32)
-        logits_indices[: len(num_scheduled_tokens_per_req)] = (
+        logits_indices = torch.zeros(target_num_reqs, dtype=torch.int32)
+        logits_indices[:actual_num_reqs] = (
             torch.from_numpy(num_scheduled_tokens_per_req) - 1
         )
-        self._logits_indices_dev.copy_(logits_indices)
-        logits_indices = self._logits_indices_dev
+        logits_indices_dev = self._logits_indices_dev[target_num_reqs]
+        logits_indices_dev.copy_(logits_indices)
+        logits_indices = logits_indices_dev
 
         if self.lora_config is not None:
             # We need to respect padding when activating LoRA adapters
@@ -1236,7 +1311,8 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         return (
             per_layer_attn_metadata,
             logits_indices,
-            num_reqs,
+            actual_num_reqs,
+            target_num_reqs,
             end_index,
         )
 
@@ -1579,6 +1655,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 attn_metadata,
                 logits_indices,
                 num_reqs,
+                target_num_reqs,
                 end_index,
             ) = self._prepare_inputs(scheduler_output, start_index)
             input_ids, inputs_embeds = self._get_model_inputs(
@@ -1596,7 +1673,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             )
             sampling_metadata = XLASupportedSamplingMetadata.from_input_batch(
                 self.input_batch,
-                self.max_num_reqs,
+                target_num_reqs,
                 sampling_device,
                 vocab_size=self.vocab_size,
             )
@@ -1610,7 +1687,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     grammar_bitmask_padded,
                     bitmask_arange,
                 ) = self.prepare_structured_decoding_input(
-                    grammar_output, self.max_num_reqs
+                    grammar_output, target_num_reqs
                 )
             torch_xla.sync(wait=False)
 
@@ -1931,13 +2008,13 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
     def _dummy_run(self, num_tokens: int, num_reqs: int, num_blocks: int) -> None:
         # Start with token ids so _get_model_inputs runs embed_input_ids and the
         # XLA graph structure matches the real execution path.
-        input_ids = torch.zeros((self.max_num_reqs, num_tokens), dtype=torch.int32).to(
+        input_ids = torch.zeros((num_reqs, num_tokens), dtype=torch.int32).to(
             self.device
         )
 
-        position_ids = torch.zeros(
-            (self.max_num_reqs, num_tokens), dtype=torch.int32
-        ).to(self.device)
+        position_ids = torch.zeros((num_reqs, num_tokens), dtype=torch.int32).to(
+            self.device
+        )
         page_table = torch.zeros((num_reqs, num_blocks), dtype=torch.int32).to(
             self.device
         )
@@ -2165,17 +2242,22 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 f"decode_only is set, only compiling decode path with num_tokens=1"
             )
 
+        num_reqs_options = sorted({self.min_num_reqs, self.max_num_reqs})
+
         configs = [
             {
                 "num_tokens": num_tokens,
+                "num_reqs": num_reqs,
                 "all_greedy": all_greedy,
                 "apply_grammar": apply_grammar,
             }
             for (
+                num_reqs,
                 num_tokens,
                 all_greedy,
                 apply_grammar,
             ) in product(
+                num_reqs_options,
                 num_tokens_paddings,
                 all_greedy_options,
                 apply_grammar_options,
@@ -2237,26 +2319,25 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         Build dummy tensors and metadata for fused-path warmup.
         """
         num_tokens = config["num_tokens"]
+        num_reqs = config["num_reqs"]
         all_greedy = config["all_greedy"]
         apply_grammar = config["apply_grammar"]
         hsize = self.model_config.get_hidden_size()
 
-        dummy_inputs = torch.zeros(
-            (self.max_num_reqs, num_tokens), dtype=torch.int32
-        ).to(self.device)
-        dummy_positions = torch.zeros(
-            (self.max_num_reqs, num_tokens), dtype=torch.int32
-        ).to(self.device)
+        dummy_inputs = torch.zeros((num_reqs, num_tokens), dtype=torch.int32).to(
+            self.device
+        )
+        dummy_positions = torch.zeros((num_reqs, num_tokens), dtype=torch.int32).to(
+            self.device
+        )
         dummy_inputs_embeds = torch.zeros(
-            (self.max_num_reqs, num_tokens, hsize), dtype=self._hidden_states_dtype
+            (num_reqs, num_tokens, hsize), dtype=self._hidden_states_dtype
         ).to(self.device)
         page_table = torch.zeros(
-            (self.num_reqs_max_model_len, self.max_num_blocks_per_req),
+            (num_reqs, self.max_num_blocks_per_req),
             dtype=torch.int32,
         ).to(self.device)
-        cache_position = torch.ones(
-            (self.num_reqs_max_model_len,), dtype=torch.int32
-        ).to(self.device)
+        cache_position = torch.ones((num_reqs,), dtype=torch.int32).to(self.device)
 
         attn_metadata = TTMetadata(
             page_table=page_table,
@@ -2274,14 +2355,12 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         )
         self._pin_input_shardings(dummy_inputs, dummy_positions, dummy_inputs_embeds)
 
-        dummy_indices = torch.zeros(self.max_num_reqs, dtype=torch.int32).to(
-            self.device
-        )
+        dummy_indices = torch.zeros(num_reqs, dtype=torch.int32).to(self.device)
 
         generate_params_if_all_greedy = not all_greedy
         dummy_sampling_metadata = XLASupportedSamplingMetadata.from_input_batch(
             self.input_batch,
-            self.max_num_reqs,
+            num_reqs,
             self.device,
             generate_params_if_all_greedy,
             vocab_size=self.vocab_size,
@@ -2293,11 +2372,9 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         dummy_bitmasks = None
         if apply_grammar:
             dummy_require_struct_decoding = self.require_structured_out_cpu[
-                : self.max_num_reqs
+                :num_reqs
             ].to(self.device)
-            dummy_grammar_bitmask = self.grammar_bitmask_cpu[: self.max_num_reqs].to(
-                self.device
-            )
+            dummy_grammar_bitmask = self.grammar_bitmask_cpu[:num_reqs].to(self.device)
             dummy_bitmasks = self.structured_decode_bitmasks.to(self.device)
 
         return (
@@ -2502,20 +2579,37 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
     def _precompile_backbone(self) -> None:
         logger.info("Compiling the model with different input shapes.")
         start = time.perf_counter()
+        num_reqs_options = sorted({self.min_num_reqs, self.max_num_reqs})
         for num_tokens in self.num_tokens_paddings:
-            logger.info("  -- num_tokens: %d", num_tokens)
-            self._dummy_run(
-                num_tokens, self.num_reqs_max_model_len, self.max_num_blocks_per_req
-            )
-            # Sync per token count so prefill and decode graphs stay separate.
-            torch_xla.sync()
-            if self.most_model_len is not None:
+            for warmup_num_reqs in num_reqs_options:
+                num_reqs_max = min(warmup_num_reqs, self.num_reqs_max_model_len)
+                logger.info(
+                    "  -- num_tokens: %d, num_reqs: %d (max_model_len path)",
+                    num_tokens,
+                    num_reqs_max,
+                )
                 self._dummy_run(
                     num_tokens,
-                    self.num_reqs_most_model_len,
-                    self.num_blocks_per_most_len_req,
+                    num_reqs_max,
+                    self.max_num_blocks_per_req,
                 )
+                # Sync per token count so prefill and decode graphs stay separate.
                 torch_xla.sync()
+                if self.most_model_len is not None:
+                    assert self.num_reqs_most_model_len is not None
+                    assert self.num_blocks_per_most_len_req is not None
+                    num_reqs_most = min(warmup_num_reqs, self.num_reqs_most_model_len)
+                    logger.info(
+                        "  -- num_tokens: %d, num_reqs: %d (most_model_len path)",
+                        num_tokens,
+                        num_reqs_most,
+                    )
+                    self._dummy_run(
+                        num_tokens,
+                        num_reqs_most,
+                        self.num_blocks_per_most_len_req,
+                    )
+                    torch_xla.sync()
         xm.wait_device_ops()
         end = time.perf_counter()
         logger.info("Compilation finished in %.2f [secs].", end - start)

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -522,6 +522,21 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 for num_reqs in {self.min_num_reqs, self.num_reqs_most_model_len}
             }
 
+        # Fail fast at startup if any per-step buffer can't be looked up by a
+        # row count _prepare_inputs will request (before SMEM clamping).
+        _reachable_num_reqs = {self.min_num_reqs, self.max_num_reqs}
+        for _name, _keys in {
+            "input_ids": {k[0] for k in self._input_ids_dev},
+            "position_ids": {k[0] for k in self._position_ids_dev},
+            "logits_indices": set(self._logits_indices_dev),
+            "page_table_dev_max": set(self._page_table_dev_max),
+            "cache_position_dev_max": set(self._cache_position_dev_max),
+        }.items():
+            assert _reachable_num_reqs <= _keys, (
+                f"{_name} buffer keyed by {sorted(_keys)} is missing reachable "
+                f"row counts {sorted(_reachable_num_reqs - _keys)}"
+            )
+
         # Layer pairings for cross-layer KV sharing.
         # If an Attention layer `layer_name` is in the keys of this dict, it
         # means this layer will perform attention using the keys and values
@@ -1707,6 +1722,9 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                         )
                     )
 
+            logger.info(f"hidden_states: {hidden_states.shape} {hidden_states}")
+            logger.info(f"logits: {logits.shape} {logits}")
+            logger.info(f"selected_token_ids: {selected_token_ids}")
             # Save hidden states (before position selection) for prompt
             # logprobs.  Only extract rows for requests that actually need
             # them, keyed by batch index, so we never copy the full

--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -56,6 +56,12 @@ class TTConfig:
     # If unset, it resolves to scheduler_config.max_num_seqs.
     min_num_seqs: Optional[int] = None
 
+    # b1-prefill batch threshold. When <= this many prefills are
+    # pending, AscendScheduler admits at most min_num_seqs fresh prefills/step
+    # (small/b1 graph, served serially) instead of one wasted-row b32 batch;
+    # above it, prefills batch as usual. 0 = off; needs min_num_seqs < max.
+    prefill_batch_threshold: int = 0
+
     batch_size: int = 1
     enable_precompile_all: bool = True
 
@@ -299,6 +305,16 @@ class TTPlatform(Platform):
                 "additional_config['min_num_seqs'] must be <= max_num_seqs "
                 "for the TT backend."
             )
+
+        # b1-prefill batch threshold: resolve default (0 = off)
+        # and persist so the AscendScheduler sees a concrete value; validate >= 0.
+        if additional_config.get("prefill_batch_threshold") is None:
+            additional_config["prefill_batch_threshold"] = 0
+        elif int(additional_config["prefill_batch_threshold"]) < 0:
+            raise ValueError(
+                "additional_config['prefill_batch_threshold'] must be >= 0."
+            )
+        vllm_config.additional_config = additional_config
 
         # Stash cpu_sampling so validate_request() can read it without
         # rebuilding TTConfig per request.

--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -50,6 +50,12 @@ class TTConfig:
     enable_const_eval_on_cpu: bool = True
 
     min_context_len: int = 128
+
+    # Minimum request-batch size to preallocate and precompile for. This is
+    # used as the lower bound for request-count shape warmup.
+    # If unset, it resolves to scheduler_config.max_num_seqs.
+    min_num_seqs: Optional[int] = None
+
     batch_size: int = 1
     enable_precompile_all: bool = True
 
@@ -270,11 +276,28 @@ class TTPlatform(Platform):
     def check_and_update_config(cls, vllm_config: VllmConfig) -> None:
         from vllm.config import CompilationMode, CUDAGraphMode
 
-        additional_config = vllm_config.additional_config or {}
+        if vllm_config.additional_config is None:
+            vllm_config.additional_config = {}
+        additional_config = vllm_config.additional_config
+        tt_config = TTConfig(**additional_config)
         if "batch_size" in additional_config:
             logger.warning(
                 "additional_config['batch_size'] is deprecated and will be removed "
                 "in a future release. Use max_num_seqs instead."
+            )
+        if tt_config.min_num_seqs is None:
+            additional_config["min_num_seqs"] = (
+                vllm_config.scheduler_config.max_num_seqs
+            )
+            tt_config.min_num_seqs = additional_config["min_num_seqs"]
+        elif tt_config.min_num_seqs < 1:
+            raise ValueError(
+                "additional_config['min_num_seqs'] must be >= 1 for the TT backend."
+            )
+        elif tt_config.min_num_seqs > vllm_config.scheduler_config.max_num_seqs:
+            raise ValueError(
+                "additional_config['min_num_seqs'] must be <= max_num_seqs "
+                "for the TT backend."
             )
 
         # Stash cpu_sampling so validate_request() can read it without

--- a/integrations/vllm_plugin/vllm_tt/scheduler/ascend_scheduler.py
+++ b/integrations/vllm_plugin/vllm_tt/scheduler/ascend_scheduler.py
@@ -119,7 +119,6 @@ class AscendScheduler(Scheduler):
             ):
                 break
 
-
             def skip_cur_request(req=request):
                 request_queue.pop_request()
                 step_skipped_waiting.prepend_request(req)

--- a/integrations/vllm_plugin/vllm_tt/scheduler/ascend_scheduler.py
+++ b/integrations/vllm_plugin/vllm_tt/scheduler/ascend_scheduler.py
@@ -52,6 +52,11 @@ class AscendScheduler(Scheduler):
         )
         self.scheduled_req_ids: set[str] = set()
         self.running: list[Request] = []
+        # b1-prefill knobs, resolved once (additional_config is
+        # immutable after engine construction). See TTConfig.prefill_batch_threshold.
+        add_cfg = vllm_config.additional_config or {}
+        self.prefill_batch_threshold = int(add_cfg.get("prefill_batch_threshold") or 0)
+        self.b1_min_num_seqs = int(add_cfg.get("min_num_seqs") or 0)
 
     def schedule(self) -> SchedulerOutput:
         # Super's schedule handles chunked prefill which is schedule both prefill and decode in one request.
@@ -82,6 +87,16 @@ class AscendScheduler(Scheduler):
         # and put back at the head of the waiting queue later
         step_skipped_waiting = create_request_queue(self.policy)
 
+        # b1-prefill cap: when few prefills are pending, admit only
+        # min_num_seqs fresh ones this step so they route to the small (b1) graph
+        # instead of one wasted-row b32 batch. Above the threshold, prefills batch
+        # as usual. See TTConfig.prefill_batch_threshold.
+        fresh_prefill_cap = None
+        if self.prefill_batch_threshold > 0 and self.b1_min_num_seqs > 0:
+            num_pending = len(self.waiting) + len(self.skipped_waiting)
+            if num_pending <= self.prefill_batch_threshold:
+                fresh_prefill_cap = self.b1_min_num_seqs
+
         # Schedule prefill requests first (unless decode is forced).
         req_index = 0
         while (self.waiting or self.skipped_waiting) and token_budget > 0:
@@ -93,6 +108,17 @@ class AscendScheduler(Scheduler):
                 break
 
             request = request_queue.peek_request()
+
+            # b1-prefill cap: stop admitting fresh prefills once the cap is
+            # hit; continuation chunks (num_computed>0) are never capped.
+            if (
+                fresh_prefill_cap is not None
+                and request.num_computed_tokens == 0
+                and len(scheduled_new_reqs) + len(scheduled_resumed_reqs)
+                >= fresh_prefill_cap
+            ):
+                break
+
 
             def skip_cur_request(req=request):
                 request_queue.pop_request()

--- a/tests/integrations/vllm_plugin/generative/test_b1_prefill.py
+++ b/tests/integrations/vllm_plugin/generative/test_b1_prefill.py
@@ -1,0 +1,189 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Standalone demo + regression for the b1-prefill optimization (tt-xla #5281).
+
+A single `min_num_seqs=1` engine compiles BOTH a b1 (`[1, n]`) and a b32
+(`[max_num_seqs, n]`) prefill graph; the scheduler picks per step by how many
+requests are being prefilled. This test fires the same prefill at four request
+shapes and prints a TTFT table comparing them:
+
+  single   : 1 request               -> b1   (the win: lone request skips the 32-row graph)
+  staggered: N reqs, ramped           -> realistic arrivals
+  burst    : N(<=threshold) reqs, sim -> b1 served serially via prefill_batch_threshold
+  batch    : M(>threshold) reqs       -> b32, correct to batch here (stable b32 anchor)
+
+One test, test_b1_prefill_ttft, runs all four shapes once and asserts the two
+wins b1-prefill should deliver:
+  1. single (b1) << batch (b32) -- the lone-request win; fails without min_num_seqs.
+  2. burst  (b1) << batch (b32) -- the small-burst win from prefill_batch_threshold;
+     with the threshold off (TEST_PREFILL_BATCH_THRESHOLD=0) it instead pins the
+     gap b1 alone leaves (the burst batches to b32, TTFT ~ the b32 batch) (#5281).
+
+Engine config via env, so this file doubles as a 3-config development demo:
+  TEST_NUM_HIDDEN_LAYERS=0          full model (default 1 = single layer, fast)
+  TEST_MIN_NUM_SEQS=0               b1 off (b32 only); =1 (default) b1 on
+  TEST_PREFILL_BATCH_THRESHOLD=0    threshold off (default 16 routes small bursts to b1)
+"""
+import asyncio
+import os
+import random
+import statistics
+import time
+from dataclasses import dataclass
+
+import pytest
+from vllm import AsyncEngineArgs, AsyncLLMEngine, SamplingParams
+from vllm.inputs import TokensPrompt
+from vllm.sampling_params import RequestOutputKind
+
+NUM_HIDDEN_LAYERS = int(os.environ.get("TEST_NUM_HIDDEN_LAYERS", "1"))  # 0 = full model
+MIN_NUM_SEQS = int(os.environ.get("TEST_MIN_NUM_SEQS", "1"))  # 0 = b1 off (b32 only)
+PREFILL_BATCH_THRESHOLD = int(os.environ.get("TEST_PREFILL_BATCH_THRESHOLD", "16"))
+
+ISL = 1024  # b1 win grows with ISL
+SMALL = 8  # burst size (<= threshold -> the gap target)
+LARGE = 24  # batch size (> threshold -> stable b32 anchor)
+RAMP_MS = 100  # staggered inter-arrival
+
+
+@dataclass
+class Stats:
+    label: str
+    ttfts_ms: list
+
+    @property
+    def median(self):
+        return statistics.median(self.ttfts_ms)
+
+    @property
+    def p90(self):
+        xs = sorted(self.ttfts_ms)
+        return xs[min(len(xs) - 1, int(0.9 * (len(xs) - 1) + 0.5))]
+
+    def row(self):
+        xs = self.ttfts_ms
+        return (
+            f"{self.label:<10} n={len(xs):<3} "
+            f"min={min(xs):8.0f}  median={self.median:8.0f}  "
+            f"p90={self.p90:8.0f}  max={max(xs):8.0f}  (ms TTFT)"
+        )
+
+
+def _distinct_prompt(seed: int):
+    # Unique token sequence per request so prefix caching can't fake TTFT.
+    rng = random.Random(f"b1test:{seed}:{ISL}")
+    return TokensPrompt(
+        prompt_token_ids=[1000 + rng.randrange(20000) for _ in range(ISL)]
+    )
+
+
+def _make_engine() -> AsyncLLMEngine:
+    additional_config = {
+        "enable_const_eval": True,
+        "min_context_len": 128,
+        "experimental_weight_dtype": "bfp_bf8",
+        "experimental_kv_cache_dtype": "bfp_bf8",
+        "cpu_sampling": False,
+        "optimization_level": 1,
+        "enable_trace": False,  # prefill-focused; trace is a decode opt
+        "fp32_dest_acc_en": False,
+    }
+    if NUM_HIDDEN_LAYERS:
+        additional_config["num_hidden_layers"] = NUM_HIDDEN_LAYERS
+    if MIN_NUM_SEQS:  # the b1 feature
+        additional_config["min_num_seqs"] = MIN_NUM_SEQS
+    if PREFILL_BATCH_THRESHOLD:  # route small bursts to b1 (#5281)
+        additional_config["prefill_batch_threshold"] = PREFILL_BATCH_THRESHOLD
+    args = AsyncEngineArgs(
+        model="Qwen/Qwen3-8B",
+        # budget must cover max_model_len * max_num_seqs; small max_model_len keeps it cheap
+        max_model_len=2048,
+        max_num_batched_tokens=2048 * 32,
+        max_num_seqs=32,
+        gpu_memory_utilization=0.3,
+        additional_config=additional_config,
+    )
+    return AsyncLLMEngine.from_engine_args(args)
+
+
+async def _one(engine, seed: int, delay_s: float) -> float:
+    if delay_s:
+        await asyncio.sleep(delay_s)
+    sp = SamplingParams(
+        max_tokens=1,
+        ignore_eos=True,
+        temperature=0.0,
+        output_kind=RequestOutputKind.DELTA,
+    )
+    t0 = time.monotonic()
+    async for _ in engine.generate(_distinct_prompt(seed), sp, request_id=f"r{seed}"):
+        return (time.monotonic() - t0) * 1e3  # first (only) token = TTFT
+    return float("nan")
+
+
+async def _scenario(engine, label, n, ramp_s, seed0) -> Stats:
+    ttfts = await asyncio.gather(
+        *[_one(engine, seed0 + i, ramp_s * i) for i in range(n)]
+    )
+    return Stats(label, list(ttfts))
+
+
+async def _sequential(engine, label, n, seed0) -> Stats:
+    # n lone requests, each awaited before the next -> always num_reqs=1 (b1).
+    # Median over a few is stable; one sample is noisy.
+    ttfts = [await _one(engine, seed0 + i, 0) for i in range(n)]
+    return Stats(label, ttfts)
+
+
+async def _collect():
+    engine = _make_engine()
+    try:
+        # Warm up both graphs (b1 via single, b32 via a batch); discard.
+        await _scenario(engine, "warm_b1", 1, 0, 0)
+        await _scenario(engine, "warm_b32", LARGE, 0, 100)
+        single = await _sequential(engine, "single", 4, 1000)
+        staggered = await _scenario(engine, "staggered", SMALL, RAMP_MS / 1e3, 2000)
+        burst = await _scenario(engine, "burst", SMALL, 0, 3000)
+        batch = await _scenario(engine, "batch", LARGE, 0, 4000)
+    finally:
+        sd = getattr(engine, "shutdown", None)  # shutdown API varies by version
+        if callable(sd):
+            sd()
+    return {s.label: s for s in (single, staggered, burst, batch)}
+
+
+def _print_table(m):
+    layers = "full" if NUM_HIDDEN_LAYERS == 0 else f"{NUM_HIDDEN_LAYERS}L"
+    print(f"\n===== b1-prefill TTFT summary (Qwen3-8B {layers}, ISL {ISL}) =====")
+    for k in ("single", "staggered", "burst", "batch"):
+        print("  " + m[k].row())
+    print(
+        f"  (single=b1; burst={SMALL}<=threshold=b1; batch={LARGE}>threshold=b32; "
+        f"set TEST_PREFILL_BATCH_THRESHOLD=0 to see the b1-alone gap)"
+    )
+
+
+@pytest.mark.nightly
+@pytest.mark.single_device
+def test_b1_prefill_ttft():
+    """Fire one min_num_seqs=1 engine at four request shapes, print the TTFT table,
+    and assert the two wins b1-prefill should deliver:
+
+      1. b1 lone-request win  -- single (b1) << batch (b32). Fails without
+         min_num_seqs (a lone request would also pad to the 32-row graph).
+      2. threshold burst win  -- burst (b1) << batch (b32). With
+         prefill_batch_threshold on (the default here) a <=threshold burst is
+         served serially on b1; turn it off (TEST_PREFILL_BATCH_THRESHOLD=0) and
+         this assert instead pins the gap b1 alone leaves (burst batches to b32)."""
+    m = asyncio.run(_collect())
+    _print_table(m)
+    assert m["single"].median < m["batch"].median / 3, (
+        f"b1 lone-request win: single (b1) {m['single'].median:.0f}ms not << batch "
+        f"(b32) {m['batch'].median:.0f}ms -- is min_num_seqs/b1 active?"
+    )
+    assert m["burst"].median < m["batch"].median / 2, (
+        f"threshold burst win: burst {m['burst'].median:.0f}ms ~ b32 batch "
+        f"{m['batch'].median:.0f}ms -- is prefill_batch_threshold active?"
+    )

--- a/tests/integrations/vllm_plugin/generative/test_b1_prefill.py
+++ b/tests/integrations/vllm_plugin/generative/test_b1_prefill.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 """
-Standalone demo + regression for the b1-prefill optimization (tt-xla #5281).
+Standalone regression for the b1-prefill optimization (tt-xla #5281).
 
 A single `min_num_seqs=1` engine compiles BOTH a b1 (`[1, n]`) and a b32
 (`[max_num_seqs, n]`) prefill graph; the scheduler picks per step by how many
@@ -15,19 +15,15 @@ shapes and prints a TTFT table comparing them:
   batch    : M(>threshold) reqs       -> b32, correct to batch here (stable b32 anchor)
 
 One test, test_b1_prefill_ttft, runs all four shapes once and asserts the two
-wins b1-prefill should deliver:
-  1. single (b1) << batch (b32) -- the lone-request win; fails without min_num_seqs.
-  2. burst  (b1) << batch (b32) -- the small-burst win from prefill_batch_threshold;
-     with the threshold off (TEST_PREFILL_BATCH_THRESHOLD=0) it instead pins the
-     gap b1 alone leaves (the burst batches to b32, TTFT ~ the b32 batch) (#5281).
+wins b1-prefill delivers:
+  1. single (b1) << batch (b32) -- the lone-request win (min_num_seqs).
+  2. burst  (b1) << batch (b32) -- the small-burst win (prefill_batch_threshold).
 
-Engine config via env, so this file doubles as a 3-config development demo:
-  TEST_NUM_HIDDEN_LAYERS=0          full model (default 1 = single layer, fast)
-  TEST_MIN_NUM_SEQS=0               b1 off (b32 only); =1 (default) b1 on
-  TEST_PREFILL_BATCH_THRESHOLD=0    threshold off (default 16 routes small bursts to b1)
+Single layer (~2 min): the b1/b32 graph selection is depth-independent, so this
+gates the feature without the full-model compile. Full-model TTFT figures live
+in the PR discussion.
 """
 import asyncio
-import os
 import random
 import statistics
 import time
@@ -37,10 +33,6 @@ import pytest
 from vllm import AsyncEngineArgs, AsyncLLMEngine, SamplingParams
 from vllm.inputs import TokensPrompt
 from vllm.sampling_params import RequestOutputKind
-
-NUM_HIDDEN_LAYERS = int(os.environ.get("TEST_NUM_HIDDEN_LAYERS", "1"))  # 0 = full model
-MIN_NUM_SEQS = int(os.environ.get("TEST_MIN_NUM_SEQS", "1"))  # 0 = b1 off (b32 only)
-PREFILL_BATCH_THRESHOLD = int(os.environ.get("TEST_PREFILL_BATCH_THRESHOLD", "16"))
 
 ISL = 1024  # b1 win grows with ISL
 SMALL = 8  # burst size (<= threshold -> the gap target)
@@ -89,13 +81,10 @@ def _make_engine() -> AsyncLLMEngine:
         "optimization_level": 1,
         "enable_trace": False,  # prefill-focused; trace is a decode opt
         "fp32_dest_acc_en": False,
+        "num_hidden_layers": 1,  # single layer: nightly ~2 min; b1/b32 selection is depth-independent
+        "min_num_seqs": 1,  # b1-prefill: also compile the [1, n] graph
+        "prefill_batch_threshold": 16,  # route a burst of <=16 pending prefills to b1
     }
-    if NUM_HIDDEN_LAYERS:
-        additional_config["num_hidden_layers"] = NUM_HIDDEN_LAYERS
-    if MIN_NUM_SEQS:  # the b1 feature
-        additional_config["min_num_seqs"] = MIN_NUM_SEQS
-    if PREFILL_BATCH_THRESHOLD:  # route small bursts to b1 (#5281)
-        additional_config["prefill_batch_threshold"] = PREFILL_BATCH_THRESHOLD
     args = AsyncEngineArgs(
         model="Qwen/Qwen3-8B",
         # budget must cover max_model_len * max_num_seqs; small max_model_len keeps it cheap
@@ -155,13 +144,12 @@ async def _collect():
 
 
 def _print_table(m):
-    layers = "full" if NUM_HIDDEN_LAYERS == 0 else f"{NUM_HIDDEN_LAYERS}L"
-    print(f"\n===== b1-prefill TTFT summary (Qwen3-8B {layers}, ISL {ISL}) =====")
+    print(f"\n===== b1-prefill TTFT summary (Qwen3-8B 1L, ISL {ISL}) =====")
     for k in ("single", "staggered", "burst", "batch"):
         print("  " + m[k].row())
     print(
-        f"  (single=b1; burst={SMALL}<=threshold=b1; batch={LARGE}>threshold=b32; "
-        f"set TEST_PREFILL_BATCH_THRESHOLD=0 to see the b1-alone gap)"
+        f"  (single=b1; burst={SMALL}<=threshold -> b1; "
+        f"batch={LARGE}>threshold -> b32)"
     )
 
 
@@ -169,14 +157,13 @@ def _print_table(m):
 @pytest.mark.single_device
 def test_b1_prefill_ttft():
     """Fire one min_num_seqs=1 engine at four request shapes, print the TTFT table,
-    and assert the two wins b1-prefill should deliver:
+    and assert the two wins b1-prefill delivers:
 
-      1. b1 lone-request win  -- single (b1) << batch (b32). Fails without
+      1. b1 lone-request win  -- single (b1) << batch (b32); fails without
          min_num_seqs (a lone request would also pad to the 32-row graph).
-      2. threshold burst win  -- burst (b1) << batch (b32). With
-         prefill_batch_threshold on (the default here) a <=threshold burst is
-         served serially on b1; turn it off (TEST_PREFILL_BATCH_THRESHOLD=0) and
-         this assert instead pins the gap b1 alone leaves (burst batches to b32)."""
+      2. threshold burst win  -- burst (b1) << batch (b32); a <=threshold burst is
+         served serially on b1 instead of one slow b32 batch (prefill_batch_threshold).
+    """
     m = asyncio.run(_collect())
     _print_table(m)
     assert m["single"].median < m["batch"].median / 3, (


### PR DESCRIPTION
### Ticket
closes #5281 

### Problem description
vLLM runner always generates graphs with max_num_reqs and incoming requests are batch padded to match the max_num_reqs. However, batch32 prefill graphs are often ~8x-15x slower in terms of TTFT than batch1 prefill graphs.

### What's changed
- Added request-count bucketing for prefill warmup and execution in the TT vLLM runner. The backend can now distinguish between a small prefill bucket and the max request-count bucket, preallocate the matching buffers, and compile the corresponding graph shapes instead of forcing all prefills through the max batch shape.
- Added a scheduler heuristic for b1-prefill via prefill_batch_threshold. When the pending prefill count is small, scheduling can prefer the small prefill path instead of filling a large batch with mostly wasted rows, which targets better TTFT for low-concurrency prefills.
- Added a dedicated standalone b1-prefill regression/demo test to exercise the new scheduling and prefill behaviour end to end, with explicit coverage around TTFT-oriented single-request prefill execution.

### Checklist
- [X] New/Existing tests provide coverage for changes
