### PR TITLE
[Benchmark] Keep lm_head logits batch-sharded in perf run

### DIFF
--- a/tests/benchmark/benchmarks/llm_benchmark.py
+++ b/tests/benchmark/benchmarks/llm_benchmark.py
@@ -30,7 +30,6 @@ from torch_xla.distributed.spmd import Mesh
 from transformers import AutoModelForCausalLM, AutoTokenizer, PreTrainedTokenizer
 from transformers.cache_utils import StaticCache
 from transformers.modeling_outputs import CausalLMOutputWithPast
-from tt_torch.sharding import sharding_constraint_hook
 from tt_torch.weight_dtype import apply_weight_dtype_overrides
 from utils import (
     build_xla_export_name,
@@ -447,11 +446,6 @@ def benchmark_llm_torch_xla(
         if shard_specs is not None:
             for tensor, shard_spec in shard_specs.items():
                 xs.mark_sharding(tensor, mesh, shard_spec)
-
-        # Apply sharding constraint on lm_head output to all_gather logits
-        if hasattr(model, "lm_head") and model.lm_head is not None:
-            hook = sharding_constraint_hook(model.lm_head, mesh, (None, None, None))
-            model.lm_head.register_forward_hook(hook)
 
     # Set XLA compilation options
     num_layers_override = getattr(model_loader, "num_layers", None)

--- a/tests/benchmark/llm_utils/decode_utils.py
+++ b/tests/benchmark/llm_utils/decode_utils.py
@@ -64,6 +64,14 @@ class LLMSamplingWrapper(torch.nn.Module):
             use_cache=use_cache,
         )
         logits = self.read_logits_fn(output)
+        if self.mesh is not None:
+            # Replicate the vocab dim (argmax over a TP-sharded dim is miscompiled) while
+            # keeping batch sharded to avoid a redundant all_gather + mesh_partition.
+            batch_axis = (
+                self.output_sharding_spec[0] if self.output_sharding_spec else None
+            )
+            logits_spec = (batch_axis,) + (None,) * (logits.dim() - 1)
+            logits = sharding_constraint_tensor(logits, self.mesh, logits_spec)
         # Only take logits for last token in prefill.
         # This is a noop for decode.
         next_token_ids = logits[:, -1].argmax(dim=-1, keepdim=True)


### PR DESCRIPTION
### Ticket
Fixes https://github.com/tenstorrent/tt-xla/issues/5511#

### Problem description

On a data-parallel decode run, `lm_head` logits come out batch-sharded, so the on-device `argmax` is naturally a local, per-sequence op. A forward hook was instead constraining the logits to fully replicated. That is only needed when logits are read back to the host, and those runs already replicate them inside the sampling wrapper, so on the performance run (which never reads logits back) it is pure overhead.

The cost is a redundant round trip on the batch axis before the argmax: the logits are forced replicated while the argmax output stays batch-sharded, so the compiler gathers the batch (16 to 64) and immediately partitions it back (64 to 16). 

This only affects data-parallel runs; a pure tensor-parallel or single-chip model has nothing to replicate and slice.

### What's changed

Drop the `lm_head` hook and apply the constraint where it is needed, just before the argmax in `LLMSamplingWrapper.forward`: keep the batch sharded, replicate only the vocab (so argmax sees the whole vocabulary). 

The batch gather and partition are gone, leaving only the required vocab gather, which is now cheaper since it runs on the batch-16 tensor. The batch axis is taken from the model's `output_sharding_spec`, falling back to fully replicated for pure tensor-parallel models; logit-collection runs are unaffected.


### Checklist
Built against tt-mlir [`5170ccfa`](https://github.com/tenstorrent/tt-mlir/commit/5170ccfa), `sh-runner=false`:
- galaxy-wh-6u: [28673788714](https://github.com/tenstorrent/tt-xla/actions/runs/28673788714) 
- qb2-blackhole: [28673791221](https://github.com/tenstorrent/tt-xla/actions/runs/28673791221) 

Remaining failures are unrelated runner device hangs / topology issues (deepseek, gpt_oss, falcon3_7b flake), not the sharding change.
