### PR TITLE
Uplift third_party/tt_forge_models to 8ac99db296d3e5dd87456bb5ff840a1b25fa33ee 2026-06-25

### DIFF
--- a/.test_durations
+++ b/.test_durations
@@ -2310,7 +2310,7 @@
     "tests/runner/test_models.py::test_all_models_torch[albert/masked_lm/pytorch-Large_v2-single_device-inference]": 74.026,
     "tests/runner/test_models.py::test_all_models_torch[vgg/pytorch-Torchvision_Vgg11-single_device-inference]": 35.269,
     "tests/runner/test_models.py::test_all_models_torch[siglip/image_text_similarity/pytorch-Base_Patch16_256_Multilingual-single_device-inference]": 78.07,
-    "tests/runner/test_models.py::test_all_models_torch[bloom/pytorch-single_device-inference]": 88.418,
+    "tests/runner/test_models.py::test_all_models_torch[bloom/pytorch-1b1-single_device-inference]": 88.418,
     "tests/runner/test_models.py::test_all_models_torch[resnext/pytorch-50_32x4d-single_device-inference]": 39.583,
     "tests/infra_tests/single_chip/test_result_assertion.py::test_fail_atol_triggers_assertion_by_default[torch]": 0.414,
     "tests/infra_tests/single_chip/test_result_assertion.py::test_fail_atol_triggers_assertion_by_default[jax]": 1.894,

--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -65,7 +65,7 @@ test_config:
     required_pcc: 0.97  # PCC drop when changing input
     status: EXPECTED_PASSING
 
-  bloom/pytorch-single_device-inference:
+  bloom/pytorch-1b1-single_device-inference:
     status: EXPECTED_PASSING
 
   xglm/pytorch-564M-single_device-inference:


### PR DESCRIPTION
This PR uplifts the third_party/tt_forge_models to the 8ac99db296d3e5dd87456bb5ff840a1b25fa33ee

[Edit] @gengelageTT : the `bloom/pytorch` variant was renamed to be `bloom/pytorch-1b1`. Updated this in test_config_inference_single_device.yaml and .test_durations.