### PR TITLE
Remove n300-llmbox from perf benchmarks

### DIFF
--- a/.github/workflows/manual-benchmark.yml
+++ b/.github/workflows/manual-benchmark.yml
@@ -19,7 +19,6 @@ on:
           - All
           - n150-perf
           - p150-perf
-          - n300-llmbox
           - galaxy-wh-6u
           - qb2-blackhole
           - galaxy-bh

--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -126,6 +126,16 @@
         "runs-on": "qb2-blackhole"
       },
       {
+        "name": "llama_3_1_70b_tp_qb2",
+        "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp_qb2",
+        "runs-on": "qb2-blackhole"
+      },
+      {
+        "name": "gpt_oss_20b_tp_batch_size_1_qb2",
+        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_batch_size_1_qb2",
+        "runs-on": "qb2-blackhole"
+      },
+      {
         "name": "falcon3_7b_tp_qb2",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b_tp_qb2",
         "runs-on": "qb2-blackhole"
@@ -141,23 +151,8 @@
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "ministral_8b_tp_qb2",
-        "pytest": "tests/benchmark/test_llms.py::test_ministral_8b_tp_qb2",
-        "runs-on": "qb2-blackhole"
-      },
-      {
-        "name": "mistral_nemo_instruct_2407_tp_qb2",
-        "pytest": "tests/benchmark/test_llms.py::test_mistral_nemo_instruct_2407_tp_qb2",
-        "runs-on": "qb2-blackhole"
-      },
-      {
         "name": "mistral_small_24b_instruct_2501_tp_qb2",
         "pytest": "tests/benchmark/test_llms.py::test_mistral_small_24b_instruct_2501_tp_qb2",
-        "runs-on": "qb2-blackhole"
-      },
-      {
-        "name": "qwen_2_5_14b_instruct_tp_qb2",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_14b_instruct_tp_qb2",
         "runs-on": "qb2-blackhole"
       },
       {
@@ -166,28 +161,26 @@
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "qwen_3_8b_tp_qb2",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_3_8b_tp_qb2",
-        "runs-on": "qb2-blackhole"
-      },
-      {
-        "name": "qwen_3_14b_tp_qb2",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_3_14b_tp_qb2",
-        "runs-on": "qb2-blackhole"
-      },
-      {
         "name": "qwen_3_32b_tp_qb2",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_32b_tp_qb2",
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "gpt_oss_20b_tp_qb2",
-        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_qb2",
-        "runs-on": "qb2-blackhole"
-      },
-      {
         "name": "gpt_oss_120b_tp_qb2_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_120b_tp_qb2",
+        "runs-on": "qb2-blackhole",
+        "accuracy-testing": true
+      },
+      {
+        "name": "llama_3_1_70b_tp_qb2_accuracy",
+        "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp_qb2",
+        "runs-on": "qb2-blackhole",
+        "accuracy-testing": true,
+        "batch-size": 16
+      },
+      {
+        "name": "gpt_oss_20b_tp_batch_size_1_qb2_accuracy",
+        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_batch_size_1_qb2",
         "runs-on": "qb2-blackhole",
         "accuracy-testing": true
       },
@@ -210,26 +203,8 @@
         "accuracy-testing": true
       },
       {
-        "name": "ministral_8b_tp_qb2_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_ministral_8b_tp_qb2",
-        "runs-on": "qb2-blackhole",
-        "accuracy-testing": true
-      },
-      {
-        "name": "mistral_nemo_instruct_2407_tp_qb2_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_mistral_nemo_instruct_2407_tp_qb2",
-        "runs-on": "qb2-blackhole",
-        "accuracy-testing": true
-      },
-      {
         "name": "mistral_small_24b_instruct_2501_tp_qb2_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_mistral_small_24b_instruct_2501_tp_qb2",
-        "runs-on": "qb2-blackhole",
-        "accuracy-testing": true
-      },
-      {
-        "name": "qwen_2_5_14b_instruct_tp_qb2_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_14b_instruct_tp_qb2",
         "runs-on": "qb2-blackhole",
         "accuracy-testing": true
       },
@@ -240,26 +215,8 @@
         "accuracy-testing": true
       },
       {
-        "name": "qwen_3_8b_tp_qb2_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_3_8b_tp_qb2",
-        "runs-on": "qb2-blackhole",
-        "accuracy-testing": true
-      },
-      {
-        "name": "qwen_3_14b_tp_qb2_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_3_14b_tp_qb2",
-        "runs-on": "qb2-blackhole",
-        "accuracy-testing": true
-      },
-      {
         "name": "qwen_3_32b_tp_qb2_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_32b_tp_qb2",
-        "runs-on": "qb2-blackhole",
-        "accuracy-testing": true
-      },
-      {
-        "name": "gpt_oss_20b_tp_qb2_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_qb2",
         "runs-on": "qb2-blackhole",
         "accuracy-testing": true
       },
@@ -651,43 +608,8 @@
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "vllm_qwen3_8b_qb2_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen3-8b-qb2-tp]",
-        "vllm": true,
-        "skip-device-perf": true,
-        "runs-on": "qb2-blackhole"
-      },
-      {
-        "name": "vllm_qwen3_14b_qb2_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen3-14b-qb2-tp]",
-        "vllm": true,
-        "skip-device-perf": true,
-        "runs-on": "qb2-blackhole"
-      },
-      {
-        "name": "vllm_qwen2_5_14b_instruct_qb2_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen2.5-14b-instruct-qb2-tp]",
-        "vllm": true,
-        "skip-device-perf": true,
-        "runs-on": "qb2-blackhole"
-      },
-      {
         "name": "vllm_qwen2_5_coder_32b_instruct_qb2_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen2.5-coder-32b-instruct-qb2-tp]",
-        "vllm": true,
-        "skip-device-perf": true,
-        "runs-on": "qb2-blackhole"
-      },
-      {
-        "name": "vllm_ministral_8b_qb2_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[ministral-8b-qb2-tp]",
-        "vllm": true,
-        "skip-device-perf": true,
-        "runs-on": "qb2-blackhole"
-      },
-      {
-        "name": "vllm_mistral_nemo_instruct_2407_qb2_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[mistral-nemo-instruct-2407-qb2-tp]",
         "vllm": true,
         "skip-device-perf": true,
         "runs-on": "qb2-blackhole"
@@ -703,6 +625,16 @@
         "name": "vllm_llama_3_1_8b_qb2_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[llama-3.1-8b-qb2-tp]",
         "vllm": true,
+        "skip-device-perf": true,
+        "runs-on": "qb2-blackhole"
+      },
+      {
+        "name": "vllm_llama_3_1_70b_qb2_tp",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[llama-3.1-70b-qb2-tp]",
+        "vllm": true,
+        "skip-stablehlo-dump": true,
+        "skip-ttir-dump": true,
+        "skip-ttnn-dump": true,
         "skip-device-perf": true,
         "runs-on": "qb2-blackhole"
       },

--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -106,50 +106,9 @@
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b"
       },
       {
-        "name": "falcon3_10b_tp",
-        "pytest": "tests/benchmark/test_llms.py::test_falcon3_10b_tp",
-        "runs-on": "n300-llmbox"
-      },
-      {
-        "name": "llama_3_1_8b_instruct_tp",
-        "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b_instruct_tp",
-        "runs-on": "n300-llmbox"
-      },
-      {
-        "name": "mistral_small_24b_instruct_2501_tp",
-        "pytest": "tests/benchmark/test_llms.py::test_mistral_small_24b_instruct_2501_tp",
-        "runs-on": "n300-llmbox"
-      },
-      {
-        "name": "qwen_2_5_coder_32b_instruct_tp",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_coder_32b_instruct_tp",
-        "runs-on": "n300-llmbox"
-      },
-      {
-        "name": "qwen_3_32b_tp",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_3_32b_tp",
-        "runs-on": "n300-llmbox"
-      },
-      {
-        "name": "test_llama_3_1_70b_tp",
-        "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp",
-        "runs-on": "n300-llmbox"
-      },
-      {
         "name": "llama_3_1_70b_tp_galaxy",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp_galaxy",
         "runs-on": "galaxy-wh-6u"
-      },
-      {
-        "name": "gpt_oss_20b_tp",
-        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp",
-        "runs-on": "n300-llmbox",
-        "skip": true
-      },
-      {
-        "name": "gpt_oss_20b_tp_batch_size_1",
-        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_batch_size_1",
-        "runs-on": "n300-llmbox"
       },
       {
         "name": "test_gpt_oss_20b_tp_galaxy_batch_size_64",
@@ -448,85 +407,6 @@
         "accuracy-testing": true
       },
       {
-        "name": "falcon3_7b_tp_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b_tp",
-        "runs-on": "n300-llmbox",
-        "accuracy-testing": true
-      },
-      {
-        "name": "falcon3_10b_tp_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_falcon3_10b_tp",
-        "runs-on": "n300-llmbox",
-        "accuracy-testing": true
-      },
-      {
-        "name": "llama_3_1_8b_instruct_tp_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b_instruct_tp",
-        "runs-on": "n300-llmbox",
-        "accuracy-testing": true
-      },
-      {
-        "name": "ministral_8b_tp_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_ministral_8b_tp",
-        "runs-on": "n300-llmbox",
-        "accuracy-testing": true
-      },
-      {
-        "name": "mistral_nemo_instruct_2407_tp_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_mistral_nemo_instruct_2407_tp",
-        "runs-on": "n300-llmbox",
-        "accuracy-testing": true
-      },
-      {
-        "name": "mistral_small_24b_instruct_2501_tp_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_mistral_small_24b_instruct_2501_tp",
-        "runs-on": "n300-llmbox",
-        "accuracy-testing": true
-      },
-      {
-        "name": "qwen_2_5_14b_instruct_tp_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_14b_instruct_tp",
-        "runs-on": "n300-llmbox",
-        "accuracy-testing": true
-      },
-      {
-        "name": "qwen_2_5_coder_32b_instruct_tp_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_coder_32b_instruct_tp",
-        "runs-on": "n300-llmbox",
-        "accuracy-testing": true
-      },
-      {
-        "name": "qwen_3_8b_tp_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_3_8b_tp",
-        "runs-on": "n300-llmbox",
-        "accuracy-testing": true
-      },
-      {
-        "name": "qwen_3_14b_tp_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_3_14b_tp",
-        "runs-on": "n300-llmbox",
-        "accuracy-testing": true
-      },
-      {
-        "name": "qwen_3_32b_tp_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_3_32b_tp",
-        "runs-on": "n300-llmbox",
-        "accuracy-testing": true
-      },
-      {
-        "name": "llama_3_1_70b_tp_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp",
-        "runs-on": "n300-llmbox",
-        "accuracy-testing": true,
-        "batch-size": 16
-      },
-      {
-        "name": "gpt_oss_20b_tp_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp",
-        "runs-on": "n300-llmbox",
-        "accuracy-testing": true
-      },
-      {
         "name": "llama_3_1_70b_tp_galaxy_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp_galaxy",
         "runs-on": "galaxy-wh-6u",
@@ -665,41 +545,6 @@
         "skip-device-perf": true
       },
       {
-        "name": "vllm_falcon3_7b_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[falcon3-7b-tp]",
-        "vllm": true,
-        "skip-device-perf": true,
-        "runs-on": "n300-llmbox"
-      },
-      {
-        "name": "vllm_falcon3_10b_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[falcon3-10b-tp]",
-        "vllm": true,
-        "skip-device-perf": true,
-        "runs-on": "n300-llmbox"
-      },
-      {
-        "name": "vllm_qwen3_8b_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen3-8b-tp]",
-        "vllm": true,
-        "skip-device-perf": true,
-        "runs-on": "n300-llmbox"
-      },
-      {
-        "name": "vllm_qwen3_14b_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen3-14b-tp]",
-        "vllm": true,
-        "skip-device-perf": true,
-        "runs-on": "n300-llmbox"
-      },
-      {
-        "name": "vllm_qwen3_32b_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen3-32b-tp]",
-        "vllm": true,
-        "skip-device-perf": true,
-        "runs-on": "n300-llmbox"
-      },
-      {
         "name": "vllm_gemma4_31b_it_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[gemma4-31b-it-tp]",
         "vllm": true,
@@ -712,61 +557,6 @@
         "vllm": true,
         "skip-device-perf": true,
         "runs-on": "qb2-blackhole"
-      },
-      {
-        "name": "vllm_qwen2_5_14b_instruct_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen2.5-14b-instruct-tp]",
-        "vllm": true,
-        "skip-device-perf": true,
-        "runs-on": "n300-llmbox"
-      },
-      {
-        "name": "vllm_qwen2_5_coder_32b_instruct_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen2.5-coder-32b-instruct-tp]",
-        "vllm": true,
-        "skip-device-perf": true,
-        "runs-on": "n300-llmbox"
-      },
-      {
-        "name": "vllm_ministral_8b_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[ministral-8b-tp]",
-        "vllm": true,
-        "skip-device-perf": true,
-        "runs-on": "n300-llmbox"
-      },
-      {
-        "name": "vllm_mistral_nemo_instruct_2407_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[mistral-nemo-instruct-2407-tp]",
-        "vllm": true,
-        "skip-device-perf": true,
-        "runs-on": "n300-llmbox"
-      },
-      {
-        "name": "vllm_mistral_small_24b_instruct_2501_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[mistral-small-24b-instruct-2501-tp]",
-        "vllm": true,
-        "skip-device-perf": true,
-        "runs-on": "n300-llmbox"
-      },
-      {
-        "name": "vllm_llama_3_1_8b_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[llama-3.1-8b-tp]",
-        "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
-        "skip-device-perf": true,
-        "runs-on": "n300-llmbox"
-      },
-      {
-        "name": "vllm_llama_3_1_70b_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[llama-3.1-70b-tp]",
-        "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
-        "skip-device-perf": true,
-        "runs-on": "n300-llmbox"
       },
       {
         "name": "wan_umt5_sharded",

--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -186,6 +186,84 @@
         "runs-on": "qb2-blackhole"
       },
       {
+        "name": "gpt_oss_120b_tp_qb2_accuracy",
+        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_120b_tp_qb2",
+        "runs-on": "qb2-blackhole",
+        "accuracy-testing": true
+      },
+      {
+        "name": "falcon3_7b_tp_qb2_accuracy",
+        "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b_tp_qb2",
+        "runs-on": "qb2-blackhole",
+        "accuracy-testing": true
+      },
+      {
+        "name": "falcon3_10b_tp_qb2_accuracy",
+        "pytest": "tests/benchmark/test_llms.py::test_falcon3_10b_tp_qb2",
+        "runs-on": "qb2-blackhole",
+        "accuracy-testing": true
+      },
+      {
+        "name": "llama_3_1_8b_instruct_tp_qb2_accuracy",
+        "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b_instruct_tp_qb2",
+        "runs-on": "qb2-blackhole",
+        "accuracy-testing": true
+      },
+      {
+        "name": "ministral_8b_tp_qb2_accuracy",
+        "pytest": "tests/benchmark/test_llms.py::test_ministral_8b_tp_qb2",
+        "runs-on": "qb2-blackhole",
+        "accuracy-testing": true
+      },
+      {
+        "name": "mistral_nemo_instruct_2407_tp_qb2_accuracy",
+        "pytest": "tests/benchmark/test_llms.py::test_mistral_nemo_instruct_2407_tp_qb2",
+        "runs-on": "qb2-blackhole",
+        "accuracy-testing": true
+      },
+      {
+        "name": "mistral_small_24b_instruct_2501_tp_qb2_accuracy",
+        "pytest": "tests/benchmark/test_llms.py::test_mistral_small_24b_instruct_2501_tp_qb2",
+        "runs-on": "qb2-blackhole",
+        "accuracy-testing": true
+      },
+      {
+        "name": "qwen_2_5_14b_instruct_tp_qb2_accuracy",
+        "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_14b_instruct_tp_qb2",
+        "runs-on": "qb2-blackhole",
+        "accuracy-testing": true
+      },
+      {
+        "name": "qwen_2_5_coder_32b_instruct_tp_qb2_accuracy",
+        "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_coder_32b_instruct_tp_qb2",
+        "runs-on": "qb2-blackhole",
+        "accuracy-testing": true
+      },
+      {
+        "name": "qwen_3_8b_tp_qb2_accuracy",
+        "pytest": "tests/benchmark/test_llms.py::test_qwen_3_8b_tp_qb2",
+        "runs-on": "qb2-blackhole",
+        "accuracy-testing": true
+      },
+      {
+        "name": "qwen_3_14b_tp_qb2_accuracy",
+        "pytest": "tests/benchmark/test_llms.py::test_qwen_3_14b_tp_qb2",
+        "runs-on": "qb2-blackhole",
+        "accuracy-testing": true
+      },
+      {
+        "name": "qwen_3_32b_tp_qb2_accuracy",
+        "pytest": "tests/benchmark/test_llms.py::test_qwen_3_32b_tp_qb2",
+        "runs-on": "qb2-blackhole",
+        "accuracy-testing": true
+      },
+      {
+        "name": "gpt_oss_20b_tp_qb2_accuracy",
+        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_qb2",
+        "runs-on": "qb2-blackhole",
+        "accuracy-testing": true
+      },
+      {
         "name": "microsoft_phi-1",
         "pytest": "tests/benchmark/test_llms.py::test_phi1"
       },
@@ -554,6 +632,76 @@
       {
         "name": "vllm_qwen3_32b_qb2_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen3-32b-qb2-tp]",
+        "vllm": true,
+        "skip-device-perf": true,
+        "runs-on": "qb2-blackhole"
+      },
+      {
+        "name": "vllm_falcon3_7b_qb2_tp",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[falcon3-7b-qb2-tp]",
+        "vllm": true,
+        "skip-device-perf": true,
+        "runs-on": "qb2-blackhole"
+      },
+      {
+        "name": "vllm_falcon3_10b_qb2_tp",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[falcon3-10b-qb2-tp]",
+        "vllm": true,
+        "skip-device-perf": true,
+        "runs-on": "qb2-blackhole"
+      },
+      {
+        "name": "vllm_qwen3_8b_qb2_tp",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen3-8b-qb2-tp]",
+        "vllm": true,
+        "skip-device-perf": true,
+        "runs-on": "qb2-blackhole"
+      },
+      {
+        "name": "vllm_qwen3_14b_qb2_tp",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen3-14b-qb2-tp]",
+        "vllm": true,
+        "skip-device-perf": true,
+        "runs-on": "qb2-blackhole"
+      },
+      {
+        "name": "vllm_qwen2_5_14b_instruct_qb2_tp",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen2.5-14b-instruct-qb2-tp]",
+        "vllm": true,
+        "skip-device-perf": true,
+        "runs-on": "qb2-blackhole"
+      },
+      {
+        "name": "vllm_qwen2_5_coder_32b_instruct_qb2_tp",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen2.5-coder-32b-instruct-qb2-tp]",
+        "vllm": true,
+        "skip-device-perf": true,
+        "runs-on": "qb2-blackhole"
+      },
+      {
+        "name": "vllm_ministral_8b_qb2_tp",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[ministral-8b-qb2-tp]",
+        "vllm": true,
+        "skip-device-perf": true,
+        "runs-on": "qb2-blackhole"
+      },
+      {
+        "name": "vllm_mistral_nemo_instruct_2407_qb2_tp",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[mistral-nemo-instruct-2407-qb2-tp]",
+        "vllm": true,
+        "skip-device-perf": true,
+        "runs-on": "qb2-blackhole"
+      },
+      {
+        "name": "vllm_mistral_small_24b_instruct_2501_qb2_tp",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[mistral-small-24b-instruct-2501-qb2-tp]",
+        "vllm": true,
+        "skip-device-perf": true,
+        "runs-on": "qb2-blackhole"
+      },
+      {
+        "name": "vllm_llama_3_1_8b_qb2_tp",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[llama-3.1-8b-qb2-tp]",
         "vllm": true,
         "skip-device-perf": true,
         "runs-on": "qb2-blackhole"

--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -121,102 +121,102 @@
         "runs-on": "galaxy-wh-6u"
       },
       {
-        "name": "gpt_oss_120b_tp",
-        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_120b_tp",
+        "name": "gpt_oss_120b_tp_qb2",
+        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_120b_tp_qb2",
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "llama_3_1_70b_tp",
-        "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp",
+        "name": "llama_3_1_70b_tp_qb2",
+        "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp_qb2",
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "gpt_oss_20b_tp_batch_size_1",
-        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_batch_size_1",
+        "name": "gpt_oss_20b_tp_batch_size_1_qb2",
+        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_batch_size_1_qb2",
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "falcon3_7b_tp",
-        "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b_tp",
+        "name": "falcon3_7b_tp_qb2",
+        "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b_tp_qb2",
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "falcon3_10b_tp",
-        "pytest": "tests/benchmark/test_llms.py::test_falcon3_10b_tp",
+        "name": "falcon3_10b_tp_qb2",
+        "pytest": "tests/benchmark/test_llms.py::test_falcon3_10b_tp_qb2",
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "llama_3_1_8b_instruct_tp",
-        "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b_instruct_tp",
+        "name": "llama_3_1_8b_instruct_tp_qb2",
+        "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b_instruct_tp_qb2",
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "mistral_small_24b_instruct_2501_tp",
-        "pytest": "tests/benchmark/test_llms.py::test_mistral_small_24b_instruct_2501_tp",
+        "name": "mistral_small_24b_instruct_2501_tp_qb2",
+        "pytest": "tests/benchmark/test_llms.py::test_mistral_small_24b_instruct_2501_tp_qb2",
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "qwen_2_5_coder_32b_instruct_tp",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_coder_32b_instruct_tp",
+        "name": "qwen_2_5_coder_32b_instruct_tp_qb2",
+        "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_coder_32b_instruct_tp_qb2",
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "qwen_3_32b_tp",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_3_32b_tp",
+        "name": "qwen_3_32b_tp_qb2",
+        "pytest": "tests/benchmark/test_llms.py::test_qwen_3_32b_tp_qb2",
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "gpt_oss_120b_tp_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_120b_tp",
+        "name": "gpt_oss_120b_tp_qb2_accuracy",
+        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_120b_tp_qb2",
         "runs-on": "qb2-blackhole",
         "accuracy-testing": true
       },
       {
-        "name": "llama_3_1_70b_tp_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp",
+        "name": "llama_3_1_70b_tp_qb2_accuracy",
+        "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp_qb2",
         "runs-on": "qb2-blackhole",
         "accuracy-testing": true,
         "batch-size": 16
       },
       {
-        "name": "gpt_oss_20b_tp_batch_size_1_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_batch_size_1",
+        "name": "gpt_oss_20b_tp_batch_size_1_qb2_accuracy",
+        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_batch_size_1_qb2",
         "runs-on": "qb2-blackhole",
         "accuracy-testing": true
       },
       {
-        "name": "falcon3_7b_tp_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b_tp",
+        "name": "falcon3_7b_tp_qb2_accuracy",
+        "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b_tp_qb2",
         "runs-on": "qb2-blackhole",
         "accuracy-testing": true
       },
       {
-        "name": "falcon3_10b_tp_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_falcon3_10b_tp",
+        "name": "falcon3_10b_tp_qb2_accuracy",
+        "pytest": "tests/benchmark/test_llms.py::test_falcon3_10b_tp_qb2",
         "runs-on": "qb2-blackhole",
         "accuracy-testing": true
       },
       {
-        "name": "llama_3_1_8b_instruct_tp_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b_instruct_tp",
+        "name": "llama_3_1_8b_instruct_tp_qb2_accuracy",
+        "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b_instruct_tp_qb2",
         "runs-on": "qb2-blackhole",
         "accuracy-testing": true
       },
       {
-        "name": "mistral_small_24b_instruct_2501_tp_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_mistral_small_24b_instruct_2501_tp",
+        "name": "mistral_small_24b_instruct_2501_tp_qb2_accuracy",
+        "pytest": "tests/benchmark/test_llms.py::test_mistral_small_24b_instruct_2501_tp_qb2",
         "runs-on": "qb2-blackhole",
         "accuracy-testing": true
       },
       {
-        "name": "qwen_2_5_coder_32b_instruct_tp_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_coder_32b_instruct_tp",
+        "name": "qwen_2_5_coder_32b_instruct_tp_qb2_accuracy",
+        "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_coder_32b_instruct_tp_qb2",
         "runs-on": "qb2-blackhole",
         "accuracy-testing": true
       },
       {
-        "name": "qwen_3_32b_tp_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_3_32b_tp",
+        "name": "qwen_3_32b_tp_qb2_accuracy",
+        "pytest": "tests/benchmark/test_llms.py::test_qwen_3_32b_tp_qb2",
         "runs-on": "qb2-blackhole",
         "accuracy-testing": true
       },
@@ -587,50 +587,50 @@
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "vllm_qwen3_32b_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen3-32b-tp]",
+        "name": "vllm_qwen3_32b_qb2_tp",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen3-32b-qb2-tp]",
         "vllm": true,
         "skip-device-perf": true,
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "vllm_falcon3_7b_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[falcon3-7b-tp]",
+        "name": "vllm_falcon3_7b_qb2_tp",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[falcon3-7b-qb2-tp]",
         "vllm": true,
         "skip-device-perf": true,
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "vllm_falcon3_10b_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[falcon3-10b-tp]",
+        "name": "vllm_falcon3_10b_qb2_tp",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[falcon3-10b-qb2-tp]",
         "vllm": true,
         "skip-device-perf": true,
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "vllm_qwen2_5_coder_32b_instruct_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen2.5-coder-32b-instruct-tp]",
+        "name": "vllm_qwen2_5_coder_32b_instruct_qb2_tp",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen2.5-coder-32b-instruct-qb2-tp]",
         "vllm": true,
         "skip-device-perf": true,
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "vllm_mistral_small_24b_instruct_2501_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[mistral-small-24b-instruct-2501-tp]",
+        "name": "vllm_mistral_small_24b_instruct_2501_qb2_tp",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[mistral-small-24b-instruct-2501-qb2-tp]",
         "vllm": true,
         "skip-device-perf": true,
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "vllm_llama_3_1_8b_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[llama-3.1-8b-tp]",
+        "name": "vllm_llama_3_1_8b_qb2_tp",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[llama-3.1-8b-qb2-tp]",
         "vllm": true,
         "skip-device-perf": true,
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "vllm_llama_3_1_70b_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[llama-3.1-70b-tp]",
+        "name": "vllm_llama_3_1_70b_qb2_tp",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[llama-3.1-70b-qb2-tp]",
         "vllm": true,
         "skip-stablehlo-dump": true,
         "skip-ttir-dump": true,

--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -121,102 +121,102 @@
         "runs-on": "galaxy-wh-6u"
       },
       {
-        "name": "gpt_oss_120b_tp_qb2",
-        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_120b_tp_qb2",
+        "name": "gpt_oss_120b_tp",
+        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_120b_tp",
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "llama_3_1_70b_tp_qb2",
-        "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp_qb2",
+        "name": "llama_3_1_70b_tp",
+        "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp",
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "gpt_oss_20b_tp_batch_size_1_qb2",
-        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_batch_size_1_qb2",
+        "name": "gpt_oss_20b_tp_batch_size_1",
+        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_batch_size_1",
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "falcon3_7b_tp_qb2",
-        "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b_tp_qb2",
+        "name": "falcon3_7b_tp",
+        "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b_tp",
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "falcon3_10b_tp_qb2",
-        "pytest": "tests/benchmark/test_llms.py::test_falcon3_10b_tp_qb2",
+        "name": "falcon3_10b_tp",
+        "pytest": "tests/benchmark/test_llms.py::test_falcon3_10b_tp",
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "llama_3_1_8b_instruct_tp_qb2",
-        "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b_instruct_tp_qb2",
+        "name": "llama_3_1_8b_instruct_tp",
+        "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b_instruct_tp",
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "mistral_small_24b_instruct_2501_tp_qb2",
-        "pytest": "tests/benchmark/test_llms.py::test_mistral_small_24b_instruct_2501_tp_qb2",
+        "name": "mistral_small_24b_instruct_2501_tp",
+        "pytest": "tests/benchmark/test_llms.py::test_mistral_small_24b_instruct_2501_tp",
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "qwen_2_5_coder_32b_instruct_tp_qb2",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_coder_32b_instruct_tp_qb2",
+        "name": "qwen_2_5_coder_32b_instruct_tp",
+        "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_coder_32b_instruct_tp",
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "qwen_3_32b_tp_qb2",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_3_32b_tp_qb2",
+        "name": "qwen_3_32b_tp",
+        "pytest": "tests/benchmark/test_llms.py::test_qwen_3_32b_tp",
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "gpt_oss_120b_tp_qb2_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_120b_tp_qb2",
+        "name": "gpt_oss_120b_tp_accuracy",
+        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_120b_tp",
         "runs-on": "qb2-blackhole",
         "accuracy-testing": true
       },
       {
-        "name": "llama_3_1_70b_tp_qb2_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp_qb2",
+        "name": "llama_3_1_70b_tp_accuracy",
+        "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp",
         "runs-on": "qb2-blackhole",
         "accuracy-testing": true,
         "batch-size": 16
       },
       {
-        "name": "gpt_oss_20b_tp_batch_size_1_qb2_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_batch_size_1_qb2",
+        "name": "gpt_oss_20b_tp_batch_size_1_accuracy",
+        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_batch_size_1",
         "runs-on": "qb2-blackhole",
         "accuracy-testing": true
       },
       {
-        "name": "falcon3_7b_tp_qb2_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b_tp_qb2",
+        "name": "falcon3_7b_tp_accuracy",
+        "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b_tp",
         "runs-on": "qb2-blackhole",
         "accuracy-testing": true
       },
       {
-        "name": "falcon3_10b_tp_qb2_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_falcon3_10b_tp_qb2",
+        "name": "falcon3_10b_tp_accuracy",
+        "pytest": "tests/benchmark/test_llms.py::test_falcon3_10b_tp",
         "runs-on": "qb2-blackhole",
         "accuracy-testing": true
       },
       {
-        "name": "llama_3_1_8b_instruct_tp_qb2_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b_instruct_tp_qb2",
+        "name": "llama_3_1_8b_instruct_tp_accuracy",
+        "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b_instruct_tp",
         "runs-on": "qb2-blackhole",
         "accuracy-testing": true
       },
       {
-        "name": "mistral_small_24b_instruct_2501_tp_qb2_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_mistral_small_24b_instruct_2501_tp_qb2",
+        "name": "mistral_small_24b_instruct_2501_tp_accuracy",
+        "pytest": "tests/benchmark/test_llms.py::test_mistral_small_24b_instruct_2501_tp",
         "runs-on": "qb2-blackhole",
         "accuracy-testing": true
       },
       {
-        "name": "qwen_2_5_coder_32b_instruct_tp_qb2_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_coder_32b_instruct_tp_qb2",
+        "name": "qwen_2_5_coder_32b_instruct_tp_accuracy",
+        "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_coder_32b_instruct_tp",
         "runs-on": "qb2-blackhole",
         "accuracy-testing": true
       },
       {
-        "name": "qwen_3_32b_tp_qb2_accuracy",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_3_32b_tp_qb2",
+        "name": "qwen_3_32b_tp_accuracy",
+        "pytest": "tests/benchmark/test_llms.py::test_qwen_3_32b_tp",
         "runs-on": "qb2-blackhole",
         "accuracy-testing": true
       },
@@ -587,50 +587,50 @@
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "vllm_qwen3_32b_qb2_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen3-32b-qb2-tp]",
+        "name": "vllm_qwen3_32b_tp",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen3-32b-tp]",
         "vllm": true,
         "skip-device-perf": true,
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "vllm_falcon3_7b_qb2_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[falcon3-7b-qb2-tp]",
+        "name": "vllm_falcon3_7b_tp",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[falcon3-7b-tp]",
         "vllm": true,
         "skip-device-perf": true,
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "vllm_falcon3_10b_qb2_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[falcon3-10b-qb2-tp]",
+        "name": "vllm_falcon3_10b_tp",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[falcon3-10b-tp]",
         "vllm": true,
         "skip-device-perf": true,
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "vllm_qwen2_5_coder_32b_instruct_qb2_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen2.5-coder-32b-instruct-qb2-tp]",
+        "name": "vllm_qwen2_5_coder_32b_instruct_tp",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen2.5-coder-32b-instruct-tp]",
         "vllm": true,
         "skip-device-perf": true,
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "vllm_mistral_small_24b_instruct_2501_qb2_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[mistral-small-24b-instruct-2501-qb2-tp]",
+        "name": "vllm_mistral_small_24b_instruct_2501_tp",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[mistral-small-24b-instruct-2501-tp]",
         "vllm": true,
         "skip-device-perf": true,
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "vllm_llama_3_1_8b_qb2_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[llama-3.1-8b-qb2-tp]",
+        "name": "vllm_llama_3_1_8b_tp",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[llama-3.1-8b-tp]",
         "vllm": true,
         "skip-device-perf": true,
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "vllm_llama_3_1_70b_qb2_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[llama-3.1-70b-qb2-tp]",
+        "name": "vllm_llama_3_1_70b_tp",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[llama-3.1-70b-tp]",
         "vllm": true,
         "skip-stablehlo-dump": true,
         "skip-ttir-dump": true,

--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -85,6 +85,23 @@ jobs:
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
 
+  perf-benchmark-accuracy:
+    if: needs.inspect-changes.outputs.skip-build-and-test == 'false' && needs.inspect-changes.outputs.only-run-forge-models != 'true' && vars.RUN_PERF_ON_UPLIFT == 'true' && github.event_name == 'pull_request' && (contains(needs.inspect-changes.outputs.detected-uplifts, 'tt-mlir') || contains(needs.inspect-changes.outputs.detected-uplifts, 'transformers'))
+    needs: [ inspect-changes, build-image, build-ttxla ]
+    uses: ./.github/workflows/call-filtered-perf-tests.yml
+    secrets: inherit
+    with:
+      docker_image: ${{ needs.build-image.outputs.docker-image-base }}
+      # On-PR accuracy uplift check: llama_3_1_70b TP accuracy on qb2-blackhole.
+      adv_filter: '[
+        { "accuracy-testing": true },
+        { "runs-on": "qb2-blackhole", "filter": ["llama_3_1_70b_tp_qb2"] } ]'
+      sh-runner: false
+      skip-device-perf: true
+      regression_check: true
+      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
+      artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
+
   test_forge_models_push:
     if: needs.inspect-changes.outputs.skip-build-and-test == 'false'
     uses: ./.github/workflows/call-test.yml
@@ -139,11 +156,12 @@ jobs:
       - test-uplift-extended
       - test-tools
       - perf-benchmark
+      - perf-benchmark-accuracy
       - build-docs
     runs-on: Ubuntu-latest
     steps:
     - name: Check if the needed jobs succeeded or failed
       uses: re-actors/alls-green@release/v1
       with:
-        allowed-skips: build-image, build-ttxla, build-ttxla-debug, test, test_forge_models_push, test-uplift-extended, test-tools, perf-benchmark, build-docs
+        allowed-skips: build-image, build-ttxla, build-ttxla-debug, test, test_forge_models_push, test-uplift-extended, test-tools, perf-benchmark, perf-benchmark-accuracy, build-docs
         jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -77,7 +77,8 @@ jobs:
       #   - llama_3_1_70b_tp_galaxy (galaxy-wh-6u): fabric pinning (#5210)
       adv_filter: '[
         { "accuracy-testing": false },
-        { "runs-on": "n150-perf", "filter": ["resnet","qwen_3_4b_embedding","llama_3_1_8b","falcon3-1b","qwen_3_8b"] } ]'
+        { "runs-on": "n150-perf", "filter": ["resnet","qwen_3_4b_embedding","llama_3_1_8b","falcon3-1b","qwen_3_8b"] },
+        { "runs-on": "qb2-blackhole", "filter": ["qwen_3_32b_tp_qb2"] } ]'
       sh-runner: false
       skip-device-perf: true
       regression_check: true

--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -78,7 +78,7 @@ jobs:
       adv_filter: '[
         { "accuracy-testing": false },
         { "runs-on": "n150-perf", "filter": ["resnet","qwen_3_4b_embedding","llama_3_1_8b","falcon3-1b","qwen_3_8b"] },
-        { "runs-on": "qb2-blackhole", "filter": ["qwen_3_32b_tp_qb2"] } ]'
+        { "runs-on": "qb2-blackhole", "filter": ["qwen_3_32b_tp"] } ]'
       sh-runner: false
       skip-device-perf: true
       regression_check: true
@@ -95,7 +95,7 @@ jobs:
       # On-PR accuracy uplift check: llama_3_1_70b TP accuracy on qb2-blackhole.
       adv_filter: '[
         { "accuracy-testing": true },
-        { "runs-on": "qb2-blackhole", "filter": ["llama_3_1_70b_tp_qb2"] } ]'
+        { "runs-on": "qb2-blackhole", "filter": ["llama_3_1_70b_tp"] } ]'
       sh-runner: false
       skip-device-perf: true
       regression_check: true

--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -78,7 +78,7 @@ jobs:
       adv_filter: '[
         { "accuracy-testing": false },
         { "runs-on": "n150-perf", "filter": ["resnet","qwen_3_4b_embedding","llama_3_1_8b","falcon3-1b","qwen_3_8b"] },
-        { "runs-on": "qb2-blackhole", "filter": ["qwen_3_32b_tp"] } ]'
+        { "runs-on": "qb2-blackhole", "filter": ["qwen_3_32b_tp_qb2"] } ]'
       sh-runner: false
       skip-device-perf: true
       regression_check: true
@@ -95,7 +95,7 @@ jobs:
       # On-PR accuracy uplift check: llama_3_1_70b TP accuracy on qb2-blackhole.
       adv_filter: '[
         { "accuracy-testing": true },
-        { "runs-on": "qb2-blackhole", "filter": ["llama_3_1_70b_tp"] } ]'
+        { "runs-on": "qb2-blackhole", "filter": ["llama_3_1_70b_tp_qb2"] } ]'
       sh-runner: false
       skip-device-perf: true
       regression_check: true

--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -95,7 +95,7 @@ jobs:
       # On-PR accuracy uplift check: llama_3_1_70b TP accuracy on qb2-blackhole.
       adv_filter: '[
         { "accuracy-testing": true },
-        { "runs-on": "qb2-blackhole", "filter": ["llama_3_1_70b_tp_qb2"] } ]'
+        { "runs-on": "qb2-blackhole", "filter": ["qwen_3_32b_tp_qb2"] } ]'
       sh-runner: false
       skip-device-perf: true
       regression_check: true

--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -74,31 +74,10 @@ jobs:
       docker_image: ${{ needs.build-image.outputs.docker-image-base }}
       # NOTE: these filters intentionally exclude perf benchmarks that hang/fail on PR
       # while keeping them live in the nightly matrix (see perf-bench-matrix.json):
-      #   - gpt_oss_20b_tp / gpt_oss_20b_tp_batch_size_1 (n300-llmbox): #5151, #5207
       #   - llama_3_1_70b_tp_galaxy (galaxy-wh-6u): fabric pinning (#5210)
-      #   - vllm_llama_3_1_70b_tp (n300-llmbox): temporarily removed from On PR because flaky, tracked in issue #5294
       adv_filter: '[
         { "accuracy-testing": false },
-        { "runs-on": "n150-perf", "filter": ["resnet","llama_3_1_8b","falcon3-1b","qwen_3_8b"] },
-        { "runs-on": "n300-llmbox", "filter": ["test_llama_3_1_70b_tp"] } ]'
-      sh-runner: false
-      skip-device-perf: true
-      regression_check: true
-      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
-      artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
-
-  perf-benchmark-accuracy:
-    if: needs.inspect-changes.outputs.skip-build-and-test == 'false' && needs.inspect-changes.outputs.only-run-forge-models != 'true' && vars.RUN_PERF_ON_UPLIFT == 'true' && github.event_name == 'pull_request' && (contains(needs.inspect-changes.outputs.detected-uplifts, 'tt-mlir') || contains(needs.inspect-changes.outputs.detected-uplifts, 'transformers'))
-    needs: [ inspect-changes, build-image, build-ttxla ]
-    uses: ./.github/workflows/call-filtered-perf-tests.yml
-    secrets: inherit
-    with:
-      docker_image: ${{ needs.build-image.outputs.docker-image-base }}
-      # NOTE: galaxy-wh-6u accuracy is excluded on PR (only entry is the failing
-      # llama_3_1_70b_tp_galaxy, fabric pinning #5210); still runs in nightly.
-      adv_filter: '[
-        { "accuracy-testing": true },
-        { "runs-on": "n300-llmbox", "filter": ["llama_3_1_8b_instruct_tp","llama_3_1_70b_tp"] } ]'
+        { "runs-on": "n150-perf", "filter": ["resnet","qwen_3_4b_embedding","llama_3_1_8b","falcon3-1b","qwen_3_8b"] } ]'
       sh-runner: false
       skip-device-perf: true
       regression_check: true
@@ -159,12 +138,11 @@ jobs:
       - test-uplift-extended
       - test-tools
       - perf-benchmark
-      - perf-benchmark-accuracy
       - build-docs
     runs-on: Ubuntu-latest
     steps:
     - name: Check if the needed jobs succeeded or failed
       uses: re-actors/alls-green@release/v1
       with:
-        allowed-skips: build-image, build-ttxla, build-ttxla-debug, test, test_forge_models_push, test-uplift-extended, test-tools, perf-benchmark, perf-benchmark-accuracy, build-docs
+        allowed-skips: build-image, build-ttxla, build-ttxla-debug, test, test_forge_models_push, test-uplift-extended, test-tools, perf-benchmark, build-docs
         jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -77,7 +77,7 @@ jobs:
       #   - llama_3_1_70b_tp_galaxy (galaxy-wh-6u): fabric pinning (#5210)
       adv_filter: '[
         { "accuracy-testing": false },
-        { "runs-on": "n150-perf", "filter": ["resnet","qwen_3_4b_embedding","llama_3_1_8b","falcon3-1b","qwen_3_8b"] },
+        { "runs-on": "n150-perf", "filter": ["resnet","llama_3_1_8b","falcon3-1b","qwen_3_8b"] },
         { "runs-on": "qb2-blackhole", "filter": ["qwen_3_32b_tp_qb2"] } ]'
       sh-runner: false
       skip-device-perf: true

--- a/.github/workflows/schedule-benchmark-experimental.yml
+++ b/.github/workflows/schedule-benchmark-experimental.yml
@@ -36,16 +36,6 @@ jobs:
       sh-runner: true
       regression_check: true
 
-  run-llmbox-accuracy-benchmarks:
-    needs: [build-image, build-ttxla]
-    secrets: inherit
-    uses: ./.github/workflows/call-filtered-perf-tests.yml
-    with:
-      adv_filter: '[ {"runs-on": "n300-llmbox", "accuracy-testing": true} ]'
-      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
-      artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
-      regression_check: true
-
   run-galaxy-accuracy-benchmarks:
     needs: [build-image, build-ttxla]
     secrets: inherit
@@ -59,7 +49,6 @@ jobs:
   fail-notify:
     needs:
       - run-n150-accuracy-benchmarks
-      - run-llmbox-accuracy-benchmarks
       - run-galaxy-accuracy-benchmarks
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/schedule-benchmark-experimental.yml
+++ b/.github/workflows/schedule-benchmark-experimental.yml
@@ -36,6 +36,16 @@ jobs:
       sh-runner: true
       regression_check: true
 
+  run-qb2-accuracy-benchmarks:
+    needs: [build-image, build-ttxla]
+    secrets: inherit
+    uses: ./.github/workflows/call-filtered-perf-tests.yml
+    with:
+      adv_filter: '[ {"runs-on": "qb2-blackhole", "accuracy-testing": true} ]'
+      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
+      artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
+      regression_check: true
+
   run-galaxy-accuracy-benchmarks:
     needs: [build-image, build-ttxla]
     secrets: inherit
@@ -49,6 +59,7 @@ jobs:
   fail-notify:
     needs:
       - run-n150-accuracy-benchmarks
+      - run-qb2-accuracy-benchmarks
       - run-galaxy-accuracy-benchmarks
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/schedule-nightly.yml
+++ b/.github/workflows/schedule-nightly.yml
@@ -94,7 +94,7 @@ jobs:
       sh-runner: false
       skip-device-perf: true
       regression_check: true
-      adv_filter: '[ {"accuracy-testing": false}, {"runs-on": "n150-perf"}, {"runs-on": "p150-perf"}, {"runs-on": "n300-llmbox"}, {"runs-on": "galaxy-wh-6u"}, {"runs-on": "qb2-blackhole"} ]'
+      adv_filter: '[ {"accuracy-testing": false}, {"runs-on": "n150-perf"}, {"runs-on": "p150-perf"}, {"runs-on": "galaxy-wh-6u"}, {"runs-on": "qb2-blackhole"} ]'
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
       wheel_build: manylinux

--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -12,8 +12,8 @@ source venv/activate
 pytest -svv tests/benchmark/test_llms.py::test_llama_3_2_1b
 pytest -svv tests/benchmark/test_vision.py::test_resnet50
 
-# LLMBOX / QB — tensor-parallel models
-pytest -svv tests/benchmark/test_llms.py::test_llama_3_1_70b_tp
+# QB2 — tensor-parallel models
+pytest -svv tests/benchmark/test_llms.py::test_llama_3_1_70b_tp_qb2
 
 # Galaxy
 pytest -svv tests/benchmark/test_llms.py::test_llama_3_1_70b_tp_galaxy

--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -65,14 +65,14 @@ Performance benchmarks run via the **"Performance benchmark"** GitHub Actions wo
 
 - **`mlir_override`** — Git SHA of a tt-mlir commit to use instead of the default toolchain. Default: empty.
 - **`test_filter`** (Filter tests based on the name property) — Comma-separated substrings to match against test names (case insensitive). E.g. `"llama,qwen"` runs all tests with "llama" or "qwen" in the name. Default: empty (all tests).
-- **`runs-on-filter`** (Architecture you want to run the tests on) — Hardware to run on: `n150`, `p150`, `n300-llmbox`, `galaxy-wh-6u`, or `All`. Default: `n150`.
+- **`runs-on-filter`** (Architecture you want to run the tests on) — Hardware to run on: `n150`, `p150`, `galaxy-wh-6u`, `qb2-blackhole`, or `All`. Default: `n150`.
 - **`sh-runner`** (Run on shared runner) — Must be set to `false` for precise performance comparison. Shared runners provide less stable results. Default: `true`.
 - **`perf_regression_check`** (Enable perf metrics regression testing) — Compare results against the last nightly run and flag >5% regressions in samples/sec. Default: `false`.
 
 ### Examples
 
 ```bash
-# Run llama and qwen benchmarks on n300-llmbox for a specific tt-mlir commit
+# Run llama and qwen benchmarks on n150 for a specific tt-mlir commit
 gh workflow run "Performance benchmark" --ref my-branch \
   -f test_filter="llama,qwen" \
   -f runs-on-filter=n150 \

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -1109,628 +1109,6 @@ def test_llama_3_1_8b(
     )
 
 
-def test_falcon3_7b_tp(
-    output_file,
-    num_layers,
-    request,
-    accuracy_testing,
-    batch_size,
-    max_output_tokens,
-    decode_only,
-    optimization_level,
-):
-    from third_party.tt_forge_models.falcon.pytorch.loader import (
-        ModelLoader,
-        ModelVariant,
-    )
-
-    variant = ModelVariant.FALCON_7B
-    test_llm_tp(
-        ModelLoader,
-        variant,
-        output_file,
-        num_layers=num_layers,
-        request=request,
-        accuracy_testing=accuracy_testing,
-        batch_size=batch_size,
-        max_output_tokens=max_output_tokens,
-        decode_only=decode_only,
-        optimization_level=(
-            optimization_level
-            if optimization_level is not None
-            else DEFAULT_TP_OPTIMIZATION_LEVEL
-        ),
-        experimental_kv_cache_dtype=None,
-    )
-
-
-def test_falcon3_10b_tp(
-    output_file,
-    num_layers,
-    request,
-    accuracy_testing,
-    batch_size,
-    max_output_tokens,
-    decode_only,
-    optimization_level,
-):
-    from third_party.tt_forge_models.falcon.pytorch.loader import (
-        ModelLoader,
-        ModelVariant,
-    )
-
-    variant = ModelVariant.FALCON_10B
-    test_llm_tp(
-        ModelLoader,
-        variant,
-        output_file,
-        num_layers=num_layers,
-        request=request,
-        accuracy_testing=accuracy_testing,
-        batch_size=batch_size,
-        max_output_tokens=max_output_tokens,
-        decode_only=decode_only,
-        optimization_level=(
-            optimization_level
-            if optimization_level is not None
-            else DEFAULT_TP_OPTIMIZATION_LEVEL
-        ),
-        experimental_kv_cache_dtype=None,
-    )
-
-
-def test_llama_3_1_8b_instruct_tp(
-    output_file,
-    num_layers,
-    request,
-    accuracy_testing,
-    batch_size,
-    max_output_tokens,
-    decode_only,
-    optimization_level,
-):
-    from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
-        ModelLoader,
-        ModelVariant,
-    )
-
-    variant = ModelVariant.LLAMA_3_1_8B_INSTRUCT
-    test_llm_tp(
-        ModelLoader,
-        variant,
-        output_file,
-        num_layers=num_layers,
-        request=request,
-        accuracy_testing=accuracy_testing,
-        batch_size=batch_size,
-        max_output_tokens=max_output_tokens,
-        decode_only=decode_only,
-        optimization_level=(
-            optimization_level
-            if optimization_level is not None
-            else DEFAULT_TP_OPTIMIZATION_LEVEL
-        ),
-    )
-
-
-def test_mistral_7b_tp(
-    output_file,
-    num_layers,
-    request,
-    accuracy_testing,
-    batch_size,
-    max_output_tokens,
-    decode_only,
-    optimization_level,
-):
-    from third_party.tt_forge_models.mistral.pytorch.loader import (
-        ModelLoader,
-        ModelVariant,
-    )
-
-    variant = ModelVariant.MISTRAL_7B_INSTRUCT_V03
-    test_llm_tp(
-        ModelLoader,
-        variant,
-        output_file,
-        num_layers=num_layers,
-        request=request,
-        accuracy_testing=accuracy_testing,
-        batch_size=batch_size,
-        max_output_tokens=max_output_tokens,
-        decode_only=decode_only,
-        optimization_level=(
-            optimization_level
-            if optimization_level is not None
-            else DEFAULT_TP_OPTIMIZATION_LEVEL
-        ),
-    )
-
-
-# Trace disabled: host/device tensor shape mismatch (https://github.com/tenstorrent/tt-xla/issues/3935)
-def test_ministral_8b_tp(
-    output_file,
-    num_layers,
-    request,
-    accuracy_testing,
-    batch_size,
-    max_output_tokens,
-    decode_only,
-    optimization_level,
-):
-    from third_party.tt_forge_models.mistral.pytorch.loader import (
-        ModelLoader,
-        ModelVariant,
-    )
-
-    variant = ModelVariant.MINISTRAL_8B
-    test_llm_tp(
-        ModelLoader,
-        variant,
-        output_file,
-        num_layers=num_layers,
-        request=request,
-        accuracy_testing=accuracy_testing,
-        batch_size=batch_size,
-        max_output_tokens=max_output_tokens,
-        decode_only=decode_only,
-        trace_enabled=False,
-        optimization_level=1,
-    )
-
-
-def test_mistral_nemo_instruct_2407_tp(
-    output_file,
-    num_layers,
-    request,
-    accuracy_testing,
-    batch_size,
-    max_output_tokens,
-    decode_only,
-    optimization_level,
-):
-    from third_party.tt_forge_models.mistral.pytorch.loader import (
-        ModelLoader,
-        ModelVariant,
-    )
-
-    variant = ModelVariant.MISTRAL_NEMO_INSTRUCT_2407
-    test_llm_tp(
-        ModelLoader,
-        variant,
-        output_file,
-        num_layers=num_layers,
-        request=request,
-        accuracy_testing=accuracy_testing,
-        batch_size=batch_size,
-        max_output_tokens=max_output_tokens,
-        decode_only=decode_only,
-        optimization_level=1,
-    )
-
-
-def test_mistral_small_24b_instruct_2501_tp(
-    output_file,
-    num_layers,
-    request,
-    accuracy_testing,
-    batch_size,
-    max_output_tokens,
-    decode_only,
-    optimization_level,
-):
-    from third_party.tt_forge_models.mistral.pytorch.loader import (
-        ModelLoader,
-        ModelVariant,
-    )
-
-    variant = ModelVariant.MISTRAL_SMALL_24B_INSTRUCT_2501
-    test_llm_tp(
-        ModelLoader,
-        variant,
-        output_file,
-        num_layers=num_layers,
-        request=request,
-        accuracy_testing=accuracy_testing,
-        batch_size=batch_size,
-        max_output_tokens=max_output_tokens,
-        decode_only=decode_only,
-        optimization_level=1,  # flaky: occasionally hangs in CI with optimization_level=2
-    )
-
-
-def test_qwen_2_5_14b_instruct_tp(
-    output_file,
-    num_layers,
-    request,
-    accuracy_testing,
-    batch_size,
-    max_output_tokens,
-    decode_only,
-    optimization_level,
-):
-    from third_party.tt_forge_models.qwen_2_5.causal_lm.pytorch.loader import (
-        ModelLoader,
-        ModelVariant,
-    )
-
-    variant = ModelVariant.QWEN_2_5_14B_INSTRUCT
-    test_llm_tp(
-        ModelLoader,
-        variant,
-        output_file,
-        num_layers=num_layers,
-        request=request,
-        accuracy_testing=accuracy_testing,
-        batch_size=batch_size,
-        max_output_tokens=max_output_tokens,
-        decode_only=decode_only,
-        optimization_level=1,
-    )
-
-
-def test_qwen_2_5_32b_instruct_tp(
-    output_file,
-    num_layers,
-    request,
-    accuracy_testing,
-    batch_size,
-    max_output_tokens,
-    decode_only,
-    optimization_level,
-):
-    from third_party.tt_forge_models.qwen_2_5.causal_lm.pytorch.loader import (
-        ModelLoader,
-        ModelVariant,
-    )
-
-    variant = ModelVariant.QWEN_2_5_32B_INSTRUCT
-    test_llm_tp(
-        ModelLoader,
-        variant,
-        output_file,
-        num_layers=num_layers,
-        request=request,
-        accuracy_testing=accuracy_testing,
-        batch_size=batch_size,
-        max_output_tokens=max_output_tokens,
-        decode_only=decode_only,
-        optimization_level=(
-            optimization_level
-            if optimization_level is not None
-            else DEFAULT_TP_OPTIMIZATION_LEVEL
-        ),
-    )
-
-
-def test_qwen_2_5_coder_32b_instruct_tp(
-    output_file,
-    num_layers,
-    request,
-    accuracy_testing,
-    batch_size,
-    max_output_tokens,
-    decode_only,
-    optimization_level,
-):
-    from third_party.tt_forge_models.qwen_2_5_coder.pytorch.loader import (
-        ModelLoader,
-        ModelVariant,
-    )
-
-    variant = ModelVariant.QWEN_2_5_CODER_32B_INSTRUCT
-    test_llm_tp(
-        ModelLoader,
-        variant,
-        output_file,
-        num_layers=num_layers,
-        request=request,
-        accuracy_testing=accuracy_testing,
-        batch_size=batch_size,
-        max_output_tokens=max_output_tokens,
-        decode_only=decode_only,
-        optimization_level=1,
-    )
-
-
-def test_qwen_3_0_6b_tp(
-    output_file,
-    num_layers,
-    request,
-    accuracy_testing,
-    batch_size,
-    max_output_tokens,
-    decode_only,
-    optimization_level,
-):
-    from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import (
-        ModelLoader,
-        ModelVariant,
-    )
-
-    variant = ModelVariant.QWEN_3_0_6B
-    test_llm_tp(
-        ModelLoader,
-        variant,
-        output_file,
-        num_layers=num_layers,
-        request=request,
-        accuracy_testing=accuracy_testing,
-        batch_size=batch_size,
-        max_output_tokens=max_output_tokens,
-        decode_only=decode_only,
-        optimization_level=(
-            optimization_level
-            if optimization_level is not None
-            else DEFAULT_TP_OPTIMIZATION_LEVEL
-        ),
-    )
-
-
-def test_qwen_3_1_7b_tp(
-    output_file,
-    num_layers,
-    request,
-    accuracy_testing,
-    batch_size,
-    max_output_tokens,
-    decode_only,
-    optimization_level,
-):
-    from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import (
-        ModelLoader,
-        ModelVariant,
-    )
-
-    variant = ModelVariant.QWEN_3_1_7B
-    test_llm_tp(
-        ModelLoader,
-        variant,
-        output_file,
-        num_layers=num_layers,
-        request=request,
-        accuracy_testing=accuracy_testing,
-        batch_size=batch_size,
-        max_output_tokens=max_output_tokens,
-        decode_only=decode_only,
-        optimization_level=(
-            optimization_level
-            if optimization_level is not None
-            else DEFAULT_TP_OPTIMIZATION_LEVEL
-        ),
-    )
-
-
-def test_qwen_3_8b_tp(
-    output_file,
-    num_layers,
-    request,
-    accuracy_testing,
-    batch_size,
-    max_output_tokens,
-    decode_only,
-    optimization_level,
-):
-    from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import (
-        ModelLoader,
-        ModelVariant,
-    )
-
-    variant = ModelVariant.QWEN_3_8B
-    test_llm_tp(
-        ModelLoader,
-        variant,
-        output_file,
-        num_layers=num_layers,
-        request=request,
-        accuracy_testing=accuracy_testing,
-        batch_size=batch_size,
-        max_output_tokens=max_output_tokens,
-        decode_only=decode_only,
-        optimization_level=1,  # flaky: occasionally hangs in CI with optimization_level=2
-    )
-
-
-def test_qwen_3_14b_tp(
-    output_file,
-    num_layers,
-    request,
-    accuracy_testing,
-    batch_size,
-    max_output_tokens,
-    decode_only,
-    optimization_level,
-):
-    from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import (
-        ModelLoader,
-        ModelVariant,
-    )
-
-    variant = ModelVariant.QWEN_3_14B
-    test_llm_tp(
-        ModelLoader,
-        variant,
-        output_file,
-        num_layers=num_layers,
-        request=request,
-        accuracy_testing=accuracy_testing,
-        batch_size=batch_size,
-        max_output_tokens=max_output_tokens,
-        decode_only=decode_only,
-        optimization_level=1,
-    )
-
-
-def test_qwen_3_32b_tp(
-    output_file,
-    num_layers,
-    request,
-    accuracy_testing,
-    batch_size,
-    max_output_tokens,
-    decode_only,
-    optimization_level,
-):
-    from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import (
-        ModelLoader,
-        ModelVariant,
-    )
-
-    variant = ModelVariant.QWEN_3_32B
-    test_llm_tp(
-        ModelLoader,
-        variant,
-        output_file,
-        num_layers=num_layers,
-        request=request,
-        accuracy_testing=accuracy_testing,
-        batch_size=batch_size,
-        max_output_tokens=max_output_tokens,
-        decode_only=decode_only,
-        optimization_level=(
-            optimization_level
-            if optimization_level is not None
-            else DEFAULT_TP_OPTIMIZATION_LEVEL
-        ),
-    )
-
-
-def test_llama_3_8b_instruct_tp(
-    output_file,
-    num_layers,
-    request,
-    accuracy_testing,
-    batch_size,
-    max_output_tokens,
-    decode_only,
-    optimization_level,
-):
-    from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
-        ModelLoader,
-        ModelVariant,
-    )
-
-    variant = ModelVariant.LLAMA_3_8B_INSTRUCT
-    test_llm_tp(
-        ModelLoader,
-        variant,
-        output_file,
-        num_layers=num_layers,
-        request=request,
-        accuracy_testing=accuracy_testing,
-        batch_size=batch_size,
-        max_output_tokens=max_output_tokens,
-        decode_only=decode_only,
-        optimization_level=(
-            optimization_level
-            if optimization_level is not None
-            else DEFAULT_TP_OPTIMIZATION_LEVEL
-        ),
-    )
-
-
-def test_llama_3_1_8b_tp(
-    output_file,
-    num_layers,
-    request,
-    accuracy_testing,
-    batch_size,
-    max_output_tokens,
-    decode_only,
-    optimization_level,
-):
-    from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
-        ModelLoader,
-        ModelVariant,
-    )
-
-    variant = ModelVariant.LLAMA_3_1_8B
-    test_llm_tp(
-        ModelLoader,
-        variant,
-        output_file,
-        num_layers=num_layers,
-        request=request,
-        accuracy_testing=accuracy_testing,
-        batch_size=batch_size,
-        max_output_tokens=max_output_tokens,
-        decode_only=decode_only,
-        optimization_level=(
-            optimization_level
-            if optimization_level is not None
-            else DEFAULT_TP_OPTIMIZATION_LEVEL
-        ),
-    )
-
-
-def test_llama_3_8b_tp(
-    output_file,
-    num_layers,
-    request,
-    accuracy_testing,
-    batch_size,
-    max_output_tokens,
-    decode_only,
-    optimization_level,
-):
-    from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
-        ModelLoader,
-        ModelVariant,
-    )
-
-    variant = ModelVariant.LLAMA_3_8B
-    test_llm_tp(
-        ModelLoader,
-        variant,
-        output_file,
-        num_layers=num_layers,
-        request=request,
-        accuracy_testing=accuracy_testing,
-        batch_size=batch_size,
-        max_output_tokens=max_output_tokens,
-        decode_only=decode_only,
-        optimization_level=(
-            optimization_level
-            if optimization_level is not None
-            else DEFAULT_TP_OPTIMIZATION_LEVEL
-        ),
-    )
-
-
-def test_llama_3_1_70b_tp(
-    output_file,
-    num_layers,
-    request,
-    accuracy_testing,
-    batch_size,
-    max_output_tokens,
-    decode_only,
-    optimization_level,
-):
-    from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
-        ModelLoader,
-        ModelVariant,
-    )
-
-    variant = ModelVariant.LLAMA_3_1_70B_INSTRUCT
-    test_llm_tp(
-        ModelLoader,
-        variant,
-        output_file,
-        num_layers=num_layers,
-        request=request,
-        accuracy_testing=accuracy_testing,
-        batch_size=batch_size,
-        max_output_tokens=max_output_tokens,
-        decode_only=decode_only,
-        weight_dtype_overrides={
-            "model.layers.*.mlp.gate_proj.weight": "bfp_bf4",
-            "model.layers.*.mlp.up_proj.weight": "bfp_bf4",
-        },
-        optimization_level=1,  # flaky: occasionally hangs in CI with optimization_level=2
-    )
-
-
 # Use 1x8 shard specs for gpt-oss-20b until https://github.com/tenstorrent/tt-xla/issues/3490 is resolved.
 def _gpt_oss_20b_mesh_config_fn(model_loader, num_devices):
     return (1, num_devices), ("batch", "model")
@@ -1750,120 +1128,6 @@ def _gpt_oss_20b_shard_spec_fn(model_loader, model):
         shard_specs[layer.mlp.experts.down_proj] = ("model", None, None)
         shard_specs[layer.mlp.experts.down_proj_bias] = ("model", None)
     return shard_specs
-
-
-# Trace disabled: ~23% slower with trace on bs=32 (https://github.com/tenstorrent/tt-xla/issues/4192)
-def test_gpt_oss_20b_tp(
-    output_file,
-    num_layers,
-    request,
-    accuracy_testing,
-    batch_size,
-    max_output_tokens,
-    decode_only,
-    optimization_level,
-):
-    from tt_torch import TT_DENSE_EXPERTS_BACKEND_NAME
-
-    from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
-        ModelLoader,
-        ModelVariant,
-    )
-
-    variant = ModelVariant.GPT_OSS_20B
-    test_llm_tp(
-        ModelLoader,
-        variant,
-        output_file,
-        num_layers=num_layers,
-        request=request,
-        accuracy_testing=accuracy_testing,
-        batch_size=batch_size,
-        max_output_tokens=max_output_tokens,
-        decode_only=decode_only,
-        mesh_config_fn=_gpt_oss_20b_mesh_config_fn,
-        shard_spec_fn=_gpt_oss_20b_shard_spec_fn,
-        trace_enabled=False,
-        optimization_level=1,
-        experts_implementation=TT_DENSE_EXPERTS_BACKEND_NAME,
-        required_pcc=0.94,
-    )
-
-
-# Test with D2M fusion enabled (enable-create-d2m-subgraphs=true).
-# FAILED: SIGSEGV in TTNNRowMajorLayoutPropagation (https://github.com/tenstorrent/tt-xla/issues/5121)
-def test_gpt_oss_20b_tp_d2m(
-    output_file,
-    num_layers,
-    request,
-    accuracy_testing,
-    batch_size,
-    max_output_tokens,
-    decode_only,
-    optimization_level,
-):
-    from tt_torch import TT_DENSE_EXPERTS_BACKEND_NAME
-
-    from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
-        ModelLoader,
-        ModelVariant,
-    )
-
-    variant = ModelVariant.GPT_OSS_20B
-    test_llm_tp(
-        ModelLoader,
-        variant,
-        output_file,
-        num_layers=num_layers,
-        request=request,
-        accuracy_testing=accuracy_testing,
-        batch_size=batch_size,
-        max_output_tokens=max_output_tokens,
-        decode_only=decode_only,
-        mesh_config_fn=_gpt_oss_20b_mesh_config_fn,
-        shard_spec_fn=_gpt_oss_20b_shard_spec_fn,
-        trace_enabled=False,
-        optimization_level=1,
-        enable_create_d2m_subgraphs=True,
-        experts_implementation=TT_DENSE_EXPERTS_BACKEND_NAME,
-    )
-
-
-# Excluded from the onPR perf filter (still runs in nightly): slice op requires
-# tile-aligned height (https://github.com/tenstorrent/tt-xla/issues/5207).
-def test_gpt_oss_20b_tp_batch_size_1(
-    output_file,
-    num_layers,
-    request,
-    accuracy_testing,
-    batch_size,
-    max_output_tokens,
-    decode_only,
-    optimization_level,
-):
-    from tt_torch import TT_DENSE_EXPERTS_BACKEND_NAME
-
-    from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
-        ModelLoader,
-        ModelVariant,
-    )
-
-    variant = ModelVariant.GPT_OSS_20B
-    test_llm_tp(
-        ModelLoader,
-        variant,
-        output_file,
-        num_layers=num_layers,
-        request=request,
-        accuracy_testing=accuracy_testing,
-        max_output_tokens=max_output_tokens,
-        decode_only=decode_only,
-        mesh_config_fn=_gpt_oss_20b_mesh_config_fn,
-        shard_spec_fn=_gpt_oss_20b_shard_spec_fn,
-        batch_size=batch_size if batch_size is not None else 1,
-        optimization_level=1,
-        experts_implementation=TT_DENSE_EXPERTS_BACKEND_NAME,
-    )
 
 
 # Excluded from the onPR perf filter (still runs in nightly): galaxy fabric "Failed
@@ -2058,11 +1322,11 @@ def test_gpt_oss_120b_tp_galaxy_batch_size_64(
     )
 
 
-def _gpt_oss_120b_qb2_mesh_config_fn(model_loader, num_devices):
+def _gpt_oss_120b_mesh_config_fn(model_loader, num_devices):
     return (1, 4), ("batch", "model")
 
 
-def _gpt_oss_120b_qb2_shard_spec_fn(model_loader, model):
+def _gpt_oss_120b_shard_spec_fn(model_loader, model):
     """QB2 (1,4) mesh shard specs — model-axis-only, no batch sharding."""
     shard_specs = {}
     shard_specs[model.model.embed_tokens.weight] = (None, None)
@@ -2081,7 +1345,7 @@ def _gpt_oss_120b_qb2_shard_spec_fn(model_loader, model):
     return shard_specs
 
 
-def test_gpt_oss_120b_tp_qb2(
+def test_gpt_oss_120b_tp(
     output_file,
     num_layers,
     request,
@@ -2119,8 +1383,8 @@ def test_gpt_oss_120b_tp_qb2(
             "model.layers.*.mlp.experts.down_proj": "bfp_bf4",
         },
         required_pcc=0.93,  # set for now as it's ~0.93 on test runs locally
-        mesh_config_fn=_gpt_oss_120b_qb2_mesh_config_fn,
-        # shard_spec_fn=_gpt_oss_120b_qb2_shard_spec_fn,
+        mesh_config_fn=_gpt_oss_120b_mesh_config_fn,
+        # shard_spec_fn=_gpt_oss_120b_shard_spec_fn,
         experts_implementation=TT_DENSE_EXPERTS_BACKEND_NAME,
     )
 
@@ -2233,7 +1497,7 @@ def test_deepseek_v3_2_exp_tp_galaxy_2_layers(
     )
 
 
-def test_falcon3_7b_tp_qb2(
+def test_falcon3_7b_tp(
     output_file,
     num_layers,
     request,
@@ -2263,7 +1527,7 @@ def test_falcon3_7b_tp_qb2(
     )
 
 
-def test_falcon3_10b_tp_qb2(
+def test_falcon3_10b_tp(
     output_file,
     num_layers,
     request,
@@ -2293,7 +1557,7 @@ def test_falcon3_10b_tp_qb2(
     )
 
 
-def test_llama_3_1_8b_instruct_tp_qb2(
+def test_llama_3_1_8b_instruct_tp(
     output_file,
     num_layers,
     request,
@@ -2323,7 +1587,7 @@ def test_llama_3_1_8b_instruct_tp_qb2(
     )
 
 
-def test_ministral_8b_tp_qb2(
+def test_ministral_8b_tp(
     output_file,
     num_layers,
     request,
@@ -2353,7 +1617,7 @@ def test_ministral_8b_tp_qb2(
     )
 
 
-def test_mistral_nemo_instruct_2407_tp_qb2(
+def test_mistral_nemo_instruct_2407_tp(
     output_file,
     num_layers,
     request,
@@ -2383,7 +1647,7 @@ def test_mistral_nemo_instruct_2407_tp_qb2(
     )
 
 
-def test_mistral_small_24b_instruct_2501_tp_qb2(
+def test_mistral_small_24b_instruct_2501_tp(
     output_file,
     num_layers,
     request,
@@ -2413,7 +1677,7 @@ def test_mistral_small_24b_instruct_2501_tp_qb2(
     )
 
 
-def test_qwen_2_5_14b_instruct_tp_qb2(
+def test_qwen_2_5_14b_instruct_tp(
     output_file,
     num_layers,
     request,
@@ -2443,7 +1707,7 @@ def test_qwen_2_5_14b_instruct_tp_qb2(
     )
 
 
-def test_qwen_2_5_coder_32b_instruct_tp_qb2(
+def test_qwen_2_5_coder_32b_instruct_tp(
     output_file,
     num_layers,
     request,
@@ -2473,7 +1737,7 @@ def test_qwen_2_5_coder_32b_instruct_tp_qb2(
     )
 
 
-def test_qwen_3_8b_tp_qb2(
+def test_qwen_3_8b_tp(
     output_file,
     num_layers,
     request,
@@ -2503,7 +1767,7 @@ def test_qwen_3_8b_tp_qb2(
     )
 
 
-def test_qwen_3_14b_tp_qb2(
+def test_qwen_3_14b_tp(
     output_file,
     num_layers,
     request,
@@ -2533,7 +1797,7 @@ def test_qwen_3_14b_tp_qb2(
     )
 
 
-def test_qwen_3_32b_tp_qb2(
+def test_qwen_3_32b_tp(
     output_file,
     num_layers,
     request,
@@ -2563,7 +1827,7 @@ def test_qwen_3_32b_tp_qb2(
     )
 
 
-def test_gpt_oss_20b_tp_qb2(
+def test_gpt_oss_20b_tp(
     output_file,
     num_layers,
     request,
@@ -2598,7 +1862,7 @@ def test_gpt_oss_20b_tp_qb2(
     )
 
 
-def test_llama_3_1_70b_tp_qb2(
+def test_llama_3_1_70b_tp(
     output_file,
     num_layers,
     request,
@@ -2632,7 +1896,9 @@ def test_llama_3_1_70b_tp_qb2(
     )
 
 
-def test_gpt_oss_20b_tp_batch_size_1_qb2(
+# Excluded from the onPR perf filter (still runs in nightly): slice op requires
+# tile-aligned height (https://github.com/tenstorrent/tt-xla/issues/5207).
+def test_gpt_oss_20b_tp_batch_size_1(
     output_file,
     num_layers,
     request,

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -1322,11 +1322,11 @@ def test_gpt_oss_120b_tp_galaxy_batch_size_64(
     )
 
 
-def _gpt_oss_120b_mesh_config_fn(model_loader, num_devices):
+def _gpt_oss_120b_qb2_mesh_config_fn(model_loader, num_devices):
     return (1, 4), ("batch", "model")
 
 
-def _gpt_oss_120b_shard_spec_fn(model_loader, model):
+def _gpt_oss_120b_qb2_shard_spec_fn(model_loader, model):
     """QB2 (1,4) mesh shard specs — model-axis-only, no batch sharding."""
     shard_specs = {}
     shard_specs[model.model.embed_tokens.weight] = (None, None)
@@ -1345,7 +1345,7 @@ def _gpt_oss_120b_shard_spec_fn(model_loader, model):
     return shard_specs
 
 
-def test_gpt_oss_120b_tp(
+def test_gpt_oss_120b_tp_qb2(
     output_file,
     num_layers,
     request,
@@ -1383,8 +1383,8 @@ def test_gpt_oss_120b_tp(
             "model.layers.*.mlp.experts.down_proj": "bfp_bf4",
         },
         required_pcc=0.93,  # set for now as it's ~0.93 on test runs locally
-        mesh_config_fn=_gpt_oss_120b_mesh_config_fn,
-        # shard_spec_fn=_gpt_oss_120b_shard_spec_fn,
+        mesh_config_fn=_gpt_oss_120b_qb2_mesh_config_fn,
+        # shard_spec_fn=_gpt_oss_120b_qb2_shard_spec_fn,
         experts_implementation=TT_DENSE_EXPERTS_BACKEND_NAME,
     )
 
@@ -1497,7 +1497,7 @@ def test_deepseek_v3_2_exp_tp_galaxy_2_layers(
     )
 
 
-def test_falcon3_7b_tp(
+def test_falcon3_7b_tp_qb2(
     output_file,
     num_layers,
     request,
@@ -1527,7 +1527,7 @@ def test_falcon3_7b_tp(
     )
 
 
-def test_falcon3_10b_tp(
+def test_falcon3_10b_tp_qb2(
     output_file,
     num_layers,
     request,
@@ -1557,7 +1557,7 @@ def test_falcon3_10b_tp(
     )
 
 
-def test_llama_3_1_8b_instruct_tp(
+def test_llama_3_1_8b_instruct_tp_qb2(
     output_file,
     num_layers,
     request,
@@ -1587,7 +1587,7 @@ def test_llama_3_1_8b_instruct_tp(
     )
 
 
-def test_ministral_8b_tp(
+def test_ministral_8b_tp_qb2(
     output_file,
     num_layers,
     request,
@@ -1617,7 +1617,7 @@ def test_ministral_8b_tp(
     )
 
 
-def test_mistral_nemo_instruct_2407_tp(
+def test_mistral_nemo_instruct_2407_tp_qb2(
     output_file,
     num_layers,
     request,
@@ -1647,7 +1647,7 @@ def test_mistral_nemo_instruct_2407_tp(
     )
 
 
-def test_mistral_small_24b_instruct_2501_tp(
+def test_mistral_small_24b_instruct_2501_tp_qb2(
     output_file,
     num_layers,
     request,
@@ -1677,7 +1677,7 @@ def test_mistral_small_24b_instruct_2501_tp(
     )
 
 
-def test_qwen_2_5_14b_instruct_tp(
+def test_qwen_2_5_14b_instruct_tp_qb2(
     output_file,
     num_layers,
     request,
@@ -1707,7 +1707,7 @@ def test_qwen_2_5_14b_instruct_tp(
     )
 
 
-def test_qwen_2_5_coder_32b_instruct_tp(
+def test_qwen_2_5_coder_32b_instruct_tp_qb2(
     output_file,
     num_layers,
     request,
@@ -1737,7 +1737,7 @@ def test_qwen_2_5_coder_32b_instruct_tp(
     )
 
 
-def test_qwen_3_8b_tp(
+def test_qwen_3_8b_tp_qb2(
     output_file,
     num_layers,
     request,
@@ -1767,7 +1767,7 @@ def test_qwen_3_8b_tp(
     )
 
 
-def test_qwen_3_14b_tp(
+def test_qwen_3_14b_tp_qb2(
     output_file,
     num_layers,
     request,
@@ -1797,7 +1797,7 @@ def test_qwen_3_14b_tp(
     )
 
 
-def test_qwen_3_32b_tp(
+def test_qwen_3_32b_tp_qb2(
     output_file,
     num_layers,
     request,
@@ -1827,7 +1827,7 @@ def test_qwen_3_32b_tp(
     )
 
 
-def test_gpt_oss_20b_tp(
+def test_gpt_oss_20b_tp_qb2(
     output_file,
     num_layers,
     request,
@@ -1862,7 +1862,7 @@ def test_gpt_oss_20b_tp(
     )
 
 
-def test_llama_3_1_70b_tp(
+def test_llama_3_1_70b_tp_qb2(
     output_file,
     num_layers,
     request,
@@ -1898,7 +1898,7 @@ def test_llama_3_1_70b_tp(
 
 # Excluded from the onPR perf filter (still runs in nightly): slice op requires
 # tile-aligned height (https://github.com/tenstorrent/tt-xla/issues/5207).
-def test_gpt_oss_20b_tp_batch_size_1(
+def test_gpt_oss_20b_tp_batch_size_1_qb2(
     output_file,
     num_layers,
     request,

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -2598,6 +2598,75 @@ def test_gpt_oss_20b_tp_qb2(
     )
 
 
+def test_llama_3_1_70b_tp_qb2(
+    output_file,
+    num_layers,
+    request,
+    accuracy_testing,
+    batch_size,
+    max_output_tokens,
+    decode_only,
+    optimization_level,
+):
+    from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import (
+        ModelLoader,
+        ModelVariant,
+    )
+
+    variant = ModelVariant.LLAMA_3_1_70B_INSTRUCT
+    test_llm_tp(
+        ModelLoader,
+        variant,
+        output_file,
+        num_layers=num_layers,
+        request=request,
+        accuracy_testing=accuracy_testing,
+        batch_size=batch_size,
+        max_output_tokens=max_output_tokens,
+        decode_only=decode_only,
+        weight_dtype_overrides={
+            "model.layers.*.mlp.gate_proj.weight": "bfp_bf4",
+            "model.layers.*.mlp.up_proj.weight": "bfp_bf4",
+        },
+        optimization_level=1,  # flaky: occasionally hangs in CI with optimization_level=2
+    )
+
+
+def test_gpt_oss_20b_tp_batch_size_1_qb2(
+    output_file,
+    num_layers,
+    request,
+    accuracy_testing,
+    batch_size,
+    max_output_tokens,
+    decode_only,
+    optimization_level,
+):
+    from tt_torch import TT_DENSE_EXPERTS_BACKEND_NAME
+
+    from third_party.tt_forge_models.gpt_oss.pytorch.loader import (
+        ModelLoader,
+        ModelVariant,
+    )
+
+    variant = ModelVariant.GPT_OSS_20B
+    test_llm_tp(
+        ModelLoader,
+        variant,
+        output_file,
+        num_layers=num_layers,
+        request=request,
+        accuracy_testing=accuracy_testing,
+        max_output_tokens=max_output_tokens,
+        decode_only=decode_only,
+        mesh_config_fn=_gpt_oss_20b_mesh_config_fn,
+        shard_spec_fn=_gpt_oss_20b_shard_spec_fn,
+        batch_size=batch_size if batch_size is not None else 1,
+        optimization_level=2,
+        experts_implementation=TT_DENSE_EXPERTS_BACKEND_NAME,
+    )
+
+
 def _deepseek_v3_1_shard_spec_fn(model_loader, model):
     """Sharding specs for DeepSeek V3.1 on 4x8 galaxy mesh with TP 8, DP 4, EP 32."""
     from tt_torch.sparse_mlp import A2aSparseMLPWithSharedExperts

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -1753,8 +1753,6 @@ def _gpt_oss_20b_shard_spec_fn(model_loader, model):
 
 
 # Trace disabled: ~23% slower with trace on bs=32 (https://github.com/tenstorrent/tt-xla/issues/4192)
-# The n300-llmbox perf entry (gpt_oss_20b_tp) is excluded from the onPR perf filter
-# (still runs in nightly): hangs on n300-llmbox (https://github.com/tenstorrent/tt-xla/issues/5151).
 def test_gpt_oss_20b_tp(
     output_file,
     num_layers,

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -193,8 +193,9 @@ SINGLE_DEVICE_CONFIGS = [
 ]
 
 
-# The _tp_config benchmarks below use a (2, 4) 2D mesh (8 devices). The
-# qb2-blackhole config (qwen3-32b-qb2) uses a 1D mesh (mesh_shape=None).
+# The _tp_config benchmarks below default to a (2, 4) 2D mesh (8 devices).
+# The qb2-blackhole configs (ids ending in -qb2-tp) use a 1D mesh
+# (mesh_shape=None, auto-sized to the machine's device count).
 TP_CONFIGS = [
     pytest.param(
         _tp_config(
@@ -226,6 +227,36 @@ TP_CONFIGS = [
     ),
     pytest.param(_gemma4_tp_config("google/gemma-4-31B-it", 32), id="gemma4-31b-it-tp"),
     pytest.param(_tp_config("Qwen/Qwen3-32B", 32), id="qwen3-32b-qb2-tp"),
+    # qb2-blackhole TP configs (1D mesh): transferred from the retired
+    # n300-llmbox (2, 4) entries. Same models, mesh_shape=None for blackhole.
+    pytest.param(_tp_config("tiiuae/Falcon3-7B-Base", 32), id="falcon3-7b-qb2-tp"),
+    pytest.param(_tp_config("tiiuae/Falcon3-10B-Base", 32), id="falcon3-10b-qb2-tp"),
+    pytest.param(_tp_config("Qwen/Qwen3-8B", 32), id="qwen3-8b-qb2-tp"),
+    pytest.param(_tp_config("Qwen/Qwen3-14B", 32), id="qwen3-14b-qb2-tp"),
+    pytest.param(
+        _tp_config("Qwen/Qwen2.5-14B-Instruct", 32),
+        id="qwen2.5-14b-instruct-qb2-tp",
+    ),
+    pytest.param(
+        _tp_config("Qwen/Qwen2.5-Coder-32B-Instruct", 32),
+        id="qwen2.5-coder-32b-instruct-qb2-tp",
+    ),
+    pytest.param(
+        _tp_config("mistralai/Ministral-8B-Instruct-2410", 32),
+        id="ministral-8b-qb2-tp",
+    ),
+    pytest.param(
+        _tp_config("mistralai/Mistral-Nemo-Instruct-2407", 32),
+        id="mistral-nemo-instruct-2407-qb2-tp",
+    ),
+    pytest.param(
+        _tp_config("mistralai/Mistral-Small-24B-Instruct-2501", 32),
+        id="mistral-small-24b-instruct-2501-qb2-tp",
+    ),
+    pytest.param(
+        _tp_config("meta-llama/Llama-3.1-8B-Instruct", 32),
+        id="llama-3.1-8b-qb2-tp",
+    ),
     pytest.param(
         _tp_config("Qwen/Qwen2.5-14B-Instruct", 32, mesh_shape=[2, 4]),
         id="qwen2.5-14b-instruct-tp",

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -160,7 +160,11 @@ SINGLE_DEVICE_CONFIGS = [
     # Llama
     pytest.param(_config("meta-llama/Llama-3.2-1B-Instruct"), id="llama-3.2-1b"),
     pytest.param(_config("meta-llama/Llama-3.2-3B-Instruct"), id="llama-3.2-3b"),
-    pytest.param(_config("meta-llama/Llama-3.1-8B-Instruct"), id="llama-3.1-8b"),
+    # opt-level 2 (the default since #5410) OOMs DRAM on n150. See https://github.com/tenstorrent/tt-xla/issues/5494.
+    pytest.param(
+        _config("meta-llama/Llama-3.1-8B-Instruct", optimization_level=0),
+        id="llama-3.1-8b",
+    ),
     # Qwen 2.5
     pytest.param(_config("Qwen/Qwen2.5-0.5B-Instruct"), id="qwen2.5-0.5b-instruct"),
     pytest.param(_config("Qwen/Qwen2.5-1.5B-Instruct"), id="qwen2.5-1.5b-instruct"),

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -193,88 +193,22 @@ SINGLE_DEVICE_CONFIGS = [
 ]
 
 
-# The _tp_config benchmarks below default to a (2, 4) 2D mesh (8 devices).
-# The qb2-blackhole configs (ids ending in -qb2-tp) use a 1D mesh
-# (mesh_shape=None, auto-sized to the machine's device count).
+# TP configs run exclusively on qb2-blackhole: 1D mesh, mesh_shape=None,
+# auto-sized to the machine's device count.
 TP_CONFIGS = [
-    pytest.param(
-        _tp_config(
-            "tiiuae/Falcon3-7B-Base",
-            32,
-            mesh_shape=[2, 4],
-            # opt-level 2 fails with an L1/circular-buffer clash; see #5438.
-            optimization_level=1,
-        ),
-        id="falcon3-7b-tp",
-    ),
-    pytest.param(
-        # opt-level 2 fails with an L1/circular-buffer clash; see #5439.
-        _tp_config(
-            "tiiuae/Falcon3-10B-Base", 32, mesh_shape=[2, 4], optimization_level=1
-        ),
-        id="falcon3-10b-tp",
-    ),
-    pytest.param(_tp_config("Qwen/Qwen3-8B", 32, mesh_shape=[2, 4]), id="qwen3-8b-tp"),
-    pytest.param(
-        _tp_config("Qwen/Qwen3-8B", 32, mesh_shape=[2, 4], optimization_level=1),
-        id="qwen3-8b-tp-opt1",
-    ),
-    pytest.param(
-        _tp_config("Qwen/Qwen3-14B", 32, mesh_shape=[2, 4]), id="qwen3-14b-tp"
-    ),
-    pytest.param(
-        _tp_config("Qwen/Qwen3-32B", 32, mesh_shape=[2, 4]), id="qwen3-32b-tp"
-    ),
-    pytest.param(_gemma4_tp_config("google/gemma-4-31B-it", 32), id="gemma4-31b-it-tp"),
-    pytest.param(_tp_config("Qwen/Qwen3-32B", 32), id="qwen3-32b-qb2-tp"),
-    # qb2-blackhole TP configs (1D mesh): transferred from the retired
-    # n300-llmbox (2, 4) entries. Same models, mesh_shape=None for blackhole.
-    pytest.param(_tp_config("tiiuae/Falcon3-7B-Base", 32), id="falcon3-7b-qb2-tp"),
-    pytest.param(_tp_config("tiiuae/Falcon3-10B-Base", 32), id="falcon3-10b-qb2-tp"),
+    pytest.param(_tp_config("Qwen/Qwen3-32B", 32), id="qwen3-32b-tp"),
+    pytest.param(_tp_config("tiiuae/Falcon3-7B-Base", 32), id="falcon3-7b-tp"),
+    pytest.param(_tp_config("tiiuae/Falcon3-10B-Base", 32), id="falcon3-10b-tp"),
     pytest.param(
         _tp_config("Qwen/Qwen2.5-Coder-32B-Instruct", 32),
-        id="qwen2.5-coder-32b-instruct-qb2-tp",
-    ),
-    pytest.param(
-        _tp_config("mistralai/Mistral-Small-24B-Instruct-2501", 32),
-        id="mistral-small-24b-instruct-2501-qb2-tp",
-    ),
-    pytest.param(
-        _tp_config("meta-llama/Llama-3.1-8B-Instruct", 32),
-        id="llama-3.1-8b-qb2-tp",
-    ),
-    pytest.param(
-        _tp_config(
-            "meta-llama/Llama-3.1-70B-Instruct",
-            32,
-            gpu_memory_utilization=0.15,
-            enable_const_eval=True,
-            experimental_weight_dtype="bfp_bf8",
-        ),
-        id="llama-3.1-70b-qb2-tp",
-    ),
-    pytest.param(
-        _tp_config("Qwen/Qwen2.5-14B-Instruct", 32, mesh_shape=[2, 4]),
-        id="qwen2.5-14b-instruct-tp",
-    ),
-    pytest.param(
-        _tp_config("Qwen/Qwen2.5-Coder-32B-Instruct", 32, mesh_shape=[2, 4]),
         id="qwen2.5-coder-32b-instruct-tp",
     ),
     pytest.param(
-        _tp_config("mistralai/Ministral-8B-Instruct-2410", 32, mesh_shape=[2, 4]),
-        id="ministral-8b-tp",
-    ),
-    pytest.param(
-        _tp_config("mistralai/Mistral-Nemo-Instruct-2407", 32, mesh_shape=[2, 4]),
-        id="mistral-nemo-instruct-2407-tp",
-    ),
-    pytest.param(
-        _tp_config("mistralai/Mistral-Small-24B-Instruct-2501", 32, mesh_shape=[2, 4]),
+        _tp_config("mistralai/Mistral-Small-24B-Instruct-2501", 32),
         id="mistral-small-24b-instruct-2501-tp",
     ),
     pytest.param(
-        _tp_config("meta-llama/Llama-3.1-8B-Instruct", 32, mesh_shape=[2, 4]),
+        _tp_config("meta-llama/Llama-3.1-8B-Instruct", 32),
         id="llama-3.1-8b-tp",
     ),
     pytest.param(
@@ -282,12 +216,12 @@ TP_CONFIGS = [
             "meta-llama/Llama-3.1-70B-Instruct",
             32,
             gpu_memory_utilization=0.15,
-            mesh_shape=[2, 4],
             enable_const_eval=True,
             experimental_weight_dtype="bfp_bf8",
         ),
         id="llama-3.1-70b-tp",
     ),
+    pytest.param(_gemma4_tp_config("google/gemma-4-31B-it", 32), id="gemma4-31b-it-tp"),
     # Verify fused decode_postprocess compiles to expected graph count (cpu_sampling=False path)
     pytest.param(
         _config("facebook/opt-125m", 1, gpu_memory_utilization=0.001),

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -194,20 +194,20 @@ SINGLE_DEVICE_CONFIGS = [
 # TP configs run exclusively on qb2-blackhole: 1D mesh, mesh_shape=None,
 # auto-sized to the machine's device count.
 TP_CONFIGS = [
-    pytest.param(_tp_config("Qwen/Qwen3-32B", 32), id="qwen3-32b-tp"),
-    pytest.param(_tp_config("tiiuae/Falcon3-7B-Base", 32), id="falcon3-7b-tp"),
-    pytest.param(_tp_config("tiiuae/Falcon3-10B-Base", 32), id="falcon3-10b-tp"),
+    pytest.param(_tp_config("Qwen/Qwen3-32B", 32), id="qwen3-32b-qb2-tp"),
+    pytest.param(_tp_config("tiiuae/Falcon3-7B-Base", 32), id="falcon3-7b-qb2-tp"),
+    pytest.param(_tp_config("tiiuae/Falcon3-10B-Base", 32), id="falcon3-10b-qb2-tp"),
     pytest.param(
         _tp_config("Qwen/Qwen2.5-Coder-32B-Instruct", 32),
-        id="qwen2.5-coder-32b-instruct-tp",
+        id="qwen2.5-coder-32b-instruct-qb2-tp",
     ),
     pytest.param(
         _tp_config("mistralai/Mistral-Small-24B-Instruct-2501", 32),
-        id="mistral-small-24b-instruct-2501-tp",
+        id="mistral-small-24b-instruct-2501-qb2-tp",
     ),
     pytest.param(
         _tp_config("meta-llama/Llama-3.1-8B-Instruct", 32),
-        id="llama-3.1-8b-tp",
+        id="llama-3.1-8b-qb2-tp",
     ),
     pytest.param(
         _tp_config(
@@ -217,7 +217,7 @@ TP_CONFIGS = [
             enable_const_eval=True,
             experimental_weight_dtype="bfp_bf8",
         ),
-        id="llama-3.1-70b-tp",
+        id="llama-3.1-70b-qb2-tp",
     ),
     pytest.param(_gemma4_tp_config("google/gemma-4-31B-it", 32), id="gemma4-31b-it-tp"),
     # Verify fused decode_postprocess compiles to expected graph count (cpu_sampling=False path)

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -193,8 +193,8 @@ SINGLE_DEVICE_CONFIGS = [
 ]
 
 
-# All _tp_config benchmarks below run on n300-llmbox (8 devices): a (2, 4) 2D
-# mesh. The qb2-blackhole config (qwen3-32b-qb2) uses a 1D mesh (mesh_shape=None).
+# The _tp_config benchmarks below use a (2, 4) 2D mesh (8 devices). The
+# qb2-blackhole config (qwen3-32b-qb2) uses a 1D mesh (mesh_shape=None).
 TP_CONFIGS = [
     pytest.param(
         _tp_config(

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -231,23 +231,9 @@ TP_CONFIGS = [
     # n300-llmbox (2, 4) entries. Same models, mesh_shape=None for blackhole.
     pytest.param(_tp_config("tiiuae/Falcon3-7B-Base", 32), id="falcon3-7b-qb2-tp"),
     pytest.param(_tp_config("tiiuae/Falcon3-10B-Base", 32), id="falcon3-10b-qb2-tp"),
-    pytest.param(_tp_config("Qwen/Qwen3-8B", 32), id="qwen3-8b-qb2-tp"),
-    pytest.param(_tp_config("Qwen/Qwen3-14B", 32), id="qwen3-14b-qb2-tp"),
-    pytest.param(
-        _tp_config("Qwen/Qwen2.5-14B-Instruct", 32),
-        id="qwen2.5-14b-instruct-qb2-tp",
-    ),
     pytest.param(
         _tp_config("Qwen/Qwen2.5-Coder-32B-Instruct", 32),
         id="qwen2.5-coder-32b-instruct-qb2-tp",
-    ),
-    pytest.param(
-        _tp_config("mistralai/Ministral-8B-Instruct-2410", 32),
-        id="ministral-8b-qb2-tp",
-    ),
-    pytest.param(
-        _tp_config("mistralai/Mistral-Nemo-Instruct-2407", 32),
-        id="mistral-nemo-instruct-2407-qb2-tp",
     ),
     pytest.param(
         _tp_config("mistralai/Mistral-Small-24B-Instruct-2501", 32),
@@ -256,6 +242,16 @@ TP_CONFIGS = [
     pytest.param(
         _tp_config("meta-llama/Llama-3.1-8B-Instruct", 32),
         id="llama-3.1-8b-qb2-tp",
+    ),
+    pytest.param(
+        _tp_config(
+            "meta-llama/Llama-3.1-70B-Instruct",
+            32,
+            gpu_memory_utilization=0.15,
+            enable_const_eval=True,
+            experimental_weight_dtype="bfp_bf8",
+        ),
+        id="llama-3.1-70b-qb2-tp",
     ),
     pytest.param(
         _tp_config("Qwen/Qwen2.5-14B-Instruct", 32, mesh_shape=[2, 4]),

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -139,8 +139,6 @@ def _gemma4_tp_config(model: str, batch_size: int):
         model,
         batch_size,
         gpu_memory_utilization=0.2,
-        # opt-level 2 fails with an L1 out-of-memory TT_FATAL; see #5440.
-        optimization_level=1,
         enable_tensor_parallel=True,
         min_context_len=32,
         enable_const_eval=True,

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -139,6 +139,8 @@ def _gemma4_tp_config(model: str, batch_size: int):
         model,
         batch_size,
         gpu_memory_utilization=0.2,
+        # opt-level 2 fails with an L1 out-of-memory TT_FATAL; see #5440.
+        optimization_level=1,
         enable_tensor_parallel=True,
         min_context_len=32,
         enable_const_eval=True,


### PR DESCRIPTION
### Ticket
Closes #4949 
Closes #5494 

### Problem description
We have successfully enabled benchmarks on qb2-blackhole.
n300-llmbox runners produce very long queue times and should be deprecated. 

### What's changed
- Removed n300-llmbox from benchmarking CI.
- Transfered vllm n300-llmbox benchmarks to qb2.
- Added `qwen_3_32b_tp_qb2` to OnPR uplift CI, both perf and accuracy benchmark.
- All prior llmbox models now run on qb2.
- Enabled opt-level=2 on vllm_falcon3_7b and vllm_falcon3_10b that were previously failing on llmbox:
#5438 
#5439 

### Checklist
- [x] [qb2-blackhole](https://github.com/tenstorrent/tt-xla/actions/runs/28512285954)
    - [llama_3_1_70b_tp PCC failure](https://github.com/tenstorrent/tt-xla/actions/runs/28512285954/job/84545923972) - issue https://github.com/tenstorrent/tt-xla/issues/5487
    - [vllm_gemma4_31b_it_tp L1 OOM](https://github.com/tenstorrent/tt-xla/actions/runs/28512285954/job/84545925404) - issue https://github.com/tenstorrent/tt-xla/issues/5440

- [x] [Sanity check](https://github.com/tenstorrent/tt-xla/actions/runs/28531561911)
    - llama-3.1-8b failing - issue https://github.com/tenstorrent/tt-xla/issues/5494 

- [x] [llama's, gemma's, falcon's test after rebase and opt-level=0 for llama-3.1-8b on all machines](https://github.com/tenstorrent/tt-xla/actions/runs/28601498692)
  