### PR TITLE
[Benchmark] Wire SRPO e2e pipeline into benchmark CI

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -91,6 +91,11 @@
         "runs-on": "qb2-blackhole"
       },
       {
+        "name": "srpo",
+        "pytest": "tests/benchmark/test_imagegen.py::test_srpo",
+        "runs-on": "qb2-blackhole"
+      },
+      {
         "name": "janus_pro_1b",
         "pytest": "tests/benchmark/test_imagegen.py::test_janus_pro"
       },

--- a/tests/benchmark/test_imagegen.py
+++ b/tests/benchmark/test_imagegen.py
@@ -555,3 +555,55 @@ def test_glm_image(output_file, request):
         width=width,
         output_image_path="test_glm_image_output.png",
     )
+
+
+def test_srpo(output_file, request):
+    """SRPO (tencent/SRPO) diffusion text-to-image benchmark (DiT tensor-parallel).
+
+    SRPO is a ~12B FLUX.1-dev fine-tune. Like FLUX.1 / GLM-Image, the heavy net
+    (FLUX DiT) runs tensor-parallel across a multi-chip mesh (Megatron-1D on the
+    model axis) while the CLIP + T5 text encoders, scheduler and taef1 VAE stay
+    on CPU. Drives the shared SrpoPipeline from tt_forge_models (companion
+    pipeline PR tenstorrent/tt-forge-models#795). 1024x1024, 28 steps,
+    guidance 3.5 (matches the SRPO nightly e2e test). Multichip — the matrix
+    pins this entry to the 4-chip blackhole (qb2-blackhole).
+    """
+    from third_party.tt_forge_models.srpo.pytorch.pipeline import (
+        HEIGHT,
+        WIDTH,
+        SrpoConfig,
+        SrpoPipeline,
+    )
+
+    prompt = "An astronaut riding a horse in a futuristic city, highly detailed"
+    num_inference_steps = 28
+    height, width = HEIGHT, WIDTH
+
+    def build_pipeline_fn(compile_options):
+        # DiT on TT (tensor-parallel sharded across the mesh); text encoders,
+        # scheduler and VAE on CPU. compile_options are already applied globally
+        # by the harness.
+        pipeline = SrpoPipeline(config=SrpoConfig(compile_options=compile_options))
+        pipeline.setup()
+
+        def generate_fn(prompt, steps):
+            return pipeline.generate(
+                prompt=prompt,
+                num_inference_steps=steps,
+                seed=DEFAULT_SEED,
+            )
+
+        return pipeline, generate_fn
+
+    test_imagegen(
+        build_pipeline_fn=build_pipeline_fn,
+        model_info_name="srpo",
+        output_file=output_file,
+        request=request,
+        prompt=prompt,
+        num_inference_steps=num_inference_steps,
+        height=height,
+        width=width,
+        optimization_level=0,
+        output_image_path="test_srpo_output.png",
+    )


### PR DESCRIPTION
### Ticket

- #5768

### Problem description

SRPO (`tencent/SRPO`, ~12B FLUX.1-dev fine-tune) passes bringup — `srpo/pytorch-Base-tensor_parallel-inference` is `EXPECTED_PASSING` on `main` — with nightly e2e coverage (#5272) and the companion tt-forge-models pipeline (tenstorrent/tt-forge-models#795) both still **in flight** as open drafts. #5272 explicitly **deferred** the benchmark entry *"once #5085's generalized image-gen harness lands"* — which it now has. Per the #5085 pattern (every bringup-passing model wired into both nightly and benchmark CI), this adds SRPO to the **perf-benchmark** harness, mirroring the FLUX.1 multichip entry (#5536).

### What's changed

- **`tests/benchmark/test_imagegen.py`** — config-driven `test_srpo` on the canonical `build_pipeline_fn -> (pipeline, generate_fn)` API, driving the shared `SrpoPipeline` from `tt_forge_models`. The FLUX DiT runs **tensor-parallel** across the mesh (Megatron-1D, model axis); the CLIP + T5 text encoders, scheduler and taef1 VAE stay on CPU. 1024×1024, 28 steps, guidance 3.5 (matches the SRPO nightly e2e test #5272). The pipeline import is **lazy** (inside the test fn), so `--collect-only` stays clean before the submodule uplift.
- **`.github/workflows/perf-bench-matrix.json`** — `srpo` entry pinned to `qb2-blackhole` (4-chip blackhole), matching the `flux1` / `flux2` multichip image-gen convention.

**No `third_party/tt_forge_models` submodule bump** — `SrpoPipeline` is picked up via the normal submodule uplift once the companion pipeline PR merges.

### Verification

- `py_compile` clean; `perf-bench-matrix.json` valid JSON; `black` + `isort` (pinned pre-commit) pass.
- The SRPO pipeline was validated end-to-end on an 8-chip n300-llmbox mesh in the nightly work (#5272 / tt-forge-models#795 report a passing 1024×1024 run). This PR only adds the benchmark wiring around that same shared pipeline.
- **`test_srpo` ran green end-to-end on a 4-chip Blackhole at TP=4** — `1 passed in 1482.98s (0:24:42)`, producing a coherent, prompt-faithful 1024×1024 image and a complete perf JSON. The 4-chip fit this entry was pinned for is confirmed: mesh `(1, 4) (None, 'model')`, 990 DiT params sharded Megatron-1D, **1** TTNN graph (no graph breaks), no OOM.

  | Metric | Value |
  |---|---|
  | `transformer_step_mean_s` | 7.970 |
  | `e2e_latency` (s) | 226.70 |
  | `images_per_second` | 0.004411 |
  | `cpu_overhead_s` | 3.53 |
  | Steady-state loop | 28/28 steps @ 7.97 s/step (no drift) |

  The numbers above are from a manual run on 4× **p150a** Blackhole. The recorded baseline should come from the `qb2-blackhole` benchmark CI run.
- **Benchmark CI run (`qb2-blackhole`, TP=4) — PASSED:** https://github.com/tenstorrent/tt-xla/actions/runs/30336126825 (`manual-benchmark.yml`, `test_filter=srpo`, `runs-on-filter=qb2-blackhole`). `1 passed` — 1024×1024, 28 steps, guidance 3.5: **1 sample, e2e 221.39 s, 0.004517 samples/s**. The run was captured on a **temporary** submodule uplift to the #795 SRPO-pipeline branch (`e4713a47`) so `srpo/pytorch/pipeline.py` resolved; that uplift has been **reverted** on this branch (submodule back to `main` SHA `75b5d091`). It will be redone as a clean `main`-SHA uplift once tt-forge-models#795 merges.




