### PR TITLE
[vLLM] Parametrize embedding benchmarks into EMBEDDING_CONFIGS

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -77,7 +77,7 @@
       },
       {
         "name": "vllm_bge_m3_encode_batch1",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_bge_m3_batch1",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_embedding_benchmark[bge-m3-batch1]",
         "vllm": true,
         "skip-stablehlo-dump": true,
         "skip-ttir-dump": true,
@@ -86,7 +86,7 @@
       },
       {
         "name": "vllm_bge_m3_encode_batch32",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_bge_m3_batch32",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_embedding_benchmark[bge-m3-batch32]",
         "vllm": true,
         "skip-stablehlo-dump": true,
         "skip-ttir-dump": true,
@@ -300,7 +300,7 @@
       },
       {
         "name": "vllm_qwen_3_4b_embedding_batch1",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_qwen3_embedding_4b_batch1",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_embedding_benchmark[qwen3-embedding-4b-batch1]",
         "vllm": true,
         "skip-stablehlo-dump": true,
         "skip-ttir-dump": true,

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -301,6 +301,20 @@ def _embedding_config(
     )
 
 
+EMBEDDING_CONFIGS = [
+    # Trace disabled: host/device tensor shape mismatch
+    # (https://github.com/tenstorrent/tt-xla/issues/3936)
+    pytest.param(
+        _embedding_config(
+            "Qwen/Qwen3-Embedding-4B", 1, max_model_len=128, enable_trace=False
+        ),
+        id="qwen3-embedding-4b-batch1",
+    ),
+    pytest.param(_embedding_config("BAAI/bge-m3", 1), id="bge-m3-batch1"),
+    pytest.param(_embedding_config("BAAI/bge-m3", 32), id="bge-m3-batch32"),
+]
+
+
 def _run_vllm_embedding_benchmark(config, output_file, request):
     resolved_display_name = resolve_display_name(request=request, fallback=config.model)
     display_name = (
@@ -317,33 +331,6 @@ def _run_vllm_embedding_benchmark(config, output_file, request):
         print(f"Results written to {output_file}")
 
 
-# Trace disabled: host/device tensor shape mismatch (https://github.com/tenstorrent/tt-xla/issues/3936)
-def test_vllm_qwen3_embedding_4b_batch1(output_file, request):
-    _run_vllm_embedding_benchmark(
-        _embedding_config(
-            "Qwen/Qwen3-Embedding-4B", 1, max_model_len=128, enable_trace=False
-        ),
-        output_file,
-        request,
-    )
-
-
-def test_vllm_bge_m3_batch1(output_file, request):
-    _run_vllm_embedding_benchmark(
-        _embedding_config("BAAI/bge-m3", 1),
-        output_file,
-        request,
-    )
-
-
-def test_vllm_bge_m3_batch32(output_file, request):
-    _run_vllm_embedding_benchmark(
-        _embedding_config("BAAI/bge-m3", 32),
-        output_file,
-        request,
-    )
-
-
 @pytest.mark.parametrize("config", SINGLE_DEVICE_CONFIGS)
 def test_vllm_benchmark(config, output_file, request):
     _run_vllm_benchmark(config, output_file, request)
@@ -352,3 +339,8 @@ def test_vllm_benchmark(config, output_file, request):
 @pytest.mark.parametrize("config", TP_CONFIGS)
 def test_vllm_tp_benchmark(config, output_file, request):
     _run_vllm_benchmark(config, output_file, request)
+
+
+@pytest.mark.parametrize("config", EMBEDDING_CONFIGS)
+def test_vllm_embedding_benchmark(config, output_file, request):
+    _run_vllm_embedding_benchmark(config, output_file, request)


### PR DESCRIPTION
### Problem Description
- Embedding benchmarks were defined as one hand-written test function per model/batch variant (`test_vllm_bge_m3_batch1`, `test_vllm_bge_m3_batch32`, `test_vllm_qwen3_embedding_4b_batch1`), unlike generative models which parametrize over the `SINGLE_DEVICE_CONFIGS` / `TP_CONFIGS` arrays. This doesn't scale as we expand the embedding config matrix — every new model/config would need another bespoke function.

### What's Changes
- Added an `EMBEDDING_CONFIGS` array (mirroring `SINGLE_DEVICE_CONFIGS` / `TP_CONFIGS`) with stable `pytest.param(..., id=...)` IDs.
- Replaced the three per-model functions with a single parametrized `test_vllm_embedding_benchmark`.
- Updated the three embedding `pytest` node IDs in `.github/workflows/perf-bench-matrix.json` to the new parametrized form (e.g. `test_vllm_embedding_benchmark[bge-m3-batch1]`).
- No behavior change: same 3 configs and args; pure refactor to ready the infra before adding new embedding models/configs.

### Checklist
- [x] New/Existing tests provide coverage for changes
