### PR TITLE
Catch SDPA composite for bool attention masks behind opt-in flag

### DIFF
--- a/python_package/tt_torch/composite_ops.py
+++ b/python_package/tt_torch/composite_ops.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import itertools
+import os
 from typing import List, Optional, Union
 
 import torch
@@ -287,6 +288,17 @@ def composite_scaled_dot_product_attention(
     )
 
     if attn_mask is not None:
+        # Fused SDPA adds the mask to the scores, and ttnn.scaled_dot_product_attention
+        # accepts only a float mask (BF16/BFP8/BFP4), so convert a bool mask to additive
+        # form (True -> 0, False -> -inf). Gated by the same flag that allows capturing
+        # a bool mask in _check_sdpa_constraints.
+        # torch reference: https://github.com/pytorch/pytorch/blob/9f48642d4bf84566ca3191576c7ff30138953af8/torch/nn/functional.py#L6365
+        # ttnn check: tt-metal .../transformer/sdpa/device/sdpa_device_operation.cpp ("must be in BF16, BFP8, or BFP4 dataformat")
+        if (
+            os.environ.get("TT_XLA_CATCH_BOOL_MASK_SDPA", "0") == "1"
+            and attn_mask.dtype == torch.bool
+        ):
+            attn_mask = torch.where(attn_mask, 0.0, float("-inf")).to(query.dtype)
         query, key, value, attn_mask = builder.mark_inputs(query, key, value, attn_mask)
     else:
         query, key, value = builder.mark_inputs(query, key, value)
@@ -509,19 +521,48 @@ def _check_sdpa_constraints(node: torch.fx.Node) -> bool:
         )
         return False
 
-    # Check all inputs are bfloat16
-    tensor_args = list(node.args) + [
-        v for v in node.kwargs.values() if isinstance(v, torch.fx.Node)
-    ]
-    for arg in tensor_args:
-        if hasattr(arg, "meta"):
+    # By default every SDPA input (including attn_mask) is gated on bf16, so a bool
+    # mask skips the composite. Catching bool masks by default regressed perf
+    # (issue #5426), so it is opt-in via TT_XLA_CATCH_BOOL_MASK_SDPA for models with
+    # no perf concern at the moment. When set, only the mask is exempted (bf16 or
+    # bool); Q/K/V are always gated on bf16.
+    def _dtype(arg):
+        if isinstance(arg, torch.fx.Node) and hasattr(arg, "meta"):
             val = arg.meta.get("example_value", None)
-            if val is not None and val.dtype != torch.bfloat16:
-                logger.debug(
-                    "composite scaled_dot_product_attention only supports bfloat16 inputs, "
-                    "skipping composite and using native implementation."
-                )
-                return False
+            if val is not None:
+                return val.dtype
+        return None
+
+    # Q/K/V (positional or named) must always be bf16.
+    qkv = list(node.args[:3]) + [
+        node.kwargs[name] for name in ("query", "key", "value") if name in node.kwargs
+    ]
+    for arg in qkv:
+        dtype = _dtype(arg)
+        if dtype is not None and dtype != torch.bfloat16:
+            logger.debug(
+                "composite scaled_dot_product_attention only supports bfloat16 Q/K/V, "
+                "skipping composite and using native implementation."
+            )
+            return False
+
+    # attn_mask dtype policy:
+    #   - bf16: accepted as-is.
+    #   - bool: accepted only under the flag; converted to an additive bf16 bias in
+    #     the composite (see composite_scaled_dot_product_attention).
+    #   - anything else (int, f32, ...): the fused kernel needs a float mask and we
+    #     do not convert it, so skip and fall back to the native implementation.
+    mask = node.args[3] if len(node.args) > 3 else node.kwargs.get("attn_mask")
+    mask_dtype = _dtype(mask)
+    if mask_dtype is not None and mask_dtype != torch.bfloat16:
+        catch_bool = os.environ.get("TT_XLA_CATCH_BOOL_MASK_SDPA", "0") == "1"
+        if not (catch_bool and mask_dtype == torch.bool):
+            logger.debug(
+                "composite scaled_dot_product_attention only supports a bfloat16 mask "
+                "(or a bool mask with TT_XLA_CATCH_BOOL_MASK_SDPA=1), "
+                "skipping composite and using native implementation."
+            )
+            return False
 
     return True
 

--- a/tests/torch/models/HunyuanImage_2_1/test_transformer.py
+++ b/tests/torch/models/HunyuanImage_2_1/test_transformer.py
@@ -11,6 +11,7 @@ import torch_xla.runtime as xr
 from infra import Framework, run_graph_test
 from infra.utilities.torch_multichip_utils import get_mesh
 
+from tests.infra.testers.compiler_config import CompilerConfig
 from third_party.tt_forge_models.hunyuan_image_2_1.pytorch import (
     ModelLoader,
     ModelVariant,
@@ -25,12 +26,14 @@ def test_transformer():
 
 
 @pytest.mark.xfail(
-    reason="Out of Memory: Not enough space to allocate 771162112 B DRAM buffer across 12 banks, where each bank needs to store 64266240 B, but bank size is 1070773184 B - https://github.com/tenstorrent/tt-xla/issues/4780"
+    reason="Out of Memory: Not enough space to allocate 117440512 B DRAM buffer across 12 banks, where each bank needs to store 9787392 B, but bank size is 1070773184 B - https://github.com/tenstorrent/tt-xla/issues/5608"
 )
 @pytest.mark.nightly
 @pytest.mark.model_test
 @pytest.mark.llmbox
-def test_transformer_sharded():
+def test_transformer_sharded(monkeypatch):
+    # Opt in to catching the SDPA composite for bool masks (auto-restored after test).
+    monkeypatch.setenv("TT_XLA_CATCH_BOOL_MASK_SDPA", "1")
     _run(sharded=True)
 
 
@@ -39,8 +42,8 @@ def _run(sharded: bool):
     torch.manual_seed(42)
 
     loader = ModelLoader(ModelVariant.TRANSFORMER)
-    model = loader.load_model(dtype_override=torch.float32)
-    inputs = loader.load_inputs(dtype_override=torch.float32)
+    model = loader.load_model(dtype_override=torch.bfloat16)
+    inputs = loader.load_inputs(dtype_override=torch.bfloat16)
 
     mesh = None
     shard_spec_fn = None
@@ -57,4 +60,5 @@ def _run(sharded: bool):
         framework=Framework.TORCH,
         mesh=mesh,
         shard_spec_fn=shard_spec_fn,
+        compiler_config=CompilerConfig(optimization_level=1),
     )

--- a/tests/torch/ops/test_composite_ops.py
+++ b/tests/torch/ops/test_composite_ops.py
@@ -27,6 +27,7 @@ from tt_torch.composite_ops import (
 )
 
 from tests.infra.evaluators.evaluation_config import ComparisonConfig
+from tests.infra.testers.compiler_config import CompilerConfig
 from tests.infra.testers.single_chip.graph.graph_tester import run_graph_test
 
 
@@ -778,4 +779,62 @@ def test_patched_sdpa(
         comparison_config=ComparisonConfig(),
         framework=Framework.TORCH,
         torch_options=options,
+    )
+
+
+@pytest.mark.nightly
+@pytest.mark.dual_chip
+@pytest.mark.parametrize(
+    "qkv_shape, mask_shape",
+    [
+        ((1, 28, 5224, 128), (1, 1, 1, 5224)),
+        ((1, 28, 1000, 128), (1, 28, 1000, 1000)),
+        ((1, 8, 256, 64), (1, 1, 1, 256)),
+        ((2, 12, 512, 128), (2, 12, 1, 512)),
+        ((1, 16, 128, 64), (1, 16, 1, 128)),
+    ],
+)
+def test_sdpa_bool_mask_broadcast(monkeypatch, qkv_shape, mask_shape):
+    """Tensor-parallel fusion of SDPA with a bool attn_mask (head-sharded Q/K/V)."""
+    monkeypatch.setenv("TT_XLA_CATCH_BOOL_MASK_SDPA", "1")
+
+    num_devices = xr.global_runtime_device_count()
+    num_heads = qkv_shape[1]
+    if num_heads % num_devices != 0:
+        pytest.skip(f"num_heads={num_heads} not divisible by num_devices={num_devices}")
+
+    class SDPAModel(torch.nn.Module):
+        def forward(self, query, key, value, attn_mask):
+            return F.scaled_dot_product_attention(
+                query, key, value, attn_mask=attn_mask
+            )
+
+    query = torch.randn(*qkv_shape, dtype=torch.bfloat16)
+    key = torch.randn(*qkv_shape, dtype=torch.bfloat16)
+    value = torch.randn(*qkv_shape, dtype=torch.bfloat16)
+
+    seq_k = mask_shape[-1]
+    attn_mask = torch.ones(*mask_shape, dtype=torch.bool)
+    attn_mask[..., -seq_k // 4 :] = False  # padding -> masked
+
+    mesh_shape = (1, num_devices)
+    device_ids = np.array(range(num_devices))
+    mesh = xs.Mesh(device_ids, mesh_shape, ("batch", "model"))
+
+    def get_shard_spec(args, kwargs):
+        head_sharded = (None, "model", None, None)
+        spec = {args[0]: head_sharded, args[1]: head_sharded, args[2]: head_sharded}
+        # A per-head mask is head-sharded like Q/K/V; a head-broadcast mask stays replicated.
+        if args[3].shape[1] != 1:
+            spec[args[3]] = head_sharded
+        return spec
+
+    run_graph_test(
+        SDPAModel(),
+        [query, key, value, attn_mask],
+        comparison_config=ComparisonConfig(),
+        framework=Framework.TORCH,
+        mesh=mesh,
+        shard_spec_fn=get_shard_spec,
+        compiler_config=CompilerConfig(optimization_level=1),
     )


### PR DESCRIPTION
### Ticket

- fixes #4780

### Problem description

- `HunyuanImage-2.1`'s transformer feeds `F.scaled_dot_product_attention` bf16 Q/K/V together with a **bool** key-padding mask of shape `[1, 1, 1, S]`. The SDPA composite was never engaging on it, so the op fell back to the native decomposition, which materialises a full `[·, ·, S, S]` **f32 score matrix → OOM** (the 771 MB DRAM buffer in [#4780](https://github.com/tenstorrent/tt-xla/issues/4780)).
- Root cause: `_check_sdpa_constraints` required **every** SDPA input — including the mask — to be bf16. A bool mask disqualified the whole node, so the composite (and thus the fused `ttnn.scaled_dot_product_attention`) never formed.

### What's changed

- **`_check_sdpa_constraints`** — always gate **Q/K/V** on bf16 (positional or named). The attention mask is gated separately: `bf16` is accepted as-is; a `bool` mask is accepted only under the flag (see below); any other dtype (`int`, `f32`, …) still skips the composite and falls back to native, since the fused kernel only accepts a float mask.
- **`composite_scaled_dot_product_attention`** — convert a bool mask to an **additive bf16 bias** (`True → 0`, `False → -inf`). The fused TTNN SDPA *adds* the mask to the scores and `TT_FATAL`s on non-float masks; a plain bool→float cast (`False → 0`) would fail to suppress padding, so the additive form is required for correctness.
- Both changes are **opt-in** behind `TT_XLA_CATCH_BOOL_MASK_SDPA` (default off). Enabling bool-mask capture globally regressed perf (#5426), so for now it's turned on per-test for models with no perf concern.
- Added `test_sdpa_bool_mask_broadcast` in `tests/torch/ops/test_composite_ops.py` — tensor-parallel (head-sharded Q/K/V), parametrized over the shapes the model produces, covering the **query-broadcast `dim2 == 1`** masks (e.g. `(1,1,1,5224)`) as well as the full per-head mask `(1,28,1000,1000)`. Verified these fuse to `ttnn.scaled_dot_product_attention` and match golden PCC.
- `test_transformer_sharded` now sets the flag; with the fix the transformer fuses SDPA across all attention blocks and the 771 MB score-matrix OOM is gone.


### Checklist

- [x] Verified through local testing on WH


### Logs

- [jul13_sdpa_mc_before_fix.log](https://github.com/user-attachments/files/29969720/jul13_sdpa_mc_before_fix.log)
- [jul14_sdpa_mc_after_fix.log](https://github.com/user-attachments/files/30015065/jul14_sdpa_mc_after_fix.log)
- [jul13_HunyuanImage_2_1_transformer_before_fix.log.zip](https://github.com/user-attachments/files/29969715/jul13_HunyuanImage_2_1_transformer_1.log.zip)
- [jul14_HunyuanImage_2_1_transformer_after_fix.log.zip](https://github.com/user-attachments/files/30015064/jul14_HunyuanImage_2_1_transformer_after_fix.log.zip)





