### PR TITLE
skip krea_realtime VAE decoder hang on n150 (#5704)

### DIFF
--- a/tests/torch/models/krea_realtime/test_vae_decoder.py
+++ b/tests/torch/models/krea_realtime/test_vae_decoder.py
@@ -17,6 +17,10 @@ from third_party.tt_forge_models.krea_realtime_video.pytorch import (
 )
 
 
+# Only hangs in the full nightly run_torch session; passes standalone. See #5704.
+@pytest.mark.skip(
+    reason="Hangs on n150 — times out the run_torch job at 240 min. https://github.com/tenstorrent/tt-xla/issues/5704"
+)
 @pytest.mark.nightly
 @pytest.mark.model_test
 @pytest.mark.single_device


### PR DESCRIPTION
Nightly 🧹 

### Checklist
- [ ] New/Existing tests provide coverage for changes
