### PR TITLE
vLLM benchmark get device info

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/worker.py
+++ b/integrations/vllm_plugin/vllm_tt/worker.py
@@ -209,7 +209,8 @@ class TTWorker:
         Reads the same PJRT runtime attributes as ``_get_device_dram_bytes``.
         ``device_count`` is the real chip count from the runtime, not
         ``world_size`` (which is forced to 1 under SPMD, where a single worker
-        drives all chips).
+        drives all chips). ``mesh_shape`` is read from the model runner after
+        it resolves the configured parallel mode and optional explicit mesh.
         """
         arch = ""
         device_count = 1
@@ -222,7 +223,16 @@ class TTWorker:
                 device_count = xr.global_runtime_device_count()
         except Exception as e:
             logger.warning("get_device_info: could not read device attributes (%s)", e)
-        return {"arch": arch, "device_count": max(int(device_count), 1)}
+
+        mesh = getattr(self.model_runner, "mesh", None)
+        mesh_shape = (
+            tuple(int(dim) for dim in mesh.mesh_shape) if mesh is not None else None
+        )
+        return {
+            "arch": arch,
+            "device_count": max(int(device_count), 1),
+            "mesh_shape": mesh_shape,
+        }
 
     def determine_available_memory(self) -> int:
         if self.model_config.runner_type == "pooling":

--- a/integrations/vllm_plugin/vllm_tt/worker.py
+++ b/integrations/vllm_plugin/vllm_tt/worker.py
@@ -203,6 +203,27 @@ class TTWorker:
             return self._DEFAULT_DEVICE_DRAM_BYTES
         return bytes_val
 
+    def get_device_info(self) -> dict:
+        """Report the TT device info this worker sees, for benchmark metadata.
+
+        Reads the same PJRT runtime attributes as ``_get_device_dram_bytes``.
+        ``device_count`` is the real chip count from the runtime, not
+        ``world_size`` (which is forced to 1 under SPMD, where a single worker
+        drives all chips).
+        """
+        arch = ""
+        device_count = 1
+        try:
+            attrs = xr.global_runtime_device_attributes()
+            if attrs:
+                arch = str(attrs[0].get("device_arch", ""))
+                device_count = len(attrs)
+            else:
+                device_count = xr.global_runtime_device_count()
+        except Exception as e:
+            logger.warning("get_device_info: could not read device attributes (%s)", e)
+        return {"arch": arch, "device_count": max(int(device_count), 1)}
+
     def determine_available_memory(self) -> int:
         if self.model_config.runner_type == "pooling":
             return int(11596411699)

--- a/tests/benchmark/benchmarks/vllm_benchmark.py
+++ b/tests/benchmark/benchmarks/vllm_benchmark.py
@@ -5,7 +5,6 @@
 import socket
 import time
 from dataclasses import dataclass, field
-from multiprocessing import get_context
 from typing import Any, Dict, List, Optional, Tuple
 
 import vllm
@@ -69,54 +68,30 @@ class VLLMEmbeddingBenchmarkConfig:
     loop_count: int = 32
 
 
-def _probe_device_info_worker(queue) -> None:
-    """Subprocess worker: query TT runtime attrs and return (arch, count)."""
-    arch = ""
-    device_count = 1
-    try:
-        import torch_xla.runtime as xr
-
-        xr.set_device_type("TT")
-        attrs = xr.global_runtime_device_attributes()
-        if attrs:
-            arch = align_arch(str(attrs[0].get("device_arch", "")).lower())
-            device_count = len(attrs)
-        else:
-            device_count = xr.global_runtime_device_count()
-    except Exception:
-        # Keep defaults on probe failure.
-        pass
-
-    queue.put((arch, max(int(device_count), 1)))
-
-
-def _probe_device_info_before_engine(
+def _get_device_info_from_engine(
+    llm: vllm.LLM,
     additional_config: Dict[str, Any],
 ) -> Tuple[str, int, Optional[Tuple[int, int]]]:
     """
-    Read real TT device info before vLLM starts its engine process.
+    Read real TT device info from the live vLLM engine's worker(s).
 
     Returns:
         (arch, device_count, mesh_shape)
     """
     arch = ""
     device_count = 1
+    try:
+        results = llm.collective_rpc("get_device_info")
+        if results and results[0]:
+            info = results[0]
+            arch = align_arch(str(info.get("arch", "")).lower())
+            device_count = max(int(info.get("device_count", 1)), 1)
+    except Exception as e:
+        print(
+            f"Warning: could not read TT device info from engine ({e}); using defaults."
+        )
+
     mesh_shape = None
-    ctx = get_context("spawn")
-    queue = ctx.Queue(maxsize=1)
-    proc = ctx.Process(target=_probe_device_info_worker, args=(queue,))
-    proc.start()
-    proc.join(timeout=20)
-
-    if proc.is_alive():
-        proc.terminate()
-        proc.join(timeout=5)
-        print("Warning: timed out while probing TT device info; using defaults.")
-    elif proc.exitcode == 0 and not queue.empty():
-        arch, device_count = queue.get()
-    else:
-        print("Warning: TT device probe subprocess failed; using defaults.")
-
     if additional_config.get("enable_tensor_parallel", False):
         configured_mesh = additional_config.get("mesh_shape")
         if isinstance(configured_mesh, (list, tuple)) and len(configured_mesh) == 2:
@@ -266,10 +241,10 @@ def benchmark_vllm(
         temperature=config.temperature,
     )
 
-    arch, device_count, mesh_shape = _probe_device_info_before_engine(
-        config.additional_config
-    )
     llm = _create_llm(config)
+    arch, device_count, mesh_shape = _get_device_info_from_engine(
+        llm, config.additional_config
+    )
 
     # chat() applies the model's chat template; generate() feeds the raw
     # prompt. Same (inputs, sampling_params) -> List[RequestOutput] signature.
@@ -391,8 +366,6 @@ def benchmark_vllm_embedding(
     """Run a vLLM embedding benchmark and return a standardised result dict."""
     prompts = [DEFAULT_PROMPT] * config.batch_size
 
-    arch, device_count, _ = _probe_device_info_before_engine(config.additional_config)
-
     llm_args: Dict[str, Any] = {
         "model": config.model,
         "max_model_len": config.max_model_len,
@@ -405,6 +378,8 @@ def benchmark_vllm_embedding(
     print(f"Creating vLLM embedding engine for {config.model} ...")
     print(f"  LLM args: {llm_args}")
     llm = vllm.LLM(**llm_args)
+
+    arch, device_count, _ = _get_device_info_from_engine(llm, config.additional_config)
 
     if config.warmup_iterations > 0:
         print(f"\nWarming up ({config.warmup_iterations} iteration(s)) ...")

--- a/tests/benchmark/benchmarks/vllm_benchmark.py
+++ b/tests/benchmark/benchmarks/vllm_benchmark.py
@@ -70,7 +70,6 @@ class VLLMEmbeddingBenchmarkConfig:
 
 def _get_device_info_from_engine(
     llm: vllm.LLM,
-    additional_config: Dict[str, Any],
 ) -> Tuple[str, int, Optional[Tuple[int, int]]]:
     """
     Read real TT device info from the live vLLM engine's worker(s).
@@ -80,24 +79,20 @@ def _get_device_info_from_engine(
     """
     arch = ""
     device_count = 1
+    mesh_shape = None
     try:
         results = llm.collective_rpc("get_device_info")
         if results and results[0]:
             info = results[0]
             arch = align_arch(str(info.get("arch", "")).lower())
             device_count = max(int(info.get("device_count", 1)), 1)
+            resolved_mesh = info.get("mesh_shape")
+            if isinstance(resolved_mesh, (list, tuple)) and len(resolved_mesh) == 2:
+                mesh_shape = (int(resolved_mesh[0]), int(resolved_mesh[1]))
     except Exception as e:
         print(
             f"Warning: could not read TT device info from engine ({e}); using defaults."
         )
-
-    mesh_shape = None
-    if additional_config.get("enable_tensor_parallel", False):
-        configured_mesh = additional_config.get("mesh_shape")
-        if isinstance(configured_mesh, (list, tuple)) and len(configured_mesh) == 2:
-            mesh_shape = (int(configured_mesh[0]), int(configured_mesh[1]))
-        elif device_count > 1:
-            mesh_shape = (device_count, 1)
 
     return arch, max(int(device_count), 1), mesh_shape
 
@@ -242,9 +237,7 @@ def benchmark_vllm(
     )
 
     llm = _create_llm(config)
-    arch, device_count, mesh_shape = _get_device_info_from_engine(
-        llm, config.additional_config
-    )
+    arch, device_count, mesh_shape = _get_device_info_from_engine(llm)
 
     # chat() applies the model's chat template; generate() feeds the raw
     # prompt. Same (inputs, sampling_params) -> List[RequestOutput] signature.
@@ -379,7 +372,7 @@ def benchmark_vllm_embedding(
     print(f"  LLM args: {llm_args}")
     llm = vllm.LLM(**llm_args)
 
-    arch, device_count, _ = _get_device_info_from_engine(llm, config.additional_config)
+    arch, device_count, _ = _get_device_info_from_engine(llm)
 
     if config.warmup_iterations > 0:
         print(f"\nWarming up ({config.warmup_iterations} iteration(s)) ...")

--- a/tests/benchmark/benchmarks/vllm_benchmark.py
+++ b/tests/benchmark/benchmarks/vllm_benchmark.py
@@ -5,10 +5,12 @@
 import socket
 import time
 from dataclasses import dataclass, field
+from multiprocessing import get_context
 from typing import Any, Dict, List, Optional, Tuple
 
 import vllm
 from utils import (
+    align_arch,
     create_benchmark_result,
     get_benchmark_metadata,
     print_benchmark_results,
@@ -65,6 +67,64 @@ class VLLMEmbeddingBenchmarkConfig:
     batch_size: int = 1
     warmup_iterations: int = 1
     loop_count: int = 32
+
+
+def _probe_device_info_worker(queue) -> None:
+    """Subprocess worker: query TT runtime attrs and return (arch, count)."""
+    arch = ""
+    device_count = 1
+    try:
+        import torch_xla.runtime as xr
+
+        xr.set_device_type("TT")
+        attrs = xr.global_runtime_device_attributes()
+        if attrs:
+            arch = align_arch(str(attrs[0].get("device_arch", "")).lower())
+            device_count = len(attrs)
+        else:
+            device_count = xr.global_runtime_device_count()
+    except Exception:
+        # Keep defaults on probe failure.
+        pass
+
+    queue.put((arch, max(int(device_count), 1)))
+
+
+def _probe_device_info_before_engine(
+    additional_config: Dict[str, Any],
+) -> Tuple[str, int, Optional[Tuple[int, int]]]:
+    """
+    Read real TT device info before vLLM starts its engine process.
+
+    Returns:
+        (arch, device_count, mesh_shape)
+    """
+    arch = ""
+    device_count = 1
+    mesh_shape = None
+    ctx = get_context("spawn")
+    queue = ctx.Queue(maxsize=1)
+    proc = ctx.Process(target=_probe_device_info_worker, args=(queue,))
+    proc.start()
+    proc.join(timeout=20)
+
+    if proc.is_alive():
+        proc.terminate()
+        proc.join(timeout=5)
+        print("Warning: timed out while probing TT device info; using defaults.")
+    elif proc.exitcode == 0 and not queue.empty():
+        arch, device_count = queue.get()
+    else:
+        print("Warning: TT device probe subprocess failed; using defaults.")
+
+    if additional_config.get("enable_tensor_parallel", False):
+        configured_mesh = additional_config.get("mesh_shape")
+        if isinstance(configured_mesh, (list, tuple)) and len(configured_mesh) == 2:
+            mesh_shape = (int(configured_mesh[0]), int(configured_mesh[1]))
+        elif device_count > 1:
+            mesh_shape = (device_count, 1)
+
+    return arch, max(int(device_count), 1), mesh_shape
 
 
 def _create_llm(config: VLLMBenchmarkConfig) -> vllm.LLM:
@@ -162,23 +222,6 @@ def _extract_metrics(
     )
 
 
-def _get_device_info(
-    config: VLLMBenchmarkConfig,
-) -> Tuple[str, int, Optional[Tuple[int, int]]]:
-    """
-    Derive device info from config.
-
-    This is a workaround as these info are needed for the benchmark schema, but
-    vLLM abstracts the device layer. Mesh shape follows the plugin convention (num_devices, 1).
-
-    Returns:
-        (arch, device_count, mesh_shape)
-    """
-    if config.additional_config.get("enable_tensor_parallel", False):
-        return "wormhole_llmbox", 8, (8, 1)
-    return "wormhole", 1, None
-
-
 def _assert_token_counts(
     outputs: List[vllm.RequestOutput], max_tokens: int, max_model_len: int
 ):
@@ -223,6 +266,9 @@ def benchmark_vllm(
         temperature=config.temperature,
     )
 
+    arch, device_count, mesh_shape = _probe_device_info_before_engine(
+        config.additional_config
+    )
     llm = _create_llm(config)
 
     # chat() applies the model's chat template; generate() feeds the raw
@@ -301,8 +347,6 @@ def benchmark_vllm(
         ttft_ms=avg_ttft_ms,
     )
 
-    arch, device_count, mesh_shape = _get_device_info(config)
-
     return create_benchmark_result(
         full_model_name=full_model_name,
         model_type=model_type,
@@ -346,6 +390,8 @@ def benchmark_vllm_embedding(
 ) -> Dict[str, Any]:
     """Run a vLLM embedding benchmark and return a standardised result dict."""
     prompts = [DEFAULT_PROMPT] * config.batch_size
+
+    arch, device_count, _ = _probe_device_info_before_engine(config.additional_config)
 
     llm_args: Dict[str, Any] = {
         "model": config.model,
@@ -417,9 +463,9 @@ def benchmark_vllm_embedding(
         torch_xla_enabled=True,
         backend="tt",
         device_name=socket.gethostname(),
-        arch="wormhole",
+        arch=arch,
         input_is_image=False,
         input_sequence_length=config.max_model_len,
-        device_count=1,
+        device_count=device_count,
         vllm=True,
     )


### PR DESCRIPTION
### Ticket
Closes #5486 

### Problem description
Currently, device info is incorrectly hardcoded in vLLM benchmarks.
Reading device info from within the benchmark script causes a hang, where vLLM spawns a separate Engine process that requires a device which is already held by PJRT plugin in the main script process.

One solution would be to create a separate process before vLLM Engine starts, just for the sake of reading device info.
More elegant solution is to get device info from within the vLLM Engine, from workers themself.

### What's changed
Implemented `get_device_info` method inside vLLM worker and used it (via `collective_rpc`) to retrieve device info in benchmarks.

### Checklist
- [x] [Llama-3.1-8b on n150, p150 and qb2-blackhole](https://github.com/tenstorrent/tt-xla/actions/runs/29277087286)
- [x] [n150, p150, qb2 and galaxy after mesh_shape modification](https://github.com/tenstorrent/tt-xla/actions/runs/29573996111)
