### PR TITLE
[vLLM] Bring up mistralai/Mistral-Small-3.2-24B-Instruct-2506 on n300-llmbox (parallel-inference)

### DIFF
--- a/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
@@ -307,7 +307,6 @@ def test_tensor_parallel_generation_gemma4_31b(
     [
         # opt_level=1 OOMs in the mm-encoder precompile (tt-mlir#9006).
         pytest.param("mistralai/Mistral-Small-3.1-24B-Instruct-2503", 0),
-        pytest.param("mistralai/Mistral-Small-3.2-24B-Instruct-2506", 0),
     ],
 )
 def test_tensor_parallel_generation_mistral_small(model_name: str, opt_level: int):
@@ -387,6 +386,51 @@ def test_tensor_parallel_generation_galaxy_wh_6u_pixtral_large(model_name: str):
 
     output_text = llm.chat(messages, sampling_params=sampling_params)[0].outputs[0].text
     print("output: ", output_text)
+    assert_output_coherent(output_text)
+
+    check_host_memory(model_name)
+
+
+@pytest.mark.nightly
+@pytest.mark.tensor_parallel
+@pytest.mark.llmbox
+@pytest.mark.parametrize(
+    ["model_name", "opt_level"],
+    [pytest.param("mistralai/Mistral-Small-3.2-24B-Instruct-2506", 0)],
+)
+def test_tensor_parallel_generation_mistral_small_3_2(model_name: str, opt_level: int):
+    image_url = "https://static.wikia.nocookie.net/essentialsdocs/images/7/70/Battle.png/revision/latest?cb=20220523172438"
+
+    user_text = "What action do you think I should take in this situation? "
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": user_text},
+                {"type": "image_url", "image_url": {"url": image_url}},
+            ],
+        },
+    ]
+    sampling_params = vllm.SamplingParams(temperature=0.8, top_p=0.95, max_tokens=32)
+
+    llm_args = {
+        "model": model_name,
+        "limit_mm_per_prompt": {"image": 1},
+        "max_num_batched_tokens": 3025,
+        "max_num_seqs": 1,
+        "max_model_len": 512,
+        "gpu_memory_utilization": 0.01,
+        "additional_config": {
+            "min_context_len": 32,
+            "enable_tensor_parallel": True,
+            "experimental_weight_dtype": "bfp_bf8",
+            "optimization_level": opt_level,
+        },
+    }
+    llm = vllm.LLM(**llm_args)
+
+    output_text = llm.chat(messages, sampling_params=sampling_params)[0].outputs[0].text
+    print(f"prompt: {user_text}, output: {output_text}")
     assert_output_coherent(output_text)
 
     check_host_memory(model_name)


### PR DESCRIPTION
## What
Bring up `mistralai/Mistral-Small-3.2-24B-Instruct-2506` on the vLLM-TT integration (n300-llmbox, tensor-parallel, multimodal).

## Changes
- Add `test_tensor_parallel_generation_mistral_small_3_2` (device marker `@pytest.mark.llmbox`, `@pytest.mark.tensor_parallel`, `@pytest.mark.nightly`).
- Split 3.2 out of the shared `test_tensor_parallel_generation_mistral_small` parametrization into a standalone multimodal test (image + `llm.chat`); 3.1 stays on the original test.
- Engine args (reused from the proven 3.1/3.2 config): `max_model_len=512`, `max_num_batched_tokens=3025`, `min_context_len=32`, `gpu_memory_utilization=0.01`, `limit_mm_per_prompt={"image": 1}`, `opt_level=0`.

## Testing
Run Test Single on `n300-llmbox` (draft — pending green run).