### PR TITLE
Reenable gemma4 opt lvl 2

### DIFF
--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -170,8 +170,6 @@ def _gemma4_tp_config(model: str, batch_size: int):
         model,
         batch_size,
         gpu_memory_utilization=0.2,
-        # opt-level 2 fails with an L1 out-of-memory TT_FATAL; see #5440.
-        optimization_level=1,
         enable_tensor_parallel=True,
         use_2d_mesh=False,
         min_context_len=32,


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-xla/issues/5440

Fixed by product of other fixes in meantime.
Benchmark run shows better perf and no errors:
https://github.com/tenstorrent/tt-xla/actions/runs/30764186655/job/91539980450

Code owners can try raising opt-level to 2 for other vllm models as well. If assistance is needed, please make a ticket similar to the one linked above.