### PR TITLE
[vLLM][tests] Add duration-based per-test timeout for generative suite

### DIFF
--- a/tests/integrations/vllm_plugin/codegen/test_codegen_emit_load.py
+++ b/tests/integrations/vllm_plugin/codegen/test_codegen_emit_load.py
@@ -42,6 +42,10 @@ def insert_sentinel(main_py: Path, sentinel: Path):
     main_py.write_text("".join(lines))
 
 
+@pytest.mark.skip(
+    reason="codegen load needs EmitPy execution (PythonModelRunner), which the "
+    "manylinux CI wheel omits; see tenstorrent/tt-xla#5481",
+)
 @pytest.mark.nightly
 @pytest.mark.single_device
 def test_vllm_codegen_emit_then_load(tmp_path):

--- a/tests/integrations/vllm_plugin/generative/conftest.py
+++ b/tests/integrations/vllm_plugin/generative/conftest.py
@@ -2,9 +2,47 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 """Shared conftest for vLLM generative tests."""
+import json
+import math
 import re
+import signal
+from pathlib import Path
 
 import psutil
+import pytest
+
+TEST_TIMEOUT_FALLBACK_SECONDS = 30 * 60
+
+
+def _load_test_durations() -> dict[str, float]:
+    """Load per-test durations from the repository .test_durations file."""
+    durations_file = Path(__file__).resolve().parents[4] / ".test_durations"
+    if not durations_file.exists():
+        return {}
+
+    try:
+        data = json.loads(durations_file.read_text())
+    except json.JSONDecodeError:
+        return {}
+
+    if not isinstance(data, dict):
+        return {}
+    print(f"Loaded test durations from {durations_file}: {data}")
+
+    return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+
+
+_TEST_DURATIONS = _load_test_durations()
+
+
+def _get_timeout_seconds(nodeid: str) -> int:
+    """Return timeout as 2x recorded duration for this test."""
+    recorded_seconds = _TEST_DURATIONS.get(nodeid)
+    print(f"nodeid={nodeid}, recorded_seconds={recorded_seconds}", flush=True)
+    if recorded_seconds is None:
+        return TEST_TIMEOUT_FALLBACK_SECONDS
+    return max(1, int(math.ceil(recorded_seconds * 2)))
+
 
 # Common English function words used by `assert_output_coherent` to detect
 # the 2D-mesh sampler garbage-output bug (issue #4440). Coherent natural-
@@ -112,3 +150,21 @@ def check_host_memory(model_name: str) -> float:
         )
 
     return rss_gb
+
+
+@pytest.fixture(autouse=True)
+def _test_timeout(request):
+    """Kill any test that hangs longer than 2x its recorded duration."""
+
+    timeout_seconds = _get_timeout_seconds(request.node.nodeid)
+
+    def _handler(_signum, _frame):
+        raise TimeoutError(f"Test {request.node.nodeid} exceeded {timeout_seconds}s")
+
+    old_handler = signal.signal(signal.SIGALRM, _handler)
+    signal.alarm(timeout_seconds)
+    try:
+        yield
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, old_handler)


### PR DESCRIPTION
### Ticket
closes #5613 

### Problem description
Runner occupied for 4 hours in case of hanged test; wasting resources.

### What's changed
- Add a timeout mechanism; use 2X of recorded duration if available in .test_duration otherwise use 30 minutes as timeout.
- Skip codegen test as it fails and may leave the device in unusable state.

### Checklist
- [X] New/Existing tests provide coverage for changes
