### PR TITLE
Resolve WH galaxy hang

### DIFF
--- a/pjrt_implementation/src/api/client_instance.cc
+++ b/pjrt_implementation/src/api/client_instance.cc
@@ -546,18 +546,14 @@ ClientInstance::computeFabricConfig(const std::vector<uint32_t> &mesh_shape) {
                         : tt::runtime::FabricConfig::DISABLED;
     return tt::runtime::MeshFabricConfig{global, {}};
   }
-  // [Workaround] The Blackhole galaxy (UBB) lacks a both-axis wrap, so
+  // [Workaround] Galaxy lacks a both-axis wrap, so
   // computeMeshFabricConfig's RING_RING is rejected as TORUS_XY by the
-  // TopologyMapper; force FABRIC_1D there. Other 32-device galaxies (e.g.
-  // Wormhole) have the wrap, so keep their auto-detected fabric.
-  bool is_blackhole = m_system_descriptor->chip_descs()->size() > 0 &&
-                      m_system_descriptor->chip_descs()->Get(0)->arch() ==
-                          ::tt::target::Arch::Blackhole;
-  if (is_blackhole && m_devices.size() == 32) {
-    LOG_F(WARNING,
-          "Auto-overriding fabric config to FABRIC_1D for the "
-          "32-device Blackhole galaxy (UBB); this is a workaround, not "
-          "expected behaviour.");
+  // TopologyMapper; force FABRIC_1D there.
+  if (m_devices.size() == 32) {
+    LOG_F(
+        WARNING,
+        "Auto-overriding fabric config to FABRIC_1D for the 32-device galaxy; "
+        "this is a workaround, not expected behaviour.");
     return tt::runtime::MeshFabricConfig{tt::runtime::FabricConfig::FABRIC_1D,
                                          {}};
   }


### PR DESCRIPTION
### Ticket
None

### Problem description
When a wh galaxy in a quad is being used, it does not wrap around x axis but it does around y axis. This means that `TORUS_Y` and `TORUS_XY` would fail. However, from tt-metal it is only checking if the machine is a galaxy and assigns `TORUS_XY`. A better solution would be from tt-metal where it checks if both axes wrap before assigning `TORUS_XY` and falling back to line if not.

### What's changed
Extended Sungjoon's fix to all galaxies. 

### Checklist
- [ ] New/Existing tests provide coverage for changes
