### PR TITLE
Fix emitpy tests false-timeout

### DIFF
--- a/.github/workflows/manual-test.yml
+++ b/.github/workflows/manual-test.yml
@@ -33,6 +33,7 @@ on:
           - 'model-test-lb-blackhole-weekly.json'
           - 'model-test-emitpy.json'
           - 'model-test-emitpy-xfail.json'
+          - 'model-test-emitpy-weekly.json'
           - 'basic-multihost-test.json'
           - 'Custom'
       test_suite_custom:

--- a/.github/workflows/manual-test.yml
+++ b/.github/workflows/manual-test.yml
@@ -32,6 +32,7 @@ on:
           - 'model-test-lb-blackhole-nightly.json'
           - 'model-test-lb-blackhole-weekly.json'
           - 'model-test-emitpy.json'
+          - 'model-test-emitpy-xfail.json'
           - 'basic-multihost-test.json'
           - 'Custom'
       test_suite_custom:

--- a/.github/workflows/schedule-nightly.yml
+++ b/.github/workflows/schedule-nightly.yml
@@ -95,6 +95,38 @@ jobs:
       dumped_irs_run_id: ${{ github.run_id }}
       target_time_min: 180
 
+  # EmitPy verification: re-run passing torch inference models via the codegen_py
+  # backend and compare against the flatbuffer result.
+  test_forge_models_emitpy:
+    uses: ./.github/workflows/call-test.yml
+    secrets: inherit
+    needs: [ build-image, build-ttxla ]
+    # This ensures the job runs regardless of success or failure of `nightly_tests`:
+    if: success() || failure()
+    with:
+      test_suite: model-test-emitpy.json
+      docker_image: ${{ needs.build-image.outputs.docker-image-base }}
+      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
+      artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
+      wheel_build: manylinux
+      dump_irs: ${{ github.event.schedule == '0 0 * * 0' }}
+
+  # EmitPy known failures: models that pass normally but fail EmitPy verification.
+  # Marked via emitpy_overrides as xfails so they are tracked separately.
+  test_forge_models_emitpy_xfail:
+    uses: ./.github/workflows/call-test.yml
+    secrets: inherit
+    needs: [ build-image, build-ttxla ]
+    # This ensures the job runs regardless of success or failure of `nightly_tests`:
+    if: success() || failure()
+    with:
+      test_suite: model-test-emitpy-xfail.json
+      docker_image: ${{ needs.build-image.outputs.docker-image-base }}
+      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
+      artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
+      wheel_build: manylinux
+      dump_irs: ${{ github.event.schedule == '0 0 * * 0' }}
+
   perf-benchmark:
     uses: ./.github/workflows/call-filtered-perf-tests.yml
     needs: [ build-image, build-ttxla ]

--- a/.github/workflows/schedule-weekly.yml
+++ b/.github/workflows/schedule-weekly.yml
@@ -63,11 +63,27 @@ jobs:
       dumped_irs_run_id: ${{ github.run_id }}
       target_time_min: 180
 
+  # EmitPy verification for tensor-parallel models on qb2 (weekly cadence, matching
+  # the normal qb2 TP job). Re-runs passing TP models via codegen_py and compares
+  # against the flatbuffer result.
+  test_forge_models_emitpy:
+    uses: ./.github/workflows/call-test.yml
+    secrets: inherit
+    needs: [ build-image, build-ttxla ]
+    with:
+      test_suite: model-test-emitpy-weekly.json
+      docker_image: ${{ needs.build-image.outputs.docker-image-base }}
+      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
+      artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
+      wheel_build: manylinux
+      dump_irs: true
+
   fail-notify:
     if: always()
     needs:
       - test_forge_models_passing
       - test_forge_models_xfail
+      - test_forge_models_emitpy
       - build-image
       - build-ttxla
     runs-on: Ubuntu-latest

--- a/.github/workflows/test-matrix-presets/model-test-emitpy-weekly.json
+++ b/.github/workflows/test-matrix-presets/model-test-emitpy-weekly.json
@@ -1,0 +1,3 @@
+[
+  {"runs-on": "qb2-blackhole", "name": "run_forge_models_multichip_torch", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "qb2-blackhole and weekly and tensor_parallel and expected_passing", "require": "alchemist", "parallel-groups": 2, "args": "--emitpy", "forge-models": true}
+]

--- a/.github/workflows/test-matrix-presets/model-test-emitpy-xfail.json
+++ b/.github/workflows/test-matrix-presets/model-test-emitpy-xfail.json
@@ -1,0 +1,4 @@
+[
+  {"runs-on": "n150", "name": "run_forge_models",             "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "n150 and nightly and emitpy_xfail and single_device and inference", "require": "alchemist", "parallel-groups": 2, "args": "--emitpy", "forge-models": true, "forked": true},
+  {"runs-on": "p150", "name": "run_forge_models",             "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "p150 and nightly and emitpy_xfail and single_device and inference", "require": "alchemist", "parallel-groups": 2, "args": "--emitpy", "forge-models": true, "forked": true}
+]

--- a/.github/workflows/test-matrix-presets/model-test-emitpy.json
+++ b/.github/workflows/test-matrix-presets/model-test-emitpy.json
@@ -1,5 +1,6 @@
 [
   {"runs-on": "n150", "name": "run_forge_models",             "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "n150 and nightly and expected_passing and single_device and inference", "require": "alchemist", "parallel-groups": 3, "args": "--emitpy", "forge-models": true, "forked": true},
   {"runs-on": "p150", "name": "run_forge_models",             "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "p150 and nightly and expected_passing and single_device and inference", "require": "alchemist", "parallel-groups": 3, "args": "--emitpy", "forge-models": true, "forked": true},
-  {"runs-on": "n300", "name": "run_forge_models_multichip",   "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "n300 and nightly and expected_passing and data_parallel and inference", "require": "alchemist", "parallel-groups": 1, "args": "--emitpy", "forge-models": true}
+  {"runs-on": "n300", "name": "run_forge_models_multichip",   "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "n300 and nightly and expected_passing and data_parallel and inference", "require": "alchemist", "args": "--emitpy", "forge-models": true},
+  {"runs-on": "galaxy-wh-6u", "name": "run_forge_models_multichip", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "galaxy-wh-6u and nightly and tensor_parallel and expected_passing", "contains": "gpt_oss/pytorch-20B", "require": "alchemist", "args": "--emitpy", "forge-models": true}
 ]

--- a/pytest.ini
+++ b/pytest.ini
@@ -15,6 +15,7 @@ markers =
     expected_passing: Test is expected to pass
     unspecified: Test has no status yet, needs triage
     placeholder: Test is a placeholder model for reporting purposes
+    emitpy_xfail: Test passes normally but is a known failure under --emitpy (via emitpy_overrides)
     # RunMode
     inference: marks test as inference
     training: marks test as training

--- a/tests/runner/conftest.py
+++ b/tests/runner/conftest.py
@@ -168,6 +168,7 @@ def pytest_collection_modifyitems(config, items):
     Also deselect tests explicitly marked with EXCLUDE_MODEL so they do not run.
     """
     arch = config.getoption("--arch")
+    emitpy = config.getoption("--emitpy")
 
     # Merge torch and jax test configs once outside the loop
     combined_test_config = torch_test_config | jax_test_config | torch_llm_test_config
@@ -181,7 +182,12 @@ def pytest_collection_modifyitems(config, items):
         if "[" in nodeid:
             nodeid = nodeid[nodeid.index("[") + 1 : -1]
 
-        meta = ModelTestConfig(combined_test_config.get(nodeid), arch)
+        # --emitpy runs prefix the id. Strip it so the
+        # config lookup matches the mode-agnostic YAML keys. emitpy=True then lets
+        # ModelTestConfig apply any emitpy_overrides on top of the base entry.
+        nodeid = nodeid.removeprefix("emitpy-")
+
+        meta = ModelTestConfig(combined_test_config.get(nodeid), arch, emitpy=emitpy)
         item._test_meta = meta  # attach for fixture access
 
         # Uncomment this to print info for each test collected.

--- a/tests/runner/conftest.py
+++ b/tests/runner/conftest.py
@@ -222,6 +222,16 @@ def pytest_collection_modifyitems(config, items):
         elif meta.status == ModelTestStatus.UNSPECIFIED:
             item.add_marker(pytest.mark.unspecified)
 
+        # Tests flipped to xfail specifically by emitpy_overrides get an extra
+        # 'emitpy_xfail' marker, so an emitpy run can select just these
+        # (via `-m emitpy_xfail`) rather than every known_failure_xfail test.
+        if (
+            emitpy
+            and meta.data.get("emitpy_overrides", {}).get("status")
+            == ModelTestStatus.KNOWN_FAILURE_XFAIL
+        ):
+            item.add_marker(pytest.mark.emitpy_xfail)
+
         # Apply any custom/extra markers from config (e.g., "push", "nightly", "weekly")
         config_markers = getattr(meta, "markers", []) or []
         for marker_name in config_markers:

--- a/tests/runner/test_config/config_loader.py
+++ b/tests/runner/test_config/config_loader.py
@@ -8,7 +8,11 @@ from typing import Any, Dict
 from ruamel.yaml import YAML
 
 from tests.infra.utilities.types import Framework
-from tests.runner.test_config.constants import ALLOWED_FIELDS, PLACEHOLDERS_FILENAME
+from tests.runner.test_config.constants import (
+    ALLOWED_FIELDS,
+    EMITPY_OVERRIDE_FIELDS,
+    PLACEHOLDERS_FILENAME,
+)
 from tests.runner.test_utils import ModelTestStatus
 from tests.utils import BringupStatus
 
@@ -70,6 +74,11 @@ def _normalize_enums_in_cfg(cfg: Dict[str, Any]) -> Dict[str, Any]:
             if isinstance(arch_cfg, dict):
                 overrides[arch] = _normalize_enums_in_cfg(arch_cfg)
 
+    # Normalize emitpy_overrides, if present
+    emitpy_overrides = cfg.get("emitpy_overrides")
+    if isinstance(emitpy_overrides, dict):
+        cfg["emitpy_overrides"] = _normalize_enums_in_cfg(emitpy_overrides)
+
     return cfg
 
 
@@ -89,6 +98,16 @@ def _validate_allowed_keys(cfg: Dict[str, Any], *, ctx: str) -> None:
         for arch, arch_cfg in overrides.items():
             if isinstance(arch_cfg, dict):
                 validate_mapping(arch_cfg, where=f"arch_overrides['{arch}']")
+
+    # emitpy_overrides is restricted to status-related fields only.
+    emitpy_overrides = cfg.get("emitpy_overrides")
+    if isinstance(emitpy_overrides, dict):
+        for k in emitpy_overrides.keys():
+            if k not in EMITPY_OVERRIDE_FIELDS:
+                raise ValueError(
+                    f"Unknown field '{k}' in emitpy_overrides of {ctx}. "
+                    f"Allowed: {sorted(EMITPY_OVERRIDE_FIELDS)}"
+                )
 
 
 # Validate that filecheck pattern files referenced in config exist in tests/filecheck/

--- a/tests/runner/test_config/constants.py
+++ b/tests/runner/test_config/constants.py
@@ -34,6 +34,8 @@ ALLOWED_FIELDS = {
     "batch_size",
     # Nested arch overrides
     "arch_overrides",
+    # Nested emitpy overrides (applied only under --emitpy, e.g. status: xfail)
+    "emitpy_overrides",
     # Needed for training tests
     "execution_pass",
     # FileCheck patterns list
@@ -45,6 +47,14 @@ ALLOWED_FIELDS = {
     "inject_custom_moe",
     # EmitPy verification: assert exact match between emitpy and flatbuffer results
     "emitpy_assert_exact",
+}
+
+# Fields allowed inside an emitpy_overrides block. Intentionally restricted to the
+# bring-up status (and its reason): emitpy_overrides only exists to flip a model's
+# pass/xfail/skip status under --emitpy, not to override comparator/compiler config.
+EMITPY_OVERRIDE_FIELDS = {
+    "status",
+    "reason",
 }
 
 # Single source of truth for the placeholders YAML filename

--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -582,6 +582,9 @@ test_config:
   phi2/causal_lm/pytorch-Phi_2-single_device-inference:
     markers: [baseline_uplift]
     status: EXPECTED_PASSING
+    emitpy_overrides:
+      status: KNOWN_FAILURE_XFAIL
+      reason: "EmitPy result differs from flatbuffer (non-exact match)"
     optimization_level: 2
 
   phi2/causal_lm/pytorch-Phi_2_Pytdml-single_device-inference:
@@ -741,6 +744,9 @@ test_config:
 
   phi1/causal_lm/pytorch-Phi_1-single_device-inference:
     status: EXPECTED_PASSING
+    emitpy_overrides:
+      status: KNOWN_FAILURE_XFAIL
+      reason: "EmitPy result differs from flatbuffer (non-exact match)"
 
   phi1/token_classification/pytorch-Phi_1-single_device-inference:
     status: EXPECTED_PASSING
@@ -791,11 +797,17 @@ test_config:
     supported_archs: ["p150"]
     status: KNOWN_FAILURE_XFAIL
     reason: "Failure due to incompatible torchvision version. Issue: https://github.com/tenstorrent/tt-xla/issues/5519"
+    emitpy_overrides:
+      status: KNOWN_FAILURE_XFAIL
+      reason: "EmitPy result differs from flatbuffer (non-exact match)"
 
   pi_0/pytorch-pi0_base-single_device-inference:
     supported_archs: ["p150"]
     status: KNOWN_FAILURE_XFAIL
     reason: "Failure due to incompatible torchvision version. Issue: https://github.com/tenstorrent/tt-xla/issues/5519"
+    emitpy_overrides:
+      status: KNOWN_FAILURE_XFAIL
+      reason: "EmitPy result differs from flatbuffer (non-exact match)"
 
   opt/qa/pytorch-1.3b-single_device-inference:
     status: EXPECTED_PASSING
@@ -939,6 +951,9 @@ test_config:
   qwen_2_5/causal_lm/pytorch-3B_Instruct-single_device-inference:
     assert_pcc: false
     status: EXPECTED_PASSING
+    emitpy_overrides:
+      status: KNOWN_FAILURE_XFAIL
+      reason: "EmitPy result differs from flatbuffer (non-exact match)"
     optimization_level: 2
 
   qwen_2_5_coder/pytorch-3B_Instruct-single_device-inference:
@@ -954,6 +969,9 @@ test_config:
   qwen_2_5/causal_lm/pytorch-1.5B_Instruct-single_device-inference:
     assert_pcc: false
     status: EXPECTED_PASSING
+    emitpy_overrides:
+      status: KNOWN_FAILURE_XFAIL
+      reason: "EmitPy result differs from flatbuffer (non-exact match)"
     markers: [push]
     optimization_level: 1
 
@@ -1015,6 +1033,9 @@ test_config:
   qwen_2_5/causal_lm/pytorch-0.5B_Instruct-single_device-inference:
     markers: [baseline_uplift]
     status: EXPECTED_PASSING
+    emitpy_overrides:
+      status: KNOWN_FAILURE_XFAIL
+      reason: "EmitPy result differs from flatbuffer (non-exact match)"
 
   llama/causal_lm/pytorch-3.2_3B_Instruct-single_device-inference:
     status: EXPECTED_PASSING
@@ -1285,6 +1306,9 @@ test_config:
   gemma/pytorch-1.1_2B_IT-single_device-inference:
     markers: [baseline_uplift]
     status: EXPECTED_PASSING
+    emitpy_overrides:
+      status: KNOWN_FAILURE_XFAIL
+      reason: "EmitPy result differs from flatbuffer (non-exact match)"
 
   nbeats/pytorch-generic_basis-single_device-inference:
     status: EXPECTED_PASSING
@@ -1446,6 +1470,9 @@ test_config:
 
   gemma/pytorch-2_2B_IT-single_device-inference:
     status: EXPECTED_PASSING
+    emitpy_overrides:
+      status: KNOWN_FAILURE_XFAIL
+      reason: "EmitPy result differs from flatbuffer (non-exact match)"
     markers: ["extended", push]
     optimization_level: 2
 
@@ -1576,6 +1603,9 @@ test_config:
 
   qwen_3/embedding/pytorch-Embedding_8B-single_device-inference:
     status: EXPECTED_PASSING
+    emitpy_overrides:
+      status: KNOWN_FAILURE_XFAIL
+      reason: "EmitPy result differs from flatbuffer (non-exact match)"
     optimization_level: 1
     arch_overrides:
       n150:
@@ -1637,6 +1667,9 @@ test_config:
 
   llama/causal_lm/pytorch-3.1_8B_Instruct-single_device-inference:
     status: EXPECTED_PASSING
+    emitpy_overrides:
+      status: KNOWN_FAILURE_XFAIL
+      reason: "EmitPy result differs from flatbuffer (non-exact match)"
     assert_pcc: false # ComputeConfig math_fidelity/fp32_dest_acc_en - https://github.com/tenstorrent/tt-xla/issues/2861
     optimization_level: 2
     arch_overrides:
@@ -1764,6 +1797,9 @@ test_config:
   qwen_2_5/causal_lm/pytorch-14B_Instruct-single_device-inference:
     supported_archs: ["p150"] # Runs as tensor_parallel for wormhole.
     status: EXPECTED_PASSING
+    emitpy_overrides:
+      status: KNOWN_FAILURE_XFAIL
+      reason: "EmitPy result differs from flatbuffer (non-exact match)"
 
   qwen_2_5/causal_lm/pytorch-14B_Instruct_1M-single_device-inference:
     arch_overrides:
@@ -1789,6 +1825,9 @@ test_config:
         bringup_status: FAILED_RUNTIME
 
   qwen_2_5/causal_lm/pytorch-7B_Instruct-single_device-inference:
+    emitpy_overrides:
+      status: KNOWN_FAILURE_XFAIL
+      reason: "EmitPy result differs from flatbuffer (non-exact match)"
     optimization_level: 1
     arch_overrides:
       p150:
@@ -2612,6 +2651,9 @@ test_config:
 
   ssd512/object_detection/pytorch-ssd512-single_device-inference:
     status: EXPECTED_PASSING
+    emitpy_overrides:
+      status: KNOWN_FAILURE_XFAIL
+      reason: "EmitPy result differs from flatbuffer (non-exact match)"
 
   qwen_3_vl/image_to_text/pytorch-2b_instruct-single_device-inference:
     status: KNOWN_FAILURE_XFAIL
@@ -2762,4 +2804,7 @@ test_config:
   gemma3/multimodal/pytorch-google/gemma-3-12b-it-single_device-inference:
     supported_archs: ["p150"]
     status: EXPECTED_PASSING
+    emitpy_overrides:
+      status: KNOWN_FAILURE_XFAIL
+      reason: "EmitPy result differs from flatbuffer (non-exact match)"
     assert_pcc: false #issue: https://github.com/tenstorrent/tt-xla/issues/5117

--- a/tests/runner/test_models.py
+++ b/tests/runner/test_models.py
@@ -77,6 +77,37 @@ test_entries_torch_regular = [
 all_test_entries = test_entries_torch_regular + test_entries_jax
 
 
+def pytest_generate_tests(metafunc):
+    """Give --emitpy runs of test_all_models_torch a distinct test id.
+
+    EmitPy runs do extra per-test work and their durations are significantly longer
+    than the normal run, so they need unique designators to differentiate them in
+    .test_durations (used for timeout estimation and split balancing). When --emitpy
+    is set we prefix the id with "emitpy". The prefix is stripped in
+    pytest_collection_modifyitems before looking up the (mode-agnostic) YAML config.
+
+    Only applies to functions that declare the emitpy_mode parameter (currently
+    just test_all_models_torch). The fixturenames guard keeps this a no-op for the
+    other functions in this module, which would otherwise error on parametrize.
+    """
+    if metafunc.config.getoption("--emitpy") and "emitpy_mode" in metafunc.fixturenames:
+        # Value is unused, only ids= affects the designator.
+        metafunc.parametrize("emitpy_mode", [None], ids=["emitpy"])
+
+
+@pytest.fixture
+def emitpy_mode(request):
+    """Fallback provider for the emitpy_mode argument on non-emitpy runs.
+
+    Tests that may run with the emitpy flag must declare emitpy_mode, so pytest
+    needs a value for it on every run. On --emitpy runs pytest_generate_tests
+    parametrizes it directly (and this fixture is bypassed). On normal runs it
+    isn't parametrized, so this supplies the default value. The value itself is
+    never read by the test.
+    """
+    return getattr(request, "param", None)
+
+
 def _run_model_test_impl(
     test_entry,
     run_mode: RunMode,
@@ -343,6 +374,7 @@ def test_all_models_torch(
     request,
     captured_output_fixture,
     clear_torchxla_computation_cache,
+    emitpy_mode,
 ):
     """PyTorch model test - delegates to shared implementation."""
     _run_model_test_impl(

--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -142,9 +142,10 @@ class ModelTestStatus(Enum):
 
 
 class ModelTestConfig:
-    def __init__(self, data, arch=None):
+    def __init__(self, data, arch=None, emitpy=False):
         self.data = data or {}
         self.arch = arch
+        self.emitpy = emitpy
 
         # For marking tests as expected passing, known failures, etc
         self.status = self._resolve("status", default=ModelTestStatus.UNSPECIFIED)
@@ -220,9 +221,15 @@ class ModelTestConfig:
         self.emitpy_assert_exact = self._resolve("emitpy_assert_exact", default=True)
 
     def _resolve(self, key, default=None):
-        overrides = self.data.get("arch_overrides", {})
-        if self.arch in overrides and key in overrides[self.arch]:
-            return overrides[self.arch][key]
+        # EmitPy runs may override the bring-up status (via emitpy_overrides,
+        # restricted to status/reason), so a model can be EXPECTED_PASSING on the
+        # normal path but xfail under --emitpy.
+        emitpy_overrides = self.data.get("emitpy_overrides", {})
+        if self.emitpy and key in emitpy_overrides:
+            return emitpy_overrides[key]
+        arch_overrides = self.data.get("arch_overrides", {})
+        if self.arch in arch_overrides and key in arch_overrides[self.arch]:
+            return arch_overrides[self.arch][key]
         return self.data.get(key, default)
 
     def to_comparison_config(self) -> ComparisonConfig:

--- a/tests/runner/validate_test_config.py
+++ b/tests/runner/validate_test_config.py
@@ -30,6 +30,7 @@ if _PROJECT_ROOT not in sys.path:
 from tests.runner.test_config.constants import (
     ALLOWED_ARCHES,
     ALLOWED_FIELDS,
+    EMITPY_OVERRIDE_FIELDS,
     FRAMEWORKS,
     LLM_BATCH_SIZES,
     LLM_MESH_SHAPES,
@@ -352,6 +353,19 @@ class TestConfigValidator:
                                         f"arch_overrides['{arch_key}'] of {ctx}. "
                                         f"Allowed: {sorted(ALLOWED_FIELDS)}"
                                     )
+
+            # Validate emitpy_overrides (restricted to status-related fields only)
+            emitpy_overrides = cfg.get("emitpy_overrides")
+            if emitpy_overrides is not None:
+                if not isinstance(emitpy_overrides, dict):
+                    errors.append(f"emitpy_overrides is not a dict in {ctx}")
+                else:
+                    for key in emitpy_overrides.keys():
+                        if key not in EMITPY_OVERRIDE_FIELDS:
+                            errors.append(
+                                f"Unknown field '{key}' in emitpy_overrides of {ctx}. "
+                                f"Allowed: {sorted(EMITPY_OVERRIDE_FIELDS)}"
+                            )
 
             # Validate filecheck references
             self._validate_filechecks(cfg, ctx, errors)


### PR DESCRIPTION
### Ticket
Closes #5513, #5349

### Problem description
Previously, emitpy tests could be triggered only manually by running the `model-test-emitpy.json` workflow. 

### What's changed
Added emitpy tests to the nightly. This includes the following:
1. **Distinct emitpy test designators + per-mode config.**
   `--emitpy` runs now get their own test ID, which is an`emitpy-` prefixed regular ID, so they no longer collide with the normal runs in `.test_durations`, and failures are attributable to the right mode. Added `emitpy_overrides` in the YAML config (restricted to `status`/`reason`, mirroring `arch_overrides`) so a model can be `EXPECTED_PASSING` normally but flipped under `--emitpy` (this is only temporary until all emitpy nightly tests are fixed).

2. **Nightly emitpy jobs + classified the current failures.**
   Added `test_forge_models_emitpy` (passing) and `test_forge_models_emitpy_xfail`
   (tracked xfails) to `schedule-nightly.yml`, mirroring the normal
   passing/xfail split. Introduced an `emitpy_xfail` marker so the xfail job
   selects only emitpy-specific failures.

3. **Multi-chip emitpy coverage.**
   Added qb2-blackhole tensor-parallel emitpy to the weekly pipeline
   (`schedule-weekly.yml`, matching qb2 TP's weekly cadence) and galaxy-wh-6u
   tensor-parallel emitpy to the nightly (limited to `gpt_oss/pytorch-20B` as an example).

### Follow-up
EmitPy test durations aren't recorded yet. They currently use the 240-min default
timeout until the first scheduled run + a `manual-update-durations` refresh.

### Checklist
- [ ] New/Existing tests provide coverage for changes
