### PR TITLE
Re-register tt_moe after per-model transformers swap

### DIFF
--- a/python_package/tt_torch/moe_backend.py
+++ b/python_package/tt_torch/moe_backend.py
@@ -492,8 +492,17 @@ _original_validator: Optional[Callable] = None
 
 
 def register_tt_moe_backend(cluster_axis: Optional[int] = None) -> None:
-    """Register tt_moe and tt_dense backends. Idempotent."""
-    global _original_validator
+    """Register tt_moe and tt_dense backends. Idempotent and re-entrant:
+    re-resolves transformers each call so it survives a version swap."""
+    global _original_validator, ALL_EXPERTS_FUNCTIONS, ExpertsInterface
+    global PreTrainedModel
+
+    import transformers.integrations.moe as _moe
+    import transformers.modeling_utils as _mu
+
+    ALL_EXPERTS_FUNCTIONS = _moe.ALL_EXPERTS_FUNCTIONS
+    ExpertsInterface = _moe.ExpertsInterface
+    PreTrainedModel = _mu.PreTrainedModel
 
     _config["cluster_axis"] = cluster_axis
     ExpertsInterface.register(TT_MOE_BACKEND_NAME, tt_experts_forward)
@@ -503,11 +512,13 @@ def register_tt_moe_backend(cluster_axis: Optional[int] = None) -> None:
     if TT_DENSE_EXPERTS_BACKEND_NAME not in ALL_EXPERTS_FUNCTIONS:
         raise RuntimeError(f"{TT_DENSE_EXPERTS_BACKEND_NAME} registration failed")
 
-    if _original_validator is not None:
-        return  # already patched
-
-    _original_validator = PreTrainedModel.get_correct_experts_implementation
-    original_validator = _original_validator
+    # Re-patch the live PreTrainedModel; a version swap brings a fresh class.
+    if getattr(
+        PreTrainedModel.get_correct_experts_implementation, "_tt_patched", False
+    ):
+        return
+    original_validator = PreTrainedModel.get_correct_experts_implementation
+    _original_validator = original_validator
 
     def patched_validator(self, requested_experts):
         if (
@@ -517,6 +528,7 @@ def register_tt_moe_backend(cluster_axis: Optional[int] = None) -> None:
             return requested_experts
         return original_validator(self, requested_experts)
 
+    patched_validator._tt_patched = True
     PreTrainedModel.get_correct_experts_implementation = patched_validator
 
 

--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -64,7 +64,7 @@ test_config:
   diffusiongemma/pytorch-26B-A4B-it-tensor_parallel-inference:
     supported_archs: [n300-llmbox]
     status: KNOWN_FAILURE_XFAIL
-    reason: "error: 'sdy.all_slice' op operates on axis '_axis_0' which is already bound by a parent sdy.manual_computation op - https://github.com/tenstorrent/tt-mlir/issues/8861"
+    reason: "Unsupported data type for remainder DataType::UINT32 - https://github.com/tenstorrent/tt-xla/issues/5423"
     inject_custom_moe: true
 
   falcon/pytorch-7B_Instruct-tensor_parallel-inference:

--- a/tests/runner/testers/torch/dynamic_torch_model_tester.py
+++ b/tests/runner/testers/torch/dynamic_torch_model_tester.py
@@ -15,7 +15,11 @@ from infra.testers.compiler_config import CompilerConfig
 from infra.testers.single_chip.model import RunMode, TorchModelTester
 from infra.utilities.torch_multichip_utils import get_mesh
 from loguru import logger
-from tt_torch.moe_backend import TT_MOE_BACKEND_NAME, get_tt_moe_shard_specs
+from tt_torch.moe_backend import (
+    TT_MOE_BACKEND_NAME,
+    get_tt_moe_shard_specs,
+    register_tt_moe_backend,
+)
 
 from tests.runner.test_utils import RunPhase
 from tests.runner.utils import TorchDynamicLoader
@@ -320,6 +324,9 @@ class DynamicTorchModelTester(TorchModelTester):
             f"Custom MoE injection enabled for this test - using {TT_MOE_BACKEND_NAME} "
             "experts backend"
         )
+        # Re-register against the live transformers (a per-model version swap
+        # wipes moe_backend's import-time registration).
+        register_tt_moe_backend()
         if hasattr(model, "config"):
             model.config._experts_implementation = TT_MOE_BACKEND_NAME
         else:


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-xla/issues/5425

### Problem description

- DiffusionGemma (`26B-A4B-it`) needs `transformers==5.12.0`, but the current env has `5.5.1`. While running its test it fails with `KeyError: 'tt_moe' is not a valid experts implementation registered in the ExpertsInterface`. `tt_moe` is registered as an import-time side-effect of `tt_torch.moe_backend`, but the dynamic runner then reinstalls the model's `transformers` version (5.5.1 → 5.12.0) — which replaces `transformers` (and its `ExpertsInterface`) in memory, dropping the registration. It's never re-applied, so the live module has no `tt_moe`.

### What's changed

- `register_tt_moe_backend()` is now re-entrant: it re-resolves `ExpertsInterface` / `ALL_EXPERTS_FUNCTIONS` / `PreTrainedModel` from the currently-loaded `transformers` on each call (and re-patches the live `PreTrainedModel`), so it targets whatever version is live.
- `_inject_custom_moe` calls it after the model loads (post version-swap), registering `tt_moe` into the live `ExpertsInterface`. Fires only when the custom backend is enabled; a no-op when no swap happened.
- **Note:** this is a workaround for the current env (transformers `5.5.1`). Once the env is uplifted to ≥ the required version (`5.12.0`), the per-model swap won't happen and I'll remove this.


### Checklist
- [x] Verify the changes through local testing in WH

### Logs

- [jun30_diffgemma_before_fix.log](https://github.com/user-attachments/files/29497048/jun30_diffgemma.log)
- [jun30_diffgemma_after_fix.log.zip](https://github.com/user-attachments/files/29497044/jun30_diffgemma_after_fix.log.zip)


