### PR TITLE
[vLLM] Precompile prefill graphs largest-first to avoid DRAM-fragmentation OOM

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -2360,6 +2360,10 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             if not (prefix_chunk and num_tokens == 1)
         ]
 
+        # Compile largest buckets first so the biggest pinned trace buffers get a
+        # clean DRAM arena, avoiding fragmentation OOMs at long context (#5522).
+        configs.sort(key=lambda c: (c["num_reqs"], c["num_tokens"]), reverse=True)
+
         for config in configs:
             if config["num_tokens"] == 1 and config["num_reqs"] != self.max_num_reqs:
                 logger.debug(
@@ -2742,9 +2746,10 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 )
                 torch_xla.sync()
 
-        num_reqs_options = sorted({self.min_num_reqs, self.max_num_reqs})
-        for num_tokens in self.num_tokens_paddings:
-            for warmup_num_reqs in num_reqs_options:
+        # Largest-first, as in _precompile_model_fused, to avoid fragmentation (#5522).
+        num_reqs_options = sorted({self.min_num_reqs, self.max_num_reqs}, reverse=True)
+        for warmup_num_reqs in num_reqs_options:
+            for num_tokens in reversed(self.num_tokens_paddings):
                 _run_backbone_dummies(num_tokens, warmup_num_reqs, prefix_chunk=False)
                 # Precompile the cached-prefix graph for prompt chunks
                 # (num_tokens > 1) so it isn't compiled on the first continuation.


### PR DESCRIPTION
### Ticket

Closes https://github.com/tenstorrent/tt-xla/issues/5522 
Closes https://github.com/tenstorrent/tt-xla/issues/5501

### Problem description

A b32, `enable_trace`, BFP8 (weights + KV) config at long context — e.g. **Llama-3.1-8B** at `max_model_len=65536`, `prefill_chunk_size=2048`, `max_num_seqs=32` on a single P150 — OOMs during warmup trace-capture. Every precompiled prefill bucket's working buffers are pinned in DRAM for replay, so all buckets coexist; warmup compiled them smallest-first, so the largest activation (the b32 × 2048 SwiGLU MLP intermediate, ~1.75 GiB) was allocated **last**, into an arena already fragmented by the smaller buckets. It fails even with plenty of total DRAM free — a contiguity miss, not capacity.

### What's changed

Precompile prefill buckets **largest-first** so the biggest buffer lands in a clean DRAM arena and the smaller ones pack into the remainder:

- `_precompile_model_fused` (device-sampling path): sort configs by `(num_reqs, num_tokens)` descending.
- `_precompile_backbone` (cpu_sampling path): iterate `num_reqs` then `num_tokens` descending.

Unconditional; no new config/knob. Compiled graphs and model outputs are unchanged — only the allocation order differs. Eliminates the chunk-2048 prefill OOM at long context, same config with only the order flipped:

| model | gpu_memory_utilization | before | after |
|---|---|---|---|
| Llama-3.1-8B @ 65536 | 0.30 / 0.325 | OOM | PASS |
| Qwen3-8B @ 40960 | 0.325 / **0.35** | OOM | PASS |

Qwen3-8B now reaches gmu 0.35 at chunk 2048; Llama-3.1-8B tops out at 0.325 (at 0.35 it becomes KV-capacity-bound rather than fragmentation-bound). No regression on the shipping config (Llama-3.1-8B, chunk 1024, gmu 0.35: throughput/TTFT and warmup time unchanged).

### Checklist

- [ ] vLLM Nightly: https://github.com/tenstorrent/tt-xla/actions/runs/28692899943
 - [x] **cpu_sampling=False**: Llama-3.1-8B, Qwen3-8B — OOM → PASS at chunk 2048.
 - [x] **cpu_sampling=True**: Llama-3.2-3B — backbone path compiles and serves.