### PR TITLE
[op-by-op] Set frontend="tt-xla" on OpTest records

### DIFF
--- a/tests/op_by_op/op_by_op_test.py
+++ b/tests/op_by_op/op_by_op_test.py
@@ -220,6 +220,7 @@ def test_op_by_op(request, whitelist, blacklist, record_property):
         compile_only=compile_only,
         debug_print=debug_print,
         failed_ops_folder=failed_ops_folder,
+        frontend="tt-xla",
     )
 
     for result in results:


### PR DESCRIPTION
### Ticket

Part of #5659 (ops-status dashboard data gaps — Gap 2: empty `frontend`).

### Problem description

`tests/op_by_op/op_by_op_test.py` never passed `frontend=` to `execute_extracted_ops`, so every `OpTest` record was produced with `frontend=None`. In the ops-status DB this means all ~30k op rows have an empty frontend, so jax/torch/framework can't be distinguished downstream.

### What's changed

Pass `frontend="tt-xla"` to `execute_extracted_ops`, matching the existing convention in `tests/runner/test_models.py:749`.

### Verification

On-device run over the op-by-op set: all resulting `OpTest` entries now carry `frontend="tt-xla"` (previously `None` on all 30,347 pre-fix production rows). Before/after proof captured (frontend `None` → `tt-xla`, 12/12 entries).

### Checklist
- [x] New/Existing tests provide coverage for changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)