### PR TITLE
Remove dual bh lb from available CI runners

### DIFF
--- a/.github/workflows/test-matrix-presets/basic-multihost-test.json
+++ b/.github/workflows/test-matrix-presets/basic-multihost-test.json
@@ -1,4 +1,3 @@
 [
-    { "runs-on": "multi-host-bh-lb-2x",  "topology": "dual_bh_loudbox_1x16", "name": "multihost tests on dual bh loudbox 1x16", "test-mark": "push", "dir": "./tests/torch/multi_host/experimental",  "multihost": true },
     { "runs-on": "multi-host-t3000", "topology": "dual_t3k", "name": "multihost tests on dual t3k", "test-mark": "push", "dir": "./tests/torch/multi_host/experimental",  "multihost": true  }
 ]


### PR DESCRIPTION
### Ticket
N/A 

### Problem description
This machine is no longer available to CI

### What's changed
Remove dual bh lb as CI runner

### Checklist
- [ ] New/Existing tests provide coverage for changes
