### PR TITLE
Add declarative activation sharding constraints

### DIFF
--- a/tests/infra/runners/torch_device_runner.py
+++ b/tests/infra/runners/torch_device_runner.py
@@ -119,6 +119,34 @@ def to_device(x, device, depth=5, moved=None):
         return x
 
 
+def _register_activation_constraints(activation_specs, mesh) -> None:
+    """Register forward hooks that constrain each module's OUTPUT sharding.
+
+    ``activation_specs`` maps a module -> output partition spec (``None`` means
+    fully replicate). Hooks are idempotent and registered at most once per module
+    (this runs on every execution). The constraint only fires for XLA tensors, so
+    it is a no-op on the CPU golden path.
+    """
+    if not activation_specs:
+        return
+    from tt_torch.sharding import sharding_constraint_tensor
+
+    def _make_hook(spec):
+        def _hook(_module, _inputs, out):
+            if not torch.is_tensor(out) or out.device.type != "xla":
+                return out
+            resolved = spec if spec is not None else tuple([None] * out.dim())
+            return sharding_constraint_tensor(out, mesh, resolved)
+
+        return _hook
+
+    for module, spec in activation_specs.items():
+        if getattr(module, "_tt_activation_constraint_hooked", False):
+            continue
+        module.register_forward_hook(_make_hook(spec))
+        module._tt_activation_constraint_hooked = True
+
+
 class TorchDeviceRunner(DeviceRunner):
     """Device runner used with torch."""
 
@@ -203,6 +231,19 @@ class TorchDeviceRunner(DeviceRunner):
         if shard_specs is not None:
             for tensor, shard_spec in shard_specs.items():
                 xs.mark_sharding(tensor, workload.mesh, shard_spec)
+
+        # Apply activation sharding constraints (on intermediate module OUTPUTS)
+        # as forward hooks. Complements the weight mark_sharding above. Registered
+        # once per module (this method runs on every execution, e.g. perf warmup).
+        if (
+            is_multichip
+            and device.type != "cpu"
+            and getattr(workload, "activation_shard_spec_fn", None)
+            and workload.model is not None
+        ):
+            _register_activation_constraints(
+                workload.activation_shard_spec_fn(workload.model), workload.mesh
+            )
 
         # In the future, we will deprecate `workload.model` and use only
         # `workload.compiled_executable` carrying the model.

--- a/tests/infra/testers/single_chip/model/model_tester.py
+++ b/tests/infra/testers/single_chip/model/model_tester.py
@@ -85,6 +85,12 @@ class ModelTester(BaseTester, ABC):
         """Optional: returns shard specs function if required; otherwise None."""
         return None
 
+    def _get_activation_shard_spec_function(self) -> Optional[Callable]:
+        """Optional: returns an activation sharding-constraint function
+        (model -> {module: output_partition_spec}) if required; otherwise None.
+        Applied as forward hooks by the device runner."""
+        return None
+
     def _get_mesh(self) -> Optional[Mesh]:
         """Optional: returns mesh if required; otherwise None."""
         return None

--- a/tests/infra/testers/single_chip/model/torch_model_tester.py
+++ b/tests/infra/testers/single_chip/model/torch_model_tester.py
@@ -145,6 +145,7 @@ class TorchModelTester(ModelTester):
             kwargs=kwargs,
             mesh=self._get_mesh(),
             shard_spec_fn=self._get_shard_specs_function(),
+            activation_shard_spec_fn=self._get_activation_shard_spec_function(),
         )
 
         if self._parallelism == Parallelism.TENSOR_PARALLEL:

--- a/tests/infra/workloads/torch_workload.py
+++ b/tests/infra/workloads/torch_workload.py
@@ -31,6 +31,7 @@ class TorchWorkload(Workload):
         static_argnames: Optional[Sequence[str]] = None,
         mesh: Optional[Mesh] = None,
         shard_spec_fn: Optional[Callable] = None,
+        activation_shard_spec_fn: Optional[Callable] = None,
     ) -> None:
 
         super().__init__(
@@ -44,6 +45,10 @@ class TorchWorkload(Workload):
         )
         self.mesh = mesh
         self.shard_spec_fn = shard_spec_fn
+        # Optional callable model -> {module: output_partition_spec}. Constrains
+        # intermediate ACTIVATIONS (applied as forward hooks by the device runner),
+        # complementing shard_spec_fn which shards weights.
+        self.activation_shard_spec_fn = activation_shard_spec_fn
         self._enable_xla_spmd_if_needed()
 
     # If model has shard specs and running on multichip mesh, then convert StableHLO

--- a/tests/runner/testers/torch/dynamic_torch_model_tester.py
+++ b/tests/runner/testers/torch/dynamic_torch_model_tester.py
@@ -237,6 +237,18 @@ class DynamicTorchModelTester(TorchModelTester):
 
         return weight_fn
 
+    def _get_activation_shard_spec_function(self):
+        """Activation sharding-constraint function from the loader.
+
+        Returns the loader's ``load_activation_shard_spec`` (model ->
+        {module: output_partition_spec}) if it exposes one; the device runner
+        applies these as forward hooks. Tensor-parallel only.
+        """
+        if self.parallelism != Parallelism.TENSOR_PARALLEL:
+            return None
+        fn = getattr(self.dynamic_loader.loader, "load_activation_shard_spec", None)
+        return fn if callable(fn) else None
+
     def _get_mesh(self):
         """Get mesh configuration from the dynamic loader if available.
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
The gated-delta (linear-attention) block uses a fused QKV projection (in_proj_qkv) whose output is later split with torch.split into separate Q, K, and V tensors.

Under tensor-parallel sharding, that fused output is sharded contiguously along the "model" axis. The torch.split then cuts that same axis at the Q/K/V boundaries but those boundaries don't align with the per-device shard boundaries. So each device ends up splitting its local shard at the wrong offsets, and Q/K/V get misaligned/scrambled before the recurrence. The model computes on garbage-partitioned data and full-model PCC collapses.

The fix is to replicate the fused output before the split so the split runs on complete, correctly-ordered data. But there was no general mechanism to constrain the sharding of intermediate activations only weights (load_shard_spec + mark_sharding).

### What's changed
Introduces a generic, opt-in mechanism where a model declares activation sharding constraints and the device runner applies them  mirroring the existing weight-sharding path. Four layers, only the first is model-specific:

- Declare (model loader, opt-in) — a loader may define load_activation_shard_spec(model) → {module: output_partition_spec} (None = replicate the module's output). (Ships separately in the tt-forge-models submodule.)
- Discover — DynamicTorchModelTester._get_activation_shard_spec_function() picks it up via getattr (tensor-parallel only); returns None if the loader doesn't define it.
- Plumb — base ModelTester._get_activation_shard_spec_function() → None (default for all models); TorchModelTester passes it into TorchWorkload.activation_shard_spec_fn.
- Apply — TorchDeviceRunner, after the weight mark_sharding, registers idempotent forward hooks that constrain each declared module's output via sharding_constraint_tensor (None → fully replicate). XLA-only, so the CPU golden path is unaffected.

**Key properties**

- Generic / model-agnostic runner: layers 2–4 contain no model-specific knowledge. Models that don't define load_activation_shard_spec flow through as None and see zero behavior change.
- Declarative: the model states intent conv1d: None; the runner owns the how.
- For gated-delta this replicates the fused-QKV conv output before the split, so Q/K/V stay aligned.

### Checklist
- [ ] New/Existing tests provide coverage for changes
