### PR TITLE
fix `manual-build.yml` startup_failure (missing permissions)

### DIFF
--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -38,6 +38,16 @@ on:
         required: false
         type: string
 
+# call-build-docker.yml pushes images to ghcr and writes checks, so the caller
+# must grant these (matches manual-test.yml). Without this block the run hits a
+# startup_failure: "requesting 'checks: write, packages: write', but is only
+# allowed 'checks: none, packages: read'".
+permissions:
+  actions: write
+  packages: write
+  checks: write
+  contents: read
+
 jobs:
   build-image:
     uses: ./.github/workflows/call-build-docker.yml


### PR DESCRIPTION
## Ticket

Follow up to https://github.com/tenstorrent/tt-xla/pull/5365 (could not test new workflow until merged)

## Problem

Dispatching the new **Manual Build Wheels** failed immediately with a `startup_failure` ([run 28176150455](https://github.com/tenstorrent/tt-xla/actions/runs/28176150455)):

> The workflow is requesting 'checks: write, packages: write', but is only allowed 'checks: none, packages: read'.

`manual-build.yml`'s `build-image` job calls `call-build-docker.yml`, which pushes images to ghcr and writes checks (`packages: write` + `checks: write`). The workflow had **no `permissions:` block**, so its `GITHUB_TOKEN` defaulted to read-only and GitHub rejected the run before any job started. This affected every dispatch, on any branch.

## Fix
Add the same `permissions:` block `manual-test.yml` already declares (it calls the same build workflows):
```yaml
permissions:
  actions: write
  packages: write
  checks: write
  contents: read
```

## Validation
Pushed to a branch and dispatched before merging ([run 28177682993](https://github.com/tenstorrent/tt-xla/actions/runs/28177682993)): the run clears startup validation and executes jobs (`build-image` runs), where the unfixed run produced zero jobs. Confirms the `startup_failure` is resolved.
