### PR TITLE
Enable forked=true for qb2 weekly tensor-parallel model tests

### DIFF
--- a/.github/workflows/test-matrix-presets/model-test-passing-weekly.json
+++ b/.github/workflows/test-matrix-presets/model-test-passing-weekly.json
@@ -10,5 +10,5 @@
   {"runs-on": "n300-llmbox", "name": "run_forge_models_multichip_torch", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "n300-llmbox and weekly and tensor_parallel and expected_passing", "parallel-groups": 1, "forge-models": true},
   {"runs-on": "n300", "name": "run_forge_models_multichip_torch", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "n300 and weekly and data_parallel and expected_passing", "parallel-groups": 8, "forge-models": true},
   {"runs-on": "n300-llmbox", "name": "run_forge_models_multichip_jax", "dir": "./tests/runner/test_models.py::test_all_models_jax", "test-mark": "n300-llmbox and weekly and tensor_parallel and expected_passing", "parallel-groups": 1, "forge-models": true},
-  {"runs-on": "qb2-blackhole", "name": "run_forge_models_multichip_torch", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "qb2-blackhole and weekly and tensor_parallel and expected_passing", "parallel-groups": 2, "forge-models": true}
+  {"runs-on": "qb2-blackhole", "name": "run_forge_models_multichip_torch", "dir": "./tests/runner/test_models.py::test_all_models_torch", "test-mark": "qb2-blackhole and weekly and tensor_parallel and expected_passing", "parallel-groups": 2, "forge-models": true, "forked": true}
 ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,5 +126,5 @@ Use `@pytest.mark.record_test_properties()` to tag tests with:
 - OpenMPI, protobuf-compiler, ccache, libnuma-dev, libhwloc-dev, libboost-all-dev
 
 ### Python Requirements
-- jax==0.7.1, jaxlib==0.7.1, torch==2.10.0
+- jax==0.7.1, jaxlib==0.7.1, torch==2.11.0
 - torch-xla (custom build from Tenstorrent PyPI)


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Weekly qb2 TP ran many models in one process. Models that pin/swap transformers polluted later tests and caused FE failures such as:
- `smart_apply() missing ... 'is_remote_code'`
- `InternalTorchDynamoError: KeyError: <Model class>`
- `KeyError: 'transformers.models.llama.modeling_llama'`
- config-as-Hub-repo-id `OSError` (e.g. Phi3Config)

Update the torch version in claude.md to the latest version once

### What's changed
With `forked: true`, each model runs in a fresh process, so transformers install/rollback from one model cannot affect the next.

ci link: https://github.com/tenstorrent/tt-xla/actions/runs/29805680225

### Checklist
- [ ] New/Existing tests provide coverage for changes
