### PR TITLE
[vLLM] Hoist TT attention batch metadata out of the compiled graph

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/attention_impls/attention.py
+++ b/integrations/vllm_plugin/vllm_tt/attention_impls/attention.py
@@ -183,7 +183,6 @@ class TTMetadata:
     chunk_start_idx: torch.Tensor
     batch_idx: Optional[torch.Tensor] = None
     num_users: Optional[int] = None
-    num_tokens: Optional[int] = None
 
     def __init__(
         self,
@@ -195,7 +194,6 @@ class TTMetadata:
         chunk_start_idx: torch.Tensor | None = None,
         batch_idx: torch.Tensor | None = None,
         num_users: Optional[int] = None,
-        num_tokens: Optional[int] = None,
     ):
         self.cache_position = cache_position
         self.attn_mask = attn_mask
@@ -205,10 +203,7 @@ class TTMetadata:
             fill_page_table if fill_page_table is not None else page_table
         )
         self.chunk_start_idx = chunk_start_idx
-        assert num_users is not None, "num_users must be provided."
-        assert num_tokens is not None, "num_tokens must be provided."
         self.num_users = num_users
-        self.num_tokens = num_tokens
         self.batch_idx = batch_idx
 
 
@@ -336,6 +331,7 @@ class TTAttentionBackendImpl(AttentionImpl):
         from collections import namedtuple
 
         num_users = attn_metadata.num_users
+        assert num_users is not None, "num_users must be provided in attn_metadata."
         orig_query_shape = query.shape
         orig_query_ndim = query.ndim
 

--- a/integrations/vllm_plugin/vllm_tt/attention_impls/attention.py
+++ b/integrations/vllm_plugin/vllm_tt/attention_impls/attention.py
@@ -181,6 +181,9 @@ class TTMetadata:
     # across users by same-stage batching). Set only on a cached-prefix chunk;
     # consumed by the chunked_scaled_dot_product_attention op.
     chunk_start_idx: torch.Tensor
+    batch_idx: Optional[torch.Tensor] = None
+    num_users: Optional[int] = None
+    num_tokens: Optional[int] = None
 
     def __init__(
         self,
@@ -190,6 +193,9 @@ class TTMetadata:
         is_causal: bool = True,
         fill_page_table: torch.Tensor | None = None,
         chunk_start_idx: torch.Tensor | None = None,
+        batch_idx: torch.Tensor | None = None,
+        num_users: Optional[int] = None,
+        num_tokens: Optional[int] = None,
     ):
         self.cache_position = cache_position
         self.attn_mask = attn_mask
@@ -199,6 +205,11 @@ class TTMetadata:
             fill_page_table if fill_page_table is not None else page_table
         )
         self.chunk_start_idx = chunk_start_idx
+        assert num_users is not None, "num_users must be provided."
+        assert num_tokens is not None, "num_tokens must be provided."
+        self.num_users = num_users
+        self.num_tokens = num_tokens
+        self.batch_idx = batch_idx
 
 
 class TTAttentionBackendImpl(AttentionImpl):
@@ -284,7 +295,7 @@ class TTAttentionBackendImpl(AttentionImpl):
             value: shape = [batch_size, num_tokens, num_kv_heads * head_size]
             output: shape = [batch_size, num_tokens, num_heads * head_size]
         """
-
+        assert attn_metadata is not None, "TT attention requires metadata."
         # Prepare inputs and metadata
         inputs = self._prepare_inputs(query, key, value, attn_metadata)
 
@@ -324,14 +335,7 @@ class TTAttentionBackendImpl(AttentionImpl):
         """Prepare and reshape input tensors for attention computation."""
         from collections import namedtuple
 
-        # Extract common metadata
-        # Handle case when cache_position is None (e.g., during profiling)
-        if attn_metadata is not None and attn_metadata.cache_position is not None:
-            num_users = attn_metadata.cache_position.shape[0]  # logical batch size
-        else:
-            # Fallback: infer from query shape
-            num_users = query.shape[0] if query.ndim > 2 else 1
-
+        num_users = attn_metadata.num_users
         orig_query_shape = query.shape
         orig_query_ndim = query.ndim
 
@@ -493,13 +497,9 @@ class TTAttentionBackendImpl(AttentionImpl):
             key_for_update = inputs.key.transpose(1, 2)
             value_for_update = inputs.value.transpose(1, 2)
 
-            # TODO(#5154): hoist to a setup-time metadata input built on CPU
-            # instead of an in-graph device constructor rebuilt per call.
-            batch_idxs = torch.arange(
-                key_for_update.shape[0],
-                dtype=torch.int32,
-                device=k_cache.device,
-            )
+            batch_idxs = attn_metadata.batch_idx
+            assert batch_idxs is not None, "batch_idx must be provided for prefill."
+
             k_cache = torch.ops.tt.paged_fill_cache(
                 k_cache,
                 key_for_update,

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -1336,7 +1336,6 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 else self.batch_idx_max_reqs
             ),
             num_users=target_num_reqs,
-            num_tokens=padded_total_num_scheduled_tokens,
         )
         # NOTE(woosuk): Due to chunked prefills, there can be at most 1 partial
         # request in the batch. While we should not sample any token from this
@@ -2110,7 +2109,6 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 else self.batch_idx_max_reqs
             ),
             num_users=num_reqs,
-            num_tokens=num_tokens,
         )
 
         per_layer_attn_metadata = dict.fromkeys(
@@ -2463,14 +2461,12 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             attn_mask=None,
             fill_page_table=fill_page_table,
             chunk_start_idx=chunk_start_idx,
-            fill_page_table=page_table,
             batch_idx=(
                 self.batch_idx_min_reqs
                 if num_reqs == self.min_num_reqs
                 else self.batch_idx_max_reqs
             ),
             num_users=num_reqs,
-            num_tokens=num_tokens,
         )
         per_layer_attn_metadata = dict.fromkeys(
             self._attention_layer_names, attn_metadata

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -636,6 +636,13 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             )
         )
 
+        self.batch_idx_min_reqs = torch.arange(
+            self.min_num_reqs, dtype=torch.int32, device="cpu"
+        ).to(self.device)
+        self.batch_idx_max_reqs = torch.arange(
+            self.max_num_reqs, dtype=torch.int32, device="cpu"
+        ).to(self.device)
+
     def _filter_weights_for_layer_override(self, weights_iterator):
         """Filter weights to only include layers that exist in the modified model."""
         if self._original_num_layers is None or self._target_num_layers is None:
@@ -1323,6 +1330,13 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             attn_mask=None,
             fill_page_table=fill_page_table,
             chunk_start_idx=chunk_start_idx,
+            batch_idx=(
+                self.batch_idx_min_reqs
+                if target_num_reqs == self.min_num_reqs
+                else self.batch_idx_max_reqs
+            ),
+            num_users=target_num_reqs,
+            num_tokens=padded_total_num_scheduled_tokens,
         )
         # NOTE(woosuk): Due to chunked prefills, there can be at most 1 partial
         # request in the batch. While we should not sample any token from this
@@ -2090,6 +2104,13 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             attn_mask=None,
             fill_page_table=fill_page_table,
             chunk_start_idx=chunk_start_idx,
+            batch_idx=(
+                self.batch_idx_min_reqs
+                if num_reqs == self.min_num_reqs
+                else self.batch_idx_max_reqs
+            ),
+            num_users=num_reqs,
+            num_tokens=num_tokens,
         )
 
         per_layer_attn_metadata = dict.fromkeys(
@@ -2442,6 +2463,14 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             attn_mask=None,
             fill_page_table=fill_page_table,
             chunk_start_idx=chunk_start_idx,
+            fill_page_table=page_table,
+            batch_idx=(
+                self.batch_idx_min_reqs
+                if num_reqs == self.min_num_reqs
+                else self.batch_idx_max_reqs
+            ),
+            num_users=num_reqs,
+            num_tokens=num_tokens,
         )
         per_layer_attn_metadata = dict.fromkeys(
             self._attention_layer_names, attn_metadata

--- a/integrations/vllm_plugin/vllm_tt/pooling_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/pooling_runner.py
@@ -980,6 +980,8 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         attn_metadata = TTMetadata(
             attn_mask=attn_mask,
             is_causal=is_causal,
+            num_users=self.input_ids_cpu.shape[0],
+            num_tokens=self.input_ids_cpu.shape[1],
         )
         # NOTE(woosuk): Due to chunked prefills, there can be at most 1 partial
         # request in the batch. While we should not sample any token from this
@@ -1462,6 +1464,8 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         attn_metadata = TTMetadata(
             attn_mask=attn_mask,
             is_causal=is_causal,
+            num_users=num_reqs,
+            num_tokens=num_tokens,
         )
 
         layer_names = get_layers_from_vllm_config(self.vllm_config, Attention).keys()

--- a/integrations/vllm_plugin/vllm_tt/pooling_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/pooling_runner.py
@@ -981,7 +981,6 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             attn_mask=attn_mask,
             is_causal=is_causal,
             num_users=self.input_ids_cpu.shape[0],
-            num_tokens=self.input_ids_cpu.shape[1],
         )
         # NOTE(woosuk): Due to chunked prefills, there can be at most 1 partial
         # request in the batch. While we should not sample any token from this
@@ -1465,7 +1464,6 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             attn_mask=attn_mask,
             is_causal=is_causal,
             num_users=num_reqs,
-            num_tokens=num_tokens,
         )
 
         layer_names = get_layers_from_vllm_config(self.vllm_config, Attention).keys()


### PR DESCRIPTION
### Ticket
closes #5154 

### Problem description
Batch index are generated for each prefill call

### What's changed
- Hoist batch index creation to runner constructer.
- Add num_user to attn_metadata and use it directly instead of deducing it

### Checklist
- [X] New/Existing tests provide coverage for changes
