### PR TITLE
[vLLM] Broaden chunked-prefill coverage across push and nightly vLLM tests

### DIFF
--- a/tests/integrations/vllm_plugin/generative/chunked_prefill_data.py
+++ b/tests/integrations/vllm_plugin/generative/chunked_prefill_data.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Shared prompt data for the multichip chunked-prefill tests."""
+
+# A prompt comfortably longer than a small prefill_chunk_size (e.g. 128) so the
+# prompt splits into several block-aligned chunks and chunks 2..N exercise the
+# cached-prefix chunked-SDPA path (tt-xla #4986/#5691). Shared by the multichip
+# chunked-prefill tests.
+CHUNKED_PREFILL_PARA = (
+    "The history of computing spans many centuries. Early mechanical "
+    "calculators gave way to electromechanical machines, and then to the "
+    "electronic digital computers that define the modern era. Each generation "
+    "brought dramatic improvements in speed, reliability, and cost. "
+)
+CHUNKED_PREFILL_PROMPT = (
+    "Continue in English. " + (CHUNKED_PREFILL_PARA * 5) + "\nContinuation:"
+)

--- a/tests/integrations/vllm_plugin/generative/conftest.py
+++ b/tests/integrations/vllm_plugin/generative/conftest.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 """Shared conftest for vLLM generative tests."""
-
 import json
 import math
 import re

--- a/tests/integrations/vllm_plugin/generative/conftest.py
+++ b/tests/integrations/vllm_plugin/generative/conftest.py
@@ -113,21 +113,6 @@ def assert_batch_grounded(outputs, checks=GROUNDED_BATCH_CHECKS) -> None:
         ), f"expected {expected!r} for {prompt!r}, got {text!r}"
 
 
-# A prompt comfortably longer than a small prefill_chunk_size (e.g. 128) so the
-# prompt splits into several block-aligned chunks and chunks 2..N exercise the
-# cached-prefix chunked-SDPA path (tt-xla #4986/#5691). Shared by the multichip
-# chunked-prefill tests.
-CHUNKED_PREFILL_PARA = (
-    "The history of computing spans many centuries. Early mechanical "
-    "calculators gave way to electromechanical machines, and then to the "
-    "electronic digital computers that define the modern era. Each generation "
-    "brought dramatic improvements in speed, reliability, and cost. "
-)
-CHUNKED_PREFILL_PROMPT = (
-    "Continue in English. " + (CHUNKED_PREFILL_PARA * 5) + "\nContinuation:"
-)
-
-
 def check_host_memory(model_name: str) -> float:
     """Assert child process RSS is below the known threshold for a model.
 

--- a/tests/integrations/vllm_plugin/generative/conftest.py
+++ b/tests/integrations/vllm_plugin/generative/conftest.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 """Shared conftest for vLLM generative tests."""
+
 import json
 import math
 import re
@@ -110,6 +111,21 @@ def assert_batch_grounded(outputs, checks=GROUNDED_BATCH_CHECKS) -> None:
         assert (
             expected.lower() in text.lower()
         ), f"expected {expected!r} for {prompt!r}, got {text!r}"
+
+
+# A prompt comfortably longer than a small prefill_chunk_size (e.g. 128) so the
+# prompt splits into several block-aligned chunks and chunks 2..N exercise the
+# cached-prefix chunked-SDPA path (tt-xla #4986/#5691). Shared by the multichip
+# chunked-prefill tests.
+CHUNKED_PREFILL_PARA = (
+    "The history of computing spans many centuries. Early mechanical "
+    "calculators gave way to electromechanical machines, and then to the "
+    "electronic digital computers that define the modern era. Each generation "
+    "brought dramatic improvements in speed, reliability, and cost. "
+)
+CHUNKED_PREFILL_PROMPT = (
+    "Continue in English. " + (CHUNKED_PREFILL_PARA * 5) + "\nContinuation:"
+)
 
 
 def check_host_memory(model_name: str) -> float:

--- a/tests/integrations/vllm_plugin/generative/test_chunked_prefill.py
+++ b/tests/integrations/vllm_plugin/generative/test_chunked_prefill.py
@@ -150,6 +150,7 @@ def test_chunk_budget_decoupled_from_max_model_len():
     assert text, "generation with budget << max_model_len was empty"
 
 
+@pytest.mark.push
 @pytest.mark.nightly
 @pytest.mark.single_device
 def test_chunked_prefill_batch_all_users_match(monkeypatch):
@@ -159,6 +160,11 @@ def test_chunked_prefill_batch_all_users_match(monkeypatch):
     correct (e.g. a stale page-table pointer or bad GQA broadcast), this test
     catches it. Also sets VLLM_XLA_CHECK_RECOMPILATION=1 to verify that the
     chunked-prefill path reuses compiled graphs after warm-up (no recompile).
+
+    On push (not just nightly): tiny opt-125m keeps it fast, and it is a real
+    chunked-prefill *correctness* signal on every PR alongside the recompile
+    guard (test_prefill_recompile.py), so a break like #5579 can't slip through
+    on a single xfailed test (tt-xla #5691).
     """
     monkeypatch.setenv("VLLM_XLA_CHECK_RECOMPILATION", "1")
 

--- a/tests/integrations/vllm_plugin/generative/test_chunked_prefill.py
+++ b/tests/integrations/vllm_plugin/generative/test_chunked_prefill.py
@@ -151,7 +151,6 @@ def test_chunk_budget_decoupled_from_max_model_len():
 
 
 @pytest.mark.push
-@pytest.mark.nightly
 @pytest.mark.single_device
 def test_chunked_prefill_batch_all_users_match(monkeypatch):
     """Batch>1 chunked prefill must produce identical output for all users.
@@ -161,10 +160,10 @@ def test_chunked_prefill_batch_all_users_match(monkeypatch):
     catches it. Also sets VLLM_XLA_CHECK_RECOMPILATION=1 to verify that the
     chunked-prefill path reuses compiled graphs after warm-up (no recompile).
 
-    On push (not just nightly): tiny opt-125m keeps it fast, and it is a real
-    chunked-prefill *correctness* signal on every PR alongside the recompile
-    guard (test_prefill_recompile.py), so a break like #5579 can't slip through
-    on a single xfailed test (tt-xla #5691).
+    On push: tiny opt-125m keeps it fast, and it is a real chunked-prefill
+    *correctness* signal on every PR alongside the recompile guard
+    (test_prefill_recompile.py), so a break like #5579 can't slip through on a
+    single xfailed test (tt-xla #5691).
     """
     monkeypatch.setenv("VLLM_XLA_CHECK_RECOMPILATION", "1")
 

--- a/tests/integrations/vllm_plugin/generative/test_data_parallel_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_data_parallel_generation.py
@@ -7,9 +7,10 @@ enable_data_parallel=True / enable_tensor_parallel=False builds an SPMD mesh
 (dp_size, 1): weights replicated, the input batch sharded on the "batch" axis
 so each replica sees a disjoint subset of sentences.
 """
+
 import pytest
 import vllm
-from conftest import assert_output_coherent, check_host_memory
+from conftest import CHUNKED_PREFILL_PROMPT, assert_output_coherent, check_host_memory
 
 
 @pytest.mark.push
@@ -84,6 +85,46 @@ def test_data_parallel_generation_n300_wider_batch(model_name: str):
         assert_output_coherent(text)
 
     check_host_memory(model_name)
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.data_parallel
+@pytest.mark.dual_chip
+@pytest.mark.parametrize("model_name", ["Qwen/Qwen3-0.6B"])
+def test_data_parallel_chunked_prefill_n300(model_name: str):
+    """Chunked prefill under DP on n300 (tt-xla #4986/#5691).
+
+    Each DP replica prefills its own sentence; prefill_chunk_size << prompt
+    length splits each into several block-aligned chunks so both replicas run
+    the cached-prefix chunked-SDPA path in parallel. Greedy for determinism;
+    coherence per replica catches a corrupted cached-prefix or a DP hang.
+
+    On push + nightly to protect chunked prefill in the DP path per #5691.
+    """
+    prompts = [CHUNKED_PREFILL_PROMPT, CHUNKED_PREFILL_PROMPT]
+    sampling_params = vllm.SamplingParams(temperature=0.0, max_tokens=32)
+    llm_args = {
+        "model": model_name,
+        "max_num_seqs": 2,
+        "max_model_len": 512,
+        "gpu_memory_utilization": 0.1,
+        "additional_config": {
+            "min_context_len": 128,
+            "enable_data_parallel": True,
+            # Opt in to chunked prefill; platform.py derives
+            # max_num_batched_tokens from this.
+            "prefill_chunk_size": 128,
+        },
+    }
+    llm = vllm.LLM(**llm_args)
+
+    outputs = llm.generate(prompts, sampling_params)
+    assert len(outputs) == len(prompts)
+    for i, out in enumerate(outputs):
+        text = out.outputs[0].text
+        print(f"replica {i}: {text}")
+        assert_output_coherent(text)
 
 
 @pytest.mark.push

--- a/tests/integrations/vllm_plugin/generative/test_data_parallel_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_data_parallel_generation.py
@@ -10,7 +10,8 @@ so each replica sees a disjoint subset of sentences.
 
 import pytest
 import vllm
-from conftest import CHUNKED_PREFILL_PROMPT, assert_output_coherent, check_host_memory
+from chunked_prefill_data import CHUNKED_PREFILL_PROMPT
+from conftest import assert_output_coherent, check_host_memory
 
 
 @pytest.mark.push
@@ -88,7 +89,6 @@ def test_data_parallel_generation_n300_wider_batch(model_name: str):
 
 
 @pytest.mark.push
-@pytest.mark.nightly
 @pytest.mark.data_parallel
 @pytest.mark.dual_chip
 @pytest.mark.parametrize("model_name", ["Qwen/Qwen3-0.6B"])
@@ -99,8 +99,6 @@ def test_data_parallel_chunked_prefill_n300(model_name: str):
     length splits each into several block-aligned chunks so both replicas run
     the cached-prefix chunked-SDPA path in parallel. Greedy for determinism;
     coherence per replica catches a corrupted cached-prefix or a DP hang.
-
-    On push + nightly to protect chunked prefill in the DP path per #5691.
     """
     prompts = [CHUNKED_PREFILL_PROMPT, CHUNKED_PREFILL_PROMPT]
     sampling_params = vllm.SamplingParams(temperature=0.0, max_tokens=32)

--- a/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 import vllm
+from chunked_prefill_data import CHUNKED_PREFILL_PROMPT
 from conftest import (
-    CHUNKED_PREFILL_PROMPT,
     GROUNDED_BATCH_CHECKS,
     assert_batch_grounded,
     assert_output_coherent,
@@ -78,7 +78,6 @@ def test_tensor_parallel_generation_llmbox_small(
     check_host_memory(model_name)
 
 
-@pytest.mark.push
 @pytest.mark.nightly
 @pytest.mark.tensor_parallel
 @pytest.mark.dual_chip
@@ -92,9 +91,6 @@ def test_tensor_parallel_chunked_prefill_n300(model_name: str):
     chips. No existing multichip test exercised this (all use max_model_len=32
     with prompts that fit one chunk). Greedy for determinism; coherence catches
     a corrupted cached-prefix (garbage) or a TP-shard hang.
-
-    On push + nightly to protect chunked prefill in the TP path per #5691 (a
-    #5579-class break fatals at engine init here too).
     """
     sampling_params = vllm.SamplingParams(temperature=0.0, max_tokens=32)
     llm_args = {

--- a/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
@@ -4,6 +4,7 @@
 import pytest
 import vllm
 from conftest import (
+    CHUNKED_PREFILL_PROMPT,
     GROUNDED_BATCH_CHECKS,
     assert_batch_grounded,
     assert_output_coherent,
@@ -75,6 +76,47 @@ def test_tensor_parallel_generation_llmbox_small(
     assert_output_coherent(output_text)
 
     check_host_memory(model_name)
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.tensor_parallel
+@pytest.mark.dual_chip
+@pytest.mark.parametrize("model_name", ["Qwen/Qwen3-0.6B"])
+def test_tensor_parallel_chunked_prefill_n300(model_name: str):
+    """Chunked prefill under pure TP on n300 (tt-xla #4986/#5691).
+
+    prefill_chunk_size << prompt length splits the prompt into several
+    block-aligned chunks, so chunks 2..N route through the cached-prefix
+    chunked-SDPA path while the KV cache and attention are sharded across the 2
+    chips. No existing multichip test exercised this (all use max_model_len=32
+    with prompts that fit one chunk). Greedy for determinism; coherence catches
+    a corrupted cached-prefix (garbage) or a TP-shard hang.
+
+    On push + nightly to protect chunked prefill in the TP path per #5691 (a
+    #5579-class break fatals at engine init here too).
+    """
+    sampling_params = vllm.SamplingParams(temperature=0.0, max_tokens=32)
+    llm_args = {
+        "model": model_name,
+        "max_num_seqs": 1,
+        "max_model_len": 512,
+        "gpu_memory_utilization": 0.1,
+        "additional_config": {
+            "min_context_len": 128,
+            "enable_tensor_parallel": True,
+            # Opt in to chunked prefill; platform.py derives
+            # max_num_batched_tokens from this.
+            "prefill_chunk_size": 128,
+        },
+    }
+    llm = vllm.LLM(**llm_args)
+
+    output_text = (
+        llm.generate([CHUNKED_PREFILL_PROMPT], sampling_params)[0].outputs[0].text
+    )
+    print(f"output: {output_text}")
+    assert_output_coherent(output_text)
 
 
 @pytest.mark.nightly


### PR DESCRIPTION
### Ticket

Closes #5691


### Problem description

Chunked prefill (#4986) is relied on by productized single-chip models and is coming online for multichip, but CI coverage was thin. The only per-PR guard was test_no_prefill_recompile; the three real correctness tests ran nightly-only and single-chip, and no multichip test exercised chunked prefill at all (every TP/DP test used max_model_len=32 with prompts that fit in a single chunk).

This left the feature fragile. When the tt-mlir uplift regressed chunked prefill in #5579 (insertTiledFixup tilized the SDPA page_table → TT_FATAL: Page table must be row major, which fatals at engine init and breaks all chunked prefill), only that single push test caught it. Once it was xfailed, the breakage went dark and later surfaced as broken productized models in tt-shield CI. The feature needs enough push coverage that no single xfail can hide a regression.


### What's changed

Broaden chunked-prefill coverage so it's protected on every PR across the single-chip, tensor-parallel, and data-parallel paths:
- Promoted the existing opt-125m batch chunked-prefill correctness test to push (was nightly-only), tiny model keeps it fast, and it's a real correctness signal on every PR alongside the recompile guard.
- Added n300 tensor-parallel chunked-prefill test (push + nightly).
- Added n300 data-parallel chunked-prefill test (push + nightly).
- Factored a shared long prompt (CHUNKED_PREFILL_PROMPT) into conftest.

The multichip tests set prefill_chunk_size well below the prompt length so the prompt splits into block-aligned chunks that route chunks 2..N through the cached-prefix chunked-SDPA path, with KV cache and attention sharded across chips, a path no prior multichip test covered. They generate greedily and assert output coherence, which catches a corrupted cached-prefix (garbage) or a shard-side hang. Impact: a #5579-class regression now fails multiple push tests across all three parallelism modes instead of slipping through on one xfailed test. (Benchmark coverage, #5404, is a deliberate follow-up in a separate PR.)


### Checklist

- [x]  this PR is the coverage; all three tests validated green on n300 hardware (single-chip push, TP, and DP) against the #5579-fixed tt-mlir pin
