### PR TITLE
[vLLM][MRv2] Add Model Runner v2 for TT (TTModelRunnerV2, single-device generate)

### DIFF
--- a/.github/workflows/test-matrix-presets/basic-test.json
+++ b/.github/workflows/test-matrix-presets/basic-test.json
@@ -16,6 +16,7 @@
   {"runs-on": "n300-llmbox",        "name": "run_vllm_llmbox_tests",  "dir": "./tests/integrations/vllm_plugin",        "test-mark": "push and tensor_parallel and llmbox and not data_parallel", "shared-runners": "true", "extra-wheel": "vllm"},
   {"runs-on": "n300-llmbox",        "name": "run_vllm_llmbox_tests",  "dir": "./tests/integrations/vllm_plugin",        "test-mark": "push and data_parallel and llmbox and not tensor_parallel", "shared-runners": "true", "extra-wheel": "vllm"},
   {"runs-on": "n300-llmbox",        "name": "run_vllm_llmbox_tests",  "dir": "./tests/integrations/vllm_plugin",        "test-mark": "push and data_parallel and tensor_parallel and llmbox", "shared-runners": "true", "extra-wheel": "vllm"},
+  {"runs-on": "cpu",                "name": "run_vllm_cpu_tests",      "dir": "./tests/integrations/vllm_plugin",        "test-mark": "push and cpu",            "shared-runners": "true", "extra-wheel": "vllm"},
   {"runs-on": "n300",               "name": "run_examples",           "dir": "./tests/examples",                        "test-mark": "push", "require":"alchemist", "parallel-groups": 3, "shared-runners": "true" },
   {"runs-on": "cpu",                "name": "run_mixed_precision_cpu","dir": "./mixed_precision",                       "test-mark": "push and cpu",            "shared-runners": "true", "forked": true }
 ]

--- a/.github/workflows/test-matrix-presets/vllm-model-tests.json
+++ b/.github/workflows/test-matrix-presets/vllm-model-tests.json
@@ -5,5 +5,6 @@
     {"runs-on": "n300", "name": "run_vllm_n300_tests", "dir": "./tests/integrations/vllm_plugin", "test-mark": "push and tensor_parallel and dual_chip", "shared-runners": "true", "extra-wheel": "vllm"},
     {"runs-on": "n300-llmbox", "name": "run_vllm_llmbox_tests", "dir": "./tests/integrations/vllm_plugin", "test-mark": "push and tensor_parallel and llmbox and not data_parallel", "shared-runners": "true", "extra-wheel": "vllm"},
     {"runs-on": "n300-llmbox", "name": "run_vllm_llmbox_tests", "dir": "./tests/integrations/vllm_plugin", "test-mark": "push and data_parallel and llmbox and not tensor_parallel", "shared-runners": "true", "extra-wheel": "vllm"},
-    {"runs-on": "n300-llmbox", "name": "run_vllm_llmbox_tests", "dir": "./tests/integrations/vllm_plugin", "test-mark": "push and data_parallel and tensor_parallel and llmbox", "shared-runners": "true", "extra-wheel": "vllm"}
+    {"runs-on": "n300-llmbox", "name": "run_vllm_llmbox_tests", "dir": "./tests/integrations/vllm_plugin", "test-mark": "push and data_parallel and tensor_parallel and llmbox", "shared-runners": "true", "extra-wheel": "vllm"},
+    {"runs-on": "cpu", "name": "run_vllm_cpu_tests", "dir": "./tests/integrations/vllm_plugin", "test-mark": "push and cpu", "shared-runners": "true", "extra-wheel": "vllm"}
 ]

--- a/integrations/vllm_plugin/vllm_tt/input_batch_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/input_batch_v2.py
@@ -1,0 +1,182 @@
+"""TT ``InputBatch`` for vLLM Model Runner v2 (MRv2).
+
+Phase 2 of the MRv2 adoption: the transient per-step batch view. Mirrors
+upstream ``vllm.v1.worker.gpu.input_batch`` (as of vLLM v0.22.1) -- the
+``InputBuffers`` (persistent device scratch) and the ``InputBatch`` dataclass
+(a fresh per-step view the runner populates).
+
+Scope / status
+--------------
+* ``InputBatch`` is a pure view: the runner rebuilds it every step from
+  ``TTRequestState`` (see request_state.py). Fields tied to features TT does
+  not support -- ``expanded_idx_mapping`` / ``expanded_local_pos`` /
+  ``num_draft_tokens*`` (spec decode) and ``dcp_local_seq_lens`` (DCP) -- are
+  kept for structural parity but degenerate to the no-spec / no-DCP path.
+* Upstream's module also holds the Triton input-prep kernels
+  (``prepare_prefill_inputs``, ``prepare_pos_seq_lens``,
+  ``combine_sampled_and_draft_tokens``, ``expand_idx_mapping``, ``post_update``,
+  ...). Those are input-prep, called from the runner's ``prepare_inputs``, and
+  have no Triton equivalent on TT. They are deferred to Phase 3, where the TT
+  runner fork substitutes host-side numpy / torch (salvage from the v1 runner's
+  ``_prepare_inputs``). We do NOT ship stubs for them here.
+* Like request_state.py, this module has no ``vllm.v1.worker.gpu.*`` dependency
+  and is import-safe, but is intentionally NOT imported from the package
+  ``__init__`` until the TT v2 runner (Phase 3) wires it in. UNVALIDATED at
+  runtime until then.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import torch
+
+from vllm.utils import random_uuid
+
+
+class TTInputBuffers:
+    """Persistent device-side scratch buffers, owned by the runner.
+
+    Sliced into per-step ``TTInputBatch`` views. Mirrors upstream
+    ``InputBuffers``.
+    """
+
+    def __init__(
+        self,
+        max_num_reqs: int,
+        max_num_tokens: int,
+        device: torch.device,
+    ):
+        self.max_num_reqs = max_num_reqs
+        self.max_num_tokens = max_num_tokens
+        self.device = device
+
+        self.input_ids = torch.zeros(max_num_tokens, dtype=torch.int32, device=device)
+        self.positions = torch.zeros(max_num_tokens, dtype=torch.int64, device=device)
+        self.query_start_loc = torch.zeros(
+            max_num_reqs + 1, dtype=torch.int32, device=device
+        )
+        self.seq_lens = torch.zeros(max_num_reqs, dtype=torch.int32, device=device)
+
+
+@dataclass
+class TTInputBatch:
+    # batch_idx -> req_id
+    req_ids: list[str]
+    num_reqs: int
+    num_reqs_after_padding: int
+
+    # batch_idx -> req_state_idx
+    idx_mapping: torch.Tensor
+    idx_mapping_np: np.ndarray
+    # Identical to idx_mapping except for spec decoding (unused on TT).
+    expanded_idx_mapping: torch.Tensor
+    # [total_num_logits] position within request for each logit.
+    expanded_local_pos: torch.Tensor
+
+    # [num_reqs] batch_idx -> num_scheduled_tokens
+    num_scheduled_tokens: np.ndarray
+    # sum(num_scheduled_tokens)
+    num_tokens: int
+    num_tokens_after_padding: int
+    # Sum of draft tokens scheduled across requests (0 on TT: no spec decode).
+    num_draft_tokens: int
+    # [num_reqs] draft tokens scheduled per request, if any.
+    num_draft_tokens_per_req: np.ndarray | None
+
+    # [num_reqs + 1]
+    query_start_loc: torch.Tensor
+    query_start_loc_np: np.ndarray
+    # [num_reqs]
+    seq_lens: torch.Tensor
+    # [num_reqs] CPU upper bound on seq_lens.
+    seq_lens_cpu_upper_bound: torch.Tensor
+    # [num_reqs] DCP per-request local seq_lens (None on TT: no DCP).
+    dcp_local_seq_lens: torch.Tensor | None
+    # [num_reqs] CPU bool array.
+    is_prefilling_np: np.ndarray
+
+    # [num_tokens_after_padding]
+    input_ids: torch.Tensor
+    # [num_tokens_after_padding]
+    positions: torch.Tensor
+
+    # [total_num_logits]
+    logits_indices: torch.Tensor
+    # [num_reqs + 1]
+    cu_num_logits: torch.Tensor
+    cu_num_logits_np: np.ndarray
+
+    # Whether any request in the batch uses structured output.
+    has_structured_output_reqs: bool
+
+    @classmethod
+    def make_dummy(
+        cls,
+        num_reqs: int,
+        num_tokens: int,
+        input_buffers: TTInputBuffers,
+    ) -> "TTInputBatch":
+        assert 0 < num_reqs <= num_tokens
+        device = input_buffers.device
+
+        req_ids = [f"req_{i}_{random_uuid()}" for i in range(num_reqs)]
+        idx_mapping_np = np.arange(num_reqs, dtype=np.int32)
+        idx_mapping = torch.arange(num_reqs, dtype=torch.int32, device=device)
+        expanded_idx_mapping = idx_mapping
+        expanded_local_pos = torch.zeros(num_reqs, dtype=torch.int32, device=device)
+
+        num_scheduled_tokens = np.full(num_reqs, num_tokens // num_reqs, dtype=np.int32)
+        num_scheduled_tokens[-1] += num_tokens % num_reqs
+        assert int(num_scheduled_tokens.sum()) == num_tokens
+
+        # seq_len equals query_len for the dummy (fresh-prefill shape).
+        input_buffers.seq_lens[:num_reqs] = num_tokens // num_reqs
+        input_buffers.seq_lens[num_reqs - 1] += num_tokens % num_reqs
+        input_buffers.seq_lens[num_reqs:] = 0
+        seq_lens = input_buffers.seq_lens[:num_reqs]
+
+        query_start_loc_np = np.empty(num_reqs + 1, dtype=np.int32)
+        query_start_loc_np[0] = 0
+        np.cumsum(num_scheduled_tokens, out=query_start_loc_np[1:])
+        input_buffers.query_start_loc[:1] = 0
+        torch.cumsum(
+            seq_lens, dim=0, out=input_buffers.query_start_loc[1 : num_reqs + 1]
+        )
+        input_buffers.query_start_loc[num_reqs + 1 :] = num_tokens
+        query_start_loc = input_buffers.query_start_loc[: num_reqs + 1]
+
+        input_ids = input_buffers.input_ids[:num_tokens].zero_()
+        positions = input_buffers.positions[:num_tokens].zero_()
+
+        logits_indices = query_start_loc[1:] - 1
+        cu_num_logits = torch.arange(num_reqs + 1, device=device, dtype=torch.int32)
+        cu_num_logits_np = np.arange(num_reqs + 1, dtype=np.int32)
+        seq_lens_cpu_upper_bound = torch.from_numpy(num_scheduled_tokens.copy())
+        return cls(
+            req_ids=req_ids,
+            num_reqs=num_reqs,
+            num_reqs_after_padding=num_reqs,
+            idx_mapping=idx_mapping,
+            idx_mapping_np=idx_mapping_np,
+            expanded_idx_mapping=expanded_idx_mapping,
+            expanded_local_pos=expanded_local_pos,
+            num_scheduled_tokens=num_scheduled_tokens,
+            num_tokens=num_tokens,
+            num_tokens_after_padding=num_tokens,
+            num_draft_tokens=0,
+            num_draft_tokens_per_req=None,
+            query_start_loc=query_start_loc,
+            query_start_loc_np=query_start_loc_np,
+            seq_lens=seq_lens,
+            seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
+            dcp_local_seq_lens=None,
+            is_prefilling_np=np.zeros(num_reqs, dtype=np.bool_),
+            input_ids=input_ids,
+            positions=positions,
+            logits_indices=logits_indices,
+            cu_num_logits=cu_num_logits,
+            cu_num_logits_np=cu_num_logits_np,
+            has_structured_output_reqs=False,
+        )

--- a/integrations/vllm_plugin/vllm_tt/input_batch_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/input_batch_v2.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
 """TT ``InputBatch`` for vLLM Model Runner v2 (MRv2).
 
 Phase 2 of the MRv2 adoption: the transient per-step batch view. Mirrors
@@ -31,7 +34,6 @@ from dataclasses import dataclass
 
 import numpy as np
 import torch
-
 from vllm.utils import random_uuid
 
 

--- a/integrations/vllm_plugin/vllm_tt/metadata.py
+++ b/integrations/vllm_plugin/vllm_tt/metadata.py
@@ -414,3 +414,32 @@ class XLASupportedSamplingMetadata:
             no_generators=not has_generators,
             q_samples=q_samples,
         )
+
+    @classmethod
+    def from_v2_states(
+        cls,
+        request_state,
+        sampling_states,
+        input_batch,
+        padded_num_reqs: int,
+        xla_device: torch.device,
+        generate_params_if_all_greedy: bool = False,
+        vocab_size: int | None = None,
+    ) -> "XLASupportedSamplingMetadata":
+        """MRv2 entry point: build sampling metadata from the split v2 state.
+
+        v2 keeps sampling params in ``TTSamplingStates`` (keyed by stable slot),
+        token history in ``TTRequestState``, and the batch->slot mapping in
+        ``TTInputBatch``. ``make_batch_view`` gathers a batch-ordered padded view
+        that reuses ``from_input_batch`` unchanged.
+        """
+        view = sampling_states.make_batch_view(
+            request_state, input_batch, padded_num_reqs
+        )
+        return cls.from_input_batch(
+            view,
+            padded_num_reqs,
+            xla_device,
+            generate_params_if_all_greedy=generate_params_if_all_greedy,
+            vocab_size=vocab_size,
+        )

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -231,7 +231,6 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         original_parallel_config: Optional[ParallelConfig] = None,
     ):
         self.tt_config = TTConfig(**vllm_config.additional_config)
-        torch_xla.set_custom_compile_options(self.tt_config.get_pjrt_compile_config())
 
         self.vllm_config = vllm_config
         self.model_config = vllm_config.model_config

--- a/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
@@ -11,11 +11,11 @@ This file is built in reviewable sub-increments. Present so far: the request
 lifecycle, the decode-first batch selection / SMEM multi-pass clamping, the host
 input-token preparation, the attention slot-mapping build (feeding
 ``TTModelState.prepare_attn``), the sampled-token writeback (``postprocess``),
-and the ``execute_model``/``sample_tokens`` two-phase driver that threads them
-together. Still to land: ``__init__``/``load_model`` (construct the state below),
-``initialize_kv_cache``, and the compiled forward graphs -- all reached through
-the single documented ``_run_model_pass`` hardware leaf, which is stubbed until
-those are ported (needs a TT device to validate).
+the ``execute_model``/``sample_tokens`` two-phase driver that threads them
+together, and ``initialize_kv_cache`` (device KV allocation). Still to land:
+``__init__``/``load_model`` (construct the state below) and the compiled forward
+graphs -- reached through the single documented ``_run_model_pass`` hardware
+leaf, which is stubbed until those are ported.
 
 Layout note
 -----------
@@ -66,6 +66,7 @@ from vllm.sampling_params import SamplingType
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
+    from vllm.v1.kv_cache_interface import KVCacheConfig
 
 
 def _get_padded_token_len(paddings: list[int], x: int) -> int:
@@ -556,4 +557,101 @@ class TTModelRunnerV2:
             "compiled forward + sample pass requires the TT v2 runner "
             "__init__/load_model + compiled graphs (MRv2 Phase 3, hardware "
             "bring-up)."
+        )
+
+    # ------------------------------------------------------------------ #
+    # KV cache allocation.
+    # ------------------------------------------------------------------ #
+
+    def _allocate_kv_caches(self, kv_cache_config: "KVCacheConfig") -> dict:
+        """Allocate the per-layer KV cache tensors on the TT device.
+
+        The device-coupled core of ``initialize_kv_cache`` (salvaged from the v1
+        fork), split out so it can be exercised on-device without the engine
+        wrappers. Standard attention gets separate ``[k_cache, v_cache]`` tensors
+        (avoids slice/concat in the compiled graph); MLA gets a single latent
+        tensor. Only one KV-cache group (no hybrid) and one owner per tensor are
+        supported. Returns ``layer_name -> tensor | [k, v]``.
+        """
+        from vllm.v1.kv_cache_interface import AttentionSpec, MLAAttentionSpec
+
+        from .attention_impls.attention import TTAttentionBackend
+        from .attention_impls.attention_mla import TTMLAAttentionBackend
+
+        groups = kv_cache_config.kv_cache_groups
+        if len(groups) > 1:
+            raise NotImplementedError(
+                "Hybrid models with more than one KV cache type are not supported yet."
+            )
+        if len(groups) == 0:
+            # Valid when only a subset of layers is compiled (layer override).
+            return {}
+
+        assert groups[0].kv_cache_spec.block_size == self.block_size, (
+            f"KV cache block_size {groups[0].kv_cache_spec.block_size} must match "
+            f"the runner block_size {self.block_size}"
+        )
+
+        kv_cache_sizes: dict[str, int] = {}
+        for tensor in kv_cache_config.kv_cache_tensors:
+            assert (
+                len(tensor.shared_by) == 1
+            ), "A KV cache tensor shared by multiple layers is not supported on TT."
+            kv_cache_sizes[tensor.shared_by[0]] = tensor.size
+
+        kv_caches: dict = {}
+        for group in groups:
+            spec = group.kv_cache_spec
+            for layer_name in group.layer_names:
+                tensor_size = kv_cache_sizes[layer_name]
+                assert tensor_size % spec.page_size_bytes == 0
+                num_blocks = tensor_size // spec.page_size_bytes
+                if isinstance(spec, MLAAttentionSpec):
+                    # Single concatenated latent KV tensor (num_kv_heads == 1).
+                    shape = TTMLAAttentionBackend.get_kv_cache_shape(
+                        num_blocks, spec.block_size, spec.num_kv_heads, spec.head_size
+                    )
+                    kv_caches[layer_name] = torch.zeros(shape, dtype=spec.dtype).to(
+                        self.device
+                    )
+                elif isinstance(spec, AttentionSpec):
+                    if self.enable_tensor_parallel:
+                        tp_size = self.original_parallel_config.tensor_parallel_size
+                        assert spec.num_kv_heads % tp_size == 0, (
+                            f"num_kv_heads {spec.num_kv_heads} must be divisible by "
+                            f"tp_size {tp_size} under SPMD"
+                        )
+                    shape = TTAttentionBackend.get_kv_cache_shape(
+                        num_blocks, spec.block_size, spec.num_kv_heads, spec.head_size
+                    )
+                    # spec.dtype may be a 1-byte accounting dtype; the device
+                    # buffers use the real transfer dtype.
+                    k = torch.zeros(shape, dtype=self.kv_cache_dtype).to(self.device)
+                    v = torch.zeros(shape, dtype=self.kv_cache_dtype).to(self.device)
+                    kv_caches[layer_name] = [k, v]
+                else:
+                    raise NotImplementedError(
+                        f"Unsupported KV cache spec: {type(spec)}"
+                    )
+        return kv_caches
+
+    def initialize_kv_cache(self, kv_cache_config: "KVCacheConfig") -> None:
+        """Allocate KV caches and bind them into the forward context.
+
+        Wraps ``_allocate_kv_caches`` with the engine integration. The common
+        single-device path allocates and binds; the SPMD KV-cache sharding and
+        KV-transfer registration (salvage v1 initialize_kv_cache 3436-3459) land
+        with the multi-device ``__init__``. ``self.kv_caches`` (a list) and
+        ``self.vllm_config`` are provided by ``__init__``.
+        """
+        from vllm.v1.worker.utils import bind_kv_cache
+
+        kv_caches = self._allocate_kv_caches(kv_cache_config)
+        if not kv_caches:
+            return
+        self.kv_cache_config = kv_cache_config
+        bind_kv_cache(
+            kv_caches,
+            self.vllm_config.compilation_config.static_forward_context,
+            self.kv_caches,
         )

--- a/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
@@ -10,11 +10,12 @@ subclassing ``GPUModelRunner``.
 This file is built in reviewable sub-increments. Present so far: the request
 lifecycle, the decode-first batch selection / SMEM multi-pass clamping, the host
 input-token preparation, the attention slot-mapping build (feeding
-``TTModelState.prepare_attn``), and the sampled-token writeback (``postprocess``).
-Still to land: ``__init__``/``load_model`` (construct the state below),
-``initialize_kv_cache``, the compiled forward graphs, and the
-``execute_model``/``sample_tokens`` multi-pass driver that threads all of the
-above together.
+``TTModelState.prepare_attn``), the sampled-token writeback (``postprocess``),
+and the ``execute_model``/``sample_tokens`` two-phase driver that threads them
+together. Still to land: ``__init__``/``load_model`` (construct the state below),
+``initialize_kv_cache``, and the compiled forward graphs -- all reached through
+the single documented ``_run_model_pass`` hardware leaf, which is stubbed until
+those are ported (needs a TT device to validate).
 
 Layout note
 -----------
@@ -40,9 +41,17 @@ state, following upstream v2 semantics (NOT the v1 fork's ``_update_states``):
   bookkeeping to ``TTRequestState``, block ids to the runner-owned block table.
 
 The runner instance is expected to carry (set up by ``__init__``, later
-sub-increment): ``req_states``, ``sampling_states``, ``block_table`` (a vLLM
-``MultiGroupBlockTable``), ``encoder_cache`` (dict), ``num_prompt_logprobs``
-(dict), ``model_state`` (or None), and ``vocab_size``.
+sub-increment): the split state (``req_states``, ``sampling_states``,
+``block_table`` -- a vLLM ``MultiGroupBlockTable``, ``encoder_cache`` dict,
+``num_prompt_logprobs`` dict, ``model_state``); scalars (``vocab_size``,
+``max_num_blocks_per_req``, ``supports_mm_inputs``, and the SMEM-cap set read by
+``_select_batch``: ``most_model_len``/``num_reqs_max_model_len``/
+``num_reqs_most_model_len``/``min_num_reqs``/``max_prefill_num_reqs``/
+``max_num_reqs``/``num_tokens_paddings``); the per-step handoff
+``scheduler_output`` (initialised to None); and the device machinery reached
+only through ``_run_model_pass`` (persistent input/attn buffers, ``model``,
+``sampler``, ``sampling_device``, ``attention_layer_names``, ``dp_size``, and the
+compiled forward graphs).
 """
 
 from __future__ import annotations
@@ -385,3 +394,166 @@ class TTModelRunnerV2:
             fill_page_table[zero_rows, :] = 0
 
         return page_table, fill_page_table, cache_position
+
+    # ------------------------------------------------------------------ #
+    # Two-phase step driver (mirrors the v1 fork + upstream v2 split).
+    # ------------------------------------------------------------------ #
+
+    def execute_model(
+        self,
+        scheduler_output: "SchedulerOutput",
+        intermediate_tensors=None,
+    ):
+        """Phase 1: apply the scheduler delta, then hand off to sample_tokens.
+
+        Mirrors the v1 fork / upstream v2 two-phase contract (the worker calls
+        execute_model then sample_tokens). All host state updates happen here via
+        the tested lifecycle; the forward + sampling are deferred to
+        sample_tokens. Returns None on a normal step (output comes from
+        sample_tokens) or an empty output when nothing is scheduled.
+        """
+        assert (
+            self.scheduler_output is None
+        ), "execute_model called before sample_tokens consumed the prior step"
+        # TT compiles one graph per (bucket) shape; keep dynamic shapes off so a
+        # new shape recompiles rather than silently falling back.
+        torch._dynamo.config.dynamic_shapes = False
+
+        self.finish_requests(scheduler_output)
+        self.add_requests(scheduler_output)
+        self.update_requests(scheduler_output)
+
+        if scheduler_output.total_num_scheduled_tokens == 0:
+            # No tokens this step (e.g. only KV-connector activity).
+            from vllm.v1.worker.gpu_model_runner import EMPTY_MODEL_RUNNER_OUTPUT
+
+            return EMPTY_MODEL_RUNNER_OUTPUT
+
+        if self.supports_mm_inputs:
+            # Needs TTModelState.get_mm_embeddings + the encoder run (deferred).
+            raise NotImplementedError(
+                "multimodal path pending get_mm_embeddings (MRv2 Phase 3)."
+            )
+
+        self.scheduler_output = scheduler_output
+        return None
+
+    def sample_tokens(self, grammar_output):
+        """Phase 2: run the (possibly multi-pass) batch loop and sample.
+
+        Composes the tested host stages -- decode-first ordering, SMEM
+        sub-batching, input-token prep, attention slot-mapping, and the
+        sampled-token writeback -- around the single hardware leaf
+        ``_run_model_pass``. The SMEM row caps mean a step may span several passes
+        (start_index advances); results are concatenated in processing order.
+        """
+        if self.scheduler_output is None:
+            # PP non-final rank / nothing stashed: output is unused.
+            return None
+        scheduler_output = self.scheduler_output
+        self.scheduler_output = None
+
+        if grammar_output is not None:
+            raise NotImplementedError(
+                "structured-output decoding pending for the v2 runner."
+            )
+        if self.num_prompt_logprobs:
+            raise NotImplementedError("prompt logprobs pending for the v2 runner.")
+
+        ordered_slots, ordered_num_tokens = self._order_scheduled_reqs(scheduler_output)
+
+        out_req_ids: list[str] = []
+        out_sampled: list[list[int]] = []
+
+        start_index = 0
+        while start_index < len(ordered_slots):
+            (
+                idx_mapping,
+                num_scheduled,
+                target_num_reqs,
+                padded_query_len,
+                end_index,
+            ) = self._select_batch(ordered_slots, ordered_num_tokens, start_index)
+
+            input_ids, positions, _query_start_loc, seq_lens, logits_indices = (
+                self._prepare_input_tokens(
+                    idx_mapping, num_scheduled, target_num_reqs, padded_query_len
+                )
+            )
+            page_table, fill_page_table, cache_position = self._prepare_attn_tensors(
+                idx_mapping,
+                num_scheduled,
+                seq_lens,
+                target_num_reqs,
+                self.max_num_blocks_per_req,
+            )
+
+            sampled = self._run_model_pass(
+                idx_mapping,
+                num_scheduled,
+                target_num_reqs,
+                padded_query_len,
+                input_ids,
+                positions,
+                logits_indices,
+                page_table,
+                fill_page_table,
+                cache_position,
+            )
+
+            valid = self.postprocess(idx_mapping, num_scheduled, sampled)
+            for b in range(len(idx_mapping)):
+                slot = int(idx_mapping[b])
+                out_req_ids.append(self.req_states.index_to_req_id[slot])
+                out_sampled.append(valid[b])
+
+            start_index = end_index
+
+        from vllm.v1.outputs import ModelRunnerOutput
+
+        return ModelRunnerOutput(
+            req_ids=out_req_ids,
+            req_id_to_index={rid: i for i, rid in enumerate(out_req_ids)},
+            sampled_token_ids=out_sampled,
+        )
+
+    def _run_model_pass(
+        self,
+        idx_mapping_np: np.ndarray,
+        num_scheduled_tokens: np.ndarray,
+        target_num_reqs: int,
+        padded_query_len: int,
+        input_ids: np.ndarray,
+        positions: np.ndarray,
+        logits_indices: np.ndarray,
+        page_table: np.ndarray,
+        fill_page_table: np.ndarray,
+        cache_position: np.ndarray,
+    ) -> list[list[int]]:
+        """Run one compiled forward + sample pass for the selected sub-batch.
+
+        The single hardware-coupled leaf of the driver -- stubbed until
+        ``__init__``/``load_model`` and the compiled graphs are ported (needs a TT
+        device to validate). Contract, salvaged from v1 sample_tokens 1888-1972 +
+        ``_model_decode``/``_model_prefill``:
+
+          1. copy the host ``input_ids``/``positions``/``page_table``/
+             ``fill_page_table``/``cache_position``/``logits_indices`` into the
+             persistent device buffers;
+          2. attn metadata: ``self.model_state.prepare_attn(self.attention_layer_names,
+             page_table_dev, cache_position_dev, fill_page_table_dev, batch_idx_dev,
+             target_num_reqs, self.dp_size)``;
+          3. sampling metadata:
+             ``XLASupportedSamplingMetadata.from_v2_states(self.req_states,
+             self.sampling_states, <view with num_reqs + idx_mapping_np>,
+             target_num_reqs, self.sampling_device, vocab_size=self.vocab_size)``;
+          4. dispatch the decode graph when ``padded_query_len == 1`` else the
+             prefill graph (or the unfused path under ``cpu_sampling``);
+          5. run the sampler and return ``sampled_token_ids`` as a batch-ordered
+             ``list[list[int]]``.
+        """
+        raise NotImplementedError(
+            "compiled forward + sample pass requires the TT v2 runner "
+            "__init__/load_model + compiled graphs (MRv2 Phase 3, hardware "
+            "bring-up)."
+        )

--- a/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
@@ -31,7 +31,6 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
-
 import vllm.envs as envs
 from vllm.sampling_params import SamplingType
 from vllm.utils.math_utils import cdiv

--- a/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
@@ -12,10 +12,11 @@ lifecycle, the decode-first batch selection / SMEM multi-pass clamping, the host
 input-token preparation, the attention slot-mapping build (feeding
 ``TTModelState.prepare_attn``), the sampled-token writeback (``postprocess``),
 the ``execute_model``/``sample_tokens`` two-phase driver that threads them
-together, and ``initialize_kv_cache`` (device KV allocation). Still to land:
-``__init__``/``load_model`` (construct the state below) and the compiled forward
-graphs -- reached through the single documented ``_run_model_pass`` hardware
-leaf, which is stubbed until those are ported.
+together, ``initialize_kv_cache`` (device KV allocation), and
+``__init__``/``load_model`` (single-device state construction + model load /
+compile). Still to land: the compiled forward graphs behind the single
+documented ``_run_model_pass`` hardware leaf (stubbed), and the multi-device
+SPMD/mesh path deferred out of ``__init__``.
 
 Layout note
 -----------
@@ -62,9 +63,12 @@ from typing import TYPE_CHECKING
 import numpy as np
 import torch
 
+import vllm.envs as envs
 from vllm.sampling_params import SamplingType
+from vllm.utils.math_utils import cdiv
 
 if TYPE_CHECKING:
+    from vllm.config import VllmConfig
     from vllm.v1.core.sched.output import SchedulerOutput
     from vllm.v1.kv_cache_interface import KVCacheConfig
 
@@ -76,8 +80,242 @@ def _get_padded_token_len(paddings: list[int], x: int) -> int:
     return paddings[index]
 
 
+def _adjust_min_token(min_token_size: int) -> int:
+    """Round min_token_size up to a power of two that is >= 32 (32B alignment)."""
+    if (min_token_size & (min_token_size - 1)) == 0 and min_token_size >= 32:
+        return min_token_size
+    if min_token_size > 32:
+        return 1 << (min_token_size - 1).bit_length()
+    return 32
+
+
+def _get_token_paddings(min_token_size: int, max_token_size: int) -> list[int]:
+    """Exponential token-length ladder from min_token_size up past max_token_size.
+
+    Always starts with 1 to support single-token decode steps.
+    """
+    num = _adjust_min_token(min_token_size)
+    paddings = [1]
+    while True:
+        paddings.append(num)
+        if num >= max_token_size:
+            break
+        num *= 2
+    return paddings
+
+
 class TTModelRunnerV2:
-    """Tenstorrent MRv2 model runner (lifecycle sub-increment; see module doc)."""
+    """Tenstorrent MRv2 model runner (see module docstring)."""
+
+    def __init__(self, vllm_config: "VllmConfig", device: torch.device) -> None:
+        """Construct the split v2 state + config scalars (single-device path).
+
+        Multi-device SPMD (mesh / tensor + data parallel) is deferred; this
+        constructor raises if those TT config flags are set. The model itself is
+        loaded and compiled in ``load_model``; ``model``/``model_state``/``sampler``
+        are None until then.
+        """
+        from vllm.v1.worker.block_table import MultiGroupBlockTable
+
+        from .attention_impls.attention import (
+            TPU_STR_DTYPE_TO_TORCH_DTYPE,
+            TTAttentionBackend,
+        )
+        from .input_batch_v2 import TTInputBuffers
+        from .request_state import TTRequestState
+        from .sampling_state_v2 import TTSamplingStates
+
+        self.vllm_config = vllm_config
+        self.model_config = vllm_config.model_config
+        self.cache_config = vllm_config.cache_config
+        self.scheduler_config = vllm_config.scheduler_config
+        self.parallel_config = vllm_config.parallel_config
+        self.load_config = vllm_config.load_config
+        self.lora_config = vllm_config.lora_config
+        self.tt_config = vllm_config.additional_config
+        self.device = device
+
+        tt = self.tt_config
+        self.enable_tensor_parallel = bool(getattr(tt, "enable_tensor_parallel", False))
+        self.enable_data_parallel = bool(getattr(tt, "enable_data_parallel", False))
+        if self.enable_tensor_parallel or self.enable_data_parallel:
+            raise NotImplementedError(
+                "Multi-device (SPMD mesh) __init__ is deferred; single device only."
+            )
+        self.dp_size = 1
+        self.mesh = None
+        self.original_parallel_config = None
+
+        self.dtype = self.model_config.dtype
+        if self.cache_config.cache_dtype == "auto":
+            self.kv_cache_dtype = (
+                TPU_STR_DTYPE_TO_TORCH_DTYPE[self.dtype]
+                if isinstance(self.dtype, str)
+                else self.dtype
+            )
+        else:
+            self.kv_cache_dtype = TPU_STR_DTYPE_TO_TORCH_DTYPE[
+                self.cache_config.cache_dtype
+            ]
+        # 1-byte accounting stand-in so vLLM budgets blocks for the BFP8 footprint.
+        self.kv_cache_spec_dtype = (
+            torch.uint8
+            if getattr(tt, "experimental_kv_cache_dtype", None) == "bfp_bf8"
+            else self.kv_cache_dtype
+        )
+
+        self.block_size = self.cache_config.block_size
+        self.max_model_len = self.model_config.max_model_len
+        self.max_num_reqs = self.scheduler_config.max_num_seqs
+        self.most_model_len = envs.VLLM_TPU_MOST_MODEL_LEN
+        self.max_num_blocks_per_req = cdiv(self.max_model_len, self.block_size)
+        self.num_blocks_per_most_len_req = (
+            cdiv(self.most_model_len, self.block_size)
+            if self.most_model_len is not None
+            else None
+        )
+
+        # Prefill request-count bucketing bounds (decode always uses max_num_reqs).
+        self.min_num_reqs = getattr(tt, "min_num_seqs", None) or self.max_num_reqs
+        self.max_prefill_num_reqs = (
+            getattr(tt, "max_prefill_num_seqs", None) or self.max_num_reqs
+        )
+
+        max_num_batched_tokens = self.scheduler_config.max_num_batched_tokens
+        min_context_len = getattr(tt, "min_context_len", 32)
+        if max_num_batched_tokens < min_context_len:
+            min_context_len = max_num_batched_tokens
+        self.prefill_chunk_budget = min(
+            getattr(
+                self.scheduler_config, "tt_prefill_chunk_size", max_num_batched_tokens
+            )
+            or max_num_batched_tokens,
+            self.max_model_len,
+        )
+        self.num_tokens_paddings = _get_token_paddings(
+            min_context_len, self.prefill_chunk_budget
+        )
+        if getattr(tt, "decode_only", False):
+            self.num_tokens_paddings = [1]
+        self.max_num_tokens = self.num_tokens_paddings[-1]
+
+        # Model dims.
+        self.num_attn_layers = self.model_config.get_num_layers_by_block_type(
+            self.parallel_config, "attention"
+        )
+        self.num_query_heads = self.model_config.get_num_attention_heads(
+            self.parallel_config
+        )
+        self.num_kv_heads = self.model_config.get_num_kv_heads(self.parallel_config)
+        self.head_size = self.model_config.get_head_size()
+        self.vocab_size = self.model_config.get_vocab_size()
+        self.supports_mm_inputs = bool(
+            getattr(self.model_config, "is_multimodal_model", False)
+        )
+
+        # SMEM row caps consumed by _select_batch.
+        self.num_reqs_max_model_len = min(
+            TTAttentionBackend.get_max_num_seqs(self.max_model_len, self.block_size),
+            self.max_num_reqs,
+        )
+        self.num_reqs_most_model_len = (
+            min(
+                TTAttentionBackend.get_max_num_seqs(
+                    self.most_model_len, self.block_size
+                ),
+                self.max_num_reqs,
+            )
+            if self.most_model_len is not None
+            else None
+        )
+
+        # Driver / graph knobs read later.
+        self.use_flat_model_io = bool(getattr(tt, "flat_model_io", False))
+        self.cpu_sampling = bool(getattr(tt, "cpu_sampling", False))
+        self.enable_decode_fused_graphs = bool(
+            getattr(tt, "enable_decode_fused_graphs", False)
+        )
+        self.sampling_device = torch.device("cpu") if self.cpu_sampling else self.device
+
+        # Split v2 state.
+        self.req_states = TTRequestState(
+            max_num_reqs=self.max_num_reqs,
+            max_model_len=self.max_model_len,
+            max_num_batched_tokens=self.max_num_tokens,
+            num_speculative_steps=0,
+            vocab_size=self.vocab_size,
+            device=self.device,
+        )
+        self.sampling_states = TTSamplingStates(
+            max_num_reqs=self.max_num_reqs, vocab_size=self.vocab_size
+        )
+        self.block_table = MultiGroupBlockTable(
+            max_num_reqs=self.max_num_reqs,
+            max_model_len=self.max_model_len,
+            max_num_batched_tokens=self.max_num_tokens,
+            pin_memory=False,
+            device=torch.device("cpu"),
+            block_sizes=[self.block_size],
+            kernel_block_sizes=[self.block_size],
+        )
+        self.input_buffers = TTInputBuffers(
+            self.max_num_reqs, self.max_num_tokens, self.device
+        )
+
+        self.encoder_cache: dict = {}
+        self.num_prompt_logprobs: dict = {}
+        self.kv_caches: list = []
+        self.kv_cache_config = None
+        # Per-step handoff between the two-phase execute_model / sample_tokens.
+        self.scheduler_output = None
+
+        # Filled by load_model.
+        self.model = None
+        self.model_state = None
+        self.sampler = None
+        self._attention_layer_names: tuple = ()
+        self.attention_layer_names: tuple = ()
+
+    def load_model(self) -> None:
+        """Load, place, and compile the model; build ModelState + sampler.
+
+        Single-device path (salvaged from the v1 fork): the multi-device weight
+        sharding, the vocab-embedding TP-rank patch, LoRA, the num-layers override,
+        and per-tensor weight-dtype overrides are deferred with the SPMD ``__init__``.
+        Needs a real model + loader, so it is validated at engine stand-up.
+        """
+        from vllm.config import get_layers_from_vllm_config, set_current_vllm_config
+        from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+        from vllm.model_executor.model_loader import get_model_loader
+
+        from .model_state import TTModelState
+        from .overrides import repair_stale_moe_closures, replace_modules
+        from .sampler import Sampler
+
+        loader = get_model_loader(self.load_config)
+        with set_current_vllm_config(self.vllm_config):
+            model = loader.load_model(
+                vllm_config=self.vllm_config, model_config=self.model_config
+            ).eval()
+        replace_modules(model)
+        self.model = model.to(self.device)
+
+        # Repair MoE routing closures that captured CPU tensors before to(device).
+        repair_stale_moe_closures(self.model)
+
+        self.model.compile(backend="tt", dynamic=False)
+        self.sampler = Sampler()
+
+        encoder_cache = self.encoder_cache if self.supports_mm_inputs else None
+        self.model_state = TTModelState(
+            self.vllm_config, self.model, encoder_cache, self.device
+        )
+
+        # Cache the attention layer names for the per-step prepare_attn fan-out.
+        self._attention_layer_names = tuple(
+            get_layers_from_vllm_config(self.vllm_config, AttentionLayerBase).keys()
+        )
+        self.attention_layer_names = self._attention_layer_names
 
     def _remove_request(self, req_id: str) -> None:
         """Free a request's slot across every per-slot table. Idempotent."""

--- a/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
@@ -14,9 +14,10 @@ input-token preparation, the attention slot-mapping build (feeding
 the ``execute_model``/``sample_tokens`` two-phase driver that threads them
 together, ``initialize_kv_cache`` (device KV allocation), and
 ``__init__``/``load_model`` (single-device state construction + model load /
-compile). Still to land: the compiled forward graphs behind the single
-documented ``_run_model_pass`` hardware leaf (stubbed), and the multi-device
-SPMD/mesh path deferred out of ``__init__``.
+compile), and ``_run_model_pass`` + the compiled forward/sample graph. The
+runner is structurally complete for the single-device greedy text path. Deferred:
+the multi-device SPMD/mesh path out of ``__init__``, ``get_mm_embeddings``, and
+the grammar / cpu_sampling / prompt-logprobs branches (driver-gated).
 
 Layout note
 -----------
@@ -771,31 +772,132 @@ class TTModelRunnerV2:
     ) -> list[list[int]]:
         """Run one compiled forward + sample pass for the selected sub-batch.
 
-        The single hardware-coupled leaf of the driver -- stubbed until
-        ``__init__``/``load_model`` and the compiled graphs are ported (needs a TT
-        device to validate). Contract, salvaged from v1 sample_tokens 1888-1972 +
-        ``_model_decode``/``_model_prefill``:
-
-          1. copy the host ``input_ids``/``positions``/``page_table``/
-             ``fill_page_table``/``cache_position``/``logits_indices`` into the
-             persistent device buffers;
-          2. attn metadata: ``self.model_state.prepare_attn(self.attention_layer_names,
-             page_table_dev, cache_position_dev, fill_page_table_dev, batch_idx_dev,
-             target_num_reqs, self.dp_size)``;
-          3. sampling metadata:
-             ``XLASupportedSamplingMetadata.from_v2_states(self.req_states,
-             self.sampling_states, <view with num_reqs + idx_mapping_np>,
-             target_num_reqs, self.sampling_device, vocab_size=self.vocab_size)``;
-          4. dispatch the decode graph when ``padded_query_len == 1`` else the
-             prefill graph (or the unfused path under ``cpu_sampling``);
-          5. run the sampler and return ``sampled_token_ids`` as a batch-ordered
-             ``list[list[int]]``.
+        Copies the host arrays to the device, builds the attention metadata
+        (``TTModelState.prepare_attn``) and sampling metadata
+        (``XLASupportedSamplingMetadata.from_v2_states``), runs the compiled
+        forward + sample, and returns the batch-ordered sampled token ids.
+        Common text path only: grammar / cpu_sampling / prompt-logprobs are
+        gated off in the driver.
         """
-        raise NotImplementedError(
-            "compiled forward + sample pass requires the TT v2 runner "
-            "__init__/load_model + compiled graphs (MRv2 Phase 3, hardware "
-            "bring-up)."
+        from types import SimpleNamespace
+
+        from .metadata import XLASupportedSamplingMetadata
+
+        dev = self.device
+        input_ids_dev = torch.from_numpy(input_ids).to(dev)
+        positions_dev = torch.from_numpy(positions).to(dev)
+        page_table_dev = torch.from_numpy(page_table).to(dev)
+        fill_page_table_dev = torch.from_numpy(fill_page_table).to(dev)
+        cache_position_dev = torch.from_numpy(cache_position).to(dev)
+        logits_indices_dev = torch.from_numpy(logits_indices).to(dev)
+        batch_idx_dev = torch.arange(target_num_reqs, dtype=torch.int32, device=dev)
+
+        attn_metadata = self.model_state.prepare_attn(
+            self.attention_layer_names,
+            page_table_dev,
+            cache_position_dev,
+            fill_page_table=fill_page_table_dev,
+            batch_idx=batch_idx_dev,
+            num_users=target_num_reqs,
+            dp_size=self.dp_size,
         )
+        # from_v2_states only reads num_reqs + idx_mapping_np off the view.
+        batch_view = SimpleNamespace(
+            num_reqs=len(idx_mapping_np), idx_mapping_np=idx_mapping_np
+        )
+        sampling_metadata = XLASupportedSamplingMetadata.from_v2_states(
+            self.req_states,
+            self.sampling_states,
+            batch_view,
+            target_num_reqs,
+            self.sampling_device,
+            vocab_size=self.vocab_size,
+        )
+
+        selected = self._forward_and_sample(
+            input_ids_dev,
+            positions_dev,
+            logits_indices_dev,
+            attn_metadata,
+            sampling_metadata,
+        )
+        # [target_num_reqs, 1] -> per active-req list; drop padding rows.
+        return selected[: len(idx_mapping_np)].cpu().tolist()
+
+    def _forward_and_sample(
+        self, input_ids, positions, logits_indices, attn_metadata, sampling_metadata
+    ):
+        """Publish the attn metadata into the forward context, then run the graph."""
+        from vllm.forward_context import set_forward_context
+
+        num_tokens = input_ids.shape[0] * input_ids.shape[1]
+        with set_forward_context(
+            attn_metadata, self.vllm_config, num_tokens=num_tokens
+        ):
+            return self._forward_and_sample_compiled(
+                input_ids, positions, logits_indices, sampling_metadata
+            )
+
+    @torch.compile(backend="tt", fullgraph=True, dynamic=False)
+    def _forward_and_sample_compiled(
+        self, input_ids, positions, logits_indices, sampling_metadata
+    ):
+        """Compiled model forward -> last-token select -> logits -> sample."""
+        model_input_ids, model_positions, model_embeds, restore_shape = (
+            self._prepare_model_call_tensors(input_ids, positions, None)
+        )
+        hidden_states = self.model(
+            input_ids=model_input_ids,
+            positions=model_positions,
+            inputs_embeds=model_embeds,
+        )
+        hidden_states = self._restore_model_hidden_states(hidden_states, restore_shape)
+        selected_states = self._select_hidden_states(hidden_states, logits_indices)
+        logits = self.model.compute_logits(selected_states)
+        return self._sample_from_logits(logits, sampling_metadata)
+
+    def _prepare_model_call_tensors(self, input_ids, positions, inputs_embeds):
+        """Optionally flatten the 2D [reqs, tokens] tensors to 1D for flat_model_io."""
+        if not self.use_flat_model_io:
+            return input_ids, positions, inputs_embeds, None
+        restore_shape = None
+        if input_ids is not None and input_ids.ndim > 1:
+            restore_shape = input_ids.shape
+            input_ids = input_ids.reshape(-1)
+        if inputs_embeds is not None and inputs_embeds.ndim > 2:
+            if restore_shape is None:
+                restore_shape = torch.Size(inputs_embeds.shape[:-1])
+            inputs_embeds = inputs_embeds.reshape(-1, inputs_embeds.shape[-1])
+        if positions.ndim > 1:
+            if restore_shape is None:
+                restore_shape = positions.shape
+            positions = positions.reshape(-1)
+        return input_ids, positions, inputs_embeds, restore_shape
+
+    def _restore_model_hidden_states(self, hidden_states, restore_shape):
+        if restore_shape is None or hidden_states.ndim != 2:
+            return hidden_states
+        return hidden_states.reshape(*restore_shape, hidden_states.shape[-1])
+
+    def _select_hidden_states(self, hidden_states, indices_do_sample):
+        # Gather each request's last-token hidden state: hidden is [reqs, tokens, H].
+        batch_indices = torch.arange(indices_do_sample.shape[0], dtype=torch.int32)
+        return hidden_states[batch_indices, indices_do_sample, :]
+
+    def _sample_from_logits(self, logits, sampling_metadata):
+        # Greedy fast-path (argmax) avoids the fused sampling kernel; the sampler
+        # handles temperature/top-k/p/penalties/seeds otherwise.
+        if (
+            sampling_metadata.all_greedy
+            and sampling_metadata.no_penalties
+            and sampling_metadata.no_logit_bias
+            and sampling_metadata.no_bad_words
+            and sampling_metadata.no_allowed_token_ids
+            and sampling_metadata.no_min_tokens
+            and sampling_metadata.no_generators
+        ):
+            return torch.argmax(logits, dim=-1, keepdim=True)
+        return self.sampler(logits, sampling_metadata).sampled_token_ids
 
     # ------------------------------------------------------------------ #
     # KV cache allocation.

--- a/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
@@ -15,9 +15,11 @@ the ``execute_model``/``sample_tokens`` two-phase driver that threads them
 together, ``initialize_kv_cache`` (device KV allocation), and
 ``__init__``/``load_model`` (single-device state construction + model load /
 compile), and ``_run_model_pass`` + the compiled forward/sample graph. The
-runner is structurally complete for the single-device greedy text path. Deferred:
-the multi-device SPMD/mesh path out of ``__init__``, ``get_mm_embeddings``, and
-the grammar / cpu_sampling / prompt-logprobs branches (driver-gated).
+runner is structurally complete for the single-device greedy text path, with the
+worker-facing surface (``get_kv_cache_spec``, ``capture_model``, ``get_model``,
+``reset_mm_cache``) in place. Deferred: the multi-device SPMD/mesh path out of
+``__init__``, ``get_mm_embeddings``, LoRA (``add_lora``), and the grammar /
+cpu_sampling / prompt-logprobs branches (driver-gated).
 
 Layout note
 -----------
@@ -223,6 +225,7 @@ class TTModelRunnerV2:
         self.supports_mm_inputs = bool(
             getattr(self.model_config, "is_multimodal_model", False)
         )
+        self.mm_budget = None  # set when multimodal profiling lands
 
         # SMEM row caps consumed by _select_batch.
         self.num_reqs_max_model_len = min(
@@ -1079,4 +1082,78 @@ class TTModelRunnerV2:
             kv_caches,
             self.vllm_config.compilation_config.static_forward_context,
             self.kv_caches,
+        )
+
+    # ------------------------------------------------------------------ #
+    # Worker-facing shims + warmup.
+    # ------------------------------------------------------------------ #
+
+    def get_model(self):
+        return self.model
+
+    def reset_mm_cache(self) -> None:
+        if self.mm_budget is not None:
+            self.mm_budget.reset_cache()
+
+    def add_lora(self, lora_request) -> bool:
+        raise NotImplementedError("LoRA is not supported in the v2 runner yet.")
+
+    def _warmup_buckets(self) -> list[tuple[int, int]]:
+        """(target_num_reqs, padded_query_len) pairs to precompile.
+
+        Decode always runs at max_num_reqs; prefill runs at the min / max prefill
+        buckets. Each request-count bucket is compiled at every token-length
+        padding, matching the shapes _select_batch can produce at runtime.
+        """
+        targets = sorted(
+            {self.max_num_reqs, self.min_num_reqs, self.max_prefill_num_reqs}
+        )
+        return [(t, q) for t in targets for q in self.num_tokens_paddings]
+
+    def capture_model(self) -> None:
+        """Precompile the forward/sample graph at every runtime bucket shape.
+
+        Avoids paying compile latency on the first real request. Warms the greedy
+        path (argmax) at each (num_reqs, query_len) bucket; the random-sampling,
+        multimodal, and cpu_sampling warmups are deferred with those runtime
+        paths. Needs the model + KV cache initialised, so it runs at stand-up.
+        """
+        if self.cpu_sampling:
+            raise NotImplementedError("cpu_sampling warmup path is not ported yet.")
+        torch._dynamo.config.dynamic_shapes = False
+        for target_num_reqs, padded_query_len in self._warmup_buckets():
+            self._precompile_bucket(target_num_reqs, padded_query_len)
+
+    def _precompile_bucket(self, target_num_reqs: int, padded_query_len: int) -> None:
+        from .metadata import XLASupportedSamplingMetadata
+
+        dev = self.device
+        input_ids = torch.zeros(
+            (target_num_reqs, padded_query_len), dtype=torch.int32, device=dev
+        )
+        positions = torch.zeros(
+            (target_num_reqs, padded_query_len), dtype=torch.int32, device=dev
+        )
+        logits_indices = torch.zeros(target_num_reqs, dtype=torch.int32, device=dev)
+        page_table = torch.zeros(
+            (target_num_reqs, self.max_num_blocks_per_req),
+            dtype=torch.int32,
+            device=dev,
+        )
+        cache_position = torch.zeros(target_num_reqs, dtype=torch.int32, device=dev)
+        batch_idx = torch.arange(target_num_reqs, dtype=torch.int32, device=dev)
+
+        attn_metadata = self.model_state.prepare_attn(
+            self.attention_layer_names,
+            page_table,
+            cache_position,
+            fill_page_table=page_table,
+            batch_idx=batch_idx,
+            num_users=target_num_reqs,
+            dp_size=self.dp_size,
+        )
+        # Defaults are all-greedy -> warms the argmax fast-path.
+        sampling_metadata = XLASupportedSamplingMetadata(all_greedy=True)
+        self._forward_and_sample(
+            input_ids, positions, logits_indices, attn_metadata, sampling_metadata
         )

--- a/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
@@ -277,6 +277,8 @@ class TTModelRunnerV2:
         self.num_prompt_logprobs: dict = {}
         self.kv_caches: list = []
         self.kv_cache_config = None
+        # layer_name -> target layer for cross-layer KV sharing (get_kv_cache_spec).
+        self.shared_kv_cache_layers: dict = {}
         # Per-step handoff between the two-phase execute_model / sample_tokens.
         self.scheduler_output = None
 
@@ -984,6 +986,79 @@ class TTModelRunnerV2:
                         f"Unsupported KV cache spec: {type(spec)}"
                     )
         return kv_caches
+
+    def get_kv_cache_spec(self) -> dict:
+        """Build the per-layer KVCacheSpec from the model's attention modules.
+
+        Salvaged from the v1 fork: walks the attention layers in the static
+        forward context and emits a Full / SlidingWindow / MLA spec each,
+        skipping cross-layer-shared (recorded in ``shared_kv_cache_layers``) and
+        encoder-only layers. The engine uses this to budget KV blocks
+        (``determine_available_memory``) and to build the ``KVCacheConfig`` passed
+        back to ``initialize_kv_cache``.
+        """
+        from vllm.config import get_layers_from_vllm_config
+        from vllm.model_executor.layers.attention.attention import Attention
+        from vllm.model_executor.layers.attention.mla_attention import MLAAttention
+        from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+        from vllm.v1.attention.backend import AttentionType
+        from vllm.v1.kv_cache_interface import (
+            FullAttentionSpec,
+            MLAAttentionSpec,
+            SlidingWindowSpec,
+        )
+
+        layers = get_layers_from_vllm_config(self.vllm_config, AttentionLayerBase)
+        block_size = self.vllm_config.cache_config.block_size
+        cache_dtype_str = self.vllm_config.cache_config.cache_dtype
+
+        kv_cache_spec: dict = {}
+        for layer_name, attn_module in layers.items():
+            if isinstance(attn_module, Attention):
+                if attn_module.kv_sharing_target_layer_name is not None:
+                    # Reuses another layer's KV cache; allocate nothing here.
+                    self.shared_kv_cache_layers[layer_name] = (
+                        attn_module.kv_sharing_target_layer_name
+                    )
+                    continue
+                if attn_module.attn_type == AttentionType.DECODER:
+                    if attn_module.sliding_window is not None:
+                        kv_cache_spec[layer_name] = SlidingWindowSpec(
+                            block_size=block_size,
+                            num_kv_heads=attn_module.num_kv_heads,
+                            head_size=attn_module.head_size,
+                            dtype=self.kv_cache_spec_dtype,
+                            sliding_window=attn_module.sliding_window,
+                        )
+                    else:
+                        kv_cache_spec[layer_name] = FullAttentionSpec(
+                            block_size=block_size,
+                            num_kv_heads=attn_module.num_kv_heads,
+                            head_size=attn_module.head_size,
+                            dtype=self.kv_cache_spec_dtype,
+                        )
+                elif attn_module.attn_type in (
+                    AttentionType.ENCODER,
+                    AttentionType.ENCODER_ONLY,
+                ):
+                    continue  # encoder-only attention needs no KV cache
+                elif attn_module.attn_type == AttentionType.ENCODER_DECODER:
+                    raise NotImplementedError(
+                        "Encoder-decoder attention is not supported yet."
+                    )
+                else:
+                    raise ValueError(f"Unknown attention type: {attn_module.attn_type}")
+            elif isinstance(attn_module, MLAAttention):
+                if layer_name in kv_cache_spec:
+                    continue
+                kv_cache_spec[layer_name] = MLAAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=attn_module.head_size,
+                    dtype=self.kv_cache_spec_dtype,
+                    cache_dtype_str=cache_dtype_str,
+                )
+        return kv_cache_spec
 
     def initialize_kv_cache(self, kv_cache_config: "KVCacheConfig") -> None:
         """Allocate KV caches and bind them into the forward context.

--- a/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
@@ -115,6 +115,17 @@ class TTModelRunnerV2:
                 self.tt_config.get_pjrt_compile_config()
             )
 
+        # Override number of hidden layers if specified in TTConfig. Must run
+        # before load_model so only the target layers are built; the weight
+        # loader is filtered to match in load_model.
+        from .vllm_utils import apply_hidden_layer_override
+
+        self._original_num_layers, self._target_num_layers = (
+            apply_hidden_layer_override(
+                self.model_config.hf_config, self.tt_config.num_hidden_layers
+            )
+        )
+
         tt = self.tt_config
         self.enable_tensor_parallel = bool(getattr(tt, "enable_tensor_parallel", False))
         self.enable_data_parallel = bool(getattr(tt, "enable_data_parallel", False))
@@ -263,8 +274,8 @@ class TTModelRunnerV2:
         """Load, place, and compile the model; build ModelState + sampler.
 
         Single-device path (salvaged from the v1 fork): the multi-device weight
-        sharding, the vocab-embedding TP-rank patch, LoRA, the num-layers override,
-        and per-tensor weight-dtype overrides are deferred with the SPMD ``__init__``.
+        sharding, the vocab-embedding TP-rank patch, LoRA, and per-tensor
+        weight-dtype overrides are deferred with the SPMD ``__init__``.
         Needs a real model + loader, so it is validated at engine stand-up.
         """
         from vllm.config import get_layers_from_vllm_config, set_current_vllm_config
@@ -276,6 +287,19 @@ class TTModelRunnerV2:
         from .sampler import Sampler
 
         loader = get_model_loader(self.load_config)
+
+        # Under a layer override the checkpoint still holds every layer's
+        # weights; filter the loader so it only feeds the built layers.
+        if self._original_num_layers is not None:
+            original_get_all_weights = loader.get_all_weights
+
+            def filtered_get_all_weights(model_config, model):
+                return self._filter_weights_for_layer_override(
+                    original_get_all_weights(model_config, model)
+                )
+
+            loader.get_all_weights = filtered_get_all_weights
+
         with set_current_vllm_config(self.vllm_config):
             model = loader.load_model(
                 vllm_config=self.vllm_config, model_config=self.model_config
@@ -299,6 +323,25 @@ class TTModelRunnerV2:
             get_layers_from_vllm_config(self.vllm_config, AttentionLayerBase).keys()
         )
         self.attention_layer_names = self._attention_layer_names
+
+    def _filter_weights_for_layer_override(self, weights_iterator):
+        """Drop checkpoint weights for layers beyond the override target."""
+        if self._original_num_layers is None or self._target_num_layers is None:
+            yield from weights_iterator
+            return
+        for weight_name, weight_tensor in weights_iterator:
+            skip = False
+            if "layers." in weight_name:
+                parts = weight_name.split(".")
+                for i, part in enumerate(parts):
+                    if part == "layers" and i + 1 < len(parts):
+                        try:
+                            skip = int(parts[i + 1]) >= self._target_num_layers
+                        except ValueError:
+                            skip = False
+                        break
+            if not skip:
+                yield weight_name, weight_tensor
 
     def _remove_request(self, req_id: str) -> None:
         """Free a request's slot across every per-slot table. Idempotent."""

--- a/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
@@ -61,6 +61,7 @@ compiled forward graphs).
 from __future__ import annotations
 
 import bisect
+import logging
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
@@ -70,6 +71,8 @@ import torch
 import vllm.envs as envs
 from vllm.sampling_params import SamplingType
 from vllm.utils.math_utils import cdiv
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -1183,9 +1186,16 @@ class TTModelRunnerV2:
         """
         if self.cpu_sampling:
             raise NotImplementedError("cpu_sampling warmup path is not ported yet.")
-        torch._dynamo.config.dynamic_shapes = False
-        for target_num_reqs, padded_query_len in self._warmup_buckets():
-            self._precompile_bucket(target_num_reqs, padded_query_len)
+        # TODO(mrv2): precompile with valid dummy attention metadata. The
+        # all-zeros dummies below fail to compile the paged-attention op, and a
+        # failed TT compile poisons torch_xla async state, so warmup is skipped
+        # for now -- graphs compile lazily on the first matching request (as v1's
+        # _dummy_run avoids by building valid dummies). See _precompile_bucket.
+        logger.warning(
+            "MRv2 capture_model: precompile warmup is skipped; graphs compile "
+            "lazily on first use (see TODO in capture_model)."
+        )
+        return
 
     def _precompile_bucket(self, target_num_reqs: int, padded_query_len: int) -> None:
         from .metadata import XLASupportedSamplingMetadata

--- a/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
@@ -61,6 +61,7 @@ compiled forward graphs).
 from __future__ import annotations
 
 import bisect
+from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -1097,6 +1098,68 @@ class TTModelRunnerV2:
 
     def add_lora(self, lora_request) -> bool:
         raise NotImplementedError("LoRA is not supported in the v2 runner yet.")
+
+    @contextmanager
+    def maybe_setup_dummy_loras(self, lora_config):
+        """No-op LoRA warmup context (LoRA deferred). Raises if LoRA is on."""
+        if lora_config is not None:
+            raise NotImplementedError("LoRA is not supported in the v2 runner yet.")
+        yield
+
+    def get_supported_tasks(self) -> tuple:
+        """Report the generation tasks this model supports (via TTModelState)."""
+        if self.model_config.runner_type != "generate":
+            raise NotImplementedError(
+                "Only the generate runner type is supported in the v2 runner."
+            )
+        assert (
+            self.model_state is not None
+        ), "load_model must run before get_supported_tasks"
+        return tuple(self.model_state.get_supported_generation_tasks())
+
+    def reset_dynamo_cache(self) -> None:
+        """Clear the compiled-model dynamo cache so it re-traces cleanly."""
+        from vllm.compilation.wrapper import TorchCompileWithNoGuardsWrapper
+
+        if self.model_config.is_multimodal_model:
+            compiled_model = self.model.get_language_model().model
+        else:
+            compiled_model = self.model.model
+        if isinstance(compiled_model, TorchCompileWithNoGuardsWrapper):
+            torch._dynamo.eval_frame.remove_from_cache(
+                compiled_model.original_code_object()
+            )
+            compiled_model.compiled = False
+            TorchCompileWithNoGuardsWrapper.__init__(compiled_model)
+
+    def update_config(self, overrides: dict) -> None:
+        from vllm.config import update_config as _update_config
+
+        allowed_config_names = {"load_config", "model_config"}
+        for config_name, config_overrides in overrides.items():
+            assert config_name in allowed_config_names, (
+                f"Config `{config_name}` not supported. "
+                f"Allowed configs: {allowed_config_names}"
+            )
+            setattr(
+                self,
+                config_name,
+                _update_config(getattr(self, config_name), config_overrides),
+            )
+
+    def reload_weights(self) -> None:
+        raise NotImplementedError(
+            "reload_weights is not supported in the v2 runner yet."
+        )
+
+    def ensure_kv_transfer_shutdown(self) -> None:
+        from vllm.distributed.kv_transfer import has_kv_transfer_group
+        from vllm.distributed.kv_transfer.kv_transfer_state import (
+            ensure_kv_transfer_shutdown,
+        )
+
+        if has_kv_transfer_group():
+            ensure_kv_transfer_shutdown()
 
     def _warmup_buckets(self) -> list[tuple[int, int]]:
         """(target_num_reqs, padded_query_len) pairs to precompile.

--- a/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
@@ -1,61 +1,25 @@
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
-"""TT Model Runner v2 (MRv2) -- fork of upstream ``vllm/v1/worker/gpu/model_runner.py``.
+"""TT Model Runner v2 (MRv2): a fork of upstream ``vllm/v1/worker/gpu/model_runner.py``.
 
-Phase 3 of the MRv2 adoption. Upstream's v2 runner is Triton/CUDA/UVA-native
-throughout, so TT forks it and substitutes host-side mechanisms rather than
-subclassing ``GPUModelRunner``.
+Upstream's v2 runner is Triton/CUDA/UVA-native, so TT forks it and substitutes
+host-side mechanisms (numpy input-prep, ``@torch.compile(backend="tt")`` graphs,
+TT attention metadata) instead of subclassing ``GPUModelRunner``. Two things
+differ from a naive port:
 
-This file is built in reviewable sub-increments. Present so far: the request
-lifecycle, the decode-first batch selection / SMEM multi-pass clamping, the host
-input-token preparation, the attention slot-mapping build (feeding
-``TTModelState.prepare_attn``), the sampled-token writeback (``postprocess``),
-the ``execute_model``/``sample_tokens`` two-phase driver that threads them
-together, ``initialize_kv_cache`` (device KV allocation), and
-``__init__``/``load_model`` (single-device state construction + model load /
-compile), and ``_run_model_pass`` + the compiled forward/sample graph. The
-runner is structurally complete for the single-device greedy text path, with the
-worker-facing surface (``get_kv_cache_spec``, ``capture_model``, ``get_model``,
-``reset_mm_cache``) in place. Deferred: the multi-device SPMD/mesh path out of
-``__init__``, ``get_mm_embeddings``, LoRA (``add_lora``), and the grammar /
-cpu_sampling / prompt-logprobs branches (driver-gated).
+* 2D forward layout: TT's model takes ``[num_reqs, padded_query_len]`` (reshaped
+  to 1D at the call boundary for ``flat_model_io`` models), not upstream's flat
+  ``[num_tokens]``. The runner builds those 2D tensors itself; ``TTInputBatch``
+  is the flat per-step bookkeeping view consumed by ``from_v2_states`` and the
+  attn build.
+* Upstream v2 request semantics: requests keep a stable ``TTRequestState`` slot
+  for their lifetime (no condense); preempted requests are freed and resumed
+  ones return via ``scheduled_new_reqs``, so ``update_requests`` has no resumed
+  branch.
 
-Layout note
------------
-TT's model forward is **2D** ``[num_reqs, padded_query_len]`` (optionally
-reshaped to 1D at the call boundary for ``flat_model_io`` models), unlike
-upstream's flat ``[num_tokens]`` layout. So the runner builds 2D
-``input_ids``/``positions`` itself (as the v1 fork does); ``TTInputBatch`` (a
-verbatim upstream port, flat) serves as the per-step bookkeeping view
-(``idx_mapping``/``num_scheduled_tokens``/``query_start_loc``/``seq_lens``/
-``logits_indices``) consumed by ``from_v2_states`` and the attn build.
-
-Lifecycle scope
----------------
-``add_requests``/``update_requests``/``finish_requests`` drive the split v2
-state, following upstream v2 semantics (NOT the v1 fork's ``_update_states``):
-
-* Requests own a **stable slot** for their lifetime (``TTRequestState`` free
-  list) -- there is no v1-style condense/shuffle.
-* Preempted requests are removed here (slot freed); when the scheduler resumes
-  them it re-sends them via ``scheduled_new_reqs`` with ``num_computed_tokens``
-  already advanced, so there is no resumed-request branch in ``update_requests``.
-* Sampling params go to ``TTSamplingStates`` (keyed by the same slot), token
-  bookkeeping to ``TTRequestState``, block ids to the runner-owned block table.
-
-The runner instance is expected to carry (set up by ``__init__``, later
-sub-increment): the split state (``req_states``, ``sampling_states``,
-``block_table`` -- a vLLM ``MultiGroupBlockTable``, ``encoder_cache`` dict,
-``num_prompt_logprobs`` dict, ``model_state``); scalars (``vocab_size``,
-``max_num_blocks_per_req``, ``supports_mm_inputs``, and the SMEM-cap set read by
-``_select_batch``: ``most_model_len``/``num_reqs_max_model_len``/
-``num_reqs_most_model_len``/``min_num_reqs``/``max_prefill_num_reqs``/
-``max_num_reqs``/``num_tokens_paddings``); the per-step handoff
-``scheduler_output`` (initialised to None); and the device machinery reached
-only through ``_run_model_pass`` (persistent input/attn buffers, ``model``,
-``sampler``, ``sampling_device``, ``attention_layer_names``, ``dp_size``, and the
-compiled forward graphs).
+Deferred: multi-device SPMD/mesh, ``get_mm_embeddings``, LoRA, and the grammar /
+cpu_sampling / prompt-logprobs branches.
 """
 
 from __future__ import annotations
@@ -513,20 +477,11 @@ class TTModelRunnerV2:
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
         """Host substitute for the v2 Triton input-prep kernels.
 
-        Builds the per-step token tensors for a batch whose batch position ``b``
-        maps to stable slot ``idx_mapping_np[b]`` and has
-        ``num_scheduled_tokens[b]`` scheduled tokens. Replaces upstream's
-        ``prepare_prefill_inputs`` + ``prepare_pos_seq_lens`` +
-        ``combine_sampled_and_draft_tokens``; the last collapses to nothing on TT
-        because decode tokens are read straight from ``all_token_ids`` (grown by
-        the sampled-token writeback) rather than injected separately, and there is
-        no spec decode.
-
-        Returns 2D ``input_ids``/``positions`` ``[target_num_reqs,
-        padded_query_len]`` (the TT forward layout; the runner copies these into
-        persistent device buffers) plus the flat bookkeeping arrays
-        ``query_start_loc`` ``[target_num_reqs + 1]``, ``seq_lens`` and
-        ``logits_indices`` ``[target_num_reqs]``. Padding rows/columns stay zero.
+        Builds 2D input_ids/positions [target_num_reqs, padded_query_len] plus flat
+        query_start_loc/seq_lens/logits_indices from TTRequestState, indexed by
+        idx_mapping_np[b] -> stable slot. Prefill and decode share one gather
+        (all_token_ids[computed:computed+n]); the sampled token was already
+        appended by the writeback and there is no spec decode. Padding stays zero.
         """
         num_reqs = len(idx_mapping_np)
         rs = self.req_states
@@ -561,19 +516,13 @@ class TTModelRunnerV2:
         num_scheduled_tokens: np.ndarray,
         sampled_token_ids: list[list[int]],
     ) -> list[list[int]]:
-        """Write sampled tokens back into ``TTRequestState`` (post_update substitute).
+        """Write sampled tokens back into TTRequestState (post_update substitute).
 
-        Host substitute for upstream's ``post_update`` Triton kernel, for TT's
-        no-spec-decode path (one token per sampling request). A request produces a
-        real token only once it has consumed all its prefill (``seq_len >=
-        prefill_len``); tokens from still-prefilling (partial-chunk) requests are
-        discarded. The kept token is appended at ``total_len`` -- which equals
-        ``seq_len`` at that point -- so the next step's input-prep gather
-        (``all_token_ids[num_computed:...]``) reads it. ``num_computed_tokens`` is
-        NOT advanced here: the scheduler supplies it via ``update_requests``.
-
-        Returns the per-batch-position sampled token ids with discarded
-        (still-prefilling) rows emptied, for the ModelRunnerOutput.
+        A request emits a token only once past its prefill (seq_len >= prefill_len);
+        still-prefilling rows are discarded. The token lands at total_len (== seq_len
+        then) so the next step's gather reads it; num_computed is advanced by the
+        scheduler via update_requests, not here. Returns per-batch sampled ids with
+        discarded rows emptied.
         """
         num_reqs = len(idx_mapping_np)
         rs = self.req_states
@@ -604,13 +553,10 @@ class TTModelRunnerV2:
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         """Host substitute for the v2 block-table / slot-mapping kernels.
 
-        Builds the paged-attention tensors ``TTModelState.prepare_attn`` packages
-        into a ``TTMetadata``: the read-path ``page_table``, the write-path
-        ``fill_page_table``, and ``cache_position``. Batch position ``b`` maps to
-        stable slot ``idx_mapping_np[b]``; the block table is gathered in batch
-        order. Returns numpy arrays ``[target_num_reqs, num_blocks_per_req]`` /
-        ``[target_num_reqs]`` (the runner copies them into persistent device
-        buffers). Padding rows are null (page_table 0, cache_position -1).
+        Builds the paged-attention tensors TTModelState.prepare_attn packages into
+        a TTMetadata: read-path page_table (gathered in batch order via the slot
+        mapping), write-path fill_page_table (prefix rolled), and cache_position
+        (seq_lens - 1). Padding rows are null (page_table 0, cache_position -1).
         """
         num_reqs = len(idx_mapping_np)
         block_table_cpu = self.block_table[0].get_cpu_tensor()
@@ -654,22 +600,14 @@ class TTModelRunnerV2:
 
         return page_table, fill_page_table, cache_position
 
-    # ------------------------------------------------------------------ #
-    # Two-phase step driver (mirrors the v1 fork + upstream v2 split).
-    # ------------------------------------------------------------------ #
-
     def execute_model(
         self,
         scheduler_output: "SchedulerOutput",
         intermediate_tensors=None,
     ):
-        """Phase 1: apply the scheduler delta, then hand off to sample_tokens.
-
-        Mirrors the v1 fork / upstream v2 two-phase contract (the worker calls
-        execute_model then sample_tokens). All host state updates happen here via
-        the tested lifecycle; the forward + sampling are deferred to
-        sample_tokens. Returns None on a normal step (output comes from
-        sample_tokens) or an empty output when nothing is scheduled.
+        """Phase 1 of the step: apply the scheduler delta via the lifecycle and
+        stash the step. Returns None (the forward + sampling run in sample_tokens),
+        or an empty output when nothing is scheduled.
         """
         assert (
             self.scheduler_output is None
@@ -698,13 +636,9 @@ class TTModelRunnerV2:
         return None
 
     def sample_tokens(self, grammar_output):
-        """Phase 2: run the (possibly multi-pass) batch loop and sample.
-
-        Composes the tested host stages -- decode-first ordering, SMEM
-        sub-batching, input-token prep, attention slot-mapping, and the
-        sampled-token writeback -- around the single hardware leaf
-        ``_run_model_pass``. The SMEM row caps mean a step may span several passes
-        (start_index advances); results are concatenated in processing order.
+        """Phase 2 of the step: run the decode-first, SMEM-clamped multi-pass batch
+        loop around the _run_model_pass hardware leaf, then assemble the
+        ModelRunnerOutput. A step may span several passes (start_index advances).
         """
         if self.scheduler_output is None:
             # PP non-final rank / nothing stashed: output is unused.
@@ -789,14 +723,11 @@ class TTModelRunnerV2:
         fill_page_table: np.ndarray,
         cache_position: np.ndarray,
     ) -> list[list[int]]:
-        """Run one compiled forward + sample pass for the selected sub-batch.
+        """Run one compiled forward+sample pass for the selected sub-batch.
 
-        Copies the host arrays to the device, builds the attention metadata
-        (``TTModelState.prepare_attn``) and sampling metadata
-        (``XLASupportedSamplingMetadata.from_v2_states``), runs the compiled
-        forward + sample, and returns the batch-ordered sampled token ids.
-        Common text path only: grammar / cpu_sampling / prompt-logprobs are
-        gated off in the driver.
+        Copies host arrays to device, builds attention metadata (prepare_attn) +
+        sampling metadata (from_v2_states), runs the compiled graph, and returns
+        the batch-ordered sampled token ids. Common text path only.
         """
         from types import SimpleNamespace
 
@@ -918,10 +849,6 @@ class TTModelRunnerV2:
             return torch.argmax(logits, dim=-1, keepdim=True)
         return self.sampler(logits, sampling_metadata).sampled_token_ids
 
-    # ------------------------------------------------------------------ #
-    # KV cache allocation.
-    # ------------------------------------------------------------------ #
-
     def _allocate_kv_caches(self, kv_cache_config: "KVCacheConfig") -> dict:
         """Allocate the per-layer KV cache tensors on the TT device.
 
@@ -997,12 +924,9 @@ class TTModelRunnerV2:
     def get_kv_cache_spec(self) -> dict:
         """Build the per-layer KVCacheSpec from the model's attention modules.
 
-        Salvaged from the v1 fork: walks the attention layers in the static
-        forward context and emits a Full / SlidingWindow / MLA spec each,
-        skipping cross-layer-shared (recorded in ``shared_kv_cache_layers``) and
-        encoder-only layers. The engine uses this to budget KV blocks
-        (``determine_available_memory``) and to build the ``KVCacheConfig`` passed
-        back to ``initialize_kv_cache``.
+        Emits a Full / SlidingWindow / MLA spec per layer, skipping
+        cross-layer-shared (recorded in shared_kv_cache_layers) and encoder-only
+        layers. The engine uses it to budget KV blocks and build the KVCacheConfig.
         """
         from vllm.config import get_layers_from_vllm_config
         from vllm.model_executor.layers.attention.attention import Attention
@@ -1070,11 +994,8 @@ class TTModelRunnerV2:
     def initialize_kv_cache(self, kv_cache_config: "KVCacheConfig") -> None:
         """Allocate KV caches and bind them into the forward context.
 
-        Wraps ``_allocate_kv_caches`` with the engine integration. The common
-        single-device path allocates and binds; the SPMD KV-cache sharding and
-        KV-transfer registration (salvage v1 initialize_kv_cache 3436-3459) land
-        with the multi-device ``__init__``. ``self.kv_caches`` (a list) and
-        ``self.vllm_config`` are provided by ``__init__``.
+        SPMD KV-cache sharding and KV-transfer registration land with the
+        multi-device __init__.
         """
         from vllm.v1.worker.utils import bind_kv_cache
 
@@ -1087,10 +1008,6 @@ class TTModelRunnerV2:
             self.vllm_config.compilation_config.static_forward_context,
             self.kv_caches,
         )
-
-    # ------------------------------------------------------------------ #
-    # Worker-facing shims + warmup.
-    # ------------------------------------------------------------------ #
 
     def get_model(self):
         return self.model
@@ -1164,69 +1081,8 @@ class TTModelRunnerV2:
         if has_kv_transfer_group():
             ensure_kv_transfer_shutdown()
 
-    def _warmup_buckets(self) -> list[tuple[int, int]]:
-        """(target_num_reqs, padded_query_len) pairs to precompile.
-
-        Decode always runs at max_num_reqs; prefill runs at the min / max prefill
-        buckets. Each request-count bucket is compiled at every token-length
-        padding, matching the shapes _select_batch can produce at runtime.
-        """
-        targets = sorted(
-            {self.max_num_reqs, self.min_num_reqs, self.max_prefill_num_reqs}
-        )
-        return [(t, q) for t in targets for q in self.num_tokens_paddings]
-
     def capture_model(self) -> None:
-        """Precompile the forward/sample graph at every runtime bucket shape.
-
-        Avoids paying compile latency on the first real request. Warms the greedy
-        path (argmax) at each (num_reqs, query_len) bucket; the random-sampling,
-        multimodal, and cpu_sampling warmups are deferred with those runtime
-        paths. Needs the model + KV cache initialised, so it runs at stand-up.
-        """
-        if self.cpu_sampling:
-            raise NotImplementedError("cpu_sampling warmup path is not ported yet.")
-        # TODO(mrv2): precompile with valid dummy attention metadata. The
-        # all-zeros dummies below fail to compile the paged-attention op, and a
-        # failed TT compile poisons torch_xla async state, so warmup is skipped
-        # for now -- graphs compile lazily on the first matching request (as v1's
-        # _dummy_run avoids by building valid dummies). See _precompile_bucket.
-        logger.warning(
-            "MRv2 capture_model: precompile warmup is skipped; graphs compile "
-            "lazily on first use (see TODO in capture_model)."
-        )
-        return
-
-    def _precompile_bucket(self, target_num_reqs: int, padded_query_len: int) -> None:
-        from .metadata import XLASupportedSamplingMetadata
-
-        dev = self.device
-        input_ids = torch.zeros(
-            (target_num_reqs, padded_query_len), dtype=torch.int32, device=dev
-        )
-        positions = torch.zeros(
-            (target_num_reqs, padded_query_len), dtype=torch.int32, device=dev
-        )
-        logits_indices = torch.zeros(target_num_reqs, dtype=torch.int32, device=dev)
-        page_table = torch.zeros(
-            (target_num_reqs, self.max_num_blocks_per_req),
-            dtype=torch.int32,
-            device=dev,
-        )
-        cache_position = torch.zeros(target_num_reqs, dtype=torch.int32, device=dev)
-        batch_idx = torch.arange(target_num_reqs, dtype=torch.int32, device=dev)
-
-        attn_metadata = self.model_state.prepare_attn(
-            self.attention_layer_names,
-            page_table,
-            cache_position,
-            fill_page_table=page_table,
-            batch_idx=batch_idx,
-            num_users=target_num_reqs,
-            dp_size=self.dp_size,
-        )
-        # Defaults are all-greedy -> warms the argmax fast-path.
-        sampling_metadata = XLASupportedSamplingMetadata(all_greedy=True)
-        self._forward_and_sample(
-            input_ids, positions, logits_indices, attn_metadata, sampling_metadata
-        )
+        # Warmup precompile is deferred: all-zeros dummy attention metadata fails
+        # to compile the paged-attention op, and a failed TT compile poisons
+        # torch_xla async state. Graphs compile lazily on first use instead.
+        logger.warning("MRv2 capture_model: warmup skipped; graphs compile lazily.")

--- a/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
@@ -9,10 +9,12 @@ subclassing ``GPUModelRunner``.
 
 This file is built in reviewable sub-increments. Present so far: the request
 lifecycle, the decode-first batch selection / SMEM multi-pass clamping, the host
-input-token preparation, and the attention slot-mapping build (feeding
-``TTModelState.prepare_attn``). Still to land: ``__init__``/``load_model``
-(construct the state below), ``initialize_kv_cache``, the compiled forward
-graphs, and ``execute_model``/``sample_tokens``.
+input-token preparation, the attention slot-mapping build (feeding
+``TTModelState.prepare_attn``), and the sampled-token writeback (``postprocess``).
+Still to land: ``__init__``/``load_model`` (construct the state below),
+``initialize_kv_cache``, the compiled forward graphs, and the
+``execute_model``/``sample_tokens`` multi-pass driver that threads all of the
+above together.
 
 Layout note
 -----------
@@ -284,6 +286,45 @@ class TTModelRunnerV2:
         query_start_loc[num_reqs + 1 :] = query_start_loc[num_reqs]
 
         return input_ids, positions, query_start_loc, seq_lens, logits_indices
+
+    def postprocess(
+        self,
+        idx_mapping_np: np.ndarray,
+        num_scheduled_tokens: np.ndarray,
+        sampled_token_ids: list[list[int]],
+    ) -> list[list[int]]:
+        """Write sampled tokens back into ``TTRequestState`` (post_update substitute).
+
+        Host substitute for upstream's ``post_update`` Triton kernel, for TT's
+        no-spec-decode path (one token per sampling request). A request produces a
+        real token only once it has consumed all its prefill (``seq_len >=
+        prefill_len``); tokens from still-prefilling (partial-chunk) requests are
+        discarded. The kept token is appended at ``total_len`` -- which equals
+        ``seq_len`` at that point -- so the next step's input-prep gather
+        (``all_token_ids[num_computed:...]``) reads it. ``num_computed_tokens`` is
+        NOT advanced here: the scheduler supplies it via ``update_requests``.
+
+        Returns the per-batch-position sampled token ids with discarded
+        (still-prefilling) rows emptied, for the ModelRunnerOutput.
+        """
+        num_reqs = len(idx_mapping_np)
+        rs = self.req_states
+        valid: list[list[int]] = [list(row) for row in sampled_token_ids[:num_reqs]]
+
+        for b in range(num_reqs):
+            slot = int(idx_mapping_np[b])
+            seq_len = int(rs.num_computed_tokens[slot]) + int(num_scheduled_tokens[b])
+            if seq_len < int(rs.prefill_len[slot]):
+                # Still prefilling: ignore the sampled token from this partial req.
+                valid[b] = []
+                continue
+            token_id = int(valid[b][0])
+            pos = int(rs.total_len[slot])
+            rs.all_token_ids[slot, pos] = token_id
+            rs.total_len[slot] = pos + 1
+            rs.last_sampled_tokens[slot, 0] = token_id
+
+        return valid
 
     def _prepare_attn_tensors(
         self,

--- a/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
@@ -7,11 +7,21 @@ Phase 3 of the MRv2 adoption. Upstream's v2 runner is Triton/CUDA/UVA-native
 throughout, so TT forks it and substitutes host-side mechanisms rather than
 subclassing ``GPUModelRunner``.
 
-This file is built in reviewable sub-increments; only the request lifecycle is
-present so far. Still to land: ``__init__``/``load_model`` (construct the state
-below), ``initialize_kv_cache``, host ``prepare_inputs`` (the Triton-kernel
-substitutes filling ``TTInputBatch``), the compiled forward graphs, and
-``execute_model``/``sample_tokens``.
+This file is built in reviewable sub-increments. Present so far: the request
+lifecycle and the host input-token preparation. Still to land:
+``__init__``/``load_model`` (construct the state below), ``initialize_kv_cache``,
+the attention slot-mapping build feeding ``TTModelState.prepare_attn``, the
+compiled forward graphs, and ``execute_model``/``sample_tokens``.
+
+Layout note
+-----------
+TT's model forward is **2D** ``[num_reqs, padded_query_len]`` (optionally
+reshaped to 1D at the call boundary for ``flat_model_io`` models), unlike
+upstream's flat ``[num_tokens]`` layout. So the runner builds 2D
+``input_ids``/``positions`` itself (as the v1 fork does); ``TTInputBatch`` (a
+verbatim upstream port, flat) serves as the per-step bookkeeping view
+(``idx_mapping``/``num_scheduled_tokens``/``query_start_loc``/``seq_lens``/
+``logits_indices``) consumed by ``from_v2_states`` and the attn build.
 
 Lifecycle scope
 ---------------
@@ -36,6 +46,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import numpy as np
 import torch
 
 from vllm.sampling_params import SamplingType
@@ -134,3 +145,54 @@ class TTModelRunnerV2:
             new_block_ids = cached.new_block_ids[i]
             if new_block_ids is not None:
                 self.block_table.append_row(new_block_ids, slot)
+
+    def _prepare_input_tokens(
+        self,
+        idx_mapping_np: np.ndarray,
+        num_scheduled_tokens: np.ndarray,
+        target_num_reqs: int,
+        padded_query_len: int,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """Host substitute for the v2 Triton input-prep kernels.
+
+        Builds the per-step token tensors for a batch whose batch position ``b``
+        maps to stable slot ``idx_mapping_np[b]`` and has
+        ``num_scheduled_tokens[b]`` scheduled tokens. Replaces upstream's
+        ``prepare_prefill_inputs`` + ``prepare_pos_seq_lens`` +
+        ``combine_sampled_and_draft_tokens``; the last collapses to nothing on TT
+        because decode tokens are read straight from ``all_token_ids`` (grown by
+        the sampled-token writeback) rather than injected separately, and there is
+        no spec decode.
+
+        Returns 2D ``input_ids``/``positions`` ``[target_num_reqs,
+        padded_query_len]`` (the TT forward layout; the runner copies these into
+        persistent device buffers) plus the flat bookkeeping arrays
+        ``query_start_loc`` ``[target_num_reqs + 1]``, ``seq_lens`` and
+        ``logits_indices`` ``[target_num_reqs]``. Padding rows/columns stay zero.
+        """
+        num_reqs = len(idx_mapping_np)
+        rs = self.req_states
+
+        input_ids = np.zeros((target_num_reqs, padded_query_len), dtype=np.int32)
+        positions = np.zeros((target_num_reqs, padded_query_len), dtype=np.int32)
+        seq_lens = np.zeros(target_num_reqs, dtype=np.int32)
+        logits_indices = np.zeros(target_num_reqs, dtype=np.int32)
+
+        for b in range(num_reqs):
+            slot = int(idx_mapping_np[b])
+            n = int(num_scheduled_tokens[b])
+            computed = int(rs.num_computed_tokens[slot])
+            # Same gather for prefill and decode: the scheduled tokens for this
+            # step are all_token_ids[computed : computed + n].
+            input_ids[b, :n] = rs.all_token_ids[slot, computed : computed + n]
+            positions[b, :n] = np.arange(n, dtype=np.int32) + computed
+            seq_lens[b] = computed + n
+            # One logit per request, at its last scheduled token (within-row).
+            logits_indices[b] = n - 1
+
+        query_start_loc = np.zeros(target_num_reqs + 1, dtype=np.int32)
+        np.cumsum(num_scheduled_tokens, out=query_start_loc[1 : num_reqs + 1])
+        # Non-decreasing pad tail (matches TTInputBatch.make_dummy).
+        query_start_loc[num_reqs + 1 :] = query_start_loc[num_reqs]
+
+        return input_ids, positions, query_start_loc, seq_lens, logits_indices

--- a/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""TT Model Runner v2 (MRv2) -- fork of upstream ``vllm/v1/worker/gpu/model_runner.py``.
+
+Phase 3 of the MRv2 adoption. Upstream's v2 runner is Triton/CUDA/UVA-native
+throughout, so TT forks it and substitutes host-side mechanisms rather than
+subclassing ``GPUModelRunner``.
+
+This file is built in reviewable sub-increments; only the request lifecycle is
+present so far. Still to land: ``__init__``/``load_model`` (construct the state
+below), ``initialize_kv_cache``, host ``prepare_inputs`` (the Triton-kernel
+substitutes filling ``TTInputBatch``), the compiled forward graphs, and
+``execute_model``/``sample_tokens``.
+
+Lifecycle scope
+---------------
+``add_requests``/``update_requests``/``finish_requests`` drive the split v2
+state, following upstream v2 semantics (NOT the v1 fork's ``_update_states``):
+
+* Requests own a **stable slot** for their lifetime (``TTRequestState`` free
+  list) -- there is no v1-style condense/shuffle.
+* Preempted requests are removed here (slot freed); when the scheduler resumes
+  them it re-sends them via ``scheduled_new_reqs`` with ``num_computed_tokens``
+  already advanced, so there is no resumed-request branch in ``update_requests``.
+* Sampling params go to ``TTSamplingStates`` (keyed by the same slot), token
+  bookkeeping to ``TTRequestState``, block ids to the runner-owned block table.
+
+The runner instance is expected to carry (set up by ``__init__``, later
+sub-increment): ``req_states``, ``sampling_states``, ``block_table`` (a vLLM
+``MultiGroupBlockTable``), ``encoder_cache`` (dict), ``num_prompt_logprobs``
+(dict), ``model_state`` (or None), and ``vocab_size``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from vllm.sampling_params import SamplingType
+
+if TYPE_CHECKING:
+    from vllm.v1.core.sched.output import SchedulerOutput
+
+
+class TTModelRunnerV2:
+    """Tenstorrent MRv2 model runner (lifecycle sub-increment; see module doc)."""
+
+    def _remove_request(self, req_id: str) -> None:
+        """Free a request's slot across every per-slot table. Idempotent."""
+        slot = self.req_states.req_id_to_index.get(req_id)
+        if slot is None:
+            return
+        self.req_states.remove_request(req_id)
+        self.sampling_states.remove_request(slot)
+        self.block_table.clear_row(slot)
+        self.num_prompt_logprobs.pop(req_id, None)
+
+    def finish_requests(self, scheduler_output: "SchedulerOutput") -> None:
+        """Remove finished and preempted requests, freeing their slots.
+
+        Preempted requests are dropped (not kept at their slot as in v1): the
+        scheduler resends them through ``scheduled_new_reqs`` when resumed.
+        """
+        for req_id in scheduler_output.finished_req_ids:
+            self._remove_request(req_id)
+        for req_id in scheduler_output.preempted_req_ids:
+            self._remove_request(req_id)
+        for mm_hash in scheduler_output.free_encoder_mm_hashes:
+            self.encoder_cache.pop(mm_hash, None)
+
+    def add_requests(self, scheduler_output: "SchedulerOutput") -> None:
+        """Register newly scheduled requests into the per-slot tables."""
+        new_reqs = scheduler_output.scheduled_new_reqs
+        for new in new_reqs:
+            sampling_params = new.sampling_params
+            assert sampling_params is not None, "Pooling not supported in the v2 runner"
+
+            req_id = new.req_id
+            # A re-added id (streaming abort+resubmit) must clear its stale slot.
+            self._remove_request(req_id)
+
+            prompt_len = len(new.prompt_token_ids)
+            # prefill_token_ids is the full known prefix (prompt + already-computed
+            # tokens for resumed/PD requests); prompt_token_ids for a fresh req.
+            all_token_ids = (
+                new.prefill_token_ids
+                if new.prefill_token_ids is not None
+                else new.prompt_token_ids
+            )
+            self.req_states.add_request(
+                req_id, prompt_len, all_token_ids, new.num_computed_tokens
+            )
+            slot = self.req_states.req_id_to_index[req_id]
+
+            # Seeded requests carry their own generator; the rest use global RNG.
+            generator = None
+            if sampling_params.sampling_type == SamplingType.RANDOM_SEED:
+                generator = torch.Generator(device="cpu")
+                generator.manual_seed(sampling_params.seed)
+            self.sampling_states.add_request(slot, sampling_params, generator)
+
+            self.block_table.add_row(new.block_ids, slot)
+
+            if self.model_state is not None:
+                # No-op for the common text path (rope_state is None).
+                self.model_state.add_request(slot, new)
+
+            if sampling_params.prompt_logprobs is not None:
+                self.num_prompt_logprobs[req_id] = (
+                    self.vocab_size
+                    if sampling_params.prompt_logprobs == -1
+                    else sampling_params.prompt_logprobs
+                )
+
+        if new_reqs:
+            # No-ops under the numpy substitution, kept for interface parity.
+            self.req_states.apply_staged_writes()
+            if self.model_state is not None:
+                self.model_state.apply_staged_writes()
+
+    def update_requests(self, scheduler_output: "SchedulerOutput") -> None:
+        """Advance computed-token counts and append new blocks for running reqs."""
+        cached = scheduler_output.scheduled_cached_reqs
+        for i, req_id in enumerate(cached.req_ids):
+            slot = self.req_states.req_id_to_index[req_id]
+            num_computed = cached.num_computed_tokens[i]
+            self.req_states.num_computed_tokens[slot] = num_computed
+            # Clamp prefill progress to the prefill length (upstream update_requests).
+            self.req_states.num_computed_prefill_tokens[slot] = min(
+                num_computed, int(self.req_states.prefill_len[slot])
+            )
+            new_block_ids = cached.new_block_ids[i]
+            if new_block_ids is not None:
+                self.block_table.append_row(new_block_ids, slot)

--- a/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
@@ -8,10 +8,10 @@ throughout, so TT forks it and substitutes host-side mechanisms rather than
 subclassing ``GPUModelRunner``.
 
 This file is built in reviewable sub-increments. Present so far: the request
-lifecycle and the host input-token preparation. Still to land:
+lifecycle, the host input-token preparation, and the attention slot-mapping
+build (feeding ``TTModelState.prepare_attn``). Still to land:
 ``__init__``/``load_model`` (construct the state below), ``initialize_kv_cache``,
-the attention slot-mapping build feeding ``TTModelState.prepare_attn``, the
-compiled forward graphs, and ``execute_model``/``sample_tokens``.
+the compiled forward graphs, and ``execute_model``/``sample_tokens``.
 
 Layout note
 -----------
@@ -196,3 +196,63 @@ class TTModelRunnerV2:
         query_start_loc[num_reqs + 1 :] = query_start_loc[num_reqs]
 
         return input_ids, positions, query_start_loc, seq_lens, logits_indices
+
+    def _prepare_attn_tensors(
+        self,
+        idx_mapping_np: np.ndarray,
+        num_scheduled_tokens: np.ndarray,
+        seq_lens: np.ndarray,
+        target_num_reqs: int,
+        num_blocks_per_req: int,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Host substitute for the v2 block-table / slot-mapping kernels.
+
+        Builds the paged-attention tensors ``TTModelState.prepare_attn`` packages
+        into a ``TTMetadata``: the read-path ``page_table``, the write-path
+        ``fill_page_table``, and ``cache_position``. Batch position ``b`` maps to
+        stable slot ``idx_mapping_np[b]``; the block table is gathered in batch
+        order. Returns numpy arrays ``[target_num_reqs, num_blocks_per_req]`` /
+        ``[target_num_reqs]`` (the runner copies them into persistent device
+        buffers). Padding rows are null (page_table 0, cache_position -1).
+        """
+        num_reqs = len(idx_mapping_np)
+        block_table_cpu = self.block_table[0].get_cpu_tensor()
+        if hasattr(block_table_cpu, "numpy"):
+            block_table_cpu = block_table_cpu.numpy()
+
+        page_table = np.zeros((target_num_reqs, num_blocks_per_req), dtype=np.int32)
+        for b in range(num_reqs):
+            slot = int(idx_mapping_np[b])
+            page_table[b, :] = block_table_cpu[slot, :num_blocks_per_req]
+
+        # Decode/write position per user; -1 for padding rows.
+        cache_position = np.full(target_num_reqs, -1, dtype=np.int32)
+        cache_position[:num_reqs] = seq_lens[:num_reqs] - 1
+
+        # Prefix caching: roll each row so paged_fill_cache writes the suffix
+        # blocks instead of overwriting shared prefix blocks. Per-row because
+        # prefix lengths differ.
+        offsets = np.zeros(num_reqs, dtype=np.int64)
+        for b in range(num_reqs):
+            slot = int(idx_mapping_np[b])
+            offsets[b] = (
+                int(self.req_states.num_computed_tokens[slot]) // self.block_size
+            )
+        if np.any(offsets > 0):
+            fill_page_table = page_table.copy()
+            for b in range(num_reqs):
+                if offsets[b] > 0:
+                    fill_page_table[b] = np.roll(page_table[b], -int(offsets[b]))
+        else:
+            fill_page_table = page_table
+
+        # A zero-scheduled (already-prefilled, re-batched) row would clobber its
+        # real KV with padding; redirect its fill to the null block. The read
+        # path keeps the real blocks.
+        zero_rows = np.nonzero(num_scheduled_tokens[:num_reqs] == 0)[0]
+        if len(zero_rows) > 0:
+            if fill_page_table is page_table:
+                fill_page_table = page_table.copy()
+            fill_page_table[zero_rows, :] = 0
+
+        return page_table, fill_page_table, cache_position

--- a/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
@@ -8,10 +8,11 @@ throughout, so TT forks it and substitutes host-side mechanisms rather than
 subclassing ``GPUModelRunner``.
 
 This file is built in reviewable sub-increments. Present so far: the request
-lifecycle, the host input-token preparation, and the attention slot-mapping
-build (feeding ``TTModelState.prepare_attn``). Still to land:
-``__init__``/``load_model`` (construct the state below), ``initialize_kv_cache``,
-the compiled forward graphs, and ``execute_model``/``sample_tokens``.
+lifecycle, the decode-first batch selection / SMEM multi-pass clamping, the host
+input-token preparation, and the attention slot-mapping build (feeding
+``TTModelState.prepare_attn``). Still to land: ``__init__``/``load_model``
+(construct the state below), ``initialize_kv_cache``, the compiled forward
+graphs, and ``execute_model``/``sample_tokens``.
 
 Layout note
 -----------
@@ -44,6 +45,7 @@ sub-increment): ``req_states``, ``sampling_states``, ``block_table`` (a vLLM
 
 from __future__ import annotations
 
+import bisect
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -53,6 +55,13 @@ from vllm.sampling_params import SamplingType
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
+
+
+def _get_padded_token_len(paddings: list[int], x: int) -> int:
+    """First padding >= x (the per-step query-length bucket)."""
+    index = bisect.bisect_left(paddings, x)
+    assert index < len(paddings)
+    return paddings[index]
 
 
 class TTModelRunnerV2:
@@ -145,6 +154,85 @@ class TTModelRunnerV2:
             new_block_ids = cached.new_block_ids[i]
             if new_block_ids is not None:
                 self.block_table.append_row(new_block_ids, slot)
+
+    def _order_scheduled_reqs(
+        self, scheduler_output: "SchedulerOutput"
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Order this step's scheduled requests decodes-first (by token count).
+
+        Returns parallel ``(slots, num_scheduled_tokens)`` arrays. Sorting by
+        ascending scheduled-token count (upstream v2 convention) groups the
+        1-token decodes ahead of the prefills so the multi-pass loop can emit
+        pure decode passes (dispatched to the decode graph) before prefills.
+        """
+        slots: list[int] = []
+        ntoks: list[int] = []
+        for req_id, n in scheduler_output.num_scheduled_tokens.items():
+            slot = self.req_states.req_id_to_index.get(req_id)
+            if slot is None:
+                continue
+            slots.append(slot)
+            ntoks.append(n)
+        ntoks_np = np.array(ntoks, dtype=np.int32)
+        order = np.argsort(ntoks_np, kind="stable")
+        return np.array(slots, dtype=np.int32)[order], ntoks_np[order]
+
+    def _select_batch(
+        self,
+        ordered_slots: np.ndarray,
+        ordered_num_tokens: np.ndarray,
+        start_index: int,
+    ) -> tuple[np.ndarray, np.ndarray, int, int, int]:
+        """Pick the sub-batch for one pass, applying the SMEM row caps.
+
+        Mirrors the v1 fork's per-pass clamping over the decode-first ordering:
+        a long request in the remaining tail forces the max-model-len row cap;
+        prefill passes are additionally capped at ``max_prefill_num_reqs`` and the
+        multi-pass loop picks up the rest. Returns ``(idx_mapping,
+        num_scheduled_tokens, target_num_reqs, padded_query_len, end_index)``.
+        """
+        # A long request anywhere in the remaining tail forces max-model-len mode
+        # (fewer rows fit SMEM), matching the v1 collection loop.
+        use_max_model_len = self.most_model_len is None
+        if not use_max_model_len and np.any(
+            ordered_num_tokens[start_index:] > self.most_model_len
+        ):
+            use_max_model_len = True
+        row_cap = (
+            self.num_reqs_max_model_len
+            if use_max_model_len
+            else self.num_reqs_most_model_len
+        )
+
+        end_index = min(len(ordered_slots), start_index + row_cap)
+        num_scheduled = ordered_num_tokens[start_index:end_index]
+
+        # Prefill pass over the cap -> trim; the next pass takes the remainder.
+        if (
+            len(num_scheduled) > self.max_prefill_num_reqs
+            and int(num_scheduled.max()) > 1
+        ):
+            end_index = start_index + self.max_prefill_num_reqs
+            num_scheduled = ordered_num_tokens[start_index:end_index]
+
+        idx_mapping = ordered_slots[start_index:end_index]
+        max_scheduled = int(num_scheduled.max())
+
+        if max_scheduled == 1:
+            # Decode always runs at the max request bucket.
+            target_num_reqs = self.max_num_reqs
+        else:
+            actual = len(num_scheduled)
+            target_num_reqs = (
+                self.min_num_reqs
+                if actual <= self.min_num_reqs
+                else self.max_prefill_num_reqs
+            )
+
+        padded_query_len = _get_padded_token_len(
+            self.num_tokens_paddings, max_scheduled
+        )
+        return idx_mapping, num_scheduled, target_num_reqs, padded_query_len, end_index
 
     def _prepare_input_tokens(
         self,

--- a/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
@@ -123,6 +123,7 @@ class TTModelRunnerV2:
             TTAttentionBackend,
         )
         from .input_batch_v2 import TTInputBuffers
+        from .platform import TTConfig
         from .request_state import TTRequestState
         from .sampling_state_v2 import TTSamplingStates
 
@@ -133,8 +134,17 @@ class TTModelRunnerV2:
         self.parallel_config = vllm_config.parallel_config
         self.load_config = vllm_config.load_config
         self.lora_config = vllm_config.lora_config
-        self.tt_config = vllm_config.additional_config
         self.device = device
+
+        # additional_config arrives as a plain dict; build the typed TTConfig
+        # (as the v1 runner does) so the field reads below see real values.
+        self.tt_config = TTConfig(**vllm_config.additional_config)
+        if self.device.type == "xla":
+            import torch_xla
+
+            torch_xla.set_custom_compile_options(
+                self.tt_config.get_pjrt_compile_config()
+            )
 
         tt = self.tt_config
         self.enable_tensor_parallel = bool(getattr(tt, "enable_tensor_parallel", False))

--- a/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
@@ -54,9 +54,18 @@ def _adjust_min_token(min_token_size: int) -> int:
     """Round min_token_size up to a power of two that is >= 32 (32B alignment)."""
     if (min_token_size & (min_token_size - 1)) == 0 and min_token_size >= 32:
         return min_token_size
+
+    # Default fallback is 32 (smallest valid input length).
+    adjusted_value = 32
     if min_token_size > 32:
-        return 1 << (min_token_size - 1).bit_length()
-    return 32
+        # Round up to the next power of two.
+        adjusted_value = 1 << (min_token_size - 1).bit_length()
+
+    logger.warning(
+        f"Flag min_context_len={min_token_size} is not a power of two and divisible by 32. "
+        f"Adjusting to the next power of two. Using min_context_len={adjusted_value}."
+    )
+    return adjusted_value
 
 
 def _get_token_paddings(min_token_size: int, max_token_size: int) -> list[int]:
@@ -108,12 +117,6 @@ class TTModelRunnerV2:
         # additional_config arrives as a plain dict; build the typed TTConfig
         # (as the v1 runner does) so the field reads below see real values.
         self.tt_config = TTConfig(**vllm_config.additional_config)
-        if self.device.type == "xla":
-            import torch_xla
-
-            torch_xla.set_custom_compile_options(
-                self.tt_config.get_pjrt_compile_config()
-            )
 
         # Override number of hidden layers if specified in TTConfig. Must run
         # before load_model so only the target layers are built; the weight
@@ -861,9 +864,15 @@ class TTModelRunnerV2:
                 restore_shape = torch.Size(inputs_embeds.shape[:-1])
             inputs_embeds = inputs_embeds.reshape(-1, inputs_embeds.shape[-1])
         if positions.ndim > 1:
-            if restore_shape is None:
-                restore_shape = positions.shape
-            positions = positions.reshape(-1)
+            if self.uses_mrope:
+                assert positions.ndim == 3 and positions.shape[0] == 3
+                positions = positions.reshape(3, -1)
+            else:
+                positions = positions.reshape(-1)
+
+        assert (
+            restore_shape is not None
+        ), "restore_shape should be set if any input is flattened."
         return input_ids, positions, inputs_embeds, restore_shape
 
     def _restore_model_hidden_states(self, hidden_states, restore_shape):

--- a/integrations/vllm_plugin/vllm_tt/model_state.py
+++ b/integrations/vllm_plugin/vllm_tt/model_state.py
@@ -1,0 +1,222 @@
+"""TT ``ModelState`` for vLLM Model Runner v2 (MRv2).
+
+This is Phase 1 of the MRv2 adoption: the model-specific ``ModelState`` layer.
+It implements the upstream ``vllm.v1.worker.gpu.model_states.interface.ModelState``
+contract (as of vLLM v0.22.1) for Tenstorrent hardware.
+
+Scope / status
+--------------
+MRv2 splits the old monolithic runner into four pieces: the runner (engine),
+``ModelState`` (model-specific logic), ``RequestState`` (persistent per-request
+table) and ``InputBatch`` (transient per-step view). This file is only the
+``ModelState`` piece.
+
+* Requires vLLM v0.22.1. The ``vllm.v1.worker.gpu.*`` modules imported below do
+  not exist on v0.19.1, so this module is intentionally NOT imported from the
+  package ``__init__`` yet -- importing it on an un-uplifted env raises
+  ImportError. It becomes live once the 0.22.1 uplift (PR #5634) lands and the
+  TT v2 runner (Phase 3) wires it in.
+* The model-agnostic methods (task discovery, the common 1D-positions input
+  path, staged-write / add_request no-ops) are implemented for real here.
+* The two methods that are coupled to the runner and to TT's own attention
+  backends -- ``prepare_attn`` and ``get_mm_embeddings`` -- raise
+  NotImplementedError with the exact contract documented. They are only
+  meaningfully implementable and testable once the TT v2 runner exists
+  (Phase 3), so we do not ship a fake body here.
+
+Why not subclass upstream ``DefaultModelState``?
+------------------------------------------------
+``DefaultModelState.__init__`` builds rope state via ``get_rope_state`` (which
+is Triton-backed, ``@triton.jit``) and ``prepare_attn`` delegates to
+``build_attn_metadata`` (cudagraph-oriented). Both assume CUDA/Triton, so
+subclassing would drag that machinery in at construction time. A standalone
+implementation lets us substitute TT equivalents cleanly.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import torch
+import torch.nn as nn
+
+from vllm.config.compilation import CUDAGraphMode
+from vllm.tasks import GenerationTask
+from vllm.v1.worker.gpu.model_states.interface import ModelState
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+    from vllm.v1.core.sched.output import NewRequestData
+    from vllm.v1.kv_cache_interface import KVCacheConfig
+    from vllm.v1.worker.gpu.input_batch import InputBatch
+    from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
+    from vllm.v1.worker.gpu.states import RequestState
+    from vllm.v1.worker.utils import AttentionGroup
+
+
+class TTModelState(ModelState):
+    """Tenstorrent implementation of the MRv2 ``ModelState`` interface.
+
+    Mirrors the structure of upstream ``DefaultModelState`` but substitutes (or
+    defers) the CUDA/Triton-specific pieces. See module docstring for status.
+    """
+
+    def __init__(
+        self,
+        vllm_config: "VllmConfig",
+        model: nn.Module,
+        encoder_cache: "EncoderCache | None",
+        device: torch.device,
+    ) -> None:
+        self.vllm_config = vllm_config
+        self.model_config = vllm_config.model_config
+        self.scheduler_config = vllm_config.scheduler_config
+        self.model = model
+        self.device = device
+
+        # Sizing, mirrored from DefaultModelState.
+        self.supports_mm_inputs = encoder_cache is not None
+        self.encoder_cache = encoder_cache
+        self.max_model_len = self.model_config.max_model_len
+        self.max_num_reqs = self.scheduler_config.max_num_seqs
+        self.max_num_tokens = self.scheduler_config.max_num_batched_tokens
+        self.dtype = self.model_config.dtype
+
+        # Rope/mrope state: upstream uses get_rope_state(), which is Triton-backed
+        # and does not run on TT. The common text-generation path uses plain 1D
+        # positions (rope_state is None -> prepare_inputs returns {}), matching
+        # DefaultModelState's common case. mrope models require a TT rope
+        # substitute; deferred to a later phase.
+        # TODO(mrv2): TT rope/mrope state for models with uses_mrope.
+        self.rope_state = None
+
+        # TODO(mrv2): construct the TT multimodal encoder runner here when
+        # get_mm_embeddings is implemented (Phase 3). Upstream builds an
+        # EncoderRunner; portability to TT is not yet validated.
+
+    def get_supported_generation_tasks(self) -> tuple[GenerationTask, ...]:
+        """Which generation tasks this model supports.
+
+        Fully portable: same logic as upstream DefaultModelState and the current
+        TT v1 runner. Lazy imports mirror upstream to avoid import cycles.
+        """
+        from vllm.model_executor.models.interfaces import (
+            supports_realtime,
+            supports_transcription,
+        )
+        from vllm.model_executor.models.interfaces_base import (
+            is_text_generation_model,
+        )
+
+        supported_tasks: list[GenerationTask] = []
+
+        if is_text_generation_model(self.model):
+            supported_tasks.append("generate")
+
+        if supports_transcription(self.model):
+            if self.model.supports_transcription_only:
+                return ("transcription",)
+            supported_tasks.append("transcription")
+
+        if supports_realtime(self.model):
+            supported_tasks.append("realtime")
+
+        return tuple(supported_tasks)
+
+    def add_request(self, req_index: int, new_req_data: "NewRequestData") -> None:
+        """Per-request model-specific setup.
+
+        Upstream initializes rope prefill positions here. With no TT rope state
+        yet (common text path), this is a no-op, matching DefaultModelState when
+        rope_state is None.
+        """
+        if self.rope_state is not None:
+            # TODO(mrv2): init TT rope prefill positions for req_index.
+            raise NotImplementedError("TT rope state not implemented yet.")
+
+    def apply_staged_writes(self) -> None:
+        """Commit any staged host->device writes owned by this ModelState.
+
+        Only rope state stages writes upstream; no-op until TT rope lands.
+        """
+        if self.rope_state is not None:
+            raise NotImplementedError("TT rope state not implemented yet.")
+
+    def postprocess_state(
+        self, input_batch: "InputBatch", num_sampled: torch.Tensor
+    ) -> None:
+        """Post-step model-specific state update. No-op for standard models."""
+        return None
+
+    def prepare_inputs(
+        self, input_batch: "InputBatch", req_states: "RequestState"
+    ) -> dict[str, Any]:
+        """Extra kwargs merged into the model call.
+
+        Common case (1D positions, no rope state): return {} so the runner's
+        default input_ids/positions/inputs_embeds are used unchanged. This
+        matches DefaultModelState.prepare_inputs. mrope models return
+        {"positions": ...}; deferred with TT rope.
+        """
+        if self.rope_state is None:
+            return {}
+        # TODO(mrv2): compute TT mrope positions and return {"positions": ...}.
+        raise NotImplementedError("TT rope state not implemented yet.")
+
+    def prepare_dummy_inputs(self, num_reqs: int, num_tokens: int) -> dict[str, Any]:
+        """Kwargs for dummy/warmup/profile runs.
+
+        Common text path needs no extra inputs. mm/rope models add
+        inputs_embeds/positions; deferred with those substitutes.
+        """
+        return {}
+
+    def get_mm_embeddings(
+        self,
+        scheduled_encoder_inputs: dict[str, list[int]],
+        input_batch: "InputBatch",
+        req_states: "RequestState",
+    ) -> torch.Tensor | None:
+        """Run the multimodal encoder and merge embeddings into input embeds.
+
+        Contract (from DefaultModelState.get_mm_embeddings):
+          1. prepare_mm_inputs(scheduled_encoder_inputs) -> (hashes, kwargs)
+          2. if kwargs: execute the encoder, cache outputs by mm_hash
+          3. gather per-token mm embeds and merge with text embeds
+          4. return inputs_embeds[:input_batch.num_tokens_after_padding]
+
+        Deferred to Phase 3: needs the TT multimodal encoder runner and the
+        runner-owned InputBatch. Salvage source in the current v1 runner:
+        model_runner.py::_execute_mm_encoder and ::_gather_mm_embeddings.
+        """
+        raise NotImplementedError(
+            "get_mm_embeddings requires the TT v2 runner + TT encoder runner "
+            "(MRv2 Phase 3)."
+        )
+
+    def prepare_attn(
+        self,
+        input_batch: "InputBatch",
+        cudagraph_mode: CUDAGraphMode,
+        block_tables: tuple[torch.Tensor, ...],
+        slot_mappings: torch.Tensor,
+        attn_groups: "list[list[AttentionGroup]]",
+        kv_cache_config: "KVCacheConfig",
+        for_capture: bool = False,
+    ) -> dict[str, Any]:
+        """Build the attention-metadata dict passed to the model forward.
+
+        Upstream DefaultModelState delegates to build_attn_metadata(), which is
+        cudagraph-oriented and drives per-backend metadata builders. TT must
+        build metadata for its OWN attention backends (see attention_impls/),
+        so this is not a straight reuse.
+
+        Deferred to Phase 3: the physical block_tables/slot_mappings are produced
+        by the runner's own prepare_attn, which does not exist for TT yet.
+        Salvage source in the current v1 runner:
+        model_runner.py::_get_slot_mapping_metadata and the attn-metadata build.
+        """
+        raise NotImplementedError(
+            "prepare_attn requires the TT v2 runner + TT attention metadata "
+            "build (MRv2 Phase 3)."
+        )

--- a/integrations/vllm_plugin/vllm_tt/model_state.py
+++ b/integrations/vllm_plugin/vllm_tt/model_state.py
@@ -18,11 +18,18 @@ table) and ``InputBatch`` (transient per-step view). This file is only the
   TT v2 runner (Phase 3) wires it in.
 * The model-agnostic methods (task discovery, the common 1D-positions input
   path, staged-write / add_request no-ops) are implemented for real here.
-* The two methods that are coupled to the runner and to TT's own attention
-  backends -- ``prepare_attn`` and ``get_mm_embeddings`` -- raise
-  NotImplementedError with the exact contract documented. They are only
-  meaningfully implementable and testable once the TT v2 runner exists
-  (Phase 3), so we do not ship a fake body here.
+* ``prepare_attn`` (Phase 3) assembles a ``TTMetadata`` from the per-step
+  device arrays the runner computes host-side and fans it out to every attention
+  layer -- the same ``dict.fromkeys(layer_names, meta)`` the v1 fork builds
+  inline. Its signature diverges from upstream's (which passes flat
+  ``block_tables``/``slot_mappings``): TT's paged ops consume
+  ``page_table``/``cache_position`` instead, so matching upstream would mean
+  re-porting Triton block-table kernels TT never uses.
+* ``get_mm_embeddings`` still raises NotImplementedError: its data seams (the
+  per-request multimodal-feature store, the padded ``input_ids`` layout it masks
+  against, and ``model.embed_multimodal``/``embed_input_ids``) are owned by the
+  TT v2 runner, which does not exist yet. It is co-implemented with that runner
+  rather than against a speculative interface. Contract documented on the method.
 
 Why not subclass upstream ``DefaultModelState``?
 ------------------------------------------------
@@ -40,18 +47,17 @@ from typing import TYPE_CHECKING, Any
 import torch
 import torch.nn as nn
 
-from vllm.config.compilation import CUDAGraphMode
 from vllm.tasks import GenerationTask
 from vllm.v1.worker.gpu.model_states.interface import ModelState
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from vllm.config import VllmConfig
     from vllm.v1.core.sched.output import NewRequestData
-    from vllm.v1.kv_cache_interface import KVCacheConfig
     from vllm.v1.worker.gpu.input_batch import InputBatch
     from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
     from vllm.v1.worker.gpu.states import RequestState
-    from vllm.v1.worker.utils import AttentionGroup
 
 
 class TTModelState(ModelState):
@@ -196,27 +202,39 @@ class TTModelState(ModelState):
 
     def prepare_attn(
         self,
-        input_batch: "InputBatch",
-        cudagraph_mode: CUDAGraphMode,
-        block_tables: tuple[torch.Tensor, ...],
-        slot_mappings: torch.Tensor,
-        attn_groups: "list[list[AttentionGroup]]",
-        kv_cache_config: "KVCacheConfig",
-        for_capture: bool = False,
+        attention_layer_names: "Iterable[str]",
+        page_table: torch.Tensor,
+        cache_position: torch.Tensor,
+        fill_page_table: torch.Tensor | None = None,
+        batch_idx: torch.Tensor | None = None,
+        num_users: int | None = None,
+        dp_size: int = 1,
+        chunk_start_idx: torch.Tensor | None = None,
+        attn_mask: torch.Tensor | None = None,
+        is_causal: bool = True,
     ) -> dict[str, Any]:
-        """Build the attention-metadata dict passed to the model forward.
+        """Assemble the per-layer attention-metadata dict for the model forward.
 
-        Upstream DefaultModelState delegates to build_attn_metadata(), which is
-        cudagraph-oriented and drives per-backend metadata builders. TT must
-        build metadata for its OWN attention backends (see attention_impls/),
-        so this is not a straight reuse.
-
-        Deferred to Phase 3: the physical block_tables/slot_mappings are produced
-        by the runner's own prepare_attn, which does not exist for TT yet.
-        Salvage source in the current v1 runner:
-        model_runner.py::_get_slot_mapping_metadata and the attn-metadata build.
+        Upstream DefaultModelState delegates to build_attn_metadata() over flat
+        block_tables/slot_mappings; TT's attention backends (see attention_impls/)
+        consume a single ``TTMetadata`` built from paged tensors instead, so the
+        signature is adapted (see module docstring). The per-step tensors are
+        computed host-side by the runner; this method only packages them and fans
+        the shared metadata out to every attention layer -- mirroring the v1
+        fork's ``dict.fromkeys(self._attention_layer_names, attn_metadata)``.
+        ``fill_page_table`` defaults to ``page_table`` (no prefix roll).
         """
-        raise NotImplementedError(
-            "prepare_attn requires the TT v2 runner + TT attention metadata "
-            "build (MRv2 Phase 3)."
+        from .attention_impls.attention import TTMetadata
+
+        attn_metadata = TTMetadata(
+            page_table=page_table,
+            cache_position=cache_position,
+            is_causal=is_causal,
+            attn_mask=attn_mask,
+            fill_page_table=fill_page_table,
+            dp_size=dp_size,
+            chunk_start_idx=chunk_start_idx,
+            batch_idx=batch_idx,
+            num_users=num_users,
         )
+        return dict.fromkeys(attention_layer_names, attn_metadata)

--- a/integrations/vllm_plugin/vllm_tt/model_state.py
+++ b/integrations/vllm_plugin/vllm_tt/model_state.py
@@ -18,18 +18,13 @@ table) and ``InputBatch`` (transient per-step view). This file is only the
   TT v2 runner (Phase 3) wires it in.
 * The model-agnostic methods (task discovery, the common 1D-positions input
   path, staged-write / add_request no-ops) are implemented for real here.
-* ``prepare_attn`` (Phase 3) assembles a ``TTMetadata`` from the per-step
-  device arrays the runner computes host-side and fans it out to every attention
-  layer -- the same ``dict.fromkeys(layer_names, meta)`` the v1 fork builds
-  inline. Its signature diverges from upstream's (which passes flat
-  ``block_tables``/``slot_mappings``): TT's paged ops consume
-  ``page_table``/``cache_position`` instead, so matching upstream would mean
-  re-porting Triton block-table kernels TT never uses.
-* ``get_mm_embeddings`` still raises NotImplementedError: its data seams (the
-  per-request multimodal-feature store, the padded ``input_ids`` layout it masks
-  against, and ``model.embed_multimodal``/``embed_input_ids``) are owned by the
-  TT v2 runner, which does not exist yet. It is co-implemented with that runner
-  rather than against a speculative interface. Contract documented on the method.
+* ``prepare_attn`` (Phase 3) assembles a ``TTMetadata`` from the per-step device
+  arrays the runner computes host-side and fans it out to every attention layer.
+  Its signature diverges from upstream's flat block_tables/slot_mappings because
+  TT's paged ops consume page_table/cache_position instead.
+* ``get_mm_embeddings`` still raises NotImplementedError: its seams (mm-feature
+  store, padded input_ids layout, model.embed_*) are runner-owned, so it is
+  co-implemented with the runner. Contract on the method.
 
 Why not subclass upstream ``DefaultModelState``?
 ------------------------------------------------
@@ -215,14 +210,11 @@ class TTModelState(ModelState):
     ) -> dict[str, Any]:
         """Assemble the per-layer attention-metadata dict for the model forward.
 
-        Upstream DefaultModelState delegates to build_attn_metadata() over flat
-        block_tables/slot_mappings; TT's attention backends (see attention_impls/)
-        consume a single ``TTMetadata`` built from paged tensors instead, so the
-        signature is adapted (see module docstring). The per-step tensors are
-        computed host-side by the runner; this method only packages them and fans
-        the shared metadata out to every attention layer -- mirroring the v1
-        fork's ``dict.fromkeys(self._attention_layer_names, attn_metadata)``.
-        ``fill_page_table`` defaults to ``page_table`` (no prefix roll).
+        TT's attention backends consume a single TTMetadata built from paged
+        tensors (page_table/cache_position/...), not upstream's flat
+        block_tables/slot_mappings, so the signature is adapted. The runner
+        computes the tensors host-side; this fans the shared metadata out to every
+        attention layer. fill_page_table defaults to page_table (no prefix roll).
         """
         from .attention_impls.attention import TTMetadata
 

--- a/integrations/vllm_plugin/vllm_tt/model_state.py
+++ b/integrations/vllm_plugin/vllm_tt/model_state.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
 """TT ``ModelState`` for vLLM Model Runner v2 (MRv2).
 
 This is Phase 1 of the MRv2 adoption: the model-specific ``ModelState`` layer.
@@ -41,7 +44,6 @@ from typing import TYPE_CHECKING, Any
 
 import torch
 import torch.nn as nn
-
 from vllm.tasks import GenerationTask
 from vllm.v1.worker.gpu.model_states.interface import ModelState
 
@@ -105,9 +107,7 @@ class TTModelState(ModelState):
             supports_realtime,
             supports_transcription,
         )
-        from vllm.model_executor.models.interfaces_base import (
-            is_text_generation_model,
-        )
+        from vllm.model_executor.models.interfaces_base import is_text_generation_model
 
         supported_tasks: list[GenerationTask] = []
 

--- a/integrations/vllm_plugin/vllm_tt/pooling_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/pooling_runner.py
@@ -233,7 +233,6 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
     ):
 
         self.tt_config = TTConfig(**vllm_config.additional_config)
-        torch_xla.set_custom_compile_options(self.tt_config.get_pjrt_compile_config())
 
         self.vllm_config = vllm_config
         self.model_config = vllm_config.model_config

--- a/integrations/vllm_plugin/vllm_tt/request_state.py
+++ b/integrations/vllm_plugin/vllm_tt/request_state.py
@@ -1,0 +1,155 @@
+"""TT ``RequestState`` for vLLM Model Runner v2 (MRv2).
+
+Phase 2 of the MRv2 adoption: the persistent per-request slot table. Mirrors
+upstream ``vllm.v1.worker.gpu.states.RequestState`` (as of vLLM v0.22.1),
+substituting host-side numpy storage for upstream's UVA / ``StagedWriteTensor``
+buffers.
+
+Scope / status
+--------------
+MRv2 splits the old monolithic runner into four pieces: the runner (engine),
+``ModelState`` (see model_state.py), ``RequestState`` (this file) and
+``InputBatch`` (see input_batch_v2.py). ``RequestState`` is the stable slot
+table that replaces v1's ``CachedRequestState`` dict + ``InputBatch`` add /
+remove / condense bookkeeping: each request owns a fixed slot for its lifetime
+and the slot is returned to a free list on removal (no condensing).
+
+* Holds ONLY token bookkeeping. Upstream keeps sampling params in the sampler
+  (``SamplingStates``) and block tables in the runner, not here; TT mirrors
+  that split -- both are deferred to Phase 3.
+* Upstream backs the per-slot arrays with ``StagedWriteTensor`` / ``UvaBackedTensor``
+  so the Triton input-prep kernels can read them on device. TT input-prep is
+  host-side (no Triton), so those device mirrors would be dead weight; we use
+  plain numpy as the single source of truth. As a result ``apply_staged_writes``
+  is a no-op -- writes land immediately.
+* This module has no ``vllm.v1.worker.gpu.*`` dependency, so unlike
+  model_state.py it is import-safe on un-uplifted envs. It is still intentionally
+  NOT imported from the package ``__init__`` until the TT v2 runner (Phase 3)
+  wires it in. UNVALIDATED at runtime until then.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    import torch
+
+
+class TTRequestState:
+    """Persistent per-request slot table for the TT MRv2 runner.
+
+    Structure-of-arrays indexed by ``req_state_idx`` (a stable slot). Mirrors
+    upstream ``RequestState`` field-for-field; see module docstring for the
+    numpy-vs-UVA substitution.
+    """
+
+    def __init__(
+        self,
+        max_num_reqs: int,
+        max_model_len: int,
+        max_num_batched_tokens: int,
+        num_speculative_steps: int,
+        vocab_size: int,
+        device: "torch.device",
+    ):
+        self.max_num_reqs = max_num_reqs
+        self.max_model_len = max_model_len
+        self.max_num_batched_tokens = max_num_batched_tokens
+        self.num_speculative_steps = num_speculative_steps
+        self.vocab_size = vocab_size
+        # Kept for parity / Phase 3 device materialization; unused host-side.
+        self.device = device
+
+        self.req_id_to_index: dict[str, int] = {}
+        self.index_to_req_id: dict[int, str] = {}
+        self.free_indices = list(range(max_num_reqs))
+
+        # Per-slot token ids. Host-side numpy (upstream: UVA StagedWriteTensor).
+        self.all_token_ids = np.zeros(
+            (self.max_num_reqs, self.max_model_len), dtype=np.int32
+        )
+
+        # prompt_len: tokens in the user prompt.
+        # prefill_len: tokens fed to the runner (>= prompt_len; larger on resume
+        #   after preemption). Prompt vs output tokens must be distinguished for
+        #   prompt logprobs and frequency penalties.
+        self.prompt_len = np.zeros(self.max_num_reqs, dtype=np.int32)
+        self.prefill_len = np.zeros(self.max_num_reqs, dtype=np.int32)
+        # total_len = prompt_len + output_len; grows as the request progresses.
+        self.total_len = np.zeros(self.max_num_reqs, dtype=np.int32)
+
+        # Number of computed tokens. Upstream splits this into a device tensor
+        # (authoritative, updated by the post_update kernel) plus an optimistic
+        # CPU mirror; host-side these collapse to one array.
+        self.num_computed_prefill_tokens = np.zeros(self.max_num_reqs, dtype=np.int32)
+        self.num_computed_tokens = np.zeros(self.max_num_reqs, dtype=np.int32)
+
+        # Last sampled token per slot (seeds the next decode input).
+        self.last_sampled_tokens = np.zeros((self.max_num_reqs, 1), dtype=np.int64)
+
+        # Draft tokens (spec decode). TT has no spec decode
+        # (num_speculative_steps == 0), so this degenerates to a zero-width row.
+        self.draft_tokens = np.zeros(
+            (self.max_num_reqs, self.num_speculative_steps), dtype=np.int64
+        )
+
+        self.next_prefill_tokens = np.zeros(self.max_num_reqs, dtype=np.int32)
+
+    @property
+    def num_reqs(self) -> int:
+        return len(self.req_id_to_index)
+
+    def add_request(
+        self,
+        req_id: str,
+        prompt_len: int,
+        all_token_ids: list[int],
+        num_computed_tokens: int,
+    ) -> None:
+        assert len(self.free_indices) > 0, "No free indices"
+        req_idx = self.free_indices.pop()
+        self.req_id_to_index[req_id] = req_idx
+        self.index_to_req_id[req_idx] = req_id
+
+        self.prompt_len[req_idx] = prompt_len
+        prefill_len = len(all_token_ids)
+        assert (
+            prefill_len >= prompt_len
+        ), f"prefill_len {prefill_len} < prompt_len {prompt_len}"
+        self.prefill_len[req_idx] = prefill_len
+        self.total_len[req_idx] = prefill_len
+        self.all_token_ids[req_idx, :prefill_len] = all_token_ids
+        self.num_computed_prefill_tokens[req_idx] = num_computed_tokens
+        self.num_computed_tokens[req_idx] = num_computed_tokens
+
+        if 0 < num_computed_tokens <= prefill_len:
+            # PD disagg / resumed requests: seed last_sampled with the last
+            # computed token so the first decode step reads the right input id.
+            # Fresh prefill (num_computed_tokens == 0) never reads this slot.
+            self.last_sampled_tokens[req_idx] = all_token_ids[num_computed_tokens - 1]
+        self.draft_tokens[req_idx] = 0
+
+    def apply_staged_writes(self) -> None:
+        """No-op: numpy writes land immediately (see module docstring).
+
+        Kept for interface parity with upstream ``RequestState`` so the Phase 3
+        runner's ``add_requests`` can call it unconditionally.
+        """
+        return None
+
+    def remove_request(self, req_id: str) -> bool:
+        req_idx = self.req_id_to_index.pop(req_id, None)
+        if req_idx is None:
+            return False
+        self.index_to_req_id.pop(req_idx, None)
+        self.free_indices.append(req_idx)
+        return True
+
+    def is_prefilling(self, idx_mapping_np: np.ndarray) -> np.ndarray:
+        return (
+            self.num_computed_prefill_tokens[idx_mapping_np]
+            < self.prefill_len[idx_mapping_np]
+        )

--- a/integrations/vllm_plugin/vllm_tt/request_state.py
+++ b/integrations/vllm_plugin/vllm_tt/request_state.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
 """TT ``RequestState`` for vLLM Model Runner v2 (MRv2).
 
 Phase 2 of the MRv2 adoption: the persistent per-request slot table. Mirrors

--- a/integrations/vllm_plugin/vllm_tt/sampling_state_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/sampling_state_v2.py
@@ -20,7 +20,6 @@ from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 import torch
-
 from vllm.sampling_params import SamplingType
 
 from .metadata import DEFAULT_SAMPLING_PARAMS

--- a/integrations/vllm_plugin/vllm_tt/sampling_state_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/sampling_state_v2.py
@@ -1,0 +1,298 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""TT ``SamplingStates`` for vLLM Model Runner v2 (MRv2).
+
+Phase 3 of the MRv2 adoption: the persistent per-request sampling-param table.
+
+MRv2 keeps sampling params OUT of ``RequestState``/``InputBatch`` (see
+request_state.py / input_batch_v2.py) and in a dedicated sampler-owned state.
+Upstream backs that with UVA ``SamplingStates`` plus separate PenaltiesState /
+LogitBiasState / BadWordsState objects, all Triton-applied on device. TT applies
+sampling host-side and on the XLA graph via ``XLASupportedSamplingMetadata`` (see
+metadata.py), so this is a plain host-side slot table.
+
+* Keyed by ``req_state_idx`` (the stable slot from ``TTRequestState``), NOT the
+  transient batch position. Each step the runner maps batch_idx -> slot via
+  ``TTInputBatch.idx_mapping_np`` and ``make_batch_view`` gathers a batch-ordered,
+  padded view that ``XLASupportedSamplingMetadata.from_v2_states`` consumes.
+* Extraction from ``SamplingParams`` mirrors the v1 fork's
+  ``input_batch.py::add_request`` exactly (greedy -> temperature 0.0; disabled
+  top_k -> vocab_size; generators only when the request carries one).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+import numpy as np
+import torch
+
+from vllm.sampling_params import SamplingType
+
+from .metadata import DEFAULT_SAMPLING_PARAMS
+
+if TYPE_CHECKING:
+    from vllm.sampling_params import SamplingParams
+
+    from .input_batch_v2 import TTInputBatch
+    from .request_state import TTRequestState
+
+
+@dataclass
+class SamplingBatchView:
+    """Batch-ordered, padded view built each step from the slot table.
+
+    Exposes exactly the attributes ``XLASupportedSamplingMetadata.from_input_batch``
+    reads, so the v2 path reuses that tested constructor unchanged.
+    """
+
+    num_reqs: int
+    vocab_size: int
+    temperature_cpu_tensor: torch.Tensor
+    top_p_cpu_tensor: torch.Tensor
+    top_k_cpu_tensor: torch.Tensor
+    min_p_cpu_tensor: torch.Tensor
+    presence_penalties_cpu_tensor: torch.Tensor
+    frequency_penalties_cpu_tensor: torch.Tensor
+    repetition_penalties_cpu_tensor: torch.Tensor
+    all_greedy: bool
+    all_random: bool
+    no_penalties: bool
+    logit_bias: list[Optional[dict[int, float]]]
+    bad_words_token_ids: dict[int, list[list[int]]]
+    min_tokens: dict[int, tuple[int, set[int]]]
+    generators: dict[int, torch.Generator]
+    no_allowed_token_ids: bool
+    allowed_token_ids_mask_cpu_tensor: Optional[torch.Tensor]
+    req_output_token_ids: list[Optional[list[int]]]
+    num_prompt_tokens: np.ndarray
+    token_ids_cpu: np.ndarray
+    max_num_logprobs: int
+
+
+class TTSamplingStates:
+    """Persistent per-slot sampling-param table for the TT MRv2 runner."""
+
+    def __init__(self, max_num_reqs: int, vocab_size: int):
+        self.max_num_reqs = max_num_reqs
+        self.vocab_size = vocab_size
+
+        self.temperature = np.full(
+            max_num_reqs, DEFAULT_SAMPLING_PARAMS["temperature"], dtype=np.float32
+        )
+        self.top_p = np.full(
+            max_num_reqs, DEFAULT_SAMPLING_PARAMS["top_p"], dtype=np.float32
+        )
+        self.top_k = np.full(
+            max_num_reqs, DEFAULT_SAMPLING_PARAMS["top_k"], dtype=np.int32
+        )
+        self.min_p = np.full(
+            max_num_reqs, DEFAULT_SAMPLING_PARAMS["min_p"], dtype=np.float32
+        )
+        self.frequency_penalties = np.full(
+            max_num_reqs,
+            DEFAULT_SAMPLING_PARAMS["frequency_penalties"],
+            dtype=np.float32,
+        )
+        self.presence_penalties = np.full(
+            max_num_reqs,
+            DEFAULT_SAMPLING_PARAMS["presence_penalties"],
+            dtype=np.float32,
+        )
+        self.repetition_penalties = np.full(
+            max_num_reqs,
+            DEFAULT_SAMPLING_PARAMS["repetition_penalties"],
+            dtype=np.float32,
+        )
+        # Default (empty) slots are greedy, matching the temperature sentinel.
+        self.is_greedy = np.ones(max_num_reqs, dtype=np.bool_)
+
+        self.min_tokens: dict[int, tuple[int, set[int]]] = {}
+        self.generators: dict[int, torch.Generator] = {}
+        self.logit_bias: list[Optional[dict[int, float]]] = [None] * max_num_reqs
+        self.bad_words_token_ids: dict[int, list[list[int]]] = {}
+        self.allowed_token_ids: dict[int, list[int]] = {}
+        self.num_logprobs: dict[int, int] = {}
+
+    def add_request(
+        self,
+        slot: int,
+        sampling_params: "SamplingParams",
+        generator: "torch.Generator | None" = None,
+    ) -> None:
+        if sampling_params.sampling_type == SamplingType.GREEDY:
+            # Zero temperature avoids a divide-by-zero in apply_temperature.
+            self.temperature[slot] = 0.0
+            self.is_greedy[slot] = True
+        else:
+            self.temperature[slot] = sampling_params.temperature
+            self.is_greedy[slot] = False
+
+        self.top_p[slot] = sampling_params.top_p
+        top_k = sampling_params.top_k
+        if not 0 < top_k < self.vocab_size:
+            top_k = self.vocab_size
+        self.top_k[slot] = top_k
+        self.min_p[slot] = sampling_params.min_p
+        self.frequency_penalties[slot] = sampling_params.frequency_penalty
+        self.presence_penalties[slot] = sampling_params.presence_penalty
+        self.repetition_penalties[slot] = sampling_params.repetition_penalty
+
+        if sampling_params.min_tokens:
+            self.min_tokens[slot] = (
+                sampling_params.min_tokens,
+                sampling_params.all_stop_token_ids,
+            )
+        # Only seeded requests carry a generator; the rest use the global RNG.
+        if generator is not None:
+            self.generators[slot] = generator
+        if sampling_params.logprobs is not None:
+            self.num_logprobs[slot] = sampling_params.logprobs
+        if sampling_params.logit_bias is not None:
+            self.logit_bias[slot] = sampling_params.logit_bias
+        if sampling_params.allowed_token_ids:
+            self.allowed_token_ids[slot] = sampling_params.allowed_token_ids
+        if sampling_params.bad_words_token_ids:
+            self.bad_words_token_ids[slot] = sampling_params.bad_words_token_ids
+
+    def remove_request(self, slot: int) -> None:
+        self.temperature[slot] = DEFAULT_SAMPLING_PARAMS["temperature"]
+        self.top_p[slot] = DEFAULT_SAMPLING_PARAMS["top_p"]
+        self.top_k[slot] = DEFAULT_SAMPLING_PARAMS["top_k"]
+        self.min_p[slot] = DEFAULT_SAMPLING_PARAMS["min_p"]
+        self.frequency_penalties[slot] = DEFAULT_SAMPLING_PARAMS["frequency_penalties"]
+        self.presence_penalties[slot] = DEFAULT_SAMPLING_PARAMS["presence_penalties"]
+        self.repetition_penalties[slot] = DEFAULT_SAMPLING_PARAMS[
+            "repetition_penalties"
+        ]
+        self.is_greedy[slot] = True
+        self.min_tokens.pop(slot, None)
+        self.generators.pop(slot, None)
+        self.logit_bias[slot] = None
+        self.bad_words_token_ids.pop(slot, None)
+        self.allowed_token_ids.pop(slot, None)
+        self.num_logprobs.pop(slot, None)
+
+    def make_batch_view(
+        self,
+        request_state: "TTRequestState",
+        input_batch: "TTInputBatch",
+        padded_num_reqs: int,
+    ) -> SamplingBatchView:
+        """Gather a batch-ordered, padded view for the current step.
+
+        ``input_batch.idx_mapping_np[b]`` gives the slot backing batch position b.
+        Active rows carry real params; padded rows [num_reqs:padded] carry the
+        sampler defaults (``from_input_batch`` overwrites them via fill_slice too).
+        """
+        num_reqs = input_batch.num_reqs
+        slots = [int(input_batch.idx_mapping_np[b]) for b in range(num_reqs)]
+        vocab = self.vocab_size
+
+        def _full(name):
+            return torch.full(
+                (padded_num_reqs,),
+                float(DEFAULT_SAMPLING_PARAMS[name]),
+                dtype=torch.float32,
+            )
+
+        temperature = _full("temperature")
+        top_p = _full("top_p")
+        min_p = _full("min_p")
+        presence = _full("presence_penalties")
+        frequency = _full("frequency_penalties")
+        repetition = _full("repetition_penalties")
+        top_k = torch.full(
+            (padded_num_reqs,),
+            int(DEFAULT_SAMPLING_PARAMS["top_k"]),
+            dtype=torch.int32,
+        )
+
+        max_model_len = request_state.all_token_ids.shape[1]
+        token_ids_cpu = np.zeros((padded_num_reqs, max_model_len), dtype=np.int32)
+        num_prompt_tokens = np.zeros(padded_num_reqs, dtype=np.int32)
+        req_output_token_ids: list[Optional[list[int]]] = [None] * padded_num_reqs
+
+        logit_bias: list[Optional[dict[int, float]]] = [None] * padded_num_reqs
+        bad_words: dict[int, list[list[int]]] = {}
+        min_tokens: dict[int, tuple[int, set[int]]] = {}
+        generators: dict[int, torch.Generator] = {}
+
+        has_allowed = any(slot in self.allowed_token_ids for slot in slots)
+        allowed_mask = (
+            torch.zeros(padded_num_reqs, vocab, dtype=torch.bool)
+            if has_allowed
+            else None
+        )
+
+        num_greedy = 0
+        has_penalties = False
+        max_num_logprobs = 0
+
+        for b, slot in enumerate(slots):
+            temperature[b] = float(self.temperature[slot])
+            top_p[b] = float(self.top_p[slot])
+            top_k[b] = int(self.top_k[slot])
+            min_p[b] = float(self.min_p[slot])
+            presence[b] = float(self.presence_penalties[slot])
+            frequency[b] = float(self.frequency_penalties[slot])
+            repetition[b] = float(self.repetition_penalties[slot])
+
+            if bool(self.is_greedy[slot]):
+                num_greedy += 1
+            if (
+                self.frequency_penalties[slot] != 0.0
+                or self.presence_penalties[slot] != 0.0
+                or self.repetition_penalties[slot] != 1.0
+            ):
+                has_penalties = True
+
+            prompt_len = int(request_state.prompt_len[slot])
+            total_len = int(request_state.total_len[slot])
+            token_ids_cpu[b] = request_state.all_token_ids[slot]
+            num_prompt_tokens[b] = prompt_len
+            req_output_token_ids[b] = request_state.all_token_ids[
+                slot, prompt_len:total_len
+            ].tolist()
+
+            logit_bias[b] = self.logit_bias[slot]
+            if slot in self.bad_words_token_ids:
+                bad_words[b] = self.bad_words_token_ids[slot]
+            if slot in self.min_tokens:
+                min_tokens[b] = self.min_tokens[slot]
+            if slot in self.generators:
+                generators[b] = self.generators[slot]
+            if slot in self.num_logprobs:
+                max_num_logprobs = max(max_num_logprobs, self.num_logprobs[slot])
+            if allowed_mask is not None and slot in self.allowed_token_ids:
+                allowed_mask[b, :] = True  # True == disallowed
+                allowed = [t for t in self.allowed_token_ids[slot] if t < vocab]
+                if allowed:
+                    allowed_mask[b, allowed] = False
+
+        return SamplingBatchView(
+            num_reqs=num_reqs,
+            vocab_size=vocab,
+            temperature_cpu_tensor=temperature,
+            top_p_cpu_tensor=top_p,
+            top_k_cpu_tensor=top_k,
+            min_p_cpu_tensor=min_p,
+            presence_penalties_cpu_tensor=presence,
+            frequency_penalties_cpu_tensor=frequency,
+            repetition_penalties_cpu_tensor=repetition,
+            all_greedy=num_reqs > 0 and num_greedy == num_reqs,
+            all_random=num_reqs > 0 and num_greedy == 0,
+            no_penalties=not has_penalties,
+            logit_bias=logit_bias,
+            bad_words_token_ids=bad_words,
+            min_tokens=min_tokens,
+            generators=generators,
+            no_allowed_token_ids=not has_allowed,
+            allowed_token_ids_mask_cpu_tensor=allowed_mask,
+            req_output_token_ids=req_output_token_ids,
+            num_prompt_tokens=num_prompt_tokens,
+            token_ids_cpu=token_ids_cpu,
+            max_num_logprobs=max_num_logprobs,
+        )

--- a/integrations/vllm_plugin/vllm_tt/sampling_state_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/sampling_state_v2.py
@@ -3,22 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 """TT ``SamplingStates`` for vLLM Model Runner v2 (MRv2).
 
-Phase 3 of the MRv2 adoption: the persistent per-request sampling-param table.
-
-MRv2 keeps sampling params OUT of ``RequestState``/``InputBatch`` (see
-request_state.py / input_batch_v2.py) and in a dedicated sampler-owned state.
-Upstream backs that with UVA ``SamplingStates`` plus separate PenaltiesState /
-LogitBiasState / BadWordsState objects, all Triton-applied on device. TT applies
-sampling host-side and on the XLA graph via ``XLASupportedSamplingMetadata`` (see
-metadata.py), so this is a plain host-side slot table.
-
-* Keyed by ``req_state_idx`` (the stable slot from ``TTRequestState``), NOT the
-  transient batch position. Each step the runner maps batch_idx -> slot via
-  ``TTInputBatch.idx_mapping_np`` and ``make_batch_view`` gathers a batch-ordered,
-  padded view that ``XLASupportedSamplingMetadata.from_v2_states`` consumes.
-* Extraction from ``SamplingParams`` mirrors the v1 fork's
-  ``input_batch.py::add_request`` exactly (greedy -> temperature 0.0; disabled
-  top_k -> vocab_size; generators only when the request carries one).
+MRv2 keeps sampling params out of RequestState/InputBatch, in a sampler-owned
+table. TT applies sampling host-side / on the XLA graph via
+XLASupportedSamplingMetadata (metadata.py), so this is a plain host-side slot
+table keyed by req_state_idx (the stable TTRequestState slot). Each step the
+runner maps batch position -> slot via TTInputBatch.idx_mapping_np, and
+make_batch_view gathers a batch-ordered padded view for from_v2_states.
+Extraction from SamplingParams mirrors the v1 input_batch.py::add_request
+(greedy -> temperature 0.0; disabled top_k -> vocab_size).
 """
 
 from __future__ import annotations

--- a/integrations/vllm_plugin/vllm_tt/worker.py
+++ b/integrations/vllm_plugin/vllm_tt/worker.py
@@ -130,7 +130,6 @@ class TTWorker:
         self.cache_config.num_cpu_blocks = num_cpu_blocks
 
     def init_device(self):
-        # os.environ["PJRT_DEVICE"] = "TT"
         xr.set_device_type("TT")
         torch.set_grad_enabled(False)
         torch.set_default_dtype(self.model_config.dtype)
@@ -144,6 +143,10 @@ class TTWorker:
         # the distributed runtime.
         self.device = torch_xla.device()
         self.device_config.device = self.device
+
+        # Apply PJRT compile options once per worker after the XLA runtime is
+        # initialized and before any model runner is constructed.
+        torch_xla.set_custom_compile_options(self.tt_config.get_pjrt_compile_config())
 
         # Set random seed.
         set_random_seed(self.model_config.seed)

--- a/integrations/vllm_plugin/vllm_tt/worker.py
+++ b/integrations/vllm_plugin/vllm_tt/worker.py
@@ -172,13 +172,25 @@ class TTWorker:
             xr.initialize_cache(per_rank_path, readonly=False)
 
         # Init ModelRunner here, so that we have access to self.device.
-        ModelRunnerClass = TTModelRunner
-        if self.model_config.runner_type == "pooling":
-            ModelRunnerClass = TTPoolingModelRunner
-
-        self.model_runner = ModelRunnerClass(
-            self.vllm_config, self.device, self.original_parallel_config
+        # Opt-in MRv2 runner (default off): gated on TT_USE_V2_MODEL_RUNNER. It is
+        # single-device generate-only for now and takes a 2-arg constructor (no
+        # original_parallel_config), so keep the v1 runner as the default path.
+        use_v2 = os.environ.get("TT_USE_V2_MODEL_RUNNER", "").lower() in (
+            "1",
+            "true",
+            "yes",
         )
+        if use_v2 and self.model_config.runner_type != "pooling":
+            from .model_runner_v2 import TTModelRunnerV2
+
+            self.model_runner = TTModelRunnerV2(self.vllm_config, self.device)
+        else:
+            ModelRunnerClass = TTModelRunner
+            if self.model_config.runner_type == "pooling":
+                ModelRunnerClass = TTPoolingModelRunner
+            self.model_runner = ModelRunnerClass(
+                self.vllm_config, self.device, self.original_parallel_config
+            )
 
         if rank == 0:
             # If usage stat is enabled, collect relevant info.

--- a/tests/integrations/vllm_plugin/mrv2/test_input_batch.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_input_batch.py
@@ -12,7 +12,6 @@ Runs on cpu (device=torch.device("cpu")), no TT hardware.
 
 import pytest
 import torch
-
 from vllm_tt.input_batch_v2 import TTInputBatch, TTInputBuffers
 
 

--- a/tests/integrations/vllm_plugin/mrv2/test_input_batch.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_input_batch.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU smoke test for the MRv2 ``TTInputBatch.make_dummy`` builder.
+
+``TTInputBatch`` (see vllm_tt/input_batch_v2.py) is a near-verbatim port of
+upstream's transient per-step view, so coverage here is intentionally light --
+one shape/layout invariant check on the dummy builder used for warmup. The
+real per-step population logic lives in the Phase 3 runner and is tested there.
+Runs on cpu (device=torch.device("cpu")), no TT hardware.
+"""
+
+import pytest
+import torch
+
+from vllm_tt.input_batch_v2 import TTInputBatch, TTInputBuffers
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+@pytest.mark.parametrize(
+    "num_reqs, num_tokens, expected_scheduled, expected_qsl, expected_logits",
+    [
+        (2, 6, [3, 3], [0, 3, 6], [2, 5]),  # even split
+        (2, 7, [3, 4], [0, 3, 7], [2, 6]),  # remainder lands on the last req
+    ],
+)
+def test_make_dummy_layout(
+    num_reqs, num_tokens, expected_scheduled, expected_qsl, expected_logits
+):
+    bufs = TTInputBuffers(max_num_reqs=4, max_num_tokens=16, device=torch.device("cpu"))
+    ib = TTInputBatch.make_dummy(
+        num_reqs=num_reqs, num_tokens=num_tokens, input_buffers=bufs
+    )
+
+    assert ib.num_reqs == num_reqs
+    assert ib.num_tokens == num_tokens
+    assert ib.num_scheduled_tokens.tolist() == expected_scheduled
+    assert int(ib.num_scheduled_tokens.sum()) == num_tokens
+    assert ib.query_start_loc.tolist() == expected_qsl
+    # One logit per request, at each request's last token.
+    assert ib.logits_indices.tolist() == expected_logits
+    assert ib.idx_mapping.tolist() == list(range(num_reqs))
+    assert tuple(ib.input_ids.shape) == (num_tokens,)
+    assert tuple(ib.positions.shape) == (num_tokens,)
+    # TT has no spec decode / DCP -> these stay at their degenerate defaults.
+    assert ib.num_draft_tokens == 0
+    assert ib.dcp_local_seq_lens is None

--- a/tests/integrations/vllm_plugin/mrv2/test_model_state.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_model_state.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU unit tests for the MRv2 ``TTModelState.prepare_attn`` assembler.
+
+``prepare_attn`` (see vllm_tt/model_state.py) packages the per-step device
+arrays the runner computes host-side into a single ``TTMetadata`` and fans it
+out to every attention layer -- mirroring the v1 fork's
+``dict.fromkeys(self._attention_layer_names, attn_metadata)``. It uses no
+instance state, so these run on cpu with no TT hardware and no model
+(the state object is allocated without ``__init__``).
+"""
+
+import pytest
+import torch
+
+from vllm_tt.attention_impls.attention import TTMetadata
+from vllm_tt.model_state import TTModelState
+
+
+def _bare_state():
+    # prepare_attn reads no self.* state; skip the heavy VllmConfig __init__.
+    return object.__new__(TTModelState)
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_prepare_attn_fans_out_shared_metadata_per_layer():
+    ms = _bare_state()
+    layers = ["layer.0", "layer.1", "layer.2"]
+    page_table = torch.zeros(4, 8, dtype=torch.int32)
+    cache_position = torch.zeros(4, dtype=torch.int32)
+    fill_page_table = torch.ones(4, 8, dtype=torch.int32)
+    batch_idx = torch.arange(4, dtype=torch.int32)
+
+    out = ms.prepare_attn(
+        layers,
+        page_table=page_table,
+        cache_position=cache_position,
+        fill_page_table=fill_page_table,
+        batch_idx=batch_idx,
+        num_users=4,
+        dp_size=2,
+    )
+
+    assert set(out.keys()) == set(layers)
+    metas = list(out.values())
+    # One shared TTMetadata object across all layers (matches dict.fromkeys).
+    assert all(m is metas[0] for m in metas)
+
+    m = metas[0]
+    assert isinstance(m, TTMetadata)
+    assert m.num_users == 4
+    assert m.dp_size == 2
+    assert m.is_causal is True
+    assert m.attn_mask is None
+    assert m.chunk_start_idx is None
+    assert m.page_table is page_table
+    assert m.fill_page_table is fill_page_table
+    assert m.cache_position is cache_position
+    assert m.batch_idx is batch_idx
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_prepare_attn_fill_page_table_defaults_to_page_table():
+    ms = _bare_state()
+    page_table = torch.zeros(2, 4, dtype=torch.int32)
+
+    out = ms.prepare_attn(
+        ["only.layer"],
+        page_table=page_table,
+        cache_position=torch.zeros(2, dtype=torch.int32),
+        num_users=2,
+    )
+
+    m = out["only.layer"]
+    # No prefix roll supplied -> fill_page_table mirrors page_table.
+    assert m.fill_page_table is page_table
+    assert m.dp_size == 1
+    assert m.batch_idx is None

--- a/tests/integrations/vllm_plugin/mrv2/test_model_state.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_model_state.py
@@ -13,7 +13,6 @@ instance state, so these run on cpu with no TT hardware and no model
 
 import pytest
 import torch
-
 from vllm_tt.attention_impls.attention import TTMetadata
 from vllm_tt.model_state import TTModelState
 

--- a/tests/integrations/vllm_plugin/mrv2/test_request_state.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_request_state.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU unit tests for the MRv2 ``TTRequestState`` slot table.
+
+``TTRequestState`` (see vllm_tt/request_state.py) is pure host-side numpy, so
+these run on a cpu-only runner with no TT hardware and no model. They pin the
+invariants that are TT's own responsibility and stable across the remaining
+MRv2 phases: the stable-slot / free-list lifecycle (which replaces v1's
+condense-and-shuffle bookkeeping and the slot-corruption bugs it caused),
+length accounting, and the numpy substitution for upstream's UVA buffers.
+
+These do NOT exercise the end-to-end runner path -- nothing consumes
+``TTRequestState`` until the Phase 3 runner exists.
+"""
+
+import numpy as np
+import pytest
+
+from vllm_tt.request_state import TTRequestState
+
+
+def make_state(max_num_reqs=4, max_model_len=32, num_speculative_steps=0):
+    return TTRequestState(
+        max_num_reqs=max_num_reqs,
+        max_model_len=max_model_len,
+        max_num_batched_tokens=64,
+        num_speculative_steps=num_speculative_steps,
+        vocab_size=1000,
+        device="cpu",
+    )
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_add_request_records_lengths_and_tokens():
+    rs = make_state()
+    rs.add_request("A", prompt_len=3, all_token_ids=[10, 11, 12], num_computed_tokens=0)
+
+    slot = rs.req_id_to_index["A"]
+    assert rs.num_reqs == 1
+    assert rs.index_to_req_id[slot] == "A"
+    assert rs.prompt_len[slot] == 3
+    assert rs.prefill_len[slot] == 3
+    assert rs.total_len[slot] == 3
+    assert rs.num_computed_tokens[slot] == 0
+    assert rs.num_computed_prefill_tokens[slot] == 0
+    np.testing.assert_array_equal(rs.all_token_ids[slot, :3], [10, 11, 12])
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_free_slot_reused_after_removal_without_condensing():
+    """A removed slot returns to the free list and is reused; other requests
+    keep their slot and tokens (no v1-style condense/shuffle)."""
+    rs = make_state(max_num_reqs=4)
+    rs.add_request("A", prompt_len=3, all_token_ids=[10, 11, 12], num_computed_tokens=0)
+    rs.add_request("B", prompt_len=2, all_token_ids=[20, 21], num_computed_tokens=0)
+    rs.add_request("C", prompt_len=1, all_token_ids=[30], num_computed_tokens=0)
+
+    slot_a, slot_b, slot_c = (rs.req_id_to_index[r] for r in ("A", "B", "C"))
+
+    assert rs.remove_request("B") is True
+    assert "B" not in rs.req_id_to_index
+    assert slot_b in rs.free_indices
+
+    # A and C are untouched by B's removal.
+    assert rs.req_id_to_index["A"] == slot_a
+    assert rs.req_id_to_index["C"] == slot_c
+    np.testing.assert_array_equal(rs.all_token_ids[slot_a, :3], [10, 11, 12])
+
+    # The next request reuses B's freed slot.
+    rs.add_request("D", prompt_len=2, all_token_ids=[40, 41], num_computed_tokens=0)
+    assert rs.req_id_to_index["D"] == slot_b
+    assert rs.num_reqs == 3
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_is_prefilling_mixed_batch():
+    rs = make_state()
+    # P is mid-prefill: 2 of 5 tokens computed.
+    rs.add_request(
+        "P", prompt_len=5, all_token_ids=[1, 2, 3, 4, 5], num_computed_tokens=2
+    )
+    # D has finished prefill (all 3 computed) -> decoding.
+    rs.add_request("D", prompt_len=3, all_token_ids=[6, 7, 8], num_computed_tokens=3)
+
+    idx = np.array([rs.req_id_to_index["P"], rs.req_id_to_index["D"]], dtype=np.int32)
+    np.testing.assert_array_equal(rs.is_prefilling(idx), [True, False])
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+@pytest.mark.parametrize(
+    "num_computed, expected_last",
+    [
+        (0, 0),  # fresh prefill: slot never seeded (stays zero-initialized)
+        (2, 8),  # resumed: seeded with all_token_ids[num_computed - 1]
+    ],
+)
+def test_resumed_request_seeds_last_sampled(num_computed, expected_last):
+    rs = make_state()
+    rs.add_request(
+        "R",
+        prompt_len=4,
+        all_token_ids=[7, 8, 9, 10],
+        num_computed_tokens=num_computed,
+    )
+    slot = rs.req_id_to_index["R"]
+    assert rs.last_sampled_tokens[slot, 0] == expected_last
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_remove_request_return_value():
+    rs = make_state()
+    rs.add_request("A", prompt_len=1, all_token_ids=[10], num_computed_tokens=0)
+
+    assert rs.remove_request("missing") is False
+    assert rs.remove_request("A") is True
+    assert rs.num_reqs == 0
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_apply_staged_writes_is_noop():
+    """Locks the numpy substitution: writes land immediately in add_request, so
+    apply_staged_writes must not mutate state (upstream flushes UVA here)."""
+    rs = make_state()
+    rs.add_request("A", prompt_len=2, all_token_ids=[10, 11], num_computed_tokens=0)
+    slot = rs.req_id_to_index["A"]
+    before = rs.all_token_ids[slot, :2].copy()
+
+    rs.apply_staged_writes()
+
+    assert rs.num_reqs == 1
+    np.testing.assert_array_equal(rs.all_token_ids[slot, :2], before)

--- a/tests/integrations/vllm_plugin/mrv2/test_request_state.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_request_state.py
@@ -16,7 +16,6 @@ These do NOT exercise the end-to-end runner path -- nothing consumes
 
 import numpy as np
 import pytest
-
 from vllm_tt.request_state import TTRequestState
 
 

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_attn_prep.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_attn_prep.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU unit tests for the MRv2 runner attention slot-mapping build.
+
+``TTModelRunnerV2._prepare_attn_tensors`` (see vllm_tt/model_runner_v2.py) is the
+host substitute for upstream's block-table / slot-mapping Triton kernels. It is
+pure numpy over ``TTRequestState`` + the runner block table, so it runs on cpu
+with no TT hardware: the runner is allocated without ``__init__`` and the block
+table is a fake returning a fixed numpy block map.
+
+They pin the paged-attention math TT owns: the batch-order gather, the prefix
+roll for ``paged_fill_cache``, the zero-scheduled-row redirect, and null padding.
+The output feeds ``TTModelState.prepare_attn`` (tested separately).
+"""
+
+import numpy as np
+import pytest
+import torch
+
+from vllm_tt.model_runner_v2 import TTModelRunnerV2
+from vllm_tt.request_state import TTRequestState
+
+VOCAB = 1000
+# slot -> block ids (row 3 is the unused/null slot).
+BLOCK_MAP = [[10, 11, 12, 13], [20, 21, 22, 23], [30, 31, 32, 33], [0, 0, 0, 0]]
+
+
+class FakeBlockTable:
+    def __init__(self, arr):
+        self._arr = arr
+
+    def __getitem__(self, group):  # block_table[0] -> the single kv group
+        return self
+
+    def get_cpu_tensor(self):
+        return self._arr
+
+
+def make_runner(block_size=2, max_num_reqs=4, max_model_len=32):
+    r = object.__new__(TTModelRunnerV2)
+    r.req_states = TTRequestState(
+        max_num_reqs=max_num_reqs,
+        max_model_len=max_model_len,
+        max_num_batched_tokens=64,
+        num_speculative_steps=0,
+        vocab_size=VOCAB,
+        device="cpu",
+    )
+    r.block_table = FakeBlockTable(torch.tensor(BLOCK_MAP, dtype=torch.int32))
+    r.block_size = block_size
+    return r
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_attn_tensors_no_prefix_gathers_in_batch_order():
+    r = make_runner()
+    # Batch order [slot1, slot0]; no computed prefix.
+    idx = np.array([1, 0], dtype=np.int32)
+    nst = np.array([5, 3], dtype=np.int32)
+    seq_lens = np.array([5, 3, 0, 0], dtype=np.int32)
+
+    page_table, fill_page_table, cache_position = r._prepare_attn_tensors(
+        idx, nst, seq_lens, target_num_reqs=4, num_blocks_per_req=4
+    )
+
+    assert page_table[0].tolist() == [20, 21, 22, 23]  # slot 1
+    assert page_table[1].tolist() == [10, 11, 12, 13]  # slot 0
+    assert page_table[2].tolist() == [0, 0, 0, 0]  # padding
+    assert cache_position.tolist() == [4, 2, -1, -1]  # seq_lens - 1, pad -1
+    # No prefix -> no roll -> fill aliases the read table.
+    assert fill_page_table is page_table
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_attn_tensors_prefix_roll():
+    r = make_runner(block_size=2)
+    # slot 0 has 4 computed tokens -> offset 4 // 2 == 2 blocks.
+    r.req_states.num_computed_tokens[0] = 4
+    idx = np.array([0], dtype=np.int32)
+    nst = np.array([3], dtype=np.int32)
+    seq_lens = np.array([7, 0], dtype=np.int32)
+
+    page_table, fill_page_table, cache_position = r._prepare_attn_tensors(
+        idx, nst, seq_lens, target_num_reqs=2, num_blocks_per_req=4
+    )
+
+    assert fill_page_table is not page_table
+    # Read path keeps the real order; write path is rolled left by 2.
+    assert page_table[0].tolist() == [10, 11, 12, 13]
+    assert fill_page_table[0].tolist() == [12, 13, 10, 11]
+    assert cache_position.tolist() == [6, -1]
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_attn_tensors_zero_scheduled_row_redirects_fill():
+    r = make_runner()
+    # Row 0 is a re-batched, already-prefilled request: 0 scheduled tokens.
+    idx = np.array([0, 1], dtype=np.int32)
+    nst = np.array([0, 3], dtype=np.int32)
+    seq_lens = np.array([5, 3, 0, 0], dtype=np.int32)
+
+    page_table, fill_page_table, _ = r._prepare_attn_tensors(
+        idx, nst, seq_lens, target_num_reqs=4, num_blocks_per_req=4
+    )
+
+    assert fill_page_table is not page_table
+    # Read path keeps slot 0's real blocks; write path is nulled so it can't
+    # clobber the KV written for that request in an earlier step.
+    assert page_table[0].tolist() == [10, 11, 12, 13]
+    assert fill_page_table[0].tolist() == [0, 0, 0, 0]
+    assert fill_page_table[1].tolist() == [20, 21, 22, 23]

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_attn_prep.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_attn_prep.py
@@ -17,7 +17,6 @@ The output feeds ``TTModelState.prepare_attn`` (tested separately).
 import numpy as np
 import pytest
 import torch
-
 from vllm_tt.model_runner_v2 import TTModelRunnerV2
 from vllm_tt.request_state import TTRequestState
 

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_batch_select.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_batch_select.py
@@ -14,10 +14,10 @@ multi-pass split, and the decode/prefill target-bucket + padded query length.
 The outputs feed ``_prepare_input_tokens`` and ``_prepare_attn_tensors``.
 """
 
-import numpy as np
-import pytest
 from types import SimpleNamespace
 
+import numpy as np
+import pytest
 from vllm_tt.model_runner_v2 import TTModelRunnerV2
 from vllm_tt.request_state import TTRequestState
 

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_batch_select.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_batch_select.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU unit tests for the MRv2 runner batch selection.
+
+``TTModelRunnerV2._order_scheduled_reqs`` / ``_select_batch`` (see
+vllm_tt/model_runner_v2.py) are pure host logic: they order a step's scheduled
+requests decodes-first and carve out one pass's sub-batch under the SMEM row
+caps. They run on cpu with no TT hardware; the SMEM-cap scalars are injected.
+
+They pin the selection math TT owns: decode-first ordering, the max/most model-len
+row cap (a long tail request forcing max-model-len mode), the prefill-cap
+multi-pass split, and the decode/prefill target-bucket + padded query length.
+The outputs feed ``_prepare_input_tokens`` and ``_prepare_attn_tensors``.
+"""
+
+import numpy as np
+import pytest
+from types import SimpleNamespace
+
+from vllm_tt.model_runner_v2 import TTModelRunnerV2
+from vllm_tt.request_state import TTRequestState
+
+VOCAB = 1000
+PADDINGS = [1, 32, 64, 128, 256]
+
+
+def make_runner(**scalars):
+    r = object.__new__(TTModelRunnerV2)
+    r.req_states = TTRequestState(
+        max_num_reqs=8,
+        max_model_len=512,
+        max_num_batched_tokens=1024,
+        num_speculative_steps=0,
+        vocab_size=VOCAB,
+        device="cpu",
+    )
+    r.most_model_len = scalars.get("most_model_len", None)
+    r.num_reqs_max_model_len = scalars.get("num_reqs_max_model_len", 3)
+    r.num_reqs_most_model_len = scalars.get("num_reqs_most_model_len", None)
+    r.max_prefill_num_reqs = scalars.get("max_prefill_num_reqs", 2)
+    r.min_num_reqs = scalars.get("min_num_reqs", 1)
+    r.max_num_reqs = scalars.get("max_num_reqs", 4)
+    r.num_tokens_paddings = scalars.get("num_tokens_paddings", PADDINGS)
+    return r
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_order_scheduled_reqs_decodes_first():
+    r = make_runner()
+    for rid, prompt in [("A", [1]), ("B", [1, 2]), ("C", [3])]:
+        r.req_states.add_request(rid, len(prompt), prompt, 0)
+    s_a = r.req_states.req_id_to_index["A"]
+    s_b = r.req_states.req_id_to_index["B"]
+    s_c = r.req_states.req_id_to_index["C"]
+
+    so = SimpleNamespace(num_scheduled_tokens={"A": 1, "B": 10, "C": 1})
+    slots, ntoks = r._order_scheduled_reqs(so)
+
+    # Ascending by scheduled tokens: decodes (A, C) before the prefill (B).
+    assert ntoks.tolist() == [1, 1, 10]
+    assert slots.tolist() == [s_a, s_c, s_b]
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_order_skips_reqs_without_slot():
+    r = make_runner()
+    r.req_states.add_request("A", 1, [1], 0)
+    s_a = r.req_states.req_id_to_index["A"]
+    so = SimpleNamespace(num_scheduled_tokens={"A": 1, "GHOST": 5})
+    slots, ntoks = r._order_scheduled_reqs(so)
+    assert slots.tolist() == [s_a]
+    assert ntoks.tolist() == [1]
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_select_batch_decode_runs_at_max_bucket():
+    r = make_runner(most_model_len=None, num_reqs_max_model_len=3, max_num_reqs=4)
+    slots = np.array([0, 1, 2], dtype=np.int32)
+    ntoks = np.array([1, 1, 1], dtype=np.int32)
+
+    idx, nst, target, padded, end = r._select_batch(slots, ntoks, 0)
+    assert idx.tolist() == [0, 1, 2]
+    assert nst.tolist() == [1, 1, 1]
+    assert target == 4  # decode -> max_num_reqs
+    assert padded == 1
+    assert end == 3
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_select_batch_prefill_cap_multipass():
+    r = make_runner(
+        most_model_len=None,
+        num_reqs_max_model_len=3,
+        max_prefill_num_reqs=2,
+        min_num_reqs=1,
+    )
+    slots = np.array([0, 1, 2, 3], dtype=np.int32)
+    ntoks = np.array([10, 20, 30, 40], dtype=np.int32)
+
+    idx0, nst0, target0, padded0, end0 = r._select_batch(slots, ntoks, 0)
+    assert idx0.tolist() == [0, 1]  # trimmed to the prefill cap
+    assert nst0.tolist() == [10, 20]
+    assert target0 == 2  # prefill bucket (actual > min_num_reqs)
+    assert padded0 == 32  # ceil-bucket of 20
+    assert end0 == 2
+
+    idx1, nst1, target1, padded1, end1 = r._select_batch(slots, ntoks, end0)
+    assert idx1.tolist() == [2, 3]
+    assert padded1 == 64  # ceil-bucket of 40
+    assert end1 == 4
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_select_batch_long_request_forces_max_model_len_cap():
+    r = make_runner(
+        most_model_len=100,
+        num_reqs_most_model_len=3,
+        num_reqs_max_model_len=2,
+        max_prefill_num_reqs=4,
+        min_num_reqs=1,
+    )
+    slots = np.array([0, 1, 2], dtype=np.int32)
+    ntoks = np.array([5, 5, 200], dtype=np.int32)  # 200 > most_model_len
+
+    idx0, nst0, target0, padded0, end0 = r._select_batch(slots, ntoks, 0)
+    # A long tail request forces the tighter max-model-len row cap (2, not 3).
+    assert idx0.tolist() == [0, 1]
+    assert end0 == 2
+    assert padded0 == 32  # ceil-bucket of 5
+
+    idx1, nst1, target1, padded1, end1 = r._select_batch(slots, ntoks, end0)
+    assert idx1.tolist() == [2]
+    assert target1 == 1  # actual (1) <= min_num_reqs
+    assert padded1 == 256  # ceil-bucket of 200
+    assert end1 == 3
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_select_batch_uses_most_model_len_cap_when_no_long_request():
+    r = make_runner(
+        most_model_len=100,
+        num_reqs_most_model_len=3,
+        num_reqs_max_model_len=2,
+        max_prefill_num_reqs=4,
+        min_num_reqs=1,
+    )
+    slots = np.array([0, 1, 2, 3], dtype=np.int32)
+    ntoks = np.array([5, 5, 5, 5], dtype=np.int32)  # none exceed most_model_len
+
+    idx0, nst0, target0, padded0, end0 = r._select_batch(slots, ntoks, 0)
+    # No long request -> the looser most-model-len row cap (3) applies.
+    assert idx0.tolist() == [0, 1, 2]
+    assert end0 == 3

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_driver.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_driver.py
@@ -20,7 +20,6 @@ from types import SimpleNamespace
 import pytest
 import torch
 from vllm.sampling_params import SamplingParams
-
 from vllm_tt.model_runner_v2 import TTModelRunnerV2
 from vllm_tt.request_state import TTRequestState
 from vllm_tt.sampling_state_v2 import TTSamplingStates

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_driver.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_driver.py
@@ -1,0 +1,181 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU integration tests for the MRv2 runner two-phase driver.
+
+``TTModelRunnerV2.execute_model`` / ``sample_tokens`` (see
+vllm_tt/model_runner_v2.py) compose the tested host stages around the single
+hardware leaf ``_run_model_pass``. By injecting a fake ``_run_model_pass`` (the
+only device-coupled call), the whole host driver -- state update, decode-first
+ordering, multi-pass loop, writeback, and output assembly -- runs on cpu with no
+TT hardware and no model.
+
+They pin the driver composition: the two-phase stash/hand-off, the decode-first
+output ordering, and that the sampled tokens flow through postprocess into both
+the ModelRunnerOutput and the request token tables.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from vllm.sampling_params import SamplingParams
+
+from vllm_tt.model_runner_v2 import TTModelRunnerV2
+from vllm_tt.request_state import TTRequestState
+from vllm_tt.sampling_state_v2 import TTSamplingStates
+
+VOCAB = 1000
+
+
+class FakeBlockTable:
+    """Host block table: stores rows on add and serves them to _prepare_attn_tensors."""
+
+    def __init__(self, max_num_reqs, max_blocks):
+        self._arr = torch.zeros((max_num_reqs, max_blocks), dtype=torch.int32)
+
+    def add_row(self, block_ids, slot):
+        ids = list(block_ids[0])  # single kv group
+        if ids:
+            self._arr[slot, : len(ids)] = torch.tensor(ids, dtype=torch.int32)
+
+    def append_row(self, block_ids, slot):
+        pass  # not exercised in these single-step scenarios
+
+    def clear_row(self, slot):
+        self._arr[slot] = 0
+
+    def __getitem__(self, group):
+        return self
+
+    def get_cpu_tensor(self):
+        return self._arr
+
+
+def make_runner(max_num_reqs=8, max_model_len=32, max_num_blocks_per_req=4):
+    r = object.__new__(TTModelRunnerV2)
+    r.req_states = TTRequestState(
+        max_num_reqs=max_num_reqs,
+        max_model_len=max_model_len,
+        max_num_batched_tokens=128,
+        num_speculative_steps=0,
+        vocab_size=VOCAB,
+        device="cpu",
+    )
+    r.sampling_states = TTSamplingStates(max_num_reqs=max_num_reqs, vocab_size=VOCAB)
+    r.block_table = FakeBlockTable(max_num_reqs, max_num_blocks_per_req)
+    r.encoder_cache = {}
+    r.num_prompt_logprobs = {}
+    r.model_state = None
+    r.vocab_size = VOCAB
+    r.scheduler_output = None
+    r.supports_mm_inputs = False
+    r.max_num_blocks_per_req = max_num_blocks_per_req
+    r.block_size = 16
+    # SMEM-cap scalars: generous so scenarios run in a single pass.
+    r.most_model_len = None
+    r.num_reqs_max_model_len = max_num_reqs
+    r.num_reqs_most_model_len = None
+    r.min_num_reqs = 1
+    r.max_prefill_num_reqs = max_num_reqs
+    r.max_num_reqs = max_num_reqs
+    r.num_tokens_paddings = [1, 32, 64, 128]
+    return r
+
+
+def new_req(req_id, prompt, block_ids=([0],)):
+    return SimpleNamespace(
+        req_id=req_id,
+        sampling_params=SamplingParams(temperature=0.0),
+        prompt_token_ids=prompt,
+        prefill_token_ids=prompt,
+        num_computed_tokens=0,
+        block_ids=block_ids,
+    )
+
+
+def make_sched(new=(), num_sched=None, total=None):
+    num_sched = dict(num_sched or {})
+    cached = SimpleNamespace(req_ids=[], num_computed_tokens=[], new_block_ids=[])
+    return SimpleNamespace(
+        scheduled_new_reqs=list(new),
+        scheduled_cached_reqs=cached,
+        num_scheduled_tokens=num_sched,
+        total_num_scheduled_tokens=(
+            sum(num_sched.values()) if total is None else total
+        ),
+        finished_req_ids=[],
+        preempted_req_ids=[],
+        free_encoder_mm_hashes=[],
+    )
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_execute_model_stashes_and_returns_none():
+    r = make_runner()
+    so = make_sched(new=[new_req("A", [1, 2, 3])], num_sched={"A": 3})
+    assert r.execute_model(so) is None
+    assert r.scheduler_output is so
+    assert r.req_states.num_reqs == 1  # add_requests ran
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_execute_model_no_tokens_returns_empty_output():
+    r = make_runner()
+    out = r.execute_model(make_sched(num_sched={}, total=0))
+    assert out is not None
+    assert out.req_ids == []
+    assert r.scheduler_output is None  # nothing stashed
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_execute_model_rejects_reentry_before_sampling():
+    r = make_runner()
+    r.scheduler_output = object()  # a step already pending
+    with pytest.raises(AssertionError):
+        r.execute_model(make_sched(new=[new_req("A", [1])], num_sched={"A": 1}))
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_sample_tokens_composes_full_prefill_batch():
+    r = make_runner()
+    so = make_sched(
+        new=[new_req("A", [1, 2, 3]), new_req("B", [4, 5])],
+        num_sched={"A": 3, "B": 2},
+    )
+    assert r.execute_model(so) is None
+
+    slot_a = r.req_states.req_id_to_index["A"]
+    slot_b = r.req_states.req_id_to_index["B"]
+
+    # Fake the one hardware leaf: return a distinct token per active req.
+    r._run_model_pass = lambda idx, ns, tnr, pql, ii, pos, li, pt, fpt, cp: [
+        [1000 + int(idx[b])] for b in range(len(idx))
+    ]
+
+    out = r.sample_tokens(None)
+
+    # Decode-first ordering puts the shorter request (B, 2 tokens) first.
+    assert out.req_ids == ["B", "A"]
+    assert out.sampled_token_ids == [[1000 + slot_b], [1000 + slot_a]]
+    assert out.req_id_to_index == {"B": 0, "A": 1}
+
+    # Writeback grew both token tables (both finished prefill this step).
+    assert r.req_states.total_len[slot_a] == 4
+    assert r.req_states.all_token_ids[slot_a, 3] == 1000 + slot_a
+    assert r.req_states.total_len[slot_b] == 3
+    assert r.req_states.all_token_ids[slot_b, 2] == 1000 + slot_b
+
+    # Step fully consumed -> ready for the next execute_model.
+    assert r.scheduler_output is None
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_sample_tokens_returns_none_without_stashed_step():
+    r = make_runner()
+    assert r.sample_tokens(None) is None

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_init.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_init.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU unit tests for the MRv2 runner __init__ state construction.
+
+``TTModelRunnerV2.__init__`` (see vllm_tt/model_runner_v2.py) extracts config
+scalars and builds the split v2 state. It reads a fixed set of vllm_config
+attributes, so a duck-typed fake config exercises it on cpu with no engine, no
+model, and no TT hardware (device=cpu). ``load_model`` needs a real model/loader
+and is validated at engine stand-up, not here.
+
+They pin the wiring: scalar/SMEM-cap derivation, the token-padding ladder, the
+constructed state tables, the not-yet-loaded (None) model handles, and the
+single-device guard.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm_tt.model_runner_v2 import TTModelRunnerV2
+from vllm_tt.request_state import TTRequestState
+from vllm_tt.sampling_state_v2 import TTSamplingStates
+
+
+def make_vllm_config(**tt_overrides):
+    model_config = SimpleNamespace(
+        dtype=torch.bfloat16,
+        max_model_len=256,
+        get_sliding_window=lambda: None,
+        get_num_layers_by_block_type=lambda pc, t: 2,
+        get_num_attention_heads=lambda pc: 8,
+        get_num_kv_heads=lambda pc: 8,
+        get_head_size=lambda: 64,
+        get_vocab_size=lambda: 1000,
+        get_inputs_embeds_size=lambda: 512,
+        is_multimodal_model=False,
+    )
+    cache_config = SimpleNamespace(block_size=32, cache_dtype="auto")
+    scheduler_config = SimpleNamespace(max_num_seqs=8, max_num_batched_tokens=2048)
+    tt_config = SimpleNamespace(
+        enable_tensor_parallel=False,
+        enable_data_parallel=False,
+        experimental_kv_cache_dtype=None,
+        min_num_seqs=None,
+        max_prefill_num_seqs=None,
+        min_context_len=32,
+        decode_only=False,
+        flat_model_io=False,
+        cpu_sampling=False,
+        enable_decode_fused_graphs=False,
+    )
+    for k, v in tt_overrides.items():
+        setattr(tt_config, k, v)
+    return SimpleNamespace(
+        model_config=model_config,
+        cache_config=cache_config,
+        scheduler_config=scheduler_config,
+        parallel_config=object(),
+        load_config=object(),
+        lora_config=None,
+        additional_config=tt_config,
+    )
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_init_scalars_and_smem_caps():
+    r = TTModelRunnerV2(make_vllm_config(), torch.device("cpu"))
+
+    assert r.block_size == 32
+    assert r.max_model_len == 256
+    assert r.max_num_reqs == 8
+    assert r.vocab_size == 1000
+    assert r.max_num_blocks_per_req == 8  # cdiv(256, 32)
+    assert r.num_kv_heads == 8
+    assert r.head_size == 64
+    assert r.kv_cache_dtype == torch.bfloat16  # cache_dtype="auto" -> model dtype
+    assert r.supports_mm_inputs is False
+    # No VLLM_TPU_MOST_MODEL_LEN by default -> only the max-model-len cap applies.
+    assert r.num_reqs_most_model_len is None
+    # get_max_num_seqs(256, 32) is huge, so the cap is max_num_reqs.
+    assert r.num_reqs_max_model_len == 8
+    assert r.min_num_reqs == 8
+    assert r.max_prefill_num_reqs == 8
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_init_token_padding_ladder():
+    r = TTModelRunnerV2(make_vllm_config(), torch.device("cpu"))
+    # _get_token_paddings(32, min(2048, 256)=256): [1] + powers of two up to >=256.
+    assert r.num_tokens_paddings == [1, 32, 64, 128, 256]
+    assert r.max_num_tokens == 256
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_init_decode_only_restricts_paddings():
+    r = TTModelRunnerV2(make_vllm_config(decode_only=True), torch.device("cpu"))
+    assert r.num_tokens_paddings == [1]
+    assert r.max_num_tokens == 1
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_init_builds_split_state_tables():
+    r = TTModelRunnerV2(make_vllm_config(), torch.device("cpu"))
+
+    assert isinstance(r.req_states, TTRequestState)
+    assert r.req_states.max_num_reqs == 8
+    assert r.req_states.max_model_len == 256
+    assert isinstance(r.sampling_states, TTSamplingStates)
+    # Block table + input buffers are constructed and correctly sized.
+    assert hasattr(r.block_table, "add_row")
+    assert tuple(r.input_buffers.input_ids.shape) == (r.max_num_tokens,)
+    # Runtime-side state initialised empty.
+    assert r.encoder_cache == {}
+    assert r.num_prompt_logprobs == {}
+    assert r.kv_caches == []
+    assert r.scheduler_output is None
+    assert r.dp_size == 1
+    assert r.enable_tensor_parallel is False
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_init_model_handles_none_until_load():
+    r = TTModelRunnerV2(make_vllm_config(), torch.device("cpu"))
+    assert r.model is None
+    assert r.model_state is None
+    assert r.sampler is None
+    assert r.attention_layer_names == ()
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_init_rejects_multi_device():
+    with pytest.raises(NotImplementedError):
+        TTModelRunnerV2(
+            make_vllm_config(enable_tensor_parallel=True), torch.device("cpu")
+        )

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_init.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_init.py
@@ -25,6 +25,7 @@ from vllm_tt.sampling_state_v2 import TTSamplingStates
 
 def make_vllm_config(**tt_overrides):
     model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(num_hidden_layers=2),
         dtype=torch.bfloat16,
         max_model_len=256,
         get_sliding_window=lambda: None,
@@ -137,3 +138,36 @@ def test_init_rejects_multi_device():
         TTModelRunnerV2(
             make_vllm_config(enable_tensor_parallel=True), torch.device("cpu")
         )
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_init_no_layer_override_by_default():
+    cfg = make_vllm_config()
+    r = TTModelRunnerV2(cfg, torch.device("cpu"))
+    # Default num_hidden_layers=0 -> no override, hf_config untouched.
+    assert r._original_num_layers is None
+    assert r._target_num_layers is None
+    assert cfg.model_config.hf_config.num_hidden_layers == 2
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_init_applies_layer_override():
+    cfg = make_vllm_config(num_hidden_layers=1)
+    r = TTModelRunnerV2(cfg, torch.device("cpu"))
+    # Override mutates hf_config so only the target layers get built.
+    assert r._original_num_layers == 2
+    assert r._target_num_layers == 1
+    assert cfg.model_config.hf_config.num_hidden_layers == 1
+    # The weight filter drops layers >= target and keeps the rest.
+    weights = [
+        ("model.layers.0.self_attn.qkv_proj.weight", 0),
+        ("model.layers.1.self_attn.qkv_proj.weight", 1),
+        ("model.embed_tokens.weight", 2),
+    ]
+    kept = [n for n, _ in r._filter_weights_for_layer_override(iter(weights))]
+    assert kept == [
+        "model.layers.0.self_attn.qkv_proj.weight",
+        "model.embed_tokens.weight",
+    ]

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_init.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_init.py
@@ -39,20 +39,10 @@ def make_vllm_config(**tt_overrides):
     )
     cache_config = SimpleNamespace(block_size=32, cache_dtype="auto")
     scheduler_config = SimpleNamespace(max_num_seqs=8, max_num_batched_tokens=2048)
-    tt_config = SimpleNamespace(
-        enable_tensor_parallel=False,
-        enable_data_parallel=False,
-        experimental_kv_cache_dtype=None,
-        min_num_seqs=None,
-        max_prefill_num_seqs=None,
-        min_context_len=32,
-        decode_only=False,
-        flat_model_io=False,
-        cpu_sampling=False,
-        enable_decode_fused_graphs=False,
-    )
-    for k, v in tt_overrides.items():
-        setattr(tt_config, k, v)
+    # additional_config is a plain dict (the runner builds TTConfig(**it), as the
+    # engine does). min_context_len pins the token-padding ladder deterministically.
+    additional_config = {"min_context_len": 32}
+    additional_config.update(tt_overrides)
     return SimpleNamespace(
         model_config=model_config,
         cache_config=cache_config,
@@ -60,7 +50,7 @@ def make_vllm_config(**tt_overrides):
         parallel_config=object(),
         load_config=object(),
         lora_config=None,
-        additional_config=tt_config,
+        additional_config=additional_config,
     )
 
 
@@ -82,8 +72,15 @@ def test_init_scalars_and_smem_caps():
     assert r.num_reqs_most_model_len is None
     # get_max_num_seqs(256, 32) is huge, so the cap is max_num_reqs.
     assert r.num_reqs_max_model_len == 8
-    assert r.min_num_reqs == 8
-    assert r.max_prefill_num_reqs == 8
+    # These fall back to max_num_reqs when the TTConfig fields are unset (None).
+    assert r.min_num_reqs == (
+        r.max_num_reqs if r.tt_config.min_num_seqs is None else r.tt_config.min_num_seqs
+    )
+    assert r.max_prefill_num_reqs == (
+        r.max_num_reqs
+        if r.tt_config.max_prefill_num_seqs is None
+        else r.tt_config.max_prefill_num_seqs
+    )
 
 
 @pytest.mark.push

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_init.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_init.py
@@ -18,7 +18,6 @@ from types import SimpleNamespace
 
 import pytest
 import torch
-
 from vllm_tt.model_runner_v2 import TTModelRunnerV2
 from vllm_tt.request_state import TTRequestState
 from vllm_tt.sampling_state_v2 import TTSamplingStates

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_input_prep.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_input_prep.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU unit tests for the MRv2 runner host input-token preparation.
+
+``TTModelRunnerV2._prepare_input_tokens`` (see vllm_tt/model_runner_v2.py) is
+the host substitute for upstream's Triton input-prep kernels. It is pure numpy
+over ``TTRequestState``, so it runs on cpu with no TT hardware and no model:
+the runner is allocated without ``__init__`` and only ``req_states`` is injected.
+
+They pin the index math that is TT's own responsibility: the unified
+prefill/decode gather, the computed-token position offset (chunked prefill), the
+2D forward layout with zero padding, and the query_start_loc cumsum + pad.
+"""
+
+import numpy as np
+import pytest
+
+from vllm_tt.model_runner_v2 import TTModelRunnerV2
+from vllm_tt.request_state import TTRequestState
+
+VOCAB = 1000
+
+
+def runner_with_reqs(max_num_reqs=4, max_model_len=32):
+    r = object.__new__(TTModelRunnerV2)
+    r.req_states = TTRequestState(
+        max_num_reqs=max_num_reqs,
+        max_model_len=max_model_len,
+        max_num_batched_tokens=64,
+        num_speculative_steps=0,
+        vocab_size=VOCAB,
+        device="cpu",
+    )
+    return r
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_prepare_input_tokens_prefill_and_decode_batch():
+    r = runner_with_reqs()
+    rs = r.req_states
+    rs.add_request(
+        "P", prompt_len=5, all_token_ids=[1, 2, 3, 4, 5], num_computed_tokens=0
+    )
+    rs.add_request("D", prompt_len=3, all_token_ids=[6, 7, 8], num_computed_tokens=0)
+    slot_p = rs.req_id_to_index["P"]
+    slot_d = rs.req_id_to_index["D"]
+    # Simulate D having decoded one token: the writeback grew its token table.
+    rs.all_token_ids[slot_d, 3] = 9
+    rs.total_len[slot_d] = 4
+    rs.num_computed_tokens[slot_d] = 3
+
+    # TT orders decodes first, then prefills; padded batch of 4.
+    idx = np.array([slot_d, slot_p], dtype=np.int32)
+    nst = np.array([1, 5], dtype=np.int32)
+    input_ids, positions, qsl, seq_lens, logits = r._prepare_input_tokens(
+        idx, nst, target_num_reqs=4, padded_query_len=5
+    )
+
+    assert input_ids.shape == (4, 5)
+    # Decode row: single last-sampled token read from all_token_ids.
+    assert input_ids[0].tolist() == [9, 0, 0, 0, 0]
+    # Prefill row: the whole prompt.
+    assert input_ids[1].tolist() == [1, 2, 3, 4, 5]
+    # Padding rows stay zero.
+    assert input_ids[2].tolist() == [0, 0, 0, 0, 0]
+    assert input_ids[3].tolist() == [0, 0, 0, 0, 0]
+
+    assert positions[0].tolist() == [3, 0, 0, 0, 0]
+    assert positions[1].tolist() == [0, 1, 2, 3, 4]
+
+    assert seq_lens.tolist() == [4, 5, 0, 0]  # computed + scheduled
+    assert logits.tolist() == [0, 4, 0, 0]  # n - 1 per request
+    # cumsum([1, 5]) = [1, 6]; tail padded with the last (non-decreasing).
+    assert qsl.tolist() == [0, 1, 6, 6, 6]
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_prepare_input_tokens_chunked_prefill_offset():
+    r = runner_with_reqs()
+    rs = r.req_states
+    rs.add_request(
+        "C", prompt_len=6, all_token_ids=[10, 11, 12, 13, 14, 15], num_computed_tokens=0
+    )
+    slot = rs.req_id_to_index["C"]
+    rs.num_computed_tokens[slot] = 2  # first chunk of 2 already computed
+
+    idx = np.array([slot], dtype=np.int32)
+    nst = np.array([3], dtype=np.int32)  # next chunk of 3 tokens
+    input_ids, positions, qsl, seq_lens, logits = r._prepare_input_tokens(
+        idx, nst, target_num_reqs=2, padded_query_len=4
+    )
+
+    # Gather starts at the computed offset.
+    assert input_ids[0].tolist() == [12, 13, 14, 0]
+    assert positions[0].tolist() == [2, 3, 4, 0]
+    assert seq_lens.tolist() == [5, 0]  # 2 + 3
+    assert logits.tolist() == [2, 0]  # n - 1
+    assert qsl.tolist() == [0, 3, 3]

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_input_prep.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_input_prep.py
@@ -15,7 +15,6 @@ prefill/decode gather, the computed-token position offset (chunked prefill), the
 
 import numpy as np
 import pytest
-
 from vllm_tt.model_runner_v2 import TTModelRunnerV2
 from vllm_tt.request_state import TTRequestState
 

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_kv_cache.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_kv_cache.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU unit tests for the MRv2 runner KV cache allocation logic.
+
+``TTModelRunnerV2._allocate_kv_caches`` (see vllm_tt/model_runner_v2.py) is the
+device-coupled core of ``initialize_kv_cache``, split out so its allocation
+logic runs portably on cpu (``device="cpu"``). On-device allocation on real TT
+hardware is exercised separately (not in the cpu-only suite).
+
+They pin the allocation contract TT owns: separate [k, v] tensors per standard
+layer with the right shape/dtype, the num_blocks = size // page_size math, and
+the hybrid / empty-group / block-size guards.
+"""
+
+import pytest
+import torch
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    KVCacheTensor,
+)
+
+from vllm_tt.model_runner_v2 import TTModelRunnerV2
+
+BLOCK_SIZE = 32
+NUM_KV_HEADS = 8
+HEAD_SIZE = 64
+
+
+def make_runner(device="cpu", kv_cache_dtype=torch.bfloat16, block_size=BLOCK_SIZE):
+    r = object.__new__(TTModelRunnerV2)
+    r.device = torch.device(device)
+    r.kv_cache_dtype = kv_cache_dtype
+    r.enable_tensor_parallel = False
+    r.block_size = block_size
+    return r
+
+
+def make_config(num_blocks=16, layers=("layer.0",), block_size=BLOCK_SIZE):
+    spec = FullAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=NUM_KV_HEADS,
+        head_size=HEAD_SIZE,
+        dtype=torch.bfloat16,
+    )
+    tensors = [
+        KVCacheTensor(size=num_blocks * spec.page_size_bytes, shared_by=[name])
+        for name in layers
+    ]
+    group = KVCacheGroupSpec(
+        layer_names=list(layers), kv_cache_spec=spec, is_eagle_group=False
+    )
+    return KVCacheConfig(
+        num_blocks=num_blocks, kv_cache_tensors=tensors, kv_cache_groups=[group]
+    )
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_allocate_standard_kv_caches_shapes_and_dtype():
+    r = make_runner()
+    num_blocks = 16
+    kv = r._allocate_kv_caches(make_config(num_blocks=num_blocks, layers=("l0", "l1")))
+
+    assert set(kv) == {"l0", "l1"}
+    for name in ("l0", "l1"):
+        k, v = kv[name]  # separate K/V tensors
+        assert tuple(k.shape) == (num_blocks, NUM_KV_HEADS, BLOCK_SIZE, HEAD_SIZE)
+        assert tuple(v.shape) == (num_blocks, NUM_KV_HEADS, BLOCK_SIZE, HEAD_SIZE)
+        assert k.dtype == torch.bfloat16
+        assert k.device.type == "cpu"
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_allocate_num_blocks_from_tensor_size():
+    r = make_runner()
+    # Two pages' worth of bytes -> two blocks.
+    spec = FullAttentionSpec(
+        block_size=BLOCK_SIZE,
+        num_kv_heads=NUM_KV_HEADS,
+        head_size=HEAD_SIZE,
+        dtype=torch.bfloat16,
+    )
+    cfg = KVCacheConfig(
+        num_blocks=2,
+        kv_cache_tensors=[
+            KVCacheTensor(size=2 * spec.page_size_bytes, shared_by=["l0"])
+        ],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                layer_names=["l0"], kv_cache_spec=spec, is_eagle_group=False
+            )
+        ],
+    )
+    k, _ = r._allocate_kv_caches(cfg)["l0"]
+    assert k.shape[0] == 2
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_allocate_kv_cache_dtype_override():
+    # spec.dtype may be a 1-byte accounting dtype; buffers use kv_cache_dtype.
+    r = make_runner(kv_cache_dtype=torch.float32)
+    k, _ = r._allocate_kv_caches(make_config())["layer.0"]
+    assert k.dtype == torch.float32
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_empty_group_config_skips():
+    r = make_runner()
+    cfg = KVCacheConfig(num_blocks=0, kv_cache_tensors=[], kv_cache_groups=[])
+    assert r._allocate_kv_caches(cfg) == {}
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_hybrid_config_rejected():
+    r = make_runner()
+    spec = FullAttentionSpec(
+        block_size=BLOCK_SIZE,
+        num_kv_heads=NUM_KV_HEADS,
+        head_size=HEAD_SIZE,
+        dtype=torch.bfloat16,
+    )
+    group = KVCacheGroupSpec(
+        layer_names=["l0"], kv_cache_spec=spec, is_eagle_group=False
+    )
+    cfg = KVCacheConfig(
+        num_blocks=1,
+        kv_cache_tensors=[KVCacheTensor(size=spec.page_size_bytes, shared_by=["l0"])],
+        kv_cache_groups=[group, group],
+    )
+    with pytest.raises(NotImplementedError):
+        r._allocate_kv_caches(cfg)
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_block_size_mismatch_rejected():
+    r = make_runner(block_size=16)  # runner block_size != config's 32
+    with pytest.raises(AssertionError):
+        r._allocate_kv_caches(make_config(block_size=BLOCK_SIZE))

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_kv_cache.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_kv_cache.py
@@ -21,7 +21,6 @@ from vllm.v1.kv_cache_interface import (
     KVCacheGroupSpec,
     KVCacheTensor,
 )
-
 from vllm_tt.model_runner_v2 import TTModelRunnerV2
 
 BLOCK_SIZE = 32

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_kv_spec.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_kv_spec.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU unit tests for the MRv2 runner get_kv_cache_spec.
+
+``TTModelRunnerV2.get_kv_cache_spec`` (see vllm_tt/model_runner_v2.py) walks the
+attention layers registered in the static forward context and emits a KVCacheSpec
+per layer. The layers normally come from a loaded model; here they are faked as
+bare ``Attention`` instances placed in a duck-typed vllm_config, so the
+spec-selection logic runs on cpu with no model or TT hardware.
+
+They pin the selection TT owns: full vs sliding-window specs, cross-layer KV
+sharing (skipped + recorded), and encoder-only layers (no KV cache).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from vllm.model_executor.layers.attention.attention import Attention
+from vllm.v1.attention.backend import AttentionType
+from vllm.v1.kv_cache_interface import FullAttentionSpec, SlidingWindowSpec
+
+from vllm_tt.model_runner_v2 import TTModelRunnerV2
+
+BLOCK_SIZE = 32
+
+
+def fake_attn(
+    num_kv_heads=8,
+    head_size=64,
+    attn_type=AttentionType.DECODER,
+    sliding_window=None,
+    kv_sharing_target_layer_name=None,
+):
+    # Bypass the heavy Attention.__init__; only these attrs are read.
+    m = object.__new__(Attention)
+    m.num_kv_heads = num_kv_heads
+    m.head_size = head_size
+    m.attn_type = attn_type
+    m.sliding_window = sliding_window
+    m.kv_sharing_target_layer_name = kv_sharing_target_layer_name
+    return m
+
+
+def make_runner(layers, cache_dtype="auto"):
+    r = object.__new__(TTModelRunnerV2)
+    r.kv_cache_spec_dtype = torch.bfloat16
+    r.shared_kv_cache_layers = {}
+    r.vllm_config = SimpleNamespace(
+        compilation_config=SimpleNamespace(static_forward_context=layers),
+        cache_config=SimpleNamespace(block_size=BLOCK_SIZE, cache_dtype=cache_dtype),
+    )
+    return r
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_full_attention_layers():
+    r = make_runner({"l0": fake_attn(), "l1": fake_attn(num_kv_heads=4, head_size=128)})
+    spec = r.get_kv_cache_spec()
+
+    assert set(spec) == {"l0", "l1"}
+    assert isinstance(spec["l0"], FullAttentionSpec)
+    assert spec["l0"].num_kv_heads == 8
+    assert spec["l0"].head_size == 64
+    assert spec["l0"].block_size == BLOCK_SIZE
+    assert spec["l0"].dtype == torch.bfloat16
+    assert spec["l1"].num_kv_heads == 4
+    assert spec["l1"].head_size == 128
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_sliding_window_layer():
+    r = make_runner({"l0": fake_attn(sliding_window=256)})
+    spec = r.get_kv_cache_spec()
+    assert isinstance(spec["l0"], SlidingWindowSpec)
+    assert spec["l0"].sliding_window == 256
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_kv_sharing_layer_skipped_and_recorded():
+    r = make_runner(
+        {
+            "l0": fake_attn(),
+            "l1": fake_attn(kv_sharing_target_layer_name="l0"),
+        }
+    )
+    spec = r.get_kv_cache_spec()
+    # The sharing layer gets no spec of its own; it is recorded as sharing l0.
+    assert set(spec) == {"l0"}
+    assert r.shared_kv_cache_layers == {"l1": "l0"}
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_encoder_only_layer_has_no_kv_cache():
+    r = make_runner(
+        {
+            "dec": fake_attn(),
+            "enc": fake_attn(attn_type=AttentionType.ENCODER_ONLY),
+        }
+    )
+    spec = r.get_kv_cache_spec()
+    assert set(spec) == {"dec"}

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_kv_spec.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_kv_spec.py
@@ -20,7 +20,6 @@ import torch
 from vllm.model_executor.layers.attention.attention import Attention
 from vllm.v1.attention.backend import AttentionType
 from vllm.v1.kv_cache_interface import FullAttentionSpec, SlidingWindowSpec
-
 from vllm_tt.model_runner_v2 import TTModelRunnerV2
 
 BLOCK_SIZE = 32

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_lifecycle.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_lifecycle.py
@@ -18,7 +18,6 @@ from types import SimpleNamespace
 
 import pytest
 from vllm.sampling_params import SamplingParams
-
 from vllm_tt.model_runner_v2 import TTModelRunnerV2
 from vllm_tt.request_state import TTRequestState
 from vllm_tt.sampling_state_v2 import TTSamplingStates

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_lifecycle.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_lifecycle.py
@@ -1,0 +1,228 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU unit tests for the MRv2 runner request lifecycle.
+
+``TTModelRunnerV2.add_requests`` / ``update_requests`` / ``finish_requests``
+(see vllm_tt/model_runner_v2.py) are pure host bookkeeping that drive the split
+v2 state (TTRequestState + TTSamplingStates + a block table). They run on cpu
+with no TT hardware and no model: the runner is allocated without ``__init__``
+and the state it touches is injected, and the block table is a recording fake
+so the tests assert the calls the lifecycle makes rather than device layout.
+
+They pin the v2 semantics that differ from the v1 fork: stable slots (no
+condense), preempted-request removal, and re-add clearing a stale slot.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from vllm.sampling_params import SamplingParams
+
+from vllm_tt.model_runner_v2 import TTModelRunnerV2
+from vllm_tt.request_state import TTRequestState
+from vllm_tt.sampling_state_v2 import TTSamplingStates
+
+VOCAB = 1000
+
+
+class FakeBlockTable:
+    """Records add/append/clear calls per slot (stands in for MultiGroupBlockTable)."""
+
+    def __init__(self):
+        self.rows: dict[int, tuple[str, object]] = {}
+        self.cleared: list[int] = []
+
+    def add_row(self, block_ids, slot):
+        self.rows[slot] = ("add", block_ids)
+
+    def append_row(self, block_ids, slot):
+        self.rows[slot] = ("append", block_ids)
+
+    def clear_row(self, slot):
+        self.cleared.append(slot)
+
+
+def make_runner(max_num_reqs=4, max_model_len=32):
+    r = object.__new__(TTModelRunnerV2)
+    r.req_states = TTRequestState(
+        max_num_reqs=max_num_reqs,
+        max_model_len=max_model_len,
+        max_num_batched_tokens=64,
+        num_speculative_steps=0,
+        vocab_size=VOCAB,
+        device="cpu",
+    )
+    r.sampling_states = TTSamplingStates(max_num_reqs=max_num_reqs, vocab_size=VOCAB)
+    r.block_table = FakeBlockTable()
+    r.encoder_cache = {}
+    r.num_prompt_logprobs = {}
+    r.model_state = None
+    r.vocab_size = VOCAB
+    return r
+
+
+def new_req(req_id, prompt, block_ids=([0],), num_computed=0, sp=None, prefill=None):
+    return SimpleNamespace(
+        req_id=req_id,
+        sampling_params=sp if sp is not None else SamplingParams(temperature=0.0),
+        prompt_token_ids=prompt,
+        prefill_token_ids=prefill if prefill is not None else prompt,
+        num_computed_tokens=num_computed,
+        block_ids=block_ids,
+    )
+
+
+def sched(
+    new=(),
+    cached_ids=(),
+    cached_computed=(),
+    cached_blocks=(),
+    finished=(),
+    preempted=(),
+    free_mm=(),
+):
+    cached = SimpleNamespace(
+        req_ids=list(cached_ids),
+        num_computed_tokens=list(cached_computed),
+        new_block_ids=list(cached_blocks),
+    )
+    return SimpleNamespace(
+        scheduled_new_reqs=list(new),
+        scheduled_cached_reqs=cached,
+        finished_req_ids=list(finished),
+        preempted_req_ids=list(preempted),
+        free_encoder_mm_hashes=list(free_mm),
+    )
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_add_request_populates_all_tables():
+    r = make_runner()
+    sp = SamplingParams(temperature=0.7, top_p=0.9)
+    r.add_requests(sched(new=[new_req("A", [10, 11, 12], block_ids=([1, 2],), sp=sp)]))
+
+    slot = r.req_states.req_id_to_index["A"]
+    assert r.req_states.num_reqs == 1
+    assert r.req_states.prompt_len[slot] == 3
+    assert r.req_states.total_len[slot] == 3
+    # Sampling params landed in the sampling table at the same slot.
+    assert bool(r.sampling_states.is_greedy[slot]) is False
+    assert r.sampling_states.temperature[slot] == pytest.approx(0.7)
+    # Block ids handed to the block table under the stable slot.
+    assert r.block_table.rows[slot] == ("add", ([1, 2],))
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_finish_frees_slot_across_tables_and_reuses():
+    r = make_runner()
+    r.add_requests(sched(new=[new_req("A", [1, 2]), new_req("B", [3])]))
+    slot_a = r.req_states.req_id_to_index["A"]
+
+    r.finish_requests(sched(finished=["A"]))
+
+    assert "A" not in r.req_states.req_id_to_index
+    assert slot_a in r.block_table.cleared
+    assert slot_a in r.req_states.free_indices
+    # Sampling slot reset to greedy default.
+    assert bool(r.sampling_states.is_greedy[slot_a]) is True
+    # Freed slot is reused by the next request.
+    r.add_requests(sched(new=[new_req("C", [7, 8])]))
+    assert r.req_states.req_id_to_index["C"] == slot_a
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_preempted_request_is_removed():
+    r = make_runner()
+    r.add_requests(sched(new=[new_req("A", [1, 2])]))
+    slot_a = r.req_states.req_id_to_index["A"]
+
+    r.finish_requests(sched(preempted=["A"]))
+    assert "A" not in r.req_states.req_id_to_index
+    assert slot_a in r.req_states.free_indices
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_readd_same_id_clears_stale_slot():
+    r = make_runner()
+    r.add_requests(sched(new=[new_req("A", [1, 2, 3])]))
+    # Re-add the same id (abort+resubmit) in a later step.
+    r.add_requests(sched(new=[new_req("A", [9])]))
+
+    assert r.req_states.num_reqs == 1
+    slot = r.req_states.req_id_to_index["A"]
+    assert r.req_states.prompt_len[slot] == 1
+    assert r.req_states.total_len[slot] == 1
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_update_advances_computed_and_appends_blocks():
+    r = make_runner()
+    r.add_requests(sched(new=[new_req("A", [1, 2, 3])]))
+    slot = r.req_states.req_id_to_index["A"]
+
+    r.update_requests(
+        sched(cached_ids=["A"], cached_computed=[2], cached_blocks=[([5],)])
+    )
+    assert r.req_states.num_computed_tokens[slot] == 2
+    assert r.block_table.rows[slot] == ("append", ([5],))
+
+    # No new blocks -> no append recorded (row unchanged from the append above).
+    r.update_requests(
+        sched(cached_ids=["A"], cached_computed=[3], cached_blocks=[None])
+    )
+    assert r.req_states.num_computed_tokens[slot] == 3
+    assert r.block_table.rows[slot] == ("append", ([5],))
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_update_clamps_num_computed_prefill_tokens():
+    r = make_runner()
+    r.add_requests(sched(new=[new_req("A", [1, 2, 3])]))  # prefill_len == 3
+    slot = r.req_states.req_id_to_index["A"]
+
+    r.update_requests(
+        sched(cached_ids=["A"], cached_computed=[5], cached_blocks=[None])
+    )
+    assert r.req_states.num_computed_tokens[slot] == 5
+    # Prefill progress is clamped to the prefill length.
+    assert r.req_states.num_computed_prefill_tokens[slot] == 3
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_prompt_logprobs_full_vocab_sentinel():
+    r = make_runner()
+    r.add_requests(
+        sched(new=[new_req("A", [1], sp=SamplingParams(prompt_logprobs=-1))])
+    )
+    assert r.num_prompt_logprobs["A"] == VOCAB
+
+    r.add_requests(sched(new=[new_req("B", [2], sp=SamplingParams(prompt_logprobs=3))]))
+    assert r.num_prompt_logprobs["B"] == 3
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_free_encoder_mm_hashes():
+    r = make_runner()
+    r.encoder_cache["hash0"] = object()
+    r.finish_requests(sched(free_mm=["hash0"]))
+    assert "hash0" not in r.encoder_cache
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_seeded_request_records_generator():
+    r = make_runner()
+    r.add_requests(
+        sched(new=[new_req("A", [1], sp=SamplingParams(temperature=0.8, seed=42))])
+    )
+    slot = r.req_states.req_id_to_index["A"]
+    assert slot in r.sampling_states.generators

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_model_pass.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_model_pass.py
@@ -1,0 +1,181 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU unit tests for the MRv2 runner _run_model_pass plumbing.
+
+``TTModelRunnerV2._run_model_pass`` (see vllm_tt/model_runner_v2.py) copies the
+host arrays to the device, builds attention + sampling metadata, runs the
+compiled forward/sample graph, and returns the sampled tokens. The metadata
+builds (TTModelState.prepare_attn + XLASupportedSamplingMetadata.from_v2_states)
+are real and run on cpu; the compiled graph itself needs a model + TT device, so
+it is faked here (and validated on real hardware separately).
+
+They pin the plumbing: host->device buffer copies, the real metadata builds, the
+compiled-graph dispatch, and output slicing to the active requests.
+"""
+
+import numpy as np
+import pytest
+import torch
+from vllm.sampling_params import SamplingParams
+
+from vllm_tt.model_runner_v2 import TTModelRunnerV2
+from vllm_tt.model_state import TTModelState
+from vllm_tt.request_state import TTRequestState
+from vllm_tt.sampling_state_v2 import TTSamplingStates
+
+VOCAB = 1000
+BLOCK_MAP = [[10, 11, 12, 13], [20, 21, 22, 23], [30, 31, 32, 33], [0, 0, 0, 0]]
+
+
+class FakeBlockTable:
+    def __init__(self, arr):
+        self._arr = arr
+
+    def __getitem__(self, group):
+        return self
+
+    def get_cpu_tensor(self):
+        return self._arr
+
+
+def make_runner(max_num_reqs=4, max_model_len=32):
+    r = object.__new__(TTModelRunnerV2)
+    r.device = torch.device("cpu")
+    r.sampling_device = torch.device("cpu")
+    r.vocab_size = VOCAB
+    r.dp_size = 1
+    r.block_size = 16
+    r.max_num_blocks_per_req = 4
+    r.attention_layer_names = ("layer.0", "layer.1")
+    r.req_states = TTRequestState(
+        max_num_reqs=max_num_reqs,
+        max_model_len=max_model_len,
+        max_num_batched_tokens=64,
+        num_speculative_steps=0,
+        vocab_size=VOCAB,
+        device="cpu",
+    )
+    r.sampling_states = TTSamplingStates(max_num_reqs=max_num_reqs, vocab_size=VOCAB)
+    r.block_table = FakeBlockTable(torch.tensor(BLOCK_MAP, dtype=torch.int32))
+    # prepare_attn uses no instance state.
+    r.model_state = object.__new__(TTModelState)
+    return r
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_run_model_pass_builds_metadata_and_returns_tokens():
+    r = make_runner()
+    # Two decoding requests occupying stable slots.
+    r.req_states.add_request(
+        "A", prompt_len=2, all_token_ids=[1, 2], num_computed_tokens=0
+    )
+    r.req_states.add_request(
+        "B", prompt_len=1, all_token_ids=[3], num_computed_tokens=0
+    )
+    slot_a = r.req_states.req_id_to_index["A"]
+    slot_b = r.req_states.req_id_to_index["B"]
+    for slot in (slot_a, slot_b):
+        r.sampling_states.add_request(slot, SamplingParams(temperature=0.0))
+
+    captured = {}
+
+    def fake_forward(
+        input_ids, positions, logits_indices, attn_metadata, sampling_metadata
+    ):
+        # The real metadata builds must have produced usable objects.
+        captured["attn_layers"] = set(attn_metadata)
+        captured["all_greedy"] = sampling_metadata.all_greedy
+        captured["input_ids_device"] = input_ids.device.type
+        n = input_ids.shape[0]
+        return torch.tensor([[100 + i] for i in range(n)], dtype=torch.int64)
+
+    r._forward_and_sample = fake_forward
+
+    idx = np.array([slot_a, slot_b], dtype=np.int32)
+    nst = np.array([1, 1], dtype=np.int32)
+    input_ids = np.zeros((2, 1), dtype=np.int32)
+    positions = np.zeros((2, 1), dtype=np.int32)
+    logits_indices = np.zeros(2, dtype=np.int32)
+    seq_lens = np.array([1, 1], dtype=np.int32)
+    page_table, fill_page_table, cache_position = r._prepare_attn_tensors(
+        idx, nst, seq_lens, target_num_reqs=2, num_blocks_per_req=4
+    )
+
+    out = r._run_model_pass(
+        idx,
+        nst,
+        2,
+        1,
+        input_ids,
+        positions,
+        logits_indices,
+        page_table,
+        fill_page_table,
+        cache_position,
+    )
+
+    # Attn metadata fanned out to every layer; greedy sampling metadata built.
+    assert captured["attn_layers"] == {"layer.0", "layer.1"}
+    assert captured["all_greedy"] is True
+    assert captured["input_ids_device"] == "cpu"
+    # Two active requests -> two token rows, padding dropped.
+    assert out == [[100], [101]]
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_run_model_pass_drops_padding_rows():
+    r = make_runner()
+    r.req_states.add_request(
+        "A", prompt_len=1, all_token_ids=[5], num_computed_tokens=0
+    )
+    slot = r.req_states.req_id_to_index["A"]
+    r.sampling_states.add_request(slot, SamplingParams(temperature=0.0))
+
+    # target_num_reqs (4) padded beyond the single active request.
+    r._forward_and_sample = lambda ii, pos, li, am, sm: torch.arange(
+        4, dtype=torch.int64
+    ).reshape(4, 1)
+
+    idx = np.array([slot], dtype=np.int32)
+    nst = np.array([1], dtype=np.int32)
+    page_table, fill_page_table, cache_position = r._prepare_attn_tensors(
+        idx, nst, np.array([1], dtype=np.int32), target_num_reqs=4, num_blocks_per_req=4
+    )
+    out = r._run_model_pass(
+        idx,
+        nst,
+        4,
+        1,
+        np.zeros((4, 1), dtype=np.int32),
+        np.zeros((4, 1), dtype=np.int32),
+        np.zeros(4, dtype=np.int32),
+        page_table,
+        fill_page_table,
+        cache_position,
+    )
+    assert out == [[0]]  # only the one active request's row
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_sample_from_logits_greedy_is_argmax():
+    r = object.__new__(TTModelRunnerV2)
+    logits = torch.tensor([[0.1, 0.9, 0.2], [0.5, 0.1, 0.3]])
+    md = type(
+        "M",
+        (),
+        dict(
+            all_greedy=True,
+            no_penalties=True,
+            no_logit_bias=True,
+            no_bad_words=True,
+            no_allowed_token_ids=True,
+            no_min_tokens=True,
+            no_generators=True,
+        ),
+    )()
+    out = r._sample_from_logits(logits, md)
+    assert out.tolist() == [[1], [0]]

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_model_pass.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_model_pass.py
@@ -18,7 +18,6 @@ import numpy as np
 import pytest
 import torch
 from vllm.sampling_params import SamplingParams
-
 from vllm_tt.model_runner_v2 import TTModelRunnerV2
 from vllm_tt.model_state import TTModelState
 from vllm_tt.request_state import TTRequestState

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_postprocess.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_postprocess.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU unit tests for the MRv2 runner sampled-token writeback.
+
+``TTModelRunnerV2.postprocess`` (see vllm_tt/model_runner_v2.py) is the host
+substitute for upstream's post_update Triton kernel. It is pure numpy over
+``TTRequestState``, so it runs on cpu with no TT hardware; only ``req_states``
+is injected.
+
+They pin the writeback math TT owns: appending the sampled token at total_len so
+the next step's input-prep reads it, discarding tokens from still-prefilling
+(partial-chunk) requests, and leaving num_computed for the scheduler to advance.
+"""
+
+import numpy as np
+import pytest
+
+from vllm_tt.model_runner_v2 import TTModelRunnerV2
+from vllm_tt.request_state import TTRequestState
+
+VOCAB = 1000
+
+
+def runner_with_reqs(max_num_reqs=4, max_model_len=32):
+    r = object.__new__(TTModelRunnerV2)
+    r.req_states = TTRequestState(
+        max_num_reqs=max_num_reqs,
+        max_model_len=max_model_len,
+        max_num_batched_tokens=64,
+        num_speculative_steps=0,
+        vocab_size=VOCAB,
+        device="cpu",
+    )
+    return r
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_postprocess_appends_decode_token():
+    r = runner_with_reqs()
+    rs = r.req_states
+    rs.add_request("D", prompt_len=3, all_token_ids=[1, 2, 3], num_computed_tokens=0)
+    slot = rs.req_id_to_index["D"]
+    rs.num_computed_tokens[slot] = 3  # prefill already consumed -> decoding
+
+    idx = np.array([slot], dtype=np.int32)
+    nst = np.array([1], dtype=np.int32)  # one decode token scheduled
+    valid = r.postprocess(idx, nst, [[99]])
+
+    assert valid == [[99]]
+    # Token landed at the old total_len; the table grew by one.
+    assert rs.all_token_ids[slot, 3] == 99
+    assert rs.total_len[slot] == 4
+    assert rs.last_sampled_tokens[slot, 0] == 99
+    # num_computed is left for the scheduler (update_requests), not advanced here.
+    assert rs.num_computed_tokens[slot] == 3
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_postprocess_discards_partial_prefill_token():
+    r = runner_with_reqs()
+    rs = r.req_states
+    rs.add_request(
+        "P", prompt_len=6, all_token_ids=[10, 11, 12, 13, 14, 15], num_computed_tokens=0
+    )
+    slot = rs.req_id_to_index["P"]
+    # First chunk of 4 tokens: seq_len (0 + 4) < prefill_len (6) -> still prefilling.
+    idx = np.array([slot], dtype=np.int32)
+    nst = np.array([4], dtype=np.int32)
+    before = rs.all_token_ids[slot].copy()
+
+    valid = r.postprocess(idx, nst, [[99]])
+
+    assert valid == [[]]  # discarded
+    assert rs.total_len[slot] == 6  # unchanged
+    np.testing.assert_array_equal(rs.all_token_ids[slot], before)
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_postprocess_final_prefill_chunk_appends():
+    r = runner_with_reqs()
+    rs = r.req_states
+    rs.add_request(
+        "F", prompt_len=6, all_token_ids=[10, 11, 12, 13, 14, 15], num_computed_tokens=0
+    )
+    slot = rs.req_id_to_index["F"]
+    rs.num_computed_tokens[slot] = 4  # first chunk already computed
+    # Final chunk of 2: seq_len (4 + 2) == prefill_len (6) -> produces a token.
+    idx = np.array([slot], dtype=np.int32)
+    nst = np.array([2], dtype=np.int32)
+
+    valid = r.postprocess(idx, nst, [[77]])
+
+    assert valid == [[77]]
+    assert rs.all_token_ids[slot, 6] == 77
+    assert rs.total_len[slot] == 7
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_postprocess_mixed_batch():
+    r = runner_with_reqs()
+    rs = r.req_states
+    rs.add_request("D", prompt_len=2, all_token_ids=[1, 2], num_computed_tokens=0)
+    rs.add_request(
+        "P", prompt_len=5, all_token_ids=[3, 4, 5, 6, 7], num_computed_tokens=0
+    )
+    slot_d = rs.req_id_to_index["D"]
+    slot_p = rs.req_id_to_index["P"]
+    rs.num_computed_tokens[slot_d] = 2  # decoding
+    # P still prefilling: 3 of 5 tokens this chunk.
+
+    idx = np.array([slot_d, slot_p], dtype=np.int32)
+    nst = np.array([1, 3], dtype=np.int32)
+    valid = r.postprocess(idx, nst, [[55], [66]])
+
+    assert valid == [[55], []]  # decode kept, partial prefill discarded
+    assert rs.all_token_ids[slot_d, 2] == 55
+    assert rs.total_len[slot_d] == 3
+    assert rs.total_len[slot_p] == 5  # unchanged

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_postprocess.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_postprocess.py
@@ -15,7 +15,6 @@ the next step's input-prep reads it, discarding tokens from still-prefilling
 
 import numpy as np
 import pytest
-
 from vllm_tt.model_runner_v2 import TTModelRunnerV2
 from vllm_tt.request_state import TTRequestState
 

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_warmup.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_warmup.py
@@ -11,7 +11,6 @@ runs on cpu with injected state.
 from types import SimpleNamespace
 
 import pytest
-
 from vllm_tt.model_runner_v2 import TTModelRunnerV2
 
 

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_warmup.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_warmup.py
@@ -13,6 +13,8 @@ They pin the warmup shape coverage (decode + prefill request buckets x every
 token-length padding, deduplicated) and the worker-facing shim behavior.
 """
 
+from types import SimpleNamespace
+
 import pytest
 
 from vllm_tt.model_runner_v2 import TTModelRunnerV2
@@ -80,3 +82,54 @@ def test_add_lora_not_supported():
     r = object.__new__(TTModelRunnerV2)
     with pytest.raises(NotImplementedError):
         r.add_lora(object())
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_maybe_setup_dummy_loras_noop_context():
+    r = object.__new__(TTModelRunnerV2)
+    with r.maybe_setup_dummy_loras(None):
+        pass  # no-op context must enter/exit cleanly
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_maybe_setup_dummy_loras_rejects_lora():
+    r = object.__new__(TTModelRunnerV2)
+    with pytest.raises(NotImplementedError):
+        with r.maybe_setup_dummy_loras(object()):
+            pass
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_get_supported_tasks_delegates_to_model_state():
+    r = object.__new__(TTModelRunnerV2)
+    r.model_config = SimpleNamespace(runner_type="generate")
+    r.model_state = SimpleNamespace(get_supported_generation_tasks=lambda: ["generate"])
+    assert r.get_supported_tasks() == ("generate",)
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_get_supported_tasks_rejects_non_generate():
+    r = object.__new__(TTModelRunnerV2)
+    r.model_config = SimpleNamespace(runner_type="pooling")
+    with pytest.raises(NotImplementedError):
+        r.get_supported_tasks()
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_update_config_rejects_unknown_config():
+    r = object.__new__(TTModelRunnerV2)
+    with pytest.raises(AssertionError):
+        r.update_config({"scheduler_config": {}})
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_reload_weights_not_supported():
+    r = object.__new__(TTModelRunnerV2)
+    with pytest.raises(NotImplementedError):
+        r.reload_weights()

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_warmup.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_warmup.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU unit tests for the MRv2 runner warmup buckets + worker shims.
+
+``TTModelRunnerV2._warmup_buckets`` / ``get_model`` / ``reset_mm_cache`` /
+``add_lora`` (see vllm_tt/model_runner_v2.py) are pure host logic; the actual
+``capture_model`` precompile forward needs a model + TT device and runs at
+stand-up. Here the bucket enumeration and the shims run on cpu with injected
+state.
+
+They pin the warmup shape coverage (decode + prefill request buckets x every
+token-length padding, deduplicated) and the worker-facing shim behavior.
+"""
+
+import pytest
+
+from vllm_tt.model_runner_v2 import TTModelRunnerV2
+
+
+def make_runner(
+    max_num_reqs=8, min_num_reqs=2, max_prefill_num_reqs=4, paddings=(1, 32)
+):
+    r = object.__new__(TTModelRunnerV2)
+    r.max_num_reqs = max_num_reqs
+    r.min_num_reqs = min_num_reqs
+    r.max_prefill_num_reqs = max_prefill_num_reqs
+    r.num_tokens_paddings = list(paddings)
+    return r
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_warmup_buckets_cover_request_and_token_shapes():
+    r = make_runner()
+    # targets = sorted({8, 2, 4}) = [2, 4, 8]; each x every token padding.
+    assert r._warmup_buckets() == [(2, 1), (2, 32), (4, 1), (4, 32), (8, 1), (8, 32)]
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_warmup_buckets_dedup_when_request_counts_equal():
+    r = make_runner(
+        max_num_reqs=8, min_num_reqs=8, max_prefill_num_reqs=8, paddings=(1, 16)
+    )
+    # All request-count buckets coincide -> a single target.
+    assert r._warmup_buckets() == [(8, 1), (8, 16)]
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_get_model_returns_the_model():
+    r = object.__new__(TTModelRunnerV2)
+    sentinel = object()
+    r.model = sentinel
+    assert r.get_model() is sentinel
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_reset_mm_cache_noop_without_budget():
+    r = object.__new__(TTModelRunnerV2)
+    r.mm_budget = None
+    r.reset_mm_cache()  # must not raise
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_reset_mm_cache_resets_budget():
+    r = object.__new__(TTModelRunnerV2)
+    calls = []
+    r.mm_budget = type("B", (), {"reset_cache": lambda self: calls.append(1)})()
+    r.reset_mm_cache()
+    assert calls == [1]
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_add_lora_not_supported():
+    r = object.__new__(TTModelRunnerV2)
+    with pytest.raises(NotImplementedError):
+        r.add_lora(object())

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_warmup.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_warmup.py
@@ -1,16 +1,11 @@
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
-"""CPU unit tests for the MRv2 runner warmup buckets + worker shims.
+"""CPU unit tests for the MRv2 runner worker-facing shims.
 
-``TTModelRunnerV2._warmup_buckets`` / ``get_model`` / ``reset_mm_cache`` /
-``add_lora`` (see vllm_tt/model_runner_v2.py) are pure host logic; the actual
-``capture_model`` precompile forward needs a model + TT device and runs at
-stand-up. Here the bucket enumeration and the shims run on cpu with injected
-state.
-
-They pin the warmup shape coverage (decode + prefill request buckets x every
-token-length padding, deduplicated) and the worker-facing shim behavior.
+get_model / reset_mm_cache / add_lora / maybe_setup_dummy_loras /
+get_supported_tasks / update_config / reload_weights are pure host logic that
+runs on cpu with injected state.
 """
 
 from types import SimpleNamespace
@@ -18,35 +13,6 @@ from types import SimpleNamespace
 import pytest
 
 from vllm_tt.model_runner_v2 import TTModelRunnerV2
-
-
-def make_runner(
-    max_num_reqs=8, min_num_reqs=2, max_prefill_num_reqs=4, paddings=(1, 32)
-):
-    r = object.__new__(TTModelRunnerV2)
-    r.max_num_reqs = max_num_reqs
-    r.min_num_reqs = min_num_reqs
-    r.max_prefill_num_reqs = max_prefill_num_reqs
-    r.num_tokens_paddings = list(paddings)
-    return r
-
-
-@pytest.mark.push
-@pytest.mark.cpu
-def test_warmup_buckets_cover_request_and_token_shapes():
-    r = make_runner()
-    # targets = sorted({8, 2, 4}) = [2, 4, 8]; each x every token padding.
-    assert r._warmup_buckets() == [(2, 1), (2, 32), (4, 1), (4, 32), (8, 1), (8, 32)]
-
-
-@pytest.mark.push
-@pytest.mark.cpu
-def test_warmup_buckets_dedup_when_request_counts_equal():
-    r = make_runner(
-        max_num_reqs=8, min_num_reqs=8, max_prefill_num_reqs=8, paddings=(1, 16)
-    )
-    # All request-count buckets coincide -> a single target.
-    assert r._warmup_buckets() == [(8, 1), (8, 16)]
 
 
 @pytest.mark.push

--- a/tests/integrations/vllm_plugin/mrv2/test_sampling_state.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_sampling_state.py
@@ -19,7 +19,6 @@ import numpy as np
 import pytest
 import torch
 from vllm.sampling_params import SamplingParams
-
 from vllm_tt.metadata import DEFAULT_SAMPLING_PARAMS, XLASupportedSamplingMetadata
 from vllm_tt.request_state import TTRequestState
 from vllm_tt.sampling_state_v2 import TTSamplingStates

--- a/tests/integrations/vllm_plugin/mrv2/test_sampling_state.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_sampling_state.py
@@ -1,0 +1,286 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU unit tests for the MRv2 sampling bridge.
+
+``TTSamplingStates`` (see vllm_tt/sampling_state_v2.py) is the persistent
+per-slot sampling-param table, and ``XLASupportedSamplingMetadata.from_v2_states``
+gathers a batch-ordered view from it + ``TTRequestState``. Both are pure
+host-side (numpy/torch-on-cpu), so these run with no TT hardware and no model.
+
+They pin the invariants that are TT's own responsibility: the ``SamplingParams``
+extraction matching the v1 fork, the stable-slot reset on removal, and the
+batch->slot gather (via ``idx_mapping``) that feeds the sampler.
+"""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+from vllm.sampling_params import SamplingParams
+
+from vllm_tt.metadata import DEFAULT_SAMPLING_PARAMS, XLASupportedSamplingMetadata
+from vllm_tt.request_state import TTRequestState
+from vllm_tt.sampling_state_v2 import TTSamplingStates
+
+VOCAB = 1000
+
+
+def make_rs(max_num_reqs=4, max_model_len=32):
+    return TTRequestState(
+        max_num_reqs=max_num_reqs,
+        max_model_len=max_model_len,
+        max_num_batched_tokens=64,
+        num_speculative_steps=0,
+        vocab_size=VOCAB,
+        device="cpu",
+    )
+
+
+def make_ss(max_num_reqs=4):
+    return TTSamplingStates(max_num_reqs=max_num_reqs, vocab_size=VOCAB)
+
+
+def ib(idx_list):
+    """Minimal TTInputBatch stand-in: make_batch_view only reads these two."""
+    return SimpleNamespace(
+        num_reqs=len(idx_list),
+        idx_mapping_np=np.array(idx_list, dtype=np.int32),
+    )
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_add_request_greedy_extraction():
+    ss = make_ss()
+    ss.add_request(2, SamplingParams(temperature=0.0))
+    assert ss.temperature[2] == 0.0
+    assert bool(ss.is_greedy[2]) is True
+    # Disabled top_k (default 0) maps to vocab_size, matching the v1 fork.
+    assert ss.top_k[2] == VOCAB
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_add_request_random_extraction():
+    ss = make_ss()
+    sp = SamplingParams(
+        temperature=0.7,
+        top_p=0.9,
+        top_k=50,
+        min_p=0.1,
+        frequency_penalty=0.5,
+        presence_penalty=0.2,
+        repetition_penalty=1.3,
+        min_tokens=3,
+        logprobs=2,
+        logit_bias={5: 2.0},
+        allowed_token_ids=[1, 2, 3],
+    )
+    ss.add_request(1, sp)
+    assert bool(ss.is_greedy[1]) is False
+    assert ss.temperature[1] == pytest.approx(0.7)
+    assert ss.top_p[1] == pytest.approx(0.9)
+    assert ss.top_k[1] == 50  # in-range top_k kept verbatim
+    assert ss.min_p[1] == pytest.approx(0.1)
+    assert ss.frequency_penalties[1] == pytest.approx(0.5)
+    assert ss.presence_penalties[1] == pytest.approx(0.2)
+    assert ss.repetition_penalties[1] == pytest.approx(1.3)
+    assert ss.min_tokens[1][0] == 3
+    assert ss.num_logprobs[1] == 2
+    assert ss.logit_bias[1] == {5: 2.0}
+    assert ss.allowed_token_ids[1] == [1, 2, 3]
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_remove_request_resets_slot():
+    ss = make_ss()
+    ss.add_request(
+        0,
+        SamplingParams(
+            temperature=0.7,
+            min_tokens=2,
+            logprobs=1,
+            logit_bias={1: 1.0},
+            allowed_token_ids=[3],
+        ),
+    )
+    ss.remove_request(0)
+    assert ss.temperature[0] == DEFAULT_SAMPLING_PARAMS["temperature"]
+    assert ss.top_k[0] == DEFAULT_SAMPLING_PARAMS["top_k"]
+    assert ss.repetition_penalties[0] == DEFAULT_SAMPLING_PARAMS["repetition_penalties"]
+    assert bool(ss.is_greedy[0]) is True
+    assert 0 not in ss.min_tokens
+    assert 0 not in ss.num_logprobs
+    assert 0 not in ss.allowed_token_ids
+    assert ss.logit_bias[0] is None
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_make_batch_view_gather_order_and_padding():
+    rs = make_rs()
+    ss = make_ss()
+    rs.add_request("A", prompt_len=2, all_token_ids=[10, 11, 12], num_computed_tokens=0)
+    rs.add_request("B", prompt_len=1, all_token_ids=[20], num_computed_tokens=0)
+    slot_a = rs.req_id_to_index["A"]
+    slot_b = rs.req_id_to_index["B"]
+    ss.add_request(slot_a, SamplingParams(temperature=0.5))
+    ss.add_request(slot_b, SamplingParams(temperature=0.9))
+
+    # Batch position 0 -> slot_b, position 1 -> slot_a (reversed vs slot order).
+    view = ss.make_batch_view(rs, ib([slot_b, slot_a]), padded_num_reqs=4)
+
+    assert view.num_reqs == 2
+    assert view.temperature_cpu_tensor[0].item() == pytest.approx(0.9)
+    assert view.temperature_cpu_tensor[1].item() == pytest.approx(0.5)
+    # Padding rows carry the sampler default.
+    assert (
+        view.temperature_cpu_tensor[2].item() == DEFAULT_SAMPLING_PARAMS["temperature"]
+    )
+    # num_prompt_tokens follows batch order; padding rows are zero.
+    assert view.num_prompt_tokens.tolist() == [1, 2, 0, 0]
+    # Output tokens derived from all_token_ids[prompt_len:total_len].
+    assert view.req_output_token_ids[0] == []
+    assert view.req_output_token_ids[1] == [12]
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_make_batch_view_rekeys_dicts_to_batch_index():
+    rs = make_rs()
+    ss = make_ss()
+    rs.add_request("A", 1, [1], 0)
+    rs.add_request("B", 1, [2], 0)
+    slot_a = rs.req_id_to_index["A"]
+    slot_b = rs.req_id_to_index["B"]
+    # Populate slot-keyed dicts directly (bad_words_token_ids is a read-only
+    # SamplingParams property, so it can't come through add_request in a unit test).
+    ss.bad_words_token_ids[slot_b] = [[9]]
+    ss.min_tokens[slot_b] = (5, {0})
+    gen = torch.Generator()
+    ss.generators[slot_b] = gen
+
+    # Batch position 0 -> slot_a, position 1 -> slot_b.
+    view = ss.make_batch_view(rs, ib([slot_a, slot_b]), padded_num_reqs=4)
+
+    assert view.bad_words_token_ids == {1: [[9]]}
+    assert view.min_tokens == {1: (5, {0})}
+    assert view.generators == {1: gen}
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_flags_mixed_greedy_random():
+    rs = make_rs()
+    ss = make_ss()
+    rs.add_request("A", 1, [1], 0)
+    rs.add_request("B", 1, [2], 0)
+    slot_a = rs.req_id_to_index["A"]
+    slot_b = rs.req_id_to_index["B"]
+    ss.add_request(slot_a, SamplingParams(temperature=0.0))  # greedy
+    ss.add_request(slot_b, SamplingParams(temperature=0.8))  # random
+
+    view = ss.make_batch_view(rs, ib([slot_a, slot_b]), padded_num_reqs=2)
+    assert view.all_greedy is False
+    assert view.all_random is False
+    assert view.no_penalties is True
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_from_v2_states_all_greedy_minimal():
+    rs = make_rs()
+    ss = make_ss()
+    rs.add_request("A", 2, [10, 11], 0)
+    slot_a = rs.req_id_to_index["A"]
+    ss.add_request(slot_a, SamplingParams(temperature=0.0))
+
+    md = XLASupportedSamplingMetadata.from_v2_states(
+        rs,
+        ss,
+        ib([slot_a]),
+        padded_num_reqs=4,
+        xla_device=torch.device("cpu"),
+        vocab_size=VOCAB,
+    )
+    assert md.all_greedy is True
+    assert md.no_penalties is True
+    # Early-return minimal path leaves the param tensors unset.
+    assert md.temperature is None
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_from_v2_states_penalties_path():
+    rs = make_rs()
+    ss = make_ss()
+    rs.add_request("A", 2, [10, 11], 0)
+    slot_a = rs.req_id_to_index["A"]
+    ss.add_request(slot_a, SamplingParams(temperature=0.7, frequency_penalty=0.5))
+
+    md = XLASupportedSamplingMetadata.from_v2_states(
+        rs,
+        ss,
+        ib([slot_a]),
+        padded_num_reqs=4,
+        xla_device=torch.device("cpu"),
+        vocab_size=VOCAB,
+    )
+    assert md.no_penalties is False
+    assert md.temperature is not None
+    assert md.output_token_counts is not None
+    assert tuple(md.output_token_counts.shape) == (4, VOCAB)
+    assert md.prompt_token_mask is not None
+    assert tuple(md.prompt_token_mask.shape) == (4, VOCAB)
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_from_v2_states_seeded_generators_build_q_samples():
+    rs = make_rs()
+    ss = make_ss()
+    rs.add_request("A", 2, [10, 11], 0)
+    slot_a = rs.req_id_to_index["A"]
+    gen = torch.Generator()
+    gen.manual_seed(123)
+    ss.add_request(slot_a, SamplingParams(temperature=0.7), generator=gen)
+
+    md = XLASupportedSamplingMetadata.from_v2_states(
+        rs,
+        ss,
+        ib([slot_a]),
+        padded_num_reqs=4,
+        xla_device=torch.device("cpu"),
+        vocab_size=VOCAB,
+    )
+    assert md.no_generators is False
+    assert md.q_samples is not None
+    assert tuple(md.q_samples.shape) == (4, VOCAB)
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_from_v2_states_allowed_token_ids_mask():
+    rs = make_rs()
+    ss = make_ss()
+    rs.add_request("A", 1, [10], 0)
+    slot_a = rs.req_id_to_index["A"]
+    ss.add_request(slot_a, SamplingParams(temperature=0.7, allowed_token_ids=[5, 7]))
+
+    md = XLASupportedSamplingMetadata.from_v2_states(
+        rs,
+        ss,
+        ib([slot_a]),
+        padded_num_reqs=2,
+        xla_device=torch.device("cpu"),
+        vocab_size=VOCAB,
+    )
+    assert md.no_allowed_token_ids is False
+    mask = md.allowed_token_ids_mask  # additive: 0.0 allowed, -inf disallowed
+    assert tuple(mask.shape) == (2, VOCAB)
+    assert mask[0, 5].item() == 0.0
+    assert mask[0, 7].item() == 0.0
+    assert mask[0, 6].item() == float("-inf")


### PR DESCRIPTION
### Ticket
closes  #5629

### Problem description
vLLM's Model Runner v2 splits the old monolithic runner into four pieces (Runner / ModelState / RequestState / InputBatch), but the v2 runner is Triton/CUDA-only with no non-GPU template, so TT can't subclass it, it has to fork and adapt, swapping every Triton/CUDA/UVA piece for a host-side equivalent. The plugin currently only runs on the legacy v1 runner; this brings up the v2 architecture on TT.

### What's changed
- The split v2 state: TTModelState, TTRequestState, TTInputBatch, and TTSamplingStates (+ a bridge that feeds TT's sampler), all host-side numpy/torch instead of Triton/UVA.
- The runner (model_runner_v2.py, TTModelRunnerV2): a fork of the upstream v2 GPU runner for the single-device generate path, request lifecycle, host substitutes for the Triton input-prep and attention slot-mapping, the @torch.compile(backend="tt") forward+sample graph, KV cache alloc, and the full worker-facing surface.
- Worker wiring: TT_USE_V2_MODEL_RUNNER selects the v2 runner, default off, so v1 stays the path until v2 is proven out.
- Tests: 81 CPU unit/integration tests covering the state pieces and every host stage of the runner.

### Verification
- [x] 81/81 CPU tests pass.
- [x] On-device (Wormhole): KV allocation and the compiled forward+sample path validated.
- [x] End-to-end, v2 vs v1 (Qwen2.5-0.5B): with the toggle on, v2 produces byte-identical greedy tokens to v1, both a single prompt and a 4-way concurrent batch (identical on all four).
- [x] End-to-end, v2 vs v1 (Qwen3-8B, num_hidden_layers=1): identical KV sizing (314,560 tokens) and byte-identical greedy tokens; no OOM.

### Notes
- Default off; v1 unchanged.
- Deferred (each guarded): multi-device SPMD, multimodal, LoRA, and grammar/cpu-sampling/prompt-logprobs. Genuinely large models still need multi-device sharding to fit, same as v1.
