### PR TITLE
Allow single-group DeepSeek-V2 MoE routing in TT forward_native

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/layers/fused_moe.py
+++ b/integrations/vllm_plugin/vllm_tt/layers/fused_moe.py
@@ -205,12 +205,20 @@ class TTRoutedExperts(RoutedExperts):
             )
         else:
             # The plain softmax top-k below does not implement the extra router
-            # features vLLM 0.25.1 exposes on RoutedExperts (grouped top-k,
-            # non-softmax scoring, e_score correction bias, router-weight-on-input).
-            # Models needing these (e.g. DeepSeek, Kimi, GLM) must run via the HF
+            # features vLLM 0.25.1 exposes on RoutedExperts (real multi-group
+            # top-k, non-softmax scoring, e_score correction bias,
+            # router-weight-on-input). A single-group config (num_expert_group<=1
+            # and topk_group<=1) is exempted: vLLM's grouped_topk degenerates to
+            # plain top-k over all experts in that case (one group spanning every
+            # expert, always selected), which is exactly what DeepSeek-V2-Lite
+            # uses (n_group=1, topk_group=1). Models with real multi-group
+            # routing (e.g. DeepSeek-V3, Kimi, GLM) must run via the HF
             # moe_backend; fail loudly rather than silently mis-routing. See #5610.
+            uses_real_grouped_topk = self.use_grouped_topk and (
+                (self.num_expert_group or 1) > 1 or (self.topk_group or 1) > 1
+            )
             if (
-                self.use_grouped_topk
+                uses_real_grouped_topk
                 or self.scoring_func != "softmax"
                 or self.e_score_correction_bias is not None
                 or self.apply_router_weight_on_input
@@ -218,7 +226,8 @@ class TTRoutedExperts(RoutedExperts):
                 raise NotImplementedError(
                     "TT vLLM FusedMoE forward_native only supports plain softmax "
                     "top-k. (use_grouped_topk="
-                    f"{self.use_grouped_topk}, scoring_func={self.scoring_func!r}, "
+                    f"{self.use_grouped_topk}, num_expert_group={self.num_expert_group}, "
+                    f"topk_group={self.topk_group}, scoring_func={self.scoring_func!r}, "
                     f"e_score_correction_bias={self.e_score_correction_bias is not None}, "
                     f"apply_router_weight_on_input={self.apply_router_weight_on_input}). "
                     "For models using these router features, please run with the HF "


### PR DESCRIPTION
## Summary
- `TTRoutedExperts.forward_native` unconditionally raised `NotImplementedError` whenever `use_grouped_topk=True`, telling callers to fall back to the HF MoE backend.
- vLLM's `DeepseekV2MoE` always constructs its `FusedMoE` with `use_grouped_topk=True`, even for `DeepSeek-V2-Lite`, whose HF config has `n_group=1` / `topk_group=1`.
- With a single expert group, vLLM's own `grouped_topk` degenerates to plain softmax top-k over all experts (the group-selection step is a no-op), which is exactly what `forward_native`'s existing plain-softmax-top-k path already computes.
- Relaxed the guard to only reject *real* multi-group routing (`num_expert_group > 1` or `topk_group > 1`), letting single-group configs like DeepSeek-V2-Lite fall through to the existing path instead of erroring out.

ci link: https://github.com/tenstorrent/tt-xla/actions/runs/30448313206

## Test plan
- [x] `pytest -svv "tests/integrations/vllm_plugin/generative/test_tensor_parallel_generation.py::test_tensor_parallel_generation_llmbox_large"` (`deepseek-ai/DeepSeek-V2-Lite`, mesh `[2,4]`) — was failing with `NotImplementedError: TT vLLM FusedMoE forward_native only supports plain softmax top-k...`, now `1 passed` on llmbox hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)