### PR TITLE
[vLLM] Support flattened inputs for all the models

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -1830,9 +1830,15 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             inputs_embeds = inputs_embeds.reshape(-1, inputs_embeds.shape[-1])
 
         if positions.ndim > 1:
-            if restore_shape is None:
-                restore_shape = positions.shape
-            positions = positions.reshape(-1)
+            if self.uses_mrope:
+                assert positions.ndim == 3 and positions.shape[0] == 3
+                positions = positions.reshape(3, -1)
+            else:
+                positions = positions.reshape(-1)
+
+        assert (
+            restore_shape is not None
+        ), "restore_shape should be set if any input is flattened."
 
         return input_ids, positions, inputs_embeds, restore_shape
 

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -2194,7 +2194,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     model = model_loader.load_model(
                         vllm_config=self.vllm_config, model_config=self.model_config
                     ).eval()
-                replace_modules(model)
+                replace_modules(model, use_flat_model_io=self.use_flat_model_io)
                 model = model.to(self.device)
 
                 if self.enable_tensor_parallel:

--- a/integrations/vllm_plugin/vllm_tt/overrides.py
+++ b/integrations/vllm_plugin/vllm_tt/overrides.py
@@ -61,7 +61,7 @@ def _promote_pre_allocated_attrs_to_buffers(model: torch.nn.Module) -> None:
         model.register_buffer(attr, t, persistent=False)
 
 
-def replace_modules(model: torch.nn.Module) -> None:
+def replace_modules(model: torch.nn.Module, *, use_flat_model_io) -> None:
     logger.info(
         "Replacing vLLM modules with TT-compatible overrides where necessary..."
     )
@@ -71,6 +71,8 @@ def replace_modules(model: torch.nn.Module) -> None:
         if fqn in MODULE_TYPE_TO_TT_OVERRIDE:
             return MODULE_TYPE_TO_TT_OVERRIDE[fqn](module)
         for base_cls, override_fn in ISINSTANCE_OVERRIDES:
+            if use_flat_model_io and base_cls is MRotaryEmbedding:
+                continue
             if isinstance(module, base_cls):
                 return override_fn(module)
         return None

--- a/integrations/vllm_plugin/vllm_tt/overrides.py
+++ b/integrations/vllm_plugin/vllm_tt/overrides.py
@@ -61,7 +61,7 @@ def _promote_pre_allocated_attrs_to_buffers(model: torch.nn.Module) -> None:
         model.register_buffer(attr, t, persistent=False)
 
 
-def replace_modules(model: torch.nn.Module, *, use_flat_model_io) -> None:
+def replace_modules(model: torch.nn.Module, *, use_flat_model_io: bool = False) -> None:
     logger.info(
         "Replacing vLLM modules with TT-compatible overrides where necessary..."
     )

--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -190,7 +190,7 @@ class TTConfig:
 
     # Flatten model I/O to a flat token stream at the model-call boundary
     # (needed by HF forwards like Gemma-4's PLE path).
-    flat_model_io: bool = False
+    flat_model_io: bool = True
 
     enable_trace: bool = False
 

--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -107,7 +107,7 @@ class TTConfig:
     enable_tensor_parallel: bool = False
 
     # Optimization level (0, 1, or 2) that controls multiple optimization passes.
-    # Level 0 (default): All optimizations disabled
+    # Level 0: All optimizations disabled
     # Level 1: Basic optimizations (optimizer + Conv2d fusion)
     # Level 2: Advanced optimizations (optimizer + memory layout + Conv2d fusion)
     optimization_level: int = 1

--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -190,7 +190,7 @@ class TTConfig:
 
     # Flatten model I/O to a flat token stream at the model-call boundary
     # (needed by HF forwards like Gemma-4's PLE path).
-    flat_model_io: bool = True
+    flat_model_io: bool = False
 
     enable_trace: bool = False
 

--- a/integrations/vllm_plugin/vllm_tt/pooling_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/pooling_runner.py
@@ -302,6 +302,7 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         parallel_config = self.parallel_config
         self.device = device
         self.check_recompilation = envs.VLLM_XLA_CHECK_RECOMPILATION
+        self.use_flat_model_io = self.tt_config.flat_model_io
 
         # Data parallel execution
         self.num_additional_inputs = 0
@@ -1214,6 +1215,48 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             # then the embedding layer is not included in the CUDA graph.
             return input_ids, None
 
+    def _prepare_model_call_tensors(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        inputs_embeds: torch.Tensor | None,
+    ) -> tuple[
+        torch.Tensor | None,
+        torch.Tensor,
+        torch.Tensor | None,
+        Optional[torch.Size],
+    ]:
+        if not self.use_flat_model_io:
+            return input_ids, positions, inputs_embeds, None
+
+        restore_shape: Optional[torch.Size] = None
+
+        if input_ids is not None and input_ids.ndim > 1:
+            restore_shape = input_ids.shape
+            input_ids = input_ids.reshape(-1)
+
+        if inputs_embeds is not None and inputs_embeds.ndim > 2:
+            if restore_shape is None:
+                restore_shape = torch.Size(inputs_embeds.shape[:-1])
+            inputs_embeds = inputs_embeds.reshape(-1, inputs_embeds.shape[-1])
+
+        if positions.ndim > 1:
+            if restore_shape is None:
+                restore_shape = positions.shape
+            positions = positions.reshape(-1)
+
+        return input_ids, positions, inputs_embeds, restore_shape
+
+    def _restore_model_hidden_states(
+        self,
+        hidden_states: torch.Tensor,
+        restore_shape: Optional[torch.Size],
+    ) -> torch.Tensor:
+        if restore_shape is None or hidden_states.ndim != 2:
+            return hidden_states
+
+        return hidden_states.reshape(*restore_shape, hidden_states.shape[-1])
+
     @torch.no_grad()
     def execute_model(
         self,
@@ -1264,10 +1307,23 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 self.vllm_config,
                 num_tokens=scheduler_output.total_num_scheduled_tokens,
             ):
+                (
+                    model_input_ids,
+                    model_positions,
+                    model_inputs_embeds,
+                    hidden_state_shape,
+                ) = self._prepare_model_call_tensors(
+                    input_ids,
+                    self.position_ids,
+                    inputs_embeds,
+                )
                 hidden_states = self.model(
-                    input_ids=input_ids,
-                    positions=self.position_ids,
-                    inputs_embeds=inputs_embeds,
+                    input_ids=model_input_ids,
+                    positions=model_positions,
+                    inputs_embeds=model_inputs_embeds,
+                )
+                hidden_states = self._restore_model_hidden_states(
+                    hidden_states, hidden_state_shape
                 )
                 hidden_states = hidden_states.to("cpu")
 
@@ -1527,9 +1583,22 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             ),
             set_forward_context(per_layer_attn_metadata, self.vllm_config, 0),
         ):
-            out = self.model(
-                input_ids=input_ids, positions=position_ids, inputs_embeds=inputs_embeds
+            (
+                model_input_ids,
+                model_positions,
+                model_inputs_embeds,
+                hidden_state_shape,
+            ) = self._prepare_model_call_tensors(
+                input_ids,
+                position_ids,
+                inputs_embeds,
             )
+            out = self.model(
+                input_ids=model_input_ids,
+                positions=model_positions,
+                inputs_embeds=model_inputs_embeds,
+            )
+            out = self._restore_model_hidden_states(out, hidden_state_shape)
         self._hidden_states_dtype = out.dtype
 
     def _set_active_loras(

--- a/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
@@ -186,7 +186,7 @@ def test_tensor_parallel_generation_llmbox_large(
     flat_model_io: bool,
 ):
     prompts = [
-        "I like taking walks in the",
+        "Continue in English: I like taking walks in the",
     ]
     sampling_params = vllm.SamplingParams(temperature=0.8, top_p=0.95, max_tokens=32)
     llm_args = {


### PR DESCRIPTION
### Ticket
closes #5774

### Problem description
vLLM plugin does not support flatten inputs across the board

### What's changed
- Update Pooling runner to support flattened inputs.
- Update model_runner to use upstream MRoPE implementation instead of overriding it with downstream version; upstream MRoPE supports flattened inputs and downstream version supports batched inputs.

### Checklist
- [X] New/Existing tests provide coverage for changes
