### PR TITLE
tt backend (non-AOT): key experimental compiled-graph cache by input shape

### DIFF
--- a/python_package/tt_torch/backend/backend.py
+++ b/python_package/tt_torch/backend/backend.py
@@ -588,19 +588,41 @@ class XLAExecutor:
         # call. Empty in the AOT path, where AOTAutograd already lifts them into
         # the incoming *args. Used by both the legacy and experimental flows.
         self.params_and_consts = params_and_consts
-        # Experimental flow only: cached torch-xla compiled graph.
-        self.compiled_graph = None
+        # Experimental flow only: cached torch-xla compiled graphs, keyed by the
+        # input shape/dtype signature. A single XLAExecutor can be invoked with
+        # more than one input shape (e.g. an LLM's prefill seq_len vs decode
+        # seq_len=1 reusing the same dynamo graph); a graph extracted for the
+        # first shape must not be reused for a different shape, or it returns a
+        # stale, wrongly-shaped result.
+        self.compiled_graphs = {}
         self.lazy_execution = lazy_execution
 
+    @staticmethod
+    def _args_shape_key(full_args):
+        # Signature of the input tensors' shapes and dtypes. Non-tensor args are
+        # included by value so differing scalars also key distinct graphs.
+        return tuple(
+            (tuple(a.shape), a.dtype) if isinstance(a, torch.Tensor) else a
+            for a in full_args
+        )
+
     def _call_experimental_compile(self, full_args):
-        if self.compiled_graph is None:
+        # Cache per input shape/dtype signature. `extract_compiled_graph`
+        # specializes the graph to the shapes of `full_args`, so reusing it for a
+        # different shape returns a stale, wrongly-shaped result. Keying by shape
+        # extracts a fresh graph for each distinct shape (e.g. prefill vs decode)
+        # while still avoiding re-tracing on repeated calls with the same shape.
+        key = self._args_shape_key(full_args)
+        compiled_graph = self.compiled_graphs.get(key)
+        if compiled_graph is None:
             # Use `torch_xla` function to replace the graph module with the `optimized_mod`.
             # This helps us avoid tracing the graph on the subsequent model execution. On the next
             # invocation of forward - `optimized_mod` will just look up in its cache and execute the graph
             # without any tracing.
-            self.compiled_graph = bridge.extract_compiled_graph(self.module, full_args)
+            compiled_graph = bridge.extract_compiled_graph(self.module, full_args)
+            self.compiled_graphs[key] = compiled_graph
 
-        return self.compiled_graph(*full_args)
+        return compiled_graph(*full_args)
 
     def __call__(self, *args):
         # Move any CPU tensors in args to XLA. Some model attributes (e.g.

--- a/tests/torch/test_xla_executor_compile_cache.py
+++ b/tests/torch/test_xla_executor_compile_cache.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression test for XLAExecutor's experimental compiled-graph cache.
+
+The non-AOT (experimental) compile path caches the torch-xla compiled graph per
+XLAExecutor. A single executor can be invoked with more than one input shape
+(e.g. an LLM's prefill seq_len vs decode seq_len=1 reusing the same dynamo
+graph). The graph returned by ``bridge.extract_compiled_graph`` is specialized
+to the shapes it was extracted with, so it must be cached *per shape*; reusing a
+prefill-shaped graph for a decode call returns a stale, wrongly-shaped result.
+
+This test mocks ``extract_compiled_graph`` (no device needed) and asserts the
+cache extracts one graph per distinct input shape and reuses it for repeats.
+"""
+
+import pytest
+import torch
+import tt_torch.backend.backend as backend_mod
+from tt_torch.backend.backend import XLAExecutor
+
+
+def _make_executor():
+    # Bypass the heavy __init__ (needs a real GraphModule/signature); we only
+    # exercise the experimental compile-cache logic.
+    ex = XLAExecutor.__new__(XLAExecutor)
+    ex.compiled_graphs = {}
+    ex.module = object()
+    ex.params_and_consts = ()
+    return ex
+
+
+def test_experimental_compile_cache_keys_by_shape(monkeypatch):
+    extractions = []
+
+    def fake_extract(module, full_args):
+        # A real extracted graph is specialized to these shapes; mimic that by
+        # returning a callable that echoes the shapes it was built for (and
+        # ignores the shapes it is later called with).
+        shapes = tuple(tuple(a.shape) for a in full_args if isinstance(a, torch.Tensor))
+        extractions.append(shapes)
+        return lambda *args: shapes
+
+    monkeypatch.setattr(backend_mod.bridge, "extract_compiled_graph", fake_extract)
+
+    ex = _make_executor()
+    prefill = (torch.zeros(32, 128, dtype=torch.long),)
+    decode = (torch.zeros(32, 1, dtype=torch.long),)
+
+    # Prefill: one extraction, graph specialized to (32, 128).
+    assert ex._call_experimental_compile(prefill) == ((32, 128),)
+    # Repeat prefill: cache hit, no new extraction.
+    assert ex._call_experimental_compile(prefill) == ((32, 128),)
+    # Decode (new shape): must extract a fresh graph specialized to (32, 1),
+    # NOT reuse the prefill graph (which would wrongly return (32, 128)).
+    assert ex._call_experimental_compile(decode) == ((32, 1),)
+    # Repeat decode: cache hit.
+    assert ex._call_experimental_compile(decode) == ((32, 1),)
+
+    assert extractions == [((32, 128),), ((32, 1),)], "one extraction per shape"
+    assert len(ex.compiled_graphs) == 2
+
+
+def test_experimental_compile_cache_distinguishes_dtype(monkeypatch):
+    extractions = []
+
+    def fake_extract(module, full_args):
+        extractions.append(tuple(a.dtype for a in full_args))
+        return lambda *args: "graph"
+
+    monkeypatch.setattr(backend_mod.bridge, "extract_compiled_graph", fake_extract)
+
+    ex = _make_executor()
+    ex._call_experimental_compile((torch.zeros(4, dtype=torch.float32),))
+    ex._call_experimental_compile((torch.zeros(4, dtype=torch.bfloat16),))
+    # Same shape, different dtype => two distinct graphs.
+    assert len(ex.compiled_graphs) == 2
+    assert len(extractions) == 2


### PR DESCRIPTION
## Summary

Fixes a stale-graph bug in the non-AOT (experimental) torch.compile path: `XLAExecutor` cached a **single** compiled graph and reused it for **every** call regardless of input shape, so an executor invoked with two shapes (e.g. an LLM's prefill `seq_len` then decode `seq_len=1`) ran the first-shape graph for the second call and returned a stale, wrongly-shaped result.

## Root cause

`XLAExecutor._call_experimental_compile` (the default path — `legacy_compile=False`):

```python
if self.compiled_graph is None:
    self.compiled_graph = bridge.extract_compiled_graph(self.module, full_args)  # specialized to FIRST shape
return self.compiled_graph(*full_args)                                            # reused for ALL shapes
```

`extract_compiled_graph` specializes the graph to the shapes in `full_args`. Caching it in a single slot means a later call with a different shape executes the wrong (earlier-shape) graph.

## Fix

Key the cache by the input tensors' shape/dtype signature, so each distinct shape extracts its own graph while repeated same-shape calls still avoid re-tracing.

## How it was found (CI proof)

`deepseek_v4` e2e (`test_prefill_and_decode_pcc_e2e`, galaxy-bh) with AOTAutograd disabled compiled and ran prefill correctly (logits `(32, 129280)`, **PCC 0.96**), then failed decode with:
```
decode[0] logits shape mismatch: cpu=(32, 129280) device=(32, 128, 512)
```
`(32, 128, 512)` is the prefill-shaped, pre-head intermediate — the stale prefill graph run for the decode input. (CI run 29982670038.) The model is deliberately written to trace two graphs — prefill and decode — which this cache defeated.

## Test

`tests/torch/test_xla_executor_compile_cache.py` — mocks `extract_compiled_graph` (no device), asserts one extraction per distinct input shape/dtype and reuse for repeats. Fails against the previous single-slot cache. Passes locally.

## Validation note

`backend.py` ships in the plugin wheel, so end-to-end validation needs a **fresh build** (not `artifact_sha` wheel-reuse). Full `deepseek_v4` e2e green also needs the companion AOTAutograd-opt-out (`tt_use_aot_autograd=False`) change. Related to #3795.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
