### PR TITLE
[vLLM] Update graph compilation check during inference

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -248,7 +248,6 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         scheduler_config = self.scheduler_config
         parallel_config = self.parallel_config
         self.device = device
-        self.check_recompilation = envs.VLLM_XLA_CHECK_RECOMPILATION
         self.use_flat_model_io = self.tt_config.flat_model_io
         self.enable_decode_fused_graphs = self.tt_config.enable_decode_fused_graphs
 
@@ -687,8 +686,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             self.mm_budget.reset_cache()
 
     def _update_num_xla_graphs(self, case_str):
-        check_comp = self.check_recompilation and not self.enforce_eager
-        if not check_comp:
+        if self.enforce_eager:
             return
 
         total_cached_graphs = xr.get_num_cached_compilation_graph()
@@ -702,30 +700,18 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self.num_xla_graphs += new_compiled_graphs
 
     def _verify_num_xla_graphs(self, case_str):
-        check_comp = self.check_recompilation and not self.enforce_eager
-        if not check_comp:
+        if self.enforce_eager:
             return
 
         curr_cached_graph = xr.get_num_cached_compilation_graph()
+        new_compiled_graphs = curr_cached_graph - self.num_xla_graphs
 
-        if not self._recompile_locked:
-            # Accept new graphs while chunk-size bucket shapes are still being
-            # seen; lock once the set is stable for a couple of steps.
-            if curr_cached_graph > self.num_xla_graphs:
-                self._update_num_xla_graphs(f"{case_str} (warm-up)")
-                self._recompile_stable_steps = 0
-            else:
-                self._recompile_stable_steps += 1
-                if self._recompile_stable_steps >= 2:
-                    self._recompile_locked = True
-            return
-
-        assert self.num_xla_graphs == curr_cached_graph, (
-            "Recompilation after warm up is detected during {}."
-            " num_xla_graphs = {} curr_cached_graph = {}".format(
-                case_str, self.num_xla_graphs, curr_cached_graph
+        if new_compiled_graphs > 0:
+            logger.error(
+                "Detected %d new XLA graph compilation(s) during sample_tokens().",
+                new_compiled_graphs,
             )
-        )
+        self.num_xla_graphs += new_compiled_graphs
 
     def _update_states(self, scheduler_output: "SchedulerOutput") -> bool:
         """Update the cached states and the persistent batch with the scheduler


### PR DESCRIPTION
### Ticket
closes #5502 

### Problem description
vLLM plugin compiles the model for all possible input shapes to avoid any compilation during inference. 

### What's changed
- Update graph compilation verifier during inference.
- Remove the exception due to _recompile_locked flag.
- Always log ERROR message in case of recompilation.
