### PR TITLE
[op-by-op] Add extract-unique-ops for global op dedup across all model IRs

### DIFF
--- a/.github/scripts/ir_process_analyzer.py
+++ b/.github/scripts/ir_process_analyzer.py
@@ -5,6 +5,7 @@
 import argparse
 import json
 import math
+import re
 import shutil
 import sys
 from pathlib import Path
@@ -296,6 +297,209 @@ def command_materialize(args: argparse.Namespace) -> int:
     return 0
 
 
+def match_and_extract_model_name(file_path: Path, ir_file_prefix: str) -> str | None:
+    """
+    Check if a file matches the IR file prefix pattern and extract its model name.
+
+    Mirrors the matching logic in tests/op_by_op/op_by_op_test.py so this pre-pass
+    selects exactly the same files the test would.
+    """
+    if not ir_file_prefix:
+        return file_path.parent.name
+
+    parts = ir_file_prefix.split("/")
+    file_prefix = parts[-1]
+    dir_parts = parts[:-1]
+
+    if not file_path.name.startswith(file_prefix):
+        return None
+
+    if not dir_parts:
+        return file_path.parent.name
+
+    path_parts = list(file_path.parts)
+    for i in range(len(path_parts) - len(dir_parts)):
+        if path_parts[i : i + len(dir_parts)] == dir_parts:
+            if i > 0:
+                return path_parts[i - 1]
+            return dir_parts[0]
+
+    return None
+
+
+def _sanitize_op_dirname(name: str) -> str:
+    """Sanitize an op name (e.g. 'stablehlo.add') into a filesystem-safe dir name."""
+    return re.sub(r"[^0-9A-Za-z]+", "_", name).strip("_") or "op"
+
+
+def extract_unique_ops(
+    root: Path,
+    ir_file_prefix: str,
+    output_root: Path,
+    whitelist: list[str] | None,
+    blacklist: list[str] | None,
+) -> dict:
+    """
+    Extract ops from every matched IR under ``root``, deduplicate globally by
+    op_string (same semantics as filter_and_deduplicate_ops in op_by_op_test.py),
+    and write each unique op as a standalone single-op MLIR module under
+    ``output_root`` in the layout the planner/test already understand
+    (``unique_ops/<op_dir>/<prefix_dirs>/<file_prefix>_<idx>.mlir``).
+
+    Returns a stats dict including the per-op manifest.
+    """
+    # Imported lazily: this is the only command that needs the explorer/tt-mlir
+    # python bindings, so `plan`/`dedupe`/`materialize` still run on runners
+    # without the wheel installed.
+    from op_by_op_infra.workflow import extract_ops_from_module
+
+    whitelist = whitelist or []
+    blacklist = blacklist or []
+
+    all_mlir_files = sorted(root.rglob("*.mlir"))
+    matched = [
+        (f, model_name)
+        for f in all_mlir_files
+        if (model_name := match_and_extract_model_name(f, ir_file_prefix)) is not None
+    ]
+
+    total_ops = 0
+    extraction_failures: list[dict] = []
+    seen: dict[str, dict] = {}  # op_string -> unique record
+    unique_records: list[dict] = []
+
+    for ir_file, model_name in matched:
+        try:
+            module = ir_file.read_text(encoding="utf-8", errors="replace")
+        except (OSError, IOError) as error:
+            print(f"WARNING: could not read {ir_file}: {error}", file=sys.stderr)
+            extraction_failures.append(
+                {"model": model_name, "file": str(ir_file), "error": str(error)}
+            )
+            continue
+
+        try:
+            ops = extract_ops_from_module(module, origin_model=model_name)
+        except Exception as error:  # noqa: BLE001 - continue-on-failure by design
+            print(
+                f"WARNING: failed to extract ops from {ir_file}: {error}",
+                file=sys.stderr,
+            )
+            extraction_failures.append(
+                {"model": model_name, "file": str(ir_file), "error": str(error)}
+            )
+            continue
+
+        for op in ops:
+            # op_name can be an MLIR StringAttr rather than a plain str; coerce so
+            # filtering, dir-name sanitizing, and JSON serialization all work.
+            op_name = str(op.op_name)
+            if whitelist:
+                if op_name not in whitelist:
+                    continue
+            elif blacklist:
+                if op_name in blacklist:
+                    continue
+
+            total_ops += 1
+            key = op.op_string
+
+            if key and key in seen:
+                record = seen[key]
+                if model_name and model_name not in record["origin_models"]:
+                    record["origin_models"].append(model_name)
+                continue
+
+            try:
+                module_str = op.as_module_str()
+            except Exception as error:  # noqa: BLE001 - skip un-serializable ops
+                print(
+                    f"WARNING: could not build module for op '{op_name}' "
+                    f"from model '{model_name}': {error}",
+                    file=sys.stderr,
+                )
+                extraction_failures.append(
+                    {"model": model_name, "op_name": op_name, "error": str(error)}
+                )
+                continue
+
+            record = {
+                "op_name": op_name,
+                "origin_models": list(op.origin_model),
+                "module_str": module_str,
+            }
+            unique_records.append(record)
+            if key:
+                seen[key] = record
+
+    # Write unique ops in a layout the existing planner + op_by_op_test consume as-is.
+    prefix_parts = (
+        ir_file_prefix.split("/") if ir_file_prefix else ["irs", "shlo_compiler"]
+    )
+    sub_dirs = prefix_parts[:-1] or ["irs"]
+    file_prefix = prefix_parts[-1] if ir_file_prefix else "shlo_compiler"
+
+    unique_root = output_root / "unique_ops"
+    manifest: list[dict] = []
+    for idx, record in enumerate(unique_records):
+        op_dir_name = f"op_{idx:05d}_{_sanitize_op_dirname(record['op_name'])}"
+        irs_dir = unique_root / op_dir_name
+        for part in sub_dirs:
+            irs_dir = irs_dir / part
+        irs_dir.mkdir(parents=True, exist_ok=True)
+        out_file = irs_dir / f"{file_prefix}_{idx:05d}.mlir"
+        out_file.write_text(record["module_str"], encoding="utf-8")
+        manifest.append(
+            {
+                "index": idx,
+                "op_name": record["op_name"],
+                "op_dir": op_dir_name,
+                "file": out_file.relative_to(output_root).as_posix(),
+                "origin_models": record["origin_models"],
+                "origin_model_count": len(record["origin_models"]),
+            }
+        )
+
+    return {
+        "root": str(root),
+        "output_root": str(output_root),
+        "matched_files": len(matched),
+        "total_ops_after_filter": total_ops,
+        "unique_ops": len(unique_records),
+        "duplicate_ops_eliminated": total_ops - len(unique_records),
+        "extraction_failures": extraction_failures,
+        "manifest": manifest,
+    }
+
+
+def command_extract_unique_ops(args: argparse.Namespace) -> int:
+    stats = extract_unique_ops(
+        args.root,
+        args.ir_file_prefix,
+        args.output_root,
+        args.whitelist.split(",") if args.whitelist else None,
+        args.blacklist.split(",") if args.blacklist else None,
+    )
+
+    if args.manifest is not None:
+        args.manifest.write_text(json.dumps(stats, indent=2), encoding="utf-8")
+
+    total = stats["total_ops_after_filter"]
+    unique = stats["unique_ops"]
+    reduction = (1 - unique / total) * 100 if total else 0.0
+    print(
+        f"Matched IR files: {stats['matched_files']}\n"
+        f"Total ops (after filter): {total}\n"
+        f"Unique ops: {unique}\n"
+        f"Duplicate ops eliminated: {stats['duplicate_ops_eliminated']} "
+        f"({reduction:.1f}% reduction)\n"
+        f"Extraction failures: {len(stats['extraction_failures'])}\n"
+        f"Unique-op modules written under: {args.output_root / 'unique_ops'}",
+        file=sys.stderr,
+    )
+    return 0
+
+
 def command_dedupe(args: argparse.Namespace) -> int:
     duplicate_model_count, removed_dir_count = remove_duplicate_models(
         args.root, args.preferred_machine
@@ -339,6 +543,29 @@ def build_parser() -> argparse.ArgumentParser:
     dedupe_parser.add_argument("--root", type=Path, required=True)
     dedupe_parser.add_argument("--preferred-machine", default="n150")
     dedupe_parser.set_defaults(func=command_dedupe)
+
+    extract_parser = subparsers.add_parser(
+        "extract-unique-ops",
+        help="Extract ops from all model IRs, deduplicate globally, and write "
+        "one standalone MLIR module per unique op.",
+    )
+    extract_parser.add_argument("--root", type=Path, required=True)
+    extract_parser.add_argument("--ir-file-prefix", default="irs/shlo_compiler")
+    extract_parser.add_argument(
+        "--output-root",
+        type=Path,
+        required=True,
+        help="Directory to write unique-op modules into (consumable by "
+        "`plan` and op_by_op_test via --folder).",
+    )
+    extract_parser.add_argument("--whitelist", default="")
+    extract_parser.add_argument("--blacklist", default="")
+    extract_parser.add_argument(
+        "--manifest",
+        type=Path,
+        help="Optional path to write the JSON stats + per-op manifest.",
+    )
+    extract_parser.set_defaults(func=command_extract_unique_ops)
 
     return parser
 


### PR DESCRIPTION
### Ticket

Part of the op-by-op analysis setup — implements Nikola's item: *"extract unique ops across all model IRs, and run only those."*

### Problem description

Today op-by-op dedup only happens **within a single processing job** (via `filter_and_deduplicate_ops` in `op_by_op_test.py`), and the pipeline splits models across many jobs. So the same op (same shapes/attrs) is compiled and executed many times across jobs — a lot of redundant device time. There was no way to compute the set of ops that are unique **across all models** and run only those.

### What's changed

Adds an `extract-unique-ops` subcommand to `.github/scripts/ir_process_analyzer.py`:

- Reads every matched IR under `--root`, splits each into constituent ops, and **deduplicates globally by `op_string`** (same semantics as `filter_and_deduplicate_ops`).
- Writes each unique op as a standalone single-op MLIR module under `<output-root>/unique_ops/`, in the **exact directory layout `plan` and `op_by_op_test` already consume** (`unique_ops/<op_dir>/<prefix_dirs>/<file_prefix>_<idx>.mlir`), so it drops into the existing pipeline with no changes to the test.
- Emits a JSON manifest (per-op: op_name, origin models, file) plus reduction stats.
- **Continue-on-failure:** IRs that can't be read/parsed/split are logged, recorded, and skipped (never abort the run). The `op_by_op_infra` import is lazy, so `plan`/`dedupe`/`materialize` still run on runners without the explorer wheel.

Wiring this into `call-process-dumped-irs.yml` (extract once globally, then plan/distribute the unique ops across jobs) is a follow-up, since it needs the explorer wheel available at plan time — will be validated via the workflow's `workflow_dispatch`.

### Verification (local, against real nightly IR dumps)

- Output **round-trips cleanly** through `op_by_op_test` (`--folder=<output>/unique_ops`): ops extracted and executed on n150, 0 extraction failures.
- Smoke set: 26 ops → **12 unique (53.8% reduction)**.
- At scale over ~1k IRs, unparseable multi-chip/Shardy modules (e.g. `sdy.manual_computation … unknown mesh`) are skipped and the rest continue.

### Checklist
- [x] New/Existing tests provide coverage for changes
