### PR TITLE
Mistral 3.1 small 24B vLLM benchmark

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -749,6 +749,13 @@
         "runs-on": "n300-llmbox"
       },
       {
+        "name": "vllm_mistral_small_3_1_24b_tp",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[mistral-small-3.1-24b-tp]",
+        "vllm": true,
+        "skip-device-perf": true,
+        "runs-on": "galaxy-wh-6u"
+      },
+      {
         "name": "vllm_llama_3_1_8b_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[llama-3.1-8b-tp]",
         "vllm": true,

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -152,7 +152,7 @@ def _mistral_small_31_tp_config(model: str, batch_size: int):
     # mirroring _gemma4_tp_config. Runs on galaxy-wh-6u in a 8x4 mesh.
     #
     # Validated max_model_len of 8192 at GMU of 0.65, but the current default
-    # of max_model_len i 128, so it needs to be overriden through the env. var.
+    # of max_model_len is 128, so it needs to be overriden through the env. var.
     cfg = _config(
         model,
         batch_size,

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -190,6 +190,12 @@ def _mistral_small_31_tp_config(model: str, batch_size: int):
     cfg.limit_mm_per_prompt = {"image": 0}
     # Instruct-tuned: drive via the chat template for coherent output.
     cfg.use_chat_template = True
+    # Optional: force a long generation so a short prompt still fills the context
+    # (e.g. TT_BENCHMARK_MAX_TOKENS=4096 with a ~12-token prompt exercises full
+    # 4096-token KV cache per sequence -- makes b32 concurrency actually bind).
+    _bench_max_tokens = os.environ.get("TT_BENCHMARK_MAX_TOKENS")
+    if _bench_max_tokens is not None:
+        cfg.max_tokens = int(_bench_max_tokens)
     return cfg
 
 

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -146,6 +146,53 @@ def _gemma4_tp_config(model: str, batch_size: int):
     return cfg
 
 
+def _mistral_small_31_tp_config(model: str, batch_size: int):
+    # Mistral-Small-3.1 is a Pixtral-based multimodal model, benchmarked
+    # text-only (limit_mm_per_prompt zeroed so the vision tower never compiles),
+    # mirroring _gemma4_tp_config. Runs on galaxy-wh-6u (32 devices).
+    #
+    # mesh_shape=[8, 4] = 4-way tensor-parallel (model axis) x 8-way batch/data
+    # axis. This matches the TP width validated for this 24B model on n300-llmbox
+    # ([2, 4], also model axis 4) and keeps 2 KV heads/device (Mistral has 8 KV
+    # heads). The mesh factoring is a perf choice to benchmark, not a correctness
+    # one; both factorings are SPMD-equivalent. (The alternative [4, 8] widens TP
+    # to 8, collapsing KV heads to 1/device, which also trips the tt-metal
+    # sdpa_decode tree-reduction cap.)
+    #
+    # Production knobs per FORGE_MODEL_INTEGRATION_GUIDE Stage 1: opt level 1,
+    # bfp_bf8 weights + KV cache, trace (enable_trace defaults True in _config),
+    # const-eval, batch 32, and b1-prefill optimization (min_num_seqs=1 +
+    # prefill_batch_threshold=16). Context length and GPU-memory utilization are
+    # swept at run time via TT_BENCHMARK_MAX_MODEL_LEN / TT_BENCHMARK_GMU.
+    #
+    # Deviation from the doc's cpu_sampling=false (on-device) target: _config
+    # force-sets cpu_sampling=True at opt>=1 (device sampling + trace + opt>=1 is
+    # rejected upstream). Reaching the device-sampling path needs that guard
+    # relaxed and is out of scope for this benchmark entry.
+    cfg = _config(
+        model,
+        batch_size,
+        gpu_memory_utilization=0.15,
+        optimization_level=1,
+        experimental_weight_dtype="bfp_bf8",
+        experimental_kv_cache_dtype="bfp_bf8",
+        enable_tensor_parallel=True,
+        use_2d_mesh=False,
+        mesh_shape=[8, 4],
+        min_context_len=32,
+        enable_const_eval=True,
+        # b1-prefill optimization: serve prefills serially (small graph) when
+        # <=16 are pending instead of a wasted-row b32 batch. Needs min_num_seqs
+        # < max_num_seqs (batch_size=32).
+        min_num_seqs=1,
+        prefill_batch_threshold=16,
+    )
+    cfg.limit_mm_per_prompt = {"image": 0}
+    # Instruct-tuned: drive via the chat template for coherent output.
+    cfg.use_chat_template = True
+    return cfg
+
+
 SINGLE_DEVICE_CONFIGS = [
     # Llama
     pytest.param(_config("meta-llama/Llama-3.2-1B-Instruct"), id="llama-3.2-1b"),
@@ -230,6 +277,12 @@ TP_CONFIGS = [
     pytest.param(
         _tp_config("mistralai/Mistral-Small-24B-Instruct-2501", 32, mesh_shape=[2, 4]),
         id="mistral-small-24b-instruct-2501-tp",
+    ),
+    pytest.param(
+        _mistral_small_31_tp_config(
+            "mistralai/Mistral-Small-3.1-24B-Instruct-2503", 32
+        ),
+        id="mistral-small-3.1-24b-tp",
     ),
     pytest.param(
         _tp_config("meta-llama/Llama-3.1-8B-Instruct", 32, mesh_shape=[2, 4]),

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -62,6 +62,8 @@ def _config(
         additional["fp32_dest_acc_en"] = fp32_dest_acc_en
     if optimization_level > 0:
         additional["optimization_level"] = optimization_level
+        # TTConfig raises if enable_trace=True AND opt>=1 AND cpu_sampling=False
+        additional["cpu_sampling"] = True
     if _BENCH_CPU_SAMPLING:
         additional["cpu_sampling"] = True
     if _BENCH_KV_CACHE_DTYPE:

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -62,8 +62,6 @@ def _config(
         additional["fp32_dest_acc_en"] = fp32_dest_acc_en
     if optimization_level > 0:
         additional["optimization_level"] = optimization_level
-        # TTConfig raises if enable_trace=True AND opt>=1 AND cpu_sampling=False
-        additional["cpu_sampling"] = True
     if _BENCH_CPU_SAMPLING:
         additional["cpu_sampling"] = True
     if _BENCH_KV_CACHE_DTYPE:
@@ -169,10 +167,14 @@ def _mistral_small_31_tp_config(model: str, batch_size: int):
     # force-sets cpu_sampling=True at opt>=1 (device sampling + trace + opt>=1 is
     # rejected upstream). Reaching the device-sampling path needs that guard
     # relaxed and is out of scope for this benchmark entry.
+    # Validated Stage 1 production point on galaxy-wh-6u [8, 4]: b32 @ 8192
+    # context, GMU 0.66 -> concurrency >= 32 (no preemption), compiles + serves
+    # + captures trace without DRAM OOM. ~8.4 tok/s/user, TTFT ~9.9s (inflated by
+    # the FABRIC_1D degraded fabric, tt-metal #43210, and cpu_sampling=True).
     cfg = _config(
         model,
         batch_size,
-        gpu_memory_utilization=0.15,
+        gpu_memory_utilization=0.65,
         optimization_level=1,
         experimental_weight_dtype="bfp_bf8",
         experimental_kv_cache_dtype="bfp_bf8",
@@ -190,9 +192,14 @@ def _mistral_small_31_tp_config(model: str, batch_size: int):
     cfg.limit_mm_per_prompt = {"image": 0}
     # Instruct-tuned: drive via the chat template for coherent output.
     cfg.use_chat_template = True
+    # Default to the validated 8192 target context; TT_BENCHMARK_MAX_MODEL_LEN
+    # still overrides (_config wires max_model_len to that env var, default 128).
+    if os.environ.get("TT_BENCHMARK_MAX_MODEL_LEN") is None:
+        cfg.max_model_len = 8192
     # Optional: force a long generation so a short prompt still fills the context
-    # (e.g. TT_BENCHMARK_MAX_TOKENS=4096 with a ~12-token prompt exercises full
-    # 4096-token KV cache per sequence -- makes b32 concurrency actually bind).
+    # (e.g. TT_BENCHMARK_MAX_TOKENS=8192 with a ~12-token prompt exercises the
+    # full 8192-token KV cache per sequence -- makes b32 concurrency actually
+    # bind, as validated above).
     _bench_max_tokens = os.environ.get("TT_BENCHMARK_MAX_TOKENS")
     if _bench_max_tokens is not None:
         cfg.max_tokens = int(_bench_max_tokens)

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -147,30 +147,10 @@ def _gemma4_tp_config(model: str, batch_size: int):
 def _mistral_small_31_tp_config(model: str, batch_size: int):
     # Mistral-Small-3.1 is a Pixtral-based multimodal model, benchmarked
     # text-only (limit_mm_per_prompt zeroed so the vision tower never compiles),
-    # mirroring _gemma4_tp_config. Runs on galaxy-wh-6u (32 devices).
+    # mirroring _gemma4_tp_config. Runs on galaxy-wh-6u in a 8x4 mesh.
     #
-    # mesh_shape=[8, 4] = 4-way tensor-parallel (model axis) x 8-way batch/data
-    # axis. This matches the TP width validated for this 24B model on n300-llmbox
-    # ([2, 4], also model axis 4) and keeps 2 KV heads/device (Mistral has 8 KV
-    # heads). The mesh factoring is a perf choice to benchmark, not a correctness
-    # one; both factorings are SPMD-equivalent. (The alternative [4, 8] widens TP
-    # to 8, collapsing KV heads to 1/device, which also trips the tt-metal
-    # sdpa_decode tree-reduction cap.)
-    #
-    # Production knobs per FORGE_MODEL_INTEGRATION_GUIDE Stage 1: opt level 1,
-    # bfp_bf8 weights + KV cache, trace (enable_trace defaults True in _config),
-    # const-eval, batch 32, and b1-prefill optimization (min_num_seqs=1 +
-    # prefill_batch_threshold=16). Context length and GPU-memory utilization are
-    # swept at run time via TT_BENCHMARK_MAX_MODEL_LEN / TT_BENCHMARK_GMU.
-    #
-    # Deviation from the doc's cpu_sampling=false (on-device) target: _config
-    # force-sets cpu_sampling=True at opt>=1 (device sampling + trace + opt>=1 is
-    # rejected upstream). Reaching the device-sampling path needs that guard
-    # relaxed and is out of scope for this benchmark entry.
-    # Validated Stage 1 production point on galaxy-wh-6u [8, 4]: b32 @ 8192
-    # context, GMU 0.66 -> concurrency >= 32 (no preemption), compiles + serves
-    # + captures trace without DRAM OOM. ~8.4 tok/s/user, TTFT ~9.9s (inflated by
-    # the FABRIC_1D degraded fabric, tt-metal #43210, and cpu_sampling=True).
+    # Validated max_model_len of 8192 at GMU of 0.65, but the current default
+    # of max_model_len i 128, so it needs to be overriden through the env. var.
     cfg = _config(
         model,
         batch_size,
@@ -192,17 +172,6 @@ def _mistral_small_31_tp_config(model: str, batch_size: int):
     cfg.limit_mm_per_prompt = {"image": 0}
     # Instruct-tuned: drive via the chat template for coherent output.
     cfg.use_chat_template = True
-    # Default to the validated 8192 target context; TT_BENCHMARK_MAX_MODEL_LEN
-    # still overrides (_config wires max_model_len to that env var, default 128).
-    if os.environ.get("TT_BENCHMARK_MAX_MODEL_LEN") is None:
-        cfg.max_model_len = 8192
-    # Optional: force a long generation so a short prompt still fills the context
-    # (e.g. TT_BENCHMARK_MAX_TOKENS=8192 with a ~12-token prompt exercises the
-    # full 8192-token KV cache per sequence -- makes b32 concurrency actually
-    # bind, as validated above).
-    _bench_max_tokens = os.environ.get("TT_BENCHMARK_MAX_TOKENS")
-    if _bench_max_tokens is not None:
-        cfg.max_tokens = int(_bench_max_tokens)
     return cfg
 
 

--- a/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
@@ -263,6 +263,51 @@ def test_tensor_parallel_generation_mistral_small(model_name: str, opt_level: in
     check_host_memory(model_name)
 
 
+@pytest.mark.nigtly
+@pytest.mark.tensor_parallel
+@pytest.mark.galaxy_wh_6u
+@pytest.mark.parametrize(
+    ["model_name", "mesh_shape", "opt_level"],
+    [pytest.param("mistralai/Mistral-Small-3.1-24B-Instruct-2503", [4, 8], 0)],
+)
+def test_tensor_parallel_generation_galaxy_wh_6u_mistral_small(
+    model_name: str, mesh_shape: list[int], opt_level: int
+):
+    image_url = "https://static.wikia.nocookie.net/essentialsdocs/images/7/70/Battle.png/revision/latest?cb=20220523172438"
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "What action do you think I should take in this situation? ",
+                },
+                {"type": "image_url", "image_url": {"url": image_url}},
+            ],
+        }
+    ]
+    sampling_params = vllm.SamplingParams(temperature=0.8, top_p=0.95, max_tokens=32)
+    llm = vllm.LLM(
+        model=model_name,
+        limit_mm_per_prompt={"image": 1},
+        max_num_batched_tokens=3025,
+        max_num_seqs=1,
+        max_model_len=512,
+        gpu_memory_utilization=0.01,
+        additional_config={
+            "min_context_len": 32,
+            "enable_tensor_parallel": True,
+            "experimental_weight_dtype": "bfp_bf8",
+            "mesh_shape": mesh_shape,
+            "optimization_level": opt_level,
+        },
+    )
+    output_text = llm.chat(messages, sampling_params=sampling_params)[0].outputs[0].text
+    print(f"output: {output_text}")
+    assert_output_coherent(output_text)
+    check_host_memory(model_name)
+
+
 @pytest.mark.nightly
 @pytest.mark.tensor_parallel
 @pytest.mark.galaxy_wh_6u

--- a/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
@@ -268,7 +268,7 @@ def test_tensor_parallel_generation_mistral_small(model_name: str, opt_level: in
 @pytest.mark.galaxy_wh_6u
 @pytest.mark.parametrize(
     ["model_name", "mesh_shape", "opt_level"],
-    [pytest.param("mistralai/Mistral-Small-3.1-24B-Instruct-2503", [4, 8], 0)],
+    [pytest.param("mistralai/Mistral-Small-3.1-24B-Instruct-2503", [8, 4], 0)],
 )
 def test_tensor_parallel_generation_galaxy_wh_6u_mistral_small(
     model_name: str, mesh_shape: list[int], opt_level: int

--- a/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
@@ -263,51 +263,6 @@ def test_tensor_parallel_generation_mistral_small(model_name: str, opt_level: in
     check_host_memory(model_name)
 
 
-@pytest.mark.nigtly
-@pytest.mark.tensor_parallel
-@pytest.mark.galaxy_wh_6u
-@pytest.mark.parametrize(
-    ["model_name", "mesh_shape", "opt_level"],
-    [pytest.param("mistralai/Mistral-Small-3.1-24B-Instruct-2503", [8, 4], 0)],
-)
-def test_tensor_parallel_generation_galaxy_wh_6u_mistral_small(
-    model_name: str, mesh_shape: list[int], opt_level: int
-):
-    image_url = "https://static.wikia.nocookie.net/essentialsdocs/images/7/70/Battle.png/revision/latest?cb=20220523172438"
-    messages = [
-        {
-            "role": "user",
-            "content": [
-                {
-                    "type": "text",
-                    "text": "What action do you think I should take in this situation? ",
-                },
-                {"type": "image_url", "image_url": {"url": image_url}},
-            ],
-        }
-    ]
-    sampling_params = vllm.SamplingParams(temperature=0.8, top_p=0.95, max_tokens=32)
-    llm = vllm.LLM(
-        model=model_name,
-        limit_mm_per_prompt={"image": 1},
-        max_num_batched_tokens=3025,
-        max_num_seqs=1,
-        max_model_len=512,
-        gpu_memory_utilization=0.01,
-        additional_config={
-            "min_context_len": 32,
-            "enable_tensor_parallel": True,
-            "experimental_weight_dtype": "bfp_bf8",
-            "mesh_shape": mesh_shape,
-            "optimization_level": opt_level,
-        },
-    )
-    output_text = llm.chat(messages, sampling_params=sampling_params)[0].outputs[0].text
-    print(f"output: {output_text}")
-    assert_output_coherent(output_text)
-    check_host_memory(model_name)
-
-
 @pytest.mark.nightly
 @pytest.mark.tensor_parallel
 @pytest.mark.galaxy_wh_6u


### PR DESCRIPTION
Bringup of Mistral 3.1 small 24B on galaxy. Task https://github.com/tenstorrent/tt-xla/issues/5458.

This PR adds the required CI vllm benchmark before the model can be integrated with tt-shield.