### PR TITLE
Exposing CCL activation lowering flag in compiler config

### DIFF
--- a/pjrt_implementation/inc/api/compile_options.h
+++ b/pjrt_implementation/inc/api/compile_options.h
@@ -44,6 +44,12 @@ struct CompileOptions {
   // Enables experimental KV cache dtype override.
   std::optional<std::string> experimental_kv_cache_dtype = std::nullopt;
 
+  // Enable activation dtype lowering around CCL ops (matmul -> reduce_scatter
+  // / all_gather -> consumer). Pattern-matches Llama-style sub-graphs
+  // (O-proj+residual, MLP). Default off; flip on
+  // per-model after validating model accuracy doesn't degrade.
+  bool enable_activation_dtype_lowering = false;
+
   // Override math fidelity for all ttnn operations exposing compute kernel
   // config. Valid values: "lofi", "hifi2", "hifi3", "hifi4", "ttnn_default".
   // "ttnn_default" - means that we don't override math_fidelity in comiler,

--- a/pjrt_implementation/src/api/compile_options.cc
+++ b/pjrt_implementation/src/api/compile_options.cc
@@ -25,6 +25,10 @@ CompileOptions CompileOptions::parse(
           .value_or(options.experimental_weight_dtype);
   options.experimental_kv_cache_dtype = internal::parseStringOption(
       compile_options, "experimental-kv-cache-dtype");
+  options.enable_activation_dtype_lowering =
+      internal::parseBoolOption(compile_options,
+                                "enable_activation_dtype_lowering")
+          .value_or(options.enable_activation_dtype_lowering);
   options.math_fidelity =
       internal::parseStringOption(compile_options, "math_fidelity");
 

--- a/pjrt_implementation/src/api/module_builder/module_builder.cc
+++ b/pjrt_implementation/src/api/module_builder/module_builder.cc
@@ -984,6 +984,8 @@ tt_pjrt_status ModuleBuilder::convertFromTTIRToTTNN(
     }
     options.experimentalKVCacheDtype = dtype.value();
   }
+  options.enableActivationDtypeLowering =
+      compile_options.enable_activation_dtype_lowering;
   options.enableTrace = compile_options.enable_trace;
   options.systemDescPath = system_descriptor_path.data();
   options.enableConstEval = compile_options.enable_const_eval;

--- a/tests/benchmark/benchmarks/llm_benchmark.py
+++ b/tests/benchmark/benchmarks/llm_benchmark.py
@@ -267,6 +267,7 @@ def benchmark_llm_torch_xla(
     use_indexer_cache: bool = False,
     enable_create_d2m_subgraphs: bool = False,
     experts_implementation: Optional[str] = None,
+    enable_activation_dtype_lowering: bool = False,
 ):
     """
     Benchmark an LLM (Large Language Model) using PyTorch and torch-xla.
@@ -477,6 +478,8 @@ def benchmark_llm_torch_xla(
         options["experimental-kv-cache-dtype"] = experimental_kv_cache_dtype
     if enable_create_d2m_subgraphs:
         options["enable_create_d2m_subgraphs"] = enable_create_d2m_subgraphs
+    if enable_activation_dtype_lowering:
+        options["enable_activation_dtype_lowering"] = "true"
 
     torch_xla.set_custom_compile_options(options)
 

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -30,6 +30,7 @@ DEFAULT_EXPERIMENTAL_WEIGHT_DTYPE = "bfp_bf8"
 DEFAULT_EXPERIMENTAL_KV_CACHE_DTYPE = "bfp_bf8"
 DEFAULT_EXPERIMENTAL_ENABLE_PERMUTE_MATMUL_FUSION = False
 DEFAULT_REQUIRED_PCC = 0.94
+DEFAULT_ENABLE_ACTIVATION_DTYPE_LOWERING = False
 
 
 def default_read_logits_fn(output):
@@ -69,6 +70,7 @@ def test_llm(
     use_indexer_cache: bool = False,
     enable_create_d2m_subgraphs: bool = False,
     experts_implementation: Optional[str] = None,
+    enable_activation_dtype_lowering: bool = DEFAULT_ENABLE_ACTIVATION_DTYPE_LOWERING,
 ):
     """Test LLM model with the given variant and optional configuration overrides.
 
@@ -170,6 +172,7 @@ def test_llm(
         use_indexer_cache=use_indexer_cache,
         enable_create_d2m_subgraphs=enable_create_d2m_subgraphs,
         experts_implementation=experts_implementation,
+        enable_activation_dtype_lowering=enable_activation_dtype_lowering,
     )
 
     if output_file:
@@ -1894,6 +1897,10 @@ def test_llama_3_1_70b_tp_galaxy(
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
         optimization_level=1,
+        # Lower activations to bfp8 around the MLP/O-proj CCL ops to cut the bytes
+        # the collectives move. Validated on the full 80-layer model: TOP1 mean
+        # 95.95% vs 95.80% baseline, TOP5 100% in both, so accuracy is preserved.
+        enable_activation_dtype_lowering=True,
     )
 
 

--- a/tests/infra/testers/compiler_config.py
+++ b/tests/infra/testers/compiler_config.py
@@ -34,6 +34,12 @@ class CompilerConfig:
     # Enables experimental KV cache dtype override in MLIR optimizer passes.
     experimental_kv_cache_dtype: Optional[str] = None
 
+    # Enable activation dtype lowering around CCL ops (matmul -> reduce_scatter
+    # all_gather -> consumer). Pattern-matches Llama-style sub-graphs
+    # (O-proj+residual, MLP). Default off; flip on
+    # per-model after validating model accuracy doesn't degrade.
+    enable_activation_dtype_lowering: bool = False
+
     # Override math fidelity for all ttnn operations exposing compute kernel
     # config. Valid values: "lofi", "hifi2", "hifi3", "hifi4", "ttnn_default".
     # "ttnn_default" - means that we don't override math_fidelity in comiler,
@@ -102,6 +108,9 @@ class CompilerConfig:
 
         if self.experimental_kv_cache_dtype is not None:
             options["experimental-kv-cache-dtype"] = self.experimental_kv_cache_dtype
+
+        if self.enable_activation_dtype_lowering:
+            options["enable_activation_dtype_lowering"] = "true"
 
         if self.math_fidelity is not None:
             options["math_fidelity"] = self.math_fidelity


### PR DESCRIPTION
### Ticket
Closes #5178

### What's changed
Exposing new Mixed Precision feature - CCL activation lowering, through compiler config
- Lowering of activation dtype from default bf16 to bfp8 around CCL operations (reduce scatter, all gather) for better perf. Moving around almost 2x less data by going from bf16 to bfp8.
- Default off. For now, it will be turned on per model if it doesn't regress the e2e accuracy. For start, turned on on llama 70b in this PR.
- Currently patterns in tt-mlir are written specifically for llama architecture, so they will under trigger by design. We will add more patterns for latest architectures (Deepseek, GLM, Kimi) and merge similar patterns to more general ones...

### Future
This feature will be worked on. Mainly adding new patterns in tt-mlir to lower CCL activation dtypes in new architectures. So if this flag is on and activations around CCLs are not lowered -> please open issue to @dgolubovicTT with a repro.
