### PR TITLE
docs: add html_theme_options, sitemap, search context to conf.py

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,11 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinxcontrib.email",
     "myst_parser",
+    "sphinx_sitemap",
 ]
+
+sitemap_locales = [None]
+sitemap_url_scheme = "{link}"
 
 source_suffix = {
     ".rst": "restructuredtext",
@@ -67,6 +71,11 @@ exclude_patterns = []
 # -- Options for HTML output -------------------------------------------------
 
 html_theme = "sphinx_rtd_theme"
+html_theme_options = {
+    "collapse_navigation": False,
+    "titles_only": True,
+    "navigation_depth": 2,
+}
 html_logo = "_static/tt_logo.svg"
 html_favicon = "_static/favicon.png"
 html_static_path = ["_static"]
@@ -75,5 +84,8 @@ html_static_path = ["_static"]
 # itself, so fonts come from the same root _static/ automatically.
 html_css_files = ["https://docs.tenstorrent.com/_static/tt_theme.css"]
 html_baseurl = "/tt-xla/"
-html_context = {"logo_link_url": "https://docs.tenstorrent.com/"}
+html_context = {
+    "logo_link_url": "https://docs.tenstorrent.com/",
+    "search_site_base_url": "https://docs.tenstorrent.com/tt-xla/",
+}
 html_last_updated_fmt = "%b %d, %Y"


### PR DESCRIPTION
## Summary

- `docs/source/conf.py`:
  - Added `html_theme_options` (collapse_navigation, titles_only, navigation_depth)
  - Added `sphinx_sitemap` to extensions with `sitemap_locales` and `sitemap_url_scheme`
  - Added `search_site_base_url: https://docs.tenstorrent.com/tt-xla/` to `html_context`
  - Preserved existing `html_css_files = ["https://docs.tenstorrent.com/_static/tt_theme.css"]`

## Merge order

Merge before `docs/theme-nav-search-modal` in this repo.

## Test plan

- [ ] Sphinx build completes without warnings
- [ ] Sitemap generated at `/sitemap.xml`