### PR TITLE
Uplift pytorch-xla to b230007

### DIFF
--- a/python_package/requirements.txt
+++ b/python_package/requirements.txt
@@ -4,7 +4,7 @@ jaxlib==0.7.1
 requests
 torch@https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl
 loguru
-torch-xla@https://pypi.eng.aws.tenstorrent.com/torch-xla/torch_xla-2.9.0%2Bgit56f8e61-cp312-cp312-linux_x86_64.whl
+torch-xla@https://pypi.eng.aws.tenstorrent.com/torch-xla/torch_xla-2.9.0%2Bgitb230007-cp312-cp312-linux_x86_64.whl
 
 # Pin nanobind to match tt-metal's version (v2.10.2) for ABI compatibility.
 # A mismatch causes segfaults in nb_type_c2p when PythonModelRunner converts


### PR DESCRIPTION
Update the torch-xla wheel pin from `git56f8e61` to `gitb230007` to incorporate https://github.com/tenstorrent/pytorch-xla/pull/37.

Fixes replay of generated code from vLLM