### PR TITLE
[runner] Wire SRPO and FIBO into tensor-parallel inference CI

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -406,3 +406,13 @@ test_config:
     supported_archs: [galaxy-wh-6u]
     status: EXPECTED_PASSING
     enable_weight_bfp8_conversion: true
+
+  # Text-to-image DiT transformers brought up multi-chip with Megatron-1D
+  # tensor parallelism (mesh (None, "model")). Both OOM on a single chip.
+  srpo/pytorch-Base-tensor_parallel-inference:
+    supported_archs: [n300-llmbox, lb-blackhole]
+    status: EXPECTED_PASSING
+
+  fibo/pytorch-Base-tensor_parallel-inference:
+    supported_archs: [n300-llmbox, lb-blackhole]
+    status: EXPECTED_PASSING


### PR DESCRIPTION
### Problem description

The **SRPO** (`tencent/SRPO`, ~12B FLUX.1-dev DiT fine-tune) and **FIBO** (`briaai/FIBO`, 8B BRIA DiT) loaders already live in `tt_forge_models` and are present at the submodule SHA `main` points to, but they had **no runner `test_config` entry**. As a result the auto-discovered tests defaulted to `UNSPECIFIED` status on the default `[n150, p150]` arch markers and never ran on a multi-chip CI machine.

### What's changed

Add tensor-parallel inference entries to `tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml`:

```yaml
srpo/pytorch-Base-tensor_parallel-inference:
  supported_archs: [n300-llmbox, lb-blackhole]
  status: EXPECTED_PASSING

fibo/pytorch-Base-tensor_parallel-inference:
  supported_archs: [n300-llmbox, lb-blackhole]
  status: EXPECTED_PASSING
```

Both transformers OOM on a single chip and are brought up multi-chip with **Megatron-1D tensor parallelism** over a `(None, "model")` mesh (see each loader's `src/shard_specs.py`), so they belong in the tensor-parallel inference config.

### Relationship to the image-gen CI PRs

This follows the same **bring-up → wire-into-CI** workflow established for the image-gen pipelines in tenstorrent/tt-xla#5085 and tenstorrent/tt-forge-models#720. The difference: SRPO/FIBO are **loader-based** models consumed by the auto-runner (`tests/runner/test_models.py`), not `pipeline.py`/`_perf` benchmark pipelines, so the wiring is a **runner `test_config` entry** rather than a benchmark-harness config + nightly pipeline test.

### Notes

- **No submodule bump required** — `main` already points to a `tt_forge_models` SHA (`ccc6366068`) containing both `srpo/pytorch/loader.py` and `fibo/pytorch/loader.py`.
- Test IDs confirmed via pytest collection:
  - `srpo/pytorch-Base-tensor_parallel-inference`
  - `fibo/pytorch-Base-tensor_parallel-inference`

### Verification
- [x] YAML parses with the loader's settings (ruamel, `allow_duplicate_keys=False`); fields ⊆ `ALLOWED_FIELDS`, arches ⊆ `ALLOWED_ARCHES`
- [x] Test IDs match auto-discovered runner entries
- [ ] Tensor-parallel CI green on `n300-llmbox` / `lb-blackhole`

🤖 Generated with [Claude Code](https://claude.com/claude-code)