### PR TITLE
Fix qb2 weekly FE failures from in-process transformers pin skew

### DIFF
--- a/.github/workflows/test-matrix-presets/model-test-passing-weekly.json
+++ b/.github/workflows/test-matrix-presets/model-test-passing-weekly.json
@@ -10,5 +10,5 @@
   {"runs-on": "n300-llmbox", "name": "run_forge_models_multichip_torch", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "n300-llmbox and weekly and tensor_parallel and expected_passing", "parallel-groups": 1, "forge-models": true},
   {"runs-on": "n300", "name": "run_forge_models_multichip_torch", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "n300 and weekly and data_parallel and expected_passing", "parallel-groups": 8, "forge-models": true},
   {"runs-on": "n300-llmbox", "name": "run_forge_models_multichip_jax", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "n300-llmbox and weekly and tensor_parallel and expected_passing", "parallel-groups": 1, "forge-models": true},
-  {"runs-on": "qb2-blackhole", "name": "run_forge_models_multichip_torch", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "qb2-blackhole and weekly and tensor_parallel and expected_passing", "parallel-groups": 2, "forge-models": true}
+  {"runs-on": "qb2-blackhole", "name": "run_forge_models_multichip_torch", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "qb2-blackhole and weekly and tensor_parallel and expected_passing", "parallel-groups": 2, "forge-models": true, "forked": true}
 ]

--- a/python_package/tt_torch/moe_backend.py
+++ b/python_package/tt_torch/moe_backend.py
@@ -16,6 +16,7 @@ Works with any ``@use_experts_implementation`` Experts module that exposes
 
 from __future__ import annotations
 
+import sys
 from typing import Any, Callable, Dict, Optional, Tuple
 
 import torch
@@ -526,7 +527,17 @@ def register_tt_moe_backend(cluster_axis: Optional[int] = None) -> None:
             and requested_experts not in _HF_BUILTIN_EXPERTS_KEYS
         ):
             return requested_experts
-        return original_validator(self, requested_experts)
+        # After RequirementsManager purges transformers.* from sys.modules,
+        # stale model classes can still reference purged modules. HF's
+        # validator does an unsafe sys.modules[cls.__module__] lookup
+        # (huggingface/transformers#45003) and raises KeyError.
+        module_name = type(self).__module__
+        if module_name not in sys.modules:
+            return requested_experts
+        try:
+            return original_validator(self, requested_experts)
+        except KeyError:
+            return requested_experts
 
     patched_validator._tt_patched = True
     PreTrainedModel.get_correct_experts_implementation = patched_validator

--- a/tests/runner/requirements.py
+++ b/tests/runner/requirements.py
@@ -449,6 +449,36 @@ class RequirementsManager:
 
         importlib.invalidate_caches()
 
+        # transformers installs Module.smart_apply; that attribute survives a
+        # sys.modules purge. Newer signatures take is_remote_code; older pins
+        # only redefine smart_apply when absent, so a 5.x→4.x downgrade leaves
+        # the new patch and breaks initialize_weights (TypeError).
+        if "transformers" in affected_normalized:
+            self._clear_transformers_monkeypatches()
+
+    @staticmethod
+    def _clear_transformers_monkeypatches() -> None:
+        """Remove transformers monkey-patches that outlive sys.modules purges."""
+        try:
+            import torch
+        except ImportError:
+            return
+
+        if hasattr(torch.nn.Module, "smart_apply"):
+            try:
+                delattr(torch.nn.Module, "smart_apply")
+                _dbg("[Requirements] cleared torch.nn.Module.smart_apply")
+            except Exception as e:
+                _dbg(f"[Requirements] failed to clear smart_apply: {e}")
+
+        try:
+            import torch._dynamo as dynamo
+
+            dynamo.reset()
+            _dbg("[Requirements] reset torch._dynamo after transformers purge")
+        except Exception as e:
+            _dbg(f"[Requirements] torch._dynamo.reset failed: {e}")
+
     @staticmethod
     def _unregister_arrow_ext_types(module) -> None:
         """Unregister any pyarrow extension types defined in *module*.


### PR DESCRIPTION
## Summary
- Enable `forked: true` for qb2-blackhole weekly tensor-parallel forge-model jobs so each model runs in an isolated process (matches n150/p150).
- Harden `RequirementsManager` cleanup after transformers swaps: clear leaked `torch.nn.Module.smart_apply` and reset Dynamo.
- Harden the MoE experts validator against HF's unsafe `sys.modules[cls.__module__]` lookup after transformers module purges.

## Problem
Weekly run https://github.com/tenstorrent/tt-xla/actions/runs/29637766029 had **11 qb2** unexpected `FAILED_FE_COMPILATION` failures. These were not StableHLO/compiler bugs — they came from **in-process transformers version skew**: qb2 weekly TP jobs ran **without** `--forked`, so per-model `RequirementsManager` pip pins polluted later tests in the same process.

## Errors this PR targets

The 11 failures clustered into multiple exception strings, but this PR directly hardens **two** distinct failure modes (plus process isolation for all):

### 1. `smart_apply() missing ... 'is_remote_code'`
**Example job:** https://github.com/tenstorrent/tt-xla/actions/runs/29637766029/job/88063045614  
**Example model:** `hyperclovax_32b/pytorch-HyperCLOVAX_SEED_Think_32B-tensor_parallel-inference`  
**Also seen on:** Nemotron Super 49B, Orion-14B

**What happens:**
- Base env uses transformers 5.x, which installs `torch.nn.Module.smart_apply(self, fn, is_remote_code)`.
- A later model pin downgrades to transformers 4.5x (e.g. HyperCLOVAX-32B `==4.52.4`, Nemotron `==4.53.3`, Orion `==4.57.1`).
- `RequirementsManager` purges `transformers.*` from `sys.modules`, but **`Module.smart_apply` survives** on the torch class.
- Older transformers only redefine `smart_apply` when absent, so it keeps calling the 5.x signature → `TypeError`.

**Fix in this PR:**
- After purging transformers, delete `torch.nn.Module.smart_apply` (and reset Dynamo) in `tests/runner/requirements.py`.

### 2. `KeyError: 'transformers.models.llama.modeling_llama'`
**Example job:** https://github.com/tenstorrent/tt-xla/actions/runs/29637766029/job/88063045614  
**Example model:** `codellama/pytorch-CodeLlama-34b-Instruct-hf-tensor_parallel-inference`  
**Also seen on:** Hermes-4-70B, WizardLM-70B, Yi-1.5-34B

**What happens:**
- After a transformers purge/swap, stale Llama class objects remain while `transformers.models.llama.modeling_llama` is gone from `sys.modules`.
- Our MoE patch calls into HF's experts validator, which does an unsafe `sys.modules[cls.__module__]` lookup ([transformers#45003](https://github.com/huggingface/transformers/issues/45003)) → `KeyError`.

**Fix in this PR:**
- In `python_package/tt_torch/moe_backend.py`, skip / catch that `KeyError` when the class module is missing from `sys.modules`.

ci link: https://github.com/tenstorrent/tt-xla/actions/runs/29756118702 (The models pass with these code changes)