### PR TITLE
[vLLM] Fix KV-head TP divisibility assert to skip MLA KV caches

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -4210,10 +4210,10 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 spec = layer_to_spec[layer_name]
                 if isinstance(spec, AttentionSpec):
                     tp_size = kv_cache_shard_factor(self)
-                    if tp_size > 1:
-                        # mark_sharding() below does the real sharding; this
-                        # just fails loudly instead of it silently falling
-                        # back to replication (see safe_mark_sharding).
+                    if tp_size > 1 and not _is_mla(spec):
+                        # Non-MLA K/V caches are sharded on the model axis below.
+                        # Fail loudly when KV heads are not TP-divisible instead
+                        # of silently replicating (see safe_mark_sharding).
                         assert spec.num_kv_heads % tp_size == 0, (
                             f"num_kv_heads {spec.num_kv_heads} must be divisible "
                             f"by tp_size {tp_size} for correct KV-head sharding"

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -4208,22 +4208,20 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 phys_blocks = pool_num_blocks
             for layer_name in kv_cache_group.layer_names:
                 spec = layer_to_spec[layer_name]
-                if isinstance(spec, AttentionSpec):
-                    tp_size = kv_cache_shard_factor(self)
-                    if tp_size > 1 and not _is_mla(spec):
-                        # Non-MLA K/V caches are sharded on the model axis below.
-                        # Fail loudly when KV heads are not TP-divisible instead
-                        # of silently replicating (see safe_mark_sharding).
-                        assert spec.num_kv_heads % tp_size == 0, (
-                            f"num_kv_heads {spec.num_kv_heads} must be divisible "
-                            f"by tp_size {tp_size} for correct KV-head sharding"
-                        )
                 shape = _kv_shape(spec, phys_blocks)
                 if _is_mla(spec):
                     kv_caches[layer_name] = torch.zeros(shape, dtype=spec.dtype).to(
                         self.device
                     )
                 elif isinstance(spec, AttentionSpec):
+                    tp_size = kv_cache_shard_factor(self)
+                    if tp_size > 1:
+                        # Fail loudly when KV heads are not TP-divisible instead
+                        # of silently replicating (see safe_mark_sharding).
+                        assert spec.num_kv_heads % tp_size == 0, (
+                            f"num_kv_heads {spec.num_kv_heads} must be divisible "
+                            f"by tp_size {tp_size} for correct KV-head sharding"
+                        )
                     # spec.dtype may be a 1-byte accounting dtype; the staged
                     # buffer uses the real transfer dtype (converted on device).
                     # Separate K and V avoid slice/concat copies in the decode graph.


### PR DESCRIPTION
### Ticket
closes #5848

### Problem description
Tensor-parallel KV-cache initialization incorrectly asserted that num_kv_heads must be divisible by TP size for MLA layers, even though MLA KV caches are replicated rather than model-axis sharded.

### What's changed
Fix KV-head TP divisibility assert to skip MLA KV caches.

### Checklist
- [X] New/Existing tests provide coverage for changes
