### PR TITLE
Add Falcon3-7B-Instruct production vLLM benchmark config

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -612,6 +612,13 @@
         "skip-device-perf": true
       },
       {
+        "name": "vllm_falcon3_7b_instruct_production",
+        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[falcon3-7b-instruct-production]",
+        "vllm": true,
+        "skip-device-perf": true,
+        "runs-on": "p150-perf"
+      },
+      {
         "name": "vllm_mistral_7b_instruct",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[mistral-7b-instruct]",
         "vllm": true,

--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -198,6 +198,40 @@ def _mistral_small_31_tp_config(model: str, batch_size: int):
     return cfg
 
 
+def _falcon3_7b_instruct_production_config():
+    # Mirrors the real single-chip (p150) production launch config from
+    # ~/scripts/model_servers/launch_falcon3_7b_instruct_uvicorn.sh (which
+    # mirrors workflows/model_specs/dev/cnn.yaml), not the minimal smoke-test
+    # defaults. Kept as the single test we maintain at production settings.
+    cfg = _config(
+        "tiiuae/Falcon3-7B-Instruct",
+        32,
+        gpu_memory_utilization=0.35,
+        optimization_level=1,
+        experimental_weight_dtype="bfp_bf8",
+        experimental_kv_cache_dtype="bfp_bf8",
+        enable_const_eval=True,
+        min_context_len=128,
+        prefill_chunk_size=1024,
+        # b1-prefill: serve prefills serially (small graph) when <=16 are
+        # pending instead of paying for a wasted-row b32 batch. Needs
+        # min_num_seqs < max_num_seqs (batch_size=32).
+        min_num_seqs=1,
+        prefill_batch_threshold=16,
+        # Cap prefill graphs at b16 instead of b32 (#5541): cuts prefill-trace
+        # DRAM residency and ~22% off compile time, with no throughput/TTFT
+        # regression measured.
+        max_prefill_num_seqs=16,
+    )
+    # max_num_batched_tokens and enable_chunked_prefill aren't set here: the
+    # plugin derives/overrides both from prefill_chunk_size (platform.py).
+    cfg.max_model_len = 32768
+    # Instruct-tuned: drive via the chat template, matching production evals
+    # (--apply_chat_template).
+    cfg.use_chat_template = True
+    return cfg
+
+
 SINGLE_DEVICE_CONFIGS = [
     # Llama
     pytest.param(_config("meta-llama/Llama-3.2-1B-Instruct"), id="llama-3.2-1b"),
@@ -236,6 +270,10 @@ SINGLE_DEVICE_CONFIGS = [
     pytest.param(
         _config("tiiuae/Falcon3-7B-Base", experimental_kv_cache_dtype=""),
         id="falcon3-7b-base",
+    ),
+    pytest.param(
+        _falcon3_7b_instruct_production_config(),
+        id="falcon3-7b-instruct-production",
     ),
     # Mistral
     pytest.param(


### PR DESCRIPTION
## Ticket

Addresses #5404 (Falcon3-7B-Instruct only — not the other models listed in that issue)

## Problem description

The existing `falcon3-7b-base` vLLM benchmark runs a minimal smoke-test config (`max_model_len=128`), not representative of how Falcon3-7B-Instruct is actually served in production. #5404 asks for benchmark coverage at each model's native max sequence length, batch-32, with the highest safe `gpu_memory_utilization` — Falcon3-7B-Instruct's native max is 32768.

## What's changed

- `tests/benchmark/test_vllm_benchmarks.py`: added `_falcon3_7b_instruct_production_config()` and a new `falcon3-7b-instruct-production` single-device benchmark entry, mirroring the real production launch config (`launch_falcon3_7b_instruct_uvicorn.sh` / `cnn.yaml` forge spec): `max_model_len=32768`, batch-32, `gpu_memory_utilization=0.35`, `optimization_level=1`, bfp8 weights/KV cache, chunked prefill (`prefill_chunk_size=1024`), b1-prefill (`min_num_seqs=1`, `prefill_batch_threshold=16`), and a b16 prefill-graph cap (`max_prefill_num_seqs=16`, from #5541) — measured to cut ~22% off compile time with no throughput/TTFT regression.
- `optimization_level=1` is intentional, not a placeholder: at this config's `max_model_len=32768` + chunked-prefill shape ladder, `optimization_level=2` took 2:00:09 to complete (full run measured) vs. 13:07 at `optimization_level=1` — 9.2x slower to compile, for +23% samples/sec (19.86 vs 16.14) but +32% worse TTFT (1146.2ms vs 866.2ms). Avoid bumping this to 2 without accounting for that compile-time cost.

## Checklist
- [x] Verified `falcon3-7b-instruct-production` passes; samples/sec and TTFT consistent across repeated runs (~15.6-16.1 samples/sec, TTFT ~850-870ms).
- [x] Run on CI via Perf Benchmark too: https://github.com/tenstorrent/tt-xla/actions/runs/30505233947
