### PR TITLE
[CI] Set TTXLA_LOGGER_LEVEL=ERROR to reduce test log spam

### DIFF
--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -409,6 +409,7 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
         HF_TOKEN: ${{ secrets.HF_TOKEN }}
         ENABLE_BRINGUP_STAGE_LOGGING: 1
+        TTXLA_LOGGER_LEVEL: ERROR
       shell: bash
       run: |
         source venv/activate


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
In nightly CI, some jobs fail with:

> This step has been truncated due to its large size. View the raw logs from the ... menu once the workflow run has completed.

Example: https://github.com/tenstorrent/tt-xla/actions/runs/30055773238/job/89439690149

Debugging showed `deepseek-ai/DeepSeek-V2-Lite` emits many tt-xla WARNING logs for `Found an argument on non-XLA device`, and those warnings print full tensor values. That spam bloats the log until GitHub truncates the step.

### What's changed
Added TTXLA_LOGGER_LEVEL: ERROR in call-test.yml to suppress WARNING-level logs (including full tensor dumps). This keeps CI logs from being truncated so all models in the job can run.

ci run: https://github.com/tenstorrent/tt-xla/actions/runs/30075357040/job/89428270033 (replicated the nightly error)
fix ci run: https://github.com/tenstorrent/tt-xla/actions/runs/30079509746/job/89441220001


### Checklist
- [ ] New/Existing tests provide coverage for changes
