### PR TITLE
Add tensor-parallel inference configs for new added models 

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -364,3 +364,45 @@ test_config:
   exaone_3_5/pytorch-EXAONE-3.5-32B-Instruct-tensor_parallel-inference:
     supported_archs: [qb2-blackhole]
     status: EXPECTED_PASSING
+
+  bloom/pytorch-176B-tensor_parallel-inference:
+    supported_archs: [galaxy-wh-6u]
+    status: EXPECTED_PASSING
+    enable_weight_bfp8_conversion: true
+
+  falcon/pytorch-180B_Chat-tensor_parallel-inference:
+    supported_archs: [galaxy-wh-6u]
+    status: EXPECTED_PASSING
+    enable_weight_bfp8_conversion: true
+
+  starcoder2/pytorch-15B-tensor_parallel-inference:
+    supported_archs: [qb2-blackhole]
+    status: EXPECTED_PASSING
+
+  orion/pytorch-14B_Chat-tensor_parallel-inference:
+    supported_archs: [qb2-blackhole]
+    status: EXPECTED_PASSING
+
+  codellama/pytorch-CodeLlama-34b-Instruct-hf-tensor_parallel-inference:
+    supported_archs: [qb2-blackhole]
+    status: EXPECTED_PASSING
+
+  wizardlm_70b/pytorch-WizardLM-70B-V1.0-tensor_parallel-inference:
+    supported_archs: [qb2-blackhole]
+    status: EXPECTED_PASSING
+    enable_weight_bfp8_conversion: true
+
+  wizardmath_70b/pytorch-WizardMath-70B-V1.0-tensor_parallel-inference:
+    supported_archs: [qb2-blackhole]
+    status: EXPECTED_PASSING
+    enable_weight_bfp8_conversion: true
+
+  hermes_4_70b/pytorch-Hermes-4-70B-tensor_parallel-inference:
+    supported_archs: [qb2-blackhole]
+    status: EXPECTED_PASSING
+    enable_weight_bfp8_conversion: true
+
+  coherlabs/pytorch-Coherelabs_c4ai_command_r_plus_08_2024-tensor_parallel-inference:
+    supported_archs: [galaxy-wh-6u]
+    status: EXPECTED_PASSING
+    enable_weight_bfp8_conversion: true


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Add tensor-parallel inference configs for new added models 

### What's changed
Add tensor-parallel inference configs for large LLMs

Add EXPECTED_PASSING entries for BLOOM-176B, Falcon-180B-Chat, StarCoder2-15B, Orion-14B-Chat, CodeLlama-34B-Instruct, WizardLM-70B, WizardMath-70B, Hermes-4-70B tensor-parallel inference tests.

BLOOM, coherlabs/pytorch-Coherelabs_c4ai_command_r_plus_08_2024 and Falcon run on galaxy-wh-6u; the rest on qb2-blackhole. Enable enable_weight_bfp8_conversion for the 70B+ models to fit weights in device memory.

### Checklist
- [ ] New/Existing tests provide coverage for changes
