### PR TITLE
[stable_diffusion_1_5] Run CLIP text encoder on TT

### DIFF
--- a/tests/torch/models/stable_diffusion_1_5/test_stable_diffusion_1_5_pipeline.py
+++ b/tests/torch/models/stable_diffusion_1_5/test_stable_diffusion_1_5_pipeline.py
@@ -4,11 +4,12 @@
 
 """Stable Diffusion 1.5 — nightly e2e pipeline test.
 
-Runs the full text-to-image pipeline end-to-end: the UNet (the heavy net) runs
-on Tenstorrent via ``torch.compile(backend="tt")`` while the precision-sensitive
-CLIP text encoder, the scheduler and the VAE stay on CPU. The reusable pipeline
-implementation lives in ``tt_forge_models`` and is shared with the image-gen
-benchmark (``tests/benchmark/test_imagegen.py``).
+Runs the full text-to-image pipeline end-to-end: the CLIP text encoder and the
+UNet (the heavy net) both run on Tenstorrent via ``torch.compile(backend="tt")``.
+The scheduler and the VAE decoder stay on CPU (VAE-on-TT currently produces
+noise from group-norm precision). The reusable pipeline implementation lives in
+``tt_forge_models`` and is shared with the image-gen benchmark
+(``tests/benchmark/test_imagegen.py``).
 """
 
 from pathlib import Path
@@ -39,8 +40,11 @@ def run_sd15_pipeline(
     num_inference_steps: int = 50,
 ):
     """Run the Stable Diffusion 1.5 pipeline and save the output image."""
-    # CLIP on CPU (precision-sensitive); UNet on TT.
-    config = SD15Config(clip_on_tt=False)
+    # CLIP + UNet on TT. CLIP runs in bf16 on device; the output stays a valid
+    # image (verified — near-identical to the CPU-CLIP baseline). VAE decode is
+    # kept on CPU: running it on TT currently produces noise (group_norm
+    # precision), even with optimization_level=1.
+    config = SD15Config(clip_on_tt=True)
     pipeline = SD15Pipeline(config=config)
     pipeline.setup()
 


### PR DESCRIPTION
### Problem description

The Stable Diffusion 1.5 e2e pipeline test runs only the **UNet** on Tenstorrent; the **CLIP text encoder** and the **VAE decoder** stay on CPU. Moving more of the compute graph onto the device is part of the ongoing "run all pipeline components on TT" effort.

### What's changed

The reusable pipeline (`third_party/tt_forge_models/stable_diffusion_1_5/pytorch/pipeline.py`) already implements a `clip_on_tt` path — `compile(backend="tt")` + move to `xla_device()`, with bf16 tokens/embeddings. This PR flips the pipeline test to `SD15Config(clip_on_tt=True)` so **CLIP + UNet both run on TT**. No change to the shipped pipeline code.

Remaining on CPU: tokenizer, PNDM scheduler, CFG/latent bookkeeping, and the VAE decoder.

### Verification (single TT device)

Prompt `"a photo of a cat"`, seed 42, 50 steps, 512×512:

| Config | CLIP | Image | PCC vs CPU-CLIP baseline |
|---|---|---|---|
| baseline (before) | CPU (fp16) | valid cat | 1.000 |
| **this PR** | **TT (bf16)** | valid cat | **0.992** |

The image is visually indistinguishable from the baseline; the delta is bf16 rounding (MAE ≈ 5/255).

### Note — VAE decoder stays on CPU

Moving the VAE decoder to TT (`vae_on_tt=True`) currently returns **noise** (PCC ≈ 0.02 vs baseline). `torch_xla.set_custom_compile_options({"optimization_level": 1})` (the group-norm composite lowering used by the Playground/SDXL VAE paths) does **not** fix it. The latents are correct (CPU VAE decodes them to a clean image), so the corruption is in the VAE compile/execution on device — tracked as follow-up; VAE decode stays on CPU here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)