### PR TITLE
Remove xfail from test_no_prefill_recompile (fixed by tt-mlir uplift - "Page table must be row major" )

### DIFF
--- a/tests/integrations/vllm_plugin/generative/test_prefill_recompile.py
+++ b/tests/integrations/vllm_plugin/generative/test_prefill_recompile.py
@@ -40,13 +40,6 @@ WORKER_TIMEOUT = 1800
 
 @pytest.mark.push
 @pytest.mark.single_device
-@pytest.mark.xfail(
-    reason=(
-        "Uplift regression: chunked-prefill SDPA page_table tilized by tt-mlir "
-        "#8953's insertTiledFixup - https://github.com/tenstorrent/tt-xla/issues/5579"
-    ),
-    strict=False,
-)
 def test_no_prefill_recompile():
     # Isolate the in-process engine in a fresh child (see module docstring). A
     # clean subprocess — not os.fork()/pytest-forked — is required: the parent


### PR DESCRIPTION
### Ticket

Closes #5579

### Problem description

- The tt-mlir uplift in #5592 (to 1f3c5ab3462f) carries the fix for the chunked-prefill SDPA page_table tilization regression from #8953's insertTiledFixup

### What's changed
- Removes the `xfail` marker from `test_no_prefill_recompile`, added as a temporary workaround

### Checklist
- [onPR](https://github.com/tenstorrent/tt-xla/actions/runs/29590039768/job/87940922963#step:19:1011) from uplift has test xpassing: `tests/integrations/vllm_plugin/generative/test_prefill_recompile.py::test_no_prefill_recompile ... XPASS`
- [x] Verified locally: test now passes with zero recompiles across all 7 ISL buckets.

