### PR TITLE
[vLLM] Teacher-forced decode accuracy testing in vLLM benchmarks

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -510,6 +510,126 @@
         "accuracy-testing": true
       },
       {
+        "name": "vllm_llama_3_2_1b_instruct_accuracy",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[llama-3.2-1b]",
+        "vllm": true,
+        "accuracy-testing": true
+      },
+      {
+        "name": "vllm_llama_3_2_3b_instruct_accuracy",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[llama-3.2-3b]",
+        "vllm": true,
+        "accuracy-testing": true
+      },
+      {
+        "name": "vllm_llama_3_1_8b_instruct_accuracy",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[llama-3.1-8b]",
+        "vllm": true,
+        "accuracy-testing": true
+      },
+      {
+        "name": "vllm_qwen2_5_0_5b_instruct_accuracy",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen2.5-0.5b-instruct]",
+        "vllm": true,
+        "accuracy-testing": true
+      },
+      {
+        "name": "vllm_qwen2_5_1_5b_instruct_accuracy",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen2.5-1.5b-instruct]",
+        "vllm": true,
+        "accuracy-testing": true
+      },
+      {
+        "name": "vllm_qwen2_5_3b_instruct_accuracy",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen2.5-3b-instruct]",
+        "vllm": true,
+        "accuracy-testing": true
+      },
+      {
+        "name": "vllm_qwen2_5_7b_instruct_accuracy",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen2.5-7b-instruct]",
+        "vllm": true,
+        "accuracy-testing": true
+      },
+      {
+        "name": "vllm_qwen3_0_6b_accuracy",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen3-0.6b]",
+        "vllm": true,
+        "accuracy-testing": true
+      },
+      {
+        "name": "vllm_qwen3_1_7b_accuracy",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen3-1.7b]",
+        "vllm": true,
+        "accuracy-testing": true
+      },
+      {
+        "name": "vllm_qwen3_4b_accuracy",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen3-4b]",
+        "vllm": true,
+        "accuracy-testing": true
+      },
+      {
+        "name": "vllm_qwen3_8b_accuracy",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen3-8b]",
+        "vllm": true,
+        "accuracy-testing": true
+      },
+      {
+        "name": "vllm_gemma_1_1_2b_it_accuracy",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[gemma-1.1-2b-it]",
+        "vllm": true,
+        "accuracy-testing": true
+      },
+      {
+        "name": "vllm_phi_1_accuracy",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[phi-1]",
+        "vllm": true,
+        "accuracy-testing": true
+      },
+      {
+        "name": "vllm_phi_1_5_accuracy",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[phi-1_5]",
+        "vllm": true,
+        "accuracy-testing": true
+      },
+      {
+        "name": "vllm_phi_2_accuracy",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[phi-2]",
+        "vllm": true,
+        "accuracy-testing": true
+      },
+      {
+        "name": "vllm_falcon3_1b_base_accuracy",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[falcon3-1b-base]",
+        "vllm": true,
+        "accuracy-testing": true
+      },
+      {
+        "name": "vllm_falcon3_3b_base_accuracy",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[falcon3-3b-base]",
+        "vllm": true,
+        "accuracy-testing": true
+      },
+      {
+        "name": "vllm_falcon3_7b_base_accuracy",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[falcon3-7b-base]",
+        "vllm": true,
+        "accuracy-testing": true
+      },
+      {
+        "name": "vllm_mistral_7b_instruct_accuracy",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[mistral-7b-instruct]",
+        "vllm": true,
+        "accuracy-testing": true
+      },
+      {
+        "name": "vllm_ministral_8b_accuracy",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[ministral-8b]",
+        "vllm": true,
+        "accuracy-testing": true
+      },
+      {
         "name": "vllm_llama_3_2_3b",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[llama-3.2-3b]",
         "vllm": true,

--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -793,6 +793,22 @@
         "runs-on": "qb2-blackhole"
       },
       {
+        "name": "vllm_llama_3_1_8b_qb2_tp_accuracy",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[llama-3.1-8b-qb2-tp]",
+        "vllm": true,
+        "skip-device-perf": true,
+        "runs-on": "qb2-blackhole",
+        "accuracy-testing": true
+      },
+      {
+        "name": "vllm_qwen3_32b_qb2_tp_accuracy",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen3-32b-qb2-tp]",
+        "vllm": true,
+        "skip-device-perf": true,
+        "runs-on": "qb2-blackhole",
+        "accuracy-testing": true
+      },
+      {
         "name": "vllm_mistral_small_3_1_24b_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[mistral-small-3.1-24b-tp]",
         "vllm": true,

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -129,6 +129,7 @@ from .vllm_utils import (
     apply_hidden_layer_override,
     determine_mesh_shape,
     prev_power_of_2,
+    teacher_forced_token,
 )
 
 
@@ -2648,8 +2649,20 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             for i in discard_sampled_tokens_req_indices:
                 valid_sampled_token_ids[i].clear()
 
-            # Append sampled tokens
+            # Append sampled tokens. For accuracy runs, teacher-force the decode
+            # by overriding the sampled token with the reference ground-truth
+            # token (via SamplingParams.extra_args). The override happens after
+            # gather_logprobs above, so `logprobs_lists` still carries the true
+            # device argmax (what accuracy scores), while the next decode input
+            # and recorded output become ground truth. No-op in production.
             for i, req_state, seq_len in request_seq_lens:
+                sampling_params = req_state.sampling_params
+                forced = teacher_forced_token(
+                    sampling_params.extra_args if sampling_params is not None else None,
+                    len(req_state.output_token_ids),
+                )
+                if forced is not None:
+                    valid_sampled_token_ids[i][0] = forced
                 token_id = valid_sampled_token_ids[i][0]
                 self.input_batch.token_ids_cpu[i, seq_len] = token_id
                 req_state.output_token_ids.append(token_id)
@@ -2667,6 +2680,21 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             self.input_batch.num_tokens[:num_reqs] += gen_lens
             self.input_batch.num_tokens_no_spec[:num_reqs] += gen_lens
             for i, req_state, seq_len in request_seq_lens:
+                # Teacher forcing is only implemented for the one-token-per-step
+                # path. Accepted draft tokens have already been through the verify
+                # pass, so their KV entries are written; overriding the token ids
+                # here would desync the cache from token_ids_cpu. Warn rather than
+                # assert, so a stray extra_args can never break a decode run.
+                extra_args = (
+                    req_state.sampling_params.extra_args
+                    if req_state.sampling_params is not None
+                    else None
+                )
+                if extra_args is not None and "teacher_forcing_tokens" in extra_args:
+                    logger.warning_once(
+                        "teacher_forcing_tokens is not supported when sampling "
+                        "multiple tokens per step (e.g. speculative decoding)."
+                    )
                 if not valid_sampled_token_ids[i]:
                     continue
                 target_slice = slice(seq_len - gen_lens[i] + 1, seq_len + 1)

--- a/integrations/vllm_plugin/vllm_tt/vllm_utils.py
+++ b/integrations/vllm_plugin/vllm_tt/vllm_utils.py
@@ -162,3 +162,27 @@ def apply_hidden_layer_override(
         return original_num_layers, target_num_layers
 
     return None, None
+
+
+def teacher_forced_token(extra_args, num_generated_tokens):
+    """Return the ground-truth token to force at a given decode step.
+
+    Accuracy benchmarks make the decode loop teacher-forced by attaching a
+    reference token sequence to each request via
+    ``SamplingParams.extra_args["teacher_forcing_tokens"]``. At decode step
+    ``num_generated_tokens`` (0-indexed: the count of tokens the request has
+    already emitted), the runner forces the sampled token to the corresponding
+    ground-truth token so the next decode step sees the reference context.
+
+    Returns None when teacher forcing is not requested (production path) or the
+    step is outside the reference window, in which case the sampled token is
+    left unchanged.
+    """
+    if not extra_args:
+        return None
+    tf = extra_args.get("teacher_forcing_tokens")
+    if not tf:
+        return None
+    if 0 <= num_generated_tokens < len(tf):
+        return tf[num_generated_tokens]
+    return None

--- a/tests/benchmark/benchmarks/llm_benchmark.py
+++ b/tests/benchmark/benchmarks/llm_benchmark.py
@@ -848,57 +848,12 @@ def benchmark_llm_torch_xla(
     ]
 
     if accuracy_testing:
-        # Compute per-user token accuracy across the batch
-        all_top1 = []
-        all_top5 = []
-        for user_idx, user_tokens in enumerate(per_user_predictions):
-            user_top1, user_top5 = token_accuracy.compute_accuracy(user_tokens)
-            all_top1.append(user_top1)
-            all_top5.append(user_top5)
+        from llm_utils.token_accuracy import score_token_accuracy
 
-        all_top1 = np.array(all_top1)
-        all_top5 = np.array(all_top5)
-
-        # Use 5th-percentile (p5) as primary metric: "95% of users are at or above this"
-        # This catches broken users that averaging would hide.
-        top1_p5 = float(np.percentile(all_top1, 5))
-        top5_p5 = float(np.percentile(all_top5, 5))
-
-        num_users = len(all_top1)
-        print(
-            f"Token accuracy over {num_users} users:\n"
-            f"  TOP1 — min={all_top1.min()*100:.2f}%  p5={top1_p5*100:.2f}%  "
-            f"median={np.median(all_top1)*100:.2f}%  mean={all_top1.mean()*100:.2f}%  "
-            f"max={all_top1.max()*100:.2f}%\n"
-            f"  TOP5 — min={all_top5.min()*100:.2f}%  p5={top5_p5*100:.2f}%  "
-            f"median={np.median(all_top5)*100:.2f}%  mean={all_top5.mean()*100:.2f}%  "
-            f"max={all_top5.max()*100:.2f}%"
+        evaluation_score, accuracy_measurements = score_token_accuracy(
+            token_accuracy, per_user_predictions
         )
-
-        # Store p5 and mean accuracy scores for regression tracking
-        evaluation_score = top1_p5  # Use TOP1 p5 as primary score
-        top1_mean = float(all_top1.mean())
-        top5_mean = float(all_top5.mean())
-        custom_measurements.extend(
-            [
-                {
-                    "measurement_name": "top1_accuracy_p5",
-                    "value": top1_p5 * 100,
-                },
-                {
-                    "measurement_name": "top5_accuracy_p5",
-                    "value": top5_p5 * 100,
-                },
-                {
-                    "measurement_name": "top1_accuracy_mean",
-                    "value": top1_mean * 100,
-                },
-                {
-                    "measurement_name": "top5_accuracy_mean",
-                    "value": top5_mean * 100,
-                },
-            ]
-        )
+        custom_measurements.extend(accuracy_measurements)
     elif decode_only:
         decode_pcc_value = _report_pcc(
             "First decode", output_logits[0][0], cpu_output_logits[1][0], required_pcc

--- a/tests/benchmark/benchmarks/vllm_benchmark.py
+++ b/tests/benchmark/benchmarks/vllm_benchmark.py
@@ -15,6 +15,14 @@ from utils import (
     print_benchmark_results,
 )
 
+# Accuracy testing: total reference length, split in half by
+# init_accuracy_testing() into prompt (prefill) and teacher-forced decode.
+# Must stay equal to test_llms.py's DEFAULT_INPUT_SEQUENCE_LENGTH: both paths
+# share the same reference_outputs/<model>.refpt files and needs_regeneration()
+# does not compare total_length, so divergence silently scores one path against
+# a mismatched context window.
+_ACCURACY_TOTAL_LENGTH = 128
+
 DEFAULT_PROMPT = (
     "Here is an exhaustive list of the best practices for writing clean code:"
 )
@@ -225,11 +233,157 @@ def _assert_no_preemptions(llm: vllm.LLM):
     assert False, "vllm:num_preemptions metric not found in engine metrics."
 
 
-def benchmark_vllm(
+def _extract_decode_predictions(
+    output: vllm.RequestOutput, expected_count: int
+) -> List[int]:
+    """Per-step device argmax token ids from a teacher-forced accuracy run.
+
+    With teacher forcing, `output.outputs[0].token_ids` are the injected
+    ground-truth tokens, so the device's own predictions must be read from the
+    per-step sample logprobs (each step's highest-logprob token is the device
+    argmax). Asserts the full decode window is present so a backend that
+    silently drops logprobs fails loudly instead of reporting a false 0%
+    accuracy regression.
+    """
+    step_logprobs = output.outputs[0].logprobs
+    assert step_logprobs is not None, (
+        "No decode logprobs returned; the vLLM backend must honor "
+        "SamplingParams(logprobs=1) for accuracy testing."
+    )
+    assert len(step_logprobs) == expected_count, (
+        f"Expected {expected_count} decode-step logprobs, got "
+        f"{len(step_logprobs)}. Backend returned an incomplete decode window."
+    )
+    predicted_tokens = []
+    for pos_logprobs in step_logprobs:
+        top1_token = max(pos_logprobs, key=lambda k: pos_logprobs[k].logprob)
+        predicted_tokens.append(top1_token)
+    return predicted_tokens
+
+
+def _perf_measurements(avg_ttft_ms: float, avg_tokens_per_sec: float) -> List[dict]:
+    return [
+        {"measurement_name": "ttft", "value": avg_ttft_ms, "target": -1},
+        {
+            "measurement_name": "samples_per_sec",
+            "value": avg_tokens_per_sec,
+            "target": -1,
+        },
+    ]
+
+
+def _benchmark_vllm_accuracy(
     config: VLLMBenchmarkConfig,
     display_name: str,
 ) -> Dict[str, Any]:
+    """Teacher-forced decode accuracy run through vLLM.
+
+    Prompts with the prefill half of the reference sequence and generates the
+    decode half; the vllm_tt runner overrides each sampled token with the
+    ground-truth token (via extra_args), so every decode step sees the reference
+    context — exactly like llm_benchmark.py. The device's own argmax per step
+    survives in `logprobs` (gathered before the override), which is what gets
+    scored. Prediction 0 comes from the prefill forward; predictions 1..N-1 come
+    from the decode kernel.
+    """
+    # Imported here rather than at module scope: llm_utils.decode_utils and
+    # transformers pull in heavy deps (decode_utils imports tracy / infra /
+    # tt_torch, hence torch_xla). Perf runs use --confcutdir=tests/benchmark
+    # specifically so torch_xla never enters the vLLM engine process.
+    from llm_utils.decode_utils import init_accuracy_testing
+    from llm_utils.token_accuracy import score_token_accuracy
+    from transformers import AutoTokenizer
+
+    # Shares the .refpt on-demand regeneration + half/half prefill/decode split
+    # with the custom torch-xla path (tests/benchmark/test_llms.py), so both
+    # paths score against identically-built reference data.
+    tokenizer = AutoTokenizer.from_pretrained(config.model)
+    token_accuracy, _ = init_accuracy_testing(
+        model_name_for_accuracy=config.model.split("/")[-1],
+        max_cache_len=_ACCURACY_TOTAL_LENGTH,
+        tokenizer=tokenizer,
+        hf_model_name=config.model,
+    )
+
+    llm = _create_llm(config)
+    arch, device_count, mesh_shape = _get_device_info_from_engine(llm)
+
+    input_prompt_tokens = token_accuracy.input_prompt.tolist()
+    ground_truth_tokens = token_accuracy.reference_tokens.tolist()
+    num_decode = len(ground_truth_tokens)
+
+    accuracy_params = vllm.SamplingParams(
+        max_tokens=num_decode,
+        ignore_eos=True,
+        temperature=0.0,
+        logprobs=1,
+        extra_args={"teacher_forcing_tokens": ground_truth_tokens},
+    )
+    print(
+        f"\nRunning accuracy test (prompt={len(input_prompt_tokens)} tokens, "
+        f"teacher-forced decode={num_decode} tokens, "
+        f"batch_size={config.batch_size})..."
+    )
+    accuracy_outputs = llm.generate(
+        [{"prompt_token_ids": input_prompt_tokens} for _ in range(config.batch_size)],
+        accuracy_params,
+    )
+
+    # A preempted request re-prefills and loses its teacher-forced context,
+    # which shows up as an accuracy drop that looks like a model regression.
+    _assert_no_preemptions(llm)
+
+    # The accuracy run is a real generate, so report perf alongside accuracy
+    # rather than leaving zeros in the record, matching llm_benchmark.py.
+    (
+        avg_ttft_ms,
+        tokens_per_user,
+        avg_decode_time_s,
+        avg_tokens_per_sec,
+    ) = _extract_metrics(accuracy_outputs)
+
+    per_user_predictions = [
+        _extract_decode_predictions(output, num_decode) for output in accuracy_outputs
+    ]
+
+    # Eyeball check on user 0: both streams are per-position teacher-forced
+    # argmax (not free-running text), so the fraction of matching tokens equals
+    # TOP1. Clamped to the window compute_accuracy() actually scores.
+    golden_ids = token_accuracy.top1_tokens.tolist()
+    scored = min(len(golden_ids), len(per_user_predictions[0]))
+    print(f"\n  [golden] {tokenizer.decode(golden_ids[:scored])!r}")
+    print(f"  [device] {tokenizer.decode(per_user_predictions[0][:scored])!r}")
+
+    evaluation_score, accuracy_measurements = score_token_accuracy(
+        token_accuracy, per_user_predictions
+    )
+
+    return _build_result(
+        config=config,
+        display_name=display_name,
+        arch=arch,
+        device_count=device_count,
+        mesh_shape=mesh_shape,
+        dataset_name="Tale of Two Cities (Reference Data)",
+        evaluation_score=evaluation_score,
+        avg_ttft_ms=avg_ttft_ms,
+        avg_decode_time_s=avg_decode_time_s,
+        avg_tokens_per_sec=avg_tokens_per_sec,
+        total_samples=sum(tokens_per_user),
+        custom_measurements=_perf_measurements(avg_ttft_ms, avg_tokens_per_sec)
+        + accuracy_measurements,
+    )
+
+
+def benchmark_vllm(
+    config: VLLMBenchmarkConfig,
+    display_name: str,
+    accuracy_testing: bool = False,
+) -> Dict[str, Any]:
     """Run a vLLM benchmark and return a standardised result dict."""
+    if accuracy_testing:
+        return _benchmark_vllm_accuracy(config, display_name)
+
     sampling_params = vllm.SamplingParams(
         max_tokens=config.max_tokens,
         ignore_eos=True,
@@ -277,26 +431,42 @@ def benchmark_vllm(
         avg_decode_time_s,
         avg_tokens_per_sec,
     ) = _extract_metrics(outputs)
-    total_samples = sum(tokens_per_user)
 
+    return _build_result(
+        config=config,
+        display_name=display_name,
+        arch=arch,
+        device_count=device_count,
+        mesh_shape=mesh_shape,
+        dataset_name="Random Data",
+        # vLLM doesn't expose raw logits, so PCC comparison is not possible.
+        evaluation_score=0.0,
+        avg_ttft_ms=avg_ttft_ms,
+        avg_decode_time_s=avg_decode_time_s,
+        avg_tokens_per_sec=avg_tokens_per_sec,
+        total_samples=sum(tokens_per_user),
+        custom_measurements=_perf_measurements(avg_ttft_ms, avg_tokens_per_sec),
+    )
+
+
+def _build_result(
+    config: VLLMBenchmarkConfig,
+    display_name: str,
+    arch: str,
+    device_count: int,
+    mesh_shape: Any,
+    dataset_name: str,
+    evaluation_score: float,
+    avg_ttft_ms: float,
+    avg_decode_time_s: float,
+    avg_tokens_per_sec: float,
+    total_samples: int,
+    custom_measurements: List[dict],
+) -> Dict[str, Any]:
+    """Print the benchmark summary and build the standardised result dict."""
     metadata = get_benchmark_metadata()
     full_model_name = config.model
     model_type = "text-generation"
-    dataset_name = "Random Data"
-    # vLLM doesn't expose raw logits, so PCC comparison is not possible.
-    evaluation_score = 0.0
-    custom_measurements = [
-        {
-            "measurement_name": "ttft",
-            "value": avg_ttft_ms,
-            "target": -1,
-        },
-        {
-            "measurement_name": "samples_per_sec",
-            "value": avg_tokens_per_sec,
-            "target": -1,
-        },
-    ]
 
     print_benchmark_results(
         model_title=full_model_name,

--- a/tests/benchmark/benchmarks/vllm_benchmark.py
+++ b/tests/benchmark/benchmarks/vllm_benchmark.py
@@ -272,6 +272,28 @@ def _perf_measurements(avg_ttft_ms: float, avg_tokens_per_sec: float) -> List[di
     ]
 
 
+def _assert_no_speculative_decode(llm: vllm.LLM) -> None:
+    """Fail an accuracy run whose engine has speculative decode enabled.
+
+    Teacher forcing only holds on the one-token-per-step path: under speculative
+    decode the accepted draft tokens have already been through the verify pass,
+    so their KV entries are written and the scored numbers would be meaningless.
+    Read off the live engine so this catches speculative decode however it was
+    configured, and call it before any generate so nothing gets published.
+
+    TTModelRunner only warns in the equivalent spot, deliberately: a stray
+    extra_args must never crash a real inference run, whose output is usable
+    even when it is not token-identical.
+    """
+    spec_config = llm.llm_engine.vllm_config.speculative_config
+    assert spec_config is None, (
+        "vLLM accuracy testing is not supported with speculative decode "
+        f"(speculative_config={spec_config}). Teacher forcing cannot override "
+        "accepted draft tokens without desyncing the KV cache from the recorded "
+        "token ids. Run accuracy with speculative decode disabled."
+    )
+
+
 def _benchmark_vllm_accuracy(
     config: VLLMBenchmarkConfig,
     display_name: str,
@@ -307,6 +329,8 @@ def _benchmark_vllm_accuracy(
 
     llm = _create_llm(config)
     arch, device_count, mesh_shape = _get_device_info_from_engine(llm)
+
+    _assert_no_speculative_decode(llm)
 
     input_prompt_tokens = token_accuracy.input_prompt.tolist()
     ground_truth_tokens = token_accuracy.reference_tokens.tolist()

--- a/tests/benchmark/llm_utils/token_accuracy.py
+++ b/tests/benchmark/llm_utils/token_accuracy.py
@@ -244,3 +244,56 @@ class TokenAccuracy:
             return True
 
         return False
+
+
+def score_token_accuracy(
+    token_accuracy: "TokenAccuracy", per_user_predictions: list[list[int]]
+) -> tuple[float, list[dict]]:
+    """Aggregate per-user TOP1/TOP5 accuracy into a score and measurements.
+
+    Shared by the custom torch-xla path (llm_benchmark.py) and the vLLM path
+    (vllm_benchmark.py) so both report identically-computed numbers under the
+    same measurement names.
+
+    Uses the 5th percentile as the primary score: "95% of users are at or above
+    this", which catches a single broken user that averaging would hide.
+
+    Returns:
+        Tuple of (evaluation_score, custom_measurements) where evaluation_score
+        is TOP1 p5 in range [0.0, 1.0] and custom_measurements is ready to
+        extend a benchmark result's measurement list.
+    """
+    import numpy as np
+
+    all_top1 = []
+    all_top5 = []
+    for user_tokens in per_user_predictions:
+        user_top1, user_top5 = token_accuracy.compute_accuracy(user_tokens)
+        all_top1.append(user_top1)
+        all_top5.append(user_top5)
+
+    all_top1 = np.array(all_top1)
+    all_top5 = np.array(all_top5)
+
+    top1_p5 = float(np.percentile(all_top1, 5))
+    top5_p5 = float(np.percentile(all_top5, 5))
+    top1_mean = float(all_top1.mean())
+    top5_mean = float(all_top5.mean())
+
+    print(
+        f"Token accuracy over {len(all_top1)} users:\n"
+        f"  TOP1 — min={all_top1.min()*100:.2f}%  p5={top1_p5*100:.2f}%  "
+        f"median={np.median(all_top1)*100:.2f}%  mean={top1_mean*100:.2f}%  "
+        f"max={all_top1.max()*100:.2f}%\n"
+        f"  TOP5 — min={all_top5.min()*100:.2f}%  p5={top5_p5*100:.2f}%  "
+        f"median={np.median(all_top5)*100:.2f}%  mean={top5_mean*100:.2f}%  "
+        f"max={all_top5.max()*100:.2f}%"
+    )
+
+    measurements = [
+        {"measurement_name": "top1_accuracy_p5", "value": top1_p5 * 100},
+        {"measurement_name": "top5_accuracy_p5", "value": top5_p5 * 100},
+        {"measurement_name": "top1_accuracy_mean", "value": top1_mean * 100},
+        {"measurement_name": "top5_accuracy_mean", "value": top5_mean * 100},
+    ]
+    return top1_p5, measurements

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -290,7 +290,7 @@ TP_CONFIGS = [
 ]
 
 
-def _run_vllm_benchmark(config, output_file, request):
+def _run_vllm_benchmark(config, output_file, request, accuracy_testing=False):
     resolved_display_name = resolve_display_name(request=request, fallback=config.model)
     display_name = (
         resolved_display_name
@@ -308,7 +308,7 @@ def _run_vllm_benchmark(config, output_file, request):
         "export_model_name", sanitize_model_name(display_name)
     )
 
-    results = benchmark_vllm(config, display_name)
+    results = benchmark_vllm(config, display_name, accuracy_testing=accuracy_testing)
 
     if output_file:
         results["project"] = "tt-forge/tt-xla"
@@ -422,13 +422,13 @@ def _run_vllm_embedding_benchmark(config, output_file, request):
 
 
 @pytest.mark.parametrize("config", SINGLE_DEVICE_CONFIGS)
-def test_vllm_benchmark(config, output_file, request):
-    _run_vllm_benchmark(config, output_file, request)
+def test_vllm_benchmark(config, output_file, request, accuracy_testing):
+    _run_vllm_benchmark(config, output_file, request, accuracy_testing=accuracy_testing)
 
 
 @pytest.mark.parametrize("config", TP_CONFIGS)
-def test_vllm_tp_benchmark(config, output_file, request):
-    _run_vllm_benchmark(config, output_file, request)
+def test_vllm_tp_benchmark(config, output_file, request, accuracy_testing):
+    _run_vllm_benchmark(config, output_file, request, accuracy_testing=accuracy_testing)
 
 
 @pytest.mark.parametrize("config", EMBEDDING_CONFIGS)

--- a/tests/integrations/vllm_plugin/sampling/test_teacher_forcing.py
+++ b/tests/integrations/vllm_plugin/sampling/test_teacher_forcing.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Unit test for the teacher-forcing override helper (no device needed)."""
+
+import pytest
+from vllm_tt.vllm_utils import teacher_forced_token
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_returns_none_when_extra_args_absent():
+    assert teacher_forced_token(None, 0) is None
+    assert teacher_forced_token({}, 0) is None
+    assert teacher_forced_token({"other": 1}, 0) is None
+    assert teacher_forced_token({"teacher_forcing_tokens": []}, 0) is None
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_returns_ground_truth_token_at_step():
+    tf = {"teacher_forcing_tokens": [10, 20, 30]}
+    assert teacher_forced_token(tf, 0) == 10
+    assert teacher_forced_token(tf, 1) == 20
+    assert teacher_forced_token(tf, 2) == 30
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_returns_none_when_step_out_of_range():
+    tf = {"teacher_forcing_tokens": [10, 20]}
+    assert teacher_forced_token(tf, 2) is None
+    assert teacher_forced_token(tf, -1) is None

--- a/tests/integrations/vllm_plugin/test_vllm_benchmark_accuracy_unit.py
+++ b/tests/integrations/vllm_plugin/test_vllm_benchmark_accuracy_unit.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the vLLM accuracy-benchmark helpers (no device, no engine).
+
+These cover code that lives in ``tests/benchmark`` but are collected from here:
+``tests/benchmark`` is only ever invoked through explicit pytest node ids taken
+from ``perf-bench-matrix.json``, so nothing under it runs as a directory and a
+test file placed there would never execute in CI. This tree is collected by
+mark, so ``push and cpu`` picks these up on the cpu runner.
+"""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+# tests/integrations/vllm_plugin/<this file> -> tests/benchmark
+_BENCHMARK_DIR = Path(__file__).resolve().parents[2] / "benchmark"
+if str(_BENCHMARK_DIR) not in sys.path:
+    sys.path.insert(0, str(_BENCHMARK_DIR))
+
+from benchmarks.vllm_benchmark import _extract_decode_predictions  # noqa: E402
+
+
+def _logprob(lp):
+    return SimpleNamespace(logprob=lp)
+
+
+def _make_output(per_step_logprobs):
+    # per_step_logprobs: list[dict[token_id -> logprob float]]
+    steps = [
+        {tid: _logprob(lp) for tid, lp in step.items()} for step in per_step_logprobs
+    ]
+    completion = SimpleNamespace(logprobs=steps)
+    return SimpleNamespace(outputs=[completion])
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_extracts_argmax_per_step():
+    out = _make_output([{5: -0.1, 9: -2.0}, {7: -0.5}, {3: -0.2, 1: -0.3}])
+    assert _extract_decode_predictions(out, 3) == [5, 7, 3]
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_asserts_on_missing_logprobs():
+    out = SimpleNamespace(outputs=[SimpleNamespace(logprobs=None)])
+    with pytest.raises(AssertionError):
+        _extract_decode_predictions(out, 3)
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_asserts_on_short_window():
+    out = _make_output([{5: -0.1}, {7: -0.5}])
+    with pytest.raises(AssertionError):
+        _extract_decode_predictions(out, 3)

--- a/tests/integrations/vllm_plugin/test_vllm_benchmark_accuracy_unit.py
+++ b/tests/integrations/vllm_plugin/test_vllm_benchmark_accuracy_unit.py
@@ -21,7 +21,10 @@ _BENCHMARK_DIR = Path(__file__).resolve().parents[2] / "benchmark"
 if str(_BENCHMARK_DIR) not in sys.path:
     sys.path.insert(0, str(_BENCHMARK_DIR))
 
-from benchmarks.vllm_benchmark import _extract_decode_predictions  # noqa: E402
+from benchmarks.vllm_benchmark import (  # noqa: E402
+    _assert_no_speculative_decode,
+    _extract_decode_predictions,
+)
 
 
 def _logprob(lp):
@@ -58,3 +61,26 @@ def test_asserts_on_short_window():
     out = _make_output([{5: -0.1}, {7: -0.5}])
     with pytest.raises(AssertionError):
         _extract_decode_predictions(out, 3)
+
+
+def _make_llm(speculative_config):
+    """Minimal stand-in for the vllm.LLM attribute chain the guard reads."""
+    return SimpleNamespace(
+        llm_engine=SimpleNamespace(
+            vllm_config=SimpleNamespace(speculative_config=speculative_config)
+        )
+    )
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_allows_accuracy_without_speculative_decode():
+    _assert_no_speculative_decode(_make_llm(None))
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_rejects_accuracy_with_speculative_decode():
+    spec = SimpleNamespace(method="ngram", num_speculative_tokens=3)
+    with pytest.raises(AssertionError, match="speculative decode"):
+        _assert_no_speculative_decode(_make_llm(spec))


### PR DESCRIPTION
### Ticket
Closes #5179

### Problem description
The vLLM benchmark path had no token-accuracy coverage. TOP1/TOP5 accuracy was only measured by the custom torch-xla path (`tests/benchmark/test_llms.py`), which runs a teacher-forced autoregressive decode loop against precomputed reference outputs. We want the same TOP1/TOP5 signal through vLLM so the vLLM backend's decode path is validated against the reference model.

The hard part is faithfully reproducing the custom path's behavior through vLLM. `llm_benchmark.py` does two things at once that vLLM's public API does not expose together:
- **Teacher-forcing** — at each decode step it feeds the reference ground-truth token instead of the model's own sampled token, which isolates per-position accuracy (one wrong token doesn't corrupt all downstream context).
- **Decode-kernel coverage** — those injected tokens flow through the real single-token decode loop (KV-cache reads, decode-time RoPE).

vLLM's `generate()` always feeds back the model's own sampled token, and neither TT sampler (device or CPU) invokes user logits processors, so there is no public hook to teacher-force the decode loop. An earlier prototype sidestepped this by measuring accuracy from a single prefill pass (`prompt_logprobs` over the full ground-truth sequence). That is teacher-forced, but every prediction is computed by the **prefill** kernel — it never exercises the decode kernel/KV-cache, so decode-path regressions (especially under `bfp_bf8`/`bfp_bf4` weights) could pass while the real decode path is broken.

### What's changed
Teacher-forced decode through vLLM, matching `llm_benchmark.py` semantics (1 prefill-position prediction + N-1 decode-kernel predictions, all teacher-forced):

- **`integrations/vllm_plugin/vllm_tt/`** — opt-in `teacher_forced_token()` helper (`vllm_utils.py`) wired into `TTModelRunner.sample_tokens`. When a request carries `SamplingParams.extra_args["teacher_forcing_tokens"]`, the sampled token is overridden with the reference ground-truth token (bounds-checked, indexed by decode step) so each decode step sees the reference context. No-op on the production path when the key is absent. The override lands **after** `gather_logprobs`, so the reported per-step logprobs keep the true device argmax — which is what gets scored. Teacher forcing applies only to the one-token-per-step path: under speculative decode the accepted draft tokens have already been through the verify pass, so their KV entries are written and overriding the token ids would desync the cache from `token_ids_cpu`. The runner asserts there rather than reporting a plausible but meaningless number.
- **`tests/benchmark/benchmarks/vllm_benchmark.py`** — the accuracy path (`_benchmark_vllm_accuracy()`) prompts with the prefill half of the reference sequence and generates the decode half (`max_tokens = decode length`, `logprobs=1`, `extra_args` carrying the ground-truth decode tokens). The device per-step argmax is read from `output.outputs[0].logprobs` and scored via the existing `TokenAccuracy`. Keeps the same measurement names (`top1/top5_accuracy_p5`, `..._mean`) and `evaluation_score = top1_p5` as the custom path, so dashboards stay compatible. Asserts the full decode window of logprobs is present, so a backend gap fails loudly instead of reporting a false 0% regression. Also prints a golden-vs-device decoded-text preview so TOP1 can be eyeballed against the text.
- **`tests/benchmark/llm_utils/token_accuracy.py`** — per-user TOP1/TOP5 aggregation extracted into `score_token_accuracy()` and shared with `llm_benchmark.py`, replacing a near-verbatim copy of that block. Both paths now report identically-computed numbers under the same measurement names. This touches the existing torch-xla accuracy path, so it was re-verified on device (see below).
- **`.github/workflows/perf-bench-matrix.json`** — single-device vLLM accuracy matrix entries.
- **`.github/workflows/test-matrix-presets/basic-test.json`** — a `push and cpu` job for `tests/integrations/vllm_plugin`, so the CPU unit tests below are actually collected. Without it nothing in that tree runs by mark on a CPU runner.
- **`tests/benchmark/test_vllm_benchmarks.py`** — plumbs the existing `--accuracy-testing` flag through `_run_vllm_benchmark` to both the single-device and TP benchmark tests.
- Unit tests, no device required: `tests/integrations/vllm_plugin/sampling/test_teacher_forcing.py` (override helper) and `tests/integrations/vllm_plugin/test_vllm_benchmark_accuracy_unit.py` (prediction extraction, fail-loud assertion).

Verified on-device (Qwen3-0.6B): `TOP1 95.31% / TOP5 100.00%` — 61 of the 64 decode positions match, which is exactly the reported 95.31%. The shared-scoring refactor was separately re-verified on the torch-xla path (`test_llms.py::test_qwen_2_5_0_5b --accuracy-testing`: 1 passed, `TOP1 95.31% / TOP5 100.00%` over 32 users). `.refpt` reference files are regenerated on demand and are not committed.
