### PR TITLE
[WAN] umt5 sharding

### DIFF
--- a/tests/torch/models/wan14b/shared.py
+++ b/tests/torch/models/wan14b/shared.py
@@ -268,6 +268,16 @@ class WanDiTWrapper(nn.Module):
 
 _MESH_SHAPES = {32: (8, 4), 8: (2, 4), 4: (1, 4), 2: (1, 2), 1: (1, 1)}
 
+# Logical roles of the two mesh axes, shared by every Wan component on the 2D
+# ("batch", "model") mesh:
+#   TP_AXIS = "model" — tensor-parallel (Megatron column→row weight sharding).
+#       Always size 4 in _MESH_SHAPES, so head/d_ff splits are size-stable.
+#   SP_AXIS = "batch" — sequence-parallel (shard the activation L dim; no weight
+#       has an L dim, so it is applied via sharding_constraint on activations).
+#       Size 1/2/8 across the 4/8/32-device meshes.
+TP_AXIS = "model"
+SP_AXIS = "batch"
+
 
 def wan22_mesh() -> Mesh:
     """2D ("batch", "model") SPMD mesh sized to current device count."""
@@ -283,36 +293,45 @@ def wan22_mesh() -> Mesh:
 
 
 # ---------------------------------------------------------------------------
-# UMT5 sharding
+# UMT5 text-encoder sharding
 # ---------------------------------------------------------------------------
+#
+# Strategy: Megatron tensor parallelism (TP) on TP_AXIS ("model", size 4) only.
+# shard_umt5_specs shards the encoder weights column→row on "model"; the residual
+# stream, norms and embedding stay replicated. Only the "model" axis is sharded;
+# the "batch" axis is replicated.
+#
+# Per block:
+#   - column-parallel q/k/v, wi_0/wi_1  → (TP_AXIS, None)   no CCL
+#   - row-parallel    o, wo             → (None, TP_AXIS)   1 all-reduce on "model"
+#   - norms / residual D / embedding    → replicated → norms stay local
+#   - relative_attention_bias (per layer) → head dim on "model"
 
 
 def shard_umt5_specs(encoder) -> dict:
-    """Build shard specs for UMT5EncoderModel weights.
-
-    Mesh axes: ("batch", "model")
-    Column-parallel (q, k, v, wi_0, wi_1):  ("model", "batch")
-    Row-parallel   (o, wo):                 ("batch", "model")
     """
-    specs = {encoder.shared.weight: (None, "batch")}
+    Megatron tensor-parallel (TP) shard specs for the UMT5 encoder weights.
+    """
+    col = (TP_AXIS, None)  # column-parallel: shard output dim (heads / d_ff)
+    row = (None, TP_AXIS)  # row-parallel:    shard input dim → all-reduce after
 
+    specs: dict = {}
     for block in encoder.encoder.block:
         sa = block.layer[0].SelfAttention
-        specs[sa.q.weight] = ("model", "batch")
-        specs[sa.k.weight] = ("model", "batch")
-        specs[sa.v.weight] = ("model", "batch")
-        specs[sa.o.weight] = ("batch", "model")
-        specs[block.layer[0].layer_norm.weight] = ("batch",)
+        specs[sa.q.weight] = col
+        specs[sa.k.weight] = col
+        specs[sa.v.weight] = col
+        specs[sa.o.weight] = row
+        # Per-layer relative position bias [num_buckets, num_heads]: shard the
+        # head dim to match the head-split q/k/v (column-parallel) activation.
         if hasattr(sa, "relative_attention_bias"):
-            specs[sa.relative_attention_bias.weight] = (None, "model")
+            specs[sa.relative_attention_bias.weight] = row
 
         ffn = block.layer[1].DenseReluDense
-        specs[ffn.wi_0.weight] = ("model", "batch")
-        specs[ffn.wi_1.weight] = ("model", "batch")
-        specs[ffn.wo.weight] = ("batch", "model")
-        specs[block.layer[1].layer_norm.weight] = ("batch",)
+        specs[ffn.wi_0.weight] = col
+        specs[ffn.wi_1.weight] = col
+        specs[ffn.wo.weight] = row
 
-    specs[encoder.encoder.final_layer_norm.weight] = ("batch",)
     return specs
 
 
@@ -433,14 +452,6 @@ def shard_vae_decoder_specs(vae, mesh: Mesh) -> dict:
 # ---------------------------------------------------------------------------
 # DiT sharding
 # ---------------------------------------------------------------------------
-
-
-# Tensor-parallel axis (Megatron column→row weight sharding); the other matrix
-# dim and all boundary tensors stay replicated.
-TP_AXIS = "model"
-# Sequence-parallel axis for DiT activation sharding (the activation L dim has
-# no analog in any weight, so it is sharded via constraints, not shard_dit_specs).
-SP_AXIS = "batch"
 
 
 def _megatron_linear_pair_specs(linear_1, linear_2) -> dict:


### PR DESCRIPTION
### Ticket
Closing #4864 

### What's changed
Refactored sharding a bit so it's more coherent with megatron-style sharding. Metal also shards this text encoder on data parallel axis, but since this is run only once (at most twice for negative prompt) it's fine to stay as is.