### PR TITLE
[vLLM][uplift] v0.26.0

### DIFF
--- a/integrations/vllm_plugin/requirements-vllm-plugin.txt
+++ b/integrations/vllm_plugin/requirements-vllm-plugin.txt
@@ -1,2 +1,2 @@
-vllm==0.25.1
+vllm==0.26.0
 transformers==5.14.1

--- a/integrations/vllm_plugin/setup.py
+++ b/integrations/vllm_plugin/setup.py
@@ -51,7 +51,7 @@ setup(
     version="0.1",
     packages=find_packages(),
     install_requires=[
-        "vllm==0.25.1",
+        "vllm==0.26.0",
         "transformers==5.14.1",
     ],
     python_requires=">=3.12, <3.13",

--- a/integrations/vllm_plugin/vllm_tt/input_batch.py
+++ b/integrations/vllm_plugin/vllm_tt/input_batch.py
@@ -15,6 +15,7 @@ from vllm.v1.outputs import LogprobsTensors
 from vllm.v1.pool.metadata import PoolingMetadata, PoolingStates
 from vllm.v1.sample.logits_processor import LogitsProcessors
 from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.utils import copy_slice
 from vllm.v1.worker.block_table import MultiGroupBlockTable
 from vllm.v1.worker.gpu_input_batch import CachedRequestState
 
@@ -32,6 +33,7 @@ class InputBatch:
         vocab_size: int,
         block_sizes: list[int],  # The block_size of each kv cache group
         kernel_block_sizes: list[int],
+        max_num_blocks_per_req: Optional[list[int]] = None,
         logitsprocs: Optional[LogitsProcessors] = None,
         logitsprocs_need_output_token_ids: bool = False,
         is_pooling_model: bool = True,
@@ -80,14 +82,19 @@ class InputBatch:
         self.num_computed_tokens_cpu = self.num_computed_tokens_cpu_tensor.numpy()
 
         # Block table.
+        if max_num_blocks_per_req is None:
+            max_num_blocks_per_req = [
+                (max_model_len + block_size - 1) // block_size
+                for block_size in block_sizes
+            ]
         self.block_table = MultiGroupBlockTable(
             max_num_reqs=max_num_reqs,
-            max_model_len=max_model_len,
             max_num_batched_tokens=max_num_batched_tokens,
             pin_memory=pin_memory,
             device=device,
             block_sizes=block_sizes,
             kernel_block_sizes=kernel_block_sizes,
+            max_num_blocks=max_num_blocks_per_req,
             cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
         )
 

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -456,7 +456,6 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 self.max_model_len * scheduler_config.max_num_seqs
                 <= scheduler_config.max_num_batched_tokens
             ), f"The max_num_batched_tokens {scheduler_config.max_num_batched_tokens} must be larger than or equal to max_model_len ({self.max_model_len}) * max_num_seqs ({scheduler_config.max_num_seqs})"
-        self.most_model_len = envs.VLLM_TPU_MOST_MODEL_LEN
         # Match vLLM's per-request block-table width, which rounds up to a
         # multiple of (128 // block_size) for attention-backend alignment (vLLM
         # #39324). Sizing the padded page-table buffer the same way keeps it >=
@@ -467,11 +466,6 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             * (128 // self.block_size)
             if self.block_size <= 128
             else _base_blocks_per_req
-        )
-        self.num_blocks_per_most_len_req = (
-            cdiv(self.most_model_len, self.block_size)
-            if self.most_model_len is not None
-            else None
         )
         # InputBatch needs to work with sampling tensors greater than padding
         # to avoid dynamic shapes. Also, avoid suboptimal alignment.
@@ -630,16 +624,6 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             device="cpu",
         )
         # adjust num_reqs to avoid SMEM OOM.
-        self.num_reqs_most_model_len = (
-            min(
-                TTAttentionBackend.get_max_num_seqs(
-                    self.most_model_len, self.block_size
-                ),
-                self.max_num_reqs,
-            )
-            if self.most_model_len is not None
-            else None
-        )
         self.num_reqs_max_model_len = min(
             TTAttentionBackend.get_max_num_seqs(self.max_model_len, self.block_size),
             self.max_num_reqs,
@@ -712,18 +696,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 self.num_reqs_max_model_len,
             )
         )
-        self._most_len_num_reqs = (
-            set(
-                _bucket_num_reqs(
-                    self.min_num_reqs,
-                    self.max_prefill_num_reqs,
-                    self.num_reqs_most_model_len,
-                )
-            )
-            if self.num_reqs_most_model_len is not None
-            else set()
-        )
-        self._reachable_num_reqs = self._max_len_num_reqs | self._most_len_num_reqs
+        self._reachable_num_reqs = set(self._max_len_num_reqs)
 
         self._input_ids_dev = {
             (num_reqs, num_tokens): _alloc_dev((num_reqs, num_tokens), torch.int32)
@@ -769,17 +742,6 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # Chunked-prefill prefix offset: persistent [1] int32 dev buffer so the
         # value can change per step under a captured trace without recompiling.
         self._chunk_start_idx_dev = _alloc_dev((1,), torch.int32)
-        if self.most_model_len is not None:
-            assert self.num_reqs_most_model_len is not None
-            assert self.num_blocks_per_most_len_req is not None
-            self._cache_position_dev_most = {
-                num_reqs: _alloc_dev((num_reqs,), self.seq_lens_cpu.dtype)
-                for num_reqs in {self.min_num_reqs, self.num_reqs_most_model_len}
-            }
-            self._cache_position_sliding_dev_most = {
-                num_reqs: _alloc_dev((num_reqs,), self.seq_lens_cpu.dtype)
-                for num_reqs in {self.min_num_reqs, self.num_reqs_most_model_len}
-            }
         # Per-group page_table / fill_page_table device buffers (nested by group
         # index); rebuilt for the real group count in initialize_kv_cache.
         # cache_position and chunk_start_idx are group-independent, so stay single.
@@ -821,15 +783,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 self._max_len_num_reqs,
             ),
         }
-        if self.most_model_len is not None:
-            _checks["page_table_dev_most"] = (
-                set(self._page_table_dev_most[0]),
-                self._most_len_num_reqs,
-            )
-            _checks["cache_position_dev_most"] = (
-                set(self._cache_position_dev_most),
-                self._most_len_num_reqs,
-            )
+
         for _name, (_keys, _needed) in _checks.items():
             assert _needed <= _keys, (
                 f"{_name} buffer keyed by {sorted(_keys)} is missing reachable "
@@ -1242,28 +1196,6 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             }
             for g in range(num_groups)
         }
-        if self.most_model_len is not None:
-            assert self.num_reqs_most_model_len is not None
-            assert self.num_blocks_per_most_len_req is not None
-            most_reqs = {self.min_num_reqs, self.num_reqs_most_model_len}
-            self._page_table_dev_most = {
-                g: {
-                    nr: _alloc_dev(
-                        (nr, _pt_width(g, self.num_blocks_per_most_len_req)), dt
-                    )
-                    for nr in most_reqs
-                }
-                for g in range(num_groups)
-            }
-            self._fill_page_table_dev_most = {
-                g: {
-                    nr: _alloc_dev(
-                        (nr, _pt_width(g, self.num_blocks_per_most_len_req)), dt
-                    )
-                    for nr in most_reqs
-                }
-                for g in range(num_groups)
-            }
         self._num_kv_cache_groups = num_groups
 
     def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
@@ -1421,40 +1353,22 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         assert start_index < num_reqs
 
         # Get the number of scheduled tokens for each request.
-        use_max_model_len = self.most_model_len is None
         num_scheduled_tokens_per_req = []
         max_num_scheduled_tokens_all_reqs = 0
         end_index = start_index
 
-        # Use either most_model_len or max_model_len depending on request size.
         for i in range(start_index, num_reqs):
             req_id = self.input_batch.req_ids[i]
             assert req_id is not None
             num_tokens = scheduler_output.num_scheduled_tokens.get(req_id, 0)
-            if (
-                not use_max_model_len
-                and self.most_model_len is not None
-                and num_tokens > self.most_model_len
-            ):
-                use_max_model_len = True
             num_scheduled_tokens_per_req.append(num_tokens)
-        if use_max_model_len:
-            if len(num_scheduled_tokens_per_req) > self.num_reqs_max_model_len:
-                num_scheduled_tokens_per_req = num_scheduled_tokens_per_req[
-                    : self.num_reqs_max_model_len
-                ]
-                end_index = start_index + self.num_reqs_max_model_len
-            else:
-                end_index = num_reqs
+        if len(num_scheduled_tokens_per_req) > self.num_reqs_max_model_len:
+            num_scheduled_tokens_per_req = num_scheduled_tokens_per_req[
+                : self.num_reqs_max_model_len
+            ]
+            end_index = start_index + self.num_reqs_max_model_len
         else:
-            assert self.num_reqs_most_model_len is not None
-            if len(num_scheduled_tokens_per_req) > self.num_reqs_most_model_len:
-                num_scheduled_tokens_per_req = num_scheduled_tokens_per_req[
-                    : self.num_reqs_most_model_len
-                ]
-                end_index = start_index + self.num_reqs_most_model_len
-            else:
-                end_index = num_reqs
+            end_index = num_reqs
 
         # Reconcile with the prefill row cap: if this is a prefill pass (any
         # request has > 1 scheduled token) and the SMEM-trimmed batch still
@@ -1481,14 +1395,8 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         num_reqs = len(num_scheduled_tokens_per_req)
         actual_num_reqs = num_reqs
 
-        # Row-count bucket for this step, clamped to the active path's SMEM seq
-        # limit (see `_select_target_num_reqs`). #5416.
-        path_max_num_reqs = (
-            self.num_reqs_max_model_len
-            if use_max_model_len
-            else self.num_reqs_most_model_len
-        )
-        assert path_max_num_reqs is not None
+        # Row-count bucket for this step, clamped to the SMEM sequence limit.
+        path_max_num_reqs = self.num_reqs_max_model_len
         is_decode_step = max_num_scheduled_tokens_all_reqs == 1
         target_num_reqs = _select_target_num_reqs(
             self.min_num_reqs,
@@ -1599,16 +1507,9 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # seq_lens / cache_position are identical across kv_cache groups (the
         # decode position is physical, not per-group), so compute them once. Only
         # the block tables differ per group (built inside the loop below).
-        if use_max_model_len:
-            assert self.num_reqs_max_model_len is not None
-            width = self.max_num_blocks_per_req
-            seq_lens = self.seq_lens_cpu[: self.num_reqs_max_model_len]
-            cache_position_dev = self._cache_position_dev_max[target_num_reqs]
-        else:
-            assert self.num_reqs_most_model_len is not None
-            width = self.num_blocks_per_most_len_req
-            seq_lens = self.seq_lens_cpu[: self.num_reqs_most_model_len]
-            cache_position_dev = self._cache_position_dev_most[target_num_reqs]
+        width = self.max_num_blocks_per_req
+        seq_lens = self.seq_lens_cpu[: self.num_reqs_max_model_len]
+        cache_position_dev = self._cache_position_dev_max[target_num_reqs]
 
         cache_position = seq_lens - 1
         cache_position = cache_position[:target_num_reqs]
@@ -1692,10 +1593,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             cp_rel = np.full((target_num_reqs,), -1, dtype=np.int64)
             if actual_num_reqs > 0:
                 cp_rel[:actual_num_reqs] = cur_pos_abs - start_block * bs_s
-            if use_max_model_len:
-                scp_dev = self._cache_position_sliding_dev_max[target_num_reqs]
-            else:
-                scp_dev = self._cache_position_sliding_dev_most[target_num_reqs]
+            scp_dev = self._cache_position_sliding_dev_max[target_num_reqs]
             scp_dev.copy_(torch.from_numpy(cp_rel).to(scp_dev.dtype))
             sliding_cache_position = scp_dev
             if self.parallel_mode in (
@@ -1757,16 +1655,8 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # => pre-hybrid behavior.
         attn_metadata_per_group: list[TTMetadata] = []
         for g in range(self._num_kv_cache_groups):
-            if use_max_model_len:
-                page_table_dev = self._page_table_dev_max[g][target_num_reqs]
-                fill_page_table_dev_buf = self._fill_page_table_dev_max[g][
-                    target_num_reqs
-                ]
-            else:
-                page_table_dev = self._page_table_dev_most[g][target_num_reqs]
-                fill_page_table_dev_buf = self._fill_page_table_dev_most[g][
-                    target_num_reqs
-                ]
+            page_table_dev = self._page_table_dev_max[g][target_num_reqs]
+            fill_page_table_dev_buf = self._fill_page_table_dev_max[g][target_num_reqs]
 
             if self._group_is_sliding[g]:
                 # Sliding: window-width rotated ring page_table + window-relative
@@ -3888,15 +3778,6 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             self.max_num_blocks_per_req,
             "max_model_len path",
         )
-        if self.most_model_len is not None:
-            assert self.num_reqs_most_model_len is not None
-            assert self.num_blocks_per_most_len_req is not None
-            _compile_path(
-                self._most_len_num_reqs,
-                self.num_reqs_most_model_len,
-                self.num_blocks_per_most_len_req,
-                "most_model_len path",
-            )
         xm.wait_device_ops()
         end = time.perf_counter()
         logger.info("Compilation finished in %.2f [secs].", end - start)
@@ -4169,12 +4050,6 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             num_tokens, self.num_reqs_max_model_len, self.max_num_blocks_per_req
         )
         torch_xla.sync()
-        if self.most_model_len is not None:
-            self._dummy_run(
-                num_tokens,
-                self.num_reqs_most_model_len,
-                self.num_blocks_per_most_len_req,
-            )
         torch_xla.sync(wait=False)
         self.encoder_cache.clear()
         gc.collect()
@@ -4921,9 +4796,8 @@ def _bucket_num_reqs(
     """Return the ``(small_prefill, big_prefill, decode)`` row-count buckets for
     one attention path.
 
-    A batch's row count is clamped to the SMEM sequence limit of the active path
-    (``path_max_num_reqs`` == ``num_reqs_max_model_len`` or
-    ``num_reqs_most_model_len``). Decode uses that limit; the prefill buckets are
+    A batch's row count is clamped to the SMEM sequence limit for the active
+    model length path. Decode uses that limit; the prefill buckets are
     ``min_num_reqs`` and ``max_prefill_num_reqs``, each clamped to it so neither
     row count exceeds what SMEM holds. See issue #5416.
     """
@@ -4938,23 +4812,15 @@ def _reachable_num_reqs(
     min_num_reqs: int,
     max_prefill_num_reqs: int,
     num_reqs_max_model_len: int,
-    num_reqs_most_model_len: Optional[int],
 ) -> set[int]:
-    """All row-count buckets `_prepare_inputs` can request across both paths.
+    """All row-count buckets `_prepare_inputs` can request.
 
     Per-batch device buffers must be keyed by exactly this set so every runtime
     ``target_num_reqs`` resolves to a preallocated buffer.
     """
-    reqs = set(
+    return set(
         _bucket_num_reqs(min_num_reqs, max_prefill_num_reqs, num_reqs_max_model_len)
     )
-    if num_reqs_most_model_len is not None:
-        reqs |= set(
-            _bucket_num_reqs(
-                min_num_reqs, max_prefill_num_reqs, num_reqs_most_model_len
-            )
-        )
-    return reqs
 
 
 def _select_target_num_reqs(

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -4143,10 +4143,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 block_sizes=block_sizes,
                 kernel_block_sizes=block_sizes,
                 max_num_blocks_per_req=[
-                    cdiv(
-                        self.max_model_len,
-                        block_sizes,
-                    )
+                    cdiv(self.max_model_len, bs) for bs in block_sizes
                 ],
                 is_pooling_model=False,
             )

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -604,6 +604,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             vocab_size=self.model_config.get_vocab_size(),
             block_sizes=[self.block_size],
             kernel_block_sizes=[self.block_size],
+            max_num_blocks_per_req=[self.max_num_blocks_per_req],
             is_pooling_model=False,
         )
 
@@ -4141,6 +4142,12 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 vocab_size=self.model_config.get_vocab_size(),
                 block_sizes=block_sizes,
                 kernel_block_sizes=block_sizes,
+                max_num_blocks_per_req=[
+                    cdiv(
+                        self.max_model_len,
+                        block_sizes,
+                    )
+                ],
                 is_pooling_model=False,
             )
         # Always (re)allocate the per-group page-table device buffers: even at an

--- a/integrations/vllm_plugin/vllm_tt/pooling_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/pooling_runner.py
@@ -422,6 +422,7 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # If there's no kv_cache_spec, we don't need KV cache block tables
         kv_cache_spec = self.get_kv_cache_spec()
         block_sizes = [self.block_size] if kv_cache_spec else []
+        max_num_blocks_per_req = [cdiv(self.max_model_len, bs) for bs in block_sizes]
 
         # Initialize input batch early to avoid AttributeError in _update_states
         self.input_batch = InputBatch(
@@ -433,6 +434,7 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             vocab_size=self.model_config.get_vocab_size(),
             block_sizes=block_sizes,
             kernel_block_sizes=block_sizes,
+            max_num_blocks_per_req=max_num_blocks_per_req,
             logitsprocs=build_logitsprocs(
                 self.vllm_config,
                 "cpu",

--- a/integrations/vllm_plugin/vllm_tt/pooling_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/pooling_runner.py
@@ -353,13 +353,7 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self.sliding_window = model_config.get_sliding_window()
         self.block_size = cache_config.block_size
         self.max_model_len = model_config.max_model_len
-        self.most_model_len = envs.VLLM_TPU_MOST_MODEL_LEN
         self.max_num_blocks_per_req = cdiv(self.max_model_len, self.block_size)
-        self.num_blocks_per_most_len_req = (
-            cdiv(self.most_model_len, self.block_size)
-            if self.most_model_len is not None
-            else None
-        )
 
         # Pooling runner always prepares request-wise batched inputs with shape
         # [num_reqs, padded_request_len]. Pad lengths are therefore bounded by
@@ -461,16 +455,6 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         )
         self.positions_np = self.positions_cpu.numpy()
         # adjust num_reqs to avoid SMEM OOM.
-        self.num_reqs_most_model_len = (
-            min(
-                TTAttentionBackend.get_max_num_seqs(
-                    self.most_model_len, self.block_size
-                ),
-                self.max_num_reqs,
-            )
-            if self.most_model_len is not None
-            else None
-        )
         self.num_reqs_max_model_len = min(
             TTAttentionBackend.get_max_num_seqs(self.max_model_len, self.block_size),
             self.max_num_reqs,
@@ -873,35 +857,22 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self.num_additional_inputs = 0
 
         # Get the number of scheduled tokens for each request.
-        use_max_model_len = self.most_model_len is None
         num_scheduled_tokens_per_req = []
         max_num_scheduled_tokens_all_reqs = 0
         end_index = start_index
 
-        # Use either most_model_len or max_model_len depending on request size.
         for i in range(start_index, num_reqs):
             req_id = self.input_batch.req_ids[i]
             assert req_id is not None
             num_tokens = scheduler_output.num_scheduled_tokens[req_id]
-            if not use_max_model_len and num_tokens > self.most_model_len:
-                use_max_model_len = True
             num_scheduled_tokens_per_req.append(num_tokens)
-        if use_max_model_len:
-            if len(num_scheduled_tokens_per_req) > self.num_reqs_max_model_len:
-                num_scheduled_tokens_per_req = num_scheduled_tokens_per_req[
-                    : self.num_reqs_max_model_len
-                ]
-                end_index = start_index + self.num_reqs_max_model_len
-            else:
-                end_index = num_reqs
+        if len(num_scheduled_tokens_per_req) > self.num_reqs_max_model_len:
+            num_scheduled_tokens_per_req = num_scheduled_tokens_per_req[
+                : self.num_reqs_max_model_len
+            ]
+            end_index = start_index + self.num_reqs_max_model_len
         else:
-            if len(num_scheduled_tokens_per_req) > self.num_reqs_most_model_len:
-                num_scheduled_tokens_per_req = num_scheduled_tokens_per_req[
-                    : self.num_reqs_most_model_len
-                ]
-                end_index = start_index + self.num_reqs_most_model_len
-            else:
-                end_index = num_reqs
+            end_index = num_reqs
         max_num_scheduled_tokens_all_reqs = max(num_scheduled_tokens_per_req)
         num_scheduled_tokens_per_req = np.array(
             num_scheduled_tokens_per_req, dtype=np.int32
@@ -981,10 +952,7 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             + num_scheduled_tokens_per_req
         )
 
-        if use_max_model_len:
-            seq_lens = self.seq_lens_cpu[:num_reqs]
-        else:
-            seq_lens = self.seq_lens_cpu[: self.num_reqs_most_model_len]
+        seq_lens = self.seq_lens_cpu[:num_reqs]
 
         if self.lora_config is not None:
             # We need to respect padding when activating LoRA adapters
@@ -1638,11 +1606,6 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     num_reqs,
                     num_tokens,
                 )
-                if self.most_model_len is not None:
-                    self._dummy_run(
-                        num_reqs,
-                        num_tokens,
-                    )
         xm.wait_device_ops()
         end = time.perf_counter()
         logger.info("Compilation finished in %.2f [secs].", end - start)
@@ -1723,8 +1686,6 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # Trigger compilation for general shape.
         torch._dynamo.config.dynamic_shapes = False
         self._dummy_run(self.max_num_reqs, self.num_reqs_max_model_len)
-        if self.most_model_len is not None:
-            self._dummy_run(self.max_num_reqs, self.num_reqs_most_model_len)
 
         torch_xla.sync(wait=False)
         xm.wait_device_ops()

--- a/integrations/vllm_plugin/vllm_tt/scheduler/ascend_scheduler.py
+++ b/integrations/vllm_plugin/vllm_tt/scheduler/ascend_scheduler.py
@@ -208,17 +208,27 @@ class AscendScheduler(Scheduler):
 
             # Get already-cached tokens.
             if request.num_computed_tokens == 0:
-                new_computed_blocks, num_new_local_computed_tokens = (
-                    self.kv_cache_manager.get_computed_blocks(request)
-                )
+                (
+                    new_computed_blocks,
+                    num_new_local_computed_tokens,
+                    # Junction to pin for sparse-retention shared-prefix
+                    # handling; 0 when no uncached shared prefix is found.
+                    request.shared_prefix_boundary,
+                ) = self.kv_cache_manager.get_computed_blocks(request)
 
                 # Get externally-cached tokens if using a KVConnector.
                 if self.connector is not None:
-                    num_external_computed_tokens, load_kv_async = (
+                    ext_tokens, load_kv_async = (
                         self.connector.get_num_new_matched_tokens(
                             request, num_new_local_computed_tokens
                         )
                     )
+                    if ext_tokens is None:
+                        # Connector could not determine the number of matched
+                        # tokens for this step; defer request.
+                        skip_cur_request()
+                        continue
+                    num_external_computed_tokens = ext_tokens
 
                 # Total computed tokens (local + external).
                 num_computed_tokens = (

--- a/tests/integrations/vllm_plugin/test_prepare_inputs_buffer_keying.py
+++ b/tests/integrations/vllm_plugin/test_prepare_inputs_buffer_keying.py
@@ -5,8 +5,8 @@
 
 ``TTModelRunner`` preallocates per-batch device buffers keyed by request-count
 buckets; ``_prepare_inputs`` looks them up by a per-step ``target_num_reqs``
-clamped to the active path's SMEM seq limit (``num_reqs_max_model_len`` /
-``num_reqs_most_model_len``), which drops below ``max_num_seqs`` at long context.
+clamped to the active path's SMEM seq limit (``num_reqs_max_model_len``),
+which drops below ``max_num_seqs`` at long context.
 Pre-fix the shared buffers were keyed by ``max_num_reqs`` while the page tables
 and warmup used the clamped count, so decode ran at the wrong row count and a
 distinct ``max_prefill_num_reqs`` hit a ``KeyError``.
@@ -31,59 +31,52 @@ def _all_reachable_targets(
     min_num_reqs,
     max_prefill_num_reqs,
     num_reqs_max_model_len,
-    num_reqs_most_model_len,
 ):
     """Every ``target_num_reqs`` ``_prepare_inputs`` can produce for a config.
 
-    Enumerates both attention paths, decode + prefill, and every possible
-    ``actual_num_reqs`` (already truncated to the path limit upstream).
+    Enumerates decode + prefill, and every possible ``actual_num_reqs``
+    (already truncated to the path limit upstream).
     """
     targets = set()
-    paths = [num_reqs_max_model_len]
-    if num_reqs_most_model_len is not None:
-        paths.append(num_reqs_most_model_len)
-    for path_max in paths:
-        for is_decode in (True, False):
-            for actual in range(1, path_max + 1):
-                targets.add(
-                    _select_target_num_reqs(
-                        min_num_reqs,
-                        max_prefill_num_reqs,
-                        path_max,
-                        is_decode,
-                        actual,
-                    )
+
+    for is_decode in (True, False):
+        for actual in range(1, num_reqs_max_model_len + 1):
+            targets.add(
+                _select_target_num_reqs(
+                    min_num_reqs,
+                    max_prefill_num_reqs,
+                    num_reqs_max_model_len,
+                    is_decode,
+                    actual,
                 )
+            )
     return targets
 
 
-# (min_num_reqs, max_prefill_num_reqs, max_num_reqs, N_max, N_most)
-# Invariants: N_max <= N_most <= max_num_reqs; max_prefill_num_reqs <= max_num_reqs.
+# (min_num_reqs, max_prefill_num_reqs, max_num_reqs, N_max)
+# Invariants: max_prefill_num_reqs <= max_num_reqs.
 _CONFIGS = [
-    # Common case: SMEM limit >= max_num_seqs, so no clamp (all counts equal).
-    (32, 32, 32, 32, None),
-    (32, 32, 32, 32, 32),
+    # Common case: SMEM limit >= max_num_seqs, so no clamp.
+    (32, 32, 32, 32),
     # min_num_seqs feature: distinct small prefill bucket, no clamp.
-    (4, 32, 32, 32, 32),
+    (4, 32, 32, 32),
     # max_prefill feature: prefill capped below decode, no clamp.
-    (4, 16, 32, 32, None),
-    # Long context: SMEM limit below max_num_seqs (the #5416 trigger), feature off.
-    (32, 32, 32, 16, None),
-    (32, 32, 32, 8, 16),
+    (4, 16, 32, 32),
+    # Long context: SMEM limit below max_num_seqs (the #5416 trigger).
+    (32, 32, 32, 16),
     # Long context + min_num_seqs feature.
-    (4, 32, 32, 16, 24),
+    (4, 32, 32, 16),
     # Long context + max_prefill below the SMEM limit (three distinct buckets).
-    (4, 16, 32, 24, None),
+    (4, 16, 32, 24),
     # Long context clamps the prefill bucket too (max_prefill > SMEM limit).
-    (4, 16, 32, 8, None),
+    (4, 16, 32, 8),
     # Extreme clamp: only one sequence fits in SMEM.
-    (32, 32, 32, 1, None),
+    (32, 32, 32, 1),
 ]
 
 
 @pytest.mark.parametrize(
-    "min_num_reqs,max_prefill_num_reqs,max_num_reqs,num_reqs_max_model_len,"
-    "num_reqs_most_model_len",
+    "min_num_reqs,max_prefill_num_reqs,max_num_reqs,num_reqs_max_model_len",
     _CONFIGS,
 )
 def test_every_target_num_reqs_has_a_buffer_key(
@@ -91,20 +84,17 @@ def test_every_target_num_reqs_has_a_buffer_key(
     max_prefill_num_reqs,
     max_num_reqs,
     num_reqs_max_model_len,
-    num_reqs_most_model_len,
 ):
     """Buffers keyed by ``_reachable_num_reqs`` cover every requestable target."""
     keys = _reachable_num_reqs(
         min_num_reqs,
         max_prefill_num_reqs,
         num_reqs_max_model_len,
-        num_reqs_most_model_len,
     )
     targets = _all_reachable_targets(
         min_num_reqs,
         max_prefill_num_reqs,
         num_reqs_max_model_len,
-        num_reqs_most_model_len,
     )
     missing = targets - keys
     assert not missing, (
@@ -114,8 +104,7 @@ def test_every_target_num_reqs_has_a_buffer_key(
 
 
 @pytest.mark.parametrize(
-    "min_num_reqs,max_prefill_num_reqs,max_num_reqs,num_reqs_max_model_len,"
-    "num_reqs_most_model_len",
+    "min_num_reqs,max_prefill_num_reqs,max_num_reqs,num_reqs_max_model_len",
     _CONFIGS,
 )
 def test_reachable_key_set_has_no_unused_keys(
@@ -123,20 +112,17 @@ def test_reachable_key_set_has_no_unused_keys(
     max_prefill_num_reqs,
     max_num_reqs,
     num_reqs_max_model_len,
-    num_reqs_most_model_len,
 ):
     """No allocated buffer key is unreachable, so the key set stays minimal."""
     keys = _reachable_num_reqs(
         min_num_reqs,
         max_prefill_num_reqs,
         num_reqs_max_model_len,
-        num_reqs_most_model_len,
     )
     targets = _all_reachable_targets(
         min_num_reqs,
         max_prefill_num_reqs,
         num_reqs_max_model_len,
-        num_reqs_most_model_len,
     )
     assert keys == targets
 
@@ -157,7 +143,7 @@ def test_decode_target_is_clamped_to_smem_limit():
     )
     assert decode_target == num_reqs_max_model_len
     assert decode_target in _reachable_num_reqs(
-        min_num_reqs, max_prefill_num_reqs, num_reqs_max_model_len, None
+        min_num_reqs, max_prefill_num_reqs, num_reqs_max_model_len
     )
 
 


### PR DESCRIPTION
### Ticket
closes #5826

### Problem description
vLLM v0.26.0 released

### What's changed
- Uplift vLLM
- Remove most_model_len path in runners and update relevant test
- Update MultiGroupBlockTable usage
- Update Schedular

### Checklist
- [X] New/Existing tests provide coverage for changes
