### PR TITLE
[vLLM] Tensor Parallel: size KV cache via gpu_mem_utilization across all chips instead of ~one chip's worth

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -3411,12 +3411,18 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 elif isinstance(kv_cache_spec, AttentionSpec):
                     if self.enable_tensor_parallel:
                         num_kv_heads = kv_cache_spec.num_kv_heads
-                        assert self.original_parallel_config is not None
-                        tp_size = self.original_parallel_config.tensor_parallel_size
-                        # TODO: Handle kv cache duplication under SPMD mode.
+                        if hasattr(self.mesh, "shape"):
+                            tp_size = self.mesh.shape()["model"]
+                        else:
+                            tp_size = dict(
+                                zip(self.mesh.axis_names, self.mesh.mesh_shape)
+                            )["model"]
+                        # mark_sharding() below does the real sharding; this
+                        # just fails loudly instead of it silently falling
+                        # back to replication (see safe_mark_sharding).
                         assert num_kv_heads % tp_size == 0, (
                             f"num_kv_heads {num_kv_heads} must be divisible by "
-                            f"tp_size {tp_size} under SPMD mode"
+                            f"tp_size {tp_size} for correct KV-head sharding"
                         )
                     kv_cache_shape = TTAttentionBackend.get_kv_cache_shape(
                         num_blocks,

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -3456,7 +3456,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             # DP+TP: leave the KV cache un-annotated (replicated under SPMD);
             # each device writes its own K/V slice via paged_update_cache. The
             # TP-only spec puts block_size on the DP axis and fails
-            # ttir.paged_update_cache. Tracked as a follow-up.
+            # ttir.paged_update_cache. Tracked in #5796.
             #
             # kv_cache_shard_factor() mirrors this branch by returning 1 for
             # DP+TP; when this is changed to really shard, update it too or

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -107,7 +107,12 @@ from .metadata import XLASupportedSamplingMetadata
 from .overrides import replace_modules
 from .platform import TTConfig
 from .sampler import Sampler
-from .vllm_distributed_utils import ParallelismMode, safe_mark_sharding, shard_model
+from .vllm_distributed_utils import (
+    ParallelismMode,
+    kv_cache_shard_factor,
+    safe_mark_sharding,
+    shard_model,
+)
 from .vllm_utils import (
     apply_hidden_layer_override,
     determine_mesh_shape,
@@ -3409,14 +3414,9 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     mla_cache = torch.zeros(kv_cache_shape, dtype=dtype).to(self.device)
                     kv_caches[layer_name] = mla_cache
                 elif isinstance(kv_cache_spec, AttentionSpec):
-                    if self.enable_tensor_parallel:
+                    tp_size = kv_cache_shard_factor(self)
+                    if tp_size > 1:
                         num_kv_heads = kv_cache_spec.num_kv_heads
-                        if hasattr(self.mesh, "shape"):
-                            tp_size = self.mesh.shape()["model"]
-                        else:
-                            tp_size = dict(
-                                zip(self.mesh.axis_names, self.mesh.mesh_shape)
-                            )["model"]
                         # mark_sharding() below does the real sharding; this
                         # just fails loudly instead of it silently falling
                         # back to replication (see safe_mark_sharding).
@@ -3457,6 +3457,10 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             # each device writes its own K/V slice via paged_update_cache. The
             # TP-only spec puts block_size on the DP axis and fails
             # ttir.paged_update_cache. Tracked as a follow-up.
+            #
+            # kv_cache_shard_factor() mirrors this branch by returning 1 for
+            # DP+TP; when this is changed to really shard, update it too or
+            # each chip will be budgeted tp_size times too little.
             pass
         elif self.enable_tensor_parallel:
             # Shard KV Cache — each entry is [k_cache, v_cache].

--- a/integrations/vllm_plugin/vllm_tt/vllm_distributed_utils.py
+++ b/integrations/vllm_plugin/vllm_tt/vllm_distributed_utils.py
@@ -96,7 +96,8 @@ def kv_cache_shard_factor(runner) -> int:
         return 1
     if runner.parallel_mode == ParallelismMode.DATA_TENSOR_PARALLEL:
         # DP+TP leaves the cache replicated, so per-chip usage already equals
-        # the full budget — no reconciliation to do.
+        # the full budget — no reconciliation to do. Sharding it properly
+        # (heads on "model", blocks on "batch") is tracked in #5796.
         return 1
     mesh = runner.mesh
     if hasattr(mesh, "shape"):

--- a/integrations/vllm_plugin/vllm_tt/vllm_distributed_utils.py
+++ b/integrations/vllm_plugin/vllm_tt/vllm_distributed_utils.py
@@ -80,6 +80,30 @@ class ParallelismMode(Enum):
     DATA_TENSOR_PARALLEL = "data_tensor_parallel"
 
 
+def kv_cache_shard_factor(runner) -> int:
+    """How many ways the KV cache is actually sharded across the mesh.
+
+    Only the "model" axis shards KV heads, so this is that axis' size — 1 when
+    the cache ends up replicated on every chip instead. Callers use it to
+    reconcile vLLM's TP-unaware block budget (which always assumes the full,
+    un-sharded num_kv_heads) with what each chip really holds.
+
+    Must stay in sync with the mark_sharding call in
+    ``TTModelRunner.initialize_kv_cache``; in particular DP+TP returns 1
+    because that path deliberately leaves the cache un-annotated.
+    """
+    if not runner.enable_tensor_parallel:
+        return 1
+    if runner.parallel_mode == ParallelismMode.DATA_TENSOR_PARALLEL:
+        # DP+TP leaves the cache replicated, so per-chip usage already equals
+        # the full budget — no reconciliation to do.
+        return 1
+    mesh = runner.mesh
+    if hasattr(mesh, "shape"):
+        return mesh.shape()["model"]
+    return dict(zip(mesh.axis_names, mesh.mesh_shape))["model"]
+
+
 class XlaMergedColumnParallelLinear(nn.Module):
 
     def __init__(

--- a/integrations/vllm_plugin/vllm_tt/worker.py
+++ b/integrations/vllm_plugin/vllm_tt/worker.py
@@ -309,6 +309,19 @@ class TTWorker:
         usable_memory_size = int(
             total_memory_size * self.cache_config.gpu_memory_utilization
         )
+        # vLLM's KV-cache budget math (max_memory_usage_bytes) uses the full,
+        # un-sharded num_kv_heads with no TP awareness, even though the cache
+        # tensor is already correctly sharded tp_size-ways via mark_sharding
+        # (confirmed in the compiled IR). Counterbalance by inflating the
+        # available budget here instead of touching the cache tensor's shape
+        # or sharding.
+        if self.model_runner.enable_tensor_parallel:
+            mesh = self.model_runner.mesh
+            if hasattr(mesh, "shape"):
+                tp_size = mesh.shape()["model"]
+            else:
+                tp_size = dict(zip(mesh.axis_names, mesh.mesh_shape))["model"]
+            usable_memory_size *= tp_size
         tpu_kv_cache_bytes = max(usable_memory_size - profiled, 0)
         head_size = self.model_config.get_head_size()
         if head_size > 0:

--- a/integrations/vllm_plugin/vllm_tt/worker.py
+++ b/integrations/vllm_plugin/vllm_tt/worker.py
@@ -44,6 +44,7 @@ from .logger import tt_init_logger
 from .model_runner import TTModelRunner
 from .platform import TTConfig
 from .pooling_runner import TTPoolingModelRunner
+from .vllm_distributed_utils import kv_cache_shard_factor
 
 logger = tt_init_logger(__name__)
 
@@ -314,14 +315,10 @@ class TTWorker:
         # tensor is already correctly sharded tp_size-ways via mark_sharding
         # (confirmed in the compiled IR). Counterbalance by inflating the
         # available budget here instead of touching the cache tensor's shape
-        # or sharding.
-        if self.model_runner.enable_tensor_parallel:
-            mesh = self.model_runner.mesh
-            if hasattr(mesh, "shape"):
-                tp_size = mesh.shape()["model"]
-            else:
-                tp_size = dict(zip(mesh.axis_names, mesh.mesh_shape))["model"]
-            usable_memory_size *= tp_size
+        # or sharding. Returns 1 where the cache is not actually sharded
+        # (no TP, or DP+TP), leaving the budget untouched.
+        kv_shard_factor = kv_cache_shard_factor(self.model_runner)
+        usable_memory_size *= kv_shard_factor
         tpu_kv_cache_bytes = max(usable_memory_size - profiled, 0)
         head_size = self.model_config.get_head_size()
         if head_size > 0:
@@ -335,10 +332,12 @@ class TTWorker:
             tpu_kv_cache_bytes = tpu_kv_cache_bytes * head_size // padded_head_size
         logger.info(
             "KV cache sizing: device DRAM = %.2f GiB, gpu_memory_utilization = %.3f, "
-            "KV cache budget = %.2f GiB",
+            "kv_shard_factor = %d, KV cache budget = %.2f GiB (%.2f GiB per chip)",
             total_memory_size / 1024**3,
             self.cache_config.gpu_memory_utilization,
+            kv_shard_factor,
             tpu_kv_cache_bytes / 1024**3,
+            tpu_kv_cache_bytes / kv_shard_factor / 1024**3,
         )
         return int(tpu_kv_cache_bytes)
 

--- a/integrations/vllm_plugin/vllm_tt/worker.py
+++ b/integrations/vllm_plugin/vllm_tt/worker.py
@@ -248,8 +248,8 @@ class TTWorker:
 
                 # Use an empty tensor instead of `None`` to force Dynamo to pass
                 # it by reference, rather by specializing on the value ``None``.
-                tpu_kv_cache = torch.tensor([0], dtype=dtype).to(self.device)
-                kv_caches[layer_name] = tpu_kv_cache
+                kv_cache = torch.tensor([0], dtype=dtype).to(self.device)
+                kv_caches[layer_name] = kv_cache
             else:
                 raise NotImplementedError(
                     f"Unsupported KV cache spec '{type(layer_spec)}'"
@@ -306,7 +306,7 @@ class TTWorker:
         # use the heuristic of 2% of weights.
         profiled = current_mem * 1.02
 
-        # Calculate the TPU KV cache size based on profiling.
+        # Calculate the KV cache size based on profiling.
         usable_memory_size = int(
             total_memory_size * self.cache_config.gpu_memory_utilization
         )
@@ -319,7 +319,7 @@ class TTWorker:
         # (no TP, or DP+TP), leaving the budget untouched.
         kv_shard_factor = kv_cache_shard_factor(self.model_runner)
         usable_memory_size *= kv_shard_factor
-        tpu_kv_cache_bytes = max(usable_memory_size - profiled, 0)
+        kv_cache_bytes = max(usable_memory_size - profiled, 0)
         head_size = self.model_config.get_head_size()
         if head_size > 0:
             padded_head_size = (
@@ -329,17 +329,17 @@ class TTWorker:
                 logger.warning_once("head size is padded to %d", padded_head_size)
             # We adjust the usable memory size for the KV cache to prevent OOM
             # errors, even after padding the head_size.
-            tpu_kv_cache_bytes = tpu_kv_cache_bytes * head_size // padded_head_size
+            kv_cache_bytes = kv_cache_bytes * head_size // padded_head_size
         logger.info(
             "KV cache sizing: device DRAM = %.2f GiB, gpu_memory_utilization = %.3f, "
             "kv_shard_factor = %d, KV cache budget = %.2f GiB (%.2f GiB per chip)",
             total_memory_size / 1024**3,
             self.cache_config.gpu_memory_utilization,
             kv_shard_factor,
-            tpu_kv_cache_bytes / 1024**3,
-            tpu_kv_cache_bytes / kv_shard_factor / 1024**3,
+            kv_cache_bytes / 1024**3,
+            kv_cache_bytes / kv_shard_factor / 1024**3,
         )
-        return int(tpu_kv_cache_bytes)
+        return int(kv_cache_bytes)
 
     def sample_tokens(self, grammar_output: "GrammarOutput") -> ModelRunnerOutput:
         return self.model_runner.sample_tokens(grammar_output)

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -166,12 +166,12 @@ def _mistral_small_31_tp_config(model: str, batch_size: int):
     # text-only (limit_mm_per_prompt zeroed so the vision tower never compiles),
     # mirroring _gemma4_tp_config. Runs on galaxy-wh-6u in a 8x4 mesh.
     #
-    # Validated max_model_len of 8192 at GMU of 0.65, but the current default
+    # Validated max_model_len of 8192 at GMU of 0.16, but the current default
     # of max_model_len is 128, so it needs to be overriden through the env. var.
     cfg = _config(
         model,
         batch_size,
-        gpu_memory_utilization=0.65,
+        gpu_memory_utilization=0.16,
         optimization_level=1,
         experimental_weight_dtype="bfp_bf8",
         experimental_kv_cache_dtype="bfp_bf8",


### PR DESCRIPTION
### Ticket
Closes #5728

### Problem

Under tensor parallelism the KV cache is correctly sharded across chips (`tp_size`-ways via `mark_sharding`, confirmed in the compiled IR), but vLLM's block-budget math (`max_memory_usage_bytes` / `page_size_bytes`) sizes blocks using the full, **un-sharded** `num_kv_heads`. In effect it assumes the entire un-sharded cache must fit on a **single chip**, so `gpu_memory_utilization` only fills `GMU / tp_size` of each chip (e.g. ~22.5% at GMU=0.9 on a 1×4 mesh).

Net effect: **the KV cache was capped at roughly one chip's worth of memory** — the aggregate DRAM of the TP group went unused, so usable context / concurrency were ~`tp_size`× lower than the hardware allows.

### What's changed

- `determine_available_memory()` scales the KV budget by the shard factor, so `gpu_memory_utilization` fills each chip as intended (GMU per chip, not GMU/`tp_size`) and the cache spans the mesh's DRAM instead of one chip's. Only the budget figure changes — the tensor's shape and sharding were already correct.
- That scaling is gated on whether the cache is **actually sharded**, via a new `kv_cache_shard_factor(runner)` in `vllm_distributed_utils.py`, rather than on `enable_tensor_parallel`. The two differ only under DP+TP, where `initialize_kv_cache()` leaves the cache replicated (the TP-only spec puts `block_size` on the DP axis and fails `ttir.paged_update_cache`); scaling there would multiply each chip's allocation instead of reconciling it, and #5779's gemma4-31b DP+TP test would have asked for 1.2× DRAM per chip. The helper returns `1` for no-TP and DP+TP, leaving both unchanged.
- `initialize_kv_cache()`'s divisibility assert now uses the same helper. It previously read `tp_size` from `original_parallel_config.tensor_parallel_size` — always `1` under this plugin's single-process SPMD model, making it a no-op. The stale `TODO: Handle kv cache duplication under SPMD mode` comment is dropped; `mark_sharding` already shards correctly.
- The `KV cache sizing` log line reports the factor and per-chip budget (visible under `tests/integrations`, whose conftest sets `TTXLA_LOGGER_LEVEL=INFO`; `tests/benchmark/` stays at the `WARN` default, where vLLM's own `GPU KV cache size` is the signal).
- `mistral-small-3.1-24b-tp`'s benchmark GMU drops 0.65 → 0.16. 0.65 was tuned against the old accounting and would now put 8.4 GiB of KV on a 12 GiB wormhole galaxy chip; 0.16 = 0.65/4 keeps the allocation its 8192-context validation ran at. The other eight TP benchmarks keep their GMUs — they have enough per-chip headroom — and single-device, embedding and DP-only benchmarks are unaffected entirely.

### Result

- gemma4-31b-it-tp (QB2, 1×4 mesh): `GPU KV cache size` **7,584 → 30,368 tokens** (~4× = `tp_size`) — i.e. the cache now spans all 4 chips instead of ~one. Run passes.
- Shard factor resolves as expected across every parallel mode: `1` for DISABLED / DP-only / DP+TP, `4` for TP-1D `(1,4)` and TP-2D `(8,4)`, `8` for TP-2D `(4,8)`.

- This changes how the KV cache is **sized** (the memory budget), not how it's **allocated** — and it deliberately makes the cache **larger** (`tp_size`× more device memory, which is the point). The allocation path is unchanged: the full un-sharded cache is still built on **host** before being sharded to devices, and this PR enlarges that build. So at high GMU / long context / large `tp_size`, the host build can now push **host** RAM to OOM during compile — a separate problem tracked in **#5764**.

### Checklist

- [x] vLLM Nightly on CI: https://github.com/tenstorrent/tt-xla/actions/runs/30219509277
- [x] passing vLLM TP Perf benchmarks, QB2 on CI: https://github.com/tenstorrent/tt-xla/actions/runs/30219140002 (all 8 qb2-blackhole TP benchmarks, incl. gemma4-31b-it and llama-3.1-70b)
- [x] passing vLLM TP Perf benchmark, Galaxy on CI: https://github.com/tenstorrent/tt-xla/actions/runs/30219140895 (`vllm_mistral_small_3_1_24b_tp` at the new GMU of 0.16)
- [x] DP+TP regression check on bh_galaxy: https://github.com/tenstorrent/tt-xla/actions/runs/30218962902 (#5779's gemma4-31b DP+TP test, confirming the guard leaves it unchanged) - ran locally.
