### PR TITLE
Modify llama-3.1-8b optimization level

### DIFF
--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -193,10 +193,7 @@ SINGLE_DEVICE_CONFIGS = [
     pytest.param(_config("meta-llama/Llama-3.2-1B-Instruct"), id="llama-3.2-1b"),
     pytest.param(_config("meta-llama/Llama-3.2-3B-Instruct"), id="llama-3.2-3b"),
     # opt-level 2 (the default since #5410) OOMs DRAM on n150. See https://github.com/tenstorrent/tt-xla/issues/5494.
-    pytest.param(
-        _config("meta-llama/Llama-3.1-8B-Instruct", optimization_level=0),
-        id="llama-3.1-8b",
-    ),
+    pytest.param(_config("meta-llama/Llama-3.1-8B-Instruct"), id="llama-3.1-8b"),
     # Qwen 2.5
     pytest.param(_config("Qwen/Qwen2.5-0.5B-Instruct"), id="qwen2.5-0.5b-instruct"),
     pytest.param(_config("Qwen/Qwen2.5-1.5B-Instruct"), id="qwen2.5-1.5b-instruct"),


### PR DESCRIPTION
### Ticket
Issue - https://github.com/tenstorrent/tt-xla/issues/5543

### Problem description
Some vLLM models were lowered to opt-level=0 due to DRAM OOM on n150 machines. But llama is fixed (7963edc84bc90b00d13c9653a1203842776e4e30) 

### What's changed
Changed optimization level for llama-3.1-8b 

cc: @vkovacevicTT 
