### PR TITLE
Dump non-XLA tensors with DEBUG logger level

### DIFF
--- a/python_package/tt_torch/backend/backend.py
+++ b/python_package/tt_torch/backend/backend.py
@@ -611,9 +611,10 @@ class XLAExecutor:
         for arg in args:
             if isinstance(arg, torch.Tensor) and arg.device.type != "xla":
                 logger.warning(
-                    f"Found an argument on non-XLA device: {arg}. "
+                    f"Found an argument on non-XLA device: {arg.shape}, {arg.dtype}. "
                     "Passing a non-XLA tensor to TT compile was likely not intended. Force moving the argument to XLA."
                 )
+                logger.debug(f"Moving an argument to XLA device: {arg}")
                 arg = arg.to(torch.device("xla"))
             moved_args.append(arg)
         args = tuple(moved_args)


### PR DESCRIPTION
### Problem description
In nightly CI, some jobs fail with:

> This step has been truncated due to its large size. View the raw logs from the ... menu once the workflow run has completed.

Example: https://github.com/tenstorrent/tt-xla/actions/runs/30055773238/job/89439690149

Debugging showed `deepseek-ai/DeepSeek-V2-Lite` emits many tt-xla WARNING logs for `Found an argument on non-XLA device`, and those warnings print full tensor values. That spam bloats the log until GitHub truncates the step.

### What's changed
- Print tensor shape and dtype with warning message.
- Print tensor values if debug log is enabled. 