### PR TITLE
[vLLM][uplift] v0.25.1

### DIFF
--- a/.github/workflows/test-matrix-presets/basic-test.json
+++ b/.github/workflows/test-matrix-presets/basic-test.json
@@ -16,6 +16,7 @@
   {"runs-on": "n300-llmbox",        "name": "run_vllm_llmbox_tests",  "dir": "./tests/integrations/vllm_plugin",        "test-mark": "push and tensor_parallel and llmbox and not data_parallel", "shared-runners": "true", "extra-wheel": "vllm"},
   {"runs-on": "n300-llmbox",        "name": "run_vllm_llmbox_tests",  "dir": "./tests/integrations/vllm_plugin",        "test-mark": "push and data_parallel and llmbox and not tensor_parallel", "shared-runners": "true", "extra-wheel": "vllm"},
   {"runs-on": "n300-llmbox",        "name": "run_vllm_llmbox_tests",  "dir": "./tests/integrations/vllm_plugin",        "test-mark": "push and data_parallel and tensor_parallel and llmbox", "shared-runners": "true", "extra-wheel": "vllm"},
+  {"runs-on": "cpu",                "name": "run_vllm_cpu_tests",      "dir": "./tests/integrations/vllm_plugin",        "test-mark": "push and cpu",            "shared-runners": "true", "extra-wheel": "vllm"},
   {"runs-on": "n300",               "name": "run_examples",           "dir": "./tests/examples",                        "test-mark": "push and not bhqb", "require":"alchemist", "parallel-groups": 3, "shared-runners": "true" },
   {"runs-on": "cpu",                "name": "run_mixed_precision_cpu","dir": "./mixed_precision",                       "test-mark": "push and cpu",            "shared-runners": "true", "forked": true }
 ]

--- a/.github/workflows/test-matrix-presets/vllm-model-tests.json
+++ b/.github/workflows/test-matrix-presets/vllm-model-tests.json
@@ -5,5 +5,6 @@
     {"runs-on": "n300", "name": "run_vllm_n300_tests", "dir": "./tests/integrations/vllm_plugin", "test-mark": "push and tensor_parallel and dual_chip", "shared-runners": "true", "extra-wheel": "vllm"},
     {"runs-on": "n300-llmbox", "name": "run_vllm_llmbox_tests", "dir": "./tests/integrations/vllm_plugin", "test-mark": "push and tensor_parallel and llmbox and not data_parallel", "shared-runners": "true", "extra-wheel": "vllm"},
     {"runs-on": "n300-llmbox", "name": "run_vllm_llmbox_tests", "dir": "./tests/integrations/vllm_plugin", "test-mark": "push and data_parallel and llmbox and not tensor_parallel", "shared-runners": "true", "extra-wheel": "vllm"},
-    {"runs-on": "n300-llmbox", "name": "run_vllm_llmbox_tests", "dir": "./tests/integrations/vllm_plugin", "test-mark": "push and data_parallel and tensor_parallel and llmbox", "shared-runners": "true", "extra-wheel": "vllm"}
+    {"runs-on": "n300-llmbox", "name": "run_vllm_llmbox_tests", "dir": "./tests/integrations/vllm_plugin", "test-mark": "push and data_parallel and tensor_parallel and llmbox", "shared-runners": "true", "extra-wheel": "vllm"},
+    {"runs-on": "cpu", "name": "run_vllm_cpu_tests", "dir": "./tests/integrations/vllm_plugin", "test-mark": "push and cpu", "shared-runners": "true", "extra-wheel": "vllm"}
 ]

--- a/.test_durations
+++ b/.test_durations
@@ -3604,7 +3604,7 @@
     "tests/integrations/vllm_plugin/generative/test_decode.py::test_decode": 55.52,
     "tests/integrations/vllm_plugin/generative/test_gemma4_generation.py::test_generation_bhqb_gemma4_26b_a4b": 447.51,
     "tests/integrations/vllm_plugin/generative/test_gemma4_generation.py::test_generation_bhqb_gemma4_image[26b_a4b]": 533.59,
-    "tests/integrations/vllm_plugin/generative/test_gemma4_generation.py::test_generation_bhqb_gemma4_image[31b]": 431.91,
+    "tests/integrations/vllm_plugin/generative/test_gemma4_generation.py::test_generation_bhqb_gemma4_image[31b]": 864.83,
     "tests/integrations/vllm_plugin/generative/test_gemma4_generation.py::test_generation_single_device_gemma4_e4b": 207.56,
     "tests/integrations/vllm_plugin/generative/test_gemma4_generation.py::test_generation_single_device_gemma4_e4b_image": 260.53,
     "tests/integrations/vllm_plugin/generative/test_kv_cache_bleed.py::test_kv_cache_no_cross_user_bleed": 188.92,

--- a/integrations/vllm_plugin/requirements-vllm-plugin.txt
+++ b/integrations/vllm_plugin/requirements-vllm-plugin.txt
@@ -1,3 +1,2 @@
-vllm==0.22.1
-transformers==5.5.1
-fastapi[standard] >= 0.133.0, < 0.137.0 # First version supporting Starlette 1.0; < 0.137.0 avoids route-tree change that breaks model-hosting-container-standards handler overrides.
+vllm==0.25.1
+transformers==5.14.1

--- a/integrations/vllm_plugin/requirements-vllm-plugin.txt
+++ b/integrations/vllm_plugin/requirements-vllm-plugin.txt
@@ -1,7 +1,2 @@
---extra-index-url https://download.pytorch.org/whl/cpu
 vllm==0.25.1
 transformers==5.14.1
-# torchaudio/torchvision are transitive deps of vllm; pin the +cpu wheels so pip
-# does not pull the CUDA builds (which fail to load against the +cpu torch).
-torchaudio@https://download.pytorch.org/whl/cpu/torchaudio-2.11.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl
-torchvision@https://download.pytorch.org/whl/cpu/torchvision-0.26.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl

--- a/integrations/vllm_plugin/requirements-vllm-plugin.txt
+++ b/integrations/vllm_plugin/requirements-vllm-plugin.txt
@@ -1,2 +1,7 @@
+--extra-index-url https://download.pytorch.org/whl/cpu
 vllm==0.25.1
 transformers==5.14.1
+# torchaudio/torchvision are transitive deps of vllm; pin the +cpu wheels so pip
+# does not pull the CUDA builds (which fail to load against the +cpu torch).
+torchaudio@https://download.pytorch.org/whl/cpu/torchaudio-2.11.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl
+torchvision@https://download.pytorch.org/whl/cpu/torchvision-0.26.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl

--- a/integrations/vllm_plugin/setup.py
+++ b/integrations/vllm_plugin/setup.py
@@ -51,9 +51,8 @@ setup(
     version="0.1",
     packages=find_packages(),
     install_requires=[
-        "vllm==0.22.1",
-        "transformers==5.5.1",
-        "fastapi[standard] >= 0.133.0, < 0.137.0",
+        "vllm==0.25.1",
+        "transformers==5.14.1",
     ],
     python_requires=">=3.12, <3.13",
     license="Apache-2.0",

--- a/integrations/vllm_plugin/vllm_tt/__init__.py
+++ b/integrations/vllm_plugin/vllm_tt/__init__.py
@@ -44,3 +44,9 @@ def register_oot_layers():
     from .layers.fused_moe import install_tt_fused_moe
 
     install_tt_fused_moe()
+
+    # Gemma4's multimodal encoder queries torch.accelerator.get_memory_info(),
+    # which asserts on the TT device; route it to a host-memory estimate.
+    from .platform import install_tt_accelerator_memory_info
+
+    install_tt_accelerator_memory_info()

--- a/integrations/vllm_plugin/vllm_tt/__init__.py
+++ b/integrations/vllm_plugin/vllm_tt/__init__.py
@@ -40,4 +40,11 @@ def register_oot_layers():
     # Registers all OOT backends
     from .attention_impls import attention_mla  # noqa: F401
 
+    # Disabled for the v0.25.1 uplift: upstream turned FusedMoE from a
+    # subclassable class into a factory function returning a MoERunner, and the
+    # op_registry_oot["FusedMoE"] hook this override relied on is no longer
+    # consulted. Re-enabling requires rewriting against the new runner_cls /
+    # routed_experts_cls (MoERunner / RoutedExperts) injection points. Tracked
+    # with Sungjoon (owner of tt_torch.moe_backend). MoE models are unsupported
+    # until then; non-MoE models are unaffected.
     # from .layers.fused_moe import TTFusedMoE  # noqa: F401

--- a/integrations/vllm_plugin/vllm_tt/__init__.py
+++ b/integrations/vllm_plugin/vllm_tt/__init__.py
@@ -40,7 +40,7 @@ def register_oot_layers():
     # Registers all OOT backends
     from .attention_impls import attention_mla  # noqa: F401
 
-    # DRAFT (pending review): patch the FusedMoE factory for TT MoE.
+    # Patch the FusedMoE factory for TT MoE.
     from .layers.fused_moe import install_tt_fused_moe
 
     install_tt_fused_moe()

--- a/integrations/vllm_plugin/vllm_tt/__init__.py
+++ b/integrations/vllm_plugin/vllm_tt/__init__.py
@@ -40,7 +40,7 @@ def register_oot_layers():
     # Registers all OOT backends
     from .attention_impls import attention_mla  # noqa: F401
 
-    # DRAFT (pending Sungjoon review): patch the FusedMoE factory for TT MoE.
+    # DRAFT (pending review): patch the FusedMoE factory for TT MoE.
     from .layers.fused_moe import install_tt_fused_moe
 
     install_tt_fused_moe()

--- a/integrations/vllm_plugin/vllm_tt/__init__.py
+++ b/integrations/vllm_plugin/vllm_tt/__init__.py
@@ -40,11 +40,7 @@ def register_oot_layers():
     # Registers all OOT backends
     from .attention_impls import attention_mla  # noqa: F401
 
-    # Disabled for the v0.25.1 uplift: upstream turned FusedMoE from a
-    # subclassable class into a factory function returning a MoERunner, and the
-    # op_registry_oot["FusedMoE"] hook this override relied on is no longer
-    # consulted. Re-enabling requires rewriting against the new runner_cls /
-    # routed_experts_cls (MoERunner / RoutedExperts) injection points. Tracked
-    # with Sungjoon (owner of tt_torch.moe_backend). MoE models are unsupported
-    # until then; non-MoE models are unaffected.
-    # from .layers.fused_moe import TTFusedMoE  # noqa: F401
+    # DRAFT (pending Sungjoon review): patch the FusedMoE factory for TT MoE.
+    from .layers.fused_moe import install_tt_fused_moe
+
+    install_tt_fused_moe()

--- a/integrations/vllm_plugin/vllm_tt/__init__.py
+++ b/integrations/vllm_plugin/vllm_tt/__init__.py
@@ -39,4 +39,5 @@ def register_oot_layers():
 
     # Registers all OOT backends
     from .attention_impls import attention_mla  # noqa: F401
-    from .layers.fused_moe import TTFusedMoE  # noqa: F401
+
+    # from .layers.fused_moe import TTFusedMoE  # noqa: F401

--- a/integrations/vllm_plugin/vllm_tt/layers/fused_moe.py
+++ b/integrations/vllm_plugin/vllm_tt/layers/fused_moe.py
@@ -204,6 +204,26 @@ class TTRoutedExperts(RoutedExperts):
                 h_flat, logits_flat, self.top_k, self.renormalize
             )
         else:
+            # The plain softmax top-k below does not implement the extra router
+            # features vLLM 0.25.1 exposes on RoutedExperts (grouped top-k,
+            # non-softmax scoring, e_score correction bias, router-weight-on-input).
+            # Models needing these (e.g. DeepSeek, Kimi, GLM) must run via the HF
+            # moe_backend; fail loudly rather than silently mis-routing. See #5610.
+            if (
+                self.use_grouped_topk
+                or self.scoring_func != "softmax"
+                or self.e_score_correction_bias is not None
+                or self.apply_router_weight_on_input
+            ):
+                raise NotImplementedError(
+                    "TT vLLM FusedMoE forward_native only supports plain softmax "
+                    "top-k. (use_grouped_topk="
+                    f"{self.use_grouped_topk}, scoring_func={self.scoring_func!r}, "
+                    f"e_score_correction_bias={self.e_score_correction_bias is not None}, "
+                    f"apply_router_weight_on_input={self.apply_router_weight_on_input}). "
+                    "For models using these router features, please run with the HF "
+                    "moe_backend (experts_implementation)."
+                )
             scores = F.softmax(logits_flat.float(), dim=-1)
             topk_weights, topk_ids = torch.topk(scores, self.top_k, dim=-1)
             if self.renormalize:

--- a/integrations/vllm_plugin/vllm_tt/layers/fused_moe.py
+++ b/integrations/vllm_plugin/vllm_tt/layers/fused_moe.py
@@ -8,32 +8,46 @@ the TT compiler) with expert dispatch delegated to ``tt_torch.moe_backend``:
 expert-parallel ``tt_experts_forward`` on a genuine 2D mesh, else dense-bmm
 ``tt_dense_experts_forward``.
 
-0.25.1 dropped the subclassable ``FusedMoE`` / ``op_registry_oot`` hook the old
-``TTFusedMoE`` used: ``FusedMoE`` is now a factory returning a ``MoERunner``, and
-the weights + routing state live on ``RoutedExperts``. So we monkey-patch the
-factory and post-process each ``MoERunner`` (Option 3): swap its quant method to
-force the monolithic path into a TT ``forward_native``, and bypass the opaque
-``vllm.moe_forward`` custom op the compiler can't trace.
+0.25.1 turned ``FusedMoE`` into a factory function returning a ``MoERunner``
+(the weights + routing state live on a ``RoutedExperts`` submodule) and dropped
+the subclassable ``FusedMoE`` / ``op_registry_oot`` hook the old ``TTFusedMoE``
+relied on. Instead it exposes ``runner_cls`` / ``routed_experts_cls`` factory
+params for out-of-tree backends. We use those seams:
 
-TODO (needs tt_torch.moe_backend owner review) before MoE models go back to
-supported: (a) confirm the TT platform never reshuffles w13/w2 out of the plain
-[E, out, in] layout at load time; (b) confirm this seam is preferred over
-``runner_cls`` / ``routed_experts_cls`` injection.
+- ``TTRoutedExperts`` (``routed_experts_cls``) owns the TT expert dispatch as a
+  real ``forward_native`` method and installs the TT quant method via the
+  supported ``_get_quant_method`` override -- no post-hoc attribute rebinding.
+- ``TTMoERunner`` (``runner_cls``) bypasses the opaque ``vllm.moe_forward``
+  custom op (untraceable by the TT compiler) by selecting the direct
+  ``_forward_impl`` path, exactly as vLLM already does for CPU/TPU.
+- ``TTUnquantizedFusedMoEMethod`` pins the ``OOT`` backend so vLLM never
+  reshuffles/repacks/pads w13/w2 out of the plain ``[E, out, in]`` layout
+  ``tt_torch.moe_backend`` expects (see ``_assert_plain_expert_layout``).
+
+``install_tt_fused_moe`` wraps the factory only to inject the two ``*_cls``
+kwargs (models call ``FusedMoE(...)`` without them); all TT behaviour lives in
+the subclasses above.
 """
 
 from __future__ import annotations
 
 import functools
-import types
 
 import torch
 import torch.nn.functional as F
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.fused_moe_method_base import (
+    FusedMoEMethodBase,
+)
 from vllm.model_executor.layers.fused_moe.oracle.unquantized import (
     UnquantizedMoeBackend,
 )
 from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
-from vllm.model_executor.layers.fused_moe.runner.moe_runner import MoERunner
+from vllm.model_executor.layers.fused_moe.runner.moe_runner import (
+    MoERunner,
+    _moe_forward,
+    _moe_forward_shared,
+)
 from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import (
     UnquantizedFusedMoEMethod,
 )
@@ -81,45 +95,63 @@ class _TTExpertView:
         raise NotImplementedError(f"TT FusedMoE: activation {activation} not supported")
 
 
-def _tt_moe_forward_native(
-    routed_experts: RoutedExperts,
-    hidden_states: torch.Tensor,
-    router_logits: torch.Tensor,
-) -> torch.Tensor:
-    """Routing + TT expert dispatch, bound onto a ``RoutedExperts`` as forward_native."""
-    from tt_torch import tt_dense_experts_forward, tt_experts_forward
-    from tt_torch.moe_backend import _mesh_info
+def _assert_plain_expert_layout(re: RoutedExperts) -> None:
+    """Guarantee w13/w2 are still the plain ``[E, out, in]`` params moe_backend reads.
 
-    orig_shape = hidden_states.shape
-    h_flat = hidden_states.view(-1, orig_shape[-1])
-    logits_flat = router_logits.view(-1, router_logits.shape[-1])
+    vLLM's ``process_weights_after_loading`` reshuffles (AITER), repacks (CPU),
+    or pads (ROCm) the expert weights for every unquantized backend EXCEPT
+    ``OOT``/``TPU``, which early-return untouched. ``TTUnquantizedFusedMoEMethod``
+    pins ``OOT`` so the plain layout survives; this asserts that invariant so a
+    future backend-selection change fails loudly instead of silently feeding
+    moe_backend a shuffled/padded tensor and computing wrong results.
 
-    if routed_experts.custom_routing_function is not None:
-        topk_weights, topk_ids = routed_experts.custom_routing_function(
-            h_flat, logits_flat, routed_experts.top_k, routed_experts.renormalize
+    Checks are on per-expert (trailing) dims only, so they hold under both dense
+    and expert-parallel (sharded ``num_local_experts``) placement.
+    """
+    w13, w2 = re.w13_weight, re.w2_weight
+    if w13.dim() != 3 or w2.dim() != 3:
+        raise AssertionError(
+            f"TT FusedMoE expects 3D [E, out, in] expert weights, got "
+            f"w13={tuple(w13.shape)} w2={tuple(w2.shape)}"
         )
-    else:
-        scores = F.softmax(logits_flat.float(), dim=-1)
-        topk_weights, topk_ids = torch.topk(scores, routed_experts.top_k, dim=-1)
-        if routed_experts.renormalize:
-            renorm = topk_weights.sum(dim=-1, keepdim=True).clamp(min=1e-9)
-            topk_weights = topk_weights / renorm
-
-    topk_weights = topk_weights.to(h_flat.dtype)
-    experts = _TTExpertView(routed_experts)
-
-    # EP is only valid on a genuine 2D mesh; otherwise fall back to dense bmm.
-    _, _, mesh_shape, _ = _mesh_info()
-    is_2d_mesh = len(mesh_shape) == 2 and all(d > 1 for d in mesh_shape)
-    if is_2d_mesh:
-        out_flat = tt_experts_forward(experts, h_flat, topk_ids, topk_weights)
-    else:
-        out_flat = tt_dense_experts_forward(experts, h_flat, topk_ids, topk_weights)
-    return out_flat.view(orig_shape)
+    if getattr(w13, "is_shuffled", False) or getattr(w2, "is_shuffled", False):
+        raise AssertionError(
+            "TT FusedMoE: expert weights are marked is_shuffled; the OOT backend "
+            "should never reshuffle. Backend selection likely regressed."
+        )
+    h = re.hidden_size
+    i = re.intermediate_size_per_partition
+    gate_up_dim = (2 if re.moe_config.is_act_and_mul else 1) * i
+    expected_w13 = (w13.shape[0], gate_up_dim, h)
+    expected_w2 = (w2.shape[0], h, i)
+    if tuple(w13.shape) != expected_w13 or tuple(w2.shape) != expected_w2:
+        raise AssertionError(
+            "TT FusedMoE: expert-weight layout changed from plain [E, out, in]. "
+            f"Expected w13={expected_w13} w2={expected_w2}, got "
+            f"w13={tuple(w13.shape)} w2={tuple(w2.shape)}. Weights were likely "
+            "padded/repacked by a non-OOT backend."
+        )
 
 
 class TTUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
-    """Forces the monolithic path onto the TT-scoped forward_native fallback."""
+    """Unquantized MoE method that dispatches experts through ``tt_torch``.
+
+    Forces the monolithic path onto the RoutedExperts ``forward_native`` fallback
+    and pins the ``OOT`` backend so ``process_weights_after_loading`` never
+    reshuffles the [E, out, in] expert weights (TODO 1).
+    """
+
+    def __init__(self, moe):
+        # Skip UnquantizedFusedMoEMethod.__init__'s call to
+        # select_unquantized_moe_backend: that picks TRITON/AITER/etc. based on
+        # live platform detection and would reshuffle/pad w13/w2. Pin OOT
+        # explicitly -- process_weights_after_loading early-returns for OOT, so
+        # the plain [E, out, in] layout survives regardless of when/where the
+        # method is constructed. moe_kernel stays None (set by base __init__),
+        # which routes apply_monolithic to forward_native below.
+        FusedMoEMethodBase.__init__(self, moe)
+        self.unquantized_backend = UnquantizedMoeBackend.OOT
+        self.experts_cls = None
 
     @property
     def is_monolithic(self) -> bool:
@@ -135,53 +167,84 @@ class TTUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
         return super().apply_monolithic(layer, x, router_logits, input_ids)
 
 
-def _patch_moe_runner(runner: MoERunner) -> MoERunner:
-    """In-place TT adaptation of a freshly-built MoERunner."""
-    routed_experts = runner.routed_experts
-    quant_method = routed_experts.quant_method
+class TTRoutedExperts(RoutedExperts):
+    """RoutedExperts whose experts run through ``tt_torch.moe_backend``.
 
-    if isinstance(quant_method, UnquantizedFusedMoEMethod) and not isinstance(
-        quant_method, TTUnquantizedFusedMoEMethod
-    ):
-        tt_method = TTUnquantizedFusedMoEMethod(routed_experts.moe_config)
-        for attr in (
-            "moe_kernel",
-            "moe_quant_config",
-            "cpu_fused_moe",
-            "unquantized_backend",
-            "experts_cls",
-        ):
-            if hasattr(quant_method, attr):
-                setattr(tt_method, attr, getattr(quant_method, attr))
-        runner._replace_quant_method(tt_method)
+    Injected via the ``routed_experts_cls`` factory param. Overrides
+    ``_get_quant_method`` to install the TT quant method (before create_weights,
+    so the plain-layout weights are created and never reshuffled) and provides
+    the TT expert dispatch as a real ``forward_native``.
+    """
 
-    routed_experts.forward_native = types.MethodType(
-        _tt_moe_forward_native, routed_experts
-    )
+    def _get_quant_method(self, prefix, quant_config, moe_config):
+        quant_method = super()._get_quant_method(prefix, quant_config, moe_config)
+        # Only the unquantized path lowers through moe_backend; leave quantized
+        # methods (quant_config != None) untouched.
+        if type(quant_method) is UnquantizedFusedMoEMethod:
+            return TTUnquantizedFusedMoEMethod(moe_config)
+        return quant_method
 
-    # Skip the opaque vllm.moe_forward custom op; call _forward_impl directly so
-    # the compiler traces the real expert ops.
-    def _forward_entry_direct(
-        hidden_states,
-        router_logits,
-        shared_experts_input,
-        input_ids,
-        _layer_name,
-        _hidden_dim_unpadded,
-    ):
-        return runner._forward_impl(
-            hidden_states, router_logits, shared_experts_input, input_ids
-        )
+    def forward_native(
+        self,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+    ) -> torch.Tensor:
+        """Routing + TT expert dispatch (the monolithic fallback for TT)."""
+        from tt_torch import tt_dense_experts_forward, tt_experts_forward
+        from tt_torch.moe_backend import _mesh_info
 
-    runner._forward_entry = _forward_entry_direct
-    return runner
+        _assert_plain_expert_layout(self)
+
+        orig_shape = hidden_states.shape
+        h_flat = hidden_states.view(-1, orig_shape[-1])
+        logits_flat = router_logits.view(-1, router_logits.shape[-1])
+
+        if self.custom_routing_function is not None:
+            topk_weights, topk_ids = self.custom_routing_function(
+                h_flat, logits_flat, self.top_k, self.renormalize
+            )
+        else:
+            scores = F.softmax(logits_flat.float(), dim=-1)
+            topk_weights, topk_ids = torch.topk(scores, self.top_k, dim=-1)
+            if self.renormalize:
+                renorm = topk_weights.sum(dim=-1, keepdim=True).clamp(min=1e-9)
+                topk_weights = topk_weights / renorm
+
+        topk_weights = topk_weights.to(h_flat.dtype)
+        experts = _TTExpertView(self)
+
+        # EP is only valid on a genuine 2D mesh; otherwise fall back to dense bmm.
+        _, _, mesh_shape, _ = _mesh_info()
+        is_2d_mesh = len(mesh_shape) == 2 and all(d > 1 for d in mesh_shape)
+        if is_2d_mesh:
+            out_flat = tt_experts_forward(experts, h_flat, topk_ids, topk_weights)
+        else:
+            out_flat = tt_dense_experts_forward(experts, h_flat, topk_ids, topk_weights)
+        return out_flat.view(orig_shape)
+
+
+class TTMoERunner(MoERunner):
+    """MoERunner that runs the MoE forward without the opaque custom op.
+
+    Injected via the ``runner_cls`` factory param. The default ``_select_forward``
+    returns ``torch.ops.vllm.moe_forward`` (an opaque custom op the TT compiler
+    can't trace into). Selecting the module-level ``_moe_forward`` /
+    ``_moe_forward_shared`` instead calls ``_forward_impl`` directly -- the same
+    path vLLM uses for CPU/TPU -- so the compiler sees the real expert ops.
+    """
+
+    def _select_forward(self):
+        return _moe_forward if self._shared_experts is None else _moe_forward_shared
 
 
 def install_tt_fused_moe() -> None:
-    """Patch the FusedMoE factory to TT-adapt every MoERunner it builds.
+    """Patch the FusedMoE factory to inject the TT runner/experts classes.
 
-    Fired from register_oot_layers before models import; patches both the
-    package symbol (what models import) and its defining module. Idempotent.
+    Fired from register_oot_layers before models import. Models call
+    ``FusedMoE(...)`` without ``runner_cls`` / ``routed_experts_cls``, so this
+    thin wrapper supplies them; all TT behaviour lives in the injected
+    subclasses. Patches both the package symbol (what models import) and its
+    defining module. Idempotent.
     """
     import vllm.model_executor.layers.fused_moe as _moe_pkg
     import vllm.model_executor.layers.fused_moe.layer as _moe_layer
@@ -192,7 +255,9 @@ def install_tt_fused_moe() -> None:
 
     @functools.wraps(orig_factory)
     def _tt_fused_moe(*args, **kwargs):
-        return _patch_moe_runner(orig_factory(*args, **kwargs))
+        kwargs.setdefault("routed_experts_cls", TTRoutedExperts)
+        kwargs.setdefault("runner_cls", TTMoERunner)
+        return orig_factory(*args, **kwargs)
 
     _tt_fused_moe._tt_patched = True
     _tt_fused_moe._tt_orig = orig_factory

--- a/integrations/vllm_plugin/vllm_tt/layers/fused_moe.py
+++ b/integrations/vllm_plugin/vllm_tt/layers/fused_moe.py
@@ -1,51 +1,129 @@
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
-"""TT FusedMoE OOT layer for vLLM.
+"""TT FusedMoE integration for vLLM 0.25.1.
 
-``TTFusedMoE`` (OOT-registered for ``FusedMoE``) replaces the upstream fused
-expert kernel — which doesn't lower cleanly through the TT compiler — with a
-TT-friendly expert dispatch delegated to ``tt_torch.moe_backend``:
+Replaces the upstream fused-expert kernel (which doesn't lower cleanly through
+the TT compiler) with expert dispatch delegated to ``tt_torch.moe_backend``:
+expert-parallel ``tt_experts_forward`` on a genuine 2D mesh, else dense-bmm
+``tt_dense_experts_forward``.
 
-* genuine 2D mesh (both axes > 1): expert-parallel ``tt_experts_forward``
-  (experts are sharded across the mesh by ``partition_fused_moe``);
-* otherwise (1D / degenerate / single chip): dense-bmm
-  ``tt_dense_experts_forward`` (route every token through every expert, then
-  mask by the routing weights).
+0.25.1 dropped the subclassable ``FusedMoE`` / ``op_registry_oot`` hook the old
+``TTFusedMoE`` used: ``FusedMoE`` is now a factory returning a ``MoERunner``, and
+the weights + routing state live on ``RoutedExperts``. So we monkey-patch the
+factory and post-process each ``MoERunner`` (Option 3): swap its quant method to
+force the monolithic path into a TT ``forward_native``, and bypass the opaque
+``vllm.moe_forward`` custom op the compiler can't trace.
 
-Routing uses the model's own ``custom_routing_function`` when present, else
-standard softmax / top_k / renormalize. Registered at import time via
-``@CustomOp.register_oot``; the import is fired from ``register_oot_layer``
-(the ``vllm.general_plugins`` entry point), mirroring the MLA backend.
+TODO (needs tt_torch.moe_backend owner review) before MoE models go back to
+supported: (a) confirm the TT platform never reshuffles w13/w2 out of the plain
+[E, out, in] layout at load time; (b) confirm this seam is preferred over
+``runner_cls`` / ``routed_experts_cls`` injection.
 """
 
 from __future__ import annotations
 
+import functools
+import types
+
 import torch
 import torch.nn.functional as F
-from vllm.model_executor.custom_op import CustomOp
+
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
-from vllm.model_executor.layers.fused_moe.layer import FusedMoE
 from vllm.model_executor.layers.fused_moe.oracle.unquantized import (
     UnquantizedMoeBackend,
 )
+from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
+from vllm.model_executor.layers.fused_moe.runner.moe_runner import MoERunner
 from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import (
     UnquantizedFusedMoEMethod,
 )
 
 
-class TTUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
-    """TT-scoped override for unquantized FusedMoE method behavior.
+class _TTExpertView:
+    """Presents a ``RoutedExperts`` as the fused-expert module moe_backend expects.
 
-    Keeps the fallback logic local to TT FusedMoE instances instead of
-    monkey-patching vLLM globally.
+    moe_backend reads only these names (weights read live, never snapshotted).
     """
+
+    # vLLM stores w13/w2 as [E, out, in]; moe_backend transposes before the bmm.
+    is_transposed = False
+
+    def __init__(self, routed_experts: RoutedExperts):
+        self._re = routed_experts
+
+    @property
+    def num_experts(self) -> int:
+        return self._re.global_num_experts
+
+    @property
+    def gate_up_proj(self) -> torch.Tensor:
+        return self._re.w13_weight
+
+    @property
+    def down_proj(self) -> torch.Tensor:
+        return self._re.w2_weight
+
+    @property
+    def gate_up_proj_bias(self):
+        return getattr(self._re, "w13_bias", None)
+
+    @property
+    def down_proj_bias(self):
+        return getattr(self._re, "w2_bias", None)
+
+    def _apply_gate(self, gate_up: torch.Tensor) -> torch.Tensor:
+        gate, up = gate_up.chunk(2, dim=-1)
+        activation = self._re.activation
+        if activation == MoEActivation.SILU:
+            return F.silu(gate) * up
+        if activation in (MoEActivation.GELU, MoEActivation.GELU_TANH):
+            return F.gelu(gate, approximate="tanh") * up
+        raise NotImplementedError(f"TT FusedMoE: activation {activation} not supported")
+
+
+def _tt_moe_forward_native(
+    routed_experts: RoutedExperts,
+    hidden_states: torch.Tensor,
+    router_logits: torch.Tensor,
+) -> torch.Tensor:
+    """Routing + TT expert dispatch, bound onto a ``RoutedExperts`` as forward_native."""
+    from tt_torch import tt_dense_experts_forward, tt_experts_forward
+    from tt_torch.moe_backend import _mesh_info
+
+    orig_shape = hidden_states.shape
+    h_flat = hidden_states.view(-1, orig_shape[-1])
+    logits_flat = router_logits.view(-1, router_logits.shape[-1])
+
+    if routed_experts.custom_routing_function is not None:
+        topk_weights, topk_ids = routed_experts.custom_routing_function(
+            h_flat, logits_flat, routed_experts.top_k, routed_experts.renormalize
+        )
+    else:
+        scores = F.softmax(logits_flat.float(), dim=-1)
+        topk_weights, topk_ids = torch.topk(scores, routed_experts.top_k, dim=-1)
+        if routed_experts.renormalize:
+            renorm = topk_weights.sum(dim=-1, keepdim=True).clamp(min=1e-9)
+            topk_weights = topk_weights / renorm
+
+    topk_weights = topk_weights.to(h_flat.dtype)
+    experts = _TTExpertView(routed_experts)
+
+    # EP is only valid on a genuine 2D mesh; otherwise fall back to dense bmm.
+    _, _, mesh_shape, _ = _mesh_info()
+    is_2d_mesh = len(mesh_shape) == 2 and all(d > 1 for d in mesh_shape)
+    if is_2d_mesh:
+        out_flat = tt_experts_forward(experts, h_flat, topk_ids, topk_weights)
+    else:
+        out_flat = tt_dense_experts_forward(experts, h_flat, topk_ids, topk_weights)
+    return out_flat.view(orig_shape)
+
+
+class TTUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
+    """Forces the monolithic path onto the TT-scoped forward_native fallback."""
 
     @property
     def is_monolithic(self) -> bool:
-        # TT uses a compile-time constant monolithic path so the runner can
-        # stay on the TT-specific apply_monolithic fallback without tracing a
-        # runtime branch on moe_kernel state.
         return True
 
     def apply_monolithic(self, layer, x, router_logits, input_ids=None):
@@ -54,131 +132,70 @@ class TTUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
             and self.moe_kernel is None
             and hasattr(layer, "forward_native")
         ):
-            # TTFusedMoE exposes forward_native(hidden_states, router_logits)
-            # that does routing + experts in a TT-friendly way without
-            # relying on vLLM's internal moe kernel object.
             return layer.forward_native(x, router_logits)
         return super().apply_monolithic(layer, x, router_logits, input_ids)
 
 
-@CustomOp.register_oot(name="FusedMoE")
-class TTFusedMoE(FusedMoE):
-    """OOT FusedMoE specialised for the TT compile pipeline (see module docstring)."""
+def _patch_moe_runner(runner: MoERunner) -> MoERunner:
+    """In-place TT adaptation of a freshly-built MoERunner."""
+    routed_experts = runner.routed_experts
+    quant_method = routed_experts.quant_method
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        # Use a TT-scoped quant method override rather than monkey-patching
-        # UnquantizedFusedMoEMethod globally.
-        if isinstance(self.quant_method, UnquantizedFusedMoEMethod) and not isinstance(
-            self.quant_method, TTUnquantizedFusedMoEMethod
+    if isinstance(quant_method, UnquantizedFusedMoEMethod) and not isinstance(
+        quant_method, TTUnquantizedFusedMoEMethod
+    ):
+        tt_method = TTUnquantizedFusedMoEMethod(routed_experts.moe_config)
+        for attr in (
+            "moe_kernel",
+            "moe_quant_config",
+            "cpu_fused_moe",
+            "unquantized_backend",
+            "experts_cls",
         ):
-            tt_method = TTUnquantizedFusedMoEMethod(self.moe_config)
+            if hasattr(quant_method, attr):
+                setattr(tt_method, attr, getattr(quant_method, attr))
+        runner._replace_quant_method(tt_method)
 
-            # Preserve runtime state initialized by vLLM on the original method.
-            for attr in (
-                "moe_kernel",
-                "moe_quant_config",
-                "cpu_fused_moe",
-                "unquantized_backend",
-                "experts_cls",
-            ):
-                if hasattr(self.quant_method, attr):
-                    setattr(tt_method, attr, getattr(self.quant_method, attr))
+    routed_experts.forward_native = types.MethodType(
+        _tt_moe_forward_native, routed_experts
+    )
 
-            self.quant_method = tt_method
-            self.base_quant_method = tt_method
-            self.runner._replace_quant_method(tt_method)
-
-        # vLLM::MoERunner calling sequence:
-        # forward
-        # └── _forward_entry
-        #     └── vllm.moe_forward or vllm.moe_forward_shared (custom op)
-        #         └── _forward_impl
-        #
-        # Override the runner's custom-op entry point to dispatch directly to the
-        # TT MoE implementation.
-        def _forward_entry_direct(
-            hidden_states,
-            router_logits,
-            shared_experts_input,
-            input_ids,
-            _layer_name,
-            _hidden_dim_unpadded,
-        ):
-            return self.runner._forward_impl(
-                self,
-                hidden_states,
-                router_logits,
-                shared_experts_input,
-                input_ids,
-            )
-
-        self.runner._forward_entry = _forward_entry_direct
-
-    # vLLM FusedMoE → tt_torch.moe_backend expert-module interface adapter.
-    @property
-    def num_experts(self):
-        return self.global_num_experts
-
-    @property
-    def gate_up_proj(self):
-        return self.w13_weight
-
-    @property
-    def down_proj(self):
-        return self.w2_weight
-
-    @property
-    def is_transposed(self):
-        # vLLM stores w13 / w2 already in row-major [E, out, in] orientation,
-        # matching tt_dense_experts_forward's "not transposed" expectation
-        # (it will transpose(-1, -2) before the bmm).
-        return False
-
-    def _apply_gate(self, gate_up):
-        gate, up = gate_up.chunk(2, dim=-1)
-        if self.activation == MoEActivation.SILU:
-            return F.silu(gate) * up
-        if self.activation == MoEActivation.GELU:
-            return F.gelu(gate, approximate="tanh") * up
-        if self.activation == MoEActivation.GELU_TANH:
-            return F.gelu(gate, approximate="tanh") * up
-        raise NotImplementedError(
-            f"TTFusedMoE: activation {self.activation} not supported"
+    # Skip the opaque vllm.moe_forward custom op; call _forward_impl directly so
+    # the compiler traces the real expert ops.
+    def _forward_entry_direct(
+        hidden_states,
+        router_logits,
+        shared_experts_input,
+        input_ids,
+        _layer_name,
+        _hidden_dim_unpadded,
+    ):
+        return runner._forward_impl(
+            hidden_states, router_logits, shared_experts_input, input_ids
         )
 
-    def forward_native(self, hidden_states, router_logits):
-        # Lazy import keeps tt_torch.moe_backend out of the import-time cycle.
-        from tt_torch import tt_dense_experts_forward, tt_experts_forward
-        from tt_torch.moe_backend import _mesh_info
+    runner._forward_entry = _forward_entry_direct
+    return runner
 
-        orig_shape = hidden_states.shape
-        h_flat = hidden_states.view(-1, orig_shape[-1])
-        # Routing operates on [T, E]; flatten any leading dims of the logits.
-        logits_flat = router_logits.view(-1, router_logits.shape[-1])
 
-        if self.custom_routing_function is not None:
-            # Model supplied its own routing (e.g. Gemma-4 folds
-            # per_expert_scale into the top-k weights here).
-            topk_weights, topk_ids = self.custom_routing_function(
-                h_flat, logits_flat, self.top_k, self.renormalize
-            )
-        else:
-            scores = F.softmax(logits_flat.float(), dim=-1)
-            topk_weights, topk_ids = torch.topk(scores, self.top_k, dim=-1)
-            if self.renormalize:
-                renorm = topk_weights.sum(dim=-1, keepdim=True).clamp(min=1e-9)
-                topk_weights = topk_weights / renorm
+def install_tt_fused_moe() -> None:
+    """Patch the FusedMoE factory to TT-adapt every MoERunner it builds.
 
-        topk_weights = topk_weights.to(h_flat.dtype)
-        # Expert-parallel tt-moe is only valid on a genuine 2D mesh (both axes
-        # > 1), where partition_fused_moe shards the experts across the mesh.
-        # On 1D / degenerate (1, N) / single-chip meshes, use dense bmm.
-        _, _, mesh_shape, _ = _mesh_info()
-        is_2d_mesh = len(mesh_shape) == 2 and all(d > 1 for d in mesh_shape)
-        if is_2d_mesh:
-            out_flat = tt_experts_forward(self, h_flat, topk_ids, topk_weights)
-        else:
-            out_flat = tt_dense_experts_forward(self, h_flat, topk_ids, topk_weights)
-        return out_flat.view(orig_shape)
+    Fired from register_oot_layers before models import; patches both the
+    package symbol (what models import) and its defining module. Idempotent.
+    """
+    import vllm.model_executor.layers.fused_moe as _moe_pkg
+    import vllm.model_executor.layers.fused_moe.layer as _moe_layer
+
+    orig_factory = _moe_layer.FusedMoE
+    if getattr(orig_factory, "_tt_patched", False):
+        return
+
+    @functools.wraps(orig_factory)
+    def _tt_fused_moe(*args, **kwargs):
+        return _patch_moe_runner(orig_factory(*args, **kwargs))
+
+    _tt_fused_moe._tt_patched = True
+    _tt_fused_moe._tt_orig = orig_factory
+    _moe_layer.FusedMoE = _tt_fused_moe
+    _moe_pkg.FusedMoE = _tt_fused_moe

--- a/integrations/vllm_plugin/vllm_tt/layers/fused_moe.py
+++ b/integrations/vllm_plugin/vllm_tt/layers/fused_moe.py
@@ -28,7 +28,6 @@ import types
 
 import torch
 import torch.nn.functional as F
-
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.fused_moe.oracle.unquantized import (
     UnquantizedMoeBackend,

--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -474,6 +474,12 @@ class TTPlatform(Platform):
                 "vllm_tt.scheduler.AscendScheduler"
             )
 
+        # TT does not support asynchronous scheduling (is_async_output_supported
+        # is False). v0.25.1 auto-enables it when left unset, which drives the
+        # AscendScheduler stale-request path into an endless preempt/retry loop.
+        # Force it off.
+        vllm_config.scheduler_config.async_scheduling = False
+
         cache_config = vllm_config.cache_config
         # For v0, the default block size is 16.
         if cache_config and cache_config.block_size is None:

--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -661,3 +661,21 @@ class TTPlatform(Platform):
         worker after initializing the device.
         """
         return
+
+
+def install_tt_accelerator_memory_info() -> None:
+    """Route ``torch.accelerator.get_memory_info`` to the TT host-memory estimate.
+
+    vLLM 0.25.1's Gemma4 multimodal encoder sizes its vision-encoder chunks with
+    ``torch.accelerator.get_memory_info()``, which asserts on the TT (xla/"jax")
+    device because it has no torch ``DeviceAllocator``. Reuse the same host-memory
+    estimate as ``TTPlatform.mem_get_info`` (the value only scales the encoder
+    chunk size, so a host-memory estimate is always safe).
+    """
+    if not hasattr(torch, "accelerator"):
+        return
+
+    def _tt_get_memory_info(device=None) -> tuple[int, int]:
+        return TTPlatform.mem_get_info()
+
+    torch.accelerator.get_memory_info = _tt_get_memory_info

--- a/integrations/vllm_plugin/vllm_tt/scheduler/ascend_scheduler.py
+++ b/integrations/vllm_plugin/vllm_tt/scheduler/ascend_scheduler.py
@@ -63,7 +63,12 @@ class AscendScheduler(Scheduler):
         # TTConfig.prefill_kv_watermark.
         self.prefill_kv_watermark = float(add_cfg.get("prefill_kv_watermark") or 0.0)
 
-    def schedule(self) -> SchedulerOutput:
+    def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
+        # v0.25.1: EngineCore calls schedule(self._should_throttle_prefills())
+        # positionally, so the parameter must exist. TT is single-instance, so
+        # DP prefill throttling is ignored. current_step advances to match the
+        # base (decode-cadence gating / stats read it).
+        self.current_step += 1
         # Super's schedule handles chunked prefill which is schedule both prefill and decode in one request.
         # if self.scheduler_config.tt_chunked_prefill_enabled:
         #     return super().schedule()
@@ -633,26 +638,13 @@ class AscendScheduler(Scheduler):
             batch = KVEventBatch(ts=time.time(), events=events)
             self.kv_event_publisher.publish(batch)
 
-        # Advance the number of computed tokens for the request AFTER
-        # the request is scheduled.
-        # 1. The scheduler_output of the current step has to include the
-        #    original number of scheduled tokens to determine input IDs.
-        # 2. Advance the number of computed tokens here allowing us to
-        #    schedule the prefill request again immediately in the next
-        #    scheduling step.
-        # 3. If some tokens (e.g. spec tokens) are rejected later, the number of
-        #    computed tokens will be adjusted in update_from_output.
-        for req_id, num_scheduled_token in num_scheduled_tokens.items():
-            request = self.requests[req_id]
-            request.num_computed_tokens += num_scheduled_token
-            request.is_prefill_chunk = request.num_computed_tokens < (
-                request.num_tokens + request.num_output_placeholders
-            )
-            scheduler_output.has_structured_output_requests |= (
-                request.use_structured_output and not request.is_prefill_chunk
-            )
-
-        self.finished_req_ids = set()  # type: ignore
+        # Advance num_computed_tokens, set is_prefill_chunk, and clear the
+        # finished/preempted id sets. Delegated to the base (v0.25.1 also
+        # records the deferred-free fence and prunes the in-flight-prefill set
+        # here); calling it keeps this override in sync with future changes.
+        if self.defer_block_free and total_num_scheduled_tokens > 0:
+            self.sched_step_seq += 1
+        self._update_after_schedule(scheduler_output)
         return scheduler_output
 
     def _block_aligned_chunk(self, num_new_tokens: int, token_budget: int) -> int:

--- a/integrations/vllm_plugin/vllm_tt/vllm_distributed_utils.py
+++ b/integrations/vllm_plugin/vllm_tt/vllm_distributed_utils.py
@@ -380,13 +380,13 @@ def partition_fused_moe(
     mesh (see below), independent of the DP/TP weight-sharding flag.
 
     vLLM stacks experts as ``w13_weight`` [E, 2*I, H] and ``w2_weight``
-    [E, H, I]. TTFusedMoE only takes the expert-parallel (tt_experts_forward)
-    path on a genuine 2D mesh (both axes > 1), where experts are distributed
-    across *all* devices via a compound sharding over both axes (e.g. (2,2) ->
-    4-way split of E). On a 1D / degenerate / single-chip mesh TTFusedMoE uses
-    the dense bmm path, which needs the full expert set on every device, so
-    leave the expert weights replicated (mirrors the is_2d guard in
-    layers/fused_moe.py)."""
+    [E, H, I] on the RoutedExperts submodule. The TT MoE path only takes the
+    expert-parallel (tt_experts_forward) path on a genuine 2D mesh (both axes >
+    1), where experts are distributed across *all* devices via a compound
+    sharding over both axes (e.g. (2,2) -> 4-way split of E). On a 1D /
+    degenerate / single-chip mesh it uses the dense bmm path, which needs the
+    full expert set on every device, so leave the expert weights replicated
+    (mirrors the is_2d guard in TTRoutedExperts.forward_native)."""
     mesh_shape = tuple(int(d) for d in mesh.mesh_shape)
     if not (len(mesh_shape) == 2 and all(d > 1 for d in mesh_shape)):
         logger.debug("Skipping expert sharding for %s on non-2D mesh", layer)
@@ -412,8 +412,12 @@ MODULE_TYPE_TO_WRAPPING_FUNC = OrderedDict(
         # that are not wrapped in vLLM's parallel linear types). Must come last
         # so the more specific vLLM types above always take priority.
         ("Linear", partition_linear),
-        ("TTFusedMoE", partition_fused_moe),
-        ("TTSharedFusedMoE", partition_fused_moe),
+        # vLLM 0.25.1 moved the stacked expert weights (w13_weight/w2_weight)
+        # from the old monolithic TTFusedMoE module onto the RoutedExperts
+        # submodule; TT injects TTRoutedExperts there (see layers/fused_moe.py).
+        # partition_fused_moe reads w13_weight/w2_weight, so it must match that
+        # class. Only fires on MoE + genuine 2D mesh (expert parallelism).
+        ("TTRoutedExperts", partition_fused_moe),
     ]
 )
 

--- a/python_package/requirements.txt
+++ b/python_package/requirements.txt
@@ -3,6 +3,7 @@ jax==0.7.1
 jaxlib==0.7.1
 requests
 torch@https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl
+torchaudio@https://download.pytorch.org/whl/cpu/torchaudio-2.11.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl
 loguru
 torch-xla@https://pypi.eng.aws.tenstorrent.com/torch-xla/torch_xla-2.9.0%2Bgitb230007-cp312-cp312-linux_x86_64.whl
 

--- a/python_package/requirements.txt
+++ b/python_package/requirements.txt
@@ -4,6 +4,7 @@ jaxlib==0.7.1
 requests
 torch@https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl
 torchaudio@https://download.pytorch.org/whl/cpu/torchaudio-2.11.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl
+torchvision@https://download.pytorch.org/whl/cpu/torchvision-0.26.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl
 loguru
 torch-xla@https://pypi.eng.aws.tenstorrent.com/torch-xla/torch_xla-2.9.0%2Bgitb230007-cp312-cp312-linux_x86_64.whl
 

--- a/python_package/requirements.txt
+++ b/python_package/requirements.txt
@@ -3,8 +3,6 @@ jax==0.7.1
 jaxlib==0.7.1
 requests
 torch@https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl
-torchaudio@https://download.pytorch.org/whl/cpu/torchaudio-2.11.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl
-torchvision@https://download.pytorch.org/whl/cpu/torchvision-0.26.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl
 loguru
 torch-xla@https://pypi.eng.aws.tenstorrent.com/torch-xla/torch_xla-2.9.0%2Bgitb230007-cp312-cp312-linux_x86_64.whl
 

--- a/venv/requirements-dev.txt
+++ b/venv/requirements-dev.txt
@@ -36,7 +36,7 @@ tabulate
 timm
 torchvision==0.26+cpu
 torchxrayvision
-transformers==5.5.1
+transformers==5.14.1
 
 wheel
 matplotlib

--- a/venv/requirements-dev.txt
+++ b/venv/requirements-dev.txt
@@ -37,7 +37,7 @@ timm
 torchaudio==2.11.0+cpu
 torchvision==0.26+cpu
 torchxrayvision
-transformers==5.14.1
+transformers==5.5.1
 
 wheel
 matplotlib

--- a/venv/requirements-dev.txt
+++ b/venv/requirements-dev.txt
@@ -34,6 +34,7 @@ sentencepiece
 setuptools
 tabulate
 timm
+torchaudio==2.11.0+cpu
 torchvision==0.26+cpu
 torchxrayvision
 transformers==5.14.1


### PR DESCRIPTION
### Ticket
closes #5743 

### Problem description
vLLM uplift

### What's changed
- vLLM uplift: target v0.25.1
- Transformers uplift (required for vLLM): target v5.14.1
- TorchAudio cpu version pinned in requirements to avoid vLLM installing non-cpu version
- Update Schedular to match upstream changes
- Update FusedMoE override implementation to match upstream changes.

### Checklist
- [X] New/Existing tests provide coverage for changes
