### PR TITLE
[vLLM] Pin opt_level=0 in chunked prefill tests to keep page_table ROW_MAJOR

### DIFF
--- a/tests/integrations/vllm_plugin/generative/test_chunked_prefill.py
+++ b/tests/integrations/vllm_plugin/generative/test_chunked_prefill.py
@@ -91,6 +91,9 @@ def _generate(max_num_batched_tokens: int) -> str:
             # length this is a single chunk (the oracle); with a small budget the
             # prompt is split into block-aligned chunks.
             "prefill_chunk_size": max_num_batched_tokens,
+            # opt1 retiles the page_table so the chunked-SDPA op aborts
+            # (page_table must stay ROW_MAJOR), so pin opt0.
+            "optimization_level": 0,
         },
     )
     sp = vllm.SamplingParams(temperature=0.0, max_tokens=_MAX_TOKENS, ignore_eos=True)
@@ -185,6 +188,8 @@ def test_chunked_prefill_batch_all_users_match(monkeypatch):
             "prefill_chunk_size": chunk,
             "enable_const_eval": True,
             "min_context_len": 32,
+            # opt0 keeps the page_table ROW_MAJOR for chunked-SDPA (see _generate).
+            "optimization_level": 0,
         },
     )
     sp = vllm.SamplingParams(temperature=0.0, max_tokens=max_tokens, ignore_eos=True)


### PR DESCRIPTION
The three chunked prefill tests fail in nightly with a `TT_FATAL page_table.layout() == Layout::ROW_MAJOR` abort in the chunked SDPA op. The tests never set `optimization_level`, so they run at the default opt1 where the layout optimizer retiles the page_table, but the op requires it to stay row major.

This sets `optimization_level=0` in both LLM configs (the `_generate` helper and the batch test), the same workaround already used by `test_llama3_3b_generation_trace_opt0`.

Verified on device (Wormhole) against main's tt-mlir pin: at opt1 all three tests hit the ROW_MAJOR abort, at opt0 all three pass with matching output.
