### PR TITLE
[Benchmark] Add pcc-only modes

### DIFF
--- a/tests/benchmark/benchmarks/llm_benchmark.py
+++ b/tests/benchmark/benchmarks/llm_benchmark.py
@@ -218,6 +218,33 @@ def transfer_to_device(input_args: dict, device: torch.device) -> dict:
     return input_args
 
 
+def _restore_cumulative_length(past_key_values, cumulative_lengths):
+    """Restore each layer's cumulative_length from a post-prefill snapshot.
+
+    transfer_to_device() zeroes cumulative_length (it assumes a fresh cache that
+    prefill will fill). When a device decode is seeded from a pre-filled CPU
+    cache (decode-only and isolated-decode PCC) the length must instead be the
+    post-prefill value, or the decode reads an empty KV window at opt_level > 0.
+    """
+    for layer, cumulative_length in zip(past_key_values.layers, cumulative_lengths):
+        if cumulative_length is not None and hasattr(layer, "cumulative_length"):
+            layer.cumulative_length.copy_(
+                cumulative_length.to(layer.cumulative_length.device)
+            )
+
+
+def _report_pcc(label, device_logits, cpu_logits, required_pcc):
+    """Print the PCC and rel_l2 of device vs CPU logits; return the PCC."""
+    pcc = compute_pcc(device_logits, cpu_logits)
+    rel_l2 = compute_rel_l2(cpu_logits, device_logits)
+    print(
+        "{} PCC={:.6f}, rel_l2={:.6e}, Required={}".format(
+            label, pcc, rel_l2, required_pcc
+        )
+    )
+    return pcc
+
+
 def _shard_kv_cache(past_key_values, mesh, kv_cache_sharding_spec):
     kv_spec = kv_cache_sharding_spec
     for layer in past_key_values.layers:
@@ -258,6 +285,7 @@ def benchmark_llm_torch_xla(
     hf_model_name_for_accuracy: str = None,
     max_output_tokens=None,
     decode_only: bool = False,
+    pcc_mode: str = "",
     weight_dtype_overrides: dict = None,
     input_output_sharding_spec=None,
     kv_cache_sharding_spec=None,
@@ -323,6 +351,17 @@ def benchmark_llm_torch_xla(
 
     if decode_only and accuracy_testing:
         raise ValueError("--decode-only cannot be combined with --accuracy-testing")
+
+    # PCC-only modes (--pcc-only / --pcc-prefill / --pcc-decode): skip warmup and
+    # the timed perf loop, run one PCC iteration, print both PCCs, assert only the
+    # selected mode's. "decode"/"both" also isolate the decode PCC by reseeding the
+    # device KV cache from the CPU-golden post-prefill cache. Prefill always runs
+    # first: the standalone decode graph crashes at optimization_level > 0.
+    pcc_mode = (pcc_mode or "").strip().lower()
+    pcc_only = pcc_mode in ("prefill", "decode", "both")
+    assert_prefill = (not pcc_only) or (pcc_mode in ("both", "prefill"))
+    assert_decode = (not pcc_only) or (pcc_mode in ("both", "decode"))
+    pcc_isolated = pcc_mode in ("decode", "both")
 
     if task != "text-generation":
         raise ValueError(
@@ -424,6 +463,17 @@ def benchmark_llm_torch_xla(
         first_decode_input_ids = input_args["input_ids"].clone()
         decode_only_cache_position = input_args["cache_position"].clone()
         decode_only_cache = input_args["past_key_values"]
+        # Post-prefill cumulative_length per layer, used to restore the
+        # reseeded isolated-decode cache (transfer_to_device zeroes it below).
+        decode_only_cumlen = [
+            (
+                layer.cumulative_length.detach().clone()
+                if hasattr(layer, "cumulative_length")
+                and layer.cumulative_length is not None
+                else None
+            )
+            for layer in decode_only_cache.layers
+        ]
 
         # Iter 1: first decode. Provides the PCC reference for device first decode.
         cpu_decode_logits, _ = generate_and_benchmark(
@@ -513,8 +563,8 @@ def benchmark_llm_torch_xla(
 
     warmup_kv_cache = None
 
-    # Warmup run (skip in decode-only mode)
-    if not decode_only:
+    # Warmup run (skip in decode-only mode and in pcc-only mode)
+    if not decode_only and not pcc_only:
         # Construct inputs for warmup run
         input_args = construct_inputs(
             tokenizer,
@@ -583,24 +633,28 @@ def benchmark_llm_torch_xla(
         _shard_kv_cache(input_args["past_key_values"], mesh, kv_cache_sharding_spec)
     if input_output_sharding_spec:
         xs.mark_sharding(input_args["input_ids"], mesh, input_output_sharding_spec)
+    if decode_only:
+        _restore_cumulative_length(input_args["past_key_values"], decode_only_cumlen)
 
     ground_truth_for_benchmark = (
         token_accuracy.reference_tokens if accuracy_testing else None
     )
 
-    # Run perf benchmark
-    print(f"\nStarting performance benchmark...")
-    _, iteration_times = generate_and_benchmark(
-        compiled_perf_model,
-        input_args,
-        device,
-        max_output_tokens,
-        verbose=True,
-        tokenizer=tokenizer,
-        ground_truth_tokens=ground_truth_for_benchmark,
-        collect_logits=False,
-    )
-    print("\nPerformance benchmark complete")
+    # Run perf benchmark (skipped in pcc-only mode for fast iteration)
+    iteration_times = []
+    if not pcc_only:
+        print(f"\nStarting performance benchmark...")
+        _, iteration_times = generate_and_benchmark(
+            compiled_perf_model,
+            input_args,
+            device,
+            max_output_tokens,
+            verbose=True,
+            tokenizer=tokenizer,
+            ground_truth_tokens=ground_truth_for_benchmark,
+            collect_logits=False,
+        )
+        print("\nPerformance benchmark complete")
 
     # ========================================================
     # PCC/TOPK BENCHMARK
@@ -617,7 +671,7 @@ def benchmark_llm_torch_xla(
     logits_wrapper.eval()
     compiled_logits = torch.compile(logits_wrapper, backend="tt")
 
-    logits_steps = max_output_tokens
+    logits_steps = (1 if decode_only else 2) if pcc_only else max_output_tokens
 
     # Reconstruct inputs for PCC/TOPK run
     input_args = construct_inputs(
@@ -641,6 +695,8 @@ def benchmark_llm_torch_xla(
         _shard_kv_cache(input_args["past_key_values"], mesh, kv_cache_sharding_spec)
     if input_output_sharding_spec:
         xs.mark_sharding(input_args["input_ids"], mesh, input_output_sharding_spec)
+    if decode_only:
+        _restore_cumulative_length(input_args["past_key_values"], decode_only_cumlen)
 
     print("\nStarting PCC/TOPK benchmark...")
 
@@ -658,10 +714,38 @@ def benchmark_llm_torch_xla(
 
         device_prefill_output_ids = input_args["input_ids"].to("cpu")
 
+        if pcc_isolated:
+            # Rebuild decode inputs from the CPU-golden post-prefill KV cache.
+            input_args = construct_inputs(
+                tokenizer,
+                model.config,
+                batch_size,
+                max_cache_len,
+                past_key_values=decode_only_cache,
+                input_prompt=custom_input_prompt,
+                input_prompt_tokens=(
+                    token_accuracy.input_prompt if accuracy_testing else None
+                ),
+                use_mla_cache=use_mla_cache,
+            )
+            input_args["input_ids"] = first_decode_input_ids.clone()
+            input_args["cache_position"] = decode_only_cache_position.clone()
+            input_args = transfer_to_device(input_args, device)
+            if is_multichip:
+                _shard_kv_cache(
+                    input_args["past_key_values"], mesh, kv_cache_sharding_spec
+                )
+            if input_output_sharding_spec:
+                xs.mark_sharding(
+                    input_args["input_ids"], mesh, input_output_sharding_spec
+                )
+            _restore_cumulative_length(
+                input_args["past_key_values"], decode_only_cumlen
+            )
         # Override device's first-decode input with CPU's prefill output when they
         # diverge, so the decode PCC reference is comparing apples to apples
         # (otherwise a poor prefill PCC compounds into the decode PCC — see #4614).
-        if not accuracy_testing and not torch.equal(
+        elif not accuracy_testing and not torch.equal(
             device_prefill_output_ids, first_decode_input_ids.cpu()
         ):
             logger.warning(
@@ -710,7 +794,7 @@ def benchmark_llm_torch_xla(
             per_user_predictions.append(user_tokens)
 
     # Calculate Time to First Token (TTFT)
-    ttft_ns = iteration_times[0] if not decode_only else 0.0
+    ttft_ns = iteration_times[0] if (not decode_only and iteration_times) else 0.0
     ttft_ms = ttft_ns / 1e6
 
     # Calculate decode time
@@ -816,46 +900,35 @@ def benchmark_llm_torch_xla(
             ]
         )
     elif decode_only:
-        decode_pcc_value = compute_pcc(output_logits[0][0], cpu_output_logits[1][0])
-        decode_rel_l2_value = compute_rel_l2(
-            cpu_output_logits[1][0], output_logits[0][0]
+        decode_pcc_value = _report_pcc(
+            "First decode", output_logits[0][0], cpu_output_logits[1][0], required_pcc
         )
-        assert (
-            decode_pcc_value >= required_pcc
-        ), f"First decode PCC failed. PCC={decode_pcc_value:.6f}, Required={required_pcc}"
-        print(
-            "First decode PCC verification passed with PCC={:.6f}, rel_l2={:.6e}".format(
-                decode_pcc_value, decode_rel_l2_value
-            )
-        )
+        if assert_decode:
+            assert (
+                decode_pcc_value >= required_pcc
+            ), f"First decode PCC failed. PCC={decode_pcc_value:.6f}, Required={required_pcc}"
     else:
-        # Check PCC for prefill
-        pcc_value = compute_pcc(output_logits[0][0], cpu_output_logits[0][0])
-        rel_l2_value = compute_rel_l2(cpu_output_logits[0][0], output_logits[0][0])
-        assert (
-            pcc_value >= required_pcc
-        ), f"Prefill PCC failed. PCC={pcc_value:.6f}, Required={required_pcc}"
-        print(
-            "Prefill PCC verification passed with PCC={:.6f}, rel_l2={:.6e}".format(
-                pcc_value, rel_l2_value
+        # Always print both PCCs; assert only the selected mode's (all modes when
+        # not in PCC-only mode).
+        pcc_value = _report_pcc(
+            "Prefill", output_logits[0][0], cpu_output_logits[0][0], required_pcc
+        )
+        decode_pcc_value = None
+        if len(output_logits) > 1 and len(cpu_output_logits) > 1:
+            decode_pcc_value = _report_pcc(
+                "First decode",
+                output_logits[1][0],
+                cpu_output_logits[1][0],
+                required_pcc,
             )
-        )
-        # Check PCC for first decode token
-        assert (
-            len(output_logits) > 1 and len(cpu_output_logits) > 1
-        ), "Not enough logits to check PCC"
-        decode_pcc_value = compute_pcc(output_logits[1][0], cpu_output_logits[1][0])
-        decode_rel_l2_value = compute_rel_l2(
-            cpu_output_logits[1][0], output_logits[1][0]
-        )
-        assert (
-            decode_pcc_value >= required_pcc
-        ), f"First decode PCC failed. PCC={decode_pcc_value:.6f}, Required={required_pcc}"
-        print(
-            "First decode PCC verification passed with PCC={:.6f}, rel_l2={:.6e}".format(
-                decode_pcc_value, decode_rel_l2_value
-            )
-        )
+        if assert_prefill:
+            assert (
+                pcc_value >= required_pcc
+            ), f"Prefill PCC failed. PCC={pcc_value:.6f}, Required={required_pcc}"
+        if assert_decode:
+            assert (
+                decode_pcc_value is not None and decode_pcc_value >= required_pcc
+            ), f"First decode PCC failed. PCC={decode_pcc_value}, Required={required_pcc}"
 
     # Get device count and mesh info for metrics
     arch = get_xla_device_arch()

--- a/tests/benchmark/conftest.py
+++ b/tests/benchmark/conftest.py
@@ -94,6 +94,30 @@ def pytest_addoption(parser):
         help="Run prefill on CPU and only decode on device. Measures decode-only throughput.",
     )
 
+    # PCC-only iteration mode for LLM benchmarks: skip warmup and the timed perf
+    # loop and run a single PCC iteration, asserting only the selected phase(s).
+    # --pcc-only (or combining --pcc-prefill with --pcc-decode) asserts both.
+    parser.addoption(
+        "--pcc-only",
+        action="store_true",
+        default=False,
+        help="LLM PCC-only mode: skip perf, run one PCC iteration, assert prefill and decode.",
+    )
+
+    parser.addoption(
+        "--pcc-prefill",
+        action="store_true",
+        default=False,
+        help="LLM PCC-only mode asserting prefill only (implies --pcc-only).",
+    )
+
+    parser.addoption(
+        "--pcc-decode",
+        action="store_true",
+        default=False,
+        help="LLM PCC-only mode asserting first-decode only (implies --pcc-only).",
+    )
+
     parser.addoption(
         "--check-fusions",
         action="store_true",

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -37,6 +37,26 @@ def default_read_logits_fn(output):
     return output.logits
 
 
+def _resolve_pcc_mode(request):
+    """Resolve the LLM PCC-only iteration mode from the --pcc-* CLI flags.
+
+    Returns "prefill" | "decode" | "both" | "" (disabled). --pcc-only, or
+    combining --pcc-prefill with --pcc-decode, asserts both phases.
+    """
+    if request is None:
+        return ""
+    pcc_only = request.config.getoption("--pcc-only")
+    pcc_prefill = request.config.getoption("--pcc-prefill")
+    pcc_decode = request.config.getoption("--pcc-decode")
+    if pcc_only or (pcc_prefill and pcc_decode):
+        return "both"
+    if pcc_prefill:
+        return "prefill"
+    if pcc_decode:
+        return "decode"
+    return ""
+
+
 def test_llm(
     ModelLoaderModule,
     variant,
@@ -163,6 +183,7 @@ def test_llm(
         hf_model_name_for_accuracy=hf_model_name,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        pcc_mode=_resolve_pcc_mode(request),
         weight_dtype_overrides=weight_dtype_overrides,
         input_output_sharding_spec=input_output_sharding_spec,
         kv_cache_sharding_spec=kv_cache_sharding_spec,


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-xla/issues/5276

### Problem description
When bisecting pcc drop, there is no elegant way to run just one iteration of isolated prefill or decode graph.

### What's changed
Added pcc modes: 
- `pcc-prefill`
- `pcc-decode` - cpu KV cache, like in `decode-only`
- `pcc-only` - isolated prefill-only and decode-only pcc

### Checklist
- [ ] New/Existing tests provide coverage for changes
