### PR TITLE
[GLM] Rework MoE routing to avoid scatter_/gather lowerings on multi-row mesh

### DIFF
--- a/python_package/tt_torch/sparse_mlp.py
+++ b/python_package/tt_torch/sparse_mlp.py
@@ -984,8 +984,18 @@ class DeepseekV3MoEToA2AAdapter(nn.Module):
                 .sum(dim=-1)
             )
             group_idx = torch.topk(group_scores, k=topk_group, dim=-1, sorted=False)[1]
-            group_mask = torch.zeros_like(group_scores)
-            group_mask.scatter_(1, group_idx, 1)
+            # one_hot + sum instead of scatter_: torch scatter_ lowers to a
+            # stablehlo.scatter whose dim-0 row index is a token iota; Shardy
+            # shards that iota WITHOUT the per-shard offset, so the group mask
+            # marks only mesh-row 0's tokens and zeros routing for rows 1-3.
+            group_mask = (
+                (
+                    group_idx.unsqueeze(-1)
+                    == torch.arange(n_group, device=group_idx.device)
+                )
+                .any(dim=1)
+                .to(group_scores.dtype)
+            )
             score_mask = (
                 group_mask.unsqueeze(-1)
                 .expand(-1, n_group, n_routed_experts // n_group)
@@ -997,7 +1007,16 @@ class DeepseekV3MoEToA2AAdapter(nn.Module):
             topk_indices = torch.topk(scores_for_choice, k=top_k, dim=-1, sorted=False)[
                 1
             ]
-            topk_weights = router_logits.gather(1, topk_indices)
+            # one_hot + einsum instead of gather: torch.gather lowers to
+            # ttir.embedding over the all-gathered [tokens*E] score table with a
+            # flat index token*E+expert computed at fp16-class precision; for
+            # mesh-rows 1-3 the large index rounds off the expert bits -> wrong
+            # weights. einsum keeps the small expert index implicit and exact.
+            _ohw = (
+                topk_indices.unsqueeze(-1)
+                == torch.arange(n_routed_experts, device=topk_indices.device)
+            ).to(router_logits.dtype)
+            topk_weights = torch.einsum("be,bke->bk", router_logits, _ohw)
             if norm_topk_prob:
                 denominator = topk_weights.sum(dim=-1, keepdim=True) + 1e-20
                 topk_weights /= denominator

--- a/python_package/tt_torch/sparse_mlp.py
+++ b/python_package/tt_torch/sparse_mlp.py
@@ -984,10 +984,8 @@ class DeepseekV3MoEToA2AAdapter(nn.Module):
                 .sum(dim=-1)
             )
             group_idx = torch.topk(group_scores, k=topk_group, dim=-1, sorted=False)[1]
-            # one_hot + sum instead of scatter_: torch scatter_ lowers to a
-            # stablehlo.scatter whose dim-0 row index is a token iota; Shardy
-            # shards that iota WITHOUT the per-shard offset, so the group mask
-            # marks only mesh-row 0's tokens and zeros routing for rows 1-3.
+            # one_hot + sum instead of scatter_: scatter_'s token-iota row index
+            # isn't offset per shard under Shardy, zeroing routing for mesh-rows 1-3.
             group_mask = (
                 (
                     group_idx.unsqueeze(-1)
@@ -1007,11 +1005,8 @@ class DeepseekV3MoEToA2AAdapter(nn.Module):
             topk_indices = torch.topk(scores_for_choice, k=top_k, dim=-1, sorted=False)[
                 1
             ]
-            # one_hot + einsum instead of gather: torch.gather lowers to
-            # ttir.embedding over the all-gathered [tokens*E] score table with a
-            # flat index token*E+expert computed at fp16-class precision; for
-            # mesh-rows 1-3 the large index rounds off the expert bits -> wrong
-            # weights. einsum keeps the small expert index implicit and exact.
+            # one_hot + einsum instead of gather: gather's flat token*E+expert
+            # index rounds off at fp16 for mesh-rows 1-3, picking wrong weights.
             _ohw = (
                 topk_indices.unsqueeze(-1)
                 == torch.arange(n_routed_experts, device=topk_indices.device)


### PR DESCRIPTION
### Ticket
Fixes https://github.com/tenstorrent/tt-xla/issues/5409

### Problem description

GLM 4.7 had good PCC (0.99) only on the first 16/64 users — those on the first of the 4 devices the batch is sharded across — because the MoE router indexes a *global* tensor with a large index that is either mis-sharded or precision-truncated. Two bugs of this class, both in `route_tokens_to_experts` (`sparse_mlp.py`):

1. **`group_mask.scatter_(1, group_idx, 1)`** — `scatter_` adds a token row-iota that Shardy shards *without* the per-shard offset, so the group mask marks only mesh-row 0 and zeros routing for rows 1-3 (`0.88 → 0.95`).
2. **`router_logits.gather(1, topk_indices)`** — lowers to `ttir.embedding` over the all-gathered `[tokens·E]` score table with a flat index `token·E + expert` computed at fp16-class precision. For rows 1-3 the large `token·E` offset rounds off the expert bits (e.g. `2609 → 2610`), gathering the wrong expert's score (`0.95 → 0.99`).



### What's changed

Replaces both ops with the `one_hot` pattern already used for XLA compat (`_topk_to_sparse_scores`), so the `arange` is over experts/groups (a model dim, **not** the sharded batch axis) and the index stays small + exact:

- **Group mask: `scatter_` → `one_hot` + `any`.**
- **Top-k weights: `gather` → `one_hot` + `einsum`.**

Both rewrites are mathematically equivalent on CPU and just workarounds around buggy `scatter` and `gather` ops to unblock glm pcc until they are fixed.

### Impact

- GLM 4.7 multi-device PCC **0.88 → 0.993 on all 4 mesh-rows** (full-batch decode PCC **0.9937**); benchmark PASSES.
- CI A/B (GLM perf, shared runner off): [no fix → fails rows 1-3](https://github.com/tenstorrent/tt-xla/actions/runs/28383288938) · [with fix → passes](https://github.com/tenstorrent/tt-xla/actions/runs/28383183382)

