### PR TITLE
Disable AOT Autograd for Segformer in benchmarks

### DIFF
--- a/tests/benchmark/benchmarks/vision_benchmark.py
+++ b/tests/benchmark/benchmarks/vision_benchmark.py
@@ -102,6 +102,7 @@ def benchmark_vision_torch_xla(
     extract_output_tensor_fn,
     display_name=None,
     required_pcc=0.97,
+    use_aot_autograd=None,
 ):
     """
     Benchmark a vision model using PyTorch and torch-xla.
@@ -159,8 +160,10 @@ def benchmark_vision_torch_xla(
 
     torch_xla.set_custom_compile_options(options)
 
-    # Compile model
-    framework_model.compile(backend="tt")
+    compile_kwargs = {}
+    if use_aot_autograd is not None:
+        compile_kwargs["options"] = {"tt_use_aot_autograd": use_aot_autograd}
+    framework_model.compile(backend="tt", **compile_kwargs)
 
     device = torch_xla.device()
 

--- a/tests/benchmark/test_vision.py
+++ b/tests/benchmark/test_vision.py
@@ -32,6 +32,7 @@ def test_vision(
     input_size=DEFAULT_INPUT_SIZE,
     data_format=DEFAULT_DATA_FORMAT,
     required_pcc=DEFAULT_REQUIRED_PCC,
+    use_aot_autograd=None,
 ):
     """Test vision model with the given configuration.
 
@@ -83,6 +84,7 @@ def test_vision(
         load_inputs_fn=load_inputs_fn,
         extract_output_tensor_fn=extract_output_tensor_fn,
         required_pcc=required_pcc,
+        use_aot_autograd=use_aot_autograd,
     )
 
     if output_file:
@@ -274,6 +276,9 @@ def test_segformer(output_file, request):
         batch_size=batch_size,
         input_size=input_size,
         data_format=data_format,
+        # AOTAutograd (default in the "tt" backend since #3795 / 39ab41b7a)
+        # regresses segformer PCC.
+        use_aot_autograd=False,
     )
 
 


### PR DESCRIPTION
### Ticket
Closes #5600 

### What's changed
Added aot_autograd flag in benchmarks.
Disabled aot_autograd for Segformer to retain good PCC.

### Checklist
- [x] [Single-chip Segformer](https://github.com/tenstorrent/tt-xla/actions/runs/29273917385)
