### PR TITLE
Drop vLLM perf test results from notes

### DIFF
--- a/.github/scripts/generate_release_reports.py
+++ b/.github/scripts/generate_release_reports.py
@@ -166,7 +166,9 @@ for perf_file, architecture in PERF_SOURCES:
 
 
 # Drop vLLM entries
-perf_data = [r for r in perf_data if "vllm" not in (r.get("Display name") or "").lower()]
+perf_data = [
+    r for r in perf_data if "vllm" not in (r.get("Display name") or "").lower()
+]
 
 # Keep the tables ordered by model name. Python's sort is stable, so rows that
 # share a model name keep their source order (n150 before p150).

--- a/.github/scripts/generate_release_reports.py
+++ b/.github/scripts/generate_release_reports.py
@@ -164,6 +164,10 @@ for perf_file, architecture in PERF_SOURCES:
         r["Hardware"] = ARCHITECTURE_TO_HARDWARE[architecture]
     perf_data += rows
 
+
+# Drop vLLM entries
+perf_data = [r for r in perf_data if "vllm" not in (r.get("Display name") or "").lower()]
+
 # Keep the tables ordered by model name. Python's sort is stable, so rows that
 # share a model name keep their source order (n150 before p150).
 perf_data.sort(key=lambda r: r["Model"])


### PR DESCRIPTION
### Ticket
/

### Problem description
VLLM perf tests show up in the release notes alongside the non vLLM ones and make the results look weird. (vLLM tests show very high samples/sec)

### What's changed
- Filter out the vLLM tests from the release notes for now.

### Checklist
- New release notes [example](https://github.com/tenstorrent/tt-xla/releases/tag/1.4.0.dev20260707002344)
