### PR TITLE
[Uplift] PyTorch v2.11.0 and vLLM v0.20.2

### DIFF
--- a/integrations/vllm_plugin/requirements-vllm-plugin.txt
+++ b/integrations/vllm_plugin/requirements-vllm-plugin.txt
@@ -1,3 +1,3 @@
-vllm==0.19.1
+vllm==0.20.2
 transformers==5.5.1
 fastapi[standard] >= 0.133.0, < 0.137.0 # First version supporting Starlette 1.0; < 0.137.0 avoids route-tree change that breaks model-hosting-container-standards handler overrides.

--- a/integrations/vllm_plugin/setup.py
+++ b/integrations/vllm_plugin/setup.py
@@ -51,7 +51,7 @@ setup(
     version="0.1",
     packages=find_packages(),
     install_requires=[
-        "vllm==0.19.1",
+        "vllm==0.20.2",
         "transformers==5.5.1",
         "fastapi[standard] >= 0.133.0, < 0.137.0",
     ],

--- a/integrations/vllm_plugin/vllm_tt/__init__.py
+++ b/integrations/vllm_plugin/vllm_tt/__init__.py
@@ -24,6 +24,19 @@ def register():
 
 
 def register_oot_layers():
+    # Patch vLLM Attention symbol from the general-plugins path.
+    import vllm.model_executor.layers.attention as _attn_pkg
+    import vllm.model_executor.layers.attention.attention as _attn_mod
+    import vllm.model_executor.layers.attention.encoder_only_attention as _enc_attn_mod
+    from vllm_tt.attention_impls.attention import TTAttention, TTEncoderOnlyAttention
+
+    _attn_mod.Attention = TTAttention
+    _attn_pkg.Attention = TTAttention
+    _enc_attn_mod.Attention = TTAttention
+
+    _enc_attn_mod.EncoderOnlyAttention = TTEncoderOnlyAttention
+    _attn_pkg.EncoderOnlyAttention = TTEncoderOnlyAttention
+
     # Registers all OOT backends
     from .attention_impls import attention_mla  # noqa: F401
     from .layers.fused_moe import TTFusedMoE  # noqa: F401

--- a/integrations/vllm_plugin/vllm_tt/__init__.py
+++ b/integrations/vllm_plugin/vllm_tt/__init__.py
@@ -26,4 +26,4 @@ def register():
 def register_oot_layers():
     # Registers all OOT backends
     from .attention_impls import attention_mla  # noqa: F401
-    from .layers.fused_moe import TTFusedMoE, TTSharedFusedMoE  # noqa: F401
+    from .layers.fused_moe import TTFusedMoE  # noqa: F401

--- a/integrations/vllm_plugin/vllm_tt/attention_impls/attention.py
+++ b/integrations/vllm_plugin/vllm_tt/attention_impls/attention.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import List, Optional
 
 import torch
+import torch.nn as nn
 import torch_xla.core.xla_builder as xb
 import torch_xla.experimental.custom_kernel  # noqa: F401
 
@@ -14,7 +15,11 @@ from torch.library import impl
 
 # from torch_xla._internal.jax_workarounds import requires_jax
 from torch_xla.experimental.custom_kernel import XLA_LIB
-from vllm.config import VllmConfig
+from vllm.config import CacheConfig, VllmConfig
+from vllm.model_executor.layers.attention.attention import Attention
+from vllm.model_executor.layers.attention.encoder_only_attention import (
+    create_encoder_only_attention_backend,
+)
 from vllm.utils.math_utils import cdiv, next_power_of_2
 from vllm.v1.attention.backend import (
     AttentionBackend,
@@ -22,6 +27,8 @@ from vllm.v1.attention.backend import (
     AttentionLayer,
     AttentionType,
 )
+from vllm.v1.attention.selector import get_attn_backend
+from vllm.v1.kv_cache_interface import KVCacheSpec
 
 from ..logger import tt_init_logger
 
@@ -291,6 +298,8 @@ class TTAttentionBackendImpl(AttentionImpl):
             output: shape = [batch_size, num_tokens, num_heads * head_size]
         """
         assert attn_metadata is not None, "TT attention requires metadata."
+        output_buffer = output
+
         # Prepare inputs and metadata
         inputs = self._prepare_inputs(query, key, value, attn_metadata)
 
@@ -313,12 +322,66 @@ class TTAttentionBackendImpl(AttentionImpl):
             assert self.sinks is None, "Attention sink is unsupported in SDPA prefill"
             # Pass kv_cache so shared-KV layers can gather K/V from the target
             # layer's paged cache (see ``_compute_full_attention`` docstring).
-            output = self._compute_full_attention(inputs, kv_cache, attn_metadata)
+            attn_output = self._compute_full_attention(inputs, kv_cache, attn_metadata)
         else:
-            output = self._compute_decode_attention(inputs, kv_cache, attn_metadata)
+            attn_output = self._compute_decode_attention(
+                inputs, kv_cache, attn_metadata
+            )
 
-        # Finalize output shape to match original input
-        return self._finalize_output(output, inputs)
+        # Reshape final output to match expected flattened shape [num_users*num_tokens, num_heads * head_size].
+        finalized_output = attn_output.reshape(-1, self.num_heads * self.head_size)
+
+        # vLLM passes a preallocated output buffer and expects attention impls
+        # to materialize results into it. Returning only a new tensor makes the
+        # custom attention path look side-effect-free to FX and can be DCE'd.
+        if output_buffer is not None:
+            output_buffer.copy_(finalized_output.reshape_as(output_buffer))
+            return output_buffer
+
+        return finalized_output
+
+    def _normalize_to_attention_format(
+        self,
+        tensor: torch.Tensor,
+        tensor_name: str,
+        expected_num_heads: int,
+        expected_head_size: int,
+        num_users: int,
+    ) -> torch.Tensor:
+        """Normalize a tensor to [users, tokens, heads, head_size] format.
+
+        The leading dimension is always treated as flattened tokens
+        (batch_size * num_tokens), never as an explicit batch axis.
+        """
+        if tensor.ndim < 2:
+            raise ValueError(
+                f"{tensor_name} must have rank >= 2, got shape={tuple(tensor.shape)}"
+            )
+
+        expected_hidden = expected_num_heads * expected_head_size
+        if tensor.ndim == 2 and tensor.shape[-1] == expected_hidden:
+            normalized = tensor.reshape(-1, expected_num_heads, expected_head_size)
+        elif (
+            tensor.ndim == 3
+            and tensor.shape[-2] == expected_num_heads
+            and tensor.shape[-1] == expected_head_size
+        ):
+            normalized = tensor
+        else:
+            raise ValueError(
+                f"{tensor_name} must be either a flattened-token tensor with "
+                f"shape[-1] == {expected_hidden} or a head-shaped tensor with "
+                f"shape[-2:] == ({expected_num_heads}, {expected_head_size}); "
+                f"got shape={tuple(tensor.shape)}"
+            )
+
+        total_tokens = normalized.shape[0]
+        if total_tokens % num_users != 0:
+            raise ValueError(
+                f"{tensor_name} total tokens ({total_tokens}) must be divisible "
+                f"by num_users ({num_users})"
+            )
+        return normalized.reshape(num_users, -1, expected_num_heads, expected_head_size)
 
     def _prepare_inputs(
         self,
@@ -335,42 +398,40 @@ class TTAttentionBackendImpl(AttentionImpl):
         orig_query_shape = query.shape
         orig_query_ndim = query.ndim
 
-        if orig_query_ndim == 3:
-            assert query.shape[0] == num_users, (
-                f"query batch dim ({query.shape[0]}) and cache_position num_users "
-                f"({num_users}) mismatch."
-            )
-            assert (
-                key.shape == value.shape
-            ), "key and value shape mismatch for batched inputs."
-        elif orig_query_ndim == 2:
-            # Reshape query to [users, tokens_per_user, hidden_size]
-            query = self._reshape_query(query, num_users)
-            key, value = self._reshape_key_value(key, value, num_users)
-        else:
+        query = self._normalize_to_attention_format(
+            query,
+            "query",
+            self.num_heads,
+            self.head_size,
+            num_users,
+        )
+        key = self._normalize_to_attention_format(
+            key,
+            "key",
+            self.num_kv_heads,
+            self.head_size,
+            num_users,
+        )
+        value = self._normalize_to_attention_format(
+            value,
+            "value",
+            self.num_kv_heads,
+            self.head_size,
+            num_users,
+        )
+
+        if key.shape != value.shape:
             raise ValueError(
-                f"Unsupported query ndim: {orig_query_ndim}, expected 2 or 3."
+                f"key and value must match after normalization, got "
+                f"key={tuple(key.shape)} value={tuple(value.shape)}"
             )
 
         users_kv = key.shape[0]
         query_num_tokens = query.shape[1]
         kv_num_tokens = key.shape[1]
-        hidden_size = query.shape[2]
 
         # Determine prefill vs decode mode
         is_prefill = query_num_tokens > 1
-
-        # Reshape Q/K/V to [batch(users), tokens, num_heads, head_size]
-        query, key, value = self._reshape_to_attention_format(
-            query,
-            key,
-            value,
-            num_users,
-            users_kv,
-            query_num_tokens,
-            kv_num_tokens,
-            hidden_size,
-        )
 
         # Create named tuple for inputs
         AttentionInputs = namedtuple(
@@ -401,68 +462,6 @@ class TTAttentionBackendImpl(AttentionImpl):
             users_kv=users_kv,
             kv_num_tokens=kv_num_tokens,
         )
-
-    def _reshape_query(self, query: torch.Tensor, num_users: int):
-        """Reshape query tensor to [users, tokens_per_user, hidden] format."""
-        # [total_tokens, hidden] (vLLM style)
-        total_tokens = query.shape[0]
-        hidden_size = query.shape[1]
-        users = num_users
-        assert (
-            total_tokens % users == 0
-        ), f"total_tokens ({total_tokens}) not divisible by num_users ({users})."
-        query_num_tokens = total_tokens // users  # tokens per user
-        query = query.view(users, query_num_tokens, hidden_size)
-
-        return query
-
-    def _reshape_key_value(self, key: torch.Tensor, value: torch.Tensor, users: int):
-        """Reshape key and value tensors to [users_kv, kv_num_tokens, hidden] format."""
-        total_k_tokens = key.shape[0]
-        kv_hidden_size = key.shape[1]
-        users_kv = users  # Assume same users as query
-        assert (
-            total_k_tokens % users_kv == 0
-        ), f"total_k_tokens ({total_k_tokens}) not divisible by users_kv ({users_kv})."
-        kv_num_tokens = total_k_tokens // users_kv
-        key = key.view(users_kv, kv_num_tokens, kv_hidden_size)
-
-        total_v_tokens = value.shape[0]
-        v_hidden_size = value.shape[1]
-        users_v = users_kv
-        assert (
-            total_v_tokens % users_v == 0
-        ), f"total_v_tokens ({total_v_tokens}) not divisible by users_v ({users_v})."
-        v_num_tokens = total_v_tokens // users_v
-        assert v_num_tokens == kv_num_tokens, "key/value token count mismatch."
-        value = value.view(users_v, v_num_tokens, v_hidden_size)
-
-        return key, value
-
-    def _reshape_to_attention_format(
-        self,
-        query: torch.Tensor,
-        key: torch.Tensor,
-        value: torch.Tensor,
-        users: int,
-        users_kv: int,
-        query_num_tokens: int,
-        kv_num_tokens: int,
-        hidden_size: int,
-    ):
-        """Reshape Q/K/V tensors to [batch(users), tokens, num_heads, head_size] format."""
-        num_heads = hidden_size // self.head_size
-        assert hidden_size % self.head_size == 0
-
-        query = query.reshape(users, query_num_tokens, num_heads, self.head_size)
-        key = key.reshape(
-            users_kv, kv_num_tokens, key.shape[-1] // self.head_size, self.head_size
-        )
-        value = value.reshape(
-            users_kv, kv_num_tokens, value.shape[-1] // self.head_size, self.head_size
-        )
-
-        return query, key, value
 
     def _handle_paged_attention(
         self, inputs, kv_cache: list[torch.Tensor], attn_metadata: TTMetadata
@@ -666,17 +665,6 @@ class TTAttentionBackendImpl(AttentionImpl):
 
         return out
 
-    def _finalize_output(self, output: torch.Tensor, inputs) -> torch.Tensor:
-        """Finalize output shape to match original input dimensions."""
-        hidden_size = inputs.orig_query_shape[-1]
-
-        # Output from both prefill and decode: [users, tokens, num_heads, head_size]
-        if inputs.orig_query_ndim == 3:
-            return output.reshape(inputs.users, inputs.query_num_tokens, hidden_size)
-        else:
-            total_tokens = inputs.users * inputs.query_num_tokens
-            return output.reshape(total_tokens, hidden_size)
-
 
 def write_to_kv_cache(
     key: torch.Tensor,
@@ -779,3 +767,135 @@ def get_page_size_bytes(
     return (
         block_size * num_combined_kv_heads * padded_head_size * kv_cache_dtype_bits // 8
     )
+
+
+class TTAttention(Attention):
+    """TT wrapper around vLLM Attention with explicit shape handling.
+
+    This class is patched into vLLM at startup and keeps the base Attention
+    behavior while normalizing query/key/value inputs to flattened 2D hidden
+    representations before dispatch. The output is validated and reshaped back
+    to the original query shape.
+    """
+
+    def __init__(self, num_heads: int, head_size: int, scale: float, **kwargs) -> None:
+        super().__init__(
+            num_heads=num_heads, head_size=head_size, scale=scale, **kwargs
+        )
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        output_shape: torch.Size | None = None,
+    ) -> torch.Tensor:
+        query_shape = query.shape
+
+        def _reshape_to_2d(
+            tensor: torch.Tensor | None,
+            tensor_name: str,
+            expected_heads: int,
+            expected_head_size: int,
+        ) -> torch.Tensor | None:
+            if tensor is None:
+                return None
+
+            if tensor.ndim < 2:
+                raise ValueError(
+                    f"{tensor_name} must have rank >= 2, got shape={tuple(tensor.shape)}"
+                )
+
+            expected_hidden = expected_heads * expected_head_size
+            if tensor.shape[-1] == expected_hidden:
+                return tensor.reshape(-1, expected_hidden)
+
+            if (
+                tensor.shape[-2] == expected_heads
+                and tensor.shape[-1] == expected_head_size
+            ):
+                return tensor.reshape(-1, expected_hidden)
+
+            raise ValueError(
+                f"{tensor_name} must satisfy one of: "
+                f"shape[-1] == {expected_hidden} or "
+                f"shape[-2:] == ({expected_heads}, {expected_head_size}); "
+                f"got shape={tuple(tensor.shape)}"
+            )
+
+        query_2d = _reshape_to_2d(
+            query,
+            "query",
+            self.num_heads,
+            self.head_size,
+        )
+        key_2d = _reshape_to_2d(
+            key,
+            "key",
+            self.num_kv_heads,
+            self.head_size,
+        )
+        value_2d = _reshape_to_2d(
+            value,
+            "value",
+            self.num_kv_heads,
+            self.head_size_v,
+        )
+
+        output_2d = super().forward(query_2d, key_2d, value_2d, output_shape)
+
+        if output_2d.numel() != query.numel():
+            raise ValueError(
+                "Cannot reshape attention output back to query shape: "
+                f"output_shape={tuple(output_2d.shape)}, "
+                f"query_shape={tuple(query_shape)}"
+            )
+
+        return output_2d.reshape(query_shape)
+
+
+class TTEncoderOnlyAttention(TTAttention):
+    """Encoder-only TT attention wrapper with explicit backend selection.
+
+    This variant builds an encoder-only backend via
+    ``create_encoder_only_attention_backend(get_attn_backend(...))`` and
+    enforces ``AttentionType.ENCODER_ONLY`` semantics. It inherits TTAttention
+    shape handling and declares no KV cache support.
+    """
+
+    def __init__(
+        self,
+        num_heads: int,
+        head_size: int,
+        scale: float,
+        cache_config: CacheConfig | None = None,
+        attn_type: str | None = None,
+        **kwargs,
+    ) -> None:
+        dtype = torch.get_default_dtype()
+        kv_cache_dtype = (
+            cache_config.cache_dtype if cache_config is not None else "auto"
+        )
+        underlying_attn_backend = get_attn_backend(
+            head_size,
+            dtype,
+            kv_cache_dtype,
+            attn_type=AttentionType.ENCODER_ONLY,
+        )
+        attn_backend = create_encoder_only_attention_backend(underlying_attn_backend)
+        if attn_type is not None:
+            assert (
+                attn_type == AttentionType.ENCODER_ONLY
+            ), "TTEncoderOnlyAttention only supports AttentionType.ENCODER_ONLY"
+        super().__init__(
+            num_heads=num_heads,
+            head_size=head_size,
+            scale=scale,
+            cache_config=cache_config,
+            attn_backend=attn_backend,
+            attn_type=AttentionType.ENCODER_ONLY,
+            **kwargs,
+        )
+
+    def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec | None:
+        return None

--- a/integrations/vllm_plugin/vllm_tt/attention_impls/attention.py
+++ b/integrations/vllm_plugin/vllm_tt/attention_impls/attention.py
@@ -330,7 +330,6 @@ class TTAttentionBackendImpl(AttentionImpl):
         # vLLM passes a preallocated output buffer and expects attention impls
         # to materialize results into it.
         output_buffer.copy_(finalized_output.reshape_as(output_buffer))
-        return
 
     def _normalize_to_attention_format(
         self,

--- a/integrations/vllm_plugin/vllm_tt/attention_impls/attention.py
+++ b/integrations/vllm_plugin/vllm_tt/attention_impls/attention.py
@@ -277,7 +277,7 @@ class TTAttentionBackendImpl(AttentionImpl):
         output: torch.Tensor | None = None,
         output_scale: torch.Tensor | None = None,
         output_block_scale: torch.Tensor | None = None,
-    ) -> torch.Tensor:
+    ) -> None:
         """Forward pass with TT attention.
 
         Args:
@@ -288,16 +288,11 @@ class TTAttentionBackendImpl(AttentionImpl):
                     - now [2, batch_size, max_seq_len, num_kv_heads, head_size]
             attn_metadata: Metadata for attention.
         Returns:
+            Use pre-allocated output buffer to return the result.
             shape = [num_tokens, num_heads * head_size]
-
-        query/key/value/output tensors have additional dimension 'batch_size'
-        for batched inputs.
-            query: shape = [batch_size, num_tokens, num_heads * head_size]
-            key: shape = [batch_size, num_tokens, num_kv_heads * head_size]
-            value: shape = [batch_size, num_tokens, num_kv_heads * head_size]
-            output: shape = [batch_size, num_tokens, num_heads * head_size]
         """
         assert attn_metadata is not None, "TT attention requires metadata."
+        assert output is not None, "TT attention requires an output buffer."
         output_buffer = output
 
         # Prepare inputs and metadata
@@ -328,17 +323,14 @@ class TTAttentionBackendImpl(AttentionImpl):
                 inputs, kv_cache, attn_metadata
             )
 
-        # Reshape final output to match expected flattened shape [num_users*num_tokens, num_heads * head_size].
+        # Reshape final output to match vLLM expected flattened shape
+        # [num_users*num_tokens, num_heads * head_size].
         finalized_output = attn_output.reshape(-1, self.num_heads * self.head_size)
 
         # vLLM passes a preallocated output buffer and expects attention impls
-        # to materialize results into it. Returning only a new tensor makes the
-        # custom attention path look side-effect-free to FX and can be DCE'd.
-        if output_buffer is not None:
-            output_buffer.copy_(finalized_output.reshape_as(output_buffer))
-            return output_buffer
-
-        return finalized_output
+        # to materialize results into it.
+        output_buffer.copy_(finalized_output.reshape_as(output_buffer))
+        return
 
     def _normalize_to_attention_format(
         self,

--- a/integrations/vllm_plugin/vllm_tt/attention_impls/attention_mla.py
+++ b/integrations/vllm_plugin/vllm_tt/attention_impls/attention_mla.py
@@ -153,7 +153,7 @@ class TTMLAAttentionBackendImpl(MLAAttentionImpl):
         layer: "MLAAttention",
         output: Optional[torch.Tensor] = None,
         **kwargs,
-    ) -> torch.Tensor:
+    ) -> None:
         """MLA attention on TT (prefill and paged decode).
         Dispatches on token count per user: prefill (S > 1) attends against the
         freshly built local latent K via tt::flash_mla_prefill; decode (S == 1)
@@ -168,6 +168,9 @@ class TTMLAAttentionBackendImpl(MLAAttentionImpl):
             output:      [tokens, num_heads * v_head_dim]   (write target)
         Returns the written output tensor.
         """
+        assert (
+            output is not None
+        ), "TTMLAAttentionBackendImpl.forward requires an output tensor."
         q_nope, q_pe = q
 
         is_prefill = self._infer_is_prefill(q_nope, attn_metadata)
@@ -213,7 +216,7 @@ class TTMLAAttentionBackendImpl(MLAAttentionImpl):
         k_lat = torch.cat([kv_c.unsqueeze(2), k_pe_v], dim=-1)  # [b, S, 1, L+R]
 
         if is_prefill:
-            return self._forward_prefill(
+            self._forward_prefill(
                 q_lat,
                 k_lat,
                 kv_cache,
@@ -226,7 +229,7 @@ class TTMLAAttentionBackendImpl(MLAAttentionImpl):
                 output,
             )
         else:
-            return self._forward_decode(
+            self._forward_decode(
                 q_lat,
                 k_lat,
                 kv_cache,
@@ -267,7 +270,7 @@ class TTMLAAttentionBackendImpl(MLAAttentionImpl):
         act_dtype: torch.dtype,
         device: torch.device,
         output: Optional[torch.Tensor],
-    ) -> torch.Tensor:
+    ) -> None:
         q_for_kernel = q_lat.transpose(1, 2).contiguous()  # [b, N, S, L+R]
         k_for_kernel = k_lat.transpose(1, 2).contiguous()  # [b, 1, S, L+R]
 
@@ -317,10 +320,8 @@ class TTMLAAttentionBackendImpl(MLAAttentionImpl):
                 )
             kv_cache.copy_(filled_cache)
 
-        if output is not None:
-            output.copy_(out)
-            return output
-        return out
+        output.copy_(out)
+        return
 
     def _forward_decode(
         self,
@@ -333,7 +334,7 @@ class TTMLAAttentionBackendImpl(MLAAttentionImpl):
         act_dtype: torch.dtype,
         device: torch.device,
         output: Optional[torch.Tensor],
-    ) -> torch.Tensor:
+    ) -> None:
         """
         Paged MLA decode on TT (one token per user, S = 1).
         Shapes:
@@ -381,10 +382,8 @@ class TTMLAAttentionBackendImpl(MLAAttentionImpl):
 
         # Reshape to vLLM's output contract: [tokens, N * V]
         out = out.reshape(users, self.num_heads * self.v_head_dim)
-        if output is not None:
-            output.copy_(out)
-            return output
-        return out
+        output.copy_(out)
+        return
 
 
 class TTMLAAttention(MLAAttention):

--- a/integrations/vllm_plugin/vllm_tt/attention_impls/attention_mla.py
+++ b/integrations/vllm_plugin/vllm_tt/attention_impls/attention_mla.py
@@ -321,7 +321,6 @@ class TTMLAAttentionBackendImpl(MLAAttentionImpl):
             kv_cache.copy_(filled_cache)
 
         output.copy_(out)
-        return
 
     def _forward_decode(
         self,
@@ -383,7 +382,6 @@ class TTMLAAttentionBackendImpl(MLAAttentionImpl):
         # Reshape to vLLM's output contract: [tokens, N * V]
         out = out.reshape(users, self.num_heads * self.v_head_dim)
         output.copy_(out)
-        return
 
 
 class TTMLAAttention(MLAAttention):

--- a/integrations/vllm_plugin/vllm_tt/layers/fused_moe.py
+++ b/integrations/vllm_plugin/vllm_tt/layers/fused_moe.py
@@ -26,54 +26,43 @@ import torch.nn.functional as F
 from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.fused_moe.layer import FusedMoE
+from vllm.model_executor.layers.fused_moe.oracle.unquantized import (
+    UnquantizedMoeBackend,
+)
+from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import (
+    UnquantizedFusedMoEMethod,
+)
 
 
-# Monkey-patch UnquantizedFusedMoEMethod to handle is_monolithic safely.
-# In vLLM 0.20.2, experts_cls can be None, which causes is_monolithic access to fail.
-def _patch_unquantized_moe_method():
-    try:
-        from vllm.model_executor.layers.fused_moe.oracle.unquantized import (
-            UnquantizedMoeBackend,
-        )
-        from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import (
-            UnquantizedFusedMoEMethod,
-        )
+class TTUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
+    """TT-scoped override for unquantized FusedMoE method behavior.
 
-        # Override is_monolithic/apply_monolithic to handle missing kernel
-        # state on OOT paths (e.g. experts_cls=None, moe_kernel=None).
-        original_apply_monolithic = UnquantizedFusedMoEMethod.apply_monolithic
+    Keeps the fallback logic local to TT FusedMoE instances instead of
+    monkey-patching vLLM globally.
+    """
 
-        @property
-        def safe_is_monolithic(self):
-            # Escape hatch for CPU, which stays on the old monolithic path.
-            if self.unquantized_backend == UnquantizedMoeBackend.CPU:
-                return True
-            # If the modular kernel was not initialized, force monolithic mode
-            # and let apply_monolithic route to the TT layer fallback.
-            if self.moe_kernel is None:
-                return True
-            return self.moe_kernel.is_monolithic
+    @property
+    def is_monolithic(self) -> bool:
+        # Escape hatch for CPU, which stays on the old monolithic path.
+        if self.unquantized_backend == UnquantizedMoeBackend.CPU:
+            return True
+        # If the modular kernel was not initialized, force monolithic mode and
+        # let apply_monolithic route to the TT layer fallback.
+        if self.moe_kernel is None:
+            return True
+        return self.moe_kernel.is_monolithic
 
-        def safe_apply_monolithic(self, layer, x, router_logits, input_ids=None):
-            if (
-                self.unquantized_backend != UnquantizedMoeBackend.CPU
-                and self.moe_kernel is None
-            ):
-                # TTFusedMoE exposes forward_native(hidden_states, router_logits)
-                # that does routing + experts in a TT-friendly way without
-                # relying on vLLM's internal moe kernel object.
-                if hasattr(layer, "forward_native"):
-                    return layer.forward_native(x, router_logits)
-            return original_apply_monolithic(self, layer, x, router_logits, input_ids)
-
-        UnquantizedFusedMoEMethod.is_monolithic = safe_is_monolithic
-        UnquantizedFusedMoEMethod.apply_monolithic = safe_apply_monolithic
-    except Exception:
-        # If patching fails, continue without it
-        pass
-
-
-_patch_unquantized_moe_method()
+    def apply_monolithic(self, layer, x, router_logits, input_ids=None):
+        if (
+            self.unquantized_backend != UnquantizedMoeBackend.CPU
+            and self.moe_kernel is None
+            and hasattr(layer, "forward_native")
+        ):
+            # TTFusedMoE exposes forward_native(hidden_states, router_logits)
+            # that does routing + experts in a TT-friendly way without
+            # relying on vLLM's internal moe kernel object.
+            return layer.forward_native(x, router_logits)
+        return super().apply_monolithic(layer, x, router_logits, input_ids)
 
 
 @CustomOp.register_oot(name="FusedMoE")
@@ -82,6 +71,28 @@ class TTFusedMoE(FusedMoE):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+        # Use a TT-scoped quant method override rather than monkey-patching
+        # UnquantizedFusedMoEMethod globally.
+        if isinstance(self.quant_method, UnquantizedFusedMoEMethod) and not isinstance(
+            self.quant_method, TTUnquantizedFusedMoEMethod
+        ):
+            tt_method = TTUnquantizedFusedMoEMethod(self.moe_config)
+
+            # Preserve runtime state initialized by vLLM on the original method.
+            for attr in (
+                "moe_kernel",
+                "moe_quant_config",
+                "cpu_fused_moe",
+                "unquantized_backend",
+                "experts_cls",
+            ):
+                if hasattr(self.quant_method, attr):
+                    setattr(tt_method, attr, getattr(self.quant_method, attr))
+
+            self.quant_method = tt_method
+            self.base_quant_method = tt_method
+            self.runner.quant_method = tt_method
 
         # Avoid the generic vLLM custom-op trampoline (`vllm.moe_forward*`) in
         # TT torch-xla compile, which can hit functionalization fallback asserts

--- a/integrations/vllm_plugin/vllm_tt/layers/fused_moe.py
+++ b/integrations/vllm_plugin/vllm_tt/layers/fused_moe.py
@@ -94,9 +94,14 @@ class TTFusedMoE(FusedMoE):
             self.base_quant_method = tt_method
             self.runner.quant_method = tt_method
 
-        # Avoid the generic vLLM custom-op trampoline (`vllm.moe_forward*`) in
-        # TT torch-xla compile, which can hit functionalization fallback asserts
-        # when executed via FX interpreter during graph extraction.
+        # vLLM::MoERunner calling sequence:
+        # forward
+        # └── _forward_entry
+        #     └── vllm.moe_forward or vllm.moe_forward_shared (custom op)
+        #         └── _forward_impl
+        #
+        # Override the runner's custom-op entry point to dispatch directly to the
+        # TT MoE implementation.
         def _forward_entry_direct(
             hidden_states,
             router_logits,

--- a/integrations/vllm_plugin/vllm_tt/layers/fused_moe.py
+++ b/integrations/vllm_plugin/vllm_tt/layers/fused_moe.py
@@ -26,12 +26,83 @@ import torch.nn.functional as F
 from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.fused_moe.layer import FusedMoE
-from vllm.model_executor.layers.fused_moe.shared_fused_moe import SharedFusedMoE
+
+
+# Monkey-patch UnquantizedFusedMoEMethod to handle is_monolithic safely.
+# In vLLM 0.20.2, experts_cls can be None, which causes is_monolithic access to fail.
+def _patch_unquantized_moe_method():
+    try:
+        from vllm.model_executor.layers.fused_moe.oracle.unquantized import (
+            UnquantizedMoeBackend,
+        )
+        from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import (
+            UnquantizedFusedMoEMethod,
+        )
+
+        # Override is_monolithic/apply_monolithic to handle missing kernel
+        # state on OOT paths (e.g. experts_cls=None, moe_kernel=None).
+        original_apply_monolithic = UnquantizedFusedMoEMethod.apply_monolithic
+
+        @property
+        def safe_is_monolithic(self):
+            # Escape hatch for CPU, which stays on the old monolithic path.
+            if self.unquantized_backend == UnquantizedMoeBackend.CPU:
+                return True
+            # If the modular kernel was not initialized, force monolithic mode
+            # and let apply_monolithic route to the TT layer fallback.
+            if self.moe_kernel is None:
+                return True
+            return self.moe_kernel.is_monolithic
+
+        def safe_apply_monolithic(self, layer, x, router_logits, input_ids=None):
+            if (
+                self.unquantized_backend != UnquantizedMoeBackend.CPU
+                and self.moe_kernel is None
+            ):
+                # TTFusedMoE exposes forward_native(hidden_states, router_logits)
+                # that does routing + experts in a TT-friendly way without
+                # relying on vLLM's internal moe kernel object.
+                if hasattr(layer, "forward_native"):
+                    return layer.forward_native(x, router_logits)
+            return original_apply_monolithic(self, layer, x, router_logits, input_ids)
+
+        UnquantizedFusedMoEMethod.is_monolithic = safe_is_monolithic
+        UnquantizedFusedMoEMethod.apply_monolithic = safe_apply_monolithic
+    except Exception:
+        # If patching fails, continue without it
+        pass
+
+
+_patch_unquantized_moe_method()
 
 
 @CustomOp.register_oot(name="FusedMoE")
 class TTFusedMoE(FusedMoE):
     """OOT FusedMoE specialised for the TT compile pipeline (see module docstring)."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Avoid the generic vLLM custom-op trampoline (`vllm.moe_forward*`) in
+        # TT torch-xla compile, which can hit functionalization fallback asserts
+        # when executed via FX interpreter during graph extraction.
+        def _forward_entry_direct(
+            hidden_states,
+            router_logits,
+            shared_experts_input,
+            input_ids,
+            _layer_name,
+            _hidden_dim_unpadded,
+        ):
+            return self.runner._forward_impl(
+                self,
+                hidden_states,
+                router_logits,
+                shared_experts_input,
+                input_ids,
+            )
+
+        self.runner._forward_entry = _forward_entry_direct
 
     # vLLM FusedMoE → tt_torch.moe_backend expert-module interface adapter.
     @property
@@ -98,17 +169,3 @@ class TTFusedMoE(FusedMoE):
         else:
             out_flat = tt_dense_experts_forward(self, h_flat, topk_ids, topk_weights)
         return out_flat.view(orig_shape)
-
-
-@CustomOp.register_oot(name="SharedFusedMoE")
-class TTSharedFusedMoE(SharedFusedMoE, TTFusedMoE):
-    """
-    OOT implementation of the SharedFusedMoE class. Used by models that have
-    shared experts.
-    """
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # Our vLLM plugin doesn't support overlapping the shared experts'
-        # forward with the all2all dispatch, so we disable it.
-        self.use_overlapped = False

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -31,6 +31,9 @@ from vllm.config import (
 )
 from vllm.distributed.kv_transfer import get_kv_transfer_group, has_kv_transfer_group
 from vllm.distributed.kv_transfer.kv_connector.utils import copy_kv_blocks
+from vllm.distributed.kv_transfer.kv_transfer_state import (
+    ensure_kv_transfer_shutdown as ensure_kv_transfer_state_shutdown,
+)
 from vllm.forward_context import get_forward_context, set_forward_context
 from vllm.lora.layers import BaseLayerWithLoRA
 from vllm.model_executor.layers.attention.attention import Attention
@@ -2099,9 +2102,10 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         # Cache attention layer names so we don't rebuild the per-layer
         # attn_metadata dict every step.
-        attn_layers = get_layers_from_vllm_config(self.vllm_config, Attention)
-        attn_layers |= get_layers_from_vllm_config(self.vllm_config, MLAAttention)
-        self._attention_layer_names = tuple(attn_layers.keys())
+        layer_type = cast(type[Any], AttentionLayerBase)
+        self._attention_layer_names = tuple(
+            get_layers_from_vllm_config(self.vllm_config, layer_type).keys()
+        )
 
     def reload_weights(self) -> None:
         assert (
@@ -3699,6 +3703,10 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 pin_memory=self.pin_memory,
             )
         )
+
+    def ensure_kv_transfer_shutdown(self) -> None:
+        if has_kv_transfer_group():
+            ensure_kv_transfer_state_shutdown()
 
 
 def _adjust_min_token(min_token_size: int) -> int:

--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -582,3 +582,10 @@ class TTPlatform(Platform):
             max_model_len,
         )
         return max_model_len
+
+    @classmethod
+    def manual_seed_all(cls, seed: int) -> None:
+        """Set RNG seed across all devices for the current platform. Set in
+        worker after initializing the device.
+        """
+        return

--- a/integrations/vllm_plugin/vllm_tt/pooling_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/pooling_runner.py
@@ -27,7 +27,9 @@ from vllm.config import (
     update_config,
 )
 from vllm.distributed.kv_transfer import get_kv_transfer_group, has_kv_transfer_group
-from vllm.distributed.kv_transfer.kv_connector.utils import copy_kv_blocks
+from vllm.distributed.kv_transfer.kv_transfer_state import (
+    ensure_kv_transfer_shutdown as ensure_kv_transfer_state_shutdown,
+)
 from vllm.forward_context import set_forward_context
 from vllm.lora.layers import BaseLayerWithLoRA
 from vllm.model_executor.layers.attention.attention import Attention
@@ -1008,10 +1010,9 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
             self.set_active_loras(self.input_batch, padded_num_scheduled_tokens_per_req)
 
-        layer_names = get_layers_from_vllm_config(self.vllm_config, Attention).keys()
-        per_layer_attn_metadata = {
-            layer_name: attn_metadata for layer_name in layer_names
-        }
+        per_layer_attn_metadata = dict.fromkeys(
+            self._attention_layer_names, attn_metadata
+        )
         return (
             per_layer_attn_metadata,
             logits_indices,
@@ -1408,6 +1409,11 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self.model.compile(backend="tt", dynamic=False)
         logger.info(f"Compiled model: \n{self.model}")
 
+        layer_type = cast(type[Any], AttentionLayerBase)
+        self._attention_layer_names = tuple(
+            get_layers_from_vllm_config(self.vllm_config, layer_type).keys()
+        )
+
     def reload_weights(self) -> None:
         assert (
             getattr(self, "model", None) is not None
@@ -1466,10 +1472,9 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             num_users=num_reqs,
         )
 
-        layer_names = get_layers_from_vllm_config(self.vllm_config, Attention).keys()
-        per_layer_attn_metadata = {
-            layer_name: attn_metadata for layer_name in layer_names
-        }
+        per_layer_attn_metadata = dict.fromkeys(
+            self._attention_layer_names, attn_metadata
+        )
 
         with (
             self.maybe_select_dummy_loras(
@@ -1753,6 +1758,10 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 pin_memory=self.pin_memory,
             )
         )
+
+    def ensure_kv_transfer_shutdown(self) -> None:
+        if has_kv_transfer_group():
+            ensure_kv_transfer_state_shutdown()
 
 
 def _get_req_paddings(min_req_size: int, max_req_size: int) -> list[int]:

--- a/integrations/vllm_plugin/vllm_tt/scheduler/ascend_scheduler.py
+++ b/integrations/vllm_plugin/vllm_tt/scheduler/ascend_scheduler.py
@@ -37,6 +37,7 @@ class AscendScheduler(Scheduler):
         kv_cache_config: KVCacheConfig,
         structured_output_manager: StructuredOutputManager,
         block_size: int,
+        hash_block_size: int | None = None,
         mm_registry: MultiModalRegistry = MULTIMODAL_REGISTRY,
         include_finished_set: bool = False,
         log_stats: bool = False,
@@ -46,6 +47,7 @@ class AscendScheduler(Scheduler):
             kv_cache_config,
             structured_output_manager,
             block_size,
+            hash_block_size,
             mm_registry,
             include_finished_set,
             log_stats,
@@ -201,6 +203,15 @@ class AscendScheduler(Scheduler):
                 num_computed_tokens = (
                     num_new_local_computed_tokens + num_external_computed_tokens
                 )
+                assert num_computed_tokens <= request.num_tokens
+
+                if request.prefill_stats is not None:
+                    assert num_computed_tokens <= request.num_prompt_tokens
+                    request.prefill_stats.set(
+                        num_prompt_tokens=request.num_prompt_tokens,
+                        num_local_cached_tokens=num_new_local_computed_tokens,
+                        num_external_cached_tokens=num_external_computed_tokens,
+                    )
             else:
                 # Remote-kv or continued chunk: pass the manager's empty-blocks
                 # singleton (allocate_slots compares it by identity).
@@ -410,9 +421,6 @@ class AscendScheduler(Scheduler):
                 step_prefill_num_computed = num_computed_tokens
             request.status = RequestStatus.RUNNING
             request.num_computed_tokens = num_computed_tokens
-            # Count the number of prefix cached tokens.
-            if request.num_cached_tokens < 0:
-                request.num_cached_tokens = num_computed_tokens
 
             # Encoder-related: commit the scheduled encoder inputs and reserve
             # space for their outputs in the encoder cache.
@@ -739,6 +747,49 @@ class AscendScheduler(Scheduler):
         model_runner_output: ModelRunnerOutput,
     ) -> dict[int, EngineCoreOutputs]:
         num_scheduled_tokens = scheduler_output.num_scheduled_tokens
+
+        req_id_to_index = model_runner_output.req_id_to_index
+
+        # Async scheduling can surface stale request ids that were scheduled
+        # but are no longer present in the runner's output map.  The request
+        # was moved to `running` and had its num_computed_tokens updated during
+        # schedule(), but the model never processed it.  Simply dropping it
+        # from num_scheduled_tokens leaves the request in `running` with an
+        # inconsistent num_computed_tokens, causing an AssertionError on the
+        # next schedule() call.  Instead, preempt the request so it is
+        # cleanly re-queued to waiting and will be retried from scratch.
+        stale_req_ids = [
+            req_id
+            for req_id in list(num_scheduled_tokens)
+            if req_id not in req_id_to_index
+        ]
+        if stale_req_ids:
+            stale_set = set(stale_req_ids)
+            for req_id in stale_req_ids:
+                num_scheduled_tokens.pop(req_id, None)
+                scheduler_output.scheduled_spec_decode_tokens.pop(req_id, None)
+                self.scheduled_req_ids.discard(req_id)
+
+            # Preempt each stale request: free its KV cache allocation, reset
+            # state, and move it back to the head of the waiting queue so it
+            # will be re-scheduled on the next step.
+            still_running = []
+            for request in self.running:
+                if request.request_id in stale_set:
+                    self.kv_cache_manager.free(request)
+                    request.status = RequestStatus.PREEMPTED
+                    request.num_computed_tokens = 0
+                    self.waiting.prepend_request(request)
+                else:
+                    still_running.append(request)
+            self.running = still_running
+
+            logger.warning(
+                "Preempted %d stale scheduled request id(s) missing from "
+                "model_runner_output (will retry): %s",
+                len(stale_req_ids),
+                stale_req_ids[:3],
+            )
 
         # NOTE(woosuk): As len(self.running) can be up to 1K or more, the below
         # loop can be a performance bottleneck. We should do our best to avoid

--- a/integrations/vllm_plugin/vllm_tt/scheduler/ascend_scheduler.py
+++ b/integrations/vllm_plugin/vllm_tt/scheduler/ascend_scheduler.py
@@ -203,10 +203,21 @@ class AscendScheduler(Scheduler):
                 num_computed_tokens = (
                     num_new_local_computed_tokens + num_external_computed_tokens
                 )
-                assert num_computed_tokens <= request.num_tokens
+                assert num_computed_tokens <= request.num_tokens, (
+                    f"Invalid token accounting for request {request.request_id}: "
+                    f"computed={num_computed_tokens} "
+                    f"(local={num_new_local_computed_tokens}, external={num_external_computed_tokens}) "
+                    f"> total_tokens={request.num_tokens}"
+                )
 
                 if request.prefill_stats is not None:
-                    assert num_computed_tokens <= request.num_prompt_tokens
+                    assert num_computed_tokens <= request.num_prompt_tokens, (
+                        f"Invalid prefill token accounting for request {request.request_id}: "
+                        f"computed={num_computed_tokens} "
+                        f"(local={num_new_local_computed_tokens}, external={num_external_computed_tokens}) "
+                        f"> prompt_tokens={request.num_prompt_tokens} "
+                        f"(total_tokens={request.num_tokens})"
+                    )
                     request.prefill_stats.set(
                         num_prompt_tokens=request.num_prompt_tokens,
                         num_local_cached_tokens=num_new_local_computed_tokens,

--- a/integrations/vllm_plugin/vllm_tt/worker.py
+++ b/integrations/vllm_plugin/vllm_tt/worker.py
@@ -6,6 +6,7 @@
 
 import os
 import sys
+import time
 from collections.abc import Callable
 from typing import Any, Optional, TypeVar
 
@@ -36,6 +37,7 @@ from vllm.v1.kv_cache_interface import AttentionSpec, KVCacheConfig, KVCacheSpec
 from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.utils import report_usage_stats
 from vllm.v1.worker.utils import bind_kv_cache
+from vllm.v1.worker.worker_base import CompilationTimes
 
 from .attention_impls.attention import TT_HEAD_SIZE_ALIGNMENT
 from .logger import tt_init_logger
@@ -348,13 +350,16 @@ class TTWorker:
     def reload_weights(self) -> None:
         self.model_runner.reload_weights()
 
-    def compile_or_warm_up_model(self) -> None:
+    def compile_or_warm_up_model(self) -> CompilationTimes:
+        start = time.perf_counter()
         if not self.model_config.enforce_eager:
             self.model_runner.capture_model()
+        language_model_time = time.perf_counter() - start
 
         # Reset the seed to ensure that the random state is not affected by
         # the model initialization and profiling.
         set_random_seed(self.model_config.seed)
+        return CompilationTimes(language_model=language_model_time, encoder=0.0)
 
     def reset_mm_cache(self) -> None:
         self.model_runner.reset_mm_cache()
@@ -374,7 +379,8 @@ class TTWorker:
         return self.model_runner.get_kv_cache_spec()
 
     def initialize_from_config(self, kv_cache_config: KVCacheConfig) -> None:
-        """Allocate GPU KV cache with the specified kv_cache_config."""
+        """Allocate KV cache with the specified kv_cache_config."""
+        ensure_kv_transfer_initialized(self.vllm_config, kv_cache_config)
         self.model_runner.initialize_kv_cache(kv_cache_config)
 
     def check_health(self) -> None:
@@ -406,8 +412,6 @@ class TTWorker:
         ensure_model_parallel_initialized(
             parallel_config.tensor_parallel_size, parallel_config.pipeline_parallel_size
         )
-
-        ensure_kv_transfer_initialized(vllm_config)
 
     def shutdown(self) -> None:
         self.model_runner.ensure_kv_transfer_shutdown()

--- a/python_package/requirements.txt
+++ b/python_package/requirements.txt
@@ -2,9 +2,9 @@
 jax==0.7.1
 jaxlib==0.7.1
 requests
-torch@https://download.pytorch.org/whl/cpu/torch-2.10.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl
+torch@https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl
 loguru
-torch-xla@https://pypi.eng.aws.tenstorrent.com/torch-xla/torch_xla-2.9.0%2Bgit8d31cb3-cp312-cp312-linux_x86_64.whl
+torch-xla@https://pypi.eng.aws.tenstorrent.com/torch-xla/torch_xla-2.9.0%2Bgit56f8e61-cp312-cp312-linux_x86_64.whl
 
 # Pin nanobind to match tt-metal's version (v2.10.2) for ABI compatibility.
 # A mismatch causes segfaults in nb_type_c2p when PythonModelRunner converts

--- a/python_package/tt_torch/utils.py
+++ b/python_package/tt_torch/utils.py
@@ -112,7 +112,9 @@ def apply_xla_dynamo_guard_repr_patch() -> None:
         code = f"___check_obj_id({ref}, {id_val}), type={type_repr}"
         self._set_guard_export_info(guard, [code], provided_func_name="ID_MATCH")
         self.get_guard_manager(guard).add_id_match_guard(
-            id_val, get_verbose_code_parts(code, guard, recompile_hint)
+            id_val,
+            get_verbose_code_parts(code, guard, recompile_hint),
+            guard.user_stack,
         )
 
         # Handle LocalSource for Module objects

--- a/tests/integrations/vllm_plugin/pooling/test_single_device.py
+++ b/tests/integrations/vllm_plugin/pooling/test_single_device.py
@@ -19,12 +19,14 @@ from tests.integrations.vllm_plugin.pooling.utils import run_pooling_test
         pytest.param(
             "Qwen/Qwen3-Embedding-0.6B",
             "baseline/qwen3_embedding_0.6B_baseline.pt",
-            75,
+            32,
         ),
     ],
 )
 def test_embedding_push(model_name: str, baseline_path, max_model_len: int):
-    run_pooling_test(model_name, baseline_path, max_model_len, min_context_len=32)
+    run_pooling_test(
+        model_name, baseline_path, max_model_len, max_num_reqs=1, min_context_len=32
+    )
 
 
 @pytest.mark.push
@@ -150,6 +152,7 @@ def test_embedding_nightly(
         baseline_path,
         max_model_len,
         experimental_weight_dtype,
+        max_num_reqs=1,
     )
 
 

--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -774,13 +774,13 @@ test_config:
 
   pi_0/pytorch-lerobot_pi0_libero_base-single_device-inference:
     supported_archs: ["p150"]
-    status: EXPECTED_PASSING
-    assert_pcc: false
-    reason: "AssertionError: PCC comparison failed. Calculated: pcc=0.8167537277595653. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/3786"
+    status: KNOWN_FAILURE_XFAIL
+    reason: "Failure due to incompatible torchvision version. Issue: https://github.com/tenstorrent/tt-xla/issues/5519"
 
   pi_0/pytorch-pi0_base-single_device-inference:
     supported_archs: ["p150"]
-    status: EXPECTED_PASSING
+    status: KNOWN_FAILURE_XFAIL
+    reason: "Failure due to incompatible torchvision version. Issue: https://github.com/tenstorrent/tt-xla/issues/5519"
 
   opt/qa/pytorch-1.3b-single_device-inference:
     status: EXPECTED_PASSING

--- a/venv/requirements-dev.txt
+++ b/venv/requirements-dev.txt
@@ -34,7 +34,7 @@ sentencepiece
 setuptools
 tabulate
 timm
-torchvision==0.25+cpu
+torchvision==0.26+cpu
 torchxrayvision
 transformers==5.5.1
 


### PR DESCRIPTION
### Ticket
closes #5559 

### What's changed
Following packages are uplifted

- PyTorch 2.10.0 -> 2.11.0
- torchvision 0.25.0+cpu -> 0.26.0+cpu
- vLLM 0.19.1 -> 0.20.2
- torch-xla (re-build against torch 2.11.0)

### Checklist
- [X] New/Existing tests provide coverage for changes
