### PR TITLE
[vLLM] Raise Ministral-8B benchmark GMU to fix KV preemptions

### DIFF
--- a/tests/benchmark/test_vllm_benchmarks.py
+++ b/tests/benchmark/test_vllm_benchmarks.py
@@ -279,7 +279,13 @@ SINGLE_DEVICE_CONFIGS = [
     pytest.param(
         _config("mistralai/Mistral-7B-Instruct-v0.3"), id="mistral-7b-instruct"
     ),
-    pytest.param(_config("mistralai/Ministral-8B-Instruct-2410"), id="ministral-8b"),
+    pytest.param(
+        _config(
+            "mistralai/Ministral-8B-Instruct-2410",
+            gpu_memory_utilization=0.12,
+        ),
+        id="ministral-8b",
+    ),
     # OPT (vLLM-only fast canary; not part of the torch-xla matrix)
     pytest.param(_config("facebook/opt-125m"), id="opt-125m"),
 ]


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/5864

### Problem description
With GMU `0.05`, the engine reported ~2,162 KV tokens (~16.9x concurrency at `max_model_len=128`). Under `batch_size=32` the run hit 100% KV usage with waiting/deferred requests and tripped `_assert_no_preemptions`.
With GMU `0.12`:
- KV cache size: ~12,463 tokens (~97x concurrency)
- All 32 requests run with 0 waiting; peak KV usage ~14–28%
- Preemption assert passes

### What's changed
- Raise `gpu_memory_utilization` for `test_vllm_benchmark[ministral-8b]` from the `_config` default `0.05` to `0.12`.
- Fixes nightly failure that started around July 30: `AssertionError: Preemptions detected: 24. KV Cache size likely needs to be increased.`

logs:
[mist1.log](https://github.com/user-attachments/files/30695319/mist1.log)

### Checklist
- [ ] New/Existing tests provide coverage for changes
