### PR TITLE
fix(docs/ci): run OpenSearch indexer with python3

### DIFF
--- a/.github/workflows/call-build-and-deploy-docs.yml
+++ b/.github/workflows/call-build-and-deploy-docs.yml
@@ -69,7 +69,9 @@ jobs:
     - name: Index docs into OpenSearch
       if: ${{ env.DOCS_SEARCH_INGEST_API_KEY != '' }}
       continue-on-error: true
-      run: python scripts/index_remote_search.py
+      # The docs build runs in the project container, which ships `python3` but
+      # not an unversioned `python` — the latter fails with exit 127.
+      run: python3 scripts/index_remote_search.py
 
     - name: Upload artifact
       uses: actions/upload-pages-artifact@57f0e8492b437b7818227931fef2faa1a379839b # v4 + upload-artifact@v7 update


### PR DESCRIPTION
## Problem
The **Index docs into OpenSearch** step in `call-build-and-deploy-docs.yml` invokes `python scripts/index_remote_search.py`. The docs build job runs inside the project container, which ships `python3` but no unversioned `python`, so the step fails:

```
python: not found
##[error]Process completed with exit code 127.
```

Because the step has `continue-on-error: true`, this failure was **silently masked** — the job stayed green while indexing never actually ran.

## Fix
Invoke the indexer with `python3` (guaranteed present; the script is stdlib-only, no deps).

## Note
The `DOCS_SEARCH_INGEST_API_KEY_DOCS_TENSTORRENT` secret is already set on this repo, but since the step never reached the API, key validity is still unverified — after this merges and runs, the indexing log should show `Indexing N documents … complete` (watch for a possible 403 if the key value is wrong, as seen previously on ttnn-visualizer).