### PR TITLE
[Benchmark] Test kimi-k2.6 instead of k2.5 and increase required pcc

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -337,9 +337,9 @@
         "runs-on": "galaxy-wh-6u"
       },
       {
-        "name": "kimi_k2_5_tp_galaxy_2_layers",
+        "name": "kimi_k2_6_tp_galaxy_2_layers",
         "pyreq": "tiktoken",
-        "pytest": "tests/benchmark/test_llms.py::test_kimi_k2_5_tp_galaxy_2_layers",
+        "pytest": "tests/benchmark/test_llms.py::test_kimi_k2_6_tp_galaxy_2_layers",
         "runs-on": "galaxy-wh-6u"
       },
       {

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -2156,12 +2156,13 @@ def test_kimi_k2_tp_galaxy_2_layers(
         experimental_kv_cache_dtype=None,
         optimization_level=0,
         trace_enabled=False,
+        required_pcc=0.99,
     )
 
 
 # Trace disabled: topk i64 indices can't reside in device DRAM inside capture_or_execute_trace
 # This test only runs 2 layers so we expect to see incoherent output
-def test_kimi_k2_5_tp_galaxy_2_layers(
+def test_kimi_k2_6_tp_galaxy_2_layers(
     output_file,
     num_layers,
     request,
@@ -2170,12 +2171,12 @@ def test_kimi_k2_5_tp_galaxy_2_layers(
     max_output_tokens,
     decode_only,
 ):
-    from third_party.tt_forge_models.kimi_k2.k2_5.pytorch.loader import (
+    from third_party.tt_forge_models.kimi_k2.k2_6.pytorch.loader import (
         ModelLoader,
         ModelVariant,
     )
 
-    variant = ModelVariant.KIMI_K2_5_MODIFIED
+    variant = ModelVariant.KIMI_K2_6_MODIFIED
     test_llm_tp(
         ModelLoader,
         variant,
@@ -2191,6 +2192,7 @@ def test_kimi_k2_5_tp_galaxy_2_layers(
         experimental_kv_cache_dtype=None,
         optimization_level=0,
         trace_enabled=False,
+        required_pcc=0.99,
     )
 
 
@@ -2686,6 +2688,7 @@ def test_deepseek_v3_1_tp_galaxy_4_layers(
         shard_spec_fn=_deepseek_v3_1_shard_spec_fn,
         required_pcc=0.96,
         experimental_kv_cache_dtype=None,
+        required_pcc=0.99,
     )
 
 

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -2686,7 +2686,6 @@ def test_deepseek_v3_1_tp_galaxy_4_layers(
         optimization_level=0,
         trace_enabled=False,
         shard_spec_fn=_deepseek_v3_1_shard_spec_fn,
-        required_pcc=0.96,
         experimental_kv_cache_dtype=None,
         required_pcc=0.99,
     )


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/4351
https://github.com/tenstorrent/tt-xla/issues/5096

### Problem description
1. We want to bringup kimi-k2.6 starting with a benchmark with a couple layers.

2. For the benchmarks of 2-4 layers, when PCC is < `0.99` it can drop significantly as more layers are run. 

### What's changed
1. Kimi-k2.5 and Kimi-k2.6 differ only by weights. Change the benchmark to run kimi-k2.6.

2.  Loading of proper weights for kimi-k2 variants was recently added in tt-forge-models which improves PCC slightly. Setting `required_pcc=0.99` for kimi-k2 variants and deepseek-v3.1 which all currently see a pcc >= `0.997` as of nightly June 25th.

### Checklist
- [x] New/Existing tests provide coverage for changes
