### PR TITLE
Change type of input params in On nightly

### DIFF
--- a/.github/workflows/manual-update-durations.yml
+++ b/.github/workflows/manual-update-durations.yml
@@ -5,108 +5,259 @@ name: Update Test Durations
 # calculates the test durations, and creates a pull request to update the `.test_durations` file.
 
 on:
+  schedule:
+    - cron: '0 0 * * 1-6'
+    - cron: '0 0 * * 0' # on Sundays, run with dump_irs=true
   workflow_dispatch:
 
 permissions:
-  actions: read
   contents: write
-  issues: write
-  pull-requests: write
+  actions: write
+  id-token: write
+  packages: write
+  checks: write
 
 jobs:
-  update_test_durations:
+  build-image:
+    uses: ./.github/workflows/call-build-docker.yml
+    secrets: inherit
+    with:
+      dockbuild: all
+
+  build-ttxla:
+    uses: ./.github/workflows/call-build.yml
+    name: "Build tt-xla"
+    secrets: inherit
+    needs: build-image
+    with:
+      docker_image: ${{ needs.build-image.outputs.docker-image }}
+      docker_image_manylinux: ${{ needs.build-image.outputs.docker-image-manylinux }}
+      build_types: release,manylinux
+
+  nightly_tests:
+    uses: ./.github/workflows/call-test.yml
+    secrets: inherit
+    needs: [ build-image, build-ttxla ]
+    with:
+      test_suite: basic-test-nightly.json
+      docker_image: ${{ needs.build-image.outputs.docker-image-base }}
+      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
+      artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
+      wheel_build: manylinux
+      dump_irs: ${{ github.event.schedule == '0 0 * * 0' }}
+
+  test_full_model:
+    uses: ./.github/workflows/call-test.yml
+    secrets: inherit
+    needs: [ build-image, build-ttxla ]
+    # This ensures the job runs regardless of success or failure of `nightly_tests`:
+    if: success() || failure()
+    with:
+      test_suite: model-test-full.json
+      docker_image: ${{ needs.build-image.outputs.docker-image-base }}
+      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
+      artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
+      wheel_build: manylinux
+      dump_irs: ${{ github.event.schedule == '0 0 * * 0' }}
+
+  # This is a single test job that runs all passing tt-forge-models tests.
+  test_forge_models_passing:
+    uses: ./.github/workflows/call-test.yml
+    secrets: inherit
+    needs: [ build-image, build-ttxla ]
+    # This ensures the job runs regardless of success or failure of `nightly_tests`:
+    if: success() || failure()
+    with:
+      test_suite: model-test-passing.json
+      docker_image: ${{ needs.build-image.outputs.docker-image-base }}
+      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
+      artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
+      wheel_build: manylinux
+      dump_irs: ${{ github.event.schedule == '0 0 * * 0' }}
+
+  # This is a single test job that runs all xfailing, skipped or placeholder tt-forge-models tests.
+  test_forge_models_xfail:
+    uses: ./.github/workflows/call-test.yml
+    secrets: inherit
+    needs: [ build-image, build-ttxla ]
+    # This ensures the job runs regardless of success or failure of `nightly_tests`:
+    if: success() || failure()
+    with:
+      test_suite: model-test-xfail.json
+      docker_image: ${{ needs.build-image.outputs.docker-image-base }}
+      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
+      artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
+      wheel_build: manylinux
+      dump_irs: ${{ github.event.schedule == '0 0 * * 0' }}
+
+  perf-benchmark:
+    uses: ./.github/workflows/call-filtered-perf-tests.yml
+    needs: [ build-image, build-ttxla ]
+    secrets: inherit
+    with:
+      docker_image: ${{ needs.build-image.outputs.docker-image-base }}
+      sh-runner: false
+      skip-device-perf: true
+      regression_check: true
+      adv_filter: '[ {"accuracy-testing": false}, {"runs-on": "n150-perf"}, {"runs-on": "p150-perf"}, {"runs-on": "n300-llmbox"}, {"runs-on": "galaxy-wh-6u"}, {"runs-on": "qb2-blackhole"} ]'
+      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
+      artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
+      wheel_build: manylinux
+
+  nightly-benchmark-report:
+    name: "Nightly benchmark report"
+    needs: [ build-image, build-ttxla, perf-benchmark ]
+    if: always()
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      actions: read
+      id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout repository
+        uses: actions/checkout@v6
         with:
-          fetch-depth: 0
-          # ref: main
-      - uses: actions/setup-python@v6
-      - name: Process test durations from latest workflows
-        id: get-test-durations
+          fetch-depth: 1
+          submodules: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install Claude Code CLI
+        run: |
+          npm install -g @anthropic-ai/claude-code
+          claude --version
+
+      - name: Run ci-benchmark-analyzer skill via Claude
         env:
           GH_TOKEN: ${{ github.token }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY_BENCHMARK_CI }}
         run: |
-          repo="tenstorrent/tt-xla"
+          # NOTE: `--allowed-tools` is variadic and would absorb the prompt arg;
+          # use `--` to terminate options before the positional prompt.
+          # `< /dev/null` suppresses the 3s stdin-wait warning when running headless.
+          claude --print \
+                 --permission-mode bypassPermissions \
+                 --model claude-opus-4-7 \
+                 --max-turns 60 \
+                 --allowed-tools "Bash(gh api:*),Bash(gh run download:*),Bash(python:*),Bash(python3:*),Bash(mkdir:*),Bash(ls:*),Bash(jq:*),Read,Write,Edit,Glob,Grep,Agent" \
+                 -- \
+                 "$(cat <<'PROMPT'
+          Use the `ci-benchmark-analyzer` skill at
+          `.claude/skills/ci-benchmark-analyzer/SKILL.md` to produce a
+          nightly report for workflow run ID `${{ github.run_id }}`.
 
-          get_test_results_from_wf() {
-            local wf_name="$1"
-            local conclusions="$2"
-            local num=5
+          Read the SKILL.md and follow it exactly. The skill will:
+            - read run metadata + jobs via `gh api`
+            - resolve the tt-mlir / tt-metal dependency chain
+            - run `.claude/skills/ci-benchmark-analyzer/scripts/fetch_perf_reports.py`
+              and `compare_nightlies.py`
+            - write `nightly-reports/nightly_${{ github.run_id }}_*.md`
 
-            # get json of the last $num workflow runs
-            gh run list --workflow $wf_name -R $repo -b main -L $num --status completed --json attempt,conclusion,databaseId >runs.json
+          Do NOT use the Glean MCP — it is not available in this CI
+          environment. Skip the "Context" enrichment and explicitly note
+          "Glean unavailable in CI" wherever the skill would have used it.
 
-            counter=0
-            while true; do
-              # Check the status of 'conclusion'
-              conclusion=$(jq -r ".[$counter].conclusion" runs.json)
+          After the report file is written, stop. Do NOT post GitHub
+          comments, create issues, or modify any files outside
+          `nightly-reports/`.
 
-              if echo "$conclusions" | grep -q -w "$conclusion"; then
-                break
-              else
-                ((++counter))
+          Use parallel subagents (via the Agent tool) wherever there is
+          independent I/O to speed up the report. Two natural fan-out points:
+            - Fetching failed-job logs: one subagent per failed job's
+              `gh api .../jobs/<id>/logs` call when there are 3+ failures.
+            - Running `fetch_perf_reports.py` (current run) and
+              `compare_nightlies.py` (current vs. previous run) concurrently
+              — they're independent and each does its own gh downloads.
+          Ask each subagent for a terse structured result (raw error label,
+          metric JSON path) rather than prose, so your context stays small.
+          PROMPT
+          )" < /dev/null
 
-                # Exit if the counter reaches $num
-                if [ $counter -ge $num ]; then
-                  echo "ERROR: Did not found good workflow within last $num. Exiting."
-                  exit 1
-                fi
-              fi
-            done
-            curr_wf_id=$(jq -r ".[$counter].databaseId" runs.json)
-            curr_wf_att=$(jq -r ".[$counter].attempt" runs.json)
-            echo "curr_$3_wf_link=\"https://github.com/$repo/actions/runs/$curr_wf_id/attempts/$curr_wf_att\"" >> "$GITHUB_OUTPUT"
-            rm -f runs.json
+      - name: Append report to job summary
+        run: |
+          REPORT=$(ls nightly-reports/nightly_${{ github.run_id }}_*.md 2>/dev/null | head -1)
+          if [ -z "$REPORT" ]; then
+            echo "::error::No nightly report was produced"
+            exit 1
+          fi
+          cat "$REPORT" >> $GITHUB_STEP_SUMMARY
 
-            gh run download $curr_wf_id --pattern "test-reports-*" -R $repo -D ${{runner.temp}}/reports
-          }
-
-          # get test results from the last nightly that was success or failure
-          get_test_results_from_wf "schedule-nightly.yml" "success,failure" "nightly"
-
-          # get test results from the last successful push
-          get_test_results_from_wf "push-main.yml" "success" "push"
-
-          # get test results from the last weekly that was success or failure
-          get_test_results_from_wf "schedule-weekly.yml" "success,failure" "weekly"
-
-          # get test results from the last weekly training that was success or failure
-          get_test_results_from_wf "schedule-weekly-training.yml" "success,failure" "weekly-training"
-
-          python .github/scripts/get_test_duration_from_junit_xmls.py ${{runner.temp}}/reports .test_durations
-          echo "" >> .test_durations
-          echo "----- NEW DURATIONS"
-          cat .test_durations
-
-          echo "TODAY=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
-
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
-        id: create-pr
+      - name: Upload report artifact
+        uses: actions/upload-artifact@v6
         with:
-          branch: test-durations-update
-          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-          author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
-          base: main
-          commit-message: "Update test durations based on latest workflows ${{ steps.get-test-durations.outputs.TODAY }}"
-          title: "Update test durations based on latest workflows ${{ steps.get-test-durations.outputs.TODAY }}"
-          body: "This PR updates test durations based on latest nightly (${{ steps.get-test-durations.outputs.curr_nightly_wf_link }}), latest weekly (${{ steps.get-test-durations.outputs.curr_weekly_wf_link }}), latest weekly training (${{ steps.get-test-durations.outputs.curr_weekly_training_wf_link }}) and latest push (${{ steps.get-test-durations.outputs.curr_push_wf_link }})"
-          labels: tooling
-          delete-branch: true
-          token: ${{ github.token }}
+          name: nightly-report-${{ github.run_id }}
+          path: nightly-reports/
+          retention-days: 90
 
-      - name: Enable Pull Request Automerge
-        if: ${{ steps.create-pr.outputs.pull-request-number }}
-        run: gh pr merge --squash --auto "${{ steps.create-pr.outputs.pull-request-number }}"
-        env:
-          GH_TOKEN: ${{ github.token }}
+  release:
+    uses: ./.github/workflows/call-release.yml
+    needs: [ build-ttxla ]
+    secrets: inherit
+    with:
+      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
+      wheel_release_artifact_name: xla-whl-manylinux${{ needs.build-ttxla.outputs.artifact_suffix }}
+      wheel_release_vllm_tt_artifact_name: vllm-tt-whl-release${{ needs.build-ttxla.outputs.artifact_suffix }}
+      is_nightly_release: true
 
-      - name: Generate Summary
-        run: |
-          echo "## Test duration report" >> $GITHUB_STEP_SUMMARY
-          echo "Used [Nightly](${{ steps.get-test-durations.outputs.curr_nightly_wf_link }})" >> $GITHUB_STEP_SUMMARY
-          echo "And [Push](${{ steps.get-test-durations.outputs.curr_push_wf_link }})" >> $GITHUB_STEP_SUMMARY
-          echo "And [Weekly](${{ steps.get-test-durations.outputs.curr_weekly_wf_link }})" >> $GITHUB_STEP_SUMMARY
-          echo "And [Weekly Training](${{ steps.get-test-durations.outputs.curr_weekly_training_wf_link }})" >> $GITHUB_STEP_SUMMARY
-          echo "Generated test durations in [Pull Request](${{ steps.create-pr.outputs.pull-request-url }})" >> $GITHUB_STEP_SUMMARY
+  release-forge:
+    uses: ./.github/workflows/call-forge-release.yml
+    needs: [ release ]
+    secrets: inherit
+    with:
+      release_tag: ${{ needs.release.outputs.release_tag }}
+
+  fail-notify:
+    if: always()
+    needs:
+      - nightly_tests
+      - test_full_model
+      - test_forge_models_passing
+      - test_forge_models_xfail
+      - build-image
+      - build-ttxla
+      - perf-benchmark
+    runs-on: Ubuntu-latest
+    outputs:
+      is-main: ${{ steps.branch-check.outputs.IS_MAIN }}
+      failed: ${{ steps.check.outputs.failure }}
+    steps:
+      - name: Check if branch is main
+        id: branch-check
+        run: echo "IS_MAIN=$(if [ '${{ github.ref }}' == 'refs/heads/main' ]; then echo true; else echo false; fi)" >> $GITHUB_OUTPUT
+      - name: Check if the needed jobs succeeded or failed
+        id: check
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}
+
+  fail-send-msg:
+    if: always()
+    needs:
+      - fail-notify
+    runs-on: Ubuntu-latest
+    steps:
+      - name: Send Fail Notification
+        if: ${{ needs.fail-notify.outputs.failed == 'true' && needs.fail-notify.outputs.is-main == 'true' }}
+        uses: slackapi/slack-github-action@v3.0.1
+        with:
+          webhook: ${{ secrets.SLACK_NIGHTLY_FAIL }}
+          webhook-type: webhook-trigger
+          payload: |
+            text: "Bad bad nightly: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}>"
+            unfurl_links: false
+            unfurl_media: false
+
+      - name: Send Success Notification
+        if: ${{ needs.fail-notify.outputs.failed == 'false' && needs.fail-notify.outputs.is-main == 'true' }}
+        uses: slackapi/slack-github-action@v3.0.1
+        with:
+          webhook: ${{ secrets.SLACK_NIGHTLY_SUCCESS }}
+          webhook-type: webhook-trigger
+          payload: |
+            text: "Good nightly: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}>"
+            unfurl_links: false
+            unfurl_media: false

--- a/.github/workflows/manual-update-durations.yml
+++ b/.github/workflows/manual-update-durations.yml
@@ -5,259 +5,108 @@ name: Update Test Durations
 # calculates the test durations, and creates a pull request to update the `.test_durations` file.
 
 on:
-  schedule:
-    - cron: '0 0 * * 1-6'
-    - cron: '0 0 * * 0' # on Sundays, run with dump_irs=true
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: write
-  actions: write
-  id-token: write
-  packages: write
-  checks: write
+  issues: write
+  pull-requests: write
 
 jobs:
-  build-image:
-    uses: ./.github/workflows/call-build-docker.yml
-    secrets: inherit
-    with:
-      dockbuild: all
-
-  build-ttxla:
-    uses: ./.github/workflows/call-build.yml
-    name: "Build tt-xla"
-    secrets: inherit
-    needs: build-image
-    with:
-      docker_image: ${{ needs.build-image.outputs.docker-image }}
-      docker_image_manylinux: ${{ needs.build-image.outputs.docker-image-manylinux }}
-      build_types: release,manylinux
-
-  nightly_tests:
-    uses: ./.github/workflows/call-test.yml
-    secrets: inherit
-    needs: [ build-image, build-ttxla ]
-    with:
-      test_suite: basic-test-nightly.json
-      docker_image: ${{ needs.build-image.outputs.docker-image-base }}
-      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
-      artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
-      wheel_build: manylinux
-      dump_irs: ${{ github.event.schedule == '0 0 * * 0' }}
-
-  test_full_model:
-    uses: ./.github/workflows/call-test.yml
-    secrets: inherit
-    needs: [ build-image, build-ttxla ]
-    # This ensures the job runs regardless of success or failure of `nightly_tests`:
-    if: success() || failure()
-    with:
-      test_suite: model-test-full.json
-      docker_image: ${{ needs.build-image.outputs.docker-image-base }}
-      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
-      artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
-      wheel_build: manylinux
-      dump_irs: ${{ github.event.schedule == '0 0 * * 0' }}
-
-  # This is a single test job that runs all passing tt-forge-models tests.
-  test_forge_models_passing:
-    uses: ./.github/workflows/call-test.yml
-    secrets: inherit
-    needs: [ build-image, build-ttxla ]
-    # This ensures the job runs regardless of success or failure of `nightly_tests`:
-    if: success() || failure()
-    with:
-      test_suite: model-test-passing.json
-      docker_image: ${{ needs.build-image.outputs.docker-image-base }}
-      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
-      artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
-      wheel_build: manylinux
-      dump_irs: ${{ github.event.schedule == '0 0 * * 0' }}
-
-  # This is a single test job that runs all xfailing, skipped or placeholder tt-forge-models tests.
-  test_forge_models_xfail:
-    uses: ./.github/workflows/call-test.yml
-    secrets: inherit
-    needs: [ build-image, build-ttxla ]
-    # This ensures the job runs regardless of success or failure of `nightly_tests`:
-    if: success() || failure()
-    with:
-      test_suite: model-test-xfail.json
-      docker_image: ${{ needs.build-image.outputs.docker-image-base }}
-      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
-      artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
-      wheel_build: manylinux
-      dump_irs: ${{ github.event.schedule == '0 0 * * 0' }}
-
-  perf-benchmark:
-    uses: ./.github/workflows/call-filtered-perf-tests.yml
-    needs: [ build-image, build-ttxla ]
-    secrets: inherit
-    with:
-      docker_image: ${{ needs.build-image.outputs.docker-image-base }}
-      sh-runner: false
-      skip-device-perf: true
-      regression_check: true
-      adv_filter: '[ {"accuracy-testing": false}, {"runs-on": "n150-perf"}, {"runs-on": "p150-perf"}, {"runs-on": "n300-llmbox"}, {"runs-on": "galaxy-wh-6u"}, {"runs-on": "qb2-blackhole"} ]'
-      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
-      artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
-      wheel_build: manylinux
-
-  nightly-benchmark-report:
-    name: "Nightly benchmark report"
-    needs: [ build-image, build-ttxla, perf-benchmark ]
-    if: always()
+  update_test_durations:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: read
-      actions: read
-      id-token: write
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
         with:
-          fetch-depth: 1
-          submodules: false
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.12'
-
-      - name: Install Claude Code CLI
-        run: |
-          npm install -g @anthropic-ai/claude-code
-          claude --version
-
-      - name: Run ci-benchmark-analyzer skill via Claude
+          fetch-depth: 0
+          # ref: main
+      - uses: actions/setup-python@v6
+      - name: Process test durations from latest workflows
+        id: get-test-durations
         env:
           GH_TOKEN: ${{ github.token }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY_BENCHMARK_CI }}
         run: |
-          # NOTE: `--allowed-tools` is variadic and would absorb the prompt arg;
-          # use `--` to terminate options before the positional prompt.
-          # `< /dev/null` suppresses the 3s stdin-wait warning when running headless.
-          claude --print \
-                 --permission-mode bypassPermissions \
-                 --model claude-opus-4-7 \
-                 --max-turns 60 \
-                 --allowed-tools "Bash(gh api:*),Bash(gh run download:*),Bash(python:*),Bash(python3:*),Bash(mkdir:*),Bash(ls:*),Bash(jq:*),Read,Write,Edit,Glob,Grep,Agent" \
-                 -- \
-                 "$(cat <<'PROMPT'
-          Use the `ci-benchmark-analyzer` skill at
-          `.claude/skills/ci-benchmark-analyzer/SKILL.md` to produce a
-          nightly report for workflow run ID `${{ github.run_id }}`.
+          repo="tenstorrent/tt-xla"
 
-          Read the SKILL.md and follow it exactly. The skill will:
-            - read run metadata + jobs via `gh api`
-            - resolve the tt-mlir / tt-metal dependency chain
-            - run `.claude/skills/ci-benchmark-analyzer/scripts/fetch_perf_reports.py`
-              and `compare_nightlies.py`
-            - write `nightly-reports/nightly_${{ github.run_id }}_*.md`
+          get_test_results_from_wf() {
+            local wf_name="$1"
+            local conclusions="$2"
+            local num=5
 
-          Do NOT use the Glean MCP — it is not available in this CI
-          environment. Skip the "Context" enrichment and explicitly note
-          "Glean unavailable in CI" wherever the skill would have used it.
+            # get json of the last $num workflow runs
+            gh run list --workflow $wf_name -R $repo -b main -L $num --status completed --json attempt,conclusion,databaseId >runs.json
 
-          After the report file is written, stop. Do NOT post GitHub
-          comments, create issues, or modify any files outside
-          `nightly-reports/`.
+            counter=0
+            while true; do
+              # Check the status of 'conclusion'
+              conclusion=$(jq -r ".[$counter].conclusion" runs.json)
 
-          Use parallel subagents (via the Agent tool) wherever there is
-          independent I/O to speed up the report. Two natural fan-out points:
-            - Fetching failed-job logs: one subagent per failed job's
-              `gh api .../jobs/<id>/logs` call when there are 3+ failures.
-            - Running `fetch_perf_reports.py` (current run) and
-              `compare_nightlies.py` (current vs. previous run) concurrently
-              — they're independent and each does its own gh downloads.
-          Ask each subagent for a terse structured result (raw error label,
-          metric JSON path) rather than prose, so your context stays small.
-          PROMPT
-          )" < /dev/null
+              if echo "$conclusions" | grep -q -w "$conclusion"; then
+                break
+              else
+                ((++counter))
 
-      - name: Append report to job summary
+                # Exit if the counter reaches $num
+                if [ $counter -ge $num ]; then
+                  echo "ERROR: Did not found good workflow within last $num. Exiting."
+                  exit 1
+                fi
+              fi
+            done
+            curr_wf_id=$(jq -r ".[$counter].databaseId" runs.json)
+            curr_wf_att=$(jq -r ".[$counter].attempt" runs.json)
+            echo "curr_$3_wf_link=\"https://github.com/$repo/actions/runs/$curr_wf_id/attempts/$curr_wf_att\"" >> "$GITHUB_OUTPUT"
+            rm -f runs.json
+
+            gh run download $curr_wf_id --pattern "test-reports-*" -R $repo -D ${{runner.temp}}/reports
+          }
+
+          # get test results from the last nightly that was success or failure
+          get_test_results_from_wf "schedule-nightly.yml" "success,failure" "nightly"
+
+          # get test results from the last successful push
+          get_test_results_from_wf "push-main.yml" "success" "push"
+
+          # get test results from the last weekly that was success or failure
+          get_test_results_from_wf "schedule-weekly.yml" "success,failure" "weekly"
+
+          # get test results from the last weekly training that was success or failure
+          get_test_results_from_wf "schedule-weekly-training.yml" "success,failure" "weekly-training"
+
+          python .github/scripts/get_test_duration_from_junit_xmls.py ${{runner.temp}}/reports .test_durations
+          echo "" >> .test_durations
+          echo "----- NEW DURATIONS"
+          cat .test_durations
+
+          echo "TODAY=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v8
+        id: create-pr
+        with:
+          branch: test-durations-update
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
+          base: main
+          commit-message: "Update test durations based on latest workflows ${{ steps.get-test-durations.outputs.TODAY }}"
+          title: "Update test durations based on latest workflows ${{ steps.get-test-durations.outputs.TODAY }}"
+          body: "This PR updates test durations based on latest nightly (${{ steps.get-test-durations.outputs.curr_nightly_wf_link }}), latest weekly (${{ steps.get-test-durations.outputs.curr_weekly_wf_link }}), latest weekly training (${{ steps.get-test-durations.outputs.curr_weekly_training_wf_link }}) and latest push (${{ steps.get-test-durations.outputs.curr_push_wf_link }})"
+          labels: tooling
+          delete-branch: true
+          token: ${{ github.token }}
+
+      - name: Enable Pull Request Automerge
+        if: ${{ steps.create-pr.outputs.pull-request-number }}
+        run: gh pr merge --squash --auto "${{ steps.create-pr.outputs.pull-request-number }}"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Generate Summary
         run: |
-          REPORT=$(ls nightly-reports/nightly_${{ github.run_id }}_*.md 2>/dev/null | head -1)
-          if [ -z "$REPORT" ]; then
-            echo "::error::No nightly report was produced"
-            exit 1
-          fi
-          cat "$REPORT" >> $GITHUB_STEP_SUMMARY
-
-      - name: Upload report artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: nightly-report-${{ github.run_id }}
-          path: nightly-reports/
-          retention-days: 90
-
-  release:
-    uses: ./.github/workflows/call-release.yml
-    needs: [ build-ttxla ]
-    secrets: inherit
-    with:
-      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
-      wheel_release_artifact_name: xla-whl-manylinux${{ needs.build-ttxla.outputs.artifact_suffix }}
-      wheel_release_vllm_tt_artifact_name: vllm-tt-whl-release${{ needs.build-ttxla.outputs.artifact_suffix }}
-      is_nightly_release: true
-
-  release-forge:
-    uses: ./.github/workflows/call-forge-release.yml
-    needs: [ release ]
-    secrets: inherit
-    with:
-      release_tag: ${{ needs.release.outputs.release_tag }}
-
-  fail-notify:
-    if: always()
-    needs:
-      - nightly_tests
-      - test_full_model
-      - test_forge_models_passing
-      - test_forge_models_xfail
-      - build-image
-      - build-ttxla
-      - perf-benchmark
-    runs-on: Ubuntu-latest
-    outputs:
-      is-main: ${{ steps.branch-check.outputs.IS_MAIN }}
-      failed: ${{ steps.check.outputs.failure }}
-    steps:
-      - name: Check if branch is main
-        id: branch-check
-        run: echo "IS_MAIN=$(if [ '${{ github.ref }}' == 'refs/heads/main' ]; then echo true; else echo false; fi)" >> $GITHUB_OUTPUT
-      - name: Check if the needed jobs succeeded or failed
-        id: check
-        uses: re-actors/alls-green@release/v1
-        with:
-          jobs: ${{ toJSON(needs) }}
-
-  fail-send-msg:
-    if: always()
-    needs:
-      - fail-notify
-    runs-on: Ubuntu-latest
-    steps:
-      - name: Send Fail Notification
-        if: ${{ needs.fail-notify.outputs.failed == 'true' && needs.fail-notify.outputs.is-main == 'true' }}
-        uses: slackapi/slack-github-action@v3.0.1
-        with:
-          webhook: ${{ secrets.SLACK_NIGHTLY_FAIL }}
-          webhook-type: webhook-trigger
-          payload: |
-            text: "Bad bad nightly: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}>"
-            unfurl_links: false
-            unfurl_media: false
-
-      - name: Send Success Notification
-        if: ${{ needs.fail-notify.outputs.failed == 'false' && needs.fail-notify.outputs.is-main == 'true' }}
-        uses: slackapi/slack-github-action@v3.0.1
-        with:
-          webhook: ${{ secrets.SLACK_NIGHTLY_SUCCESS }}
-          webhook-type: webhook-trigger
-          payload: |
-            text: "Good nightly: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}>"
-            unfurl_links: false
-            unfurl_media: false
+          echo "## Test duration report" >> $GITHUB_STEP_SUMMARY
+          echo "Used [Nightly](${{ steps.get-test-durations.outputs.curr_nightly_wf_link }})" >> $GITHUB_STEP_SUMMARY
+          echo "And [Push](${{ steps.get-test-durations.outputs.curr_push_wf_link }})" >> $GITHUB_STEP_SUMMARY
+          echo "And [Weekly](${{ steps.get-test-durations.outputs.curr_weekly_wf_link }})" >> $GITHUB_STEP_SUMMARY
+          echo "And [Weekly Training](${{ steps.get-test-durations.outputs.curr_weekly_training_wf_link }})" >> $GITHUB_STEP_SUMMARY
+          echo "Generated test durations in [Pull Request](${{ steps.create-pr.outputs.pull-request-url }})" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/schedule-nightly.yml
+++ b/.github/workflows/schedule-nightly.yml
@@ -4,7 +4,6 @@ on:
   schedule:
     - cron: '0 0 * * 1-6'
     - cron: '0 0 * * 0' # on Sundays, run with dump_irs=true
-  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/schedule-nightly.yml
+++ b/.github/workflows/schedule-nightly.yml
@@ -39,7 +39,7 @@ jobs:
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
       wheel_build: manylinux
-      dump_irs: ${{ github.event.schedule == '0 0 * * 0' && 'true' || 'false' }}
+      dump_irs: ${{ github.event.schedule == '0 0 * * 0' && true || false }}
 
   test_full_model:
     uses: ./.github/workflows/call-test.yml
@@ -53,7 +53,7 @@ jobs:
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
       wheel_build: manylinux
-      dump_irs: ${{ github.event.schedule == '0 0 * * 0' && 'true' || 'false' }}
+      dump_irs: ${{ github.event.schedule == '0 0 * * 0' && true || false }}
 
   # This is a single test job that runs all passing tt-forge-models tests.
   test_forge_models_passing:
@@ -68,7 +68,7 @@ jobs:
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
       wheel_build: manylinux
-      dump_irs: ${{ github.event.schedule == '0 0 * * 0' && 'true' || 'false' }}
+      dump_irs: ${{ github.event.schedule == '0 0 * * 0' && true || false }}
 
   # This is a single test job that runs all xfailing, skipped or placeholder tt-forge-models tests.
   test_forge_models_xfail:
@@ -83,7 +83,7 @@ jobs:
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
       wheel_build: manylinux
-      dump_irs: ${{ github.event.schedule == '0 0 * * 0' && 'true' || 'false' }}
+      dump_irs: ${{ github.event.schedule == '0 0 * * 0' && true || false }}
 
   perf-benchmark:
     uses: ./.github/workflows/call-filtered-perf-tests.yml

--- a/.github/workflows/schedule-nightly.yml
+++ b/.github/workflows/schedule-nightly.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: '0 0 * * 1-6'
     - cron: '0 0 * * 0' # on Sundays, run with dump_irs=true
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -39,7 +40,7 @@ jobs:
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
       wheel_build: manylinux
-      dump_irs: ${{ github.event.schedule == '0 0 * * 0' && true || false }}
+      dump_irs: ${{ github.event.schedule == '0 0 * * 0' }}
 
   test_full_model:
     uses: ./.github/workflows/call-test.yml
@@ -53,7 +54,7 @@ jobs:
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
       wheel_build: manylinux
-      dump_irs: ${{ github.event.schedule == '0 0 * * 0' && true || false }}
+      dump_irs: ${{ github.event.schedule == '0 0 * * 0' }}
 
   # This is a single test job that runs all passing tt-forge-models tests.
   test_forge_models_passing:
@@ -68,7 +69,7 @@ jobs:
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
       wheel_build: manylinux
-      dump_irs: ${{ github.event.schedule == '0 0 * * 0' && true || false }}
+      dump_irs: ${{ github.event.schedule == '0 0 * * 0' }}
 
   # This is a single test job that runs all xfailing, skipped or placeholder tt-forge-models tests.
   test_forge_models_xfail:
@@ -83,7 +84,7 @@ jobs:
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
       wheel_build: manylinux
-      dump_irs: ${{ github.event.schedule == '0 0 * * 0' && true || false }}
+      dump_irs: ${{ github.event.schedule == '0 0 * * 0' }}
 
   perf-benchmark:
     uses: ./.github/workflows/call-filtered-perf-tests.yml


### PR DESCRIPTION
### Ticket
/

### Problem description
- Some of the test suites in On nightly fail on call and are skipped because the input param is of the wrong type (expected boolean, string is passed).

### What's changed
- Change the type of input params to boolean.

### Checklist
- [ ] [Example](https://github.com/tenstorrent/tt-xla/actions/runs/28647772885) of the new On nightly
