### PR TITLE
Remove qwen_3_4b_embedding from perf benchmark job in pr-main.yml

### DIFF
--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -79,7 +79,7 @@ jobs:
       #   - vllm_llama_3_1_70b_tp (n300-llmbox): temporarily removed from On PR because flaky, tracked in issue #5294
       adv_filter: '[
         { "accuracy-testing": false },
-        { "runs-on": "n150-perf", "filter": ["resnet","qwen_3_4b_embedding","llama_3_1_8b","falcon3-1b","qwen_3_8b"] },
+        { "runs-on": "n150-perf", "filter": ["resnet","llama_3_1_8b","falcon3-1b","qwen_3_8b"] },
         { "runs-on": "n300-llmbox", "filter": ["test_llama_3_1_70b_tp"] } ]'
       sh-runner: false
       skip-device-perf: true


### PR DESCRIPTION
Title. Unblocks tt-mlir uplift; issue https://github.com/tenstorrent/tt-xla/issues/5478.