### PR TITLE
[CI] Dump irs on weekly/Sunday nightly

### DIFF
--- a/.github/workflows/call-process-dumped-irs.yml
+++ b/.github/workflows/call-process-dumped-irs.yml
@@ -6,7 +6,22 @@ on:
   workflow_call:
     inputs:
       docker_image:
-        description: 'Docker image to use for processing (e.g., ghcr.io/tenstorrent/tt-xla/tt-xla-ci-ubuntu-22-04:latest)'
+        description: 'Docker image to use for processing'
+        required: true
+        type: string
+      dumped_irs_run_id:
+        description: 'Run ID of the workflow that dumped IRs'
+        required: true
+        type: string
+      shared-runners:
+        description: 'Use shared runners'
+        required: false
+        type: boolean
+        default: false
+  workflow_dispatch:
+    inputs:
+      docker_image:
+        description: 'Docker image to use for processing'
         required: true
         type: string
       dumped_irs_run_id:

--- a/.github/workflows/schedule-nightly.yml
+++ b/.github/workflows/schedule-nightly.yml
@@ -2,7 +2,8 @@ name: On nightly
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * 1-6'
+    - cron: '0 0 * * 0' # on Sundays, run with dump_irs=true
 
 permissions:
   contents: write
@@ -38,6 +39,7 @@ jobs:
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
       wheel_build: manylinux
+      dump_irs: ${{ github.event.schedule == '0 0 * * 0' && 'true' || 'false' }}
 
   test_full_model:
     uses: ./.github/workflows/call-test.yml
@@ -51,6 +53,7 @@ jobs:
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
       wheel_build: manylinux
+      dump_irs: ${{ github.event.schedule == '0 0 * * 0' && 'true' || 'false' }}
 
   # This is a single test job that runs all passing tt-forge-models tests.
   test_forge_models_passing:
@@ -65,6 +68,7 @@ jobs:
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
       wheel_build: manylinux
+      dump_irs: ${{ github.event.schedule == '0 0 * * 0' && 'true' || 'false' }}
 
   # This is a single test job that runs all xfailing, skipped or placeholder tt-forge-models tests.
   test_forge_models_xfail:
@@ -79,6 +83,7 @@ jobs:
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
       wheel_build: manylinux
+      dump_irs: ${{ github.event.schedule == '0 0 * * 0' && 'true' || 'false' }}
 
   perf-benchmark:
     uses: ./.github/workflows/call-filtered-perf-tests.yml

--- a/.github/workflows/schedule-weekly.yml
+++ b/.github/workflows/schedule-weekly.yml
@@ -39,6 +39,7 @@ jobs:
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
       wheel_build: manylinux
+      dump_irs: true
 
   test_forge_models_xfail:
     uses: ./.github/workflows/call-test.yml
@@ -50,6 +51,7 @@ jobs:
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
       wheel_build: manylinux
+      dump_irs: true
 
   fail-notify:
     if: always()


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-forge/issues/953

### What's changed
Dump irs on weekly and Sunday nightly runs. This will allow us to have overall picture of size and quantity of irs for weekly processing.
Add manual dispatch to Process irs workflow so we can test processing manually.
 
### Checklist
- [ ] New/Existing tests provide coverage for changes
