### PR TITLE
[Benchmark] Increase deepseek-v3.1 and GLM4.7 batch size to 128

### DIFF
--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -1470,7 +1470,7 @@ def test_kimi_k2_6_tp_galaxy_2_layers(
         num_layers=2,
         request=request,
         accuracy_testing=accuracy_testing,
-        batch_size=128,
+        batch_size=64,  # Decode pcc drops for batch 128 - Issue: https://github.com/tenstorrent/tt-xla/issues/5558
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
         input_output_sharding_spec=("batch", None),

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -1434,7 +1434,7 @@ def test_kimi_k2_tp_galaxy_2_layers(
         num_layers=2,
         request=request,
         accuracy_testing=accuracy_testing,
-        batch_size=64,  # Test hangs for a batch size of 128 - Issue: https://github.com/tenstorrent/tt-xla/issues/4565
+        batch_size=64,  # Decode pcc drops for batch 128 - Issue: https://github.com/tenstorrent/tt-xla/issues/5558
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
         input_output_sharding_spec=("batch", None),
@@ -1470,7 +1470,7 @@ def test_kimi_k2_6_tp_galaxy_2_layers(
         num_layers=2,
         request=request,
         accuracy_testing=accuracy_testing,
-        batch_size=64,  # Test hangs for a batch size of 128 - Issue: https://github.com/tenstorrent/tt-xla/issues/4565
+        batch_size=128,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
         input_output_sharding_spec=("batch", None),
@@ -2035,7 +2035,7 @@ def test_deepseek_v3_1_tp_galaxy_4_layers(
         num_layers=4 if num_layers is None else num_layers,
         request=request,
         accuracy_testing=accuracy_testing,
-        batch_size=64,  # Test hangs for a batch size of 128 - Issue: https://github.com/tenstorrent/tt-xla/issues/4565
+        batch_size=128,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
         input_output_sharding_spec=("batch", None),
@@ -2129,7 +2129,7 @@ def test_glm_4_7_tp_galaxy_4_layers(
         num_layers=4 if num_layers is None else num_layers,
         request=request,
         accuracy_testing=accuracy_testing,
-        batch_size=64,  # Test hangs for a batch size of 128 - Issue: https://github.com/tenstorrent/tt-xla/issues/4565
+        batch_size=64,  # Process silently terminates early for batch 128 - Issue: https://github.com/tenstorrent/tt-xla/issues/5560
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
         optimization_level=0,

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -2129,7 +2129,7 @@ def test_glm_4_7_tp_galaxy_4_layers(
         num_layers=4 if num_layers is None else num_layers,
         request=request,
         accuracy_testing=accuracy_testing,
-        batch_size=64,  # Process silently terminates early for batch 128 - Issue: https://github.com/tenstorrent/tt-xla/issues/5560
+        batch_size=128,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
         optimization_level=0,
@@ -2138,4 +2138,5 @@ def test_glm_4_7_tp_galaxy_4_layers(
         input_output_sharding_spec=("batch", None),
         kv_cache_sharding_spec=("batch", "model", None, None),
         required_pcc=0.99,
+        experts_implementation="eager",
     )


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/4565 
[EDIT]: and https://github.com/tenstorrent/tt-xla/issues/5560

### Problem description
Kimi-k2, Kimi-k2.6 and Deepseek-v3.1 were previously hanging for batch 128 but are now running with a metal fix that was uplifted. Kimi-k2 ([EDIT]: and kimi-k2.6) sees a PCC drop in decode https://github.com/tenstorrent/tt-xla/issues/5558 for batch 128 but ~~Kimi-k2.6 and~~ Deepseek-v3.1 pass for `require_pcc=0.99` and can be updated. [EDIT]: ~~GLM4.7 is failing on cpu for batch 128 https://github.com/tenstorrent/tt-xla/issues/5560.~~ GLM4.7 fails on CPU since the experts implementation is `batched_mm` by default which causes OOM - the experts implementation on device is already overridden. 

### What's changed
Set `batch_size=128` for newly passing tests and point to issues tracking new failures for `batch_size=128`.

[EDIT]: Set `experts_implementation="eager"` for GLM4.7.

### Checklist
- [x] New/Existing tests provide coverage for changes
