### PR TITLE
[vLLM] Fix Gemma4 related tests for nightly

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -283,6 +283,21 @@ class TTPlatform(Platform):
         raise NotImplementedError
 
     @classmethod
+    def mem_get_info(cls) -> tuple[int, int]:
+        """Return ``(free, total)`` memory in bytes.
+
+        Some upstream multimodal models call this to size a
+        memory-safe chunk for the vision encoder. TT device DRAM is managed by
+        tt-metal and not queryable through this CUDA-style hook, so we report
+        host memory: the value only scales the encoder chunk size (smaller ->
+        more, smaller passes), so a host-memory estimate is always safe.
+        """
+        import psutil
+
+        vm = psutil.virtual_memory()
+        return vm.available, vm.total
+
+    @classmethod
     def is_async_output_supported(cls, enforce_eager: Optional[bool]) -> bool:
         return False
 

--- a/tests/integrations/vllm_plugin/generative/test_gemma4_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_gemma4_generation.py
@@ -33,9 +33,6 @@ def test_generation_single_device_gemma4_e4b():
             "use_2d_mesh": False,
             "cpu_sampling": False,
             "flat_model_io": True,
-            # opt_level=1 overflows L1 with the SDPA decode circular buffers
-            # (tt-mlir#9039).
-            "optimization_level": 0,
         },
     }
     llm = vllm.LLM(**llm_args)
@@ -64,9 +61,6 @@ def test_generation_bhqb_gemma4_26b_a4b():
             "min_context_len": 32,
             "enable_tensor_parallel": True,
             "use_2d_mesh": True,
-            # opt_level=1 exceeds the SDPA decode tree-reduction limit
-            # (tt-mlir#9007).
-            "optimization_level": 0,
         },
     }
     llm = vllm.LLM(**llm_args)

--- a/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
@@ -219,9 +219,8 @@ def test_tensor_parallel_generation_galaxy_wh_6u_mistral_large(
 @pytest.mark.parametrize(
     ["mesh_shape", "opt_level"],
     [
-        # Both [1, 4] and [8, 4] exceed the SDPA decode tree-reduction limit at
-        # opt_level=1 (tt-mlir#9007).
-        pytest.param([1, 4], 0, marks=pytest.mark.bhqb),
+        # [8, 4] exceed the SDPA decode tree-reduction limit at opt_level=1 (tt-mlir#9007).
+        pytest.param([1, 4], 1, marks=pytest.mark.bhqb),
         pytest.param([8, 4], 0, marks=pytest.mark.bh_galaxy),
     ],
 )


### PR DESCRIPTION
### Ticket
N/A

### Problem description
vLLM [nightly failure](https://github.com/tenstorrent/tt-xla/actions/runs/29738443687/job/88339426102#step:19:5328)
And opt_level>0 for gemma4 tests

### What's changed
Nightly failure for vLLM gemma-4 image model.
Bump up opt_level=1 for gemma4 bhqb tests

### Checklist
- [ ] New/Existing tests provide coverage for changes
