### PR TITLE
[vLLM] Add DP+TP chunked-prefill tests

### DIFF
--- a/tests/integrations/vllm_plugin/generative/conftest.py
+++ b/tests/integrations/vllm_plugin/generative/conftest.py
@@ -112,6 +112,31 @@ def assert_batch_grounded(outputs, checks=GROUNDED_BATCH_CHECKS) -> None:
         ), f"expected {expected!r} for {prompt!r}, got {text!r}"
 
 
+def assert_slots_agree(outputs, prompts) -> None:
+    """Slots sharing a prompt must generate identical, coherent output.
+
+    The batch repeats a few base prompts, so greedy sampling makes slots holding
+    the same prompt directly comparable and a mismatch names the corrupted slot.
+    Coherence is checked too, since equality alone would pass if every slot were
+    identically garbled.
+    """
+    n = len(dict.fromkeys(prompts))
+    token_ids = [list(out.outputs[0].token_ids) for out in outputs]
+
+    for i, out in enumerate(outputs):
+        text = out.outputs[0].text
+        print(f"slot {i} (prompt {i % n}): {text}")
+        assert_output_coherent(text)
+
+    for i in range(n, len(token_ids)):
+        ref = i % n
+        assert token_ids[i] == token_ids[ref], (
+            f"slot {i} disagrees with slot {ref} on an identical prompt under "
+            "greedy decoding -- that slot's KV state is corrupt.\n"
+            f"  slot {ref}: {token_ids[ref]}\n  slot {i}: {token_ids[i]}"
+        )
+
+
 def check_host_memory(model_name: str) -> float:
     """Assert child process RSS is below the known threshold for a model.
 

--- a/tests/integrations/vllm_plugin/generative/test_data_tensor_parallel_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_data_tensor_parallel_generation.py
@@ -14,6 +14,7 @@ from conftest import (
     GROUNDED_BATCH_CHECKS,
     assert_batch_grounded,
     assert_output_coherent,
+    assert_slots_agree,
     check_host_memory,
 )
 
@@ -89,6 +90,120 @@ def test_data_tensor_parallel_generation_wider_batch(model_name: str):
     for (prompt, _), out in zip(checks, outputs):
         print(f"prompt: {prompt}, output: {out.outputs[0].text}")
     assert_batch_grounded(outputs, checks)
+
+    check_host_memory(model_name)
+
+
+@pytest.mark.nightly
+@pytest.mark.data_parallel
+@pytest.mark.tensor_parallel
+@pytest.mark.llmbox
+@pytest.mark.parametrize("batch_size", [32, 64])
+@pytest.mark.parametrize("model_name", ["Qwen/Qwen3-0.6B"])
+def test_data_tensor_parallel_chunked_prefill_llmbox(model_name: str, batch_size: int):
+    """Chunked prefill under DP+TP on llmbox (tt-xla #4986/#5691)."""
+    prompts = [
+        "Continue in English: I like taking walks in the evening after work, "
+        "usually along the river path that starts behind the old train station "
+        "and follows the water for about two miles before it turns back toward "
+        "the main road, and on a clear night you can see the lights of the town "
+        "reflected in the water while people cycle past and dogs run ahead of "
+        "their owners, and by the time I reach the bridge the shops have closed "
+        "and the streets are quiet enough that I can hear my own footsteps, and "
+        "it gives me time to think about everything that happened during the day "
+        "before I go home and start cooking dinner, which is why the part of the "
+        "day I look forward to most is",
+        "Continue in English: The weather today is",
+        "Continue in English: My favourite season is autumn, mostly because the "
+        "air turns cool enough for a jacket but not so cold that you dread going "
+        "outside, and the trees along my street change colour over about two "
+        "weeks until the whole road is orange and red and the pavement is "
+        "covered in leaves that crunch when you step on them, and the evenings "
+        "get dark early enough that the windows of the houses all light up by "
+        "six o'clock, which makes the walk home feel warmer than it actually is, "
+        "and on the weekends there is usually enough sun to sit outside with a "
+        "coffee for an hour, and I always tell myself that this year I will take "
+        "more photographs before the leaves are gone, so the thing I look "
+        "forward to every year is",
+        "Continue in English: The best book I have read is",
+    ] * (batch_size // 4)
+    sampling_params = vllm.SamplingParams(temperature=0.0, max_tokens=32)
+    llm_args = {
+        "model": model_name,
+        "max_num_seqs": batch_size,
+        "max_model_len": 1024,
+        "gpu_memory_utilization": 0.25,
+        "additional_config": {
+            "min_context_len": 32,
+            "enable_tensor_parallel": True,
+            "enable_data_parallel": True,
+            "cpu_sampling": False,
+            "prefill_chunk_size": 128,
+        },
+    }
+    llm = vllm.LLM(**llm_args)
+
+    outputs = llm.generate(prompts, sampling_params)
+    assert len(outputs) == len(prompts)
+    assert_slots_agree(outputs, prompts)
+
+    check_host_memory(model_name)
+
+
+@pytest.mark.nightly
+@pytest.mark.data_parallel
+@pytest.mark.tensor_parallel
+@pytest.mark.llmbox
+@pytest.mark.parametrize("batch_size", [32, 64])
+@pytest.mark.parametrize("model_name", ["Qwen/Qwen3-8B"])
+def test_data_tensor_parallel_chunked_prefill_llmbox_large(
+    model_name: str, batch_size: int
+):
+    """Chunked prefill under DP+TP on llmbox with TP-sharded 8B weights."""
+    prompts = [
+        "Continue in English: I like taking walks in the evening after work, "
+        "usually along the river path that starts behind the old train station "
+        "and follows the water for about two miles before it turns back toward "
+        "the main road, and on a clear night you can see the lights of the town "
+        "reflected in the water while people cycle past and dogs run ahead of "
+        "their owners, and by the time I reach the bridge the shops have closed "
+        "and the streets are quiet enough that I can hear my own footsteps, and "
+        "it gives me time to think about everything that happened during the day "
+        "before I go home and start cooking dinner, which is why the part of the "
+        "day I look forward to most is",
+        "Continue in English: The weather today is",
+        "Continue in English: My favourite season is autumn, mostly because the "
+        "air turns cool enough for a jacket but not so cold that you dread going "
+        "outside, and the trees along my street change colour over about two "
+        "weeks until the whole road is orange and red and the pavement is "
+        "covered in leaves that crunch when you step on them, and the evenings "
+        "get dark early enough that the windows of the houses all light up by "
+        "six o'clock, which makes the walk home feel warmer than it actually is, "
+        "and on the weekends there is usually enough sun to sit outside with a "
+        "coffee for an hour, and I always tell myself that this year I will take "
+        "more photographs before the leaves are gone, so the thing I look "
+        "forward to every year is",
+        "Continue in English: The best book I have read is",
+    ] * (batch_size // 4)
+    sampling_params = vllm.SamplingParams(temperature=0.0, max_tokens=32)
+    llm_args = {
+        "model": model_name,
+        "max_num_seqs": batch_size,
+        "max_model_len": 1024,
+        "gpu_memory_utilization": 0.25,
+        "additional_config": {
+            "min_context_len": 32,
+            "enable_tensor_parallel": True,
+            "enable_data_parallel": True,
+            "cpu_sampling": False,
+            "prefill_chunk_size": 128,
+        },
+    }
+    llm = vllm.LLM(**llm_args)
+
+    outputs = llm.generate(prompts, sampling_params)
+    assert len(outputs) == len(prompts)
+    assert_slots_agree(outputs, prompts)
 
     check_host_memory(model_name)
 


### PR DESCRIPTION
### Problem description

#5692 broadened chunked-prefill coverage to single-chip, TP-only and DP-only, but skipped DP+TP. All three existing DP+TP tests use `max_model_len=32` with prompts that fit in one chunk, so the cached-prefix chunked-SDPA path was never exercised on a 2D mesh.

### What's changed

Two nightly llmbox tests (Qwen3-0.6B and Qwen3-8B), parametrized on `batch_size` 32 and 64, with `prefill_chunk_size=128` and `max_model_len=1024`. Each batch mixes prompts longer than the chunk (so they split and route chunks 2..N through the cached-prefix path) with short single-chunk prompts, so one step contains sequences at different prefill stages.

`assert_slots_agree` in conftest: the batch repeats a few base prompts, so under greedy sampling slots holding the same prompt must produce identical token ids and a mismatch names the corrupted slot. Coherence is asserted too, since equality alone passes if every slot is identically garbled.

### Test

Validated on n300-llmbox (2x4 mesh). Draft because these currently **fail**, due to two bugs found:

1. Device hang: `paged_fill_cache` got a tilized page table under DP+TP chunked prefill. Fixed by #5797; these tests need it to get past engine init.
2. Output corruption: with #5797 applied the tests run to completion, but slots holding the same prompt diverge. Short single-chunk prompts are corrupted only when batched alongside multi-chunk ones, so it looks related to rows sitting at different prefill stages in one step. Still under investigation. Not sure if #5799 alone fixes it.

Will un-draft once those land and the tests pass.