### PR TITLE
Replace deprecated torch._check_is_size with torch._check in split_with_sizes

### DIFF
--- a/python_package/tt_torch/backend/decompositions.py
+++ b/python_package/tt_torch/backend/decompositions.py
@@ -220,8 +220,8 @@ def split_with_sizes(
     # NB: Perform the check_is_size tests first so that the
     # sum test does not try to do a replacement
     for i in range(len(split_sizes)):
-        torch._check_is_size(
-            split_sizes[i],
+        torch._check(
+            split_sizes[i] >= 0,
             lambda: "split_with_sizes expects split_sizes have only non-negative entries",
         )
     torch._check_with(


### PR DESCRIPTION
## Ticket

Closes #5814

## Problem description

`split_with_sizes` in `decompositions.py` calls the deprecated `torch._check_is_size`, which emits a noisy `FutureWarning` on every invocation. Introduced via the PyTorch 2.11.0 uplift (#5617).

## What's changed

- `python_package/tt_torch/backend/decompositions.py`: replaced `torch._check_is_size(split_sizes[i], msg)` with `torch._check(split_sizes[i] >= 0, msg)`, per PyTorch's own deprecation guidance for this call site.

## Checklist
- [x] Verified `test_opt_generation` passes and the warning no longer appears in output (before/after logs: https://gist.github.com/kmabeeTT/e4b09a6482656dc7912d18829ebcb7e6)
