### PR TITLE
Enable VAE on TT for Playground v2.5 and SDXL Lightning

### DIFF
--- a/tests/benchmark/benchmarks/sdxl_lightning_pipeline.py
+++ b/tests/benchmark/benchmarks/sdxl_lightning_pipeline.py
@@ -38,7 +38,7 @@ class SDXLLightningConfig:
         text_encoder_on_tt: bool = True,
         text_encoder_2_on_tt: bool = True,
         unet_on_tt: bool = True,
-        vae_on_tt: bool = False,
+        vae_on_tt: bool = True,
         compile_options: Optional[dict] = None,
     ):
         self.model_id = MODEL_ID

--- a/tests/benchmark/test_imagegen.py
+++ b/tests/benchmark/test_imagegen.py
@@ -92,14 +92,6 @@ def test_imagegen(
             json.dump(results, file, indent=2)
 
 
-@pytest.mark.xfail(
-    reason=(
-        "VAE compile TT_FATAL during warmup (cores harvested / device_hash mismatch), "
-        "possibly due to recent uplift — "
-        "https://github.com/tenstorrent/tt-xla/issues/5176"
-    ),
-    strict=False,
-)
 def test_playground_v2_5(output_file, request):
     from benchmarks.playground_v2_5_pipeline import (
         PlaygroundV25Config,
@@ -159,14 +151,10 @@ def test_sdxl_lightning(output_file, request):
     height = width = 1024
 
     def build_pipeline_fn(compile_options):
-        # Text encoders + UNet on TT; VAE on CPU. The VAE OOMs from GroupNorm
-        # decomposition at opt_level=0; opt_level=1 enables the composite
-        # ttnn.group_norm which lets the VAE pass, but switching opt level
-        # (UNet opt 0 -> VAE opt 1) trips a device-hash mismatch
-        # (https://github.com/tenstorrent/tt-xla/issues/5176). So keep the VAE on
-        # CPU until tt-metal https://github.com/tenstorrent/tt-metal/pull/46959 lands.
+        # All 4 components on TT. compile_options forwarded into Config so the
+        # VAE-only opt_level switch can merge instead of clobbering.
         pipeline = SDXLLightningPipeline(
-            config=SDXLLightningConfig(vae_on_tt=False, compile_options=compile_options)
+            config=SDXLLightningConfig(compile_options=compile_options)
         )
         pipeline.setup()
 

--- a/tests/torch/models/playground_v2_5/test_playground_v2_5_pipeline.py
+++ b/tests/torch/models/playground_v2_5/test_playground_v2_5_pipeline.py
@@ -390,14 +390,6 @@ def run_playground_v25_pipeline(
     return output_path
 
 
-@pytest.mark.xfail(
-    reason=(
-        "VAE compile TT_FATAL during warmup (cores harvested / device_hash mismatch), "
-        "possibly due to recent uplift — "
-        "https://github.com/tenstorrent/tt-xla/issues/5176"
-    ),
-    strict=False,
-)
 @pytest.mark.nightly
 @pytest.mark.model_test
 @pytest.mark.single_device

--- a/tests/torch/models/sdxl_lightning/test_sdxl_lightning_pipeline.py
+++ b/tests/torch/models/sdxl_lightning/test_sdxl_lightning_pipeline.py
@@ -4,10 +4,10 @@
 
 """SDXL-Lightning — nightly e2e pipeline test.
 
-Each nn.Module component (text_encoder, text_encoder_2, unet) is moved to
-Tenstorrent via `model.compile(backend="tt") + model.to(xla_device())`. The VAE
-runs on CPU (avoids a TT opt-level switch that trips a device-hash mismatch —
-tt-xla #5176 / tt-metal #46959). Tokenizer and scheduler always stay on CPU.
+Each nn.Module component (text_encoder, text_encoder_2, unet, vae) is moved to
+Tenstorrent via `model.compile(backend="tt") + model.to(xla_device())`. Tokenizer
+and scheduler always stay on CPU. CPU→TT→CPU device switching is done inline at
+the call site of each nn component.
 """
 
 from pathlib import Path
@@ -45,7 +45,7 @@ class SDXLLightningConfig:
         text_encoder_on_tt: bool = True,
         text_encoder_2_on_tt: bool = True,
         unet_on_tt: bool = True,
-        vae_on_tt: bool = False,
+        vae_on_tt: bool = True,
     ):
         self.model_id = MODEL_ID
         self.width = WIDTH


### PR DESCRIPTION
### Ticket

- closes https://github.com/tenstorrent/tt-xla/issues/5306
- closes https://github.com/tenstorrent/tt-xla/issues/5307
- closes https://github.com/tenstorrent/tt-xla/issues/5176

### Problem description

- Required fix ([#46959](https://github.com/tenstorrent/tt-metal/pull/46959)) is tracked by tt-xla now via latest uplifts. So VAE can run on tt now

### What's changed

- Enable VAE on TT for Playground v2.5 and SDXL Lightning

### Checklist

Performance Benchmark

- [x] n150 - https://github.com/tenstorrent/tt-xla/actions/runs/28349963072
- [x] p150 - https://github.com/tenstorrent/tt-xla/actions/runs/28349988190

Nightly run

- [x] n150 - [local_nightly_run_n150.zip](https://github.com/user-attachments/files/29454196/local_nightly_run_n150.zip)
- [x] p150 - https://github.com/tenstorrent/tt-xla/actions/runs/28350319361/job/83983661931
