### PR TITLE
Restore 1D mesh for gemma4-31b-it-tp benchmark on QB2

### DIFF
--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -134,8 +134,11 @@ def _gemma4_tp_config(model: str, batch_size: int):
     # ::test_tensor_parallel_generation_gemma4_31b:
     #   - limit_mm_per_prompt zeroed so the vision/audio tower never compiles
     #   - max_num_batched_tokens floored at 2560 (MultiModalBudget video floor)
-    #   - flat_model_io for Gemma-4's PLE forward; default mesh_shape=None ->
-    #     1D mesh (gemma4 TP runs on qb2-blackhole)
+    #   - flat_model_io for Gemma-4's PLE forward; use_2d_mesh=False -> 1D mesh
+    #     (gemma4 TP runs on qb2-blackhole). mesh_shape=None alone is NOT
+    #     enough for a 1D mesh -- TTConfig.use_2d_mesh defaults to True, so
+    #     without this explicit False, determine_mesh_shape() picks a 2D
+    #     (2, 2) mesh for 4 devices instead of the intended 1D (1, 4).
     cfg = _config(
         model,
         batch_size,
@@ -143,6 +146,7 @@ def _gemma4_tp_config(model: str, batch_size: int):
         # opt-level 2 fails with an L1 out-of-memory TT_FATAL; see #5440.
         optimization_level=1,
         enable_tensor_parallel=True,
+        use_2d_mesh=False,
         min_context_len=32,
         enable_const_eval=True,
         experimental_weight_dtype="",


### PR DESCRIPTION
### Ticket
#5728 related (more narrow PR here)

### Problem description
- gemma4-31b-it-tp on QB2 was running on a 2D (2, 2) mesh instead of the intended 1D (1, 4) -- silently regressed by https://github.com/tenstorrent/tt-xla/pull/5224 (Jun 17), which updated the shared _tp_config() helper's use_2d_mesh default but didn't account for _gemma4_tp_config() never routing through that helper, so it fell back to TTConfig's class default (True).
- Slower perf and garbage output currently with 2,2 mesh shape

### What's changed
- Restore the explicit use_2d_mesh=False in _gemma4_tp_config() (tests/benchmark/test_vllm_benchmarks.py) so gemma4-31b-it-tp runs on the intended 1D (1, 4) mesh again.
- decode jumps from 5.5 tok/sec to 7.0 tok/sec locally w/ this change and garbage output seen with mesh_shape=(2,2) is gone, now it looks sensible

### Checklist
-  [x] gemma4-31b-it QB2 vLLM Perf test on CI: https://github.com/tenstorrent/tt-xla/actions/runs/29801283956
