### PR TITLE
Add tt_preserve_matmul_input_dtype compile option

### DIFF
--- a/python_package/tt_torch/backend/backend.py
+++ b/python_package/tt_torch/backend/backend.py
@@ -64,7 +64,15 @@ def torch_pass_pipeline(
     if enable_composite_ops:
         handle_composite_ops(gm)
 
-    decompositions = populate_decompositions()
+    # When set, decompose matmul/linear without upcasting operands to f32 (keeps
+    # bf16 weights bf16). Opt-in per model to avoid changing device numerics
+    # globally.
+    preserve_matmul_input_dtype = (
+        bool(options.get("tt_preserve_matmul_input_dtype", False)) if options else False
+    )
+    decompositions = populate_decompositions(
+        preserve_matmul_input_dtype=preserve_matmul_input_dtype
+    )
 
     program = torch.export.export(
         gm,

--- a/python_package/tt_torch/backend/decompositions.py
+++ b/python_package/tt_torch/backend/decompositions.py
@@ -470,7 +470,27 @@ def _get_custom_decompositions() -> DecompositionTable:
     }
 
 
-def populate_decompositions() -> DecompositionTable:
+def addmm_keep_input_dtype(self, mat1, mat2, beta=1, alpha=1):
+    """addmm decomposition that does NOT upcast operands to f32.
+
+    torch._decomp's addmm is wrapped in @pw_cast_for_opmath, which upcasts bf16/
+    fp16 operands to f32 for the mm and downcasts the result. That materializes
+    matmul weights in f32 — fine normally, but for models that fuse many matmuls
+    sharing one input into a single large weight (e.g. HunyuanVideo's AdaLayerNorm
+    modulation), the f32 weight can blow the DRAM budget. This variant keeps the
+    inputs' dtype (bf16 stays bf16); device accumulation precision is still
+    governed by fp32_dest_acc_en. Opt-in via the tt_preserve_matmul_input_dtype
+    compile option.
+    """
+    out = torch.mm(mat1, mat2)
+    if beta == 0:
+        return alpha * out
+    return alpha * out + beta * self
+
+
+def populate_decompositions(
+    preserve_matmul_input_dtype: bool = False,
+) -> DecompositionTable:
     decompositions = torch._decomp.core_aten_decompositions()
 
     # Pytorch folds batch dimensions of bmms https://github.com/pytorch/pytorch/blob/a5436a5e8e4ee42d1debf52c2786c7ae0043a434/aten/src/ATen/native/LinearAlgebra.cpp#L1999.
@@ -485,5 +505,10 @@ def populate_decompositions() -> DecompositionTable:
 
     decompositions.update(get_decompositions(_get_default_decomposition_ops()))
     decompositions.update(_get_custom_decompositions())
+
+    # Override the f32-upcasting addmm decomposition with a dtype-preserving one.
+    # Must come after the updates above so it wins.
+    if preserve_matmul_input_dtype:
+        decompositions[torch.ops.aten.addmm.default] = addmm_keep_input_dtype
 
     return decompositions

--- a/tests/torch/models/hunyuan_video/test_transformer.py
+++ b/tests/torch/models/hunyuan_video/test_transformer.py
@@ -19,9 +19,6 @@ def test_transformer():
     _run(sharded=False)
 
 
-@pytest.mark.xfail(
-    reason="Out of Memory: Not enough space to allocate 75497472 B DRAM buffer across 12 banks - https://github.com/tenstorrent/tt-xla/issues/4790"
-)
 def test_transformer_sharded():
     _run(sharded=True)
 
@@ -43,10 +40,17 @@ def _run(sharded: bool):
         mesh = get_mesh(mesh_shape, mesh_names)
         shard_spec_fn = loader.load_shard_spec
 
+    # Keep matmul/linear operands in bf16 during device compilation instead of the
+    # default f32 upcast. Otherwise the fused AdaLayerNorm modulation weight is
+    # materialized in f32 (~3.4 GB) and OOMs DRAM. This only affects the TT
+    # compile path; the CPU golden is unchanged.
+    torch_options = {"tt_preserve_matmul_input_dtype": True}
+
     run_graph_test(
         model,
         inputs,
         framework=Framework.TORCH,
         mesh=mesh,
         shard_spec_fn=shard_spec_fn,
+        torch_options=torch_options,
     )


### PR DESCRIPTION
### Ticket
Fixes #5474 

### Problem description

tests/torch/models/hunyuan_video/test_transformer.py::test_transformer_sharded fails with a device DRAM out-of-memory at a ttnn.concat:

```
TT_FATAL: Out of Memory: Not enough space to allocate 3416260608 B DRAM buffer
across 12 banks, where each bank needs to store 284688384 B, but bank size is
1070773184 B (allocated: 809780928 B, free: 260992256 B) (bank_manager.cpp:462)
```

### What's changed

- The 3.4 GB buffer is the AdaLayerNorm modulation weight. All 81 modulation linears across the transformer (norm1.linear, norm1_context.linear, single-block norm.linear, final norm_out.linear, and the token refiner's HunyuanVideoAdaNorm.linear) share the same temb input, so tt-mlir's common-operand matmul fusion concatenates them into one 768 × 1,112,064 weight. That weight is f32 — even though the model is bf16 — because tt_torch's decomposition of aten.linear/aten.addmm (in torch_pass_pipeline's run_decompositions) upcasts every matmul operand to f32. The upcast comes from torch._decomp's addmm, which is wrapped in @pw_cast_for_opmath (bf16/fp16 → f32 for the op, result back down). f32 × the fused width = 3.4 GB, which overflows per-bank DRAM. This was isolated by tracing the model through dynamo (bf16 preserved) and then running the captured graph through torch_pass_pipeline stage by stage: run_decompositions is the stage that flips bf16→f32.

- The fix: a device-only, opt-in decomposition option tt_preserve_matmul_input_dtype. When set, populate_decompositions overrides aten.addmm with addmm_keep_input_dtype — a decomposition to torch.mm + bias add that omits the @pw_cast_for_opmath upcast, so bf16 operands stay bf16 (accumulation precision is still governed by fp32_dest_acc_en). With operands kept in bf16, the fused modulation constant materializes in bf16 (~1.7 GB, ~136 MiB/bank, under the ~249 MiB free) and the OOM clears.

- Plumbing and scope: the flag flows through torch.compile(options=...) → torch_pass_pipeline, which reads options.get("tt_preserve_matmul_input_dtype") and passes it to populate_decompositions. It is enabled for test_transformer_sharded via torch_options. Because the override lives only in the device decomposition path, the eager CPU golden is byte-for-byte unchanged; because it is opt-in, every other model keeps the default f32 upcast (no blast radius). Note the flag keeps all of the flagged model's matmul operands in their input dtype, not only the modulation linears; fp32_dest_acc_en preserves accumulation precision. No model or shard-spec changes are required, so the existing contracting-dim sharding still applies.

With these changes the sharded HunyuanVideo transformer test now compiles and runs end-to-end on 8 devices, with the CPU reference values unchanged.

### Logs
[hunyuan_transformer_before_fix.zip](https://github.com/user-attachments/files/29536669/hunyuan_transformer_before_fix.zip)
[hunyuan_video_transformer_after_fix_jul3.zip](https://github.com/user-attachments/files/29618433/hunyuan_video_transformer_after_fix_jul3.zip)