### PR TITLE
[vLLM] Fix global vs local row indexing in multi-pass prefill

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -1362,7 +1362,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         for i, n in enumerate(num_scheduled_tokens_per_req):
             positions = (
                 torch.arange(n, dtype=torch.int32)
-                + self.input_batch.num_computed_tokens_cpu[i]
+                + self.input_batch.num_computed_tokens_cpu[start_index + i]
             )
             if self.uses_mrope:
                 arange[:, i, :n] = positions
@@ -1381,9 +1381,9 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # Fill input_ids with the newly scheduled tokens for each request, starting
         # from the current computed token offset.
         for i, n in enumerate(num_scheduled_tokens_per_req):
-            computed_tokens = self.input_batch.num_computed_tokens_cpu[i]
+            computed_tokens = self.input_batch.num_computed_tokens_cpu[start_index + i]
             input_ids_cpu[i, :n] = self.input_batch.token_ids_cpu_tensor[
-                i, computed_tokens : n + computed_tokens
+                start_index + i, computed_tokens : n + computed_tokens
             ]
 
         # Move input_ids and position_ids to the target device for execution.
@@ -1410,7 +1410,9 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self.query_start_loc_np[num_reqs + 1 :] = 1
 
         self.seq_lens_np[:num_reqs] = (
-            self.input_batch.num_computed_tokens_cpu[:num_reqs]
+            self.input_batch.num_computed_tokens_cpu[
+                start_index : start_index + num_reqs
+            ]
             + num_scheduled_tokens_per_req
         )
 
@@ -1419,22 +1421,24 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             page_table = self.block_table_cpu[
                 :target_num_reqs, : self.max_num_blocks_per_req
             ]
-            page_table[:actual_num_reqs, : self.max_num_blocks_per_req] = (
-                self.input_batch.block_table[0].get_cpu_tensor()[
-                    :actual_num_reqs, : self.max_num_blocks_per_req
-                ]
-            )
+            page_table[
+                :actual_num_reqs, : self.max_num_blocks_per_req
+            ] = self.input_batch.block_table[0].get_cpu_tensor()[
+                start_index : start_index + actual_num_reqs,
+                : self.max_num_blocks_per_req,
+            ]
             seq_lens = self.seq_lens_cpu[: self.num_reqs_max_model_len]
         else:
             assert self.num_reqs_most_model_len is not None
             page_table = self.block_table_cpu[
                 :target_num_reqs, : self.num_blocks_per_most_len_req
             ]
-            page_table[:actual_num_reqs, : self.num_blocks_per_most_len_req] = (
-                self.input_batch.block_table[0].get_cpu_tensor()[
-                    :actual_num_reqs, : self.num_blocks_per_most_len_req
-                ]
-            )
+            page_table[
+                :actual_num_reqs, : self.num_blocks_per_most_len_req
+            ] = self.input_batch.block_table[0].get_cpu_tensor()[
+                start_index : start_index + actual_num_reqs,
+                : self.num_blocks_per_most_len_req,
+            ]
             seq_lens = self.seq_lens_cpu[: self.num_reqs_most_model_len]
 
         cache_position = seq_lens - 1
@@ -1450,7 +1454,9 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # different prefix length, so we roll per-row. Done outside the
         # compiled graph to avoid shape-change recompilation.
         offsets = (
-            self.input_batch.num_computed_tokens_cpu[:actual_num_reqs]
+            self.input_batch.num_computed_tokens_cpu[
+                start_index : start_index + actual_num_reqs
+            ]
             // self.block_size
             if actual_num_reqs > 0
             else np.array([], dtype=np.int64)
@@ -1524,7 +1530,9 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # Cached-prefix prefill chunk (L > 1 and num_computed > 0): attends over
         # the paged cache via the chunked SDPA op. Decode (L == 1) and first-chunk
         # prefill take the standard path (chunk_start_idx stays None).
-        num_computed_for_reqs = self.input_batch.num_computed_tokens_cpu[:num_reqs]
+        num_computed_for_reqs = self.input_batch.num_computed_tokens_cpu[
+            start_index : start_index + num_reqs
+        ]
         prefix_chunk_step = padded_total_num_scheduled_tokens > 1 and bool(
             np.any(num_computed_for_reqs > 0)
         )


### PR DESCRIPTION
### Problem description

`_prepare_inputs` handles rows `[start_index, num_reqs)` of `input_batch`, but reads per-request state with **local** 0-based indices:

```python
+ self.input_batch.num_computed_tokens_cpu[i]                      # needs start_index + i
computed_tokens = self.input_batch.num_computed_tokens_cpu[i]
input_ids_cpu[i, :n] = self.input_batch.token_ids_cpu_tensor[i, ...]
self.seq_lens_np[:num_reqs] = self.input_batch.num_computed_tokens_cpu[:num_reqs] + ...
page_table[:actual_num_reqs] = ...block_table[0].get_cpu_tensor()[:actual_num_reqs]
```

The caller uses the right convention (`local_idx = i - start_index`, `model_runner.py:2328`), so on any pass with `start_index > 0` the requests are fed the **first** N rows' prompt tokens, computed-token offsets and block tables instead of their own.

Multi-pass fires whenever the prefill row cap trims the batch — i.e. when `max_prefill_num_seqs` is set, or `num_reqs_max_model_len` (SMEM) is below `max_num_seqs`. With the default (no cap) there is a single pass and this is dormant.

### What's changed

Offset the 8 `input_batch` reads by `start_index`. Destinations stay local — only the source indexing changes.

### Test

n300-llmbox, Qwen3-0.6B, TP-only, no chunking, batch 64, uniform 96-token prompt (so all 64 slots must produce identical greedy output), `max_prefill_num_seqs=16` to force 4 passes:

| | correct rows |
|---|---|
| before | 17/64 — only pass 1 (`start_index=0`) plus the 1-row warm step |
| after | **64/64** |

Corruption boundaries lined up exactly with the logged pass boundaries (`start_index=0/16/32/48`), and the failing rows re-emitted the *start* of their prompt, consistent with reading another row's state.

Found while investigating DP+TP chunked-prefill accuracy; unrelated to that root cause, filed separately since it is a standalone latent bug.

### Note

Setting `max_prefill_num_seqs` under data parallelism separately trips `assert max_num_scheduled_tokens_all_reqs > 0`: the cap slices the first N rows positionally, but DP intentionally retains already-prefilled requests as inert zero-scheduled rows (`model_runner.py:934-943`), so a pass can select N rows that are all inert. Not addressed here.