### PR TITLE
[CI] Run ir processing on weekends (nightly/weekly)

### DIFF
--- a/.github/workflows/schedule-nightly.yml
+++ b/.github/workflows/schedule-nightly.yml
@@ -27,7 +27,7 @@ jobs:
     with:
       docker_image: ${{ needs.build-image.outputs.docker-image }}
       docker_image_manylinux: ${{ needs.build-image.outputs.docker-image-manylinux }}
-      build_types: release,manylinux
+      build_types: release,manylinux,explorer
 
   nightly_tests:
     uses: ./.github/workflows/call-test.yml
@@ -84,6 +84,16 @@ jobs:
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
       wheel_build: manylinux
       dump_irs: ${{ github.event.schedule == '0 0 * * 0' }}
+
+  process_ir:
+    if: always() && !cancelled() && github.event.schedule == '0 0 * * 0'
+    uses: ./.github/workflows/call-process-dumped-irs.yml
+    needs: [ build-image, build-ttxla, nightly_tests, test_full_model, test_forge_models_passing, test_forge_models_xfail ]
+    secrets: inherit
+    with:
+      docker_image: ${{ needs.build-image.outputs.docker-image }}
+      dumped_irs_run_id: ${{ github.run_id }}
+      target_time_min: 180
 
   perf-benchmark:
     uses: ./.github/workflows/call-filtered-perf-tests.yml

--- a/.github/workflows/schedule-weekly.yml
+++ b/.github/workflows/schedule-weekly.yml
@@ -26,7 +26,7 @@ jobs:
     with:
       docker_image: ${{ needs.build-image.outputs.docker-image }}
       docker_image_manylinux: ${{ needs.build-image.outputs.docker-image-manylinux }}
-      build_types: release,manylinux
+      build_types: release,manylinux,explorer
 
   # This is a single test job that runs all passing tt-forge-models tests.
   test_forge_models_passing:
@@ -52,6 +52,16 @@ jobs:
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
       wheel_build: manylinux
       dump_irs: true
+
+  process_ir:
+    if: always() && !cancelled()
+    uses: ./.github/workflows/call-process-dumped-irs.yml
+    needs: [ build-image, build-ttxla, test_forge_models_passing, test_forge_models_xfail ]
+    secrets: inherit
+    with:
+      docker_image: ${{ needs.build-image.outputs.docker-image }}
+      dumped_irs_run_id: ${{ github.run_id }}
+      target_time_min: 180
 
   fail-notify:
     if: always()


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-forge/issues/953

### Problem description
IRs are dumped on weekends, but not processed (and reported).

### What's changed
Enable processing of dumped irs on weekend runs (nightly/weekly)

### Checklist
- [ ] New/Existing tests provide coverage for changes
