### PR TITLE
Re-enable Wan 2.2 DiT component tests in CI

### DIFF
--- a/tests/torch/models/wan14b/test_wan_dit.py
+++ b/tests/torch/models/wan14b/test_wan_dit.py
@@ -71,9 +71,6 @@ def test_wan_dit_720p_sharded():
     _run("720p", sharded=True)
 
 
-@pytest.mark.xfail(
-    reason="PCC comparison fails on the full DiT (DiT sharding limitation)"
-)
 @pytest.mark.nightly
 @pytest.mark.model_test
 @pytest.mark.qb2_blackhole

--- a/tests/torch/models/wan5b/test_wan_dit.py
+++ b/tests/torch/models/wan5b/test_wan_dit.py
@@ -53,7 +53,6 @@ COMPILER_CONFIG = CompilerConfig(
 @pytest.mark.qb2_blackhole
 @pytest.mark.lb_blackhole
 @pytest.mark.bh_galaxy
-@pytest.mark.xfail(reason="PCC comparison fails: ~0.35 on full model (required 0.99)")
 def test_wan_dit_720p_sharded():
     _run("720p", sharded=True)
 
@@ -63,7 +62,6 @@ def test_wan_dit_720p_sharded():
 @pytest.mark.qb2_blackhole
 @pytest.mark.lb_blackhole
 @pytest.mark.bh_galaxy
-@pytest.mark.xfail(reason="PCC comparison fails: ~0.32 on full model (required 0.99)")
 def test_wan_dit_480p_sharded():
     _run("480p", sharded=True)
 


### PR DESCRIPTION
### Ticket
None 

### Problem description
Due to conv3d-related PCC issues, Wan DiT tests were marked xfail.

### What's changed
Now that conv3d config issue is [fixed](https://github.com/tenstorrent/tt-mlir/pull/8791) we may enable those tests in CI again.

### Checklist
- [ ] New/Existing tests provide coverage for changes
