### PR TITLE
Fix bge-m3 flattened-IO regression: bf16 linears and host-side reshape

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/pooling_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/pooling_runner.py
@@ -303,6 +303,9 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self.device = device
         self.check_recompilation = envs.VLLM_XLA_CHECK_RECOMPILATION
         self.use_flat_model_io = self.tt_config.flat_model_io
+        # Rank-2 shape to restore hidden states to when _prepare_inputs flattened
+        # the model inputs on the host; None when it did not.
+        self.flat_io_restore_shape = None
 
         # Data parallel execution
         self.num_additional_inputs = 0
@@ -938,8 +941,18 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 arange = torch.cat([arange, zero_rows], dim=0)
                 attn_mask_batch_size += self.num_additional_inputs
 
-        self.input_ids = self.input_ids_cpu.to(self.device)
-        self.position_ids = arange.to(self.device)
+        # Flattened model IO wants rank-1 inputs. Reshaping on the host keeps the
+        # pre-model eager region free of device ops, which otherwise compiles one
+        # reshape program per input-shape bucket. Data parallel marks sharding on
+        # the rank-2 tensors, so it keeps them and flattens on device later.
+        self.flat_io_restore_shape = None
+        if self.use_flat_model_io and not self.enable_data_parallel:
+            self.flat_io_restore_shape = self.input_ids_cpu.shape
+            self.input_ids = self.input_ids_cpu.reshape(-1).to(self.device)
+            self.position_ids = arange.reshape(-1).to(self.device)
+        else:
+            self.input_ids = self.input_ids_cpu.to(self.device)
+            self.position_ids = arange.to(self.device)
 
         # Prepare the attention metadata.
         self.query_start_loc_np[0] = 0
@@ -976,7 +989,7 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         if not self.is_decoder_only_attn_layers:
             attn_mask = generate_attn_mask(
                 seq_lens,
-                self.input_ids.shape[-1],
+                self.input_ids_cpu.shape[-1],
                 attn_mask_batch_size,
                 self.is_decoder_only_attn_layers,
                 self.dtype,
@@ -1199,7 +1212,9 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         if not self.use_flat_model_io:
             return input_ids, positions, inputs_embeds, None
 
-        restore_shape: Optional[torch.Size] = None
+        # _prepare_inputs already flattened on the host where it could, in which
+        # case the reshapes below are no-ops and only the restore shape is needed.
+        restore_shape: Optional[torch.Size] = self.flat_io_restore_shape
 
         if input_ids is not None and input_ids.ndim > 1:
             restore_shape = input_ids.shape
@@ -1292,10 +1307,13 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     positions=model_positions,
                     inputs_embeds=model_inputs_embeds,
                 )
+                # Restore on the host: an eager reshape of the device tensor would
+                # compile a program per input-shape bucket, and the result is bound
+                # for the CPU on the next line anyway.
+                hidden_states = hidden_states.to("cpu")
                 hidden_states = self._restore_model_hidden_states(
                     hidden_states, hidden_state_shape
                 )
-                hidden_states = hidden_states.to("cpu")
 
             # Split along batch dimension and remove the extra dimension
             hidden_states_list = [
@@ -1496,19 +1514,24 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
     @torch.no_grad()
     def _dummy_run(self, num_reqs: int, num_tokens: int) -> None:
         torch._dynamo.config.dynamic_shapes = False
+        # Match the shape the real path feeds the model, so warmup compiles the
+        # programs execution will actually use rather than a rank-2 variant plus a
+        # reshape program per bucket.
+        flatten_io = self.use_flat_model_io and not self.enable_data_parallel
+        self.flat_io_restore_shape = (
+            torch.Size((num_reqs, num_tokens)) if flatten_io else None
+        )
+        ids_shape = (num_reqs * num_tokens,) if flatten_io else (num_reqs, num_tokens)
+
         if self.supports_mm_inputs:
             input_ids = None
             inputs_embeds = torch.zeros(
                 (num_tokens, self.hidden_size), dtype=self.dtype, device=self.device
             )
         else:
-            input_ids = torch.zeros((num_reqs, num_tokens), dtype=torch.int32).to(
-                self.device
-            )
+            input_ids = torch.zeros(ids_shape, dtype=torch.int32).to(self.device)
             inputs_embeds = None
-        position_ids = torch.zeros((num_reqs, num_tokens), dtype=torch.int32).to(
-            self.device
-        )
+        position_ids = torch.zeros(ids_shape, dtype=torch.int32).to(self.device)
         context_lens = torch.ones((num_reqs,), dtype=torch.int32)
 
         # Mark inputs for data parallel sharding.
@@ -1525,7 +1548,7 @@ class TTPoolingModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         if not self.is_decoder_only_attn_layers:
             attn_mask = generate_attn_mask(
                 context_lens,
-                input_ids.shape[-1],
+                num_tokens,
                 num_reqs,
                 self.is_decoder_only_attn_layers,
                 self.dtype,

--- a/python_package/tt_torch/backend/passes.py
+++ b/python_package/tt_torch/backend/passes.py
@@ -670,6 +670,43 @@ def clamp_neg_getitem_bounds(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
     return gm
 
 
+# Decompositions of the fused add+matmul ops route every operand through float32
+# irrespective of the model dtype. A rank-2 activation makes nn.Linear lower to
+# addmm instead of mm, so with flattened model IO this hits every linear in the
+# graph and drags whole encoders into f32. Refs: tt-xla #5756.
+_FLOAT32_PROMOTING_MATMULS = (
+    "aten::addmm",
+    "aten::addmv",
+    "aten::addbmm",
+    "aten::baddbmm",
+)
+
+
+def _dtype_cast_target(node):
+    """
+    (spelling, target dtype) of a pure dtype-cast node, or None if not one.
+
+    Decompositions spell the cast either as prims::convert_element_type or as
+    aten::_to_copy with a dtype kwarg. For _to_copy, any kwarg that also relocates
+    the tensor (device/layout/memory_format) means it is not a pure cast and must
+    be left alone.
+    """
+    if node.op != "call_function" or not hasattr(node.target, "name"):
+        return None
+    if not node.args or not isinstance(node.args[0], torch.fx.Node):
+        return None
+
+    name = node.target.name()
+    if "prims::convert_element_type" in name:
+        dtype = node.args[1] if len(node.args) > 1 else node.kwargs.get("dtype")
+        return ("convert_element_type", dtype)
+    if "aten::_to_copy" in name:
+        if any(key not in ("dtype", "non_blocking") for key in node.kwargs):
+            return None
+        return ("_to_copy", node.kwargs.get("dtype"))
+    return None
+
+
 def bypass_dtype_promotion_and_redundant_cast(gm, example_inputs):
     """
     Removes casting of nodes to float32 unless they were explicitly set by the user.
@@ -679,22 +716,35 @@ def bypass_dtype_promotion_and_redundant_cast(gm, example_inputs):
     """
     removed_non_redundant_casts = False
     for node in gm.graph.nodes:
-        if (
-            node.op == "call_function"
-            and hasattr(node.target, "name")
-            and "prims::convert_element_type" in node.target.name()
-        ):
-            is_unwanted_dtype_promotion = (
-                node.meta["original_aten"]._name != "aten::_to_copy"
-                and node.args[1] == torch.float32
-            )
-            node_meta = node.args[0].meta
-            meta_val = node_meta.get("tensor_meta") or node_meta.get("val")
-            is_redundant_cast = meta_val is not None and meta_val.dtype == node.args[1]
+        cast = _dtype_cast_target(node)
+        if cast is None:
+            continue
+        spelling, cast_dtype = cast
 
-            if is_unwanted_dtype_promotion or is_redundant_cast:
-                node.replace_all_uses_with(node.args[0])
-                removed_non_redundant_casts |= is_unwanted_dtype_promotion
+        # A cast the user wrote keeps original_aten == aten::_to_copy; anything else
+        # attributes the cast to the op being decomposed.
+        original_aten = getattr(node.meta.get("original_aten"), "_name", None)
+        if spelling == "convert_element_type":
+            is_unwanted_dtype_promotion = (
+                original_aten is not None
+                and original_aten != "aten::_to_copy"
+                and cast_dtype == torch.float32
+            )
+        else:
+            # _to_copy is also how an explicit user .to() is spelled, so restrict
+            # this spelling to the decompositions known to promote for opmath.
+            is_unwanted_dtype_promotion = (
+                original_aten in _FLOAT32_PROMOTING_MATMULS
+                and cast_dtype == torch.float32
+            )
+
+        node_meta = node.args[0].meta
+        meta_val = node_meta.get("tensor_meta") or node_meta.get("val")
+        is_redundant_cast = meta_val is not None and meta_val.dtype == cast_dtype
+
+        if is_unwanted_dtype_promotion or is_redundant_cast:
+            node.replace_all_uses_with(node.args[0])
+            removed_non_redundant_casts |= is_unwanted_dtype_promotion
 
     gm.graph.eliminate_dead_code()
     gm.graph.lint()

--- a/python_package/tt_torch/backend/passes.py
+++ b/python_package/tt_torch/backend/passes.py
@@ -671,9 +671,10 @@ def clamp_neg_getitem_bounds(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
 
 
 # Decompositions of the fused add+matmul ops route every operand through float32
-# irrespective of the model dtype. A rank-2 activation makes nn.Linear lower to
-# addmm instead of mm, so with flattened model IO this hits every linear in the
-# graph and drags whole encoders into f32. Refs: tt-xla #5756.
+# irrespective of the model dtype. A biased nn.Linear reaches addmm only at rank 2
+# on XLA -- aten::linear skips its flatten-to-addmm shortcut for XLA tensors, so
+# rank 3 stays on mm + add -- which is why flattened model IO drags whole encoders
+# into f32 while batched IO does not. Refs: tt-xla #5756.
 _FLOAT32_PROMOTING_MATMULS = (
     "aten::addmm",
     "aten::addmv",

--- a/tests/filecheck/linear_bias_rank2_bf16.ttnn.mlir
+++ b/tests/filecheck/linear_bias_rank2_bf16.ttnn.mlir
@@ -1,0 +1,5 @@
+// A rank-2 activation through a biased nn.Linear decomposes to aten::addmm, and
+// PyTorch's addmm decomposition upcasts every operand to f32. The linear must stay
+// bf16 on all three operands and the result. Refs: tt-xla #5756.
+//CHECK: "ttnn.linear"
+//CHECK-SAME: (tensor<{{[0-9x]+}}xbf16{{[^)]*}}, tensor<{{[0-9x]+}}xbf16{{[^)]*}}, tensor<{{[0-9x]+}}xbf16{{[^)]*}}) -> tensor<{{[0-9x]+}}xbf16

--- a/tests/integrations/vllm_plugin/pooling/test_single_device.py
+++ b/tests/integrations/vllm_plugin/pooling/test_single_device.py
@@ -31,6 +31,34 @@ def test_embedding_push(model_name: str, baseline_path, max_model_len: int):
 
 @pytest.mark.push
 @pytest.mark.single_device
+@pytest.mark.parametrize(
+    ["model_name", "baseline_path", "max_model_len"],
+    [
+        pytest.param(
+            "Qwen/Qwen3-Embedding-0.6B",
+            "baseline/qwen3_embedding_0.6B_baseline.pt",
+            32,
+        ),
+    ],
+)
+def test_embedding_flat_model_io(model_name: str, baseline_path, max_model_len: int):
+    """Flattened model IO must match the same baseline as the batched path.
+
+    Flattening hands the model rank-2 activations, which lower through a
+    different set of aten ops than rank-3 does. Refs: tt-xla #5756.
+    """
+    run_pooling_test(
+        model_name,
+        baseline_path,
+        max_model_len,
+        max_num_reqs=1,
+        min_context_len=32,
+        flat_model_io=True,
+    )
+
+
+@pytest.mark.push
+@pytest.mark.single_device
 def test_embed_qwen3_reduced_dims():
     prompts = [
         "Hello, my name is",

--- a/tests/integrations/vllm_plugin/pooling/test_single_device.py
+++ b/tests/integrations/vllm_plugin/pooling/test_single_device.py
@@ -46,12 +46,15 @@ def test_embedding_flat_model_io(model_name: str, baseline_path, max_model_len: 
 
     Flattening hands the model rank-2 activations, which lower through a
     different set of aten ops than rank-3 does. Refs: tt-xla #5756.
+
+    Runs multi-request so the flatten/restore actually spans rows; batch 2 is
+    skipped for this model in `test_batched_inference` (segfaults, issue #3094).
     """
     run_pooling_test(
         model_name,
         baseline_path,
         max_model_len,
-        max_num_reqs=1,
+        max_num_reqs=4,
         min_context_len=32,
         flat_model_io=True,
     )

--- a/tests/integrations/vllm_plugin/pooling/utils.py
+++ b/tests/integrations/vllm_plugin/pooling/utils.py
@@ -24,6 +24,7 @@ def run_pooling_test(
     use_2d_mesh: bool = False,
     mesh_shape: list[int] | None = None,
     shard_weights_on_batch_axis: bool = True,
+    flat_model_io: bool = False,
 ):
     path = os.path.join(os.path.dirname(__file__), baseline_path)
     loaded_data = torch.load(path)
@@ -52,6 +53,7 @@ def run_pooling_test(
             "use_2d_mesh": use_2d_mesh,
             "mesh_shape": mesh_shape,
             "shard_weights_on_batch_axis": shard_weights_on_batch_axis,
+            "flat_model_io": flat_model_io,
         },
     }
     model = vllm.LLM(**llm_args)

--- a/tests/torch/test_torch_filecheck.py
+++ b/tests/torch/test_torch_filecheck.py
@@ -113,3 +113,30 @@ def test_model_filecheck(request):
         dtype_override=None,
     )
     tester.test(request=request)
+
+
+@pytest.mark.nightly
+@pytest.mark.single_device
+@pytest.mark.filecheck(["linear_bias_rank2_bf16.ttnn.mlir"])
+def test_linear_bias_rank2_stays_bf16(request):
+    """A rank-2 activation through a biased bf16 Linear must not be promoted to f32.
+
+    Rank-2 activations lower via aten::addmm, whose PyTorch decomposition upcasts
+    all operands to f32; the flattened model IO path hits this on every linear.
+    Refs: tt-xla #5756.
+    """
+
+    class BiasedLinearModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(64, 128, bias=True, dtype=torch.bfloat16)
+
+        def forward(self, x):
+            return self.linear(x)
+
+    run_op_test(
+        BiasedLinearModel(),
+        [torch.randn(32, 64, dtype=torch.bfloat16)],
+        framework=Framework.TORCH,
+        request=request,
+    )


### PR DESCRIPTION
### Ticket
Closes #5756

### Problem description

bge-m3 regressed 30-54% with `flat_model_io` while other models were perf neutral. Two independent causes, both triggered by the flattened path handing the model rank-2 activations instead of rank-3.

**1. The encoder silently ran in f32.** A rank-2 activation makes `nn.Linear` lower to `aten::addmm` instead of `aten::mm`, and PyTorch's `addmm` decomposition routes every operand through float32 for opmath. With flattened IO that hit all 9216 linears: 288 bf16->f32 typecasts, weights transposed *and* upcast in const-eval, and no `transpose_b` folding or gelu fusion because converts sat between the ops.

`bypass_dtype_promotion_and_redundant_cast` already existed to undo exactly this ("Pytorch insists on casting nodes to float32 during decompositions"), but it only recognised the `prims::convert_element_type` spelling and read the target dtype from `args[1]`. These casts arrive as `aten::_to_copy` with dtype in kwargs, so every one slipped through.

**2. Flattening compiled a reshape program per input shape.** The flatten reshapes ran on the device, outside the compiled model. Eager ops there become their own XLA program, and the program is shape-specialised, so each distinct input shape needed its own compilation. `_dummy_run` produced one per warmup bucket (96, alongside the 96 model programs); `_prepare_inputs` produced more for real requests, so a shape first seen mid-run compiled then -- putting a 4.3s compile inside the benchmark's timed loop.

Worth noting for anyone reading the original numbers: the benchmark averages all iterations, so those compiles dominated the reported figure. Steady-state per-iteration latency was always ~0.33s in both modes. Identical code measured 41, 53, 60, 74 and 97 samples/sec across runs depending on how many compiles landed inside the window.

### What's changed

**`passes.py`** - read the cast's target dtype from either spelling. For `_to_copy`, strip only casts attributed to the fused add+matmul decompositions (`addmm`/`addmv`/`addbmm`/`baddbmm`), since `_to_copy` is also how an explicit user `.to()` is spelled, and leave alone any `_to_copy` carrying device/layout/memory_format kwargs (those relocate the tensor, not just retype it). Batched inputs lower to `aten::mm` and emit no casts at all, so their IR is byte-identical.

**`pooling_runner.py`** - reshape on the host, before the tensors reach the device, in both `_prepare_inputs` and `_dummy_run`, and restore the hidden states after the CPU transfer rather than before it. A host reshape needs no program at all. Data parallel marks sharding on the rank-2 tensors, so it keeps the existing device-side path.

bge-m3 batch32, trace disabled, on n150-class silicon:

| | samples/sec | graphs (reshape helpers) |
|---|---|---|
| neither fix | 41.6 (41-74 across runs) | 199 (103) |
| pooling fix only | 67.3 | 97 (1) |
| **both** | **98.7** | **97 (1)** |
| batched reference | 96.7-97.6 | 97 (1) |

Flattened now matches the batched graph count exactly and edges past it on throughput, which is the expected outcome -- flattening genuinely removes work from the model graph (9512 reshapes vs 18810). Flattened embeddings are bit-identical to batched. Batched is unaffected: same 97 graphs, same throughput, same embeddings.

### Checklist
- [x] New/Existing tests provide coverage for changes
- [x] New `test_embedding_flat_model_io` runs the pooling path with `flat_model_io`  enabled against the same baseline as the batched test. Nothing enabled the flag  before, which is how the f32 regression shipped unnoticed.
- [x] New filecheck test `test_linear_bias_rank2_stays_bf16` asserts a biased rank-2  bf16 linear keeps bf16 operands. The existing `test_model_filecheck` has a  rank-2 bf16 linear but with `bias=False`, which lowers to `mm` and never  exercised the `addmm` path.
- [x] vLLM pooling suites all green: 18 passed/1 skipped single-device, 7 DP,  9 TP + DP+TP.
- [x] 'tests/torch/ops` + `tests/torch/graphs` A/B'd with and without the dtype fix:  identical failure sets (153 failed / 274 passed either way, all pre-existing on  the test box), so the pass change introduces no new failures.
