### PR TITLE
[vLLM][MRv2] Telemetry + visualizer (#5715)

### DIFF
--- a/examples/vllm/telemetry/README.md
+++ b/examples/vllm/telemetry/README.md
@@ -11,7 +11,7 @@ Two layers are instrumented, because they answer different questions:
 | Layer | Process | Answers |
 |---|---|---|
 | **Scheduler** (`AscendScheduler`) | EngineCore | *intent* — what each step decided: prefill vs decode, preemption, queue depth, KV/batch utilization |
-| **Runner** (`TTModelRunner`) | Worker | *reality* — batch occupancy, executed prefill/decode pass split, actual decode rate, per-request lifecycle |
+| **Runner** (`TTModelRunnerV2` / `TTModelRunner`) | Worker | *reality* — slot occupancy, executed prefill/decode pass split, actual decode rate, per-request lifecycle |
 
 The two run in separate processes and each writes its own sink; records carry
 `request_id` (+ a monotonic `step`) so you can join them offline.
@@ -54,21 +54,28 @@ llm = vllm.LLM(
 
 ### Requirements
 
-- **The v1 model runner** (`TTModelRunner`) — the runner-side collector lives
-  there, so no `additional_config` routing knob is needed. Pooling models use
-  `pooling_runner.py` and emit no runner telemetry.
+- **Either generative runner.** The collector lives in both
+  `TTModelRunnerV2` and `TTModelRunner`, so no routing knob is needed;
+  `use_v2_model_runner` selects between them and defaults to v2. Pooling models
+  use `pooling_runner.py` and emit no runner telemetry.
 - Scheduler-side telemetry is emitted for any non-pooling model (which use
   `AscendScheduler`), independent of the runner.
 
-### Reading v1 slot output
+### Reading slot output
 
-v1's `InputBatch` is a *condensing* batch: when a request leaves, later rows
-compact down to fill the gap, so a row index is not a stable identity across
-steps. Occupancy, utilization, and the pass split are exact; a per-row timeline
-shows row **reuse** rather than a request holding one slot for its lifetime.
-Join on `request_id` (not `slot`) when following a single request.
+The two runners model slots differently, and it shows up in the sinks.
 
-Two consequences show up in real output. From a 4-prompt run on n150:
+v2's `TTRequestState` is a persistent slot table: a request holds one slot for
+its lifetime, so `slot` is a stable identity and a per-row timeline reads as one
+request per row. Re-admission happens only on abort + resubmit.
+
+v1's `InputBatch` condenses: when a request leaves, later rows compact down to
+fill the gap, so a row index identifies a position rather than a request.
+Occupancy, utilization, and the pass split stay exact; a per-row timeline shows
+row **reuse**, with consecutive segments of one row belonging to different
+requests. Join on `request_id` when following a single request.
+
+Two consequences show up in v1 output. From a 4-prompt run on n150:
 
 ```
 adm 0-94dd32b8 slot 0 step 0 prompt 8 cached 0 hit False readmission False

--- a/examples/vllm/telemetry/run_telemetry_demo.py
+++ b/examples/vllm/telemetry/run_telemetry_demo.py
@@ -49,7 +49,7 @@ def main():
         additional_config={
             "enable_const_eval": False,
             "min_context_len": 256,
-            # Turn telemetry on (v1 runner: the default on main).
+            # Turn telemetry on; v2 is the default runner on this branch.
             "telemetry_enabled": True,
             "telemetry_dir": str(tele_dir),
             "telemetry_flush_ms": 200,

--- a/integrations/vllm_plugin/vllm_tt/input_batch_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/input_batch_v2.py
@@ -1,0 +1,184 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""TT ``InputBatch`` for vLLM Model Runner v2 (MRv2).
+
+Phase 2 of the MRv2 adoption: the transient per-step batch view. Mirrors
+upstream ``vllm.v1.worker.gpu.input_batch`` (as of vLLM v0.22.1) -- the
+``InputBuffers`` (persistent device scratch) and the ``InputBatch`` dataclass
+(a fresh per-step view the runner populates).
+
+Scope / status
+--------------
+* ``InputBatch`` is a pure view: the runner rebuilds it every step from
+  ``TTRequestState`` (see request_state.py). Fields tied to features TT does
+  not support -- ``expanded_idx_mapping`` / ``expanded_local_pos`` /
+  ``num_draft_tokens*`` (spec decode) and ``dcp_local_seq_lens`` (DCP) -- are
+  kept for structural parity but degenerate to the no-spec / no-DCP path.
+* Upstream's module also holds the Triton input-prep kernels
+  (``prepare_prefill_inputs``, ``prepare_pos_seq_lens``,
+  ``combine_sampled_and_draft_tokens``, ``expand_idx_mapping``, ``post_update``,
+  ...). Those are input-prep, called from the runner's ``prepare_inputs``, and
+  have no Triton equivalent on TT. They are deferred to Phase 3, where the TT
+  runner fork substitutes host-side numpy / torch (salvage from the v1 runner's
+  ``_prepare_inputs``). We do NOT ship stubs for them here.
+* Like request_state.py, this module has no ``vllm.v1.worker.gpu.*`` dependency
+  and is import-safe, but is intentionally NOT imported from the package
+  ``__init__`` until the TT v2 runner (Phase 3) wires it in. UNVALIDATED at
+  runtime until then.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import torch
+from vllm.utils import random_uuid
+
+
+class TTInputBuffers:
+    """Persistent device-side scratch buffers, owned by the runner.
+
+    Sliced into per-step ``TTInputBatch`` views. Mirrors upstream
+    ``InputBuffers``.
+    """
+
+    def __init__(
+        self,
+        max_num_reqs: int,
+        max_num_tokens: int,
+        device: torch.device,
+    ):
+        self.max_num_reqs = max_num_reqs
+        self.max_num_tokens = max_num_tokens
+        self.device = device
+
+        self.input_ids = torch.zeros(max_num_tokens, dtype=torch.int32, device=device)
+        self.positions = torch.zeros(max_num_tokens, dtype=torch.int64, device=device)
+        self.query_start_loc = torch.zeros(
+            max_num_reqs + 1, dtype=torch.int32, device=device
+        )
+        self.seq_lens = torch.zeros(max_num_reqs, dtype=torch.int32, device=device)
+
+
+@dataclass
+class TTInputBatch:
+    # batch_idx -> req_id
+    req_ids: list[str]
+    num_reqs: int
+    num_reqs_after_padding: int
+
+    # batch_idx -> req_state_idx
+    idx_mapping: torch.Tensor
+    idx_mapping_np: np.ndarray
+    # Identical to idx_mapping except for spec decoding (unused on TT).
+    expanded_idx_mapping: torch.Tensor
+    # [total_num_logits] position within request for each logit.
+    expanded_local_pos: torch.Tensor
+
+    # [num_reqs] batch_idx -> num_scheduled_tokens
+    num_scheduled_tokens: np.ndarray
+    # sum(num_scheduled_tokens)
+    num_tokens: int
+    num_tokens_after_padding: int
+    # Sum of draft tokens scheduled across requests (0 on TT: no spec decode).
+    num_draft_tokens: int
+    # [num_reqs] draft tokens scheduled per request, if any.
+    num_draft_tokens_per_req: np.ndarray | None
+
+    # [num_reqs + 1]
+    query_start_loc: torch.Tensor
+    query_start_loc_np: np.ndarray
+    # [num_reqs]
+    seq_lens: torch.Tensor
+    # [num_reqs] CPU upper bound on seq_lens.
+    seq_lens_cpu_upper_bound: torch.Tensor
+    # [num_reqs] DCP per-request local seq_lens (None on TT: no DCP).
+    dcp_local_seq_lens: torch.Tensor | None
+    # [num_reqs] CPU bool array.
+    is_prefilling_np: np.ndarray
+
+    # [num_tokens_after_padding]
+    input_ids: torch.Tensor
+    # [num_tokens_after_padding]
+    positions: torch.Tensor
+
+    # [total_num_logits]
+    logits_indices: torch.Tensor
+    # [num_reqs + 1]
+    cu_num_logits: torch.Tensor
+    cu_num_logits_np: np.ndarray
+
+    # Whether any request in the batch uses structured output.
+    has_structured_output_reqs: bool
+
+    @classmethod
+    def make_dummy(
+        cls,
+        num_reqs: int,
+        num_tokens: int,
+        input_buffers: TTInputBuffers,
+    ) -> "TTInputBatch":
+        assert 0 < num_reqs <= num_tokens
+        device = input_buffers.device
+
+        req_ids = [f"req_{i}_{random_uuid()}" for i in range(num_reqs)]
+        idx_mapping_np = np.arange(num_reqs, dtype=np.int32)
+        idx_mapping = torch.arange(num_reqs, dtype=torch.int32, device=device)
+        expanded_idx_mapping = idx_mapping
+        expanded_local_pos = torch.zeros(num_reqs, dtype=torch.int32, device=device)
+
+        num_scheduled_tokens = np.full(num_reqs, num_tokens // num_reqs, dtype=np.int32)
+        num_scheduled_tokens[-1] += num_tokens % num_reqs
+        assert int(num_scheduled_tokens.sum()) == num_tokens
+
+        # seq_len equals query_len for the dummy (fresh-prefill shape).
+        input_buffers.seq_lens[:num_reqs] = num_tokens // num_reqs
+        input_buffers.seq_lens[num_reqs - 1] += num_tokens % num_reqs
+        input_buffers.seq_lens[num_reqs:] = 0
+        seq_lens = input_buffers.seq_lens[:num_reqs]
+
+        query_start_loc_np = np.empty(num_reqs + 1, dtype=np.int32)
+        query_start_loc_np[0] = 0
+        np.cumsum(num_scheduled_tokens, out=query_start_loc_np[1:])
+        input_buffers.query_start_loc[:1] = 0
+        torch.cumsum(
+            seq_lens, dim=0, out=input_buffers.query_start_loc[1 : num_reqs + 1]
+        )
+        input_buffers.query_start_loc[num_reqs + 1 :] = num_tokens
+        query_start_loc = input_buffers.query_start_loc[: num_reqs + 1]
+
+        input_ids = input_buffers.input_ids[:num_tokens].zero_()
+        positions = input_buffers.positions[:num_tokens].zero_()
+
+        logits_indices = query_start_loc[1:] - 1
+        cu_num_logits = torch.arange(num_reqs + 1, device=device, dtype=torch.int32)
+        cu_num_logits_np = np.arange(num_reqs + 1, dtype=np.int32)
+        seq_lens_cpu_upper_bound = torch.from_numpy(num_scheduled_tokens.copy())
+        return cls(
+            req_ids=req_ids,
+            num_reqs=num_reqs,
+            num_reqs_after_padding=num_reqs,
+            idx_mapping=idx_mapping,
+            idx_mapping_np=idx_mapping_np,
+            expanded_idx_mapping=expanded_idx_mapping,
+            expanded_local_pos=expanded_local_pos,
+            num_scheduled_tokens=num_scheduled_tokens,
+            num_tokens=num_tokens,
+            num_tokens_after_padding=num_tokens,
+            num_draft_tokens=0,
+            num_draft_tokens_per_req=None,
+            query_start_loc=query_start_loc,
+            query_start_loc_np=query_start_loc_np,
+            seq_lens=seq_lens,
+            seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
+            dcp_local_seq_lens=None,
+            is_prefilling_np=np.zeros(num_reqs, dtype=np.bool_),
+            input_ids=input_ids,
+            positions=positions,
+            logits_indices=logits_indices,
+            cu_num_logits=cu_num_logits,
+            cu_num_logits_np=cu_num_logits_np,
+            has_structured_output_reqs=False,
+        )

--- a/integrations/vllm_plugin/vllm_tt/metadata.py
+++ b/integrations/vllm_plugin/vllm_tt/metadata.py
@@ -490,3 +490,32 @@ class XLASupportedSamplingMetadata:
             no_generators=not has_generators,
             q_samples=q_samples,
         )
+
+    @classmethod
+    def from_v2_states(
+        cls,
+        request_state,
+        sampling_states,
+        input_batch,
+        padded_num_reqs: int,
+        xla_device: torch.device,
+        generate_params_if_all_greedy: bool = False,
+        vocab_size: int | None = None,
+    ) -> "XLASupportedSamplingMetadata":
+        """MRv2 entry point: build sampling metadata from the split v2 state.
+
+        v2 keeps sampling params in ``TTSamplingStates`` (keyed by stable slot),
+        token history in ``TTRequestState``, and the batch->slot mapping in
+        ``TTInputBatch``. ``make_batch_view`` gathers a batch-ordered padded view
+        that reuses ``from_input_batch`` unchanged.
+        """
+        view = sampling_states.make_batch_view(
+            request_state, input_batch, padded_num_reqs
+        )
+        return cls.from_input_batch(
+            view,
+            padded_num_reqs,
+            xla_device,
+            generate_params_if_all_greedy=generate_params_if_all_greedy,
+            vocab_size=vocab_size,
+        )

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -303,7 +303,6 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         original_parallel_config: Optional[ParallelConfig] = None,
     ):
         self.tt_config = TTConfig(**vllm_config.additional_config)
-        torch_xla.set_custom_compile_options(self.tt_config.get_pjrt_compile_config())
 
         self.vllm_config = vllm_config
         self.model_config = vllm_config.model_config
@@ -558,7 +557,9 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self.vocab_size = model_config.get_vocab_size()
 
         if self.lora_config is not None:
-            self.vocab_size += self.lora_config.lora_extra_vocab_size
+            # lora_extra_vocab_size was removed in vllm 0.20.2; add it only when
+            # the installed LoRAConfig still exposes it.
+            self.vocab_size += getattr(self.lora_config, "lora_extra_vocab_size", 0)
 
         # Multi-modal data support
         self.mm_registry = MULTIMODAL_REGISTRY

--- a/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
@@ -151,6 +151,20 @@ class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self.lora_config = vllm_config.lora_config
         self.device = device
 
+        # Speculative decode (ngram). Mirrors v1: num_spec_tokens gates the whole
+        # path, drafter is only built for the ngram method.
+        self.speculative_config = getattr(vllm_config, "speculative_config", None)
+        self.num_spec_tokens = 0
+        self.drafter = None
+        self._draft_token_ids: list[list[int]] | None = None
+        self._draft_token_req_ids: list[str] | None = None
+        if self.speculative_config is not None:
+            self.num_spec_tokens = self.speculative_config.num_speculative_tokens
+            if self.speculative_config.method == "ngram":
+                from vllm.v1.spec_decode.ngram_proposer import NgramProposer
+
+                self.drafter = NgramProposer(vllm_config)
+
         # additional_config arrives as a plain dict; build the typed TTConfig
         # (as the v1 runner does) so the field reads below see real values.
         self.tt_config = TTConfig(**vllm_config.additional_config)
@@ -284,7 +298,7 @@ class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             max_num_reqs=self.max_num_reqs,
             max_model_len=self.max_model_len,
             max_num_batched_tokens=self.max_num_tokens,
-            num_speculative_steps=0,
+            num_speculative_steps=self.num_spec_tokens,
             vocab_size=self.vocab_size,
             device=self.device,
         )
@@ -432,6 +446,7 @@ class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         from .model_state import TTModelState
         from .overrides import repair_stale_moe_closures, replace_modules
+        from .rejection_sampler import RejectionSampler
         from .sampler import Sampler
 
         logger.info("Loading model %s ...", self.model_config.model)
@@ -500,6 +515,7 @@ class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self.model.compile(backend="tt", dynamic=False)
         logger.info("Model loaded and registered for tt compilation.")
         self.sampler = Sampler()
+        self.rejection_sampler = RejectionSampler(self.sampler)
 
         encoder_cache = self.encoder_cache if self.supports_mm_inputs else None
         self.model_state = TTModelState(
@@ -745,14 +761,20 @@ class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         num_scheduled_tokens: np.ndarray,
         target_num_reqs: int,
         padded_query_len: int,
+        spec_decode_metadata=None,
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
         """Host substitute for the v2 Triton input-prep kernels.
 
         Builds 2D input_ids/positions [target_num_reqs, padded_query_len] plus flat
-        query_start_loc/seq_lens/logits_indices from TTRequestState, indexed by
-        idx_mapping_np[b] -> stable slot. Prefill and decode share one gather
+        query_start_loc/seq_lens from TTRequestState, indexed by idx_mapping_np[b]
+        -> stable slot. Prefill and decode share one gather
         (all_token_ids[computed:computed+n]); the sampled token was already
-        appended by the writeback and there is no spec decode. Padding stays zero.
+        appended by the writeback, and staged drafts sit right after it. Padding
+        stays zero.
+
+        logits_indices is flat [target_num_reqs] (one logit at each request's last
+        scheduled token), or packed [target_num_reqs, num_spec_tokens+1] under spec
+        decode so draft and bonus logits come out of a single pass.
         """
         num_reqs = len(idx_mapping_np)
         rs = self.req_states
@@ -773,6 +795,19 @@ class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             seq_lens[b] = computed + n
             # One logit per request, at its last scheduled token (within-row).
             logits_indices[b] = n - 1
+
+        if spec_decode_metadata is not None:
+            # Packed [reqs, spec_width]: draft rows index the first draft_len
+            # positions, every remaining column points at the bonus logit.
+            spec_width = self.num_spec_tokens + 1
+            packed = np.zeros((target_num_reqs, spec_width), dtype=np.int32)
+            for b in range(num_reqs):
+                bonus_idx = int(num_scheduled_tokens[b]) - 1
+                packed[b, :] = bonus_idx
+                draft_len = spec_decode_metadata.num_draft_tokens[b]
+                if draft_len:
+                    packed[b, :draft_len] = np.arange(draft_len, dtype=np.int32)
+            logits_indices = packed
 
         query_start_loc = np.zeros(target_num_reqs + 1, dtype=np.int32)
         np.cumsum(num_scheduled_tokens, out=query_start_loc[1 : num_reqs + 1])
@@ -905,6 +940,73 @@ class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         is_mm_embed = is_mm_embed.to(self.device)
         return mm_embeds, is_mm_embed, mm_indices
 
+    def _apply_scheduled_drafts(self, scheduler_output: "SchedulerOutput") -> None:
+        """Stage this step's scheduled draft tokens into the slot table.
+
+        The scheduler already counts drafts in num_scheduled_tokens, so the input
+        gather reads them straight out of all_token_ids once staged here.
+        """
+        if not self.num_spec_tokens:
+            return
+        rs = self.req_states
+        scheduled = (
+            getattr(scheduler_output, "scheduled_spec_decode_tokens", None) or {}
+        )
+        for req_id, slot in rs.req_id_to_index.items():
+            drafts = scheduled.get(req_id)
+            if drafts:
+                rs.set_draft_tokens(slot, [int(t) for t in drafts])
+            else:
+                rs.clear_draft_tokens(slot)
+
+    def _build_spec_decode_metadata(self, idx_mapping_np: np.ndarray):
+        """Per-pass SpecDecodeMetadata over the packed [reqs, spec_width] logits.
+
+        Returns None when spec decode is off or no request in this pass carries
+        drafts, which keeps the non-spec path on the flat one-logit-per-request
+        layout. Mirrors the v1 builder.
+        """
+        if not self.num_spec_tokens:
+            return None
+        rs = self.req_states
+        num_draft = [int(rs.num_draft_tokens[int(s)]) for s in idx_mapping_np]
+        if not any(num_draft):
+            return None
+
+        from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
+
+        spec_width = self.num_spec_tokens + 1
+        flat: list[int] = []
+        target_logits_indices: list[int] = []
+        bonus_logits_indices: list[int] = []
+        for b, draft_len in enumerate(num_draft):
+            base = b * spec_width
+            slot = int(idx_mapping_np[b])
+            flat.extend(int(t) for t in rs.draft_tokens[slot, :draft_len])
+            target_logits_indices.extend(range(base, base + draft_len))
+            bonus_logits_indices.append(base + spec_width - 1)
+
+        dev = self.device
+        cu_num_draft = np.cumsum(np.array(num_draft, dtype=np.int32), dtype=np.int32)
+        cu_num_sampled = np.cumsum(
+            np.array([d + 1 for d in num_draft], dtype=np.int32), dtype=np.int32
+        )
+        return SpecDecodeMetadata(
+            draft_token_ids=torch.tensor(flat, dtype=torch.int32).to(dev),
+            num_draft_tokens=num_draft,
+            cu_num_draft_tokens=torch.from_numpy(cu_num_draft).to(dev),
+            cu_num_sampled_tokens=torch.from_numpy(cu_num_sampled).to(dev),
+            target_logits_indices=torch.tensor(
+                target_logits_indices, dtype=torch.int32
+            ).to(dev),
+            bonus_logits_indices=torch.tensor(
+                bonus_logits_indices, dtype=torch.int32
+            ).to(dev),
+            logits_indices=torch.arange(
+                len(num_draft) * spec_width, dtype=torch.int32
+            ).to(dev),
+        )
+
     def postprocess(
         self,
         idx_mapping_np: np.ndarray,
@@ -934,11 +1036,15 @@ class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 # Still prefilling: ignore the sampled token from this partial req.
                 valid[b] = []
                 continue
-            token_id = int(valid[b][0])
+            # Spec decode accepts 1..num_spec_tokens+1 tokens per request; the
+            # non-spec path always yields exactly one.
+            tokens = [int(t) for t in valid[b]]
+            if not tokens:
+                continue
             pos = int(rs.total_len[slot])
-            rs.all_token_ids[slot, pos] = token_id
-            rs.total_len[slot] = pos + 1
-            rs.last_sampled_tokens[slot, 0] = token_id
+            rs.all_token_ids[slot, pos : pos + len(tokens)] = tokens
+            rs.total_len[slot] = pos + len(tokens)
+            rs.last_sampled_tokens[slot, 0] = tokens[-1]
 
         return valid
 
@@ -1028,6 +1134,8 @@ class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 return self.kv_connector_no_forward(scheduler_output, self.vllm_config)
             return EMPTY_MODEL_RUNNER_OUTPUT
 
+        self._apply_scheduled_drafts(scheduler_output)
+
         if self.supports_mm_inputs and scheduler_output.scheduled_encoder_inputs:
             # Run the vision/multimodal encoder once per step; outputs are cached
             # by mm_hash and consumed per pass in _run_model_pass. Text-only
@@ -1080,6 +1188,8 @@ class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 prompt_lp_hs,
             )
 
+        self.propose_draft_token_ids(out_req_ids, out_sampled)
+
         prompt_logprobs_dict = self._get_prompt_logprobs_dict(
             prompt_lp_hs, scheduler_output
         )
@@ -1093,6 +1203,52 @@ class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             prompt_logprobs_dict=prompt_logprobs_dict,
             kv_connector_output=kv_connector_output,
         )
+
+    def propose_draft_token_ids(
+        self, out_req_ids: list[str], out_sampled: list[list[int]]
+    ) -> None:
+        """Run the ngram proposer over this step's accepted tokens.
+
+        Drafts are cached for the scheduler to pick up via take_draft_token_ids.
+        Host-only (the proposer is CPU/numpy), so nothing is compiled here.
+        """
+        self._draft_token_req_ids = []
+        self._draft_token_ids = []
+        if not self.drafter or not self.num_spec_tokens or not out_req_ids:
+            return
+        if not any(out_sampled):
+            return
+
+        rs = self.req_states
+        # num_tokens_no_spec: committed context length, drafts excluded. total_len
+        # already excludes staged drafts and includes this step's accepted tokens.
+        slots = [rs.req_id_to_index[rid] for rid in out_req_ids]
+        num_tokens_no_spec = np.array(
+            [int(rs.total_len[s]) for s in slots], dtype=np.int32
+        )
+        token_ids_cpu = np.zeros((len(slots), self.max_model_len), dtype=np.int32)
+        for i, slot in enumerate(slots):
+            n = int(rs.total_len[slot])
+            token_ids_cpu[i, :n] = rs.all_token_ids[slot, :n]
+
+        drafts = self.drafter.propose(
+            [list(row) for row in out_sampled], num_tokens_no_spec, token_ids_cpu
+        )
+        for req_id, draft in zip(out_req_ids, drafts):
+            if draft:
+                self._draft_token_req_ids.append(req_id)
+                self._draft_token_ids.append(draft)
+
+    def take_draft_token_ids(self):
+        """Hand this step's cached drafts to the scheduler (once)."""
+        if not self.num_spec_tokens or not self._draft_token_req_ids:
+            return None
+        from vllm.v1.outputs import DraftTokenIds
+
+        out = DraftTokenIds(self._draft_token_req_ids, self._draft_token_ids)
+        self._draft_token_ids = None
+        self._draft_token_req_ids = None
+        return out
 
     @staticmethod
     def _has_kv_transfer_group() -> bool:
@@ -1121,9 +1277,15 @@ class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 end_index,
             ) = self._select_batch(ordered_slots, ordered_num_tokens, start_index)
 
+            spec_md = self._build_spec_decode_metadata(idx_mapping)
+
             input_ids, positions, _query_start_loc, seq_lens, logits_indices = (
                 self._prepare_input_tokens(
-                    idx_mapping, num_scheduled, target_num_reqs, padded_query_len
+                    idx_mapping,
+                    num_scheduled,
+                    target_num_reqs,
+                    padded_query_len,
+                    spec_md,
                 )
             )
             page_table, fill_page_table, cache_position = self._prepare_attn_tensors(
@@ -1147,6 +1309,7 @@ class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 cache_position,
                 want_prompt_hs,
                 grammar_output,
+                spec_md,
             )
             if want_prompt_hs:
                 sampled, hidden_states = pass_result
@@ -1186,6 +1349,7 @@ class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         cache_position: np.ndarray,
         want_prompt_hs: bool = False,
         grammar_output=None,
+        spec_decode_metadata=None,
     ):
         """Run one compiled forward+sample pass for the selected sub-batch.
 
@@ -1199,6 +1363,7 @@ class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         from types import SimpleNamespace
 
         from .metadata import XLASupportedSamplingMetadata
+        from .rejection_sampler import RejectionSampler
 
         dev = self.device
         input_ids_dev = torch.from_numpy(input_ids).to(dev)
@@ -1273,6 +1438,14 @@ class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # a plain python bool so dynamo specializes a separate graph (no-grammar
         # path unaffected).
         apply_grammar = grammar_output is not None
+        spec_active = spec_decode_metadata is not None
+        if apply_grammar and spec_active:
+            # Same limitation as v1: tenstorrent/tt-xla#5701.
+            logger.warning_once(
+                "Speculative decoding with grammar is not supported yet. "
+                "Disabling grammar for this step."
+            )
+            apply_grammar = False
         require_struct = grammar_bitmask = bitmasks = None
         if apply_grammar:
             require_struct, grammar_bitmask, bitmasks = (
@@ -1293,11 +1466,27 @@ class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             require_struct,
             grammar_bitmask,
             bitmasks,
+            logits_only=spec_active,
         )
         if want_prompt_hs:
             forward_out, hidden_states = result
         else:
             forward_out, hidden_states = result, None
+        if spec_active:
+            # Rejection sampling runs outside torch.compile: variable draft
+            # lengths and early exit on rejection are request-wise dynamic
+            # control flow dynamo cannot trace into a stable fullgraph.
+            selected = self.rejection_sampler(
+                spec_decode_metadata,
+                None,
+                forward_out,
+                sampling_metadata=sampling_metadata,
+            ).sampled_token_ids
+            sampled, _ = RejectionSampler.parse_output(selected, self.vocab_size)
+            sampled = sampled[: len(idx_mapping_np)]
+            if want_prompt_hs:
+                return sampled, hidden_states
+            return sampled
         if self.cpu_sampling:
             # forward_out is logits [target_num_reqs, vocab]; mask (grammar) and
             # sample on host. Device sampling masks inside _sample_compiled.
@@ -1332,6 +1521,7 @@ class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         require_struct_decoding=None,
         grammar_bitmask=None,
         bitmasks=None,
+        logits_only=False,
     ):
         """Run the forward->logits graph, then (device path) the sampling graph.
 
@@ -1356,8 +1546,9 @@ class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             )
         logits, hidden_states = fwd if want_prompt_hs else (fwd, None)
 
-        if self.cpu_sampling:
-            # Stop at logits; grammar + sampling run on the host.
+        if self.cpu_sampling or logits_only:
+            # Stop at logits; grammar + sampling run on the host (spec decode
+            # rejection-samples them outside the compiled region).
             out = logits
         else:
             out = self._sample_compiled(
@@ -1479,8 +1670,18 @@ class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
     def _select_hidden_states(self, hidden_states, indices_do_sample):
         # Gather each request's last-token hidden state: hidden is [reqs, tokens, H].
-        batch_indices = torch.arange(indices_do_sample.shape[0], dtype=torch.int32)
-        result = hidden_states[batch_indices, indices_do_sample, :]
+        if indices_do_sample.ndim == 1:
+            batch_indices = torch.arange(indices_do_sample.shape[0], dtype=torch.int32)
+            result = hidden_states[batch_indices, indices_do_sample, :]
+        else:
+            # Spec decode: [reqs, spec_width] indices -> flat [reqs*spec_width, H]
+            # so the rejection sampler's flat target/bonus indices line up.
+            batch_indices = torch.arange(
+                indices_do_sample.shape[0], dtype=torch.int32
+            ).unsqueeze(1)
+            batch_indices = batch_indices.expand_as(indices_do_sample)
+            result = hidden_states[batch_indices, indices_do_sample, :]
+            result = result.reshape(-1, result.shape[-1])
         if self.enable_tensor_parallel and self.use_2d_mesh:
             result = sharding_constraint_tensor(result, self.mesh, (None, None))
         return result

--- a/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
@@ -38,6 +38,7 @@ from vllm.v1.worker.kv_connector_model_runner_mixin import KVConnectorModelRunne
 from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
 
 from .logger import tt_init_logger
+from .telemetry import RunnerTelemetry, resolve_config
 from .vllm_distributed_utils import ParallelismMode, safe_mark_sharding, shard_model
 
 logger = tt_init_logger(__name__)
@@ -115,6 +116,9 @@ def replace_set_lora(model):
 
 class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
     """Tenstorrent MRv2 model runner (see module docstring)."""
+
+    # Instances built without __init__ read this; disabled opens no files.
+    _telemetry = RunnerTelemetry(False, "", 1.0)
 
     def __init__(
         self,
@@ -300,6 +304,14 @@ class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self.input_buffers = TTInputBuffers(
             self.max_num_reqs, self.max_num_tokens, self.device
         )
+
+        # Gating resolved in TTPlatform.check_and_update_config.
+        tele_enabled, tele_dir, tele_flush_s = resolve_config(
+            enabled=getattr(self.tt_config, "telemetry_enabled", False),
+            directory=getattr(self.tt_config, "telemetry_dir", None),
+            flush_ms=getattr(self.tt_config, "telemetry_flush_ms", None),
+        )
+        self._telemetry = RunnerTelemetry(tele_enabled, tele_dir, tele_flush_s)
 
         self.encoder_cache: dict = {}
         self.num_prompt_logprobs: dict = {}
@@ -549,6 +561,16 @@ class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         scheduler resends them through ``scheduled_new_reqs`` when resumed.
         """
         for req_id in scheduler_output.finished_req_ids:
+            if self._telemetry.enabled:
+                slot = self.req_states.req_id_to_index.get(req_id)
+                if slot is not None:
+                    prompt_len = int(self.req_states.prompt_len[slot])
+                    self._telemetry.on_request_completed(
+                        req_id,
+                        slot,
+                        prompt_len,
+                        int(self.req_states.total_len[slot]) - prompt_len,
+                    )
             self._remove_request(req_id)
         for req_id in scheduler_output.preempted_req_ids:
             self._remove_request(req_id)
@@ -563,7 +585,11 @@ class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             assert sampling_params is not None, "Pooling not supported in the v2 runner"
 
             req_id = new.req_id
-            # A re-added id (streaming abort+resubmit) must clear its stale slot.
+            # A re-added id (streaming abort+resubmit) must clear its stale slot;
+            # read the re-admission flag first, since clearing erases the evidence.
+            tele_readmission = (
+                self._telemetry.enabled and req_id in self.req_states.req_id_to_index
+            )
             self._remove_request(req_id)
 
             prompt_len = len(new.prompt_token_ids)
@@ -578,6 +604,16 @@ class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 req_id, prompt_len, all_token_ids, new.num_computed_tokens
             )
             slot = self.req_states.req_id_to_index[req_id]
+
+            if self._telemetry.enabled:
+                self._telemetry.on_request_admitted(
+                    req_id,
+                    slot,
+                    prompt_len,
+                    int(self.req_states.prefill_len[slot]),
+                    num_cached_tokens=int(new.num_computed_tokens),
+                    readmission=tele_readmission,
+                )
 
             # Seeded requests carry their own generator; the rest use global RNG.
             generator = None
@@ -1150,7 +1186,7 @@ class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 kv_connector_output = stack.enter_context(
                     self.maybe_get_kv_connector_output(scheduler_output)
                 )
-            self._run_pass_loop(
+            tele_passes = self._run_pass_loop(
                 ordered_slots,
                 ordered_num_tokens,
                 grammar_output,
@@ -1159,8 +1195,19 @@ class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 out_sampled,
                 prompt_lp_hs,
             )
+            # An implicit None return from the loop must not break the step.
+            tele_passes = tele_passes or (0, 0, 0)
 
         self.propose_draft_token_ids(out_req_ids, out_sampled)
+
+        # Per-step occupancy plus this step's pass split, from the loop's tally.
+        if self._telemetry.enabled:
+            self._telemetry.on_step(
+                self.req_states,
+                prefill_passes=tele_passes[0],
+                decode_passes=tele_passes[1],
+                emitted_tokens=tele_passes[2],
+            )
 
         prompt_logprobs_dict = self._get_prompt_logprobs_dict(
             prompt_lp_hs, scheduler_output
@@ -1237,8 +1284,16 @@ class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         out_req_ids: list,
         out_sampled: list,
         prompt_lp_hs: dict,
-    ) -> None:
-        """Decode-first multi-pass loop; appends into the caller's output lists."""
+    ) -> tuple[int, int, int]:
+        """Decode-first multi-pass loop; appends into the caller's output lists.
+
+        Returns ``(prefill_passes, decode_passes, emitted_tokens)`` for telemetry;
+        all zero when telemetry is disabled.
+        """
+        tele_on = self._telemetry.enabled
+        tele_prefill_passes = 0
+        tele_decode_passes = 0
+        tele_emitted_tokens = 0
         start_index = 0
         while start_index < len(ordered_slots):
             (
@@ -1296,7 +1351,21 @@ class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             else:
                 sampled = pass_result
 
+            # Row state after the pass and tokens-per-row both misclassify: a
+            # completed single-shot prefill, and a spec-decode verification pass.
+            pass_prefill = False
+            if tele_on:
+                rs = self.req_states
+                for b in range(len(idx_mapping)):
+                    if int(num_scheduled[b]) == 0:
+                        continue
+                    slot = int(idx_mapping[b])
+                    if int(rs.num_computed_tokens[slot]) < int(rs.prefill_len[slot]):
+                        pass_prefill = True
+                        break
+
             valid = self.postprocess(idx_mapping, num_scheduled, sampled)
+            pass_emitted = 0
             for b in range(len(idx_mapping)):
                 if int(num_scheduled[b]) == 0:
                     # DP padding row: not scheduled this step, don't report it.
@@ -1304,8 +1373,20 @@ class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 slot = int(idx_mapping[b])
                 out_req_ids.append(self.req_states.index_to_req_id[slot])
                 out_sampled.append(valid[b])
+                if tele_on and valid[b]:
+                    # len() per row keeps this accepted tokens/step under spec decode.
+                    pass_emitted += len(valid[b])
+            if tele_on:
+                tele_emitted_tokens += pass_emitted
+                if pass_prefill:
+                    tele_prefill_passes += 1
+                elif pass_emitted > 0:
+                    # Empty passes count as neither.
+                    tele_decode_passes += 1
 
             start_index = end_index
+
+        return tele_prefill_passes, tele_decode_passes, tele_emitted_tokens
 
     def _run_model_pass(
         self,

--- a/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
@@ -1,0 +1,2128 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""TT Model Runner v2 (MRv2): a fork of upstream ``vllm/v1/worker/gpu/model_runner.py``.
+
+Upstream's v2 runner is Triton/CUDA/UVA-native, so TT forks it and substitutes
+host-side mechanisms (numpy input-prep, ``@torch.compile(backend="tt")`` graphs,
+TT attention metadata) instead of subclassing ``GPUModelRunner``. Two things
+differ from a naive port:
+
+* 2D forward layout: TT's model takes ``[num_reqs, padded_query_len]`` (reshaped
+  to 1D at the call boundary for ``flat_model_io`` models), not upstream's flat
+  ``[num_tokens]``. The runner builds those 2D tensors itself; ``TTInputBatch``
+  is the flat per-step bookkeeping view consumed by ``from_v2_states`` and the
+  attn build.
+* Upstream v2 request semantics: requests keep a stable ``TTRequestState`` slot
+  for their lifetime (no condense); preempted requests are freed and resumed
+  ones return via ``scheduled_new_reqs``, so ``update_requests`` has no resumed
+  branch.
+
+Deferred: multi-device SPMD/mesh, ``get_mm_embeddings``, LoRA, and the grammar /
+cpu_sampling / prompt-logprobs branches.
+"""
+
+from __future__ import annotations
+
+import bisect
+import logging
+from typing import TYPE_CHECKING, Optional
+
+import numpy as np
+import torch
+import vllm.envs as envs
+from tt_torch.sharding import sharding_constraint_tensor
+from vllm.sampling_params import SamplingType
+from vllm.utils.math_utils import cdiv
+from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
+
+from .vllm_distributed_utils import ParallelismMode, safe_mark_sharding, shard_model
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+    from vllm.v1.core.sched.output import SchedulerOutput
+    from vllm.v1.kv_cache_interface import KVCacheConfig
+
+
+def _get_padded_token_len(paddings: list[int], x: int) -> int:
+    """First padding >= x (the per-step query-length bucket)."""
+    index = bisect.bisect_left(paddings, x)
+    assert index < len(paddings)
+    return paddings[index]
+
+
+def _adjust_min_token(min_token_size: int) -> int:
+    """Round min_token_size up to a power of two that is >= 32 (32B alignment)."""
+    if (min_token_size & (min_token_size - 1)) == 0 and min_token_size >= 32:
+        return min_token_size
+
+    # Default fallback is 32 (smallest valid input length).
+    adjusted_value = 32
+    if min_token_size > 32:
+        # Round up to the next power of two.
+        adjusted_value = 1 << (min_token_size - 1).bit_length()
+
+    logger.warning(
+        f"Flag min_context_len={min_token_size} is not a power of two and divisible by 32. "
+        f"Adjusting to the next power of two. Using min_context_len={adjusted_value}."
+    )
+    return adjusted_value
+
+
+def _get_token_paddings(min_token_size: int, max_token_size: int) -> list[int]:
+    """Exponential token-length ladder from min_token_size up past max_token_size.
+
+    Always starts with 1 to support single-token decode steps.
+    """
+    num = _adjust_min_token(min_token_size)
+    paddings = [1]
+    while True:
+        paddings.append(num)
+        if num >= max_token_size:
+            break
+        num *= 2
+    return paddings
+
+
+def replace_set_lora(model):
+    """Wrap each LoRA layer's set_lora/reset_lora with a torch_xla.sync.
+
+    Ported from the v1 runner: the integer LoRA index would otherwise trigger a
+    recompilation, so a sync captures the input/metadata updates around it.
+    """
+    import torch_xla
+    from vllm.lora.layers import BaseLayerWithLoRA
+
+    def _tpu_set_lora(self, index, lora_a, lora_b, embeddings_tensor, bias=None):
+        self._original_set_lora(index, lora_a, lora_b, embeddings_tensor)
+        torch_xla.sync(wait=False)
+
+    def _tpu_reset_lora(self, index):
+        self._original_reset_lora(index)
+        torch_xla.sync(wait=False)
+
+    for _, module in model.named_modules():
+        if isinstance(module, BaseLayerWithLoRA):
+            module._original_set_lora = module.set_lora
+            module._original_reset_lora = module.reset_lora
+            module.set_lora = _tpu_set_lora.__get__(module, module.__class__)
+            module.reset_lora = _tpu_reset_lora.__get__(module, module.__class__)
+
+
+class TTModelRunnerV2(LoRAModelRunnerMixin):
+    """Tenstorrent MRv2 model runner (see module docstring)."""
+
+    def __init__(
+        self,
+        vllm_config: "VllmConfig",
+        device: torch.device,
+        original_parallel_config=None,
+    ) -> None:
+        """Construct the split v2 state + config scalars.
+
+        When TP/DP is enabled the SPMD device mesh is built here (see
+        ``_build_device_mesh``); ``original_parallel_config`` carries the real
+        (pre-collapse) parallel sizes from the worker. The model itself is
+        loaded and compiled in ``load_model``; ``model``/``model_state``/``sampler``
+        are None until then.
+        """
+        from vllm.v1.worker.block_table import MultiGroupBlockTable
+
+        from .attention_impls.attention import (
+            TPU_STR_DTYPE_TO_TORCH_DTYPE,
+            TTAttentionBackend,
+        )
+        from .input_batch_v2 import TTInputBuffers
+        from .platform import TTConfig
+        from .request_state import TTRequestState
+        from .sampling_state_v2 import TTSamplingStates
+
+        self.vllm_config = vllm_config
+        self.model_config = vllm_config.model_config
+        self.cache_config = vllm_config.cache_config
+        self.scheduler_config = vllm_config.scheduler_config
+        self.parallel_config = vllm_config.parallel_config
+        self.load_config = vllm_config.load_config
+        self.lora_config = vllm_config.lora_config
+        self.device = device
+
+        # additional_config arrives as a plain dict; build the typed TTConfig
+        # (as the v1 runner does) so the field reads below see real values.
+        self.tt_config = TTConfig(**vllm_config.additional_config)
+
+        # Override number of hidden layers if specified in TTConfig. Must run
+        # before load_model so only the target layers are built; the weight
+        # loader is filtered to match in load_model.
+        from .vllm_utils import apply_hidden_layer_override
+
+        self._original_num_layers, self._target_num_layers = (
+            apply_hidden_layer_override(
+                self.model_config.hf_config, self.tt_config.num_hidden_layers
+            )
+        )
+
+        tt = self.tt_config
+        self.enable_tensor_parallel = bool(getattr(tt, "enable_tensor_parallel", False))
+        self.enable_data_parallel = bool(getattr(tt, "enable_data_parallel", False))
+        self.use_2d_mesh = getattr(tt, "use_2d_mesh", True)
+        self.is_sharded_compute_logits = False
+        self.original_parallel_config = original_parallel_config
+
+        # max_num_reqs may be rounded up to a dp_size multiple by the mesh build,
+        # so it must be set before it sizes the state tables below.
+        self.max_num_reqs = self.scheduler_config.max_num_seqs
+        self.dp_size = 1
+        self.mesh = None
+        self.parallel_mode = ParallelismMode.DISABLED
+        if self.enable_tensor_parallel or self.enable_data_parallel:
+            self._build_device_mesh()
+
+        self.dtype = self.model_config.dtype
+        if self.cache_config.cache_dtype == "auto":
+            self.kv_cache_dtype = (
+                TPU_STR_DTYPE_TO_TORCH_DTYPE[self.dtype]
+                if isinstance(self.dtype, str)
+                else self.dtype
+            )
+        else:
+            self.kv_cache_dtype = TPU_STR_DTYPE_TO_TORCH_DTYPE[
+                self.cache_config.cache_dtype
+            ]
+        # 1-byte accounting stand-in so vLLM budgets blocks for the BFP8 footprint.
+        self.kv_cache_spec_dtype = (
+            torch.uint8
+            if getattr(tt, "experimental_kv_cache_dtype", None) == "bfp_bf8"
+            else self.kv_cache_dtype
+        )
+
+        self.block_size = self.cache_config.block_size
+        self.max_model_len = self.model_config.max_model_len
+        self.most_model_len = envs.VLLM_TPU_MOST_MODEL_LEN
+        self.max_num_blocks_per_req = cdiv(self.max_model_len, self.block_size)
+        self.num_blocks_per_most_len_req = (
+            cdiv(self.most_model_len, self.block_size)
+            if self.most_model_len is not None
+            else None
+        )
+
+        # Prefill request-count bucketing bounds (decode always uses max_num_reqs).
+        self.min_num_reqs = getattr(tt, "min_num_seqs", None) or self.max_num_reqs
+        self.max_prefill_num_reqs = (
+            getattr(tt, "max_prefill_num_seqs", None) or self.max_num_reqs
+        )
+
+        max_num_batched_tokens = self.scheduler_config.max_num_batched_tokens
+        min_context_len = getattr(tt, "min_context_len", 32)
+        if max_num_batched_tokens < min_context_len:
+            min_context_len = max_num_batched_tokens
+        self.prefill_chunk_budget = min(
+            getattr(
+                self.scheduler_config, "tt_prefill_chunk_size", max_num_batched_tokens
+            )
+            or max_num_batched_tokens,
+            self.max_model_len,
+        )
+        self.num_tokens_paddings = _get_token_paddings(
+            min_context_len, self.prefill_chunk_budget
+        )
+        if getattr(tt, "decode_only", False):
+            self.num_tokens_paddings = [1]
+        self.max_num_tokens = self.num_tokens_paddings[-1]
+
+        # Model dims.
+        self.num_attn_layers = self.model_config.get_num_layers_by_block_type(
+            self.parallel_config, "attention"
+        )
+        self.num_query_heads = self.model_config.get_num_attention_heads(
+            self.parallel_config
+        )
+        self.num_kv_heads = self.model_config.get_num_kv_heads(self.parallel_config)
+        self.head_size = self.model_config.get_head_size()
+        self.vocab_size = self.model_config.get_vocab_size()
+        if self.lora_config is not None:
+            # lora_extra_vocab_size was removed in vllm 0.20.2; add it only when
+            # the installed LoRAConfig still exposes it.
+            self.vocab_size += getattr(self.lora_config, "lora_extra_vocab_size", 0)
+        # M-RoPE models feed 3D [3, reqs, tokens] position ids to the model.
+        self.uses_mrope = self.model_config.uses_mrope
+        self.supports_mm_inputs = bool(
+            getattr(self.model_config, "is_multimodal_model", False)
+        )
+        self.mm_budget = None  # set when multimodal profiling lands
+
+        # SMEM row caps consumed by _select_batch.
+        self.num_reqs_max_model_len = min(
+            TTAttentionBackend.get_max_num_seqs(self.max_model_len, self.block_size),
+            self.max_num_reqs,
+        )
+        self.num_reqs_most_model_len = (
+            min(
+                TTAttentionBackend.get_max_num_seqs(
+                    self.most_model_len, self.block_size
+                ),
+                self.max_num_reqs,
+            )
+            if self.most_model_len is not None
+            else None
+        )
+
+        # Driver / graph knobs read later.
+        self.use_flat_model_io = bool(getattr(tt, "flat_model_io", False))
+        self.cpu_sampling = bool(getattr(tt, "cpu_sampling", False))
+        self.enable_decode_fused_graphs = bool(
+            getattr(tt, "enable_decode_fused_graphs", False)
+        )
+        self.sampling_device = torch.device("cpu") if self.cpu_sampling else self.device
+
+        # Split v2 state.
+        self.req_states = TTRequestState(
+            max_num_reqs=self.max_num_reqs,
+            max_model_len=self.max_model_len,
+            max_num_batched_tokens=self.max_num_tokens,
+            num_speculative_steps=0,
+            vocab_size=self.vocab_size,
+            device=self.device,
+        )
+        self.sampling_states = TTSamplingStates(
+            max_num_reqs=self.max_num_reqs, vocab_size=self.vocab_size
+        )
+        self.block_table = MultiGroupBlockTable(
+            max_num_reqs=self.max_num_reqs,
+            max_model_len=self.max_model_len,
+            max_num_batched_tokens=self.max_num_tokens,
+            pin_memory=False,
+            device=torch.device("cpu"),
+            block_sizes=[self.block_size],
+            kernel_block_sizes=[self.block_size],
+        )
+        self.input_buffers = TTInputBuffers(
+            self.max_num_reqs, self.max_num_tokens, self.device
+        )
+
+        self.encoder_cache: dict = {}
+        self.num_prompt_logprobs: dict = {}
+        # Partial prompt-logprobs results for chunked prefills, keyed by req_id.
+        self.in_progress_prompt_logprobs: dict = {}
+        # Active LoRA request per stable slot (None/absent -> base model).
+        self.lora_requests_by_slot: dict = {}
+        # Multimodal feature list per stable slot (for the encoder run + gather).
+        self.mm_features_by_slot: dict = {}
+
+        # Structured-output (grammar) buffers. Filled per pass in
+        # prepare_structured_decoding_input, keyed by batch position.
+        self.grammar_bitmask_cpu = torch.zeros(
+            (self.max_num_reqs, cdiv(self.vocab_size, 32)),
+            dtype=torch.int32,
+            device="cpu",
+        )
+        self.require_structured_out_cpu = torch.zeros(
+            (self.max_num_reqs, 1), dtype=torch.bool, device="cpu"
+        )
+        # Power-of-2 masks for on-device bitmask unpacking via bitwise_and
+        # (bitwise_right_shift is unsupported on TT). uint32->int32 view avoids
+        # overflow at bit 31.
+        _bitmask_values = np.array([1 << i for i in range(32)], dtype=np.uint32).view(
+            np.int32
+        )
+        self.structured_decode_bitmasks = torch.from_numpy(_bitmask_values.copy())
+        self.kv_caches: list = []
+        self.kv_cache_config = None
+        # layer_name -> target layer for cross-layer KV sharing (get_kv_cache_spec).
+        self.shared_kv_cache_layers: dict = {}
+        # Per-step handoff between the two-phase execute_model / sample_tokens.
+        self.scheduler_output = None
+
+        # Filled by load_model.
+        self.model = None
+        self.model_state = None
+        self.sampler = None
+        self._attention_layer_names: tuple = ()
+        self.attention_layer_names: tuple = ()
+
+    def _build_device_mesh(self) -> None:
+        """Select the parallelism mode and build the SPMD device mesh.
+
+        Ported from the v1 runner: disables TP/DP that the available device count
+        can't support, derives the ``(batch, model)`` mesh via
+        ``determine_mesh_shape``, sets ``dp_size`` (>1 only in DP modes), and
+        rounds ``max_num_reqs`` up to a ``dp_size`` multiple. No-ops to the
+        single-device path (mesh stays None) when both flags end up disabled.
+        """
+        import torch_xla.distributed.spmd as xs
+        import torch_xla.runtime as xr
+
+        from .vllm_utils import determine_mesh_shape
+
+        num_devices = xr.global_runtime_device_count()
+        if self.enable_tensor_parallel and num_devices == 1:
+            logger.warning("Tensor parallel needs >1 device; found 1. Disabling TP.")
+            self.enable_tensor_parallel = False
+        if self.enable_data_parallel and (self.max_num_reqs <= 1 or num_devices == 1):
+            logger.warning(
+                "Data parallel needs >1 device and max_num_seqs > 1. Disabling DP."
+            )
+            self.enable_data_parallel = False
+
+        if self.enable_data_parallel and self.enable_tensor_parallel:
+            self.parallel_mode = ParallelismMode.DATA_TENSOR_PARALLEL
+        elif self.enable_data_parallel:
+            self.parallel_mode = ParallelismMode.DATA_PARALLEL_ONLY
+        elif self.enable_tensor_parallel:
+            # An explicit 2D mesh_shape (no size-1 axis) forces TP-2D even when
+            # use_2d_mesh is unset, matching the mesh determine_mesh_shape builds.
+            explicit_2d_mesh = (
+                self.tt_config.mesh_shape is not None
+                and 1 not in self.tt_config.mesh_shape
+            )
+            self.parallel_mode = (
+                ParallelismMode.TENSOR_PARALLEL_ONLY_2D
+                if (self.use_2d_mesh or explicit_2d_mesh)
+                else ParallelismMode.TENSOR_PARALLEL_ONLY_1D
+            )
+        else:
+            self.parallel_mode = ParallelismMode.DISABLED
+            return
+
+        mesh_shape = determine_mesh_shape(
+            num_devices, self.parallel_mode, self.tt_config.mesh_shape
+        )
+        device_ids = np.array(range(num_devices))
+        self.mesh = xs.Mesh(device_ids, mesh_shape, ("batch", "model"))
+        # mesh_shape[0] ("batch" axis) is a DP replica count only in DP modes; in
+        # pure-TP the batch axis is a TP axis, so dp_size stays 1.
+        if self.parallel_mode in (
+            ParallelismMode.DATA_PARALLEL_ONLY,
+            ParallelismMode.DATA_TENSOR_PARALLEL,
+        ):
+            self.dp_size = mesh_shape[0]
+        self.use_2d_mesh = 1 not in mesh_shape
+        xs.set_global_mesh(self.mesh)
+
+        if self.enable_data_parallel and self.dp_size > 1:
+            remainder = self.max_num_reqs % self.dp_size
+            if remainder != 0:
+                adjusted = self.max_num_reqs + self.dp_size - remainder
+                logger.warning(
+                    "Data parallel requires max_num_reqs divisible by dp_size; "
+                    "adjusting from %d to %d.",
+                    self.max_num_reqs,
+                    adjusted,
+                )
+                self.max_num_reqs = adjusted
+
+    def load_model(self) -> None:
+        """Load, place, and compile the model; build ModelState + sampler.
+
+        Under TP the weights are sharded across the mesh (via ``shard_model``)
+        and the embedding load is wrapped in the vocab TP-rank patch. LoRA and
+        per-tensor weight-dtype overrides are still deferred. Needs a real model
+        + loader, so it is validated at engine stand-up.
+        """
+        from contextlib import nullcontext
+
+        from vllm.config import get_layers_from_vllm_config, set_current_vllm_config
+        from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+        from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
+        from vllm.model_executor.model_loader import get_model_loader
+
+        from .model_state import TTModelState
+        from .overrides import repair_stale_moe_closures, replace_modules
+        from .sampler import Sampler
+
+        logger.info("Loading model %s ...", self.model_config.model)
+        loader = get_model_loader(self.load_config)
+
+        # Under a layer override the checkpoint still holds every layer's
+        # weights; filter the loader so it only feeds the built layers.
+        if self._original_num_layers is not None:
+            original_get_all_weights = loader.get_all_weights
+
+            def filtered_get_all_weights(model_config, model):
+                return self._filter_weights_for_layer_override(
+                    original_get_all_weights(model_config, model)
+                )
+
+            loader.get_all_weights = filtered_get_all_weights
+
+        # xm's rank assignment differs from gloo's; the embedding all-gather
+        # ordering depends on the xm rank, so patch it only for the weight load.
+        vocab_rank_patch = nullcontext()
+        if self.enable_tensor_parallel:
+            from unittest.mock import patch
+
+            import torch_xla.runtime as xr
+
+            vocab_rank_patch = patch(
+                "vllm.model_executor.layers.vocab_parallel_embedding."
+                "get_tensor_model_parallel_rank",
+                return_value=xr.global_ordinal(),
+            )
+
+        with set_current_vllm_config(self.vllm_config), vocab_rank_patch:
+            model = loader.load_model(
+                vllm_config=self.vllm_config, model_config=self.model_config
+            ).eval()
+        replace_modules(model)
+        self.model = model.to(self.device)
+
+        # Repair MoE routing closures that captured CPU tensors before to(device).
+        repair_stale_moe_closures(self.model)
+
+        # Wrap with LoRA layers after the model is on device, before compile
+        # (ported from the v1 runner). replace_set_lora adds the torch_xla.sync
+        # the integer LoRA index needs.
+        if self.lora_config is not None:
+            logger.info("Loading LoRA model...")
+            self.model = self.load_lora_model(self.model, self.vllm_config, self.device)
+            replace_set_lora(self.model)
+
+        # Shard weights across the mesh before compile so the annotations are
+        # captured in the traced graph. Pure-TP always shards on the batch axis
+        # (it is itself a TP axis there); DP+TP honours the config knob.
+        if self.enable_tensor_parallel:
+            shard_on_batch_axis = (
+                self.tt_config.shard_weights_on_batch_axis
+                if self.parallel_mode == ParallelismMode.DATA_TENSOR_PARALLEL
+                else True
+            )
+            shard_model(self.model, self.mesh, shard_on_batch_axis)
+
+        # MM models nest lm_head, so walk the tree for any ParallelLMHead.
+        self.is_sharded_compute_logits = self.enable_tensor_parallel and any(
+            isinstance(m, ParallelLMHead) for m in self.model.modules()
+        )
+
+        self.model.compile(backend="tt", dynamic=False)
+        logger.info("Model loaded and registered for tt compilation.")
+        self.sampler = Sampler()
+
+        encoder_cache = self.encoder_cache if self.supports_mm_inputs else None
+        self.model_state = TTModelState(
+            self.vllm_config, self.model, encoder_cache, self.device
+        )
+
+        # Cache the attention layer names for the per-step prepare_attn fan-out.
+        self._attention_layer_names = tuple(
+            get_layers_from_vllm_config(self.vllm_config, AttentionLayerBase).keys()
+        )
+        self.attention_layer_names = self._attention_layer_names
+
+    def _filter_weights_for_layer_override(self, weights_iterator):
+        """Drop checkpoint weights for layers beyond the override target."""
+        if self._original_num_layers is None or self._target_num_layers is None:
+            yield from weights_iterator
+            return
+        for weight_name, weight_tensor in weights_iterator:
+            skip = False
+            if "layers." in weight_name:
+                parts = weight_name.split(".")
+                for i, part in enumerate(parts):
+                    if part == "layers" and i + 1 < len(parts):
+                        try:
+                            skip = int(parts[i + 1]) >= self._target_num_layers
+                        except ValueError:
+                            skip = False
+                        break
+            if not skip:
+                yield weight_name, weight_tensor
+
+    def _remove_request(self, req_id: str) -> None:
+        """Free a request's slot across every per-slot table. Idempotent."""
+        slot = self.req_states.req_id_to_index.get(req_id)
+        if slot is None:
+            return
+        self.req_states.remove_request(req_id)
+        self.sampling_states.remove_request(slot)
+        self.block_table.clear_row(slot)
+        self.num_prompt_logprobs.pop(req_id, None)
+        self.lora_requests_by_slot.pop(slot, None)
+        self.mm_features_by_slot.pop(slot, None)
+
+    def finish_requests(self, scheduler_output: "SchedulerOutput") -> None:
+        """Remove finished and preempted requests, freeing their slots.
+
+        Preempted requests are dropped (not kept at their slot as in v1): the
+        scheduler resends them through ``scheduled_new_reqs`` when resumed.
+        """
+        for req_id in scheduler_output.finished_req_ids:
+            self._remove_request(req_id)
+        for req_id in scheduler_output.preempted_req_ids:
+            self._remove_request(req_id)
+        for mm_hash in scheduler_output.free_encoder_mm_hashes:
+            self.encoder_cache.pop(mm_hash, None)
+
+    def add_requests(self, scheduler_output: "SchedulerOutput") -> None:
+        """Register newly scheduled requests into the per-slot tables."""
+        new_reqs = scheduler_output.scheduled_new_reqs
+        for new in new_reqs:
+            sampling_params = new.sampling_params
+            assert sampling_params is not None, "Pooling not supported in the v2 runner"
+
+            req_id = new.req_id
+            # A re-added id (streaming abort+resubmit) must clear its stale slot.
+            self._remove_request(req_id)
+
+            prompt_len = len(new.prompt_token_ids)
+            # prefill_token_ids is the full known prefix (prompt + already-computed
+            # tokens for resumed/PD requests); prompt_token_ids for a fresh req.
+            all_token_ids = (
+                new.prefill_token_ids
+                if new.prefill_token_ids is not None
+                else new.prompt_token_ids
+            )
+            self.req_states.add_request(
+                req_id, prompt_len, all_token_ids, new.num_computed_tokens
+            )
+            slot = self.req_states.req_id_to_index[req_id]
+
+            # Seeded requests carry their own generator; the rest use global RNG.
+            generator = None
+            if sampling_params.sampling_type == SamplingType.RANDOM_SEED:
+                generator = torch.Generator(device="cpu")
+                generator.manual_seed(sampling_params.seed)
+            self.sampling_states.add_request(slot, sampling_params, generator)
+
+            self.block_table.add_row(new.block_ids, slot)
+
+            if new.lora_request is not None:
+                self.lora_requests_by_slot[slot] = new.lora_request
+
+            if self.supports_mm_inputs and new.mm_features:
+                self.mm_features_by_slot[slot] = new.mm_features
+
+            if self.model_state is not None:
+                # No-op for the common text path (rope_state is None).
+                self.model_state.add_request(slot, new)
+
+            if sampling_params.prompt_logprobs is not None:
+                self.num_prompt_logprobs[req_id] = (
+                    self.vocab_size
+                    if sampling_params.prompt_logprobs == -1
+                    else sampling_params.prompt_logprobs
+                )
+
+        if new_reqs:
+            # No-ops under the numpy substitution, kept for interface parity.
+            self.req_states.apply_staged_writes()
+            if self.model_state is not None:
+                self.model_state.apply_staged_writes()
+
+    def update_requests(self, scheduler_output: "SchedulerOutput") -> None:
+        """Advance computed-token counts and append new blocks for running reqs."""
+        cached = scheduler_output.scheduled_cached_reqs
+        for i, req_id in enumerate(cached.req_ids):
+            slot = self.req_states.req_id_to_index[req_id]
+            num_computed = cached.num_computed_tokens[i]
+            self.req_states.num_computed_tokens[slot] = num_computed
+            # Clamp prefill progress to the prefill length (upstream update_requests).
+            self.req_states.num_computed_prefill_tokens[slot] = min(
+                num_computed, int(self.req_states.prefill_len[slot])
+            )
+            new_block_ids = cached.new_block_ids[i]
+            if new_block_ids is not None:
+                self.block_table.append_row(new_block_ids, slot)
+
+    def _order_scheduled_reqs(
+        self, scheduler_output: "SchedulerOutput"
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Order this step's scheduled requests decodes-first (by token count).
+
+        Returns parallel ``(slots, num_scheduled_tokens)`` arrays. Sorting by
+        ascending scheduled-token count (upstream v2 convention) groups the
+        1-token decodes ahead of the prefills so the multi-pass loop can emit
+        pure decode passes (dispatched to the decode graph) before prefills.
+        """
+        sched = scheduler_output.num_scheduled_tokens
+        if self.dp_size > 1:
+            # DP: a request's batch position picks its DP replica, so it must equal
+            # the request's stable slot for its whole life (KV is written at prefill
+            # and read at decode on the same replica). Return the FULL replica grid
+            # -- every slot 0..max_num_reqs-1, position b == slot b -- with per-slot
+            # token counts (0 for inactive or unscheduled slots); _select_batch runs
+            # it as one full-width pass. Listing only active slots (or ranking them)
+            # would shift a lone prefilling request to position 0 and read its KV off
+            # the wrong replica at decode.
+            idx_to_req = self.req_states.index_to_req_id
+            slots = np.arange(self.max_num_reqs, dtype=np.int32)
+            ntoks_np = np.array(
+                [sched.get(idx_to_req.get(s), 0) for s in range(self.max_num_reqs)],
+                dtype=np.int32,
+            )
+            return slots, ntoks_np
+
+        slots: list[int] = []
+        ntoks: list[int] = []
+        for req_id, n in sched.items():
+            slot = self.req_states.req_id_to_index.get(req_id)
+            if slot is None:
+                continue
+            slots.append(slot)
+            ntoks.append(n)
+        ntoks_np = np.array(ntoks, dtype=np.int32)
+        order = np.argsort(ntoks_np, kind="stable")
+        return np.array(slots, dtype=np.int32)[order], ntoks_np[order]
+
+    def _select_batch(
+        self,
+        ordered_slots: np.ndarray,
+        ordered_num_tokens: np.ndarray,
+        start_index: int,
+    ) -> tuple[np.ndarray, np.ndarray, int, int, int]:
+        """Pick the sub-batch for one pass, applying the SMEM row caps.
+
+        Mirrors the v1 fork's per-pass clamping over the decode-first ordering:
+        a long request in the remaining tail forces the max-model-len row cap;
+        prefill passes are additionally capped at ``max_prefill_num_reqs`` and the
+        multi-pass loop picks up the rest. Returns ``(idx_mapping,
+        num_scheduled_tokens, target_num_reqs, padded_query_len, end_index)``.
+        """
+        if self.dp_size > 1:
+            # DP grid is one full-width pass; positions already map to replicas
+            # (see _order_scheduled_reqs), so no SMEM re-clamp or reorder here.
+            max_scheduled = max(int(ordered_num_tokens.max()), 1)
+            padded_query_len = _get_padded_token_len(
+                self.num_tokens_paddings, max_scheduled
+            )
+            return (
+                ordered_slots,
+                ordered_num_tokens,
+                self.max_num_reqs,
+                padded_query_len,
+                len(ordered_slots),
+            )
+
+        # A long request anywhere in the remaining tail forces max-model-len mode
+        # (fewer rows fit SMEM), matching the v1 collection loop.
+        use_max_model_len = self.most_model_len is None
+        if not use_max_model_len and np.any(
+            ordered_num_tokens[start_index:] > self.most_model_len
+        ):
+            use_max_model_len = True
+        row_cap = (
+            self.num_reqs_max_model_len
+            if use_max_model_len
+            else self.num_reqs_most_model_len
+        )
+
+        end_index = min(len(ordered_slots), start_index + row_cap)
+        num_scheduled = ordered_num_tokens[start_index:end_index]
+
+        # Prefill pass over the cap -> trim; the next pass takes the remainder.
+        if (
+            len(num_scheduled) > self.max_prefill_num_reqs
+            and int(num_scheduled.max()) > 1
+        ):
+            end_index = start_index + self.max_prefill_num_reqs
+            num_scheduled = ordered_num_tokens[start_index:end_index]
+
+        idx_mapping = ordered_slots[start_index:end_index]
+        max_scheduled = int(num_scheduled.max())
+
+        if max_scheduled == 1:
+            # Decode always runs at the max request bucket.
+            target_num_reqs = self.max_num_reqs
+        else:
+            actual = len(num_scheduled)
+            target_num_reqs = (
+                self.min_num_reqs
+                if actual <= self.min_num_reqs
+                else self.max_prefill_num_reqs
+            )
+
+        padded_query_len = _get_padded_token_len(
+            self.num_tokens_paddings, max_scheduled
+        )
+        return idx_mapping, num_scheduled, target_num_reqs, padded_query_len, end_index
+
+    def _prepare_input_tokens(
+        self,
+        idx_mapping_np: np.ndarray,
+        num_scheduled_tokens: np.ndarray,
+        target_num_reqs: int,
+        padded_query_len: int,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """Host substitute for the v2 Triton input-prep kernels.
+
+        Builds 2D input_ids/positions [target_num_reqs, padded_query_len] plus flat
+        query_start_loc/seq_lens/logits_indices from TTRequestState, indexed by
+        idx_mapping_np[b] -> stable slot. Prefill and decode share one gather
+        (all_token_ids[computed:computed+n]); the sampled token was already
+        appended by the writeback and there is no spec decode. Padding stays zero.
+        """
+        num_reqs = len(idx_mapping_np)
+        rs = self.req_states
+
+        input_ids = np.zeros((target_num_reqs, padded_query_len), dtype=np.int32)
+        positions = np.zeros((target_num_reqs, padded_query_len), dtype=np.int32)
+        seq_lens = np.zeros(target_num_reqs, dtype=np.int32)
+        logits_indices = np.zeros(target_num_reqs, dtype=np.int32)
+
+        for b in range(num_reqs):
+            slot = int(idx_mapping_np[b])
+            n = int(num_scheduled_tokens[b])
+            computed = int(rs.num_computed_tokens[slot])
+            # Same gather for prefill and decode: the scheduled tokens for this
+            # step are all_token_ids[computed : computed + n].
+            input_ids[b, :n] = rs.all_token_ids[slot, computed : computed + n]
+            positions[b, :n] = np.arange(n, dtype=np.int32) + computed
+            seq_lens[b] = computed + n
+            # One logit per request, at its last scheduled token (within-row).
+            logits_indices[b] = n - 1
+
+        query_start_loc = np.zeros(target_num_reqs + 1, dtype=np.int32)
+        np.cumsum(num_scheduled_tokens, out=query_start_loc[1 : num_reqs + 1])
+        # Non-decreasing pad tail (matches TTInputBatch.make_dummy).
+        query_start_loc[num_reqs + 1 :] = query_start_loc[num_reqs]
+
+        if self.uses_mrope:
+            # M-RoPE position ids are 3D [3, reqs, tokens]. For text-only inputs
+            # every plane is identical, making it equivalent to 1D RoPE (see
+            # https://arxiv.org/abs/2409.12191). Mirrors the v1 runner.
+            positions = np.broadcast_to(
+                positions, (3, target_num_reqs, padded_query_len)
+            ).copy()
+
+        return input_ids, positions, query_start_loc, seq_lens, logits_indices
+
+    def _execute_mm_encoder(self, scheduler_output: "SchedulerOutput") -> None:
+        """Run the multimodal encoder for this step and cache outputs by mm_hash.
+
+        Ported from the v1 runner (_execute_mm_encoder). Reads mm features from
+        the per-slot table instead of self.requests, and assumes whole mm items
+        (no scatter_mm_placeholders dynamism), like the v1 runner.
+        """
+        from typing import cast
+
+        import torch_xla
+        from vllm.model_executor.models.interfaces import SupportsMultiModal
+        from vllm.multimodal.utils import group_mm_kwargs_by_modality
+        from vllm.v1.worker.utils import sanity_check_mm_encoder_outputs
+
+        scheduled_encoder_inputs = scheduler_output.scheduled_encoder_inputs
+        if not scheduled_encoder_inputs:
+            return
+
+        mm_kwargs = []
+        mm_hashes_pos = []
+        for req_id, encoder_input_ids in scheduled_encoder_inputs.items():
+            slot = self.req_states.req_id_to_index[req_id]
+            mm_features = self.mm_features_by_slot.get(slot, [])
+            for mm_input_id in encoder_input_ids:
+                mm_feature = mm_features[mm_input_id]
+                if mm_feature.data is None:
+                    continue
+                mm_kwargs.append((mm_feature.modality, mm_feature.data))
+                mm_hashes_pos.append((mm_feature.identifier, mm_feature.mm_position))
+
+        model = cast(SupportsMultiModal, self.model)
+        encoder_outputs = []
+        for _, num_items, mm_kwargs_group in group_mm_kwargs_by_modality(
+            mm_kwargs, device=self.device, pin_memory=False
+        ):
+            torch_xla.sync(wait=False)
+            curr_group_outputs = model.embed_multimodal(**mm_kwargs_group)
+            torch_xla.sync(wait=False)
+            sanity_check_mm_encoder_outputs(
+                curr_group_outputs, expected_num_items=num_items
+            )
+            for output in curr_group_outputs:
+                encoder_outputs.append(output)
+
+        for (mm_hash, _pos), output in zip(mm_hashes_pos, encoder_outputs):
+            self.encoder_cache[mm_hash] = output
+
+    def _gather_mm_embeddings(
+        self,
+        idx_mapping_np: np.ndarray,
+        num_scheduled_tokens: np.ndarray,
+        padded_query_len: int,
+    ):
+        """Build the per-pass mm-embed mask + flat scatter indices (v1
+        _gather_mm_embeddings port). The mask is [target_num_reqs,
+        padded_query_len] to match input_ids (each request's scheduled tokens
+        start at column 0); mm_indices are its row-major True positions, consumed
+        by get_mm_embeddings' index_copy merge.
+        """
+        target_num_reqs = len(idx_mapping_np)
+        is_mm_embed = torch.zeros(
+            (target_num_reqs, padded_query_len), dtype=torch.bool, device="cpu"
+        )
+        mm_embeds = []
+
+        for b in range(target_num_reqs):
+            n = int(num_scheduled_tokens[b])
+            if n == 0:
+                continue
+            slot = int(idx_mapping_np[b])
+            num_computed_tokens = int(self.req_states.num_computed_tokens[slot])
+            for mm_feature in self.mm_features_by_slot.get(slot, []):
+                pos_info = mm_feature.mm_position
+                start_pos = pos_info.offset
+                num_encoder_tokens = pos_info.length
+
+                if start_pos >= num_computed_tokens + n:
+                    break
+                if start_pos + num_encoder_tokens <= num_computed_tokens:
+                    continue
+
+                start_idx = max(num_computed_tokens - start_pos, 0)
+                end_idx = min(num_computed_tokens - start_pos + n, num_encoder_tokens)
+                assert start_idx < end_idx
+                curr_embeds_start, curr_embeds_end = (
+                    pos_info.get_embeds_indices_in_range(start_idx, end_idx)
+                )
+                if curr_embeds_start == curr_embeds_end:
+                    continue
+
+                encoder_output = self.encoder_cache.get(mm_feature.identifier)
+                assert (
+                    encoder_output is not None
+                ), f"Encoder cache miss for {mm_feature.identifier}."
+
+                if (is_embed := pos_info.is_embed) is not None:
+                    is_embed = is_embed[start_idx:end_idx]
+                    mm_embeds_item = encoder_output[curr_embeds_start:curr_embeds_end]
+                else:
+                    mm_embeds_item = encoder_output[start_idx:end_idx]
+
+                # Column of this request's row where the placeholder begins
+                # (input_ids stores scheduled tokens from column 0).
+                col_base = start_pos - num_computed_tokens
+                if is_embed is None:
+                    is_mm_embed[b, col_base + start_idx : col_base + end_idx] = True
+                else:
+                    is_mm_embed[
+                        b, col_base + start_idx : col_base + end_idx
+                    ] |= is_embed
+                mm_embeds.append(mm_embeds_item)
+
+        mm_indices = is_mm_embed.flatten().nonzero(as_tuple=True)[0].to(self.device)
+        is_mm_embed = is_mm_embed.to(self.device)
+        return mm_embeds, is_mm_embed, mm_indices
+
+    def postprocess(
+        self,
+        idx_mapping_np: np.ndarray,
+        num_scheduled_tokens: np.ndarray,
+        sampled_token_ids: list[list[int]],
+    ) -> list[list[int]]:
+        """Write sampled tokens back into TTRequestState (post_update substitute).
+
+        A request emits a token only once past its prefill (seq_len >= prefill_len);
+        still-prefilling rows are discarded. The token lands at total_len (== seq_len
+        then) so the next step's gather reads it; num_computed is advanced by the
+        scheduler via update_requests, not here. Returns per-batch sampled ids with
+        discarded rows emptied.
+        """
+        num_reqs = len(idx_mapping_np)
+        rs = self.req_states
+        valid: list[list[int]] = [list(row) for row in sampled_token_ids[:num_reqs]]
+
+        for b in range(num_reqs):
+            slot = int(idx_mapping_np[b])
+            if int(num_scheduled_tokens[b]) == 0:
+                # DP padding row (unscheduled this step): emits no token.
+                valid[b] = []
+                continue
+            seq_len = int(rs.num_computed_tokens[slot]) + int(num_scheduled_tokens[b])
+            if seq_len < int(rs.prefill_len[slot]):
+                # Still prefilling: ignore the sampled token from this partial req.
+                valid[b] = []
+                continue
+            token_id = int(valid[b][0])
+            pos = int(rs.total_len[slot])
+            rs.all_token_ids[slot, pos] = token_id
+            rs.total_len[slot] = pos + 1
+            rs.last_sampled_tokens[slot, 0] = token_id
+
+        return valid
+
+    def _prepare_attn_tensors(
+        self,
+        idx_mapping_np: np.ndarray,
+        num_scheduled_tokens: np.ndarray,
+        seq_lens: np.ndarray,
+        target_num_reqs: int,
+        num_blocks_per_req: int,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Host substitute for the v2 block-table / slot-mapping kernels.
+
+        Builds the paged-attention tensors TTModelState.prepare_attn packages into
+        a TTMetadata: read-path page_table (gathered in batch order via the slot
+        mapping), write-path fill_page_table (prefix rolled), and cache_position
+        (seq_lens - 1). Padding rows are null (page_table 0, cache_position -1).
+        """
+        num_reqs = len(idx_mapping_np)
+        block_table_cpu = self.block_table[0].get_cpu_tensor()
+        if hasattr(block_table_cpu, "numpy"):
+            block_table_cpu = block_table_cpu.numpy()
+
+        page_table = np.zeros((target_num_reqs, num_blocks_per_req), dtype=np.int32)
+        for b in range(num_reqs):
+            slot = int(idx_mapping_np[b])
+            page_table[b, :] = block_table_cpu[slot, :num_blocks_per_req]
+
+        # Decode/write position per user; -1 for padding rows.
+        cache_position = np.full(target_num_reqs, -1, dtype=np.int32)
+        cache_position[:num_reqs] = seq_lens[:num_reqs] - 1
+
+        # Prefix caching: roll each row so paged_fill_cache writes the suffix
+        # blocks instead of overwriting shared prefix blocks. Per-row because
+        # prefix lengths differ.
+        offsets = np.zeros(num_reqs, dtype=np.int64)
+        for b in range(num_reqs):
+            slot = int(idx_mapping_np[b])
+            offsets[b] = (
+                int(self.req_states.num_computed_tokens[slot]) // self.block_size
+            )
+        if np.any(offsets > 0):
+            fill_page_table = page_table.copy()
+            for b in range(num_reqs):
+                if offsets[b] > 0:
+                    fill_page_table[b] = np.roll(page_table[b], -int(offsets[b]))
+        else:
+            fill_page_table = page_table
+
+        # A zero-scheduled (already-prefilled, re-batched) row would clobber its
+        # real KV with padding; redirect its fill to the null block. The read
+        # path keeps the real blocks.
+        zero_rows = np.nonzero(num_scheduled_tokens[:num_reqs] == 0)[0]
+        if len(zero_rows) > 0:
+            if fill_page_table is page_table:
+                fill_page_table = page_table.copy()
+            fill_page_table[zero_rows, :] = 0
+
+        return page_table, fill_page_table, cache_position
+
+    def execute_model(
+        self,
+        scheduler_output: "SchedulerOutput",
+        intermediate_tensors=None,
+    ):
+        """Phase 1 of the step: apply the scheduler delta via the lifecycle and
+        stash the step. Returns None (the forward + sampling run in sample_tokens),
+        or an empty output when nothing is scheduled.
+        """
+        assert (
+            self.scheduler_output is None
+        ), "execute_model called before sample_tokens consumed the prior step"
+        # TT compiles one graph per (bucket) shape; keep dynamic shapes off so a
+        # new shape recompiles rather than silently falling back.
+        torch._dynamo.config.dynamic_shapes = False
+
+        self.finish_requests(scheduler_output)
+        self.add_requests(scheduler_output)
+        self.update_requests(scheduler_output)
+
+        if scheduler_output.total_num_scheduled_tokens == 0:
+            # No tokens this step (e.g. only KV-connector activity).
+            from vllm.v1.worker.gpu_model_runner import EMPTY_MODEL_RUNNER_OUTPUT
+
+            return EMPTY_MODEL_RUNNER_OUTPUT
+
+        if self.supports_mm_inputs and scheduler_output.scheduled_encoder_inputs:
+            # Run the vision/multimodal encoder once per step; outputs are cached
+            # by mm_hash and consumed per pass in _run_model_pass. Text-only
+            # requests skip this (no scheduled encoder inputs).
+            self._execute_mm_encoder(scheduler_output)
+
+        self.scheduler_output = scheduler_output
+        return None
+
+    def sample_tokens(self, grammar_output):
+        """Phase 2 of the step: run the decode-first, SMEM-clamped multi-pass batch
+        loop around the _run_model_pass hardware leaf, then assemble the
+        ModelRunnerOutput. A step may span several passes (start_index advances).
+        """
+        if self.scheduler_output is None:
+            # PP non-final rank / nothing stashed: output is unused.
+            return None
+        scheduler_output = self.scheduler_output
+        self.scheduler_output = None
+
+        ordered_slots, ordered_num_tokens = self._order_scheduled_reqs(scheduler_output)
+
+        out_req_ids: list[str] = []
+        out_sampled: list[list[int]] = []
+        # Capture per-request prompt hidden states (keyed by slot) when any
+        # scheduled request wants prompt logprobs.
+        want_prompt_hs = bool(self.num_prompt_logprobs)
+        prompt_lp_hs: dict[int, torch.Tensor] = {}
+
+        start_index = 0
+        while start_index < len(ordered_slots):
+            (
+                idx_mapping,
+                num_scheduled,
+                target_num_reqs,
+                padded_query_len,
+                end_index,
+            ) = self._select_batch(ordered_slots, ordered_num_tokens, start_index)
+
+            input_ids, positions, _query_start_loc, seq_lens, logits_indices = (
+                self._prepare_input_tokens(
+                    idx_mapping, num_scheduled, target_num_reqs, padded_query_len
+                )
+            )
+            page_table, fill_page_table, cache_position = self._prepare_attn_tensors(
+                idx_mapping,
+                num_scheduled,
+                seq_lens,
+                target_num_reqs,
+                self.max_num_blocks_per_req,
+            )
+
+            pass_result = self._run_model_pass(
+                idx_mapping,
+                num_scheduled,
+                target_num_reqs,
+                padded_query_len,
+                input_ids,
+                positions,
+                logits_indices,
+                page_table,
+                fill_page_table,
+                cache_position,
+                want_prompt_hs,
+                grammar_output,
+            )
+            if want_prompt_hs:
+                sampled, hidden_states = pass_result
+                # Copy only the rows for requests that need prompt logprobs
+                # (keyed by stable slot), so the big hidden tensor never fully
+                # leaves the device.
+                for b in range(len(idx_mapping)):
+                    slot = int(idx_mapping[b])
+                    req_id = self.req_states.index_to_req_id.get(slot)
+                    if req_id in self.num_prompt_logprobs:
+                        prompt_lp_hs[slot] = hidden_states[b].cpu()
+            else:
+                sampled = pass_result
+
+            valid = self.postprocess(idx_mapping, num_scheduled, sampled)
+            for b in range(len(idx_mapping)):
+                if int(num_scheduled[b]) == 0:
+                    # DP padding row: not scheduled this step, don't report it.
+                    continue
+                slot = int(idx_mapping[b])
+                out_req_ids.append(self.req_states.index_to_req_id[slot])
+                out_sampled.append(valid[b])
+
+            start_index = end_index
+
+        prompt_logprobs_dict = self._get_prompt_logprobs_dict(
+            prompt_lp_hs, scheduler_output
+        )
+
+        from vllm.v1.outputs import ModelRunnerOutput
+
+        return ModelRunnerOutput(
+            req_ids=out_req_ids,
+            req_id_to_index={rid: i for i, rid in enumerate(out_req_ids)},
+            sampled_token_ids=out_sampled,
+            prompt_logprobs_dict=prompt_logprobs_dict,
+        )
+
+    def _run_model_pass(
+        self,
+        idx_mapping_np: np.ndarray,
+        num_scheduled_tokens: np.ndarray,
+        target_num_reqs: int,
+        padded_query_len: int,
+        input_ids: np.ndarray,
+        positions: np.ndarray,
+        logits_indices: np.ndarray,
+        page_table: np.ndarray,
+        fill_page_table: np.ndarray,
+        cache_position: np.ndarray,
+        want_prompt_hs: bool = False,
+        grammar_output=None,
+    ):
+        """Run one compiled forward+sample pass for the selected sub-batch.
+
+        Copies host arrays to device, builds attention metadata (prepare_attn) +
+        sampling metadata (from_v2_states), runs the compiled graph, and returns
+        the batch-ordered sampled token ids. Common text path only. When
+        ``want_prompt_hs`` is set, also returns the per-batch pre-selection hidden
+        states (device tensor [target_num_reqs, padded_query_len, H]) for prompt
+        logprobs.
+        """
+        from types import SimpleNamespace
+
+        from .metadata import XLASupportedSamplingMetadata
+
+        dev = self.device
+        input_ids_dev = torch.from_numpy(input_ids).to(dev)
+        positions_dev = torch.from_numpy(positions).to(dev)
+        page_table_dev = torch.from_numpy(page_table).to(dev)
+        fill_page_table_dev = torch.from_numpy(fill_page_table).to(dev)
+        cache_position_dev = torch.from_numpy(cache_position).to(dev)
+        logits_indices_dev = torch.from_numpy(logits_indices).to(dev)
+        batch_idx_dev = torch.from_numpy(np.arange(target_num_reqs, dtype=np.int32)).to(
+            dev
+        )
+
+        # Pin input shardings eagerly (not inside the compiled graph, whose
+        # dynamo trace can't run safe_mark_sharding's replicate-fallback logging).
+        self._pin_input_shardings(input_ids_dev, positions_dev, None)
+
+        if self.parallel_mode in (
+            ParallelismMode.DATA_PARALLEL_ONLY,
+            ParallelismMode.DATA_TENSOR_PARALLEL,
+        ):
+            # These share the DP-sharded K/V input's per-device leading dim;
+            # batch_idx feeds paged_fill_cache, whose verifier requires dim0 to
+            # equal the per-device batch.
+            safe_mark_sharding(page_table_dev, self.mesh, ("batch", None))
+            safe_mark_sharding(cache_position_dev, self.mesh, ("batch",))
+            safe_mark_sharding(batch_idx_dev, self.mesh, ("batch",))
+            safe_mark_sharding(fill_page_table_dev, self.mesh, ("batch", None))
+
+        attn_metadata = self.model_state.prepare_attn(
+            self.attention_layer_names,
+            page_table_dev,
+            cache_position_dev,
+            fill_page_table=fill_page_table_dev,
+            batch_idx=batch_idx_dev,
+            num_users=target_num_reqs,
+            dp_size=self.dp_size,
+        )
+        # from_v2_states only reads num_reqs + idx_mapping_np off the view.
+        batch_view = SimpleNamespace(
+            num_reqs=len(idx_mapping_np), idx_mapping_np=idx_mapping_np
+        )
+        sampling_metadata = XLASupportedSamplingMetadata.from_v2_states(
+            self.req_states,
+            self.sampling_states,
+            batch_view,
+            target_num_reqs,
+            self.sampling_device,
+            vocab_size=self.vocab_size,
+        )
+
+        if self.lora_config is not None:
+            prompt_map, token_map, lora_reqs = self._make_lora_inputs(
+                idx_mapping_np, num_scheduled_tokens
+            )
+            self._set_active_loras(prompt_map, token_map, lora_reqs)
+
+        # Multimodal: merge gathered encoder embeds into the text embeds and feed
+        # the model inputs_embeds (input_ids=None). Text-only requests on a mm
+        # model still take this path (mm_embeds empty -> pure text embeddings).
+        model_input_ids = input_ids_dev
+        inputs_embeds_dev = None
+        if self.supports_mm_inputs:
+            mm_embeds, is_mm_embed, mm_indices = self._gather_mm_embeddings(
+                idx_mapping_np, num_scheduled_tokens, padded_query_len
+            )
+            inputs_embeds_dev = self.model_state.get_mm_embeddings(
+                input_ids_dev, mm_embeds, is_mm_embed, mm_indices
+            )
+            model_input_ids = None
+
+        # Structured output: build the per-pass grammar tensors; apply_grammar is
+        # a plain python bool so dynamo specializes a separate graph (no-grammar
+        # path unaffected).
+        apply_grammar = grammar_output is not None
+        require_struct = grammar_bitmask = bitmasks = None
+        if apply_grammar:
+            require_struct, grammar_bitmask, bitmasks = (
+                self.prepare_structured_decoding_input(
+                    grammar_output, idx_mapping_np, target_num_reqs
+                )
+            )
+
+        result = self._forward_and_sample(
+            model_input_ids,
+            positions_dev,
+            logits_indices_dev,
+            attn_metadata,
+            sampling_metadata,
+            want_prompt_hs,
+            inputs_embeds_dev,
+            apply_grammar,
+            require_struct,
+            grammar_bitmask,
+            bitmasks,
+        )
+        if want_prompt_hs:
+            forward_out, hidden_states = result
+        else:
+            forward_out, hidden_states = result, None
+        if self.cpu_sampling:
+            # forward_out is logits [target_num_reqs, vocab]; sample on host.
+            selected = self.sample_from_logits_cpu(forward_out, sampling_metadata)
+        else:
+            selected = forward_out
+        # [target_num_reqs, 1] -> per active-req list; drop padding rows.
+        # Transfer first, then slice on host: a device-side slice of the ROW_MAJOR
+        # sampled-id tensor forces a to_layout typecast tt-mlir can't lower (v1-aligned).
+        sampled = selected.cpu()[: len(idx_mapping_np)].tolist()
+        if want_prompt_hs:
+            return sampled, hidden_states
+        return sampled
+
+    def _forward_and_sample(
+        self,
+        input_ids,
+        positions,
+        logits_indices,
+        attn_metadata,
+        sampling_metadata,
+        want_prompt_hs=False,
+        inputs_embeds=None,
+        apply_grammar=False,
+        require_struct_decoding=None,
+        grammar_bitmask=None,
+        bitmasks=None,
+    ):
+        """Publish the attn metadata into the forward context, then run the graph."""
+        from vllm.forward_context import set_forward_context
+
+        # Multimodal passes inputs_embeds with input_ids=None; both are 2D
+        # [reqs, tokens(, H)] so the token count is the leading two dims.
+        ref = input_ids if input_ids is not None else inputs_embeds
+        num_tokens = ref.shape[0] * ref.shape[1]
+        # Under cpu_sampling the graph returns logits and never touches the
+        # sampling metadata, so keep its host tensors out of the compiled graph.
+        sm_for_graph = None if self.cpu_sampling else sampling_metadata
+        with set_forward_context(
+            attn_metadata, self.vllm_config, num_tokens=num_tokens
+        ):
+            return self._forward_and_sample_compiled(
+                input_ids,
+                positions,
+                logits_indices,
+                sm_for_graph,
+                want_prompt_hs,
+                inputs_embeds,
+                apply_grammar,
+                require_struct_decoding,
+                grammar_bitmask,
+                bitmasks,
+            )
+
+    @torch.compile(backend="tt", fullgraph=True, dynamic=False)
+    def _forward_and_sample_compiled(
+        self,
+        input_ids,
+        positions,
+        logits_indices,
+        sampling_metadata,
+        want_prompt_hs,
+        inputs_embeds=None,
+        apply_grammar=False,
+        require_struct_decoding=None,
+        grammar_bitmask=None,
+        bitmasks=None,
+    ):
+        """Compiled model forward -> last-token select -> logits -> sample.
+
+        ``want_prompt_hs`` and ``apply_grammar`` are plain python bools so dynamo
+        specializes separate graphs (prompt-logprobs hidden-state return / grammar
+        masking); the common path stays unaffected. ``inputs_embeds`` is set (with
+        ``input_ids=None``) on the multimodal path.
+        """
+        model_input_ids, model_positions, model_embeds, restore_shape = (
+            self._prepare_model_call_tensors(input_ids, positions, inputs_embeds)
+        )
+        hidden_states = self.model(
+            input_ids=model_input_ids,
+            positions=model_positions,
+            inputs_embeds=model_embeds,
+        )
+        hidden_states = self._restore_model_hidden_states(hidden_states, restore_shape)
+        selected_states = self._select_hidden_states(hidden_states, logits_indices)
+        logits = self.model.compute_logits(selected_states)
+        # Replicate sharded logits: hooks can't reach ParallelLMHead
+        # (quant_method.apply bypasses __call__) and all_gather is a no-op at
+        # world_size 1, so the constraint must sit inside the compiled graph.
+        if self.enable_tensor_parallel and self.is_sharded_compute_logits:
+            logits = sharding_constraint_tensor(logits, self.mesh, (None, None))
+        # Structured output: mask logits to grammar-allowed tokens before sampling.
+        if apply_grammar:
+            logits = self.structured_decode(
+                require_struct_decoding, grammar_bitmask, logits, bitmasks
+            )
+        # cpu_sampling: stop the compiled graph at logits and sample on the host
+        # (mirrors the v1 _model_unfused path); otherwise sample on device.
+        if self.cpu_sampling:
+            out = logits
+        else:
+            out = self._sample_from_logits(logits, sampling_metadata)
+        if want_prompt_hs:
+            return out, hidden_states
+        return out
+
+    def _pin_input_shardings(self, input_ids, positions, inputs_embeds) -> None:
+        """Pin model inputs on the batch/mesh axis so warmup and inference trace
+        the same graph. No-op off the SPMD path (ported from the v1 runner)."""
+        if not self.enable_tensor_parallel and self.parallel_mode not in (
+            ParallelismMode.DATA_PARALLEL_ONLY,
+            ParallelismMode.DATA_TENSOR_PARALLEL,
+        ):
+            return
+        # 2D mesh: batch dim -> "batch"; pure 1D-TP: "batch" is size 1, use "model".
+        batch_axis = "batch" if self.use_2d_mesh else "model"
+        if input_ids is not None:
+            safe_mark_sharding(input_ids, self.mesh, (batch_axis, None))
+        if inputs_embeds is not None:
+            safe_mark_sharding(inputs_embeds, self.mesh, (batch_axis, None, None))
+        # positions: pin only for DP modes; under pure-TP it drives GSPMD into a
+        # batch-axis reduce_scatter that hits a tt-mlir to_layout bug.
+        if self.parallel_mode in (
+            ParallelismMode.DATA_PARALLEL_ONLY,
+            ParallelismMode.DATA_TENSOR_PARALLEL,
+        ):
+            safe_mark_sharding(positions, self.mesh, (batch_axis, None))
+
+    def _prepare_model_call_tensors(self, input_ids, positions, inputs_embeds):
+        """Optionally flatten the 2D [reqs, tokens] tensors to 1D for flat_model_io."""
+        if not self.use_flat_model_io:
+            return input_ids, positions, inputs_embeds, None
+        restore_shape = None
+        if input_ids is not None and input_ids.ndim > 1:
+            restore_shape = input_ids.shape
+            input_ids = input_ids.reshape(-1)
+        if inputs_embeds is not None and inputs_embeds.ndim > 2:
+            if restore_shape is None:
+                restore_shape = torch.Size(inputs_embeds.shape[:-1])
+            inputs_embeds = inputs_embeds.reshape(-1, inputs_embeds.shape[-1])
+        if positions.ndim > 1:
+            if self.uses_mrope:
+                assert positions.ndim == 3 and positions.shape[0] == 3
+                positions = positions.reshape(3, -1)
+            else:
+                positions = positions.reshape(-1)
+
+        assert (
+            restore_shape is not None
+        ), "restore_shape should be set if any input is flattened."
+        return input_ids, positions, inputs_embeds, restore_shape
+
+    def _restore_model_hidden_states(self, hidden_states, restore_shape):
+        if restore_shape is None or hidden_states.ndim != 2:
+            return hidden_states
+        return hidden_states.reshape(*restore_shape, hidden_states.shape[-1])
+
+    def _select_hidden_states(self, hidden_states, indices_do_sample):
+        # Gather each request's last-token hidden state: hidden is [reqs, tokens, H].
+        batch_indices = torch.arange(indices_do_sample.shape[0], dtype=torch.int32)
+        result = hidden_states[batch_indices, indices_do_sample, :]
+        if self.enable_tensor_parallel and self.use_2d_mesh:
+            result = sharding_constraint_tensor(result, self.mesh, (None, None))
+        return result
+
+    def _sample_from_logits(self, logits, sampling_metadata):
+        # Greedy fast-path (argmax) avoids the fused sampling kernel; the sampler
+        # handles temperature/top-k/p/penalties/seeds otherwise.
+        if (
+            sampling_metadata.all_greedy
+            and sampling_metadata.no_penalties
+            and sampling_metadata.no_logit_bias
+            and sampling_metadata.no_bad_words
+            and sampling_metadata.no_allowed_token_ids
+            and sampling_metadata.no_min_tokens
+            and sampling_metadata.no_generators
+        ):
+            return torch.argmax(logits, dim=-1, keepdim=True)
+        return self.sampler(logits, sampling_metadata).sampled_token_ids
+
+    def prepare_structured_decoding_input(
+        self, grammar_output, idx_mapping_np, num_reqs
+    ):
+        """Build the per-pass structured-decoding tensors (ported from v1).
+
+        Keyed by batch position b (not the v1 persistent input_batch index): the
+        request at slot ``idx_mapping_np[b]`` fills row b. ``grammar_bitmask`` has
+        one row per structured request (scheduler order), so index it by the
+        enumerate position so passes that hold only some structured requests stay
+        aligned.
+        """
+        grammar_bitmask = grammar_output.grammar_bitmask
+        self.grammar_bitmask_cpu.zero_()
+        self.require_structured_out_cpu.zero_()
+
+        pos_by_req = {}
+        for b in range(len(idx_mapping_np)):
+            rid = self.req_states.index_to_req_id.get(int(idx_mapping_np[b]))
+            if rid is not None:
+                pos_by_req[rid] = b
+
+        for mask_idx, req_id in enumerate(grammar_output.structured_output_request_ids):
+            b = pos_by_req.get(req_id)
+            if b is None:
+                continue
+            self.grammar_bitmask_cpu[b] = torch.from_numpy(grammar_bitmask[mask_idx])
+            self.require_structured_out_cpu[b] = True
+
+        return (
+            self.require_structured_out_cpu[:num_reqs].to(self.device),
+            self.grammar_bitmask_cpu[:num_reqs].to(self.device),
+            self.structured_decode_bitmasks.to(self.device),
+        )
+
+    def structured_decode(
+        self, require_struct_decoding, grammar_bitmask, logits, bitmasks
+    ):
+        """Mask logits to grammar-allowed tokens for rows requiring it (v1 port)."""
+        return torch.where(
+            require_struct_decoding,
+            self._apply_grammar_bitmask(logits, grammar_bitmask, bitmasks),
+            logits,
+        )
+
+    def _apply_grammar_bitmask(self, logits, grammar_bitmask, bitmasks):
+        # Unpack the bitmask on-device with bitwise_and against power-of-2 masks
+        # (bitwise_right_shift is unsupported on TT). grammar_bitmask:
+        # [batch, ceil(vocab/32)] int32; bitmasks: [32] int32 = [1,2,...,2^31].
+        bits = grammar_bitmask.unsqueeze(-1) & bitmasks
+        allowed = (bits != 0).reshape(logits.shape[0], -1)[:, : self.vocab_size]
+        return torch.where(allowed, logits, torch.full_like(logits, float("-inf")))
+
+    def sample_from_logits_cpu(self, logits, sampling_metadata):
+        """Sample on CPU instead of compiling a device sampling graph.
+
+        Ported from the v1 runner: supports greedy, temperature, top-k/top-p and
+        penalty-based sampling. Uses Gumbel-max (argmax of logits + Gumbel noise)
+        rather than torch.multinomial, which serializes over the batch.
+        """
+        logits = logits.cpu()
+
+        if not sampling_metadata.no_penalties:
+            output_counts = sampling_metadata.output_token_counts
+            occurred_output = output_counts > 0
+            prompt_mask = sampling_metadata.prompt_token_mask
+            rep_pen = sampling_metadata.repetition_penalties.unsqueeze(1)
+            rep_mask = occurred_output | prompt_mask
+            penalty_factor = torch.where(logits > 0, torch.reciprocal(rep_pen), rep_pen)
+            logits = torch.where(rep_mask, logits * penalty_factor, logits)
+            freq_pen = sampling_metadata.frequency_penalties.unsqueeze(1)
+            logits -= freq_pen * output_counts.to(logits.dtype)
+            pres_pen = sampling_metadata.presence_penalties.unsqueeze(1)
+            logits -= pres_pen * occurred_output.to(logits.dtype)
+
+        if sampling_metadata.all_greedy:
+            return torch.argmax(logits, dim=-1, keepdim=True)
+
+        temp = sampling_metadata.temperature
+        temp = torch.where(temp < 1e-6, torch.ones_like(temp), temp)
+        logits = logits / temp.unsqueeze(1)
+
+        has_topk = sampling_metadata.top_k is not None
+        has_topp = sampling_metadata.top_p is not None
+        top_k = sampling_metadata.top_k if has_topk else None
+        top_p = sampling_metadata.top_p if has_topp else None
+
+        # Fast path: all requests share the same k > 0 -- single batched topk
+        # reduces vocab from 128K to k before the top-p sort.
+        uniform_k = 0
+        if has_topk:
+            k = int(top_k[0].item())
+            if 0 < k < logits.size(1) and (top_k == k).all():
+                uniform_k = k
+
+        if uniform_k > 0:
+            topk_vals, topk_idx = torch.topk(logits, uniform_k, dim=-1)
+
+            if has_topp:
+                for i in range(topk_vals.size(0)):
+                    p = float(top_p[i].item())
+                    if p < 1.0:
+                        sorted_vals, sort_idx = torch.sort(
+                            topk_vals[i], descending=True
+                        )
+                        probs = torch.softmax(sorted_vals, dim=-1)
+                        mask = torch.cumsum(probs, dim=-1) - probs >= p
+                        sorted_vals[mask] = float("-inf")
+                        topk_vals[i].scatter_(0, sort_idx, sorted_vals)
+
+            greedy = torch.argmax(topk_vals, dim=-1)
+            gumbel = -torch.log(
+                -torch.log(torch.rand_like(topk_vals.float()) + 1e-20) + 1e-20
+            )
+            random = torch.argmax(topk_vals + gumbel, dim=-1)
+            sampled_local = torch.where(temp < 1e-6, greedy, random)
+            return topk_idx.gather(-1, sampled_local.unsqueeze(-1))
+
+        # Slow path: mixed k values or k=0 -- per-request filtering on full vocab.
+        if has_topk:
+            for i in range(logits.size(0)):
+                k = int(top_k[i].item())
+                if k > 0 and k < logits.size(1):
+                    topk_vals, _ = torch.topk(logits[i], k)
+                    logits[i][logits[i] < topk_vals[-1]] = float("-inf")
+
+        if has_topp:
+            for i in range(logits.size(0)):
+                p = float(top_p[i].item())
+                if p < 1.0:
+                    sorted_logits, sorted_indices = torch.sort(
+                        logits[i], descending=True
+                    )
+                    probs = torch.softmax(sorted_logits, dim=-1)
+                    mask = torch.cumsum(probs, dim=-1) - probs >= p
+                    sorted_logits[mask] = float("-inf")
+                    logits[i].scatter_(0, sorted_indices, sorted_logits)
+
+        greedy = torch.argmax(logits, dim=-1)
+        gumbel = -torch.log(-torch.log(torch.rand_like(logits.float()) + 1e-20) + 1e-20)
+        random = torch.argmax(logits + gumbel, dim=-1)
+        return torch.where(temp < 1e-6, greedy, random).unsqueeze(-1)
+
+    def compute_logits(self, sample_hidden_states):
+        """Vocab logits for the given hidden states (ported from the v1 runner)."""
+        logits = self.model.compute_logits(sample_hidden_states)
+        # Replicate sharded logits for SPMD (see _forward_and_sample_compiled).
+        if self.enable_tensor_parallel and self.is_sharded_compute_logits:
+            logits = sharding_constraint_tensor(logits, self.mesh, (None, None))
+        return logits
+
+    @torch.compile(backend="tt", fullgraph=True, dynamic=False)
+    def compute_logits_compiled(self, sample_hidden_states):
+        """Compiled wrapper for compute_logits warmup / prompt-logprobs reuse."""
+        return self.compute_logits(sample_hidden_states)
+
+    def gather_logprobs(self, logits, token_ids):
+        """Top-k logprobs + the given tokens' logprobs (ported from the v1 runner).
+
+        Uses a fixed ``max_logprobs`` width so one compiled graph serves every
+        request; callers trim to their per-request count on CPU.
+        """
+        logprobs = self.sampler.compute_logprobs(logits)
+        return self.sampler.gather_logprobs(
+            logprobs,
+            self.model_config.max_logprobs,
+            token_ids=token_ids.squeeze(-1),
+        )
+
+    @torch.compile(backend="tt", fullgraph=True, dynamic=False)
+    def gather_logprobs_compiled(self, logits, token_ids):
+        """Compiled wrapper for gather_logprobs warmup / prompt-logprobs reuse."""
+        return self.gather_logprobs(logits, token_ids)
+
+    def _get_prompt_logprobs_dict(self, prompt_lp_hs, scheduler_output):
+        """Compute prompt logprobs for prefilling requests (ported from v1).
+
+        For each request with prompt_logprobs enabled, processes this step's
+        prompt positions in batches of max_num_reqs through compute_logits /
+        gather_logprobs so the vocab-sized tensors stay on device; only the small
+        gathered result moves to CPU. ``prompt_lp_hs`` holds per-slot hidden
+        states [padded_query_len, H] captured during the step's forward passes.
+        """
+        if not self.num_prompt_logprobs:
+            return {}
+
+        from vllm.v1.outputs import LogprobsTensors
+
+        in_progress = self.in_progress_prompt_logprobs
+        result: dict[str, Optional[LogprobsTensors]] = {}
+        completed: list[str] = []
+
+        batch_hs_buf: Optional[torch.Tensor] = None
+        batch_tgt_buf = torch.zeros(self.max_num_reqs, 1, dtype=torch.int64)
+
+        for req_id, num_plp in self.num_prompt_logprobs.items():
+            # gather_logprobs is compiled for max_logprobs; clamp so the trim
+            # slice below never reads past the gathered columns.
+            num_plp = min(num_plp, self.model_config.max_logprobs)
+            slot = self.req_states.req_id_to_index.get(req_id)
+            num_tokens = scheduler_output.num_scheduled_tokens.get(req_id)
+            if slot is None or num_tokens is None:
+                continue
+
+            num_prompt_tokens = int(self.req_states.prompt_len[slot])
+            prompt_token_ids = self.req_states.all_token_ids[slot, :num_prompt_tokens]
+
+            logprobs_tensors = in_progress.get(req_id)
+            if logprobs_tensors is None:
+                logprobs_tensors = LogprobsTensors.empty_cpu(
+                    num_prompt_tokens - 1, num_plp + 1
+                )
+                in_progress[req_id] = logprobs_tensors
+
+            start_idx = int(self.req_states.num_computed_tokens[slot])
+            start_tok = start_idx + 1
+            num_remaining = num_prompt_tokens - start_tok
+
+            if num_tokens <= num_remaining:
+                num_logits = num_tokens
+            else:
+                num_logits = num_remaining
+                completed.append(req_id)
+                result[req_id] = logprobs_tensors
+
+            if num_logits <= 0:
+                continue
+
+            hs_cpu = prompt_lp_hs.get(slot)
+            assert hs_cpu is not None, (
+                f"req {req_id} (slot {slot}) not found in prompt_lp_hs — "
+                f"state inconsistency"
+            )
+            hs_cpu = hs_cpu[:num_logits, :]
+
+            if batch_hs_buf is None or batch_hs_buf.shape[-1] != hs_cpu.shape[-1]:
+                batch_hs_buf = torch.zeros(
+                    self.max_num_reqs, hs_cpu.shape[-1], dtype=hs_cpu.dtype
+                )
+
+            all_tgt_ids = prompt_token_ids[start_tok : start_tok + num_logits]
+
+            for batch_start in range(0, num_logits, self.max_num_reqs):
+                batch_end = min(batch_start + self.max_num_reqs, num_logits)
+                batch_size = batch_end - batch_start
+
+                batch_hs_buf.zero_()
+                batch_hs_buf[:batch_size] = hs_cpu[batch_start:batch_end]
+                batch_hs_dev = batch_hs_buf.to(self.device)
+
+                logits = self.compute_logits(batch_hs_dev)
+
+                batch_tgt_buf.zero_()
+                batch_tgt_buf[:batch_size, 0] = torch.tensor(
+                    all_tgt_ids[batch_start:batch_end], dtype=torch.int64
+                )
+                batch_tgt_dev = batch_tgt_buf.to(self.device)
+
+                lp_tensors = self.gather_logprobs(logits, batch_tgt_dev)
+
+                ids_cpu = lp_tensors.logprob_token_ids.cpu()
+                lps_cpu = lp_tensors.logprobs.cpu()
+                ranks_cpu = lp_tensors.selected_token_ranks.cpu()
+
+                dest = slice(start_idx + batch_start, start_idx + batch_end)
+                logprobs_tensors.logprob_token_ids[dest] = ids_cpu[
+                    :batch_size, : num_plp + 1
+                ]
+                logprobs_tensors.logprobs[dest] = lps_cpu[:batch_size, : num_plp + 1]
+                logprobs_tensors.selected_token_ranks[dest] = ranks_cpu[:batch_size]
+
+        for req_id in completed:
+            del self.num_prompt_logprobs[req_id]
+            del in_progress[req_id]
+
+        return result
+
+    def _allocate_kv_caches(self, kv_cache_config: "KVCacheConfig") -> dict:
+        """Allocate the per-layer KV cache tensors on the TT device.
+
+        The device-coupled core of ``initialize_kv_cache`` (salvaged from the v1
+        fork), split out so it can be exercised on-device without the engine
+        wrappers. Standard attention gets separate ``[k_cache, v_cache]`` tensors
+        (avoids slice/concat in the compiled graph); MLA gets a single latent
+        tensor. Only one KV-cache group (no hybrid) and one owner per tensor are
+        supported. Returns ``layer_name -> tensor | [k, v]``.
+        """
+        from vllm.v1.kv_cache_interface import (
+            AttentionSpec,
+            MLAAttentionSpec,
+            UniformTypeKVCacheSpecs,
+        )
+
+        def _layer_spec(group_spec, name):
+            # Heterogeneous same-type layers (e.g. Gemma-4's mixed head dims) are
+            # merged into one group whose spec is a UniformTypeKVCacheSpecs; the
+            # real per-layer spec (with its own page_size/head_size) is inside.
+            if isinstance(group_spec, UniformTypeKVCacheSpecs):
+                return group_spec.kv_cache_specs[name]
+            return group_spec
+
+        from .attention_impls.attention import TTAttentionBackend
+        from .attention_impls.attention_mla import TTMLAAttentionBackend
+
+        groups = kv_cache_config.kv_cache_groups
+        if len(groups) > 1:
+            raise NotImplementedError(
+                "Hybrid models with more than one KV cache type are not supported yet."
+            )
+        if len(groups) == 0:
+            # Valid when only a subset of layers is compiled (layer override).
+            return {}
+
+        assert groups[0].kv_cache_spec.block_size == self.block_size, (
+            f"KV cache block_size {groups[0].kv_cache_spec.block_size} must match "
+            f"the runner block_size {self.block_size}"
+        )
+
+        kv_cache_sizes: dict[str, int] = {}
+        for tensor in kv_cache_config.kv_cache_tensors:
+            assert (
+                len(tensor.shared_by) == 1
+            ), "A KV cache tensor shared by multiple layers is not supported on TT."
+            kv_cache_sizes[tensor.shared_by[0]] = tensor.size
+
+        kv_caches: dict = {}
+        for group in groups:
+            for layer_name in group.layer_names:
+                spec = _layer_spec(group.kv_cache_spec, layer_name)
+                tensor_size = kv_cache_sizes[layer_name]
+                assert tensor_size % spec.page_size_bytes == 0
+                num_blocks = tensor_size // spec.page_size_bytes
+                if isinstance(spec, MLAAttentionSpec):
+                    # Single concatenated latent KV tensor (num_kv_heads == 1).
+                    shape = TTMLAAttentionBackend.get_kv_cache_shape(
+                        num_blocks, spec.block_size, spec.num_kv_heads, spec.head_size
+                    )
+                    kv_caches[layer_name] = torch.zeros(shape, dtype=spec.dtype).to(
+                        self.device
+                    )
+                elif isinstance(spec, AttentionSpec):
+                    if self.enable_tensor_parallel:
+                        tp_size = self.original_parallel_config.tensor_parallel_size
+                        assert spec.num_kv_heads % tp_size == 0, (
+                            f"num_kv_heads {spec.num_kv_heads} must be divisible by "
+                            f"tp_size {tp_size} under SPMD"
+                        )
+                    shape = TTAttentionBackend.get_kv_cache_shape(
+                        num_blocks, spec.block_size, spec.num_kv_heads, spec.head_size
+                    )
+                    # spec.dtype may be a 1-byte accounting dtype; the device
+                    # buffers use the real transfer dtype.
+                    k = torch.zeros(shape, dtype=self.kv_cache_dtype).to(self.device)
+                    v = torch.zeros(shape, dtype=self.kv_cache_dtype).to(self.device)
+                    kv_caches[layer_name] = [k, v]
+                else:
+                    raise NotImplementedError(
+                        f"Unsupported KV cache spec: {type(spec)}"
+                    )
+        return kv_caches
+
+    def _maybe_setup_cross_layer_kv_sharing(
+        self, kv_caches: dict, kv_cache_config: "KVCacheConfig"
+    ) -> None:
+        """Point cross-layer KV-sharing (child) layers at the target's cache.
+
+        Gemma-4's last layers allocate no cache of their own and reuse an earlier
+        layer's; without this they keep an empty placeholder and decode indexes
+        it (kv_cache[0]) on an empty tensor. Mirrors the v1 runner.
+        """
+        if not self.shared_kv_cache_layers:
+            return
+        from vllm.v1.worker.utils import add_kv_sharing_layers_to_kv_cache_groups
+
+        add_kv_sharing_layers_to_kv_cache_groups(
+            self.shared_kv_cache_layers, kv_cache_config.kv_cache_groups
+        )
+        for child, target in self.shared_kv_cache_layers.items():
+            kv_caches[child] = kv_caches[target]
+
+    def get_kv_cache_spec(self) -> dict:
+        """Build the per-layer KVCacheSpec from the model's attention modules.
+
+        Emits a Full / SlidingWindow / MLA spec per layer, skipping
+        cross-layer-shared (recorded in shared_kv_cache_layers) and encoder-only
+        layers. The engine uses it to budget KV blocks and build the KVCacheConfig.
+        """
+        from vllm.config import get_layers_from_vllm_config
+        from vllm.model_executor.layers.attention.attention import Attention
+        from vllm.model_executor.layers.attention.mla_attention import MLAAttention
+        from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+        from vllm.v1.attention.backend import AttentionType
+        from vllm.v1.kv_cache_interface import (
+            FullAttentionSpec,
+            MLAAttentionSpec,
+            SlidingWindowSpec,
+        )
+
+        layers = get_layers_from_vllm_config(self.vllm_config, AttentionLayerBase)
+        block_size = self.vllm_config.cache_config.block_size
+        cache_dtype_str = self.vllm_config.cache_config.cache_dtype
+
+        kv_cache_spec: dict = {}
+        for layer_name, attn_module in layers.items():
+            if isinstance(attn_module, Attention):
+                if attn_module.kv_sharing_target_layer_name is not None:
+                    # Reuses another layer's KV cache; allocate nothing here.
+                    self.shared_kv_cache_layers[layer_name] = (
+                        attn_module.kv_sharing_target_layer_name
+                    )
+                    continue
+                if attn_module.attn_type == AttentionType.DECODER:
+                    if attn_module.sliding_window is not None:
+                        kv_cache_spec[layer_name] = SlidingWindowSpec(
+                            block_size=block_size,
+                            num_kv_heads=attn_module.num_kv_heads,
+                            head_size=attn_module.head_size,
+                            dtype=self.kv_cache_spec_dtype,
+                            sliding_window=attn_module.sliding_window,
+                        )
+                    else:
+                        kv_cache_spec[layer_name] = FullAttentionSpec(
+                            block_size=block_size,
+                            num_kv_heads=attn_module.num_kv_heads,
+                            head_size=attn_module.head_size,
+                            dtype=self.kv_cache_spec_dtype,
+                        )
+                elif attn_module.attn_type in (
+                    AttentionType.ENCODER,
+                    AttentionType.ENCODER_ONLY,
+                ):
+                    continue  # encoder-only attention needs no KV cache
+                elif attn_module.attn_type == AttentionType.ENCODER_DECODER:
+                    raise NotImplementedError(
+                        "Encoder-decoder attention is not supported yet."
+                    )
+                else:
+                    raise ValueError(f"Unknown attention type: {attn_module.attn_type}")
+            elif isinstance(attn_module, MLAAttention):
+                if layer_name in kv_cache_spec:
+                    continue
+                kv_cache_spec[layer_name] = MLAAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=attn_module.head_size,
+                    dtype=self.kv_cache_spec_dtype,
+                    cache_dtype_str=cache_dtype_str,
+                )
+        return kv_cache_spec
+
+    def initialize_kv_cache(self, kv_cache_config: "KVCacheConfig") -> None:
+        """Allocate KV caches, bind them into the forward context, and (under TP)
+        shard them across the mesh. KV-transfer registration is still deferred.
+        """
+        from vllm.v1.worker.utils import bind_kv_cache
+
+        kv_caches = self._allocate_kv_caches(kv_cache_config)
+        if not kv_caches:
+            return
+        self._maybe_setup_cross_layer_kv_sharing(kv_caches, kv_cache_config)
+        logger.info("Allocated KV cache for %d attention layer(s).", len(kv_caches))
+        self.kv_cache_config = kv_cache_config
+        bind_kv_cache(
+            kv_caches,
+            self.vllm_config.compilation_config.static_forward_context,
+            self.kv_caches,
+        )
+
+        if self.parallel_mode == ParallelismMode.DATA_TENSOR_PARALLEL:
+            # DP+TP: leave replicated; each device writes its own slice via
+            # paged_update_cache. A TP-only spec puts block_size on the DP axis
+            # and fails ttir.paged_update_cache (follow-up).
+            return
+        if self.enable_tensor_parallel:
+            import torch_xla.distributed.spmd as xs
+
+            for entry in self.kv_caches:
+                is_pair = isinstance(entry, (list, tuple))
+                for cache in entry if is_pair else [entry]:
+                    assert cache.ndim == 4, "KV cache tensor must be 4D."
+                    if is_pair:
+                        # Shard standard K/V on num_kv_heads over the "model" axis.
+                        safe_mark_sharding(
+                            cache, self.mesh, (None, "model", None, None)
+                        )
+                    else:
+                        # Replicate the MLA latent KV cache.
+                        xs.mark_sharding(cache, self.mesh, (None, None, None, None))
+
+    def get_model(self):
+        return self.model
+
+    def reset_mm_cache(self) -> None:
+        if self.mm_budget is not None:
+            self.mm_budget.reset_cache()
+
+    # add_lora / maybe_setup_dummy_loras / maybe_select_dummy_loras /
+    # list_loras / remove_lora / pin_lora come from LoRAModelRunnerMixin.
+
+    def _set_active_loras(
+        self, prompt_lora_mapping, token_lora_mapping, lora_requests, *args, **kwargs
+    ) -> None:
+        """Activate LoRAs, bracketing with torch_xla.sync (ported from v1).
+
+        The syncs capture the input/metadata updates around the integer LoRA
+        index, which would otherwise force a recompile.
+        """
+        import torch_xla
+
+        torch_xla.sync(wait=False)
+        super()._set_active_loras(
+            prompt_lora_mapping, token_lora_mapping, lora_requests, *args, **kwargs
+        )
+        torch_xla.sync(wait=False)
+
+    def _make_lora_inputs(self, idx_mapping_np, num_scheduled_tokens):
+        """Build (prompt, token) LoRA id mappings + active requests for a pass.
+
+        Host substitute for InputBatch.make_lora_inputs: repeats each request's
+        LoRA id (0 = base model) by its sampled-token count (1) and scheduled-
+        token count, gathered in batch order via idx_mapping.
+        """
+        prompt_lora_mapping: list[int] = []
+        token_lora_mapping: list[int] = []
+        lora_requests = set()
+        for b in range(len(idx_mapping_np)):
+            slot = int(idx_mapping_np[b])
+            lora_req = self.lora_requests_by_slot.get(slot)
+            lora_id = lora_req.lora_int_id if lora_req is not None else 0
+            prompt_lora_mapping.append(lora_id)
+            token_lora_mapping.extend([lora_id] * int(num_scheduled_tokens[b]))
+            if lora_req is not None:
+                lora_requests.add(lora_req)
+        return tuple(prompt_lora_mapping), tuple(token_lora_mapping), lora_requests
+
+    def get_supported_tasks(self) -> tuple:
+        """Report the generation tasks this model supports (via TTModelState)."""
+        if self.model_config.runner_type != "generate":
+            raise NotImplementedError(
+                "Only the generate runner type is supported in the v2 runner."
+            )
+        assert (
+            self.model_state is not None
+        ), "load_model must run before get_supported_tasks"
+        return tuple(self.model_state.get_supported_generation_tasks())
+
+    def reset_dynamo_cache(self) -> None:
+        """Clear the compiled-model dynamo cache so it re-traces cleanly."""
+        from vllm.compilation.wrapper import TorchCompileWithNoGuardsWrapper
+
+        if self.model_config.is_multimodal_model:
+            compiled_model = self.model.get_language_model().model
+        else:
+            compiled_model = self.model.model
+        if isinstance(compiled_model, TorchCompileWithNoGuardsWrapper):
+            torch._dynamo.eval_frame.remove_from_cache(
+                compiled_model.original_code_object()
+            )
+            compiled_model.compiled = False
+            TorchCompileWithNoGuardsWrapper.__init__(compiled_model)
+
+    def update_config(self, overrides: dict) -> None:
+        from vllm.config import update_config as _update_config
+
+        allowed_config_names = {"load_config", "model_config"}
+        for config_name, config_overrides in overrides.items():
+            assert config_name in allowed_config_names, (
+                f"Config `{config_name}` not supported. "
+                f"Allowed configs: {allowed_config_names}"
+            )
+            setattr(
+                self,
+                config_name,
+                _update_config(getattr(self, config_name), config_overrides),
+            )
+
+    def reload_weights(self) -> None:
+        raise NotImplementedError(
+            "reload_weights is not supported in the v2 runner yet."
+        )
+
+    def ensure_kv_transfer_shutdown(self) -> None:
+        from vllm.distributed.kv_transfer import has_kv_transfer_group
+        from vllm.distributed.kv_transfer.kv_transfer_state import (
+            ensure_kv_transfer_shutdown,
+        )
+
+        if has_kv_transfer_group():
+            ensure_kv_transfer_shutdown()
+
+    def _warmup_buckets(self) -> list[tuple[int, int]]:
+        """(target_num_reqs, padded_query_len) pairs to precompile.
+
+        Decode always runs at max_num_reqs; prefill runs at the min / max prefill
+        buckets. Each request-count bucket is compiled at every token-length
+        padding, matching the shapes _select_batch can produce at runtime.
+        """
+        targets = sorted(
+            {self.max_num_reqs, self.min_num_reqs, self.max_prefill_num_reqs}
+        )
+        return [(t, q) for t in targets for q in self.num_tokens_paddings]
+
+    def capture_model(self) -> None:
+        """Precompile the forward/sample graph at every runtime bucket shape.
+
+        Warms the graph once with the DP input/KV shardings pinned so the first
+        real request pays no compile latency and traces the same graph warmup did.
+        Uses valid dummy attention metadata (non-zero cache_position, real
+        batch_idx) — all-zeros dummies fail to compile the paged-attention op.
+        Greedy (argmax) path only; multimodal warmup is deferred. Under
+        cpu_sampling the graph returns logits (host sampling is eager), so the
+        same precompile warms the correct graph.
+        """
+        import time
+
+        import torch_xla
+
+        torch._dynamo.config.dynamic_shapes = False
+        start = time.perf_counter()
+        buckets = self._warmup_buckets()
+        logger.info("MRv2 warmup: precompiling %d bucket(s).", len(buckets))
+        # Activate dummy LoRAs for the warmup so the compiled graphs match the
+        # LoRA runtime shapes (no-op context when lora_config is None).
+        with self.maybe_setup_dummy_loras(self.lora_config):
+            for target_num_reqs, padded_query_len in buckets:
+                logger.info(
+                    "MRv2 warmup: num_reqs=%d, query_len=%d",
+                    target_num_reqs,
+                    padded_query_len,
+                )
+                if self.lora_config is not None:
+                    self.maybe_select_dummy_loras(
+                        self.lora_config,
+                        np.array([target_num_reqs], dtype=np.int32),
+                    )
+                self._precompile_bucket(target_num_reqs, padded_query_len)
+                # Sync per bucket so prefill and decode graphs stay separate.
+                torch_xla.sync()
+        torch_xla.sync()
+        logger.info("MRv2 warmup finished in %.2f [secs].", time.perf_counter() - start)
+
+    def _precompile_bucket(self, target_num_reqs: int, padded_query_len: int) -> None:
+        """Trace the fused forward+sample graph for one bucket with valid dummies.
+
+        Mirrors _run_model_pass's device-tensor + sharding sequence so the warmed
+        graph matches inference exactly (input shardings pinned eagerly; page /
+        cache / batch_idx sharded on the DP batch axis).
+        """
+        from .metadata import XLASupportedSamplingMetadata
+
+        dev = self.device
+        input_ids = torch.zeros(
+            (target_num_reqs, padded_query_len), dtype=torch.int32
+        ).to(dev)
+        positions_shape = (
+            (3, target_num_reqs, padded_query_len)
+            if self.uses_mrope
+            else (target_num_reqs, padded_query_len)
+        )
+        positions = torch.zeros(positions_shape, dtype=torch.int32).to(dev)
+        logits_indices = torch.zeros(target_num_reqs, dtype=torch.int32).to(dev)
+        page_table = torch.zeros(
+            (target_num_reqs, self.max_num_blocks_per_req), dtype=torch.int32
+        ).to(dev)
+        fill_page_table = torch.zeros(
+            (target_num_reqs, self.max_num_blocks_per_req), dtype=torch.int32
+        ).to(dev)
+        # Non-zero write position: all-zeros makes the paged cache op fail to
+        # compile (matches v1's _dummy_run, which uses ones).
+        cache_position = torch.ones(target_num_reqs, dtype=torch.int32).to(dev)
+        # from_numpy (not on-device arange) so the DP "batch" sharding sticks.
+        batch_idx = torch.from_numpy(np.arange(target_num_reqs, dtype=np.int32)).to(dev)
+
+        self._pin_input_shardings(input_ids, positions, None)
+        if self.parallel_mode in (
+            ParallelismMode.DATA_PARALLEL_ONLY,
+            ParallelismMode.DATA_TENSOR_PARALLEL,
+        ):
+            safe_mark_sharding(page_table, self.mesh, ("batch", None))
+            safe_mark_sharding(cache_position, self.mesh, ("batch",))
+            safe_mark_sharding(batch_idx, self.mesh, ("batch",))
+            safe_mark_sharding(fill_page_table, self.mesh, ("batch", None))
+
+        attn_metadata = self.model_state.prepare_attn(
+            self.attention_layer_names,
+            page_table,
+            cache_position,
+            fill_page_table=fill_page_table,
+            batch_idx=batch_idx,
+            num_users=target_num_reqs,
+            dp_size=self.dp_size,
+        )
+        # Defaults are all-greedy -> warms the argmax fast-path.
+        sampling_metadata = XLASupportedSamplingMetadata(all_greedy=True)
+        self._forward_and_sample(
+            input_ids, positions, logits_indices, attn_metadata, sampling_metadata
+        )

--- a/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
@@ -36,9 +36,10 @@ from vllm.sampling_params import SamplingType
 from vllm.utils.math_utils import cdiv
 from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
 
+from .logger import tt_init_logger
 from .vllm_distributed_utils import ParallelismMode, safe_mark_sharding, shard_model
 
-logger = logging.getLogger(__name__)
+logger = tt_init_logger(__name__)
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig

--- a/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
@@ -1253,8 +1253,16 @@ class TTModelRunnerV2(LoRAModelRunnerMixin):
         else:
             forward_out, hidden_states = result, None
         if self.cpu_sampling:
-            # forward_out is logits [target_num_reqs, vocab]; sample on host.
-            selected = self.sample_from_logits_cpu(forward_out, sampling_metadata)
+            # forward_out is logits [target_num_reqs, vocab]; mask (grammar) and
+            # sample on host. Device sampling masks inside _sample_compiled.
+            selected = self.sample_from_logits_cpu(
+                forward_out,
+                sampling_metadata,
+                apply_grammar,
+                require_struct,
+                grammar_bitmask,
+                bitmasks,
+            )
         else:
             selected = forward_out
         # [target_num_reqs, 1] -> per active-req list; drop padding rows.
@@ -1279,52 +1287,61 @@ class TTModelRunnerV2(LoRAModelRunnerMixin):
         grammar_bitmask=None,
         bitmasks=None,
     ):
-        """Publish the attn metadata into the forward context, then run the graph."""
+        """Run the forward->logits graph, then (device path) the sampling graph.
+
+        The forward and the post-processing are compiled as two separate graphs so
+        sampling variants don't re-specialize the expensive model forward:
+        ``_forward_to_logits_compiled`` keys only on shape and ``want_prompt_hs``,
+        while ``_sample_compiled`` keys on ``apply_grammar`` and the sampling mode.
+        Under cpu_sampling the sampling graph is skipped -- the caller masks and
+        samples on the host (see ``sample_from_logits_cpu``).
+        """
         from vllm.forward_context import set_forward_context
 
         # Multimodal passes inputs_embeds with input_ids=None; both are 2D
         # [reqs, tokens(, H)] so the token count is the leading two dims.
         ref = input_ids if input_ids is not None else inputs_embeds
         num_tokens = ref.shape[0] * ref.shape[1]
-        # Under cpu_sampling the graph returns logits and never touches the
-        # sampling metadata, so keep its host tensors out of the compiled graph.
-        sm_for_graph = None if self.cpu_sampling else sampling_metadata
         with set_forward_context(
             attn_metadata, self.vllm_config, num_tokens=num_tokens
         ):
-            return self._forward_and_sample_compiled(
-                input_ids,
-                positions,
-                logits_indices,
-                sm_for_graph,
-                want_prompt_hs,
-                inputs_embeds,
+            fwd = self._forward_to_logits_compiled(
+                input_ids, positions, logits_indices, inputs_embeds, want_prompt_hs
+            )
+        logits, hidden_states = fwd if want_prompt_hs else (fwd, None)
+
+        if self.cpu_sampling:
+            # Stop at logits; grammar + sampling run on the host.
+            out = logits
+        else:
+            out = self._sample_compiled(
+                logits,
+                sampling_metadata,
                 apply_grammar,
                 require_struct_decoding,
                 grammar_bitmask,
                 bitmasks,
             )
+        if want_prompt_hs:
+            return out, hidden_states
+        return out
 
     @torch.compile(backend="tt", fullgraph=True, dynamic=False)
-    def _forward_and_sample_compiled(
+    def _forward_to_logits_compiled(
         self,
         input_ids,
         positions,
         logits_indices,
-        sampling_metadata,
-        want_prompt_hs,
         inputs_embeds=None,
-        apply_grammar=False,
-        require_struct_decoding=None,
-        grammar_bitmask=None,
-        bitmasks=None,
+        want_prompt_hs=False,
     ):
-        """Compiled model forward -> last-token select -> logits -> sample.
+        """Compiled model forward -> last-token select -> logits.
 
-        ``want_prompt_hs`` and ``apply_grammar`` are plain python bools so dynamo
-        specializes separate graphs (prompt-logprobs hidden-state return / grammar
-        masking); the common path stays unaffected. ``inputs_embeds`` is set (with
-        ``input_ids=None``) on the multimodal path.
+        Keys only on shape and ``want_prompt_hs`` (which additionally returns the
+        pre-selection hidden states for prompt logprobs); grammar and sampling
+        live in ``_sample_compiled``, so the heavy forward is never re-specialized
+        per post-processing combo. ``inputs_embeds`` is set (with ``input_ids=None``)
+        on the multimodal path.
         """
         model_input_ids, model_positions, model_embeds, restore_shape = (
             self._prepare_model_call_tensors(input_ids, positions, inputs_embeds)
@@ -1336,26 +1353,32 @@ class TTModelRunnerV2(LoRAModelRunnerMixin):
         )
         hidden_states = self._restore_model_hidden_states(hidden_states, restore_shape)
         selected_states = self._select_hidden_states(hidden_states, logits_indices)
-        logits = self.model.compute_logits(selected_states)
-        # Replicate sharded logits: hooks can't reach ParallelLMHead
-        # (quant_method.apply bypasses __call__) and all_gather is a no-op at
-        # world_size 1, so the constraint must sit inside the compiled graph.
-        if self.enable_tensor_parallel and self.is_sharded_compute_logits:
-            logits = sharding_constraint_tensor(logits, self.mesh, (None, None))
-        # Structured output: mask logits to grammar-allowed tokens before sampling.
+        logits = self.compute_logits(selected_states)
+        if want_prompt_hs:
+            return logits, hidden_states
+        return logits
+
+    @torch.compile(backend="tt", fullgraph=True, dynamic=False)
+    def _sample_compiled(
+        self,
+        logits,
+        sampling_metadata,
+        apply_grammar=False,
+        require_struct_decoding=None,
+        grammar_bitmask=None,
+        bitmasks=None,
+    ):
+        """Compiled grammar-mask + device sample over precomputed logits.
+
+        ``apply_grammar`` is a plain python bool so dynamo specializes the
+        grammar / no-grammar paths separately; only this small post-logits graph
+        recompiles, not the forward.
+        """
         if apply_grammar:
             logits = self.structured_decode(
                 require_struct_decoding, grammar_bitmask, logits, bitmasks
             )
-        # cpu_sampling: stop the compiled graph at logits and sample on the host
-        # (mirrors the v1 _model_unfused path); otherwise sample on device.
-        if self.cpu_sampling:
-            out = logits
-        else:
-            out = self._sample_from_logits(logits, sampling_metadata)
-        if want_prompt_hs:
-            return out, hidden_states
-        return out
+        return self._sample_from_logits(logits, sampling_metadata)
 
     def _pin_input_shardings(self, input_ids, positions, inputs_embeds) -> None:
         """Pin model inputs on the batch/mesh axis so warmup and inference trace
@@ -1483,7 +1506,15 @@ class TTModelRunnerV2(LoRAModelRunnerMixin):
         allowed = (bits != 0).reshape(logits.shape[0], -1)[:, : self.vocab_size]
         return torch.where(allowed, logits, torch.full_like(logits, float("-inf")))
 
-    def sample_from_logits_cpu(self, logits, sampling_metadata):
+    def sample_from_logits_cpu(
+        self,
+        logits,
+        sampling_metadata,
+        apply_grammar=False,
+        require_struct_decoding=None,
+        grammar_bitmask=None,
+        bitmasks=None,
+    ):
         """Sample on CPU instead of compiling a device sampling graph.
 
         Ported from the v1 runner: supports greedy, temperature, top-k/top-p and
@@ -1491,6 +1522,16 @@ class TTModelRunnerV2(LoRAModelRunnerMixin):
         rather than torch.multinomial, which serializes over the batch.
         """
         logits = logits.cpu()
+
+        # Grammar masking for the host path (the device path masks inside
+        # _sample_compiled); move the grammar tensors to host to match logits.
+        if apply_grammar:
+            logits = self.structured_decode(
+                require_struct_decoding.cpu(),
+                grammar_bitmask.cpu(),
+                logits,
+                bitmasks.cpu(),
+            )
 
         if not sampling_metadata.no_penalties:
             output_counts = sampling_metadata.output_token_counts
@@ -1576,7 +1617,9 @@ class TTModelRunnerV2(LoRAModelRunnerMixin):
     def compute_logits(self, sample_hidden_states):
         """Vocab logits for the given hidden states (ported from the v1 runner)."""
         logits = self.model.compute_logits(sample_hidden_states)
-        # Replicate sharded logits for SPMD (see _forward_and_sample_compiled).
+        # Replicate sharded logits for SPMD: hooks can't reach ParallelLMHead
+        # (quant_method.apply bypasses __call__) and all_gather is a no-op at
+        # world_size 1, so the constraint must sit inside the compiled graph.
         if self.enable_tensor_parallel and self.is_sharded_compute_logits:
             logits = sharding_constraint_tensor(logits, self.mesh, (None, None))
         return logits

--- a/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
@@ -294,12 +294,12 @@ class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         )
         self.block_table = MultiGroupBlockTable(
             max_num_reqs=self.max_num_reqs,
-            max_model_len=self.max_model_len,
             max_num_batched_tokens=self.max_num_tokens,
             pin_memory=False,
             device=torch.device("cpu"),
             block_sizes=[self.block_size],
             kernel_block_sizes=[self.block_size],
+            max_num_blocks=[self.max_num_blocks_per_req],
         )
         self.input_buffers = TTInputBuffers(
             self.max_num_reqs, self.max_num_tokens, self.device

--- a/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
@@ -25,6 +25,7 @@ cpu_sampling / prompt-logprobs branches.
 from __future__ import annotations
 
 import bisect
+import contextlib
 import logging
 from typing import TYPE_CHECKING, Optional
 
@@ -34,6 +35,7 @@ import vllm.envs as envs
 from tt_torch.sharding import sharding_constraint_tensor
 from vllm.sampling_params import SamplingType
 from vllm.utils.math_utils import cdiv
+from vllm.v1.worker.kv_connector_model_runner_mixin import KVConnectorModelRunnerMixin
 from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
 
 from .logger import tt_init_logger
@@ -112,7 +114,7 @@ def replace_set_lora(model):
             module.reset_lora = _tpu_reset_lora.__get__(module, module.__class__)
 
 
-class TTModelRunnerV2(LoRAModelRunnerMixin):
+class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
     """Tenstorrent MRv2 model runner (see module docstring)."""
 
     def __init__(
@@ -1018,9 +1020,12 @@ class TTModelRunnerV2(LoRAModelRunnerMixin):
         self.update_requests(scheduler_output)
 
         if scheduler_output.total_num_scheduled_tokens == 0:
-            # No tokens this step (e.g. only KV-connector activity).
+            from vllm.distributed.kv_transfer import has_kv_transfer_group
             from vllm.v1.worker.gpu_model_runner import EMPTY_MODEL_RUNNER_OUTPUT
 
+            if has_kv_transfer_group():
+                # Nothing to run, but the connector still has sends/recvs to drive.
+                return self.kv_connector_no_forward(scheduler_output, self.vllm_config)
             return EMPTY_MODEL_RUNNER_OUTPUT
 
         if self.supports_mm_inputs and scheduler_output.scheduled_encoder_inputs:
@@ -1052,6 +1057,60 @@ class TTModelRunnerV2(LoRAModelRunnerMixin):
         want_prompt_hs = bool(self.num_prompt_logprobs)
         prompt_lp_hs: dict[int, torch.Tensor] = {}
 
+        kv_connector_output = None
+        with contextlib.ExitStack() as stack:
+            if self._has_kv_transfer_group():
+                # Once per step, not per pass: get_finished() reports a transfer
+                # only on its first call, so per-pass entry would drop finished
+                # send/recv ids. start_load_kv needs an active forward context,
+                # so push a token-less one as kv_connector_no_forward does.
+                from vllm.forward_context import set_forward_context
+
+                stack.enter_context(set_forward_context(None, self.vllm_config))
+                kv_connector_output = stack.enter_context(
+                    self.maybe_get_kv_connector_output(scheduler_output)
+                )
+            self._run_pass_loop(
+                ordered_slots,
+                ordered_num_tokens,
+                grammar_output,
+                want_prompt_hs,
+                out_req_ids,
+                out_sampled,
+                prompt_lp_hs,
+            )
+
+        prompt_logprobs_dict = self._get_prompt_logprobs_dict(
+            prompt_lp_hs, scheduler_output
+        )
+
+        from vllm.v1.outputs import ModelRunnerOutput
+
+        return ModelRunnerOutput(
+            req_ids=out_req_ids,
+            req_id_to_index={rid: i for i, rid in enumerate(out_req_ids)},
+            sampled_token_ids=out_sampled,
+            prompt_logprobs_dict=prompt_logprobs_dict,
+            kv_connector_output=kv_connector_output,
+        )
+
+    @staticmethod
+    def _has_kv_transfer_group() -> bool:
+        from vllm.distributed.kv_transfer import has_kv_transfer_group
+
+        return has_kv_transfer_group()
+
+    def _run_pass_loop(
+        self,
+        ordered_slots,
+        ordered_num_tokens,
+        grammar_output,
+        want_prompt_hs: bool,
+        out_req_ids: list,
+        out_sampled: list,
+        prompt_lp_hs: dict,
+    ) -> None:
+        """Decode-first multi-pass loop; appends into the caller's output lists."""
         start_index = 0
         while start_index < len(ordered_slots):
             (
@@ -1112,19 +1171,6 @@ class TTModelRunnerV2(LoRAModelRunnerMixin):
                 out_sampled.append(valid[b])
 
             start_index = end_index
-
-        prompt_logprobs_dict = self._get_prompt_logprobs_dict(
-            prompt_lp_hs, scheduler_output
-        )
-
-        from vllm.v1.outputs import ModelRunnerOutput
-
-        return ModelRunnerOutput(
-            req_ids=out_req_ids,
-            req_id_to_index={rid: i for i, rid in enumerate(out_req_ids)},
-            sampled_token_ids=out_sampled,
-            prompt_logprobs_dict=prompt_logprobs_dict,
-        )
 
     def _run_model_pass(
         self,
@@ -1924,8 +1970,8 @@ class TTModelRunnerV2(LoRAModelRunnerMixin):
         return kv_cache_spec
 
     def initialize_kv_cache(self, kv_cache_config: "KVCacheConfig") -> None:
-        """Allocate KV caches, bind them into the forward context, and (under TP)
-        shard them across the mesh. KV-transfer registration is still deferred.
+        """Allocate KV caches, bind them into the forward context, register them
+        with the KV-transfer group, and (under TP) shard them across the mesh.
         """
         from vllm.v1.worker.utils import bind_kv_cache
 
@@ -1940,6 +1986,7 @@ class TTModelRunnerV2(LoRAModelRunnerMixin):
             self.vllm_config.compilation_config.static_forward_context,
             self.kv_caches,
         )
+        self._register_kv_caches_for_transfer(kv_caches)
 
         if self.parallel_mode == ParallelismMode.DATA_TENSOR_PARALLEL:
             # DP+TP: leave replicated; each device writes its own slice via
@@ -1961,6 +2008,25 @@ class TTModelRunnerV2(LoRAModelRunnerMixin):
                     else:
                         # Replicate the MLA latent KV cache.
                         xs.mark_sharding(cache, self.mesh, (None, None, None, None))
+
+    def _register_kv_caches_for_transfer(self, kv_caches: dict) -> None:
+        """Hand the allocated caches to the KV-connector, if one is configured.
+
+        Without this a disaggregated-serving setup silently transfers nothing.
+        """
+        from vllm.distributed.kv_transfer import (
+            get_kv_transfer_group,
+            has_kv_transfer_group,
+        )
+        from vllm.distributed.kv_transfer.kv_connector.utils import copy_kv_blocks
+
+        if not has_kv_transfer_group():
+            return
+        get_kv_transfer_group().register_kv_caches(kv_caches)
+        get_kv_transfer_group().set_host_xfer_buffer_ops(copy_kv_blocks)
+        logger.info(
+            "Registered %d KV cache layer(s) with the KV connector.", len(kv_caches)
+        )
 
     def get_model(self):
         return self.model
@@ -2050,8 +2116,14 @@ class TTModelRunnerV2(LoRAModelRunnerMixin):
             )
 
     def reload_weights(self) -> None:
-        raise NotImplementedError(
-            "reload_weights is not supported in the v2 runner yet."
+        from vllm.model_executor.model_loader import get_model_loader
+
+        assert (
+            getattr(self, "model", None) is not None
+        ), "Cannot reload weights before model is loaded."
+        logger.info("Reloading weights inplace...")
+        get_model_loader(self.load_config).load_weights(
+            self.model, model_config=self.model_config
         )
 
     def ensure_kv_transfer_shutdown(self) -> None:

--- a/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner_v2.py
@@ -31,7 +31,6 @@ from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 import torch
-import vllm.envs as envs
 from tt_torch.sharding import sharding_constraint_tensor
 from vllm.sampling_params import SamplingType
 from vllm.utils.math_utils import cdiv
@@ -216,13 +215,7 @@ class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         self.block_size = self.cache_config.block_size
         self.max_model_len = self.model_config.max_model_len
-        self.most_model_len = envs.VLLM_TPU_MOST_MODEL_LEN
         self.max_num_blocks_per_req = cdiv(self.max_model_len, self.block_size)
-        self.num_blocks_per_most_len_req = (
-            cdiv(self.most_model_len, self.block_size)
-            if self.most_model_len is not None
-            else None
-        )
 
         # Prefill request-count bucketing bounds (decode always uses max_num_reqs).
         self.min_num_reqs = getattr(tt, "min_num_seqs", None) or self.max_num_reqs
@@ -273,16 +266,6 @@ class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self.num_reqs_max_model_len = min(
             TTAttentionBackend.get_max_num_seqs(self.max_model_len, self.block_size),
             self.max_num_reqs,
-        )
-        self.num_reqs_most_model_len = (
-            min(
-                TTAttentionBackend.get_max_num_seqs(
-                    self.most_model_len, self.block_size
-                ),
-                self.max_num_reqs,
-            )
-            if self.most_model_len is not None
-            else None
         )
 
         # Driver / graph knobs read later.
@@ -691,10 +674,10 @@ class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
     ) -> tuple[np.ndarray, np.ndarray, int, int, int]:
         """Pick the sub-batch for one pass, applying the SMEM row caps.
 
-        Mirrors the v1 fork's per-pass clamping over the decode-first ordering:
-        a long request in the remaining tail forces the max-model-len row cap;
-        prefill passes are additionally capped at ``max_prefill_num_reqs`` and the
-        multi-pass loop picks up the rest. Returns ``(idx_mapping,
+        Mirrors the v1 fork's per-pass clamping over the decode-first ordering.
+        The row cap is always the max-model-len cap; prefill passes are
+        additionally capped at ``max_prefill_num_reqs`` and the multi-pass loop
+        picks up the rest. Returns ``(idx_mapping,
         num_scheduled_tokens, target_num_reqs, padded_query_len, end_index)``.
         """
         if self.dp_size > 1:
@@ -712,18 +695,7 @@ class TTModelRunnerV2(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 len(ordered_slots),
             )
 
-        # A long request anywhere in the remaining tail forces max-model-len mode
-        # (fewer rows fit SMEM), matching the v1 collection loop.
-        use_max_model_len = self.most_model_len is None
-        if not use_max_model_len and np.any(
-            ordered_num_tokens[start_index:] > self.most_model_len
-        ):
-            use_max_model_len = True
-        row_cap = (
-            self.num_reqs_max_model_len
-            if use_max_model_len
-            else self.num_reqs_most_model_len
-        )
+        row_cap = self.num_reqs_max_model_len
 
         end_index = min(len(ordered_slots), start_index + row_cap)
         num_scheduled = ordered_num_tokens[start_index:end_index]

--- a/integrations/vllm_plugin/vllm_tt/model_state.py
+++ b/integrations/vllm_plugin/vllm_tt/model_state.py
@@ -1,0 +1,244 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""TT ``ModelState`` for vLLM Model Runner v2 (MRv2).
+
+This is Phase 1 of the MRv2 adoption: the model-specific ``ModelState`` layer.
+It implements the upstream ``vllm.v1.worker.gpu.model_states.interface.ModelState``
+contract (as of vLLM v0.22.1) for Tenstorrent hardware.
+
+Scope / status
+--------------
+MRv2 splits the old monolithic runner into four pieces: the runner (engine),
+``ModelState`` (model-specific logic), ``RequestState`` (persistent per-request
+table) and ``InputBatch`` (transient per-step view). This file is only the
+``ModelState`` piece.
+
+* Requires vLLM v0.22.1. The ``vllm.v1.worker.gpu.*`` modules imported below do
+  not exist on v0.19.1, so this module is intentionally NOT imported from the
+  package ``__init__`` yet -- importing it on an un-uplifted env raises
+  ImportError. It becomes live once the 0.22.1 uplift (PR #5634) lands and the
+  TT v2 runner (Phase 3) wires it in.
+* The model-agnostic methods (task discovery, the common 1D-positions input
+  path, staged-write / add_request no-ops) are implemented for real here.
+* ``prepare_attn`` (Phase 3) assembles a ``TTMetadata`` from the per-step device
+  arrays the runner computes host-side and fans it out to every attention layer.
+  Its signature diverges from upstream's flat block_tables/slot_mappings because
+  TT's paged ops consume page_table/cache_position instead.
+* ``get_mm_embeddings`` still raises NotImplementedError: its seams (mm-feature
+  store, padded input_ids layout, model.embed_*) are runner-owned, so it is
+  co-implemented with the runner. Contract on the method.
+
+Why not subclass upstream ``DefaultModelState``?
+------------------------------------------------
+``DefaultModelState.__init__`` builds rope state via ``get_rope_state`` (which
+is Triton-backed, ``@triton.jit``) and ``prepare_attn`` delegates to
+``build_attn_metadata`` (cudagraph-oriented). Both assume CUDA/Triton, so
+subclassing would drag that machinery in at construction time. A standalone
+implementation lets us substitute TT equivalents cleanly.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import torch
+import torch.nn as nn
+from vllm.tasks import GenerationTask
+from vllm.v1.worker.gpu.model_states.interface import ModelState
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from vllm.config import VllmConfig
+    from vllm.v1.core.sched.output import NewRequestData
+    from vllm.v1.worker.gpu.input_batch import InputBatch
+    from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
+    from vllm.v1.worker.gpu.states import RequestState
+
+
+class TTModelState(ModelState):
+    """Tenstorrent implementation of the MRv2 ``ModelState`` interface.
+
+    Mirrors the structure of upstream ``DefaultModelState`` but substitutes (or
+    defers) the CUDA/Triton-specific pieces. See module docstring for status.
+    """
+
+    def __init__(
+        self,
+        vllm_config: "VllmConfig",
+        model: nn.Module,
+        encoder_cache: "EncoderCache | None",
+        device: torch.device,
+    ) -> None:
+        self.vllm_config = vllm_config
+        self.model_config = vllm_config.model_config
+        self.scheduler_config = vllm_config.scheduler_config
+        self.model = model
+        self.device = device
+
+        # Sizing, mirrored from DefaultModelState.
+        self.supports_mm_inputs = encoder_cache is not None
+        self.encoder_cache = encoder_cache
+        self.max_model_len = self.model_config.max_model_len
+        self.max_num_reqs = self.scheduler_config.max_num_seqs
+        self.max_num_tokens = self.scheduler_config.max_num_batched_tokens
+        self.dtype = self.model_config.dtype
+        # v0.25.1 ModelState base sets this (via its concrete __init__); TT does
+        # not call super().__init__ (it would build a CUDA EncoderRunner we
+        # defer), so set it here for inherited hooks that read it.
+        self.inputs_embeds_size = self.model_config.get_inputs_embeds_size()
+
+        # Rope/mrope state: upstream uses get_rope_state(), which is Triton-backed
+        # and does not run on TT. The common text-generation path uses plain 1D
+        # positions (rope_state is None -> prepare_inputs returns {}), matching
+        # DefaultModelState's common case. mrope models require a TT rope
+        # substitute; deferred to a later phase.
+        # TODO(mrv2): TT rope/mrope state for models with uses_mrope.
+        self.rope_state = None
+
+        # TODO(mrv2): construct the TT multimodal encoder runner here when
+        # get_mm_embeddings is implemented (Phase 3). Upstream builds an
+        # EncoderRunner; portability to TT is not yet validated.
+
+    def get_supported_generation_tasks(self) -> tuple[GenerationTask, ...]:
+        """Which generation tasks this model supports.
+
+        Fully portable: same logic as upstream DefaultModelState and the current
+        TT v1 runner. Lazy imports mirror upstream to avoid import cycles.
+        """
+        from vllm.model_executor.models.interfaces import (
+            supports_realtime,
+            supports_transcription,
+        )
+        from vllm.model_executor.models.interfaces_base import is_text_generation_model
+
+        supported_tasks: list[GenerationTask] = []
+
+        if is_text_generation_model(self.model):
+            supported_tasks.append("generate")
+
+        if supports_transcription(self.model):
+            if self.model.supports_transcription_only:
+                return ("transcription",)
+            supported_tasks.append("transcription")
+
+        if supports_realtime(self.model):
+            supported_tasks.append("realtime")
+
+        return tuple(supported_tasks)
+
+    def add_request(self, req_index: int, new_req_data: "NewRequestData") -> None:
+        """Per-request model-specific setup.
+
+        Upstream initializes rope prefill positions here. With no TT rope state
+        yet (common text path), this is a no-op, matching DefaultModelState when
+        rope_state is None.
+        """
+        if self.rope_state is not None:
+            # TODO(mrv2): init TT rope prefill positions for req_index.
+            raise NotImplementedError("TT rope state not implemented yet.")
+
+    def apply_staged_writes(self) -> None:
+        """Commit any staged host->device writes owned by this ModelState.
+
+        Only rope state stages writes upstream; no-op until TT rope lands.
+        """
+        if self.rope_state is not None:
+            raise NotImplementedError("TT rope state not implemented yet.")
+
+    def postprocess_state(
+        self,
+        idx_mapping: torch.Tensor,
+        num_sampled: torch.Tensor,
+        num_computed_tokens: torch.Tensor | None = None,
+    ) -> None:
+        """Post-step model-specific state update. No-op for standard models.
+
+        Signature matches the v0.25.1 ``ModelState`` ABC (was
+        ``(input_batch, num_sampled)`` in 0.22.1). TT's v2 runner does not call
+        this yet; kept ABC-aligned so DiffusionGemmaModelState can override it.
+        """
+        return None
+
+    def prepare_inputs(
+        self, input_batch: "InputBatch", req_states: "RequestState"
+    ) -> dict[str, Any]:
+        """Extra kwargs merged into the model call.
+
+        Common case (1D positions, no rope state): return {} so the runner's
+        default input_ids/positions/inputs_embeds are used unchanged. This
+        matches DefaultModelState.prepare_inputs. mrope models return
+        {"positions": ...}; deferred with TT rope.
+        """
+        if self.rope_state is None:
+            return {}
+        # TODO(mrv2): compute TT mrope positions and return {"positions": ...}.
+        raise NotImplementedError("TT rope state not implemented yet.")
+
+    def prepare_dummy_inputs(self, num_reqs: int, num_tokens: int) -> dict[str, Any]:
+        """Kwargs for dummy/warmup/profile runs.
+
+        Common text path needs no extra inputs. mm/rope models add
+        inputs_embeds/positions; deferred with those substitutes.
+        """
+        return {}
+
+    def get_mm_embeddings(
+        self,
+        input_ids: torch.Tensor,
+        mm_embeds: list[torch.Tensor],
+        is_mm_embed: torch.Tensor,
+        mm_indices: torch.Tensor,
+    ) -> torch.Tensor:
+        """Merge text + gathered multimodal embeddings (v1 _get_model_inputs port).
+
+        Embeds the input via ``embed_input_ids``, then scatters the encoder
+        embeddings in with a static ``index_copy`` -- not ``masked_scatter_``,
+        which lowers to a dynamic-shaped op the Shardy/SPMD pass rejects.
+        """
+        inputs_embeds = self.model.embed_input_ids(input_ids, is_multimodal=is_mm_embed)
+        if mm_embeds:
+            mm_flat = torch.cat(list(mm_embeds)).to(inputs_embeds.dtype)
+            original_shape = inputs_embeds.shape
+            hidden_size = original_shape[-1]
+            inputs_embeds = inputs_embeds.reshape(-1, hidden_size)
+            inputs_embeds = inputs_embeds.index_copy(0, mm_indices, mm_flat)
+            inputs_embeds = inputs_embeds.reshape(original_shape)
+        return inputs_embeds
+
+    def prepare_attn(
+        self,
+        attention_layer_names: "Iterable[str]",
+        page_table: torch.Tensor,
+        cache_position: torch.Tensor,
+        fill_page_table: torch.Tensor | None = None,
+        batch_idx: torch.Tensor | None = None,
+        num_users: int | None = None,
+        dp_size: int = 1,
+        chunk_start_idx: torch.Tensor | None = None,
+        attn_mask: torch.Tensor | None = None,
+        is_causal: bool = True,
+    ) -> dict[str, Any]:
+        """Assemble the per-layer attention-metadata dict for the model forward.
+
+        TT's attention backends consume a single TTMetadata built from paged
+        tensors (page_table/cache_position/...), not upstream's flat
+        block_tables/slot_mappings, so the signature is adapted. The runner
+        computes the tensors host-side; this fans the shared metadata out to every
+        attention layer. fill_page_table defaults to page_table (no prefix roll).
+        """
+        from .attention_impls.attention import TTMetadata
+
+        attn_metadata = TTMetadata(
+            page_table=page_table,
+            cache_position=cache_position,
+            is_causal=is_causal,
+            attn_mask=attn_mask,
+            fill_page_table=fill_page_table,
+            dp_size=dp_size,
+            chunk_start_idx=chunk_start_idx,
+            batch_idx=batch_idx,
+            num_users=num_users,
+        )
+        return dict.fromkeys(attention_layer_names, attn_metadata)

--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -124,6 +124,10 @@ class TTConfig:
     # TPU model loader to share the model across multiple devices.
     enable_tensor_parallel: bool = False
 
+    # Model Runner v2 (TTModelRunnerV2) is the default runner; set False in
+    # additional_config to fall back to v1. Ignored for pooling models (always v1).
+    use_v2_model_runner: bool = True
+
     # Optimization level (0, 1, or 2) that controls multiple optimization passes.
     # Level 0: All optimizations disabled
     # Level 1: Basic optimizations (optimizer + Conv2d fusion)
@@ -366,8 +370,9 @@ class TTPlatform(Platform):
 
     @classmethod
     def get_punica_wrapper(cls) -> str:
-        return NotImplementedError
-        # return "vllm.lora.punica_wrapper.punica_tpu.PunicaWrapperTPU"
+        # vllm 0.20.2 removed punica_tpu (which TT previously used); the CPU
+        # wrapper is the only remaining non-Triton LoRA punica implementation.
+        return "vllm.lora.punica_wrapper.punica_cpu.PunicaWrapperCPU"
 
     @classmethod
     def get_infinity_values(cls, dtype: torch.dtype) -> tuple[float, float]:

--- a/integrations/vllm_plugin/vllm_tt/pooling_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/pooling_runner.py
@@ -233,7 +233,6 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
     ):
 
         self.tt_config = TTConfig(**vllm_config.additional_config)
-        torch_xla.set_custom_compile_options(self.tt_config.get_pjrt_compile_config())
 
         self.vllm_config = vllm_config
         self.model_config = vllm_config.model_config
@@ -378,7 +377,9 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self.vocab_size = model_config.get_vocab_size()
 
         if self.lora_config is not None:
-            self.vocab_size += self.lora_config.lora_extra_vocab_size
+            # lora_extra_vocab_size was removed in vllm 0.20.2; add it only when
+            # the installed LoRAConfig still exposes it.
+            self.vocab_size += getattr(self.lora_config, "lora_extra_vocab_size", 0)
 
         # Multi-modal data support
         self.mm_registry = MULTIMODAL_REGISTRY

--- a/integrations/vllm_plugin/vllm_tt/request_state.py
+++ b/integrations/vllm_plugin/vllm_tt/request_state.py
@@ -93,11 +93,12 @@ class TTRequestState:
         # Last sampled token per slot (seeds the next decode input).
         self.last_sampled_tokens = np.zeros((self.max_num_reqs, 1), dtype=np.int64)
 
-        # Draft tokens (spec decode). TT has no spec decode
-        # (num_speculative_steps == 0), so this degenerates to a zero-width row.
+        # Draft tokens (spec decode); zero-width when num_speculative_steps == 0.
         self.draft_tokens = np.zeros(
             (self.max_num_reqs, self.num_speculative_steps), dtype=np.int64
         )
+        # How many of draft_tokens[slot] are live this step (drafts vary in length).
+        self.num_draft_tokens = np.zeros(self.max_num_reqs, dtype=np.int32)
 
         self.next_prefill_tokens = np.zeros(self.max_num_reqs, dtype=np.int32)
 
@@ -134,6 +135,27 @@ class TTRequestState:
             # Fresh prefill (num_computed_tokens == 0) never reads this slot.
             self.last_sampled_tokens[req_idx] = all_token_ids[num_computed_tokens - 1]
         self.draft_tokens[req_idx] = 0
+        self.num_draft_tokens[req_idx] = 0
+
+    def set_draft_tokens(self, req_idx: int, drafts: list[int]) -> None:
+        """Stage this step's drafts for a slot (spec decode).
+
+        Drafts land in all_token_ids right after the committed tokens so the
+        input gather picks them up, but total_len does NOT advance: they are
+        unverified. Accepted tokens overwrite them in the writeback.
+        """
+        n = len(drafts)
+        assert n <= self.num_speculative_steps, (
+            f"{n} drafts exceeds num_speculative_steps " f"{self.num_speculative_steps}"
+        )
+        self.num_draft_tokens[req_idx] = n
+        if n:
+            self.draft_tokens[req_idx, :n] = drafts
+            pos = int(self.total_len[req_idx])
+            self.all_token_ids[req_idx, pos : pos + n] = drafts
+
+    def clear_draft_tokens(self, req_idx: int) -> None:
+        self.num_draft_tokens[req_idx] = 0
 
     def apply_staged_writes(self) -> None:
         """No-op: numpy writes land immediately (see module docstring).

--- a/integrations/vllm_plugin/vllm_tt/request_state.py
+++ b/integrations/vllm_plugin/vllm_tt/request_state.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""TT ``RequestState`` for vLLM Model Runner v2 (MRv2).
+
+Phase 2 of the MRv2 adoption: the persistent per-request slot table. Mirrors
+upstream ``vllm.v1.worker.gpu.states.RequestState`` (as of vLLM v0.22.1),
+substituting host-side numpy storage for upstream's UVA / ``StagedWriteTensor``
+buffers.
+
+Scope / status
+--------------
+MRv2 splits the old monolithic runner into four pieces: the runner (engine),
+``ModelState`` (see model_state.py), ``RequestState`` (this file) and
+``InputBatch`` (see input_batch_v2.py). ``RequestState`` is the stable slot
+table that replaces v1's ``CachedRequestState`` dict + ``InputBatch`` add /
+remove / condense bookkeeping: each request owns a fixed slot for its lifetime
+and the slot is returned to a free list on removal (no condensing).
+
+* Holds ONLY token bookkeeping. Upstream keeps sampling params in the sampler
+  (``SamplingStates``) and block tables in the runner, not here; TT mirrors
+  that split -- both are deferred to Phase 3.
+* Upstream backs the per-slot arrays with ``StagedWriteTensor`` / ``UvaBackedTensor``
+  so the Triton input-prep kernels can read them on device. TT input-prep is
+  host-side (no Triton), so those device mirrors would be dead weight; we use
+  plain numpy as the single source of truth. As a result ``apply_staged_writes``
+  is a no-op -- writes land immediately.
+* This module has no ``vllm.v1.worker.gpu.*`` dependency, so unlike
+  model_state.py it is import-safe on un-uplifted envs. It is still intentionally
+  NOT imported from the package ``__init__`` until the TT v2 runner (Phase 3)
+  wires it in. UNVALIDATED at runtime until then.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    import torch
+
+
+class TTRequestState:
+    """Persistent per-request slot table for the TT MRv2 runner.
+
+    Structure-of-arrays indexed by ``req_state_idx`` (a stable slot). Mirrors
+    upstream ``RequestState`` field-for-field; see module docstring for the
+    numpy-vs-UVA substitution.
+    """
+
+    def __init__(
+        self,
+        max_num_reqs: int,
+        max_model_len: int,
+        max_num_batched_tokens: int,
+        num_speculative_steps: int,
+        vocab_size: int,
+        device: "torch.device",
+    ):
+        self.max_num_reqs = max_num_reqs
+        self.max_model_len = max_model_len
+        self.max_num_batched_tokens = max_num_batched_tokens
+        self.num_speculative_steps = num_speculative_steps
+        self.vocab_size = vocab_size
+        # Kept for parity / Phase 3 device materialization; unused host-side.
+        self.device = device
+
+        self.req_id_to_index: dict[str, int] = {}
+        self.index_to_req_id: dict[int, str] = {}
+        self.free_indices = list(range(max_num_reqs))
+
+        # Per-slot token ids. Host-side numpy (upstream: UVA StagedWriteTensor).
+        self.all_token_ids = np.zeros(
+            (self.max_num_reqs, self.max_model_len), dtype=np.int32
+        )
+
+        # prompt_len: tokens in the user prompt.
+        # prefill_len: tokens fed to the runner (>= prompt_len; larger on resume
+        #   after preemption). Prompt vs output tokens must be distinguished for
+        #   prompt logprobs and frequency penalties.
+        self.prompt_len = np.zeros(self.max_num_reqs, dtype=np.int32)
+        self.prefill_len = np.zeros(self.max_num_reqs, dtype=np.int32)
+        # total_len = prompt_len + output_len; grows as the request progresses.
+        self.total_len = np.zeros(self.max_num_reqs, dtype=np.int32)
+
+        # Number of computed tokens. Upstream splits this into a device tensor
+        # (authoritative, updated by the post_update kernel) plus an optimistic
+        # CPU mirror; host-side these collapse to one array.
+        self.num_computed_prefill_tokens = np.zeros(self.max_num_reqs, dtype=np.int32)
+        self.num_computed_tokens = np.zeros(self.max_num_reqs, dtype=np.int32)
+
+        # Last sampled token per slot (seeds the next decode input).
+        self.last_sampled_tokens = np.zeros((self.max_num_reqs, 1), dtype=np.int64)
+
+        # Draft tokens (spec decode). TT has no spec decode
+        # (num_speculative_steps == 0), so this degenerates to a zero-width row.
+        self.draft_tokens = np.zeros(
+            (self.max_num_reqs, self.num_speculative_steps), dtype=np.int64
+        )
+
+        self.next_prefill_tokens = np.zeros(self.max_num_reqs, dtype=np.int32)
+
+    @property
+    def num_reqs(self) -> int:
+        return len(self.req_id_to_index)
+
+    def add_request(
+        self,
+        req_id: str,
+        prompt_len: int,
+        all_token_ids: list[int],
+        num_computed_tokens: int,
+    ) -> None:
+        assert len(self.free_indices) > 0, "No free indices"
+        req_idx = self.free_indices.pop()
+        self.req_id_to_index[req_id] = req_idx
+        self.index_to_req_id[req_idx] = req_id
+
+        self.prompt_len[req_idx] = prompt_len
+        prefill_len = len(all_token_ids)
+        assert (
+            prefill_len >= prompt_len
+        ), f"prefill_len {prefill_len} < prompt_len {prompt_len}"
+        self.prefill_len[req_idx] = prefill_len
+        self.total_len[req_idx] = prefill_len
+        self.all_token_ids[req_idx, :prefill_len] = all_token_ids
+        self.num_computed_prefill_tokens[req_idx] = num_computed_tokens
+        self.num_computed_tokens[req_idx] = num_computed_tokens
+
+        if 0 < num_computed_tokens <= prefill_len:
+            # PD disagg / resumed requests: seed last_sampled with the last
+            # computed token so the first decode step reads the right input id.
+            # Fresh prefill (num_computed_tokens == 0) never reads this slot.
+            self.last_sampled_tokens[req_idx] = all_token_ids[num_computed_tokens - 1]
+        self.draft_tokens[req_idx] = 0
+
+    def apply_staged_writes(self) -> None:
+        """No-op: numpy writes land immediately (see module docstring).
+
+        Kept for interface parity with upstream ``RequestState`` so the Phase 3
+        runner's ``add_requests`` can call it unconditionally.
+        """
+        return None
+
+    def remove_request(self, req_id: str) -> bool:
+        req_idx = self.req_id_to_index.pop(req_id, None)
+        if req_idx is None:
+            return False
+        self.index_to_req_id.pop(req_idx, None)
+        self.free_indices.append(req_idx)
+        return True
+
+    def is_prefilling(self, idx_mapping_np: np.ndarray) -> np.ndarray:
+        return (
+            self.num_computed_prefill_tokens[idx_mapping_np]
+            < self.prefill_len[idx_mapping_np]
+        )

--- a/integrations/vllm_plugin/vllm_tt/sampling_state_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/sampling_state_v2.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Optional
 import numpy as np
 import torch
 from vllm.sampling_params import SamplingType
+from vllm.v1.sample.logits_processor import LogitsProcessors
 
 from .metadata import DEFAULT_SAMPLING_PARAMS
 
@@ -61,6 +62,13 @@ class SamplingBatchView:
     num_prompt_tokens: np.ndarray
     token_ids_cpu: np.ndarray
     max_num_logprobs: int
+    # Pooling-only in upstream; always False on the v2 generation path.
+    logits_processing_needs_token_ids: np.ndarray
+    # v2 hard-codes num_speculative_steps=0, so no drafts to expose.
+    spec_token_ids: list[list[int]]
+    # Neither TT runner builds custom logits processors.
+    logitsprocs: LogitsProcessors
+    logitsprocs_need_output_token_ids: bool
 
 
 class TTSamplingStates:
@@ -286,4 +294,8 @@ class TTSamplingStates:
             num_prompt_tokens=num_prompt_tokens,
             token_ids_cpu=token_ids_cpu,
             max_num_logprobs=max_num_logprobs,
+            logits_processing_needs_token_ids=np.zeros(padded_num_reqs, dtype=bool),
+            spec_token_ids=[[] for _ in range(padded_num_reqs)],
+            logitsprocs=LogitsProcessors(),
+            logitsprocs_need_output_token_ids=False,
         )

--- a/integrations/vllm_plugin/vllm_tt/sampling_state_v2.py
+++ b/integrations/vllm_plugin/vllm_tt/sampling_state_v2.py
@@ -1,0 +1,289 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""TT ``SamplingStates`` for vLLM Model Runner v2 (MRv2).
+
+MRv2 keeps sampling params out of RequestState/InputBatch, in a sampler-owned
+table. TT applies sampling host-side / on the XLA graph via
+XLASupportedSamplingMetadata (metadata.py), so this is a plain host-side slot
+table keyed by req_state_idx (the stable TTRequestState slot). Each step the
+runner maps batch position -> slot via TTInputBatch.idx_mapping_np, and
+make_batch_view gathers a batch-ordered padded view for from_v2_states.
+Extraction from SamplingParams mirrors the v1 input_batch.py::add_request
+(greedy -> temperature 0.0; disabled top_k -> vocab_size).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+import numpy as np
+import torch
+from vllm.sampling_params import SamplingType
+
+from .metadata import DEFAULT_SAMPLING_PARAMS
+
+if TYPE_CHECKING:
+    from vllm.sampling_params import SamplingParams
+
+    from .input_batch_v2 import TTInputBatch
+    from .request_state import TTRequestState
+
+
+@dataclass
+class SamplingBatchView:
+    """Batch-ordered, padded view built each step from the slot table.
+
+    Exposes exactly the attributes ``XLASupportedSamplingMetadata.from_input_batch``
+    reads, so the v2 path reuses that tested constructor unchanged.
+    """
+
+    num_reqs: int
+    vocab_size: int
+    temperature_cpu_tensor: torch.Tensor
+    top_p_cpu_tensor: torch.Tensor
+    top_k_cpu_tensor: torch.Tensor
+    min_p_cpu_tensor: torch.Tensor
+    presence_penalties_cpu_tensor: torch.Tensor
+    frequency_penalties_cpu_tensor: torch.Tensor
+    repetition_penalties_cpu_tensor: torch.Tensor
+    all_greedy: bool
+    all_random: bool
+    no_penalties: bool
+    logit_bias: list[Optional[dict[int, float]]]
+    bad_words_token_ids: dict[int, list[list[int]]]
+    min_tokens: dict[int, tuple[int, set[int]]]
+    generators: dict[int, torch.Generator]
+    no_allowed_token_ids: bool
+    allowed_token_ids_mask_cpu_tensor: Optional[torch.Tensor]
+    req_output_token_ids: list[Optional[list[int]]]
+    num_prompt_tokens: np.ndarray
+    token_ids_cpu: np.ndarray
+    max_num_logprobs: int
+
+
+class TTSamplingStates:
+    """Persistent per-slot sampling-param table for the TT MRv2 runner."""
+
+    def __init__(self, max_num_reqs: int, vocab_size: int):
+        self.max_num_reqs = max_num_reqs
+        self.vocab_size = vocab_size
+
+        self.temperature = np.full(
+            max_num_reqs, DEFAULT_SAMPLING_PARAMS["temperature"], dtype=np.float32
+        )
+        self.top_p = np.full(
+            max_num_reqs, DEFAULT_SAMPLING_PARAMS["top_p"], dtype=np.float32
+        )
+        self.top_k = np.full(
+            max_num_reqs, DEFAULT_SAMPLING_PARAMS["top_k"], dtype=np.int32
+        )
+        self.min_p = np.full(
+            max_num_reqs, DEFAULT_SAMPLING_PARAMS["min_p"], dtype=np.float32
+        )
+        self.frequency_penalties = np.full(
+            max_num_reqs,
+            DEFAULT_SAMPLING_PARAMS["frequency_penalties"],
+            dtype=np.float32,
+        )
+        self.presence_penalties = np.full(
+            max_num_reqs,
+            DEFAULT_SAMPLING_PARAMS["presence_penalties"],
+            dtype=np.float32,
+        )
+        self.repetition_penalties = np.full(
+            max_num_reqs,
+            DEFAULT_SAMPLING_PARAMS["repetition_penalties"],
+            dtype=np.float32,
+        )
+        # Default (empty) slots are greedy, matching the temperature sentinel.
+        self.is_greedy = np.ones(max_num_reqs, dtype=np.bool_)
+
+        self.min_tokens: dict[int, tuple[int, set[int]]] = {}
+        self.generators: dict[int, torch.Generator] = {}
+        self.logit_bias: list[Optional[dict[int, float]]] = [None] * max_num_reqs
+        self.bad_words_token_ids: dict[int, list[list[int]]] = {}
+        self.allowed_token_ids: dict[int, list[int]] = {}
+        self.num_logprobs: dict[int, int] = {}
+
+    def add_request(
+        self,
+        slot: int,
+        sampling_params: "SamplingParams",
+        generator: "torch.Generator | None" = None,
+    ) -> None:
+        if sampling_params.sampling_type == SamplingType.GREEDY:
+            # Zero temperature avoids a divide-by-zero in apply_temperature.
+            self.temperature[slot] = 0.0
+            self.is_greedy[slot] = True
+        else:
+            self.temperature[slot] = sampling_params.temperature
+            self.is_greedy[slot] = False
+
+        self.top_p[slot] = sampling_params.top_p
+        top_k = sampling_params.top_k
+        if not 0 < top_k < self.vocab_size:
+            top_k = self.vocab_size
+        self.top_k[slot] = top_k
+        self.min_p[slot] = sampling_params.min_p
+        self.frequency_penalties[slot] = sampling_params.frequency_penalty
+        self.presence_penalties[slot] = sampling_params.presence_penalty
+        self.repetition_penalties[slot] = sampling_params.repetition_penalty
+
+        if sampling_params.min_tokens:
+            self.min_tokens[slot] = (
+                sampling_params.min_tokens,
+                sampling_params.all_stop_token_ids,
+            )
+        # Only seeded requests carry a generator; the rest use the global RNG.
+        if generator is not None:
+            self.generators[slot] = generator
+        if sampling_params.logprobs is not None:
+            self.num_logprobs[slot] = sampling_params.logprobs
+        if sampling_params.logit_bias is not None:
+            self.logit_bias[slot] = sampling_params.logit_bias
+        if sampling_params.allowed_token_ids:
+            self.allowed_token_ids[slot] = sampling_params.allowed_token_ids
+        if sampling_params.bad_words_token_ids:
+            self.bad_words_token_ids[slot] = sampling_params.bad_words_token_ids
+
+    def remove_request(self, slot: int) -> None:
+        self.temperature[slot] = DEFAULT_SAMPLING_PARAMS["temperature"]
+        self.top_p[slot] = DEFAULT_SAMPLING_PARAMS["top_p"]
+        self.top_k[slot] = DEFAULT_SAMPLING_PARAMS["top_k"]
+        self.min_p[slot] = DEFAULT_SAMPLING_PARAMS["min_p"]
+        self.frequency_penalties[slot] = DEFAULT_SAMPLING_PARAMS["frequency_penalties"]
+        self.presence_penalties[slot] = DEFAULT_SAMPLING_PARAMS["presence_penalties"]
+        self.repetition_penalties[slot] = DEFAULT_SAMPLING_PARAMS[
+            "repetition_penalties"
+        ]
+        self.is_greedy[slot] = True
+        self.min_tokens.pop(slot, None)
+        self.generators.pop(slot, None)
+        self.logit_bias[slot] = None
+        self.bad_words_token_ids.pop(slot, None)
+        self.allowed_token_ids.pop(slot, None)
+        self.num_logprobs.pop(slot, None)
+
+    def make_batch_view(
+        self,
+        request_state: "TTRequestState",
+        input_batch: "TTInputBatch",
+        padded_num_reqs: int,
+    ) -> SamplingBatchView:
+        """Gather a batch-ordered, padded view for the current step.
+
+        ``input_batch.idx_mapping_np[b]`` gives the slot backing batch position b.
+        Active rows carry real params; padded rows [num_reqs:padded] carry the
+        sampler defaults (``from_input_batch`` overwrites them via fill_slice too).
+        """
+        num_reqs = input_batch.num_reqs
+        slots = [int(input_batch.idx_mapping_np[b]) for b in range(num_reqs)]
+        vocab = self.vocab_size
+
+        def _full(name):
+            return torch.full(
+                (padded_num_reqs,),
+                float(DEFAULT_SAMPLING_PARAMS[name]),
+                dtype=torch.float32,
+            )
+
+        temperature = _full("temperature")
+        top_p = _full("top_p")
+        min_p = _full("min_p")
+        presence = _full("presence_penalties")
+        frequency = _full("frequency_penalties")
+        repetition = _full("repetition_penalties")
+        top_k = torch.full(
+            (padded_num_reqs,),
+            int(DEFAULT_SAMPLING_PARAMS["top_k"]),
+            dtype=torch.int32,
+        )
+
+        max_model_len = request_state.all_token_ids.shape[1]
+        token_ids_cpu = np.zeros((padded_num_reqs, max_model_len), dtype=np.int32)
+        num_prompt_tokens = np.zeros(padded_num_reqs, dtype=np.int32)
+        req_output_token_ids: list[Optional[list[int]]] = [None] * padded_num_reqs
+
+        logit_bias: list[Optional[dict[int, float]]] = [None] * padded_num_reqs
+        bad_words: dict[int, list[list[int]]] = {}
+        min_tokens: dict[int, tuple[int, set[int]]] = {}
+        generators: dict[int, torch.Generator] = {}
+
+        has_allowed = any(slot in self.allowed_token_ids for slot in slots)
+        allowed_mask = (
+            torch.zeros(padded_num_reqs, vocab, dtype=torch.bool)
+            if has_allowed
+            else None
+        )
+
+        num_greedy = 0
+        has_penalties = False
+        max_num_logprobs = 0
+
+        for b, slot in enumerate(slots):
+            temperature[b] = float(self.temperature[slot])
+            top_p[b] = float(self.top_p[slot])
+            top_k[b] = int(self.top_k[slot])
+            min_p[b] = float(self.min_p[slot])
+            presence[b] = float(self.presence_penalties[slot])
+            frequency[b] = float(self.frequency_penalties[slot])
+            repetition[b] = float(self.repetition_penalties[slot])
+
+            if bool(self.is_greedy[slot]):
+                num_greedy += 1
+            if (
+                self.frequency_penalties[slot] != 0.0
+                or self.presence_penalties[slot] != 0.0
+                or self.repetition_penalties[slot] != 1.0
+            ):
+                has_penalties = True
+
+            prompt_len = int(request_state.prompt_len[slot])
+            total_len = int(request_state.total_len[slot])
+            token_ids_cpu[b] = request_state.all_token_ids[slot]
+            num_prompt_tokens[b] = prompt_len
+            req_output_token_ids[b] = request_state.all_token_ids[
+                slot, prompt_len:total_len
+            ].tolist()
+
+            logit_bias[b] = self.logit_bias[slot]
+            if slot in self.bad_words_token_ids:
+                bad_words[b] = self.bad_words_token_ids[slot]
+            if slot in self.min_tokens:
+                min_tokens[b] = self.min_tokens[slot]
+            if slot in self.generators:
+                generators[b] = self.generators[slot]
+            if slot in self.num_logprobs:
+                max_num_logprobs = max(max_num_logprobs, self.num_logprobs[slot])
+            if allowed_mask is not None and slot in self.allowed_token_ids:
+                allowed_mask[b, :] = True  # True == disallowed
+                allowed = [t for t in self.allowed_token_ids[slot] if t < vocab]
+                if allowed:
+                    allowed_mask[b, allowed] = False
+
+        return SamplingBatchView(
+            num_reqs=num_reqs,
+            vocab_size=vocab,
+            temperature_cpu_tensor=temperature,
+            top_p_cpu_tensor=top_p,
+            top_k_cpu_tensor=top_k,
+            min_p_cpu_tensor=min_p,
+            presence_penalties_cpu_tensor=presence,
+            frequency_penalties_cpu_tensor=frequency,
+            repetition_penalties_cpu_tensor=repetition,
+            all_greedy=num_reqs > 0 and num_greedy == num_reqs,
+            all_random=num_reqs > 0 and num_greedy == 0,
+            no_penalties=not has_penalties,
+            logit_bias=logit_bias,
+            bad_words_token_ids=bad_words,
+            min_tokens=min_tokens,
+            generators=generators,
+            no_allowed_token_ids=not has_allowed,
+            allowed_token_ids_mask_cpu_tensor=allowed_mask,
+            req_output_token_ids=req_output_token_ids,
+            num_prompt_tokens=num_prompt_tokens,
+            token_ids_cpu=token_ids_cpu,
+            max_num_logprobs=max_num_logprobs,
+        )

--- a/integrations/vllm_plugin/vllm_tt/telemetry.py
+++ b/integrations/vllm_plugin/vllm_tt/telemetry.py
@@ -415,12 +415,11 @@ class RunnerTelemetry(_JsonlSink):
     ) -> None:
         """Hook: end of the runner's ``sample_tokens``. O(active_slots).
 
-        ``emitted_tokens`` counts *tokens* emitted this step, not emitting rows
-        (rows still prefilling emit none). Decode rate is emitted-tokens /
-        wall-time since the previous step, i.e. *accepted* tokens/step. On the v1
-        runner that distinction is live rather than theoretical: with spec decode
-        a row can accept several tokens in one step, and the caller sums
-        the per-row accepted lengths (``gen_lens``) rather than counting rows.
+        ``emitted_tokens`` counts *tokens* emitted this step; rows still
+        prefilling emit none. Decode rate is emitted-tokens / wall-time since the
+        previous step, i.e. *accepted* tokens/step. Both runners run ngram
+        speculative decode, where one row can accept several tokens in a step, so
+        callers sum per-row accepted lengths.
         """
         if not self.enabled:
             return

--- a/integrations/vllm_plugin/vllm_tt/worker.py
+++ b/integrations/vllm_plugin/vllm_tt/worker.py
@@ -131,7 +131,6 @@ class TTWorker:
         self.cache_config.num_cpu_blocks = num_cpu_blocks
 
     def init_device(self):
-        # os.environ["PJRT_DEVICE"] = "TT"
         xr.set_device_type("TT")
         torch.set_grad_enabled(False)
         torch.set_default_dtype(self.model_config.dtype)
@@ -145,6 +144,10 @@ class TTWorker:
         # the distributed runtime.
         self.device = torch_xla.device()
         self.device_config.device = self.device
+
+        # Apply PJRT compile options once per worker after the XLA runtime is
+        # initialized and before any model runner is constructed.
+        torch_xla.set_custom_compile_options(self.tt_config.get_pjrt_compile_config())
 
         # Set random seed.
         set_random_seed(self.model_config.seed)
@@ -173,13 +176,22 @@ class TTWorker:
             xr.initialize_cache(per_rank_path, readonly=False)
 
         # Init ModelRunner here, so that we have access to self.device.
-        ModelRunnerClass = TTModelRunner
-        if self.model_config.runner_type == "pooling":
-            ModelRunnerClass = TTPoolingModelRunner
+        # Opt-in MRv2 runner (default off): gated on TTConfig.use_v2_model_runner.
+        # Generate-only for now, so keep the v1 runner as the default path.
+        use_v2 = self.tt_config.use_v2_model_runner
+        if use_v2 and self.model_config.runner_type != "pooling":
+            from .model_runner_v2 import TTModelRunnerV2
 
-        self.model_runner = ModelRunnerClass(
-            self.vllm_config, self.device, self.original_parallel_config
-        )
+            self.model_runner = TTModelRunnerV2(
+                self.vllm_config, self.device, self.original_parallel_config
+            )
+        else:
+            ModelRunnerClass = TTModelRunner
+            if self.model_config.runner_type == "pooling":
+                ModelRunnerClass = TTPoolingModelRunner
+            self.model_runner = ModelRunnerClass(
+                self.vllm_config, self.device, self.original_parallel_config
+            )
 
         if rank == 0:
             # If usage stat is enabled, collect relevant info.

--- a/tests/integrations/vllm_plugin/conftest.py
+++ b/tests/integrations/vllm_plugin/conftest.py
@@ -10,6 +10,7 @@ traceback, so finalize never fires and the EngineCore subprocess
 holding the TT device outlives the test — hanging the next one. Shut
 them down explicitly on failure.
 """
+
 import gc
 import os
 

--- a/tests/integrations/vllm_plugin/generative/test_gemma4_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_gemma4_generation.py
@@ -112,6 +112,8 @@ def test_generation_single_device_gemma4_e4b_image():
             "use_2d_mesh": False,
             "cpu_sampling": True,
             "flat_model_io": True,
+            # Image input: MRv2 mm-encoder not wired yet; run on the v1 runner.
+            "use_v2_model_runner": False,
         },
     }
     llm = vllm.LLM(**llm_args)
@@ -166,6 +168,8 @@ def test_generation_bhqb_gemma4_image(model_name, use_2d_mesh):
             "use_2d_mesh": use_2d_mesh,
             "cpu_sampling": False,
             "flat_model_io": True,
+            # Image input: MRv2 mm-encoder not wired yet; run on the v1 runner.
+            "use_v2_model_runner": False,
         },
     }
     llm = vllm.LLM(**llm_args)

--- a/tests/integrations/vllm_plugin/generative/test_mrope.py
+++ b/tests/integrations/vllm_plugin/generative/test_mrope.py
@@ -25,6 +25,8 @@ def test_mrope():
         "limit_mm_per_prompt": {"image": 0, "video": 0, "audio": 0},
         "additional_config": {
             "min_context_len": 32,
+            # mrope not yet supported by MRv2; run on the v1 runner.
+            "use_v2_model_runner": False,
         },
     }
     llm = vllm.LLM(**llm_args)

--- a/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py
@@ -335,6 +335,8 @@ def test_tensor_parallel_generation_mistral_small(model_name: str):
             "min_context_len": 32,
             "enable_tensor_parallel": True,
             "experimental_weight_dtype": "bfp_bf8",
+            # Image input: MRv2 mm-encoder not wired yet; run on the v1 runner.
+            "use_v2_model_runner": False,
         },
     }
     llm = vllm.LLM(**llm_args)
@@ -379,6 +381,8 @@ def test_tensor_parallel_generation_galaxy_wh_6u_pixtral_large(model_name: str):
             "min_context_len": 1024,
             "enable_tensor_parallel": True,
             "experimental_weight_dtype": "bfp_bf8",
+            # Image input: MRv2 mm-encoder not wired yet; run on the v1 runner.
+            "use_v2_model_runner": False,
         },
     }
     llm = vllm.LLM(**llm_args)

--- a/tests/integrations/vllm_plugin/mrv2/test_input_batch.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_input_batch.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU smoke test for the MRv2 ``TTInputBatch.make_dummy`` builder.
+
+``TTInputBatch`` (see vllm_tt/input_batch_v2.py) is a near-verbatim port of
+upstream's transient per-step view, so coverage here is intentionally light --
+one shape/layout invariant check on the dummy builder used for warmup. The
+real per-step population logic lives in the Phase 3 runner and is tested there.
+Runs on cpu (device=torch.device("cpu")), no TT hardware.
+"""
+
+import pytest
+import torch
+from vllm_tt.input_batch_v2 import TTInputBatch, TTInputBuffers
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+@pytest.mark.parametrize(
+    "num_reqs, num_tokens, expected_scheduled, expected_qsl, expected_logits",
+    [
+        (2, 6, [3, 3], [0, 3, 6], [2, 5]),  # even split
+        (2, 7, [3, 4], [0, 3, 7], [2, 6]),  # remainder lands on the last req
+    ],
+)
+def test_make_dummy_layout(
+    num_reqs, num_tokens, expected_scheduled, expected_qsl, expected_logits
+):
+    bufs = TTInputBuffers(max_num_reqs=4, max_num_tokens=16, device=torch.device("cpu"))
+    ib = TTInputBatch.make_dummy(
+        num_reqs=num_reqs, num_tokens=num_tokens, input_buffers=bufs
+    )
+
+    assert ib.num_reqs == num_reqs
+    assert ib.num_tokens == num_tokens
+    assert ib.num_scheduled_tokens.tolist() == expected_scheduled
+    assert int(ib.num_scheduled_tokens.sum()) == num_tokens
+    assert ib.query_start_loc.tolist() == expected_qsl
+    # One logit per request, at each request's last token.
+    assert ib.logits_indices.tolist() == expected_logits
+    assert ib.idx_mapping.tolist() == list(range(num_reqs))
+    assert tuple(ib.input_ids.shape) == (num_tokens,)
+    assert tuple(ib.positions.shape) == (num_tokens,)
+    # TT has no spec decode / DCP -> these stay at their degenerate defaults.
+    assert ib.num_draft_tokens == 0
+    assert ib.dcp_local_seq_lens is None

--- a/tests/integrations/vllm_plugin/mrv2/test_model_state.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_model_state.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU unit tests for the MRv2 ``TTModelState.prepare_attn`` assembler.
+
+``prepare_attn`` (see vllm_tt/model_state.py) packages the per-step device
+arrays the runner computes host-side into a single ``TTMetadata`` and fans it
+out to every attention layer -- mirroring the v1 fork's
+``dict.fromkeys(self._attention_layer_names, attn_metadata)``. It uses no
+instance state, so these run on cpu with no TT hardware and no model
+(the state object is allocated without ``__init__``).
+"""
+
+import pytest
+import torch
+from vllm_tt.attention_impls.attention import TTMetadata
+from vllm_tt.model_state import TTModelState
+
+
+def _bare_state():
+    # prepare_attn reads no self.* state; skip the heavy VllmConfig __init__.
+    return object.__new__(TTModelState)
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_prepare_attn_fans_out_shared_metadata_per_layer():
+    ms = _bare_state()
+    layers = ["layer.0", "layer.1", "layer.2"]
+    page_table = torch.zeros(4, 8, dtype=torch.int32)
+    cache_position = torch.zeros(4, dtype=torch.int32)
+    fill_page_table = torch.ones(4, 8, dtype=torch.int32)
+    batch_idx = torch.arange(4, dtype=torch.int32)
+
+    out = ms.prepare_attn(
+        layers,
+        page_table=page_table,
+        cache_position=cache_position,
+        fill_page_table=fill_page_table,
+        batch_idx=batch_idx,
+        num_users=4,
+        dp_size=2,
+    )
+
+    assert set(out.keys()) == set(layers)
+    metas = list(out.values())
+    # One shared TTMetadata object across all layers (matches dict.fromkeys).
+    assert all(m is metas[0] for m in metas)
+
+    m = metas[0]
+    assert isinstance(m, TTMetadata)
+    assert m.num_users == 4
+    assert m.dp_size == 2
+    assert m.is_causal is True
+    assert m.attn_mask is None
+    assert m.chunk_start_idx is None
+    assert m.page_table is page_table
+    assert m.fill_page_table is fill_page_table
+    assert m.cache_position is cache_position
+    assert m.batch_idx is batch_idx
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_prepare_attn_fill_page_table_defaults_to_page_table():
+    ms = _bare_state()
+    page_table = torch.zeros(2, 4, dtype=torch.int32)
+
+    out = ms.prepare_attn(
+        ["only.layer"],
+        page_table=page_table,
+        cache_position=torch.zeros(2, dtype=torch.int32),
+        num_users=2,
+    )
+
+    m = out["only.layer"]
+    # No prefix roll supplied -> fill_page_table mirrors page_table.
+    assert m.fill_page_table is page_table
+    assert m.dp_size == 1
+    assert m.batch_idx is None

--- a/tests/integrations/vllm_plugin/mrv2/test_request_state.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_request_state.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU unit tests for the MRv2 ``TTRequestState`` slot table.
+
+``TTRequestState`` (see vllm_tt/request_state.py) is pure host-side numpy, so
+these run on a cpu-only runner with no TT hardware and no model. They pin the
+invariants that are TT's own responsibility and stable across the remaining
+MRv2 phases: the stable-slot / free-list lifecycle (which replaces v1's
+condense-and-shuffle bookkeeping and the slot-corruption bugs it caused),
+length accounting, and the numpy substitution for upstream's UVA buffers.
+
+These do NOT exercise the end-to-end runner path -- nothing consumes
+``TTRequestState`` until the Phase 3 runner exists.
+"""
+
+import numpy as np
+import pytest
+from vllm_tt.request_state import TTRequestState
+
+
+def make_state(max_num_reqs=4, max_model_len=32, num_speculative_steps=0):
+    return TTRequestState(
+        max_num_reqs=max_num_reqs,
+        max_model_len=max_model_len,
+        max_num_batched_tokens=64,
+        num_speculative_steps=num_speculative_steps,
+        vocab_size=1000,
+        device="cpu",
+    )
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_add_request_records_lengths_and_tokens():
+    rs = make_state()
+    rs.add_request("A", prompt_len=3, all_token_ids=[10, 11, 12], num_computed_tokens=0)
+
+    slot = rs.req_id_to_index["A"]
+    assert rs.num_reqs == 1
+    assert rs.index_to_req_id[slot] == "A"
+    assert rs.prompt_len[slot] == 3
+    assert rs.prefill_len[slot] == 3
+    assert rs.total_len[slot] == 3
+    assert rs.num_computed_tokens[slot] == 0
+    assert rs.num_computed_prefill_tokens[slot] == 0
+    np.testing.assert_array_equal(rs.all_token_ids[slot, :3], [10, 11, 12])
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_free_slot_reused_after_removal_without_condensing():
+    """A removed slot returns to the free list and is reused; other requests
+    keep their slot and tokens (no v1-style condense/shuffle)."""
+    rs = make_state(max_num_reqs=4)
+    rs.add_request("A", prompt_len=3, all_token_ids=[10, 11, 12], num_computed_tokens=0)
+    rs.add_request("B", prompt_len=2, all_token_ids=[20, 21], num_computed_tokens=0)
+    rs.add_request("C", prompt_len=1, all_token_ids=[30], num_computed_tokens=0)
+
+    slot_a, slot_b, slot_c = (rs.req_id_to_index[r] for r in ("A", "B", "C"))
+
+    assert rs.remove_request("B") is True
+    assert "B" not in rs.req_id_to_index
+    assert slot_b in rs.free_indices
+
+    # A and C are untouched by B's removal.
+    assert rs.req_id_to_index["A"] == slot_a
+    assert rs.req_id_to_index["C"] == slot_c
+    np.testing.assert_array_equal(rs.all_token_ids[slot_a, :3], [10, 11, 12])
+
+    # The next request reuses B's freed slot.
+    rs.add_request("D", prompt_len=2, all_token_ids=[40, 41], num_computed_tokens=0)
+    assert rs.req_id_to_index["D"] == slot_b
+    assert rs.num_reqs == 3
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_is_prefilling_mixed_batch():
+    rs = make_state()
+    # P is mid-prefill: 2 of 5 tokens computed.
+    rs.add_request(
+        "P", prompt_len=5, all_token_ids=[1, 2, 3, 4, 5], num_computed_tokens=2
+    )
+    # D has finished prefill (all 3 computed) -> decoding.
+    rs.add_request("D", prompt_len=3, all_token_ids=[6, 7, 8], num_computed_tokens=3)
+
+    idx = np.array([rs.req_id_to_index["P"], rs.req_id_to_index["D"]], dtype=np.int32)
+    np.testing.assert_array_equal(rs.is_prefilling(idx), [True, False])
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+@pytest.mark.parametrize(
+    "num_computed, expected_last",
+    [
+        (0, 0),  # fresh prefill: slot never seeded (stays zero-initialized)
+        (2, 8),  # resumed: seeded with all_token_ids[num_computed - 1]
+    ],
+)
+def test_resumed_request_seeds_last_sampled(num_computed, expected_last):
+    rs = make_state()
+    rs.add_request(
+        "R",
+        prompt_len=4,
+        all_token_ids=[7, 8, 9, 10],
+        num_computed_tokens=num_computed,
+    )
+    slot = rs.req_id_to_index["R"]
+    assert rs.last_sampled_tokens[slot, 0] == expected_last
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_remove_request_return_value():
+    rs = make_state()
+    rs.add_request("A", prompt_len=1, all_token_ids=[10], num_computed_tokens=0)
+
+    assert rs.remove_request("missing") is False
+    assert rs.remove_request("A") is True
+    assert rs.num_reqs == 0
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_apply_staged_writes_is_noop():
+    """Locks the numpy substitution: writes land immediately in add_request, so
+    apply_staged_writes must not mutate state (upstream flushes UVA here)."""
+    rs = make_state()
+    rs.add_request("A", prompt_len=2, all_token_ids=[10, 11], num_computed_tokens=0)
+    slot = rs.req_id_to_index["A"]
+    before = rs.all_token_ids[slot, :2].copy()
+
+    rs.apply_staged_writes()
+
+    assert rs.num_reqs == 1
+    np.testing.assert_array_equal(rs.all_token_ids[slot, :2], before)

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_attn_prep.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_attn_prep.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU unit tests for the MRv2 runner attention slot-mapping build.
+
+``TTModelRunnerV2._prepare_attn_tensors`` (see vllm_tt/model_runner_v2.py) is the
+host substitute for upstream's block-table / slot-mapping Triton kernels. It is
+pure numpy over ``TTRequestState`` + the runner block table, so it runs on cpu
+with no TT hardware: the runner is allocated without ``__init__`` and the block
+table is a fake returning a fixed numpy block map.
+
+They pin the paged-attention math TT owns: the batch-order gather, the prefix
+roll for ``paged_fill_cache``, the zero-scheduled-row redirect, and null padding.
+The output feeds ``TTModelState.prepare_attn`` (tested separately).
+"""
+
+import numpy as np
+import pytest
+import torch
+from vllm_tt.model_runner_v2 import TTModelRunnerV2
+from vllm_tt.request_state import TTRequestState
+
+VOCAB = 1000
+# slot -> block ids (row 3 is the unused/null slot).
+BLOCK_MAP = [[10, 11, 12, 13], [20, 21, 22, 23], [30, 31, 32, 33], [0, 0, 0, 0]]
+
+
+class FakeBlockTable:
+    def __init__(self, arr):
+        self._arr = arr
+
+    def __getitem__(self, group):  # block_table[0] -> the single kv group
+        return self
+
+    def get_cpu_tensor(self):
+        return self._arr
+
+
+def make_runner(block_size=2, max_num_reqs=4, max_model_len=32):
+    r = object.__new__(TTModelRunnerV2)
+    r.req_states = TTRequestState(
+        max_num_reqs=max_num_reqs,
+        max_model_len=max_model_len,
+        max_num_batched_tokens=64,
+        num_speculative_steps=0,
+        vocab_size=VOCAB,
+        device="cpu",
+    )
+    r.block_table = FakeBlockTable(torch.tensor(BLOCK_MAP, dtype=torch.int32))
+    r.block_size = block_size
+    return r
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_attn_tensors_no_prefix_gathers_in_batch_order():
+    r = make_runner()
+    # Batch order [slot1, slot0]; no computed prefix.
+    idx = np.array([1, 0], dtype=np.int32)
+    nst = np.array([5, 3], dtype=np.int32)
+    seq_lens = np.array([5, 3, 0, 0], dtype=np.int32)
+
+    page_table, fill_page_table, cache_position = r._prepare_attn_tensors(
+        idx, nst, seq_lens, target_num_reqs=4, num_blocks_per_req=4
+    )
+
+    assert page_table[0].tolist() == [20, 21, 22, 23]  # slot 1
+    assert page_table[1].tolist() == [10, 11, 12, 13]  # slot 0
+    assert page_table[2].tolist() == [0, 0, 0, 0]  # padding
+    assert cache_position.tolist() == [4, 2, -1, -1]  # seq_lens - 1, pad -1
+    # No prefix -> no roll -> fill aliases the read table.
+    assert fill_page_table is page_table
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_attn_tensors_prefix_roll():
+    r = make_runner(block_size=2)
+    # slot 0 has 4 computed tokens -> offset 4 // 2 == 2 blocks.
+    r.req_states.num_computed_tokens[0] = 4
+    idx = np.array([0], dtype=np.int32)
+    nst = np.array([3], dtype=np.int32)
+    seq_lens = np.array([7, 0], dtype=np.int32)
+
+    page_table, fill_page_table, cache_position = r._prepare_attn_tensors(
+        idx, nst, seq_lens, target_num_reqs=2, num_blocks_per_req=4
+    )
+
+    assert fill_page_table is not page_table
+    # Read path keeps the real order; write path is rolled left by 2.
+    assert page_table[0].tolist() == [10, 11, 12, 13]
+    assert fill_page_table[0].tolist() == [12, 13, 10, 11]
+    assert cache_position.tolist() == [6, -1]
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_attn_tensors_zero_scheduled_row_redirects_fill():
+    r = make_runner()
+    # Row 0 is a re-batched, already-prefilled request: 0 scheduled tokens.
+    idx = np.array([0, 1], dtype=np.int32)
+    nst = np.array([0, 3], dtype=np.int32)
+    seq_lens = np.array([5, 3, 0, 0], dtype=np.int32)
+
+    page_table, fill_page_table, _ = r._prepare_attn_tensors(
+        idx, nst, seq_lens, target_num_reqs=4, num_blocks_per_req=4
+    )
+
+    assert fill_page_table is not page_table
+    # Read path keeps slot 0's real blocks; write path is nulled so it can't
+    # clobber the KV written for that request in an earlier step.
+    assert page_table[0].tolist() == [10, 11, 12, 13]
+    assert fill_page_table[0].tolist() == [0, 0, 0, 0]
+    assert fill_page_table[1].tolist() == [20, 21, 22, 23]

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_batch_select.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_batch_select.py
@@ -9,7 +9,7 @@ requests decodes-first and carve out one pass's sub-batch under the SMEM row
 caps. They run on cpu with no TT hardware; the SMEM-cap scalars are injected.
 
 They pin the selection math TT owns: decode-first ordering, the max/most model-len
-row cap (a long tail request forcing max-model-len mode), the prefill-cap
+row cap, the prefill-cap
 multi-pass split, and the decode/prefill target-bucket + padded query length.
 The outputs feed ``_prepare_input_tokens`` and ``_prepare_attn_tensors``.
 """
@@ -36,9 +36,7 @@ def make_runner(**scalars):
         vocab_size=VOCAB,
         device="cpu",
     )
-    r.most_model_len = scalars.get("most_model_len", None)
     r.num_reqs_max_model_len = scalars.get("num_reqs_max_model_len", 3)
-    r.num_reqs_most_model_len = scalars.get("num_reqs_most_model_len", None)
     r.max_prefill_num_reqs = scalars.get("max_prefill_num_reqs", 2)
     r.min_num_reqs = scalars.get("min_num_reqs", 1)
     r.max_num_reqs = scalars.get("max_num_reqs", 4)
@@ -118,7 +116,7 @@ def test_select_batch_dp_single_full_width_pass():
 @pytest.mark.push
 @pytest.mark.cpu
 def test_select_batch_decode_runs_at_max_bucket():
-    r = make_runner(most_model_len=None, num_reqs_max_model_len=3, max_num_reqs=4)
+    r = make_runner(num_reqs_max_model_len=3, max_num_reqs=4)
     slots = np.array([0, 1, 2], dtype=np.int32)
     ntoks = np.array([1, 1, 1], dtype=np.int32)
 
@@ -134,7 +132,6 @@ def test_select_batch_decode_runs_at_max_bucket():
 @pytest.mark.cpu
 def test_select_batch_prefill_cap_multipass():
     r = make_runner(
-        most_model_len=None,
         num_reqs_max_model_len=3,
         max_prefill_num_reqs=2,
         min_num_reqs=1,
@@ -157,19 +154,17 @@ def test_select_batch_prefill_cap_multipass():
 
 @pytest.mark.push
 @pytest.mark.cpu
-def test_select_batch_long_request_forces_max_model_len_cap():
+def test_select_batch_row_cap_is_always_max_model_len():
     r = make_runner(
-        most_model_len=100,
-        num_reqs_most_model_len=3,
         num_reqs_max_model_len=2,
         max_prefill_num_reqs=4,
         min_num_reqs=1,
     )
     slots = np.array([0, 1, 2], dtype=np.int32)
-    ntoks = np.array([5, 5, 200], dtype=np.int32)  # 200 > most_model_len
+    ntoks = np.array([5, 5, 200], dtype=np.int32)
 
     idx0, nst0, target0, padded0, end0 = r._select_batch(slots, ntoks, 0)
-    # A long tail request forces the tighter max-model-len row cap (2, not 3).
+    # Row cap is always max-model-len cap.
     assert idx0.tolist() == [0, 1]
     assert end0 == 2
     assert padded0 == 32  # ceil-bucket of 5
@@ -183,18 +178,18 @@ def test_select_batch_long_request_forces_max_model_len_cap():
 
 @pytest.mark.push
 @pytest.mark.cpu
-def test_select_batch_uses_most_model_len_cap_when_no_long_request():
+def test_select_batch_short_rows_still_use_max_model_len_cap():
     r = make_runner(
-        most_model_len=100,
-        num_reqs_most_model_len=3,
         num_reqs_max_model_len=2,
         max_prefill_num_reqs=4,
         min_num_reqs=1,
     )
     slots = np.array([0, 1, 2, 3], dtype=np.int32)
-    ntoks = np.array([5, 5, 5, 5], dtype=np.int32)  # none exceed most_model_len
+    ntoks = np.array([5, 5, 5, 5], dtype=np.int32)
 
     idx0, nst0, target0, padded0, end0 = r._select_batch(slots, ntoks, 0)
-    # No long request -> the looser most-model-len row cap (3) applies.
-    assert idx0.tolist() == [0, 1, 2]
-    assert end0 == 3
+    assert idx0.tolist() == [0, 1]
+    assert nst0.tolist() == [5, 5]
+    assert target0 == 2
+    assert padded0 == 32
+    assert end0 == 2

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_batch_select.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_batch_select.py
@@ -1,0 +1,200 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU unit tests for the MRv2 runner batch selection.
+
+``TTModelRunnerV2._order_scheduled_reqs`` / ``_select_batch`` (see
+vllm_tt/model_runner_v2.py) are pure host logic: they order a step's scheduled
+requests decodes-first and carve out one pass's sub-batch under the SMEM row
+caps. They run on cpu with no TT hardware; the SMEM-cap scalars are injected.
+
+They pin the selection math TT owns: decode-first ordering, the max/most model-len
+row cap (a long tail request forcing max-model-len mode), the prefill-cap
+multi-pass split, and the decode/prefill target-bucket + padded query length.
+The outputs feed ``_prepare_input_tokens`` and ``_prepare_attn_tensors``.
+"""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from vllm_tt.model_runner_v2 import TTModelRunnerV2
+from vllm_tt.request_state import TTRequestState
+
+VOCAB = 1000
+PADDINGS = [1, 32, 64, 128, 256]
+
+
+def make_runner(**scalars):
+    r = object.__new__(TTModelRunnerV2)
+    max_num_reqs = scalars.get("max_num_reqs", 4)
+    r.req_states = TTRequestState(
+        max_num_reqs=max_num_reqs,
+        max_model_len=512,
+        max_num_batched_tokens=1024,
+        num_speculative_steps=0,
+        vocab_size=VOCAB,
+        device="cpu",
+    )
+    r.most_model_len = scalars.get("most_model_len", None)
+    r.num_reqs_max_model_len = scalars.get("num_reqs_max_model_len", 3)
+    r.num_reqs_most_model_len = scalars.get("num_reqs_most_model_len", None)
+    r.max_prefill_num_reqs = scalars.get("max_prefill_num_reqs", 2)
+    r.min_num_reqs = scalars.get("min_num_reqs", 1)
+    r.max_num_reqs = scalars.get("max_num_reqs", 4)
+    r.num_tokens_paddings = scalars.get("num_tokens_paddings", PADDINGS)
+    r.dp_size = scalars.get("dp_size", 1)
+    return r
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_order_scheduled_reqs_decodes_first():
+    r = make_runner()
+    for rid, prompt in [("A", [1]), ("B", [1, 2]), ("C", [3])]:
+        r.req_states.add_request(rid, len(prompt), prompt, 0)
+    s_a = r.req_states.req_id_to_index["A"]
+    s_b = r.req_states.req_id_to_index["B"]
+    s_c = r.req_states.req_id_to_index["C"]
+
+    so = SimpleNamespace(num_scheduled_tokens={"A": 1, "B": 10, "C": 1})
+    slots, ntoks = r._order_scheduled_reqs(so)
+
+    # Ascending by scheduled tokens: decodes (A, C) before the prefill (B).
+    assert ntoks.tolist() == [1, 1, 10]
+    assert slots.tolist() == [s_a, s_c, s_b]
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_order_skips_reqs_without_slot():
+    r = make_runner()
+    r.req_states.add_request("A", 1, [1], 0)
+    s_a = r.req_states.req_id_to_index["A"]
+    so = SimpleNamespace(num_scheduled_tokens={"A": 1, "GHOST": 5})
+    slots, ntoks = r._order_scheduled_reqs(so)
+    assert slots.tolist() == [s_a]
+    assert ntoks.tolist() == [1]
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_order_dp_full_grid_position_equals_slot():
+    # Under DP the batch position picks the DP replica, so it must equal the
+    # request's slot. Ordering returns the FULL replica grid (every slot
+    # 0..max_num_reqs-1, position == slot) with per-slot token counts, even when
+    # only a subset of slots holds a request -- a lone prefilling request must
+    # stay at its own slot's position, not slide to position 0.
+    r = make_runner(dp_size=2, max_num_reqs=4)
+    for rid, prompt in [("A", [1]), ("B", [1, 2]), ("C", [3])]:
+        r.req_states.add_request(rid, len(prompt), prompt, 0)
+    s_b = r.req_states.req_id_to_index["B"]
+
+    # Only B is scheduled this step; every other grid position pads to 0 tokens.
+    so = SimpleNamespace(num_scheduled_tokens={"B": 5})
+    slots, ntoks = r._order_scheduled_reqs(so)
+
+    assert slots.tolist() == [0, 1, 2, 3]
+    assert ntoks[s_b] == 5
+    assert [ntoks[i] for i in range(4) if i != s_b] == [0, 0, 0]
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_select_batch_dp_single_full_width_pass():
+    # DP: one full-width pass, target == max_num_reqs, no reorder/re-clamp; the
+    # padded query length follows the widest scheduled row.
+    r = make_runner(dp_size=2, max_num_reqs=4)
+    slots = np.array([0, 1, 2, 3], dtype=np.int32)
+    ntoks = np.array([0, 5, 0, 1], dtype=np.int32)
+    idx, nst, target, padded, end = r._select_batch(slots, ntoks, 0)
+    assert idx.tolist() == [0, 1, 2, 3]
+    assert nst.tolist() == [0, 5, 0, 1]
+    assert target == 4
+    assert padded == 32  # first bucket >= 5
+    assert end == 4  # single pass consumes the whole grid
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_select_batch_decode_runs_at_max_bucket():
+    r = make_runner(most_model_len=None, num_reqs_max_model_len=3, max_num_reqs=4)
+    slots = np.array([0, 1, 2], dtype=np.int32)
+    ntoks = np.array([1, 1, 1], dtype=np.int32)
+
+    idx, nst, target, padded, end = r._select_batch(slots, ntoks, 0)
+    assert idx.tolist() == [0, 1, 2]
+    assert nst.tolist() == [1, 1, 1]
+    assert target == 4  # decode -> max_num_reqs
+    assert padded == 1
+    assert end == 3
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_select_batch_prefill_cap_multipass():
+    r = make_runner(
+        most_model_len=None,
+        num_reqs_max_model_len=3,
+        max_prefill_num_reqs=2,
+        min_num_reqs=1,
+    )
+    slots = np.array([0, 1, 2, 3], dtype=np.int32)
+    ntoks = np.array([10, 20, 30, 40], dtype=np.int32)
+
+    idx0, nst0, target0, padded0, end0 = r._select_batch(slots, ntoks, 0)
+    assert idx0.tolist() == [0, 1]  # trimmed to the prefill cap
+    assert nst0.tolist() == [10, 20]
+    assert target0 == 2  # prefill bucket (actual > min_num_reqs)
+    assert padded0 == 32  # ceil-bucket of 20
+    assert end0 == 2
+
+    idx1, nst1, target1, padded1, end1 = r._select_batch(slots, ntoks, end0)
+    assert idx1.tolist() == [2, 3]
+    assert padded1 == 64  # ceil-bucket of 40
+    assert end1 == 4
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_select_batch_long_request_forces_max_model_len_cap():
+    r = make_runner(
+        most_model_len=100,
+        num_reqs_most_model_len=3,
+        num_reqs_max_model_len=2,
+        max_prefill_num_reqs=4,
+        min_num_reqs=1,
+    )
+    slots = np.array([0, 1, 2], dtype=np.int32)
+    ntoks = np.array([5, 5, 200], dtype=np.int32)  # 200 > most_model_len
+
+    idx0, nst0, target0, padded0, end0 = r._select_batch(slots, ntoks, 0)
+    # A long tail request forces the tighter max-model-len row cap (2, not 3).
+    assert idx0.tolist() == [0, 1]
+    assert end0 == 2
+    assert padded0 == 32  # ceil-bucket of 5
+
+    idx1, nst1, target1, padded1, end1 = r._select_batch(slots, ntoks, end0)
+    assert idx1.tolist() == [2]
+    assert target1 == 1  # actual (1) <= min_num_reqs
+    assert padded1 == 256  # ceil-bucket of 200
+    assert end1 == 3
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_select_batch_uses_most_model_len_cap_when_no_long_request():
+    r = make_runner(
+        most_model_len=100,
+        num_reqs_most_model_len=3,
+        num_reqs_max_model_len=2,
+        max_prefill_num_reqs=4,
+        min_num_reqs=1,
+    )
+    slots = np.array([0, 1, 2, 3], dtype=np.int32)
+    ntoks = np.array([5, 5, 5, 5], dtype=np.int32)  # none exceed most_model_len
+
+    idx0, nst0, target0, padded0, end0 = r._select_batch(slots, ntoks, 0)
+    # No long request -> the looser most-model-len row cap (3) applies.
+    assert idx0.tolist() == [0, 1, 2]
+    assert end0 == 3

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_cpu_sampling.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_cpu_sampling.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU unit tests for MRv2 host-side sampling (sample_from_logits_cpu).
+
+``TTModelRunnerV2.sample_from_logits_cpu`` is the cpu_sampling path (Gumbel-max
+instead of a compiled device sampling graph). These tests pin the greedy,
+temperature/top-k, and penalty behaviour purely on CPU (no device).
+"""
+from types import SimpleNamespace
+
+import pytest
+import torch
+from vllm_tt.model_runner_v2 import TTModelRunnerV2
+
+
+def runner():
+    return object.__new__(TTModelRunnerV2)
+
+
+def greedy_meta():
+    return SimpleNamespace(no_penalties=True, all_greedy=True)
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_cpu_sampling_greedy_is_argmax():
+    r = runner()
+    logits = torch.tensor([[1.0, 5.0, 2.0], [9.0, 0.0, 3.0]])
+    out = r.sample_from_logits_cpu(logits, greedy_meta())
+    assert out.shape == (2, 1)
+    assert out[:, 0].tolist() == [1, 0]
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_cpu_sampling_uniform_topk_stays_in_topk():
+    r = runner()
+    torch.manual_seed(0)
+    vocab = 20
+    logits = torch.randn(3, vocab)
+    k = 4
+    meta = SimpleNamespace(
+        no_penalties=True,
+        all_greedy=False,
+        temperature=torch.ones(3),
+        top_k=torch.full((3,), k, dtype=torch.int32),
+        top_p=None,
+    )
+    out = r.sample_from_logits_cpu(logits, meta)
+    assert out.shape == (3, 1)
+    # Every sampled token must be within that row's top-k set.
+    for i in range(3):
+        topk_idx = torch.topk(logits[i], k).indices.tolist()
+        assert int(out[i, 0]) in topk_idx
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_cpu_sampling_near_zero_temp_is_greedy_even_in_random_path():
+    r = runner()
+    logits = torch.tensor([[1.0, 5.0, 2.0, 0.0]])
+    meta = SimpleNamespace(
+        no_penalties=True,
+        all_greedy=False,  # forces the random branch, but temp ~ 0 -> greedy
+        temperature=torch.tensor([1e-9]),
+        top_k=None,
+        top_p=None,
+    )
+    out = r.sample_from_logits_cpu(logits, meta)
+    assert int(out[0, 0]) == 1  # argmax
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_cpu_sampling_repetition_penalty_suppresses_token():
+    r = runner()
+    # Token 0 is the argmax; a strong repetition penalty on it should flip the
+    # greedy pick to the next-best token.
+    logits = torch.tensor([[5.0, 4.0, 1.0]])
+    meta = SimpleNamespace(
+        no_penalties=False,
+        all_greedy=True,
+        output_token_counts=torch.tensor([[3.0, 0.0, 0.0]]),
+        prompt_token_mask=torch.tensor([[False, False, False]]),
+        repetition_penalties=torch.tensor([2.0]),
+        frequency_penalties=torch.tensor([0.0]),
+        presence_penalties=torch.tensor([0.0]),
+    )
+    out = r.sample_from_logits_cpu(logits, meta)
+    # Positive logit / rep_pen -> 5.0/2 = 2.5 < 4.0, so token 1 wins.
+    assert int(out[0, 0]) == 1

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_driver.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_driver.py
@@ -76,9 +76,7 @@ def make_runner(max_num_reqs=8, max_model_len=32, max_num_blocks_per_req=4):
     r.max_num_blocks_per_req = max_num_blocks_per_req
     r.block_size = 16
     # SMEM-cap scalars: generous so scenarios run in a single pass.
-    r.most_model_len = None
     r.num_reqs_max_model_len = max_num_reqs
-    r.num_reqs_most_model_len = None
     r.min_num_reqs = 1
     r.max_prefill_num_reqs = max_num_reqs
     r.max_num_reqs = max_num_reqs

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_driver.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_driver.py
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU integration tests for the MRv2 runner two-phase driver.
+
+``TTModelRunnerV2.execute_model`` / ``sample_tokens`` (see
+vllm_tt/model_runner_v2.py) compose the tested host stages around the single
+hardware leaf ``_run_model_pass``. By injecting a fake ``_run_model_pass`` (the
+only device-coupled call), the whole host driver -- state update, decode-first
+ordering, multi-pass loop, writeback, and output assembly -- runs on cpu with no
+TT hardware and no model.
+
+They pin the driver composition: the two-phase stash/hand-off, the decode-first
+output ordering, and that the sampled tokens flow through postprocess into both
+the ModelRunnerOutput and the request token tables.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from vllm.sampling_params import SamplingParams
+from vllm_tt.model_runner_v2 import TTModelRunnerV2
+from vllm_tt.request_state import TTRequestState
+from vllm_tt.sampling_state_v2 import TTSamplingStates
+
+VOCAB = 1000
+
+
+class FakeBlockTable:
+    """Host block table: stores rows on add and serves them to _prepare_attn_tensors."""
+
+    def __init__(self, max_num_reqs, max_blocks):
+        self._arr = torch.zeros((max_num_reqs, max_blocks), dtype=torch.int32)
+
+    def add_row(self, block_ids, slot):
+        ids = list(block_ids[0])  # single kv group
+        if ids:
+            self._arr[slot, : len(ids)] = torch.tensor(ids, dtype=torch.int32)
+
+    def append_row(self, block_ids, slot):
+        pass  # not exercised in these single-step scenarios
+
+    def clear_row(self, slot):
+        self._arr[slot] = 0
+
+    def __getitem__(self, group):
+        return self
+
+    def get_cpu_tensor(self):
+        return self._arr
+
+
+def make_runner(max_num_reqs=8, max_model_len=32, max_num_blocks_per_req=4):
+    r = object.__new__(TTModelRunnerV2)
+    r.uses_mrope = False
+    r.req_states = TTRequestState(
+        max_num_reqs=max_num_reqs,
+        max_model_len=max_model_len,
+        max_num_batched_tokens=128,
+        num_speculative_steps=0,
+        vocab_size=VOCAB,
+        device="cpu",
+    )
+    r.sampling_states = TTSamplingStates(max_num_reqs=max_num_reqs, vocab_size=VOCAB)
+    r.block_table = FakeBlockTable(max_num_reqs, max_num_blocks_per_req)
+    r.encoder_cache = {}
+    r.num_prompt_logprobs = {}
+    r.lora_requests_by_slot = {}
+    r.mm_features_by_slot = {}
+    r.lora_config = None
+    r.model_state = None
+    r.vocab_size = VOCAB
+    r.scheduler_output = None
+    r.supports_mm_inputs = False
+    r.max_num_blocks_per_req = max_num_blocks_per_req
+    r.block_size = 16
+    # SMEM-cap scalars: generous so scenarios run in a single pass.
+    r.most_model_len = None
+    r.num_reqs_max_model_len = max_num_reqs
+    r.num_reqs_most_model_len = None
+    r.min_num_reqs = 1
+    r.max_prefill_num_reqs = max_num_reqs
+    r.max_num_reqs = max_num_reqs
+    r.num_tokens_paddings = [1, 32, 64, 128]
+    r.dp_size = 1
+    return r
+
+
+def new_req(req_id, prompt, block_ids=([0],)):
+    return SimpleNamespace(
+        req_id=req_id,
+        sampling_params=SamplingParams(temperature=0.0),
+        prompt_token_ids=prompt,
+        prefill_token_ids=prompt,
+        num_computed_tokens=0,
+        block_ids=block_ids,
+        lora_request=None,
+    )
+
+
+def make_sched(new=(), num_sched=None, total=None):
+    num_sched = dict(num_sched or {})
+    cached = SimpleNamespace(req_ids=[], num_computed_tokens=[], new_block_ids=[])
+    return SimpleNamespace(
+        scheduled_new_reqs=list(new),
+        scheduled_cached_reqs=cached,
+        num_scheduled_tokens=num_sched,
+        total_num_scheduled_tokens=(
+            sum(num_sched.values()) if total is None else total
+        ),
+        finished_req_ids=[],
+        preempted_req_ids=[],
+        free_encoder_mm_hashes=[],
+    )
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_execute_model_stashes_and_returns_none():
+    r = make_runner()
+    so = make_sched(new=[new_req("A", [1, 2, 3])], num_sched={"A": 3})
+    assert r.execute_model(so) is None
+    assert r.scheduler_output is so
+    assert r.req_states.num_reqs == 1  # add_requests ran
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_execute_model_no_tokens_returns_empty_output():
+    r = make_runner()
+    out = r.execute_model(make_sched(num_sched={}, total=0))
+    assert out is not None
+    assert out.req_ids == []
+    assert r.scheduler_output is None  # nothing stashed
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_execute_model_rejects_reentry_before_sampling():
+    r = make_runner()
+    r.scheduler_output = object()  # a step already pending
+    with pytest.raises(AssertionError):
+        r.execute_model(make_sched(new=[new_req("A", [1])], num_sched={"A": 1}))
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_sample_tokens_composes_full_prefill_batch():
+    r = make_runner()
+    so = make_sched(
+        new=[new_req("A", [1, 2, 3]), new_req("B", [4, 5])],
+        num_sched={"A": 3, "B": 2},
+    )
+    assert r.execute_model(so) is None
+
+    slot_a = r.req_states.req_id_to_index["A"]
+    slot_b = r.req_states.req_id_to_index["B"]
+
+    # Fake the one hardware leaf: return a distinct token per active req.
+    r._run_model_pass = lambda idx, ns, tnr, pql, ii, pos, li, pt, fpt, cp, *a, **k: [
+        [1000 + int(idx[b])] for b in range(len(idx))
+    ]
+
+    out = r.sample_tokens(None)
+
+    # Decode-first ordering puts the shorter request (B, 2 tokens) first.
+    assert out.req_ids == ["B", "A"]
+    assert out.sampled_token_ids == [[1000 + slot_b], [1000 + slot_a]]
+    assert out.req_id_to_index == {"B": 0, "A": 1}
+
+    # Writeback grew both token tables (both finished prefill this step).
+    assert r.req_states.total_len[slot_a] == 4
+    assert r.req_states.all_token_ids[slot_a, 3] == 1000 + slot_a
+    assert r.req_states.total_len[slot_b] == 3
+    assert r.req_states.all_token_ids[slot_b, 2] == 1000 + slot_b
+
+    # Step fully consumed -> ready for the next execute_model.
+    assert r.scheduler_output is None
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_sample_tokens_returns_none_without_stashed_step():
+    r = make_runner()
+    assert r.sample_tokens(None) is None

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_driver.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_driver.py
@@ -84,6 +84,13 @@ def make_runner(max_num_reqs=8, max_model_len=32, max_num_blocks_per_req=4):
     r.max_num_reqs = max_num_reqs
     r.num_tokens_paddings = [1, 32, 64, 128]
     r.dp_size = 1
+    # Spec decode off by default; scenarios that want it set these.
+    r.device = torch.device("cpu")
+    r.max_model_len = max_model_len
+    r.num_spec_tokens = 0
+    r.drafter = None
+    r._draft_token_ids = None
+    r._draft_token_req_ids = None
     return r
 
 

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_grammar.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_grammar.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU unit tests for MRv2 structured-output (grammar) host logic.
+
+``TTModelRunnerV2._apply_grammar_bitmask`` / ``structured_decode`` mask logits to
+grammar-allowed tokens using a bitwise_and unpack (TT has no bitwise_right_shift),
+and ``prepare_structured_decoding_input`` places each structured request's bitmask
+row at its per-pass batch position (keyed by idx_mapping, not the v1 persistent
+input_batch index). These run purely on CPU.
+"""
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+from vllm.utils.math_utils import cdiv
+from vllm_tt.model_runner_v2 import TTModelRunnerV2
+
+VOCAB = 40
+
+
+def make_runner(max_num_reqs=4):
+    r = object.__new__(TTModelRunnerV2)
+    r.device = torch.device("cpu")
+    r.vocab_size = VOCAB
+    r.max_num_reqs = max_num_reqs
+    r.grammar_bitmask_cpu = torch.zeros(
+        (max_num_reqs, cdiv(VOCAB, 32)), dtype=torch.int32
+    )
+    r.require_structured_out_cpu = torch.zeros((max_num_reqs, 1), dtype=torch.bool)
+    bm = np.array([1 << i for i in range(32)], dtype=np.uint32).view(np.int32)
+    r.structured_decode_bitmasks = torch.from_numpy(bm.copy())
+    r.req_states = SimpleNamespace(index_to_req_id={})
+    return r
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_apply_grammar_bitmask_allows_only_set_bits():
+    r = make_runner()
+    # Allow tokens 0, 3, 33 -> word0 bits {0,3}=0b1001=9, word1 bit (33-32=1)=2.
+    grammar_bitmask = torch.tensor([[9, 2]], dtype=torch.int32)
+    logits = torch.ones(1, VOCAB)
+    out = r._apply_grammar_bitmask(
+        logits, grammar_bitmask, r.structured_decode_bitmasks
+    )
+    allowed = {i for i in range(VOCAB) if out[0, i].item() != float("-inf")}
+    assert allowed == {0, 3, 33}
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_structured_decode_only_masks_flagged_rows():
+    r = make_runner()
+    # Row 0 requires grammar (allow only token 1); row 1 is free.
+    require = torch.tensor([[True], [False]])
+    grammar_bitmask = torch.tensor([[0b10, 0], [0, 0]], dtype=torch.int32)
+    logits = torch.ones(2, VOCAB)
+    out = r.structured_decode(
+        require, grammar_bitmask, logits, r.structured_decode_bitmasks
+    )
+    # Row 0: only token 1 survives.
+    assert out[0, 1].item() == 1.0
+    assert out[0, 0].item() == float("-inf")
+    # Row 1: untouched.
+    assert torch.all(out[1] == 1.0)
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_prepare_structured_decoding_input_keys_by_batch_position():
+    r = make_runner()
+    # Slots -> req_ids; this pass batches slots [2, 0] at positions [0, 1].
+    r.req_states.index_to_req_id = {0: "A", 2: "B", 3: "C"}
+    idx_mapping = np.array([2, 0], dtype=np.int32)
+
+    # grammar_bitmask has one row per structured request, in scheduler order.
+    # "C" is structured but not in this pass -> its row must be skipped by id,
+    # not by position (enumerate index keeps rows aligned).
+    grammar_output = SimpleNamespace(
+        grammar_bitmask=np.array([[7], [0], [1]], dtype=np.int32),
+        structured_output_request_ids=["B", "C", "A"],
+    )
+    require, bitmask, bitmasks = r.prepare_structured_decoding_input(
+        grammar_output, idx_mapping, num_reqs=2
+    )
+
+    # B at position 0 (mask row 0 = 7), A at position 1 (mask row 2 = 1).
+    assert require[:, 0].tolist() == [True, True]
+    assert bitmask[0, 0].item() == 7
+    assert bitmask[1, 0].item() == 1
+    assert bitmasks.shape == (32,)

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_init.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_init.py
@@ -1,0 +1,230 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU unit tests for the MRv2 runner __init__ state construction.
+
+``TTModelRunnerV2.__init__`` (see vllm_tt/model_runner_v2.py) extracts config
+scalars and builds the split v2 state. It reads a fixed set of vllm_config
+attributes, so a duck-typed fake config exercises it on cpu with no engine, no
+model, and no TT hardware (device=cpu). ``load_model`` needs a real model/loader
+and is validated at engine stand-up, not here.
+
+They pin the wiring: scalar/SMEM-cap derivation, the token-padding ladder, the
+constructed state tables, the not-yet-loaded (None) model handles, and the
+single-device guard.
+"""
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+from vllm_tt.model_runner_v2 import TTModelRunnerV2
+from vllm_tt.request_state import TTRequestState
+from vllm_tt.sampling_state_v2 import TTSamplingStates
+from vllm_tt.vllm_distributed_utils import ParallelismMode
+
+
+@contextmanager
+def fake_mesh(num_devices):
+    """Stub the torch_xla runtime/SPMD calls so mesh build is hw-independent."""
+    with patch(
+        "torch_xla.runtime.global_runtime_device_count", return_value=num_devices
+    ), patch(
+        "torch_xla.distributed.spmd.Mesh", side_effect=lambda ids, shape, names: shape
+    ), patch(
+        "torch_xla.distributed.spmd.set_global_mesh"
+    ):
+        yield
+
+
+def make_vllm_config(**tt_overrides):
+    model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(num_hidden_layers=2),
+        dtype=torch.bfloat16,
+        max_model_len=256,
+        get_sliding_window=lambda: None,
+        get_num_layers_by_block_type=lambda pc, t: 2,
+        get_num_attention_heads=lambda pc: 8,
+        get_num_kv_heads=lambda pc: 8,
+        get_head_size=lambda: 64,
+        get_vocab_size=lambda: 1000,
+        get_inputs_embeds_size=lambda: 512,
+        is_multimodal_model=False,
+        uses_mrope=False,
+    )
+    cache_config = SimpleNamespace(block_size=32, cache_dtype="auto")
+    scheduler_config = SimpleNamespace(max_num_seqs=8, max_num_batched_tokens=2048)
+    # additional_config is a plain dict (the runner builds TTConfig(**it), as the
+    # engine does). min_context_len pins the token-padding ladder deterministically.
+    additional_config = {"min_context_len": 32}
+    additional_config.update(tt_overrides)
+    return SimpleNamespace(
+        model_config=model_config,
+        cache_config=cache_config,
+        scheduler_config=scheduler_config,
+        parallel_config=object(),
+        load_config=object(),
+        lora_config=None,
+        additional_config=additional_config,
+    )
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_init_scalars_and_smem_caps():
+    r = TTModelRunnerV2(make_vllm_config(), torch.device("cpu"))
+
+    assert r.block_size == 32
+    assert r.max_model_len == 256
+    assert r.max_num_reqs == 8
+    assert r.vocab_size == 1000
+    assert r.max_num_blocks_per_req == 8  # cdiv(256, 32)
+    assert r.num_kv_heads == 8
+    assert r.head_size == 64
+    assert r.kv_cache_dtype == torch.bfloat16  # cache_dtype="auto" -> model dtype
+    assert r.supports_mm_inputs is False
+    # No VLLM_TPU_MOST_MODEL_LEN by default -> only the max-model-len cap applies.
+    assert r.num_reqs_most_model_len is None
+    # get_max_num_seqs(256, 32) is huge, so the cap is max_num_reqs.
+    assert r.num_reqs_max_model_len == 8
+    # These fall back to max_num_reqs when the TTConfig fields are unset (None).
+    assert r.min_num_reqs == (
+        r.max_num_reqs if r.tt_config.min_num_seqs is None else r.tt_config.min_num_seqs
+    )
+    assert r.max_prefill_num_reqs == (
+        r.max_num_reqs
+        if r.tt_config.max_prefill_num_seqs is None
+        else r.tt_config.max_prefill_num_seqs
+    )
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_init_token_padding_ladder():
+    r = TTModelRunnerV2(make_vllm_config(), torch.device("cpu"))
+    # _get_token_paddings(32, min(2048, 256)=256): [1] + powers of two up to >=256.
+    assert r.num_tokens_paddings == [1, 32, 64, 128, 256]
+    assert r.max_num_tokens == 256
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_init_decode_only_restricts_paddings():
+    r = TTModelRunnerV2(make_vllm_config(decode_only=True), torch.device("cpu"))
+    assert r.num_tokens_paddings == [1]
+    assert r.max_num_tokens == 1
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_init_builds_split_state_tables():
+    r = TTModelRunnerV2(make_vllm_config(), torch.device("cpu"))
+
+    assert isinstance(r.req_states, TTRequestState)
+    assert r.req_states.max_num_reqs == 8
+    assert r.req_states.max_model_len == 256
+    assert isinstance(r.sampling_states, TTSamplingStates)
+    # Block table + input buffers are constructed and correctly sized.
+    assert hasattr(r.block_table, "add_row")
+    assert tuple(r.input_buffers.input_ids.shape) == (r.max_num_tokens,)
+    # Runtime-side state initialised empty.
+    assert r.encoder_cache == {}
+    assert r.num_prompt_logprobs == {}
+    assert r.kv_caches == []
+    assert r.scheduler_output is None
+    assert r.dp_size == 1
+    assert r.enable_tensor_parallel is False
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_init_model_handles_none_until_load():
+    r = TTModelRunnerV2(make_vllm_config(), torch.device("cpu"))
+    assert r.model is None
+    assert r.model_state is None
+    assert r.sampler is None
+    assert r.attention_layer_names == ()
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_init_single_device_when_flags_off():
+    r = TTModelRunnerV2(make_vllm_config(), torch.device("cpu"))
+    assert r.parallel_mode == ParallelismMode.DISABLED
+    assert r.mesh is None
+    assert r.dp_size == 1
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_init_tp_only_builds_2d_mesh():
+    with fake_mesh(8):
+        r = TTModelRunnerV2(
+            make_vllm_config(enable_tensor_parallel=True), torch.device("cpu")
+        )
+    # Pure TP on 8 devices -> (2,4) mesh, but dp_size stays 1 (batch axis is a TP axis).
+    assert r.parallel_mode == ParallelismMode.TENSOR_PARALLEL_ONLY_2D
+    assert r.mesh == (2, 4)
+    assert r.dp_size == 1
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_init_dp_tp_sets_dp_size():
+    with fake_mesh(8):
+        r = TTModelRunnerV2(
+            make_vllm_config(enable_tensor_parallel=True, enable_data_parallel=True),
+            torch.device("cpu"),
+        )
+    assert r.parallel_mode == ParallelismMode.DATA_TENSOR_PARALLEL
+    assert r.dp_size == 2  # mesh_shape[0] of (2,4)
+    assert r.max_num_reqs % r.dp_size == 0
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_init_single_device_disables_parallel():
+    with fake_mesh(1):
+        r = TTModelRunnerV2(
+            make_vllm_config(enable_tensor_parallel=True, enable_data_parallel=True),
+            torch.device("cpu"),
+        )
+    # One device -> both disabled, falls back to the single-device path.
+    assert r.parallel_mode == ParallelismMode.DISABLED
+    assert r.mesh is None
+    assert r.dp_size == 1
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_init_no_layer_override_by_default():
+    cfg = make_vllm_config()
+    r = TTModelRunnerV2(cfg, torch.device("cpu"))
+    # Default num_hidden_layers=0 -> no override, hf_config untouched.
+    assert r._original_num_layers is None
+    assert r._target_num_layers is None
+    assert cfg.model_config.hf_config.num_hidden_layers == 2
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_init_applies_layer_override():
+    cfg = make_vllm_config(num_hidden_layers=1)
+    r = TTModelRunnerV2(cfg, torch.device("cpu"))
+    # Override mutates hf_config so only the target layers get built.
+    assert r._original_num_layers == 2
+    assert r._target_num_layers == 1
+    assert cfg.model_config.hf_config.num_hidden_layers == 1
+    # The weight filter drops layers >= target and keeps the rest.
+    weights = [
+        ("model.layers.0.self_attn.qkv_proj.weight", 0),
+        ("model.layers.1.self_attn.qkv_proj.weight", 1),
+        ("model.embed_tokens.weight", 2),
+    ]
+    kept = [n for n, _ in r._filter_weights_for_layer_override(iter(weights))]
+    assert kept == [
+        "model.layers.0.self_attn.qkv_proj.weight",
+        "model.embed_tokens.weight",
+    ]

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_init.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_init.py
@@ -67,6 +67,7 @@ def make_vllm_config(**tt_overrides):
         parallel_config=object(),
         load_config=object(),
         lora_config=None,
+        speculative_config=None,
         additional_config=additional_config,
     )
 
@@ -195,6 +196,42 @@ def test_init_single_device_disables_parallel():
     assert r.parallel_mode == ParallelismMode.DISABLED
     assert r.mesh is None
     assert r.dp_size == 1
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_init_without_speculative_config_disables_spec_decode():
+    r = TTModelRunnerV2(make_vllm_config(), torch.device("cpu"))
+    assert r.num_spec_tokens == 0
+    assert r.drafter is None
+    assert r.req_states.num_speculative_steps == 0
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_init_sizes_draft_table_from_speculative_config(monkeypatch):
+    cfg = make_vllm_config()
+    cfg.speculative_config = SimpleNamespace(num_speculative_tokens=3, method="ngram")
+    sentinel = object()
+    monkeypatch.setattr(
+        "vllm.v1.spec_decode.ngram_proposer.NgramProposer",
+        lambda vllm_config: sentinel,
+    )
+    r = TTModelRunnerV2(cfg, torch.device("cpu"))
+    assert r.num_spec_tokens == 3
+    assert r.drafter is sentinel
+    assert r.req_states.draft_tokens.shape[1] == 3
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_init_skips_drafter_for_non_ngram_method():
+    cfg = make_vllm_config()
+    cfg.speculative_config = SimpleNamespace(num_speculative_tokens=2, method="eagle")
+    r = TTModelRunnerV2(cfg, torch.device("cpu"))
+    # Verification still runs; only the ngram proposer is TT-supported.
+    assert r.num_spec_tokens == 2
+    assert r.drafter is None
 
 
 @pytest.mark.push

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_init.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_init.py
@@ -86,8 +86,6 @@ def test_init_scalars_and_smem_caps():
     assert r.head_size == 64
     assert r.kv_cache_dtype == torch.bfloat16  # cache_dtype="auto" -> model dtype
     assert r.supports_mm_inputs is False
-    # No VLLM_TPU_MOST_MODEL_LEN by default -> only the max-model-len cap applies.
-    assert r.num_reqs_most_model_len is None
     # get_max_num_seqs(256, 32) is huge, so the cap is max_num_reqs.
     assert r.num_reqs_max_model_len == 8
     # These fall back to max_num_reqs when the TTConfig fields are unset (None).

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_input_prep.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_input_prep.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU unit tests for the MRv2 runner host input-token preparation.
+
+``TTModelRunnerV2._prepare_input_tokens`` (see vllm_tt/model_runner_v2.py) is
+the host substitute for upstream's Triton input-prep kernels. It is pure numpy
+over ``TTRequestState``, so it runs on cpu with no TT hardware and no model:
+the runner is allocated without ``__init__`` and only ``req_states`` is injected.
+
+They pin the index math that is TT's own responsibility: the unified
+prefill/decode gather, the computed-token position offset (chunked prefill), the
+2D forward layout with zero padding, and the query_start_loc cumsum + pad.
+"""
+
+import numpy as np
+import pytest
+from vllm_tt.model_runner_v2 import TTModelRunnerV2
+from vllm_tt.request_state import TTRequestState
+
+VOCAB = 1000
+
+
+def runner_with_reqs(max_num_reqs=4, max_model_len=32):
+    r = object.__new__(TTModelRunnerV2)
+    r.uses_mrope = False
+    r.req_states = TTRequestState(
+        max_num_reqs=max_num_reqs,
+        max_model_len=max_model_len,
+        max_num_batched_tokens=64,
+        num_speculative_steps=0,
+        vocab_size=VOCAB,
+        device="cpu",
+    )
+    return r
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_prepare_input_tokens_prefill_and_decode_batch():
+    r = runner_with_reqs()
+    rs = r.req_states
+    rs.add_request(
+        "P", prompt_len=5, all_token_ids=[1, 2, 3, 4, 5], num_computed_tokens=0
+    )
+    rs.add_request("D", prompt_len=3, all_token_ids=[6, 7, 8], num_computed_tokens=0)
+    slot_p = rs.req_id_to_index["P"]
+    slot_d = rs.req_id_to_index["D"]
+    # Simulate D having decoded one token: the writeback grew its token table.
+    rs.all_token_ids[slot_d, 3] = 9
+    rs.total_len[slot_d] = 4
+    rs.num_computed_tokens[slot_d] = 3
+
+    # TT orders decodes first, then prefills; padded batch of 4.
+    idx = np.array([slot_d, slot_p], dtype=np.int32)
+    nst = np.array([1, 5], dtype=np.int32)
+    input_ids, positions, qsl, seq_lens, logits = r._prepare_input_tokens(
+        idx, nst, target_num_reqs=4, padded_query_len=5
+    )
+
+    assert input_ids.shape == (4, 5)
+    # Decode row: single last-sampled token read from all_token_ids.
+    assert input_ids[0].tolist() == [9, 0, 0, 0, 0]
+    # Prefill row: the whole prompt.
+    assert input_ids[1].tolist() == [1, 2, 3, 4, 5]
+    # Padding rows stay zero.
+    assert input_ids[2].tolist() == [0, 0, 0, 0, 0]
+    assert input_ids[3].tolist() == [0, 0, 0, 0, 0]
+
+    assert positions[0].tolist() == [3, 0, 0, 0, 0]
+    assert positions[1].tolist() == [0, 1, 2, 3, 4]
+
+    assert seq_lens.tolist() == [4, 5, 0, 0]  # computed + scheduled
+    assert logits.tolist() == [0, 4, 0, 0]  # n - 1 per request
+    # cumsum([1, 5]) = [1, 6]; tail padded with the last (non-decreasing).
+    assert qsl.tolist() == [0, 1, 6, 6, 6]
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_prepare_input_tokens_chunked_prefill_offset():
+    r = runner_with_reqs()
+    rs = r.req_states
+    rs.add_request(
+        "C", prompt_len=6, all_token_ids=[10, 11, 12, 13, 14, 15], num_computed_tokens=0
+    )
+    slot = rs.req_id_to_index["C"]
+    rs.num_computed_tokens[slot] = 2  # first chunk of 2 already computed
+
+    idx = np.array([slot], dtype=np.int32)
+    nst = np.array([3], dtype=np.int32)  # next chunk of 3 tokens
+    input_ids, positions, qsl, seq_lens, logits = r._prepare_input_tokens(
+        idx, nst, target_num_reqs=2, padded_query_len=4
+    )
+
+    # Gather starts at the computed offset.
+    assert input_ids[0].tolist() == [12, 13, 14, 0]
+    assert positions[0].tolist() == [2, 3, 4, 0]
+    assert seq_lens.tolist() == [5, 0]  # 2 + 3
+    assert logits.tolist() == [2, 0]  # n - 1
+    assert qsl.tolist() == [0, 3, 3]
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_prepare_input_tokens_mrope_three_identical_planes():
+    # M-RoPE builds 3D [3, reqs, tokens] positions; text-only inputs have three
+    # identical planes (equivalent to 1D RoPE).
+    r = runner_with_reqs()
+    r.uses_mrope = True
+    rs = r.req_states
+    rs.add_request("P", prompt_len=4, all_token_ids=[1, 2, 3, 4], num_computed_tokens=0)
+    slot = rs.req_id_to_index["P"]
+    idx = np.array([slot], dtype=np.int32)
+    nst = np.array([4], dtype=np.int32)
+    input_ids, positions, _qsl, _seq, _logits = r._prepare_input_tokens(
+        idx, nst, target_num_reqs=2, padded_query_len=4
+    )
+
+    assert input_ids.shape == (2, 4)  # input_ids stays 2D
+    assert positions.shape == (3, 2, 4)
+    plane = [0, 1, 2, 3]
+    for p in range(3):
+        assert positions[p, 0].tolist() == plane
+    # All three planes identical.
+    assert (positions[0] == positions[1]).all()
+    assert (positions[0] == positions[2]).all()

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_kv_cache.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_kv_cache.py
@@ -1,0 +1,220 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU unit tests for the MRv2 runner KV cache allocation logic.
+
+``TTModelRunnerV2._allocate_kv_caches`` (see vllm_tt/model_runner_v2.py) is the
+device-coupled core of ``initialize_kv_cache``, split out so its allocation
+logic runs portably on cpu (``device="cpu"``). On-device allocation on real TT
+hardware is exercised separately (not in the cpu-only suite).
+
+They pin the allocation contract TT owns: separate [k, v] tensors per standard
+layer with the right shape/dtype, the num_blocks = size // page_size math, and
+the hybrid / empty-group / block-size guards.
+"""
+
+import inspect
+
+import pytest
+import torch
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    KVCacheTensor,
+)
+from vllm_tt.model_runner_v2 import TTModelRunnerV2
+
+BLOCK_SIZE = 32
+NUM_KV_HEADS = 8
+HEAD_SIZE = 64
+
+# is_eagle_group was added to KVCacheGroupSpec after vllm 0.19; pass it only
+# when the installed version accepts it so the suite runs on both.
+_GROUP_HAS_EAGLE = "is_eagle_group" in inspect.signature(KVCacheGroupSpec).parameters
+
+
+def make_group(layer_names, kv_cache_spec):
+    kwargs = {"layer_names": list(layer_names), "kv_cache_spec": kv_cache_spec}
+    if _GROUP_HAS_EAGLE:
+        kwargs["is_eagle_group"] = False
+    return KVCacheGroupSpec(**kwargs)
+
+
+def make_runner(device="cpu", kv_cache_dtype=torch.bfloat16, block_size=BLOCK_SIZE):
+    r = object.__new__(TTModelRunnerV2)
+    r.device = torch.device(device)
+    r.kv_cache_dtype = kv_cache_dtype
+    r.enable_tensor_parallel = False
+    r.block_size = block_size
+    return r
+
+
+def make_config(num_blocks=16, layers=("layer.0",), block_size=BLOCK_SIZE):
+    spec = FullAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=NUM_KV_HEADS,
+        head_size=HEAD_SIZE,
+        dtype=torch.bfloat16,
+    )
+    tensors = [
+        KVCacheTensor(size=num_blocks * spec.page_size_bytes, shared_by=[name])
+        for name in layers
+    ]
+    group = make_group(layers, spec)
+    return KVCacheConfig(
+        num_blocks=num_blocks, kv_cache_tensors=tensors, kv_cache_groups=[group]
+    )
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_allocate_standard_kv_caches_shapes_and_dtype():
+    r = make_runner()
+    num_blocks = 16
+    kv = r._allocate_kv_caches(make_config(num_blocks=num_blocks, layers=("l0", "l1")))
+
+    assert set(kv) == {"l0", "l1"}
+    for name in ("l0", "l1"):
+        k, v = kv[name]  # separate K/V tensors
+        assert tuple(k.shape) == (num_blocks, NUM_KV_HEADS, BLOCK_SIZE, HEAD_SIZE)
+        assert tuple(v.shape) == (num_blocks, NUM_KV_HEADS, BLOCK_SIZE, HEAD_SIZE)
+        assert k.dtype == torch.bfloat16
+        assert k.device.type == "cpu"
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_allocate_num_blocks_from_tensor_size():
+    r = make_runner()
+    # Two pages' worth of bytes -> two blocks.
+    spec = FullAttentionSpec(
+        block_size=BLOCK_SIZE,
+        num_kv_heads=NUM_KV_HEADS,
+        head_size=HEAD_SIZE,
+        dtype=torch.bfloat16,
+    )
+    cfg = KVCacheConfig(
+        num_blocks=2,
+        kv_cache_tensors=[
+            KVCacheTensor(size=2 * spec.page_size_bytes, shared_by=["l0"])
+        ],
+        kv_cache_groups=[make_group(["l0"], spec)],
+    )
+    k, _ = r._allocate_kv_caches(cfg)["l0"]
+    assert k.shape[0] == 2
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_allocate_kv_cache_dtype_override():
+    # spec.dtype may be a 1-byte accounting dtype; buffers use kv_cache_dtype.
+    r = make_runner(kv_cache_dtype=torch.float32)
+    k, _ = r._allocate_kv_caches(make_config())["layer.0"]
+    assert k.dtype == torch.float32
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_empty_group_config_skips():
+    r = make_runner()
+    cfg = KVCacheConfig(num_blocks=0, kv_cache_tensors=[], kv_cache_groups=[])
+    assert r._allocate_kv_caches(cfg) == {}
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_allocate_uniform_type_heterogeneous_head_sizes():
+    # Gemma-4-style: same-type attention layers with different head sizes are
+    # merged into one group whose spec is a UniformTypeKVCacheSpecs. Allocation
+    # must unwrap the per-layer spec (its own page_size/head_size), not use the
+    # group wrapper's, or the tensor_size % page_size assert fails for a layer.
+    from vllm.v1.kv_cache_interface import UniformTypeKVCacheSpecs
+
+    r = make_runner()
+    spec_a = FullAttentionSpec(
+        block_size=BLOCK_SIZE,
+        num_kv_heads=NUM_KV_HEADS,
+        head_size=64,
+        dtype=torch.bfloat16,
+    )
+    spec_b = FullAttentionSpec(
+        block_size=BLOCK_SIZE,
+        num_kv_heads=NUM_KV_HEADS,
+        head_size=128,
+        dtype=torch.bfloat16,
+    )
+    group_spec = UniformTypeKVCacheSpecs(
+        block_size=BLOCK_SIZE, kv_cache_specs={"l0": spec_a, "l1": spec_b}
+    )
+    nblocks = 4
+    cfg = KVCacheConfig(
+        num_blocks=nblocks,
+        kv_cache_tensors=[
+            KVCacheTensor(size=nblocks * spec_a.page_size_bytes, shared_by=["l0"]),
+            KVCacheTensor(size=nblocks * spec_b.page_size_bytes, shared_by=["l1"]),
+        ],
+        kv_cache_groups=[make_group(["l0", "l1"], group_spec)],
+    )
+    caches = r._allocate_kv_caches(cfg)
+    # Each layer allocated with its own head size (last dim), not the wrapper's.
+    assert caches["l0"][0].shape[-1] == 64
+    assert caches["l1"][0].shape[-1] == 128
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_hybrid_config_rejected():
+    r = make_runner()
+    spec = FullAttentionSpec(
+        block_size=BLOCK_SIZE,
+        num_kv_heads=NUM_KV_HEADS,
+        head_size=HEAD_SIZE,
+        dtype=torch.bfloat16,
+    )
+    group = make_group(["l0"], spec)
+    cfg = KVCacheConfig(
+        num_blocks=1,
+        kv_cache_tensors=[KVCacheTensor(size=spec.page_size_bytes, shared_by=["l0"])],
+        kv_cache_groups=[group, group],
+    )
+    with pytest.raises(NotImplementedError):
+        r._allocate_kv_caches(cfg)
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_block_size_mismatch_rejected():
+    r = make_runner(block_size=16)  # runner block_size != config's 32
+    with pytest.raises(AssertionError):
+        r._allocate_kv_caches(make_config(block_size=BLOCK_SIZE))
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_cross_layer_kv_sharing_points_child_at_target():
+    # Gemma-4: a child layer reuses an earlier layer's KV cache. Wiring must
+    # alias the child to the target's tensors and add it to the target's group,
+    # or decode indexes the child's empty placeholder (kv_cache[0]) and crashes.
+    r = make_runner()
+    r.shared_kv_cache_layers = {"l1": "l0"}
+    cfg = make_config(layers=("l0",))  # only the target allocates a cache
+    kv = r._allocate_kv_caches(cfg)
+    assert set(kv) == {"l0"}
+
+    r._maybe_setup_cross_layer_kv_sharing(kv, cfg)
+
+    assert kv["l1"] is kv["l0"]  # child aliases the target's [k, v]
+    assert "l1" in cfg.kv_cache_groups[0].layer_names
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_cross_layer_kv_sharing_noop_without_shared_layers():
+    r = make_runner()
+    r.shared_kv_cache_layers = {}
+    cfg = make_config(layers=("l0",))
+    kv = r._allocate_kv_caches(cfg)
+    r._maybe_setup_cross_layer_kv_sharing(kv, cfg)
+    assert set(kv) == {"l0"}
+    assert cfg.kv_cache_groups[0].layer_names == ["l0"]

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_kv_connector.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_kv_connector.py
@@ -1,0 +1,155 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU tests for the MRv2 runner's KV-connector (disaggregated serving) wiring.
+
+Three seams, all no-ops when no transfer group is configured:
+* ``initialize_kv_cache`` registers the allocated caches with the connector.
+* ``execute_model`` drives send/recv even on a step that schedules no tokens.
+* ``sample_tokens`` opens the connector lifecycle ONCE per step, around the whole
+  multi-pass loop, and attaches the resulting output.
+
+The once-per-step property is the load-bearing one: ``get_finished()`` reports a
+transfer only on its first call, so entering per pass would drop finished
+send/recv ids on every pass after the first.
+"""
+
+import contextlib
+from types import SimpleNamespace
+
+import pytest
+from test_runner_driver import make_runner, make_sched
+from vllm_tt.model_runner_v2 import TTModelRunnerV2
+
+
+class FakeConnector:
+    def __init__(self):
+        self.registered = None
+        self.xfer_ops = None
+
+    def register_kv_caches(self, kv_caches):
+        self.registered = kv_caches
+
+    def set_host_xfer_buffer_ops(self, fn):
+        self.xfer_ops = fn
+
+
+@pytest.fixture
+def connector(monkeypatch):
+    """Install a fake transfer group; yields it plus an enter-counting context."""
+    fake = FakeConnector()
+    monkeypatch.setattr(
+        "vllm.distributed.kv_transfer.has_kv_transfer_group", lambda: True
+    )
+    monkeypatch.setattr(
+        "vllm.distributed.kv_transfer.get_kv_transfer_group", lambda: fake
+    )
+    return fake
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_register_kv_caches_noop_without_transfer_group(monkeypatch):
+    monkeypatch.setattr(
+        "vllm.distributed.kv_transfer.has_kv_transfer_group", lambda: False
+    )
+    r = object.__new__(TTModelRunnerV2)
+    # Must not raise, and must not touch get_kv_transfer_group.
+    r._register_kv_caches_for_transfer({"layer0": object()})
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_register_kv_caches_hands_caches_to_connector(connector):
+    r = object.__new__(TTModelRunnerV2)
+    caches = {"layer0": object(), "layer1": object()}
+    r._register_kv_caches_for_transfer(caches)
+    assert connector.registered is caches
+    assert connector.xfer_ops is not None
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_no_token_step_drives_connector_instead_of_empty_output(monkeypatch):
+    r = make_runner()
+    r.vllm_config = SimpleNamespace()
+    monkeypatch.setattr(r, "_has_kv_transfer_group", lambda: True, raising=False)
+    monkeypatch.setattr(
+        "vllm.distributed.kv_transfer.has_kv_transfer_group", lambda: True
+    )
+    sentinel = SimpleNamespace(req_ids=["sentinel"])
+    monkeypatch.setattr(
+        TTModelRunnerV2,
+        "kv_connector_no_forward",
+        staticmethod(lambda so, cfg: sentinel),
+    )
+    out = r.execute_model(make_sched(num_sched={}, total=0))
+    assert out is sentinel
+    assert r.scheduler_output is None  # nothing stashed
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_no_token_step_returns_empty_output_without_connector():
+    r = make_runner()
+    out = r.execute_model(make_sched(num_sched={}, total=0))
+    assert out.req_ids == []
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_sample_tokens_opens_connector_once_around_the_whole_pass_loop(monkeypatch):
+    r = make_runner()
+    r.vllm_config = SimpleNamespace()
+    r.scheduler_output = make_sched(num_sched={}, total=0)
+
+    enters = []
+    active = []
+    kv_out = SimpleNamespace(finished_sending=None)
+
+    @contextlib.contextmanager
+    def fake_connector_output(scheduler_output, defer_finalize=False):
+        enters.append(scheduler_output)
+        active.append(True)
+        try:
+            yield kv_out
+        finally:
+            active.pop()
+
+    monkeypatch.setattr(r, "_has_kv_transfer_group", lambda: True, raising=False)
+    monkeypatch.setattr(
+        r, "maybe_get_kv_connector_output", fake_connector_output, raising=False
+    )
+    # The runner pushes a token-less forward context so start_load_kv has one.
+    monkeypatch.setattr(
+        "vllm.forward_context.set_forward_context",
+        lambda *a, **k: contextlib.nullcontext(),
+    )
+
+    # Several passes' worth of work, but the connector must be entered once.
+    loop_calls = []
+
+    def fake_loop(*a, **k):
+        loop_calls.append(bool(active))  # connector active while passes run?
+        loop_calls.append(bool(active))
+
+    monkeypatch.setattr(r, "_run_pass_loop", fake_loop, raising=False)
+    monkeypatch.setattr(r, "_get_prompt_logprobs_dict", lambda *a, **k: {})
+
+    out = r.sample_tokens(None)
+
+    assert len(enters) == 1, "connector lifecycle must open once per step"
+    assert all(loop_calls), "passes must run inside the connector window"
+    assert out.kv_connector_output is kv_out
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_sample_tokens_leaves_connector_output_none_without_group(monkeypatch):
+    r = make_runner()
+    r.scheduler_output = make_sched(num_sched={}, total=0)
+    monkeypatch.setattr(r, "_run_pass_loop", lambda *a, **k: None, raising=False)
+    monkeypatch.setattr(r, "_get_prompt_logprobs_dict", lambda *a, **k: {})
+
+    out = r.sample_tokens(None)
+    assert out.kv_connector_output is None

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_kv_spec.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_kv_spec.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU unit tests for the MRv2 runner get_kv_cache_spec.
+
+``TTModelRunnerV2.get_kv_cache_spec`` (see vllm_tt/model_runner_v2.py) walks the
+attention layers registered in the static forward context and emits a KVCacheSpec
+per layer. The layers normally come from a loaded model; here they are faked as
+bare ``Attention`` instances placed in a duck-typed vllm_config, so the
+spec-selection logic runs on cpu with no model or TT hardware.
+
+They pin the selection TT owns: full vs sliding-window specs, cross-layer KV
+sharing (skipped + recorded), and encoder-only layers (no KV cache).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from vllm.model_executor.layers.attention.attention import Attention
+from vllm.v1.attention.backend import AttentionType
+from vllm.v1.kv_cache_interface import FullAttentionSpec, SlidingWindowSpec
+from vllm_tt.model_runner_v2 import TTModelRunnerV2
+
+BLOCK_SIZE = 32
+
+
+def fake_attn(
+    num_kv_heads=8,
+    head_size=64,
+    attn_type=AttentionType.DECODER,
+    sliding_window=None,
+    kv_sharing_target_layer_name=None,
+):
+    # Bypass the heavy Attention.__init__; only these attrs are read.
+    m = object.__new__(Attention)
+    m.num_kv_heads = num_kv_heads
+    m.head_size = head_size
+    m.attn_type = attn_type
+    m.sliding_window = sliding_window
+    m.kv_sharing_target_layer_name = kv_sharing_target_layer_name
+    return m
+
+
+def make_runner(layers, cache_dtype="auto"):
+    r = object.__new__(TTModelRunnerV2)
+    r.kv_cache_spec_dtype = torch.bfloat16
+    r.shared_kv_cache_layers = {}
+    r.vllm_config = SimpleNamespace(
+        compilation_config=SimpleNamespace(static_forward_context=layers),
+        cache_config=SimpleNamespace(block_size=BLOCK_SIZE, cache_dtype=cache_dtype),
+    )
+    return r
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_full_attention_layers():
+    r = make_runner({"l0": fake_attn(), "l1": fake_attn(num_kv_heads=4, head_size=128)})
+    spec = r.get_kv_cache_spec()
+
+    assert set(spec) == {"l0", "l1"}
+    assert isinstance(spec["l0"], FullAttentionSpec)
+    assert spec["l0"].num_kv_heads == 8
+    assert spec["l0"].head_size == 64
+    assert spec["l0"].block_size == BLOCK_SIZE
+    assert spec["l0"].dtype == torch.bfloat16
+    assert spec["l1"].num_kv_heads == 4
+    assert spec["l1"].head_size == 128
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_sliding_window_layer():
+    r = make_runner({"l0": fake_attn(sliding_window=256)})
+    spec = r.get_kv_cache_spec()
+    assert isinstance(spec["l0"], SlidingWindowSpec)
+    assert spec["l0"].sliding_window == 256
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_kv_sharing_layer_skipped_and_recorded():
+    r = make_runner(
+        {
+            "l0": fake_attn(),
+            "l1": fake_attn(kv_sharing_target_layer_name="l0"),
+        }
+    )
+    spec = r.get_kv_cache_spec()
+    # The sharing layer gets no spec of its own; it is recorded as sharing l0.
+    assert set(spec) == {"l0"}
+    assert r.shared_kv_cache_layers == {"l1": "l0"}
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_encoder_only_layer_has_no_kv_cache():
+    r = make_runner(
+        {
+            "dec": fake_attn(),
+            "enc": fake_attn(attn_type=AttentionType.ENCODER_ONLY),
+        }
+    )
+    spec = r.get_kv_cache_spec()
+    assert set(spec) == {"dec"}

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_lifecycle.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_lifecycle.py
@@ -1,0 +1,232 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU unit tests for the MRv2 runner request lifecycle.
+
+``TTModelRunnerV2.add_requests`` / ``update_requests`` / ``finish_requests``
+(see vllm_tt/model_runner_v2.py) are pure host bookkeeping that drive the split
+v2 state (TTRequestState + TTSamplingStates + a block table). They run on cpu
+with no TT hardware and no model: the runner is allocated without ``__init__``
+and the state it touches is injected, and the block table is a recording fake
+so the tests assert the calls the lifecycle makes rather than device layout.
+
+They pin the v2 semantics that differ from the v1 fork: stable slots (no
+condense), preempted-request removal, and re-add clearing a stale slot.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from vllm.sampling_params import SamplingParams
+from vllm_tt.model_runner_v2 import TTModelRunnerV2
+from vllm_tt.request_state import TTRequestState
+from vllm_tt.sampling_state_v2 import TTSamplingStates
+
+VOCAB = 1000
+
+
+class FakeBlockTable:
+    """Records add/append/clear calls per slot (stands in for MultiGroupBlockTable)."""
+
+    def __init__(self):
+        self.rows: dict[int, tuple[str, object]] = {}
+        self.cleared: list[int] = []
+
+    def add_row(self, block_ids, slot):
+        self.rows[slot] = ("add", block_ids)
+
+    def append_row(self, block_ids, slot):
+        self.rows[slot] = ("append", block_ids)
+
+    def clear_row(self, slot):
+        self.cleared.append(slot)
+
+
+def make_runner(max_num_reqs=4, max_model_len=32):
+    r = object.__new__(TTModelRunnerV2)
+    r.req_states = TTRequestState(
+        max_num_reqs=max_num_reqs,
+        max_model_len=max_model_len,
+        max_num_batched_tokens=64,
+        num_speculative_steps=0,
+        vocab_size=VOCAB,
+        device="cpu",
+    )
+    r.sampling_states = TTSamplingStates(max_num_reqs=max_num_reqs, vocab_size=VOCAB)
+    r.block_table = FakeBlockTable()
+    r.encoder_cache = {}
+    r.num_prompt_logprobs = {}
+    r.lora_requests_by_slot = {}
+    r.mm_features_by_slot = {}
+    r.lora_config = None
+    r.supports_mm_inputs = False
+    r.model_state = None
+    r.vocab_size = VOCAB
+    return r
+
+
+def new_req(req_id, prompt, block_ids=([0],), num_computed=0, sp=None, prefill=None):
+    return SimpleNamespace(
+        req_id=req_id,
+        sampling_params=sp if sp is not None else SamplingParams(temperature=0.0),
+        prompt_token_ids=prompt,
+        prefill_token_ids=prefill if prefill is not None else prompt,
+        num_computed_tokens=num_computed,
+        block_ids=block_ids,
+        lora_request=None,
+    )
+
+
+def sched(
+    new=(),
+    cached_ids=(),
+    cached_computed=(),
+    cached_blocks=(),
+    finished=(),
+    preempted=(),
+    free_mm=(),
+):
+    cached = SimpleNamespace(
+        req_ids=list(cached_ids),
+        num_computed_tokens=list(cached_computed),
+        new_block_ids=list(cached_blocks),
+    )
+    return SimpleNamespace(
+        scheduled_new_reqs=list(new),
+        scheduled_cached_reqs=cached,
+        finished_req_ids=list(finished),
+        preempted_req_ids=list(preempted),
+        free_encoder_mm_hashes=list(free_mm),
+    )
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_add_request_populates_all_tables():
+    r = make_runner()
+    sp = SamplingParams(temperature=0.7, top_p=0.9)
+    r.add_requests(sched(new=[new_req("A", [10, 11, 12], block_ids=([1, 2],), sp=sp)]))
+
+    slot = r.req_states.req_id_to_index["A"]
+    assert r.req_states.num_reqs == 1
+    assert r.req_states.prompt_len[slot] == 3
+    assert r.req_states.total_len[slot] == 3
+    # Sampling params landed in the sampling table at the same slot.
+    assert bool(r.sampling_states.is_greedy[slot]) is False
+    assert r.sampling_states.temperature[slot] == pytest.approx(0.7)
+    # Block ids handed to the block table under the stable slot.
+    assert r.block_table.rows[slot] == ("add", ([1, 2],))
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_finish_frees_slot_across_tables_and_reuses():
+    r = make_runner()
+    r.add_requests(sched(new=[new_req("A", [1, 2]), new_req("B", [3])]))
+    slot_a = r.req_states.req_id_to_index["A"]
+
+    r.finish_requests(sched(finished=["A"]))
+
+    assert "A" not in r.req_states.req_id_to_index
+    assert slot_a in r.block_table.cleared
+    assert slot_a in r.req_states.free_indices
+    # Sampling slot reset to greedy default.
+    assert bool(r.sampling_states.is_greedy[slot_a]) is True
+    # Freed slot is reused by the next request.
+    r.add_requests(sched(new=[new_req("C", [7, 8])]))
+    assert r.req_states.req_id_to_index["C"] == slot_a
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_preempted_request_is_removed():
+    r = make_runner()
+    r.add_requests(sched(new=[new_req("A", [1, 2])]))
+    slot_a = r.req_states.req_id_to_index["A"]
+
+    r.finish_requests(sched(preempted=["A"]))
+    assert "A" not in r.req_states.req_id_to_index
+    assert slot_a in r.req_states.free_indices
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_readd_same_id_clears_stale_slot():
+    r = make_runner()
+    r.add_requests(sched(new=[new_req("A", [1, 2, 3])]))
+    # Re-add the same id (abort+resubmit) in a later step.
+    r.add_requests(sched(new=[new_req("A", [9])]))
+
+    assert r.req_states.num_reqs == 1
+    slot = r.req_states.req_id_to_index["A"]
+    assert r.req_states.prompt_len[slot] == 1
+    assert r.req_states.total_len[slot] == 1
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_update_advances_computed_and_appends_blocks():
+    r = make_runner()
+    r.add_requests(sched(new=[new_req("A", [1, 2, 3])]))
+    slot = r.req_states.req_id_to_index["A"]
+
+    r.update_requests(
+        sched(cached_ids=["A"], cached_computed=[2], cached_blocks=[([5],)])
+    )
+    assert r.req_states.num_computed_tokens[slot] == 2
+    assert r.block_table.rows[slot] == ("append", ([5],))
+
+    # No new blocks -> no append recorded (row unchanged from the append above).
+    r.update_requests(
+        sched(cached_ids=["A"], cached_computed=[3], cached_blocks=[None])
+    )
+    assert r.req_states.num_computed_tokens[slot] == 3
+    assert r.block_table.rows[slot] == ("append", ([5],))
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_update_clamps_num_computed_prefill_tokens():
+    r = make_runner()
+    r.add_requests(sched(new=[new_req("A", [1, 2, 3])]))  # prefill_len == 3
+    slot = r.req_states.req_id_to_index["A"]
+
+    r.update_requests(
+        sched(cached_ids=["A"], cached_computed=[5], cached_blocks=[None])
+    )
+    assert r.req_states.num_computed_tokens[slot] == 5
+    # Prefill progress is clamped to the prefill length.
+    assert r.req_states.num_computed_prefill_tokens[slot] == 3
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_prompt_logprobs_full_vocab_sentinel():
+    r = make_runner()
+    r.add_requests(
+        sched(new=[new_req("A", [1], sp=SamplingParams(prompt_logprobs=-1))])
+    )
+    assert r.num_prompt_logprobs["A"] == VOCAB
+
+    r.add_requests(sched(new=[new_req("B", [2], sp=SamplingParams(prompt_logprobs=3))]))
+    assert r.num_prompt_logprobs["B"] == 3
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_free_encoder_mm_hashes():
+    r = make_runner()
+    r.encoder_cache["hash0"] = object()
+    r.finish_requests(sched(free_mm=["hash0"]))
+    assert "hash0" not in r.encoder_cache
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_seeded_request_records_generator():
+    r = make_runner()
+    r.add_requests(
+        sched(new=[new_req("A", [1], sp=SamplingParams(temperature=0.8, seed=42))])
+    )
+    slot = r.req_states.req_id_to_index["A"]
+    assert slot in r.sampling_states.generators

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_lora.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_lora.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU unit tests for MRv2 LoRA host mapping (_make_lora_inputs).
+
+``TTModelRunnerV2._make_lora_inputs`` is the host substitute for
+InputBatch.make_lora_inputs: it turns the per-slot active-LoRA table into the
+(prompt_lora_mapping, token_lora_mapping, lora_requests) triple the LoRA mixin's
+_set_active_loras consumes.
+"""
+import numpy as np
+import pytest
+from vllm_tt.model_runner_v2 import TTModelRunnerV2
+
+
+class FakeLoRA:
+    """Hashable stand-in for LoRARequest (added to a set in _make_lora_inputs)."""
+
+    def __init__(self, int_id):
+        self.lora_int_id = int_id
+
+
+def runner(slot_to_lora):
+    r = object.__new__(TTModelRunnerV2)
+    r.lora_requests_by_slot = slot_to_lora
+    return r
+
+
+def lora(int_id):
+    return FakeLoRA(int_id)
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_make_lora_inputs_repeats_by_token_counts():
+    lora_a = lora(1)
+    lora_b = lora(2)
+    # slot 5 -> lora 1, slot 3 -> lora 2.
+    r = runner({5: lora_a, 3: lora_b})
+    idx = np.array([5, 3], dtype=np.int32)
+    nst = np.array([2, 4], dtype=np.int32)
+
+    prompt_map, token_map, reqs = r._make_lora_inputs(idx, nst)
+
+    # One sampled token per request -> one prompt-map entry per request.
+    assert prompt_map == (1, 2)
+    # token map repeats each id by its scheduled-token count.
+    assert token_map == (1, 1, 2, 2, 2, 2)
+    assert reqs == {lora_a, lora_b}
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_make_lora_inputs_base_model_is_zero():
+    lora_a = lora(7)
+    # slot 0 has a LoRA; slot 1 is base model (no entry -> id 0).
+    r = runner({0: lora_a})
+    idx = np.array([0, 1], dtype=np.int32)
+    nst = np.array([1, 3], dtype=np.int32)
+
+    prompt_map, token_map, reqs = r._make_lora_inputs(idx, nst)
+
+    assert prompt_map == (7, 0)
+    assert token_map == (7, 0, 0, 0)
+    # Only the real LoRA request is active.
+    assert reqs == {lora_a}
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_make_lora_inputs_all_base_model():
+    r = runner({})
+    idx = np.array([2, 4], dtype=np.int32)
+    nst = np.array([1, 1], dtype=np.int32)
+
+    prompt_map, token_map, reqs = r._make_lora_inputs(idx, nst)
+
+    assert prompt_map == (0, 0)
+    assert token_map == (0, 0)
+    assert reqs == set()

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_model_pass.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_model_pass.py
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU unit tests for the MRv2 runner _run_model_pass plumbing.
+
+``TTModelRunnerV2._run_model_pass`` (see vllm_tt/model_runner_v2.py) copies the
+host arrays to the device, builds attention + sampling metadata, runs the
+compiled forward/sample graph, and returns the sampled tokens. The metadata
+builds (TTModelState.prepare_attn + XLASupportedSamplingMetadata.from_v2_states)
+are real and run on cpu; the compiled graph itself needs a model + TT device, so
+it is faked here (and validated on real hardware separately).
+
+They pin the plumbing: host->device buffer copies, the real metadata builds, the
+compiled-graph dispatch, and output slicing to the active requests.
+"""
+
+import numpy as np
+import pytest
+import torch
+from vllm.sampling_params import SamplingParams
+from vllm_tt.model_runner_v2 import TTModelRunnerV2
+from vllm_tt.model_state import TTModelState
+from vllm_tt.request_state import TTRequestState
+from vllm_tt.sampling_state_v2 import TTSamplingStates
+from vllm_tt.vllm_distributed_utils import ParallelismMode
+
+VOCAB = 1000
+BLOCK_MAP = [[10, 11, 12, 13], [20, 21, 22, 23], [30, 31, 32, 33], [0, 0, 0, 0]]
+
+
+class FakeBlockTable:
+    def __init__(self, arr):
+        self._arr = arr
+
+    def __getitem__(self, group):
+        return self
+
+    def get_cpu_tensor(self):
+        return self._arr
+
+
+def make_runner(max_num_reqs=4, max_model_len=32):
+    r = object.__new__(TTModelRunnerV2)
+    r.device = torch.device("cpu")
+    r.sampling_device = torch.device("cpu")
+    r.cpu_sampling = False
+    r.lora_config = None
+    r.lora_requests_by_slot = {}
+    r.supports_mm_inputs = False
+    r.mm_features_by_slot = {}
+    r.vocab_size = VOCAB
+    r.dp_size = 1
+    r.parallel_mode = ParallelismMode.DISABLED
+    r.enable_tensor_parallel = False
+    r.block_size = 16
+    r.max_num_blocks_per_req = 4
+    r.attention_layer_names = ("layer.0", "layer.1")
+    r.req_states = TTRequestState(
+        max_num_reqs=max_num_reqs,
+        max_model_len=max_model_len,
+        max_num_batched_tokens=64,
+        num_speculative_steps=0,
+        vocab_size=VOCAB,
+        device="cpu",
+    )
+    r.sampling_states = TTSamplingStates(max_num_reqs=max_num_reqs, vocab_size=VOCAB)
+    r.block_table = FakeBlockTable(torch.tensor(BLOCK_MAP, dtype=torch.int32))
+    # prepare_attn uses no instance state.
+    r.model_state = object.__new__(TTModelState)
+    return r
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_run_model_pass_builds_metadata_and_returns_tokens():
+    r = make_runner()
+    # Two decoding requests occupying stable slots.
+    r.req_states.add_request(
+        "A", prompt_len=2, all_token_ids=[1, 2], num_computed_tokens=0
+    )
+    r.req_states.add_request(
+        "B", prompt_len=1, all_token_ids=[3], num_computed_tokens=0
+    )
+    slot_a = r.req_states.req_id_to_index["A"]
+    slot_b = r.req_states.req_id_to_index["B"]
+    for slot in (slot_a, slot_b):
+        r.sampling_states.add_request(slot, SamplingParams(temperature=0.0))
+
+    captured = {}
+
+    def fake_forward(
+        input_ids,
+        positions,
+        logits_indices,
+        attn_metadata,
+        sampling_metadata,
+        want_prompt_hs=False,
+        inputs_embeds=None,
+        *a,
+        **k,
+    ):
+        # The real metadata builds must have produced usable objects.
+        captured["attn_layers"] = set(attn_metadata)
+        captured["all_greedy"] = sampling_metadata.all_greedy
+        captured["input_ids_device"] = input_ids.device.type
+        n = input_ids.shape[0]
+        return torch.tensor([[100 + i] for i in range(n)], dtype=torch.int64)
+
+    r._forward_and_sample = fake_forward
+
+    idx = np.array([slot_a, slot_b], dtype=np.int32)
+    nst = np.array([1, 1], dtype=np.int32)
+    input_ids = np.zeros((2, 1), dtype=np.int32)
+    positions = np.zeros((2, 1), dtype=np.int32)
+    logits_indices = np.zeros(2, dtype=np.int32)
+    seq_lens = np.array([1, 1], dtype=np.int32)
+    page_table, fill_page_table, cache_position = r._prepare_attn_tensors(
+        idx, nst, seq_lens, target_num_reqs=2, num_blocks_per_req=4
+    )
+
+    out = r._run_model_pass(
+        idx,
+        nst,
+        2,
+        1,
+        input_ids,
+        positions,
+        logits_indices,
+        page_table,
+        fill_page_table,
+        cache_position,
+    )
+
+    # Attn metadata fanned out to every layer; greedy sampling metadata built.
+    assert captured["attn_layers"] == {"layer.0", "layer.1"}
+    assert captured["all_greedy"] is True
+    assert captured["input_ids_device"] == "cpu"
+    # Two active requests -> two token rows, padding dropped.
+    assert out == [[100], [101]]
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_run_model_pass_drops_padding_rows():
+    r = make_runner()
+    r.req_states.add_request(
+        "A", prompt_len=1, all_token_ids=[5], num_computed_tokens=0
+    )
+    slot = r.req_states.req_id_to_index["A"]
+    r.sampling_states.add_request(slot, SamplingParams(temperature=0.0))
+
+    # target_num_reqs (4) padded beyond the single active request.
+    r._forward_and_sample = lambda ii, pos, li, am, sm, *a, **k: torch.arange(
+        4, dtype=torch.int64
+    ).reshape(4, 1)
+
+    idx = np.array([slot], dtype=np.int32)
+    nst = np.array([1], dtype=np.int32)
+    page_table, fill_page_table, cache_position = r._prepare_attn_tensors(
+        idx, nst, np.array([1], dtype=np.int32), target_num_reqs=4, num_blocks_per_req=4
+    )
+    out = r._run_model_pass(
+        idx,
+        nst,
+        4,
+        1,
+        np.zeros((4, 1), dtype=np.int32),
+        np.zeros((4, 1), dtype=np.int32),
+        np.zeros(4, dtype=np.int32),
+        page_table,
+        fill_page_table,
+        cache_position,
+    )
+    assert out == [[0]]  # only the one active request's row
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_sample_from_logits_greedy_is_argmax():
+    r = object.__new__(TTModelRunnerV2)
+    logits = torch.tensor([[0.1, 0.9, 0.2], [0.5, 0.1, 0.3]])
+    md = type(
+        "M",
+        (),
+        dict(
+            all_greedy=True,
+            no_penalties=True,
+            no_logit_bias=True,
+            no_bad_words=True,
+            no_allowed_token_ids=True,
+            no_min_tokens=True,
+            no_generators=True,
+        ),
+    )()
+    out = r._sample_from_logits(logits, md)
+    assert out.tolist() == [[1], [0]]

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_multimodal.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_multimodal.py
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU unit tests for MRv2 multimodal host logic.
+
+``TTModelRunnerV2._gather_mm_embeddings`` builds the per-pass mm-embed mask and
+flat scatter indices, and ``TTModelState.get_mm_embeddings`` merges the gathered
+encoder embeddings into the text embeddings with a static ``index_copy`` (not
+``masked_scatter_``). These tests pin the mask layout / index math and the merge
+purely on CPU with a fake encoder cache and a fake embed_input_ids.
+"""
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+from vllm_tt.model_runner_v2 import TTModelRunnerV2
+from vllm_tt.model_state import TTModelState
+
+HID = 4
+
+
+def pos_info(offset, length):
+    # Whole-item placeholder (is_embed None); identity embed index mapping.
+    return SimpleNamespace(
+        offset=offset,
+        length=length,
+        is_embed=None,
+        get_embeds_indices_in_range=lambda s, e: (s, e),
+    )
+
+
+def mm_feature(identifier, offset, length):
+    return SimpleNamespace(identifier=identifier, mm_position=pos_info(offset, length))
+
+
+def gather_runner(mm_features_by_slot, num_computed_by_slot, encoder_cache):
+    r = object.__new__(TTModelRunnerV2)
+    r.device = torch.device("cpu")
+    r.mm_features_by_slot = mm_features_by_slot
+    r.encoder_cache = encoder_cache
+    n = max(num_computed_by_slot) + 1 if num_computed_by_slot else 1
+    r.req_states = SimpleNamespace(num_computed_tokens=np.zeros(8, dtype=np.int32))
+    for slot, c in num_computed_by_slot.items():
+        r.req_states.num_computed_tokens[slot] = c
+    return r
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_gather_mm_embeddings_mask_and_indices():
+    # Request at slot 2, image placeholder at prompt positions [0, 3) (3 tokens),
+    # scheduled as a fresh prefill of 4 tokens at batch position 0.
+    enc = torch.arange(3 * HID, dtype=torch.float32).reshape(3, HID)
+    r = gather_runner(
+        mm_features_by_slot={2: [mm_feature("h0", offset=0, length=3)]},
+        num_computed_by_slot={2: 0},
+        encoder_cache={"h0": enc},
+    )
+    idx = np.array([2], dtype=np.int32)
+    nst = np.array([4], dtype=np.int32)
+
+    mm_embeds, is_mm_embed, mm_indices = r._gather_mm_embeddings(idx, nst, 4)
+
+    # Mask: row 0, columns 0..2 are mm tokens; column 3 is text.
+    assert is_mm_embed.shape == (1, 4)
+    assert is_mm_embed[0].tolist() == [True, True, True, False]
+    # Flat row-major positions of the True cells (row0 cols 0,1,2).
+    assert mm_indices.tolist() == [0, 1, 2]
+    # One gathered embedding block of the 3 image tokens.
+    assert len(mm_embeds) == 1
+    assert torch.equal(mm_embeds[0], enc)
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_gather_mm_embeddings_no_features_is_empty():
+    r = gather_runner({}, {0: 0}, {})
+    idx = np.array([0], dtype=np.int32)
+    nst = np.array([2], dtype=np.int32)
+    mm_embeds, is_mm_embed, mm_indices = r._gather_mm_embeddings(idx, nst, 2)
+    assert mm_embeds == []
+    assert not is_mm_embed.any()
+    assert mm_indices.numel() == 0
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_get_mm_embeddings_index_copy_merge():
+    # Fake model: embed_input_ids returns token id broadcast to HID; the merge
+    # replaces the masked rows with the encoder embeddings via index_copy.
+    ms = object.__new__(TTModelState)
+
+    def embed_input_ids(input_ids, is_multimodal=None):
+        # [reqs, tokens] -> [reqs, tokens, HID], value = token id.
+        return input_ids.unsqueeze(-1).to(torch.float32).expand(-1, -1, HID).clone()
+
+    ms.model = SimpleNamespace(embed_input_ids=embed_input_ids)
+
+    input_ids = torch.tensor([[5, 6, 7, 8]], dtype=torch.int32)  # [1, 4]
+    is_mm_embed = torch.tensor([[True, True, True, False]])
+    mm_indices = torch.tensor([0, 1, 2], dtype=torch.int64)
+    mm_flat = torch.arange(3 * HID, dtype=torch.float32).reshape(3, HID)
+
+    out = ms.get_mm_embeddings(input_ids, [mm_flat], is_mm_embed, mm_indices)
+
+    assert out.shape == (1, 4, HID)
+    # First three rows replaced by the encoder embeddings.
+    assert torch.equal(out.reshape(-1, HID)[:3], mm_flat)
+    # Last (text) row is the token-id embedding for token 8.
+    assert torch.equal(out[0, 3], torch.full((HID,), 8.0))
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_get_mm_embeddings_text_only_no_merge():
+    ms = object.__new__(TTModelState)
+    ms.model = SimpleNamespace(
+        embed_input_ids=lambda ids, is_multimodal=None: torch.zeros((*ids.shape, HID))
+    )
+    input_ids = torch.tensor([[1, 2]], dtype=torch.int32)
+    is_mm_embed = torch.zeros((1, 2), dtype=torch.bool)
+    # Empty mm_embeds -> pure text embeddings, no index_copy.
+    out = ms.get_mm_embeddings(
+        input_ids, [], is_mm_embed, torch.tensor([], dtype=torch.int64)
+    )
+    assert out.shape == (1, 2, HID)
+    assert torch.count_nonzero(out) == 0

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_postprocess.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_postprocess.py
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU unit tests for the MRv2 runner sampled-token writeback.
+
+``TTModelRunnerV2.postprocess`` (see vllm_tt/model_runner_v2.py) is the host
+substitute for upstream's post_update Triton kernel. It is pure numpy over
+``TTRequestState``, so it runs on cpu with no TT hardware; only ``req_states``
+is injected.
+
+They pin the writeback math TT owns: appending the sampled token at total_len so
+the next step's input-prep reads it, discarding tokens from still-prefilling
+(partial-chunk) requests, and leaving num_computed for the scheduler to advance.
+"""
+
+import numpy as np
+import pytest
+from vllm_tt.model_runner_v2 import TTModelRunnerV2
+from vllm_tt.request_state import TTRequestState
+
+VOCAB = 1000
+
+
+def runner_with_reqs(max_num_reqs=4, max_model_len=32):
+    r = object.__new__(TTModelRunnerV2)
+    r.req_states = TTRequestState(
+        max_num_reqs=max_num_reqs,
+        max_model_len=max_model_len,
+        max_num_batched_tokens=64,
+        num_speculative_steps=0,
+        vocab_size=VOCAB,
+        device="cpu",
+    )
+    return r
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_postprocess_appends_decode_token():
+    r = runner_with_reqs()
+    rs = r.req_states
+    rs.add_request("D", prompt_len=3, all_token_ids=[1, 2, 3], num_computed_tokens=0)
+    slot = rs.req_id_to_index["D"]
+    rs.num_computed_tokens[slot] = 3  # prefill already consumed -> decoding
+
+    idx = np.array([slot], dtype=np.int32)
+    nst = np.array([1], dtype=np.int32)  # one decode token scheduled
+    valid = r.postprocess(idx, nst, [[99]])
+
+    assert valid == [[99]]
+    # Token landed at the old total_len; the table grew by one.
+    assert rs.all_token_ids[slot, 3] == 99
+    assert rs.total_len[slot] == 4
+    assert rs.last_sampled_tokens[slot, 0] == 99
+    # num_computed is left for the scheduler (update_requests), not advanced here.
+    assert rs.num_computed_tokens[slot] == 3
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_postprocess_discards_partial_prefill_token():
+    r = runner_with_reqs()
+    rs = r.req_states
+    rs.add_request(
+        "P", prompt_len=6, all_token_ids=[10, 11, 12, 13, 14, 15], num_computed_tokens=0
+    )
+    slot = rs.req_id_to_index["P"]
+    # First chunk of 4 tokens: seq_len (0 + 4) < prefill_len (6) -> still prefilling.
+    idx = np.array([slot], dtype=np.int32)
+    nst = np.array([4], dtype=np.int32)
+    before = rs.all_token_ids[slot].copy()
+
+    valid = r.postprocess(idx, nst, [[99]])
+
+    assert valid == [[]]  # discarded
+    assert rs.total_len[slot] == 6  # unchanged
+    np.testing.assert_array_equal(rs.all_token_ids[slot], before)
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_postprocess_final_prefill_chunk_appends():
+    r = runner_with_reqs()
+    rs = r.req_states
+    rs.add_request(
+        "F", prompt_len=6, all_token_ids=[10, 11, 12, 13, 14, 15], num_computed_tokens=0
+    )
+    slot = rs.req_id_to_index["F"]
+    rs.num_computed_tokens[slot] = 4  # first chunk already computed
+    # Final chunk of 2: seq_len (4 + 2) == prefill_len (6) -> produces a token.
+    idx = np.array([slot], dtype=np.int32)
+    nst = np.array([2], dtype=np.int32)
+
+    valid = r.postprocess(idx, nst, [[77]])
+
+    assert valid == [[77]]
+    assert rs.all_token_ids[slot, 6] == 77
+    assert rs.total_len[slot] == 7
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_postprocess_mixed_batch():
+    r = runner_with_reqs()
+    rs = r.req_states
+    rs.add_request("D", prompt_len=2, all_token_ids=[1, 2], num_computed_tokens=0)
+    rs.add_request(
+        "P", prompt_len=5, all_token_ids=[3, 4, 5, 6, 7], num_computed_tokens=0
+    )
+    slot_d = rs.req_id_to_index["D"]
+    slot_p = rs.req_id_to_index["P"]
+    rs.num_computed_tokens[slot_d] = 2  # decoding
+    # P still prefilling: 3 of 5 tokens this chunk.
+
+    idx = np.array([slot_d, slot_p], dtype=np.int32)
+    nst = np.array([1, 3], dtype=np.int32)
+    valid = r.postprocess(idx, nst, [[55], [66]])
+
+    assert valid == [[55], []]  # decode kept, partial prefill discarded
+    assert rs.all_token_ids[slot_d, 2] == 55
+    assert rs.total_len[slot_d] == 3
+    assert rs.total_len[slot_p] == 5  # unchanged

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_prompt_logprobs.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_prompt_logprobs.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU unit tests for MRv2 prompt-logprobs host logic.
+
+``TTModelRunnerV2._get_prompt_logprobs_dict`` reprocesses each prefilling
+request's prompt positions through compute_logits / gather_logprobs and packs
+the per-position top-k logprobs into ``LogprobsTensors``. These tests pin the
+host bookkeeping (position math, chunked continuation, completion / cleanup)
+with the two device leaves (compute_logits, gather_logprobs) faked.
+"""
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+from vllm.v1.outputs import LogprobsTensors
+from vllm_tt.model_runner_v2 import TTModelRunnerV2
+
+VOCAB = 50
+HID = 8
+MAX_LOGPROBS = 5
+
+
+class FakeReqStates:
+    def __init__(self, slot, prompt_tokens, num_computed):
+        self.req_id_to_index = {"r0": slot}
+        self.index_to_req_id = {slot: "r0"}
+        n = len(prompt_tokens)
+        self.prompt_len = np.zeros(slot + 1, dtype=np.int32)
+        self.prompt_len[slot] = n
+        self.num_computed_tokens = np.zeros(slot + 1, dtype=np.int32)
+        self.num_computed_tokens[slot] = num_computed
+        self.all_token_ids = np.zeros((slot + 1, max(n, 8)), dtype=np.int32)
+        self.all_token_ids[slot, :n] = prompt_tokens
+
+
+def make_runner(req_states, num_plp):
+    r = object.__new__(TTModelRunnerV2)
+    r.device = torch.device("cpu")
+    r.max_num_reqs = 8
+    r.model_config = SimpleNamespace(max_logprobs=MAX_LOGPROBS)
+    r.req_states = req_states
+    r.num_prompt_logprobs = {"r0": num_plp}
+    r.in_progress_prompt_logprobs = {}
+
+    # compute_logits: hidden [B, HID] -> deterministic logits [B, VOCAB].
+    r.compute_logits = lambda hs: torch.arange(VOCAB, dtype=torch.float32).repeat(
+        hs.shape[0], 1
+    )
+
+    # gather_logprobs: return a marker per row so placement is checkable. The
+    # token id column 0 encodes the batch row (so dest-slice writes are visible).
+    def fake_gather(logits, token_ids):
+        b = logits.shape[0]
+        ids = (
+            torch.arange(b, dtype=torch.int32).unsqueeze(1).repeat(1, MAX_LOGPROBS + 1)
+        )
+        lps = torch.full((b, MAX_LOGPROBS + 1), -0.5, dtype=torch.float32)
+        ranks = torch.ones(b, dtype=torch.int32)
+        return LogprobsTensors(ids, lps, ranks)
+
+    r.gather_logprobs = fake_gather
+    return r
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_prompt_logprobs_single_step_full_prefill():
+    # 4-token prompt, computed in one step. Result has num_prompt_tokens-1 rows.
+    rs = FakeReqStates(slot=2, prompt_tokens=[10, 20, 30, 40], num_computed=0)
+    r = make_runner(rs, num_plp=3)
+    prompt_lp_hs = {2: torch.ones(4, HID)}
+    sched = SimpleNamespace(num_scheduled_tokens={"r0": 4})
+
+    out = r._get_prompt_logprobs_dict(prompt_lp_hs, sched)
+
+    assert set(out.keys()) == {"r0"}
+    lt = out["r0"]
+    assert lt.logprob_token_ids.shape == (3, 4)  # num_plp+1 columns
+    assert lt.logprobs.shape == (3, 4)
+    # Completed request is cleaned up.
+    assert "r0" not in r.num_prompt_logprobs
+    assert "r0" not in r.in_progress_prompt_logprobs
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_prompt_logprobs_num_plp_clamped_to_max():
+    rs = FakeReqStates(slot=0, prompt_tokens=[1, 2, 3], num_computed=0)
+    r = make_runner(rs, num_plp=999)  # exceeds MAX_LOGPROBS
+    prompt_lp_hs = {0: torch.ones(3, HID)}
+    sched = SimpleNamespace(num_scheduled_tokens={"r0": 3})
+
+    out = r._get_prompt_logprobs_dict(prompt_lp_hs, sched)
+    # Trimmed to MAX_LOGPROBS + 1 columns.
+    assert out["r0"].logprob_token_ids.shape == (2, MAX_LOGPROBS + 1)
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_prompt_logprobs_chunked_not_yet_complete():
+    # 6-token prompt, only 3 scheduled this step -> not complete, stays in-progress.
+    rs = FakeReqStates(slot=1, prompt_tokens=[1, 2, 3, 4, 5, 6], num_computed=0)
+    r = make_runner(rs, num_plp=2)
+    prompt_lp_hs = {1: torch.ones(3, HID)}
+    sched = SimpleNamespace(num_scheduled_tokens={"r0": 3})
+
+    out = r._get_prompt_logprobs_dict(prompt_lp_hs, sched)
+    # Not yet completed: no result emitted, still tracked.
+    assert out == {}
+    assert "r0" in r.num_prompt_logprobs
+    assert "r0" in r.in_progress_prompt_logprobs
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_prompt_logprobs_empty_when_none_requested():
+    rs = FakeReqStates(slot=0, prompt_tokens=[1, 2], num_computed=0)
+    r = make_runner(rs, num_plp=1)
+    r.num_prompt_logprobs = {}  # nothing requested
+    out = r._get_prompt_logprobs_dict({}, SimpleNamespace(num_scheduled_tokens={}))
+    assert out == {}

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_spec_decode.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_spec_decode.py
@@ -1,0 +1,246 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU tests for MRv2 speculative decode (ngram) host plumbing.
+
+The rejection-sampling math lives in rejection_sampler.py and is covered by
+tests/integrations/vllm_plugin/sampling/test_speculative_decode.py. What is
+tested here is the v2-specific plumbing around it:
+
+* staging scheduled drafts into the slot table without committing them
+* the per-pass SpecDecodeMetadata (flat target/bonus indices over the packed
+  [reqs, spec_width] logits layout)
+* the packed logits_indices those metadata index into
+* multi-token writeback (spec decode accepts 1..spec_width tokens per request)
+* the ngram proposal / take_draft_token_ids handoff
+"""
+
+import numpy as np
+import pytest
+from test_runner_driver import make_runner, make_sched, new_req
+
+
+def spec_runner(num_spec_tokens=3, **kw):
+    r = make_runner(**kw)
+    r.num_spec_tokens = num_spec_tokens
+    # Re-size the draft table for the requested spec width.
+    r.req_states.num_speculative_steps = num_spec_tokens
+    r.req_states.draft_tokens = np.zeros(
+        (r.req_states.max_num_reqs, num_spec_tokens), dtype=np.int64
+    )
+    return r
+
+
+def seed_decoding_req(r, req_id="A", prompt=(1, 2, 3), sampled=9):
+    """Add a request and advance it past prefill by one sampled token."""
+    r.execute_model(
+        make_sched(new=[new_req(req_id, list(prompt))], num_sched={req_id: len(prompt)})
+    )
+    r.scheduler_output = None
+    slot = r.req_states.req_id_to_index[req_id]
+    rs = r.req_states
+    pos = int(rs.total_len[slot])
+    rs.all_token_ids[slot, pos] = sampled
+    rs.total_len[slot] = pos + 1
+    rs.num_computed_tokens[slot] = pos
+    rs.num_computed_prefill_tokens[slot] = int(rs.prefill_len[slot])
+    return slot
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_apply_scheduled_drafts_stages_without_committing():
+    r = spec_runner()
+    slot = seed_decoding_req(r)
+    rs = r.req_states
+    total_before = int(rs.total_len[slot])
+
+    so = make_sched(num_sched={"A": 3}, total=3)
+    so.scheduled_spec_decode_tokens = {"A": [11, 12]}
+    r._apply_scheduled_drafts(so)
+
+    assert int(rs.num_draft_tokens[slot]) == 2
+    assert list(rs.draft_tokens[slot, :2]) == [11, 12]
+    # Drafts are readable by the input gather...
+    assert list(rs.all_token_ids[slot, total_before : total_before + 2]) == [11, 12]
+    # ...but uncommitted: total_len must not move.
+    assert int(rs.total_len[slot]) == total_before
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_apply_scheduled_drafts_clears_slots_without_drafts():
+    r = spec_runner()
+    slot = seed_decoding_req(r)
+    so = make_sched(num_sched={"A": 3}, total=3)
+    so.scheduled_spec_decode_tokens = {"A": [11, 12]}
+    r._apply_scheduled_drafts(so)
+
+    so2 = make_sched(num_sched={"A": 1}, total=1)
+    so2.scheduled_spec_decode_tokens = {}
+    r._apply_scheduled_drafts(so2)
+    assert int(r.req_states.num_draft_tokens[slot]) == 0
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_apply_scheduled_drafts_noop_when_spec_disabled():
+    r = make_runner()  # num_spec_tokens == 0
+    slot = seed_decoding_req(r)
+    so = make_sched(num_sched={"A": 1}, total=1)
+    so.scheduled_spec_decode_tokens = {"A": [11]}
+    r._apply_scheduled_drafts(so)
+    assert int(r.req_states.num_draft_tokens[slot]) == 0
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_spec_metadata_is_none_when_disabled_or_no_drafts():
+    r = make_runner()
+    slot = seed_decoding_req(r)
+    assert r._build_spec_decode_metadata(np.array([slot])) is None
+
+    r2 = spec_runner()
+    slot2 = seed_decoding_req(r2)
+    # Spec enabled but nothing drafted this step -> stay on the flat layout.
+    assert r2._build_spec_decode_metadata(np.array([slot2])) is None
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_spec_metadata_indices_over_packed_layout():
+    r = spec_runner(num_spec_tokens=3)
+    slot_a = seed_decoding_req(r, "A", (1, 2, 3))
+    slot_b = seed_decoding_req(r, "B", (4, 5), sampled=8)
+
+    so = make_sched(num_sched={"A": 3, "B": 1}, total=4)
+    # A drafts 2 tokens, B drafts none.
+    so.scheduled_spec_decode_tokens = {"A": [11, 12]}
+    r._apply_scheduled_drafts(so)
+
+    md = r._build_spec_decode_metadata(np.array([slot_a, slot_b]))
+    assert md is not None
+    assert md.num_draft_tokens == [2, 0]
+    assert list(md.draft_token_ids.numpy()) == [11, 12]
+
+    spec_width = 4  # num_spec_tokens + 1
+    # A's two draft logits sit at packed rows 0..1; bonus is the last column of
+    # each request's block.
+    assert list(md.target_logits_indices.numpy()) == [0, 1]
+    assert list(md.bonus_logits_indices.numpy()) == [
+        spec_width - 1,
+        2 * spec_width - 1,
+    ]
+    assert list(md.cu_num_draft_tokens.numpy()) == [2, 2]
+    assert list(md.cu_num_sampled_tokens.numpy()) == [3, 4]
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_packed_logits_indices_point_at_drafts_then_bonus():
+    r = spec_runner(num_spec_tokens=3)
+    slot = seed_decoding_req(r, "A", (1, 2, 3))
+    so = make_sched(num_sched={"A": 3}, total=3)
+    so.scheduled_spec_decode_tokens = {"A": [11, 12]}
+    r._apply_scheduled_drafts(so)
+
+    idx = np.array([slot])
+    md = r._build_spec_decode_metadata(idx)
+    num_sched = np.array([3], dtype=np.int32)
+    *_, logits_indices = r._prepare_input_tokens(idx, num_sched, 1, 8, md)
+
+    assert logits_indices.shape == (1, 4)
+    # First two columns index this request's two draft positions; the rest all
+    # point at the bonus (last scheduled) position.
+    assert list(logits_indices[0]) == [0, 1, 2, 2]
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_flat_logits_indices_without_spec_metadata():
+    r = spec_runner()
+    slot = seed_decoding_req(r, "A", (1, 2, 3))
+    idx = np.array([slot])
+    *_, logits_indices = r._prepare_input_tokens(
+        idx, np.array([1], dtype=np.int32), 1, 8, None
+    )
+    assert logits_indices.shape == (1,)
+    assert int(logits_indices[0]) == 0
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_postprocess_commits_all_accepted_tokens():
+    r = spec_runner()
+    slot = seed_decoding_req(r, "A", (1, 2, 3))
+    rs = r.req_states
+    total_before = int(rs.total_len[slot])
+
+    # Three accepted tokens (two drafts confirmed + bonus).
+    valid = r.postprocess(np.array([slot]), np.array([3]), [[21, 22, 23]])
+
+    assert valid[0] == [21, 22, 23]
+    assert int(rs.total_len[slot]) == total_before + 3
+    assert list(rs.all_token_ids[slot, total_before : total_before + 3]) == [21, 22, 23]
+    # last_sampled seeds the next step's input: must be the final accepted token.
+    assert int(rs.last_sampled_tokens[slot, 0]) == 23
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_postprocess_single_token_path_unchanged():
+    r = make_runner()
+    slot = seed_decoding_req(r, "A", (1, 2, 3))
+    rs = r.req_states
+    total_before = int(rs.total_len[slot])
+    r.postprocess(np.array([slot]), np.array([1]), [[42]])
+    assert int(rs.total_len[slot]) == total_before + 1
+    assert int(rs.last_sampled_tokens[slot, 0]) == 42
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_propose_draft_token_ids_caches_and_hands_off():
+    r = spec_runner()
+    seed_decoding_req(r, "A", (1, 2, 3))
+
+    class FakeProposer:
+        def __init__(self):
+            self.seen = None
+
+        def propose(self, sampled, num_tokens_no_spec, token_ids_cpu):
+            self.seen = (sampled, num_tokens_no_spec.copy())
+            return [[71, 72]]
+
+    r.drafter = FakeProposer()
+    r.propose_draft_token_ids(["A"], [[21]])
+
+    out = r.take_draft_token_ids()
+    assert out.req_ids == ["A"]
+    assert out.draft_token_ids == [[71, 72]]
+    # Taking twice must not re-emit the same drafts.
+    assert r.take_draft_token_ids() is None
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_propose_draft_token_ids_noop_without_drafter():
+    r = spec_runner()
+    seed_decoding_req(r, "A", (1, 2, 3))
+    r.propose_draft_token_ids(["A"], [[21]])
+    assert r.take_draft_token_ids() is None
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_propose_draft_token_ids_skips_when_nothing_accepted():
+    r = spec_runner()
+    seed_decoding_req(r, "A", (1, 2, 3))
+
+    class BoomProposer:
+        def propose(self, *a):
+            raise AssertionError("must not draft with no accepted tokens")
+
+    r.drafter = BoomProposer()
+    r.propose_draft_token_ids(["A"], [[]])
+    assert r.take_draft_token_ids() is None

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_telemetry.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_telemetry.py
@@ -1,0 +1,337 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the env-gated serving telemetry collectors.
+
+Pure host-side: no TT device, no vLLM engine. Exercises the gating contract
+(disabled => zero files, zero I/O), env-var precedence, the buffered-flush
+policy (no per-step disk writes), and the record schema for both the scheduler
+and runner collectors.
+"""
+import json
+import os
+
+import numpy as np
+import pytest
+from vllm_tt.telemetry import (
+    RUNNER_FILENAME,
+    RUNNER_SNAPSHOT_FILENAME,
+    SCHEDULER_FILENAME,
+    RunnerTelemetry,
+    SchedulerTelemetry,
+    reset_sinks,
+    resolve_config,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    for var in ("TTXLA_TELEMETRY", "TTXLA_TELEMETRY_DIR", "TTXLA_TELEMETRY_FLUSH_MS"):
+        monkeypatch.delenv(var, raising=False)
+
+
+class _FakeReqStates:
+    """Minimal stand-in for TTRequestState with the fields on_step reads."""
+
+    def __init__(self, slots, max_num_reqs=32):
+        # slots: {req_id: (slot_idx, num_computed, prefill_len, total_len)}
+        self.req_id_to_index = {rid: s[0] for rid, s in slots.items()}
+        occupied = set(self.req_id_to_index.values())
+        self.free_indices = [i for i in range(max_num_reqs) if i not in occupied]
+        self.num_computed_tokens = np.zeros(max_num_reqs, dtype=np.int32)
+        self.prefill_len = np.zeros(max_num_reqs, dtype=np.int32)
+        self.total_len = np.zeros(max_num_reqs, dtype=np.int32)
+        for _rid, (idx, computed, plen, tlen) in slots.items():
+            self.num_computed_tokens[idx] = computed
+            self.prefill_len[idx] = plen
+            self.total_len[idx] = tlen
+
+
+def _read_jsonl(path):
+    with open(path) as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+# --------------------------------------------------------------------------- #
+# resolve_config
+# --------------------------------------------------------------------------- #
+@pytest.mark.push
+@pytest.mark.cpu
+def test_resolve_config_defaults():
+    enabled, directory, flush_s = resolve_config()
+    assert enabled is False
+    assert directory == "./tt_telemetry"
+    assert flush_s == 1.0
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_resolve_config_env_overrides_config(monkeypatch, tmp_path):
+    monkeypatch.setenv("TTXLA_TELEMETRY", "yes")
+    monkeypatch.setenv("TTXLA_TELEMETRY_DIR", str(tmp_path))
+    monkeypatch.setenv("TTXLA_TELEMETRY_FLUSH_MS", "250")
+    # Config says disabled/elsewhere; env must win.
+    enabled, directory, flush_s = resolve_config(
+        enabled=False, directory="/other", flush_ms=9999
+    )
+    assert enabled is True
+    assert directory == str(tmp_path)
+    assert flush_s == 0.25
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+@pytest.mark.parametrize(
+    "val,expected", [("1", True), ("on", True), ("0", False), ("off", False)]
+)
+def test_resolve_config_truthiness(monkeypatch, val, expected):
+    monkeypatch.setenv("TTXLA_TELEMETRY", val)
+    assert resolve_config()[0] is expected
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_resolve_config_bad_flush_ms_falls_back(monkeypatch):
+    monkeypatch.setenv("TTXLA_TELEMETRY_FLUSH_MS", "not-a-number")
+    assert resolve_config(enabled=True)[2] == 1.0
+
+
+# --------------------------------------------------------------------------- #
+# Disabled => zero-cost, no files
+# --------------------------------------------------------------------------- #
+@pytest.mark.push
+@pytest.mark.cpu
+def test_disabled_collectors_write_nothing(tmp_path):
+    runner = RunnerTelemetry(False, str(tmp_path), 0.0)
+    scheduler = SchedulerTelemetry(False, str(tmp_path), 0.0)
+    assert runner.enabled is False and scheduler.enabled is False
+
+    runner.on_request_admitted("r0", 0, 10, 10)
+    runner.on_step(
+        _FakeReqStates({}), prefill_passes=0, decode_passes=0, emitted_tokens=0
+    )
+    runner.flush()
+    scheduler.on_schedule(
+        num_running=1,
+        max_running=32,
+        num_waiting=0,
+        num_free_blocks=10,
+        num_total_blocks=10,
+        prefill_new=0,
+        prefill_resumed=0,
+        prefill_partial=0,
+        running_scheduled=1,
+        preempted=0,
+        decode_gated=False,
+        decodes_displaced=0,
+        total_scheduled_tokens=1,
+    )
+    scheduler.flush()
+    assert os.listdir(tmp_path) == []
+
+
+# --------------------------------------------------------------------------- #
+# Buffered flush: no per-step disk I/O
+# --------------------------------------------------------------------------- #
+@pytest.mark.push
+@pytest.mark.cpu
+def test_records_buffer_until_flush(tmp_path):
+    # Large flush interval => on_step never triggers an interval flush.
+    runner = RunnerTelemetry(True, str(tmp_path), flush_s=3600.0)
+    rs = _FakeReqStates({"r0": (0, 5, 10, 10)})
+    runner.on_step(rs, prefill_passes=1, decode_passes=0, emitted_tokens=0)
+    # jsonl exists (truncated on init) but holds no step record yet.
+    jsonl = os.path.join(tmp_path, RUNNER_FILENAME)
+    assert _read_jsonl(jsonl) == []
+    runner.flush()
+    assert len(_read_jsonl(jsonl)) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Runner records
+# --------------------------------------------------------------------------- #
+@pytest.mark.push
+@pytest.mark.cpu
+def test_runner_admit_and_complete_records(tmp_path):
+    runner = RunnerTelemetry(True, str(tmp_path), 0.0)
+    runner.on_request_admitted("r0", 3, prompt_len=10, prefill_len=10)
+    runner.on_request_admitted("r1", 4, prompt_len=8, prefill_len=12)  # prefix hit
+    runner.on_request_completed("r0", 3, prompt_len=10, output_len=20)
+    runner.flush()
+    recs = _read_jsonl(os.path.join(tmp_path, RUNNER_FILENAME))
+    admitted = [r for r in recs if r["event"] == "request_admitted"]
+    completed = [r for r in recs if r["event"] == "request_completed"]
+    assert {r["request_id"] for r in admitted} == {"r0", "r1"}
+    assert (
+        next(r for r in admitted if r["request_id"] == "r0")["prefix_cache_hit"]
+        is False
+    )
+    assert (
+        next(r for r in admitted if r["request_id"] == "r1")["prefix_cache_hit"] is True
+    )
+    assert completed[0]["request_id"] == "r0" and completed[0]["output_len"] == 20
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_runner_step_occupancy_and_snapshot(tmp_path):
+    runner = RunnerTelemetry(True, str(tmp_path), 0.0)
+    # r0 still prefilling (computed < prefill_len), r1 decoding.
+    rs = _FakeReqStates({"r0": (0, 5, 10, 5), "r1": (1, 12, 12, 15)}, max_num_reqs=32)
+    runner.on_step(rs, prefill_passes=1, decode_passes=1, emitted_tokens=1)
+    runner.flush()
+    step = [
+        r
+        for r in _read_jsonl(os.path.join(tmp_path, RUNNER_FILENAME))
+        if r["event"] == "step"
+    ][0]
+    assert step["slots_occupied"] == 2
+    assert step["slots_free"] == 30
+    assert step["num_prefilling"] == 1
+    assert step["num_decoding"] == 1
+    assert step["prefill_passes"] == 1 and step["decode_passes"] == 1
+    assert step["emitted_tokens"] == 1
+    # First step has no prior timestamp => decode rate undefined.
+    assert step["decode_rate_toks_per_s"] is None
+
+    # Snapshot file holds the latest per-slot picture.
+    with open(os.path.join(tmp_path, RUNNER_SNAPSHOT_FILENAME)) as f:
+        snap = json.load(f)
+    assert {s["request_id"] for s in snap["slots"]} == {"r0", "r1"}
+    assert {s["state"] for s in snap["slots"]} == {"PREFILL", "DECODE"}
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_runner_decode_rate_after_two_steps(tmp_path):
+    runner = RunnerTelemetry(True, str(tmp_path), 0.0)
+    rs = _FakeReqStates({"r0": (0, 12, 12, 15)})
+    runner.on_step(rs, prefill_passes=0, decode_passes=1, emitted_tokens=1)
+    runner.on_step(rs, prefill_passes=0, decode_passes=1, emitted_tokens=1)
+    runner.flush()
+    steps = [
+        r
+        for r in _read_jsonl(os.path.join(tmp_path, RUNNER_FILENAME))
+        if r["event"] == "step"
+    ]
+    assert steps[0]["decode_rate_toks_per_s"] is None
+    # Second step has a positive dt and one emitted token => positive rate.
+    assert steps[1]["decode_rate_toks_per_s"] is not None
+    assert steps[1]["decode_rate_toks_per_s"] > 0
+
+
+# --------------------------------------------------------------------------- #
+# Scheduler records
+# --------------------------------------------------------------------------- #
+@pytest.mark.push
+@pytest.mark.cpu
+def test_scheduler_utilization_and_cumulative_counters(tmp_path):
+    sched = SchedulerTelemetry(True, str(tmp_path), 0.0)
+    sched.on_schedule(
+        num_running=8,
+        max_running=32,
+        num_waiting=4,
+        num_free_blocks=100,
+        num_total_blocks=400,
+        prefill_new=2,
+        prefill_resumed=0,
+        prefill_partial=1,
+        running_scheduled=0,
+        preempted=1,
+        decode_gated=True,
+        decodes_displaced=8,
+        total_scheduled_tokens=512,
+        watermark_rejects=2,
+        b1_cap_hit=True,
+    )
+    sched.on_schedule(
+        num_running=8,
+        max_running=32,
+        num_waiting=2,
+        num_free_blocks=300,
+        num_total_blocks=400,
+        prefill_new=0,
+        prefill_resumed=0,
+        prefill_partial=0,
+        running_scheduled=8,
+        preempted=0,
+        decode_gated=False,
+        decodes_displaced=0,
+        total_scheduled_tokens=8,
+    )
+    sched.flush()
+    recs = _read_jsonl(os.path.join(tmp_path, SCHEDULER_FILENAME))
+    assert len(recs) == 2
+    assert recs[0]["kv_util"] == 0.75  # (400-100)/400
+    assert recs[0]["batch_util"] == 0.25  # 8/32
+    assert recs[0]["decode_gated"] is True and recs[0]["decodes_displaced"] == 8
+    # Cumulative counters accumulate across steps.
+    assert recs[1]["cum_preempted"] == 1
+    assert recs[1]["cum_decode_stalled_steps"] == 1  # only step 0 was gated
+    assert recs[1]["cum_watermark_rejects"] == 2
+    assert recs[1]["cum_b1_cap_hits"] == 1
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_reset_sinks_clears_all_sinks(tmp_path):
+    # A restart must not leave a prior run's data lingering through warmup.
+    for name in (SCHEDULER_FILENAME, RUNNER_FILENAME, RUNNER_SNAPSHOT_FILENAME):
+        (tmp_path / name).write_text("stale from a previous run")
+    reset_sinks(str(tmp_path))
+    assert os.listdir(tmp_path) == []
+    # Idempotent, and a missing directory is a no-op (best-effort).
+    reset_sinks(str(tmp_path))
+    reset_sinks(str(tmp_path / "does_not_exist"))
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_admitted_record_carries_cached_tokens(tmp_path):
+    # v2 signals a hit as prefill_len > prompt_len, v1 as advanced
+    # num_computed_tokens; the record accepts both.
+    runner = RunnerTelemetry(True, str(tmp_path), 0.0)
+    runner.on_request_admitted("v2hit", 0, 8, 12)  # v2 style: prefix beyond prompt
+    runner.on_request_admitted("v1hit", 1, 8, 8, num_cached_tokens=6)  # v1 style
+    runner.on_request_admitted("miss", 2, 8, 8)
+    runner.flush()
+    adm = {
+        r["request_id"]: r
+        for r in _read_jsonl(os.path.join(tmp_path, RUNNER_FILENAME))
+        if r["event"] == "request_admitted"
+    }
+    assert adm["v2hit"]["prefix_cache_hit"] is True
+    assert adm["v1hit"]["prefix_cache_hit"] is True
+    assert adm["v1hit"]["num_cached_tokens"] == 6
+    assert adm["miss"]["prefix_cache_hit"] is False
+    assert adm["miss"]["num_cached_tokens"] == 0
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_readmission_is_distinguishable_from_first_admission(tmp_path):
+    # Fires on v2 only when an id arrives while a stale slot holds it; routine
+    # on v1. Consumers filter on it so requests served are not double-counted.
+    runner = RunnerTelemetry(True, str(tmp_path), 0.0)
+    runner.on_request_admitted("r0", 0, 8, 8, readmission=False)
+    runner.on_request_admitted("r0", 0, 8, 8, num_cached_tokens=8, readmission=True)
+    runner.flush()
+    adm = [
+        r
+        for r in _read_jsonl(os.path.join(tmp_path, RUNNER_FILENAME))
+        if r["event"] == "request_admitted"
+    ]
+    assert len(adm) == 2 and len({r["request_id"] for r in adm}) == 1
+    assert adm[0]["readmission"] is False
+    assert adm[1]["readmission"] is True and adm[1]["prefix_cache_hit"] is True
+    assert len([r for r in adm if not r["readmission"]]) == 1
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_stale_sink_truncated_on_init(tmp_path):
+    path = tmp_path / SCHEDULER_FILENAME
+    path.write_text('{"stale":true}\n')
+    SchedulerTelemetry(True, str(tmp_path), 0.0)
+    # A fresh run must not replay a prior run's records.
+    assert path.read_text() == ""

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_warmup.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_warmup.py
@@ -78,10 +78,34 @@ def test_update_config_rejects_unknown_config():
 
 @pytest.mark.push
 @pytest.mark.cpu
-def test_reload_weights_not_supported():
+def test_reload_weights_requires_a_loaded_model():
     r = object.__new__(TTModelRunnerV2)
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(AssertionError, match="before model is loaded"):
         r.reload_weights()
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_reload_weights_loads_inplace(monkeypatch):
+    r = object.__new__(TTModelRunnerV2)
+    r.model = object()
+    r.load_config = object()
+    r.model_config = object()
+
+    calls = {}
+
+    class _Loader:
+        def load_weights(self, model, model_config):
+            calls["model"] = model
+            calls["model_config"] = model_config
+
+    monkeypatch.setattr(
+        "vllm.model_executor.model_loader.get_model_loader",
+        lambda load_config: _Loader(),
+    )
+    r.reload_weights()
+    assert calls["model"] is r.model
+    assert calls["model_config"] is r.model_config
 
 
 @pytest.mark.push

--- a/tests/integrations/vllm_plugin/mrv2/test_runner_warmup.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_runner_warmup.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU unit tests for the MRv2 runner worker-facing shims.
+
+get_model / reset_mm_cache / add_lora / maybe_setup_dummy_loras /
+get_supported_tasks / update_config / reload_weights are pure host logic that
+runs on cpu with injected state.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from vllm_tt.model_runner_v2 import TTModelRunnerV2
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_get_model_returns_the_model():
+    r = object.__new__(TTModelRunnerV2)
+    sentinel = object()
+    r.model = sentinel
+    assert r.get_model() is sentinel
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_reset_mm_cache_noop_without_budget():
+    r = object.__new__(TTModelRunnerV2)
+    r.mm_budget = None
+    r.reset_mm_cache()  # must not raise
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_reset_mm_cache_resets_budget():
+    r = object.__new__(TTModelRunnerV2)
+    calls = []
+    r.mm_budget = type("B", (), {"reset_cache": lambda self: calls.append(1)})()
+    r.reset_mm_cache()
+    assert calls == [1]
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_maybe_setup_dummy_loras_noop_context():
+    # With no LoRA config the mixin context is a clean no-op.
+    r = object.__new__(TTModelRunnerV2)
+    with r.maybe_setup_dummy_loras(None):
+        pass
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_get_supported_tasks_delegates_to_model_state():
+    r = object.__new__(TTModelRunnerV2)
+    r.model_config = SimpleNamespace(runner_type="generate")
+    r.model_state = SimpleNamespace(get_supported_generation_tasks=lambda: ["generate"])
+    assert r.get_supported_tasks() == ("generate",)
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_get_supported_tasks_rejects_non_generate():
+    r = object.__new__(TTModelRunnerV2)
+    r.model_config = SimpleNamespace(runner_type="pooling")
+    with pytest.raises(NotImplementedError):
+        r.get_supported_tasks()
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_update_config_rejects_unknown_config():
+    r = object.__new__(TTModelRunnerV2)
+    with pytest.raises(AssertionError):
+        r.update_config({"scheduler_config": {}})
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_reload_weights_not_supported():
+    r = object.__new__(TTModelRunnerV2)
+    with pytest.raises(NotImplementedError):
+        r.reload_weights()
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_warmup_buckets_cover_all_shapes():
+    r = object.__new__(TTModelRunnerV2)
+    r.max_num_reqs = 8
+    r.min_num_reqs = 2
+    r.max_prefill_num_reqs = 4
+    r.num_tokens_paddings = [1, 32, 64]
+    buckets = r._warmup_buckets()
+    # Every distinct request-count crossed with every token padding.
+    assert set(buckets) == {(t, q) for t in (2, 4, 8) for q in (1, 32, 64)}
+    assert len(buckets) == 9
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_warmup_buckets_dedup_equal_counts():
+    r = object.__new__(TTModelRunnerV2)
+    r.max_num_reqs = 4
+    r.min_num_reqs = 4
+    r.max_prefill_num_reqs = 4
+    r.num_tokens_paddings = [1, 16]
+    buckets = r._warmup_buckets()
+    # Collapsed to a single request-count bucket.
+    assert buckets == [(4, 1), (4, 16)]

--- a/tests/integrations/vllm_plugin/mrv2/test_sampling_state.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_sampling_state.py
@@ -278,8 +278,14 @@ def test_from_v2_states_allowed_token_ids_mask():
         vocab_size=VOCAB,
     )
     assert md.no_allowed_token_ids is False
-    mask = md.allowed_token_ids_mask  # additive: 0.0 allowed, -inf disallowed
-    assert tuple(mask.shape) == (2, VOCAB)
-    assert mask[0, 5].item() == 0.0
-    assert mask[0, 7].item() == 0.0
-    assert mask[0, 6].item() == float("-inf")
+    bool_mask = md.allowed_token_ids_mask  # upstream contract: True == disallowed
+    assert tuple(bool_mask.shape) == (2, VOCAB)
+    assert bool_mask[0, 5].item() is False
+    assert bool_mask[0, 7].item() is False
+    assert bool_mask[0, 6].item() is True
+
+    additive = md.allowed_token_ids_additive_mask  # 0.0 allowed, -inf disallowed
+    assert tuple(additive.shape) == (2, VOCAB)
+    assert additive[0, 5].item() == 0.0
+    assert additive[0, 7].item() == 0.0
+    assert additive[0, 6].item() == float("-inf")

--- a/tests/integrations/vllm_plugin/mrv2/test_sampling_state.py
+++ b/tests/integrations/vllm_plugin/mrv2/test_sampling_state.py
@@ -1,0 +1,285 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CPU unit tests for the MRv2 sampling bridge.
+
+``TTSamplingStates`` (see vllm_tt/sampling_state_v2.py) is the persistent
+per-slot sampling-param table, and ``XLASupportedSamplingMetadata.from_v2_states``
+gathers a batch-ordered view from it + ``TTRequestState``. Both are pure
+host-side (numpy/torch-on-cpu), so these run with no TT hardware and no model.
+
+They pin the invariants that are TT's own responsibility: the ``SamplingParams``
+extraction matching the v1 fork, the stable-slot reset on removal, and the
+batch->slot gather (via ``idx_mapping``) that feeds the sampler.
+"""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+from vllm.sampling_params import SamplingParams
+from vllm_tt.metadata import DEFAULT_SAMPLING_PARAMS, XLASupportedSamplingMetadata
+from vllm_tt.request_state import TTRequestState
+from vllm_tt.sampling_state_v2 import TTSamplingStates
+
+VOCAB = 1000
+
+
+def make_rs(max_num_reqs=4, max_model_len=32):
+    return TTRequestState(
+        max_num_reqs=max_num_reqs,
+        max_model_len=max_model_len,
+        max_num_batched_tokens=64,
+        num_speculative_steps=0,
+        vocab_size=VOCAB,
+        device="cpu",
+    )
+
+
+def make_ss(max_num_reqs=4):
+    return TTSamplingStates(max_num_reqs=max_num_reqs, vocab_size=VOCAB)
+
+
+def ib(idx_list):
+    """Minimal TTInputBatch stand-in: make_batch_view only reads these two."""
+    return SimpleNamespace(
+        num_reqs=len(idx_list),
+        idx_mapping_np=np.array(idx_list, dtype=np.int32),
+    )
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_add_request_greedy_extraction():
+    ss = make_ss()
+    ss.add_request(2, SamplingParams(temperature=0.0))
+    assert ss.temperature[2] == 0.0
+    assert bool(ss.is_greedy[2]) is True
+    # Disabled top_k (default 0) maps to vocab_size, matching the v1 fork.
+    assert ss.top_k[2] == VOCAB
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_add_request_random_extraction():
+    ss = make_ss()
+    sp = SamplingParams(
+        temperature=0.7,
+        top_p=0.9,
+        top_k=50,
+        min_p=0.1,
+        frequency_penalty=0.5,
+        presence_penalty=0.2,
+        repetition_penalty=1.3,
+        min_tokens=3,
+        logprobs=2,
+        logit_bias={5: 2.0},
+        allowed_token_ids=[1, 2, 3],
+    )
+    ss.add_request(1, sp)
+    assert bool(ss.is_greedy[1]) is False
+    assert ss.temperature[1] == pytest.approx(0.7)
+    assert ss.top_p[1] == pytest.approx(0.9)
+    assert ss.top_k[1] == 50  # in-range top_k kept verbatim
+    assert ss.min_p[1] == pytest.approx(0.1)
+    assert ss.frequency_penalties[1] == pytest.approx(0.5)
+    assert ss.presence_penalties[1] == pytest.approx(0.2)
+    assert ss.repetition_penalties[1] == pytest.approx(1.3)
+    assert ss.min_tokens[1][0] == 3
+    assert ss.num_logprobs[1] == 2
+    assert ss.logit_bias[1] == {5: 2.0}
+    assert ss.allowed_token_ids[1] == [1, 2, 3]
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_remove_request_resets_slot():
+    ss = make_ss()
+    ss.add_request(
+        0,
+        SamplingParams(
+            temperature=0.7,
+            min_tokens=2,
+            logprobs=1,
+            logit_bias={1: 1.0},
+            allowed_token_ids=[3],
+        ),
+    )
+    ss.remove_request(0)
+    assert ss.temperature[0] == DEFAULT_SAMPLING_PARAMS["temperature"]
+    assert ss.top_k[0] == DEFAULT_SAMPLING_PARAMS["top_k"]
+    assert ss.repetition_penalties[0] == DEFAULT_SAMPLING_PARAMS["repetition_penalties"]
+    assert bool(ss.is_greedy[0]) is True
+    assert 0 not in ss.min_tokens
+    assert 0 not in ss.num_logprobs
+    assert 0 not in ss.allowed_token_ids
+    assert ss.logit_bias[0] is None
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_make_batch_view_gather_order_and_padding():
+    rs = make_rs()
+    ss = make_ss()
+    rs.add_request("A", prompt_len=2, all_token_ids=[10, 11, 12], num_computed_tokens=0)
+    rs.add_request("B", prompt_len=1, all_token_ids=[20], num_computed_tokens=0)
+    slot_a = rs.req_id_to_index["A"]
+    slot_b = rs.req_id_to_index["B"]
+    ss.add_request(slot_a, SamplingParams(temperature=0.5))
+    ss.add_request(slot_b, SamplingParams(temperature=0.9))
+
+    # Batch position 0 -> slot_b, position 1 -> slot_a (reversed vs slot order).
+    view = ss.make_batch_view(rs, ib([slot_b, slot_a]), padded_num_reqs=4)
+
+    assert view.num_reqs == 2
+    assert view.temperature_cpu_tensor[0].item() == pytest.approx(0.9)
+    assert view.temperature_cpu_tensor[1].item() == pytest.approx(0.5)
+    # Padding rows carry the sampler default.
+    assert (
+        view.temperature_cpu_tensor[2].item() == DEFAULT_SAMPLING_PARAMS["temperature"]
+    )
+    # num_prompt_tokens follows batch order; padding rows are zero.
+    assert view.num_prompt_tokens.tolist() == [1, 2, 0, 0]
+    # Output tokens derived from all_token_ids[prompt_len:total_len].
+    assert view.req_output_token_ids[0] == []
+    assert view.req_output_token_ids[1] == [12]
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_make_batch_view_rekeys_dicts_to_batch_index():
+    rs = make_rs()
+    ss = make_ss()
+    rs.add_request("A", 1, [1], 0)
+    rs.add_request("B", 1, [2], 0)
+    slot_a = rs.req_id_to_index["A"]
+    slot_b = rs.req_id_to_index["B"]
+    # Populate slot-keyed dicts directly (bad_words_token_ids is a read-only
+    # SamplingParams property, so it can't come through add_request in a unit test).
+    ss.bad_words_token_ids[slot_b] = [[9]]
+    ss.min_tokens[slot_b] = (5, {0})
+    gen = torch.Generator()
+    ss.generators[slot_b] = gen
+
+    # Batch position 0 -> slot_a, position 1 -> slot_b.
+    view = ss.make_batch_view(rs, ib([slot_a, slot_b]), padded_num_reqs=4)
+
+    assert view.bad_words_token_ids == {1: [[9]]}
+    assert view.min_tokens == {1: (5, {0})}
+    assert view.generators == {1: gen}
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_flags_mixed_greedy_random():
+    rs = make_rs()
+    ss = make_ss()
+    rs.add_request("A", 1, [1], 0)
+    rs.add_request("B", 1, [2], 0)
+    slot_a = rs.req_id_to_index["A"]
+    slot_b = rs.req_id_to_index["B"]
+    ss.add_request(slot_a, SamplingParams(temperature=0.0))  # greedy
+    ss.add_request(slot_b, SamplingParams(temperature=0.8))  # random
+
+    view = ss.make_batch_view(rs, ib([slot_a, slot_b]), padded_num_reqs=2)
+    assert view.all_greedy is False
+    assert view.all_random is False
+    assert view.no_penalties is True
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_from_v2_states_all_greedy_minimal():
+    rs = make_rs()
+    ss = make_ss()
+    rs.add_request("A", 2, [10, 11], 0)
+    slot_a = rs.req_id_to_index["A"]
+    ss.add_request(slot_a, SamplingParams(temperature=0.0))
+
+    md = XLASupportedSamplingMetadata.from_v2_states(
+        rs,
+        ss,
+        ib([slot_a]),
+        padded_num_reqs=4,
+        xla_device=torch.device("cpu"),
+        vocab_size=VOCAB,
+    )
+    assert md.all_greedy is True
+    assert md.no_penalties is True
+    # Early-return minimal path leaves the param tensors unset.
+    assert md.temperature is None
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_from_v2_states_penalties_path():
+    rs = make_rs()
+    ss = make_ss()
+    rs.add_request("A", 2, [10, 11], 0)
+    slot_a = rs.req_id_to_index["A"]
+    ss.add_request(slot_a, SamplingParams(temperature=0.7, frequency_penalty=0.5))
+
+    md = XLASupportedSamplingMetadata.from_v2_states(
+        rs,
+        ss,
+        ib([slot_a]),
+        padded_num_reqs=4,
+        xla_device=torch.device("cpu"),
+        vocab_size=VOCAB,
+    )
+    assert md.no_penalties is False
+    assert md.temperature is not None
+    assert md.output_token_counts is not None
+    assert tuple(md.output_token_counts.shape) == (4, VOCAB)
+    assert md.prompt_token_mask is not None
+    assert tuple(md.prompt_token_mask.shape) == (4, VOCAB)
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_from_v2_states_seeded_generators_build_q_samples():
+    rs = make_rs()
+    ss = make_ss()
+    rs.add_request("A", 2, [10, 11], 0)
+    slot_a = rs.req_id_to_index["A"]
+    gen = torch.Generator()
+    gen.manual_seed(123)
+    ss.add_request(slot_a, SamplingParams(temperature=0.7), generator=gen)
+
+    md = XLASupportedSamplingMetadata.from_v2_states(
+        rs,
+        ss,
+        ib([slot_a]),
+        padded_num_reqs=4,
+        xla_device=torch.device("cpu"),
+        vocab_size=VOCAB,
+    )
+    assert md.no_generators is False
+    assert md.q_samples is not None
+    assert tuple(md.q_samples.shape) == (4, VOCAB)
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_from_v2_states_allowed_token_ids_mask():
+    rs = make_rs()
+    ss = make_ss()
+    rs.add_request("A", 1, [10], 0)
+    slot_a = rs.req_id_to_index["A"]
+    ss.add_request(slot_a, SamplingParams(temperature=0.7, allowed_token_ids=[5, 7]))
+
+    md = XLASupportedSamplingMetadata.from_v2_states(
+        rs,
+        ss,
+        ib([slot_a]),
+        padded_num_reqs=2,
+        xla_device=torch.device("cpu"),
+        vocab_size=VOCAB,
+    )
+    assert md.no_allowed_token_ids is False
+    mask = md.allowed_token_ids_mask  # additive: 0.0 allowed, -inf disallowed
+    assert tuple(mask.shape) == (2, VOCAB)
+    assert mask[0, 5].item() == 0.0
+    assert mask[0, 7].item() == 0.0
+    assert mask[0, 6].item() == float("-inf")


### PR DESCRIPTION
Part of #5715, for Model Runner v2. The v1 half landed on `main` as `b1f76f33d` (#5808), and brought the shared collector, the visualizer, the examples and the scheduler-side hook with it. This PR adds the runner-side collector to `TTModelRunnerV2`.

> **Base:** this PR targets `akhan/vllm-v2-features`, since the hooks live in `TTModelRunnerV2`. Retarget to `main` once MRv2 merges.

## What this PR changes

Five files. Two are the work:

| File | Change |
|---|---|
| `vllm_tt/model_runner_v2.py` | +89 — the collector, admit/complete hooks, the pass classifier, and the pass-loop tally |
| `tests/integrations/vllm_plugin/mrv2/test_runner_telemetry.py` | +337 — 14 test functions, 17 collected, marked `push` + `cpu` |

Three are already-merged shared files that carry a v2 delta:

- `vllm_tt/telemetry.py` — the `on_step` docstring attributed the multi-token accept path to the v1 runner; both runners run ngram spec decode now.
- `examples/vllm/telemetry/README.md` — names both runners, and its slot-output section covers v2's persistent slot table alongside v1's condensing batch.
- `examples/vllm/telemetry/run_telemetry_demo.py` — its comment named v1 as the default runner.

## How the v2 hooks work

- **They live in `_run_pass_loop`**, which this base introduced when it split `sample_tokens`. The loop returns `(prefill_passes, decode_passes, emitted_tokens)` and `sample_tokens` emits from that tally.
- **Pass classification survives speculative decode.** A pass counts as prefill when any scheduled row still has computed tokens below its prefill boundary, read before `postprocess`. Two simpler tests fail: row state *after* the pass calls a completed single-shot prefill a decode pass, and tokens-per-row calls a spec-decode verification pass a prefill pass, since a decoding row is scheduled `1 + num_speculative_tokens`.
- **Accepted-tokens/step is live here.** This base ports ngram speculative decode to v2 (`946d30a65`): `postprocess` commits every accepted draft, so a row can contribute several tokens in one step and the hook sums per-row lengths.
- **`readmission` fires rarely on v2.** The slot table holds a request across steps, so it triggers only when an id arrives while a stale slot still holds it (abort + resubmit). v1 re-admits routinely. A v2 request resumed from preemption arrives as a fresh request and shows as nonzero `num_cached_tokens` instead.
- **Off by default and zero-cost when off**: one cached bool on the hot path, plus a class-level disabled collector so instances built without `__init__` inherit it.

## What it builds on (already merged)

`main` carries the rest, so none of it is in this diff:

| Piece | Where |
|---|---|
| `SchedulerTelemetry` + the `AscendScheduler` hook | `vllm_tt/scheduler/ascend_scheduler.py` |
| `RunnerTelemetry` / `SchedulerTelemetry` collectors, sink and flush policy | `vllm_tt/telemetry.py` |
| Config resolution and env gating | `vllm_tt/platform.py` |
| Visualizer (`report` / `live`) | `scripts/telemetry/telemetry_viz.py` |
| README, three demos, HTTP load generator | `examples/vllm/telemetry/` |

The two collectors run in separate processes and write separate JSON-lines sinks (`scheduler.jsonl`, `runner.jsonl`, `runner_snapshot.json`), correlated offline on `request_id`. The scheduler answers *intent* — prefill vs decode, preemption, queue depth, KV/batch utilization, watermark rejects, b1-cap hits. This PR supplies the *reality* half on v2: slot occupancy, executed pass split, actual decode rate, per-request lifecycle.

## Testing

`-m "push and cpu"` over `tests/integrations/vllm_plugin` collects the new file; the mrv2 suite covers gating, env precedence, buffered flush, record schemas, disabled ⇒ zero files, and the cached-token and re-admission signals.

Measured on n150 (wh-17) under vLLM 0.26.0, Qwen3-0.6B, one run per scenario.

| Scenario | steps | peak slots | prefill / decode passes | tokens | tok/s median | notes |
|---|---|---|---|---|---|---|
| `run_telemetry_demo.py` | 33 | 4 / 4 | 2 / 31 | 128 | 40.0 | 2 prefill-stalled steps |
| `run_telemetry_oversubscribed.py` | 97 | 4 / 4 | 3 / 94 | 384 | 39.7 | max queue depth 4 |
| `run_telemetry_memory_pressure.py` | 200 | 16 / 16 | 12 / 188 | 768 | 27.1 | KV pinned at 95%, 1621 watermark rejects, 0 preemptions |
| `api_load_test.py` (live server) | 131 | 4 / 4 | 7 / 124 | 512 | 39.3 | 7 prefill-stalled steps |

The pass split agrees with the v1 runner to within one pass on every scenario (2/31, 3/94, 12/188, 7–8/124), from independently written hooks over different state models.

Running the same four scenarios with `use_v2_model_runner: False` also shows what the telemetry is for: under 0.26.0 the memory-pressure case costs v2 ~2.7x the decode rate it reached under 0.25.1 (73.3 → 27.1 tok/s), because v2 now fills all 16 slots and chunks prefill to a 95% KV peak instead of single-shot prefilling 8 rows at 75%. Deterministic across two runs; v1 is unchanged in that scenario. Under `vllm serve` the gap runs the other way — v1's median step is 443.2 ms against v2's 101.7 ms on identical work.

## What the output looks like

The merged visualizer rendering v2 telemetry from the three demos. These captures predate the pass-classification fix, so their prefill/decode split differs from the table above; the occupancy, decode-rate and utilization panels are unaffected.

Simple:

<img width="1126" height="1746" alt="image" src="https://github.com/user-attachments/assets/6054aba6-57dc-4093-b905-08a4c797cb71" />

Oversubcribed:

<img width="1099" height="1842" alt="image" src="https://github.com/user-attachments/assets/38dad7b3-6bbd-4e5a-938b-04025808d157" />

Memory pressure:

<img width="1100" height="1704" alt="image" src="https://github.com/user-attachments/assets/e49997f9-5d3f-4199-aadd-3f0cc82bb254" />

## Notes

- Draft until MRv2 stabilises, per the review note on this PR.
- Carries a second commit that fixes the base's `MultiGroupBlockTable` call for vLLM 0.26.0. `TTModelRunnerV2.__init__` raises `TypeError` without it, so no engine starts on the default runner and 14 mrv2 init tests fail. Drop that commit once the base fixes the call.
- Pooling-runner telemetry is scoped separately in #5812 and deferred.
- Primary consumers to validate against: #4891 / #4301 (batch-32 prefill efficiency), #5034 (decode regression).
- Telemetry output defaults under `tt_telemetry/`, git-ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

