### PR TITLE
[benchmark] Use TP-only mesh for llama_3_1_70b_tp_qb2 to fix decode PCC (#5487)

### DIFF
--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -1878,6 +1878,16 @@ def test_llama_3_1_70b_tp_qb2(
     )
 
     variant = ModelVariant.LLAMA_3_1_70B_INSTRUCT
+
+    # The loader's default 70B mesh on QB2 is (2, N//2) = a 2-way data-parallel
+    # "batch" axis x tensor-parallel "model" axis. That DP batch axis corrupts the
+    # first-decode KV-cache read (garbage/NaN logits, decode PCC ~0 -> issue #5487),
+    # even though the SDPA-decode op itself is correct (Falcon-10B, which uses a
+    # TP-only mesh + the same op, decodes fine). Use a TP-only mesh here: decode PCC
+    # recovers to ~0.999, and TP=N uses less memory/chip than DP=2 x TP=(N/2).
+    def _qb2_tp_only_mesh(model_loader, num_devices):
+        return (1, num_devices), ("batch", "model")
+
     test_llm_tp(
         ModelLoader,
         variant,
@@ -1888,11 +1898,12 @@ def test_llama_3_1_70b_tp_qb2(
         batch_size=batch_size,
         max_output_tokens=max_output_tokens,
         decode_only=decode_only,
+        mesh_config_fn=_qb2_tp_only_mesh,
         weight_dtype_overrides={
             "model.layers.*.mlp.gate_proj.weight": "bfp_bf4",
             "model.layers.*.mlp.up_proj.weight": "bfp_bf4",
         },
-        optimization_level=1,  # flaky: occasionally hangs in CI with optimization_level=2
+        optimization_level=2,  # TP-only mesh fixes the opt-2 decode failure (#5487)
     )
 
 

--- a/tests/benchmark/test_llms.py
+++ b/tests/benchmark/test_llms.py
@@ -1879,12 +1879,16 @@ def test_llama_3_1_70b_tp_qb2(
 
     variant = ModelVariant.LLAMA_3_1_70B_INSTRUCT
 
-    # The loader's default 70B mesh on QB2 is (2, N//2) = a 2-way data-parallel
-    # "batch" axis x tensor-parallel "model" axis. That DP batch axis corrupts the
-    # first-decode KV-cache read (garbage/NaN logits, decode PCC ~0 -> issue #5487),
-    # even though the SDPA-decode op itself is correct (Falcon-10B, which uses a
-    # TP-only mesh + the same op, decodes fine). Use a TP-only mesh here: decode PCC
-    # recovers to ~0.999, and TP=N uses less memory/chip than DP=2 x TP=(N/2).
+    # The loader's default 70B mesh on QB2 is (2, N//2): despite the "batch" axis
+    # name it is NOT data-parallel -- inputs are replicated and the weights are
+    # sharded across BOTH axes (2D tensor parallelism; the only qb2 model doing so,
+    # and the only one exercising distributed_rms_norm). That multi-axis weight
+    # sharding corrupts the first-decode KV-cache read (garbage/NaN logits, decode
+    # PCC ~0 -> issue #5487), even though the SDPA-decode op itself is correct
+    # (Falcon-10B uses a single-axis TP mesh + the same op and decodes fine). Use a
+    # single-axis TP-only mesh here: decode PCC recovers to ~0.999. Restoring the
+    # 2D weight-sharded mesh (regaining distributed_rms_norm coverage) is tracked
+    # in issue #5738.
     def _qb2_tp_only_mesh(model_loader, num_devices):
         return (1, num_devices), ("batch", "model")
 


### PR DESCRIPTION
## Problem

`test_llama_3_1_70b_tp_qb2` uses the loader's default 70B mesh `(2, N//2)`. Despite the `"batch"` axis name, this is **not** data-parallel — inputs are replicated and the weights are sharded across **both** axes (2D tensor parallelism; the only qb2 model doing so, and the only one exercising `distributed_rms_norm`). That multi-axis weight sharding corrupts the first-decode KV-cache read (prefill fine ~0.995, first-decode logits garbage → decode PCC ≈ 0). See #5487.

Per the investigation in #5487, this is **not** the decode op, opt level, bf8 cache, bf4 MLP, or trace — all ruled out by experiment. `test_falcon3_10b_tp_qb2` uses the same decode op + bf8 cache but a **single-axis TP `(1,N)` mesh** and decodes fine.

## Fix

Use a single-axis TP-only `(1, N)` mesh for this test: decode PCC recovers to ~0.999. This also unblocks `optimization_level=2` (previously pinned to `1` due to an opt-2 hang).

This is a temporary workaround — collapsing to a single axis drops CI coverage of the multi-axis weight-sharding path and `distributed_rms_norm` on qb2. Restoring the 2D weight-sharded mesh is tracked in **#5738**.

## Verification

This change is byte-identical to branch `rpavlovic/fix-llama70b-qb2-decode-tp-mesh`, which was validated in CI as documented in #5487 (qb2-blackhole, 80 layers, opt-2 — decode PCC recovered to ~0.999): run https://github.com/tenstorrent/tt-xla/actions/runs/29535389034. Locally in this session only a syntax parse was performed; the accuracy numbers above come from that prior CI run.

Fixes #5487
Refs #5738

🤖 Generated with [Claude Code](https://claude.com/claude-code)