### PR TITLE
[vLLM] Serving telemetry for the v1 model runner (#5715)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ tests/benchmark/reference_outputs/*.refpt
 
 # Tracy profiling files
 /tracy_artifacts/
+
+# vLLM serving telemetry output (issue #5715); default dir is <cwd>/tt_telemetry
+tt_telemetry/

--- a/examples/vllm/telemetry/README.md
+++ b/examples/vllm/telemetry/README.md
@@ -1,0 +1,257 @@
+# vLLM Serving Telemetry
+
+Env-gated instrumentation for the vLLM TT serving path
+([issue #5715](https://github.com/tenstorrent/tt-xla/issues/5715)). It exposes
+the scheduling/runtime signals that are otherwise invisible when debugging
+serving performance (KV thrashing, prefill stalling decode, batch under-fill),
+as JSON-lines you can inspect or visualize.
+
+Two layers are instrumented, because they answer different questions:
+
+| Layer | Process | Answers |
+|---|---|---|
+| **Scheduler** (`AscendScheduler`) | EngineCore | *intent* — what each step decided: prefill vs decode, preemption, queue depth, KV/batch utilization |
+| **Runner** (`TTModelRunner`) | Worker | *reality* — batch occupancy, executed prefill/decode pass split, actual decode rate, per-request lifecycle |
+
+The two run in separate processes and each writes its own sink; records carry
+`request_id` (+ a monotonic `step`) so you can join them offline.
+
+Telemetry is **off by default** and **zero-cost when off** (a single boolean
+check on the hot path). When on, it never does per-step disk I/O — records
+buffer in memory and flush on an interval, at request completion, and at exit.
+
+## Enabling it
+
+Two equivalent ways; **environment variables take precedence** over
+`additional_config` (same pattern as `prefill_kv_watermark`).
+
+### Environment variables
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `TTXLA_TELEMETRY` | unset (off) | truthy (`1`/`true`/`yes`/`on`) enables emission |
+| `TTXLA_TELEMETRY_DIR` | `./tt_telemetry` | output directory for the sinks |
+| `TTXLA_TELEMETRY_FLUSH_MS` | `1000` | minimum gap between disk flushes |
+
+```bash
+TTXLA_TELEMETRY=1 TTXLA_TELEMETRY_DIR=./tt_telemetry \
+  vllm serve Qwen/Qwen3-0.6B \
+    --max-num-seqs 4 --max-model-len 1024 --max-num-batched-tokens 4096
+```
+
+### `additional_config` knobs
+
+```python
+llm = vllm.LLM(
+    model="Qwen/Qwen3-0.6B",
+    additional_config={
+        "telemetry_enabled": True,
+        "telemetry_dir": "tt_telemetry",
+        "telemetry_flush_ms": 200,
+    },
+)
+```
+
+### Requirements
+
+- **The v1 model runner** (`TTModelRunner`) — the runner-side collector lives
+  there, so no `additional_config` routing knob is needed. Pooling models use
+  `pooling_runner.py` and emit no runner telemetry.
+- Scheduler-side telemetry is emitted for any non-pooling model (which use
+  `AscendScheduler`), independent of the runner.
+
+### Reading v1 slot output
+
+v1's `InputBatch` is a *condensing* batch: when a request leaves, later rows
+compact down to fill the gap, so a row index is not a stable identity across
+steps. Occupancy, utilization, and the pass split are exact; a per-row timeline
+shows row **reuse** rather than a request holding one slot for its lifetime.
+Join on `request_id` (not `slot`) when following a single request.
+
+Two consequences show up in real output. From a 4-prompt run on n150:
+
+```
+adm 0-94dd32b8 slot 0 step 0 prompt 8 cached 0 hit False readmission False
+adm 1-a7a7ee6c slot 0 step 1 ...
+adm 0-94dd32b8 slot 3 step 2 prompt 8 cached 8 hit True  readmission True
+```
+
+- **A request can be admitted more than once.** Unscheduling a request removes
+  it from the persistent batch; it is re-added later, typically at a different
+  row (here `0-94dd32b8` moves row 0 -> row 3). So `request_admitted` records
+  outnumber requests — 5 records for 4 requests above. Counting requests served
+  means counting distinct `request_id`, or filtering `readmission == false`.
+  These records *are* the re-admission signal, useful in their own right.
+- **A re-admitted request reports `prefix_cache_hit`** against its own
+  already-computed prefix (`cached 8` of an 8-token prompt), which is a true
+  cache hit but not the cross-request hit you are usually hunting. Filter on
+  `readmission` when looking for the latter.
+
+## Output files
+
+Written under the telemetry directory:
+
+| File | Contents |
+|---|---|
+| `scheduler.jsonl` | one record per `schedule()` step: `num_running`, `num_waiting`, `batch_util`, `kv_util`, prefill/decode counts, `preempted`, `decode_gated` (+ `decodes_displaced`), `watermark_rejects`, `b1_cap_hit`, and `cum_*` run totals |
+| `runner.jsonl` | per-step records (`slots_occupied/free`, `num_prefilling/decoding`, `prefill_passes`, `decode_passes`, `emitted_tokens`, `decode_rate_toks_per_s`) plus `request_admitted` / `request_completed` events |
+| `runner_snapshot.json` | latest per-slot state, atomically overwritten — a cheap "current state" view for live monitoring |
+
+Decode rate is defined as **accepted tokens / step**, so it stays meaningful if
+speculative decode lands.
+
+## Quick start
+
+```bash
+source venv/activate
+python examples/vllm/telemetry/run_telemetry_demo.py
+```
+
+Each demo writes to its own subfolder under `tt_telemetry/` by default
+(`tt_telemetry/demo`, `.../oversubscribed`, `.../memory_pressure`); the whole
+`tt_telemetry/` tree is git-ignored. Override with `--dir`.
+
+This runs four prompts through Qwen3-0.6B with `max_num_seqs=4` (so all four
+share the batch and decode concurrently), then prints a summary confirming the
+sinks were written — e.g. peak slots occupied, decode rate, and how many steps a
+prefill stalled in-flight decode.
+
+Flags: `--dir` (output dir), `--max-num-seqs` (batch capacity), `--max-tokens`.
+
+### Oversubscribed variant
+
+[`run_telemetry_oversubscribed.py`](run_telemetry_oversubscribed.py) submits
+**more requests than the batch has slots** (8 prompts, `max_num_seqs=4`), so the
+scheduler admits four and the rest queue, getting admitted as running requests
+finish:
+
+```bash
+python examples/vllm/telemetry/run_telemetry_oversubscribed.py
+```
+
+This is what exercises the queueing signals a full-batch run cannot. On an n150
+it reports the batch pinned at 4 slots with a **max queue depth of 4** and
+**7 of 8 requests waiting** for a slot before admission. (Preemption stays 0
+here — that needs KV-cache pressure, not just a full batch; drive longer
+sequences or a higher `gpu_memory_utilization` to provoke it.)
+
+Flags: `--dir`, `--max-num-seqs`, `--num-prompts`, `--max-tokens`.
+
+### Memory-pressure variant
+
+[`run_telemetry_memory_pressure.py`](run_telemetry_memory_pressure.py) submits
+requests with a **large ISL** (16 requests x 2048-token prompts by default), so
+KV cache — not the slot count — becomes the binding constraint. Prompts are
+built to an exact length and made distinct per request so prefix caching cannot
+share their blocks.
+
+```bash
+python examples/vllm/telemetry/run_telemetry_memory_pressure.py
+```
+
+On an n150 (KV pool ~22.3k tokens, ~2.2k tokens per request) this shows the
+fresh-prefill watermark at work: the batch **self-limits to 8 of 16 slots**,
+**peak `kv_util` caps at ~75%** — exactly the default `prefill_kv_watermark`
+reserve of 25% — and the scheduler logs hundreds of **`watermark_rejects`**
+(declining to admit a fresh prefill so in-flight decodes keep their KV), with
+**0 preemptions**. The watermark is trading admission latency for decode
+stability; set `additional_config['prefill_kv_watermark']=0` to disable it and
+watch rejects turn into preemptions instead.
+
+Flags: `--dir`, `--isl`, `--max-num-seqs`, `--num-prompts`, `--max-tokens`,
+`--gpu-mem-util` (lower shrinks the KV pool for more pressure).
+
+## Visualizing
+
+[`scripts/telemetry/telemetry_viz.py`](../../../scripts/telemetry/telemetry_viz.py) turns the sinks
+into a single self-contained, dependency-free (stdlib-only), theme-aware
+interactive HTML dashboard — slot-occupancy timeline, decode-rate line with a
+prefill-stall event rug, KV/batch utilization, a per-request Gantt, the current
+slot table, and run-total event chips.
+
+```bash
+# Post-hoc: write a standalone HTML report from a finished run
+python scripts/telemetry/telemetry_viz.py report --dir tt_telemetry/memory_pressure
+#   -> tt_telemetry/memory_pressure/report.html  (open in a browser; data embedded)
+
+# Live: serve a dashboard that polls the sinks while a model is serving
+python scripts/telemetry/telemetry_viz.py live --dir tt_telemetry/memory_pressure --port 8009
+#   -> http://127.0.0.1:8009/     (slot state / decode rate update in place)
+```
+
+### Live monitoring
+
+Live mode runs a small local web server that re-reads the sinks every
+`--interval-ms` and re-renders in place, so you point it at whatever directory a
+*running* serving process is writing to. It shines against the **online server**
+(continuous traffic), not a one-shot `generate()` that finishes in seconds.
+
+**Terminal 1 — serve with telemetry on.** The env vars are the gate; a low flush
+keeps the view responsive (the viewer can't show data faster than the producer
+flushes it — the 1000 ms default feels laggy):
+
+```bash
+source venv/activate
+TTXLA_TELEMETRY=1 \
+TTXLA_TELEMETRY_DIR=tt_telemetry/serve \
+TTXLA_TELEMETRY_FLUSH_MS=200 \
+  vllm serve Qwen/Qwen3-0.6B \
+    --max-num-seqs 16 --max-model-len 2048 --max-num-batched-tokens 32768 \
+    --gpu-memory-utilization 0.2
+```
+
+**Terminal 2 — the viewer**, pointed at the *same* directory:
+
+```bash
+python scripts/telemetry/telemetry_viz.py live --dir tt_telemetry/serve --port 8009
+#   -> open http://127.0.0.1:8009/  (over Remote-SSH, the port is auto-forwarded)
+```
+
+**Terminal 3 — send overlapping requests** with the load generator below (or
+curl the OpenAI-compatible endpoint / any load tool). As traffic flows, the
+dashboard shows slots filling, the queue forming, and the decode rate moving —
+where you catch KV thrashing or prefill stalling decode as it happens. The
+"live" badge flips to "stalled" once the files stop changing.
+
+Notes: the serving process's telemetry dir and the viewer's `--dir` must match;
+flags are `--dir`, `--port` (default 8009), `--interval-ms` (default 500).
+
+### API load test
+
+[`api_load_test.py`](api_load_test.py) drives a running server over the HTTP
+API with many long, concurrent requests (stdlib only — no extra deps). Because
+requests arrive over the network and overlap, it produces the queueing and
+TTFT-under-load that offline `generate()` cannot.
+
+```bash
+python examples/vllm/telemetry/api_load_test.py \
+    --num-requests 48 --concurrency 16 --isl 1200 --max-tokens 96
+```
+
+It streams (for TTFT) and prints a load summary — throughput, output token rate,
+and e2e / TTFT p50/p95. On an n150 against a `max_num_seqs=16` server, 48
+concurrent ~1200-token requests drive **peak `kv_util` ~80%**, **queue depth
+14**, and **hundreds of `watermark_rejects`**, with **TTFT p95 ~100 s** — the
+long TTFT is almost entirely admission wait behind the KV watermark, which the
+telemetry makes legible. Prompts are made distinct per request so prefix caching
+does not collapse their KV.
+
+To model mixed traffic, randomize input/output lengths per request: `--isl-min`
+draws each input length from `[isl-min, --isl]` and `--osl-min` draws each output
+length from `[osl-min, --max-tokens]` (deterministic per `--seed`). Preview the
+plan without sending anything via `--dry-run`:
+
+```bash
+python examples/vllm/telemetry/api_load_test.py \
+    --num-requests 48 --concurrency 16 \
+    --isl 2000 --isl-min 500 --max-tokens 128 --osl-min 16 --max-model-len 2048
+```
+
+Each request's `input + output` is capped to fit `--max-model-len` (default
+2048; set it to match your server) — the server rejects a request that exceeds
+its context window, and the prompt builder only approximates the token count, so
+a slack margin is reserved. If a length is capped the tool prints a note.
+
+Flags: `--url`, `--model`, `--num-requests`, `--concurrency`, `--isl`,
+`--isl-min`, `--max-tokens`, `--osl-min`, `--max-model-len`, `--seed`,
+`--stagger-ms`, `--timeout`, `--no-stream`, `--dry-run`.

--- a/examples/vllm/telemetry/api_load_test.py
+++ b/examples/vllm/telemetry/api_load_test.py
@@ -1,0 +1,311 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""API load test for a live vLLM TT server.
+
+A client-side load generator for the OpenAI-compatible HTTP API. Point it at a
+running ``vllm serve`` (with telemetry enabled) to drive real serving load --
+long prompts, many in flight -- while you watch the scheduler/runner telemetry
+update live. Unlike the offline `generate()` demos, requests arrive over the
+network and overlap, so this is what surfaces queueing, TTFT-under-load, and
+KV pressure the way production traffic does.
+
+Input and output lengths can be randomized per request (``--isl-min`` /
+``--osl-min``) to model mixed traffic; use ``--dry-run`` to preview the plan.
+
+    # terminal 1 -- serve with telemetry on (low flush = responsive live view)
+    TTXLA_TELEMETRY=1 TTXLA_TELEMETRY_DIR=tt_telemetry/serve \
+    TTXLA_TELEMETRY_FLUSH_MS=200 \
+      vllm serve Qwen/Qwen3-0.6B --max-num-seqs 16 --max-model-len 2048 \
+        --gpu-memory-utilization 0.2
+
+    # terminal 2 -- live dashboard
+    python scripts/telemetry/telemetry_viz.py live --dir tt_telemetry/serve
+
+    # terminal 3 -- run the load test
+    python examples/vllm/telemetry/api_load_test.py \
+        --num-requests 64 --concurrency 16 --isl 1500 --max-tokens 128
+
+Stdlib only (urllib + threads); no extra dependencies.
+"""
+import argparse
+import json
+import random
+import time
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+# Unique preamble + rotation per prompt, so prefix caching cannot collapse them
+# into one shared prefix and erase the per-request KV cost.
+SENTENCES = [
+    "The turbine spun in the coastal wind under a bright and cloudless sky.",
+    "A cartographer folded the old map along its worn and softened creases.",
+    "Migrating cranes traced a long arc above the flooded rice paddies.",
+    "The archivist catalogued each letter by date, sender, and faded postmark.",
+    "Basalt columns stepped down to the sea in perfect hexagonal tiles.",
+    "A luthier sanded the maple back until the grain caught the lamplight.",
+    "The glacier calved with a report that rolled across the still fjord.",
+    "Fireflies pulsed in slow waves along the edge of the summer meadow.",
+]
+
+
+def build_prompt(i, approx_tokens):
+    """A distinct prompt of roughly `approx_tokens` tokens (~1.3 tokens/word)."""
+    words_needed = max(1, int(approx_tokens / 1.3))
+    base = (
+        f"Passage {i}. "
+        + " ".join(SENTENCES[(i + j) % len(SENTENCES)] for j in range(len(SENTENCES)))
+    ).split()
+    reps = -(-words_needed // len(base))  # ceil
+    return " ".join((base * reps)[:words_needed])
+
+
+def build_plan(rng, n, isl, isl_min, osl, osl_min, max_model_len):
+    """Per-request (input_len, output_len) pairs, kept within the context window.
+
+    When ``isl_min`` / ``osl_min`` are set and below the max, each request draws
+    its length uniformly from [min, max] to model mixed traffic; otherwise the
+    length is fixed at the max. Deterministic for a given rng seed.
+
+    ``input + output`` is capped at ``max_model_len`` minus a slack margin: the
+    server rejects a request whose prompt + max_tokens exceed the context
+    window, and build_prompt only approximates the token count (BOS + tokenizer
+    variance can push the real prompt a little past its target). Returns
+    ``(plan, clamped)`` where ``clamped`` is True if any input length was capped.
+    """
+    slack = max(64, int(0.03 * max_model_len))
+    budget = max_model_len - slack
+    clamped = False
+    plan = []
+    for _ in range(n):
+        o = rng.randint(osl_min, osl) if (osl_min and osl_min < osl) else osl
+        o = max(1, min(o, budget - 1))  # always leave room for >=1 input token
+        hi = min(isl, budget - o)
+        if hi < isl:
+            clamped = True
+        lo = isl_min if (isl_min and isl_min < hi) else hi
+        lo = max(1, min(lo, hi))
+        i = rng.randint(lo, hi) if lo < hi else hi
+        plan.append((max(1, i), o))
+    return plan, clamped
+
+
+def one_request(args, idx, isl, osl):
+    """Fire one completion request; return timing + token counts (or an error).
+
+    ``isl`` / ``osl`` are this request's input / output lengths (see build_plan).
+    """
+    url = args.url.rstrip("/") + "/completions"
+    body = {
+        "model": args.model,
+        "prompt": build_prompt(idx, isl),
+        "max_tokens": osl,
+        "temperature": 0.0,
+        "stream": args.stream,
+    }
+    if args.stream:
+        body["stream_options"] = {"include_usage": True}
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    t0 = time.monotonic()
+    ttft = None
+    out_tokens = 0
+    prompt_tokens = None
+    try:
+        resp = urllib.request.urlopen(req, timeout=args.timeout)
+        if args.stream:
+            chunks = 0
+            for raw in resp:
+                line = raw.decode("utf-8", "ignore").strip()
+                if not line.startswith("data:"):
+                    continue
+                payload = line[len("data:") :].strip()
+                if payload == "[DONE]":
+                    break
+                try:
+                    chunk = json.loads(payload)
+                except json.JSONDecodeError:
+                    continue
+                choices = chunk.get("choices") or []
+                if choices and choices[0].get("text"):
+                    if ttft is None:
+                        ttft = time.monotonic() - t0
+                    chunks += 1
+                usage = chunk.get("usage")
+                if usage:
+                    prompt_tokens = usage.get("prompt_tokens", prompt_tokens)
+                    out_tokens = usage.get("completion_tokens", out_tokens)
+            if not out_tokens:  # usage not reported: approximate by chunk count
+                out_tokens = chunks
+        else:
+            payload = json.loads(resp.read().decode())
+            usage = payload.get("usage") or {}
+            prompt_tokens = usage.get("prompt_tokens")
+            out_tokens = usage.get("completion_tokens", 0)
+        return {
+            "ok": True,
+            "e2e": time.monotonic() - t0,
+            "ttft": ttft,
+            "out_tokens": out_tokens,
+            "prompt_tokens": prompt_tokens,
+        }
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError) as e:
+        return {"ok": False, "e2e": time.monotonic() - t0, "error": str(e)}
+
+
+def _pct(values, q):
+    if not values:
+        return None
+    s = sorted(values)
+    return s[min(len(s) - 1, int(q * len(s)))]
+
+
+def summarize(results, wall):
+    ok = [r for r in results if r["ok"]]
+    fail = [r for r in results if not r["ok"]]
+    e2e = [r["e2e"] for r in ok]
+    ttfts = [r["ttft"] for r in ok if r.get("ttft") is not None]
+    out_total = sum(r["out_tokens"] or 0 for r in ok)
+    in_toks = [r["prompt_tokens"] for r in ok if r.get("prompt_tokens")]
+    out_toks = [r["out_tokens"] for r in ok if r.get("out_tokens")]
+
+    print("\n=== load summary ===", flush=True)
+    print(f"  completed / failed   : {len(ok)} / {len(fail)}")
+    print(f"  wall time            : {wall:.1f} s")
+    print(f"  request throughput   : {len(ok) / wall:.2f} req/s")
+    print(f"  output token rate    : {out_total / wall:.1f} tok/s")
+    if in_toks:
+        print(f"  input tokens min/max : {min(in_toks)} / {max(in_toks)}")
+    if out_toks:
+        print(f"  output tokens min/max: {min(out_toks)} / {max(out_toks)}")
+    if e2e:
+        print(f"  e2e latency p50/p95  : {_pct(e2e, .5):.2f} / {_pct(e2e, .95):.2f} s")
+    if ttfts:
+        print(
+            f"  TTFT p50/p95         : {_pct(ttfts, .5):.2f} / {_pct(ttfts, .95):.2f} s"
+        )
+    if fail:
+        print(f"  first error          : {fail[0]['error']}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--url", default="http://127.0.0.1:8000/v1", help="OpenAI-compatible base URL"
+    )
+    ap.add_argument("--model", default="Qwen/Qwen3-0.6B", help="served model name")
+    ap.add_argument(
+        "--num-requests", type=int, default=64, help="total requests to send"
+    )
+    ap.add_argument(
+        "--concurrency", type=int, default=16, help="max requests in flight"
+    )
+    ap.add_argument(
+        "--isl", type=int, default=1500, help="prompt tokens per request (the max)"
+    )
+    ap.add_argument(
+        "--isl-min",
+        type=int,
+        default=None,
+        help="if set (< --isl), draw each request's input length from [isl-min, isl]",
+    )
+    ap.add_argument(
+        "--max-tokens",
+        type=int,
+        default=128,
+        help="tokens to generate per request (the max)",
+    )
+    ap.add_argument(
+        "--osl-min",
+        type=int,
+        default=None,
+        help="if set (< --max-tokens), draw each request's output length from "
+        "[osl-min, max-tokens]",
+    )
+    ap.add_argument(
+        "--max-model-len",
+        type=int,
+        default=2048,
+        help="server context window; input+output per request is capped to fit it",
+    )
+    ap.add_argument(
+        "--seed", type=int, default=0, help="RNG seed for ISL/OSL randomization"
+    )
+    ap.add_argument(
+        "--stagger-ms", type=float, default=0.0, help="delay between launching requests"
+    )
+    ap.add_argument(
+        "--timeout", type=float, default=600.0, help="per-request timeout (s)"
+    )
+    ap.add_argument(
+        "--no-stream",
+        dest="stream",
+        action="store_false",
+        help="disable streaming (no TTFT)",
+    )
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print the ISL/OSL plan and exit without sending requests",
+    )
+    args = ap.parse_args()
+
+    # Seeded on purpose: --seed must reproduce the same ISL/OSL plan, which is
+    # what --dry-run previews. These draws are token lengths, never secrets.
+    rng = random.Random(args.seed)
+    plan, clamped = build_plan(
+        rng,
+        args.num_requests,
+        args.isl,
+        args.isl_min,
+        args.max_tokens,
+        args.osl_min,
+        args.max_model_len,
+    )
+    isl_desc = f"{args.isl_min}-{args.isl}" if args.isl_min else str(args.isl)
+    osl_desc = (
+        f"{args.osl_min}-{args.max_tokens}" if args.osl_min else str(args.max_tokens)
+    )
+    if clamped:
+        print(
+            f"note: input length capped so input+output fits --max-model-len "
+            f"{args.max_model_len} (pass a larger --max-model-len if the server "
+            "allows it).",
+            flush=True,
+        )
+
+    if args.dry_run:
+        print(f"ISL/OSL plan (seed {args.seed}), ISL {isl_desc}, OSL {osl_desc}:")
+        for i, (isl, osl) in enumerate(plan):
+            print(f"  req {i:>3}: isl={isl:>5}  osl={osl:>4}")
+        return
+
+    print(
+        f"Load testing {args.url} with {args.num_requests} requests "
+        f"(ISL {isl_desc} tok, OSL {osl_desc} tok, concurrency "
+        f"{args.concurrency}, stream={args.stream})",
+        flush=True,
+    )
+    results = []
+    start = time.monotonic()
+    with ThreadPoolExecutor(max_workers=args.concurrency) as ex:
+        futures = []
+        for i in range(args.num_requests):
+            futures.append(ex.submit(one_request, args, i, plan[i][0], plan[i][1]))
+            if args.stagger_ms:
+                time.sleep(args.stagger_ms / 1000.0)
+        done = 0
+        for f in as_completed(futures):
+            results.append(f.result())
+            done += 1
+            if done % max(1, args.num_requests // 10) == 0:
+                print(f"  {done}/{args.num_requests} done", flush=True)
+    summarize(results, time.monotonic() - start)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/vllm/telemetry/run_telemetry_demo.py
+++ b/examples/vllm/telemetry/run_telemetry_demo.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Serving-telemetry demo for the vLLM TT plugin.
+
+Runs a small batch of prompts through Qwen3-0.6B with telemetry enabled, then verifies the JSON-lines sinks were written and
+prints a short summary. Enabling telemetry here goes through ``additional_config``
+so the script is self-contained; the equivalent env-var form is in the README.
+
+    source venv/activate
+    python examples/vllm/telemetry/run_telemetry_demo.py
+
+Visualize the result with:
+
+    python scripts/telemetry/telemetry_viz.py report --dir tt_telemetry/demo   # static HTML
+    python scripts/telemetry/telemetry_viz.py live   --dir tt_telemetry/demo   # live dashboard
+"""
+import argparse
+import json
+from pathlib import Path
+
+import vllm
+
+PROMPTS = [
+    "Write a haiku about the ocean.",
+    "List three prime numbers.",
+    "What is the capital of France?",
+    "Explain gravity in one sentence.",
+]
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--dir", default="tt_telemetry/demo", help="telemetry output dir")
+    ap.add_argument("--max-num-seqs", type=int, default=4, help="batch capacity")
+    ap.add_argument("--max-tokens", type=int, default=32, help="tokens per request")
+    args = ap.parse_args()
+
+    tele_dir = Path(args.dir).resolve()
+    max_model_len = 1024
+    # Single-shot prefill: the budget must cover a full prompt per row
+    # (max_num_batched_tokens >= max_model_len * max_num_seqs).
+    llm = vllm.LLM(
+        model="Qwen/Qwen3-0.6B",
+        max_model_len=max_model_len,
+        max_num_batched_tokens=max_model_len * args.max_num_seqs,
+        max_num_seqs=args.max_num_seqs,
+        gpu_memory_utilization=0.2,
+        additional_config={
+            "enable_const_eval": False,
+            "min_context_len": 256,
+            # Turn telemetry on (v1 runner: the default on main).
+            "telemetry_enabled": True,
+            "telemetry_dir": str(tele_dir),
+            "telemetry_flush_ms": 200,
+        },
+    )
+
+    params = vllm.SamplingParams(temperature=0, max_tokens=args.max_tokens)
+    # A single batched generate() enqueues all prompts before the engine steps,
+    # so they share the batch (up to max_num_seqs run concurrently).
+    outs = llm.generate(PROMPTS, params)
+    print("\n=== generations ===", flush=True)
+    for o in outs:
+        print(repr(o.outputs[0].text[:60]), flush=True)
+
+    verify(tele_dir)
+
+
+def verify(tele_dir):
+    sched = tele_dir / "scheduler.jsonl"
+    runner = tele_dir / "runner.jsonl"
+    snap = tele_dir / "runner_snapshot.json"
+
+    def _jsonl(p):
+        if not p.exists():
+            return []
+        return [json.loads(l) for l in p.read_text().splitlines() if l.strip()]
+
+    s_recs, r_recs = _jsonl(sched), _jsonl(runner)
+    steps = [r for r in r_recs if r.get("event") == "step"]
+    admits = {r["request_id"] for r in r_recs if r.get("event") == "request_admitted"}
+    completes = {
+        r["request_id"] for r in r_recs if r.get("event") == "request_completed"
+    }
+    rates = [
+        r["decode_rate_toks_per_s"] for r in steps if r.get("decode_rate_toks_per_s")
+    ]
+
+    print("\n=== telemetry files ===", flush=True)
+    for p in (sched, runner, snap):
+        size = p.stat().st_size if p.exists() else 0
+        print(f"  {p.name}: {'OK' if p.exists() else 'MISSING'} ({size} bytes)")
+
+    print("\n=== summary ===", flush=True)
+    print(f"  scheduler records  : {len(s_recs)}")
+    print(f"  runner step records: {len(steps)}")
+    print(f"  requests admitted / completed: {len(admits)} / {len(completes)}")
+    print(
+        f"  max slots occupied : {max((r['slots_occupied'] for r in steps), default=0)}"
+    )
+    print(
+        f"  stalled-by-prefill : {sum(1 for r in s_recs if r.get('decode_gated'))} steps"
+    )
+    print(f"  sample decode rates (tok/s): {rates[:5]}")
+
+    assert s_recs, "no scheduler telemetry emitted"
+    assert steps, "no runner step telemetry emitted"
+    assert admits, "no request_admitted records"
+    print(f"\nTelemetry written to {tele_dir}", flush=True)
+    print(
+        "Visualize: python scripts/telemetry/telemetry_viz.py report --dir "
+        f"{tele_dir}",
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/vllm/telemetry/run_telemetry_memory_pressure.py
+++ b/examples/vllm/telemetry/run_telemetry_memory_pressure.py
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Memory-pressure serving-telemetry demo for the vLLM TT plugin.
+
+Submits several requests with a LARGE input sequence length (ISL). Each long
+prompt holds many KV-cache blocks, so a handful of them concurrently drive the
+KV pool toward the fresh-prefill watermark. That surfaces the pressure signals a
+short-prompt run never triggers: high ``kv_util``, ``watermark_rejects`` (the TT
+scheduler declining to admit a fresh prefill so in-flight decodes keep their KV
+instead of being preempted), and a batch that self-limits below ``max_num_seqs``
+because KV -- not the slot count -- is the binding constraint.
+
+    source venv/activate
+    python examples/vllm/telemetry/run_telemetry_memory_pressure.py
+
+The prompts are built to an exact token length AND made distinct per request, so
+prefix caching cannot share their KV blocks (identical prompts would collapse to
+one shared prefix and remove the pressure this demo is about).
+
+    python scripts/telemetry/telemetry_viz.py report --dir tt_telemetry/memory_pressure
+"""
+import argparse
+import json
+from pathlib import Path
+
+import vllm
+from vllm import TokensPrompt
+
+# Varied sentences; rotated + prefixed per request so no two prompts share a
+# leading KV block (prefix caching keys on 32-token blocks).
+SENTENCES = [
+    "The turbine spun in the coastal wind under a bright and cloudless sky.",
+    "A cartographer folded the old map along its worn and softened creases.",
+    "Migrating cranes traced a long arc above the flooded rice paddies.",
+    "The archivist catalogued each letter by date, sender, and faded postmark.",
+    "Basalt columns stepped down to the sea in perfect hexagonal tiles.",
+    "A luthier sanded the maple back until the grain caught the lamplight.",
+    "The glacier calved with a report that rolled across the still fjord.",
+    "Fireflies pulsed in slow waves along the edge of the summer meadow.",
+    "The signalman lowered the lamp and the night train sighed to a halt.",
+    "Salt crystals bloomed white across the cracked floor of the dry lake.",
+    "A beekeeper lifted the frame, heavy and golden, from the humming hive.",
+    "The observatory dome rotated, seams grinding, toward the rising planet.",
+]
+
+
+def build_prompts(tokenizer, num_prompts, isl):
+    """Return `num_prompts` distinct TokensPrompts, each exactly `isl` tokens."""
+    prompts = []
+    for i in range(num_prompts):
+        rotated = " ".join(
+            SENTENCES[(i + j) % len(SENTENCES)] for j in range(len(SENTENCES))
+        )
+        seed = f"Passage {i}. {rotated} "
+        ids = tokenizer(seed, add_special_tokens=False).input_ids or [0]
+        reps = -(-isl // len(ids))  # ceil division
+        prompts.append(TokensPrompt(prompt_token_ids=(ids * reps)[:isl]))
+    return prompts
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--dir", default="tt_telemetry/memory_pressure", help="telemetry output dir"
+    )
+    ap.add_argument("--isl", type=int, default=2048, help="prompt length in tokens")
+    ap.add_argument("--max-num-seqs", type=int, default=16, help="batch capacity")
+    ap.add_argument("--num-prompts", type=int, default=16, help="requests to submit")
+    ap.add_argument("--max-tokens", type=int, default=48, help="tokens per request")
+    ap.add_argument(
+        "--prefill-chunk",
+        type=int,
+        default=512,
+        help="per-sequence prefill chunk (0 = single-shot; see note in main)",
+    )
+    ap.add_argument(
+        "--gpu-mem-util",
+        type=float,
+        default=0.2,
+        help="fraction of device memory (smaller -> smaller KV pool -> more pressure)",
+    )
+    args = ap.parse_args()
+
+    tele_dir = Path(args.dir).resolve()
+    max_model_len = args.isl + args.max_tokens + 64
+    if args.prefill_chunk > 0:
+        # Chunked prefill requires max_model_len to be a multiple of 256.
+        max_model_len = -(-max_model_len // 256) * 256
+    # Single-shot prefill at this scale needs a 34560-token budget, which does
+    # not compile; the chunk bounds the graph and TTPlatform derives the budget.
+    tt_config = {
+        "enable_const_eval": False,
+        "min_context_len": 256,
+        "telemetry_enabled": True,
+        "telemetry_dir": str(tele_dir),
+        "telemetry_flush_ms": 200,
+    }
+    if args.prefill_chunk > 0:
+        tt_config["prefill_chunk_size"] = args.prefill_chunk
+        budget = args.prefill_chunk * args.max_num_seqs
+    else:
+        budget = max_model_len * args.max_num_seqs
+    llm = vllm.LLM(
+        model="Qwen/Qwen3-0.6B",
+        max_model_len=max_model_len,
+        max_num_batched_tokens=budget,
+        max_num_seqs=args.max_num_seqs,
+        gpu_memory_utilization=args.gpu_mem_util,
+        additional_config=tt_config,
+    )
+
+    prompts = build_prompts(llm.get_tokenizer(), args.num_prompts, args.isl)
+    params = vllm.SamplingParams(temperature=0, max_tokens=args.max_tokens)
+    print(
+        f"\n=== {len(prompts)} requests x {args.isl}-token prompts "
+        f"(batch capacity {args.max_num_seqs}) ===",
+        flush=True,
+    )
+    outs = llm.generate(prompts, params)
+    print(f"completed {len(outs)} requests", flush=True)
+
+    verify(tele_dir, args.max_num_seqs)
+
+
+def verify(tele_dir, max_num_seqs):
+    def _jsonl(p):
+        p = tele_dir / p
+        if not p.exists():
+            return []
+        return [json.loads(l) for l in p.read_text().splitlines() if l.strip()]
+
+    s_recs = _jsonl("scheduler.jsonl")
+    r_recs = _jsonl("runner.jsonl")
+    steps = [r for r in r_recs if r.get("event") == "step"]
+    admits = [r for r in r_recs if r.get("event") == "request_admitted"]
+    completes = [r for r in r_recs if r.get("event") == "request_completed"]
+
+    peak_kv = max((r.get("kv_util", 0) or 0 for r in s_recs), default=0)
+    wm_rejects = max((r.get("cum_watermark_rejects", 0) for r in s_recs), default=0)
+    preempted = max((r.get("cum_preempted", 0) for r in s_recs), default=0)
+    max_wait = max((r.get("num_waiting", 0) for r in s_recs), default=0)
+    max_occ = max((r.get("slots_occupied", 0) for r in steps), default=0)
+
+    print("\n=== summary ===", flush=True)
+    print(f"  requests admitted / completed: {len(admits)} / {len(completes)}")
+    print(f"  batch capacity (max slots)   : {max_num_seqs}")
+    print(f"  max slots occupied           : {max_occ}")
+    print(f"  peak KV utilization          : {peak_kv * 100:.1f}%")
+    print(f"  watermark rejects (fresh prefill declined): {wm_rejects}")
+    print(f"  preemptions                  : {preempted}")
+    print(f"  max queue depth (num_waiting) : {max_wait}")
+
+    assert s_recs and steps, "no telemetry emitted"
+    pressure = peak_kv >= 0.5 or wm_rejects > 0 or preempted > 0
+    if pressure:
+        print(
+            "\nMemory pressure observed (high KV utilization / watermark rejects / "
+            "preemption).",
+            flush=True,
+        )
+    else:
+        print(
+            "\nNo memory pressure seen. Increase --isl or --num-prompts, or lower "
+            "--gpu-mem-util, to shrink KV headroom.",
+            flush=True,
+        )
+    print(f"Telemetry written to {tele_dir}", flush=True)
+    print(
+        f"Visualize: python scripts/telemetry/telemetry_viz.py report --dir {tele_dir}",
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/vllm/telemetry/run_telemetry_oversubscribed.py
+++ b/examples/vllm/telemetry/run_telemetry_oversubscribed.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Oversubscribed serving-telemetry demo for the vLLM TT plugin.
+
+Like run_telemetry_demo.py, but submits MORE requests than the batch has slots
+(8 prompts, max_num_seqs=4). A single batched generate() enqueues all of them,
+so the scheduler can only admit `max_num_seqs` at a time and the rest wait in
+the queue, getting admitted as running requests finish. This exercises the
+signals that a full-batch run does not: non-zero queue depth (`num_waiting`) and
+re-admission (requests admitted well after step 0).
+
+    source venv/activate
+    python examples/vllm/telemetry/run_telemetry_oversubscribed.py
+
+Then visualize -- the KV/batch-utilization chart shows the batch pinned at
+capacity while the queue drains:
+
+    python scripts/telemetry/telemetry_viz.py report --dir tt_telemetry/oversubscribed
+"""
+import argparse
+import json
+from pathlib import Path
+
+import vllm
+
+# Eight distinct prompts (> the default 4 slots) so the queue stays non-empty.
+PROMPTS = [
+    "Write a haiku about the ocean.",
+    "List three prime numbers.",
+    "What is the capital of France?",
+    "Explain gravity in one sentence.",
+    "Name a primary color.",
+    "What is 12 times 8?",
+    "Give one fact about the moon.",
+    "Translate 'hello' into Spanish.",
+]
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--dir", default="tt_telemetry/oversubscribed", help="telemetry output dir"
+    )
+    ap.add_argument(
+        "--max-num-seqs", type=int, default=4, help="batch capacity (slots)"
+    )
+    ap.add_argument(
+        "--num-prompts",
+        type=int,
+        default=len(PROMPTS),
+        help="how many prompts to submit (cycled from the pool)",
+    )
+    ap.add_argument("--max-tokens", type=int, default=48, help="tokens per request")
+    args = ap.parse_args()
+
+    if args.num_prompts <= args.max_num_seqs:
+        print(
+            f"warning: num_prompts ({args.num_prompts}) <= max_num_seqs "
+            f"({args.max_num_seqs}); nothing will queue. Raise --num-prompts "
+            "or lower --max-num-seqs to oversubscribe."
+        )
+    prompts = [PROMPTS[i % len(PROMPTS)] for i in range(args.num_prompts)]
+
+    tele_dir = Path(args.dir).resolve()
+    max_model_len = 1024
+    # Single-shot prefill: the budget must cover a full prompt per row
+    # (max_num_batched_tokens >= max_model_len * max_num_seqs).
+    llm = vllm.LLM(
+        model="Qwen/Qwen3-0.6B",
+        max_model_len=max_model_len,
+        max_num_batched_tokens=max_model_len * args.max_num_seqs,
+        max_num_seqs=args.max_num_seqs,
+        gpu_memory_utilization=0.2,
+        additional_config={
+            "enable_const_eval": False,
+            "min_context_len": 256,
+            "telemetry_enabled": True,
+            "telemetry_dir": str(tele_dir),
+            "telemetry_flush_ms": 200,
+        },
+    )
+
+    params = vllm.SamplingParams(temperature=0, max_tokens=args.max_tokens)
+    outs = llm.generate(prompts, params)
+    print(
+        f"\n=== {len(outs)} generations (batch capacity {args.max_num_seqs}) ===",
+        flush=True,
+    )
+    for o in outs:
+        print(repr(o.outputs[0].text[:50]), flush=True)
+
+    verify(tele_dir, args.max_num_seqs)
+
+
+def verify(tele_dir, max_num_seqs):
+    sched = tele_dir / "scheduler.jsonl"
+    runner = tele_dir / "runner.jsonl"
+
+    def _jsonl(p):
+        if not p.exists():
+            return []
+        return [json.loads(l) for l in p.read_text().splitlines() if l.strip()]
+
+    s_recs, r_recs = _jsonl(sched), _jsonl(runner)
+    steps = [r for r in r_recs if r.get("event") == "step"]
+    admits = [r for r in r_recs if r.get("event") == "request_admitted"]
+    completes = [r for r in r_recs if r.get("event") == "request_completed"]
+    max_wait = max((r.get("num_waiting", 0) for r in s_recs), default=0)
+    max_occ = max((r.get("slots_occupied", 0) for r in steps), default=0)
+    # Re-admissions: requests admitted after the batch first filled (step > 0),
+    # i.e. only after an earlier request freed a slot.
+    readmitted = [a for a in admits if a.get("step", 0) > 0]
+    preempted = max((r.get("cum_preempted", 0) for r in s_recs), default=0)
+
+    print("\n=== summary ===", flush=True)
+    print(f"  requests admitted / completed: {len(admits)} / {len(completes)}")
+    print(f"  batch capacity (max slots)   : {max_num_seqs}")
+    print(f"  max slots occupied           : {max_occ}")
+    print(f"  max queue depth (num_waiting) : {max_wait}")
+    print(f"  requests that waited for a slot: {len(readmitted)}")
+    print(f"  preemptions                  : {preempted}")
+
+    assert s_recs and steps, "no telemetry emitted"
+    if len(admits) > max_num_seqs:
+        assert max_wait > 0, (
+            "expected a non-empty queue when oversubscribed, but num_waiting "
+            "was always 0"
+        )
+        print(
+            "\nOversubscription confirmed: more requests than slots, queue drained "
+            "as requests completed.",
+            flush=True,
+        )
+    print(f"Telemetry written to {tele_dir}", flush=True)
+    print(
+        f"Visualize: python scripts/telemetry/telemetry_viz.py report --dir {tele_dir}",
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -119,6 +119,7 @@ from .swa_cache_utils import (
     sliding_ring_phys_blocks,
     sliding_window_blocks,
 )
+from .telemetry import RunnerTelemetry, resolve_config
 from .vllm_distributed_utils import (
     ParallelismMode,
     kv_cache_shard_factor,
@@ -240,7 +241,60 @@ def generate_attn_mask(
 # The dummy_run should be comprehensive, ensuring all potential input shapes and
 # branch predictions are included as subgraph inputs to facilitate
 # pre-compilation.
+class _V1SlotView:
+    """Adapter presenting ``InputBatch`` rows the way RunnerTelemetry reads slots.
+
+    RunnerTelemetry is written against the v2 persistent slot table
+    (``TTRequestState``): ``req_id_to_index`` / ``free_indices`` plus per-slot
+    ``num_computed_tokens`` / ``prefill_len`` / ``total_len``. v1 keeps the same
+    information in a *condensing* ``InputBatch`` (rows compact on removal, so a
+    row index is not a stable identity across steps) with different names, and
+    the prefill boundary lives on ``CachedRequestState.num_prompt_tokens``
+    rather than in a per-slot array.
+
+    Building this view per step keeps telemetry.py identical across v1 and v2 --
+    one record schema, one visualizer. It is constructed only when telemetry is
+    enabled, and is O(active rows).
+    """
+
+    __slots__ = (
+        "req_id_to_index",
+        "free_indices",
+        "num_computed_tokens",
+        "prefill_len",
+        "total_len",
+    )
+
+    def __init__(self, input_batch, requests, scheduler_output) -> None:
+        num_reqs = input_batch.num_reqs
+        self.req_id_to_index = dict(input_batch.req_id_to_index)
+        # v1 has no free list: unoccupied rows are simply the tail of the batch.
+        self.free_indices = range(num_reqs, input_batch.max_num_reqs)
+        self.num_computed_tokens = {}
+        self.prefill_len = {}
+        self.total_len = {}
+        for req_id, slot in self.req_id_to_index.items():
+            req_state = requests.get(req_id)
+            if req_state is None:
+                # on_step swallows exceptions: an unpopulated slot drops the
+                # whole step record, so zero-fill instead.
+                self.num_computed_tokens[slot] = 0
+                self.prefill_len[slot] = 0
+                self.total_len[slot] = 0
+                continue
+            scheduled = scheduler_output.num_scheduled_tokens.get(req_id, 0)
+            # Must match sample_tokens' prefill test.
+            self.num_computed_tokens[slot] = int(req_state.num_computed_tokens) + int(
+                scheduled
+            )
+            self.prefill_len[slot] = int(req_state.num_prompt_tokens)
+            self.total_len[slot] = int(req_state.num_tokens)
+
+
 class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
+    # Instances built without __init__ read this; disabled opens no files.
+    _telemetry = RunnerTelemetry(False, "", 1.0)
+
     def __init__(
         self,
         vllm_config: VllmConfig,
@@ -558,6 +612,14 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             kernel_block_sizes=[self.block_size],
             is_pooling_model=False,
         )
+
+        # Gating resolved in TTPlatform.check_and_update_config.
+        tele_enabled, tele_dir, tele_flush_s = resolve_config(
+            enabled=getattr(self.tt_config, "telemetry_enabled", False),
+            directory=getattr(self.tt_config, "telemetry_dir", None),
+            flush_ms=getattr(self.tt_config, "telemetry_flush_ms", None),
+        )
+        self._telemetry = RunnerTelemetry(tele_enabled, tele_dir, tele_flush_s)
 
         # Cached torch/numpy tensor
         # The pytorch tensor and numpy array share the same buffer.
@@ -931,6 +993,16 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         """
         # Remove finished requests from the cached states.
         for req_id in scheduler_output.finished_req_ids:
+            if self._telemetry.enabled:
+                # Read before the state is dropped.
+                done = self.requests.get(req_id)
+                if done is not None:
+                    self._telemetry.on_request_completed(
+                        req_id,
+                        self.input_batch.req_id_to_index.get(req_id, -1),
+                        int(done.num_prompt_tokens),
+                        len(done.output_token_ids),
+                    )
             self.requests.pop(req_id, None)
             self.num_prompt_logprobs.pop(req_id, None)
 
@@ -1055,11 +1127,28 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # Add the new or resumed requests to the persistent batch.
         # The smaller empty indices are filled first.
         removed_req_indices = sorted(removed_req_indices, reverse=True)
+        # Only genuinely new requests appear in scheduled_new_reqs.
+        tele_new_req_ids = (
+            {new.req_id for new in scheduler_output.scheduled_new_reqs}
+            if self._telemetry.enabled
+            else frozenset()
+        )
         for req_id in req_ids_to_add:
             req_state = self.requests[req_id]
             # Fill the empty index or append to the end
             req_index = removed_req_indices.pop() if removed_req_indices else None
             self.input_batch.add_request(req_state, req_index)
+            if self._telemetry.enabled:
+                # req_index is None for an appended row, so read back the
+                # assigned index. A prefix-cache hit shows as nonzero cached tokens.
+                self._telemetry.on_request_admitted(
+                    req_id,
+                    self.input_batch.req_id_to_index.get(req_id, -1),
+                    int(req_state.num_prompt_tokens),
+                    int(req_state.num_prompt_tokens),
+                    num_cached_tokens=int(req_state.num_computed_tokens),
+                    readmission=req_id not in tele_new_req_ids,
+                )
 
         # Condense the batched states if there are empty indices.
         if removed_req_indices:
@@ -2428,6 +2517,11 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # batch index.  Only populated for requests that need prompt logprobs.
         prompt_lp_hs: dict[int, torch.Tensor] = {}
 
+        # Telemetry: per-step pass split, counted per chunk below.
+        tele_on = self._telemetry.enabled
+        tele_prefill_passes = 0
+        tele_decode_passes = 0
+
         while start_index < self.input_batch.num_reqs:
             (
                 attn_metadata,
@@ -2487,6 +2581,23 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     grammar_output, target_num_reqs
                 )
             torch_xla.sync(wait=False)
+
+            if tele_on:
+                # Tokens-per-row and the graph's seq dim both exceed 1 for a
+                # spec-decode verification pass, so neither identifies prefill.
+                pass_prefill = False
+                for tele_rid in self.input_batch.req_ids[start_index:end_index]:
+                    tele_rs = self.requests.get(tele_rid)
+                    if (
+                        tele_rs is not None
+                        and tele_rs.num_computed_tokens < tele_rs.num_prompt_tokens
+                    ):
+                        pass_prefill = True
+                        break
+                if pass_prefill:
+                    tele_prefill_passes += 1
+                else:
+                    tele_decode_passes += 1
 
             if self.tt_config.cpu_sampling:
                 hidden_states, logits, selected_token_ids, kv_connector_output = (
@@ -2674,6 +2785,18 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     valid_sampled_token_ids[i]
                 )
                 req_state.output_token_ids.extend(valid_sampled_token_ids[i])
+
+        if tele_on:
+            # len() per row keeps this accepted tokens/step under spec decode.
+            tele_emitted_tokens = sum(
+                len(valid_sampled_token_ids[i]) for i, _, _ in request_seq_lens
+            )
+            self._telemetry.on_step(
+                _V1SlotView(self.input_batch, self.requests, scheduler_output),
+                prefill_passes=tele_prefill_passes,
+                decode_passes=tele_decode_passes,
+                emitted_tokens=tele_emitted_tokens,
+            )
 
         model_runner_output = ModelRunnerOutput(
             req_ids=req_ids,

--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -89,6 +89,24 @@ class TTConfig:
     # Resolved/validated in TTPlatform.check_and_update_config.
     prefill_kv_watermark: float = 0.25
 
+    # Serving telemetry. When True, the scheduler and the v1 model
+    # runner emit JSON-lines telemetry (batch occupancy, prefill/decode pass
+    # split, decode rate, preemption, queue depth, KV/batch utilization) for
+    # offline analysis. Zero-cost when off (a single bool check on the hot path).
+    # No per-step disk I/O: records buffer in memory and flush on an interval /
+    # at request completion / at shutdown. See vllm_tt/telemetry.py.
+    # Override at runtime with env var TTXLA_TELEMETRY (truthy), which takes
+    # precedence over additional_config. Resolved in check_and_update_config.
+    telemetry_enabled: bool = False
+
+    # Directory for telemetry JSON-lines sinks (scheduler.jsonl, runner.jsonl,
+    # runner_snapshot.json). Env override: TTXLA_TELEMETRY_DIR. Default ./tt_telemetry.
+    telemetry_dir: str = "./tt_telemetry"
+
+    # Minimum gap (milliseconds) between telemetry disk flushes. Env override:
+    # TTXLA_TELEMETRY_FLUSH_MS. Default 1000.
+    telemetry_flush_ms: float = 1000.0
+
     batch_size: int = 1
     enable_precompile_all: bool = True
 
@@ -466,6 +484,40 @@ class TTPlatform(Platform):
                 f"must be in [0, 1); got {wm}."
             )
         additional_config["prefill_kv_watermark"] = wm
+
+        # Written back so the runner (typed TTConfig) and the scheduler (raw
+        # additional_config, separate process) read the same settings.
+        tele_enabled = bool(additional_config.get("telemetry_enabled", False))
+        env_tele = os.environ.get("TTXLA_TELEMETRY")
+        if env_tele is not None:
+            tele_enabled = env_tele.strip().lower() in {"1", "true", "yes", "on"}
+        additional_config["telemetry_enabled"] = tele_enabled
+
+        env_tele_dir = os.environ.get("TTXLA_TELEMETRY_DIR", "").strip()
+        # reset_sinks joins this path, so an empty value would delete
+        # sink-named files from the process CWD.
+        additional_config["telemetry_dir"] = (
+            env_tele_dir
+            or (additional_config.get("telemetry_dir") or "").strip()
+            or TTConfig.telemetry_dir
+        )
+
+        env_tele_flush = os.environ.get("TTXLA_TELEMETRY_FLUSH_MS")
+        if env_tele_flush is not None:
+            try:
+                additional_config["telemetry_flush_ms"] = float(env_tele_flush)
+            except ValueError:
+                # A telemetry knob must never crash the engine.
+                additional_config["telemetry_flush_ms"] = TTConfig.telemetry_flush_ms
+        elif additional_config.get("telemetry_flush_ms") is None:
+            additional_config["telemetry_flush_ms"] = TTConfig.telemetry_flush_ms
+
+        # Must precede every collector: the scheduler's is built after warmup
+        # and the snapshot is never truncated on init.
+        if additional_config["telemetry_enabled"]:
+            from .telemetry import reset_sinks
+
+            reset_sinks(additional_config["telemetry_dir"])
 
         vllm_config.additional_config = additional_config
 

--- a/integrations/vllm_plugin/vllm_tt/scheduler/ascend_scheduler.py
+++ b/integrations/vllm_plugin/vllm_tt/scheduler/ascend_scheduler.py
@@ -63,6 +63,16 @@ class AscendScheduler(Scheduler):
         # TTConfig.prefill_kv_watermark.
         self.prefill_kv_watermark = float(add_cfg.get("prefill_kv_watermark") or 0.0)
 
+        # Gating resolved in TTPlatform.check_and_update_config.
+        from vllm_tt.telemetry import SchedulerTelemetry, resolve_config
+
+        tele_enabled, tele_dir, tele_flush_s = resolve_config(
+            enabled=add_cfg.get("telemetry_enabled", False),
+            directory=add_cfg.get("telemetry_dir"),
+            flush_ms=add_cfg.get("telemetry_flush_ms"),
+        )
+        self._telemetry = SchedulerTelemetry(tele_enabled, tele_dir, tele_flush_s)
+
     def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
         # v0.25.1: EngineCore calls schedule(self._should_throttle_prefills())
         # positionally, so the parameter must exist. TT is single-instance, so
@@ -96,6 +106,10 @@ class AscendScheduler(Scheduler):
         # Partial prefill chunks scheduled this step: kept out of self.running
         # until prefill completes, so excluded from the scheduled-vs-running check.
         num_partial_prefill_scheduled = 0
+
+        # TT-specific decisions this step, for telemetry.
+        tele_watermark_rejects = 0
+        tele_b1_cap_hit = False
 
         # Stage (num_computed_tokens) of the first prefill scheduled this step.
         # Only same-stage prefills batch together; mixing a fresh request with a
@@ -144,6 +158,8 @@ class AscendScheduler(Scheduler):
                 and len(scheduled_new_reqs) + len(scheduled_resumed_reqs)
                 >= fresh_prefill_cap
             ):
+                if self._telemetry.enabled:
+                    tele_b1_cap_hit = True
                 break
 
             def skip_cur_request(req=request):
@@ -359,6 +375,8 @@ class AscendScheduler(Scheduler):
                 request, num_new_tokens, blocks, watermark
             ):
                 # Scheduling would exceed watermark, skip.
+                if self._telemetry.enabled:
+                    tele_watermark_rejects += 1
                 skip_cur_request()
                 continue
 
@@ -451,6 +469,10 @@ class AscendScheduler(Scheduler):
         # Put back any skipped requests at the head of the waiting queue
         if step_skipped_waiting:
             self.skipped_waiting.prepend_requests(step_skipped_waiting)
+
+        # Any prefill scheduled here skips the decode gate below.
+        tele_decode_gated = len(self.scheduled_req_ids) != 0
+        tele_decodes_displaced = len(self.running) if tele_decode_gated else 0
 
         # If no prefill requests are scheduled (or prefill skipped),
         # schedule decode requests next (unless prefill is forced).
@@ -624,6 +646,27 @@ class AscendScheduler(Scheduler):
             finished_req_ids=self.finished_req_ids,  # type: ignore
             free_encoder_mm_hashes=self.encoder_cache_manager.get_freed_mm_hashes(),
         )
+
+        # schedule() has one exit; an early return added above here would
+        # silently drop steps.
+        if self._telemetry.enabled:
+            self._telemetry.on_schedule(
+                num_running=len(self.running),
+                max_running=self.max_num_running_reqs,
+                num_waiting=len(self.waiting) + len(self.skipped_waiting),
+                num_free_blocks=self.kv_cache_manager.block_pool.get_num_free_blocks(),
+                num_total_blocks=self.kv_cache_config.num_blocks,
+                prefill_new=len(scheduled_new_reqs),
+                prefill_resumed=len(scheduled_resumed_reqs),
+                prefill_partial=num_partial_prefill_scheduled,
+                running_scheduled=len(scheduled_running_reqs),
+                preempted=len(preempted_reqs),
+                decode_gated=tele_decode_gated,
+                decodes_displaced=tele_decodes_displaced,
+                total_scheduled_tokens=total_num_scheduled_tokens,
+                watermark_rejects=tele_watermark_rejects,
+                b1_cap_hit=tele_b1_cap_hit,
+            )
 
         # NOTE(Kuntai): this function is designed for multiple purposes:
         # 1. Plan the KV cache store

--- a/integrations/vllm_plugin/vllm_tt/telemetry.py
+++ b/integrations/vllm_plugin/vllm_tt/telemetry.py
@@ -1,0 +1,489 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Env-gated, hot-path-safe serving telemetry for the vLLM TT engine.
+# Instruments the two layers that answer different questions about a serving run:
+#
+#   * SchedulerTelemetry  (AscendScheduler, EngineCore process) -- INTENT: what
+#     each step decided and why work stalled (prefill blocking decode,
+#     preemption, queue depth, KV/batch utilization).
+#   * RunnerTelemetry     (TTModelRunner[V2], Worker process)   -- REALITY: batch
+#     occupancy, executed batch composition, prefill/decode pass split, and the
+#     actual decode rate.
+#
+# The two run in separate processes and cannot share a Python object, so each
+# writes its own JSON-lines sink; records carry ``request_id`` and a monotonic
+# step index so a consumer joins them offline.
+#
+# Hard rules:
+#   - STDLIB ONLY. This lives in the EngineCore / Worker hot path; never pull in
+#     anything heavy.
+#   - Disabled path is a single cached ``enabled`` bool check: no allocation,
+#     no I/O, must never perturb the inference it measures.
+#   - NO per-step disk I/O at the default flush interval -- per-step writes would
+#     distort the decode rate being measured. Records accumulate in memory and
+#     flush on a wall-clock interval, at request completion, and at shutdown.
+#     TTXLA_TELEMETRY_FLUSH_MS=0 means "no minimum gap", i.e. flush every step:
+#     an explicit opt-in for a live viewer or a test that wants records
+#     immediately, at the cost of the guarantee above. Do not use it to measure
+#     decode rate.
+#   - Per-step work is O(active_slots), never O(output_len).
+#
+# Gating is resolved in ``TTPlatform.check_and_update_config`` (env overrides
+# ``additional_config``, mirroring ``prefill_kv_watermark``) and passed to the
+# collector constructors; ``resolve_config`` below re-reads the env so a
+# collector built directly in a test still honors ``TTXLA_TELEMETRY``.
+#
+# Env vars (each overrides the matching ``additional_config`` knob):
+#   TTXLA_TELEMETRY           truthy ("1","true","yes","on") enables emission
+#   TTXLA_TELEMETRY_DIR       sink directory (default: ./tt_telemetry)
+#   TTXLA_TELEMETRY_FLUSH_MS  min gap between disk flushes (default: 1000)
+#
+# Sinks (all under the configured dir):
+#   scheduler.jsonl       append-only per-step scheduler-decision records
+#   runner.jsonl          append-only per-step runner records + per-request
+#                         completion records
+#   runner_snapshot.json  latest slot-occupancy snapshot, atomically
+#                         overwritten, for a cheap "current state" view
+
+import atexit
+import json
+import os
+import time
+from typing import Any, Optional
+
+# Bump when the record field layout changes so consumers can detect mismatches.
+SCHEMA_VERSION = 1
+
+SCHEDULER_FILENAME = "scheduler.jsonl"
+RUNNER_FILENAME = "runner.jsonl"
+RUNNER_SNAPSHOT_FILENAME = "runner_snapshot.json"
+
+DEFAULT_DIR = "./tt_telemetry"
+DEFAULT_FLUSH_MS = 1000.0
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _is_truthy(value: Any) -> bool:
+    return str(value).strip().lower() in _TRUTHY
+
+
+def resolve_config(
+    enabled: Optional[bool] = None,
+    directory: Optional[str] = None,
+    flush_ms: Optional[float] = None,
+) -> tuple[bool, str, float]:
+    """Resolve telemetry settings, letting env vars override the passed config.
+
+    ``TTPlatform.check_and_update_config`` already folds the env overrides into
+    ``additional_config``; re-reading here keeps a collector constructed
+    directly (e.g. in a unit test) consistent with the env.
+
+    Returns ``(enabled, directory, flush_seconds)``.
+    """
+    env_enabled = os.environ.get("TTXLA_TELEMETRY")
+    if env_enabled is not None:
+        enabled = _is_truthy(env_enabled)
+    enabled = bool(enabled)
+
+    directory = (
+        os.environ.get("TTXLA_TELEMETRY_DIR", "").strip()
+        or (directory or "").strip()
+        or DEFAULT_DIR
+    )
+
+    raw_flush = os.environ.get("TTXLA_TELEMETRY_FLUSH_MS")
+    if raw_flush is None:
+        raw_flush = flush_ms
+    try:
+        flush_ms_val = float(raw_flush) if raw_flush is not None else DEFAULT_FLUSH_MS
+    except (TypeError, ValueError):
+        flush_ms_val = DEFAULT_FLUSH_MS
+    return enabled, directory, max(0.0, flush_ms_val / 1000.0)
+
+
+def reset_sinks(directory):
+    """Delete stale sink files so a fresh run starts empty.
+
+    Meant to run ONCE at engine startup, before the per-process collectors are
+    constructed, so a live viewer never shows a prior run's data during the new
+    run's (long) warmup. Each collector truncates its own JSON-lines file on
+    construction, but that is not enough on its own: the scheduler collector is
+    built only after warmup, and ``runner_snapshot.json`` is never truncated on
+    init (only overwritten on the first step) -- so both would otherwise linger
+    through the warmup window. Best-effort; missing files/dir are ignored.
+    """
+    for name in (SCHEDULER_FILENAME, RUNNER_FILENAME, RUNNER_SNAPSHOT_FILENAME):
+        try:
+            os.remove(os.path.join(directory, name))
+        except OSError:
+            pass
+
+
+class _JsonlSink:
+    """Base collector: buffered JSON-lines writing with interval flush.
+
+    Records are appended to an in-memory buffer and written to disk only on
+    ``flush`` (interval / completion / shutdown), so the measured decode loop is
+    never blocked on per-step I/O. When disabled, ``enabled`` is False and every
+    hook is a guarded no-op.
+    """
+
+    def __init__(
+        self,
+        enabled: bool,
+        directory: str,
+        flush_s: float,
+        jsonl_name: str,
+        snapshot_name: Optional[str] = None,
+    ) -> None:
+        self.enabled = bool(enabled)
+        self._flush_s = flush_s
+        self._jsonl_path: Optional[str] = None
+        self._snapshot_path: Optional[str] = None
+        self._buf: list[dict[str, Any]] = []
+        self._last_flush = time.monotonic()
+        self.step_idx = 0
+        if not self.enabled:
+            return
+        try:
+            os.makedirs(directory, exist_ok=True)
+            self._jsonl_path = os.path.join(directory, jsonl_name)
+            if snapshot_name is not None:
+                self._snapshot_path = os.path.join(directory, snapshot_name)
+            # Truncate any stale sink so a consumer doesn't replay a prior run.
+            open(self._jsonl_path, "w").close()
+            # Flush buffered records at shutdown so the tail isn't lost.
+            atexit.register(self.flush)
+        except OSError:
+            # Never crash the engine over telemetry; just disable.
+            self.enabled = False
+
+    def _emit(self, record: dict[str, Any]) -> None:
+        """Buffer one record in memory (no I/O)."""
+        self._buf.append(record)
+
+    def _maybe_flush(self, now: float) -> None:
+        # flush_s == 0 flushes every step: the documented meaning of
+        # FLUSH_MS=0, relied on by the tests and the live dashboard.
+        if (now - self._last_flush) >= self._flush_s:
+            self.flush(now)
+
+    def flush(self, now: Optional[float] = None) -> None:
+        """Append buffered records to the JSON-lines sink. Best-effort."""
+        if now is None:
+            now = time.monotonic()
+        self._last_flush = now
+        if not self.enabled or not self._buf or self._jsonl_path is None:
+            return
+        try:
+            with open(self._jsonl_path, "a") as f:
+                for record in self._buf:
+                    f.write(json.dumps(record, separators=(",", ":")) + "\n")
+        except (OSError, TypeError, ValueError):
+            pass
+        self._buf.clear()
+
+    def _write_snapshot(self, obj: dict[str, Any]) -> None:
+        """Atomically overwrite the snapshot file (temp + os.replace) so a
+        reader never sees a half-written file."""
+        if self._snapshot_path is None:
+            return
+        try:
+            tmp = self._snapshot_path + ".tmp"
+            with open(tmp, "w") as f:
+                json.dump(obj, f, separators=(",", ":"))
+            os.replace(tmp, self._snapshot_path)
+        except (OSError, TypeError, ValueError):
+            pass
+
+
+class SchedulerTelemetry(_JsonlSink):
+    """Per-step scheduler-decision telemetry for ``AscendScheduler``.
+
+    One record per ``schedule()`` call capturing the decision (prefill vs decode
+    split, preemption, queue depth) and utilization (KV pool, running batch).
+    Cumulative counters let a consumer read totals without re-aggregating.
+    """
+
+    def __init__(self, enabled: bool, directory: str, flush_s: float) -> None:
+        super().__init__(enabled, directory, flush_s, SCHEDULER_FILENAME)
+        self._total_preempted = 0
+        self._total_decode_stalled_steps = 0
+        self._total_watermark_rejects = 0
+        self._total_b1_cap_hits = 0
+
+    def on_schedule(
+        self,
+        *,
+        num_running: int,
+        max_running: int,
+        num_waiting: int,
+        num_free_blocks: int,
+        num_total_blocks: int,
+        prefill_new: int,
+        prefill_resumed: int,
+        prefill_partial: int,
+        running_scheduled: int,
+        preempted: int,
+        decode_gated: bool,
+        decodes_displaced: int,
+        total_scheduled_tokens: int,
+        watermark_rejects: int = 0,
+        b1_cap_hit: bool = False,
+    ) -> None:
+        """Hook: end of ``AscendScheduler.schedule()`` (append-only tail)."""
+        if not self.enabled:
+            return
+        try:
+            now = time.monotonic()
+            self.step_idx += 1
+            self._total_preempted += preempted
+            if decode_gated:
+                self._total_decode_stalled_steps += 1
+            self._total_watermark_rejects += watermark_rejects
+            if b1_cap_hit:
+                self._total_b1_cap_hits += 1
+
+            kv_util = (
+                (num_total_blocks - num_free_blocks) / num_total_blocks
+                if num_total_blocks > 0
+                else None
+            )
+            batch_util = num_running / max_running if max_running > 0 else None
+
+            self._emit(
+                {
+                    "schema": SCHEMA_VERSION,
+                    "layer": "scheduler",
+                    "ts": time.time(),
+                    "step": self.step_idx,
+                    "num_running": num_running,
+                    "max_running": max_running,
+                    "num_waiting": num_waiting,
+                    "batch_util": (
+                        round(batch_util, 4) if batch_util is not None else None
+                    ),
+                    "kv_util": round(kv_util, 4) if kv_util is not None else None,
+                    "num_free_blocks": num_free_blocks,
+                    "num_total_blocks": num_total_blocks,
+                    "prefill_new": prefill_new,
+                    "prefill_resumed": prefill_resumed,
+                    "prefill_partial": prefill_partial,
+                    "running_scheduled": running_scheduled,
+                    "preempted": preempted,
+                    # Prefill-first gate; decodes_displaced counts the running
+                    # decodes that had to wait.
+                    "decode_gated": bool(decode_gated),
+                    "decodes_displaced": decodes_displaced,
+                    "watermark_rejects": watermark_rejects,
+                    "b1_cap_hit": bool(b1_cap_hit),
+                    "total_scheduled_tokens": total_scheduled_tokens,
+                    "cum_preempted": self._total_preempted,
+                    "cum_decode_stalled_steps": self._total_decode_stalled_steps,
+                    "cum_watermark_rejects": self._total_watermark_rejects,
+                    "cum_b1_cap_hits": self._total_b1_cap_hits,
+                }
+            )
+            self._maybe_flush(now)
+        except Exception:
+            # Telemetry must never take down the engine.
+            pass
+
+
+class RunnerTelemetry(_JsonlSink):
+    """Slot / decode-rate telemetry for the model runner.
+
+    Reads a slot view of the runner's batch, so per-step work is O(active_slots).
+    Emits per-step records (occupancy, prefill/decode pass split, decode rate)
+    plus per-request completion records, and keeps a latest-state snapshot for
+    live viewing.
+
+    The view is whatever the runner passes to ``on_step``: the v2 runner hands
+    over its persistent slot table (``TTRequestState``) directly; the v1 runner
+    builds ``model_runner._V1SlotView`` over its condensing ``InputBatch``. One
+    consequence is worth knowing when reading the output: v1 row indices are not
+    stable identities -- ``InputBatch.condense`` compacts rows when a request
+    leaves -- so a v1 slot timeline shows row reuse where v2 shows residency.
+    """
+
+    def __init__(self, enabled: bool, directory: str, flush_s: float) -> None:
+        super().__init__(
+            enabled,
+            directory,
+            flush_s,
+            RUNNER_FILENAME,
+            snapshot_name=RUNNER_SNAPSHOT_FILENAME,
+        )
+        self._last_step_ts: Optional[float] = None
+
+    def on_request_admitted(
+        self,
+        req_id: str,
+        slot: int,
+        prompt_len: int,
+        prefill_len: int,
+        *,
+        num_cached_tokens: int = 0,
+        readmission: bool = False,
+    ) -> None:
+        """Hook: the runner's admission path (per admitted row). O(1).
+
+        ``prefill_len`` is the absolute prefill boundary -- the full known prefix
+        before generation starts -- not the number of tokens left to compute.
+
+        The two runners signal a prefix-cache hit differently: v2 carries a
+        ``prefill_token_ids`` prefix that can exceed the prompt, so
+        ``prefill_len > prompt_len``; v1 has no such field and instead admits the
+        request with ``num_computed_tokens`` already advanced. Accept both so the
+        record means the same thing on either runner.
+
+        ``readmission`` distinguishes a request entering the batch again from a
+        first admission, so consumers counting requests served -- or hunting
+        genuine cross-request prefix hits -- can filter it out. The runners reach
+        this state differently:
+
+        * v1 removes any request it did not schedule this step from the batch and
+          re-adds it later, usually at a different row. This is common, so
+          admission records routinely outnumber requests, and a re-admitted
+          request reports ``prefix_cache_hit`` against its own prefix.
+        * v2 keeps a request in its slot across steps, so this only fires when an
+          id arrives while a stale slot still holds it (abort + resubmit). A v2
+          request resumed from preemption instead arrives as a fresh request and
+          shows up as nonzero ``num_cached_tokens`` / ``prefill_len >
+          prompt_len``, not as a re-admission.
+        """
+        if not self.enabled:
+            return
+        try:
+            self._emit(
+                {
+                    "schema": SCHEMA_VERSION,
+                    "layer": "runner",
+                    "event": "request_admitted",
+                    "ts": time.time(),
+                    "step": self.step_idx,
+                    "request_id": req_id,
+                    "slot": slot,
+                    "prompt_len": prompt_len,
+                    "prefill_len": prefill_len,
+                    "num_cached_tokens": num_cached_tokens,
+                    "prefix_cache_hit": prefill_len > prompt_len
+                    or num_cached_tokens > 0,
+                    "readmission": readmission,
+                }
+            )
+        except Exception:
+            pass
+
+    def on_request_completed(
+        self, req_id: str, slot: int, prompt_len: int, output_len: int
+    ) -> None:
+        """Hook: the runner's request-teardown path (per freed slot). O(1).
+
+        Flushes so a completed request is visible promptly to a consumer.
+        """
+        if not self.enabled:
+            return
+        try:
+            self._emit(
+                {
+                    "schema": SCHEMA_VERSION,
+                    "layer": "runner",
+                    "event": "request_completed",
+                    "ts": time.time(),
+                    "step": self.step_idx,
+                    "request_id": req_id,
+                    "slot": slot,
+                    "prompt_len": prompt_len,
+                    "output_len": output_len,
+                }
+            )
+            self.flush()
+        except Exception:
+            pass
+
+    def on_step(
+        self,
+        req_states: Any,
+        *,
+        prefill_passes: int,
+        decode_passes: int,
+        emitted_tokens: int,
+    ) -> None:
+        """Hook: end of the runner's ``sample_tokens``. O(active_slots).
+
+        ``emitted_tokens`` counts *tokens* emitted this step, not emitting rows
+        (rows still prefilling emit none). Decode rate is emitted-tokens /
+        wall-time since the previous step, i.e. *accepted* tokens/step. On the v1
+        runner that distinction is live rather than theoretical: with spec decode
+        a row can accept several tokens in one step, and the caller sums
+        the per-row accepted lengths (``gen_lens``) rather than counting rows.
+        """
+        if not self.enabled:
+            return
+        try:
+            now = time.monotonic()
+            self.step_idx += 1
+
+            occupied = len(req_states.req_id_to_index)
+            free = len(req_states.free_indices)
+            total_slots = occupied + free
+
+            prefilling = 0
+            decoding = 0
+            slots: list[dict[str, Any]] = []
+            for req_id, slot in req_states.req_id_to_index.items():
+                computed = int(req_states.num_computed_tokens[slot])
+                prefill_len = int(req_states.prefill_len[slot])
+                state = "PREFILL" if computed < prefill_len else "DECODE"
+                if state == "PREFILL":
+                    prefilling += 1
+                else:
+                    decoding += 1
+                slots.append(
+                    {
+                        "slot": slot,
+                        "request_id": req_id,
+                        "state": state,
+                        "num_computed_tokens": computed,
+                        "prefill_len": prefill_len,
+                        "total_len": int(req_states.total_len[slot]),
+                    }
+                )
+
+            dt = None if self._last_step_ts is None else (now - self._last_step_ts)
+            self._last_step_ts = now
+            decode_rate = (emitted_tokens / dt) if (dt is not None and dt > 0) else None
+
+            record = {
+                "schema": SCHEMA_VERSION,
+                "layer": "runner",
+                "event": "step",
+                "ts": time.time(),
+                "step": self.step_idx,
+                "slots_occupied": occupied,
+                "slots_free": free,
+                "slots_total": total_slots,
+                "slot_util": (
+                    round(occupied / total_slots, 4) if total_slots > 0 else None
+                ),
+                "num_prefilling": prefilling,
+                "num_decoding": decoding,
+                # Per-step pass split: a pass is a prefill pass if any row in it
+                # is still below its prefill_len, else a decode pass.
+                "prefill_passes": prefill_passes,
+                "decode_passes": decode_passes,
+                "emitted_tokens": emitted_tokens,
+                "step_dt_s": round(dt, 6) if dt is not None else None,
+                "decode_rate_toks_per_s": (
+                    round(decode_rate, 2) if decode_rate is not None else None
+                ),
+            }
+            self._emit(record)
+            self._write_snapshot({**record, "slots": slots})
+            self._maybe_flush(now)
+        except Exception:
+            pass

--- a/scripts/telemetry/telemetry_viz.py
+++ b/scripts/telemetry/telemetry_viz.py
@@ -1,0 +1,246 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Visualize vLLM serving telemetry.
+
+Consumes the JSON-lines sinks written by vllm_tt/telemetry.py
+(scheduler.jsonl, runner.jsonl, runner_snapshot.json) and renders a single
+self-contained interactive HTML dashboard: slot-occupancy timeline,
+decode-rate / KV / batch-utilization overlays, a per-request Gantt, and an
+event strip (prefill-stalled-decode, preemption, watermark rejects, b1 caps).
+
+Two modes:
+
+  report  Parse a finished run's sinks and write a standalone HTML file
+          (data embedded; no server needed to view).
+
+            python scripts/telemetry/telemetry_viz.py report [--dir tt_telemetry] \
+                [--out tt_telemetry/report.html]
+
+  live    Serve the same dashboard on localhost and poll the sinks while a
+          model is serving, so slot state / decode rate update in place.
+
+            python scripts/telemetry/telemetry_viz.py live [--dir tt_telemetry] \
+                [--port 8009] [--interval-ms 500]
+
+The dashboard is dependency-free (stdlib only) and theme-aware (light/dark).
+"""
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+SCHEDULER_FILE = "scheduler.jsonl"
+RUNNER_FILE = "runner.jsonl"
+SNAPSHOT_FILE = "runner_snapshot.json"
+
+
+# --------------------------------------------------------------------------- #
+# Parsing
+# --------------------------------------------------------------------------- #
+def _read_jsonl(path):
+    if not os.path.exists(path):
+        return []
+    out = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                out.append(json.loads(line))
+            except json.JSONDecodeError:
+                # A live tail may catch a half-written final line; skip it.
+                continue
+    return out
+
+
+def load(directory):
+    """Load and split the telemetry sinks into the shape the page renders from."""
+    d = Path(directory)
+    scheduler = _read_jsonl(d / SCHEDULER_FILE)
+    runner = _read_jsonl(d / RUNNER_FILE)
+    snapshot = None
+    snap_path = d / SNAPSHOT_FILE
+    if snap_path.exists():
+        try:
+            snapshot = json.loads(snap_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            snapshot = None
+
+    runner_steps = [r for r in runner if r.get("event") == "step"]
+    admits = [r for r in runner if r.get("event") == "request_admitted"]
+    completes = [r for r in runner if r.get("event") == "request_completed"]
+    return {
+        "scheduler": scheduler,
+        "runner_steps": runner_steps,
+        "admits": admits,
+        "completes": completes,
+        "snapshot": snapshot,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# HTML rendering
+# --------------------------------------------------------------------------- #
+def render_html(data, live=False, interval_ms=500, body_only=False):
+    payload = json.dumps(data, separators=(",", ":"))
+    page = (
+        _template()
+        .replace("/*__LIVE__*/", "true" if live else "false")
+        .replace("/*__INTERVAL__*/", str(int(interval_ms)))
+        .replace("/*__DATA__*/", payload if not live else "null")
+    )
+    if not body_only:
+        return page
+    # Emit page content only (style + body markup + script), no document
+    # scaffolding: suitable for a host that wraps it in its own <head>/<body>
+    # skeleton (e.g. a claude.ai Artifact). The <title> is dropped (the host
+    # supplies it); the <style> block is kept (inline CSS is still required).
+    start = page.index("<style>")
+    end = page.index("</script>") + len("</script>")
+    chunk = page[start:end]
+    return chunk.replace("</head>", "").replace("<body>", "").strip()
+
+
+_TEMPLATE_PATH = Path(__file__).resolve().parent / "telemetry_viz_template.html"
+_TEMPLATE = None
+
+
+def _template():
+    """Read (and cache) the page template shipped beside this script."""
+    global _TEMPLATE
+    if _TEMPLATE is None:
+        try:
+            _TEMPLATE = _TEMPLATE_PATH.read_text()
+        except OSError as e:
+            raise SystemExit(
+                f"telemetry_viz: cannot read page template " f"{_TEMPLATE_PATH}: {e}"
+            )
+    return _TEMPLATE
+
+
+# --------------------------------------------------------------------------- #
+# Modes
+# --------------------------------------------------------------------------- #
+def cmd_report(args):
+    data = load(args.dir)
+    n_sched = len(data["scheduler"])
+    n_run = len(data["runner_steps"])
+    if n_sched == 0 and n_run == 0:
+        print(
+            f"No telemetry found in {args.dir!r} "
+            f"(looked for {SCHEDULER_FILE} / {RUNNER_FILE}). "
+            f"Run a serving job with TTXLA_TELEMETRY=1 first.",
+            file=sys.stderr,
+        )
+        return 1
+    out = args.out or os.path.join(args.dir, "report.html")
+    Path(out).write_text(render_html(data, live=False, body_only=args.body_only))
+    print(f"Wrote {out}")
+    print(f"  scheduler steps: {n_sched}")
+    print(f"  runner steps:    {n_run}")
+    print(
+        f"  requests:        {len(data['admits'])} admitted, "
+        f"{len(data['completes'])} completed"
+    )
+    print(f"Open it: file://{os.path.abspath(out)}")
+    return 0
+
+
+def cmd_live(args):
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+    directory = args.dir
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *a):  # quiet
+            pass
+
+        def _send(self, body, ctype):
+            self.send_response(200)
+            self.send_header("Content-Type", ctype)
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Cache-Control", "no-store")
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self):
+            path = self.path.split("?", 1)[0]
+            if path in ("/", "/index.html"):
+                html = render_html(None, live=True, interval_ms=args.interval_ms)
+                self._send(html.encode(), "text/html; charset=utf-8")
+            elif path == "/data.json":
+                self._send(json.dumps(load(directory)).encode(), "application/json")
+            else:
+                self.send_error(404)
+
+    try:
+        srv = ThreadingHTTPServer(("127.0.0.1", args.port), Handler)
+    except OSError as e:
+        print(
+            f"error: cannot bind to port {args.port}: {e}\n"
+            f"Is another telemetry_viz process already running?  "
+            f"Try: lsof -ti :{args.port} | xargs kill",
+            file=sys.stderr,
+        )
+        return 1
+    url = f"http://127.0.0.1:{args.port}/"
+    print(f"Serving telemetry dashboard for {directory!r} at {url}")
+    print(f"Polling every {args.interval_ms} ms. Ctrl-C to stop.")
+    try:
+        srv.serve_forever()
+    except KeyboardInterrupt:
+        print("\nstopped.")
+    finally:
+        srv.server_close()
+    return 0
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    sub = p.add_subparsers(dest="mode", required=True)
+
+    pr = sub.add_parser(
+        "report", help="write a standalone HTML report from a finished run"
+    )
+    pr.add_argument(
+        "--dir",
+        default="tt_telemetry",
+        help="telemetry directory (default: tt_telemetry)",
+    )
+    pr.add_argument(
+        "--out", default=None, help="output HTML path (default: <dir>/report.html)"
+    )
+    pr.add_argument(
+        "--body-only",
+        action="store_true",
+        help="emit page content only (no <html>/<head>/<body>), for embedding in "
+        "a host that supplies the document skeleton",
+    )
+    pr.set_defaults(func=cmd_report)
+
+    pl = sub.add_parser("live", help="serve a live-updating dashboard on localhost")
+    pl.add_argument(
+        "--dir",
+        default="tt_telemetry",
+        help="telemetry directory (default: tt_telemetry)",
+    )
+    pl.add_argument("--port", type=int, default=8009, help="port (default: 8009)")
+    pl.add_argument(
+        "--interval-ms",
+        type=int,
+        default=500,
+        help="browser poll interval (default: 500)",
+    )
+    pl.set_defaults(func=cmd_live)
+
+    args = p.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/telemetry/telemetry_viz_template.html
+++ b/scripts/telemetry/telemetry_viz_template.html
@@ -1,0 +1,504 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>vLLM TT serving telemetry</title>
+<style>
+  :root{
+    --plane:#f9f9f7; --surface:#fcfcfb; --ink:#0b0b0b; --ink2:#52514e;
+    --muted:#898781; --grid:#e1e0d9; --axis:#c3c2b7; --ring:rgba(11,11,11,0.10);
+    --prefill:#eb6834;   /* orange  (slot 2) */
+    --decode:#2a78d6;    /* blue    (slot 1) */
+    --kv:#2a78d6;        /* blue    */
+    --batch:#1baf7a;     /* aqua    (slot 3) */
+    --good:#0ca30c; --warning:#fab219; --serious:#ec835a; --critical:#d03b3b;
+    --g1:#2a78d6; --g2:#eb6834; --g3:#1baf7a; --g4:#eda100;
+    --g5:#e87ba4; --g6:#008300; --g7:#4a3aa7; --g8:#e34948;
+    color-scheme:light;
+  }
+  @media (prefers-color-scheme:dark){
+    :root:where(:not([data-theme="light"])){
+      --plane:#0d0d0d; --surface:#1a1a19; --ink:#fff; --ink2:#c3c2b7;
+      --muted:#898781; --grid:#2c2c2a; --axis:#383835; --ring:rgba(255,255,255,0.10);
+      --prefill:#d95926; --decode:#3987e5; --kv:#3987e5; --batch:#199e70;
+      --g1:#3987e5; --g2:#d95926; --g3:#199e70; --g4:#c98500;
+      --g5:#d55181; --g6:#008300; --g7:#9085e9; --g8:#e66767;
+      color-scheme:dark;
+    }
+  }
+  :root[data-theme="dark"]{
+    --plane:#0d0d0d; --surface:#1a1a19; --ink:#fff; --ink2:#c3c2b7;
+    --muted:#898781; --grid:#2c2c2a; --axis:#383835; --ring:rgba(255,255,255,0.10);
+    --prefill:#d95926; --decode:#3987e5; --kv:#3987e5; --batch:#199e70;
+    --g1:#3987e5; --g2:#d95926; --g3:#199e70; --g4:#c98500;
+    --g5:#d55181; --g6:#008300; --g7:#9085e9; --g8:#e66767;
+    color-scheme:dark;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--plane);color:var(--ink);
+    font-family:system-ui,-apple-system,"Segoe UI",sans-serif;font-size:14px;line-height:1.45}
+  .wrap{max-width:1080px;margin:0 auto;padding:24px 20px 64px}
+  header{display:flex;align-items:baseline;justify-content:space-between;gap:16px;flex-wrap:wrap}
+  h1{font-size:20px;margin:0 0 2px}
+  .sub{color:var(--ink2);font-size:13px}
+  .controls{display:flex;gap:8px;align-items:center}
+  button{font:inherit;color:var(--ink);background:var(--surface);border:1px solid var(--ring);
+    border-radius:8px;padding:6px 12px;cursor:pointer}
+  button:hover{border-color:var(--axis)}
+  .badge{display:inline-flex;align-items:center;gap:6px;font-size:12px;color:var(--ink2)}
+  .dot{width:8px;height:8px;border-radius:50%;display:inline-block}
+  .live-on{color:var(--good)} .live-off{color:var(--muted)}
+  .tiles{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:12px;margin:20px 0}
+  .tile{background:var(--surface);border:1px solid var(--ring);border-radius:12px;padding:14px 16px}
+  .tile .k{color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:.04em}
+  .tile .v{font-size:26px;margin-top:4px}
+  .tile .u{color:var(--ink2);font-size:13px;margin-left:4px}
+  figure{margin:22px 0 0;background:var(--surface);border:1px solid var(--ring);
+    border-radius:12px;padding:16px 16px 8px}
+  figcaption{font-size:14px;font-weight:600;margin-bottom:2px}
+  .capsub{color:var(--ink2);font-size:12px;margin-bottom:8px}
+  .legend{display:flex;gap:16px;flex-wrap:wrap;margin:2px 0 8px;font-size:12px;color:var(--ink2)}
+  .legend span{display:inline-flex;align-items:center;gap:6px}
+  .swatch{width:12px;height:12px;border-radius:3px;display:inline-block}
+  .chart{width:100%}
+  svg{display:block;width:100%;height:auto}
+  .grid line{stroke:var(--grid);stroke-width:1}
+  .axis line{stroke:var(--axis);stroke-width:1}
+  .tick{fill:var(--muted);font-size:11px;font-variant-numeric:tabular-nums}
+  .alab{fill:var(--ink2);font-size:11px}
+  .crosshair{stroke:var(--axis);stroke-width:1;stroke-dasharray:3 3;visibility:hidden}
+  .events .ev{cursor:pointer}
+  .glabel{fill:var(--ink);font-size:11px;font-variant-numeric:tabular-nums}
+  .tooltip{position:fixed;pointer-events:none;z-index:20;background:var(--surface);
+    color:var(--ink);border:1px solid var(--ring);border-radius:8px;padding:8px 10px;
+    font-size:12px;box-shadow:0 4px 16px rgba(0,0,0,.18);visibility:hidden;max-width:280px}
+  .tooltip b{font-weight:600}
+  .tooltip .row{display:flex;justify-content:space-between;gap:14px}
+  .tooltip .k{color:var(--ink2)}
+  .tblwrap{overflow-x:auto;margin-top:10px;display:none}
+  table{border-collapse:collapse;font-size:12px;font-variant-numeric:tabular-nums;width:100%}
+  th,td{text-align:right;padding:4px 8px;border-bottom:1px solid var(--grid);white-space:nowrap}
+  th:first-child,td:first-child{text-align:left}
+  th{color:var(--muted);font-weight:600;position:sticky;top:0;background:var(--surface)}
+  .empty{color:var(--muted);padding:28px 0;text-align:center}
+  .statuschips{display:flex;gap:14px;flex-wrap:wrap;margin-top:4px}
+  .chip{display:inline-flex;align-items:center;gap:7px;font-size:13px}
+  .chip .n{font-variant-numeric:tabular-nums;font-weight:600}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <div>
+      <h1>vLLM TT serving telemetry</h1>
+      <div class="sub" id="sub">&nbsp;</div>
+    </div>
+    <div class="controls">
+      <span class="badge" id="livebadge"></span>
+      <button id="tableToggle" type="button">Show data tables</button>
+      <button id="themeToggle" type="button">Toggle theme</button>
+    </div>
+  </header>
+
+  <section class="tiles" id="tiles"></section>
+
+  <figure>
+    <figcaption>Slot occupancy over steps</figcaption>
+    <div class="capsub">Per step: how many of the runner's slots are prefilling vs decoding. Dashed line = total slots (batch capacity).</div>
+    <div class="legend">
+      <span><i class="swatch" style="background:var(--decode)"></i>decoding</span>
+      <span><i class="swatch" style="background:var(--prefill)"></i>prefilling</span>
+      <span><i class="swatch" style="background:var(--axis)"></i>total slots</span>
+    </div>
+    <div class="chart" id="c_occ"></div>
+    <div class="tblwrap" id="t_occ"></div>
+  </figure>
+
+  <figure>
+    <figcaption>Decode rate over steps</figcaption>
+    <div class="capsub">Accepted tokens emitted per second (runner). Ticks below mark steps where a prefill stalled in-flight decode.</div>
+    <div class="chart" id="c_rate"></div>
+    <div class="tblwrap" id="t_rate"></div>
+  </figure>
+
+  <figure>
+    <figcaption>KV-cache &amp; batch utilization over steps</figcaption>
+    <div class="capsub">Scheduler view. KV = used blocks / total; batch = running requests / max. Both are fractions on one 0–100% axis.</div>
+    <div class="legend">
+      <span><i class="swatch" style="background:var(--kv)"></i>KV utilization</span>
+      <span><i class="swatch" style="background:var(--batch)"></i>batch utilization</span>
+    </div>
+    <div class="chart" id="c_util"></div>
+    <div class="tblwrap" id="t_util"></div>
+  </figure>
+
+  <figure>
+    <figcaption>Per-request lifecycle</figcaption>
+    <div class="capsub">Each row is a request, from admission to completion (x = step). Label shows request id and output length.</div>
+    <div class="chart" id="c_gantt"></div>
+    <div class="tblwrap" id="t_gantt"></div>
+  </figure>
+
+  <figure id="fig_snap">
+    <figcaption>Current slot table</figcaption>
+    <div class="capsub" id="snapsub">Latest per-slot state from runner_snapshot.json.</div>
+    <div id="c_snap"></div>
+  </figure>
+
+  <figure>
+    <figcaption>Scheduler events (run totals)</figcaption>
+    <div class="capsub">TT-specific decisions accumulated over the run.</div>
+    <div class="statuschips" id="chips"></div>
+  </figure>
+</div>
+
+<div class="tooltip" id="tip"></div>
+
+<script>
+const LIVE = /*__LIVE__*/;
+const INTERVAL = /*__INTERVAL__*/;
+let DATA = /*__DATA__*/;
+
+const tip = document.getElementById('tip');
+const css = (n)=>getComputedStyle(document.documentElement).getPropertyValue(n).trim();
+const fmt = (x,d=0)=> x==null||Number.isNaN(x) ? '—' : Number(x).toLocaleString(undefined,{maximumFractionDigits:d,minimumFractionDigits:d>0?0:0});
+const pct = (x)=> x==null ? '—' : (100*x).toFixed(1)+'%';
+
+function showTip(html, ev){
+  tip.innerHTML = html;
+  tip.style.visibility='visible';
+  const pad=14, w=tip.offsetWidth, h=tip.offsetHeight;
+  let x=ev.clientX+pad, y=ev.clientY+pad;
+  if(x+w>window.innerWidth) x=ev.clientX-w-pad;
+  if(y+h>window.innerHeight) y=ev.clientY-h-pad;
+  tip.style.left=x+'px'; tip.style.top=y+'px';
+}
+const hideTip = ()=>{ tip.style.visibility='hidden'; };
+
+// ---- tiny SVG helpers -----------------------------------------------------
+const SVGNS='http://www.w3.org/2000/svg';
+function el(tag, attrs){ const e=document.createElementNS(SVGNS,tag);
+  for(const k in attrs) e.setAttribute(k, attrs[k]); return e; }
+function scale(d0,d1,r0,r1){ const m=(r1-r0)/((d1-d0)||1); return v=>r0+(v-d0)*m; }
+function niceTicks(max,n=5){ if(max<=0) return [0]; const step=Math.max(1,Math.ceil(max/n));
+  const out=[]; for(let v=0; v<=max+1e-9; v+=step) out.push(v); return out; }
+
+// mount: measure width, (re)draw responsively
+const _mounts=[];
+function mount(id, height, draw){
+  const host=document.getElementById(id);
+  const render=()=>{ const w=host.clientWidth||720; host.innerHTML='';
+    const svg=el('svg',{viewBox:`0 0 ${w} ${height}`,width:w,height:height});
+    host.appendChild(svg); draw(svg,w,height); };
+  _mounts.push(render); render();
+  if(!mount._ro){ mount._ro=new ResizeObserver(()=>{ for(const r of _mounts) r(); });
+    mount._ro.observe(document.body); }
+}
+function remount(){ for(const r of _mounts) r(); }
+
+const PAD={l:44,r:14,t:12,b:26};
+function axes(svg,w,h,xmax,ymax,yfmt,xlabel,yticks){
+  const ix=scale(0,xmax,PAD.l,w-PAD.r), iy=scale(0,ymax,h-PAD.b,PAD.t);
+  const g=el('g',{}); svg.appendChild(g);
+  const grid=el('g',{class:'grid'}); g.appendChild(grid);
+  for(const yt of (yticks||niceTicks(ymax))){ const y=iy(yt);
+    grid.appendChild(el('line',{x1:PAD.l,y1:y,x2:w-PAD.r,y2:y}));
+    const t=el('text',{class:'tick',x:PAD.l-6,y:y+3,'text-anchor':'end'}); t.textContent=yfmt(yt); g.appendChild(t);
+  }
+  const xt=niceTicks(xmax, Math.min(8,xmax));
+  for(const xv of xt){ const x=ix(xv);
+    const t=el('text',{class:'tick',x:x,y:h-PAD.b+16,'text-anchor':'middle'}); t.textContent=xv; g.appendChild(t);
+  }
+  const ax=el('g',{class:'axis'}); g.appendChild(ax);
+  ax.appendChild(el('line',{x1:PAD.l,y1:h-PAD.b,x2:w-PAD.r,y2:h-PAD.b}));
+  if(xlabel){ const t=el('text',{class:'alab',x:(w-PAD.r+PAD.l)/2,y:h-2,'text-anchor':'middle'}); t.textContent=xlabel; g.appendChild(t); }
+  return {ix,iy};
+}
+// crosshair + hover overlay shared by the step timeline charts
+function hoverLayer(svg,w,h,xmax,rows,onIdx){
+  const ix=scale(0,xmax,PAD.l,w-PAD.r);
+  const ch=el('line',{class:'crosshair',y1:PAD.t,y2:h-PAD.b}); svg.appendChild(ch);
+  const rect=el('rect',{x:PAD.l,y:PAD.t,width:Math.max(1,w-PAD.r-PAD.l),height:Math.max(1,h-PAD.b-PAD.t),fill:'transparent'});
+  svg.appendChild(rect);
+  const steps=rows.map(r=>r.step);
+  rect.addEventListener('pointermove',(ev)=>{
+    const pt=svg.getBoundingClientRect(); const sx=(ev.clientX-pt.left)*(w/pt.width);
+    let best=0,bd=1e9; for(let i=0;i<steps.length;i++){const d=Math.abs(ix(steps[i])-sx); if(d<bd){bd=d;best=i;}}
+    const row=rows[best]; if(!row) return; ch.setAttribute('x1',ix(row.step)); ch.setAttribute('x2',ix(row.step));
+    ch.style.visibility='visible'; onIdx(best,row,ev);
+  });
+  rect.addEventListener('pointerleave',()=>{ ch.style.visibility='hidden'; hideTip(); });
+}
+const trow=(k,v)=>`<div class="row"><span class="k">${k}</span><span>${v}</span></div>`;
+
+// ---- charts ---------------------------------------------------------------
+function chartOccupancy(){
+  const rows=DATA.runner_steps; const host='c_occ';
+  if(!rows.length){ document.getElementById(host).innerHTML='<div class="empty">no runner step records</div>'; return; }
+  const xmax=Math.max(...rows.map(r=>r.step),1);
+  const cap=Math.max(...rows.map(r=>r.slots_total||0),1);
+  const ymax=Math.max(cap, ...rows.map(r=>(r.num_prefilling||0)+(r.num_decoding||0)),1);
+  mount(host,210,(svg,w,h)=>{
+    const {ix,iy}=axes(svg,w,h,xmax,ymax,v=>v,'step');
+    const base=h-PAD.b;
+    // stacked area: decode (bottom) + prefill (top), 2px surface gap between
+    const dPts=[], pTopPts=[], pBotPts=[];
+    for(const r of rows){ const d=r.num_decoding||0, p=r.num_prefilling||0;
+      dPts.push([ix(r.step),iy(d)]); pBotPts.push([ix(r.step),iy(d)]); pTopPts.push([ix(r.step),iy(d+p)]); }
+    const areaPath=(top,botY)=>{ let s='M'+top[0][0]+','+botY; for(const q of top) s+=' L'+q[0]+','+q[1];
+      s+=' L'+top[top.length-1][0]+','+botY+' Z'; return s; };
+    svg.appendChild(el('path',{d:areaPath(dPts,base),fill:'var(--decode)','fill-opacity':.85}));
+    // prefill band sits above decode; draw as polygon between pBot and pTop
+    let pp='M'+pBotPts[0][0]+','+pBotPts[0][1];
+    for(const q of pTopPts) pp+=' L'+q[0]+','+q[1];
+    for(let i=pBotPts.length-1;i>=0;i--) pp+=' L'+pBotPts[i][0]+','+pBotPts[i][1];
+    pp+=' Z';
+    svg.appendChild(el('path',{d:pp,fill:'var(--prefill)','fill-opacity':.9,stroke:'var(--surface)','stroke-width':1}));
+    // capacity reference line
+    svg.appendChild(el('line',{x1:PAD.l,y1:iy(cap),x2:w-PAD.r,y2:iy(cap),
+      stroke:'var(--axis)','stroke-width':1.5,'stroke-dasharray':'5 4'}));
+    hoverLayer(svg,w,h,xmax,rows,(i,row,ev)=>{
+      showTip(`<b>step ${row.step}</b>`+trow('decoding',row.num_decoding||0)
+        +trow('prefilling',row.num_prefilling||0)+trow('occupied',row.slots_occupied||0)
+        +trow('free',row.slots_free||0)+trow('capacity',cap),ev);
+    });
+  });
+  tableFor('t_occ',['step','slots_occupied','slots_free','num_prefilling','num_decoding','slot_util'],rows,
+    {slot_util:pct});
+}
+
+function chartRate(){
+  const rows=DATA.runner_steps.filter(r=>r.decode_rate_toks_per_s!=null); const host='c_rate';
+  const all=DATA.runner_steps;
+  if(!all.length){ document.getElementById(host).innerHTML='<div class="empty">no runner step records</div>'; return; }
+  const xmax=Math.max(...all.map(r=>r.step),1);
+  const ymax=Math.max(...rows.map(r=>r.decode_rate_toks_per_s),1);
+  const gated=new Set(DATA.scheduler.filter(s=>s.decode_gated).map(s=>s.step));
+  mount(host,200,(svg,w,h)=>{
+    const {ix,iy}=axes(svg,w,h,xmax,ymax,v=>v,'step');
+    if(rows.length){ let s='M'+ix(rows[0].step)+','+iy(rows[0].decode_rate_toks_per_s);
+      for(const r of rows) s+=' L'+ix(r.step)+','+iy(r.decode_rate_toks_per_s);
+      svg.appendChild(el('path',{d:s,fill:'none',stroke:'var(--decode)','stroke-width':2,
+        'stroke-linejoin':'round','stroke-linecap':'round'})); }
+    // event rug: prefill-stalled steps
+    const rug=el('g',{class:'events'}); svg.appendChild(rug);
+    for(const step of gated){ const x=ix(step);
+      const m=el('line',{class:'ev',x1:x,y1:h-PAD.b+2,x2:x,y2:h-PAD.b+9,stroke:'var(--warning)','stroke-width':2});
+      m.addEventListener('pointerenter',(ev)=>showTip(`<b>step ${step}</b>`+trow('event','prefill stalled decode'),ev));
+      m.addEventListener('pointerleave',hideTip); rug.appendChild(m); }
+    hoverLayer(svg,w,h,xmax,all,(i,row,ev)=>{
+      showTip(`<b>step ${row.step}</b>`+trow('decode rate',fmt(row.decode_rate_toks_per_s,1)+' tok/s')
+        +trow('emitted',row.emitted_tokens||0)+trow('step dt',row.step_dt_s==null?'—':fmt(row.step_dt_s*1000,0)+' ms')
+        +trow('prefill/decode passes',(row.prefill_passes||0)+' / '+(row.decode_passes||0))
+        +(gated.has(row.step)?trow('⚠','prefill stalled decode'):''),ev);
+    });
+  });
+  tableFor('t_rate',['step','decode_rate_toks_per_s','emitted_tokens','prefill_passes','decode_passes','step_dt_s'],all,
+    {decode_rate_toks_per_s:v=>fmt(v,1),step_dt_s:v=>v==null?'—':fmt(v*1000,0)});
+}
+
+function chartUtil(){
+  const rows=DATA.scheduler; const host='c_util';
+  if(!rows.length){ document.getElementById(host).innerHTML='<div class="empty">no scheduler records</div>'; return; }
+  const xmax=Math.max(...rows.map(r=>r.step),1);
+  mount(host,200,(svg,w,h)=>{
+    const {ix,iy}=axes(svg,w,h,xmax,1,v=>Math.round(v*100)+'%','step',[0,.25,.5,.75,1]);
+    const line=(key,color)=>{ const pts=rows.filter(r=>r[key]!=null);
+      if(!pts.length) return; let s='M'+ix(pts[0].step)+','+iy(pts[0][key]);
+      for(const r of pts) s+=' L'+ix(r.step)+','+iy(r[key]);
+      svg.appendChild(el('path',{d:s,fill:'none',stroke:color,'stroke-width':2,
+        'stroke-linejoin':'round','stroke-linecap':'round'})); };
+    line('kv_util','var(--kv)'); line('batch_util','var(--batch)');
+    hoverLayer(svg,w,h,xmax,rows,(i,row,ev)=>{
+      showTip(`<b>step ${row.step}</b>`+trow('KV util',pct(row.kv_util))+trow('batch util',pct(row.batch_util))
+        +trow('running',(row.num_running||0)+' / '+(row.max_running||0))
+        +trow('waiting',row.num_waiting||0)+trow('free blocks',(row.num_free_blocks||0)+' / '+(row.num_total_blocks||0)),ev);
+    });
+  });
+  tableFor('t_util',['step','kv_util','batch_util','num_running','num_waiting','preempted'],rows,
+    {kv_util:pct,batch_util:pct});
+}
+
+function chartGantt(){
+  const A=DATA.admits, C=DATA.completes; const host='c_gantt';
+  if(!A.length){ document.getElementById(host).innerHTML='<div class="empty">no request records</div>'; return; }
+  const cmap={}; for(const c of C) cmap[c.request_id]=c;
+  const reqs=A.map(a=>({id:a.request_id,slot:a.slot,start:a.step,prompt:a.prompt_len,prefill:a.prefill_len,
+    prefix_hit:a.prefix_cache_hit, end:(cmap[a.request_id]||{}).step, out:(cmap[a.request_id]||{}).output_len}))
+    .sort((x,y)=>x.start-y.start);
+  const stepMax=Math.max(1,...DATA.runner_steps.map(r=>r.step),...C.map(c=>c.step||0));
+  const rowH=26, h=PAD.t+reqs.length*rowH+PAD.b;
+  const GPAD={l:150,r:60};
+  mount(host,h,(svg,w,hh)=>{
+    const ix=scale(0,stepMax,GPAD.l,w-GPAD.r);
+    // x grid + ticks
+    const g=el('g',{class:'grid'}); svg.appendChild(g);
+    for(const xv of niceTicks(stepMax,Math.min(8,stepMax))){ const x=ix(xv);
+      g.appendChild(el('line',{x1:x,y1:PAD.t,x2:x,y2:hh-PAD.b}));
+      const t=el('text',{class:'tick',x:x,y:hh-PAD.b+16,'text-anchor':'middle'}); t.textContent=xv; svg.appendChild(t); }
+    const xl=el('text',{class:'alab',x:(GPAD.l+w-GPAD.r)/2,y:hh-2,'text-anchor':'middle'}); xl.textContent='step'; svg.appendChild(xl);
+    reqs.forEach((r,i)=>{
+      const y=PAD.t+i*rowH+3, bh=rowH-10;
+      const color=`var(--g${(i%8)+1})`;
+      const end=(r.end==null?stepMax:r.end);
+      const x0=ix(r.start), x1=Math.max(x0+2,ix(end));
+      const lab=el('text',{class:'glabel',x:GPAD.l-10,y:y+bh-2,'text-anchor':'end'});
+      lab.textContent=r.id.length>16?r.id.slice(0,16)+'…':r.id; svg.appendChild(lab);
+      const bar=el('rect',{x:x0,y:y,width:x1-x0,height:bh,rx:4,fill:color,'fill-opacity':.9,
+        stroke:'var(--surface)','stroke-width':1});
+      bar.addEventListener('pointermove',(ev)=>showTip(`<b>${r.id}</b>`
+        +trow('slot',r.slot)+trow('admitted step',r.start)+trow('completed step',r.end==null?'(running)':r.end)
+        +trow('prompt len',r.prompt)+trow('output len',r.out==null?'—':r.out)
+        +trow('prefix-cache hit',r.prefix_hit?'yes':'no'),ev));
+      bar.addEventListener('pointerleave',hideTip); svg.appendChild(bar);
+      const olab=el('text',{class:'glabel',x:x1+6,y:y+bh-2}); olab.setAttribute('fill','var(--ink2)');
+      olab.textContent=(r.out==null?'':('+'+r.out+' tok')); svg.appendChild(olab);
+    });
+  });
+  tableFor('t_gantt',['request_id','slot','prompt_len','prefill_len','prefix_cache_hit'],A,{});
+}
+
+function snapPanel(){
+  const s=DATA.snapshot; const host=document.getElementById('c_snap');
+  document.getElementById('snapsub').textContent = s
+    ? `As of step ${s.step} · ${s.slots_occupied}/${s.slots_total} slots occupied · ${fmt(s.decode_rate_toks_per_s,1)} tok/s`
+    : 'no snapshot yet';
+  if(!s || !s.slots || !s.slots.length){ host.innerHTML='<div class="empty">no active slots</div>'; return; }
+  const rows=[...s.slots].sort((a,b)=>a.slot-b.slot);
+  let html='<div class="tblwrap" style="display:block"><table><thead><tr>'
+    +'<th>slot</th><th>request</th><th>state</th><th>computed</th><th>prefill_len</th><th>total_len</th></tr></thead><tbody>';
+  for(const r of rows){ const c=r.state==='DECODE'?'var(--decode)':'var(--prefill)';
+    html+=`<tr><td>${r.slot}</td><td style="text-align:left">${r.request_id}</td>`
+      +`<td style="text-align:left"><span class="dot" style="background:${c}"></span> ${r.state}</td>`
+      +`<td>${r.num_computed_tokens}</td><td>${r.prefill_len}</td><td>${r.total_len}</td></tr>`; }
+  html+='</tbody></table></div>'; host.innerHTML=html;
+}
+
+function chips(){
+  const S=DATA.scheduler; const host=document.getElementById('chips');
+  const last=S[S.length-1]||{};
+  const items=[
+    ['prefill stalled decode', last.cum_decode_stalled_steps||0, 'var(--warning)', 'steps'],
+    ['preemptions', last.cum_preempted||0, 'var(--critical)', ''],
+    ['watermark rejects', last.cum_watermark_rejects||0, 'var(--serious)', ''],
+    ['b1-cap hits', last.cum_b1_cap_hits||0, 'var(--g7)', ''],
+  ];
+  host.innerHTML=items.map(([k,n,c,u])=>`<span class="chip"><span class="dot" style="background:${c}"></span>`
+    +`<span class="n">${n}</span> ${k}${u?(' '+u):''}</span>`).join('');
+}
+
+// Run clock. Duration is measured on the server (record ts, one clock), but in
+// live mode it keeps ticking between polls using CLIENT-side elapsed time added
+// to that server baseline — so it advances smoothly even while idle, and is
+// immune to client/server clock skew (only client-time deltas are added). The
+// anchor only resets when the server's latest ts advances; while stalled (poll
+// failing) the value freezes.
+let _run={start:null,lastTs:null,anchorMs:0};
+let _stalled=false, _frozenDur=0;
+function _allTs(d){
+  return [].concat(d.scheduler||[], d.runner_steps||[], d.admits||[], d.completes||[])
+    .map(r=>r.ts).filter(Boolean);
+}
+function updateRun(){
+  const ts=_allTs(DATA); if(!ts.length) return;
+  const start=Math.min(...ts), last=Math.max(...ts);
+  _run.start = _run.start==null ? start : Math.min(_run.start,start);
+  if(_run.lastTs==null || last>_run.lastTs){ _run.lastTs=last; _run.anchorMs=Date.now(); }
+}
+function liveDuration(){
+  if(_run.start==null) return 0;
+  if(_stalled) return _frozenDur;
+  let d=_run.lastTs-_run.start;
+  if(LIVE) d+=(Date.now()-_run.anchorMs)/1000;
+  return Math.max(0,d);
+}
+
+function tiles(){
+  const R=DATA.runner_steps, S=DATA.scheduler;
+  const rates=R.map(r=>r.decode_rate_toks_per_s).filter(v=>v!=null);
+  const meanRate=rates.length?rates.reduce((a,b)=>a+b,0)/rates.length:null;
+  const peakOcc=R.length?Math.max(...R.map(r=>r.slots_occupied||0)):0;
+  const cap=R.length?Math.max(...R.map(r=>r.slots_total||0)):0;
+  const last=S[S.length-1]||{};
+  const T=[
+    ['requests', `${DATA.completes.length}<span class="u">/ ${DATA.admits.length}</span>`],
+    ['mean decode rate', meanRate==null?'—':`${fmt(meanRate,1)}<span class="u">tok/s</span>`],
+    ['peak slots used', `${peakOcc}<span class="u">/ ${cap}</span>`],
+    ['scheduler steps', `${S.length}`],
+    ['stalled-by-prefill', `${last.cum_decode_stalled_steps||0}<span class="u">steps</span>`],
+    ['run duration', `<span id="run-dur">${fmt(liveDuration(),0)}</span><span class="u">s</span>`],
+  ];
+  document.getElementById('tiles').innerHTML=T.map(([k,v])=>
+    `<div class="tile"><div class="k">${k}</div><div class="v">${v}</div></div>`).join('');
+}
+
+function tableFor(id, cols, rows, fmts){
+  const host=document.getElementById(id); if(!rows.length){ host.innerHTML=''; return; }
+  let html='<table><thead><tr>'+cols.map(c=>`<th>${c}</th>`).join('')+'</tr></thead><tbody>';
+  for(const r of rows){ html+='<tr>'+cols.map(c=>{ let v=r[c];
+    if(fmts&&fmts[c]) v=fmts[c](v); else if(typeof v==='boolean') v=v?'yes':'no'; else if(v==null) v='—';
+    return `<td>${v}</td>`; }).join('')+'</tr>'; }
+  html+='</tbody></table>'; host.innerHTML=html;
+}
+
+function renderAll(){
+  if(!DATA){ return; }
+  updateRun();
+  const S=DATA.scheduler||[], R=DATA.runner_steps||[];
+  document.getElementById('sub').textContent =
+    `${S.length} scheduler steps · ${R.length} runner steps · ${DATA.admits.length} requests`
+    + (LIVE?' · live':'');
+  _mounts.length=0;
+  tiles(); chartOccupancy(); chartRate(); chartUtil(); chartGantt(); snapPanel(); chips();
+}
+
+// ---- controls -------------------------------------------------------------
+document.getElementById('themeToggle').addEventListener('click',()=>{
+  const cur=document.documentElement.getAttribute('data-theme');
+  const next = cur==='dark' ? 'light' : (cur==='light' ? '' : 'dark');
+  if(next) document.documentElement.setAttribute('data-theme',next);
+  else document.documentElement.removeAttribute('data-theme');
+  remount();
+});
+let tablesOn=false;
+document.getElementById('tableToggle').addEventListener('click',(e)=>{
+  tablesOn=!tablesOn;
+  document.querySelectorAll('.tblwrap').forEach(t=>{ if(!t.closest('#c_snap')) t.style.display=tablesOn?'block':'none'; });
+  e.target.textContent=tablesOn?'Hide data tables':'Show data tables';
+});
+
+function setLiveBadge(on){
+  const b=document.getElementById('livebadge');
+  if(!LIVE){ b.innerHTML=''; return; }
+  b.innerHTML = on
+    ? '<span class="dot live-on" style="background:var(--good)"></span><span class="live-on">live</span>'
+    : '<span class="dot live-off" style="background:var(--muted)"></span><span class="live-off">stalled</span>';
+}
+
+function markStalled(){
+  if(!_stalled){ _frozenDur=liveDuration(); _stalled=true; }
+  setLiveBadge(false);
+}
+async function poll(){
+  try{ const r=await fetch('data.json?ts='+Date.now(),{cache:'no-store'});
+    if(r.ok){ DATA=await r.json(); _stalled=false; renderAll(); setLiveBadge(true); }
+    else markStalled(); }
+  catch(e){ markStalled(); }
+}
+
+function tickDuration(){
+  const el=document.getElementById('run-dur');
+  if(el) el.textContent=fmt(liveDuration(),0);
+}
+
+if(LIVE){
+  setLiveBadge(false); poll(); setInterval(poll, INTERVAL);
+  // Advance the run-duration readout every second, independent of the poll
+  // cadence, so it reads as a running clock rather than jumping on data changes.
+  setInterval(tickDuration, 1000);
+}
+else { renderAll(); }
+</script>
+</body>
+</html>

--- a/tests/integrations/vllm_plugin/test_telemetry.py
+++ b/tests/integrations/vllm_plugin/test_telemetry.py
@@ -1,0 +1,415 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the env-gated serving telemetry collectors.
+
+Pure host-side: no TT device, no vLLM engine. Exercises the gating contract
+(disabled => zero files, zero I/O), env-var precedence, the buffered-flush
+policy (no per-step disk writes), and the record schema for both the scheduler
+and runner collectors.
+
+This is the v1-runner branch: the collectors are shared with the v2 runner, so
+most of this file is runner-agnostic. The exceptions are covered at the bottom --
+``_V1SlotView`` (which adapts v1's condensing ``InputBatch`` to the slot view
+the collector reads) and v1's prefix-cache-hit signal (``num_cached_tokens``
+rather than ``prefill_len > prompt_len``).
+"""
+import json
+import os
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from vllm_tt.model_runner import _V1SlotView
+from vllm_tt.telemetry import (
+    RUNNER_FILENAME,
+    RUNNER_SNAPSHOT_FILENAME,
+    SCHEDULER_FILENAME,
+    RunnerTelemetry,
+    SchedulerTelemetry,
+    reset_sinks,
+    resolve_config,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    for var in ("TTXLA_TELEMETRY", "TTXLA_TELEMETRY_DIR", "TTXLA_TELEMETRY_FLUSH_MS"):
+        monkeypatch.delenv(var, raising=False)
+
+
+class _FakeReqStates:
+    """Minimal stand-in for TTRequestState with the fields on_step reads."""
+
+    def __init__(self, slots, max_num_reqs=32):
+        # slots: {req_id: (slot_idx, num_computed, prefill_len, total_len)}
+        self.req_id_to_index = {rid: s[0] for rid, s in slots.items()}
+        occupied = set(self.req_id_to_index.values())
+        self.free_indices = [i for i in range(max_num_reqs) if i not in occupied]
+        self.num_computed_tokens = np.zeros(max_num_reqs, dtype=np.int32)
+        self.prefill_len = np.zeros(max_num_reqs, dtype=np.int32)
+        self.total_len = np.zeros(max_num_reqs, dtype=np.int32)
+        for _rid, (idx, computed, plen, tlen) in slots.items():
+            self.num_computed_tokens[idx] = computed
+            self.prefill_len[idx] = plen
+            self.total_len[idx] = tlen
+
+
+def _read_jsonl(path):
+    with open(path) as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+# --------------------------------------------------------------------------- #
+# resolve_config
+# --------------------------------------------------------------------------- #
+@pytest.mark.push
+@pytest.mark.cpu
+def test_resolve_config_defaults():
+    enabled, directory, flush_s = resolve_config()
+    assert enabled is False
+    assert directory == "./tt_telemetry"
+    assert flush_s == 1.0
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_resolve_config_env_overrides_config(monkeypatch, tmp_path):
+    monkeypatch.setenv("TTXLA_TELEMETRY", "yes")
+    monkeypatch.setenv("TTXLA_TELEMETRY_DIR", str(tmp_path))
+    monkeypatch.setenv("TTXLA_TELEMETRY_FLUSH_MS", "250")
+    # Config says disabled/elsewhere; env must win.
+    enabled, directory, flush_s = resolve_config(
+        enabled=False, directory="/other", flush_ms=9999
+    )
+    assert enabled is True
+    assert directory == str(tmp_path)
+    assert flush_s == 0.25
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+@pytest.mark.parametrize(
+    "val,expected", [("1", True), ("on", True), ("0", False), ("off", False)]
+)
+def test_resolve_config_truthiness(monkeypatch, val, expected):
+    monkeypatch.setenv("TTXLA_TELEMETRY", val)
+    assert resolve_config()[0] is expected
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_resolve_config_bad_flush_ms_falls_back(monkeypatch):
+    monkeypatch.setenv("TTXLA_TELEMETRY_FLUSH_MS", "not-a-number")
+    assert resolve_config(enabled=True)[2] == 1.0
+
+
+# --------------------------------------------------------------------------- #
+# Disabled => zero-cost, no files
+# --------------------------------------------------------------------------- #
+@pytest.mark.push
+@pytest.mark.cpu
+def test_disabled_collectors_write_nothing(tmp_path):
+    runner = RunnerTelemetry(False, str(tmp_path), 0.0)
+    scheduler = SchedulerTelemetry(False, str(tmp_path), 0.0)
+    assert runner.enabled is False and scheduler.enabled is False
+
+    runner.on_request_admitted("r0", 0, 10, 10)
+    runner.on_step(
+        _FakeReqStates({}), prefill_passes=0, decode_passes=0, emitted_tokens=0
+    )
+    runner.flush()
+    scheduler.on_schedule(
+        num_running=1,
+        max_running=32,
+        num_waiting=0,
+        num_free_blocks=10,
+        num_total_blocks=10,
+        prefill_new=0,
+        prefill_resumed=0,
+        prefill_partial=0,
+        running_scheduled=1,
+        preempted=0,
+        decode_gated=False,
+        decodes_displaced=0,
+        total_scheduled_tokens=1,
+    )
+    scheduler.flush()
+    assert os.listdir(tmp_path) == []
+
+
+# --------------------------------------------------------------------------- #
+# Buffered flush: no per-step disk I/O
+# --------------------------------------------------------------------------- #
+@pytest.mark.push
+@pytest.mark.cpu
+def test_records_buffer_until_flush(tmp_path):
+    # Large flush interval => on_step never triggers an interval flush.
+    runner = RunnerTelemetry(True, str(tmp_path), flush_s=3600.0)
+    rs = _FakeReqStates({"r0": (0, 5, 10, 10)})
+    runner.on_step(rs, prefill_passes=1, decode_passes=0, emitted_tokens=0)
+    # jsonl exists (truncated on init) but holds no step record yet.
+    jsonl = os.path.join(tmp_path, RUNNER_FILENAME)
+    assert _read_jsonl(jsonl) == []
+    runner.flush()
+    assert len(_read_jsonl(jsonl)) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Runner records
+# --------------------------------------------------------------------------- #
+@pytest.mark.push
+@pytest.mark.cpu
+def test_runner_admit_and_complete_records(tmp_path):
+    runner = RunnerTelemetry(True, str(tmp_path), 0.0)
+    runner.on_request_admitted("r0", 3, prompt_len=10, prefill_len=10)
+    runner.on_request_admitted("r1", 4, prompt_len=8, prefill_len=12)  # prefix hit
+    runner.on_request_completed("r0", 3, prompt_len=10, output_len=20)
+    runner.flush()
+    recs = _read_jsonl(os.path.join(tmp_path, RUNNER_FILENAME))
+    admitted = [r for r in recs if r["event"] == "request_admitted"]
+    completed = [r for r in recs if r["event"] == "request_completed"]
+    assert {r["request_id"] for r in admitted} == {"r0", "r1"}
+    assert (
+        next(r for r in admitted if r["request_id"] == "r0")["prefix_cache_hit"]
+        is False
+    )
+    assert (
+        next(r for r in admitted if r["request_id"] == "r1")["prefix_cache_hit"] is True
+    )
+    assert completed[0]["request_id"] == "r0" and completed[0]["output_len"] == 20
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_runner_step_occupancy_and_snapshot(tmp_path):
+    runner = RunnerTelemetry(True, str(tmp_path), 0.0)
+    # r0 still prefilling (computed < prefill_len), r1 decoding.
+    rs = _FakeReqStates({"r0": (0, 5, 10, 5), "r1": (1, 12, 12, 15)}, max_num_reqs=32)
+    runner.on_step(rs, prefill_passes=1, decode_passes=1, emitted_tokens=1)
+    runner.flush()
+    step = [
+        r
+        for r in _read_jsonl(os.path.join(tmp_path, RUNNER_FILENAME))
+        if r["event"] == "step"
+    ][0]
+    assert step["slots_occupied"] == 2
+    assert step["slots_free"] == 30
+    assert step["num_prefilling"] == 1
+    assert step["num_decoding"] == 1
+    assert step["prefill_passes"] == 1 and step["decode_passes"] == 1
+    assert step["emitted_tokens"] == 1
+    # First step has no prior timestamp => decode rate undefined.
+    assert step["decode_rate_toks_per_s"] is None
+
+    # Snapshot file holds the latest per-slot picture.
+    with open(os.path.join(tmp_path, RUNNER_SNAPSHOT_FILENAME)) as f:
+        snap = json.load(f)
+    assert {s["request_id"] for s in snap["slots"]} == {"r0", "r1"}
+    assert {s["state"] for s in snap["slots"]} == {"PREFILL", "DECODE"}
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_runner_decode_rate_after_two_steps(tmp_path):
+    runner = RunnerTelemetry(True, str(tmp_path), 0.0)
+    rs = _FakeReqStates({"r0": (0, 12, 12, 15)})
+    runner.on_step(rs, prefill_passes=0, decode_passes=1, emitted_tokens=1)
+    runner.on_step(rs, prefill_passes=0, decode_passes=1, emitted_tokens=1)
+    runner.flush()
+    steps = [
+        r
+        for r in _read_jsonl(os.path.join(tmp_path, RUNNER_FILENAME))
+        if r["event"] == "step"
+    ]
+    assert steps[0]["decode_rate_toks_per_s"] is None
+    # Second step has a positive dt and one emitted token => positive rate.
+    assert steps[1]["decode_rate_toks_per_s"] is not None
+    assert steps[1]["decode_rate_toks_per_s"] > 0
+
+
+# --------------------------------------------------------------------------- #
+# Scheduler records
+# --------------------------------------------------------------------------- #
+@pytest.mark.push
+@pytest.mark.cpu
+def test_scheduler_utilization_and_cumulative_counters(tmp_path):
+    sched = SchedulerTelemetry(True, str(tmp_path), 0.0)
+    sched.on_schedule(
+        num_running=8,
+        max_running=32,
+        num_waiting=4,
+        num_free_blocks=100,
+        num_total_blocks=400,
+        prefill_new=2,
+        prefill_resumed=0,
+        prefill_partial=1,
+        running_scheduled=0,
+        preempted=1,
+        decode_gated=True,
+        decodes_displaced=8,
+        total_scheduled_tokens=512,
+        watermark_rejects=2,
+        b1_cap_hit=True,
+    )
+    sched.on_schedule(
+        num_running=8,
+        max_running=32,
+        num_waiting=2,
+        num_free_blocks=300,
+        num_total_blocks=400,
+        prefill_new=0,
+        prefill_resumed=0,
+        prefill_partial=0,
+        running_scheduled=8,
+        preempted=0,
+        decode_gated=False,
+        decodes_displaced=0,
+        total_scheduled_tokens=8,
+    )
+    sched.flush()
+    recs = _read_jsonl(os.path.join(tmp_path, SCHEDULER_FILENAME))
+    assert len(recs) == 2
+    assert recs[0]["kv_util"] == 0.75  # (400-100)/400
+    assert recs[0]["batch_util"] == 0.25  # 8/32
+    assert recs[0]["decode_gated"] is True and recs[0]["decodes_displaced"] == 8
+    # Cumulative counters accumulate across steps.
+    assert recs[1]["cum_preempted"] == 1
+    assert recs[1]["cum_decode_stalled_steps"] == 1  # only step 0 was gated
+    assert recs[1]["cum_watermark_rejects"] == 2
+    assert recs[1]["cum_b1_cap_hits"] == 1
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_reset_sinks_clears_all_sinks(tmp_path):
+    # A restart must not leave a prior run's data lingering through warmup.
+    for name in (SCHEDULER_FILENAME, RUNNER_FILENAME, RUNNER_SNAPSHOT_FILENAME):
+        (tmp_path / name).write_text("stale from a previous run")
+    reset_sinks(str(tmp_path))
+    assert os.listdir(tmp_path) == []
+    # Idempotent, and a missing directory is a no-op (best-effort).
+    reset_sinks(str(tmp_path))
+    reset_sinks(str(tmp_path / "does_not_exist"))
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_stale_sink_truncated_on_init(tmp_path):
+    path = tmp_path / SCHEDULER_FILENAME
+    path.write_text('{"stale":true}\n')
+    SchedulerTelemetry(True, str(tmp_path), 0.0)
+    # A fresh run must not replay a prior run's records.
+    assert path.read_text() == ""
+
+
+# --------------------------------------------------------------------------- #
+# v1-specific: the InputBatch -> slot-view adapter
+# --------------------------------------------------------------------------- #
+def _fake_v1_state(rows, max_num_reqs=8, scheduled=None):
+    """Build (input_batch, requests, scheduler_output) stand-ins for the view.
+
+    ``rows``: {req_id: (row_index, num_computed_tokens, num_prompt_tokens,
+    num_output_tokens)}. Mirrors what v1 keeps across InputBatch (row indices)
+    and CachedRequestState (token counts).
+    """
+    input_batch = SimpleNamespace(
+        num_reqs=len(rows),
+        max_num_reqs=max_num_reqs,
+        req_id_to_index={rid: r[0] for rid, r in rows.items()},
+    )
+    requests = {
+        rid: SimpleNamespace(
+            num_computed_tokens=computed,
+            num_prompt_tokens=prompt,
+            num_tokens=prompt + out,
+        )
+        for rid, (_idx, computed, prompt, out) in rows.items()
+    }
+    scheduler_output = SimpleNamespace(num_scheduled_tokens=scheduled or {})
+    return input_batch, requests, scheduler_output
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_v1_slot_view_maps_rows_and_free_tail():
+    # Two occupied rows out of 8: v1 has no free list, so the free slots are
+    # the tail of the batch rather than an explicit set of indices.
+    view = _V1SlotView(
+        *_fake_v1_state({"a": (0, 10, 10, 3), "b": (1, 4, 10, 0)}, max_num_reqs=8)
+    )
+    assert view.req_id_to_index == {"a": 0, "b": 1}
+    assert len(view.free_indices) == 6
+    assert view.prefill_len[0] == 10 and view.total_len[0] == 13
+    assert view.num_computed_tokens[1] == 4
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_v1_slot_view_counts_scheduled_tokens_toward_prefill():
+    # The view folds in this step's scheduled tokens, so a row finishing its
+    # prefill now reports DECODE.
+    view = _V1SlotView(*_fake_v1_state({"a": (0, 6, 10, 0)}, scheduled={"a": 4}))
+    assert view.num_computed_tokens[0] == 10
+    assert view.prefill_len[0] == 10  # => DECODE, not PREFILL
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_v1_slot_view_tolerates_row_without_cached_state(tmp_path):
+    # A row present in the batch but missing from `requests` must not raise:
+    # telemetry never crashes the engine.
+    input_batch, requests, sched = _fake_v1_state({"a": (0, 1, 4, 0)})
+    requests.pop("a")
+    view = _V1SlotView(input_batch, requests, sched)
+    assert view.req_id_to_index == {"a": 0}
+    # Zeroed rather than dropped: on_step swallows exceptions, so an
+    # unpopulated slot would lose the whole step record.
+    assert view.prefill_len == {0: 0} and view.num_computed_tokens == {0: 0}
+    runner = RunnerTelemetry(True, str(tmp_path), 0.0)
+    runner.on_step(view, prefill_passes=0, decode_passes=1, emitted_tokens=1)
+    steps = [r for r in _read_jsonl(tmp_path / RUNNER_FILENAME) if r["event"] == "step"]
+    assert len(steps) == 1 and steps[0]["slots_occupied"] == 1
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_v1_prefix_cache_hit_reported_via_cached_tokens(tmp_path):
+    # v2 signals a hit as prefill_len > prompt_len, v1 as advanced
+    # num_computed_tokens; both must land as prefix_cache_hit.
+    runner = RunnerTelemetry(True, str(tmp_path), 0.0)
+    runner.on_request_admitted("miss", 0, 10, 10, num_cached_tokens=0)
+    runner.on_request_admitted("hit", 1, 10, 10, num_cached_tokens=6)
+    runner.flush()
+    admitted = {
+        r["request_id"]: r
+        for r in _read_jsonl(tmp_path / RUNNER_FILENAME)
+        if r["event"] == "request_admitted"
+    }
+    assert admitted["miss"]["prefix_cache_hit"] is False
+    assert admitted["hit"]["prefix_cache_hit"] is True
+    assert admitted["hit"]["num_cached_tokens"] == 6
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_readmission_is_distinguishable_from_first_admission(tmp_path):
+    # Re-admission at a new row with its own prefix cached, so admissions
+    # outnumber requests and the hit is not a cross-request one.
+    runner = RunnerTelemetry(True, str(tmp_path), 0.0)
+    runner.on_request_admitted("r0", 0, 8, 8, num_cached_tokens=0, readmission=False)
+    runner.on_request_admitted("r0", 3, 8, 8, num_cached_tokens=8, readmission=True)
+    runner.flush()
+    adm = [
+        r
+        for r in _read_jsonl(tmp_path / RUNNER_FILENAME)
+        if r["event"] == "request_admitted"
+    ]
+    assert len(adm) == 2 and len({r["request_id"] for r in adm}) == 1
+    first, again = adm
+    assert first["readmission"] is False and first["slot"] == 0
+    # Same request, different row -- the condensing batch reassigned it.
+    assert again["readmission"] is True and again["slot"] == 3
+    assert again["prefix_cache_hit"] is True
+    # Counting distinct request_ids (or filtering readmission) is what gives 1.
+    assert len([r for r in adm if not r["readmission"]]) == 1


### PR DESCRIPTION
Implements #5715 (vLLM telemetry) for the V1 model runner. #5787 adds similar telemetry for Model Runner v2.

Env-gated serving telemetry for the vLLM TT path, plus tooling to consume it. Most of these signals are already computed during serving and emitted nowhere; this change emits them. The counters themselves are existing state.

Sample screenshot of a test with some memory pressure (more examples in #5787 )

<img width="1100" height="1704" alt="image" src="https://github.com/user-attachments/assets/044d1b1f-89db-42f6-a71f-05e2d61afb5f" />

## What's here

**Two layers are instrumented**, because they answer different questions:

| Layer | Process | Signals |
|---|---|---|
| `SchedulerTelemetry` (`AscendScheduler`) | EngineCore | *intent* — prefill vs decode, preemption, queue depth, KV/batch utilization, TT-specific watermark rejects and b1-cap hits |
| `RunnerTelemetry` (`TTModelRunner`) | Worker | *reality* — batch occupancy, prefill/decode pass split, actual decode rate, per-request lifecycle |

They run in separate processes and write separate JSON-lines sinks (`scheduler.jsonl`, `runner.jsonl`, `runner_snapshot.json`), correlated offline on `request_id` plus a monotonic step index.

**Metric → source**, covering what the issue asked for:

| Requested signal | Where it comes from |
|---|---|
| Rows used + state (prefilling / decoding) | `InputBatch.req_id_to_index` vs `max_num_reqs`; state from computed+scheduled tokens against the prompt length |
| A new request stalling in-flight decodes | Prefill-first means any step scheduling a prefill skips the decode gate — counted, along with the displaced decode requests |
| Actual decode rate | Tokens emitted per step ÷ wall-time between steps |
| Preemption / eviction / re-admission | Scheduler preemption branch; `readmission` on the runner's admission record |
| Queue depth | `len(waiting) + len(skipped_waiting)` |
| KV / batch utilization | Occupied rows ÷ `max_num_reqs`; free blocks ÷ total blocks |
| Prefill interruptions, % time decoding | Per-step prefill-pass vs decode-pass split; watermark rejects and b1-cap hits scheduler-side |

## Design constraints

- **Off by default and zero-cost when off** — a single cached bool on the hot path. The runner also carries a class-level disabled collector, so instances built without `__init__` (the `object.__new__` unit-test helpers) inherit it. Without that default those instances raise `AttributeError` on the first hook.
- **No per-step disk I/O**, which would distort the decode rate being measured — records buffer in memory and flush on an interval, at request completion, and at exit. A disabled collector opens no files and registers no `atexit` hook. `TTXLA_TELEMETRY_FLUSH_MS=0` explicitly opts into per-step flushing for live viewing; the default interval is what preserves the guarantee.
- **Env-gated** via `TTXLA_TELEMETRY[_DIR|_FLUSH_MS]`, or `additional_config` (`telemetry_enabled` / `telemetry_dir` / `telemetry_flush_ms`). Env overrides config, resolved once in `TTPlatform.check_and_update_config` and written back so both processes agree — the same idiom as `prefill_kv_watermark`. A malformed flush interval falls back to the default instead of crashing the engine.
- **Pass classification survives speculative decode.** A pass counts as prefill when any row scheduled in it still has computed tokens below its prompt length. Classifying on the graph's seq dim or on tokens-per-row would be wrong: with ngram speculative decode (#5542) a *decoding* row carries `1 + num_speculative_tokens` tokens through the wider graph.
- **Scheduler hooks are append-only** after the `SchedulerOutput` is built, which is what let them survive the 0.25.1 uplift (#5744) rewriting `schedule()`'s head and tail. `schedule()` has a single return, so every step is recorded.

## Reading the runner output

`InputBatch` is a *condensing* batch: when a request leaves, later rows compact down to fill the gap, so a row index identifies a slot for one step only. Occupancy, utilization and the pass split are exact; a per-row timeline shows rows being **reused** as requests come and go. Follow a single request by `request_id`, not by row.

Two consequences show up in real output, both documented in the README with an example from an n150 run:

- **A request can be admitted more than once.** Unscheduling removes it from the batch and it is re-added later, typically at a different row. Admission records therefore outnumber requests (5 records for 4 requests in that run), so counting requests served means counting distinct `request_id` or filtering `readmission == false`. Those records are also the re-admission signal the issue asked for.
- **A re-admitted request reports `prefix_cache_hit`** against its own already-computed prefix — a true cache hit, but not the cross-request hit usually being hunted. Filter on `readmission` for that.

Decode rate counts **tokens emitted per step, not emitting rows**, so it stays correct as accepted-tokens/step under speculative decode (#5542), where one row can accept several tokens in a step.

## Tooling

- **`scripts/telemetry/telemetry_viz.py`** — stdlib-only, self-contained, theme-aware HTML dashboard: occupancy timeline, decode rate with a prefill-stall event rug, KV/batch utilization, per-request Gantt, live row table, event chips. `report` writes a standalone file; `live` serves a localhost dashboard that polls the sinks during serving.
- **`examples/vllm/telemetry/`** — a how-to README, three demos (full batch, oversubscription, KV pressure), and a stdlib-only HTTP load generator for driving a live `vllm serve` while watching the dashboard.

## Testing

- `tests/integrations/vllm_plugin/test_telemetry.py` — 20 host-side tests, marked `push` + `cpu` so `run_vllm_cpu_tests` collects them: gating, env precedence, buffered-flush policy, record schemas, disabled ⇒ zero files, the slot-view adapter (row/free-tail mapping, folding this step's scheduled tokens into the prefill test), `num_cached_tokens`, `readmission`, and a row missing its cached state — which must keep the row visible with zeroed counters, since `on_step` swallows exceptions and an unpopulated row would drop the entire step record.
- **Verified on n150 hardware**: `vllm_tt` resolves to the checkout rather than an installed wheel; the collector defaults off; 20 unit tests pass in a real vLLM env; with `TTXLA_TELEMETRY=0` overriding `telemetry_enabled=True` the engine runs to completion and writes nothing; enabled, a 4-prompt run produces 33 steps, peak 4 rows, 2 prefill vs 31 decode passes, 128 accepted tokens, ~37 tok/s, and renders a report.
- Full `main` pipeline green.


