### PR TITLE
[CI] Add vLLM nightly model-output summary via Claude skill

### DIFF
--- a/.claude/skills/vllm-nightly-log/SKILL.md
+++ b/.claude/skills/vllm-nightly-log/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: vllm-nightly-log
+description: Extract the generated text from the vLLM jobs of a tt-xla GitHub Actions run (nightly schedule or manual Run Test with vllm-model-tests*.json). Takes a run ID provided by the user or by CI (numeric ID or run URL), finds every vLLM job (run_vllm_n150_tests, run_vllm_n300_tests, run_vllm_llmbox_tests, run_vllm_galaxy_wh_6u_tests, run_vllm_bhqb_tests, run_vllm_p150_tests), pulls each job log, and writes a plain-text .log file grouped by test file. For each captured generation it records the full pytest node id (test), the model id when one is detected, the device, and the generated output text the test printed (the `output:` / `prompt: ..., output: ...` lines), filtering out progress-bar noise. Use whenever the user or CI gives a run ID and wants a log of vLLM model outputs. Never default to the latest run; if no run ID is in the message, ask once.
+allowed-tools: Read, Write, Glob, Grep, Bash(gh api *), Bash(gh run view *), Bash(gh run list *), Bash(python3 *), Bash(python *), Bash(mkdir -p *)
+argument-hint: run-id-or-url [output-path]
+---
+
+# vLLM Nightly Model-Output Log
+
+Given a tt-xla GitHub Actions run that includes vLLM jobs (scheduled nightly
+**or** a manual **Run Test** with `vllm-model-tests-nightly.json` /
+`vllm-model-tests.json`), produce a plain-text log file that lists
+**every vLLM generation that ran**, grouped by test file, with these fields per block:
+
+- **test** — the full pytest node id, e.g.
+  `tests/integrations/vllm_plugin/generative/test_llama3_3b_generation.py::test_llama3_3b_generation`.
+  This is the primary identifier for every output.
+- **model** — the HF model id (e.g. `meta-llama/Llama-3.2-3B`), shown **only when
+  one is actually detected** in the log (a real `org/Model` id in the node-id
+  param or a vLLM `model='...'` config line). It is omitted when the test does
+  not name a model — the node id already identifies the test, so we never guess.
+- **device** — e.g. `n300`, `n300-llmbox`, `galaxy-wh-6u`
+- **output** — the generated text the test printed (`output: ...`), plus the prompt when present
+
+Blocks are **grouped by test `file_path`**: one `####`-banner section per file,
+with an `outputs:` count, then all of that file's blocks underneath (across every
+device). This lets you scan the run one test file at a time.
+
+This skill is **vLLM-only**. It ignores every non-vLLM job in the run. It is a
+sibling of `ci-benchmark-analyzer` but does a different job: it does not analyze
+perf or diagnose failures — it captures what the models generated.
+
+## Input handling
+
+**The run ID must come from the caller** (interactive user **or** CI prompt).
+Do not guess it and do not default to "latest".
+
+| Input | Resolve to run ID |
+|-------|-------------------|
+| Numeric run ID | use directly |
+| GitHub Actions URL | extract the `actions/runs/<ID>` segment |
+
+An optional second argument is the output path (default `vllm-nightly-<RUN_ID>.log`
+in the current directory). If the user/CI names a path (e.g.
+`vllm-nightly-logs/vllm-nightly-<RUN_ID>.log`), write there. **Never ask for the
+output path** — if it was not supplied, silently use the default.
+
+**CI / non-interactive:** When the invoking message already includes a run ID
+(e.g. GitHub Actions passes `${{ github.run_id }}`), use that ID immediately.
+Do **not** ask for the run ID. Do **not** wait for confirmation. Proceed to the
+extractor.
+
+## What counts as a vLLM job
+
+vLLM jobs come from
+`.github/workflows/test-matrix-presets/vllm-model-tests-nightly.json` (and the
+push variant `vllm-model-tests.json`). Their job names all match
+`run_vllm_<device>_tests`, and the device token is embedded in the name:
+
+| Job name | Device |
+|----------|--------|
+| `run_vllm_n150_tests` | n150 |
+| `run_vllm_p150_tests` | p150 |
+| `run_vllm_n300_tests` | n300 |
+| `run_vllm_llmbox_tests` | n300-llmbox |
+| `run_vllm_galaxy_wh_6u_tests` | galaxy-wh-6u |
+| `run_vllm_bhqb_tests` | qb2-blackhole |
+
+Match on the `run_vllm_..._tests` name prefix; parse the device token from the
+name. Unknown tokens fall back to the raw token.
+
+## How the generated text appears in logs
+
+The tests print the generated text with one of these forms (see
+`tests/integrations/vllm_plugin/generative/`):
+
+```python
+print(f"prompt: {prompts[0]}, output: {output_text}")   # -> prompt: ..., output: ...
+print("output: ", output_text)                           # -> output:  ...
+print(f"output: {output_text}")                          # -> output: ...
+```
+
+The **test** identity is taken from the pytest node id printed in the log
+(`tests/.../test_file.py::test_name[params]`) and is tracked as the run walks the
+log, so each captured output is attributed to the test that was running. The
+**model** is filled in only when a genuine `org/Model` id appears — either in the
+node-id parameter (e.g. `test_...[meta-llama/Llama-3.2-3B]`) or in a vLLM engine
+config line (`model='...'`); bare params like `[n300]` or `[single_device]` are
+device/config tokens, not models, so they are left as node-id-only (no `model:`
+line). The device comes from the job name.
+
+**Noise filtering.** vLLM's tqdm progress bars and throughput summaries also
+contain the substring `output:` (e.g. `est. speed ... output: 6.80 toks/s`).
+These are **not** generated text and are dropped — the script filters out any
+`output:` line matching `toks/s`, `est. speed`, `it/s`, `Processed prompts`,
+`Adding requests`, `EngineCore pid=`, or log-level markers. Only real generated
+text survives.
+
+## Workflow
+
+1. **Preflight: confirm `gh` is authenticated FIRST.** As the very first action
+   when this skill starts — before asking anything — run `gh auth status`. If it
+   fails (not logged in / no token), stop and tell the user to authenticate. Do
+   NOT ask for the run ID and do NOT run the extractor yet, since both need `gh`.
+   In CI, `GH_TOKEN` is usually already set — if `gh auth status` succeeds,
+   continue. Interactively, show these options (the `!` prefix runs the command
+   in-session so the auth persists):
+
+   - `! gh auth login` — interactive login, or
+   - `! export GH_TOKEN=<your-token>` — if they have a token handy
+
+   Once `gh` can reach the repo (default `tenstorrent/tt-xla`), continue to
+   step 2.
+
+2. **Resolve the run ID.**
+   - If the invoking message already includes a numeric run ID or Actions URL
+     (including CI prompts that pass `${{ github.run_id }}`), use it and skip
+     asking. This is the normal path in GitHub Actions.
+   - Otherwise, ask *exactly one* question as a **plain-text message** (do NOT
+     use the `AskUserQuestion` tool — it cannot take a free-text run ID). Write:
+     *"Please provide the run ID (numeric ID or the GitHub Actions run URL) you
+     want the vLLM model-output log for."*
+     Then stop and wait for the user's reply.
+   - Ask nothing else. Do **not** ask about the output path, device filtering,
+     format, or anything beyond the run ID — use the defaults for all of those.
+   - Resolve the run ID: numeric ID used directly; a GitHub Actions URL →
+     extract the `actions/runs/<ID>` segment.
+   - Once you have the run ID, proceed through the remaining steps without any
+     further questions or confirmations.
+   - Never guess or default to the latest run.
+
+3. Run the bundled extractor — it lists the vLLM jobs, downloads each job log,
+   parses the test/model/device/output, filters progress-bar noise, groups by
+   test file, and writes the `.log` at the requested path (the `.json` sidecar
+   is written to `/tmp/<log-basename>.json`, not next to the log):
+
+   ```bash
+   python3 <skill-path>/scripts/extract_vllm_outputs.py <RUN_ID> --output <OUTPUT_PATH>
+   ```
+
+   The script prints the jobs it found to stderr and the entry count on
+   completion. A job whose log cannot be fetched (HTTP 404 — logs expired or
+   never uploaded) is **skipped, not fatal**: the script logs
+   `(log unavailable — skipping this job)` and continues with the rest, then
+   reports how many jobs were skipped.
+
+4. Read the resulting `.log` and give the user a short summary: how many vLLM
+   jobs were found, how many outputs were captured, how many jobs (if any) were
+   skipped for unavailable logs, and call out any job whose `conclusion` was not
+   `success` (those may have produced no `output:` line because they crashed
+   before generation).
+
+5. If **zero** outputs were captured but jobs exist, say so plainly — the tests
+   may run under pytest stdout capture so `output:` lines only surface on
+   failure or with `-s`. Point the user at the job URLs the script listed rather
+   than inventing output.
+
+## Output format
+
+The `.log` file is grouped by test file. Each file gets a `####` banner with an
+`outputs:` count, followed by one `====` block per captured output:
+
+```
+################################################################################
+file_path: tests/integrations/vllm_plugin/generative/test_llama3_3b_generation.py
+outputs:   6
+################################################################################
+================================================================================
+test:   tests/integrations/vllm_plugin/generative/test_llama3_3b_generation.py::test_llama3_3b_generation
+model:  meta-llama/Llama-3.2-3B
+device: n300
+prompt: I like taking walks in the
+output: park near my house, especially in autumn when ...
+job:    run_vllm_n300_tests  (https://github.com/tenstorrent/tt-xla/actions/runs/.../job/...)
+================================================================================
+...
+```
+
+- `test:` is always the **full** node id (path + `::test_name` + `[params]`) —
+  never abbreviated.
+- `model:` is present only when a real model id was detected; otherwise the
+  block is identified by its node id alone.
+- Files appear in first-seen order; blocks keep their in-file order, so the same
+  test across n150/p150/n300 sits together within its file section.
+
+The `.json` sidecar — written to `/tmp/<log-basename>.json` — holds the same
+entries as a **flat list** (one object per output with `test`, `model`,
+`device`, `prompt`, `output`, `job`, `job_url`), so downstream tools can regroup
+or filter however they like.
+
+## Notes
+
+- `gh` must be authenticated with access to `tenstorrent/tt-xla`.
+- In scheduled nightlies, `.github/workflows/schedule-nightly.yml` invokes this
+  skill via Claude after `nightly_tests` and publishes the log to the
+  **vLLM nightly model outputs** job summary (run ID = `${{ github.run_id }}`).
+- Do not fabricate model output. Only report `output:` text actually present in
+  the logs; if a model has no captured output, omit it (the script already does).
+- Progress-bar / throughput lines (`toks/s`, `est. speed`, `it/s`, …) are not
+  generated text and are filtered out — do not report them as model output.
+- A test with no detectable model id is still captured; it is identified by its
+  full node id with no `model:` line — this is expected, not a bug.
+- A job whose log 404s is skipped (not fatal); mention any skipped jobs in the
+  summary and point the user at those job URLs.
+- The script never modifies the repo — it only reads run logs and writes the
+  requested `.log`/`.json` files.

--- a/.claude/skills/vllm-nightly-log/scripts/extract_vllm_outputs.py
+++ b/.claude/skills/vllm-nightly-log/scripts/extract_vllm_outputs.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Extract per-model generated text from the vLLM jobs of a tt-xla nightly run.
+
+For a given GitHub Actions run, this finds every vLLM job (job name matches
+``run_vllm_<device>_tests``), downloads its log, and pulls out, for every model
+that ran, the generated text the test printed via lines like::
+
+    prompt: I like taking walks in the, output: park near my house ...
+    output:  <generated text>
+    output: <generated text>
+
+It writes a plain-text ``.log`` file with one block per (model, device, output)
+and also emits a ``.json`` sidecar with the same data for downstream use.
+
+Usage:
+    python extract_vllm_outputs.py <RUN_ID> [--output /home/vllm1.log]
+                                            [--repo tenstorrent/tt-xla]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+DEFAULT_REPO = "tenstorrent/tt-xla"
+
+# Job name -> friendly device. The device token is embedded in the matrix job
+# name (see .github/workflows/test-matrix-presets/vllm-model-tests-nightly.json).
+JOB_NAME_RE = re.compile(r"run_vllm_([a-z0-9_]+?)_tests", re.IGNORECASE)
+DEVICE_MAP = {
+    "n150": "n150",
+    "p150": "p150",
+    "n300": "n300",
+    "llmbox": "n300-llmbox",
+    "galaxy_wh_6u": "galaxy-wh-6u",
+    "bhqb": "qb2-blackhole",
+}
+
+# GitHub prefixes every log line with an ISO-8601 timestamp; strip it.
+TS_RE = re.compile(r"^\S*?\d{4}-\d\d-\d\dT[\d:.]+Z\s?")
+
+# A pytest node id, optionally parametrized: ...py::test_name[param0-param1]
+NODEID_RE = re.compile(r"(tests/\S+?\.py::[A-Za-z0-9_]+)(\[[^\]]*\])?")
+# HuggingFace-style model id: org/Model-Name
+HF_RE = re.compile(r"[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+")
+# vLLM engine init / config lines that name the model.
+MODEL_EQ_RE = re.compile(r"""model(?:_name)?['"]?\s*[=:]\s*['"]([^'"]+)['"]""")
+
+# The generated-text prints. Order matters: try the prompt+output form first.
+PROMPT_OUTPUT_RE = re.compile(
+    r"\bprompt:\s*(?P<prompt>.*?),\s*output:\s*(?P<output>.*)$"
+)
+OUTPUT_RE = re.compile(r"\boutput:\s*(?P<output>.*)$")
+
+# Lines whose `output:` is not generated text but vLLM/engine chatter:
+# tqdm progress bars ("6.80 toks/s]"), throughput summaries ("est. speed ...
+# output: N toks/s"), and log lines. Drop these so the log holds real text only.
+NOISE_RE = re.compile(
+    r"toks/s|est\.\s*speed|it/s|Processed prompts|Adding requests|"
+    r"EngineCore pid=|\bWARNING:|\bINFO\b|\bDEBUG\b|\bERROR\b\s+\d",
+    re.IGNORECASE,
+)
+
+
+def run_gh(
+    args: list[str], *, binary: bool = False, fatal: bool = True
+) -> str | bytes | None:
+    """Run a `gh` command and return stdout.
+
+    On failure, exit the process when ``fatal`` (the default); otherwise write
+    the error to stderr and return ``None`` so the caller can skip and continue.
+    """
+    proc = subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=not binary,
+    )
+    if proc.returncode != 0:
+        err = proc.stderr if not binary else proc.stderr.decode("utf-8", "replace")
+        sys.stderr.write(f"gh {' '.join(args)} failed:\n{err}\n")
+        if fatal:
+            sys.exit(1)
+        return None
+    return proc.stdout
+
+
+def list_vllm_jobs(repo: str, run_id: str) -> list[dict]:
+    """Return the vLLM jobs of a run as {id, name, device, conclusion, html_url}."""
+    raw = run_gh(
+        [
+            "api",
+            f"repos/{repo}/actions/runs/{run_id}/jobs?per_page=100",
+            "--paginate",
+            "--jq",
+            ".jobs[]",
+        ]
+    )
+    jobs = []
+    for line in str(raw).splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        job = json.loads(line)
+        m = JOB_NAME_RE.search(job.get("name", ""))
+        if not m:
+            continue
+        token = m.group(1).lower()
+        jobs.append(
+            {
+                "id": job["id"],
+                "name": job["name"],
+                "device": DEVICE_MAP.get(token, token),
+                "conclusion": job.get("conclusion"),
+                "status": job.get("status"),
+                "html_url": job.get("html_url"),
+            }
+        )
+    return jobs
+
+
+def fetch_job_log(repo: str, job_id: int) -> str | None:
+    """Return the plain-text log of a single job, or ``None`` if unavailable.
+
+    Log fetches can 404 (logs expired / not yet uploaded / job never emitted a
+    log) — treat that as a skippable job rather than aborting the whole run.
+    """
+    raw = run_gh(["api", f"repos/{repo}/actions/jobs/{job_id}/logs"], fatal=False)
+    return None if raw is None else str(raw)
+
+
+def strip_ts(line: str) -> str:
+    return TS_RE.sub("", line).rstrip("\n")
+
+
+def model_from_param(param: str | None) -> str | None:
+    """Return a real HF model id from a pytest param blob, or None.
+
+    Only genuine ``org/Model`` ids count. A bare param like ``[n300]`` or
+    ``[temperature-values0-n300]`` carries no model — we do not guess one; the
+    full node id (captured separately) already identifies the test.
+    """
+    if not param:
+        return None
+    inner = param.strip("[]")
+    hf = HF_RE.search(inner)
+    return hf.group(0) if hf else None
+
+
+def extract_entries(log: str, device: str, job: dict) -> list[dict]:
+    """Walk a job log and pull (test, model, device, prompt, output) tuples.
+
+    Each output is keyed on the full pytest node id of the currently-running
+    test (``path.py::test_name[params]``). A real HF model id is attached only
+    when one is actually seen — in the node-id param or a vLLM ``model='...'``
+    config line — otherwise ``model`` is left ``None`` and the node id stands
+    on its own.
+    """
+    entries: list[dict] = []
+    current_test: str | None = None
+    current_model: str | None = None
+
+    def add(prompt: str | None, output: str) -> None:
+        if NOISE_RE.search(output):
+            return
+        entries.append(
+            {
+                "test": current_test,
+                "model": current_model,
+                "device": device,
+                "prompt": prompt.strip() if prompt else None,
+                "output": output.strip(),
+                "job": job["name"],
+                "job_url": job["html_url"],
+            }
+        )
+
+    for raw_line in log.splitlines():
+        line = strip_ts(raw_line)
+
+        # Track the running test from its node id (full path::test[params]).
+        node = NODEID_RE.search(line)
+        if node:
+            nodeid = node.group(1) + (node.group(2) or "")
+            # A fresh test resets the model unless the param names a real one.
+            if nodeid != current_test:
+                current_test = nodeid
+                current_model = model_from_param(node.group(2))
+
+        # A vLLM engine/config line names the model directly (hardcoded models).
+        eq = MODEL_EQ_RE.search(line)
+        if eq and "/" in eq.group(1):
+            current_model = eq.group(1)
+
+        # The generated text.
+        po = PROMPT_OUTPUT_RE.search(line)
+        if po:
+            add(po.group("prompt"), po.group("output"))
+            continue
+        out = OUTPUT_RE.search(line)
+        if out and "prompt:" not in line:
+            add(None, out.group("output"))
+    return entries
+
+
+def write_log(
+    entries: list[dict], run_id: str, jobs: list[dict], out_path: Path
+) -> None:
+    sep = "=" * 80
+    lines: list[str] = []
+    lines.append(sep)
+    lines.append(f"vLLM nightly model outputs — run {run_id}")
+    lines.append(
+        f"vLLM jobs found: {len(jobs)} | model outputs captured: {len(entries)}"
+    )
+    lines.append(sep)
+    lines.append("")
+
+    if not entries:
+        lines.append("No model outputs found in the vLLM job logs.")
+        lines.append(
+            "The tests may not print `output:` lines under CI capture, or the "
+            "jobs may have failed before generation. Check the job logs directly:"
+        )
+        for j in jobs:
+            lines.append(
+                f"  - {j['name']} ({j['device']}) [{j['conclusion']}] {j['html_url']}"
+            )
+        out_path.write_text("\n".join(lines) + "\n")
+        return
+
+    # Group by test file path so every file's outputs sit together. File order
+    # follows first appearance; entries keep their in-file order.
+    fsep = "#" * 80
+
+    def file_of(e: dict) -> str:
+        test = e.get("test") or "(unknown)"
+        return test.split("::", 1)[0]
+
+    groups: dict[str, list[dict]] = {}
+    for e in entries:
+        groups.setdefault(file_of(e), []).append(e)
+
+    for fpath, group in groups.items():
+        lines.append(fsep)
+        lines.append(f"file_path: {fpath}")
+        lines.append(f"outputs:   {len(group)}")
+        lines.append(fsep)
+        for e in group:
+            lines.append(sep)
+            lines.append(f"test:   {e.get('test') or '(unknown)'}")
+            if e.get("model"):
+                lines.append(f"model:  {e['model']}")
+            lines.append(f"device: {e['device']}")
+            if e.get("prompt"):
+                lines.append(f"prompt: {e['prompt']}")
+            lines.append(f"output: {e['output']}")
+            lines.append(f"job:    {e['job']}  ({e['job_url']})")
+        lines.append(sep)
+        lines.append("")
+    out_path.write_text("\n".join(lines) + "\n")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("run_id", help="GitHub Actions nightly run ID")
+    ap.add_argument(
+        "--output",
+        "-o",
+        default=None,
+        help="Output .log path (default: vllm-nightly-<RUN_ID>.log in cwd)",
+    )
+    ap.add_argument("--repo", default=DEFAULT_REPO)
+    args = ap.parse_args()
+
+    out_path = Path(args.output or f"vllm-nightly-{args.run_id}.log")
+
+    jobs = list_vllm_jobs(args.repo, args.run_id)
+    if not jobs:
+        sys.stderr.write(
+            f"No vLLM jobs (run_vllm_*_tests) found in run {args.run_id}.\n"
+        )
+        sys.exit(2)
+
+    sys.stderr.write(f"Found {len(jobs)} vLLM job(s):\n")
+    all_entries: list[dict] = []
+    skipped: list[dict] = []
+    for job in jobs:
+        sys.stderr.write(f"  - {job['name']} ({job['device']}) [{job['conclusion']}]\n")
+        log = fetch_job_log(args.repo, job["id"])
+        if log is None:
+            sys.stderr.write("    (log unavailable — skipping this job)\n")
+            skipped.append(job)
+            continue
+        all_entries.extend(extract_entries(log, job["device"], job))
+    if skipped:
+        sys.stderr.write(
+            f"\n{len(skipped)} job(s) had no fetchable log and were skipped.\n"
+        )
+
+    write_log(all_entries, args.run_id, jobs, out_path)
+
+    # The .log is the deliverable and stays at the requested path; the JSON
+    # sidecar is a scratch artifact, so keep it under /tmp (basename only).
+    json_path = Path("/tmp") / out_path.with_suffix(".json").name
+    json_path.write_text(json.dumps(all_entries, indent=2) + "\n")
+
+    sys.stderr.write(
+        f"\nWrote {len(all_entries)} model output(s) to {out_path}\n"
+        f"JSON sidecar: {json_path}\n"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/schedule-nightly.yml
+++ b/.github/workflows/schedule-nightly.yml
@@ -188,6 +188,105 @@ jobs:
           path: nightly-reports/
           retention-days: 90
 
+  # Runs the vllm-nightly-log Claude skill after nightly_tests finishes and
+  # publishes model generation outputs to this job's GitHub Actions summary
+  # (sidebar: "vLLM nightly model outputs"). Unlike torch/jax, pytest's
+  # test-summary does not surface vLLM generations — this fills that gap.
+  vllm-nightly-log-report:
+    name: "vLLM nightly model outputs"
+    needs: [ nightly_tests ]
+    if: always() && needs.nightly_tests.result != 'cancelled'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          submodules: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install Claude Code CLI
+        run: |
+          npm install -g @anthropic-ai/claude-code
+          claude --version
+
+      - name: Run vllm-nightly-log skill via Claude
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY_BENCHMARK_CI }}
+        run: |
+          mkdir -p vllm-nightly-logs
+          # NOTE: `--allowed-tools` is variadic and would absorb the prompt arg;
+          # use `--` to terminate options before the positional prompt.
+          # `< /dev/null` suppresses the 3s stdin-wait warning when running headless.
+          claude --print \
+                 --permission-mode bypassPermissions \
+                 --model claude-opus-4-7 \
+                 --max-turns 30 \
+                 --allowed-tools "Bash(gh api:*),Bash(gh auth:*),Bash(gh run view:*),Bash(gh run list:*),Bash(python:*),Bash(python3:*),Bash(mkdir:*),Bash(ls:*),Read,Write,Glob,Grep" \
+                 -- \
+                 "$(cat <<'PROMPT'
+          Use the `vllm-nightly-log` skill at
+          `.claude/skills/vllm-nightly-log/SKILL.md` for nightly run ID
+          `${{ github.run_id }}`.
+
+          The run ID is already provided — do NOT ask for it. Skip the
+          interactive run-ID question and proceed immediately.
+
+          Read the SKILL.md and follow it exactly. The skill will:
+            - confirm `gh` auth
+            - run
+              `.claude/skills/vllm-nightly-log/scripts/extract_vllm_outputs.py`
+              with run ID `${{ github.run_id }}` and write the log to
+              `vllm-nightly-logs/vllm-nightly-${{ github.run_id }}.log`
+            - summarize how many vLLM jobs / outputs were captured
+
+          After the log file is written, stop. Do NOT post GitHub comments,
+          create issues, or modify any files outside `vllm-nightly-logs/`.
+          PROMPT
+          )" < /dev/null
+
+      - name: Append log to job summary
+        run: |
+          LOG="vllm-nightly-logs/vllm-nightly-${{ github.run_id }}.log"
+          if [ ! -f "$LOG" ]; then
+            # Skill default path if Claude wrote to cwd instead
+            ALT="vllm-nightly-${{ github.run_id }}.log"
+            if [ -f "$ALT" ]; then
+              mkdir -p vllm-nightly-logs
+              mv "$ALT" "$LOG"
+            else
+              echo "::error::No vLLM nightly log was produced for run ${{ github.run_id }}"
+              exit 1
+            fi
+          fi
+          {
+            echo "## vLLM nightly model outputs"
+            echo
+            echo "Produced by \`.claude/skills/vllm-nightly-log\` for run \`${{ github.run_id }}\`."
+            echo
+            echo '```text'
+            cat "$LOG"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload log artifact
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: vllm-nightly-log-${{ github.run_id }}
+          path: vllm-nightly-logs/
+          retention-days: 90
+          if-no-files-found: warn
+
   release:
     uses: ./.github/workflows/call-release.yml
     needs: [ build-ttxla ]


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Nightly runs include many vLLM jobs (`run_vllm_*_tests`), but unlike torch/jax
there is no useful model-output summary in the run UI. As more vLLM models are
added, it becomes hard to open each job log and check what each model generated.
### What's changed
- Added Claude skill `.claude/skills/vllm-nightly-log` to collect generated
  text from all vLLM jobs in a run and write a single summary log.
- Wired the skill into nightly CI (`schedule-nightly.yml`) so after
  `nightly_tests` finishes, a **vLLM nightly model outputs** job runs the skill
  with `${{ github.run_id }}` and publishes the summary to the job summary +
  artifact.
- Validated the same flow via **Run Test** (`manual-test.yml`) using
  `vllm-model-tests-nightly.json`:
  - Skill summary produced:
    https://github.com/tenstorrent/tt-xla/actions/runs/29189301865
    https://github.com/tenstorrent/tt-xla/actions/runs/29193245689

### Checklist
- [ ] New/Existing tests provide coverage for changes

