### PR TITLE
Extend n150 LLM checks and enable perf regression checks for uplift OnPR

### DIFF
--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -74,17 +74,16 @@ jobs:
       docker_image: ${{ needs.build-image.outputs.docker-image-base }}
       # NOTE: these filters intentionally exclude perf benchmarks that hang/fail on PR
       # while keeping them live in the nightly matrix (see perf-bench-matrix.json):
-      #   - llama_3_1_8b_instruct (n150): hang (#5282, fix tt-metal#47221)
       #   - gpt_oss_20b_tp / gpt_oss_20b_tp_batch_size_1 (n300-llmbox): #5151, #5207
       #   - llama_3_1_70b_tp_galaxy (galaxy-wh-6u): fabric pinning (#5210)
       #   - vllm_llama_3_1_70b_tp (n300-llmbox): temporarily removed from On PR because flaky, tracked in issue #5294
       adv_filter: '[
         { "accuracy-testing": false },
-        { "runs-on": "n150-perf", "filter": ["resnet","qwen_3_4b_embedding"] },
+        { "runs-on": "n150-perf", "filter": ["resnet","qwen_3_4b_embedding","llama_3_1_8b","falcon3-1b","qwen_3_8b"] },
         { "runs-on": "n300-llmbox", "filter": ["test_llama_3_1_70b_tp"] } ]'
       sh-runner: false
       skip-device-perf: true
-      regression_check: false
+      regression_check: true
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
 

--- a/.github/workflows/schedule-nightly.yml
+++ b/.github/workflows/schedule-nightly.yml
@@ -89,7 +89,7 @@ jobs:
       sh-runner: false
       skip-device-perf: true
       regression_check: true
-      adv_filter: '[ {"accuracy-testing": false}, {"runs-on": "n150-perf"}, {"runs-on": "p150-perf"}, {"runs-on": "n300-llmbox"}, {"runs-on": "galaxy-wh-6u"}, {"runs-on": "qb2-blackhole"}, {"runs-on": "galaxy-bh"} ]'
+      adv_filter: '[ {"accuracy-testing": false}, {"runs-on": "n150-perf"}, {"runs-on": "p150-perf"}, {"runs-on": "n300-llmbox"}, {"runs-on": "galaxy-wh-6u"}, {"runs-on": "qb2-blackhole"} ]'
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
       wheel_build: manylinux

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -1070,10 +1070,6 @@ def test_ministral_8b(
     )
 
 
-# The n150 perf entry (llama_3_1_8b_instruct) is excluded from the onPR perf filter
-# (still runs in nightly): device hang during uplift
-# (https://github.com/tenstorrent/tt-xla/issues/5282, fix in
-# https://github.com/tenstorrent/tt-metal/pull/47221). The accuracy entry still runs.
 def test_llama_3_1_8b(
     output_file,
     num_layers,


### PR DESCRIPTION
### Ticket
Closes #5392

### What's changed
Enabled "Check perf regression" on uplift OnPR benchmark tests.
Re-enabled llama_3_1_8b (https://github.com/tenstorrent/tt-xla/issues/5282) and extended n150 LLM tests.

Since https://github.com/tenstorrent/tt-xla/pull/5222 broke [benchmark On Nightly](https://github.com/tenstorrent/tt-xla/actions/runs/28306395273/job/83863219239), removed `galaxy-bh` from "runs-on" as a fix.