### PR TITLE
Skip process-irs when dump_irs is off and no IR artifacts exist

### DIFF
--- a/.github/workflows/call-process-dumped-irs.yml
+++ b/.github/workflows/call-process-dumped-irs.yml
@@ -81,6 +81,14 @@ jobs:
           art_count=$(echo "$artifacts_json" | jq '[.artifacts[] | select(.name | startswith("ir-dumps-"))] | length')
           echo "Found $art_count artifacts matching 'ir-dumps-*'"
 
+          if [ "$art_count" -eq 0 ]; then
+            echo "No ir-dumps-* artifacts in this run; skipping IR processing."
+            echo "skip_ir_processing=true" >> "$GITHUB_OUTPUT"
+            echo "ir_count=0" >> "$GITHUB_OUTPUT"
+            echo 'job_matrix={"include":[]}' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           # Get artifacts for this run
           echo "=== Downloading dumped IRs from workflow run ${{ inputs.dumped_irs_run_id }} ==="
           gh run download ${{ inputs.dumped_irs_run_id }} \


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Run Test was failing in `process-irs / check_dumped_irs` when no IR dumps
were produced: `gh run download --pattern ir-dumps-*` exits non-zero if there
are no matching artifacts.
- Failing: https://github.com/tenstorrent/tt-xla/actions/runs/29189301865
- Also: https://github.com/tenstorrent/tt-xla/actions/runs/29135452446
Note: dumps are not only controlled by `inputs.dump_irs` — they can also be
enabled per-model via the test-matrix JSON — so `process-irs` should still
always run and skip quickly when there is nothing to process.
### What's changed
- In `call-process-dumped-irs.yml`, if no `ir-dumps-*` artifacts exist, set
  `skip_ir_processing=true` and exit 0 instead of failing on download.
  
Verified green after the fix:
https://github.com/tenstorrent/tt-xla/actions/runs/29191537814

### Checklist
- [ ] New/Existing tests provide coverage for changes
