### PR TITLE
[runner] Enable SRPO CLIP + T5 text encoder single-device inference

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -60,6 +60,10 @@ test_config:
   srpo/pytorch-TextEncoder-single_device-inference:
     status: EXPECTED_PASSING  # SRPO/FLUX.1-dev CLIP-L text encoder (openai/clip-vit-large-patch14) on TT; passes at default pcc 0.99.
 
+  srpo/pytorch-T5TextEncoder-single_device-inference:
+    required_pcc: 0.96  # SRPO/FLUX.1-dev T5-v1.1-XXL text encoder (text_encoder_2) on TT. Calculated pcc=0.9686 (bf16, 24-layer T5 v1.1; same weights as SD3 text_encoder_3). Required default 0.99.
+    status: EXPECTED_PASSING
+
   wide_resnet/pytorch-50.2-single_device-inference:
     required_pcc: 0.98
     status: EXPECTED_PASSING

--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -57,6 +57,9 @@ test_config:
     required_pcc: 0.97
     status: EXPECTED_PASSING
 
+  srpo/pytorch-TextEncoder-single_device-inference:
+    status: EXPECTED_PASSING  # SRPO/FLUX.1-dev CLIP-L text encoder (openai/clip-vit-large-patch14) on TT; passes at default pcc 0.99.
+
   wide_resnet/pytorch-50.2-single_device-inference:
     required_pcc: 0.98
     status: EXPECTED_PASSING


### PR DESCRIPTION
### Ticket
N/A — component bringup follow-up to the SRPO text-encoder variants (tt-forge-models companion PR #812).

### Problem description
SRPO's FLUX.1-dev text towers (CLIP-L + T5-v1.1-XXL) ran only on CPU. tt-forge-models #812 adds `TEXT_ENCODER` (CLIP) and `T5_TEXT_ENCODER` component variants (the `stable_diffusion_1_5` / `stable_diffusion_3` pattern); nothing wired them into the runner.

### What's changed
Add two single-device runner entries to `tests/runner/test_config/torch/test_config_inference_single_device.yaml`:
- `srpo/pytorch-TextEncoder-single_device-inference` — `EXPECTED_PASSING` (CLIP-L; default PCC 0.99).
- `srpo/pytorch-T5TextEncoder-single_device-inference` — `EXPECTED_PASSING`, `required_pcc: 0.96` (T5-v1.1-XXL; pcc=0.9686, same as SD3 `text_encoder_3`).

### Verification (TT device)
- CLIP `TextEncoder`: **PASSED** at default PCC 0.99 (~27 s).
- T5 `T5TextEncoder`: **PASSED** at pcc=0.9686 / required 0.96 (~56 s).

### Land order
merge tt-forge-models#812 -> uplift `third_party/tt_forge_models` on tt-xla -> these entries resolve and run. This PR carries **no submodule bump** (same as the SD 1.5 / SD 3 TextEncoder wiring).

### Checklist
- [x] New/Existing tests provide coverage for changes
