### PR TITLE
[vLLM] DP+TP Chunked Prefill support fixes

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -2617,11 +2617,17 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         for i, req_id in zip(range(num_reqs), self.input_batch.req_ids):
             assert req_id is not None
             req_state = self.requests[req_id]
-            seq_len = (
-                req_state.num_computed_tokens
-                + scheduler_output.num_scheduled_tokens.get(req_id, 0)
-            )
-            if seq_len >= req_state.num_tokens:
+            num_sched = scheduler_output.num_scheduled_tokens.get(req_id, 0)
+            seq_len = req_state.num_computed_tokens + num_sched
+            if num_sched == 0:
+                # Row scheduled no tokens this step, so it produced no real
+                # logits: logits_indices is num_scheduled - 1 == -1, which
+                # gathers the last padded position (zeros) and samples token 0.
+                # Under DP such rows are retained rather than removed, and any
+                # already-prefilled row idles while others finish their prefill
+                # chunks, so without this its bogus token would be appended.
+                discard_sampled_tokens_req_indices.append(i)
+            elif seq_len >= req_state.num_tokens:
                 request_seq_lens.append((i, req_state, seq_len))
             else:
                 # Ignore the sampled token from the partial request.

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -1637,15 +1637,19 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # prefill take the standard path (chunk_start_idx stays None). Shared
         # across all groups.
         num_computed_for_reqs = self.input_batch.num_computed_tokens_cpu[:num_reqs]
-        prefix_chunk_step = padded_total_num_scheduled_tokens > 1 and bool(
-            np.any(num_computed_for_reqs > 0)
+        active_rows = num_scheduled_tokens_per_req > 0
+        num_computed_active = num_computed_for_reqs[active_rows]
+        prefix_chunk_step = (
+            padded_total_num_scheduled_tokens > 1
+            and num_computed_active.size > 0
+            and bool(np.all(num_computed_active > 0))
         )
         chunk_start_idx = None
         if prefix_chunk_step and self._chunked_sdpa_active:
             # Same-stage batching => one shared [1] prefix offset; the op masks
             # causally and applies it internally (no host attn_mask).
             self._chunk_start_idx_dev.copy_(
-                torch.tensor([int(num_computed_for_reqs[0])], dtype=torch.int32)
+                torch.tensor([int(num_computed_active.min())], dtype=torch.int32)
             )
             chunk_start_idx = self._chunk_start_idx_dev
 


### PR DESCRIPTION
### Problem description

`chunk_start_idx` — the cached-prefix offset handed to `chunked_scaled_dot_product_attention` — and the decision to take the chunked path at all were derived from **all** batch rows, and the offset specifically from **row 0**:

```python
num_computed_for_reqs = self.input_batch.num_computed_tokens_cpu[:num_reqs]   # ALL rows
prefix_chunk_step = padded_total_num_scheduled_tokens > 1 and bool(
    np.any(num_computed_for_reqs > 0)                                        # ANY row
)
    torch.tensor([int(num_computed_for_reqs[0])], dtype=torch.int32)          # row 0
```

The inline comment ("Same-stage batching => one shared [1] prefix offset") states the assumption, but nothing enforces it. Under DP, already-prefilled unscheduled requests are deliberately kept pinned in `input_batch` (`model_runner.py:934-943`, to preserve slot->replica affinity) and retain their final `num_computed_tokens`. So a step can contain rows at several stages, and:

- `np.any` forces a step of **fresh** prefills onto the cached-prefix path, and
- an inactive row 0 supplies its offset to every actively-prefilling row.

Instrumented prefill trace, DP+TP (2x4), Qwen3-0.6B, chunk 128, batch 64:

| step | reqs | scheduled tokens | zero-scheduled rows | outcome |
|---|---|---|---|---|
| 2 | 16 | `[7]x16`, offsets `[4]x16` | none | correct |
| 3 | 49 | `[0]x16 + [8,128,11,...]` | `[0..15]` | corrupt — forced onto chunked path with offset 135 |
| 4 | 64 | `[0]x17+[18]+[0]x31+[18]x15` | 48 rows | corrupt — offset 135 used for rows at 128 |

The prompt occupying row 0 was the only one to receive a correct offset.

### What's changed

Restrict both the mode decision and the offset to rows with `num_scheduled_tokens > 0`, and warn if active rows ever disagree (the scheduler's same-stage latch, `ascend_scheduler.py:237-241`, should prevent it).

### Test

n300-llmbox (2x4), Qwen3-0.6B, `max_model_len=1024`, `prefill_chunk_size=128`, batch 64, greedy, prompts of 135/146 tokens (so they split into 128 + remainder):

| | output |
|---|---|
| before | `' Contination Contination Contin Contin'`, `' every and I I AM AND I AM AND'`, `'\n\n\n\n...'` (empty) |
| after | `' The weather today is very cold and very rainy.'`, `' the return of the leaves to the trees...'` |

Same config on Qwen3-8B (TP-sharded weights + DP-sharded KV + chunked prefill) now produces 64/64 coherent generations; the two chunked long prompts are identical across all 16 slots each (one prompt 15/16).

Residual cross-slot differences remain on prompts whose continuation is genuinely ambiguous (e.g. "The best book I have read is" -> "The Alchemist" vs "I Am Malala"). Those reproduce with `cpu_sampling=True` and without DP, so they originate in the logits rather than in this path, and are not addressed here.