### PR TITLE
[Z-Image] Add e2e text-to-image pipeline: nightly + benchmark

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -100,6 +100,11 @@
         "pytest": "tests/benchmark/test_imagegen.py::test_janus_pro_7b"
       },
       {
+        "name": "zimage",
+        "pytest": "tests/benchmark/test_imagegen.py::test_zimage",
+        "runs-on": "p150-perf"
+      },
+      {
         "name": "bge_m3_encode",
         "pyreq": "transformers==4.57.1 FlagEmbedding",
         "pytest": "tests/benchmark/test_encoders.py::test_bge_m3"

--- a/tests/benchmark/benchmarks/zimage_pipeline.py
+++ b/tests/benchmark/benchmarks/zimage_pipeline.py
@@ -25,7 +25,7 @@ import time
 from typing import Optional
 
 import torch
-import torch_xla.core.xla_model as xm
+import torch_xla
 from diffusers import FlowMatchEulerDiscreteScheduler
 from loguru import logger
 
@@ -115,23 +115,22 @@ class ZImagePipeline_TT:
         self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
             REPO_ID, subfolder="scheduler"
         )
-        self._device = xm.xla_device()
+        self._device = torch_xla.device()
 
-        # Load on CPU and only register the tt backend here. Each component is
-        # moved to device in generate() right before it runs and evicted after,
-        # so peak DRAM ~= max(component) not sum — the Qwen3 encoder + ~6.2B
-        # transformer + VAE do not all sit on the single chip at once.
+        # Load the raw modules on CPU. Each component is moved to device in
+        # generate() right before it runs, compiled fresh with torch.compile,
+        # then evicted (moved back to CPU + its compiled graph dropped) so peak
+        # DRAM ~= max(component) not sum — the Qwen3 encoder + ~6.2B transformer
+        # + VAE do not all sit on the single chip at once. Keeping the raw
+        # modules lets each generate() (warmup + steady) rebuild its compiled
+        # wrappers fresh, mirroring the flux2 benchmark.
         self.text_encoder = _TextEncoderWrapper(load_text_encoder(DTYPE)).eval()
         self.transformer = _TransformerWrapper(load_transformer(DTYPE)).eval()
         self.vae = _VaeDecodeWrapper(load_vae(DTYPE)).eval()
 
-        self.text_encoder.compile(backend="tt")
-        self.transformer.compile(backend="tt")
-        self.vae.compile(backend="tt")
-
-    def _encode(self, prompt: str) -> torch.Tensor:
+    def _encode(self, prompt: str, encoder) -> torch.Tensor:
         input_ids, attention_mask = tokenize_prompt(prompt)
-        hidden = self.text_encoder(
+        hidden = encoder(
             input_ids.to(self._device), attention_mask.bool().to(self._device)
         )
         hidden = hidden.cpu()  # forces sync
@@ -157,12 +156,15 @@ class ZImagePipeline_TT:
             # ── Text encoder (Qwen3) → prompt embeds, then evict ─────────
             logger.info("[STAGE] Text encoder: start")
             self.text_encoder = self.text_encoder.to(self._device)
+            te_compiled = torch.compile(self.text_encoder, backend="tt")
             t0 = time.perf_counter()
-            cap_pos = self._encode(prompt)
-            cap_neg = self._encode(NEGATIVE_PROMPT) if do_cfg else None
+            cap_pos = self._encode(prompt, te_compiled)
+            cap_neg = self._encode(NEGATIVE_PROMPT, te_compiled) if do_cfg else None
             self._perf["components"]["text_encoder"] = time.perf_counter() - t0
             self.text_encoder = self.text_encoder.to("cpu")
+            del te_compiled
             gc.collect()
+            torch_xla.sync()
             logger.info("[STAGE] Text encoder: done")
 
             # ── Latents (fp32 on CPU) ────────────────────────────────────
@@ -203,15 +205,16 @@ class ZImagePipeline_TT:
                 f"({num_inference_steps} steps)"
             )
             self.transformer = self.transformer.to(self._device)
+            tf_compiled = torch.compile(self.transformer, backend="tt")
             for i, t in enumerate(timesteps):
                 logger.info(f"[STEP] Transformer step {i + 1}/{num_inference_steps}")
                 timestep = ((1000 - t.expand(1)) / 1000).to(DTYPE)
                 latent_input = latents.to(DTYPE)
 
                 t0 = time.perf_counter()
-                pos = self._forward(latent_input, timestep, cap_pos)
+                pos = self._forward(tf_compiled, latent_input, timestep, cap_pos)
                 if do_cfg:
-                    neg = self._forward(latent_input, timestep, cap_neg)
+                    neg = self._forward(tf_compiled, latent_input, timestep, cap_neg)
                     pred = pos + GUIDANCE_SCALE * (pos - neg)
                 else:
                     pred = pos
@@ -222,24 +225,29 @@ class ZImagePipeline_TT:
                     noise_pred.to(torch.float32), t, latents, return_dict=False
                 )[0]
             self.transformer = self.transformer.to("cpu")
+            del tf_compiled
             gc.collect()
+            torch_xla.sync()
             logger.info("[STAGE] Transformer denoising loop: done")
 
             # ── VAE decode → raw pixels in [-1, 1], then evict ───────────
             logger.info("[STAGE] VAE decode: start")
             self.vae = self.vae.to(self._device)
+            vae_compiled = torch.compile(self.vae, backend="tt")
             t0 = time.perf_counter()
-            image = self.vae(latents.to(self._device)).cpu().float()
+            image = vae_compiled(latents.to(self._device)).cpu().float()
             self._perf["components"]["vae"] = time.perf_counter() - t0
             self.vae = self.vae.to("cpu")
+            del vae_compiled
             gc.collect()
+            torch_xla.sync()
             logger.info("[STAGE] VAE decode: done")
 
         self._perf["total"] = time.perf_counter() - t_total_start
         return image
 
-    def _forward(self, latents, timestep, cap_feats) -> torch.Tensor:
-        out = self.transformer(
+    def _forward(self, transformer, latents, timestep, cap_feats) -> torch.Tensor:
+        out = transformer(
             latents.to(self._device),
             timestep.to(self._device),
             cap_feats.to(self._device),

--- a/tests/benchmark/benchmarks/zimage_pipeline.py
+++ b/tests/benchmark/benchmarks/zimage_pipeline.py
@@ -90,12 +90,17 @@ class ZImageConfig:
         height: int = HEIGHT,
         width: int = WIDTH,
         compile_options: Optional[dict] = None,
+        vae_tiling: bool = True,
     ):
         self.height = height
         self.width = width
         self.vae_scale_factor = VAE_SCALE_FACTOR
         # Forwarded for parity with the other imagegen pipelines; unused inline.
         self.compile_options = compile_options or {}
+        # Tiled VAE decode keeps the 1280x720 decode activations small so the
+        # host-side spike during decode stays bounded. Flip off to revert to a
+        # single full-frame decode.
+        self.vae_tiling = vae_tiling
 
 
 class ZImagePipeline_TT:
@@ -110,17 +115,6 @@ class ZImagePipeline_TT:
             REPO_ID, subfolder="scheduler"
         )
         self._device = torch_xla.device()
-
-        # Load the raw modules on CPU. Each component is moved to device in
-        # generate() right before it runs, compiled fresh with torch.compile,
-        # then evicted (moved back to CPU + its compiled graph dropped) so peak
-        # DRAM ~= max(component) not sum — the Qwen3 encoder + ~6.2B transformer
-        # + VAE do not all sit on the single chip at once. Keeping the raw
-        # modules lets each generate() (warmup + steady) rebuild its compiled
-        # wrappers fresh.
-        self.text_encoder = _TextEncoderWrapper(load_text_encoder(DTYPE)).eval()
-        self.transformer = _TransformerWrapper(load_transformer(DTYPE)).eval()
-        self.vae = _VaeDecodeWrapper(load_vae(DTYPE)).eval()
 
     def _encode(self, prompt: str, encoder) -> torch.Tensor:
         input_ids, attention_mask = tokenize_prompt(prompt)
@@ -147,16 +141,18 @@ class ZImagePipeline_TT:
         t_total_start = time.perf_counter()
 
         with torch.no_grad():
-            # ── Text encoder (Qwen3) → prompt embeds, then evict ─────────
+            # ── Text encoder (Qwen3) → prompt embeds, then free ──────────
+            # Loaded here (not in setup) and fully released at the end of the
+            # stage so its ~7.5 GB never overlaps the transformer or VAE on host.
             logger.info("[STAGE] Text encoder: start")
-            self.text_encoder = self.text_encoder.to(self._device)
-            te_compiled = torch.compile(self.text_encoder, backend="tt")
+            text_encoder = _TextEncoderWrapper(load_text_encoder(DTYPE)).eval()
+            text_encoder = text_encoder.to(self._device)
+            te_compiled = torch.compile(text_encoder, backend="tt")
             t0 = time.perf_counter()
             cap_pos = self._encode(prompt, te_compiled)
             cap_neg = self._encode(NEGATIVE_PROMPT, te_compiled) if do_cfg else None
             self._perf["components"]["text_encoder"] = time.perf_counter() - t0
-            self.text_encoder = self.text_encoder.to("cpu")
-            del te_compiled
+            del te_compiled, text_encoder
             gc.collect()
             torch_xla.sync()
             logger.info("[STAGE] Text encoder: done")
@@ -198,8 +194,9 @@ class ZImagePipeline_TT:
                 f"[STAGE] Transformer denoising loop: start "
                 f"({num_inference_steps} steps)"
             )
-            self.transformer = self.transformer.to(self._device)
-            tf_compiled = torch.compile(self.transformer, backend="tt")
+            transformer = _TransformerWrapper(load_transformer(DTYPE)).eval()
+            transformer = transformer.to(self._device)
+            tf_compiled = torch.compile(transformer, backend="tt")
             for i, t in enumerate(timesteps):
                 logger.info(f"[STEP] Transformer step {i + 1}/{num_inference_steps}")
                 timestep = ((1000 - t.expand(1)) / 1000).to(DTYPE)
@@ -218,21 +215,26 @@ class ZImagePipeline_TT:
                 latents = self.scheduler.step(
                     noise_pred.to(torch.float32), t, latents, return_dict=False
                 )[0]
-            self.transformer = self.transformer.to("cpu")
-            del tf_compiled
+            # Free the transformer (~12 GB) + its compiled graph before the VAE
+            # decode so the decode stage runs with only the VAE resident on host.
+            del tf_compiled, transformer
             gc.collect()
             torch_xla.sync()
             logger.info("[STAGE] Transformer denoising loop: done")
 
-            # ── VAE decode → raw pixels in [-1, 1], then evict ───────────
+            # ── VAE decode → raw pixels in [-1, 1], then free ────────────
             logger.info("[STAGE] VAE decode: start")
-            self.vae = self.vae.to(self._device)
-            vae_compiled = torch.compile(self.vae, backend="tt")
+            vae_wrapper = _VaeDecodeWrapper(load_vae(DTYPE)).eval()
+            if self.config.vae_tiling and hasattr(vae_wrapper.vae, "enable_tiling"):
+                # Tiled decode bounds the 1280x720 decode activations (and their
+                # host staging) to a single tile instead of the full frame.
+                vae_wrapper.vae.enable_tiling()
+            vae_wrapper = vae_wrapper.to(self._device)
+            vae_compiled = torch.compile(vae_wrapper, backend="tt")
             t0 = time.perf_counter()
             image = vae_compiled(latents.to(self._device)).cpu().float()
             self._perf["components"]["vae"] = time.perf_counter() - t0
-            self.vae = self.vae.to("cpu")
-            del vae_compiled
+            del vae_compiled, vae_wrapper
             gc.collect()
             torch_xla.sync()
             logger.info("[STAGE] VAE decode: done")

--- a/tests/benchmark/benchmarks/zimage_pipeline.py
+++ b/tests/benchmark/benchmarks/zimage_pipeline.py
@@ -12,12 +12,6 @@ compute module runs on one Blackhole chip, compiled with
   - text encoder (Qwen3)                 → components["text_encoder"]
   - transformer (ZImageTransformer2DModel) denoise loop → steps
   - VAE decoder (AutoencoderKL)          → components["vae"]
-
-Classifier-free guidance runs cond + uncond as two separate batch=1 passes
-(the transformer's complex RoPE only legalizes at batch=1 on the pinned
-tt-mlir; batch=2 fails, tt-mlir #8874). Z-Image has a single text encoder, so
-it reports only the components it runs — the harness drops absent components
-from the report (model-agnostic ``components``/``steps`` schema).
 """
 
 import gc
@@ -123,7 +117,7 @@ class ZImagePipeline_TT:
         # DRAM ~= max(component) not sum — the Qwen3 encoder + ~6.2B transformer
         # + VAE do not all sit on the single chip at once. Keeping the raw
         # modules lets each generate() (warmup + steady) rebuild its compiled
-        # wrappers fresh, mirroring the flux2 benchmark.
+        # wrappers fresh.
         self.text_encoder = _TextEncoderWrapper(load_text_encoder(DTYPE)).eval()
         self.transformer = _TransformerWrapper(load_transformer(DTYPE)).eval()
         self.vae = _VaeDecodeWrapper(load_vae(DTYPE)).eval()
@@ -199,7 +193,7 @@ class ZImagePipeline_TT:
             self.scheduler.set_begin_index(0)
             timesteps = self.scheduler.timesteps
 
-            # ── Denoising loop (transformer; CFG = 2 batch=1 passes) ─────
+            # ── Denoising loop (transformer) ─────
             logger.info(
                 f"[STAGE] Transformer denoising loop: start "
                 f"({num_inference_steps} steps)"

--- a/tests/benchmark/benchmarks/zimage_pipeline.py
+++ b/tests/benchmark/benchmarks/zimage_pipeline.py
@@ -1,0 +1,247 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Z-Image — single-chip benchmark-side pipeline for the imagegen harness.
+
+Mirrors the nightly e2e test (tests/torch/models/z_image/test_pipeline.py) but
+instruments per-component timings into ``self._perf`` for the harness. Every
+compute module runs on one Blackhole chip, compiled with
+``torch.compile(backend="tt")``:
+
+  - text encoder (Qwen3)                 → components["text_encoder"]
+  - transformer (ZImageTransformer2DModel) denoise loop → steps
+  - VAE decoder (AutoencoderKL)          → components["vae"]
+
+Classifier-free guidance runs cond + uncond as two separate batch=1 passes
+(the transformer's complex RoPE only legalizes at batch=1 on the pinned
+tt-mlir; batch=2 fails, tt-mlir #8874). Z-Image has a single text encoder, so
+it reports only the components it runs — the harness drops absent components
+from the report (model-agnostic ``components``/``steps`` schema).
+"""
+
+import gc
+import time
+from typing import Optional
+
+import torch
+import torch_xla.core.xla_model as xm
+from diffusers import FlowMatchEulerDiscreteScheduler
+from loguru import logger
+
+from third_party.tt_forge_models.z_image.pytorch.src.model_utils import (
+    DTYPE,
+    GUIDANCE_SCALE,
+    HEIGHT,
+    LATENT_CHANNELS,
+    NEGATIVE_PROMPT,
+    REPO_ID,
+    SEED,
+    VAE_SCALE_FACTOR,
+    WIDTH,
+    load_text_encoder,
+    load_transformer,
+    load_vae,
+    tokenize_prompt,
+)
+
+
+def _calculate_shift(image_seq_len, base_seq=256, max_seq=4096, base=0.5, max_=1.15):
+    m = (max_ - base) / (max_seq - base_seq)
+    return image_seq_len * m + (base - m * base_seq)
+
+
+class _TextEncoderWrapper(torch.nn.Module):
+    def __init__(self, encoder):
+        super().__init__()
+        self.encoder = encoder
+
+    def forward(self, input_ids, attention_mask):
+        out = self.encoder(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            output_hidden_states=True,
+        )
+        return out.hidden_states[-2]
+
+
+class _TransformerWrapper(torch.nn.Module):
+    """One batch=1 transformer pass; cap_feats is (L, D)."""
+
+    def __init__(self, transformer):
+        super().__init__()
+        self.transformer = transformer
+
+    def forward(self, latents, timestep, cap_feats):
+        x_list = list(latents.unsqueeze(2).unbind(dim=0))
+        t = timestep.reshape(-1).to(dtype=latents.dtype)
+        out = self.transformer(x_list, t, [cap_feats], return_dict=False)[0]
+        return torch.stack([o.float() for o in out], dim=0)
+
+
+class _VaeDecodeWrapper(torch.nn.Module):
+    def __init__(self, vae):
+        super().__init__()
+        self.vae = vae
+
+    def forward(self, latents):
+        z = latents.to(dtype=self.vae.dtype)
+        z = (z / self.vae.config.scaling_factor) + self.vae.config.shift_factor
+        return self.vae.decode(z, return_dict=False)[0]
+
+
+class ZImageConfig:
+    def __init__(
+        self,
+        height: int = HEIGHT,
+        width: int = WIDTH,
+        compile_options: Optional[dict] = None,
+    ):
+        self.height = height
+        self.width = width
+        self.vae_scale_factor = VAE_SCALE_FACTOR
+        # Forwarded for parity with the other imagegen pipelines; unused inline.
+        self.compile_options = compile_options or {}
+
+
+class ZImagePipeline_TT:
+    """Z-Image text-to-image pipeline with every module on a single TT chip."""
+
+    def __init__(self, config: ZImageConfig):
+        self.config = config
+        self._perf = {}
+
+    def setup(self):
+        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
+            REPO_ID, subfolder="scheduler"
+        )
+        self._device = xm.xla_device()
+
+        # Load on CPU and only register the tt backend here. Each component is
+        # moved to device in generate() right before it runs and evicted after,
+        # so peak DRAM ~= max(component) not sum — the Qwen3 encoder + ~6.2B
+        # transformer + VAE do not all sit on the single chip at once.
+        self.text_encoder = _TextEncoderWrapper(load_text_encoder(DTYPE)).eval()
+        self.transformer = _TransformerWrapper(load_transformer(DTYPE)).eval()
+        self.vae = _VaeDecodeWrapper(load_vae(DTYPE)).eval()
+
+        self.text_encoder.compile(backend="tt")
+        self.transformer.compile(backend="tt")
+        self.vae.compile(backend="tt")
+
+    def _encode(self, prompt: str) -> torch.Tensor:
+        input_ids, attention_mask = tokenize_prompt(prompt)
+        hidden = self.text_encoder(
+            input_ids.to(self._device), attention_mask.bool().to(self._device)
+        )
+        hidden = hidden.cpu()  # forces sync
+        mask = attention_mask[0].bool()
+        return hidden[0][mask].to(DTYPE)
+
+    def generate(
+        self,
+        prompt: str,
+        num_inference_steps: int,
+        seed: Optional[int] = SEED,
+    ) -> torch.Tensor:
+        do_cfg = GUIDANCE_SCALE > 0
+        self._perf = {
+            "components": {},
+            "steps": [],
+            "step_metric_name": "transformer_step",
+            "total": None,
+        }
+        t_total_start = time.perf_counter()
+
+        with torch.no_grad():
+            # ── Text encoder (Qwen3) → prompt embeds, then evict ─────────
+            logger.info("[STAGE] Text encoder: start")
+            self.text_encoder = self.text_encoder.to(self._device)
+            t0 = time.perf_counter()
+            cap_pos = self._encode(prompt)
+            cap_neg = self._encode(NEGATIVE_PROMPT) if do_cfg else None
+            self._perf["components"]["text_encoder"] = time.perf_counter() - t0
+            self.text_encoder = self.text_encoder.to("cpu")
+            gc.collect()
+            logger.info("[STAGE] Text encoder: done")
+
+            # ── Latents (fp32 on CPU) ────────────────────────────────────
+            vsf = self.config.vae_scale_factor
+            latent_h = 2 * (int(self.config.height) // (vsf * 2))
+            latent_w = 2 * (int(self.config.width) // (vsf * 2))
+            generator = torch.Generator(device="cpu").manual_seed(seed or SEED)
+            latents = torch.randn(
+                (1, LATENT_CHANNELS, latent_h, latent_w),
+                generator=generator,
+                dtype=torch.float32,
+            )
+
+            # ── Timesteps (resolution-dependent mu shift) ────────────────
+            image_seq_len = (latent_h // 2) * (latent_w // 2)
+            mu = _calculate_shift(
+                image_seq_len,
+                self.scheduler.config.get("base_image_seq_len", 256),
+                self.scheduler.config.get("max_image_seq_len", 4096),
+                self.scheduler.config.get("base_shift", 0.5),
+                self.scheduler.config.get("max_shift", 1.15),
+            )
+            self.scheduler.sigma_min = 0.0
+            set_ts_kwargs = {}
+            import inspect
+
+            if "mu" in inspect.signature(self.scheduler.set_timesteps).parameters:
+                set_ts_kwargs["mu"] = mu
+            self.scheduler.set_timesteps(
+                num_inference_steps, device="cpu", **set_ts_kwargs
+            )
+            self.scheduler.set_begin_index(0)
+            timesteps = self.scheduler.timesteps
+
+            # ── Denoising loop (transformer; CFG = 2 batch=1 passes) ─────
+            logger.info(
+                f"[STAGE] Transformer denoising loop: start "
+                f"({num_inference_steps} steps)"
+            )
+            self.transformer = self.transformer.to(self._device)
+            for i, t in enumerate(timesteps):
+                logger.info(f"[STEP] Transformer step {i + 1}/{num_inference_steps}")
+                timestep = ((1000 - t.expand(1)) / 1000).to(DTYPE)
+                latent_input = latents.to(DTYPE)
+
+                t0 = time.perf_counter()
+                pos = self._forward(latent_input, timestep, cap_pos)
+                if do_cfg:
+                    neg = self._forward(latent_input, timestep, cap_neg)
+                    pred = pos + GUIDANCE_SCALE * (pos - neg)
+                else:
+                    pred = pos
+                self._perf["steps"].append(time.perf_counter() - t0)
+
+                noise_pred = (-pred).squeeze(2)
+                latents = self.scheduler.step(
+                    noise_pred.to(torch.float32), t, latents, return_dict=False
+                )[0]
+            self.transformer = self.transformer.to("cpu")
+            gc.collect()
+            logger.info("[STAGE] Transformer denoising loop: done")
+
+            # ── VAE decode → raw pixels in [-1, 1], then evict ───────────
+            logger.info("[STAGE] VAE decode: start")
+            self.vae = self.vae.to(self._device)
+            t0 = time.perf_counter()
+            image = self.vae(latents.to(self._device)).cpu().float()
+            self._perf["components"]["vae"] = time.perf_counter() - t0
+            self.vae = self.vae.to("cpu")
+            gc.collect()
+            logger.info("[STAGE] VAE decode: done")
+
+        self._perf["total"] = time.perf_counter() - t_total_start
+        return image
+
+    def _forward(self, latents, timestep, cap_feats) -> torch.Tensor:
+        out = self.transformer(
+            latents.to(self._device),
+            timestep.to(self._device),
+            cap_feats.to(self._device),
+        )
+        return out.cpu().float()  # forces sync

--- a/tests/benchmark/benchmarks/zimage_pipeline.py
+++ b/tests/benchmark/benchmarks/zimage_pipeline.py
@@ -4,7 +4,7 @@
 
 """Z-Image — single-chip benchmark-side pipeline for the imagegen harness.
 
-Mirrors the nightly e2e test (tests/torch/models/z_image/test_pipeline.py) but
+Mirrors the nightly e2e test (tests/torch/models/z_image/test_z_image_pipeline.py) but
 instruments per-component timings into ``self._perf`` for the harness. Every
 compute module runs on one Blackhole chip, compiled with
 ``torch.compile(backend="tt")``:

--- a/tests/benchmark/test_imagegen.py
+++ b/tests/benchmark/test_imagegen.py
@@ -353,6 +353,56 @@ def test_flux(output_file, request):
     )
 
 
+def test_zimage(output_file, request):
+    from benchmarks.zimage_pipeline import ZImageConfig, ZImagePipeline_TT
+
+    from third_party.tt_forge_models.z_image.pytorch.src.model_utils import (
+        GUIDANCE_SCALE,
+        HEIGHT,
+        NUM_INFERENCE_STEPS,
+        PROMPT,
+        WIDTH,
+    )
+
+    # Z-Image: ~6.2B ZImageTransformer2DModel + Qwen3 text encoder + VAE, all on
+    # one Blackhole chip (OOMs on single Wormhole). CFG runs as two batch=1
+    # passes. Blackhole-only — wired to p150-perf in perf-bench-matrix.json.
+    prompt = PROMPT
+    num_inference_steps = NUM_INFERENCE_STEPS
+    height = HEIGHT
+    width = WIDTH
+
+    def build_pipeline_fn(compile_options):
+        pipeline = ZImagePipeline_TT(
+            config=ZImageConfig(compile_options=compile_options)
+        )
+        pipeline.setup()
+
+        def generate_fn(prompt, steps):
+            return pipeline.generate(
+                prompt=prompt,
+                num_inference_steps=steps,
+                seed=DEFAULT_SEED,
+            )
+
+        return pipeline, generate_fn
+
+    test_imagegen(
+        build_pipeline_fn=build_pipeline_fn,
+        model_info_name="zimage",
+        output_file=output_file,
+        request=request,
+        prompt=prompt,
+        num_inference_steps=num_inference_steps,
+        height=height,
+        width=width,
+        # opt_level=1 keeps GroupNorm as native ttnn.group_norm so the VAE decode
+        # at 1280x720 does not OOM (issue #4755).
+        optimization_level=1,
+        output_image_path="test_zimage_output.png",
+    )
+
+
 def _run_janus_pro_benchmark(
     model_id, model_info_name, output_image_path, output_file, request
 ):

--- a/tests/torch/models/z_image/test_pipeline.py
+++ b/tests/torch/models/z_image/test_pipeline.py
@@ -11,7 +11,7 @@ flow, mirroring diffusers ``ZImagePipeline.__call__``:
     FlowMatchEulerDiscreteScheduler) -> AutoencoderKL decode -> PIL image.
 
 Each component compiles with the ``tt`` backend and runs on a single
-Blackhole chip. Source inference parameters (prompt, 1280x720, 4 steps,
+Blackhole chip. Source inference parameters (prompt, 1280x720, 50 steps,
 guidance_scale=4.0) are used so the run produces a realistic image, matching
 the pattern of the FLUX.1 / FLUX.2 / Janus-Pro component-based model tests.
 """
@@ -29,13 +29,7 @@ import torch_xla.runtime as xr
 from diffusers import FlowMatchEulerDiscreteScheduler
 from diffusers.image_processor import VaeImageProcessor
 from infra import RunMode
-from utils import (
-    BringupStatus,
-    Category,
-    ModelGroup,
-    TTArch,
-    get_torch_device_arch,
-)
+from utils import BringupStatus, Category, ModelGroup, TTArch, get_torch_device_arch
 
 from third_party.tt_forge_models.z_image.pytorch.src.model_utils import (
     CFG_NORMALIZATION,
@@ -56,7 +50,6 @@ from third_party.tt_forge_models.z_image.pytorch.src.model_utils import (
     load_transformer,
     load_vae,
 )
-
 
 # --- diffusers.pipelines.z_image.pipeline_z_image helpers (inlined) ---------
 
@@ -267,9 +260,7 @@ class ZImagePipeline:
                 pos = self._transformer_step(latent_input, timestep_input, cap_pos)
 
                 if do_cfg:
-                    neg = self._transformer_step(
-                        latent_input, timestep_input, cap_neg
-                    )
+                    neg = self._transformer_step(latent_input, timestep_input, cap_neg)
                     pred = pos + guidance_scale * (pos - neg)
                     if cfg_normalization and float(cfg_normalization) > 0.0:
                         ori = torch.linalg.vector_norm(pos)

--- a/tests/torch/models/z_image/test_pipeline.py
+++ b/tests/torch/models/z_image/test_pipeline.py
@@ -28,6 +28,14 @@ import torch_xla.core.xla_model as xm
 import torch_xla.runtime as xr
 from diffusers import FlowMatchEulerDiscreteScheduler
 from diffusers.image_processor import VaeImageProcessor
+from infra import RunMode
+from utils import (
+    BringupStatus,
+    Category,
+    ModelGroup,
+    TTArch,
+    get_torch_device_arch,
+)
 
 from third_party.tt_forge_models.z_image.pytorch.src.model_utils import (
     CFG_NORMALIZATION,
@@ -316,7 +324,16 @@ def run_zimage_pipeline(
 
 
 @pytest.mark.model_test
+@pytest.mark.nightly
 @pytest.mark.single_device
+@pytest.mark.large
+@pytest.mark.record_test_properties(
+    category=Category.MODEL_TEST,
+    model_name="ZImage_Pipeline",
+    model_group=ModelGroup.RED,
+    run_mode=RunMode.INFERENCE,
+    bringup_status=BringupStatus.PASSED,
+)
 def test_pipeline():
     """Full Z-Image text-to-image e2e on a single Blackhole chip.
 
@@ -324,6 +341,10 @@ def test_pipeline():
     decode at 1280x720 does not OOM (issue #4755).
     """
     xr.set_device_type("TT")
+    # The ~6.2B transformer + Qwen3 encoder + VAE fit a single Blackhole but OOM
+    # on a single Wormhole (n150), so this e2e is Blackhole-only (issue #4756).
+    if get_torch_device_arch() != TTArch.BLACKHOLE:
+        pytest.skip("Z-Image e2e runs on Blackhole only (OOMs on single Wormhole)")
     torch.manual_seed(SEED)
 
     output_path = "test_zimage_output.png"

--- a/tests/torch/models/z_image/test_pipeline.py
+++ b/tests/torch/models/z_image/test_pipeline.py
@@ -1,0 +1,346 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Z-Image — end-to-end text-to-image pipeline (Tongyi-MAI/Z-Image).
+
+Stitches the three validated single-chip components into the full generation
+flow, mirroring diffusers ``ZImagePipeline.__call__``:
+
+    Qwen3 text encoder -> ZImageTransformer2DModel denoising loop (CFG +
+    FlowMatchEulerDiscreteScheduler) -> AutoencoderKL decode -> PIL image.
+
+Each component compiles with the ``tt`` backend and runs on a single
+Blackhole chip. Source inference parameters (prompt, 1280x720, 4 steps,
+guidance_scale=4.0) are used so the run produces a realistic image, matching
+the pattern of the FLUX.1 / FLUX.2 / Janus-Pro component-based model tests.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.core.xla_model as xm
+import torch_xla.runtime as xr
+from diffusers import FlowMatchEulerDiscreteScheduler
+from diffusers.image_processor import VaeImageProcessor
+
+from third_party.tt_forge_models.z_image.pytorch.src.model_utils import (
+    CFG_NORMALIZATION,
+    DTYPE,
+    GUIDANCE_SCALE,
+    HEIGHT,
+    LATENT_CHANNELS,
+    MAX_SEQUENCE_LENGTH,
+    NEGATIVE_PROMPT,
+    NUM_INFERENCE_STEPS,
+    PROMPT,
+    REPO_ID,
+    SEED,
+    VAE_SCALE_FACTOR,
+    WIDTH,
+    load_text_encoder,
+    load_tokenizer,
+    load_transformer,
+    load_vae,
+)
+
+
+# --- diffusers.pipelines.z_image.pipeline_z_image helpers (inlined) ---------
+
+
+def calculate_shift(
+    image_seq_len,
+    base_seq_len: int = 256,
+    max_seq_len: int = 4096,
+    base_shift: float = 0.5,
+    max_shift: float = 1.15,
+):
+    m = (max_shift - base_shift) / (max_seq_len - base_seq_len)
+    b = base_shift - m * base_seq_len
+    return image_seq_len * m + b
+
+
+def retrieve_timesteps(scheduler, num_inference_steps, device, **kwargs):
+    scheduler.set_timesteps(num_inference_steps, device=device, **kwargs)
+    return scheduler.timesteps, num_inference_steps
+
+
+# --- TT-compilable component wrappers (tensor in / tensor out) ---------------
+
+
+class TextEncoderWrapper(torch.nn.Module):
+    """Qwen3 encoder -> penultimate hidden state (hidden_states[-2])."""
+
+    def __init__(self, encoder):
+        super().__init__()
+        self.encoder = encoder
+
+    def forward(self, input_ids, attention_mask):
+        out = self.encoder(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            output_hidden_states=True,
+        )
+        return out.hidden_states[-2]
+
+
+class CondTransformerWrapper(torch.nn.Module):
+    """Single (conditional) transformer pass; cap_feats is (L, D)."""
+
+    def __init__(self, transformer):
+        super().__init__()
+        self.transformer = transformer
+
+    def forward(self, latents, timestep, cap_feats):
+        x_list = list(latents.unsqueeze(2).unbind(dim=0))
+        t = timestep.reshape(-1).to(dtype=latents.dtype)
+        out = self.transformer(x_list, t, [cap_feats], return_dict=False)[0]
+        return torch.stack([o.float() for o in out], dim=0)
+
+
+class VaeDecodeWrapper(torch.nn.Module):
+    """Undo latent scaling, then AutoencoderKL.decode -> pixels."""
+
+    def __init__(self, vae):
+        super().__init__()
+        self.vae = vae
+
+    def forward(self, latents):
+        z = latents.to(dtype=self.vae.dtype)
+        z = (z / self.vae.config.scaling_factor) + self.vae.config.shift_factor
+        return self.vae.decode(z, return_dict=False)[0]
+
+
+# --- Pipeline ---------------------------------------------------------------
+
+
+class ZImagePipeline:
+    """Self-contained Z-Image text-to-image pipeline for TT bring-up."""
+
+    def __init__(self, run_on_tt: bool = True, dtype: torch.dtype = DTYPE):
+        self.run_on_tt = run_on_tt
+        self.dtype = dtype
+        self.vae_scale_factor = VAE_SCALE_FACTOR
+
+    def setup(self):
+        self.tokenizer = load_tokenizer()
+        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
+            REPO_ID, subfolder="scheduler"
+        )
+
+        text_encoder = TextEncoderWrapper(load_text_encoder(self.dtype)).eval()
+        transformer = load_transformer(self.dtype)
+        # Complex-valued RoPE only legalizes at batch=1 on the pinned tt-mlir
+        # (batch=2 broadcast fails, tt-mlir #8874), so classifier-free guidance
+        # runs cond and uncond as two separate batch=1 passes (as WAN does).
+        self.transformer = CondTransformerWrapper(transformer).eval()
+        vae = load_vae(self.dtype)
+        self.image_processor = VaeImageProcessor(
+            vae_scale_factor=self.vae_scale_factor * 2
+        )
+        vae_decoder = VaeDecodeWrapper(vae).eval()
+
+        if self.run_on_tt:
+            device = xm.xla_device()
+            text_encoder.compile(backend="tt")
+            self.transformer.compile(backend="tt")
+            vae_decoder.compile(backend="tt")
+            self.text_encoder = text_encoder.to(device)
+            self.transformer = self.transformer.to(device)
+            self.vae_decoder = vae_decoder.to(device)
+            self._device = device
+        else:
+            self.text_encoder = text_encoder
+            self.vae_decoder = vae_decoder
+            self._device = torch.device("cpu")
+
+    def _to_tt(self, x):
+        return x.to(device=self._device) if self.run_on_tt else x
+
+    @staticmethod
+    def _to_cpu(x):
+        return x.to("cpu")
+
+    def _encode_prompt(self, prompt: str) -> torch.Tensor:
+        """Tokenize (chat template) -> penultimate hidden state, mask-trimmed."""
+        messages = [{"role": "user", "content": prompt}]
+        text = self.tokenizer.apply_chat_template(
+            messages,
+            tokenize=False,
+            add_generation_prompt=True,
+            enable_thinking=True,
+        )
+        text_inputs = self.tokenizer(
+            [text],
+            padding="max_length",
+            max_length=MAX_SEQUENCE_LENGTH,
+            truncation=True,
+            return_tensors="pt",
+        )
+        input_ids = self._to_tt(text_inputs.input_ids)
+        attention_mask = self._to_tt(text_inputs.attention_mask.bool())
+
+        hidden = self.text_encoder(input_ids, attention_mask)
+        hidden = self._to_cpu(hidden)
+        mask = text_inputs.attention_mask[0].bool()
+        # Ragged, mask-trimmed embedding for this prompt: (valid_len, dim).
+        return hidden[0][mask].to(self.dtype)
+
+    def _transformer_step(self, latents, timestep, cap_feats):
+        """One batch=1 transformer pass; returns CPU fp32 (1, C, 1, H, W)."""
+        out = self.transformer(
+            self._to_tt(latents),
+            self._to_tt(timestep),
+            self._to_tt(cap_feats),
+        )
+        return self._to_cpu(out).float()
+
+    def generate(
+        self,
+        prompt: str = PROMPT,
+        negative_prompt: str = NEGATIVE_PROMPT,
+        height: int = HEIGHT,
+        width: int = WIDTH,
+        num_inference_steps: int = NUM_INFERENCE_STEPS,
+        guidance_scale: float = GUIDANCE_SCALE,
+        cfg_normalization: bool = CFG_NORMALIZATION,
+        seed: int = SEED,
+        output_type: str = "pil",
+    ):
+        do_cfg = guidance_scale > 0
+        cpu = torch.device("cpu")
+
+        with torch.no_grad():
+            # 1. Text encoding (Qwen3, penultimate layer).
+            cap_pos = self._encode_prompt(prompt)
+            cap_neg = self._encode_prompt(negative_prompt) if do_cfg else None
+
+            # 2. Latents (fp32 on CPU; scheduler math stays fp32).
+            latent_h = 2 * (int(height) // (self.vae_scale_factor * 2))
+            latent_w = 2 * (int(width) // (self.vae_scale_factor * 2))
+            generator = torch.Generator(device="cpu").manual_seed(seed)
+            latents = torch.randn(
+                (1, LATENT_CHANNELS, latent_h, latent_w),
+                generator=generator,
+                dtype=torch.float32,
+                device=cpu,
+            )
+
+            # 3. Timesteps with resolution-dependent shift (mu).
+            image_seq_len = (latent_h // 2) * (latent_w // 2)
+            mu = calculate_shift(
+                image_seq_len,
+                self.scheduler.config.get("base_image_seq_len", 256),
+                self.scheduler.config.get("max_image_seq_len", 4096),
+                self.scheduler.config.get("base_shift", 0.5),
+                self.scheduler.config.get("max_shift", 1.15),
+            )
+            self.scheduler.sigma_min = 0.0
+            set_ts_kwargs = {}
+            if "mu" in inspect.signature(self.scheduler.set_timesteps).parameters:
+                set_ts_kwargs["mu"] = mu
+            timesteps, _ = retrieve_timesteps(
+                self.scheduler, num_inference_steps, cpu, **set_ts_kwargs
+            )
+            self.scheduler.set_begin_index(0)
+
+            # 4. Denoising loop.
+            for i, t in enumerate(timesteps):
+                timestep = t.expand(1)
+                timestep = (1000 - timestep) / 1000
+                latent_input = latents.to(self.dtype)
+                timestep_input = timestep.to(self.dtype)
+
+                pos = self._transformer_step(latent_input, timestep_input, cap_pos)
+
+                if do_cfg:
+                    neg = self._transformer_step(
+                        latent_input, timestep_input, cap_neg
+                    )
+                    pred = pos + guidance_scale * (pos - neg)
+                    if cfg_normalization and float(cfg_normalization) > 0.0:
+                        ori = torch.linalg.vector_norm(pos)
+                        new = torch.linalg.vector_norm(pred)
+                        max_norm = ori * float(cfg_normalization)
+                        if new > max_norm:
+                            pred = pred * (max_norm / new)
+                    noise_pred = pred
+                else:
+                    noise_pred = pos
+
+                noise_pred = noise_pred.squeeze(2)
+                noise_pred = -noise_pred
+                latents = self.scheduler.step(
+                    noise_pred.to(torch.float32), t, latents, return_dict=False
+                )[0]
+                print(f"  denoise step {i + 1}/{num_inference_steps}")
+
+            if output_type == "latent":
+                return latents
+
+            # 5. VAE decode (scaling folded into the wrapper).
+            image = self.vae_decoder(self._to_tt(latents))
+            image = self._to_cpu(image).float()
+            return self.image_processor.postprocess(image, output_type=output_type)
+
+
+def run_zimage_pipeline(
+    output_path: str = "zimage_output.png",
+    num_inference_steps: int = NUM_INFERENCE_STEPS,
+    output_type: str = "pil",
+    run_on_tt: bool = True,
+):
+    torch_xla.set_custom_compile_options({"optimization_level": 1})
+
+    pipeline = ZImagePipeline(run_on_tt=run_on_tt)
+    pipeline.setup()
+
+    result = pipeline.generate(
+        num_inference_steps=num_inference_steps,
+        output_type=output_type,
+    )
+
+    if output_type == "latent":
+        print(f"Latent output shape: {result.shape}")
+        return result
+
+    image = result[0]
+    image.save(output_path)
+    print(f"Image saved to {output_path} ({image.size})")
+    return result
+
+
+@pytest.mark.model_test
+@pytest.mark.single_device
+def test_pipeline():
+    """Full Z-Image text-to-image e2e on a single Blackhole chip.
+
+    optimization_level=1 keeps GroupNorm as native ttnn.group_norm so the VAE
+    decode at 1280x720 does not OOM (issue #4755).
+    """
+    xr.set_device_type("TT")
+    torch.manual_seed(SEED)
+
+    output_path = "test_zimage_output.png"
+    output_file = Path(output_path)
+    if output_file.exists():
+        output_file.unlink()
+
+    images = run_zimage_pipeline(output_path=output_path, output_type="pil")
+
+    assert images is not None, "Pipeline returned None"
+    assert len(images) == 1, f"Expected 1 image, got {len(images)}"
+    from PIL import Image
+
+    assert isinstance(images[0], Image.Image), "Output is not a PIL image"
+    assert output_file.exists(), "Output image was not saved"
+    print("Z-Image e2e pipeline test passed.")
+
+
+if __name__ == "__main__":
+    test_pipeline()

--- a/tests/torch/models/z_image/test_z_image_pipeline.py
+++ b/tests/torch/models/z_image/test_z_image_pipeline.py
@@ -29,6 +29,8 @@ import torch_xla.runtime as xr
 from diffusers import FlowMatchEulerDiscreteScheduler
 from diffusers.image_processor import VaeImageProcessor
 from infra import RunMode
+from loguru import logger
+from PIL import Image
 from utils import BringupStatus, Category, ModelGroup, TTArch, get_torch_device_arch
 
 from third_party.tt_forge_models.z_image.pytorch.src.model_utils import (
@@ -123,8 +125,7 @@ class VaeDecodeWrapper(torch.nn.Module):
 class ZImagePipeline:
     """Self-contained Z-Image text-to-image pipeline for TT bring-up."""
 
-    def __init__(self, run_on_tt: bool = True, dtype: torch.dtype = DTYPE):
-        self.run_on_tt = run_on_tt
+    def __init__(self, dtype: torch.dtype = DTYPE):
         self.dtype = dtype
         self.vae_scale_factor = VAE_SCALE_FACTOR
 
@@ -146,22 +147,17 @@ class ZImagePipeline:
         )
         vae_decoder = VaeDecodeWrapper(vae).eval()
 
-        if self.run_on_tt:
-            device = xm.xla_device()
-            text_encoder.compile(backend="tt")
-            self.transformer.compile(backend="tt")
-            vae_decoder.compile(backend="tt")
-            self.text_encoder = text_encoder.to(device)
-            self.transformer = self.transformer.to(device)
-            self.vae_decoder = vae_decoder.to(device)
-            self._device = device
-        else:
-            self.text_encoder = text_encoder
-            self.vae_decoder = vae_decoder
-            self._device = torch.device("cpu")
+        device = xm.xla_device()
+        text_encoder.compile(backend="tt")
+        self.transformer.compile(backend="tt")
+        vae_decoder.compile(backend="tt")
+        self.text_encoder = text_encoder.to(device)
+        self.transformer = self.transformer.to(device)
+        self.vae_decoder = vae_decoder.to(device)
+        self._device = device
 
     def _to_tt(self, x):
-        return x.to(device=self._device) if self.run_on_tt else x
+        return x.to(device=self._device)
 
     @staticmethod
     def _to_cpu(x):
@@ -277,7 +273,7 @@ class ZImagePipeline:
                 latents = self.scheduler.step(
                     noise_pred.to(torch.float32), t, latents, return_dict=False
                 )[0]
-                print(f"  denoise step {i + 1}/{num_inference_steps}")
+                logger.info(f"  denoise step {i + 1}/{num_inference_steps}")
 
             if output_type == "latent":
                 return latents
@@ -292,11 +288,10 @@ def run_zimage_pipeline(
     output_path: str = "zimage_output.png",
     num_inference_steps: int = NUM_INFERENCE_STEPS,
     output_type: str = "pil",
-    run_on_tt: bool = True,
 ):
     torch_xla.set_custom_compile_options({"optimization_level": 1})
 
-    pipeline = ZImagePipeline(run_on_tt=run_on_tt)
+    pipeline = ZImagePipeline()
     pipeline.setup()
 
     result = pipeline.generate(
@@ -305,17 +300,17 @@ def run_zimage_pipeline(
     )
 
     if output_type == "latent":
-        print(f"Latent output shape: {result.shape}")
+        logger.info(f"Latent output shape: {result.shape}")
         return result
 
     image = result[0]
     image.save(output_path)
-    print(f"Image saved to {output_path} ({image.size})")
+    logger.info(f"Image saved to {output_path} ({image.size})")
     return result
 
 
-@pytest.mark.model_test
 @pytest.mark.nightly
+@pytest.mark.model_test
 @pytest.mark.single_device
 @pytest.mark.large
 @pytest.mark.record_test_properties(
@@ -325,7 +320,7 @@ def run_zimage_pipeline(
     run_mode=RunMode.INFERENCE,
     bringup_status=BringupStatus.PASSED,
 )
-def test_pipeline():
+def test_z_image_pipeline():
     """Full Z-Image text-to-image e2e on a single Blackhole chip.
 
     optimization_level=1 keeps GroupNorm as native ttnn.group_norm so the VAE
@@ -347,12 +342,10 @@ def test_pipeline():
 
     assert images is not None, "Pipeline returned None"
     assert len(images) == 1, f"Expected 1 image, got {len(images)}"
-    from PIL import Image
-
     assert isinstance(images[0], Image.Image), "Output is not a PIL image"
     assert output_file.exists(), "Output image was not saved"
-    print("Z-Image e2e pipeline test passed.")
-
-
-if __name__ == "__main__":
-    test_pipeline()
+    with Image.open(output_path) as img:
+        width, height = img.size
+        assert width == WIDTH, f"Expected width {WIDTH}, got {width}"
+        assert height == HEIGHT, f"Expected height {HEIGHT}, got {height}"
+    logger.info(f"Z-Image e2e pipeline test passed ({width}x{height}).")

--- a/tests/torch/models/z_image/test_z_image_pipeline.py
+++ b/tests/torch/models/z_image/test_z_image_pipeline.py
@@ -12,8 +12,7 @@ flow, mirroring diffusers ``ZImagePipeline.__call__``:
 
 Each component compiles with the ``tt`` backend and runs on a single
 Blackhole chip. Source inference parameters (prompt, 1280x720, 50 steps,
-guidance_scale=4.0) are used so the run produces a realistic image, matching
-the pattern of the FLUX.1 / FLUX.2 / Janus-Pro component-based model tests.
+guidance_scale=4.0) are used so the run produces a realistic image.
 """
 
 from __future__ import annotations
@@ -141,9 +140,6 @@ class ZImagePipeline:
         # do not all fit resident on a single Blackhole (issue #4756), so each is
         # placed -> used -> evicted in turn, keeping peak DRAM ~= max(component).
         self.text_encoder = TextEncoderWrapper(load_text_encoder(self.dtype)).eval()
-        # Complex-valued RoPE only legalizes at batch=1 on the pinned tt-mlir
-        # (batch=2 broadcast fails, tt-mlir #8874), so classifier-free guidance
-        # runs cond and uncond as two separate batch=1 passes (as WAN does).
         self.transformer = CondTransformerWrapper(load_transformer(self.dtype)).eval()
         self.vae_decoder = VaeDecodeWrapper(load_vae(self.dtype)).eval()
         self.image_processor = VaeImageProcessor(

--- a/tests/torch/models/z_image/test_z_image_pipeline.py
+++ b/tests/torch/models/z_image/test_z_image_pipeline.py
@@ -18,13 +18,14 @@ the pattern of the FLUX.1 / FLUX.2 / Janus-Pro component-based model tests.
 
 from __future__ import annotations
 
+import gc
 import inspect
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
 import torch
 import torch_xla
-import torch_xla.core.xla_model as xm
 import torch_xla.runtime as xr
 from diffusers import FlowMatchEulerDiscreteScheduler
 from diffusers.image_processor import VaeImageProcessor
@@ -135,26 +136,20 @@ class ZImagePipeline:
             REPO_ID, subfolder="scheduler"
         )
 
-        text_encoder = TextEncoderWrapper(load_text_encoder(self.dtype)).eval()
-        transformer = load_transformer(self.dtype)
+        # Components are loaded on CPU and placed on-device one at a time (see
+        # _on_device): the ~6.2B transformer, the Qwen3 text encoder and the VAE
+        # do not all fit resident on a single Blackhole (issue #4756), so each is
+        # placed -> used -> evicted in turn, keeping peak DRAM ~= max(component).
+        self.text_encoder = TextEncoderWrapper(load_text_encoder(self.dtype)).eval()
         # Complex-valued RoPE only legalizes at batch=1 on the pinned tt-mlir
         # (batch=2 broadcast fails, tt-mlir #8874), so classifier-free guidance
         # runs cond and uncond as two separate batch=1 passes (as WAN does).
-        self.transformer = CondTransformerWrapper(transformer).eval()
-        vae = load_vae(self.dtype)
+        self.transformer = CondTransformerWrapper(load_transformer(self.dtype)).eval()
+        self.vae_decoder = VaeDecodeWrapper(load_vae(self.dtype)).eval()
         self.image_processor = VaeImageProcessor(
             vae_scale_factor=self.vae_scale_factor * 2
         )
-        vae_decoder = VaeDecodeWrapper(vae).eval()
-
-        device = xm.xla_device()
-        text_encoder.compile(backend="tt")
-        self.transformer.compile(backend="tt")
-        vae_decoder.compile(backend="tt")
-        self.text_encoder = text_encoder.to(device)
-        self.transformer = self.transformer.to(device)
-        self.vae_decoder = vae_decoder.to(device)
-        self._device = device
+        self._device = torch_xla.device()
 
     def _to_tt(self, x):
         return x.to(device=self._device)
@@ -163,7 +158,26 @@ class ZImagePipeline:
     def _to_cpu(x):
         return x.to("cpu")
 
-    def _encode_prompt(self, prompt: str) -> torch.Tensor:
+    @contextmanager
+    def _on_device(self, module):
+        """Place one component on-device (compiled), then evict it afterwards.
+
+        Keeps only a single heavy component resident at a time (see setup): the
+        module is moved to device and compiled with the tt backend for the
+        duration of the block, then moved back to CPU and its compiled graph
+        dropped so the next component has the DRAM headroom it needs.
+        """
+        module.to(self._device)
+        compiled = torch.compile(module, backend="tt")
+        try:
+            yield compiled
+        finally:
+            module.to("cpu")
+            del compiled
+            gc.collect()
+            torch_xla.sync()
+
+    def _encode_prompt(self, prompt: str, encoder) -> torch.Tensor:
         """Tokenize (chat template) -> penultimate hidden state, mask-trimmed."""
         messages = [{"role": "user", "content": prompt}]
         text = self.tokenizer.apply_chat_template(
@@ -182,15 +196,15 @@ class ZImagePipeline:
         input_ids = self._to_tt(text_inputs.input_ids)
         attention_mask = self._to_tt(text_inputs.attention_mask.bool())
 
-        hidden = self.text_encoder(input_ids, attention_mask)
+        hidden = encoder(input_ids, attention_mask)
         hidden = self._to_cpu(hidden)
         mask = text_inputs.attention_mask[0].bool()
         # Ragged, mask-trimmed embedding for this prompt: (valid_len, dim).
         return hidden[0][mask].to(self.dtype)
 
-    def _transformer_step(self, latents, timestep, cap_feats):
+    def _transformer_step(self, transformer, latents, timestep, cap_feats):
         """One batch=1 transformer pass; returns CPU fp32 (1, C, 1, H, W)."""
-        out = self.transformer(
+        out = transformer(
             self._to_tt(latents),
             self._to_tt(timestep),
             self._to_tt(cap_feats),
@@ -213,9 +227,13 @@ class ZImagePipeline:
         cpu = torch.device("cpu")
 
         with torch.no_grad():
-            # 1. Text encoding (Qwen3, penultimate layer).
-            cap_pos = self._encode_prompt(prompt)
-            cap_neg = self._encode_prompt(negative_prompt) if do_cfg else None
+            # 1. Text encoding (Qwen3, penultimate layer); encoder resident only
+            #    for this block, then evicted before the transformer is placed.
+            with self._on_device(self.text_encoder) as encoder:
+                cap_pos = self._encode_prompt(prompt, encoder)
+                cap_neg = (
+                    self._encode_prompt(negative_prompt, encoder) if do_cfg else None
+                )
 
             # 2. Latents (fp32 on CPU; scheduler math stays fp32).
             latent_h = 2 * (int(height) // (self.vae_scale_factor * 2))
@@ -246,41 +264,49 @@ class ZImagePipeline:
             )
             self.scheduler.set_begin_index(0)
 
-            # 4. Denoising loop.
-            for i, t in enumerate(timesteps):
-                timestep = t.expand(1)
-                timestep = (1000 - timestep) / 1000
-                latent_input = latents.to(self.dtype)
-                timestep_input = timestep.to(self.dtype)
+            # 4. Denoising loop; transformer resident only for this block, then
+            #    evicted before the VAE is placed.
+            with self._on_device(self.transformer) as transformer:
+                for i, t in enumerate(timesteps):
+                    timestep = t.expand(1)
+                    timestep = (1000 - timestep) / 1000
+                    latent_input = latents.to(self.dtype)
+                    timestep_input = timestep.to(self.dtype)
 
-                pos = self._transformer_step(latent_input, timestep_input, cap_pos)
+                    pos = self._transformer_step(
+                        transformer, latent_input, timestep_input, cap_pos
+                    )
 
-                if do_cfg:
-                    neg = self._transformer_step(latent_input, timestep_input, cap_neg)
-                    pred = pos + guidance_scale * (pos - neg)
-                    if cfg_normalization and float(cfg_normalization) > 0.0:
-                        ori = torch.linalg.vector_norm(pos)
-                        new = torch.linalg.vector_norm(pred)
-                        max_norm = ori * float(cfg_normalization)
-                        if new > max_norm:
-                            pred = pred * (max_norm / new)
-                    noise_pred = pred
-                else:
-                    noise_pred = pos
+                    if do_cfg:
+                        neg = self._transformer_step(
+                            transformer, latent_input, timestep_input, cap_neg
+                        )
+                        pred = pos + guidance_scale * (pos - neg)
+                        if cfg_normalization and float(cfg_normalization) > 0.0:
+                            ori = torch.linalg.vector_norm(pos)
+                            new = torch.linalg.vector_norm(pred)
+                            max_norm = ori * float(cfg_normalization)
+                            if new > max_norm:
+                                pred = pred * (max_norm / new)
+                        noise_pred = pred
+                    else:
+                        noise_pred = pos
 
-                noise_pred = noise_pred.squeeze(2)
-                noise_pred = -noise_pred
-                latents = self.scheduler.step(
-                    noise_pred.to(torch.float32), t, latents, return_dict=False
-                )[0]
-                logger.info(f"  denoise step {i + 1}/{num_inference_steps}")
+                    noise_pred = noise_pred.squeeze(2)
+                    noise_pred = -noise_pred
+                    latents = self.scheduler.step(
+                        noise_pred.to(torch.float32), t, latents, return_dict=False
+                    )[0]
+                    logger.info(f"  denoise step {i + 1}/{num_inference_steps}")
 
             if output_type == "latent":
                 return latents
 
-            # 5. VAE decode (scaling folded into the wrapper).
-            image = self.vae_decoder(self._to_tt(latents))
-            image = self._to_cpu(image).float()
+            # 5. VAE decode (scaling folded into the wrapper); VAE resident only
+            #    for this block.
+            with self._on_device(self.vae_decoder) as vae_decoder:
+                image = vae_decoder(self._to_tt(latents))
+                image = self._to_cpu(image).float()
             return self.image_processor.postprocess(image, output_type=output_type)
 
 


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/4707

### Problem description

- Z-Image passed component bring-up (Qwen3 text encoder, transformer, VAE decoder — added in #4764) and the full e2e text-to-image pipeline runs on Tenstorrent, but there was no e2e pipeline has to be wired.
- This mirrors the image-gen pattern introduced in #5044 (Playground v2.5) and extended by SDXL-Lightning (#5244), Janus-Pro (#5291) and FLUX.2 (#5359): a model whose components pass bring-up should get an e2e pipeline in nightly + a perf benchmark.
- Z-Image is a **single-chip Blackhole** image-gen model: the ~6.2B `ZImageTransformer2DModel` + Qwen3 text encoder + `AutoencoderKL` all fit one Blackhole chip. It OOMs on a single Wormhole (n150), so it targets **`p150`** and skips Wormhole (#4756).

### What's changed

Wires the full Z-Image pipeline (a self-contained pipeline mirroring diffusers `ZImagePipeline.__call__`; every compute module runs on TT via `torch.compile(backend="tt")` on a single chip) into nightly + benchmark CI, following the `playground_v2_5` / `sdxl_lightning` e2e conventions.

- **Nightly** (`tests/torch/models/z_image/test_z_image_pipeline.py`): self-contained — pipeline class + test inline, imports from `third_party.tt_forge_models` (no import from `examples/`). Markers: `model_test`, `nightly`, `single_device`, `large`, `record_test_properties`; skips on Wormhole (`get_torch_device_arch`) since the model OOMs on a single n150 — so it runs on `p150` via the existing `run_large_torch` standalone-models job (`model-test-full`). **Classifier-free guidance runs cond + uncond as two separate batch=1 passes**: the transformer's complex-valued RoPE only legalizes at batch=1 on the pinned tt-mlir (batch=2 broadcast fails, tt-mlir #8874). `optimization_level=1` keeps GroupNorm as native `ttnn.group_norm` so the 1280×720 VAE decode does not OOM (#4755). Uses the source inference params (1280×720, 50 steps, guidance_scale=4, empty negative prompt) so the run reproduces a realistic image.
- **Benchmark**: the shared diffusion harness `tests/benchmark/benchmarks/imagegen_benchmark.py` is made component-set-agnostic — a model reports only the components it runs (Z-Image has a single text encoder, so `te2` is omitted from the breakdown + measurements), with an optional per-step label. **SDXL/Playground output is unchanged.** A self-contained single-chip `benchmarks/zimage_pipeline.py` runs each module on the chip only while it is active and evicts it after (peak DRAM ≈ max(component), not sum — the encoder + transformer + VAE never all sit on one chip), with per-component `_perf` timing (te1 / transformer steps / vae). Entry `test_zimage` in `test_imagegen.py`. Two-pass warmup + steady-state. `optimization_level=1`.
- **Matrix**: `zimage` entry added to `.github/workflows/perf-bench-matrix.json` with `runs-on: p150-perf` (single Blackhole; OOMs on n150).

### Last commit — lower benchmark peak host RAM

`01f16190a` — **[z_image] Lower e2e benchmark peak host RAM (per-stage load+free + tiled VAE)**:

- Loads each component from disk right before its stage and fully frees it (`del` + `gc.collect`) after it runs, instead of preloading all three modules on host in `setup()`. Bounds peak host RAM to ~max(component) instead of sum(components) — the Qwen3 encoder + ~6.2B transformer + VAE no longer sit in host memory simultaneously.
- Enables tiled VAE decode to bound the 1280×720 decode activations.
- Measured: single-chip benchmark **peak host RSS ~75 GB → ~24 GB**, with no output change (VAE tiling PCC 0.99995 vs full-frame).

### Validation

Validated on p150 Blackhole (single chip; `optimization_level=1`, batch=1, bfloat16, 1280×720, 50 steps, CFG ⇒ 2 transformer forwards/step).

**Local (this branch @ `01f16190a`):**

| Test | Result | Time |
| --- | --- | --- |
| `test_z_image_pipeline` (nightly e2e) | ✅ passed | 57m49s (cold cache, 50 steps) |

Benchmark (`test_zimage`) perf numbers are from the p150-perf CI runs below.

**Benchmark CI (`test_zimage`, p150-perf) — both runner types passed:**

| metric | shared runner | dedicated runner (nightly-equivalent) |
| --- | --- | --- |
| run | [29719750312](https://github.com/tenstorrent/tt-xla/actions/runs/29719750312) | [29719754955](https://github.com/tenstorrent/tt-xla/actions/runs/29719754955) |
| host `device_count` | 1 | 4 |
| e2e latency | 1673.9 s | 1527.8 s |
| images / sec | 5.97e-4 | 6.55e-4 |
| text encoder | 76.1 s | 34.8 s |
| transformer step (mean) | 31.11 s | 29.51 s |
| VAE decode | 36.0 s | 14.9 s |
| cpu overhead | 6.1 s | 2.7 s |



Both the nightly and benchmark passes produce a coherent 720×1280 image (a red cube on a white table, matching the prompt).

### Checklist

- [x] Validate nightly e2e on single p150 Blackhole
- [x] Validate benchmark (`test_zimage`) on single p150 Blackhole
- [x] Confirm single-chip imagegen (SDXL-Lightning / Playground) benchmark unaffected by the harness change
- [x] Perf benchmark CI — shared runner (`sh-runner=true`): https://github.com/tenstorrent/tt-xla/actions/runs/29719750312
- [x] Perf benchmark CI — dedicated runner (`sh-runner=false`): https://github.com/tenstorrent/tt-xla/actions/runs/29719754955

### Logs
- [zimage_nightly.log](https://github.com/user-attachments/files/29969212/zimage_nightly.log), [zimage_benchmark.log](https://github.com/user-attachments/files/29969216/zimage_benchmark.log)
