### PR TITLE
SDPA composite bool mask catch

### DIFF
--- a/python_package/tt_torch/composite_ops.py
+++ b/python_package/tt_torch/composite_ops.py
@@ -287,6 +287,13 @@ def composite_scaled_dot_product_attention(
     )
 
     if attn_mask is not None:
+        # Fused SDPA adds the mask to the scores, and ttnn.scaled_dot_product_attention
+        # accepts only a float mask (BF16/BFP8/BFP4 — TT_FATALs otherwise), so convert a
+        # bool mask to additive form (True -> 0, False -> -inf).
+        # torch reference: https://github.com/pytorch/pytorch/blob/9f48642d4bf84566ca3191576c7ff30138953af8/torch/nn/functional.py#L6365
+        # ttnn check: tt-metal .../transformer/sdpa/device/sdpa_device_operation.cpp ("must be in BF16, BFP8, or BFP4 dataformat")
+        if attn_mask.dtype == torch.bool:
+            attn_mask = torch.where(attn_mask, 0.0, float("-inf")).to(query.dtype)
         query, key, value, attn_mask = builder.mark_inputs(query, key, value, attn_mask)
     else:
         query, key, value = builder.mark_inputs(query, key, value)
@@ -496,9 +503,10 @@ def replace_rms_norm_module(
 
 def _check_sdpa_constraints(node: torch.fx.Node) -> bool:
     """
-    Check that SDPA inputs are bfloat16, the only dtype our composite supports.
-    Also, check for dropout_p > 0, which is not supported in composite SDPA.
-    If either of these conditions are met, skip the composite and use the native implementation.
+    Check that the SDPA Q/K/V inputs are bfloat16 (the only dtype our composite
+    supports) and that dropout_p == 0. The attn_mask is not gated on dtype, so a
+    bool or additive-float mask does not disqualify the composite.
+    If a constraint fails, skip the composite and use the native implementation.
     """
     # Dropout is not supported in composite SDPA
     dropout_p = node.kwargs.get("dropout_p", 0.0)
@@ -509,17 +517,18 @@ def _check_sdpa_constraints(node: torch.fx.Node) -> bool:
         )
         return False
 
-    # Check all inputs are bfloat16
-    tensor_args = list(node.args) + [
-        v for v in node.kwargs.values() if isinstance(v, torch.fx.Node)
+    # Gate only Q/K/V on dtype (the first three operands, positional or named);
+    # attn_mask (operand 4) is excluded on purpose.
+    qkv = list(node.args[:3]) + [
+        node.kwargs[name] for name in ("query", "key", "value") if name in node.kwargs
     ]
-    for arg in tensor_args:
-        if hasattr(arg, "meta"):
+    for arg in qkv:
+        if isinstance(arg, torch.fx.Node) and hasattr(arg, "meta"):
             val = arg.meta.get("example_value", None)
             if val is not None and val.dtype != torch.bfloat16:
                 logger.debug(
-                    "composite scaled_dot_product_attention only supports bfloat16 inputs, "
-                    "skipping composite and using native implementation."
+                    "composite scaled_dot_product_attention only supports bfloat16 "
+                    "Q/K/V inputs, skipping composite and using native implementation."
                 )
                 return False
 

--- a/tests/torch/ops/test_composite_ops.py
+++ b/tests/torch/ops/test_composite_ops.py
@@ -779,3 +779,49 @@ def test_patched_sdpa(
         framework=Framework.TORCH,
         torch_options=options,
     )
+
+
+@pytest.mark.nightly
+@pytest.mark.single_device
+@pytest.mark.parametrize(
+    "q_shape, kv_shape, mask_shape, scale",
+    [
+        ((1, 28, 5224, 128), (1, 28, 5224, 128), (1, 1, 5224, 5224), None),
+        ((1, 1, 32, 32), (1, 1, 32, 32), (1, 1, 32, 32), 0.125),
+        ((1, 8, 64, 64), (1, 8, 64, 64), (1, 1, 64, 64), 0.5),
+        ((1, 8, 64, 64), (1, 8, 64, 64), (1, 8, 64, 64), None),
+        ((1, 4, 64, 32), (1, 4, 128, 32), (1, 1, 64, 128), 0.25),
+    ],
+)
+def test_sdpa_bool_mask(q_shape, kv_shape, mask_shape, scale):
+    class SDPAModel(torch.nn.Module):
+        def __init__(self, scale):
+            super().__init__()
+            self.scale = scale
+
+        def forward(self, query, key, value, attn_mask):
+            return F.scaled_dot_product_attention(
+                query=query,
+                key=key,
+                value=value,
+                attn_mask=attn_mask,
+                dropout_p=0.0,
+                is_causal=False,
+                scale=self.scale,
+                enable_gqa=False,
+            )
+
+    query = torch.randn(*q_shape, dtype=torch.bfloat16)
+    key = torch.randn(*kv_shape, dtype=torch.bfloat16)
+    value = torch.randn(*kv_shape, dtype=torch.bfloat16)
+    attn_mask = torch.ones(*mask_shape, dtype=torch.bool).tril()
+
+    model = SDPAModel(scale)
+    inputs = [query, key, value, attn_mask]
+
+    run_graph_test(
+        model,
+        inputs,
+        comparison_config=ComparisonConfig(),
+        framework=Framework.TORCH,
+    )


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
This fix (https://github.com/tenstorrent/tt-xla/pull/5289) was reverted due to a perf regression. This is fixable by https://github.com/tenstorrent/tt-xla/pull/5514 (removal of inflated k and v).

> [!NOTE]
> Merge https://github.com/tenstorrent/tt-xla/pull/5514 before this PR

### What's changed
Reverted commit.

### Checklist
- [ ] New/Existing tests provide coverage for changes
