### PR TITLE
Remove Mixtral and Pixtral placeholders after bringup

### DIFF
--- a/tests/runner/test_config/torch/test_config_placeholders.yaml
+++ b/tests/runner/test_config/torch/test_config_placeholders.yaml
@@ -23,8 +23,6 @@ PLACEHOLDER_MODELS:
     bringup_status: NOT_STARTED
   genmo/mochi-1-preview:
     bringup_status: NOT_STARTED
-  mistralai/Mixtral-8x7B-Instruct-v0.1:
-    bringup_status: NOT_STARTED
   Hiperglobal Shallow uNet:
     bringup_status: NOT_STARTED
   KLA K-SegNet:
@@ -34,8 +32,6 @@ PLACEHOLDER_MODELS:
   MiniMaxAI/MiniMax-Text-01:
     bringup_status: NOT_STARTED
   MiniMaxAI/MiniMax-VL-01:
-    bringup_status: NOT_STARTED
-  mistralai/Pixtral-Large-Instruct-2411:
     bringup_status: NOT_STARTED
   Gaussian Splatting:
     bringup_status: NOT_STARTED


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description

- `mistralai/Mixtral-8x7B-Instruct-v0.1` successfully brought up in PyTorch
- `mistralai/Pixtral-Large-Instruct-2411` successfully brought up in vLLM
- Both models are passing end-to-end

### What's changed

Remove Mixtral and Pixtral entries from the placeholders YAML file so they are no longer reported as `NOT_STARTED` / ModelGroup.RED on the dashboard.

### Checklist
- [ ] New/Existing tests provide coverage for changes
