### PR TITLE
Don't schedule prefill unless there is enough kv cache left to fulfil decode stage

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -3,6 +3,8 @@
 # SPDX-FileCopyrightText: Portions (c) 2025 Tenstorrent AI ULC
 
 import contextlib
+import os
+import sys
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional, Union, cast
 
@@ -61,6 +63,20 @@ class TTConfig:
     # (small/b1 graph, served serially) instead of one wasted-row b32 batch;
     # above it, prefills batch as usual. 0 = off; needs min_num_seqs < max.
     prefill_batch_threshold: int = 0
+
+    # KV-cache high-watermark for *fresh* prefill admission, as a fraction of
+    # the block pool (tt-xla: large-context concurrency thrash). AscendScheduler
+    # stops admitting NEW prefills once doing so would leave less than this
+    # fraction of the pool free, reserving headroom for in-flight requests to
+    # finish decoding instead of evicting (preempting) them and re-prefilling.
+    # Continuation chunks of already-started prefills and decode are NOT gated
+    # (decode may use the pool to 100%). A forward-progress guard always admits
+    # at least one prefill when nothing is running, so a single large prompt is
+    # never starved. 0.0 = off (legacy 1% watermark for all prefills).
+    # Default 0.25 (reserve 25% free => stop admitting above ~75% usage).
+    # Override at runtime with env var TT_PREFILL_KV_WATERMARK_percent (a
+    # percent, e.g. 25), which takes precedence over additional_config.
+    prefill_kv_watermark: float = 0.25
 
     batch_size: int = 1
     enable_precompile_all: bool = True
@@ -314,6 +330,24 @@ class TTPlatform(Platform):
             raise ValueError(
                 "additional_config['prefill_batch_threshold'] must be >= 0."
             )
+
+        # KV-cache high-watermark for fresh-prefill admission. Resolve default
+        # (0.25), apply the TT_PREFILL_KV_WATERMARK_percent env override (a
+        # percent, e.g. 25 -> 0.25), and persist a concrete fraction so the
+        # AscendScheduler reads it directly; validate it is in [0, 1).
+        if additional_config.get("prefill_kv_watermark") is None:
+            additional_config["prefill_kv_watermark"] = TTConfig.prefill_kv_watermark
+        env_wm = os.environ.get("TT_PREFILL_KV_WATERMARK_percent")
+        if env_wm is not None:
+            additional_config["prefill_kv_watermark"] = float(env_wm) / 100.0
+        wm = float(additional_config["prefill_kv_watermark"])
+        if not (0.0 <= wm < 1.0):
+            raise ValueError(
+                "prefill_kv_watermark (TT_PREFILL_KV_WATERMARK_percent / 100) "
+                f"must be in [0, 1); got {wm}."
+            )
+        additional_config["prefill_kv_watermark"] = wm
+
         vllm_config.additional_config = additional_config
 
         # Stash cpu_sampling so validate_request() can read it without

--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -76,6 +76,7 @@ class TTConfig:
     # Default 0.25 (reserve 25% free => stop admitting above ~75% usage).
     # Override at runtime with env var TT_XLA_PREFILL_KV_WATERMARK_PERCENT (a
     # percent, e.g. 25), which takes precedence over additional_config.
+    # Resolved/validated in TTPlatform.check_and_update_config.
     prefill_kv_watermark: float = 0.25
 
     batch_size: int = 1
@@ -331,10 +332,9 @@ class TTPlatform(Platform):
                 "additional_config['prefill_batch_threshold'] must be >= 0."
             )
 
-        # KV-cache high-watermark for fresh-prefill admission. Resolve default
-        # (0.25), apply the TT_XLA_PREFILL_KV_WATERMARK_PERCENT env override (a
-        # percent, e.g. 25 -> 0.25), and persist a concrete fraction so the
-        # AscendScheduler reads it directly; validate it is in [0, 1).
+        # Resolve prefill_kv_watermark to a concrete fraction the scheduler can
+        # read directly: default, then env override (percent), then validate.
+        # See TTConfig.prefill_kv_watermark.
         if additional_config.get("prefill_kv_watermark") is None:
             additional_config["prefill_kv_watermark"] = TTConfig.prefill_kv_watermark
         env_wm = os.environ.get("TT_XLA_PREFILL_KV_WATERMARK_PERCENT")

--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -74,7 +74,7 @@ class TTConfig:
     # at least one prefill when nothing is running, so a single large prompt is
     # never starved. 0.0 = off (legacy 1% watermark for all prefills).
     # Default 0.25 (reserve 25% free => stop admitting above ~75% usage).
-    # Override at runtime with env var TT_PREFILL_KV_WATERMARK_percent (a
+    # Override at runtime with env var TT_XLA_PREFILL_KV_WATERMARK_PERCENT (a
     # percent, e.g. 25), which takes precedence over additional_config.
     prefill_kv_watermark: float = 0.25
 
@@ -332,18 +332,18 @@ class TTPlatform(Platform):
             )
 
         # KV-cache high-watermark for fresh-prefill admission. Resolve default
-        # (0.25), apply the TT_PREFILL_KV_WATERMARK_percent env override (a
+        # (0.25), apply the TT_XLA_PREFILL_KV_WATERMARK_PERCENT env override (a
         # percent, e.g. 25 -> 0.25), and persist a concrete fraction so the
         # AscendScheduler reads it directly; validate it is in [0, 1).
         if additional_config.get("prefill_kv_watermark") is None:
             additional_config["prefill_kv_watermark"] = TTConfig.prefill_kv_watermark
-        env_wm = os.environ.get("TT_PREFILL_KV_WATERMARK_percent")
+        env_wm = os.environ.get("TT_XLA_PREFILL_KV_WATERMARK_PERCENT")
         if env_wm is not None:
             additional_config["prefill_kv_watermark"] = float(env_wm) / 100.0
         wm = float(additional_config["prefill_kv_watermark"])
         if not (0.0 <= wm < 1.0):
             raise ValueError(
-                "prefill_kv_watermark (TT_PREFILL_KV_WATERMARK_percent / 100) "
+                "prefill_kv_watermark (TT_XLA_PREFILL_KV_WATERMARK_PERCENT / 100) "
                 f"must be in [0, 1); got {wm}."
             )
         additional_config["prefill_kv_watermark"] = wm

--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -74,7 +74,7 @@ class TTConfig:
     # at least one prefill when nothing is running, so a single large prompt is
     # never starved. 0.0 = off (legacy 1% watermark for all prefills).
     # Default 0.25 (reserve 25% free => stop admitting above ~75% usage).
-    # Override at runtime with env var TT_XLA_PREFILL_KV_WATERMARK_PERCENT (a
+    # Override at runtime with env var TTXLA_PREFILL_KV_WATERMARK_PERCENT (a
     # percent, e.g. 25), which takes precedence over additional_config.
     # Resolved/validated in TTPlatform.check_and_update_config.
     prefill_kv_watermark: float = 0.25
@@ -337,13 +337,13 @@ class TTPlatform(Platform):
         # See TTConfig.prefill_kv_watermark.
         if additional_config.get("prefill_kv_watermark") is None:
             additional_config["prefill_kv_watermark"] = TTConfig.prefill_kv_watermark
-        env_wm = os.environ.get("TT_XLA_PREFILL_KV_WATERMARK_PERCENT")
+        env_wm = os.environ.get("TTXLA_PREFILL_KV_WATERMARK_PERCENT")
         if env_wm is not None:
             additional_config["prefill_kv_watermark"] = float(env_wm) / 100.0
         wm = float(additional_config["prefill_kv_watermark"])
         if not (0.0 <= wm < 1.0):
             raise ValueError(
-                "prefill_kv_watermark (TT_XLA_PREFILL_KV_WATERMARK_PERCENT / 100) "
+                "prefill_kv_watermark (TTXLA_PREFILL_KV_WATERMARK_PERCENT / 100) "
                 f"must be in [0, 1); got {wm}."
             )
         additional_config["prefill_kv_watermark"] = wm

--- a/integrations/vllm_plugin/vllm_tt/scheduler/ascend_scheduler.py
+++ b/integrations/vllm_plugin/vllm_tt/scheduler/ascend_scheduler.py
@@ -57,6 +57,15 @@ class AscendScheduler(Scheduler):
         add_cfg = vllm_config.additional_config or {}
         self.prefill_batch_threshold = int(add_cfg.get("prefill_batch_threshold") or 0)
         self.b1_min_num_seqs = int(add_cfg.get("min_num_seqs") or 0)
+        # KV-cache high-watermark for *fresh* prefill admission, as a fraction
+        # of the block pool. Once admitting a new prefill would leave less than
+        # this fraction free, stop admitting fresh prefills and let the running
+        # batch drain (decode is never gated and may use the pool to 100%). This
+        # reserves headroom so in-flight requests finish decoding instead of
+        # being preempted and re-prefilled (large-context concurrency thrash).
+        # 0.0 falls back to the base per-request watermark for all prefills.
+        # Resolved/validated/env-overridden in TTPlatform.check_and_update_config.
+        self.prefill_kv_watermark = float(add_cfg.get("prefill_kv_watermark") or 0.0)
 
     def schedule(self) -> SchedulerOutput:
         # Super's schedule handles chunked prefill which is schedule both prefill and decode in one request.
@@ -247,7 +256,29 @@ class AscendScheduler(Scheduler):
                         skip_cur_request()
                         continue
 
-            watermark = getattr(self.scheduler_config, "watermark", 0.01)
+            base_watermark = getattr(self.scheduler_config, "watermark", 0.01)
+            # KV-cache high-watermark admission gate. Gate only FRESH prefills
+            # (num_computed_tokens == 0): once admitting one would leave less
+            # than prefill_kv_watermark of the pool free, stop admitting new
+            # prefills so the running batch can finish decoding (decode is never
+            # gated) instead of being preempted and re-prefilled. Continuation
+            # chunks of an already-started prefill keep the base watermark so an
+            # in-flight prefill is never stranded. Forward-progress guard: when
+            # nothing is running and nothing has been scheduled yet this step,
+            # fall back to the base watermark so a single large prompt that
+            # exceeds the reserve is still admitted (otherwise it deadlocks).
+            nothing_scheduled_yet = not (
+                scheduled_new_reqs or scheduled_resumed_reqs or scheduled_running_reqs
+            )
+            force_progress = not self.running and nothing_scheduled_yet
+            if (
+                self.prefill_kv_watermark > 0.0
+                and request.num_computed_tokens == 0
+                and not force_progress
+            ):
+                watermark = self.prefill_kv_watermark
+            else:
+                watermark = base_watermark
             if not self._check_watermark_for_prefill(
                 request, num_new_tokens, blocks, watermark
             ):

--- a/integrations/vllm_plugin/vllm_tt/scheduler/ascend_scheduler.py
+++ b/integrations/vllm_plugin/vllm_tt/scheduler/ascend_scheduler.py
@@ -57,14 +57,8 @@ class AscendScheduler(Scheduler):
         add_cfg = vllm_config.additional_config or {}
         self.prefill_batch_threshold = int(add_cfg.get("prefill_batch_threshold") or 0)
         self.b1_min_num_seqs = int(add_cfg.get("min_num_seqs") or 0)
-        # KV-cache high-watermark for *fresh* prefill admission, as a fraction
-        # of the block pool. Once admitting a new prefill would leave less than
-        # this fraction free, stop admitting fresh prefills and let the running
-        # batch drain (decode is never gated and may use the pool to 100%). This
-        # reserves headroom so in-flight requests finish decoding instead of
-        # being preempted and re-prefilled (large-context concurrency thrash).
-        # 0.0 falls back to the base per-request watermark for all prefills.
-        # Resolved/validated/env-overridden in TTPlatform.check_and_update_config.
+        # Fresh-prefill KV-cache admission watermark (0.0 = off). See
+        # TTConfig.prefill_kv_watermark.
         self.prefill_kv_watermark = float(add_cfg.get("prefill_kv_watermark") or 0.0)
 
     def schedule(self) -> SchedulerOutput:
@@ -257,16 +251,13 @@ class AscendScheduler(Scheduler):
                         continue
 
             base_watermark = getattr(self.scheduler_config, "watermark", 0.01)
-            # KV-cache high-watermark admission gate. Gate only FRESH prefills
-            # (num_computed_tokens == 0): once admitting one would leave less
-            # than prefill_kv_watermark of the pool free, stop admitting new
-            # prefills so the running batch can finish decoding (decode is never
-            # gated) instead of being preempted and re-prefilled. Continuation
-            # chunks of an already-started prefill keep the base watermark so an
-            # in-flight prefill is never stranded. Forward-progress guard: when
-            # nothing is running and nothing has been scheduled yet this step,
-            # fall back to the base watermark so a single large prompt that
-            # exceeds the reserve is still admitted (otherwise it deadlocks).
+            # Apply the high-watermark only to FRESH prefills
+            # (num_computed_tokens == 0); continuation chunks keep the base
+            # watermark so an in-flight prefill is never stranded. The
+            # forward-progress guard falls back to the base watermark when
+            # nothing is running or scheduled yet, so a single large prompt that
+            # exceeds the reserve still gets admitted instead of deadlocking.
+            # See TTConfig.prefill_kv_watermark.
             nothing_scheduled_yet = not (
                 scheduled_new_reqs or scheduled_resumed_reqs or scheduled_running_reqs
             )


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/5468)

### Problem description
When generating high OSL sequences if a prefill is scheduled with low KV cache availability, it will be serviced, then immediately discarded as there is not enough cache available to fulfill decode. 

### What's changed
Added minimal overhead, defaults to 25%, controllable by `TT_XLA_PREFILL_KV_WATERMARK_PERCENT` 

### Checklist
- [x] New/Existing tests provide coverage for changes
