### PR TITLE
[MoE] Shard multimodal VLM experts by resolving decoder at language_model.layers

### DIFF
--- a/python_package/tt_torch/moe_backend.py
+++ b/python_package/tt_torch/moe_backend.py
@@ -541,7 +541,14 @@ def get_tt_moe_shard_specs(
     shard_specs = original_spec_fn(model)
     expert_axis: Any = tuple(mesh_names) if len(mesh_names) > 1 else mesh_names[0]
 
-    layers = getattr(getattr(model, "model", None), "layers", None)
+    # Decoder layers live at model.model.layers for causal-LM MoE, but at
+    # model.model.language_model.layers for multimodal (VLM) MoE, where
+    # model.model only exposes .visual and .language_model. Check both so the
+    # expert-dimension sharding is applied in either topology.
+    inner = getattr(model, "model", None)
+    layers = getattr(inner, "layers", None)
+    if layers is None:
+        layers = getattr(getattr(inner, "language_model", None), "layers", None)
     if layers is None:
         return shard_specs
 


### PR DESCRIPTION

### Ticket
Link to Github Issue

### Problem description
`get_tt_moe_shard_specs` locates the decoder layers at `model.model.layers` to apply expert-dimension sharding to the routed MoE experts. That path exists on causal-LM MoE models but not on multimodal VLM MoE models whose decoder lives at `model.model.language_model.layers` (`model.model` only exposes `.visual` and `.language_model`). The lookup returned `None`, the function early-returned, and the expert weights (`experts.gate_up_proj` / `down_proj`) were never expert-sharded  they stayed replicated on every device.

The expert-parallel forward (`_tt_experts_forward_ep`: `all_to_all_dispatch` + `sparse_matmul`) assumes each device holds `E / num_devices` experts. With the weights replicated instead, the dispatched-token layout and the expert-weight
count disagree, and a downstream reshape gets a tensor whose volume != its target:

```
    TT_FATAL: Invalid arguments to reshape new_volume == old_volume
    RuntimeError: Bad StatusOr access: INTERNAL: Error code: 13
```

Surfaced on Qwen3.5-35B-A3B multimodal (VLM) tensor-parallel inference with `inject_custom_moe: true`.

### What's changed
Resolve the decoder layers in both topologies: try `model.model.layers`, then fall back to `model.model.language_model.layers`. Purely additive the causal-LM path is unchanged, so existing MoE models behave identically.

### Checklist
- [ ] New/Existing tests provide coverage for changes
