### PR TITLE
Filter uplift PRs out of release "What's Changed"

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+# Configuration for GitHub's automatically generated release notes.
+# Consumed by `generate_release_notes: true` in call-publish-release.yml.
+# Docs: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+changelog:
+  exclude:
+    # Keep automated dependency/version uplift PRs out of "What's Changed".
+    # `uplift*` matches any label with the "uplift" prefix
+    # (uplift, uplift-mlir, uplift-forge-models, ...).
+    labels:
+      - "uplift*"
+  categories:
+    - title: What's Changed
+      labels:
+        - "*"


### PR DESCRIPTION
## Problem

The release "What's Changed" section lists every merged PR since the previous tag, which is very verbose — dominated by automated `uplift*` dependency/version bump PRs.

## Change

Add `.github/release.yml` to configure GitHub's built-in release-notes generator 