### PR TITLE
[vLLM] Fix b1-prefill nightly OOM: shrink prefill bucket + KV reservation

### DIFF
--- a/tests/integrations/vllm_plugin/generative/test_b1_prefill.py
+++ b/tests/integrations/vllm_plugin/generative/test_b1_prefill.py
@@ -87,22 +87,12 @@ def _make_engine() -> AsyncLLMEngine:
     }
     args = AsyncEngineArgs(
         model="Qwen/Qwen3-8B",
-        # The prefill token bucket is the smallest power of 2 >= min(
-        # max_num_batched_tokens, max_model_len) (exponential ladder, see
-        # _get_token_paddings), and the b_max prefill activation is
-        # max_num_seqs x bucket x intermediate x 4B. max_model_len=2048 -> a 2048
-        # bucket -> 32 x 2048 x 12288 x 4 = 3 GB, which OOM'd capture_model on the
-        # single-chip n150 (#5533). max_model_len=1024 drops to a 1024 bucket,
-        # halving the activation to 1.5 GB (needs ISL <= 1023). budget must still
-        # cover max_model_len * max_num_seqs.
+        # max_model_len=1024 (not 2048) and gpu_memory_utilization=0.1 (not 0.3)
+        # keep the b_max prefill activation and KV reservation within N150 DRAM.
+        # See #5533 for the sizing rationale. (needs ISL <= 1023)
         max_model_len=1024,
         max_num_batched_tokens=1024 * 32,
         max_num_seqs=32,
-        # KV cache is reserved at this fraction of DRAM up front. max_tokens=1 means
-        # the test barely uses KV, but at 0.3 the reservation (~3.9 GB) left the banks
-        # ~90% full, so the batch scenario's runtime b_max prefill activation OOM'd
-        # mid-serving (#5533). 0.1 still leaves KV for >600 seqs (test needs <=24) and
-        # frees the DRAM the activation needs.
         gpu_memory_utilization=0.1,
         additional_config=additional_config,
     )

--- a/tests/integrations/vllm_plugin/generative/test_b1_prefill.py
+++ b/tests/integrations/vllm_plugin/generative/test_b1_prefill.py
@@ -34,7 +34,7 @@ from vllm import AsyncEngineArgs, AsyncLLMEngine, SamplingParams
 from vllm.inputs import TokensPrompt
 from vllm.sampling_params import RequestOutputKind
 
-ISL = 1024  # b1 win grows with ISL
+ISL = 1000  # <=1023 so max_model_len can be 1024 -> 1024 token bucket (see _make_engine); b1 win grows with ISL
 SMALL = 8  # burst size (<= threshold -> the gap target)
 LARGE = 24  # batch size (> threshold -> stable b32 anchor)
 RAMP_MS = 100  # staggered inter-arrival
@@ -87,11 +87,23 @@ def _make_engine() -> AsyncLLMEngine:
     }
     args = AsyncEngineArgs(
         model="Qwen/Qwen3-8B",
-        # budget must cover max_model_len * max_num_seqs; small max_model_len keeps it cheap
-        max_model_len=2048,
-        max_num_batched_tokens=2048 * 32,
+        # The prefill token bucket is the smallest power of 2 >= min(
+        # max_num_batched_tokens, max_model_len) (exponential ladder, see
+        # _get_token_paddings), and the b_max prefill activation is
+        # max_num_seqs x bucket x intermediate x 4B. max_model_len=2048 -> a 2048
+        # bucket -> 32 x 2048 x 12288 x 4 = 3 GB, which OOM'd capture_model on the
+        # single-chip n150 (#5533). max_model_len=1024 drops to a 1024 bucket,
+        # halving the activation to 1.5 GB (needs ISL <= 1023). budget must still
+        # cover max_model_len * max_num_seqs.
+        max_model_len=1024,
+        max_num_batched_tokens=1024 * 32,
         max_num_seqs=32,
-        gpu_memory_utilization=0.3,
+        # KV cache is reserved at this fraction of DRAM up front. max_tokens=1 means
+        # the test barely uses KV, but at 0.3 the reservation (~3.9 GB) left the banks
+        # ~90% full, so the batch scenario's runtime b_max prefill activation OOM'd
+        # mid-serving (#5533). 0.1 still leaves KV for >600 seqs (test needs <=24) and
+        # frees the DRAM the activation needs.
+        gpu_memory_utilization=0.1,
         additional_config=additional_config,
     )
     return AsyncLLMEngine.from_engine_args(args)


### PR DESCRIPTION
### Ticket
closes [#5533](https://github.com/tenstorrent/tt-xla/issues/5533)

### Problem

`test_b1_prefill_ttft` has failed every night since it merged (#5363, 06-30). There are **two** distinct single-chip n150 DRAM OOMs, both addressed here.

**1. `capture_model` (precompile).** The b_max prefill MLP activation is:

```
max_num_seqs(32) x bucket(2048) x intermediate(12288) x 4B = 3 GB   (256 MB/bank)
```

bucket is the smallest power of 2 >= min(max_num_batched_tokens, max_model_len) (exponential ladder in _get_token_paddings). max_model_len=2048 -> a 2048 bucket -> the activation doesn't fit the largest free block.

**2. Mid-serving (the `batch` scenario).** After the bucket fix, the engine gets past capture and dies during the 24-request batch step on an `805 MB` activation, with banks ~90% full. `gpu_memory_utilization=0.3` reserved a KV cache sized for ~1.9M tokens (~3.9 GB), but the test does `max_tokens=1` and uses ~23K tokens, the over-reservation leaves no room for the runtime prefill activation.

### Fix

- **Bucket 2048 -> 1024:** `max_model_len 2048 -> 1024` (halves the capture activation to 1.5 GB) and `ISL 1024 → 1000` (a 1024 bucket needs `ISL + 1 <= 1024`). `max_num_batched_tokens` follows to `1024*32` (keeps the `>= max_model_len * max_num_seqs` invariant).
- **KV reservation:** `gpu_memory_utilization 0.3 -> 0.1`, still leaves KV for >600 seqs (the test needs <=24), frees the DRAM the runtime activation needs.

Reducing `max_num_seqs` instead can't fix (1): at a 2048 bucket even 24 seqs is 2.4 GB. The feature under test is untouched, b1-vs-b_max selection, `min_num_seqs`, `prefill_batch_threshold`, all four scenarios, and both assertions are unchanged.

This is a memory-capacity limit, not a functional bug: P150 runs fine at max_model_len=2048 (larger DRAM), N150 needs the 1024 cap. Full sizing rationale lives on #5533.

### Verification

- [x] `test_b1_prefill_ttft` passes on n150  locally and on CI https://github.com/tenstorrent/tt-xla/actions/runs/28979131155

