### PR TITLE
Fix several nightly failures from July 6, 2026

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -390,6 +390,10 @@ test_config:
   motif_image_6B_preview/text_to_image/pytorch-Motif-Image-6B-Preview-single_device-inference:
     status: KNOWN_FAILURE_XFAIL
     reason: "DYNAMO_FAKE_TENSORS_FX_NODE: Dynamo failed to run FX node with fake tensors: aten.add.Tensor — two different devices xla:0, cpu"
+    arch_overrides:
+      n150:
+        status: NOT_SUPPORTED_SKIP
+        reason: "Host OOM: process SIGKILL (signal 9) on n150 runner during nightly (heavy model exceeds host memory); cannot run to its classified failure"
 
   nanogpt/pytorch-Default-single_device-inference:
     status: EXPECTED_PASSING
@@ -1566,6 +1570,10 @@ test_config:
   vadv2/pytorch-single_device-inference:
     status: KNOWN_FAILURE_XFAIL
     reason: "RuntimeError('Check failed: handle->HasValue(): Trying to access XLA data for tensor with ID 5271 while an async operation is in flight: UNKNOWN_SCALAR[]')"
+    arch_overrides:
+      n150:
+        status: NOT_SUPPORTED_SKIP
+        reason: "Host OOM: process SIGKILL (signal 9) on n150 runner during nightly (heavy model exceeds host memory); cannot run to its classified failure"
 
   huggyllama/pytorch-Llama_7B-single_device-inference:
     status: EXPECTED_PASSING

--- a/tests/runner/test_config/torch_llm/test_config_training_single_device.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_training_single_device.yaml
@@ -49,8 +49,13 @@ test_config:
 
 
   phi1/causal_lm/pytorch-Phi_1-llm_prefill-seq_128-batch_4-single_device-mesh_default-training:
-    status: EXPECTED_PASSING
-    required_pcc: 0.98
+    arch_overrides:
+      n150:
+        status: KNOWN_FAILURE_XFAIL
+        reason: "Out of Memory: Not enough space to allocate 8388608 B DRAM buffer across 12 banks - https://github.com/tenstorrent/tt-xla/issues/5340"
+      p150:
+        assert_pcc: false
+        status: EXPECTED_PASSING
 
   phi1_lora/causal_lm/pytorch-Phi_1-llm_prefill-seq_128-batch_4-single_device-mesh_default-training:
     arch_overrides:

--- a/tests/runner/test_config/torch_llm/test_config_training_single_device.yaml
+++ b/tests/runner/test_config/torch_llm/test_config_training_single_device.yaml
@@ -54,8 +54,8 @@ test_config:
         status: KNOWN_FAILURE_XFAIL
         reason: "Out of Memory: Not enough space to allocate 8388608 B DRAM buffer across 12 banks - https://github.com/tenstorrent/tt-xla/issues/5340"
       p150:
-        assert_pcc: false
         status: EXPECTED_PASSING
+        required_pcc: 0.98
 
   phi1_lora/causal_lm/pytorch-Phi_1-llm_prefill-seq_128-batch_4-single_device-mesh_default-training:
     arch_overrides:

--- a/tests/torch/models/wan5b/shared.py
+++ b/tests/torch/models/wan5b/shared.py
@@ -90,6 +90,25 @@ def load_first_frame_image(image_path: Path, height: int, width: int) -> torch.T
     return tensor.unsqueeze(0).unsqueeze(2).to(torch.bfloat16)  # (1, 3, 1, H, W)
 
 
+def make_synthetic_first_frame(height: int, width: int) -> torch.Tensor:
+    """Deterministic stand-in first-frame image in the exact
+    (1, 3, 1, H, W) bf16 [-1, 1] format ``load_first_frame_image`` returns.
+
+    The e2e comparison derives both the reference and the device output from
+    this same frame, so pixel *content* never affects pass/fail — only that a
+    valid frame flows through the encoder. Content must be deterministic (no
+    unseeded randomness) so runs are reproducible; a fixed RGB gradient does.
+    """
+    ys, xs = np.mgrid[0:height, 0:width].astype(np.float32)
+    r = xs / max(width - 1, 1)
+    g = ys / max(height - 1, 1)
+    b = (r + g) / 2.0
+    arr = np.stack([r, g, b], axis=-1)  # (H, W, 3) in [0, 1]
+    tensor = torch.from_numpy(arr).permute(2, 0, 1)  # (3, H, W)
+    tensor = tensor * 2.0 - 1.0  # [-1, 1]
+    return tensor.unsqueeze(0).unsqueeze(2).to(torch.bfloat16)  # (1, 3, 1, H, W)
+
+
 # ---------------------------------------------------------------------------
 # Prompt cleaning — matches diffusers/pipeline_wan.py:78-93 and Wan repo.
 # ---------------------------------------------------------------------------

--- a/tests/torch/models/wan5b/test_wan22_e2e.py
+++ b/tests/torch/models/wan5b/test_wan22_e2e.py
@@ -477,7 +477,7 @@ def _run_vae(
             on_tt=TT_VAE_DECODER,
             mesh=mesh,
             shard_module=decoder_wrapper.vae,
-            shard_fn=shard_vae_decoder_specs,
+            shard_fn=lambda m: shard_vae_decoder_specs(m, mesh),
         )
     _record(timings_slot, time.perf_counter() - t0)
     return result
@@ -592,7 +592,7 @@ def _run(
             on_tt=TT_VAE_ENCODER,
             mesh=_mesh,
             shard_module=components.vae_encoder.vae,
-            shard_fn=shard_vae_encoder_specs,
+            shard_fn=lambda m: shard_vae_encoder_specs(m, _mesh),
         )
         _record(timings.vae_encoder, time.perf_counter() - t)
         _log(

--- a/tests/torch/models/wan5b/test_wan22_e2e.py
+++ b/tests/torch/models/wan5b/test_wan22_e2e.py
@@ -39,10 +39,10 @@ from .shared import (
     VAEEncoderWrapper,
     WanDiTWrapper,
     load_dit,
-    load_first_frame_image,
     load_tokenizer,
     load_umt5,
     load_vae,
+    make_synthetic_first_frame,
     prompt_clean,
     run_component,
     shard_dit_specs,
@@ -183,9 +183,11 @@ def _build_components(mode: str) -> _Components:
 # ---------------------------------------------------------------------------
 
 
-# First-frame conditioning image for i2v. Resized via cover-fit + center
-# crop to the active resolution. Ignored when mode == "t2v".
-IMAGE_PATH = Path(__file__).parent / "reze.jpg"
+# First-frame conditioning input for i2v. Generated deterministically at the
+# active resolution (see make_synthetic_first_frame); content is irrelevant to
+# pass/fail since reference and device outputs derive from the same frame.
+# Ignored when mode == "t2v". The stem is a stable string used in output names.
+SYNTHETIC_FRAME_STEM = "synthetic_first_frame"
 _OUT_DIR = Path(__file__).parent / "generated"
 
 
@@ -207,7 +209,7 @@ def _devtag(mode: str) -> str:
 def _stem(mode: str, resolution: str) -> str:
     base = f"wan22_{mode}_{resolution}_steps{NUM_STEPS}_{_devtag(mode)}"
     if mode == "i2v":
-        base += f"_{IMAGE_PATH.stem}"
+        base += f"_{SYNTHETIC_FRAME_STEM}"
     return base
 
 
@@ -580,9 +582,10 @@ def _run(
     image_latent = None
     if mode == "i2v":
         assert components.vae_encoder is not None, "i2v requires components.vae_encoder"
-        image = load_first_frame_image(IMAGE_PATH, shapes["video_h"], shapes["video_w"])
+        image = make_synthetic_first_frame(shapes["video_h"], shapes["video_w"])
         _log(
-            f"i2v first-frame loaded image={IMAGE_PATH.name} shape={tuple(image.shape)}"
+            f"i2v first-frame synthesized name={SYNTHETIC_FRAME_STEM} "
+            f"shape={tuple(image.shape)}"
         )
 
         t = time.perf_counter()


### PR DESCRIPTION
This PR clears the actionable failures from nightly run on July 6, 2026,
one bug per paragraph below. No device-side compiler bugs are touched.

The wan5b end-to-end tests raised `shard_vae_decoder_specs() missing 1 required
positional argument: 'mesh'` because `run_component()` calls its shard callback
with one argument, but the two VAE shard functions take `(vae, mesh)`. Both VAE
call sites are now wrapped in a lambda capturing the mesh.

The wan5b image-to-video tests failed with `FileNotFoundError` on `reze.jpg`, an
uncommitted first-frame image. It is replaced with `make_synthetic_first_frame()`,
a deterministic generator producing the exact tensor `load_first_frame_image`
returned. The test is a smoke test with no numerical checks, so content of the image is
irrelevant.

The phi1 batch_4 training test OOM-ed on n150 but was marked `EXPECTED_PASSING` on
all arches, the lone sibling missing the n150 override. It is now
`KNOWN_FAILURE_XFAIL` on n150 and `EXPECTED_PASSING` on p150.

Two heavy models, motif_image_6B_preview and vadv2, were SIGKILL-ed by the host
OOM killer on n150, which xfail cannot absorb (a process kill surfaces as a
teardown ERROR). Both are now `NOT_SUPPORTED_SKIP` on n150 via `arch_override`s, so
they skip before running.