### PR TITLE
Stop triggering qb2-blackhole perf tests

### DIFF
--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -138,7 +138,6 @@ jobs:
       - test-uplift-extended
       - test-tools
       - perf-benchmark
-      - perf-benchmark-accuracy
       - build-docs
     runs-on: Ubuntu-latest
     steps:

--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -77,28 +77,10 @@ jobs:
       #   - llama_3_1_70b_tp_galaxy (galaxy-wh-6u): fabric pinning (#5210)
       adv_filter: '[
         { "accuracy-testing": false },
-        { "runs-on": "n150-perf", "filter": ["resnet","llama_3_1_8b","falcon3-1b","qwen_3_8b"] },
-        { "runs-on": "qb2-blackhole", "filter": ["qwen_3_32b_tp_qb2"] } ]'
+        { "runs-on": "n150-perf", "filter": ["resnet","llama_3_1_8b","falcon3-1b","qwen_3_8b"] } ]'
       sh-runner: false
       skip-device-perf: true
       regression_check: false # toggle on #5486 completion
-      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
-      artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
-
-  perf-benchmark-accuracy:
-    if: needs.inspect-changes.outputs.skip-build-and-test == 'false' && needs.inspect-changes.outputs.only-run-forge-models != 'true' && vars.RUN_PERF_ON_UPLIFT == 'true' && github.event_name == 'pull_request' && (contains(needs.inspect-changes.outputs.detected-uplifts, 'tt-mlir') || contains(needs.inspect-changes.outputs.detected-uplifts, 'transformers'))
-    needs: [ inspect-changes, build-image, build-ttxla ]
-    uses: ./.github/workflows/call-filtered-perf-tests.yml
-    secrets: inherit
-    with:
-      docker_image: ${{ needs.build-image.outputs.docker-image-base }}
-      # On-PR accuracy uplift check: llama_3_1_70b TP accuracy on qb2-blackhole.
-      adv_filter: '[
-        { "accuracy-testing": true },
-        { "runs-on": "qb2-blackhole", "filter": ["qwen_3_32b_tp_qb2"] } ]'
-      sh-runner: false
-      skip-device-perf: true
-      regression_check: true
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
 

--- a/.github/workflows/schedule-benchmark-experimental.yml
+++ b/.github/workflows/schedule-benchmark-experimental.yml
@@ -49,7 +49,6 @@ jobs:
   fail-notify:
     needs:
       - run-n150-accuracy-benchmarks
-      - run-qb2-accuracy-benchmarks
       - run-galaxy-accuracy-benchmarks
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/schedule-benchmark-experimental.yml
+++ b/.github/workflows/schedule-benchmark-experimental.yml
@@ -36,16 +36,6 @@ jobs:
       sh-runner: true
       regression_check: true
 
-  run-qb2-accuracy-benchmarks:
-    needs: [build-image, build-ttxla]
-    secrets: inherit
-    uses: ./.github/workflows/call-filtered-perf-tests.yml
-    with:
-      adv_filter: '[ {"runs-on": "qb2-blackhole", "accuracy-testing": true} ]'
-      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
-      artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
-      regression_check: true
-
   run-galaxy-accuracy-benchmarks:
     needs: [build-image, build-ttxla]
     secrets: inherit

--- a/.github/workflows/schedule-nightly.yml
+++ b/.github/workflows/schedule-nightly.yml
@@ -94,7 +94,7 @@ jobs:
       sh-runner: false
       skip-device-perf: true
       regression_check: true
-      adv_filter: '[ {"accuracy-testing": false}, {"runs-on": "n150-perf"}, {"runs-on": "p150-perf"}, {"runs-on": "galaxy-wh-6u"}, {"runs-on": "qb2-blackhole"} ]'
+      adv_filter: '[ {"accuracy-testing": false}, {"runs-on": "n150-perf"}, {"runs-on": "p150-perf"}, {"runs-on": "galaxy-wh-6u"}]'
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
       wheel_build: manylinux


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/5625

### Problem description
Performance benchmark tests for qb2 have been killing machines during test execution ([example](https://github.com/tenstorrent/tt-xla/actions/runs/29245566873/job/86807959213)).
After the job crashes the machine is no longer reachable over network and needs to get rebooted with PDU.
This means that other model/functional (non perf) tests which execute on qb2s and are working fine can't execute, since all machines are dead.

### What's changed
Performance benchmark qb2 test triggers have been removed from nightly and on pr workflows until the issue is resolved.
As soon as the fix is live, this PR will get reverted.

### Checklist
- [ ] New/Existing tests provide coverage for changes
