### PR TITLE
[Benchmark] Add Wan 2.2 A14B e2e image-to-video pipeline benchmark

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -908,6 +908,20 @@
         "runs-on": [
           "qb2-blackhole"
         ]
+      },
+      {
+        "name": "wan14b_e2e_480p_sharded",
+        "pytest": "tests/benchmark/test_wan.py::test_wan_e2e[14b-480p-sharded]",
+        "runs-on": [
+          "qb2-blackhole"
+        ]
+      },
+      {
+        "name": "wan14b_e2e_720p_sharded",
+        "pytest": "tests/benchmark/test_wan.py::test_wan_e2e[14b-720p-sharded]",
+        "runs-on": [
+          "qb2-blackhole"
+        ]
       }
     ]
   }

--- a/tests/benchmark/benchmarks/video_gen_pipeline_benchmark.py
+++ b/tests/benchmark/benchmarks/video_gen_pipeline_benchmark.py
@@ -1,0 +1,205 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+End-to-end benchmark harness for video-generation *pipelines*.
+
+``video_gen_benchmark.py`` benchmarks one component at a time (a single forward
+pass of the DiT, VAE or text encoder). This harness benchmarks the whole
+pipeline: one call produces one video, so the reported figure is
+generation latency rather than per-forward latency.
+
+Structurally this mirrors ``imagegen_benchmark.benchmark_imagegen_torch_xla``
+(warmup pass at 1 step to force compilation, then a steady-state pass at the
+real step count) and consumes the same model-agnostic ``pipeline._perf``
+schema, so a video pipeline and an image pipeline report comparably.
+
+Reported metrics
+----------------
+``total_time`` and ``total_samples`` are the primary pair — the Forge dashboard
+derives secs/sample from ``total_time / total_samples`` and falls back to
+``forward_pass_time_ms``, so both are emitted. Per-stage times (text encoder,
+VAE, mean DiT step, CPU overhead) come through as custom measurements.
+"""
+
+# Built-in modules
+import socket
+import time
+
+import torch_xla
+import torch_xla.runtime as xr
+from utils import (
+    build_xla_export_name,
+    create_benchmark_result,
+    get_benchmark_metadata,
+    get_xla_device_arch,
+    print_benchmark_results,
+)
+
+xr.set_device_type("TT")
+
+# Where the compiler dumps stablehlo/ttir/ttnn + flatbuffer artifacts; the perf
+# CI collects them from here (matches the other harnesses).
+MODULE_EXPORT_PATH = "modules"
+
+# Steps used for the warmup generation. One step is enough to trigger the
+# first-forward compile of every component, including both DiT experts.
+WARMUP_STEPS = 1
+
+
+def benchmark_video_gen_pipeline_torch_xla(
+    *,
+    build_pipeline_fn,
+    model_info_name,
+    display_name,
+    prompt,
+    num_inference_steps,
+    compiler_config,
+    ttnn_perf_metrics_output_file,
+    frame_shape,
+    data_format="bfloat16",
+):
+    """Benchmark a full video-generation pipeline on the TT backend.
+
+    Args:
+        build_pipeline_fn: ``fn(compile_options) -> (pipeline, generate_fn)``.
+            ``generate_fn(prompt, num_inference_steps)`` runs one full
+            generation; ``pipeline._perf`` carries the per-stage timings.
+        model_info_name: Full model name for reporting. For the dashboard's E2E
+            view this must contain "E2E" (see tests/benchmark/test_wan.py).
+        display_name: Short name used for export / perf-metric file naming.
+        num_inference_steps: Denoising steps for the steady-state pass.
+        compiler_config: ``CompilerConfig`` supplying tt-mlir compile options.
+        frame_shape: ``(channels, height, width)`` of one output frame, for
+            reporting.
+        data_format: Precision string for reporting.
+
+    Returns:
+        Standardized benchmark result dictionary.
+    """
+    xr.set_device_type("TT")
+
+    options = compiler_config.to_torch_compile_options()
+    options["export_path"] = MODULE_EXPORT_PATH
+    options["export_model_name"] = build_xla_export_name(
+        model_name=display_name,
+        num_layers=None,
+        batch_size=1,
+        input_sequence_length=None,
+    )
+    options["ttnn_perf_metrics_enabled"] = True
+    options["ttnn_perf_metrics_output_file"] = ttnn_perf_metrics_output_file
+
+    # Compile options are set inside the builder too (it must set them before
+    # the first XLA op), but set them here as well so a builder that does not
+    # is still covered.
+    torch_xla.set_custom_compile_options(options)
+
+    pipeline, generate_fn = build_pipeline_fn(options)
+
+    print("Starting warmup pass (includes compile)...")
+    warmup_start = time.perf_counter()
+    generate_fn(prompt, WARMUP_STEPS)
+    print(f"Warmup pass: {time.perf_counter() - warmup_start:.3f}s")
+
+    print("Starting steady-state pass...")
+    steady_state_start = time.perf_counter()
+    generate_fn(prompt, num_inference_steps)
+    steady_state_time = time.perf_counter() - steady_state_start
+    print(f"Steady-state pass: {steady_state_time:.3f}s")
+
+    # One video per generation.
+    total_samples = 1
+    samples_per_sec = total_samples / steady_state_time
+
+    perf = pipeline._perf
+    components = perf["components"]
+    steps = perf["steps"]
+    step_metric_name = perf["step_metric_name"]
+    step_mean_s = sum(steps) / len(steps) if steps else 0.0
+    tt_components_total = sum(components.values()) + sum(steps)
+    cpu_overhead = max(0.0, perf["total"] - tt_components_total)
+
+    metadata = get_benchmark_metadata()
+    model_type = "Video Generation, Image-to-Video"
+    dataset_name = "Text Prompt + First Frame"
+
+    print_benchmark_results(
+        model_title=model_info_name,
+        full_model_name=model_info_name,
+        model_type=model_type,
+        dataset_name=dataset_name,
+        date=metadata["date"],
+        machine_name=metadata["machine_name"],
+        total_time=steady_state_time,
+        total_samples=total_samples,
+        samples_per_sec=samples_per_sec,
+        evaluation_score=None,
+        batch_size=1,
+        data_format=data_format,
+        input_size=frame_shape,
+    )
+    component_lines = "".join(
+        f"|   {name} (s):  {value:.3f}\n" for name, value in components.items()
+    )
+    print(
+        f"| Num inference steps: {num_inference_steps}\n"
+        f"| Denoise steps measured: {len(steps)}\n"
+        f"| Steady-state:\n"
+        f"{component_lines}"
+        f"|   {step_metric_name} mean (s):  {step_mean_s:.3f}\n"
+        f"|   CPU overhead (s):    {cpu_overhead:.3f}"
+    )
+
+    custom_measurements = [
+        {"measurement_name": "videos_per_second", "value": samples_per_sec},
+        {"measurement_name": "e2e_latency", "value": steady_state_time},
+        {"measurement_name": f"{step_metric_name}_mean_s", "value": step_mean_s},
+        {"measurement_name": "cpu_overhead_s", "value": cpu_overhead},
+        # The dashboard falls back to forward_pass_time_ms when the
+        # total_time/total_samples pair is unavailable; for a pipeline the
+        # equivalent "one forward" is one full generation.
+        {
+            "measurement_name": "forward_pass_time_ms",
+            "value": steady_state_time * 1000.0,
+            "iteration": 1,
+        },
+    ]
+    for name, value in components.items():
+        custom_measurements.append({"measurement_name": f"{name}_s", "value": value})
+    # One measurement per denoise step, so step-level variance is visible.
+    for i, seconds in enumerate(steps):
+        custom_measurements.append(
+            {
+                "measurement_name": f"{step_metric_name}_time_ms",
+                "value": seconds * 1000.0,
+                "iteration": i + 1,
+            }
+        )
+
+    return create_benchmark_result(
+        full_model_name=model_info_name,
+        model_type=model_type,
+        dataset_name=dataset_name,
+        num_layers=-1,
+        batch_size=1,
+        input_size=frame_shape,
+        loop_count=num_inference_steps,
+        data_format=data_format,
+        total_time=steady_state_time,
+        total_samples=total_samples,
+        evaluation_score=None,
+        custom_measurements=custom_measurements,
+        optimization_level=compiler_config.optimization_level,
+        program_cache_enabled=True,
+        trace_enabled=compiler_config.enable_trace,
+        model_info=model_info_name,
+        display_name=display_name,
+        torch_xla_enabled=True,
+        backend="tt",
+        device_name=socket.gethostname(),
+        arch=get_xla_device_arch(),
+        device_count=xr.global_runtime_device_count(),
+        input_is_image=False,
+    )

--- a/tests/benchmark/benchmarks/wan_pipeline.py
+++ b/tests/benchmark/benchmarks/wan_pipeline.py
@@ -1,0 +1,262 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Wan 2.2 image-to-video pipeline running on the Tenstorrent backend.
+
+Unlike the per-component Wan benchmarks (``tests/benchmark/test_wan.py``), this
+drives the *whole* pipeline: UMT5 text encode -> multi-step denoise -> VAE
+decode, producing one video per generation.
+
+Design note — why diffusers drives the loop
+-------------------------------------------
+The A14B I2V pipeline has three pieces of correctness-critical math that are
+easy to get subtly wrong:
+
+  * the DiT takes 36 input channels (16 noisy latent + 16 image-condition
+    latent + 4 mask), not the VAE's ``z_dim``;
+  * A14B is a two-expert MoE — ``transformer`` (high noise) and
+    ``transformer_2`` (low noise), switched partway through the schedule at
+    ``boundary_ratio`` (0.9 for i2v);
+  * the conditioning frame must stay fixed across denoise iterations.
+
+Rather than reimplement that, this module keeps ``diffusers``'
+:class:`WanImageToVideoPipeline` as the driver (diffusers >= 0.39 supports
+``transformer_2`` / ``boundary_ratio`` / ``expand_timesteps`` natively) and only
+swaps each *component* for a torch-compiled, device-resident proxy. So all
+pipeline math stays upstream's, and we control execution + timing.
+
+Per-stage timings land in ``self._perf`` using the same model-agnostic schema
+the image-gen harness consumes:
+
+    _perf = {
+        "components": {<name>: seconds, ...},   # scalar per-stage times
+        "steps": [seconds, ...],                # per denoise-step times
+        "step_metric_name": "dit_step",
+        "total": seconds,                       # full generate() wall time
+    }
+"""
+
+import time
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+import torch
+import torch_xla
+import torch_xla.core.xla_model as xm
+from infra.utilities.torch_multichip_utils import enable_spmd
+
+
+class _TimedDeviceModule(torch.nn.Module):
+    """Device-resident, torch-compiled stand-in for one pipeline component.
+
+    Attribute access falls through to the original module, so diffusers keeps
+    seeing everything it expects (``config``, ``dtype``, ``add_noise``, ...)
+    while ``forward`` runs the compiled version on device and records its time.
+
+    ``slot`` selects where the timing goes: a name records a scalar into
+    ``_perf["components"][slot]``; ``None`` appends to ``_perf["steps"]`` (used
+    for the DiT, which is called once per denoise step).
+    """
+
+    def __init__(self, raw, perf: dict, slot: Optional[str], run_context=None):
+        super().__init__()
+        # Bypass nn.Module.__setattr__ for the raw handle so it is not
+        # registered as a submodule (it is already on device; re-registering
+        # would make .to()/state_dict() walk multi-billion-parameter weights).
+        object.__setattr__(self, "_raw", raw)
+        object.__setattr__(self, "_perf", perf)
+        object.__setattr__(self, "_slot", slot)
+        object.__setattr__(self, "_run_context", run_context)
+        object.__setattr__(self, "_compiled", torch.compile(raw, backend="tt"))
+
+    def forward(self, *args, **kwargs):
+        ctx = self._run_context() if self._run_context is not None else None
+        t0 = time.perf_counter()
+        if ctx is None:
+            out = self._compiled(*args, **kwargs)
+        else:
+            with ctx:
+                out = self._compiled(*args, **kwargs)
+        elapsed = time.perf_counter() - t0
+        if self._slot is None:
+            self._perf["steps"].append(elapsed)
+        else:
+            self._perf["components"][self._slot] = (
+                self._perf["components"].get(self._slot, 0.0) + elapsed
+            )
+        return out
+
+    def __getattr__(self, name):
+        # nn.Module.__getattr__ only runs for misses on the instance dict, which
+        # is exactly when we want to delegate to the wrapped module.
+        try:
+            return super().__getattr__(name)
+        except AttributeError:
+            return getattr(object.__getattribute__(self, "_raw"), name)
+
+
+@dataclass
+class WanI2VConfig:
+    """One Wan I2V pipeline configuration.
+
+    Attributes:
+        shared: The family's ``shared.py`` module (loaders, ``RESOLUTIONS``,
+            ``wan22_mesh``, shard specs, ``make_synthetic_first_frame``).
+        resolution: Key into ``shared.RESOLUTIONS`` ("480p" / "720p").
+        prompt / negative_prompt: Text conditioning.
+        guidance_scale: CFG scale for the high-noise expert.
+        guidance_scale_2: CFG scale for the low-noise expert.
+        sharded: Whether to run under SPMD sharding across ``wan22_mesh``.
+        dit_patches: Monkey patches applied before building the DiT.
+        dit_run_context: Zero-arg callable returning a context manager wrapping
+            each DiT forward (``torch_function_override_disabled``).
+        vae_run_context: Same, for the VAE decoder (``safe_xla_slicing``).
+    """
+
+    shared: object
+    resolution: str
+    prompt: str
+    negative_prompt: str = ""
+    guidance_scale: float = 3.5
+    guidance_scale_2: float = 3.5
+    sharded: bool = True
+    dit_patches: tuple = ()
+    dit_run_context: Optional[Callable] = None
+    vae_run_context: Optional[Callable] = None
+
+
+class WanI2VPipeline_TT:
+    """Wan 2.2 I2V pipeline with every component executing on Tenstorrent."""
+
+    def __init__(self, config: WanI2VConfig, compile_options: dict):
+        self.config = config
+        self._perf = {}
+        self.mesh = None
+
+        shared = config.shared
+        for patch in config.dit_patches:
+            patch()
+
+        # SPMD must be enabled before any XLA op is issued.
+        if config.sharded:
+            self.mesh = shared.wan22_mesh()
+            if len(self.mesh.device_ids) > 1:
+                enable_spmd()
+            else:
+                self.mesh = None
+
+        torch_xla.set_custom_compile_options(compile_options)
+        self.device = xm.xla_device()
+
+        self.shapes = shared.RESOLUTIONS[config.resolution]
+        self._build()
+
+    def _build(self) -> None:
+        from diffusers import WanImageToVideoPipeline
+
+        shared = self.config.shared
+
+        # Two 14B experts: `transformer` (high noise) + `transformer_2` (low
+        # noise). Both are resident simultaneously because diffusers switches
+        # between them mid-schedule.
+        raw_umt5 = shared.load_umt5().eval().bfloat16()
+        raw_vae = shared.load_vae().eval().bfloat16()
+        raw_dit_high = shared.load_dit(subfolder="transformer").eval().bfloat16()
+        raw_dit_low = shared.load_dit(subfolder="transformer_2").eval().bfloat16()
+
+        self._perf = {
+            "components": {},
+            "steps": [],
+            "step_metric_name": "dit_step",
+            "total": 0.0,
+        }
+
+        # Move to device, then shard (sharding must see XLA tensors).
+        raw_umt5 = raw_umt5.to(self.device)
+        raw_vae = raw_vae.to(self.device)
+        raw_dit_high = raw_dit_high.to(self.device)
+        raw_dit_low = raw_dit_low.to(self.device)
+
+        if self.mesh is not None:
+            shared.shard_umt5_specs(raw_umt5, self.mesh)
+            shared.shard_vae_decoder_specs(raw_vae, self.mesh)
+            for dit in (raw_dit_high, raw_dit_low):
+                shared.shard_dit_specs(dit, self.mesh)
+                shared.apply_dit_sp_activation_sharding(dit, self.mesh)
+
+        cfg = self.config
+        self.pipeline = WanImageToVideoPipeline(
+            tokenizer=shared.load_tokenizer(),
+            text_encoder=_TimedDeviceModule(raw_umt5, self._perf, "text_encoder"),
+            vae=_TimedDeviceModule(raw_vae, self._perf, "vae", cfg.vae_run_context),
+            scheduler=self._build_scheduler(),
+            image_processor=None,
+            image_encoder=None,
+            transformer=_TimedDeviceModule(
+                raw_dit_high, self._perf, None, cfg.dit_run_context
+            ),
+            transformer_2=_TimedDeviceModule(
+                raw_dit_low, self._perf, None, cfg.dit_run_context
+            ),
+            boundary_ratio=shared.BOUNDARY_RATIO["i2v"],
+            expand_timesteps=False,
+        )
+
+    def _build_scheduler(self):
+        from diffusers import UniPCMultistepScheduler
+
+        return UniPCMultistepScheduler(
+            prediction_type="flow_prediction",
+            use_flow_sigmas=True,
+            num_train_timesteps=1000,
+            flow_shift=5.0,
+        )
+
+    def first_frame(self) -> torch.Tensor:
+        """Deterministic conditioning frame at the configured resolution."""
+        return self.config.shared.make_synthetic_first_frame(
+            self.shapes["video_h"], self.shapes["video_w"]
+        )
+
+    def generate(self, prompt: str, num_inference_steps: int):
+        """Run one full text+image -> video generation.
+
+        Returns the generated video frames. Resets ``_perf`` timings so each
+        call reports only its own stage times.
+        """
+        self._perf["components"] = {}
+        self._perf["steps"] = []
+
+        cfg = self.config
+        t_total = time.perf_counter()
+        with torch.no_grad():
+            output = self.pipeline(
+                image=self.first_frame(),
+                prompt=prompt,
+                negative_prompt=cfg.negative_prompt or None,
+                height=self.shapes["video_h"],
+                width=self.shapes["video_w"],
+                num_frames=self.shapes["num_frames"],
+                num_inference_steps=num_inference_steps,
+                guidance_scale=cfg.guidance_scale,
+                guidance_scale_2=cfg.guidance_scale_2,
+                output_type="pt",
+                return_dict=False,
+            )[0]
+        self._perf["total"] = time.perf_counter() - t_total
+        return output
+
+
+def build_wan_i2v_pipeline(config: WanI2VConfig):
+    """Factory matching the harness' ``build_pipeline_fn`` contract.
+
+    Returns ``fn(compile_options) -> (pipeline, generate_fn)``.
+    """
+
+    def _build(compile_options: dict):
+        pipeline = WanI2VPipeline_TT(config, compile_options)
+        return pipeline, pipeline.generate
+
+    return _build

--- a/tests/benchmark/test_wan.py
+++ b/tests/benchmark/test_wan.py
@@ -37,6 +37,10 @@ import pytest
 import torch
 import torch_xla.distributed.spmd as xs
 from benchmarks.video_gen_benchmark import benchmark_video_gen_torch_xla
+from benchmarks.video_gen_pipeline_benchmark import (
+    benchmark_video_gen_pipeline_torch_xla,
+)
+from benchmarks.wan_pipeline import WanI2VConfig, build_wan_i2v_pipeline
 from utils import aggregate_ttnn_perf_metrics, resolve_display_name
 
 from tests.infra.testers.compiler_config import CompilerConfig
@@ -71,6 +75,22 @@ TEXT_SEQ_LEN = 512  # UMT5 output / DiT cross-attention sequence length
 TEXT_EMBED_DIM = 4096  # UMT5 hidden size
 DENOISE_TIMESTEP = 500.0  # arbitrary mid-schedule step for a single forward
 DIT_MAX_BLOCKS = 0  # 0 = run the full transformer (30 blocks 5B / 40 blocks A14B)
+
+# --- End-to-end (full pipeline) benchmark settings ---
+# Denoising steps for the steady-state e2e pass. Lower than the 40 the Wan repo
+# uses for final quality: this measures latency, not output quality, and each
+# step is a full 14B DiT forward (x2 for CFG), so 40 would dominate CI time.
+E2E_NUM_STEPS = 8
+E2E_PROMPT = (
+    "A cinematic shot of a small wooden sailboat crossing a calm bay at sunset, "
+    "gentle waves, warm golden light"
+)
+E2E_NEGATIVE_PROMPT = (
+    "blurry, low quality, distorted, watermark, text, static, overexposed"
+)
+# CFG scales for the high-noise and low-noise experts respectively.
+E2E_GUIDANCE_SCALE = 3.5
+E2E_GUIDANCE_SCALE_2 = 3.5
 
 # (resolution, sharded) variants, with clean node-ids for matrix references,
 # e.g. tests/benchmark/test_wan.py::test_wan_dit[14b-480p-sharded]
@@ -403,6 +423,60 @@ def benchmark_dit(family, resolution, sharded, output_file, request):
     )
 
 
+def benchmark_e2e(family, resolution, sharded, output_file, request):
+    """Full image-to-video pipeline: text encode -> denoise loop -> VAE decode.
+
+    Reports one row per run with ``model_info_name`` ending in ``-E2E``. That
+    suffix is load-bearing: the Forge dashboard's model-performance page selects
+    its E2E series by matching ``/e2e|end[_ -]?to[_ -]?end/i`` against
+    ``ml_model_name`` + ``display_name``, so renaming it silently empties that
+    chart.
+
+    Unlike the per-component benchmarks this does not check PCC — there is no
+    practical CPU golden for a full 14B multi-step generation. It is a latency
+    measurement; per-component correctness is covered by the component
+    benchmarks and the functional tests.
+    """
+    shared = family.shared
+    torch.manual_seed(SEED)
+
+    config = WanI2VConfig(
+        shared=shared,
+        resolution=resolution,
+        prompt=E2E_PROMPT,
+        negative_prompt=E2E_NEGATIVE_PROMPT,
+        guidance_scale=E2E_GUIDANCE_SCALE,
+        guidance_scale_2=E2E_GUIDANCE_SCALE_2,
+        sharded=sharded,
+        dit_patches=family.dit_patches,
+        dit_run_context=family.dit_override_disabled,
+        vae_run_context=family.safe_xla_slicing,
+    )
+
+    model_info_name = f"{family.name_prefix}-E2E"
+    display_name = resolve_display_name(request=request, fallback=model_info_name)
+    shapes = shared.RESOLUTIONS[resolution]
+
+    results = benchmark_video_gen_pipeline_torch_xla(
+        build_pipeline_fn=build_wan_i2v_pipeline(config),
+        model_info_name=model_info_name,
+        display_name=display_name,
+        prompt=E2E_PROMPT,
+        num_inference_steps=E2E_NUM_STEPS,
+        # The DiT config drives the denoise loop, which dominates e2e time.
+        compiler_config=family.dit_config,
+        ttnn_perf_metrics_output_file=f"tt_xla_{display_name}_perf_metrics",
+        frame_shape=(3, shapes["video_h"], shapes["video_w"]),
+    )
+
+    if output_file:
+        results["project"] = "tt-forge/tt-xla"
+        results["model_rawname"] = model_info_name
+        aggregate_ttnn_perf_metrics(f"tt_xla_{display_name}_perf_metrics", results)
+        with open(output_file, "w") as file:
+            json.dump(results, file, indent=2)
+
+
 # ---------------------------------------------------------------------------
 # Family manifests + discoverable test functions
 # ---------------------------------------------------------------------------
@@ -441,6 +515,17 @@ FAMILIES = [_FAMILY_5B, _FAMILY_14B]
 # once — on A14B — to avoid a redundant duplicate run.
 UMT5_FAMILIES = [_FAMILY_14B]
 
+# E2E runs only on A14B: it is the I2V model the dashboard tracks, and its
+# two-expert schedule is what the pipeline-level benchmark exercises.
+E2E_FAMILIES = [_FAMILY_14B]
+
+# E2E holds both 14B experts resident simultaneously, so only the sharded
+# variants are viable — unsharded would not fit.
+E2E_VARIANTS = [
+    pytest.param("480p", True, id="480p-sharded"),
+    pytest.param("720p", True, id="720p-sharded"),
+]
+
 
 # UMT5 output is resolution-independent, so only the sharding axis is varied.
 @pytest.mark.parametrize("sharded", SHARDING_VARIANTS)
@@ -465,3 +550,9 @@ def test_wan_vae_decoder(family, resolution, sharded, output_file, request):
 @pytest.mark.parametrize("family", FAMILIES)
 def test_wan_dit(family, resolution, sharded, output_file, request):
     benchmark_dit(family, resolution, sharded, output_file, request)
+
+
+@pytest.mark.parametrize("resolution,sharded", E2E_VARIANTS)
+@pytest.mark.parametrize("family", E2E_FAMILIES)
+def test_wan_e2e(family, resolution, sharded, output_file, request):
+    benchmark_e2e(family, resolution, sharded, output_file, request)

--- a/tests/torch/models/wan14b/shared.py
+++ b/tests/torch/models/wan14b/shared.py
@@ -106,6 +106,26 @@ def load_first_frame_image(image_path: Path, height: int, width: int) -> torch.T
     return tensor.unsqueeze(0).unsqueeze(2).to(torch.bfloat16)  # (1, 3, 1, H, W)
 
 
+def make_synthetic_first_frame(height: int, width: int) -> torch.Tensor:
+    """Deterministic stand-in first-frame image in the exact
+    (1, 3, 1, H, W) bf16 [-1, 1] format ``load_first_frame_image`` returns.
+
+    Mirrors ``wan5b.shared.make_synthetic_first_frame``. Used by the e2e
+    benchmark, which measures generation latency rather than output quality, so
+    pixel *content* is irrelevant — only that a valid frame flows through the
+    pipeline. Content must be deterministic (no unseeded randomness) so runs are
+    reproducible; a fixed RGB gradient does.
+    """
+    ys, xs = np.mgrid[0:height, 0:width].astype(np.float32)
+    r = xs / max(width - 1, 1)
+    g = ys / max(height - 1, 1)
+    b = (r + g) / 2.0
+    arr = np.stack([r, g, b], axis=-1)  # (H, W, 3) in [0, 1]
+    tensor = torch.from_numpy(arr).permute(2, 0, 1)  # (3, H, W)
+    tensor = tensor * 2.0 - 1.0  # [-1, 1]
+    return tensor.unsqueeze(0).unsqueeze(2).to(torch.bfloat16)  # (1, 3, 1, H, W)
+
+
 # ---------------------------------------------------------------------------
 # Prompt cleaning — matches diffusers/pipeline_wan.py:78-93 and Wan repo.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
> [!WARNING]
> **This code has never been executed.** It targets `qb2-blackhole`; I wrote it on a 2×n300 host, so the pipeline has not run once. Everything static is verified (below), but treat the runtime behaviour as unproven and please run it on qb2/galaxy before merging.

### Ticket

The Forge dashboard's [model-performance page](http://yyz2-forge-dash.local.tenstorrent.com:8000/model-performance) shows **"E2E tracking is not yet enabled. This chart will populate automatically once E2E benchmark runs are recorded."**

### Problem description

That page is hardcoded to one model with five component tabs:

```js
G1 = [{id:"wan2.2-i2v-a14b", label:"Wan 2.2 I2V A14B", pattern:"Wan2.2-I2V-A14B"}]
```

Four tabs are populated — VAE encoder, VAE decoder, UMT5 text encoder, DiT. The fifth is gated on:

```js
{id:"e2e", matches: e => /e2e|end[_ -]?to[_ -]?end/i.test(`${e.ml_model_name} ${e.display_name}`)}
```

Checking the live API, **0 of 1,650 rows in `/api/model-performance` match that regex**, and the 11 scheduled wan entries in `perf-bench-matrix.json` are exactly the four populated tabs. So the message is accurate: no end-to-end run has ever been recorded, because no such benchmark existed. The only full-pipeline Wan test in the repo is `tests/torch/models/wan5b/test_wan22_e2e.py` — 5B, and the page only lists A14B, so it could never populate this chart.

### What's changed

**`tests/benchmark/benchmarks/wan_pipeline.py`** (new) — `WanI2VPipeline_TT` keeps diffusers' `WanImageToVideoPipeline` as the driver and swaps each *component* for a torch-compiled, device-resident proxy (`_TimedDeviceModule`, which delegates attribute access to the wrapped module so diffusers keeps seeing `config`/`dtype`/etc.).

This is deliberate. A14B I2V has three pieces of easy-to-get-subtly-wrong math, and delegating keeps them upstream's rather than my reimplementation:
- the DiT takes **36 input channels** (16 noisy latent + 16 image-condition latent + 4 mask), not the VAE's `z_dim`;
- A14B is a **two-expert MoE** — `transformer` (high noise) / `transformer_2` (low noise), switched mid-schedule at `boundary_ratio` (0.9 for i2v);
- the conditioning frame must stay fixed across denoise iterations.

diffusers 0.39.0 supports `transformer_2` / `boundary_ratio` / `expand_timesteps` natively (verified against the installed version), so all of that stays upstream. Per-stage timings land in `_perf` using the same model-agnostic schema the image-gen harness already consumes.

**`tests/benchmark/benchmarks/video_gen_pipeline_benchmark.py`** (new) — whole-pipeline harness. `video_gen_benchmark.py` measures one component's forward pass; this measures one *generation* (one video = one sample), mirroring `benchmark_imagegen_torch_xla`'s warmup-then-steady-state shape.

On metric naming: the dashboard computes secs/sample as `total_time / total_samples` and falls back to `forward_pass_time_ms / 1000`. This emits both via the standard `create_benchmark_result` path, so **no new metric name is introduced** and the chart renders with the existing plumbing.

**`tests/benchmark/test_wan.py`** — `test_wan_e2e` over `E2E_VARIANTS`. Sharded only (both 14B experts are resident simultaneously, so unsharded would not fit), 8 denoise steps, and no PCC check since there is no practical CPU golden for a full multi-step 14B generation. The `-E2E` suffix on `model_info_name` is load-bearing and commented as such — renaming it silently empties the chart again.

**`tests/torch/models/wan14b/shared.py`** — adds `make_synthetic_first_frame`, ported from `wan5b`, which was the one piece of the shared surface 14B was missing.

**`.github/workflows/perf-bench-matrix.json`** — `wan14b_e2e_480p_sharded` and `wan14b_e2e_720p_sharded` on `qb2-blackhole`.

### Verification

Static only — no execution:

| Check | Result |
|---|---|
| Both node ids collect | `test_wan_e2e[14b-480p-sharded]`, `test_wan_e2e[14b-720p-sharded]` ✅ |
| All 13 wan matrix entries collectable | 0 missing (node ids match matrix strings exactly) |
| New imports resolve | collection succeeded, so `wan_pipeline` + `video_gen_pipeline_benchmark` import cleanly |
| Reported name passes the E2E regex | `Wan2.2-I2V-A14B-E2E` → `True` (and `-DiT` → `False`, so existing tabs are unaffected) |
| Reported name passes the page's model filter | contains `Wan2.2-I2V-A14B` ✅ |
| Matrix JSON parses | ✅ |
| `black` | clean on all changed files |
| diffusers two-expert support | `WanImageToVideoPipeline.__init__` accepts `transformer_2` / `boundary_ratio` / `expand_timesteps` on 0.39.0 ✅ |

### What I could not check, and where I'd expect trouble

Nothing below has been exercised, so this is where review attention is most useful:

1. **Memory.** Both 14B experts plus UMT5 and the VAE resident at once. If this OOMs, the fix is probably sequential expert loading at the boundary switch rather than both up front — a real change in shape, not a tweak.
2. **`_TimedDeviceModule` fidelity.** Attribute delegation covers what diffusers reads on the components, but I could not enumerate every attribute the pipeline touches at runtime. A missing passthrough would surface as an `AttributeError` on the first generation.
3. **Sharding both experts.** `shard_dit_specs` + `apply_dit_sp_activation_sharding` are applied to each expert independently; whether that composes when two sharded DiTs coexist on one mesh is untested.
4. **`E2E_NUM_STEPS = 8`** is a latency/CI-time compromise, not a quality setting (the Wan repo uses 40). Worth a second opinion on whether 8 is representative enough to trend.
5. **Scheduler config.** `UniPCMultistepScheduler(flow_shift=5.0)` mirrors the 5B e2e test; the correct A14B value should be confirmed against the model card.

### Checklist
- [ ] Validated on qb2-blackhole / BH galaxy — **required before merge**
- [x] New/Existing tests provide coverage for changes
