### PR TITLE
[pjrt] Support rank-0 (scalar) complex host buffers

### DIFF
--- a/pjrt_implementation/src/api/buffer_instance.cc
+++ b/pjrt_implementation/src/api/buffer_instance.cc
@@ -399,12 +399,7 @@ BufferInstance::calculateShape(const std::int64_t *dims, size_t num_dims,
   }
 
   // Complex tensors have no runtime equivalent dtype, so they are stored as
-  // float tensors with a trailing dimension of 2 for interleaved real/imag
-  // (tt-mlir maps tensor<...xcomplex<f32>> to tensor<...x2xf32>). This applies
-  // uniformly across ranks, including rank-0 complex scalars, which become a
-  // rank-1 tensor<2xf32>. The resulting shape/strides mismatch (strides has no
-  // entry for the trailing dim) is expected by the runtime, which treats such
-  // complex tensors as contiguous.
+  // float tensors with a trailing dimension of 2 for interleaved real/imag.
   if (data_type_utils::isComplexPJRTType(data_type)) {
     shape.push_back(2);
   }

--- a/pjrt_implementation/src/api/buffer_instance.cc
+++ b/pjrt_implementation/src/api/buffer_instance.cc
@@ -393,18 +393,18 @@ void BufferInstance::allocateUninitialized(const std::int64_t *byte_strides,
 std::vector<std::uint32_t>
 BufferInstance::calculateShape(const std::int64_t *dims, size_t num_dims,
                                PJRT_Buffer_Type data_type) {
-  if (data_type_utils::isComplexPJRTType(data_type) && num_dims == 0) {
-    // Throw error if complex tensor num_dims == 0.
-    TT_THROW("Complex tensor with num_dims == 0 is not supported.");
-  }
-
   std::vector<std::uint32_t> shape;
   for (size_t i = 0; i < num_dims; ++i) {
     shape.push_back(dims[i]);
   }
 
   // Complex tensors have no runtime equivalent dtype, so they are stored as
-  // float tensors with a trailing dimension of 2 for interleaved real/imag.
+  // float tensors with a trailing dimension of 2 for interleaved real/imag
+  // (tt-mlir maps tensor<...xcomplex<f32>> to tensor<...x2xf32>). This applies
+  // uniformly across ranks, including rank-0 complex scalars, which become a
+  // rank-1 tensor<2xf32>. The resulting shape/strides mismatch (strides has no
+  // entry for the trailing dim) is expected by the runtime, which treats such
+  // complex tensors as contiguous.
   if (data_type_utils::isComplexPJRTType(data_type)) {
     shape.push_back(2);
   }

--- a/tests/torch/ops/test_complex.py
+++ b/tests/torch/ops/test_complex.py
@@ -242,6 +242,38 @@ def test_complex_mul(shape: tuple, dtype: torch.dtype, request):
 @pytest.mark.nightly
 @pytest.mark.single_device
 @pytest.mark.record_test_properties(
+    category=Category.OP_TEST, torch_op_name="torch.mul"
+)
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.complex64, torch.complex128],
+    ids=["complex64", "complex128"],
+)
+def test_complex_mul_scalar(dtype: torch.dtype, request):
+    """Rank-0 (scalar) complex inputs are transferred directly from host to
+    device, exercising BufferInstance::calculateShape with num_dims == 0. This
+    previously threw "Complex tensor with num_dims == 0 is not supported."
+    (seen in DeepSeek-V2-Lite-Chat's rotary embedding)."""
+
+    class ComplexMul(torch.nn.Module):
+        def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            return x * y
+
+    run_op_test(
+        ComplexMul(),
+        [
+            torch.tensor(1.5 + 2.5j, dtype=dtype),
+            torch.tensor(-0.5 + 1.0j, dtype=dtype),
+        ],
+        framework=Framework.TORCH,
+        request=request,
+    )
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.single_device
+@pytest.mark.record_test_properties(
     category=Category.OP_TEST, torch_op_name="torch.slice"
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Running `deepseek-ai/DeepSeek-V2-Lite-Chat` on the TT backend crashed during
host-to-device transfer with:

RuntimeError: TT_THROW @ .../pjrt_implementation/src/api/buffer_instance.cc:398: tt::exception
info:
Complex tensor with num_dims == 0 is not supported.

`BufferInstance::calculateShape` explicitly threw whenever it received a complex
buffer with `num_dims == 0` â i.e. a rank-0 complex **scalar**. DeepSeek-V2's
rotary embedding produces exactly such a value, which reaches a `mul` and gets
transferred to device via `PjRtComputationClient::TransferShardsToDevice`,
triggering the throw and aborting the run.


### What's changed
Removed the `num_dims == 0` guard in `calculateShape` so scalar complex buffers
flow through the standard complex-tensor path.

The guard was unnecessary. tt-mlir represents complex tensors by appending a
trailing dimension of 2 (`tensor<...xcomplex<f32>>` â `tensor<...x2xf32>`), which
maps a rank-0 complex scalar cleanly to a rank-1 `tensor<2xf32>` â consistent
with how complex tensors of every other rank are already handled. The runtime
also already tolerates the shape/strides length mismatch that complex tensors
create (`stride.size() != shape.size()` is explicitly treated as contiguous in
`runtime.cpp`), so the scalar case (shape `[2]`, strides `[]`) is already
supported downstream.


### Checklist
- [ ] New/Existing tests provide coverage for changes
