### PR TITLE
Add Dual QBAE to multihost CI  as 2x4xp150 + temporarily remove nonfunctional dual T3K

### DIFF
--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -241,8 +241,6 @@ jobs:
         MULTIHOST_WORKER_IMAGE: ${{ inputs.docker_image }}
         SSH_AUTH_SOCK: /var/run/mpirun/id_rsa_multihost_ssh_agent_sock
       run: |
-        echo "SLEEPING FOREVER"
-        sleep infinity
         .github/scripts/multihost-start-workers.sh "$MULTIHOST_WORKER_IMAGE" /etc/mpirun/hostfile
         source venv/activate
         python scripts/multihost_topology.py \

--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -241,6 +241,8 @@ jobs:
         MULTIHOST_WORKER_IMAGE: ${{ inputs.docker_image }}
         SSH_AUTH_SOCK: /var/run/mpirun/id_rsa_multihost_ssh_agent_sock
       run: |
+        echo "SLEEPING FOREVER"
+        sleep infinity
         .github/scripts/multihost-start-workers.sh "$MULTIHOST_WORKER_IMAGE" /etc/mpirun/hostfile
         source venv/activate
         python scripts/multihost_topology.py \

--- a/.github/workflows/test-matrix-presets/basic-multihost-test.json
+++ b/.github/workflows/test-matrix-presets/basic-multihost-test.json
@@ -1,4 +1,3 @@
 [
-    { "runs-on": "multi-host-t3000", "topology": "dual_t3k", "name": "multihost tests on dual t3k", "test-mark": "push", "dir": "./tests/torch/multi_host/experimental",  "multihost": true  },
     { "runs-on": "multihost-dual-qbae", "topology": "dual_bh_quietbox", "name": "multihost tests on dual QBAE (2x4xp150)", "test-mark": "push", "dir": "./tests/torch/multi_host/experimental",  "multihost": true  }
 ]

--- a/.github/workflows/test-matrix-presets/basic-multihost-test.json
+++ b/.github/workflows/test-matrix-presets/basic-multihost-test.json
@@ -1,3 +1,4 @@
 [
-    { "runs-on": "multi-host-t3000", "topology": "dual_t3k", "name": "multihost tests on dual t3k", "test-mark": "push", "dir": "./tests/torch/multi_host/experimental",  "multihost": true  }
+    { "runs-on": "multi-host-t3000", "topology": "dual_t3k", "name": "multihost tests on dual t3k", "test-mark": "push", "dir": "./tests/torch/multi_host/experimental",  "multihost": true  },
+    { "runs-on": "multihost-dual-qbae", "topology": "dual_bh_quietbox", "name": "multihost tests on dual QBAE (2x4xp150)", "test-mark": "push", "dir": "./tests/torch/multi_host/experimental",  "multihost": true  }
 ]

--- a/scripts/multihost_topology.py
+++ b/scripts/multihost_topology.py
@@ -102,7 +102,7 @@ TOPOLOGIES: Dict[str, MultihostConfiguration] = {
         rank_binding="dual_bh_quietbox",
         controller_host_name="forge-qbae-01",
         hosts_list="qb-bh03,qb-bh04",
-        tt_distributed_tcp_iface="enp10s0f1np1",
+        tt_distributed_tcp_iface="",
     ),
     "dual_t3k": MultihostConfiguration(
         rank_binding="dual_t3k",

--- a/scripts/multihost_topology.py
+++ b/scripts/multihost_topology.py
@@ -100,8 +100,8 @@ TOPOLOGIES: Dict[str, MultihostConfiguration] = {
     ),
     "dual_bh_quietbox": MultihostConfiguration(
         rank_binding="dual_bh_quietbox",
-        controller_host_name="forge-qbae-01",
-        hosts_list="qb-bh03,qb-bh04",
+        controller_host_name="qb-gh03",
+        hosts_list="qb-gh03,qb-gh04",
         tt_distributed_tcp_iface="",
     ),
     "dual_t3k": MultihostConfiguration(

--- a/scripts/multihost_topology.py
+++ b/scripts/multihost_topology.py
@@ -102,7 +102,7 @@ TOPOLOGIES: Dict[str, MultihostConfiguration] = {
         rank_binding="dual_bh_quietbox",
         controller_host_name="qb-gh03",
         hosts_list="qb-gh03,qb-gh04",
-        tt_distributed_tcp_iface="",
+        tt_distributed_tcp_iface="enp201s0",
     ),
     "dual_t3k": MultihostConfiguration(
         rank_binding="dual_t3k",

--- a/scripts/multihost_topology.py
+++ b/scripts/multihost_topology.py
@@ -101,7 +101,7 @@ TOPOLOGIES: Dict[str, MultihostConfiguration] = {
     "dual_bh_quietbox": MultihostConfiguration(
         rank_binding="dual_bh_quietbox",
         controller_host_name="forge-qbae-01",
-        hosts_list="forge-qbae-01,forge-qbae-02",
+        hosts_list="qb-bh03,qb-bh04",
         tt_distributed_tcp_iface="enp10s0f1np1",
     ),
     "dual_t3k": MultihostConfiguration(


### PR DESCRIPTION
### Ticket
N/A

### Problem description
We traded in the CIV1 dual BH LB for dual QBAE in metal infra cluster; need to target it

### What's changed
- update hardcoded details for (tbd - make dynamic, esp hostname selection, though selection of net iface seems complex)
- remove dual t3k for now, since it is missing a custom ACTIONS_RUNNER_CONTAINER_HOOKS that is manually provisioned for now. Pending - merge of tt-forge-infra + MIW => tt-ansible, or at least manual provisioning of @nsumrakTT 's container W/A to enable host network fwd on MIW-provisioned machines

### Checklist
- [x] Example workflow - https://github.com/tenstorrent/tt-xla/actions/runs/29531111107/job/87731523236