### PR TITLE
[vLLM] Remove benchmark workaround forcing cpu_sampling=True at opt>=1

### DIFF
--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -69,8 +69,6 @@ def _config(
         additional["fp32_dest_acc_en"] = fp32_dest_acc_en
     if optimization_level:
         additional["optimization_level"] = optimization_level
-        # TTConfig raises if enable_trace=True AND opt>=1 AND cpu_sampling=False
-        additional["cpu_sampling"] = True
     if _BENCH_CPU_SAMPLING:
         additional["cpu_sampling"] = True
     if _BENCH_KV_CACHE_DTYPE:


### PR DESCRIPTION
### Ticket
closes #5403

### Problem description
`tests/benchmark/test_vllm_benchmarks.py::_config` forced `cpu_sampling=True` whenever `optimization_level > 0`. That line was added in #4654 as a workaround for the tt-xla #4570 guard, which raised when `enable_trace=True` + opt≥1 +`cpu_sampling=False`.

That guard is now gone, and opt=1 is the default (#5327), so device sampling can run at opt≥1. But this stale workaround kept the benchmarks pinned to the slower host-sampling path. It was gated on regression #5401 (from tt-mlir uplift #5302),
which temporarily made device sampling slower, that has since been fixed and verified.

### What's changed
- Remove the two lines that force `cpu_sampling=True` at opt≥1, restoring device sampling as the benchmark default.
- `_BENCH_CPU_SAMPLING` still lets callers opt back into host sampling via env var.

Device sampling is now the faster path. Before/after (b32, seq128, single chip,`pytest -svv`):

| model | samples/s (host, before) | samples/s (device, after) | Δ | TTFT Δ |
|---|---|---|---|---|
| Llama-3.2-3B | 26.37 | 37.43 | **+42%** | **−40%** |
| Qwen3-8B | 15.33 | 20.65 | **+35%** | **−40%** |
| Falcon3-7B-base | 17.78 | 22.18 | **+25%** | **−36%** |
| Llama-3.1-8B (opt=0 control) | 18.57 | 18.39 | ~0% | ~0% |

Llama-3.1-8B overrides `optimization_level=0` (#5494) so it never hit the guard

### Checklist
- [x] vLLM benchmark run confirming device ≥ host
