### PR TITLE
Fix uplift label exclusion in release notes config

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,10 +4,12 @@
 changelog:
   exclude:
     # Keep automated dependency/version uplift PRs out of "What's Changed".
-    # `uplift*` matches any label with the "uplift" prefix
-    # (uplift, uplift-mlir, uplift-forge-models, ...).
+    # NOTE: exclude.labels does NOT support glob/wildcards (only categories.labels
+    # does), so each uplift label must be listed explicitly by exact name.
     labels:
-      - "uplift*"
+      - "uplift"
+      - "uplift-mlir"
+      - "uplift-forge-models"
   categories:
     - title: What's Changed
       labels:


### PR DESCRIPTION
## Problem

The `.github/release.yml` added in #5556 was meant to keep uplift PRs out of the auto-generated "What's Changed" release notes, but it didn't work. Looks like GitHub honors the `*` glob **only** in the `categories.labels` section, **not** in `exclude.labels`, where labels are matched by exact name. 

## Fix

List each uplift label explicitly by exact name (`uplift`, `uplift-mlir`, `uplift-forge-models`).