### PR TITLE
[op-by-op] Continue processing when an IR fails to split

### DIFF
--- a/tests/op_by_op/op_by_op_test.py
+++ b/tests/op_by_op/op_by_op_test.py
@@ -161,19 +161,40 @@ def test_op_by_op(request, whitelist, blacklist, record_property):
             pytest.skip(f"No .mlir files found in {folder_path}")
 
     ops = []
+    # Collect per-file failures so that a single unreadable or unsplittable IR does
+    # not abort the whole job (which would drop every remaining model/op). Each
+    # failing file is logged, recorded, and skipped so processing continues.
+    extraction_failures = []
     for ir_file_path, origin_model in matched_files:
         try:
             with open(ir_file_path, "r") as f:
                 module = f.read()
         except (FileNotFoundError, IOError, OSError) as e:
-            pytest.fail(
-                f"Op-by-op test failed because IR file couldn't be read.\n"
-                f"File: {ir_file_path}\n"
-                f"Error: {e}"
+            print(
+                f"WARNING: Skipping IR file that couldn't be read.\n"
+                f"  File: {ir_file_path}\n"
+                f"  Model: {origin_model}\n"
+                f"  Error: {e}"
             )
+            extraction_failures.append(
+                {"model": origin_model, "file": str(ir_file_path), "error": str(e)}
+            )
+            continue
         print(f"Processing IR file: {ir_file_path}")
 
-        module_ops = extract_ops_from_module(module, origin_model=origin_model)
+        try:
+            module_ops = extract_ops_from_module(module, origin_model=origin_model)
+        except Exception as e:
+            print(
+                f"WARNING: Failed to extract ops from IR file, skipping.\n"
+                f"  File: {ir_file_path}\n"
+                f"  Model: {origin_model}\n"
+                f"  Error: {e}"
+            )
+            extraction_failures.append(
+                {"model": origin_model, "file": str(ir_file_path), "error": str(e)}
+            )
+            continue
         ops.extend(module_ops)
 
     filtered_ops = filter_and_deduplicate_ops(
@@ -182,6 +203,9 @@ def test_op_by_op(request, whitelist, blacklist, record_property):
 
     record_property("total_ops_before_filtering", len(ops))
     record_property("total_ops_after_filtering", len(filtered_ops))
+    record_property("extraction_failures", len(extraction_failures))
+    if extraction_failures:
+        record_property("extraction_failure_details", extraction_failures)
     record_property("ir_folder", str(folder_path))
     record_property("ir_file_prefix", ir_file_prefix if ir_file_prefix else None)
     record_property("compile_only", compile_only)


### PR DESCRIPTION
### Ticket

Closes #5628

### Problem description

Op-by-op processing stops after a single failure, dropping every remaining model/op in the job.

The execution infra in tt-mlir (`op_by_op_infra`) is already robust per-op (each op is compiled/run in an isolated subprocess with timeouts; segfaults surface as `RuntimeError`). The gap is on the tt-xla side: in `tests/op_by_op/op_by_op_test.py`, the per-file `extract_ops_from_module()` call is **not** wrapped in `try/except`. Since all IRs are split up-front (before any execution) into one op list, a single IR the splitter can't handle — e.g. missing `@main` func, CPU-hoisted ops, which raise `ValueError`/`AssertionError` — aborts the **entire** test → 0 ops processed across all models in that job.

### What's changed

- Guard the per-file read and `extract_ops_from_module()` call: on failure, log it, record it, and `continue` to the next file instead of aborting the whole run.
- Record `extraction_failures` (count) and `extraction_failure_details` (model / file / error) in the test properties so skipped IRs are visible in the report/dashboard instead of disappearing silently.

### Verification

Ran on an n150 with real nightly IR dumps plus a deliberately malformed IR (no `@main`):
- malformed IR → caught & skipped (`extraction_failures = 1`, recorded)
- good model → still fully extracted (26 ops) and executed (11 pass / 1 fail)

Pre-fix, that same run aborted at extraction with 0 ops processed.

### Note

Two related issues remain in tt-mlir (`python/common/compile_and_run_utils.py`) and will be handled in a separate upstream PR: `ProcessManager.stop()` joins with no timeout (can deadlock on a hung compile), and `result_queue` isn't drained after a timeout (stale result can be misattributed to the next op).

### Checklist
- [x] New/Existing tests provide coverage for changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)