### PR TITLE
Clamp OOB negative slices on eager + exported paths (#4465)

### DIFF
--- a/python_package/tt_torch/backend/backend.py
+++ b/python_package/tt_torch/backend/backend.py
@@ -47,6 +47,7 @@ from .passes import (
     bypass_assert_tensor_metadata,
     bypass_dtype_promotion_and_redundant_cast,
     bypass_redundant_getitem,
+    clamp_neg_getitem_bounds,
     clamp_neg_slice_bounds,
     fold_view_bmm_view_to_einsum,
     handle_composite_ops,
@@ -700,6 +701,9 @@ def aot_backend(
     options: dict[str, bool] | None,
 ):
     """AOTAutograd backend: run decompositions and trace through aot_autograd with _fw_compiler."""
+    # Clamp OOB negative slices before AOTAutograd records the view-meta (#4465).
+    gm = clamp_neg_getitem_bounds(gm)
+
     # Rewrite AdaptiveAvgPool1d/2d(1) to torch.mean before AOTAutograd tracing.
     # There is a Torch/TorchXLA bug where fakified XLA tensors fault in AdaptiveAveragePool, because of an as_strided_ call
     # THIS IS A HACK https://github.com/tenstorrent/tt-xla/issues/3549

--- a/python_package/tt_torch/backend/passes.py
+++ b/python_package/tt_torch/backend/passes.py
@@ -8,6 +8,7 @@ import torch
 from torch.export.graph_signature import InputKind, OutputKind
 from tt_torch import composite_ops
 from tt_torch.fusion_providers import FusionProvider
+from tt_torch.slice_bounds import clamp_neg_slice_key
 from ttxla_tools.logging import logger
 
 
@@ -588,6 +589,45 @@ def clamp_neg_slice_bounds(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                 f"(dim {dim}, size {dim_size})"
             )
             node.args = tuple(new_args)
+            changed = True
+    if changed:
+        gm.graph.lint()
+        gm.recompile()
+    return gm
+
+
+def clamp_neg_getitem_bounds(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
+    """Pre-AOTAutograd clamp for OOB negative slices as ``operator.getitem`` nodes.
+
+    Must run before AOTAutograd so functionalization records the clamped view-meta
+    sequence; otherwise the runtime view-alias replay uses the original bound and
+    raises "Value out of range". Companion to clamp_neg_slice_bounds. Refs: #4465.
+    """
+    changed = False
+    for node in gm.graph.nodes:
+        if (
+            node.op != "call_function"
+            or node.target is not operator.getitem
+            or len(node.args) != 2
+        ):
+            continue
+        inp, key = node.args
+        if not isinstance(inp, torch.fx.Node):
+            continue
+        key_tuple = key if isinstance(key, tuple) else (key,)
+        if not any(isinstance(k, slice) for k in key_tuple):
+            continue
+        shape = getattr(inp.meta.get("example_value"), "shape", None)
+        if shape is None:
+            shape = getattr(inp.meta.get("val"), "shape", None)
+        if shape is None:
+            continue
+        new_key, node_changed = clamp_neg_slice_key(shape, key)
+        if node_changed:
+            logger.debug(
+                f"clamp_neg_getitem_bounds: clamped {node.name} key {key} -> {new_key}"
+            )
+            node.args = (inp, new_key)
             changed = True
     if changed:
         gm.graph.lint()

--- a/python_package/tt_torch/slice_bounds.py
+++ b/python_package/tt_torch/slice_bounds.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Shared helper for clamping out-of-range negative slice bounds (tt-xla #4465).
+
+CPU eager clamps a slice bound ``< -dim_size`` to ``-dim_size``; XLA rejects it.
+Reused by the eager ``__getitem__`` override and the pre-AOTAutograd getitem pass.
+"""
+import torch
+
+
+def clamp_neg_slice_key(shape: torch.Size, key):
+    """Clamp negative slice starts/ends ``< -dim_size`` in a ``__getitem__`` key.
+
+    Returns ``(new_key, changed)``. Bails on Ellipsis; leaves symbolic dims and
+    non-slice indices untouched.
+    """
+    key_tuple = key if isinstance(key, tuple) else (key,)
+    if any(k is Ellipsis for k in key_tuple):
+        return key, False
+
+    changed = False
+    out = []
+    dim = 0
+    for k in key_tuple:
+        if k is None:  # newaxis inserts a dim, consumes none of ``shape``
+            out.append(k)
+            continue
+        if isinstance(k, slice) and dim < len(shape):
+            size = shape[dim]
+            if isinstance(size, int):
+                start, stop, step = k.start, k.stop, k.step
+                if isinstance(start, int) and start < -size:
+                    start = -size
+                    changed = True
+                if isinstance(stop, int) and stop < -size:
+                    stop = -size
+                    changed = True
+                k = slice(start, stop, step)
+        dim += 1  # int / slice / tensor index each consume one dim
+        out.append(k)
+
+    if not changed:
+        return key, False
+    return (tuple(out) if isinstance(key, tuple) else out[0]), True

--- a/python_package/tt_torch/torch_overrides.py
+++ b/python_package/tt_torch/torch_overrides.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import torch
 from torch.overrides import TorchFunctionMode
+from tt_torch.slice_bounds import clamp_neg_slice_key
 
 
 def _unflatten_to_shape(
@@ -94,6 +95,19 @@ def _unfold_via_gather(
 class TorchFunctionOverride(TorchFunctionMode):
     def __torch_function__(self, func, types, args, kwargs=None):
         kwargs = kwargs or {}
+
+        # Clamp OOB negative slices on the eager XLA path (tt-xla #4465); the
+        # traced path is handled by clamp_neg_slice_bounds / clamp_neg_getitem_bounds.
+        if (
+            func.__name__ == "__getitem__"
+            and not torch.compiler.is_compiling()
+            and len(args) >= 2
+            and isinstance(args[0], torch.Tensor)
+            and args[0].device.type == "xla"
+        ):
+            new_key, changed = clamp_neg_slice_key(args[0].shape, args[1])
+            if changed:
+                args = (args[0], new_key, *args[2:])
 
         if func.__name__ == "unflatten":
             tensor = args[0]

--- a/tests/torch/models/krea_realtime/test_vae_decoder.py
+++ b/tests/torch/models/krea_realtime/test_vae_decoder.py
@@ -8,7 +8,8 @@ import pytest
 import torch
 import torch_xla
 import torch_xla.runtime as xr
-from infra import Framework, run_graph_test
+from infra import Framework, RunMode, run_graph_test
+from utils import BringupStatus, Category, ModelGroup
 
 from third_party.tt_forge_models.krea_realtime_video.pytorch import (
     ModelLoader,
@@ -16,8 +17,15 @@ from third_party.tt_forge_models.krea_realtime_video.pytorch import (
 )
 
 
-@pytest.mark.xfail(
-    reason="VAE temporal slice fails on TT (out-of-range slice on size-1 dim) — https://github.com/tenstorrent/tt-xla/issues/4465"
+@pytest.mark.nightly
+@pytest.mark.model_test
+@pytest.mark.single_device
+@pytest.mark.record_test_properties(
+    category=Category.MODEL_TEST,
+    model_name="KreaRealtimeVideo_VAEDecoder",
+    model_group=ModelGroup.RED,
+    run_mode=RunMode.INFERENCE,
+    bringup_status=BringupStatus.PASSED,
 )
 def test_vae_decoder():
     xr.set_device_type("TT")

--- a/tests/torch/ops/test_slice.py
+++ b/tests/torch/ops/test_slice.py
@@ -83,3 +83,84 @@ def test_slice_oob_empty(start, end):
         out = model(x).to("cpu")
 
     assert out.shape == expected
+
+
+@pytest.mark.single_device
+@pytest.mark.record_test_properties(
+    category=Category.OP_TEST,
+    torch_op_name="torch.ops.aten.slice.Tensor",
+)
+@pytest.mark.parametrize(
+    ["start", "end"],
+    [
+        (-1023, None),  # neg_start: x[:, :, -1023:, :]  -> full dim (clamped)
+        (None, -1023),  # neg_end:   x[:, :, :-1023, :]  -> empty (clamped)
+    ],
+    ids=["neg_start", "neg_end"],
+)
+def test_slice_oob_eager(start, end):
+    """OOB negative slice run eagerly on an XLA tensor: exercises the eager
+    TorchFunctionOverride.__getitem__ clamp (the graph-break path, #4465)."""
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    x_cpu = torch.randn(SHAPE, dtype=torch.bfloat16)
+    expected = x_cpu[:, :, start:end, :]
+
+    out = x_cpu.to(xm.xla_device())[:, :, start:end, :].to("cpu")
+
+    assert out.shape == expected.shape
+    if out.numel() > 0:
+        assert torch.allclose(out.float(), expected.float())
+
+
+@pytest.mark.parametrize(
+    ["shape", "key", "expected_key", "expected_changed"],
+    [
+        # size-1 dim, start -2 -> -1 (the krea VAE decoder pattern)
+        (
+            (1, 16, 1, 60, 104),
+            (slice(None), slice(None), slice(-2, None), slice(None), slice(None)),
+            (slice(None), slice(None), slice(-1, None), slice(None), slice(None)),
+            True,
+        ),
+        # in-range negative slice: untouched
+        (
+            (1, 16, 4, 60, 104),
+            (slice(None), slice(None), slice(-2, None)),
+            (slice(None), slice(None), slice(-2, None)),
+            False,
+        ),
+        # negative stop out of range
+        ((5,), (slice(None, -9),), (slice(None, -5),), True),
+        # single (non-tuple) slice key
+        ((3,), slice(-9, None), slice(-3, None), True),
+        # None / newaxis keeps the dim mapping correct
+        (
+            (1, 1),
+            (None, slice(-3, None), slice(None)),
+            (None, slice(-1, None), slice(None)),
+            True,
+        ),
+        # Ellipsis -> bail (ambiguous dim mapping)
+        ((1, 2, 3), (Ellipsis, slice(-9, None)), (Ellipsis, slice(-9, None)), False),
+        # int index consumes a dim; following slice clamps against the right dim
+        ((4, 1), (0, slice(-5, None)), (0, slice(-1, None)), True),
+    ],
+    ids=[
+        "size1_start",
+        "in_range",
+        "neg_stop",
+        "single_slice",
+        "newaxis",
+        "ellipsis_bail",
+        "int_index",
+    ],
+)
+def test_clamp_neg_slice_key(shape, key, expected_key, expected_changed):
+    """Unit test for the shared clamp helper (no device required)."""
+    from tt_torch.slice_bounds import clamp_neg_slice_key
+
+    new_key, changed = clamp_neg_slice_key(torch.Size(shape), key)
+    assert changed == expected_changed
+    assert new_key == expected_key


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-xla/issues/4465

### Problem description

- The krea Realtime VAE decoder (diffusers `AutoencoderKLWan`) slices `x[:, :, -CACHE_T:, :, :]` (`CACHE_T=2`) on a **size-1** temporal dim, i.e. `start=-2` on a dim whose valid range is `[-1, 0]`.
- On CPU, `Tensor.__getitem__` silently **clamps** an out-of-range negative bound to `-dim_size`. On XLA/TT the strict `aten.slice.Tensor` overload instead rejects `start < -size` and raises `RuntimeError: Value out of range`.
- The already-merged `clamp_neg_slice_bounds` FX pass (#5211) only reaches slices captured in the **exported** graph. The VAE decoder's slice never gets there: diffusers' `AutoencoderKLWan._decode` runs a per-frame Python loop with mutable feat-cache state and a data-dependent `if cache_x.shape[2] < 2` guard, which forces a **Dynamo graph break** (`TORCH_LOGS=graph_breaks` shows all 50 breaks at the always-on `TorchFunctionOverride` fallthrough, dropping the decode frame to eager). The slice then lowers straight through the eager `__torch_function__` path to strict `aten.slice` — a path the FX pass never sees.
- While fixing this I also found `tests/torch/ops/test_slice.py` failing its two **negative** out-of-range cases on `main`: after AOTAutograd became the default (#3795), `clamp_neg_slice_bounds` still clamps the compute graph, but AOTAutograd captures the slice output's **view-meta sequence** during functionalization and replays it at runtime (`_aot_autograd/functional_utils.py` `apply_view_meta_sequence`) using the **original** out-of-range bound — raising before the clamped graph matters.

### What's changed

- Add a shared helper `tt_torch/slice_bounds.py::clamp_neg_slice_key` that clamps out-of-range negative `slice` starts/ends in a `__getitem__` key to `-dim_size` (CPU eager semantics); it bails on `Ellipsis` and leaves symbolic dims / non-slice indices untouched.
- **Eager path (#4465):** a `__getitem__` branch in the always-on `TorchFunctionOverride` (`torch_overrides.py`), guarded to eager (`not torch.compiler.is_compiling()`) and XLA tensors, so the traced path is untouched and no new `TorchFunctionMode` is introduced.
- **Exported path (test_slice regression):** a new `clamp_neg_getitem_bounds` FX pass run in `aot_backend` **before** `aot_autograd`, where the slice is still a single `operator.getitem` node — so functionalization records the clamped view-meta and the runtime replay uses the clamped bound.
- Tests: `test_slice.py` gains `test_slice_oob_eager` (eager XLA path) and a device-free unit test for `clamp_neg_slice_key`; `test_vae_decoder` is un-`xfail`ed now that the model passes end-to-end.

### Checklist
- [x] Verify the changes through local testing in WH (single device)

### Logs
- Failing Model log - [model_test_FAIL_before_fix.log](https://github.com/user-attachments/files/30047304/model_test_FAIL_before_fix.log)

- Passing logs (Model and unit tests) - [model_test_PASS_xfail_removed.log](https://github.com/user-attachments/files/30047310/model_test_PASS_xfail_removed.log), [op_test_slice_ALL_PASS_after_fix.log](https://github.com/user-attachments/files/30047311/op_test_slice_ALL_PASS_after_fix.log)

