### PR TITLE
[vLLM] DP+TP chunked prefill: sharding and buffer-sizing fixes

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -565,7 +565,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             self.max_num_reqs,
         )
         self.query_start_loc_cpu = torch.zeros(
-            self.max_num_tokens + 1,
+            self.max_num_reqs + 1,
             dtype=torch.int32,
             device="cpu",
             pin_memory=self.pin_memory,
@@ -573,7 +573,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self.query_start_loc_np = self.query_start_loc_cpu.numpy()
 
         self.seq_lens_cpu = torch.zeros(
-            self.max_num_tokens,
+            self.max_num_reqs,
             dtype=torch.int32,
             device="cpu",
             pin_memory=self.pin_memory,

--- a/integrations/vllm_plugin/vllm_tt/vllm_distributed_utils.py
+++ b/integrations/vllm_plugin/vllm_tt/vllm_distributed_utils.py
@@ -318,8 +318,8 @@ def partition_column_parallel_linear(
     layer: torch.nn.Module, mesh: xs.Mesh, shard_weights_on_batch_axis: bool = True
 ) -> torch.nn.Module:
     assert isinstance(layer, ColumnParallelLinear)
-    # Weight is [output, input]: output on the "model" (TP) axis, input replicated.
-    safe_mark_sharding(layer.weight, mesh, ("model", None))
+    batch_axis = "batch" if shard_weights_on_batch_axis else None
+    safe_mark_sharding(layer.weight, mesh, ("model", batch_axis))
     logger.debug("Applied parallel sharding to %s", layer)
     return layer
 


### PR DESCRIPTION
## Problem

Chunked prefill at batch 256 on an 8x4 DP+TP mesh (Qwen3-32B) compiles, then dies at the first generation step:

```
ValueError: provided out is the wrong size for the accumulation
```

`query_start_loc_cpu` and `seq_lens_cpu` are indexed per request but were sized by `max_num_tokens`. Without chunked prefill `max_num_tokens >= max_num_seqs` always held. Under chunked prefill `max_num_tokens` is the per-sequence chunk budget (128), smaller than `max_num_seqs` (256), so `np.cumsum` rejects the short `out=` slice.

Separately, `partition_column_parallel_linear` accepts `shard_weights_on_batch_axis` but ignores it, unlike its Merged and QKV siblings.

## What's changed

Size `query_start_loc_cpu` and `seq_lens_cpu` by `max_num_reqs`, since every use site is request-indexed and `num_reqs` is always clamped to it.

Honor `shard_weights_on_batch_axis` in `partition_column_parallel_linear`. No effect on Qwen3-32B, which instantiates no bare `ColumnParallelLinear`.

Verified on a 32 chip Blackhole galaxy, mesh (8,4), Qwen3-32B with chunked prefill. Batch 256 completes 256/256 prompts at 1024 and 16384 context on a 2 layer model. Batch 16 at 4096 context on the full 64 layer model generates coherent output, with identical single-chunk prompts in different batch rows producing byte-identical results.

_**Note**_: An earlier revision of this PR also pinned the users dim on `RowParallelLinear` output to work around a missing users factor in the tt-mlir chunked SDPA sharding rule. That workaround has been dropped in favour of fixing the rule itself, tenstorrent/tt-mlir#9135 and tenstorrent/tt-mlir#9142.
