### PR TITLE
ci: add manual-build.yml dispatchable build-only workflow

### DIFF
--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -1,0 +1,60 @@
+name: Manual Build Wheels
+
+# Build-only entry point (no tests). Dispatch this to build tt-xla wheels for a
+# branch/SHA and consume the resulting artifacts elsewhere — e.g. tt-shield forge
+# image builds, which resolve a tt-xla ref to its xla-whl-manylinux* (pjrt) and
+# vllm-tt-whl-release* artifacts.
+#
+# Mirrors manual-test.yml's build path (build-image -> build-ttxla) but skips the
+# test job. build_types defaults to 'release,manylinux' so a single dispatch emits
+# the full set the forge flow expects: xla-whl-manylinux*, vllm-tt-whl-release*,
+# and xla-whl-release*.
+
+run-name: 'Build ( ${{ inputs.build_types }} ) ${{ github.ref_name }}'
+
+concurrency:
+  group: manual-build-${{ github.ref }}-${{ inputs.build_types }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_types:
+        description: 'Build types (comma-separated): release,explorer,manylinux'
+        default: 'release,manylinux'
+        type: string
+        required: false
+      mlir_override:
+        description: 'Git SHA of commit in tenstorrent/tt-mlir'
+        required: false
+        type: string
+      force_rebuild:
+        description: 'Force rebuild even if an artifact already exists for this commit'
+        type: boolean
+        required: false
+        default: false
+      artifact_sha:
+        description: 'tt-xla commit SHA to reuse pre-built artifacts from (leave empty to build fresh)'
+        required: false
+        type: string
+
+jobs:
+  build-image:
+    uses: ./.github/workflows/call-build-docker.yml
+    secrets: inherit
+    with:
+      mlir_override: ${{ inputs.mlir_override }}
+      # 'all' also builds the manylinux docker image, needed when manylinux is requested
+      dockbuild: ${{ contains(inputs.build_types, 'manylinux') && 'all' || 'ci' }}
+
+  build-ttxla:
+    needs: build-image
+    uses: ./.github/workflows/call-build.yml
+    secrets: inherit
+    with:
+      docker_image: ${{ needs.build-image.outputs.docker-image }}
+      docker_image_manylinux: ${{ needs.build-image.outputs.docker-image-manylinux }}
+      mlir_override: ${{ inputs.mlir_override }}
+      build_types: ${{ inputs.build_types }}
+      force_rebuild: ${{ inputs.force_rebuild }}
+      artifact_sha: ${{ inputs.artifact_sha }}


### PR DESCRIPTION
## What
Adds `manual-build.yml`, a `workflow_dispatch` entry point that builds tt-xla wheels for a branch/SHA **without running any tests**. It mirrors `manual-test.yml`'s build path (`build-image` → `build-ttxla`) but drops the test job.

`build_types` defaults to `release,manylinux`, so a single dispatch emits the full artifact set downstream consumers expect: `xla-whl-manylinux*` (pjrt), `vllm-tt-whl-release*`, and `xla-whl-release*`.

## Why
Supports the on-demand forge-image flow in tenstorrent/tt-shield#818 (and PR https://github.com/tenstorrent/tt-shield/pull/820), which resolves a tt-xla ref to its CI-built wheels. Today the only dispatchable path to a manylinux wheel is `manual-test.yml` with `manylinux_build: true`, which forces selecting a test list and then running tests — so devs kick off a throwaway test run just to get wheels and have to remember to cancel it. This gives a clean "just build" button instead.

## Notes
- `call-build.yml` can't be dispatched standalone (it needs `docker_image`/`docker_image_manylinux` from `call-build-docker.yml`), so this wrapper runs that docker job first. `dockbuild` is set to `all` when `manylinux` is requested, else `ci`.
- **Artifact reuse:** on a single-parent commit with no `mlir_override`, `call-build.yml` reuses existing same-SHA artifacts and skips building — so a run can finish green without producing *new* artifacts (consumers find them by `head_sha` across all runs). Use `force_rebuild: true` to force a fresh build.
- `concurrency` cancels superseded in-flight builds for the same ref + build types.

## Testing
Can't be dispatched until merged — GitHub only exposes `workflow_dispatch` for workflows on the default branch. Confidence pre-merge: it's a thin wrapper over `call-build-docker.yml` + `call-build.yml` (both already on `main` and exercised constantly by nightly/PR builds), using the same `build-image` → `build-ttxla` wiring as `manual-test.yml`, a path already confirmed to produce the correct wheels.
