### PR TITLE
[GLM Image] Add e2e pipeline in nightly and benchmark CI

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -105,6 +105,11 @@
         "runs-on": "p150-perf"
       },
       {
+        "name": "glm_image",
+        "pytest": "tests/benchmark/test_imagegen.py::test_glm_image",
+        "runs-on": "qb2-blackhole"
+      },
+      {
         "name": "bge_m3_encode",
         "pyreq": "transformers==4.57.1 FlagEmbedding",
         "pytest": "tests/benchmark/test_encoders.py::test_bge_m3"

--- a/tests/benchmark/benchmarks/glm_image_pipeline.py
+++ b/tests/benchmark/benchmarks/glm_image_pipeline.py
@@ -1,0 +1,261 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""GLM-Image — benchmark-side pipeline for the imagegen harness.
+
+GLM-Image is a diffusion text-to-image model whose DiT transformer runs
+**tensor-parallel** across a multi-chip mesh, while the AR vision-language
+encoder, the T5 glyph text encoder, the FlowMatchEuler scheduler and the VAE
+decode stay on CPU. The end-to-end pipeline (device split + DiT sharding) lives
+in ``tt_forge_models`` and is the same one the nightly pipeline test drives.
+
+The imagegen harness (``benchmarks/imagegen_benchmark.py``) needs two things the
+base ``GlmImagePipeline`` does not provide:
+
+  - a ``generate(prompt, num_inference_steps, ...)`` that accepts the step count
+    per call (warmup uses 1 step, steady-state uses the full count), and
+  - a ``self._perf`` dict populated with per-component / per-step timings.
+
+So this module subclasses the ``tt_forge_models`` pipeline and overrides
+``generate`` to add both, without duplicating the model loading / sharding
+setup. The denoising body mirrors the base pipeline's t2i path exactly; the only
+additions are the ``num_inference_steps`` override and the timing hooks.
+"""
+
+import time
+from typing import Optional
+
+import numpy as np
+import torch
+import torch_xla.core.xla_model as xm
+from loguru import logger
+
+from third_party.tt_forge_models.glm_image.pytorch.src.pipeline import (
+    CPU_DTYPE,
+    HEIGHT,
+    PROMPT,
+    SEED,
+    TRANSFORMER_DTYPE,
+    WIDTH,
+    GlmImageConfig,
+)
+from third_party.tt_forge_models.glm_image.pytorch.src.pipeline import (
+    GlmImagePipeline as _BaseGlmImagePipeline,
+)
+
+__all__ = ["GlmImageConfig", "GlmImagePipeline", "PROMPT", "SEED", "HEIGHT", "WIDTH"]
+
+
+class GlmImagePipeline(_BaseGlmImagePipeline):
+    """GLM-Image pipeline with benchmark-harness timing instrumentation.
+
+    Reuses the base pipeline's model loading and DiT tensor-parallel sharding
+    (``setup``/``load_models``/``shard_to_tt``) and only overrides ``generate``
+    to accept a per-call ``num_inference_steps`` and to populate ``self._perf``.
+    """
+
+    @torch.no_grad()
+    def generate(
+        self,
+        prompt: str = PROMPT,
+        seed: Optional[int] = SEED,
+        num_inference_steps: Optional[int] = None,
+        output_type: str = "latent",
+    ):
+        """Run the GLM-Image t2i pipeline and record per-stage timings.
+
+        Mirrors ``tt_forge_models`` ``GlmImagePipeline.generate`` (CPU AR prior
+        tokens + T5 encode + FlowMatchEuler scheduler + VAE decode; DiT denoise
+        on TT), adding:
+
+          - ``num_inference_steps``: overrides ``config.num_inference_steps`` for
+            this call (the harness warms up with 1 step, then runs the full count).
+          - ``self._perf``: harness-readable timings. ``components`` holds scalar
+            per-stage seconds (AR prior tokens, T5 encode, VAE decode -- all CPU),
+            ``steps`` holds per-DiT-step seconds (the TT-resident denoise work;
+            the ``_to_cpu`` cast after each step's forwards forces a device sync
+            so the timer captures real device time), ``step_metric_name`` labels
+            the per-step metric, and ``total`` is the full ``generate`` wall time.
+
+        Returns the raw VAE decode ``(B, 3, H, W)`` in ``[-1, 1]`` when
+        ``output_type="latent"`` (what ``utils.save_image`` expects); other
+        ``output_type`` values match the base pipeline's post-processing.
+        """
+        from diffusers.pipelines.glm_image.pipeline_glm_image import (
+            calculate_shift,
+            retrieve_timesteps,
+        )
+
+        self._perf = {
+            "components": {},
+            "steps": [],
+            "step_metric_name": "transformer_step",
+            "total": None,
+        }
+        t_total_start = time.perf_counter()
+
+        pipe = self.pipe
+        transformer = self.transformer
+        vae = self.vae
+        scheduler = self.scheduler
+        on_tt = self.config.transformer_on_tt
+        cpu = torch.device("cpu")
+
+        height, width = self.config.height, self.config.width
+        num_inference_steps = num_inference_steps or self.config.num_inference_steps
+        guidance_scale = self.config.guidance_scale
+        do_cfg = guidance_scale > 1
+        B = 1
+
+        def _to_tt(x, dtype=None):
+            if not on_tt:
+                return x
+            if dtype is not None:
+                x = x.to(dtype)
+            return x.to(xm.xla_device())
+
+        def _to_cpu(x):
+            return x.to("cpu") if on_tt else x
+
+        generator = torch.Generator(device="cpu")
+        if seed is not None:
+            generator.manual_seed(seed)
+
+        # ── AR prior-token generation (CPU, vision-language encoder) ──────
+        logger.info("[STAGE] AR prior-token generation (CPU): start")
+        t0 = time.perf_counter()
+        prior_token_ids, _, _ = pipe.generate_prior_tokens(
+            prompt=prompt,
+            image=None,  # text-to-image
+            height=height,
+            width=width,
+            device=cpu,
+            generator=generator,
+        )
+        self._perf["components"]["ar_prior_tokens"] = time.perf_counter() - t0
+        logger.info("[STAGE] AR prior-token generation (CPU): done")
+
+        # ── T5 glyph text encode (CPU) ────────────────────────────────────
+        logger.info("[STAGE] T5 glyph text encode (CPU): start")
+        t0 = time.perf_counter()
+        prompt_embeds, negative_prompt_embeds = pipe.encode_prompt(
+            prompt,
+            do_classifier_free_guidance=do_cfg,
+            num_images_per_prompt=1,
+            device=cpu,
+            dtype=CPU_DTYPE,
+            max_sequence_length=self.config.max_sequence_length,
+        )
+        self._perf["components"]["t5_encode"] = time.perf_counter() - t0
+        logger.info("[STAGE] T5 glyph text encode (CPU): done")
+
+        # ── Latents + timestep conditioning (CPU) ─────────────────────────
+        latents = pipe.prepare_latents(
+            batch_size=B,
+            num_channels_latents=transformer.config.in_channels,
+            height=height,
+            width=width,
+            dtype=CPU_DTYPE,
+            device=cpu,
+            generator=generator,
+        )
+        target_size = torch.tensor([[height, width]], dtype=CPU_DTYPE)
+        crop_coords = torch.tensor([[0, 0]], dtype=CPU_DTYPE)
+
+        # ── Timesteps (FlowMatchEuler with resolution-dependent shift) ─────
+        image_seq_len = (
+            (height // pipe.vae_scale_factor) * (width // pipe.vae_scale_factor)
+        ) // (transformer.config.patch_size**2)
+        timesteps = np.linspace(
+            scheduler.config.num_train_timesteps, 1.0, num_inference_steps + 1
+        )[:-1]
+        timesteps = timesteps.astype(np.int64).astype(np.float32)
+        sigmas = timesteps / scheduler.config.num_train_timesteps
+        mu = calculate_shift(
+            image_seq_len,
+            scheduler.config.get("base_image_seq_len", 256),
+            scheduler.config.get("base_shift", 0.25),
+            scheduler.config.get("max_shift", 0.75),
+        )
+        timesteps, num_inference_steps = retrieve_timesteps(
+            scheduler, num_inference_steps, cpu, timesteps, sigmas, mu=mu
+        )
+
+        # ── Loop-invariant DiT inputs: cast to bf16 + move to TT once ──────
+        prior_ids_tt = _to_tt(prior_token_ids)
+        drop_cond_tt = _to_tt(torch.full_like(prior_token_ids, False, dtype=torch.bool))
+        drop_uncond_tt = _to_tt(
+            torch.full_like(prior_token_ids, True, dtype=torch.bool)
+        )
+        eh_cond = _to_tt(prompt_embeds, TRANSFORMER_DTYPE)
+        eh_uncond = (
+            _to_tt(negative_prompt_embeds, TRANSFORMER_DTYPE) if do_cfg else None
+        )
+        target_size_tt = _to_tt(target_size)
+        crop_coords_tt = _to_tt(crop_coords)
+
+        def _dit(hidden, enc, drop, ts):
+            return transformer(
+                hidden_states=hidden,
+                encoder_hidden_states=enc,
+                prior_token_id=prior_ids_tt,
+                prior_token_drop=drop,
+                timestep=ts,
+                target_size=target_size_tt,
+                crop_coords=crop_coords_tt,
+                return_dict=False,
+                kv_caches=None,  # t2i: no condition-image KV cache
+            )[0]
+
+        # ── Denoising loop (DiT on TT, scheduler on CPU) ───────────────────
+        logger.info(f"[STAGE] DiT denoising loop: start ({len(timesteps)} steps)")
+        for i, t in enumerate(timesteps):
+            logger.info(f"[STEP] DiT step {i + 1}/{len(timesteps)}")
+            # Per-step DiT time: the two CFG forwards plus the TT→CPU cast that
+            # forces the device sync, so the timer captures real device work.
+            t0 = time.perf_counter()
+            latent_input = _to_tt(latents, TRANSFORMER_DTYPE)
+            timestep = _to_tt(t.expand(B) - 1)
+
+            noise_pred_cond = _to_cpu(
+                _dit(latent_input, eh_cond, drop_cond_tt, timestep)
+            ).float()
+            if do_cfg:
+                noise_pred_uncond = _to_cpu(
+                    _dit(latent_input, eh_uncond, drop_uncond_tt, timestep)
+                ).float()
+                noise_pred = noise_pred_uncond + guidance_scale * (
+                    noise_pred_cond - noise_pred_uncond
+                )
+            else:
+                noise_pred = noise_pred_cond
+            self._perf["steps"].append(time.perf_counter() - t0)
+
+            latents = scheduler.step(noise_pred, t, latents, return_dict=False)[0]
+        logger.info("[STAGE] DiT denoising loop: done")
+
+        # ── VAE decode (CPU) -> RGB image in [-1, 1] ───────────────────────
+        logger.info("[STAGE] VAE decode (CPU): start")
+        t0 = time.perf_counter()
+        latents = latents.to(vae.dtype)
+        latents_mean = (
+            torch.tensor(vae.config.latents_mean)
+            .view(1, vae.config.latent_channels, 1, 1)
+            .to(latents.device, latents.dtype)
+        )
+        latents_std = (
+            torch.tensor(vae.config.latents_std)
+            .view(1, vae.config.latent_channels, 1, 1)
+            .to(latents.device, latents.dtype)
+        )
+        latents = latents * latents_std + latents_mean
+        image = vae.decode(latents, return_dict=False)[0]
+        self._perf["components"]["vae"] = time.perf_counter() - t0
+        logger.info("[STAGE] VAE decode (CPU): done")
+
+        # Post-process ([-1, 1] -> output_type) via the diffusers image processor.
+        image = pipe.image_processor.postprocess(image, output_type=output_type)
+
+        self._perf["total"] = time.perf_counter() - t_total_start
+        return image

--- a/tests/benchmark/test_imagegen.py
+++ b/tests/benchmark/test_imagegen.py
@@ -507,3 +507,51 @@ def test_janus_pro_7b(output_file, request):
         output_file=output_file,
         request=request,
     )
+
+
+def test_glm_image(output_file, request):
+    """GLM-Image diffusion text-to-image benchmark (DiT tensor-parallel).
+
+    Unlike the single-chip SD models above, GLM-Image's DiT transformer runs
+    tensor-parallel across a multi-chip mesh (the AR vision-language encoder, T5
+    glyph encoder, FlowMatchEuler scheduler and VAE decode stay on CPU). The
+    matrix pins this entry to an llmbox (n300-llmbox) runner so the mesh is available.
+    """
+    from benchmarks.glm_image_pipeline import (
+        HEIGHT,
+        PROMPT,
+        WIDTH,
+        GlmImageConfig,
+        GlmImagePipeline,
+    )
+
+    prompt = PROMPT
+    num_inference_steps = 50
+    height, width = HEIGHT, WIDTH
+
+    def build_pipeline_fn(compile_options):
+        # DiT on TT (tensor-parallel sharded across the mesh); AR / T5 / scheduler
+        # / VAE on CPU. compile_options are already applied globally by the harness.
+        pipeline = GlmImagePipeline(config=GlmImageConfig())
+        pipeline.setup()
+
+        def generate_fn(prompt, steps):
+            return pipeline.generate(
+                prompt=prompt,
+                seed=DEFAULT_SEED,
+                num_inference_steps=steps,
+            )
+
+        return pipeline, generate_fn
+
+    test_imagegen(
+        build_pipeline_fn=build_pipeline_fn,
+        model_info_name="glm-image",
+        output_file=output_file,
+        request=request,
+        prompt=prompt,
+        num_inference_steps=num_inference_steps,
+        height=height,
+        width=width,
+        output_image_path="test_glm_image_output.png",
+    )

--- a/tests/torch/models/glm_image/test_pipeline.py
+++ b/tests/torch/models/glm_image/test_pipeline.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""GLM-Image — nightly e2e text-to-image pipeline test with per-step PCC checks.
+
+GLM-Image is a diffusion text-to-image model whose DiT transformer runs
+tensor-parallel across a multi-chip mesh, while the AR vision-language
+encoder, the T5 glyph text encoder, the FlowMatchEuler scheduler and the VAE
+decode stay on CPU. This drives the shared GlmImagePipeline from
+tt_forge_model` (the same pipeline the image-gen benchmark uses) end-to-end,
+gates its numerics per denoising step and asserts the saved image dimensions.
+
+The test fails fast the moment any DiT step drops below ``PCC_THRESHOLD``. The pipeline
+itself keeps using the TT outputs.
+
+The DiT is the only component that runs on TT in this pipeline — the T5
+encoder, the vision-language encoder and the VAE all run on CPU here.
+"""
+
+from pathlib import Path
+
+import pytest
+import torch
+import torch_xla.runtime as xr
+from infra import RunMode
+from infra.evaluators import PccConfig, TorchComparisonEvaluator
+from infra.evaluators.evaluation_config import ComparisonConfig
+from loguru import logger
+from PIL import Image
+from utils import BringupStatus, Category
+
+from third_party.tt_forge_models.config import Parallelism
+from third_party.tt_forge_models.glm_image.pytorch import ModelLoader, ModelVariant
+from third_party.tt_forge_models.glm_image.pytorch.src.pipeline import (
+    HEIGHT,
+    PROMPT,
+    WIDTH,
+    GlmImageConfig,
+    GlmImagePipeline,
+)
+
+VARIANT_NAME = ModelVariant.TRANSFORMER
+MODEL_INFO = ModelLoader._get_model_info(VARIANT_NAME)
+
+SEED = 42
+NUM_INFERENCE_STEPS = 30
+# bf16 DiT on TT vs a clean fp32 CPU reference. Mirrors tt-xla#5480's 0.99 gate;
+# tune against the first nightly if the bf16/fp32 gap sits below this.
+PCC_THRESHOLD = 0.99
+
+
+_PCC_EVALUATOR = TorchComparisonEvaluator(ComparisonConfig(assert_on_failure=False))
+_PCC_CONFIG = PccConfig()
+
+
+def _pcc(device_out, golden_out) -> float:
+    return float(_PCC_EVALUATOR._compare_pcc(device_out, golden_out, _PCC_CONFIG))
+
+
+def _attach_dit_pcc_check(pipeline: GlmImagePipeline) -> None:
+    """Wrap the pipeline's DiT forward with an inline fp32-CPU-twin PCC check.
+
+    Only the DiT transformer runs on TT, so it is the sole component gated here.
+    After each TT forward the same inputs are replayed on a lazily loaded fp32
+    CPU twin and PCC is asserted inline, so the test fails fast on the first
+    diverging denoising step (checked per CFG forward: conditional + uncond).
+
+    Must be called after ``pipeline.setup()`` — setup shards the DiT and moves
+    it to the XLA device, and ``pipeline.transformer`` is the object
+    ``generate()`` invokes.
+    """
+    transformer = pipeline.transformer
+    # Bound method of the (already-patched) class forward; captured before the
+    # instance attribute below shadows it.
+    orig_forward = transformer.forward
+
+    twin = {"model": None}
+    step = {"n": 0}
+
+    def _cpu_twin():
+        # Loaded on first use: a fresh fp32 CPU copy of the DiT. It stays plain
+        # fp32 (no bf16 cast, no force_fp32_layernorm patch) so it is a clean
+        # golden reference for the bf16 TT DiT.
+        if twin["model"] is None:
+            logger.info("[PCC] loading CPU fp32 DiT twin")
+            twin["model"] = ModelLoader(ModelVariant.TRANSFORMER).load_model(
+                dtype_override=torch.float32
+            )
+        return twin["model"]
+
+    def _cpu(x):
+        # Move to CPU and upcast floats to fp32 so the twin sees the same values
+        # the TT DiT consumed; leave int/bool tensors (prior ids/drop) untouched.
+        if not isinstance(x, torch.Tensor):
+            return x
+        x = x.to("cpu")
+        return x.float() if x.is_floating_point() else x
+
+    def wrapped_forward(*args, **kwargs):
+        # Real TT forward — the pipeline continues with this output.
+        out = orig_forward(*args, **kwargs)
+        device_sample = out[0] if isinstance(out, (tuple, list)) else out
+        device_sample = device_sample.to("cpu").float()
+
+        # Replay the same inputs on the fp32 CPU twin. The pipeline always calls
+        # the DiT with these keywords (see GlmImagePipeline.generate._dit).
+        golden_sample = _cpu_twin()(
+            _cpu(kwargs["hidden_states"]),
+            _cpu(kwargs["encoder_hidden_states"]),
+            _cpu(kwargs["prior_token_id"]),
+            _cpu(kwargs["prior_token_drop"]),
+            _cpu(kwargs["timestep"]),
+            _cpu(kwargs["target_size"]),
+            _cpu(kwargs["crop_coords"]),
+        )
+
+        step["n"] += 1
+        pcc = _pcc(device_sample, golden_sample)
+        logger.info(f"[PCC] dit forward {step['n']}: pcc={pcc:.6f}")
+        assert (
+            pcc >= PCC_THRESHOLD
+        ), f"DiT forward {step['n']} PCC {pcc:.6f} below threshold {PCC_THRESHOLD}"
+
+        return out
+
+    transformer.forward = wrapped_forward
+
+
+@pytest.mark.nightly
+@pytest.mark.model_test
+@pytest.mark.lb_blackhole
+@pytest.mark.tensor_parallel
+@pytest.mark.large
+@pytest.mark.record_test_properties(
+    category=Category.MODEL_TEST,
+    model_info=MODEL_INFO,
+    parallelism=Parallelism.TENSOR_PARALLEL,
+    run_mode=RunMode.INFERENCE,
+    bringup_status=BringupStatus.PASSED,
+)
+def test_pipeline():
+    """Run the GLM-Image pipeline (DiT tensor-parallel) with per-step DiT PCC."""
+    xr.set_device_type("TT")
+
+    pipeline = GlmImagePipeline(
+        config=GlmImageConfig(num_inference_steps=NUM_INFERENCE_STEPS)
+    )
+    pipeline.setup()
+
+    # Gate the DiT (the only TT component) against an fp32 CPU twin per step.
+    _attach_dit_pcc_check(pipeline)
+
+    # ``generate`` post-processes via the diffusers image processor and returns a
+    # list of PIL images (output_type="pil").
+    images = pipeline.generate(prompt=PROMPT, seed=SEED)
+
+    output_path = "glm_image_pipeline_output.png"
+    images[0].save(output_path)
+
+    assert Path(output_path).exists(), f"Output image {output_path} was not created"
+    with Image.open(output_path) as img:
+        width, height = img.size
+        assert width == WIDTH, f"Expected width {WIDTH}, got {width}"
+        assert height == HEIGHT, f"Expected height {HEIGHT}, got {height}"


### PR DESCRIPTION
### Ticket

- Fixes #5571 

### Problem description

To add GLM Image Text-to-image model to nightly + benchmark CI. 

### What's changed

- Adds a per-step PCC gate to the GLM-Image nightly e2e pipeline test (tests/torch/models/glm_image/test_pipeline.py), following the playground_v2_5 / sdxl_lightning e2e conventions (tt-xla#5480). GLM-Image is a diffusion text-to-image model (not next-scale autoregressive): a DiT transformer (GlmImageTransformer2DModel, 30 blocks) denoises the latent over a FlowMatchEuler schedule with classifier-free guidance.

- Nightly (tests/torch/models/glm_image/test_pipeline.py): drives the shared GlmImagePipeline from tt_forge_models (the same pipeline the imagegen benchmark uses) end-to-end. The DiT runs on TT in bf16, tensor-parallel sharded on the ("batch","model") mesh. The AR vision-language encoder (prior-token generation), the T5 glyph text encoder, the FlowMatchEuler scheduler, and the BSQ VAE decode all stay on CPU. Native target 1024×1024; run at 30 inference steps. Markers: nightly, model_test, llmbox, tensor_parallel, large, record_test_properties.

- Per-step PCC gate (nightly): the DiT is the only component on TT, so it's the only component gated. After every per-step, per-CFG-branch TT forward, the same (CPU-cast, upcast-to-fp32) inputs are fed to a lazily-loaded fp32 CPU twin of the transformer and logits/output are compared inline. _pcc computes PCC via TorchComparisonEvaluator and the check fails fast the moment any forward drops below PCC_THRESHOLD = 0.99. The pipeline itself keeps using the TT outputs (real deployment behavior); the twin is purely observational.

- Submodule left untouched. GLM's pipeline lives in the shared third_party/tt_forge_models submodule and is reused by the benchmark, so the test monkeypatches pipeline.transformer.forward after setup() rather than editing the submodule. The twin is loaded lazily on the first forward; other callers (benchmark, examples) are unchanged and the submodule carries no tt-xla test dependency.

- Here only the DiT runs on TT — the T5 encoder, vision-language encoder, and VAE only touch TT in their isolated component tests (test_text_encoder.py, test_transformer.py, test_vae_decoder.py, test_vision_language_encoder.py), so those are retained for coverage.

- Sequential classifier-free guidance (pre-existing in the pipeline): cond and uncond are run as two batch-1 forwards per step and combined on the output; this is why the 30-step run performs 60 gated forwards.

### Validation: 
All 30 steps (both CFG branches — 60 forwards) passed the 0.99 gate; the pipeline then decoded a coherent 1024×1024 image and the dimension asserts passed.

| Test | Result | Time |
| --- | --- | --- |
| `test_pipeline.py::test_infinity_pipeline` (nightly e2e + per-scale PCC) | ✅ passed | 1h08m07s (4087.67s) |

Per-step DiT PCC vs. fp32 CPU twin (min = 0.999727, step 5 uncond; max = 0.999896):

| Scale | cond | uncond |
| --- | --- | --- |
| 1–10 | 0.999844–0.999889| 0.999727–0.999891 |
| 11-20 | 0.999862–0.999892 | 0.999813–0.999896 |
| 21-30 | 0.999814–0.999891 | 0.999807–0.999876| 


Final image generated from pipeline:
<img width="1024" height="1024" alt="glm_image_pipeline_output_jul14" src="https://github.com/user-attachments/assets/e8b5104f-bfcf-4123-9bd3-14afefa0c1e7" />


### Checklist

- [x] Validate nightly e2e + benchmark on qb2 blackhole

- [x] Perf benchmark CI run (glm_image, qb2 blackhole): https://github.com/tenstorrent/tt-xla/actions/runs/29722400701



