### PR TITLE
[forge-models] Fix Transformers 5.x model load failures in CI

### DIFF
--- a/tests/runner/conftest.py
+++ b/tests/runner/conftest.py
@@ -7,6 +7,9 @@ import os
 import pytest
 
 from tests.runner.requirements import RequirementsManager
+from third_party.tt_forge_models.tools.transformers_compat import (
+    apply_transformers_compat_patches,
+)
 from tests.runner.test_config.constants import ALLOWED_ARCHES
 from tests.runner.test_config.jax import test_config as jax_test_config
 from tests.runner.test_config.torch import test_config as torch_test_config
@@ -57,12 +60,14 @@ def pytest_sessionstart(session):
     inherited by all children via fork().
     """
     RequirementsManager.capture_golden_state()
+    apply_transformers_compat_patches()
 
 
 @pytest.fixture(autouse=True)
 def restore_pip_env_if_dirty():
     """Restore pip environment before each test if a previous fork was killed."""
     RequirementsManager.check_and_restore_environment()
+    apply_transformers_compat_patches()
 
 
 def _get_model_group_from_item(item):

--- a/tests/runner/requirements.py
+++ b/tests/runner/requirements.py
@@ -254,6 +254,7 @@ class RequirementsManager:
             f"[Requirements] __enter__: changed_versions={sorted(self._changed_versions.keys())}"
         )
         self._purge_stale_modules()
+        self._apply_transformers_compat_patches()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
@@ -305,6 +306,7 @@ class RequirementsManager:
                         os.unlink(restore_file)
 
             self._purge_stale_modules()
+            self._apply_transformers_compat_patches()
         finally:
             # Always release the lock if held
             if self._lock_file is not None:
@@ -401,6 +403,14 @@ class RequirementsManager:
                 f"'{normalized_fallback}'."
             )
         return {normalized_fallback}
+
+    @staticmethod
+    def _apply_transformers_compat_patches() -> None:
+        from third_party.tt_forge_models.tools.transformers_compat import (
+            apply_transformers_compat_patches,
+        )
+
+        apply_transformers_compat_patches()
 
     def _purge_stale_modules(self) -> None:
         """Remove changed/new packages from sys.modules so re-imports load from disk.


### PR DESCRIPTION
## Summary

Weekly CI model tests started failing after the repo default was uplifted to **Transformers 5.5.1**. This PR adds shared compatibility helpers under `third_party/tt_forge_models/tools/` and wires them into the forge test runner so model loading works again across affected loaders.

- **`transformers_compat.py`**: patches `smart_apply` to tolerate legacy 2-arg init functions when Transformers 5.x passes `(module, is_remote_code)`, and rewrites `from_pretrained()` calls that incorrectly pass a `PreTrainedConfig` as the first argument (which otherwise becomes strings like `Qwen2Config { ... }` and fails Hub validation).
- **`hf_loading.py`**: shared tokenizer/model load helpers that apply compat patches and avoid invalid kwargs (e.g. `torch_dtype` on tokenizers).

Also includes small loader/runner follow-ups needed for the failing models:
- Hook compat patches in `tests/runner/conftest.py` and `tests/runner/requirements.py` (including after per-model transformers upgrades/purges).
- Remove `torch_dtype` from tokenizer loads where applicable.
- Add `trust_remote_code=True` for CohereLabs loaders.
- Align `hyperclovax_32b` to `transformers>=5.9.0`.

Submodule: `tt-forge-models` @ `baf653e9ae` on branch `fix/transformers-5-compat-forge-loaders` (https://github.com/tenstorrent/tt-forge-models/tree/fix/transformers-5-compat-forge-loaders).

### Models addressed

**`smart_apply` / weight init**
- `exaone_3_5/pytorch-EXAONE-3.5-32B-Instruct`
- `falcon/pytorch-40B_Instruct`
- `hyperclovax/pytorch-HyperCLOVAX_SEED_Think_14B`
- `coherlabs/pytorch-Coherelabs_c4ai_command_r_v01`
- `coherlabs/pytorch-Coherelabs_aya_23_35b`
- `hyperclovax_32b/pytorch-HyperCLOVAX_SEED_Think_32B`

**Config passed as repo id**
- `baichuan_m2/pytorch-Baichuan-M2-32B`
- `phind/pytorch-Phind-CodeLlama-34B-v2`
- `deepseek/qwen/pytorch-R1_Distill_14B`
- `deepseek/deepseek_coder/pytorch-33B_Instruct`
- `vicuna/pytorch-33B_v1.3`
- `mistral/codestral/pytorch-Codestral-22B-v0.1`
- `wizardmath_70b/pytorch-WizardMath-70B-V1.0`

## Test plan

- [ ] Verify compat patches apply before model load in forge tests (`conftest` autouse fixture + requirements purge path)
- [ ] Smoke-load affected models locally (one from each failure bucket)
- [ ] Re-run weekly tensor-parallel inference matrix (or targeted subset) and confirm Transformers load errors are gone
- [ ] Confirm no regressions on models without per-model requirements pins

Made with [Cursor](https://cursor.com)