### PR TITLE
[vLLM] Run Mistral-Small TP multimodal test at default opt_level=1

### DIFF
--- a/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
@@ -303,14 +303,13 @@ def test_tensor_parallel_generation_gemma4_31b(
 @pytest.mark.tensor_parallel
 @pytest.mark.llmbox
 @pytest.mark.parametrize(
-    ["model_name", "opt_level"],
+    ["model_name"],
     [
-        # opt_level=1 OOMs in the mm-encoder precompile (tt-mlir#9006).
-        pytest.param("mistralai/Mistral-Small-3.1-24B-Instruct-2503", 0),
-        pytest.param("mistralai/Mistral-Small-3.2-24B-Instruct-2506", 0),
+        pytest.param("mistralai/Mistral-Small-3.1-24B-Instruct-2503"),
+        pytest.param("mistralai/Mistral-Small-3.2-24B-Instruct-2506"),
     ],
 )
-def test_tensor_parallel_generation_mistral_small(model_name: str, opt_level: int):
+def test_tensor_parallel_generation_mistral_small(model_name: str):
     image_url = "https://static.wikia.nocookie.net/essentialsdocs/images/7/70/Battle.png/revision/latest?cb=20220523172438"
 
     user_text = "What action do you think I should take in this situation? "
@@ -336,7 +335,6 @@ def test_tensor_parallel_generation_mistral_small(model_name: str, opt_level: in
             "min_context_len": 32,
             "enable_tensor_parallel": True,
             "experimental_weight_dtype": "bfp_bf8",
-            "optimization_level": opt_level,
         },
     }
     llm = vllm.LLM(**llm_args)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/9006

### Problem description
- Run Mistral-Small TP multimodal test at default opt_level=1

### What's changed

- Both variants are passing with `opt_level=1`, so remove the `opt_level` parameterization and the `optimization_level` override. The vLLM TT platform default is already set to `optimization_level=1`.

ci link: https://github.com/tenstorrent/tt-xla/actions/runs/30069998977

### Checklist
- [ ] New/Existing tests provide coverage for changes
