### PR TITLE
Comparator: use live transformers.Cache so DynamicCache converts after requirements swap

### DIFF
--- a/tests/infra/evaluators/torch_comparison_evaluator.py
+++ b/tests/infra/evaluators/torch_comparison_evaluator.py
@@ -59,7 +59,12 @@ class TorchComparisonEvaluator(ComparisonEvaluator):
             return tensor
 
         def convert_and_match(tensor):
-            if isinstance(tensor, Cache):
+            # Use the live transformers.Cache, not the module-level import.
+            # Per-model requirements swaps reload transformers, so a static
+            # isinstance check would miss the model's reloaded cache class.
+            import transformers
+
+            if isinstance(tensor, transformers.Cache):
                 # New transformers library uses Cache classes (DynamicCache, StaticCache)
                 # with CacheLayers/StaticLayers instead of raw tensors. Convert to legacy
                 # (keys, values) tuple per layer so the comparator can compare tensors.

--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -64,7 +64,7 @@ test_config:
   diffusiongemma/pytorch-26B-A4B-it-tensor_parallel-inference:
     supported_archs: [n300-llmbox]
     status: KNOWN_FAILURE_XFAIL
-    reason: "Unsupported data type for remainder DataType::UINT32 - https://github.com/tenstorrent/tt-xla/issues/5423"
+    reason: "AssertionError: Evaluation result 0 failed: PCC comparison failed. Calculated: pcc=0.9603734111616014. Required: pcc=0.99 - https://github.com/tenstorrent/tt-xla/issues/5642"
     inject_custom_moe: true
 
   falcon/pytorch-7B_Instruct-tensor_parallel-inference:


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-xla/issues/5643

### Problem description

- `TorchComparisonEvaluator` crashes during output comparison with: `TypeError: equal(): argument 'input' (position 1) must be Tensor, not DynamicCache`
- The comparator converts KV caches via `_cache_to_legacy`, gated on `isinstance(tensor, Cache)` where `Cache` is imported at module load. When a model's `requirements.txt` swaps the transformers version, `RequirementsManager` purges transformers from `sys.modules` and it is re-imported — so the model's `DynamicCache` comes from a different `Cache` class object than the one the evaluator imported. `isinstance` returns `False`, the cache is never converted, and the raw `DynamicCache` reaches `torch.equal`.
- This hits any model whose required transformers differs from the base env, forcing a swap. e.g. the base env ships transformers `5.5.1`, but DiffusionGemma needs `>=5.11.0` (verified with `5.12.0`) — so `RequirementsManager` swaps `5.5.1 → 5.12.0`, triggering the re-import and the mismatch.

### What's changed

- Resolve `Cache` from the live `transformers` module inside `convert_and_match` instead of the module-level import, so the `isinstance` check matches the model's reloaded cache class.
- Impact: caches are correctly converted to legacy `(key, value)` tensors again; comparison (incl. `past_key_values`) works across per-model transformers swaps, fixing the crash.

### Checklist
- [x] Verify the changes through local testing in WH

### Logs

- [jul15_diffgemma_sanity_before_fix.log](https://github.com/user-attachments/files/30048849/jul15_diffgemma_output_error.log)
- [jul15_diffgemma_before_fix.log.zip](https://github.com/user-attachments/files/30048847/jul15_diffgemma_after_workaround_removal_debug_1.log.zip)
- [jul15_diffgemma_after_fix.log.zip](https://github.com/user-attachments/files/30048846/jul15_diffgemma_after_fix.log.zip)
- [jul15_diffgemma_sanity_after_fix.log](https://github.com/user-attachments/files/30048851/jul15_diffgemma_sanity_after_fix.log)
- [test_diffgemma_sanity.py](https://github.com/user-attachments/files/30048853/test_diffgemma_cpu.py)
