### PR TITLE
[vLLM] Hybrid KV cache: cap sliding-window ring by max_model_len

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -4113,7 +4113,9 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self._group_window_blocks = [
             (
                 sliding_window_blocks(
-                    g.kv_cache_spec.sliding_window, g.kv_cache_spec.block_size
+                    g.kv_cache_spec.sliding_window,
+                    g.kv_cache_spec.block_size,
+                    self.max_model_len,
                 )
                 if isinstance(g.kv_cache_spec, SlidingWindowSpec)
                 else 0

--- a/integrations/vllm_plugin/vllm_tt/swa_cache_utils.py
+++ b/integrations/vllm_plugin/vllm_tt/swa_cache_utils.py
@@ -21,15 +21,22 @@ from vllm.utils.math_utils import cdiv
 PAGE_TABLE_STICK_BLOCK_ALIGNMENT = 8
 
 
-def sliding_window_blocks(sliding_window: int, block_size: int) -> int:
+def sliding_window_blocks(
+    sliding_window: int, block_size: int, max_model_len: int
+) -> int:
     """Blocks per user in a sliding ring, page-table-stick aligned.
 
     ``cdiv(window, block_size) + 1`` covers a window straddling a block
     boundary; the round-up satisfies the stick alignment above. The ring is
     over-provisioned to that width -- the sliding_window mask still limits
     attention to the real window.
+
+    Capped by ``max_model_len``: no request can ever hold more context than
+    that, so a layer's static sliding_window (e.g. 1024) must not size the
+    ring past the model_len a shorter-context run actually needs.
     """
-    n = cdiv(sliding_window, block_size) + 1
+    window = min(sliding_window, max_model_len)
+    n = cdiv(window, block_size) + 1
     align = PAGE_TABLE_STICK_BLOCK_ALIGNMENT
     return ((n + align - 1) // align) * align
 

--- a/integrations/vllm_plugin/vllm_tt/worker.py
+++ b/integrations/vllm_plugin/vllm_tt/worker.py
@@ -347,7 +347,9 @@ class TTWorker:
                 # Same helpers the model runner sizes the rings with, so the
                 # reservation here cannot drift from what it later allocates.
                 window_blocks = sliding_window_blocks(
-                    layer_spec.sliding_window, layer_spec.block_size
+                    layer_spec.sliding_window,
+                    layer_spec.block_size,
+                    self.model_runner.max_model_len,
                 )
                 sliding_reserve += sliding_ring_reserve_bytes(
                     window_blocks, max_num_reqs, layer_spec.page_size_bytes

--- a/tests/integrations/vllm_plugin/test_swa_cache_utils.py
+++ b/tests/integrations/vllm_plugin/test_swa_cache_utils.py
@@ -29,7 +29,8 @@ pytestmark = [pytest.mark.push, pytest.mark.cpu]
     [(1024, 32), (4096, 32), (512, 64), (1, 32), (8192, 128), (1023, 32)],
 )
 def test_sliding_window_blocks_alignment_and_slack(window, block_size):
-    wb = sliding_window_blocks(window, block_size)
+    # max_model_len far above window: not clamped, same math as before.
+    wb = sliding_window_blocks(window, block_size, max_model_len=1_000_000)
     # stick alignment: window_blocks int32 ids must be a 32-byte multiple
     assert wb % PAGE_TABLE_STICK_BLOCK_ALIGNMENT == 0
     assert wb * 4 % 32 == 0
@@ -41,7 +42,18 @@ def test_sliding_window_blocks_alignment_and_slack(window, block_size):
 
 def test_sliding_window_blocks_gemma4_case():
     # gemma-4: 1024-token window, 32-token blocks -> 33 needed -> 40 aligned
-    assert sliding_window_blocks(1024, 32) == 40
+    assert sliding_window_blocks(1024, 32, max_model_len=1_000_000) == 40
+
+
+def test_sliding_window_blocks_capped_by_shorter_max_model_len():
+    # max_model_len (128) well below the layer's static sliding_window
+    # (1024): no request can ever need more than max_model_len tokens, so
+    # the ring must size off 128, not 1024 -> 5 needed -> 8 aligned.
+    assert sliding_window_blocks(1024, 32, max_model_len=128) == 8
+    # equal to the uncapped case once max_model_len reaches the window.
+    assert sliding_window_blocks(1024, 32, max_model_len=1024) == sliding_window_blocks(
+        1024, 32, max_model_len=1_000_000
+    )
 
 
 def test_phys_blocks_reserves_one_subring_per_slot_plus_null():


### PR DESCRIPTION
### Ticket

https://github.com/tenstorrent/tt-xla/issues/5727

### Problem description

Fix merged via #5786 sizes each sliding-window layer's KV cache as a per-user, window-sized ring buffer, but `sliding_window_blocks()` (shared by `worker.py`'s byte reservation and `model_runner.py`'s allocation) sizes that ring off the model's static `sliding_window` alone, with no ceiling from `max_model_len`. When `max_model_len` is smaller (e.g. gemma-4-31B-it's default benchmark config: `sliding_window=1024`, `max_model_len=128`), the ring is still sized for the full window per concurrent user, even though no request can ever exceed `max_model_len` tokens.

This exact scenario was flagged in #5786's own [review thread](https://github.com/tenstorrent/tt-xla/pull/5786#discussion_r3678585860), but the fix there only capped `sliding_page_table_width()` (a device-side assert), not the ring's physical reservation — so the over-allocation itself remained.

### Repro

The issue's own baseline repro (`gpu_memory_utilization=0.2`, `max_num_seqs=32`, `max_model_len=128`) was passing before the fix but fails after the fix

```bash
pytest -svv "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[gemma4-31b-it-tp]"

  WARNING vllm_tt.worker: Sliding ring reservation (31.27 GiB) >= KV budget (25.50 GiB); no room for full-attention pool.
  ValueError: No available memory for the cache blocks.
  ```
  
50 sliding layers x 32 concurrent users x the uncapped 1024-token window reserve 31.27 GiB up front regardless of the 128-token `max_model_len`, leaving nothing for the 10 full-attention layers. So #5786 fixes the long-context case #5727 was filed for, but regresses the issue's own short-context baseline test to a hard OOM.

### What's changed

- `sliding_window_blocks()` now takes `max_model_len` and sizes the ring off `min(sliding_window, max_model_len)`. Both call sites pass it through so they stay in sync, per the same invariant #5786 already relies on. Whenever `max_model_len >= sliding_window` (the long-context case #5786 targets), `min()` is a no-op — sizing is unchanged.
- `test_swa_cache_utils.py`: updated both `sliding_window_blocks()` call sites for the new arg, added a test covering the capped and uncapped cases. All 18 tests pass.

### Testing
- [x] Existing and new unit tests passing locally, `test_swa_cache_utils.py` and `test_model_runner_buffer_keying.py`
- [x] Hardware re-run of the issue's baseline repro with this fix on top of #5786: **PASSED** — `GPU KV cache size: 18,664 tokens`, 145.81x concurrency, no reservation warning.
- [x] CI run of baseline gemma4-31b-it too: https://github.com/tenstorrent/tt-xla/actions/runs/30509163997