### PR TITLE
[vLLM][MRv2] Add multi-device (TP/DP/DP+TP) support to TTModelRunnerV2

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
@@ -558,9 +558,22 @@ class TTModelRunnerV2:
         1-token decodes ahead of the prefills so the multi-pass loop can emit
         pure decode passes (dispatched to the decode graph) before prefills.
         """
+        sched = scheduler_output.num_scheduled_tokens
+        if self.dp_size > 1:
+            # DP: a request's batch position determines its DP replica, so it must
+            # be stable across prefill and decode (KV is written and read on the
+            # same replica). Order all active slots ascending by slot and pad the
+            # unscheduled ones with 0 tokens so positions never shift step-to-step.
+            items = sorted(
+                self.req_states.req_id_to_index.items(), key=lambda kv: kv[1]
+            )
+            slots = np.array([slot for _, slot in items], dtype=np.int32)
+            ntoks_np = np.array([sched.get(rid, 0) for rid, _ in items], dtype=np.int32)
+            return slots, ntoks_np
+
         slots: list[int] = []
         ntoks: list[int] = []
-        for req_id, n in scheduler_output.num_scheduled_tokens.items():
+        for req_id, n in sched.items():
             slot = self.req_states.req_id_to_index.get(req_id)
             if slot is None:
                 continue
@@ -689,6 +702,10 @@ class TTModelRunnerV2:
 
         for b in range(num_reqs):
             slot = int(idx_mapping_np[b])
+            if int(num_scheduled_tokens[b]) == 0:
+                # DP padding row (unscheduled this step): emits no token.
+                valid[b] = []
+                continue
             seq_len = int(rs.num_computed_tokens[slot]) + int(num_scheduled_tokens[b])
             if seq_len < int(rs.prefill_len[slot]):
                 # Still prefilling: ignore the sampled token from this partial req.
@@ -855,6 +872,9 @@ class TTModelRunnerV2:
 
             valid = self.postprocess(idx_mapping, num_scheduled, sampled)
             for b in range(len(idx_mapping)):
+                if int(num_scheduled[b]) == 0:
+                    # DP padding row: not scheduled this step, don't report it.
+                    continue
                 slot = int(idx_mapping[b])
                 out_req_ids.append(self.req_states.index_to_req_id[slot])
                 out_sampled.append(valid[b])

--- a/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
@@ -32,8 +32,11 @@ from typing import TYPE_CHECKING
 import numpy as np
 import torch
 import vllm.envs as envs
+from tt_torch.sharding import sharding_constraint_tensor
 from vllm.sampling_params import SamplingType
 from vllm.utils.math_utils import cdiv
+
+from .vllm_distributed_utils import ParallelismMode, safe_mark_sharding, shard_model
 
 logger = logging.getLogger(__name__)
 
@@ -101,7 +104,6 @@ class TTModelRunnerV2:
         from .platform import TTConfig
         from .request_state import TTRequestState
         from .sampling_state_v2 import TTSamplingStates
-        from .vllm_distributed_utils import ParallelismMode
 
         self.vllm_config = vllm_config
         self.model_config = vllm_config.model_config
@@ -293,7 +295,6 @@ class TTModelRunnerV2:
         import torch_xla.distributed.spmd as xs
         import torch_xla.runtime as xr
 
-        from .vllm_distributed_utils import ParallelismMode
         from .vllm_utils import determine_mesh_shape
 
         num_devices = xr.global_runtime_device_count()
@@ -371,7 +372,6 @@ class TTModelRunnerV2:
         from .model_state import TTModelState
         from .overrides import repair_stale_moe_closures, replace_modules
         from .sampler import Sampler
-        from .vllm_distributed_utils import ParallelismMode, shard_model
 
         loader = get_model_loader(self.load_config)
 
@@ -901,6 +901,18 @@ class TTModelRunnerV2:
         logits_indices_dev = torch.from_numpy(logits_indices).to(dev)
         batch_idx_dev = torch.arange(target_num_reqs, dtype=torch.int32, device=dev)
 
+        if self.parallel_mode in (
+            ParallelismMode.DATA_PARALLEL_ONLY,
+            ParallelismMode.DATA_TENSOR_PARALLEL,
+        ):
+            # These share the DP-sharded K/V input's per-device leading dim;
+            # batch_idx feeds paged_fill_cache, whose verifier requires dim0 to
+            # equal the per-device batch.
+            safe_mark_sharding(page_table_dev, self.mesh, ("batch", None))
+            safe_mark_sharding(cache_position_dev, self.mesh, ("batch",))
+            safe_mark_sharding(batch_idx_dev, self.mesh, ("batch",))
+            safe_mark_sharding(fill_page_table_dev, self.mesh, ("batch", None))
+
         attn_metadata = self.model_state.prepare_attn(
             self.attention_layer_names,
             page_table_dev,
@@ -952,6 +964,8 @@ class TTModelRunnerV2:
         self, input_ids, positions, logits_indices, sampling_metadata
     ):
         """Compiled model forward -> last-token select -> logits -> sample."""
+        # Pin input shardings on the 2D tensors before the flatten (mirrors v1).
+        self._pin_input_shardings(input_ids, positions, None)
         model_input_ids, model_positions, model_embeds, restore_shape = (
             self._prepare_model_call_tensors(input_ids, positions, None)
         )
@@ -963,7 +977,34 @@ class TTModelRunnerV2:
         hidden_states = self._restore_model_hidden_states(hidden_states, restore_shape)
         selected_states = self._select_hidden_states(hidden_states, logits_indices)
         logits = self.model.compute_logits(selected_states)
+        # Replicate sharded logits: hooks can't reach ParallelLMHead
+        # (quant_method.apply bypasses __call__) and all_gather is a no-op at
+        # world_size 1, so the constraint must sit inside the compiled graph.
+        if self.enable_tensor_parallel and self.is_sharded_compute_logits:
+            logits = sharding_constraint_tensor(logits, self.mesh, (None, None))
         return self._sample_from_logits(logits, sampling_metadata)
+
+    def _pin_input_shardings(self, input_ids, positions, inputs_embeds) -> None:
+        """Pin model inputs on the batch/mesh axis so warmup and inference trace
+        the same graph. No-op off the SPMD path (ported from the v1 runner)."""
+        if not self.enable_tensor_parallel and self.parallel_mode not in (
+            ParallelismMode.DATA_PARALLEL_ONLY,
+            ParallelismMode.DATA_TENSOR_PARALLEL,
+        ):
+            return
+        # 2D mesh: batch dim -> "batch"; pure 1D-TP: "batch" is size 1, use "model".
+        batch_axis = "batch" if self.use_2d_mesh else "model"
+        if input_ids is not None:
+            safe_mark_sharding(input_ids, self.mesh, (batch_axis, None))
+        if inputs_embeds is not None:
+            safe_mark_sharding(inputs_embeds, self.mesh, (batch_axis, None, None))
+        # positions: pin only for DP modes; under pure-TP it drives GSPMD into a
+        # batch-axis reduce_scatter that hits a tt-mlir to_layout bug.
+        if self.parallel_mode in (
+            ParallelismMode.DATA_PARALLEL_ONLY,
+            ParallelismMode.DATA_TENSOR_PARALLEL,
+        ):
+            safe_mark_sharding(positions, self.mesh, (batch_axis, None))
 
     def _prepare_model_call_tensors(self, input_ids, positions, inputs_embeds):
         """Optionally flatten the 2D [reqs, tokens] tensors to 1D for flat_model_io."""
@@ -991,7 +1032,10 @@ class TTModelRunnerV2:
     def _select_hidden_states(self, hidden_states, indices_do_sample):
         # Gather each request's last-token hidden state: hidden is [reqs, tokens, H].
         batch_indices = torch.arange(indices_do_sample.shape[0], dtype=torch.int32)
-        return hidden_states[batch_indices, indices_do_sample, :]
+        result = hidden_states[batch_indices, indices_do_sample, :]
+        if self.enable_tensor_parallel and self.use_2d_mesh:
+            result = sharding_constraint_tensor(result, self.mesh, (None, None))
+        return result
 
     def _sample_from_logits(self, logits, sampling_metadata):
         # Greedy fast-path (argmax) avoids the fused sampling kernel; the sampler
@@ -1151,10 +1195,8 @@ class TTModelRunnerV2:
         return kv_cache_spec
 
     def initialize_kv_cache(self, kv_cache_config: "KVCacheConfig") -> None:
-        """Allocate KV caches and bind them into the forward context.
-
-        SPMD KV-cache sharding and KV-transfer registration land with the
-        multi-device __init__.
+        """Allocate KV caches, bind them into the forward context, and (under TP)
+        shard them across the mesh. KV-transfer registration is still deferred.
         """
         from vllm.v1.worker.utils import bind_kv_cache
 
@@ -1167,6 +1209,27 @@ class TTModelRunnerV2:
             self.vllm_config.compilation_config.static_forward_context,
             self.kv_caches,
         )
+
+        if self.parallel_mode == ParallelismMode.DATA_TENSOR_PARALLEL:
+            # DP+TP: leave replicated; each device writes its own slice via
+            # paged_update_cache. A TP-only spec puts block_size on the DP axis
+            # and fails ttir.paged_update_cache (follow-up).
+            return
+        if self.enable_tensor_parallel:
+            import torch_xla.distributed.spmd as xs
+
+            for entry in self.kv_caches:
+                is_pair = isinstance(entry, (list, tuple))
+                for cache in entry if is_pair else [entry]:
+                    assert cache.ndim == 4, "KV cache tensor must be 4D."
+                    if is_pair:
+                        # Shard standard K/V on num_kv_heads over the "model" axis.
+                        safe_mark_sharding(
+                            cache, self.mesh, (None, "model", None, None)
+                        )
+                    else:
+                        # Replicate the MLA latent KV cache.
+                        xs.mark_sharding(cache, self.mesh, (None, None, None, None))
 
     def get_model(self):
         return self.model

--- a/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
@@ -356,18 +356,22 @@ class TTModelRunnerV2:
     def load_model(self) -> None:
         """Load, place, and compile the model; build ModelState + sampler.
 
-        Single-device path (salvaged from the v1 fork): the multi-device weight
-        sharding, the vocab-embedding TP-rank patch, LoRA, and per-tensor
-        weight-dtype overrides are deferred with the SPMD ``__init__``.
-        Needs a real model + loader, so it is validated at engine stand-up.
+        Under TP the weights are sharded across the mesh (via ``shard_model``)
+        and the embedding load is wrapped in the vocab TP-rank patch. LoRA and
+        per-tensor weight-dtype overrides are still deferred. Needs a real model
+        + loader, so it is validated at engine stand-up.
         """
+        from contextlib import nullcontext
+
         from vllm.config import get_layers_from_vllm_config, set_current_vllm_config
         from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+        from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
         from vllm.model_executor.model_loader import get_model_loader
 
         from .model_state import TTModelState
         from .overrides import repair_stale_moe_closures, replace_modules
         from .sampler import Sampler
+        from .vllm_distributed_utils import ParallelismMode, shard_model
 
         loader = get_model_loader(self.load_config)
 
@@ -383,7 +387,21 @@ class TTModelRunnerV2:
 
             loader.get_all_weights = filtered_get_all_weights
 
-        with set_current_vllm_config(self.vllm_config):
+        # xm's rank assignment differs from gloo's; the embedding all-gather
+        # ordering depends on the xm rank, so patch it only for the weight load.
+        vocab_rank_patch = nullcontext()
+        if self.enable_tensor_parallel:
+            from unittest.mock import patch
+
+            import torch_xla.runtime as xr
+
+            vocab_rank_patch = patch(
+                "vllm.model_executor.layers.vocab_parallel_embedding."
+                "get_tensor_model_parallel_rank",
+                return_value=xr.global_ordinal(),
+            )
+
+        with set_current_vllm_config(self.vllm_config), vocab_rank_patch:
             model = loader.load_model(
                 vllm_config=self.vllm_config, model_config=self.model_config
             ).eval()
@@ -392,6 +410,22 @@ class TTModelRunnerV2:
 
         # Repair MoE routing closures that captured CPU tensors before to(device).
         repair_stale_moe_closures(self.model)
+
+        # Shard weights across the mesh before compile so the annotations are
+        # captured in the traced graph. Pure-TP always shards on the batch axis
+        # (it is itself a TP axis there); DP+TP honours the config knob.
+        if self.enable_tensor_parallel:
+            shard_on_batch_axis = (
+                self.tt_config.shard_weights_on_batch_axis
+                if self.parallel_mode == ParallelismMode.DATA_TENSOR_PARALLEL
+                else True
+            )
+            shard_model(self.model, self.mesh, shard_on_batch_axis)
+
+        # MM models nest lm_head, so walk the tree for any ParallelLMHead.
+        self.is_sharded_compute_logits = self.enable_tensor_parallel and any(
+            isinstance(m, ParallelLMHead) for m in self.model.modules()
+        )
 
         self.model.compile(backend="tt", dynamic=False)
         self.sampler = Sampler()

--- a/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
@@ -919,7 +919,9 @@ class TTModelRunnerV2:
         fill_page_table_dev = torch.from_numpy(fill_page_table).to(dev)
         cache_position_dev = torch.from_numpy(cache_position).to(dev)
         logits_indices_dev = torch.from_numpy(logits_indices).to(dev)
-        batch_idx_dev = torch.arange(target_num_reqs, dtype=torch.int32, device=dev)
+        batch_idx_dev = torch.from_numpy(np.arange(target_num_reqs, dtype=np.int32)).to(
+            dev
+        )
 
         # Pin input shardings eagerly (not inside the compiled graph, whose
         # dynamo trace can't run safe_mark_sharding's replicate-fallback logging).

--- a/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
@@ -560,15 +560,20 @@ class TTModelRunnerV2:
         """
         sched = scheduler_output.num_scheduled_tokens
         if self.dp_size > 1:
-            # DP: a request's batch position determines its DP replica, so it must
-            # be stable across prefill and decode (KV is written and read on the
-            # same replica). Order all active slots ascending by slot and pad the
-            # unscheduled ones with 0 tokens so positions never shift step-to-step.
-            items = sorted(
-                self.req_states.req_id_to_index.items(), key=lambda kv: kv[1]
+            # DP: a request's batch position picks its DP replica, so it must equal
+            # the request's stable slot for its whole life (KV is written at prefill
+            # and read at decode on the same replica). Return the FULL replica grid
+            # -- every slot 0..max_num_reqs-1, position b == slot b -- with per-slot
+            # token counts (0 for inactive or unscheduled slots); _select_batch runs
+            # it as one full-width pass. Listing only active slots (or ranking them)
+            # would shift a lone prefilling request to position 0 and read its KV off
+            # the wrong replica at decode.
+            idx_to_req = self.req_states.index_to_req_id
+            slots = np.arange(self.max_num_reqs, dtype=np.int32)
+            ntoks_np = np.array(
+                [sched.get(idx_to_req.get(s), 0) for s in range(self.max_num_reqs)],
+                dtype=np.int32,
             )
-            slots = np.array([slot for _, slot in items], dtype=np.int32)
-            ntoks_np = np.array([sched.get(rid, 0) for rid, _ in items], dtype=np.int32)
             return slots, ntoks_np
 
         slots: list[int] = []
@@ -597,6 +602,21 @@ class TTModelRunnerV2:
         multi-pass loop picks up the rest. Returns ``(idx_mapping,
         num_scheduled_tokens, target_num_reqs, padded_query_len, end_index)``.
         """
+        if self.dp_size > 1:
+            # DP grid is one full-width pass; positions already map to replicas
+            # (see _order_scheduled_reqs), so no SMEM re-clamp or reorder here.
+            max_scheduled = max(int(ordered_num_tokens.max()), 1)
+            padded_query_len = _get_padded_token_len(
+                self.num_tokens_paddings, max_scheduled
+            )
+            return (
+                ordered_slots,
+                ordered_num_tokens,
+                self.max_num_reqs,
+                padded_query_len,
+                len(ordered_slots),
+            )
+
         # A long request anywhere in the remaining tail forces max-model-len mode
         # (fewer rows fit SMEM), matching the v1 collection loop.
         use_max_model_len = self.most_model_len is None
@@ -1327,8 +1347,102 @@ class TTModelRunnerV2:
         if has_kv_transfer_group():
             ensure_kv_transfer_shutdown()
 
+    def _warmup_buckets(self) -> list[tuple[int, int]]:
+        """(target_num_reqs, padded_query_len) pairs to precompile.
+
+        Decode always runs at max_num_reqs; prefill runs at the min / max prefill
+        buckets. Each request-count bucket is compiled at every token-length
+        padding, matching the shapes _select_batch can produce at runtime.
+        """
+        targets = sorted(
+            {self.max_num_reqs, self.min_num_reqs, self.max_prefill_num_reqs}
+        )
+        return [(t, q) for t in targets for q in self.num_tokens_paddings]
+
     def capture_model(self) -> None:
-        # Warmup precompile is deferred: all-zeros dummy attention metadata fails
-        # to compile the paged-attention op, and a failed TT compile poisons
-        # torch_xla async state. Graphs compile lazily on first use instead.
-        logger.warning("MRv2 capture_model: warmup skipped; graphs compile lazily.")
+        """Precompile the forward/sample graph at every runtime bucket shape.
+
+        Warms the graph once with the DP input/KV shardings pinned so the first
+        real request pays no compile latency and traces the same graph warmup did.
+        Uses valid dummy attention metadata (non-zero cache_position, real
+        batch_idx) — all-zeros dummies fail to compile the paged-attention op.
+        Greedy (argmax) path only; sampler / multimodal / cpu_sampling warmups are
+        deferred with those runtime paths.
+        """
+        if self.cpu_sampling:
+            raise NotImplementedError("cpu_sampling warmup path is not ported yet.")
+        import time
+
+        import torch_xla
+
+        torch._dynamo.config.dynamic_shapes = False
+        start = time.perf_counter()
+        buckets = self._warmup_buckets()
+        logger.info("MRv2 warmup: precompiling %d bucket(s).", len(buckets))
+        for target_num_reqs, padded_query_len in buckets:
+            logger.info(
+                "MRv2 warmup: num_reqs=%d, query_len=%d",
+                target_num_reqs,
+                padded_query_len,
+            )
+            self._precompile_bucket(target_num_reqs, padded_query_len)
+            # Sync per bucket so prefill and decode graphs stay separate.
+            torch_xla.sync()
+        torch_xla.sync()
+        logger.info("MRv2 warmup finished in %.2f [secs].", time.perf_counter() - start)
+
+    def _precompile_bucket(self, target_num_reqs: int, padded_query_len: int) -> None:
+        """Trace the fused forward+sample graph for one bucket with valid dummies.
+
+        Mirrors _run_model_pass's device-tensor + sharding sequence so the warmed
+        graph matches inference exactly (input shardings pinned eagerly; page /
+        cache / batch_idx sharded on the DP batch axis).
+        """
+        from .metadata import XLASupportedSamplingMetadata
+
+        dev = self.device
+        input_ids = torch.zeros(
+            (target_num_reqs, padded_query_len), dtype=torch.int32
+        ).to(dev)
+        positions = torch.zeros(
+            (target_num_reqs, padded_query_len), dtype=torch.int32
+        ).to(dev)
+        logits_indices = torch.zeros(target_num_reqs, dtype=torch.int32).to(dev)
+        page_table = torch.zeros(
+            (target_num_reqs, self.max_num_blocks_per_req), dtype=torch.int32
+        ).to(dev)
+        fill_page_table = torch.zeros(
+            (target_num_reqs, self.max_num_blocks_per_req), dtype=torch.int32
+        ).to(dev)
+        # Non-zero write position: all-zeros makes the paged cache op fail to
+        # compile (matches v1's _dummy_run, which uses ones).
+        cache_position = torch.ones(target_num_reqs, dtype=torch.int32).to(dev)
+        # from_numpy (not on-device arange) so the DP "batch" sharding sticks.
+        batch_idx = torch.from_numpy(
+            np.arange(target_num_reqs, dtype=np.int32)
+        ).to(dev)
+
+        self._pin_input_shardings(input_ids, positions, None)
+        if self.parallel_mode in (
+            ParallelismMode.DATA_PARALLEL_ONLY,
+            ParallelismMode.DATA_TENSOR_PARALLEL,
+        ):
+            safe_mark_sharding(page_table, self.mesh, ("batch", None))
+            safe_mark_sharding(cache_position, self.mesh, ("batch",))
+            safe_mark_sharding(batch_idx, self.mesh, ("batch",))
+            safe_mark_sharding(fill_page_table, self.mesh, ("batch", None))
+
+        attn_metadata = self.model_state.prepare_attn(
+            self.attention_layer_names,
+            page_table,
+            cache_position,
+            fill_page_table=fill_page_table,
+            batch_idx=batch_idx,
+            num_users=target_num_reqs,
+            dp_size=self.dp_size,
+        )
+        # Defaults are all-greedy -> warms the argmax fast-path.
+        sampling_metadata = XLASupportedSamplingMetadata(all_greedy=True)
+        self._forward_and_sample(
+            input_ids, positions, logits_indices, attn_metadata, sampling_metadata
+        )

--- a/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
@@ -77,11 +77,17 @@ def _get_token_paddings(min_token_size: int, max_token_size: int) -> list[int]:
 class TTModelRunnerV2:
     """Tenstorrent MRv2 model runner (see module docstring)."""
 
-    def __init__(self, vllm_config: "VllmConfig", device: torch.device) -> None:
-        """Construct the split v2 state + config scalars (single-device path).
+    def __init__(
+        self,
+        vllm_config: "VllmConfig",
+        device: torch.device,
+        original_parallel_config=None,
+    ) -> None:
+        """Construct the split v2 state + config scalars.
 
-        Multi-device SPMD (mesh / tensor + data parallel) is deferred; this
-        constructor raises if those TT config flags are set. The model itself is
+        When TP/DP is enabled the SPMD device mesh is built here (see
+        ``_build_device_mesh``); ``original_parallel_config`` carries the real
+        (pre-collapse) parallel sizes from the worker. The model itself is
         loaded and compiled in ``load_model``; ``model``/``model_state``/``sampler``
         are None until then.
         """
@@ -95,6 +101,7 @@ class TTModelRunnerV2:
         from .platform import TTConfig
         from .request_state import TTRequestState
         from .sampling_state_v2 import TTSamplingStates
+        from .vllm_distributed_utils import ParallelismMode
 
         self.vllm_config = vllm_config
         self.model_config = vllm_config.model_config
@@ -129,13 +136,18 @@ class TTModelRunnerV2:
         tt = self.tt_config
         self.enable_tensor_parallel = bool(getattr(tt, "enable_tensor_parallel", False))
         self.enable_data_parallel = bool(getattr(tt, "enable_data_parallel", False))
-        if self.enable_tensor_parallel or self.enable_data_parallel:
-            raise NotImplementedError(
-                "Multi-device (SPMD mesh) __init__ is deferred; single device only."
-            )
+        self.use_2d_mesh = getattr(tt, "use_2d_mesh", True)
+        self.is_sharded_compute_logits = False
+        self.original_parallel_config = original_parallel_config
+
+        # max_num_reqs may be rounded up to a dp_size multiple by the mesh build,
+        # so it must be set before it sizes the state tables below.
+        self.max_num_reqs = self.scheduler_config.max_num_seqs
         self.dp_size = 1
         self.mesh = None
-        self.original_parallel_config = None
+        self.parallel_mode = ParallelismMode.DISABLED
+        if self.enable_tensor_parallel or self.enable_data_parallel:
+            self._build_device_mesh()
 
         self.dtype = self.model_config.dtype
         if self.cache_config.cache_dtype == "auto":
@@ -157,7 +169,6 @@ class TTModelRunnerV2:
 
         self.block_size = self.cache_config.block_size
         self.max_model_len = self.model_config.max_model_len
-        self.max_num_reqs = self.scheduler_config.max_num_seqs
         self.most_model_len = envs.VLLM_TPU_MOST_MODEL_LEN
         self.max_num_blocks_per_req = cdiv(self.max_model_len, self.block_size)
         self.num_blocks_per_most_len_req = (
@@ -269,6 +280,78 @@ class TTModelRunnerV2:
         self.sampler = None
         self._attention_layer_names: tuple = ()
         self.attention_layer_names: tuple = ()
+
+    def _build_device_mesh(self) -> None:
+        """Select the parallelism mode and build the SPMD device mesh.
+
+        Ported from the v1 runner: disables TP/DP that the available device count
+        can't support, derives the ``(batch, model)`` mesh via
+        ``determine_mesh_shape``, sets ``dp_size`` (>1 only in DP modes), and
+        rounds ``max_num_reqs`` up to a ``dp_size`` multiple. No-ops to the
+        single-device path (mesh stays None) when both flags end up disabled.
+        """
+        import torch_xla.distributed.spmd as xs
+        import torch_xla.runtime as xr
+
+        from .vllm_distributed_utils import ParallelismMode
+        from .vllm_utils import determine_mesh_shape
+
+        num_devices = xr.global_runtime_device_count()
+        if self.enable_tensor_parallel and num_devices == 1:
+            logger.warning("Tensor parallel needs >1 device; found 1. Disabling TP.")
+            self.enable_tensor_parallel = False
+        if self.enable_data_parallel and (self.max_num_reqs <= 1 or num_devices == 1):
+            logger.warning(
+                "Data parallel needs >1 device and max_num_seqs > 1. Disabling DP."
+            )
+            self.enable_data_parallel = False
+
+        if self.enable_data_parallel and self.enable_tensor_parallel:
+            self.parallel_mode = ParallelismMode.DATA_TENSOR_PARALLEL
+        elif self.enable_data_parallel:
+            self.parallel_mode = ParallelismMode.DATA_PARALLEL_ONLY
+        elif self.enable_tensor_parallel:
+            # An explicit 2D mesh_shape (no size-1 axis) forces TP-2D even when
+            # use_2d_mesh is unset, matching the mesh determine_mesh_shape builds.
+            explicit_2d_mesh = (
+                self.tt_config.mesh_shape is not None
+                and 1 not in self.tt_config.mesh_shape
+            )
+            self.parallel_mode = (
+                ParallelismMode.TENSOR_PARALLEL_ONLY_2D
+                if (self.use_2d_mesh or explicit_2d_mesh)
+                else ParallelismMode.TENSOR_PARALLEL_ONLY_1D
+            )
+        else:
+            self.parallel_mode = ParallelismMode.DISABLED
+            return
+
+        mesh_shape = determine_mesh_shape(
+            num_devices, self.parallel_mode, self.tt_config.mesh_shape
+        )
+        device_ids = np.array(range(num_devices))
+        self.mesh = xs.Mesh(device_ids, mesh_shape, ("batch", "model"))
+        # mesh_shape[0] ("batch" axis) is a DP replica count only in DP modes; in
+        # pure-TP the batch axis is a TP axis, so dp_size stays 1.
+        if self.parallel_mode in (
+            ParallelismMode.DATA_PARALLEL_ONLY,
+            ParallelismMode.DATA_TENSOR_PARALLEL,
+        ):
+            self.dp_size = mesh_shape[0]
+        self.use_2d_mesh = 1 not in mesh_shape
+        xs.set_global_mesh(self.mesh)
+
+        if self.enable_data_parallel and self.dp_size > 1:
+            remainder = self.max_num_reqs % self.dp_size
+            if remainder != 0:
+                adjusted = self.max_num_reqs + self.dp_size - remainder
+                logger.warning(
+                    "Data parallel requires max_num_reqs divisible by dp_size; "
+                    "adjusting from %d to %d.",
+                    self.max_num_reqs,
+                    adjusted,
+                )
+                self.max_num_reqs = adjusted
 
     def load_model(self) -> None:
         """Load, place, and compile the model; build ModelState + sampler.

--- a/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
@@ -901,6 +901,10 @@ class TTModelRunnerV2:
         logits_indices_dev = torch.from_numpy(logits_indices).to(dev)
         batch_idx_dev = torch.arange(target_num_reqs, dtype=torch.int32, device=dev)
 
+        # Pin input shardings eagerly (not inside the compiled graph, whose
+        # dynamo trace can't run safe_mark_sharding's replicate-fallback logging).
+        self._pin_input_shardings(input_ids_dev, positions_dev, None)
+
         if self.parallel_mode in (
             ParallelismMode.DATA_PARALLEL_ONLY,
             ParallelismMode.DATA_TENSOR_PARALLEL,
@@ -964,8 +968,6 @@ class TTModelRunnerV2:
         self, input_ids, positions, logits_indices, sampling_metadata
     ):
         """Compiled model forward -> last-token select -> logits -> sample."""
-        # Pin input shardings on the 2D tensors before the flatten (mirrors v1).
-        self._pin_input_shardings(input_ids, positions, None)
         model_input_ids, model_positions, model_embeds, restore_shape = (
             self._prepare_model_call_tensors(input_ids, positions, None)
         )

--- a/integrations/vllm_plugin/vllm_tt/worker.py
+++ b/integrations/vllm_plugin/vllm_tt/worker.py
@@ -172,9 +172,8 @@ class TTWorker:
             xr.initialize_cache(per_rank_path, readonly=False)
 
         # Init ModelRunner here, so that we have access to self.device.
-        # Opt-in MRv2 runner (default off): gated on TT_USE_V2_MODEL_RUNNER. It is
-        # single-device generate-only for now and takes a 2-arg constructor (no
-        # original_parallel_config), so keep the v1 runner as the default path.
+        # Opt-in MRv2 runner (default off): gated on TT_USE_V2_MODEL_RUNNER.
+        # Generate-only for now, so keep the v1 runner as the default path.
         use_v2 = os.environ.get("TT_USE_V2_MODEL_RUNNER", "").lower() in (
             "1",
             "true",
@@ -183,7 +182,9 @@ class TTWorker:
         if use_v2 and self.model_config.runner_type != "pooling":
             from .model_runner_v2 import TTModelRunnerV2
 
-            self.model_runner = TTModelRunnerV2(self.vllm_config, self.device)
+            self.model_runner = TTModelRunnerV2(
+                self.vllm_config, self.device, self.original_parallel_config
+            )
         else:
             ModelRunnerClass = TTModelRunner
             if self.model_config.runner_type == "pooling":

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_batch_select.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_batch_select.py
@@ -42,6 +42,7 @@ def make_runner(**scalars):
     r.min_num_reqs = scalars.get("min_num_reqs", 1)
     r.max_num_reqs = scalars.get("max_num_reqs", 4)
     r.num_tokens_paddings = scalars.get("num_tokens_paddings", PADDINGS)
+    r.dp_size = scalars.get("dp_size", 1)
     return r
 
 
@@ -73,6 +74,30 @@ def test_order_skips_reqs_without_slot():
     slots, ntoks = r._order_scheduled_reqs(so)
     assert slots.tolist() == [s_a]
     assert ntoks.tolist() == [1]
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_order_dp_stable_positions_pads_unscheduled():
+    # Under DP a request's position (= its DP replica) must be stable across
+    # steps, so ordering covers all active slots (sorted) with unscheduled ones
+    # padded to 0 tokens, regardless of which are scheduled this step.
+    r = make_runner(dp_size=2)
+    for rid, prompt in [("A", [1]), ("B", [1, 2]), ("C", [3])]:
+        r.req_states.add_request(rid, len(prompt), prompt, 0)
+    s_a = r.req_states.req_id_to_index["A"]
+    s_b = r.req_states.req_id_to_index["B"]
+    s_c = r.req_states.req_id_to_index["C"]
+
+    # Only B is scheduled this step; A and C are padded, positions kept by slot.
+    so = SimpleNamespace(num_scheduled_tokens={"B": 5})
+    slots, ntoks = r._order_scheduled_reqs(so)
+
+    order = sorted([s_a, s_b, s_c])
+    assert slots.tolist() == order
+    assert ntoks[order.index(s_b)] == 5
+    assert ntoks[order.index(s_a)] == 0
+    assert ntoks[order.index(s_c)] == 0
 
 
 @pytest.mark.push

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_batch_select.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_batch_select.py
@@ -27,8 +27,9 @@ PADDINGS = [1, 32, 64, 128, 256]
 
 def make_runner(**scalars):
     r = object.__new__(TTModelRunnerV2)
+    max_num_reqs = scalars.get("max_num_reqs", 4)
     r.req_states = TTRequestState(
-        max_num_reqs=8,
+        max_num_reqs=max_num_reqs,
         max_model_len=512,
         max_num_batched_tokens=1024,
         num_speculative_steps=0,
@@ -78,26 +79,40 @@ def test_order_skips_reqs_without_slot():
 
 @pytest.mark.push
 @pytest.mark.cpu
-def test_order_dp_stable_positions_pads_unscheduled():
-    # Under DP a request's position (= its DP replica) must be stable across
-    # steps, so ordering covers all active slots (sorted) with unscheduled ones
-    # padded to 0 tokens, regardless of which are scheduled this step.
-    r = make_runner(dp_size=2)
+def test_order_dp_full_grid_position_equals_slot():
+    # Under DP the batch position picks the DP replica, so it must equal the
+    # request's slot. Ordering returns the FULL replica grid (every slot
+    # 0..max_num_reqs-1, position == slot) with per-slot token counts, even when
+    # only a subset of slots holds a request -- a lone prefilling request must
+    # stay at its own slot's position, not slide to position 0.
+    r = make_runner(dp_size=2, max_num_reqs=4)
     for rid, prompt in [("A", [1]), ("B", [1, 2]), ("C", [3])]:
         r.req_states.add_request(rid, len(prompt), prompt, 0)
-    s_a = r.req_states.req_id_to_index["A"]
     s_b = r.req_states.req_id_to_index["B"]
-    s_c = r.req_states.req_id_to_index["C"]
 
-    # Only B is scheduled this step; A and C are padded, positions kept by slot.
+    # Only B is scheduled this step; every other grid position pads to 0 tokens.
     so = SimpleNamespace(num_scheduled_tokens={"B": 5})
     slots, ntoks = r._order_scheduled_reqs(so)
 
-    order = sorted([s_a, s_b, s_c])
-    assert slots.tolist() == order
-    assert ntoks[order.index(s_b)] == 5
-    assert ntoks[order.index(s_a)] == 0
-    assert ntoks[order.index(s_c)] == 0
+    assert slots.tolist() == [0, 1, 2, 3]
+    assert ntoks[s_b] == 5
+    assert [ntoks[i] for i in range(4) if i != s_b] == [0, 0, 0]
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_select_batch_dp_single_full_width_pass():
+    # DP: one full-width pass, target == max_num_reqs, no reorder/re-clamp; the
+    # padded query length follows the widest scheduled row.
+    r = make_runner(dp_size=2, max_num_reqs=4)
+    slots = np.array([0, 1, 2, 3], dtype=np.int32)
+    ntoks = np.array([0, 5, 0, 1], dtype=np.int32)
+    idx, nst, target, padded, end = r._select_batch(slots, ntoks, 0)
+    assert idx.tolist() == [0, 1, 2, 3]
+    assert nst.tolist() == [0, 5, 0, 1]
+    assert target == 4
+    assert padded == 32  # first bucket >= 5
+    assert end == 4  # single pass consumes the whole grid
 
 
 @pytest.mark.push

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_driver.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_driver.py
@@ -79,6 +79,7 @@ def make_runner(max_num_reqs=8, max_model_len=32, max_num_blocks_per_req=4):
     r.max_prefill_num_reqs = max_num_reqs
     r.max_num_reqs = max_num_reqs
     r.num_tokens_paddings = [1, 32, 64, 128]
+    r.dp_size = 1
     return r
 
 

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_init.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_init.py
@@ -14,13 +14,29 @@ constructed state tables, the not-yet-loaded (None) model handles, and the
 single-device guard.
 """
 
+from contextlib import contextmanager
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 import torch
 from vllm_tt.model_runner_v2 import TTModelRunnerV2
 from vllm_tt.request_state import TTRequestState
 from vllm_tt.sampling_state_v2 import TTSamplingStates
+from vllm_tt.vllm_distributed_utils import ParallelismMode
+
+
+@contextmanager
+def fake_mesh(num_devices):
+    """Stub the torch_xla runtime/SPMD calls so mesh build is hw-independent."""
+    with patch(
+        "torch_xla.runtime.global_runtime_device_count", return_value=num_devices
+    ), patch(
+        "torch_xla.distributed.spmd.Mesh", side_effect=lambda ids, shape, names: shape
+    ), patch(
+        "torch_xla.distributed.spmd.set_global_mesh"
+    ):
+        yield
 
 
 def make_vllm_config(**tt_overrides):
@@ -133,11 +149,51 @@ def test_init_model_handles_none_until_load():
 
 @pytest.mark.push
 @pytest.mark.cpu
-def test_init_rejects_multi_device():
-    with pytest.raises(NotImplementedError):
-        TTModelRunnerV2(
+def test_init_single_device_when_flags_off():
+    r = TTModelRunnerV2(make_vllm_config(), torch.device("cpu"))
+    assert r.parallel_mode == ParallelismMode.DISABLED
+    assert r.mesh is None
+    assert r.dp_size == 1
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_init_tp_only_builds_2d_mesh():
+    with fake_mesh(8):
+        r = TTModelRunnerV2(
             make_vllm_config(enable_tensor_parallel=True), torch.device("cpu")
         )
+    # Pure TP on 8 devices -> (2,4) mesh, but dp_size stays 1 (batch axis is a TP axis).
+    assert r.parallel_mode == ParallelismMode.TENSOR_PARALLEL_ONLY_2D
+    assert r.mesh == (2, 4)
+    assert r.dp_size == 1
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_init_dp_tp_sets_dp_size():
+    with fake_mesh(8):
+        r = TTModelRunnerV2(
+            make_vllm_config(enable_tensor_parallel=True, enable_data_parallel=True),
+            torch.device("cpu"),
+        )
+    assert r.parallel_mode == ParallelismMode.DATA_TENSOR_PARALLEL
+    assert r.dp_size == 2  # mesh_shape[0] of (2,4)
+    assert r.max_num_reqs % r.dp_size == 0
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_init_single_device_disables_parallel():
+    with fake_mesh(1):
+        r = TTModelRunnerV2(
+            make_vllm_config(enable_tensor_parallel=True, enable_data_parallel=True),
+            torch.device("cpu"),
+        )
+    # One device -> both disabled, falls back to the single-device path.
+    assert r.parallel_mode == ParallelismMode.DISABLED
+    assert r.mesh is None
+    assert r.dp_size == 1
 
 
 @pytest.mark.push

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_model_pass.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_model_pass.py
@@ -22,6 +22,7 @@ from vllm_tt.model_runner_v2 import TTModelRunnerV2
 from vllm_tt.model_state import TTModelState
 from vllm_tt.request_state import TTRequestState
 from vllm_tt.sampling_state_v2 import TTSamplingStates
+from vllm_tt.vllm_distributed_utils import ParallelismMode
 
 VOCAB = 1000
 BLOCK_MAP = [[10, 11, 12, 13], [20, 21, 22, 23], [30, 31, 32, 33], [0, 0, 0, 0]]
@@ -44,6 +45,7 @@ def make_runner(max_num_reqs=4, max_model_len=32):
     r.sampling_device = torch.device("cpu")
     r.vocab_size = VOCAB
     r.dp_size = 1
+    r.parallel_mode = ParallelismMode.DISABLED
     r.block_size = 16
     r.max_num_blocks_per_req = 4
     r.attention_layer_names = ("layer.0", "layer.1")

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_model_pass.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_model_pass.py
@@ -46,6 +46,7 @@ def make_runner(max_num_reqs=4, max_model_len=32):
     r.vocab_size = VOCAB
     r.dp_size = 1
     r.parallel_mode = ParallelismMode.DISABLED
+    r.enable_tensor_parallel = False
     r.block_size = 16
     r.max_num_blocks_per_req = 4
     r.attention_layer_names = ("layer.0", "layer.1")

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_warmup.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_warmup.py
@@ -98,3 +98,32 @@ def test_reload_weights_not_supported():
     r = object.__new__(TTModelRunnerV2)
     with pytest.raises(NotImplementedError):
         r.reload_weights()
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_warmup_buckets_cover_all_shapes():
+    r = object.__new__(TTModelRunnerV2)
+    r.max_num_reqs = 8
+    r.min_num_reqs = 2
+    r.max_prefill_num_reqs = 4
+    r.num_tokens_paddings = [1, 32, 64]
+    buckets = r._warmup_buckets()
+    # Every distinct request-count crossed with every token padding.
+    assert set(buckets) == {
+        (t, q) for t in (2, 4, 8) for q in (1, 32, 64)
+    }
+    assert len(buckets) == 9
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_warmup_buckets_dedup_equal_counts():
+    r = object.__new__(TTModelRunnerV2)
+    r.max_num_reqs = 4
+    r.min_num_reqs = 4
+    r.max_prefill_num_reqs = 4
+    r.num_tokens_paddings = [1, 16]
+    buckets = r._warmup_buckets()
+    # Collapsed to a single request-count bucket.
+    assert buckets == [(4, 1), (4, 16)]


### PR DESCRIPTION
### Ticket
Part of #5629

### Problem description
The V2 runner from #5673 only ran on a single device. Production models are sharded across chips, so V2 can't replace V1 until it does tensor-parallel and data-parallel too. This adds TP, DP, and DP+TP to the V2 runner.

### What's changed
- Build the SPMD mesh in the runner __init__ (TP/DP mode selection, dp_size, max_num_seqs rounding), and have the worker pass the real parallel config through.
- Shard the weights in load_model (shard_model plus the vocab TP-rank patch).
- Add the forward SPMD annotations (input pinning, hidden-state and logits sharding constraints).
- Shard the KV cache and the per-step paged tensors on the DP batch axis.
- Pin each request's DP batch row to its slot so it keeps the same replica across prefill and decode (this was the tricky one).
- Warm up the graph in capture_model with valid dummies.

### Verification
- [x] 88 CPU tests pass.
- [x] On device (8x Wormhole): TP gives byte-identical greedy tokens to V1.
- [x] On device: DP and DP+TP give byte-identical greedy tokens to V1 on both batch slots (Qwen3-0.6B).

### Notes
- Stacked on #5673; I'll retarget the base to main once that lands.
- Still default off behind TT_USE_V2_MODEL_RUNNER, so V1 is untouched.
- The rest of the V2 features (multimodal, LoRA, grammar, prompt-logprobs, mrope, spec-decode) are still deferred and will land together in one more PR.
