### PR TITLE
[vLLM] Relax greedy TP tests to smoke checks on n300_llmbox

### DIFF
--- a/tests/integrations/vllm_plugin/sampling/test_sampling_params.py
+++ b/tests/integrations/vllm_plugin/sampling/test_sampling_params.py
@@ -210,25 +210,19 @@ def test_sampling_has_diversity_when_temp_positive(llm, prompt):
     assert_diverse(texts)
 
 
-@for_targets(
-    single_device="push",
-    n300="push",
-    n300_llmbox=(
-        "push",
-        pytest.mark.xfail(
-            strict=False,
-            reason=(
-                "Flaky under TP: greedy decode is not run-to-run reproducible at "
-                "a near-tie logit (same-graph cross-chip reduction nondeterminism; "
-                "argmax is deterministic, the logits themselves flip). Tracked in "
-                "tt-xla #5520; proper fix (fp32 dest-acc on the logit path) in a "
-                "follow-up PR."
-            ),
-        ),
-    ),
-)
-def test_greedy_determinism(llm, prompt):
-    """Verify greedy sampling (temperature=0) is deterministic."""
+@for_targets(single_device="push", n300="push", n300_llmbox="push")
+def test_greedy_determinism(llm, prompt, request):
+    """Verify greedy sampling (temperature=0) is deterministic.
+
+    On single_device and n300, greedy decode is bit-reproducible across calls
+    and we assert that directly. Under TP on n300_llmbox it is not: at a
+    near-tie logit the cross-chip reduction order is not stable run-to-run, so
+    argmax (itself deterministic) can flip between two otherwise-identical
+    calls. There we only smoke-check that generation runs and isn't degenerate;
+    exact greedy semantics are owned by the synthetic suite
+    (test_sampling_params_synthetic.py). Tracked in tt-xla #5520.
+    """
+    is_tp_llmbox = request.node.callspec.id == "n300_llmbox"
     params = vllm.SamplingParams(temperature=0.0, max_tokens=20)
 
     outputs = []
@@ -237,9 +231,14 @@ def test_greedy_determinism(llm, prompt):
         outputs.append(output)
         print(f"[TESTOUT test_greedy_determinism] Run {i+1}: {output}")
 
-    assert (
-        outputs[0] == outputs[1] == outputs[2]
-    ), "Greedy sampling must be deterministic"
+    if is_tp_llmbox:
+        assert all(
+            len(o) > 0 for o in outputs
+        ), "Greedy sampling must produce output under TP"
+    else:
+        assert (
+            outputs[0] == outputs[1] == outputs[2]
+        ), "Greedy sampling must be deterministic"
 
     # Guard against degenerate output (e.g. all token_id 0 under TP).
     token_ids = llm.generate(prompt, params, use_tqdm=False)[0].outputs[0].token_ids
@@ -558,26 +557,18 @@ def test_logit_bias(llm, prompt):
     )
 
 
-@for_targets(
-    single_device="nightly",
-    n300="nightly",
-    n300_llmbox=(
-        "nightly",
-        pytest.mark.xfail(
-            strict=False,
-            reason=(
-                "Flaky under TP: greedy decode is not run-to-run reproducible at "
-                "a near-tie logit, so the position-2 stop token can be missed. "
-                "Same-graph cross-chip reduction nondeterminism (argmax is "
-                "deterministic; the logits themselves flip). Tracked in tt-xla "
-                "#5520; proper fix (fp32 dest-acc on the logit path) in a "
-                "follow-up PR."
-            ),
-        ),
-    ),
-)
-def test_stop_token_ids(llm, prompt):
-    """Test that stop_token_ids halts generation at the specified token."""
+@for_targets(single_device="nightly", n300="nightly", n300_llmbox="nightly")
+def test_stop_token_ids(llm, prompt, request):
+    """Test that stop_token_ids halts generation at the specified token.
+
+    On single_device and n300, greedy is bit-reproducible across calls, so we
+    assert that re-running greedy with baseline_tokens[2] as a stop_token_id
+    halts by position 3. Under TP on n300_llmbox that assumption breaks (near-tie
+    logits flip run-to-run), so there we only smoke-check that generation still
+    runs; exact stop-token halting is owned by the synthetic suite
+    (test_sampling_params_synthetic.py). Tracked in tt-xla #5520.
+    """
+    is_tp_llmbox = request.node.callspec.id == "n300_llmbox"
     baseline_params = vllm.SamplingParams(temperature=0.0, max_tokens=16)
     baseline = llm.generate(prompt, baseline_params, use_tqdm=False)[0].outputs[0]
     baseline_tokens = list(baseline.token_ids)
@@ -595,9 +586,15 @@ def test_stop_token_ids(llm, prompt):
             f"[TESTOUT test_stop_token_ids] stop_token_ids=[{stop_id}]:"
             f" {len(output.token_ids)} tokens, text: {output.text[:50]}..."
         )
-        assert (
-            len(output.token_ids) <= 3
-        ), f"Should stop at or before token {stop_id}, got {len(output.token_ids)} tokens"
+        if is_tp_llmbox:
+            assert (
+                len(output.token_ids) >= 1
+            ), "Generation with stop_token_ids set should still run"
+        else:
+            assert len(output.token_ids) <= 3, (
+                f"Should stop at or before token {stop_id}, "
+                f"got {len(output.token_ids)} tokens"
+            )
 
 
 @for_targets(single_device="nightly", n300="nightly", n300_llmbox="nightly")
@@ -776,32 +773,22 @@ def test_allowed_token_ids(llm, prompt):
         )
 
 
-@for_targets(
-    single_device="nightly",
-    n300="nightly",
-    n300_llmbox=(
-        "nightly",
-        pytest.mark.xfail(
-            strict=False,
-            reason=(
-                "Flaky under TP: greedy decode is not run-to-run reproducible at "
-                "a near-tie logit, so the position-2 stop token can be missed. "
-                "Same-graph cross-chip reduction nondeterminism (argmax is "
-                "deterministic; the logits themselves flip). Tracked in tt-xla "
-                "#5520; proper fix (fp32 dest-acc on the logit path) in a "
-                "follow-up PR."
-            ),
-        ),
-    ),
-)
-def test_min_tokens(llm, prompt):
+@for_targets(single_device="nightly", n300="nightly", n300_llmbox="nightly")
+def test_min_tokens(llm, prompt, request):
     """Test that min_tokens suppresses stop_token_ids until the minimum is reached.
 
-    Runs a greedy baseline to find a token that appears early in the output,
-    then uses it as a stop_token_id. Without min_tokens, generation stops at
-    that token (verified by the baseline). With min_tokens set above that
-    position, generation must continue past it.
+    Runs a greedy baseline to find a token that appears early, then uses it as a
+    stop_token_id. The `output length >= min_tokens` check is the core contract
+    and holds on every target. On single_device and n300 we additionally verify,
+    using cross-call greedy bit-reproducibility, that the stop token halts early
+    without min_tokens and never appears in the suppressed window. Under TP on
+    n300_llmbox that reproducibility does not hold (near-tie logits flip
+    run-to-run), so those two extra asserts are skipped there; the exact `-inf`
+    masking is owned by the synthetic suite
+    (test_sampling_params_synthetic.py::test_min_tokens). Tracked in tt-xla #5520.
     """
+    is_tp_llmbox = request.node.callspec.id == "n300_llmbox"
+
     # Greedy baseline — find a token that appears early.
     baseline_params = vllm.SamplingParams(temperature=0.0, max_tokens=32)
     baseline = llm.generate(prompt, baseline_params, use_tqdm=False)[0].outputs[0]
@@ -818,23 +805,24 @@ def test_min_tokens(llm, prompt):
     # Pick the 3rd token as a stop_token_id.
     stop_id = baseline_ids[2]
 
-    # Verify that stop_token_id actually stops generation early.
-    stop_params = vllm.SamplingParams(
-        temperature=0.0, max_tokens=32, stop_token_ids=[stop_id]
-    )
-    stop_output = llm.generate(prompt, stop_params, use_tqdm=False)[0].outputs[0]
-    stop_len = len(stop_output.token_ids)
-    print(
-        f"[TESTOUT test_min_tokens] stop_token_ids=[{stop_id}]: "
-        f"{stop_len} tokens (should be <= 3)"
-    )
-    assert stop_len <= 3, (
-        f"stop_token_ids=[{stop_id}] should stop generation at or before "
-        f"position 3, got {stop_len} tokens"
-    )
+    # Off-TP: verify the stop token halts generation early (needs cross-call
+    # reproducibility).
+    if not is_tp_llmbox:
+        stop_params = vllm.SamplingParams(
+            temperature=0.0, max_tokens=32, stop_token_ids=[stop_id]
+        )
+        stop_output = llm.generate(prompt, stop_params, use_tqdm=False)[0].outputs[0]
+        stop_len = len(stop_output.token_ids)
+        print(
+            f"[TESTOUT test_min_tokens] stop_token_ids=[{stop_id}]: "
+            f"{stop_len} tokens (should be <= 3)"
+        )
+        assert stop_len <= 3, (
+            f"stop_token_ids=[{stop_id}] should stop generation at or before "
+            f"position 3, got {stop_len} tokens"
+        )
 
-    # Now use min_tokens=8 with the same stop_token_id.
-    # min_tokens must suppress the stop token until 8 tokens are generated.
+    # min_tokens must suppress the stop token until min_tok tokens are generated.
     min_tok = 8
     params = vllm.SamplingParams(
         temperature=0.0,
@@ -852,24 +840,21 @@ def test_min_tokens(llm, prompt):
 
     assert n_tokens >= min_tok, (
         f"With min_tokens={min_tok} and stop_token_ids=[{stop_id}], "
-        f"output must have at least {min_tok} tokens, got {n_tokens}. "
-        f"Without min_tokens, generation stopped at {stop_len} tokens — "
+        f"output must have at least {min_tok} tokens, got {n_tokens} — "
         f"min_tokens enforcement is not working."
     )
 
-    # The stop token must not appear in the first min_tokens positions.
-    # Without sampler-level suppression, the model still freely samples the
-    # stop token (the engine just doesn't halt) — so greedy decoding would
-    # produce the same token at the same position as the baseline.
-    # With suppression, the stop token's logit is -inf and cannot be sampled.
-    early_ids = list(output.token_ids[:min_tok])
-    print(f"[TESTOUT test_min_tokens] first {min_tok} token_ids: {early_ids}")
-    assert stop_id not in early_ids, (
-        f"Stop token {stop_id} was sampled at position "
-        f"{early_ids.index(stop_id)} (within first {min_tok} tokens). "
-        f"The sampler should suppress it via -inf logit masking, not just "
-        f"rely on the engine to ignore it."
-    )
+    # Off-TP: the suppressed stop token must not appear in the first min_tok
+    # positions (compares against baseline positions, needs reproducibility).
+    if not is_tp_llmbox:
+        early_ids = list(output.token_ids[:min_tok])
+        print(f"[TESTOUT test_min_tokens] first {min_tok} token_ids: {early_ids}")
+        assert stop_id not in early_ids, (
+            f"Stop token {stop_id} was sampled at position "
+            f"{early_ids.index(stop_id)} (within first {min_tok} tokens). "
+            f"The sampler should suppress it via -inf logit masking, not just "
+            f"rely on the engine to ignore it."
+        )
 
 
 @for_targets(single_device="nightly", n300="nightly", n300_llmbox="nightly")


### PR DESCRIPTION
### Ticket

Relates to #5520

### Problem description

Three greedy (temperature=0) vLLM sampling tests flake intermittently on n300_llmbox. Each takes a token from a greedy baseline generate() and asserts on a second greedy generate(), i.e. they assume greedy is bit-reproducible across calls. Under TP that assumption breaks: at a near-tie logit the cross-chip reduction order is not stable run-to-run, so argmax (itself deterministic) can flip between two otherwise-identical calls. The tests were being masked with xfail(strict=False), which hid the flake and left them proving nothing on n300_llmbox.

### What's changed

Removed the xfail markers and scoped the reproducibility-dependent assertions to the targets where greedy is stable (single_device, n300), keeping only robust checks on n300_llmbox:

- test_greedy_determinism : keeps the strict "3 runs identical" assert off-TP; on n300_llmbox smoke-checks that each run is non-empty. Degenerate-output guard kept for all targets.
- test_stop_token_ids : keeps the strict "halts at/before position 3" assert off-TP; on n300_llmbox smoke-checks that generation runs.
- test_min_tokens : the core output length >= min_tokens contract runs on all targets; the two baseline-reproduction asserts (stops early without min_tokens; suppressed stop token absent from the first min_tokens positions) are gated to off-TP.

Exact sampler semantics (min_tokens / stop-token / logit-bias masking) remain fully proven with fixed logits, no hardware, in the synthetic suite (test_sampling_params_synthetic.py), and the strong contracts still run end-to-end on single_device and n300.

#5520 stays open to track the underlying cross-chip reduction-order nondeterminism; if bit-accurate greedy under TP is ever required, the fix belongs lower down (deterministic all-reduce in tt-metal), not in these tests.

