### PR TITLE
[vLLM] Hybrid KV cache : per-layer sliding-window ring buffer

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -74,6 +74,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheGroupSpec,
     KVCacheSpec,
     MLAAttentionSpec,
+    SlidingWindowMLASpec,
     SlidingWindowSpec,
     UniformTypeKVCacheSpecs,
 )
@@ -111,6 +112,13 @@ from .overrides import replace_modules
 from .platform import TTConfig
 from .rejection_sampler import RejectionSampler
 from .sampler import Sampler
+from .swa_cache_utils import (
+    assign_ring_slots,
+    build_sliding_ring_page_table,
+    sliding_page_table_width,
+    sliding_ring_phys_blocks,
+    sliding_window_blocks,
+)
 from .vllm_distributed_utils import (
     ParallelismMode,
     kv_cache_shard_factor,
@@ -395,7 +403,17 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 <= scheduler_config.max_num_batched_tokens
             ), f"The max_num_batched_tokens {scheduler_config.max_num_batched_tokens} must be larger than or equal to max_model_len ({self.max_model_len}) * max_num_seqs ({scheduler_config.max_num_seqs})"
         self.most_model_len = envs.VLLM_TPU_MOST_MODEL_LEN
-        self.max_num_blocks_per_req = cdiv(self.max_model_len, self.block_size)
+        # Match vLLM's per-request block-table width, which rounds up to a
+        # multiple of (128 // block_size) for attention-backend alignment (vLLM
+        # #39324). Sizing the padded page-table buffer the same way keeps it >=
+        # that width (initialize_kv_cache asserts this).
+        _base_blocks_per_req = cdiv(self.max_model_len, self.block_size)
+        self.max_num_blocks_per_req = (
+            cdiv(_base_blocks_per_req, 128 // self.block_size)
+            * (128 // self.block_size)
+            if self.block_size <= 128
+            else _base_blocks_per_req
+        )
         self.num_blocks_per_most_len_req = (
             cdiv(self.most_model_len, self.block_size)
             if self.most_model_len is not None
@@ -564,6 +582,29 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             TTAttentionBackend.get_max_num_seqs(self.max_model_len, self.block_size),
             self.max_num_reqs,
         )
+        # Hybrid (multi-group) KV cache state. Defaults describe a single
+        # full-attention group (identical to the pre-hybrid path); (re)set in
+        # initialize_kv_cache once the real kv_cache_groups are known.
+        # _layer_to_group maps each attention layer to its group index so
+        # _prepare_inputs can hand each layer its own group's page table.
+        self._num_kv_cache_groups = 1
+        self._layer_to_group: dict[str, int] = {}
+        # Per-user sliding-ring slots, keyed by req_id so a request keeps its
+        # physical sub-ring across InputBatch row-condensing. Freed on request
+        # exit and reused. See swa_cache_utils.assign_ring_slots.
+        self._req_ring_slot: dict[str, int] = {}
+        self._free_ring_slots: list[int] = list(range(self.max_num_reqs))
+        # Per-group block sizes. vLLM's page-size unification can assign a
+        # different block_size per group when head dims differ across attention
+        # types, so page tables are padded to the widest group's width and each
+        # group uses its own block_size for the prefix-roll offset.
+        self._group_block_sizes: list[int] = [self.block_size]
+        # Per-group sliding-window classification. Sliding groups get a small
+        # physical ring buffer (window_blocks) instead of the full pool, and
+        # _prepare_inputs feeds them a positional ring page_table rather than
+        # absolute block ids. Set in initialize_kv_cache.
+        self._group_is_sliding: list[bool] = [False]
+        self._group_window_blocks: list[int] = [0]
         self.query_start_loc_cpu = torch.zeros(
             self.max_num_tokens + 1,
             dtype=torch.int32,
@@ -643,29 +684,19 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             num_reqs: _alloc_dev((num_reqs,), torch.int32)
             for num_reqs in self._reachable_num_reqs
         }
-        self._page_table_dev_max = {
-            num_reqs: _alloc_dev(
-                (num_reqs, self.max_num_blocks_per_req),
-                self.block_table_cpu.dtype,
-            )
-            for num_reqs in {
-                self.min_num_reqs,
-                self.max_prefill_num_reqs,
-                self.num_reqs_max_model_len,
-            }
-        }
-        self._fill_page_table_dev_max = {
-            num_reqs: _alloc_dev(
-                (num_reqs, self.max_num_blocks_per_req),
-                self.block_table_cpu.dtype,
-            )
-            for num_reqs in {
-                self.min_num_reqs,
-                self.max_prefill_num_reqs,
-                self.num_reqs_max_model_len,
-            }
-        }
         self._cache_position_dev_max = {
+            num_reqs: _alloc_dev((num_reqs,), self.seq_lens_cpu.dtype)
+            for num_reqs in {
+                self.min_num_reqs,
+                self.max_prefill_num_reqs,
+                self.num_reqs_max_model_len,
+            }
+        }
+        # Sliding groups use a window-relative (rotated) cache_position, distinct
+        # from the full groups' absolute one. Separate buffer so both reach the
+        # compiled graph as distinct inputs; all sliding groups share window
+        # geometry so one buffer family suffices.
+        self._cache_position_sliding_dev_max = {
             num_reqs: _alloc_dev((num_reqs,), self.seq_lens_cpu.dtype)
             for num_reqs in {
                 self.min_num_reqs,
@@ -679,24 +710,18 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         if self.most_model_len is not None:
             assert self.num_reqs_most_model_len is not None
             assert self.num_blocks_per_most_len_req is not None
-            self._page_table_dev_most = {
-                num_reqs: _alloc_dev(
-                    (num_reqs, self.num_blocks_per_most_len_req),
-                    self.block_table_cpu.dtype,
-                )
-                for num_reqs in {self.min_num_reqs, self.num_reqs_most_model_len}
-            }
-            self._fill_page_table_dev_most = {
-                num_reqs: _alloc_dev(
-                    (num_reqs, self.num_blocks_per_most_len_req),
-                    self.block_table_cpu.dtype,
-                )
-                for num_reqs in {self.min_num_reqs, self.num_reqs_most_model_len}
-            }
             self._cache_position_dev_most = {
                 num_reqs: _alloc_dev((num_reqs,), self.seq_lens_cpu.dtype)
                 for num_reqs in {self.min_num_reqs, self.num_reqs_most_model_len}
             }
+            self._cache_position_sliding_dev_most = {
+                num_reqs: _alloc_dev((num_reqs,), self.seq_lens_cpu.dtype)
+                for num_reqs in {self.min_num_reqs, self.num_reqs_most_model_len}
+            }
+        # Per-group page_table / fill_page_table device buffers (nested by group
+        # index); rebuilt for the real group count in initialize_kv_cache.
+        # cache_position and chunk_start_idx are group-independent, so stay single.
+        self._alloc_page_table_device_buffers(self._num_kv_cache_groups)
 
         # Persistent per-row-count batch indices for paged_fill_cache, keyed like
         # the page tables so dim0 matches the DP-sharded K/V batch
@@ -711,7 +736,9 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # Fail fast at startup if any per-step buffer can't be looked up by a
         # row count `_prepare_inputs` will request. Buffers shared across both
         # attention paths must cover every reachable count; the per-path page
-        # tables only need their own path's clamped counts (see #5416).
+        # tables only need their own path's clamped counts (see #5416). Page
+        # tables are nested by kv-cache group and all groups share the same
+        # num_reqs keys, so check group 0.
         _checks = {
             "input_ids": (
                 {k[0] for k in self._input_ids_dev},
@@ -724,7 +751,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             "logits_indices": (set(self._logits_indices_dev), self._reachable_num_reqs),
             "batch_idx": (set(self._batch_idx_dev), self._reachable_num_reqs),
             "page_table_dev_max": (
-                set(self._page_table_dev_max),
+                set(self._page_table_dev_max[0]),
                 self._max_len_num_reqs,
             ),
             "cache_position_dev_max": (
@@ -734,7 +761,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         }
         if self.most_model_len is not None:
             _checks["page_table_dev_most"] = (
-                set(self._page_table_dev_most),
+                set(self._page_table_dev_most[0]),
                 self._most_len_num_reqs,
             )
             _checks["cache_position_dev_most"] = (
@@ -1084,6 +1111,72 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         return tuple(tasks)
 
+    def _alloc_page_table_device_buffers(self, num_groups: int) -> None:
+        """(Re)allocate per-group page_table / fill_page_table device buffers.
+
+        Each kv_cache_group has its own block table, so every group needs its own
+        page_table / fill_page_table buffer. Buffers are nested dicts keyed
+        [group_idx][num_reqs]; num_groups == 1 reproduces the pre-hybrid buffers.
+        """
+
+        def _alloc_dev(shape, dtype):
+            return torch.zeros(shape, dtype=dtype, device="cpu").to(self.device)
+
+        dt = self.block_table_cpu.dtype
+        max_reqs = {
+            self.min_num_reqs,
+            self.max_prefill_num_reqs,
+            self.num_reqs_max_model_len,
+        }
+
+        # Per-group page-table width: sliding groups only address their small
+        # window ring, so their page_table is that narrow (the paged ops require
+        # page_table_width <= cache_num_blocks). Full groups use the base width.
+        def _pt_width(g, base_width):
+            if g < len(self._group_is_sliding) and self._group_is_sliding[g]:
+                return sliding_page_table_width(
+                    self._group_window_blocks[g], base_width
+                )
+            return base_width
+
+        self._page_table_dev_max = {
+            g: {
+                nr: _alloc_dev((nr, _pt_width(g, self.max_num_blocks_per_req)), dt)
+                for nr in max_reqs
+            }
+            for g in range(num_groups)
+        }
+        self._fill_page_table_dev_max = {
+            g: {
+                nr: _alloc_dev((nr, _pt_width(g, self.max_num_blocks_per_req)), dt)
+                for nr in max_reqs
+            }
+            for g in range(num_groups)
+        }
+        if self.most_model_len is not None:
+            assert self.num_reqs_most_model_len is not None
+            assert self.num_blocks_per_most_len_req is not None
+            most_reqs = {self.min_num_reqs, self.num_reqs_most_model_len}
+            self._page_table_dev_most = {
+                g: {
+                    nr: _alloc_dev(
+                        (nr, _pt_width(g, self.num_blocks_per_most_len_req)), dt
+                    )
+                    for nr in most_reqs
+                }
+                for g in range(num_groups)
+            }
+            self._fill_page_table_dev_most = {
+                g: {
+                    nr: _alloc_dev(
+                        (nr, _pt_width(g, self.num_blocks_per_most_len_req)), dt
+                    )
+                    for nr in most_reqs
+                }
+                for g in range(num_groups)
+            }
+        self._num_kv_cache_groups = num_groups
+
     def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
         """
         Generates the KVCacheSpec by parsing the kv cache format from each
@@ -1414,57 +1507,124 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             + num_scheduled_tokens_per_req
         )
 
+        # seq_lens / cache_position are identical across kv_cache groups (the
+        # decode position is physical, not per-group), so compute them once. Only
+        # the block tables differ per group (built inside the loop below).
         if use_max_model_len:
             assert self.num_reqs_max_model_len is not None
-            page_table = self.block_table_cpu[
-                :target_num_reqs, : self.max_num_blocks_per_req
-            ]
-            page_table[:actual_num_reqs, : self.max_num_blocks_per_req] = (
-                self.input_batch.block_table[0].get_cpu_tensor()[
-                    :actual_num_reqs, : self.max_num_blocks_per_req
-                ]
-            )
+            width = self.max_num_blocks_per_req
             seq_lens = self.seq_lens_cpu[: self.num_reqs_max_model_len]
+            cache_position_dev = self._cache_position_dev_max[target_num_reqs]
         else:
             assert self.num_reqs_most_model_len is not None
-            page_table = self.block_table_cpu[
-                :target_num_reqs, : self.num_blocks_per_most_len_req
-            ]
-            page_table[:actual_num_reqs, : self.num_blocks_per_most_len_req] = (
-                self.input_batch.block_table[0].get_cpu_tensor()[
-                    :actual_num_reqs, : self.num_blocks_per_most_len_req
-                ]
-            )
+            width = self.num_blocks_per_most_len_req
             seq_lens = self.seq_lens_cpu[: self.num_reqs_most_model_len]
+            cache_position_dev = self._cache_position_dev_most[target_num_reqs]
 
         cache_position = seq_lens - 1
         cache_position = cache_position[:target_num_reqs]
-
         if actual_num_reqs == 1:
             cache_position[1:] = -1
-            page_table[1:, :] = 0
+        # Clear unused rows so persistent device buffers don't keep stale values.
+        cache_position[actual_num_reqs:] = -1
+        cache_position_dev.copy_(cache_position)
+        cache_position = cache_position_dev
 
-        # With prefix caching, some blocks are already filled. Roll each
-        # user's page_table row so paged_fill_cache writes to suffix blocks
-        # instead of overwriting shared prefix blocks. Each user may have a
-        # different prefix length, so we roll per-row. Done outside the
-        # compiled graph to avoid shape-change recompilation.
-        offsets = (
+        # Sliding groups use a window-sized ring: page_table width is
+        # window_blocks and cache_position is window-relative via a per-user
+        # rotation (computed once; all sliding groups share window geometry).
+        # Rotating so the gathered window is in logical order makes the write land
+        # in the correct ring slot and keeps the read's causal + sliding_window
+        # mask correct. At context <= window this degenerates to an identity
+        # page_table + absolute cache_position.
+        sliding_page_table = None
+        sliding_fill_page_table = None
+        sliding_cache_position = None
+        if any(self._group_is_sliding):
+            si = self._group_is_sliding.index(True)
+            bs_s = self._group_block_sizes[si]
+            wb = self._group_window_blocks[si]
+            sliding_width = sliding_page_table_width(wb, width)
+            cur_pos_abs = (seq_lens.numpy() - 1)[:actual_num_reqs].astype(np.int64)
+            cur_block = cur_pos_abs // bs_s
+            num_win = np.minimum(cur_block + 1, wb)
+            start_block = cur_block - num_win + 1
+            # Guard the not-yet-supported sliding-window prefill cases: only rows
+            # being filled (num_scheduled>1) are affected, because paged_fill_cache
+            # matches fill block k positionally to page_table[k] and would corrupt
+            # KV when the fill spans past the window (start_block>0) or continues a
+            # cached prefix (num_computed>0). Decode rows are correct at any context.
+            if actual_num_reqs > 0:
+                nsched = np.asarray(num_scheduled_tokens_per_req[:actual_num_reqs])
+                num_computed = np.asarray(
+                    self.input_batch.num_computed_tokens_cpu[:actual_num_reqs]
+                )
+                filling = nsched > 1
+                bad = filling & ((start_block > 0) | (num_computed > 0))
+                if np.any(bad):
+                    raise NotImplementedError(
+                        "sliding-window prefill for context > window or with "
+                        "prefix caching / chunked prefill (num_computed > 0) is "
+                        "not yet supported on TT"
+                    )
+            # Per-user ring: each request owns a stable physical sub-ring, and
+            # block 0 is a shared null sink that padded / inactive rows
+            # (page_table value 0) write to harmlessly.
+            pt = np.zeros((target_num_reqs, sliding_width), dtype=np.int64)
+            if actual_num_reqs > 0:
+                slots = assign_ring_slots(
+                    self.input_batch.req_ids[:actual_num_reqs],
+                    self.input_batch.req_ids[: self.input_batch.num_reqs],
+                    self._req_ring_slot,
+                    self._free_ring_slots,
+                )
+                pt[:actual_num_reqs] = build_sliding_ring_page_table(
+                    start_block, slots, wb, sliding_width
+                )
+            sliding_page_table = torch.from_numpy(pt.astype(np.int32)).to(
+                self.block_table_cpu.dtype
+            )
+            # fill == read, except inactive (0-token) active rows redirect to the
+            # null block so a re-batched running request's prefill write can't
+            # clobber its ring (mirrors the full-attention zero_sched handling).
+            pt_fill = pt
+            zsr = np.nonzero(num_scheduled_tokens_per_req == 0)[0]
+            zsr = zsr[zsr < actual_num_reqs]
+            if len(zsr) > 0:
+                pt_fill = pt.copy()
+                pt_fill[zsr, :] = 0
+            sliding_fill_page_table = (
+                sliding_page_table
+                if pt_fill is pt
+                else torch.from_numpy(pt_fill.astype(np.int32)).to(
+                    self.block_table_cpu.dtype
+                )
+            )
+            cp_rel = np.full((target_num_reqs,), -1, dtype=np.int64)
+            if actual_num_reqs > 0:
+                cp_rel[:actual_num_reqs] = cur_pos_abs - start_block * bs_s
+            if use_max_model_len:
+                scp_dev = self._cache_position_sliding_dev_max[target_num_reqs]
+            else:
+                scp_dev = self._cache_position_sliding_dev_most[target_num_reqs]
+            scp_dev.copy_(torch.from_numpy(cp_rel).to(scp_dev.dtype))
+            sliding_cache_position = scp_dev
+            if self.parallel_mode in (
+                ParallelismMode.DATA_PARALLEL_ONLY,
+                ParallelismMode.DATA_TENSOR_PARALLEL,
+            ):
+                safe_mark_sharding(sliding_cache_position, self.mesh, ("batch",))
+
+        # With prefix caching, some blocks are already filled. Roll each user's
+        # page_table row so paged_fill_cache writes to suffix blocks instead of
+        # overwriting shared prefix blocks. The roll is in block units, so the
+        # offset depends on the group's block_size -> computed per group in the
+        # loop below from this raw token count.
+        num_computed_tokens_slice = (
             self.input_batch.num_computed_tokens_cpu[:actual_num_reqs]
-            // self.block_size
             if actual_num_reqs > 0
             else np.array([], dtype=np.int64)
         )
-        if np.any(offsets > 0):
-            fill_page_table = page_table.clone()
-            for i in range(actual_num_reqs):
-                if offsets[i] > 0:
-                    fill_page_table[i] = torch.roll(
-                        page_table[i], shifts=-int(offsets[i])
-                    )
-        else:
-            fill_page_table = page_table
-
         # A running (already-prefilled) request re-batched into a later prefill
         # step contributes 0 new tokens. paged_fill_cache still writes its row,
         # and since fill_page_table[row] points at that request's real blocks, it
@@ -1473,57 +1633,21 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # tail, so the tail-clearing below misses it. Redirect these rows' fill to
         # the null block (0); the read-path page_table keeps the real blocks.
         zero_sched_rows = np.nonzero(num_scheduled_tokens_per_req == 0)[0]
-        if len(zero_sched_rows) > 0:
-            if fill_page_table is page_table:
-                fill_page_table = page_table.clone()
-            fill_page_table[zero_sched_rows, :] = 0
-
-        if use_max_model_len:
-            cache_position_dev = self._cache_position_dev_max[target_num_reqs]
-            page_table_dev = self._page_table_dev_max[target_num_reqs]
-            fill_page_table_dev_buf = self._fill_page_table_dev_max[target_num_reqs]
-        else:
-            cache_position_dev = self._cache_position_dev_most[target_num_reqs]
-            page_table_dev = self._page_table_dev_most[target_num_reqs]
-            fill_page_table_dev_buf = self._fill_page_table_dev_most[target_num_reqs]
-
-        # Clear unused rows so persistent device buffers don't keep stale
-        # block indices from a previous call (would surface as KV bleed).
-        cache_position[actual_num_reqs:] = -1
-        page_table[actual_num_reqs:, :] = 0
-        if fill_page_table is not page_table:
-            fill_page_table[actual_num_reqs:, :] = 0
-
-        cache_position_dev.copy_(cache_position)
-        page_table_dev.copy_(page_table)
-        if fill_page_table is page_table:
-            fill_page_table_dev = page_table_dev
-        else:
-            fill_page_table_dev_buf.copy_(fill_page_table)
-            fill_page_table_dev = fill_page_table_dev_buf
-
-        cache_position = cache_position_dev
-        page_table = page_table_dev
-        fill_page_table = fill_page_table_dev
 
         batch_idx = self._batch_idx_dev[target_num_reqs]
         if self.parallel_mode in (
             ParallelismMode.DATA_PARALLEL_ONLY,
             ParallelismMode.DATA_TENSOR_PARALLEL,
         ):
-            # page_table / cache_position / batch_idx must share the K/V input's
-            # per-device leading dim, so shard them on "batch" to match the
-            # DP-sharded inputs. batch_idx feeds paged_fill_cache, whose verifier
-            # requires its dim0 to equal the per-device batch.
-            safe_mark_sharding(page_table, self.mesh, ("batch", None))
+            # cache_position / batch_idx are shared across groups; shard once.
+            # (per-group page_table / fill_page_table are sharded in the loop.)
             safe_mark_sharding(cache_position, self.mesh, ("batch",))
             safe_mark_sharding(batch_idx, self.mesh, ("batch",))
-            if fill_page_table is not page_table:
-                safe_mark_sharding(fill_page_table, self.mesh, ("batch", None))
 
         # Cached-prefix prefill chunk (L > 1 and num_computed > 0): attends over
         # the paged cache via the chunked SDPA op. Decode (L == 1) and first-chunk
-        # prefill take the standard path (chunk_start_idx stays None).
+        # prefill take the standard path (chunk_start_idx stays None). Shared
+        # across all groups.
         num_computed_for_reqs = self.input_batch.num_computed_tokens_cpu[:num_reqs]
         prefix_chunk_step = padded_total_num_scheduled_tokens > 1 and bool(
             np.any(num_computed_for_reqs > 0)
@@ -1537,6 +1661,133 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             )
             chunk_start_idx = self._chunk_start_idx_dev
 
+        # Build one TTMetadata per kv_cache group, each carrying that group's own
+        # page_table / fill_page_table. The per-layer fan-out below hands each
+        # attention layer its group's metadata, so a sliding-window layer never
+        # receives a full-attention layer's block ids. Single group => list of 1
+        # => pre-hybrid behavior.
+        attn_metadata_per_group: list[TTMetadata] = []
+        for g in range(self._num_kv_cache_groups):
+            if use_max_model_len:
+                page_table_dev = self._page_table_dev_max[g][target_num_reqs]
+                fill_page_table_dev_buf = self._fill_page_table_dev_max[g][
+                    target_num_reqs
+                ]
+            else:
+                page_table_dev = self._page_table_dev_most[g][target_num_reqs]
+                fill_page_table_dev_buf = self._fill_page_table_dev_most[g][
+                    target_num_reqs
+                ]
+
+            if self._group_is_sliding[g]:
+                # Sliding: window-width rotated ring page_table + window-relative
+                # cache_position (computed above; shared across sliding groups).
+                # fill == read except for inactive-row null redirect (also above).
+                page_table_dev.copy_(sliding_page_table)
+                if sliding_fill_page_table is sliding_page_table:
+                    fill_page_table_dev = page_table_dev
+                else:
+                    fill_page_table_dev_buf.copy_(sliding_fill_page_table)
+                    fill_page_table_dev = fill_page_table_dev_buf
+                if self.parallel_mode in (
+                    ParallelismMode.DATA_PARALLEL_ONLY,
+                    ParallelismMode.DATA_TENSOR_PARALLEL,
+                ):
+                    safe_mark_sharding(page_table_dev, self.mesh, ("batch", None))
+                    if fill_page_table_dev is not page_table_dev:
+                        safe_mark_sharding(
+                            fill_page_table_dev, self.mesh, ("batch", None)
+                        )
+                attn_metadata_per_group.append(
+                    TTMetadata(
+                        page_table=page_table_dev,
+                        cache_position=sliding_cache_position,
+                        is_causal=True,
+                        attn_mask=None,
+                        fill_page_table=fill_page_table_dev,
+                        dp_size=self.dp_size,
+                        chunk_start_idx=chunk_start_idx,
+                        batch_idx=batch_idx,
+                        num_users=target_num_reqs,
+                    )
+                )
+                continue
+
+            # Full attention: vLLM's absolute block ids + absolute cache_position.
+            block_size_g = self._group_block_sizes[g]
+            group_block_table = self.input_batch.block_table[g].get_cpu_tensor()
+            # This group's block table may be narrower than the uniform buffer
+            # width (a larger block_size -> fewer blocks/req). Copy its own width
+            # into the padded page table; padding columns stay 0 (null block).
+            copy_width = min(group_block_table.shape[1], width)
+
+            # Fresh per-group host staging (not the shared block_table_cpu
+            # scratch) so each group's device buffer is copied from an independent
+            # host tensor and all snapshots stay valid.
+            page_table = torch.zeros(
+                (target_num_reqs, width), dtype=self.block_table_cpu.dtype
+            )
+            page_table[:actual_num_reqs, :copy_width] = group_block_table[
+                :actual_num_reqs, :copy_width
+            ]
+            if actual_num_reqs == 1:
+                page_table[1:, :] = 0
+
+            offsets = (
+                num_computed_tokens_slice // block_size_g
+                if actual_num_reqs > 0
+                else num_computed_tokens_slice
+            )
+            if np.any(offsets > 0):
+                fill_page_table = page_table.clone()
+                for i in range(actual_num_reqs):
+                    if offsets[i] > 0:
+                        fill_page_table[i] = torch.roll(
+                            page_table[i], shifts=-int(offsets[i])
+                        )
+            else:
+                fill_page_table = page_table
+            if len(zero_sched_rows) > 0:
+                if fill_page_table is page_table:
+                    fill_page_table = page_table.clone()
+                fill_page_table[zero_sched_rows, :] = 0
+
+            # Clear unused rows so persistent device buffers don't keep stale
+            # block indices from a previous call (would surface as KV bleed).
+            page_table[actual_num_reqs:, :] = 0
+            if fill_page_table is not page_table:
+                fill_page_table[actual_num_reqs:, :] = 0
+
+            page_table_dev.copy_(page_table)
+            if fill_page_table is page_table:
+                fill_page_table_dev = page_table_dev
+            else:
+                fill_page_table_dev_buf.copy_(fill_page_table)
+                fill_page_table_dev = fill_page_table_dev_buf
+
+            if self.parallel_mode in (
+                ParallelismMode.DATA_PARALLEL_ONLY,
+                ParallelismMode.DATA_TENSOR_PARALLEL,
+            ):
+                # page_table shares the K/V input's per-device leading dim.
+                safe_mark_sharding(page_table_dev, self.mesh, ("batch", None))
+                if fill_page_table_dev is not page_table_dev:
+                    safe_mark_sharding(fill_page_table_dev, self.mesh, ("batch", None))
+
+            attn_metadata_per_group.append(
+                TTMetadata(
+                    page_table=page_table_dev,
+                    cache_position=cache_position,
+                    is_causal=True,
+                    attn_mask=None,
+                    fill_page_table=fill_page_table_dev,
+                    dp_size=self.dp_size,
+                    chunk_start_idx=chunk_start_idx,
+                    batch_idx=batch_idx,
+                    num_users=target_num_reqs,
+                )
+            )
+
         if self.lora_config is not None:
             # We need to respect padding when activating LoRA adapters
             padded_num_scheduled_tokens_per_req = np.copy(
@@ -1548,17 +1799,6 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
             self.set_active_loras(self.input_batch, padded_num_scheduled_tokens_per_req)
 
-        attn_metadata = TTMetadata(
-            page_table=page_table,
-            cache_position=cache_position,
-            is_causal=True,
-            attn_mask=None,
-            fill_page_table=fill_page_table,
-            dp_size=self.dp_size,
-            chunk_start_idx=chunk_start_idx,
-            batch_idx=batch_idx,
-            num_users=target_num_reqs,
-        )
         spec_decode_metadata = self._create_spec_decode_metadata(
             scheduler_output=scheduler_output,
             start_index=start_index,
@@ -1607,9 +1847,12 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
             self.set_active_loras(self.input_batch, padded_num_scheduled_tokens_per_req)
 
-        per_layer_attn_metadata = dict.fromkeys(
-            self._attention_layer_names, attn_metadata
-        )
+        # Route each attention layer to its kv_cache group's metadata. Layers
+        # with no KV group (e.g. encoder-only) fall back to group 0.
+        per_layer_attn_metadata = {
+            ln: attn_metadata_per_group[self._layer_to_group.get(ln, 0)]
+            for ln in self._attention_layer_names
+        }
         return (
             per_layer_attn_metadata,
             logits_indices,
@@ -2622,9 +2865,6 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 safe_mark_sharding(input_ids, self.mesh, ("batch", None))
             safe_mark_sharding(position_ids, self.mesh, ("batch", None))
 
-        page_table = torch.zeros((num_reqs, num_blocks), dtype=torch.int32).to(
-            self.device
-        )
         cache_position = torch.ones((num_reqs,), dtype=torch.int32).to(self.device)
 
         batch_idx = self._batch_idx_dev[num_reqs]
@@ -2632,47 +2872,78 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             ParallelismMode.DATA_PARALLEL_ONLY,
             ParallelismMode.DATA_TENSOR_PARALLEL,
         ):
-            # page_table / cache_position / batch_idx must share the K/V input's
-            # per-device leading dim, so shard them on "batch" to match the
-            # DP-sharded inputs (batch_idx feeds paged_fill_cache).
-            safe_mark_sharding(page_table, self.mesh, ("batch", None))
+            # cache_position / batch_idx are shared across groups; shard once.
             safe_mark_sharding(cache_position, self.mesh, ("batch",))
             safe_mark_sharding(batch_idx, self.mesh, ("batch",))
 
         # prefix_chunk=True precompiles the cached-prefix prefill graph: chunk_start_idx
         # routes attention through the chunked SDPA op. Only reached when the op is
         # usable (see _precompile_backbone gating on _chunked_sdpa_active).
-        fill_page_table = None
         chunk_start_idx = None
         if prefix_chunk:
-            # A continuation chunk uses a distinct fill_page_table at runtime;
-            # pass a separate tensor so the traced graph has matching input arity
-            # (else an extra graph recompiles at runtime).
-            fill_page_table = torch.zeros((num_reqs, num_blocks), dtype=torch.int32).to(
+            # fill_page_table is built per kv-cache group below (and sharded
+            # there, as #5797 requires) instead of once here.
+            chunk_start_idx = torch.zeros((1,), dtype=torch.int32).to(self.device)
+
+        # One dummy page_table (and fill_page_table) per kv_cache group so the
+        # traced graph has the same number of distinct page_table inputs as the
+        # runtime fan-out (else an extra graph recompiles). Sliding groups get a
+        # window-width page_table and a distinct (relative) cache_position.
+        sliding_cache_position = None
+        if any(self._group_is_sliding):
+            sliding_cache_position = torch.ones((num_reqs,), dtype=torch.int32).to(
                 self.device
             )
             if self.parallel_mode in (
                 ParallelismMode.DATA_PARALLEL_ONLY,
                 ParallelismMode.DATA_TENSOR_PARALLEL,
             ):
-                safe_mark_sharding(fill_page_table, self.mesh, ("batch", None))
-            chunk_start_idx = torch.zeros((1,), dtype=torch.int32).to(self.device)
+                safe_mark_sharding(sliding_cache_position, self.mesh, ("batch",))
+        attn_metadata_per_group = []
+        for _g in range(self._num_kv_cache_groups):
+            if self._group_is_sliding[_g]:
+                pt_w = sliding_page_table_width(
+                    self._group_window_blocks[_g], num_blocks
+                )
+                grp_cache_position = sliding_cache_position
+            else:
+                pt_w = num_blocks
+                grp_cache_position = cache_position
+            page_table = torch.zeros((num_reqs, pt_w), dtype=torch.int32).to(
+                self.device
+            )
+            fill_page_table = None
+            if prefix_chunk:
+                # A continuation chunk uses a distinct fill_page_table at runtime;
+                # pass a separate tensor so the traced graph has matching arity.
+                fill_page_table = torch.zeros((num_reqs, pt_w), dtype=torch.int32).to(
+                    self.device
+                )
+            if self.parallel_mode in (
+                ParallelismMode.DATA_PARALLEL_ONLY,
+                ParallelismMode.DATA_TENSOR_PARALLEL,
+            ):
+                safe_mark_sharding(page_table, self.mesh, ("batch", None))
+                if fill_page_table is not None:
+                    safe_mark_sharding(fill_page_table, self.mesh, ("batch", None))
+            attn_metadata_per_group.append(
+                TTMetadata(
+                    page_table=page_table,
+                    cache_position=grp_cache_position,
+                    is_causal=True,
+                    attn_mask=None,
+                    dp_size=self.dp_size,
+                    fill_page_table=fill_page_table,
+                    chunk_start_idx=chunk_start_idx,
+                    batch_idx=batch_idx,
+                    num_users=num_reqs,
+                )
+            )
 
-        attn_metadata = TTMetadata(
-            page_table=page_table,
-            cache_position=cache_position,
-            is_causal=True,
-            attn_mask=None,
-            dp_size=self.dp_size,
-            fill_page_table=fill_page_table,
-            chunk_start_idx=chunk_start_idx,
-            batch_idx=batch_idx,
-            num_users=num_reqs,
-        )
-
-        per_layer_attn_metadata = dict.fromkeys(
-            self._attention_layer_names, attn_metadata
-        )
+        per_layer_attn_metadata = {
+            ln: attn_metadata_per_group[self._layer_to_group.get(ln, 0)]
+            for ln in self._attention_layer_names
+        }
         if self.uses_mrope:
             position_ids = position_ids.unsqueeze(0).expand(3, -1, -1)
 
@@ -3067,10 +3338,6 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         dummy_inputs_embeds = torch.zeros(
             (num_reqs, num_tokens, hsize), dtype=self._hidden_states_dtype
         ).to(self.device)
-        page_table = torch.zeros(
-            (num_reqs, self.max_num_blocks_per_req),
-            dtype=torch.int32,
-        ).to(self.device)
         cache_position = torch.ones((num_reqs,), dtype=torch.int32).to(self.device)
 
         batch_idx = self._batch_idx_dev[num_reqs]
@@ -3078,10 +3345,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             ParallelismMode.DATA_PARALLEL_ONLY,
             ParallelismMode.DATA_TENSOR_PARALLEL,
         ):
-            # batch_idx feeds paged_fill_cache; shard it on "batch" like
-            # page_table / cache_position so its per-device dim0 matches the
-            # DP-sharded K/V input.
-            safe_mark_sharding(page_table, self.mesh, ("batch", None))
+            # cache_position / batch_idx are shared across groups; shard once.
             safe_mark_sharding(cache_position, self.mesh, ("batch",))
             safe_mark_sharding(batch_idx, self.mesh, ("batch",))
 
@@ -3089,33 +3353,69 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # graph is compiled here (mirrors _dummy_run); chunk_start_idx routes
         # attention through the chunked op, and a distinct fill_page_table tensor
         # keeps the traced input arity matching runtime.
-        fill_page_table = page_table
         chunk_start_idx = None
         if prefix_chunk:
-            fill_page_table = torch.zeros(
-                (num_reqs, self.max_num_blocks_per_req), dtype=torch.int32
-            ).to(self.device)
+            # fill_page_table is built per kv-cache group below (and sharded
+            # there, as #5797 requires) instead of once here.
+            chunk_start_idx = torch.zeros((1,), dtype=torch.int32).to(self.device)
+
+        # One dummy page_table (and fill_page_table) per kv_cache group so the
+        # traced graph's distinct page_table input count matches the runtime
+        # fan-out. Sliding groups get a window-width page_table and a distinct
+        # (relative) cache_position.
+        sliding_cache_position = None
+        if any(self._group_is_sliding):
+            sliding_cache_position = torch.ones((num_reqs,), dtype=torch.int32).to(
+                self.device
+            )
             if self.parallel_mode in (
                 ParallelismMode.DATA_PARALLEL_ONLY,
                 ParallelismMode.DATA_TENSOR_PARALLEL,
             ):
-                safe_mark_sharding(fill_page_table, self.mesh, ("batch", None))
-            chunk_start_idx = torch.zeros((1,), dtype=torch.int32).to(self.device)
-
-        attn_metadata = TTMetadata(
-            page_table=page_table,
-            cache_position=cache_position,
-            is_causal=True,
-            attn_mask=None,
-            fill_page_table=fill_page_table,
-            dp_size=self.dp_size,
-            chunk_start_idx=chunk_start_idx,
-            batch_idx=batch_idx,
-            num_users=num_reqs,
-        )
-        per_layer_attn_metadata = dict.fromkeys(
-            self._attention_layer_names, attn_metadata
-        )
+                safe_mark_sharding(sliding_cache_position, self.mesh, ("batch",))
+        attn_metadata_per_group = []
+        for _g in range(self._num_kv_cache_groups):
+            if self._group_is_sliding[_g]:
+                pt_w = sliding_page_table_width(
+                    self._group_window_blocks[_g], self.max_num_blocks_per_req
+                )
+                grp_cache_position = sliding_cache_position
+            else:
+                pt_w = self.max_num_blocks_per_req
+                grp_cache_position = cache_position
+            page_table = torch.zeros(
+                (num_reqs, pt_w),
+                dtype=torch.int32,
+            ).to(self.device)
+            fill_page_table = page_table
+            if prefix_chunk:
+                fill_page_table = torch.zeros((num_reqs, pt_w), dtype=torch.int32).to(
+                    self.device
+                )
+            if self.parallel_mode in (
+                ParallelismMode.DATA_PARALLEL_ONLY,
+                ParallelismMode.DATA_TENSOR_PARALLEL,
+            ):
+                safe_mark_sharding(page_table, self.mesh, ("batch", None))
+                if fill_page_table is not page_table:
+                    safe_mark_sharding(fill_page_table, self.mesh, ("batch", None))
+            attn_metadata_per_group.append(
+                TTMetadata(
+                    page_table=page_table,
+                    cache_position=grp_cache_position,
+                    is_causal=True,
+                    attn_mask=None,
+                    fill_page_table=fill_page_table,
+                    dp_size=self.dp_size,
+                    chunk_start_idx=chunk_start_idx,
+                    batch_idx=batch_idx,
+                    num_users=num_reqs,
+                )
+            )
+        per_layer_attn_metadata = {
+            ln: attn_metadata_per_group[self._layer_to_group.get(ln, 0)]
+            for ln in self._attention_layer_names
+        }
 
         dummy_inputs, dummy_inputs_embeds = self._get_model_inputs(
             dummy_inputs, mm_embed_inputs=None
@@ -3786,12 +4086,6 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             kv_cache_config: Configuration for the KV cache, including the KV
             cache size of each layer
         """
-        if len(kv_cache_config.kv_cache_groups) > 1:
-            raise NotImplementedError(
-                "Hybrid models with more than one KV cache type are not "
-                "supported yet."
-            )
-
         # This may be a valid config if full model is not being compiled; for
         # example, using num_hidden_layers override to compile only a subset of
         # layers. In that case, we should not raise an error but just skip the
@@ -3802,10 +4096,42 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             )
             return
 
-        if (
-            kv_cache_config.kv_cache_groups[0].kv_cache_spec.block_size
-            != self.block_size
-        ):
+        # Hybrid models (sliding-window + full-attention layers) produce >1
+        # kv_cache_group. vLLM may assign a different block_size per group
+        # (page-size unification across heterogeneous head dims), so keep the
+        # per-group block sizes and pad page tables to the widest group.
+        groups = kv_cache_config.kv_cache_groups
+        block_sizes = [g.kv_cache_spec.block_size for g in groups]
+        self._group_block_sizes = block_sizes
+        # Classify groups sliding vs full before allocating device buffers so the
+        # per-group page-table widths (window_blocks for sliding) are correct.
+        self._group_is_sliding = [
+            isinstance(g.kv_cache_spec, SlidingWindowSpec) for g in groups
+        ]
+
+        # Ring width per user; the worker reserves bytes with the same helper.
+        self._group_window_blocks = [
+            (
+                sliding_window_blocks(
+                    g.kv_cache_spec.sliding_window, g.kv_cache_spec.block_size
+                )
+                if isinstance(g.kv_cache_spec, SlidingWindowSpec)
+                else 0
+            )
+            for g in groups
+        ]
+        # All sliding groups must share window geometry (block_size, window) so a
+        # single relative-cache_position buffer serves them (see __init__).
+        _sw = {
+            (g.kv_cache_spec.block_size, self._group_window_blocks[i])
+            for i, g in enumerate(groups)
+            if self._group_is_sliding[i]
+        }
+        assert len(_sw) <= 1, f"non-uniform sliding groups not supported yet: {_sw}"
+        # Rebuild the InputBatch with one block table per group (the initial one
+        # built in __init__ has a single block table). Also (re)allocate the
+        # per-group page-table device buffers to match the real group count.
+        if len(groups) != self._num_kv_cache_groups:
             self.input_batch = InputBatch(
                 max_num_reqs=self.max_num_reqs,
                 max_model_len=self.max_model_len,
@@ -3813,81 +4139,112 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 device="cpu",
                 pin_memory=self.pin_memory,
                 vocab_size=self.model_config.get_vocab_size(),
-                block_sizes=[
-                    kv_cache_config.kv_cache_groups[0].kv_cache_spec.block_size
-                ],
-                kernel_block_sizes=[
-                    kv_cache_config.kv_cache_groups[0].kv_cache_spec.block_size
-                ],
+                block_sizes=block_sizes,
+                kernel_block_sizes=block_sizes,
                 is_pooling_model=False,
             )
-        # Verify dtype compatibility between block_table_cpu and input_batch
-        assert (
-            self.block_table_cpu.dtype
-            == self.input_batch.block_table[0].get_cpu_tensor().dtype
-        )
-
-        kv_cache_sizes = {}
-        for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
-            assert len(kv_cache_tensor.shared_by) == 1, (
-                "KV cache tensor shared by multiple layers is not supported in " "TPU."
+        # Always (re)allocate the per-group page-table device buffers: even at an
+        # unchanged group count, sliding groups need window-width buffers (the
+        # __init__ default built them at full width). The realloc is idempotent.
+        self._alloc_page_table_device_buffers(len(groups))
+        # Verify block_table dtype compatibility and that every group's
+        # block-table width fits the uniform (padded) page-table buffer width.
+        # max_num_blocks_per_req is sized from the base (smallest) block_size and
+        # so is the widest group; fail loudly if a future config is smaller.
+        for g in range(len(groups)):
+            bt = self.input_batch.block_table[g].get_cpu_tensor()
+            assert self.block_table_cpu.dtype == bt.dtype
+            assert bt.shape[1] <= self.max_num_blocks_per_req, (
+                f"group {g} block-table width {bt.shape[1]} exceeds the padded "
+                f"page-table buffer width {self.max_num_blocks_per_req} "
+                f"(block_sizes={block_sizes})"
             )
-            kv_cache_sizes[kv_cache_tensor.shared_by[0]] = kv_cache_tensor.size
 
-        kv_caches: dict[str, torch.Tensor] = {}
-        for kv_cache_group in kv_cache_config.kv_cache_groups:
+        # Resolve each layer's per-layer spec. vLLM's byte-overlay (one buffer,
+        # per-layer reshaped views) is impossible on TT (TILE layout + torch
+        # can't alias), so every layer gets its own real tensor:
+        #   - full groups: physical = the shared pool's num_blocks (page_table
+        #     carries absolute block ids).
+        #   - sliding groups: physical = a small window-sized ring buffer;
+        #     _prepare_inputs feeds them a positional ring page_table so they
+        #     never index the full pool.
+        # The worker reserves the sliding rings' bytes before vLLM sizes
+        # num_blocks, so full + sliding fit `available` without the overlay.
+        layer_to_spec: dict[str, KVCacheSpec] = {}
+        for kv_cache_group in groups:
+            gspec = kv_cache_group.kv_cache_spec
             for layer_name in kv_cache_group.layer_names:
-                kv_cache_spec = _get_layer_kv_cache_spec(
-                    kv_cache_group.kv_cache_spec, layer_name
+                layer_to_spec[layer_name] = _get_layer_kv_cache_spec(gspec, layer_name)
+
+        # SlidingWindowMLASpec subclasses SlidingWindowSpec (not MLAAttentionSpec),
+        # so isinstance(spec, MLAAttentionSpec) alone would misclassify a
+        # sliding-window MLA layer as non-MLA. Match both MLA spec types.
+        def _is_mla(spec):
+            return isinstance(spec, (MLAAttentionSpec, SlidingWindowMLASpec))
+
+        def _kv_shape(spec, num_blocks):
+            backend = TTMLAAttentionBackend if _is_mla(spec) else TTAttentionBackend
+            return backend.get_kv_cache_shape(
+                num_blocks, spec.block_size, spec.num_kv_heads, spec.head_size
+            )
+
+        pool_num_blocks = kv_cache_config.num_blocks
+        kv_caches: dict[str, torch.Tensor] = {}
+        for g, kv_cache_group in enumerate(groups):
+            if self._group_is_sliding[g]:
+                # Per-user ring: max_num_reqs window_blocks sub-rings + a leading
+                # null block (block 0). Each request maps to a stable sub-ring
+                # [1 + slot*wb, 1 + (slot+1)*wb) (assign_ring_slots), so
+                # concurrent requests never collide; padded / inactive rows write
+                # to block 0 harmlessly. The worker reserves these bytes up front.
+                phys_blocks = sliding_ring_phys_blocks(
+                    self._group_window_blocks[g], self.max_num_reqs
                 )
-                tensor_size = kv_cache_sizes[layer_name]
-                assert tensor_size % kv_cache_spec.page_size_bytes == 0
-                num_blocks = tensor_size // kv_cache_spec.page_size_bytes  # noqa
-                if isinstance(kv_cache_spec, MLAAttentionSpec):
-                    # MLA stores a SINGLE concatenated latent KV tensor per
-                    # slot (num_kv_heads == 1, head_size == kv_lora_rank +
-                    # qk_rope_head_dim).
-                    kv_cache_shape = TTMLAAttentionBackend.get_kv_cache_shape(
-                        num_blocks,
-                        kv_cache_spec.block_size,
-                        kv_cache_spec.num_kv_heads,
-                        kv_cache_spec.head_size,
-                    )
-                    dtype = kv_cache_spec.dtype
-                    mla_cache = torch.zeros(kv_cache_shape, dtype=dtype).to(self.device)
-                    kv_caches[layer_name] = mla_cache
-                elif isinstance(kv_cache_spec, AttentionSpec):
+            else:
+                phys_blocks = pool_num_blocks
+            for layer_name in kv_cache_group.layer_names:
+                spec = layer_to_spec[layer_name]
+                if isinstance(spec, AttentionSpec):
                     tp_size = kv_cache_shard_factor(self)
                     if tp_size > 1:
-                        num_kv_heads = kv_cache_spec.num_kv_heads
                         # mark_sharding() below does the real sharding; this
                         # just fails loudly instead of it silently falling
                         # back to replication (see safe_mark_sharding).
-                        assert num_kv_heads % tp_size == 0, (
-                            f"num_kv_heads {num_kv_heads} must be divisible by "
-                            f"tp_size {tp_size} for correct KV-head sharding"
+                        assert spec.num_kv_heads % tp_size == 0, (
+                            f"num_kv_heads {spec.num_kv_heads} must be divisible "
+                            f"by tp_size {tp_size} for correct KV-head sharding"
                         )
-                    kv_cache_shape = TTAttentionBackend.get_kv_cache_shape(
-                        num_blocks,
-                        kv_cache_spec.block_size,
-                        kv_cache_spec.num_kv_heads,
-                        kv_cache_spec.head_size,
+                shape = _kv_shape(spec, phys_blocks)
+                if _is_mla(spec):
+                    kv_caches[layer_name] = torch.zeros(shape, dtype=spec.dtype).to(
+                        self.device
                     )
+                elif isinstance(spec, AttentionSpec):
                     # spec.dtype may be a 1-byte accounting dtype; the staged
                     # buffer uses the real transfer dtype (converted on device).
-                    dtype = self.kv_cache_dtype
-
-                    # Allocate separate K and V cache tensors to avoid
-                    # slice/concat copies in the compiled decode graph.
-                    k_cache = torch.zeros(kv_cache_shape, dtype=dtype).to(self.device)
-                    v_cache = torch.zeros(kv_cache_shape, dtype=dtype).to(self.device)
-
+                    # Separate K and V avoid slice/concat copies in the decode graph.
+                    k_cache = torch.zeros(shape, dtype=self.kv_cache_dtype).to(
+                        self.device
+                    )
+                    v_cache = torch.zeros(shape, dtype=self.kv_cache_dtype).to(
+                        self.device
+                    )
                     kv_caches[layer_name] = [k_cache, v_cache]
                 else:
                     raise NotImplementedError
 
         # Set up cross-layer KV cache sharing if needed
         self.maybe_setup_cross_layer_kv_sharing(kv_caches, kv_cache_config)
+
+        # Map each attention layer to its kv_cache group index, driving the
+        # per-layer attention-metadata fan-out in _prepare_inputs / dummy runs.
+        # Built after cross-layer sharing so shared layers resolve to the correct
+        # group.
+        self._layer_to_group = {
+            ln: g
+            for g, grp in enumerate(kv_cache_config.kv_cache_groups)
+            for ln in grp.layer_names
+        }
 
         bind_kv_cache(
             kv_caches,
@@ -3906,11 +4263,17 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             # each chip will be budgeted tp_size times too little.
             pass
         elif self.enable_tensor_parallel:
-            # Shard KV Cache — each entry is [k_cache, v_cache].
+            # Shard KV Cache — each entry is [k_cache, v_cache]. The same physical
+            # buffer can appear under multiple layers (cross-layer sharing), so
+            # dedup by tensor identity to mark each buffer's sharding exactly once.
+            _sharded_ids: set[int] = set()
             for entry in self.kv_caches:
                 is_pair = isinstance(entry, (list, tuple))
                 caches = entry if is_pair else [entry]
                 for cache in caches:
+                    if id(cache) in _sharded_ids:
+                        continue
+                    _sharded_ids.add(id(cache))
                     assert cache.ndim == 4, "KV cache tensor must be 4D."
                     if is_pair:
                         safe_mark_sharding(

--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -336,6 +336,13 @@ class TTPlatform(Platform):
         return vm.available, vm.total
 
     @classmethod
+    def support_hybrid_kv_cache(cls) -> bool:
+        # Emit per-attention-type kv_cache_groups (like every other platform);
+        # the base default False downgrades sliding-window layers to full
+        # attention, making them pay the full max_model_len KV cost.
+        return True
+
+    @classmethod
     def is_async_output_supported(cls, enforce_eager: Optional[bool]) -> bool:
         return False
 

--- a/integrations/vllm_plugin/vllm_tt/swa_cache_utils.py
+++ b/integrations/vllm_plugin/vllm_tt/swa_cache_utils.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Pure helpers for the hybrid KV sliding-window ring buffers.
+
+Shared by the worker (byte reservation) and the model runner (physical sizing,
+slot assignment, page-table rotation) so the geometry cannot drift between the
+two: the worker reserves exactly what the runner later allocates.
+
+Everything here is pure (numpy / ints only, no device or vLLM state) so it can
+be unit tested without hardware.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from vllm.utils.math_utils import cdiv
+
+# A paged-op page-table stick is window_blocks int32 block ids and must be
+# 32-byte aligned: window_blocks * 4 % 32 == 0 -> window_blocks % 8 == 0.
+PAGE_TABLE_STICK_BLOCK_ALIGNMENT = 8
+
+
+def sliding_window_blocks(sliding_window: int, block_size: int) -> int:
+    """Blocks per user in a sliding ring, page-table-stick aligned.
+
+    ``cdiv(window, block_size) + 1`` covers a window straddling a block
+    boundary; the round-up satisfies the stick alignment above. The ring is
+    over-provisioned to that width -- the sliding_window mask still limits
+    attention to the real window.
+    """
+    n = cdiv(sliding_window, block_size) + 1
+    align = PAGE_TABLE_STICK_BLOCK_ALIGNMENT
+    return ((n + align - 1) // align) * align
+
+
+def sliding_ring_phys_blocks(window_blocks: int, max_num_reqs: int) -> int:
+    """Physical blocks for one sliding layer: one sub-ring per batch slot, plus
+    a leading null block (index 0) that padded / inactive rows write to."""
+    return window_blocks * max_num_reqs + 1
+
+
+def sliding_ring_reserve_bytes(
+    window_blocks: int, max_num_reqs: int, page_size_bytes: int
+) -> int:
+    """Bytes one sliding layer's ring costs, in vLLM's KV accounting units.
+
+    NOTE the units: vLLM sizes the block pool with the full, un-sharded
+    ``page_size_bytes``, and the worker inflates the budget by the KV shard
+    factor to match. The reservation is therefore counted the same way -- do NOT
+    divide by the shard count here, or the rings get under-reserved by that
+    factor.
+    """
+    return sliding_ring_phys_blocks(window_blocks, max_num_reqs) * page_size_bytes
+
+
+def sliding_page_table_width(window_blocks: int, base_width: int) -> int:
+    """Page-table width for a sliding group: the ring never needs more columns
+    than its window, but stays within the full-attention buffer width."""
+    return min(window_blocks, base_width)
+
+
+def assign_ring_slots(
+    row_req_ids: list[str],
+    batch_req_ids: list[str],
+    req_ring_slot: dict[str, int],
+    free_ring_slots: list[int],
+) -> np.ndarray:
+    """Assign each request a stable per-user sliding-ring slot.
+
+    The physical sliding ring is split into one sub-ring per slot; a request
+    must keep the SAME slot for its lifetime, otherwise a subsequent decode step
+    would read/write a different sub-ring. Keying the slot by req_id (not batch
+    row) makes it survive InputBatch row-condensing, which reorders rows when
+    requests finish.
+
+    ``row_req_ids`` are the requests to return slots for (the current prepare
+    pass's rows). ``batch_req_ids`` is the full current batch, used to reclaim
+    the slots of departed requests -- reclaiming against the full batch (not the
+    per-pass subset) means a partial pass never frees a still-live request's
+    slot. Freed slots are reused by later requests, whose fresh prefill
+    overwrites the sub-ring. Mutates ``req_ring_slot`` and ``free_ring_slots`` in
+    place and returns an int64 array of slots aligned with ``row_req_ids``.
+    """
+    active = set(batch_req_ids)
+    for rid in [r for r in req_ring_slot if r not in active]:
+        free_ring_slots.append(req_ring_slot.pop(rid))
+    # Hand out the smallest free slot first (deterministic across steps).
+    free_ring_slots.sort(reverse=True)
+    slots = []
+    for rid in row_req_ids:
+        slot = req_ring_slot.get(rid)
+        if slot is None:
+            slot = free_ring_slots.pop()
+            req_ring_slot[rid] = slot
+        slots.append(slot)
+    return np.array(slots, dtype=np.int64)
+
+
+def build_sliding_ring_page_table(
+    start_block: np.ndarray,
+    slots: np.ndarray,
+    window_blocks: int,
+    width: int,
+) -> np.ndarray:
+    """Page table (rows x width) pointing into each request's own sub-ring.
+
+    Row i owns physical blocks ``[1 + slots[i]*wb, 1 + (slots[i]+1)*wb)``. The
+    window is rotated into logical order (``% wb``) so the fill lands on the
+    correct ring position and the read's causal + sliding_window mask stays
+    correct. Block 0 is left for the shared null sink.
+    """
+    jr = np.arange(width)
+    rot = (start_block[:, None] + jr[None, :]) % window_blocks
+    return rot + (1 + slots * window_blocks)[:, None]

--- a/integrations/vllm_plugin/vllm_tt/worker.py
+++ b/integrations/vllm_plugin/vllm_tt/worker.py
@@ -33,7 +33,12 @@ from vllm.tasks import SupportedTask
 from vllm.utils.math_utils import cdiv
 from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE, set_random_seed
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
-from vllm.v1.kv_cache_interface import AttentionSpec, KVCacheConfig, KVCacheSpec
+from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
+    KVCacheConfig,
+    KVCacheSpec,
+    SlidingWindowSpec,
+)
 from vllm.v1.outputs import DraftTokenIds, ModelRunnerOutput
 from vllm.v1.utils import report_usage_stats
 from vllm.v1.worker.utils import bind_kv_cache
@@ -44,6 +49,7 @@ from .logger import tt_init_logger
 from .model_runner import TTModelRunner
 from .platform import TTConfig
 from .pooling_runner import TTPoolingModelRunner
+from .swa_cache_utils import sliding_ring_reserve_bytes, sliding_window_blocks
 from .vllm_distributed_utils import kv_cache_shard_factor
 
 logger = tt_init_logger(__name__)
@@ -330,6 +336,43 @@ class TTWorker:
             # We adjust the usable memory size for the KV cache to prevent OOM
             # errors, even after padding the head_size.
             kv_cache_bytes = kv_cache_bytes * head_size // padded_head_size
+        # Reserve physical bytes for sliding-window layers' small ring buffers.
+        # Every layer gets its own tensor (no byte-overlay on TT), so carving the
+        # rings out here keeps the full-attention pool + rings within the budget.
+        max_num_reqs = self.model_runner.max_num_reqs
+        sliding_reserve = 0
+        num_sliding = 0
+        for layer_spec in kv_cache_spec.values():
+            if isinstance(layer_spec, SlidingWindowSpec):
+                # Same helpers the model runner sizes the rings with, so the
+                # reservation here cannot drift from what it later allocates.
+                window_blocks = sliding_window_blocks(
+                    layer_spec.sliding_window, layer_spec.block_size
+                )
+                sliding_reserve += sliding_ring_reserve_bytes(
+                    window_blocks, max_num_reqs, layer_spec.page_size_bytes
+                )
+                num_sliding += 1
+        if sliding_reserve > 0:
+            logger.info(
+                "Reserving %.3f GiB for %d sliding-window per-user rings "
+                "(max_num_reqs=%d, kv_shard_factor=%d)",
+                sliding_reserve / 1024**3,
+                num_sliding,
+                max_num_reqs,
+                kv_shard_factor,
+            )
+            if sliding_reserve >= kv_cache_bytes:
+                logger.warning(
+                    "Sliding ring reservation (%.2f GiB) >= KV budget "
+                    "(%.2f GiB); no room for full-attention pool. Raise "
+                    "gpu_memory_utilization or lower max_num_seqs.",
+                    sliding_reserve / 1024**3,
+                    kv_cache_bytes / 1024**3,
+                )
+            # Leave the full-attention pool whatever remains (vLLM's own check
+            # will error clearly if that is too small for max_model_len).
+            kv_cache_bytes = max(kv_cache_bytes - sliding_reserve, 0)
         logger.info(
             "KV cache sizing: device DRAM = %.2f GiB, gpu_memory_utilization = %.3f, "
             "kv_shard_factor = %d, KV cache budget = %.2f GiB (%.2f GiB per chip)",

--- a/tests/integrations/vllm_plugin/test_model_runner_buffer_keying.py
+++ b/tests/integrations/vllm_plugin/test_model_runner_buffer_keying.py
@@ -87,8 +87,8 @@ def test_per_batch_buffers_keyed_by_smem_clamped_count(
     assert set(runner._batch_idx_dev) == reachable
     # ...which includes the clamped decode target the runtime will request...
     assert runner.num_reqs_max_model_len in input_ids_keys
-    # ...and page tables share the max-path subset.
-    assert runner._max_len_num_reqs <= set(runner._page_table_dev_max)
+    # ...and page tables (nested per kv-cache group) share the max-path subset.
+    assert runner._max_len_num_reqs <= set(runner._page_table_dev_max[0])
 
     # Regression guard: the pre-#5416 keying used max_num_reqs, which under the
     # clamp is absent from the (now consistent) key set.

--- a/tests/integrations/vllm_plugin/test_swa_cache_utils.py
+++ b/tests/integrations/vllm_plugin/test_swa_cache_utils.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the sliding-window ring helpers.
+
+These are pure functions (no device, no vLLM engine), so they run anywhere and
+pin down the invariants the worker's byte reservation and the model runner's
+allocation both depend on.
+"""
+
+import numpy as np
+import pytest
+from vllm.utils.math_utils import cdiv
+from vllm_tt.swa_cache_utils import (
+    PAGE_TABLE_STICK_BLOCK_ALIGNMENT,
+    assign_ring_slots,
+    build_sliding_ring_page_table,
+    sliding_page_table_width,
+    sliding_ring_phys_blocks,
+    sliding_ring_reserve_bytes,
+    sliding_window_blocks,
+)
+
+pytestmark = [pytest.mark.push, pytest.mark.cpu]
+
+
+@pytest.mark.parametrize(
+    "window,block_size",
+    [(1024, 32), (4096, 32), (512, 64), (1, 32), (8192, 128), (1023, 32)],
+)
+def test_sliding_window_blocks_alignment_and_slack(window, block_size):
+    wb = sliding_window_blocks(window, block_size)
+    # stick alignment: window_blocks int32 ids must be a 32-byte multiple
+    assert wb % PAGE_TABLE_STICK_BLOCK_ALIGNMENT == 0
+    assert wb * 4 % 32 == 0
+    # covers the window plus one slack block for a straddling request...
+    assert wb >= cdiv(window, block_size) + 1
+    # ...without over-provisioning by more than the alignment step
+    assert wb - (cdiv(window, block_size) + 1) < PAGE_TABLE_STICK_BLOCK_ALIGNMENT
+
+
+def test_sliding_window_blocks_gemma4_case():
+    # gemma-4: 1024-token window, 32-token blocks -> 33 needed -> 40 aligned
+    assert sliding_window_blocks(1024, 32) == 40
+
+
+def test_phys_blocks_reserves_one_subring_per_slot_plus_null():
+    assert sliding_ring_phys_blocks(40, 32) == 40 * 32 + 1
+    # slot s occupies [1 + s*wb, 1 + (s+1)*wb); the last slot must fit exactly
+    wb, n = 40, 32
+    assert 1 + (n - 1) * wb + wb == sliding_ring_phys_blocks(wb, n)
+
+
+def test_reserve_bytes_uses_unsharded_page_size():
+    # vLLM sizes the pool with the full page_size_bytes and the worker inflates
+    # the budget by the shard factor, so the reservation must NOT be divided.
+    wb, n, page = 40, 32, 256 * 1024
+    assert sliding_ring_reserve_bytes(wb, n, page) == (wb * n + 1) * page
+
+
+def test_page_table_width_is_capped_by_the_buffer():
+    assert sliding_page_table_width(40, 4096) == 40  # ring is narrower
+    assert sliding_page_table_width(40, 8) == 8  # buffer is narrower
+
+
+def _slots(rows, batch, mapping, free):
+    return list(assign_ring_slots(rows, batch, mapping, free))
+
+
+def test_assign_ring_slots_is_stable_across_condense():
+    mapping, free = {}, list(range(4))
+    assert _slots(["a", "b", "c"], ["a", "b", "c"], mapping, free) == [0, 1, 2]
+    # "a" finishes; InputBatch condenses and reorders the remaining rows
+    assert _slots(["c", "b"], ["c", "b"], mapping, free) == [2, 1]
+    # a request must never change slot while it is alive
+    assert mapping["b"] == 1 and mapping["c"] == 2
+
+
+def test_assign_ring_slots_reclaims_and_reuses_smallest():
+    mapping, free = {}, list(range(3))
+    _slots(["a", "b", "c"], ["a", "b", "c"], mapping, free)
+    # "a" and "b" leave -> their slots come back, smallest handed out first
+    assert _slots(["c", "d"], ["c", "d"], mapping, free) == [2, 0]
+    assert _slots(["c", "d", "e"], ["c", "d", "e"], mapping, free) == [2, 0, 1]
+
+
+def test_assign_ring_slots_does_not_free_live_requests_on_a_partial_pass():
+    # rows may be a subset of the batch (multi-pass prepare); reclaiming against
+    # the full batch keeps the un-listed request's slot reserved.
+    mapping, free = {}, list(range(2))
+    _slots(["a", "b"], ["a", "b"], mapping, free)
+    assert _slots(["a"], ["a", "b"], mapping, free) == [0]
+    assert mapping["b"] == 1 and 1 not in free
+
+
+def test_assign_ring_slots_exhausted_pool_raises():
+    mapping, free = {}, [0]
+    _slots(["a"], ["a"], mapping, free)
+    with pytest.raises(IndexError):
+        _slots(["a", "b"], ["a", "b"], mapping, free)
+
+
+def test_page_table_stays_inside_each_users_subring():
+    wb, width = 8, 8
+    start_block = np.array([0, 3], dtype=np.int64)
+    slots = np.array([0, 2], dtype=np.int64)
+    pt = build_sliding_ring_page_table(start_block, slots, wb, width)
+    assert pt.shape == (2, width)
+    for row, slot in enumerate(slots):
+        lo, hi = 1 + slot * wb, 1 + (slot + 1) * wb
+        assert pt[row].min() >= lo and pt[row].max() < hi
+        # every block of the sub-ring is used exactly once
+        assert sorted(pt[row].tolist()) == list(range(lo, hi))
+    # block 0 is reserved as the null sink and must never be handed out
+    assert (pt != 0).all()
+
+
+def test_page_table_below_window_is_identity_within_the_subring():
+    wb, width = 8, 8
+    pt = build_sliding_ring_page_table(
+        np.array([0], dtype=np.int64), np.array([1], dtype=np.int64), wb, width
+    )
+    assert pt[0].tolist() == [1 + wb + i for i in range(width)]
+
+
+def test_page_table_wraps_once_past_the_window():
+    wb, width = 8, 8
+    # start_block=3 -> logical order 3,4,..,7,0,1,2 inside the sub-ring
+    pt = build_sliding_ring_page_table(
+        np.array([3], dtype=np.int64), np.array([0], dtype=np.int64), wb, width
+    )
+    assert pt[0].tolist() == [1 + ((3 + i) % wb) for i in range(width)]


### PR DESCRIPTION


### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/5727)

### Problem description
Sliding window requires only size of window length for cache, but current vLLM pays this for full attention which makes constraint on context length

### What's changed
Each sliding-window layer gets a per-user, window-sized ring buffer instead of paying the full max_model_len KV cost; window_blocks rounds up to a multiple of 8 for 32-byte page-table stick alignment. Also pin the gemma-4-31B TP benchmark to qb2's 1x4 mesh (mesh_shape=[1, 4]) -- the inherited use_2d_mesh=True 2x2 default deadlocks its RMS-norm all_gather at 128K.

### Checklist
- [ ] New/Existing tests provide coverage for changes
