### PR TITLE
Temporarily disable profiling for manylinux (released) whl to solve tracy host memory leak

### DIFF
--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -84,6 +84,8 @@ jobs:
       regression_check: false # toggle on #5486 completion
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
+      # temporary override due to tt-xla #5663
+      wheel_build: release
 
   perf-benchmark-accuracy:
     if: needs.inspect-changes.outputs.skip-build-and-test == 'false' && needs.inspect-changes.outputs.only-run-forge-models != 'true' && vars.RUN_PERF_ON_UPLIFT == 'true' && github.event_name == 'pull_request' && (contains(needs.inspect-changes.outputs.detected-uplifts, 'tt-mlir') || contains(needs.inspect-changes.outputs.detected-uplifts, 'transformers'))
@@ -101,6 +103,8 @@ jobs:
       regression_check: true
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
+      # temporary override due to tt-xla #5663
+      wheel_build: release
 
   test_forge_models_push:
     if: needs.inspect-changes.outputs.skip-build-and-test == 'false'

--- a/.github/workflows/schedule-nightly.yml
+++ b/.github/workflows/schedule-nightly.yml
@@ -107,7 +107,8 @@ jobs:
       adv_filter: '[ {"accuracy-testing": false}, {"runs-on": "n150-perf"}, {"runs-on": "p150-perf"}, {"runs-on": "galaxy-wh-6u"}, {"runs-on": "qb2-blackhole"} ]'
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
-      wheel_build: manylinux
+      # temporary override, default to manylinux, due to tt-xla #5663
+      wheel_build: release
 
   nightly-benchmark-report:
     name: "Nightly benchmark report"

--- a/python_package/setup.py
+++ b/python_package/setup.py
@@ -298,6 +298,7 @@ class CMakeBuildPy(build_py):
         code_coverage = "OFF"
         enable_explorer = "OFF"
         enable_emitpy_execution = "ON"
+        enable_profiling = "ON"
 
         if config.build_type == "codecov":
             code_coverage = "ON"
@@ -308,6 +309,10 @@ class CMakeBuildPy(build_py):
             # avoid depending on the embedded-Python runner and its non-portable
             # transitive ABI surface.
             enable_emitpy_execution = "OFF"
+
+            # tt-xla 5504 - temporarily disabling release wheel tracy-enabled build
+            # due to host memory leak
+            enable_profiling = "OFF"
 
         cmake_args = [
             "-G",
@@ -322,7 +327,9 @@ class CMakeBuildPy(build_py):
             "-DTTXLA_ENABLE_EMITPY_EXECUTION=" + enable_emitpy_execution,
             "-DCMAKE_INSTALL_PREFIX=" + str(install_dir),
             "-DTT_USE_SYSTEM_SFPI=ON",
+            "-DTTMLIR_ENABLE_PERF_TRACE=" + enable_profiling,
         ]
+
         build_command = ["--build", "build"]
         install_command = ["--install", "build"]
 


### PR DESCRIPTION
To be REVERTED when https://github.com/tenstorrent/tracy/pull/40/ is merged and uplifted to tt-xla.

### Ticket
#5504 

### Problem description
Temporary fix for #5504 until tracy patch lands and can be uplifted.


### What's changed
manylinux build takes is_ci() path -> under this path, disable tracy which is on by default

### Checklist
- [x] New/Existing tests provide coverage for changes
