### PR TITLE
Fix device-count mismatch for no-input graphs on multi-device runs

### DIFF
--- a/pjrt_implementation/inc/api/client_instance.h
+++ b/pjrt_implementation/inc/api/client_instance.h
@@ -154,7 +154,8 @@ public:
       const PJRT_Program *mlir_program,
       LoadedExecutableInstance **out_executable,
       const std::unordered_map<std::string, std::string> &compile_options,
-      const std::optional<std::vector<int64_t>> &replica_device_ids);
+      const std::optional<std::vector<int64_t>> &replica_device_ids,
+      size_t target_num_devices = 1);
 
 private:
   tt_pjrt_status populateDevices();

--- a/pjrt_implementation/inc/api/module_builder/module_builder.h
+++ b/pjrt_implementation/inc/api/module_builder/module_builder.h
@@ -129,7 +129,7 @@ public:
       const std::string_view &mlir_code,
       const std::string &system_descriptor_path,
       const std::unordered_map<std::string, std::string> &compile_options,
-      tt::pjrt::ClientInstance *client_instance);
+      tt::pjrt::ClientInstance *client_instance, size_t target_num_devices = 1);
 
   // Gets the first sdy.Mesh op of a mlir module with shardy dialect enbaled.
   // Could be used to extract mesh attribute from the module so we can use it as
@@ -200,12 +200,11 @@ private:
   tt_pjrt_status runCompilerStableHLOPipeline(
       mlir::OwningOpRef<mlir::ModuleOp> &mlir_module,
       const std::vector<int64_t> &result_presharded,
-      const std::vector<mlir::tt::sharding_utils::MeshSharding>
-          &output_shardings,
       const std::optional<std::string> &export_path,
       const std::string &model_name = "",
       const std::optional<std::vector<uint32_t>> &current_mesh_shape =
-          std::nullopt);
+          std::nullopt,
+      size_t target_num_devices = 1);
 
   // Converts StableHLO module to TTIR module.
   tt_pjrt_status

--- a/pjrt_implementation/src/api/client_instance.cc
+++ b/pjrt_implementation/src/api/client_instance.cc
@@ -478,13 +478,14 @@ tt_pjrt_status ClientInstance::populateMemories() {
 tt_pjrt_status ClientInstance::compileMlirProgram(
     const PJRT_Program *mlir_program, LoadedExecutableInstance **out_executable,
     const std::unordered_map<std::string, std::string> &compile_options,
-    const std::optional<std::vector<int64_t>> &replica_device_ids) {
+    const std::optional<std::vector<int64_t>> &replica_device_ids,
+    size_t target_num_devices) {
 
   std::string_view mlir_code(mlir_program->code, mlir_program->code_size);
 
   std::tuple<tt_pjrt_status, std::shared_ptr<ExecutableImage>> compile_result =
       m_module_builder->buildModule(mlir_code, m_cached_system_descriptor_path,
-                                    compile_options, this);
+                                    compile_options, this, target_num_devices);
   tt_pjrt_status status = std::get<tt_pjrt_status>(compile_result);
   if (!tt_pjrt_status_is_ok(status)) {
     return status;
@@ -840,6 +841,13 @@ PJRT_Error *onClientCompile(PJRT_Client_Compile_Args *args) {
     return *ErrorInstance::makeError(compile_options_status).release();
   }
 
+  // Execution device count from the device assignment (>1 for a multi-device
+  // run) tells the module builder to give no-input graphs the full mesh instead
+  // of collapsing it. Assumes pure SPMD (num_replicas == 1), which holds for
+  // the torch-xla / JAX SPMD compiles here.
+  size_t target_num_devices =
+      replica_device_ids.has_value() ? replica_device_ids->size() : 1;
+
   std::string_view program_format(args->program->format,
                                   args->program->format_size);
   if (program_format != module_builder::c_mlir_format_name) {
@@ -855,7 +863,7 @@ PJRT_Error *onClientCompile(PJRT_Client_Compile_Args *args) {
   tt_pjrt_status compile_status = client_instance->compileMlirProgram(
       args->program,
       reinterpret_cast<LoadedExecutableInstance **>(&args->executable),
-      compile_options_map, replica_device_ids);
+      compile_options_map, replica_device_ids, target_num_devices);
 
   return *ErrorInstance::makeError(compile_status).release();
 }

--- a/pjrt_implementation/src/api/module_builder/module_builder.cc
+++ b/pjrt_implementation/src/api/module_builder/module_builder.cc
@@ -98,19 +98,6 @@ moduleHasAnyFuncArguments(const mlir::OwningOpRef<mlir::ModuleOp> &m) {
   return public_func_ops[0].getNumArguments() > 0;
 }
 
-// Returns true if any sharding genuinely partitions a tensor across devices
-// (`MeshShardType::Devices`). Replicate / presharded-replicate shardings do not
-// count, since they do not require a multi-device mesh.
-static bool anyShardedAcrossDevices(
-    const std::vector<mlir::tt::sharding_utils::MeshSharding> &shardings) {
-  return std::any_of(
-      shardings.begin(), shardings.end(),
-      [](const mlir::tt::sharding_utils::MeshSharding &sharding) {
-        return sharding.getShardType() ==
-               mlir::tt::ttcore::MeshShardType::Devices;
-      });
-}
-
 // Maps per-axis fabric config to TTNN mesh topology for CCL operations.
 static std::vector<mlir::tt::ttcore::Topology>
 fabricConfigToMeshTopology(const tt::runtime::MeshFabricConfig &fabricConfig) {
@@ -299,7 +286,7 @@ ModuleBuilder::buildModule(
     const std::string_view &mlir_code,
     const std::string &system_descriptor_path,
     const std::unordered_map<std::string, std::string> &compile_options_map,
-    ClientInstance *client_instance) {
+    ClientInstance *client_instance, size_t target_num_devices) {
   DLOG_F(LOG_DEBUG, "ModuleBuilder::buildModule");
 
   auto compile_options = CompileOptions::parse(compile_options_map);
@@ -371,10 +358,10 @@ ModuleBuilder::buildModule(
       parent_mesh ? std::make_optional(tt::runtime::getMeshShape(*parent_mesh))
                   : std::nullopt;
 
-  status = runCompilerStableHLOPipeline(
-      mlir_module, result_presharded, output_shardings,
-      compile_options.export_path, compile_options.export_model_name,
-      current_mesh_shape);
+  status = runCompilerStableHLOPipeline(mlir_module, result_presharded,
+                                        compile_options.export_path,
+                                        compile_options.export_model_name,
+                                        current_mesh_shape, target_num_devices);
   if (!tt_pjrt_status_is_ok(status)) {
     return {status, nullptr};
   }
@@ -749,27 +736,21 @@ std::vector<int64_t> ModuleBuilder::collectResultPresharded(
 tt_pjrt_status ModuleBuilder::runCompilerStableHLOPipeline(
     mlir::OwningOpRef<mlir::ModuleOp> &mlir_module,
     const std::vector<int64_t> &result_presharded,
-    const std::vector<mlir::tt::sharding_utils::MeshSharding> &output_shardings,
     const std::optional<std::string> &export_path,
     const std::string &model_name,
-    const std::optional<std::vector<uint32_t>> &current_mesh_shape) {
+    const std::optional<std::vector<uint32_t>> &current_mesh_shape,
+    size_t target_num_devices) {
   mlir::PassManager stablehlo_pipeline_pm(mlir_module.get()->getName(),
                                           mlir::PassManager::Nesting::Implicit);
   mlir::tt::stablehlo::StableHLOPipelineOptions stablehlo_pipeline_options;
   stablehlo_pipeline_options.resultPresharded = result_presharded;
 
-  // A graph with no inputs inherits the full device mesh so that a genuinely
-  // distributed result lands on all devices (see #4439). But that is only
-  // correct when something is actually sharded across devices: a no-input graph
-  // that merely produces a replicated value (e.g. gemma's standalone
-  // `sqrt(hidden_size)` scalar normalizer) is executed on a single device, so
-  // stamping it with the full mesh inflates the device count and breaks
-  // execution with a "Device count mismatch" error. Only adopt the full mesh
-  // when a result is genuinely device-sharded; otherwise let it default to a
-  // single device.
+  // A no-input graph on a multi-device run must adopt the full mesh: a no-input
+  // replicated value (e.g. a const-folded torch.arange) would otherwise default
+  // to 1x1, collapse the mesh, and break the live sharded buffers.
+  // See https://github.com/tenstorrent/tt-xla/issues/5360
   if (current_mesh_shape.has_value() && current_mesh_shape->size() == 2 &&
-      !moduleHasAnyFuncArguments(mlir_module) &&
-      anyShardedAcrossDevices(output_shardings)) {
+      !moduleHasAnyFuncArguments(mlir_module) && target_num_devices > 1) {
     stablehlo_pipeline_options.meshShape = {
         static_cast<int64_t>((*current_mesh_shape)[0]),
         static_cast<int64_t>((*current_mesh_shape)[1])};

--- a/tests/torch/models/HunyuanImage_2_1/test_transformer.py
+++ b/tests/torch/models/HunyuanImage_2_1/test_transformer.py
@@ -25,7 +25,7 @@ def test_transformer():
 
 
 @pytest.mark.xfail(
-    reason="Out of Memory: Not enough space to allocate 234881024 B DRAM buffer across 12 banks, where each bank needs to store 19574784 B, but bank size is 1071821792 B - https://github.com/tenstorrent/tt-xla/issues/4780"
+    reason="Out of Memory: Not enough space to allocate 771162112 B DRAM buffer across 12 banks, where each bank needs to store 64266240 B, but bank size is 1070773184 B - https://github.com/tenstorrent/tt-xla/issues/4780"
 )
 @pytest.mark.nightly
 @pytest.mark.model_test

--- a/tests/torch/ops/test_arange.py
+++ b/tests/torch/ops/test_arange.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""torch.arange no-input-graph sharding repro: it const-folds to a no-argument graph
+that collapses the mesh [1,4]->[1,1] while a sharded buffer is live -> device mismatch.
+"""
+
+import numpy as np
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_op_test
+from torch_xla.distributed.spmd import Mesh
+from utils import Category
+
+DIM = 64
+
+
+class Arange(torch.nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.proj = torch.nn.Linear(
+            dim, dim, bias=False, dtype=torch.bfloat16
+        )  # sharded buffer
+
+    def forward(self, x):
+        return torch.arange(0, DIM, dtype=torch.float32, device=x.device)
+
+
+@pytest.mark.nightly
+@pytest.mark.llmbox
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST, torch_op_name="torch.arange"
+)
+def test_arange_no_input_graph_sharding():
+    model = Arange(DIM)
+    num_devices = xr.global_runtime_device_count()
+    mesh = Mesh(np.array(range(num_devices)), (1, num_devices), ("batch", "model"))
+
+    run_op_test(
+        model,
+        [torch.randn(1, DIM, dtype=torch.bfloat16)],
+        framework=Framework.TORCH,
+        mesh=mesh,
+        shard_spec_fn=lambda m: {m.proj.weight: ("model", "batch")},
+    )


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-xla/issues/5360

### Problem description

- Sharded models that contain a no-input graph hit Device count mismatch: N vs 1 (e.g. HunyuanImage 2.1 transformer on llmbox, [#5360](https://github.com/tenstorrent/tt-xla/issues/5360)). A const-folded no-input graph (e.g. torch.arange in RoPE) is stamped with a 1×1 mesh, which reshapes the device mesh [1,N] -> [1,1] and breaks the live sharded buffers. Full root cause: [#5360](https://github.com/tenstorrent/tt-xla/issues/5360).

### What's changed

- A no-input graph now adopts the full mesh when either its result is device-sharded or the run targets more than one device. The execution device count (num_partitions, parsed from ExecutableBuildOptionsProto) is threaded through compileMlirProgram -> buildModule -> runCompilerStableHLOPipeline and used as the discriminator.

### What's changed

- A no-input graph now adopts the full mesh when the run targets more than one device. The execution device count (from the device assignment) is threaded through compileMlirProgram -> buildModule -> runCompilerStableHLOPipeline and used as the discriminator.
- Removed the now-unused `anyShardedAcrossDevices` helper (its only caller was the simplified condition).
- Added a minimal `torch.arange` sanity test (`tests/torch/ops/test_arange.py`) that reproduces the mismatch on a multi-device mesh as a regression guard.

### Checklist
- [x] Verify the changes through local testing on sanity and model in WH

### Logs

- [jun24_arange_before_fix.log](https://github.com/user-attachments/files/29303232/jun24_arange_before_fix_final.log)
- [jun24_HunyuanImage_2_1_transformer_before_fix.log](https://github.com/user-attachments/files/29303233/jun24_HunyuanImage_2_1_transformer_before_fix.log)
- [jul1_arange.log](https://github.com/user-attachments/files/29542222/jul1_arange.log)
- [jul1_hunyuanImage_2_1_transformer_after_fix.log](https://github.com/user-attachments/files/29542224/jul1_hunyuanImage_2_1_transformer_after_fix.log)

