### PR TITLE
Release device weights before EmitPy run to avoid double residency

### DIFF
--- a/tests/infra/testers/single_chip/model/torch_model_tester.py
+++ b/tests/infra/testers/single_chip/model/torch_model_tester.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import collections
+import gc
 import os
 import shutil
 import tempfile
@@ -360,6 +361,27 @@ class TorchModelTester(ModelTester):
         # and only want to report on the backward result
         return backward_result, forward_result
 
+    def _release_device_weights(self) -> None:
+        """Drop the model's on-device weights so the runtime's const-eval cache drains.
+
+        The runtime keeps preprocessed weights in a process-global const-eval
+        cache. An entry is evicted only when one of the input tensors that
+        produced it is destroyed (``GlobalTensorCache::store`` registers an
+        on-destroy callback on each input for exactly that purpose). Moving the
+        model off device destroys those tensors, so the cache drains through its
+        intended mechanism.
+
+        Safe to call before a subsequent device run: ``DeviceRunner.run_on_device``
+        re-places the workload on device on every invocation.
+        """
+        model = getattr(self._workload, "model", None)
+        if model is None or not hasattr(model, "to"):
+            return
+        model.to("cpu")
+        # Parameters are freed once the device tensors are unreferenced. Collect
+        # so that happens here rather than at an arbitrary later point.
+        gc.collect()
+
     def verify_emitpy(
         self,
         fb_reference,
@@ -406,6 +428,13 @@ class TorchModelTester(ModelTester):
             self._compile_for_tt_device(
                 self._workload, options={"tt_legacy_compile": True}
             )
+
+            # Release the flatbuffer run's on-device weights before the EmitPy run
+            # so its retained const-eval results are evicted. Otherwise both runs'
+            # weights are co-resident and peak DRAM roughly doubles, which OOMs on
+            # devices with smaller DRAM (n150), while those with larger DRAM
+            # (p150) mask it.
+            self._release_device_weights()
 
             emitpy_result = self._run_on_tt_device(self._workload)
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
EmitPy run of `qwen_3/embedding/Embedding_8B` ran out of DRAM on n150.
The issue is that the runtime keeps preprocessed weights in a process-global const-eval cache and evicts an entry only when one of the input tensors that produced it is destroyed. Since the model stays on device, the flatbuffer reference run's weights remain resident when the generated EmitPy program streams its own copy, roughly doubling peak DRAM usage. 
A device with more DRAM (p150) masks the problem.

### What's changed
Move the model off device before the EmitPy run. That destroys the input tensors
which produced the flatbuffer run's const-eval entries, so the runtime evicts
them and frees their DRAM.

The EmitPy run then puts the model back: `DeviceRunner.run_on_device` re-places
the workload on device on every invocation.

### Checklist
- [Before the fix: qwen_3/embedding/Embedding_8B failed](https://github.com/tenstorrent/tt-xla/actions/runs/30834714297/job/91757210908)
- [After the fix: qwen_3/embedding/Embedding_8B passed](https://github.com/tenstorrent/tt-xla/actions/runs/30834626200) 
