### PR TITLE
[vLLM] Shard fill_page_table in warm-up to fix DP+TP chunked-prefill hang

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -2646,6 +2646,11 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             fill_page_table = torch.zeros((num_reqs, num_blocks), dtype=torch.int32).to(
                 self.device
             )
+            if self.parallel_mode in (
+                ParallelismMode.DATA_PARALLEL_ONLY,
+                ParallelismMode.DATA_TENSOR_PARALLEL,
+            ):
+                safe_mark_sharding(fill_page_table, self.mesh, ("batch", None))
             chunk_start_idx = torch.zeros((1,), dtype=torch.int32).to(self.device)
 
         attn_metadata = TTMetadata(
@@ -3085,6 +3090,11 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             fill_page_table = torch.zeros(
                 (num_reqs, self.max_num_blocks_per_req), dtype=torch.int32
             ).to(self.device)
+            if self.parallel_mode in (
+                ParallelismMode.DATA_PARALLEL_ONLY,
+                ParallelismMode.DATA_TENSOR_PARALLEL,
+            ):
+                safe_mark_sharding(fill_page_table, self.mesh, ("batch", None))
             chunk_start_idx = torch.zeros((1,), dtype=torch.int32).to(self.device)
 
         attn_metadata = TTMetadata(


### PR DESCRIPTION
### Problem description
Closes #5734 

DP+TP chunked prefill hangs the device during engine init. `ttnn.paged_fill_cache` receives a **tilized** page table:

```
%arg1 = tensor<32x32xsi32>, memref<32x32xsi32>              row-major, global batch
%76   = ttnn.mesh_partition(%arg1) {cluster_axis=0, dim=0}   -> 16x32, still row-major
%83   = ttnn.to_layout(%76)                                  -> !ttcore.tile<32x32, si32>   TILE
        ttnn.paged_fill_cache(cache, fill, %83, batch_idx)    -> device timeout / hang
```

`fill_page_table` is a second page table, created only for chunked prefill (`page_table` rolled per row so the fill writes suffix blocks instead of overwriting the cached prefix). `_prepare_inputs` shards it, but `_dummy_run` and `_get_dummy_inputs` create it *after* the block that shards `page_table` / `cache_position` / `batch_idx`, so the warm-up graph takes it replicated. Shardy then has to `all_slice` it into a `mesh_partition`, and the resulting value, no longer a func arg, gets the default TILE layout. Page tables that stay func args are row-major.

Needs both DP and chunked prefill, which is why nothing caught it: without chunking `fill_page_table is page_table` (already sharded), and TP-only has no batch axis to slice on.

Same class as #5579 (`insertTiledFixup` tilizing the SDPA page_table), but reached via the reshard. SDPA has `TT_FATAL: Page table must be row major`; `paged_fill_cache` has no such guard, so it hangs silently instead.

### What's changed

Shard `fill_page_table` on `("batch", None)` in both warm-up builders, matching `_prepare_inputs`. These are `torch.zeros` placeholders, so this only affects the traced graph's input sharding, so no numerical change. Also makes warm-up input shardings match the runtime step, removing a latent recompile on the first continuation chunk.

### Test

n300-llmbox (2x4 mesh), Qwen3-0.6B, `prefill_chunk_size=128`, `max_model_len=1024`, batch 32 and 64:

| | before | after |
|---|---|---|
| `mesh_partition` on si32 | 1 | 0 |
| page table at `paged_fill_cache` | TILE | ROW_MAJOR |
| result | hang (`device timeout, unrecoverable`) | runs to completion |

Also verified unaffected: TP-only + chunked, and DP+TP without chunking (both already row-major, still pass).