### PR TITLE
[vLLM] Decouple the max prefill request-count bucket from decode

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -333,6 +333,14 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         if resolved_min_num_reqs is None:
             resolved_min_num_reqs = self.max_num_reqs
         self.min_num_reqs = resolved_min_num_reqs
+        # Prefill graphs compile at this batch shape; decode always uses
+        # max_num_reqs. Defaults to max_num_reqs when not configured so
+        # the feature is a transparent no-op unless explicitly enabled.
+        self.max_prefill_num_reqs = (
+            self.tt_config.max_prefill_num_seqs
+            if self.tt_config.max_prefill_num_seqs is not None
+            else self.max_num_reqs
+        )
         if scheduler_config.max_num_batched_tokens < self.tt_config.min_context_len:
             logger.warning(
                 f"max_num_batched_tokens {scheduler_config.max_num_batched_tokens} is less than min_context_len {self.tt_config.min_context_len}, setting min_context_len to max_num_batched_tokens"
@@ -504,7 +512,11 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         self._input_ids_dev = {
             (num_reqs, num_tokens): _alloc_dev((num_reqs, num_tokens), torch.int32)
-            for num_reqs in {self.min_num_reqs, self.max_num_reqs}
+            for num_reqs in {
+                self.min_num_reqs,
+                self.max_prefill_num_reqs,
+                self.max_num_reqs,
+            }
             for num_tokens in self.num_tokens_paddings
         }
         self._position_ids_dev = {
@@ -516,30 +528,50 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 ),
                 torch.int32,
             )
-            for num_reqs in {self.min_num_reqs, self.max_num_reqs}
+            for num_reqs in {
+                self.min_num_reqs,
+                self.max_prefill_num_reqs,
+                self.max_num_reqs,
+            }
             for num_tokens in self.num_tokens_paddings
         }
         self._logits_indices_dev = {
             num_reqs: _alloc_dev((num_reqs,), torch.int32)
-            for num_reqs in {self.min_num_reqs, self.max_num_reqs}
+            for num_reqs in {
+                self.min_num_reqs,
+                self.max_prefill_num_reqs,
+                self.max_num_reqs,
+            }
         }
         self._page_table_dev_max = {
             num_reqs: _alloc_dev(
                 (num_reqs, self.max_num_blocks_per_req),
                 self.block_table_cpu.dtype,
             )
-            for num_reqs in {self.min_num_reqs, self.num_reqs_max_model_len}
+            for num_reqs in {
+                self.min_num_reqs,
+                self.max_prefill_num_reqs,
+                self.num_reqs_max_model_len,
+            }
         }
         self._fill_page_table_dev_max = {
             num_reqs: _alloc_dev(
                 (num_reqs, self.max_num_blocks_per_req),
                 self.block_table_cpu.dtype,
             )
-            for num_reqs in {self.min_num_reqs, self.num_reqs_max_model_len}
+            for num_reqs in {
+                self.min_num_reqs,
+                self.max_prefill_num_reqs,
+                self.num_reqs_max_model_len,
+            }
         }
         self._cache_position_dev_max = {
             num_reqs: _alloc_dev((num_reqs,), self.seq_lens_cpu.dtype)
-            for num_reqs in {self.min_num_reqs, self.num_reqs_max_model_len}
+            for num_reqs in {
+                self.min_num_reqs,
+                self.max_prefill_num_reqs,
+                self.num_reqs_max_model_len,
+            }
         }
         # Chunked-prefill prefix offset: persistent [1] int32 dev buffer so the
         # value can change per step under a captured trace without recompiling.
@@ -568,7 +600,11 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         # Fail fast at startup if any per-step buffer can't be looked up by a
         # row count _prepare_inputs will request (before SMEM clamping).
-        _reachable_num_reqs = {self.min_num_reqs, self.max_num_reqs}
+        _reachable_num_reqs = {
+            self.min_num_reqs,
+            self.max_prefill_num_reqs,
+            self.max_num_reqs,
+        }
         for _name, _keys in {
             "input_ids": {k[0] for k in self._input_ids_dev},
             "position_ids": {k[0] for k in self._position_ids_dev},
@@ -641,6 +677,16 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self.batch_idx_max_reqs = torch.arange(
             self.max_num_reqs, dtype=torch.int32, device="cpu"
         ).to(self.device)
+        # Reuse max tensor when prefill ceiling == decode ceiling; allocate a
+        # separate tensor when max_prefill_num_reqs < max_num_reqs so the
+        # traced graph sees the correct (smaller) batch dimension.
+        self.batch_idx_max_prefill_reqs = (
+            self.batch_idx_max_reqs
+            if self.max_prefill_num_reqs == self.max_num_reqs
+            else torch.arange(
+                self.max_prefill_num_reqs, dtype=torch.int32, device="cpu"
+            ).to(self.device)
+        )
 
     def _filter_weights_for_layer_override(self, weights_iterator):
         """Filter weights to only include layers that exist in the modified model."""
@@ -1085,6 +1131,21 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             else:
                 end_index = num_reqs
 
+        # Reconcile with the prefill row cap: if this is a prefill pass (any
+        # request has > 1 scheduled token) and the SMEM-trimmed batch still
+        # exceeds max_prefill_num_reqs, trim again. The multi-pass loop
+        # (start_index → end_index in sample_tokens) then picks up the
+        # remaining requests on the next iteration.
+        # Decode passes (all tokens == 1) always run at max_num_reqs and are
+        # not subject to this cap.
+        _prefill_cap = self.max_prefill_num_reqs
+        if (
+            len(num_scheduled_tokens_per_req) > _prefill_cap
+            and max(num_scheduled_tokens_per_req) > 1
+        ):
+            num_scheduled_tokens_per_req = num_scheduled_tokens_per_req[:_prefill_cap]
+            end_index = start_index + _prefill_cap
+
         max_num_scheduled_tokens_all_reqs = max(num_scheduled_tokens_per_req)
         num_scheduled_tokens_per_req = np.array(
             num_scheduled_tokens_per_req, dtype=np.int32
@@ -1096,7 +1157,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         actual_num_reqs = num_reqs
 
         # Decode always runs with max request shape. For prefill, keep runtime
-        # request shape aligned with warmup by selecting min or max bucket.
+        # request shape aligned with warmup by selecting min or max prefill bucket.
         is_decode_step = max_num_scheduled_tokens_all_reqs == 1
         if is_decode_step:
             target_num_reqs = self.max_num_reqs
@@ -1104,7 +1165,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             target_num_reqs = (
                 self.min_num_reqs
                 if actual_num_reqs <= self.min_num_reqs
-                else self.max_num_reqs
+                else self.max_prefill_num_reqs
             )
 
         # Compute the padded total number of scheduled tokens so that all requests
@@ -1319,7 +1380,11 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             batch_idx=(
                 self.batch_idx_min_reqs
                 if target_num_reqs == self.min_num_reqs
-                else self.batch_idx_max_reqs
+                else (
+                    self.batch_idx_max_prefill_reqs
+                    if target_num_reqs == self.max_prefill_num_reqs
+                    else self.batch_idx_max_reqs
+                )
             ),
             num_users=target_num_reqs,
         )
@@ -2092,7 +2157,11 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             batch_idx=(
                 self.batch_idx_min_reqs
                 if num_reqs == self.min_num_reqs
-                else self.batch_idx_max_reqs
+                else (
+                    self.batch_idx_max_prefill_reqs
+                    if num_reqs == self.max_prefill_num_reqs
+                    else self.batch_idx_max_reqs
+                )
             ),
             num_users=num_reqs,
         )
@@ -2312,7 +2381,9 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 f"decode_only is set, only compiling decode path with num_tokens=1"
             )
 
-        num_reqs_options = sorted({self.min_num_reqs, self.max_num_reqs})
+        num_reqs_options = sorted(
+            {self.min_num_reqs, self.max_prefill_num_reqs, self.max_num_reqs}
+        )
 
         # Compile the cached-prefix (chunked SDPA op) graph in addition to the
         # standard one, but only when the op is usable; otherwise the first
@@ -2354,6 +2425,14 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             if config["num_tokens"] == 1 and config["num_reqs"] != self.max_num_reqs:
                 logger.debug(
                     f"Skipping config={config} because decode path only supports max_num_reqs={self.max_num_reqs}"
+                )
+                continue
+            if (
+                config["num_tokens"] != 1
+                and config["num_reqs"] > self.max_prefill_num_reqs
+            ):
+                logger.debug(
+                    f"Skipping config={config} because prefill is capped at max_prefill_num_reqs={self.max_prefill_num_reqs}"
                 )
                 continue
 
@@ -2454,7 +2533,11 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             batch_idx=(
                 self.batch_idx_min_reqs
                 if num_reqs == self.min_num_reqs
-                else self.batch_idx_max_reqs
+                else (
+                    self.batch_idx_max_prefill_reqs
+                    if num_reqs == self.max_prefill_num_reqs
+                    else self.batch_idx_max_reqs
+                )
             ),
             num_users=num_reqs,
         )
@@ -2733,9 +2816,18 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 torch_xla.sync()
 
         # Largest-first, as in _precompile_model_fused, to avoid fragmentation (#5522).
-        num_reqs_options = sorted({self.min_num_reqs, self.max_num_reqs}, reverse=True)
+        num_reqs_options = sorted(
+            {self.min_num_reqs, self.max_prefill_num_reqs, self.max_num_reqs},
+            reverse=True,
+        )
         for warmup_num_reqs in num_reqs_options:
             for num_tokens in reversed(self.num_tokens_paddings):
+                # Decode (num_tokens == 1) only at max_num_reqs; prefill capped
+                # at max_prefill_num_reqs to match _precompile_model_fused.
+                if num_tokens == 1 and warmup_num_reqs != self.max_num_reqs:
+                    continue
+                if num_tokens != 1 and warmup_num_reqs > self.max_prefill_num_reqs:
+                    continue
                 _run_backbone_dummies(num_tokens, warmup_num_reqs, prefix_chunk=False)
                 # Precompile the cached-prefix graph for prompt chunks
                 # (num_tokens > 1) so it isn't compiled on the first continuation.

--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -58,6 +58,16 @@ class TTConfig:
     # If unset, it resolves to scheduler_config.max_num_seqs.
     min_num_seqs: Optional[int] = None
 
+    # Maximum request-batch size for *prefill* compilation and tracing.
+    # When set to a value smaller than max_num_seqs, prefill graphs compile
+    # and trace at this batch shape instead of max_num_seqs. With
+    # enable_trace=True, each traced bucket keeps its peak activations
+    # resident in DRAM; capping prefill here is the primary knob for
+    # reducing prefill DRAM footprint. Decode is unaffected (always
+    # compiles at max_num_seqs). Must satisfy min_num_seqs <=
+    # max_prefill_num_seqs <= max_num_seqs. Defaults to max_num_seqs.
+    max_prefill_num_seqs: Optional[int] = None
+
     # b1-prefill batch threshold. When <= this many prefills are
     # pending, AscendScheduler admits at most min_num_seqs fresh prefills/step
     # (small/b1 graph, served serially) instead of one wasted-row b32 batch;
@@ -316,18 +326,40 @@ class TTPlatform(Platform):
                 "additional_config['batch_size'] is deprecated and will be removed "
                 "in a future release. Use max_num_seqs instead."
             )
-        if tt_config.min_num_seqs is None:
-            additional_config["min_num_seqs"] = (
-                vllm_config.scheduler_config.max_num_seqs
+
+        max_num_seqs = vllm_config.scheduler_config.max_num_seqs
+
+        # Resolve/validate max_prefill_num_seqs first so min_num_seqs can default to it.
+        if tt_config.max_prefill_num_seqs is None:
+            additional_config["max_prefill_num_seqs"] = max_num_seqs
+            tt_config.max_prefill_num_seqs = additional_config["max_prefill_num_seqs"]
+        elif tt_config.max_prefill_num_seqs < 1:
+            raise ValueError(
+                "additional_config['max_prefill_num_seqs'] must be >= 1 for the TT backend."
             )
+        elif tt_config.max_prefill_num_seqs > max_num_seqs:
+            raise ValueError(
+                "additional_config['max_prefill_num_seqs'] must be <= max_num_seqs "
+                "for the TT backend."
+            )
+
+        # Resolve/validate min_num_seqs after max_prefill_num_seqs.
+        if tt_config.min_num_seqs is None:
+            additional_config["min_num_seqs"] = tt_config.max_prefill_num_seqs
             tt_config.min_num_seqs = additional_config["min_num_seqs"]
         elif tt_config.min_num_seqs < 1:
             raise ValueError(
                 "additional_config['min_num_seqs'] must be >= 1 for the TT backend."
             )
-        elif tt_config.min_num_seqs > vllm_config.scheduler_config.max_num_seqs:
+        elif tt_config.min_num_seqs > max_num_seqs:
             raise ValueError(
                 "additional_config['min_num_seqs'] must be <= max_num_seqs "
+                "for the TT backend."
+            )
+
+        if tt_config.max_prefill_num_seqs < tt_config.min_num_seqs:
+            raise ValueError(
+                "additional_config['max_prefill_num_seqs'] must be >= min_num_seqs "
                 "for the TT backend."
             )
 

--- a/tests/integrations/vllm_plugin/generative/test_max_prefill_num_seqs.py
+++ b/tests/integrations/vllm_plugin/generative/test_max_prefill_num_seqs.py
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import re
+
+import pytest
+import vllm
+
+MAX_MODEL_LEN = 32
+MAX_NUM_SEQS = 32
+MAX_PREFILL_NUM_SEQS = 16
+NUM_HIDDEN_LAYERS = 1
+NUM_PROMPTS = 32
+
+
+def _make_llm(model_name: str) -> vllm.LLM:
+    llm_args = {
+        "model": model_name,
+        "max_num_batched_tokens": MAX_MODEL_LEN * MAX_NUM_SEQS,
+        "max_num_seqs": MAX_NUM_SEQS,
+        "max_model_len": MAX_MODEL_LEN,
+        "gpu_memory_utilization": 0.002,
+        "disable_log_stats": True,
+        "additional_config": {
+            "enable_const_eval": True,
+            "min_context_len": MAX_MODEL_LEN,
+            "num_hidden_layers": NUM_HIDDEN_LAYERS,
+            "max_prefill_num_seqs": MAX_PREFILL_NUM_SEQS,
+            "min_num_seqs": 1,
+        },
+    }
+    return vllm.LLM(**llm_args)
+
+
+def _compile_log_patterns() -> (
+    tuple[re.Pattern[str], re.Pattern[str], re.Pattern[str], re.Pattern[str]]
+):
+    decode_pattern = re.compile(
+        r"Compiling graph for config=\{'num_tokens': 1, 'num_reqs': 32,"
+    )
+    capped_prefill_pattern = re.compile(
+        r"Compiling graph for config=\{'num_tokens': 32, 'num_reqs': 16,"
+    )
+    min_prefill_pattern = re.compile(
+        r"Compiling graph for config=\{'num_tokens': 32, 'num_reqs': 1,"
+    )
+    uncapped_prefill_pattern = re.compile(
+        r"Compiling graph for config=\{'num_tokens': 32, 'num_reqs': 32,"
+    )
+    return (
+        decode_pattern,
+        capped_prefill_pattern,
+        min_prefill_pattern,
+        uncapped_prefill_pattern,
+    )
+
+
+def _recompile_error_pattern() -> re.Pattern[str]:
+    return re.compile(
+        r"Detected \d+ new XLA graph compilation\(s\) during sample_tokens\(\)\."
+    )
+
+
+def _compiled_shape_pattern() -> re.Pattern[str]:
+    return re.compile(
+        r"Compiling graph for config=\{'num_tokens': (?P<num_tokens>\d+), 'num_reqs': (?P<num_reqs>\d+),"
+    )
+
+
+@pytest.mark.nightly
+@pytest.mark.single_device
+def test_max_prefill_num_seqs_uses_capped_prefill_shape(captured_output_fixture):
+    """Verify the captured TT compile logs contain exactly the expected decode
+    and prefill shapes for max_prefill_num_seqs=16 and min_num_seqs=1, with no
+    unexpected prefill bucket and no runtime recompilation warning.
+    """
+    prompts = ["I like taking walks in the"] * NUM_PROMPTS
+    sampling_params = vllm.SamplingParams(temperature=0.8, top_p=0.95, max_tokens=2)
+
+    llm = _make_llm("Qwen/Qwen3-0.6B")
+    try:
+        outputs = llm.generate(prompts, sampling_params)
+    finally:
+        del llm
+
+    captured = captured_output_fixture.readouterr()
+    logs = captured.out + captured.err
+    (
+        decode_pattern,
+        capped_prefill_pattern,
+        min_prefill_pattern,
+        uncapped_prefill_pattern,
+    ) = _compile_log_patterns()
+    recompile_error_pattern = _recompile_error_pattern()
+    compiled_shape_pattern = _compiled_shape_pattern()
+    compiled_shapes = {
+        (int(match.group("num_tokens")), int(match.group("num_reqs")))
+        for match in compiled_shape_pattern.finditer(logs)
+    }
+
+    assert len(outputs) == NUM_PROMPTS
+    assert outputs[0].outputs, "expected at least one generated output"
+    assert decode_pattern.search(logs), (
+        "expected decode compilation at max_num_seqs=32; logs did not contain "
+        "the decode shape"
+    )
+    assert capped_prefill_pattern.search(logs), (
+        "expected prefill compilation at max_prefill_num_seqs=16; logs did not "
+        "contain the capped prefill shape"
+    )
+    assert min_prefill_pattern.search(logs), (
+        "expected prefill compilation at min_num_seqs=1; logs did not contain "
+        "the min prefill shape"
+    )
+    assert not uncapped_prefill_pattern.search(
+        logs
+    ), "prefill compiled at num_reqs=32 even though max_prefill_num_seqs=16"
+    assert not recompile_error_pattern.search(
+        logs
+    ), "runtime logs reported new XLA graph compilation(s) during sample_tokens()"
+    assert compiled_shapes == {
+        (1, 32),
+        (32, 16),
+        (32, 1),
+    }, f"unexpected compile shapes in logs: {sorted(compiled_shapes)}"


### PR DESCRIPTION
### Ticket
closes #5525 

### Problem description
Prefill graphs are compiled and traced at max_num_seqs (b32) to match the decode batch. But prefill activations scale linearly with the request-count bucket, and with enable_trace: true each bucket's peak activation stays resident in DRAM for the life of the trace. The b32 prefill traces are the single largest tunable consumer of prefill DRAM — and decode is the only reason prefill is pinned to b32, even though prefill and decode have no need to share a batch shape.

### What's changed
Add TT backend support for max_prefill_num_seqs so prefill can use a smaller
request bucket than decode. 

### Checklist
- [X] New/Existing tests provide coverage for changes
