### PR TITLE
[codegen] TTNN codegen trace visualization tools

### DIFF
--- a/scripts/codegen_trace_graph.py
+++ b/scripts/codegen_trace_graph.py
@@ -8,15 +8,20 @@
 Produces a single self-contained HTML file (no external libraries, no CDN, works
 offline and inside sandboxed viewers) with an SVG dataflow DAG:
 
-  * nodes are ttnn ops (and input[i] leaves), colored by op family, labeled with
-    op name + result shape (shapes sourced from the sibling ttnn.mlir);
-  * a top-down layered layout (longest-path depth) with weight/constant leaves
-    pulled down next to their first consumer to keep edges short;
-  * pan (drag), zoom (wheel), hover-to-highlight a node's direct edges, click to
-    pin a node's full ancestor+descendant lineage, and a live op-name filter.
+  * plumbing (to_device / to_layout / from_device / to_memory_config / typecast /
+    reshape) is collapsed by default so the compute backbone stands out; edges are
+    rewired through the folded nodes. Disable with --no-collapse.
+  * left-to-right flow (longest-path depth) with weight/input leaves stacked above
+    their consumer, so the backbone stays compact instead of a tall single column;
+  * labeled stage bands (conv / pool / linear / norm / attention / reshape /
+    elementwise / embed) behind the graph. Disable with --no-stages.
+  * each node shows op + var + result shape (shapes from the sibling ttnn.mlir);
+  * pan (drag), zoom (wheel), hover to highlight a node's edges, click to pin its
+    full ancestor+descendant lineage, and a live op/var filter.
 
 Usage:
-    codegen_trace_graph.py <path/to/main.py> [-o out.html] [--mlir ttnn.mlir]
+    codegen_trace_graph.py <path>/main.py [-o out.html] [--mlir ttnn.mlir]
+                           [--no-collapse] [--no-stages]
 """
 
 import argparse
@@ -27,115 +32,196 @@ import os
 from codegen_trace_table import build_trace
 
 
-# op-family -> fill color (kept close to the table's accent colors)
+# op-family -> fill color (aligned with the table's accent colors)
 OP_COLORS = {
     "matmul": "#0aa77a", "linear": "#0aa77a",
-    "rms_norm": "#c58a1a", "conv2d": "#2d7dd2", "max_pool2d": "#2d7dd2",
-    "embedding": "#8a2be2",
-    "to_device": "#9aa0a6", "to_layout": "#9aa0a6", "from_device": "#9aa0a6",
-    "to_memory_config": "#9aa0a6", "typecast": "#b0b6bb",
-    "slice": "#7d8b99", "reshape": "#7d8b99", "permute": "#7d8b99",
-    "concat": "#7d8b99",
+    "rms_norm": "#c58a1a", "conv2d": "#2d7dd2", "max_pool2d": "#2467b0",
+    "embedding": "#8a2be2", "permute": "#7d8b99", "concat": "#7d8b99",
     "argmax": "#c0392b", "max": "#c0392b", "sum": "#c0392b",
+    "relu": "#16a085", "silu": "#16a085", "exp": "#1f9e8f", "log": "#1f9e8f",
+    "add": "#4b8b3b", "subtract": "#4b8b3b", "multiply": "#4b8b3b",
+    "sin": "#4b8b3b", "cos": "#4b8b3b",
     "paged_scaled_dot_product_attention_decode": "#d35400",
     "paged_update_cache": "#e67e22",
+    # plumbing (only shown with --no-collapse)
+    "to_device": "#9aa0a6", "to_layout": "#9aa0a6", "from_device": "#9aa0a6",
+    "to_memory_config": "#9aa0a6", "typecast": "#b0b6bb", "reshape": "#aeb6bd",
+    "slice": "#aeb6bd",
 }
 DEFAULT_COLOR = "#5b6b7b"
 INPUT_COLOR = "#b03a5b"
 
-COL_W = 210     # horizontal spacing within a layer
-ROW_H = 78      # vertical spacing between layers
-NODE_W = 176
-NODE_H = 44
+# ops folded away when --collapse (default). Shape/layout/movement only.
+PLUMBING = {"to_device", "to_layout", "from_device", "to_memory_config",
+            "typecast", "reshape"}
+
+# op -> logical stage family (for the background bands)
+FAMILY = {
+    "conv2d": "conv", "max_pool2d": "pool",
+    "linear": "linear", "matmul": "linear",
+    "rms_norm": "norm", "embedding": "embed",
+    "paged_scaled_dot_product_attention_decode": "attention",
+    "paged_update_cache": "attention",
+    "permute": "reshape", "reshape": "reshape", "concat": "reshape",
+    "slice": "reshape",
+}
+BAND_TINT = {
+    "conv": "#e9f1fb", "pool": "#e0eafa", "linear": "#e7f7ef", "norm": "#faf1e0",
+    "attention": "#fdece0", "embed": "#f1eafb", "reshape": "#eef1f3",
+    "elementwise": "#f5f6f7",
+}
+
+COL_W = 210      # x spacing between depth layers
+NODE_W = 178
+NODE_H = 58
+ROW_GAP = 84     # cross-axis spacing for branches at the same depth
+IN_FIRST = NODE_H + 30   # gap from backbone up to the first stacked input
+IN_GAP = NODE_H + 14     # gap between stacked inputs
 
 
 def bare_op(op):
     return op.rsplit(".", 1)[-1] if op else "?"
 
 
-def build_graph(tr):
-    """Turn a trace dict into (nodes, edges) with computed x/y positions."""
+def family_of(bare):
+    return FAMILY.get(bare, "elementwise")
+
+
+def build_graph(tr, collapse=True):
+    """Return (node_list, edges, bands). Positions are baked into each node."""
     rows = tr["rows"]
     arg_info = tr["arg_info"]
     out_set = set(tr["outputs"])
 
-    # node registry keyed by var name (and input[i] leaf keys)
     nodes = {}   # key -> dict
 
-    def ensure_input_node(key):
+    def ensure_input(key):
         if key in nodes:
             return
         label, kind, shape = key, "input", ""
-        m = key[key.find("[") + 1:key.find("]")] if key.startswith("input[") else None
-        if m is not None and m.isdigit() and int(m) < len(arg_info):
-            info = arg_info[int(m)]
-            label = info["label"] or key
-            kind = info["kind"] or "input"
-            shape = info["shape"]
-        nodes[key] = {
-            "key": key, "op": "input", "bare": "input", "label": label,
-            "kind": kind, "shape": shape, "is_input": True, "is_output": False,
-            "preds": [], "depth": 0,
-        }
+        if key.startswith("input["):
+            idx = key[key.find("[") + 1:key.find("]")]
+            if idx.isdigit() and int(idx) < len(arg_info):
+                info = arg_info[int(idx)]
+                label = info["label"] or key
+                kind = info["kind"] or "input"
+                shape = info["shape"]
+        nodes[key] = {"key": key, "bare": "input", "label": label, "kind": kind,
+                      "shape": shape, "is_input": True,
+                      "is_output": False, "preds": []}
 
-    order = []  # keys in program order (compute nodes only)
+    order = []   # compute nodes in program order
     for step, out, op, inputs, dtype, layout, mem, shape in rows:
         for i in inputs:
             if i.startswith("input["):
-                ensure_input_node(i)
-        nodes[out] = {
-            "key": out, "op": op, "bare": bare_op(op), "label": out,
-            "kind": "", "shape": shape, "is_input": False,
-            "is_output": out in out_set, "preds": list(inputs), "depth": 0,
-        }
+                ensure_input(i)
+        nodes[out] = {"key": out, "bare": bare_op(op), "label": out, "kind": "",
+                      "shape": shape, "is_input": False,
+                      "is_output": out in out_set, "preds": list(inputs)}
         order.append(out)
 
-    # longest-path depth in program order (rows are already topologically sorted)
-    for key in order:
-        n = nodes[key]
-        d = 0
-        for p in n["preds"]:
-            if p in nodes:
-                d = max(d, nodes[p]["depth"] + 1)
-        n["depth"] = d
+    def kept(n):
+        return n["is_input"] or n["is_output"] or n["bare"] not in PLUMBING
 
-    # collect successors, then pull leaf inputs down to (min successor depth - 1)
+    # fold plumbing: resolve each node's real (kept) predecessors in topo order
+    if collapse:
+        real = {}
+        input_keys = [k for k in nodes if nodes[k]["is_input"]]
+        for key in input_keys + order:          # sources first, then topo
+            rp = []
+            for p in nodes[key]["preds"]:
+                if p not in nodes:
+                    continue
+                src = [p] if kept(nodes[p]) else real.get(p, [])
+                for pp in src:
+                    if pp not in rp:
+                        rp.append(pp)
+            real[key] = rp
+        keep = [k for k in nodes if kept(nodes[k])]
+        for k in keep:
+            nodes[k]["preds"] = real[k]
+        nodes = {k: nodes[k] for k in keep}
+        order = [k for k in order if k in nodes]
+
     succ = {k: [] for k in nodes}
-    for key in order:
-        for p in nodes[key]["preds"]:
+    for k in nodes:
+        for p in nodes[k]["preds"]:
             if p in nodes:
-                succ[p].append(key)
-    for n in nodes.values():
-        if n["is_input"] and succ[n["key"]]:
-            n["depth"] = max(0, min(nodes[s]["depth"] for s in succ[n["key"]]) - 1)
+                succ[p].append(k)
 
-    # assign a column index within each depth (compute chain first, then leaves)
+    # longest-path depth over non-input predecessors (program order is topo)
+    for key in order:
+        d = 0
+        for p in nodes[key]["preds"]:
+            if p in nodes and not nodes[p]["is_input"]:
+                d = max(d, nodes[p].get("depth", 0) + 1)
+        nodes[key]["depth"] = d
+
     by_depth = {}
-    for key in order:                                   # compute nodes first
+    for key in order:
         by_depth.setdefault(nodes[key]["depth"], []).append(key)
-    for key, n in nodes.items():                        # then input leaves
-        if n["is_input"]:
-            by_depth.setdefault(n["depth"], []).append(key)
+    for d, keys in by_depth.items():
+        c = len(keys)
+        for i, key in enumerate(keys):
+            nodes[key]["x"] = d * COL_W
+            nodes[key]["y"] = (i - (c - 1) / 2) * ROW_GAP
 
-    id_of = {}
-    node_list = []
-    for depth in sorted(by_depth):
-        for col, key in enumerate(by_depth[depth]):
-            n = nodes[key]
-            nid = len(node_list)
-            id_of[key] = nid
-            n["id"] = nid
-            n["x"] = col * COL_W
-            n["y"] = depth * ROW_H
+    # place input leaves stacked above their (earliest) consumer
+    slots = {}
+    for key, n in nodes.items():
+        if not n["is_input"]:
+            continue
+        cons = [s for s in succ[key] if not nodes[s]["is_input"]]
+        if not cons:
+            n["x"], n["y"] = 0, 0
+            continue
+        c = min(cons, key=lambda s: nodes[s]["x"])
+        slot = slots.get(c, 0)
+        slots[c] = slot + 1
+        n["x"] = nodes[c]["x"]
+        n["y"] = nodes[c]["y"] - IN_FIRST - slot * IN_GAP
+
+    # ids: compute nodes first (in depth order), then inputs
+    node_list, id_of = [], {}
+    for d in sorted(by_depth):
+        for key in by_depth[d]:
+            nodes[key]["id"] = len(node_list)
+            id_of[key] = len(node_list)
+            node_list.append(nodes[key])
+    for key, n in nodes.items():
+        if n["is_input"]:
+            n["id"] = len(node_list)
+            id_of[key] = len(node_list)
             node_list.append(n)
 
     edges = []
-    for key in order:
+    for key in nodes:
         for p in nodes[key]["preds"]:
             if p in nodes:
                 edges.append((id_of[p], id_of[key]))
 
-    return node_list, edges
+    # stage bands: merge consecutive depths sharing a family
+    bands = []
+    if by_depth:
+        top = min(n["y"] for n in node_list)
+        bottom = max(n["y"] + NODE_H for n in node_list)
+        depths = sorted(by_depth)
+        fam = {d: family_of(nodes[by_depth[d][0]]["bare"]) for d in depths}
+        i = 0
+        while i < len(depths):
+            j = i
+            while j + 1 < len(depths) and fam[depths[j + 1]] == fam[depths[i]]:
+                j += 1
+            d0, d1 = depths[i], depths[j]
+            x0 = d0 * COL_W - 26
+            x1 = d1 * COL_W + NODE_W + 26
+            bands.append({
+                "x": x0, "w": x1 - x0, "y": top - 30, "h": (bottom - top) + 60,
+                "label": fam[depths[i]], "tint": BAND_TINT.get(fam[depths[i]], "#f2f3f4"),
+            })
+            i = j + 1
+
+    return node_list, edges, bands
 
 
 def color_for(n):
@@ -144,26 +230,58 @@ def color_for(n):
     return OP_COLORS.get(n["bare"], DEFAULT_COLOR)
 
 
-def render(tr, main_path, out_path):
-    nodes, edges = build_graph(tr)
+def edge_path(a, b):
+    acx, acy = a["x"] + NODE_W / 2, a["y"] + NODE_H / 2
+    bcx, bcy = b["x"] + NODE_W / 2, b["y"] + NODE_H / 2
+    dx, dy = bcx - acx, bcy - acy
+    if abs(dx) >= abs(dy):                                 # horizontal-ish
+        if dx >= 0:
+            x1, y1, x2, y2 = a["x"] + NODE_W, acy, b["x"], bcy
+        else:
+            x1, y1, x2, y2 = a["x"], acy, b["x"] + NODE_W, bcy
+        mx = (x1 + x2) / 2
+        return f"M{x1:.0f},{y1:.0f} C{mx:.0f},{y1:.0f} {mx:.0f},{y2:.0f} {x2:.0f},{y2:.0f}"
+    if dy >= 0:                                            # vertical-ish
+        x1, y1, x2, y2 = acx, a["y"] + NODE_H, bcx, b["y"]
+    else:
+        x1, y1, x2, y2 = acx, a["y"], bcx, b["y"] + NODE_H
+    my = (y1 + y2) / 2
+    return f"M{x1:.0f},{y1:.0f} C{x1:.0f},{my:.0f} {x2:.0f},{my:.0f} {x2:.0f},{y2:.0f}"
+
+
+def trunc(s, n=24):
+    return s if len(s) <= n else s[:n - 1] + "…"
+
+
+def render(tr, main_path, out_path, collapse=True, stages=True):
+    nodes, edges, bands = build_graph(tr, collapse=collapse)
+    if not stages:
+        bands = []
     esc = html.escape
 
-    max_x = max((n["x"] for n in nodes), default=0) + NODE_W + 40
-    max_y = max((n["y"] for n in nodes), default=0) + NODE_H + 40
+    xs = [n["x"] for n in nodes] or [0]
+    ys = [n["y"] for n in nodes] or [0]
+    minx = min(xs) - 34
+    top = min(ys)
+    miny = top - 56
+    w = (max(n["x"] + NODE_W for n in nodes) - minx) + 34 if nodes else 100
+    h = (max(n["y"] + NODE_H for n in nodes) - miny) + 34 if nodes else 100
 
-    # SVG edges
-    edge_svg = []
-    for s, t in edges:
-        a, b = nodes[s], nodes[t]
-        x1, y1 = a["x"] + NODE_W / 2, a["y"] + NODE_H
-        x2, y2 = b["x"] + NODE_W / 2, b["y"]
-        my = (y1 + y2) / 2
-        edge_svg.append(
-            f'<path class=edge data-s="{s}" data-t="{t}" '
-            f'd="M{x1:.0f},{y1:.0f} C{x1:.0f},{my:.0f} {x2:.0f},{my:.0f} {x2:.0f},{y2:.0f}"/>'
+    band_svg = []
+    for b in bands:
+        band_svg.append(
+            f'<g><rect class=band x="{b["x"]:.0f}" y="{b["y"]:.0f}" '
+            f'width="{b["w"]:.0f}" height="{b["h"]:.0f}" fill="{b["tint"]}"/>'
+            f'<text class=blab x="{b["x"] + 10:.0f}" y="{b["y"] + 16:.0f}">'
+            f'{esc(b["label"].upper())}</text></g>'
         )
 
-    # SVG nodes
+    edge_svg = []
+    for s, t in edges:
+        edge_svg.append(
+            f'<path class=edge data-s="{s}" data-t="{t}" d="{edge_path(nodes[s], nodes[t])}"/>'
+        )
+
     node_svg = []
     for n in nodes:
         title = esc(n["key"])
@@ -171,29 +289,30 @@ def render(tr, main_path, out_path):
             title += f'  ({esc(n["label"])})'
         if n["shape"]:
             title += f'  [{esc(n["shape"])}]'
+        if n["is_input"]:
+            l1, l2 = esc(trunc(n["label"], 22)), esc(n["key"])
+        else:
+            l1, l2 = esc(n["bare"]), esc(trunc(n["key"], 22))
+        l3 = esc(n["shape"] or "")
         stroke = "#111" if n["is_output"] else "none"
-        label = esc(n["label"] if n["is_input"] else n["bare"])
-        if len(label) > 24:
-            label = label[:23] + "…"
-        sub = esc(n["shape"] or "")
         node_svg.append(
-            f'<g class=node data-id="{n["id"]}" transform="translate({n["x"]},{n["y"]})">'
+            f'<g class=node data-id="{n["id"]}" transform="translate({n["x"]:.0f},{n["y"]:.0f})">'
             f'<title>{title}</title>'
-            f'<rect width="{NODE_W}" height="{NODE_H}" rx="6" '
-            f'fill="{color_for(n)}" stroke="{stroke}" stroke-width="2"/>'
-            f'<text class=nlab x="8" y="18">{label}</text>'
-            f'<text class=nsub x="8" y="35">{sub}</text>'
+            f'<rect width="{NODE_W}" height="{NODE_H}" rx="7" fill="{color_for(n)}" '
+            f'stroke="{stroke}" stroke-width="2.5"/>'
+            f'<text class=nop x="10" y="19">{l1}</text>'
+            f'<text class=nvar x="10" y="35">{l2}</text>'
+            f'<text class=nshape x="10" y="50">{l3}</text>'
             f'</g>'
         )
-
-    # adjacency for lineage highlighting (built in JS from these)
-    edge_json = json.dumps(edges)
 
     op_counts = {}
     for n in nodes:
         if not n["is_input"]:
             op_counts[n["bare"]] = op_counts.get(n["bare"], 0) + 1
     legend = " · ".join(f"{k}:{v}" for k, v in sorted(op_counts.items(), key=lambda x: -x[1]))
+    mode = "collapsed" if collapse else "full"
+    graph_name = os.path.basename(os.path.dirname(os.path.abspath(main_path)))
 
     doc = f"""<!doctype html><meta charset=utf-8>
 <title>Dataflow graph</title>
@@ -205,30 +324,35 @@ def render(tr, main_path, out_path):
  #wrap{{position:absolute;top:0;left:0;right:0;bottom:0;padding-top:38px;box-sizing:border-box}}
  svg{{width:100%;height:100%;cursor:grab;user-select:none;background:#fbfbfc}}
  svg.grab{{cursor:grabbing}}
- .edge{{fill:none;stroke:#bcc4cc;stroke-width:1.5}}
- .node text{{pointer-events:none;fill:#fff}}
- .nlab{{font-weight:600}} .nsub{{fill:#eef;font-size:10px;opacity:.85}}
+ .band{{opacity:.85}}
+ .blab{{fill:#8a94a0;font-size:12px;font-weight:700;letter-spacing:.12em}}
+ .edge{{fill:none;stroke:#c2cad2;stroke-width:1.5}}
+ .node text{{pointer-events:none}}
+ .nop{{fill:#fff;font-weight:700}}
+ .nvar{{fill:#fff;opacity:.72;font-size:10px}}
+ .nshape{{fill:#eaf6ff;font-size:10px}}
  .edge.hi{{stroke:#111;stroke-width:2.5}}
- .edge.dim,.node.dim{{opacity:.12}}
- .node.hi rect{{stroke:#111;stroke-width:3}}
+ .edge.dim,.node.dim{{opacity:.1}}
+ .node.hi rect{{stroke:#111;stroke-width:3.5}}
 </style>
 <div id=bar>
- <b>{esc(os.path.basename(os.path.dirname(os.path.abspath(main_path))))}</b>
- <span>{len(nodes)} nodes · {len(edges)} edges</span>
+ <b>{esc(graph_name)}</b>
+ <span>{len(nodes)} nodes · {len(edges)} edges · {mode}</span>
  <input id=f placeholder="filter by op / var…">
  <span id=hint style="color:#888">drag=pan · wheel=zoom · hover=edges · click=lineage · esc=reset</span>
  <span class=leg>{esc(legend)}</span>
 </div>
 <div id=wrap>
-<svg id=svg viewBox="-20 -20 {max_x} {max_y}">
+<svg id=svg viewBox="{minx:.0f} {miny:.0f} {w:.0f} {h:.0f}">
 <g id=scene>
+<g id=bands pointer-events="none">{''.join(band_svg)}</g>
 <g id=edges>{''.join(edge_svg)}</g>
 <g id=nodes>{''.join(node_svg)}</g>
 </g>
 </svg>
 </div>
 <script>
-const EDGES = {edge_json};
+const EDGES = {json.dumps(edges)};
 const svg = document.getElementById('svg');
 const succ = {{}}, pred = {{}};
 for (const [s,t] of EDGES) {{ (succ[s]=succ[s]||[]).push(t); (pred[t]=pred[t]||[]).push(s); }}
@@ -236,8 +360,7 @@ const nodeEls = [...document.querySelectorAll('.node')];
 const edgeEls = [...document.querySelectorAll('.edge')];
 const nodeById = {{}}; nodeEls.forEach(e => nodeById[e.dataset.id]=e);
 
-// ---- pan / zoom via viewBox ----
-let vb = svg.getAttribute('viewBox').split(' ').map(Number); // x,y,w,h
+let vb = svg.getAttribute('viewBox').split(' ').map(Number);
 function setVB(){{ svg.setAttribute('viewBox', vb.join(' ')); }}
 svg.addEventListener('wheel', e => {{
   e.preventDefault();
@@ -256,30 +379,27 @@ addEventListener('mousemove', e => {{ if(!drag)return;
   vb[1]=drag.vy-(e.clientY-drag.y)/r.height*vb[3]; setVB(); }});
 addEventListener('mouseup', ()=>{{ drag=null; svg.classList.remove('grab'); }});
 
-// ---- highlight ----
 function clear(){{ [...nodeEls,...edgeEls].forEach(e=>e.classList.remove('hi','dim')); }}
-function highlightNeighbors(id){{
-  clear();
-  const keep=new Set([id]);
+function neighbors(id){{
+  clear(); const keep=new Set([id]);
   (succ[id]||[]).forEach(t=>keep.add(t)); (pred[id]||[]).forEach(s=>keep.add(s));
   nodeEls.forEach(e=>e.classList.toggle('dim', !keep.has(+e.dataset.id)));
   nodeById[id].classList.add('hi');
-  edgeEls.forEach(e=>{{ const s=+e.dataset.s,t=+e.dataset.t;
-    if(s===id||t===id){{e.classList.add('hi');}} else {{e.classList.add('dim');}} }});
+  edgeEls.forEach(e=>{{const s=+e.dataset.s,t=+e.dataset.t;
+    e.classList.add(s===id||t===id?'hi':'dim');}});
 }}
 function lineage(id){{
-  const up=new Set(), dn=new Set(); let st=[id];
-  while(st.length){{const n=st.pop(); (pred[n]||[]).forEach(p=>{{if(!up.has(p)){{up.add(p);st.push(p);}}}});}}
-  st=[id]; while(st.length){{const n=st.pop(); (succ[n]||[]).forEach(s=>{{if(!dn.has(s)){{dn.add(s);st.push(s);}}}});}}
+  const up=new Set(),dn=new Set(); let st=[id];
+  while(st.length){{const n=st.pop();(pred[n]||[]).forEach(p=>{{if(!up.has(p)){{up.add(p);st.push(p);}}}});}}
+  st=[id]; while(st.length){{const n=st.pop();(succ[n]||[]).forEach(s=>{{if(!dn.has(s)){{dn.add(s);st.push(s);}}}});}}
   const keep=new Set([id,...up,...dn]); clear();
   nodeEls.forEach(e=>{{const i=+e.dataset.id; if(!keep.has(i))e.classList.add('dim'); else if(i===id)e.classList.add('hi');}});
   edgeEls.forEach(e=>{{const s=+e.dataset.s,t=+e.dataset.t;
-    if(keep.has(s)&&keep.has(t))e.classList.add('hi'); else e.classList.add('dim');}});
+    e.classList.add(keep.has(s)&&keep.has(t)?'hi':'dim');}});
 }}
 let pinned=null;
-nodeEls.forEach(e=>{{
-  const id=+e.dataset.id;
-  e.addEventListener('mouseenter',()=>{{ if(pinned===null) highlightNeighbors(id); }});
+nodeEls.forEach(e=>{{ const id=+e.dataset.id;
+  e.addEventListener('mouseenter',()=>{{ if(pinned===null) neighbors(id); }});
   e.addEventListener('mouseleave',()=>{{ if(pinned===null) clear(); }});
   e.addEventListener('click',ev=>{{ ev.stopPropagation();
     if(pinned===id){{pinned=null;clear();}} else {{pinned=id;lineage(id);}} }});
@@ -287,7 +407,6 @@ nodeEls.forEach(e=>{{
 svg.addEventListener('click',()=>{{ if(pinned!==null){{pinned=null;clear();}} }});
 addEventListener('keydown',e=>{{ if(e.key==='Escape'){{pinned=null;clear();}} }});
 
-// ---- filter ----
 document.getElementById('f').addEventListener('input',function(){{
   const q=this.value.toLowerCase(); pinned=null;
   nodeEls.forEach(e=>{{
@@ -308,12 +427,17 @@ def main():
     ap.add_argument("path")
     ap.add_argument("-o", "--out")
     ap.add_argument("--mlir")
+    ap.add_argument("--no-collapse", action="store_true",
+                    help="keep plumbing ops (to_device/to_layout/reshape/...) as nodes")
+    ap.add_argument("--no-stages", action="store_true",
+                    help="omit the labeled stage bands")
     args = ap.parse_args()
 
     tr = build_trace(args.path, args.mlir)
     out_path = args.out or os.path.join(
         os.path.dirname(os.path.abspath(args.path)), "graph.html")
-    n, e = render(tr, args.path, out_path)
+    n, e = render(tr, args.path, out_path,
+                  collapse=not args.no_collapse, stages=not args.no_stages)
     note = "" if tr["has_shapes"] else "  (no ttnn.mlir -> shapes blank)"
     print(f"wrote {out_path}  ({n} nodes, {e} edges){note}")
 

--- a/scripts/codegen_trace_graph.py
+++ b/scripts/codegen_trace_graph.py
@@ -31,52 +31,84 @@ import os
 
 from codegen_trace_table import build_trace
 
-
 # op-family -> fill color (aligned with the table's accent colors)
 OP_COLORS = {
-    "matmul": "#0aa77a", "linear": "#0aa77a",
-    "rms_norm": "#c58a1a", "conv2d": "#2d7dd2", "max_pool2d": "#2467b0",
-    "embedding": "#8a2be2", "permute": "#7d8b99", "concat": "#7d8b99",
-    "argmax": "#c0392b", "max": "#c0392b", "sum": "#c0392b",
-    "relu": "#16a085", "silu": "#16a085", "exp": "#1f9e8f", "log": "#1f9e8f",
-    "add": "#4b8b3b", "subtract": "#4b8b3b", "multiply": "#4b8b3b",
-    "sin": "#4b8b3b", "cos": "#4b8b3b",
+    "matmul": "#0aa77a",
+    "linear": "#0aa77a",
+    "rms_norm": "#c58a1a",
+    "conv2d": "#2d7dd2",
+    "max_pool2d": "#2467b0",
+    "embedding": "#8a2be2",
+    "permute": "#7d8b99",
+    "concat": "#7d8b99",
+    "argmax": "#c0392b",
+    "max": "#c0392b",
+    "sum": "#c0392b",
+    "relu": "#16a085",
+    "silu": "#16a085",
+    "exp": "#1f9e8f",
+    "log": "#1f9e8f",
+    "add": "#4b8b3b",
+    "subtract": "#4b8b3b",
+    "multiply": "#4b8b3b",
+    "sin": "#4b8b3b",
+    "cos": "#4b8b3b",
     "paged_scaled_dot_product_attention_decode": "#d35400",
     "paged_update_cache": "#e67e22",
     # plumbing (only shown with --no-collapse)
-    "to_device": "#9aa0a6", "to_layout": "#9aa0a6", "from_device": "#9aa0a6",
-    "to_memory_config": "#9aa0a6", "typecast": "#b0b6bb", "reshape": "#aeb6bd",
+    "to_device": "#9aa0a6",
+    "to_layout": "#9aa0a6",
+    "from_device": "#9aa0a6",
+    "to_memory_config": "#9aa0a6",
+    "typecast": "#b0b6bb",
+    "reshape": "#aeb6bd",
     "slice": "#aeb6bd",
 }
 DEFAULT_COLOR = "#5b6b7b"
 INPUT_COLOR = "#b03a5b"
 
 # ops folded away when --collapse (default). Shape/layout/movement only.
-PLUMBING = {"to_device", "to_layout", "from_device", "to_memory_config",
-            "typecast", "reshape"}
+PLUMBING = {
+    "to_device",
+    "to_layout",
+    "from_device",
+    "to_memory_config",
+    "typecast",
+    "reshape",
+}
 
 # op -> logical stage family (for the background bands)
 FAMILY = {
-    "conv2d": "conv", "max_pool2d": "pool",
-    "linear": "linear", "matmul": "linear",
-    "rms_norm": "norm", "embedding": "embed",
+    "conv2d": "conv",
+    "max_pool2d": "pool",
+    "linear": "linear",
+    "matmul": "linear",
+    "rms_norm": "norm",
+    "embedding": "embed",
     "paged_scaled_dot_product_attention_decode": "attention",
     "paged_update_cache": "attention",
-    "permute": "reshape", "reshape": "reshape", "concat": "reshape",
+    "permute": "reshape",
+    "reshape": "reshape",
+    "concat": "reshape",
     "slice": "reshape",
 }
 BAND_TINT = {
-    "conv": "#e9f1fb", "pool": "#e0eafa", "linear": "#e7f7ef", "norm": "#faf1e0",
-    "attention": "#fdece0", "embed": "#f1eafb", "reshape": "#eef1f3",
+    "conv": "#e9f1fb",
+    "pool": "#e0eafa",
+    "linear": "#e7f7ef",
+    "norm": "#faf1e0",
+    "attention": "#fdece0",
+    "embed": "#f1eafb",
+    "reshape": "#eef1f3",
     "elementwise": "#f5f6f7",
 }
 
-COL_W = 210      # x spacing between depth layers
+COL_W = 210  # x spacing between depth layers
 NODE_W = 178
 NODE_H = 58
-ROW_GAP = 84     # cross-axis spacing for branches at the same depth
-IN_FIRST = NODE_H + 30   # gap from backbone up to the first stacked input
-IN_GAP = NODE_H + 14     # gap between stacked inputs
+ROW_GAP = 84  # cross-axis spacing for branches at the same depth
+IN_FIRST = NODE_H + 30  # gap from backbone up to the first stacked input
+IN_GAP = NODE_H + 14  # gap between stacked inputs
 
 
 def bare_op(op):
@@ -93,31 +125,45 @@ def build_graph(tr, collapse=True):
     arg_info = tr["arg_info"]
     out_set = set(tr["outputs"])
 
-    nodes = {}   # key -> dict
+    nodes = {}  # key -> dict
 
     def ensure_input(key):
         if key in nodes:
             return
         label, kind, shape = key, "input", ""
         if key.startswith("input["):
-            idx = key[key.find("[") + 1:key.find("]")]
+            idx = key[key.find("[") + 1 : key.find("]")]
             if idx.isdigit() and int(idx) < len(arg_info):
                 info = arg_info[int(idx)]
                 label = info["label"] or key
                 kind = info["kind"] or "input"
                 shape = info["shape"]
-        nodes[key] = {"key": key, "bare": "input", "label": label, "kind": kind,
-                      "shape": shape, "is_input": True,
-                      "is_output": False, "preds": []}
+        nodes[key] = {
+            "key": key,
+            "bare": "input",
+            "label": label,
+            "kind": kind,
+            "shape": shape,
+            "is_input": True,
+            "is_output": False,
+            "preds": [],
+        }
 
-    order = []   # compute nodes in program order
+    order = []  # compute nodes in program order
     for step, out, op, inputs, dtype, layout, mem, shape in rows:
         for i in inputs:
             if i.startswith("input["):
                 ensure_input(i)
-        nodes[out] = {"key": out, "bare": bare_op(op), "label": out, "kind": "",
-                      "shape": shape, "is_input": False,
-                      "is_output": out in out_set, "preds": list(inputs)}
+        nodes[out] = {
+            "key": out,
+            "bare": bare_op(op),
+            "label": out,
+            "kind": "",
+            "shape": shape,
+            "is_input": False,
+            "is_output": out in out_set,
+            "preds": list(inputs),
+        }
         order.append(out)
 
     def kept(n):
@@ -127,7 +173,7 @@ def build_graph(tr, collapse=True):
     if collapse:
         real = {}
         input_keys = [k for k in nodes if nodes[k]["is_input"]]
-        for key in input_keys + order:          # sources first, then topo
+        for key in input_keys + order:  # sources first, then topo
             rp = []
             for p in nodes[key]["preds"]:
                 if p not in nodes:
@@ -215,10 +261,16 @@ def build_graph(tr, collapse=True):
             d0, d1 = depths[i], depths[j]
             x0 = d0 * COL_W - 26
             x1 = d1 * COL_W + NODE_W + 26
-            bands.append({
-                "x": x0, "w": x1 - x0, "y": top - 30, "h": (bottom - top) + 60,
-                "label": fam[depths[i]], "tint": BAND_TINT.get(fam[depths[i]], "#f2f3f4"),
-            })
+            bands.append(
+                {
+                    "x": x0,
+                    "w": x1 - x0,
+                    "y": top - 30,
+                    "h": (bottom - top) + 60,
+                    "label": fam[depths[i]],
+                    "tint": BAND_TINT.get(fam[depths[i]], "#f2f3f4"),
+                }
+            )
             i = j + 1
 
     return node_list, edges, bands
@@ -234,14 +286,16 @@ def edge_path(a, b):
     acx, acy = a["x"] + NODE_W / 2, a["y"] + NODE_H / 2
     bcx, bcy = b["x"] + NODE_W / 2, b["y"] + NODE_H / 2
     dx, dy = bcx - acx, bcy - acy
-    if abs(dx) >= abs(dy):                                 # horizontal-ish
+    if abs(dx) >= abs(dy):  # horizontal-ish
         if dx >= 0:
             x1, y1, x2, y2 = a["x"] + NODE_W, acy, b["x"], bcy
         else:
             x1, y1, x2, y2 = a["x"], acy, b["x"] + NODE_W, bcy
         mx = (x1 + x2) / 2
-        return f"M{x1:.0f},{y1:.0f} C{mx:.0f},{y1:.0f} {mx:.0f},{y2:.0f} {x2:.0f},{y2:.0f}"
-    if dy >= 0:                                            # vertical-ish
+        return (
+            f"M{x1:.0f},{y1:.0f} C{mx:.0f},{y1:.0f} {mx:.0f},{y2:.0f} {x2:.0f},{y2:.0f}"
+        )
+    if dy >= 0:  # vertical-ish
         x1, y1, x2, y2 = acx, a["y"] + NODE_H, bcx, b["y"]
     else:
         x1, y1, x2, y2 = acx, a["y"], bcx, b["y"] + NODE_H
@@ -250,7 +304,7 @@ def edge_path(a, b):
 
 
 def trunc(s, n=24):
-    return s if len(s) <= n else s[:n - 1] + "…"
+    return s if len(s) <= n else s[: n - 1] + "…"
 
 
 def render(tr, main_path, out_path, collapse=True, stages=True):
@@ -297,20 +351,22 @@ def render(tr, main_path, out_path, collapse=True, stages=True):
         stroke = "#111" if n["is_output"] else "none"
         node_svg.append(
             f'<g class=node data-id="{n["id"]}" transform="translate({n["x"]:.0f},{n["y"]:.0f})">'
-            f'<title>{title}</title>'
+            f"<title>{title}</title>"
             f'<rect width="{NODE_W}" height="{NODE_H}" rx="7" fill="{color_for(n)}" '
             f'stroke="{stroke}" stroke-width="2.5"/>'
             f'<text class=nop x="10" y="19">{l1}</text>'
             f'<text class=nvar x="10" y="35">{l2}</text>'
             f'<text class=nshape x="10" y="50">{l3}</text>'
-            f'</g>'
+            f"</g>"
         )
 
     op_counts = {}
     for n in nodes:
         if not n["is_input"]:
             op_counts[n["bare"]] = op_counts.get(n["bare"], 0) + 1
-    legend = " · ".join(f"{k}:{v}" for k, v in sorted(op_counts.items(), key=lambda x: -x[1]))
+    legend = " · ".join(
+        f"{k}:{v}" for k, v in sorted(op_counts.items(), key=lambda x: -x[1])
+    )
     mode = "collapsed" if collapse else "full"
     graph_name = os.path.basename(os.path.dirname(os.path.abspath(main_path)))
 
@@ -427,17 +483,27 @@ def main():
     ap.add_argument("path")
     ap.add_argument("-o", "--out")
     ap.add_argument("--mlir")
-    ap.add_argument("--no-collapse", action="store_true",
-                    help="keep plumbing ops (to_device/to_layout/reshape/...) as nodes")
-    ap.add_argument("--no-stages", action="store_true",
-                    help="omit the labeled stage bands")
+    ap.add_argument(
+        "--no-collapse",
+        action="store_true",
+        help="keep plumbing ops (to_device/to_layout/reshape/...) as nodes",
+    )
+    ap.add_argument(
+        "--no-stages", action="store_true", help="omit the labeled stage bands"
+    )
     args = ap.parse_args()
 
     tr = build_trace(args.path, args.mlir)
     out_path = args.out or os.path.join(
-        os.path.dirname(os.path.abspath(args.path)), "graph.html")
-    n, e = render(tr, args.path, out_path,
-                  collapse=not args.no_collapse, stages=not args.no_stages)
+        os.path.dirname(os.path.abspath(args.path)), "graph.html"
+    )
+    n, e = render(
+        tr,
+        args.path,
+        out_path,
+        collapse=not args.no_collapse,
+        stages=not args.no_stages,
+    )
     note = "" if tr["has_shapes"] else "  (no ttnn.mlir -> shapes blank)"
     print(f"wrote {out_path}  ({n} nodes, {e} edges){note}")
 

--- a/scripts/codegen_trace_graph.py
+++ b/scripts/codegen_trace_graph.py
@@ -29,7 +29,7 @@ import html
 import json
 import os
 
-from codegen_trace_table import build_trace
+from codegen_trace_table import build_trace, load_template
 
 # op-family -> fill color (aligned with the table's accent colors)
 OP_COLORS = {
@@ -370,108 +370,19 @@ def render(tr, main_path, out_path, collapse=True, stages=True):
     mode = "collapsed" if collapse else "full"
     graph_name = os.path.basename(os.path.dirname(os.path.abspath(main_path)))
 
-    doc = f"""<!doctype html><meta charset=utf-8>
-<title>Dataflow graph</title>
-<style>
- html,body{{margin:0;height:100%;font:13px ui-monospace,Menlo,Consolas,monospace;background:#fff;color:#111}}
- #bar{{padding:6px 10px;border-bottom:1px solid #ddd;display:flex;gap:12px;align-items:center;flex-wrap:wrap}}
- #bar b{{font-weight:600}} #bar .leg{{color:#666;font-size:11px}}
- input{{font:inherit;padding:3px 6px;width:220px}}
- #wrap{{position:absolute;top:0;left:0;right:0;bottom:0;padding-top:38px;box-sizing:border-box}}
- svg{{width:100%;height:100%;cursor:grab;user-select:none;background:#fbfbfc}}
- svg.grab{{cursor:grabbing}}
- .band{{opacity:.85}}
- .blab{{fill:#8a94a0;font-size:12px;font-weight:700;letter-spacing:.12em}}
- .edge{{fill:none;stroke:#c2cad2;stroke-width:1.5}}
- .node text{{pointer-events:none}}
- .nop{{fill:#fff;font-weight:700}}
- .nvar{{fill:#fff;opacity:.72;font-size:10px}}
- .nshape{{fill:#eaf6ff;font-size:10px}}
- .edge.hi{{stroke:#111;stroke-width:2.5}}
- .edge.dim,.node.dim{{opacity:.1}}
- .node.hi rect{{stroke:#111;stroke-width:3.5}}
-</style>
-<div id=bar>
- <b>{esc(graph_name)}</b>
- <span>{len(nodes)} nodes · {len(edges)} edges · {mode}</span>
- <input id=f placeholder="filter by op / var…">
- <span id=hint style="color:#888">drag=pan · wheel=zoom · hover=edges · click=lineage · esc=reset</span>
- <span class=leg>{esc(legend)}</span>
-</div>
-<div id=wrap>
-<svg id=svg viewBox="{minx:.0f} {miny:.0f} {w:.0f} {h:.0f}">
-<g id=scene>
-<g id=bands pointer-events="none">{''.join(band_svg)}</g>
-<g id=edges>{''.join(edge_svg)}</g>
-<g id=nodes>{''.join(node_svg)}</g>
-</g>
-</svg>
-</div>
-<script>
-const EDGES = {json.dumps(edges)};
-const svg = document.getElementById('svg');
-const succ = {{}}, pred = {{}};
-for (const [s,t] of EDGES) {{ (succ[s]=succ[s]||[]).push(t); (pred[t]=pred[t]||[]).push(s); }}
-const nodeEls = [...document.querySelectorAll('.node')];
-const edgeEls = [...document.querySelectorAll('.edge')];
-const nodeById = {{}}; nodeEls.forEach(e => nodeById[e.dataset.id]=e);
-
-let vb = svg.getAttribute('viewBox').split(' ').map(Number);
-function setVB(){{ svg.setAttribute('viewBox', vb.join(' ')); }}
-svg.addEventListener('wheel', e => {{
-  e.preventDefault();
-  const r = svg.getBoundingClientRect();
-  const mx = vb[0] + (e.clientX-r.left)/r.width*vb[2];
-  const my = vb[1] + (e.clientY-r.top)/r.height*vb[3];
-  const k = e.deltaY>0 ? 1.1 : 1/1.1;
-  vb[0]=mx-(mx-vb[0])*k; vb[1]=my-(my-vb[1])*k; vb[2]*=k; vb[3]*=k; setVB();
-}}, {{passive:false}});
-let drag=null;
-svg.addEventListener('mousedown', e => {{ if(e.target.closest('.node'))return;
-  drag={{x:e.clientX,y:e.clientY,vx:vb[0],vy:vb[1]}}; svg.classList.add('grab'); }});
-addEventListener('mousemove', e => {{ if(!drag)return;
-  const r=svg.getBoundingClientRect();
-  vb[0]=drag.vx-(e.clientX-drag.x)/r.width*vb[2];
-  vb[1]=drag.vy-(e.clientY-drag.y)/r.height*vb[3]; setVB(); }});
-addEventListener('mouseup', ()=>{{ drag=null; svg.classList.remove('grab'); }});
-
-function clear(){{ [...nodeEls,...edgeEls].forEach(e=>e.classList.remove('hi','dim')); }}
-function neighbors(id){{
-  clear(); const keep=new Set([id]);
-  (succ[id]||[]).forEach(t=>keep.add(t)); (pred[id]||[]).forEach(s=>keep.add(s));
-  nodeEls.forEach(e=>e.classList.toggle('dim', !keep.has(+e.dataset.id)));
-  nodeById[id].classList.add('hi');
-  edgeEls.forEach(e=>{{const s=+e.dataset.s,t=+e.dataset.t;
-    e.classList.add(s===id||t===id?'hi':'dim');}});
-}}
-function lineage(id){{
-  const up=new Set(),dn=new Set(); let st=[id];
-  while(st.length){{const n=st.pop();(pred[n]||[]).forEach(p=>{{if(!up.has(p)){{up.add(p);st.push(p);}}}});}}
-  st=[id]; while(st.length){{const n=st.pop();(succ[n]||[]).forEach(s=>{{if(!dn.has(s)){{dn.add(s);st.push(s);}}}});}}
-  const keep=new Set([id,...up,...dn]); clear();
-  nodeEls.forEach(e=>{{const i=+e.dataset.id; if(!keep.has(i))e.classList.add('dim'); else if(i===id)e.classList.add('hi');}});
-  edgeEls.forEach(e=>{{const s=+e.dataset.s,t=+e.dataset.t;
-    e.classList.add(keep.has(s)&&keep.has(t)?'hi':'dim');}});
-}}
-let pinned=null;
-nodeEls.forEach(e=>{{ const id=+e.dataset.id;
-  e.addEventListener('mouseenter',()=>{{ if(pinned===null) neighbors(id); }});
-  e.addEventListener('mouseleave',()=>{{ if(pinned===null) clear(); }});
-  e.addEventListener('click',ev=>{{ ev.stopPropagation();
-    if(pinned===id){{pinned=null;clear();}} else {{pinned=id;lineage(id);}} }});
-}});
-svg.addEventListener('click',()=>{{ if(pinned!==null){{pinned=null;clear();}} }});
-addEventListener('keydown',e=>{{ if(e.key==='Escape'){{pinned=null;clear();}} }});
-
-document.getElementById('f').addEventListener('input',function(){{
-  const q=this.value.toLowerCase(); pinned=null;
-  nodeEls.forEach(e=>{{
-    const t=(e.querySelector('title').textContent+' '+e.textContent).toLowerCase();
-    e.classList.toggle('dim', q!=='' && !t.includes(q));
-  }});
-  edgeEls.forEach(e=>e.classList.remove('hi','dim'));
-}});
-</script>"""
+    doc = (
+        load_template("codegen_trace_graph_template.html")
+        .replace("__VIEWBOX__", f"{minx:.0f} {miny:.0f} {w:.0f} {h:.0f}")
+        .replace("<!--__NAME__-->", esc(graph_name))
+        .replace(
+            "<!--__STATS__-->", f"{len(nodes)} nodes · {len(edges)} edges · {mode}"
+        )
+        .replace("<!--__LEGEND__-->", esc(legend))
+        .replace("<!--__BANDS__-->", "".join(band_svg))
+        .replace("<!--__EDGES__-->", "".join(edge_svg))
+        .replace("<!--__NODES__-->", "".join(node_svg))
+        .replace("/*__EDGES__*/", json.dumps(edges))
+    )
 
     with open(out_path, "w") as f:
         f.write(doc)

--- a/scripts/codegen_trace_graph.py
+++ b/scripts/codegen_trace_graph.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Render a TTNN codegen graph's main.py as an interactive dataflow graph.
+
+Produces a single self-contained HTML file (no external libraries, no CDN, works
+offline and inside sandboxed viewers) with an SVG dataflow DAG:
+
+  * nodes are ttnn ops (and input[i] leaves), colored by op family, labeled with
+    op name + result shape (shapes sourced from the sibling ttnn.mlir);
+  * a top-down layered layout (longest-path depth) with weight/constant leaves
+    pulled down next to their first consumer to keep edges short;
+  * pan (drag), zoom (wheel), hover-to-highlight a node's direct edges, click to
+    pin a node's full ancestor+descendant lineage, and a live op-name filter.
+
+Usage:
+    codegen_trace_graph.py <path/to/main.py> [-o out.html] [--mlir ttnn.mlir]
+"""
+
+import argparse
+import html
+import json
+import os
+
+from codegen_trace_table import build_trace
+
+
+# op-family -> fill color (kept close to the table's accent colors)
+OP_COLORS = {
+    "matmul": "#0aa77a", "linear": "#0aa77a",
+    "rms_norm": "#c58a1a", "conv2d": "#2d7dd2", "max_pool2d": "#2d7dd2",
+    "embedding": "#8a2be2",
+    "to_device": "#9aa0a6", "to_layout": "#9aa0a6", "from_device": "#9aa0a6",
+    "to_memory_config": "#9aa0a6", "typecast": "#b0b6bb",
+    "slice": "#7d8b99", "reshape": "#7d8b99", "permute": "#7d8b99",
+    "concat": "#7d8b99",
+    "argmax": "#c0392b", "max": "#c0392b", "sum": "#c0392b",
+    "paged_scaled_dot_product_attention_decode": "#d35400",
+    "paged_update_cache": "#e67e22",
+}
+DEFAULT_COLOR = "#5b6b7b"
+INPUT_COLOR = "#b03a5b"
+
+COL_W = 210     # horizontal spacing within a layer
+ROW_H = 78      # vertical spacing between layers
+NODE_W = 176
+NODE_H = 44
+
+
+def bare_op(op):
+    return op.rsplit(".", 1)[-1] if op else "?"
+
+
+def build_graph(tr):
+    """Turn a trace dict into (nodes, edges) with computed x/y positions."""
+    rows = tr["rows"]
+    arg_info = tr["arg_info"]
+    out_set = set(tr["outputs"])
+
+    # node registry keyed by var name (and input[i] leaf keys)
+    nodes = {}   # key -> dict
+
+    def ensure_input_node(key):
+        if key in nodes:
+            return
+        label, kind, shape = key, "input", ""
+        m = key[key.find("[") + 1:key.find("]")] if key.startswith("input[") else None
+        if m is not None and m.isdigit() and int(m) < len(arg_info):
+            info = arg_info[int(m)]
+            label = info["label"] or key
+            kind = info["kind"] or "input"
+            shape = info["shape"]
+        nodes[key] = {
+            "key": key, "op": "input", "bare": "input", "label": label,
+            "kind": kind, "shape": shape, "is_input": True, "is_output": False,
+            "preds": [], "depth": 0,
+        }
+
+    order = []  # keys in program order (compute nodes only)
+    for step, out, op, inputs, dtype, layout, mem, shape in rows:
+        for i in inputs:
+            if i.startswith("input["):
+                ensure_input_node(i)
+        nodes[out] = {
+            "key": out, "op": op, "bare": bare_op(op), "label": out,
+            "kind": "", "shape": shape, "is_input": False,
+            "is_output": out in out_set, "preds": list(inputs), "depth": 0,
+        }
+        order.append(out)
+
+    # longest-path depth in program order (rows are already topologically sorted)
+    for key in order:
+        n = nodes[key]
+        d = 0
+        for p in n["preds"]:
+            if p in nodes:
+                d = max(d, nodes[p]["depth"] + 1)
+        n["depth"] = d
+
+    # collect successors, then pull leaf inputs down to (min successor depth - 1)
+    succ = {k: [] for k in nodes}
+    for key in order:
+        for p in nodes[key]["preds"]:
+            if p in nodes:
+                succ[p].append(key)
+    for n in nodes.values():
+        if n["is_input"] and succ[n["key"]]:
+            n["depth"] = max(0, min(nodes[s]["depth"] for s in succ[n["key"]]) - 1)
+
+    # assign a column index within each depth (compute chain first, then leaves)
+    by_depth = {}
+    for key in order:                                   # compute nodes first
+        by_depth.setdefault(nodes[key]["depth"], []).append(key)
+    for key, n in nodes.items():                        # then input leaves
+        if n["is_input"]:
+            by_depth.setdefault(n["depth"], []).append(key)
+
+    id_of = {}
+    node_list = []
+    for depth in sorted(by_depth):
+        for col, key in enumerate(by_depth[depth]):
+            n = nodes[key]
+            nid = len(node_list)
+            id_of[key] = nid
+            n["id"] = nid
+            n["x"] = col * COL_W
+            n["y"] = depth * ROW_H
+            node_list.append(n)
+
+    edges = []
+    for key in order:
+        for p in nodes[key]["preds"]:
+            if p in nodes:
+                edges.append((id_of[p], id_of[key]))
+
+    return node_list, edges
+
+
+def color_for(n):
+    if n["is_input"]:
+        return INPUT_COLOR
+    return OP_COLORS.get(n["bare"], DEFAULT_COLOR)
+
+
+def render(tr, main_path, out_path):
+    nodes, edges = build_graph(tr)
+    esc = html.escape
+
+    max_x = max((n["x"] for n in nodes), default=0) + NODE_W + 40
+    max_y = max((n["y"] for n in nodes), default=0) + NODE_H + 40
+
+    # SVG edges
+    edge_svg = []
+    for s, t in edges:
+        a, b = nodes[s], nodes[t]
+        x1, y1 = a["x"] + NODE_W / 2, a["y"] + NODE_H
+        x2, y2 = b["x"] + NODE_W / 2, b["y"]
+        my = (y1 + y2) / 2
+        edge_svg.append(
+            f'<path class=edge data-s="{s}" data-t="{t}" '
+            f'd="M{x1:.0f},{y1:.0f} C{x1:.0f},{my:.0f} {x2:.0f},{my:.0f} {x2:.0f},{y2:.0f}"/>'
+        )
+
+    # SVG nodes
+    node_svg = []
+    for n in nodes:
+        title = esc(n["key"])
+        if n["is_input"] and n["label"] != n["key"]:
+            title += f'  ({esc(n["label"])})'
+        if n["shape"]:
+            title += f'  [{esc(n["shape"])}]'
+        stroke = "#111" if n["is_output"] else "none"
+        label = esc(n["label"] if n["is_input"] else n["bare"])
+        if len(label) > 24:
+            label = label[:23] + "…"
+        sub = esc(n["shape"] or "")
+        node_svg.append(
+            f'<g class=node data-id="{n["id"]}" transform="translate({n["x"]},{n["y"]})">'
+            f'<title>{title}</title>'
+            f'<rect width="{NODE_W}" height="{NODE_H}" rx="6" '
+            f'fill="{color_for(n)}" stroke="{stroke}" stroke-width="2"/>'
+            f'<text class=nlab x="8" y="18">{label}</text>'
+            f'<text class=nsub x="8" y="35">{sub}</text>'
+            f'</g>'
+        )
+
+    # adjacency for lineage highlighting (built in JS from these)
+    edge_json = json.dumps(edges)
+
+    op_counts = {}
+    for n in nodes:
+        if not n["is_input"]:
+            op_counts[n["bare"]] = op_counts.get(n["bare"], 0) + 1
+    legend = " · ".join(f"{k}:{v}" for k, v in sorted(op_counts.items(), key=lambda x: -x[1]))
+
+    doc = f"""<!doctype html><meta charset=utf-8>
+<title>Dataflow graph</title>
+<style>
+ html,body{{margin:0;height:100%;font:13px ui-monospace,Menlo,Consolas,monospace;background:#fff;color:#111}}
+ #bar{{padding:6px 10px;border-bottom:1px solid #ddd;display:flex;gap:12px;align-items:center;flex-wrap:wrap}}
+ #bar b{{font-weight:600}} #bar .leg{{color:#666;font-size:11px}}
+ input{{font:inherit;padding:3px 6px;width:220px}}
+ #wrap{{position:absolute;top:0;left:0;right:0;bottom:0;padding-top:38px;box-sizing:border-box}}
+ svg{{width:100%;height:100%;cursor:grab;user-select:none;background:#fbfbfc}}
+ svg.grab{{cursor:grabbing}}
+ .edge{{fill:none;stroke:#bcc4cc;stroke-width:1.5}}
+ .node text{{pointer-events:none;fill:#fff}}
+ .nlab{{font-weight:600}} .nsub{{fill:#eef;font-size:10px;opacity:.85}}
+ .edge.hi{{stroke:#111;stroke-width:2.5}}
+ .edge.dim,.node.dim{{opacity:.12}}
+ .node.hi rect{{stroke:#111;stroke-width:3}}
+</style>
+<div id=bar>
+ <b>{esc(os.path.basename(os.path.dirname(os.path.abspath(main_path))))}</b>
+ <span>{len(nodes)} nodes · {len(edges)} edges</span>
+ <input id=f placeholder="filter by op / var…">
+ <span id=hint style="color:#888">drag=pan · wheel=zoom · hover=edges · click=lineage · esc=reset</span>
+ <span class=leg>{esc(legend)}</span>
+</div>
+<div id=wrap>
+<svg id=svg viewBox="-20 -20 {max_x} {max_y}">
+<g id=scene>
+<g id=edges>{''.join(edge_svg)}</g>
+<g id=nodes>{''.join(node_svg)}</g>
+</g>
+</svg>
+</div>
+<script>
+const EDGES = {edge_json};
+const svg = document.getElementById('svg');
+const succ = {{}}, pred = {{}};
+for (const [s,t] of EDGES) {{ (succ[s]=succ[s]||[]).push(t); (pred[t]=pred[t]||[]).push(s); }}
+const nodeEls = [...document.querySelectorAll('.node')];
+const edgeEls = [...document.querySelectorAll('.edge')];
+const nodeById = {{}}; nodeEls.forEach(e => nodeById[e.dataset.id]=e);
+
+// ---- pan / zoom via viewBox ----
+let vb = svg.getAttribute('viewBox').split(' ').map(Number); // x,y,w,h
+function setVB(){{ svg.setAttribute('viewBox', vb.join(' ')); }}
+svg.addEventListener('wheel', e => {{
+  e.preventDefault();
+  const r = svg.getBoundingClientRect();
+  const mx = vb[0] + (e.clientX-r.left)/r.width*vb[2];
+  const my = vb[1] + (e.clientY-r.top)/r.height*vb[3];
+  const k = e.deltaY>0 ? 1.1 : 1/1.1;
+  vb[0]=mx-(mx-vb[0])*k; vb[1]=my-(my-vb[1])*k; vb[2]*=k; vb[3]*=k; setVB();
+}}, {{passive:false}});
+let drag=null;
+svg.addEventListener('mousedown', e => {{ if(e.target.closest('.node'))return;
+  drag={{x:e.clientX,y:e.clientY,vx:vb[0],vy:vb[1]}}; svg.classList.add('grab'); }});
+addEventListener('mousemove', e => {{ if(!drag)return;
+  const r=svg.getBoundingClientRect();
+  vb[0]=drag.vx-(e.clientX-drag.x)/r.width*vb[2];
+  vb[1]=drag.vy-(e.clientY-drag.y)/r.height*vb[3]; setVB(); }});
+addEventListener('mouseup', ()=>{{ drag=null; svg.classList.remove('grab'); }});
+
+// ---- highlight ----
+function clear(){{ [...nodeEls,...edgeEls].forEach(e=>e.classList.remove('hi','dim')); }}
+function highlightNeighbors(id){{
+  clear();
+  const keep=new Set([id]);
+  (succ[id]||[]).forEach(t=>keep.add(t)); (pred[id]||[]).forEach(s=>keep.add(s));
+  nodeEls.forEach(e=>e.classList.toggle('dim', !keep.has(+e.dataset.id)));
+  nodeById[id].classList.add('hi');
+  edgeEls.forEach(e=>{{ const s=+e.dataset.s,t=+e.dataset.t;
+    if(s===id||t===id){{e.classList.add('hi');}} else {{e.classList.add('dim');}} }});
+}}
+function lineage(id){{
+  const up=new Set(), dn=new Set(); let st=[id];
+  while(st.length){{const n=st.pop(); (pred[n]||[]).forEach(p=>{{if(!up.has(p)){{up.add(p);st.push(p);}}}});}}
+  st=[id]; while(st.length){{const n=st.pop(); (succ[n]||[]).forEach(s=>{{if(!dn.has(s)){{dn.add(s);st.push(s);}}}});}}
+  const keep=new Set([id,...up,...dn]); clear();
+  nodeEls.forEach(e=>{{const i=+e.dataset.id; if(!keep.has(i))e.classList.add('dim'); else if(i===id)e.classList.add('hi');}});
+  edgeEls.forEach(e=>{{const s=+e.dataset.s,t=+e.dataset.t;
+    if(keep.has(s)&&keep.has(t))e.classList.add('hi'); else e.classList.add('dim');}});
+}}
+let pinned=null;
+nodeEls.forEach(e=>{{
+  const id=+e.dataset.id;
+  e.addEventListener('mouseenter',()=>{{ if(pinned===null) highlightNeighbors(id); }});
+  e.addEventListener('mouseleave',()=>{{ if(pinned===null) clear(); }});
+  e.addEventListener('click',ev=>{{ ev.stopPropagation();
+    if(pinned===id){{pinned=null;clear();}} else {{pinned=id;lineage(id);}} }});
+}});
+svg.addEventListener('click',()=>{{ if(pinned!==null){{pinned=null;clear();}} }});
+addEventListener('keydown',e=>{{ if(e.key==='Escape'){{pinned=null;clear();}} }});
+
+// ---- filter ----
+document.getElementById('f').addEventListener('input',function(){{
+  const q=this.value.toLowerCase(); pinned=null;
+  nodeEls.forEach(e=>{{
+    const t=(e.querySelector('title').textContent+' '+e.textContent).toLowerCase();
+    e.classList.toggle('dim', q!=='' && !t.includes(q));
+  }});
+  edgeEls.forEach(e=>e.classList.remove('hi','dim'));
+}});
+</script>"""
+
+    with open(out_path, "w") as f:
+        f.write(doc)
+    return len(nodes), len(edges)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("path")
+    ap.add_argument("-o", "--out")
+    ap.add_argument("--mlir")
+    args = ap.parse_args()
+
+    tr = build_trace(args.path, args.mlir)
+    out_path = args.out or os.path.join(
+        os.path.dirname(os.path.abspath(args.path)), "graph.html")
+    n, e = render(tr, args.path, out_path)
+    note = "" if tr["has_shapes"] else "  (no ttnn.mlir -> shapes blank)"
+    print(f"wrote {out_path}  ({n} nodes, {e} edges){note}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/codegen_trace_graph_template.html
+++ b/scripts/codegen_trace_graph_template.html
@@ -1,0 +1,102 @@
+<!doctype html><meta charset=utf-8>
+<title>Dataflow graph</title>
+<style>
+ html,body{margin:0;height:100%;font:13px ui-monospace,Menlo,Consolas,monospace;background:#fff;color:#111}
+ #bar{padding:6px 10px;border-bottom:1px solid #ddd;display:flex;gap:12px;align-items:center;flex-wrap:wrap}
+ #bar b{font-weight:600} #bar .leg{color:#666;font-size:11px}
+ input{font:inherit;padding:3px 6px;width:220px}
+ #wrap{position:absolute;top:0;left:0;right:0;bottom:0;padding-top:38px;box-sizing:border-box}
+ svg{width:100%;height:100%;cursor:grab;user-select:none;background:#fbfbfc}
+ svg.grab{cursor:grabbing}
+ .band{opacity:.85}
+ .blab{fill:#8a94a0;font-size:12px;font-weight:700;letter-spacing:.12em}
+ .edge{fill:none;stroke:#c2cad2;stroke-width:1.5}
+ .node text{pointer-events:none}
+ .nop{fill:#fff;font-weight:700}
+ .nvar{fill:#fff;opacity:.72;font-size:10px}
+ .nshape{fill:#eaf6ff;font-size:10px}
+ .edge.hi{stroke:#111;stroke-width:2.5}
+ .edge.dim,.node.dim{opacity:.1}
+ .node.hi rect{stroke:#111;stroke-width:3.5}
+</style>
+<div id=bar>
+ <b><!--__NAME__--></b>
+ <span><!--__STATS__--></span>
+ <input id=f placeholder="filter by op / var…">
+ <span id=hint style="color:#888">drag=pan · wheel=zoom · hover=edges · click=lineage · esc=reset</span>
+ <span class=leg><!--__LEGEND__--></span>
+</div>
+<div id=wrap>
+<svg id=svg viewBox="__VIEWBOX__">
+<g id=scene>
+<g id=bands pointer-events="none"><!--__BANDS__--></g>
+<g id=edges><!--__EDGES__--></g>
+<g id=nodes><!--__NODES__--></g>
+</g>
+</svg>
+</div>
+<script>
+const EDGES = /*__EDGES__*/;
+const svg = document.getElementById('svg');
+const succ = {}, pred = {};
+for (const [s,t] of EDGES) { (succ[s]=succ[s]||[]).push(t); (pred[t]=pred[t]||[]).push(s); }
+const nodeEls = [...document.querySelectorAll('.node')];
+const edgeEls = [...document.querySelectorAll('.edge')];
+const nodeById = {}; nodeEls.forEach(e => nodeById[e.dataset.id]=e);
+
+let vb = svg.getAttribute('viewBox').split(' ').map(Number);
+function setVB(){ svg.setAttribute('viewBox', vb.join(' ')); }
+svg.addEventListener('wheel', e => {
+  e.preventDefault();
+  const r = svg.getBoundingClientRect();
+  const mx = vb[0] + (e.clientX-r.left)/r.width*vb[2];
+  const my = vb[1] + (e.clientY-r.top)/r.height*vb[3];
+  const k = e.deltaY>0 ? 1.1 : 1/1.1;
+  vb[0]=mx-(mx-vb[0])*k; vb[1]=my-(my-vb[1])*k; vb[2]*=k; vb[3]*=k; setVB();
+}, {passive:false});
+let drag=null;
+svg.addEventListener('mousedown', e => { if(e.target.closest('.node'))return;
+  drag={x:e.clientX,y:e.clientY,vx:vb[0],vy:vb[1]}; svg.classList.add('grab'); });
+addEventListener('mousemove', e => { if(!drag)return;
+  const r=svg.getBoundingClientRect();
+  vb[0]=drag.vx-(e.clientX-drag.x)/r.width*vb[2];
+  vb[1]=drag.vy-(e.clientY-drag.y)/r.height*vb[3]; setVB(); });
+addEventListener('mouseup', ()=>{ drag=null; svg.classList.remove('grab'); });
+
+function clear(){ [...nodeEls,...edgeEls].forEach(e=>e.classList.remove('hi','dim')); }
+function neighbors(id){
+  clear(); const keep=new Set([id]);
+  (succ[id]||[]).forEach(t=>keep.add(t)); (pred[id]||[]).forEach(s=>keep.add(s));
+  nodeEls.forEach(e=>e.classList.toggle('dim', !keep.has(+e.dataset.id)));
+  nodeById[id].classList.add('hi');
+  edgeEls.forEach(e=>{const s=+e.dataset.s,t=+e.dataset.t;
+    e.classList.add(s===id||t===id?'hi':'dim');});
+}
+function lineage(id){
+  const up=new Set(),dn=new Set(); let st=[id];
+  while(st.length){const n=st.pop();(pred[n]||[]).forEach(p=>{if(!up.has(p)){up.add(p);st.push(p);}});}
+  st=[id]; while(st.length){const n=st.pop();(succ[n]||[]).forEach(s=>{if(!dn.has(s)){dn.add(s);st.push(s);}});}
+  const keep=new Set([id,...up,...dn]); clear();
+  nodeEls.forEach(e=>{const i=+e.dataset.id; if(!keep.has(i))e.classList.add('dim'); else if(i===id)e.classList.add('hi');});
+  edgeEls.forEach(e=>{const s=+e.dataset.s,t=+e.dataset.t;
+    e.classList.add(keep.has(s)&&keep.has(t)?'hi':'dim');});
+}
+let pinned=null;
+nodeEls.forEach(e=>{ const id=+e.dataset.id;
+  e.addEventListener('mouseenter',()=>{ if(pinned===null) neighbors(id); });
+  e.addEventListener('mouseleave',()=>{ if(pinned===null) clear(); });
+  e.addEventListener('click',ev=>{ ev.stopPropagation();
+    if(pinned===id){pinned=null;clear();} else {pinned=id;lineage(id);} });
+});
+svg.addEventListener('click',()=>{ if(pinned!==null){pinned=null;clear();} });
+addEventListener('keydown',e=>{ if(e.key==='Escape'){pinned=null;clear();} });
+
+document.getElementById('f').addEventListener('input',function(){
+  const q=this.value.toLowerCase(); pinned=null;
+  nodeEls.forEach(e=>{
+    const t=(e.querySelector('title').textContent+' '+e.textContent).toLowerCase();
+    e.classList.toggle('dim', q!=='' && !t.includes(q));
+  });
+  edgeEls.forEach(e=>e.classList.remove('hi','dim'));
+});
+</script>

--- a/scripts/codegen_trace_table.py
+++ b/scripts/codegen_trace_table.py
@@ -12,6 +12,7 @@ a live filter box.
 
 Usage:
     codegen_trace_table.py <path/to/main.py> [-o out.html] [--mlir ttnn.mlir]
+                           [--no-plumbing]
 
 Shapes are pulled from ttnn.mlir (auto-detected as a sibling of main.py). main.py
 and ttnn.mlir are both linear traces of the same IR, so the k-th occurrence of an
@@ -34,6 +35,9 @@ NAME_MAP = {
 }
 # ops whose result shape == shape of their first tensor operand (no MLIR result)
 PASSTHROUGH = {"to_device", "to_layout", "to_memory_config", "paged_update_cache"}
+# pure shape/layout/movement ops hidden by --no-plumbing (matches the graph tool)
+PLUMBING = {"to_device", "to_layout", "from_device", "to_memory_config",
+            "typecast", "reshape"}
 
 
 def pretty_arg_name(raw):
@@ -241,6 +245,10 @@ def main():
     ap.add_argument("-o", "--out")
     ap.add_argument("--mlir", help="ttnn.mlir to source tensor shapes from "
                                    "(default: sibling ttnn.mlir)")
+    ap.add_argument("--no-plumbing", action="store_true",
+                    help="hide plumbing ops (to_device/to_layout/from_device/"
+                         "to_memory_config/typecast/reshape); rewire kept ops' "
+                         "inputs through the folded ops")
     args = ap.parse_args()
 
     tr = build_trace(args.path, args.mlir)
@@ -253,9 +261,47 @@ def main():
     shape_hits, shape_misses = tr["shape_hits"], tr["shape_misses"]
     out_set = set(outputs)
 
+    # optional: hide plumbing ops, rewiring kept ops' inputs through the folded
+    # plumbing to the nearest real (non-plumbing) producer var.
+    def bare(op):
+        return op.rsplit(".", 1)[-1] if op else op
+    producer = {r[1]: r for r in rows}          # out var -> row
+    plumb_vars = {r[1] for r in rows if bare(r[2]) in PLUMBING}
+    display = rows
+    if args.no_plumbing:
+        memo = {}
+        def kept_srcs(var, seen=None):
+            if var in memo:
+                return memo[var]
+            seen = seen or set()
+            if var in seen:
+                return []
+            seen.add(var)
+            r = producer.get(var)
+            if r is None or bare(r[2]) not in PLUMBING:
+                res = [var]                     # leaf (input[i]) or real producer
+            else:
+                res = []
+                for inp in r[3]:
+                    for s in kept_srcs(inp, seen):
+                        if s not in res:
+                            res.append(s)
+            memo[var] = res
+            return res
+        display = []
+        for step, out, op, inputs, dtype, layout, mem, shape in rows:
+            if bare(op) in PLUMBING:
+                continue
+            new_inputs = []
+            for inp in inputs:
+                for s in kept_srcs(inp):
+                    if s not in new_inputs:
+                        new_inputs.append(s)
+            display.append([step, out, op, new_inputs, dtype, layout, mem, shape])
+
     # ---- emit HTML ----
     op_counts = {}
-    for r in rows:
+    for r in display:
         op_counts[r[2]] = op_counts.get(r[2], 0) + 1
 
     def esc(x):
@@ -286,8 +332,10 @@ def main():
                   + (f' ({shape_misses} unknown)' if shape_misses else '')
                   + f' from {esc(os.path.basename(mlir_path))}'
                   if op_shapes else ' &middot; no MLIR shapes')
+    op_count_note = (f'{len(display)} ops (of {len(rows)}, plumbing hidden)'
+                     if args.no_plumbing else f'{len(rows)} ops')
     parts.append(f'<div class=meta>{esc(os.path.abspath(args.path))} &middot; '
-                 f'{len(rows)} ops &middot; {len(outputs)} outputs{shape_note}<br>'
+                 f'{op_count_note} &middot; {len(outputs)} outputs{shape_note}<br>'
                  + " &middot; ".join(f"{esc(k.replace('ttnn.',''))}:{v}"
                                      for k, v in sorted(op_counts.items(), key=lambda x: -x[1]))
                  + "</div>")
@@ -312,10 +360,12 @@ def main():
             return f'<span class=in title="{title}">{esc(i)}</span>{name_html}'
         return f'<span class=in>{esc(i)}</span>'
 
-    for step, out, op, inputs, dtype, layout, mem, shape in rows:
+    for step, out, op, inputs, dtype, layout, mem, shape in display:
         opshort = op.replace("ttnn.", "")
         ins = ", ".join(render_input(i) for i in inputs)
-        frees = ", ".join(f'<span class=free>{esc(v)}</span>' for v in freed_at.get(step, []))
+        frees = ", ".join(f'<span class=free>{esc(v)}</span>'
+                          for v in freed_at.get(step, [])
+                          if not (args.no_plumbing and v in plumb_vars))
         out_cls = " class=out" if out in out_set else ""
         if shape:
             dims, _, stype = shape.partition("·")

--- a/scripts/codegen_trace_table.py
+++ b/scripts/codegen_trace_table.py
@@ -40,6 +40,7 @@ def load_template(name):
 # main.py op name -> MLIR op name
 NAME_MAP = {
     "slice": "slice_static",
+    "batch_norm": "batch_norm_inference",
     "paged_scaled_dot_product_attention_decode": "paged_scaled_dot_product_attention_decode",
     "paged_update_cache": "paged_update_cache",
 }

--- a/scripts/codegen_trace_table.py
+++ b/scripts/codegen_trace_table.py
@@ -101,7 +101,7 @@ def parse_mlir_shapes(path):
     op_shapes = defaultdict(list)
     # result-producing ops:  %N = "ttnn.NAME"(...) ... -> tensor<DIMSxDTYPE,
     for m in re.finditer(
-        r'%\d+ = "ttnn\.([a-z_]+)"\(.*?->\s*tensor<([0-9x]+)x([a-z0-9_]+)[,>]',
+        r'%\d+ = "ttnn\.([a-z0-9_]+)"\(.*?->\s*tensor<([0-9x]+)x([a-z0-9_]+)[,>]',
         text,
     ):
         op_shapes[m.group(1)].append(f"{m.group(2)}·{m.group(3)}")

--- a/scripts/codegen_trace_table.py
+++ b/scripts/codegen_trace_table.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Render a TTNN codegen graph's main.py as a plain HTML table of computation steps.
+
+Each row is one ttnn op in execution order, with its output tensor, inputs,
+result shape (sourced from the sibling ttnn.mlir), dtype/layout/memory, and the
+tensors it deallocates. Produces a self-contained, dependency-free HTML file with
+a live filter box.
+
+Usage:
+    codegen_trace_table.py <path/to/main.py> [-o out.html] [--mlir ttnn.mlir]
+
+Shapes are pulled from ttnn.mlir (auto-detected as a sibling of main.py). main.py
+and ttnn.mlir are both linear traces of the same IR, so the k-th occurrence of an
+op in one matches the k-th in the other; shape-preserving ops (to_device,
+to_layout, to_memory_config, paged_update_cache) inherit their input's shape.
+"""
+import argparse
+import ast
+import html
+import os
+import re
+from collections import defaultdict
+
+
+# main.py op name -> MLIR op name
+NAME_MAP = {
+    "slice": "slice_static",
+    "paged_scaled_dot_product_attention_decode": "paged_scaled_dot_product_attention_decode",
+    "paged_update_cache": "paged_update_cache",
+}
+# ops whose result shape == shape of their first tensor operand (no MLIR result)
+PASSTHROUGH = {"to_device", "to_layout", "to_memory_config", "paged_update_cache"}
+
+
+def pretty_arg_name(raw):
+    """Turn a raw ttir.name into a short readable label."""
+    if not raw:
+        return ""
+    if "kv_cache" in raw:
+        lm = re.search(r"layers_(\d+)", raw)
+        km = re.search(r"(kv_cache_\d+)", raw)
+        if lm and km:
+            return f"layers.{lm.group(1)}.{km.group(1)}"
+    s = re.sub(r"^L__self___(model_)+", "", raw)   # drop L__self___model_model_
+    s = re.sub(r"^model_", "", s)
+    return s
+
+
+def parse_mlir_shapes(path):
+    """Return (arg_info, op_shapes) where op_shapes maps mlir_op_name -> list of
+    result shape-strings in program order, and arg_info is an ordered list (by %argN)
+    of dicts: {shape, name, label, kind}."""
+    text = open(path).read()
+    # func signature: capture ordered %argN with tensor type + attribute block
+    sig = re.search(r"func\.func @main\((.*?)\)\s", text, re.S)
+    arg_info = []
+    if sig:
+        for m in re.finditer(
+            r"%arg\d+:\s*tensor<([0-9x]+)x([a-z0-9_]+),[^{]*\{([^}]*)\}", sig.group(1)
+        ):
+            attrs = m.group(3)
+            nm = re.search(r'ttir\.name = "([^"]*)"', attrs)
+            name = nm.group(1) if nm else ""
+            kd = re.search(r"argument_type<(\w+)>", attrs)
+            kind = kd.group(1) if kd else ""
+            if "kv_cache" in attrs:
+                kind = "kv_cache"
+            arg_info.append({
+                "shape": f"{m.group(1)}·{m.group(2)}",
+                "name": name,
+                "label": pretty_arg_name(name),
+                "kind": kind,
+            })
+
+    op_shapes = defaultdict(list)
+    # result-producing ops:  %N = "ttnn.NAME"(...) ... -> tensor<DIMSxDTYPE,
+    for m in re.finditer(
+        r'%\d+ = "ttnn\.([a-z_]+)"\(.*?->\s*tensor<([0-9x]+)x([a-z0-9_]+)[,>]',
+        text,
+    ):
+        op_shapes[m.group(1)].append(f"{m.group(2)}·{m.group(3)}")
+    return arg_info, op_shapes
+
+
+def unparse_short(node, maxlen=48):
+    try:
+        s = ast.unparse(node)
+    except Exception:
+        s = "<?>"
+    s = " ".join(s.split())
+    return s if len(s) <= maxlen else s[: maxlen - 1] + "…"
+
+
+def call_name(call):
+    """Return e.g. 'ttnn.matmul' for a Call node, or None."""
+    f = call.func
+    parts = []
+    while isinstance(f, ast.Attribute):
+        parts.append(f.attr)
+        f = f.value
+    if isinstance(f, ast.Name):
+        parts.append(f.id)
+    return ".".join(reversed(parts)) if parts else None
+
+
+def referenced_vars(node, defined):
+    """Collect input references: prior variables and input[i] subscripts."""
+    refs = []
+    seen = set()
+    for n in ast.walk(node):
+        if isinstance(n, ast.Subscript) and isinstance(n.value, ast.Name):
+            key = ast.unparse(n)
+            if n.value.id == "input" and key not in seen:
+                seen.add(key)
+                refs.append(key)
+        elif isinstance(n, ast.Name) and n.id in defined and n.id not in seen:
+            seen.add(n.id)
+            refs.append(n.id)
+    return refs
+
+
+def kw_summary(call):
+    """Pull dtype / layout / memory kind out of keyword args."""
+    dtype = layout = mem = ""
+    for kw in call.keywords:
+        val = ast.unparse(kw.value) if kw.value is not None else ""
+        if kw.arg == "dtype":
+            dtype = val.replace("ttnn.DataType.", "")
+        elif kw.arg == "memory_config":
+            if "L1" in val:
+                mem = "L1"
+            elif "DRAM" in val:
+                mem = "DRAM"
+    # layout appears as positional (ttnn.Layout.TILE) or keyword
+    txt = ast.unparse(call)
+    if "Layout.TILE" in txt:
+        layout = "TILE"
+    elif "Layout.ROW_MAJOR" in txt:
+        layout = "ROW_MAJOR"
+    return dtype, layout, mem
+
+
+def build_trace(main_path, mlir_path=None):
+    """Parse a codegen main.py (and its sibling ttnn.mlir) into an ordered op trace.
+
+    Returns a dict with:
+      rows       : list of [step, out, op, inputs, dtype, layout, mem, shape]
+      arg_info   : ordered per-%argN metadata (shape/name/label/kind)
+      outputs    : vars returned by forward()
+      freed_at   : {step: [vars deallocated right after that step]}
+      var_shapes : {var: shape-string}
+      mlir_path, has_shapes, shape_hits, shape_misses
+    """
+    tree = ast.parse(open(main_path).read())
+    fn = next(n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "forward")
+
+    if mlir_path is None:
+        mlir_path = os.path.join(os.path.dirname(os.path.abspath(main_path)), "ttnn.mlir")
+    arg_info, op_shapes = ([], {})
+    if os.path.exists(mlir_path):
+        arg_info, op_shapes = parse_mlir_shapes(mlir_path)
+    op_cursor = defaultdict(int)     # mlir_op_name -> next occurrence index to consume
+    var_shapes = {}                  # main.py var -> shape string
+    shape_hits = shape_misses = 0
+
+    def bare_op(op):
+        return op.rsplit(".", 1)[-1] if op else op
+
+    def first_operand_shape(inputs):
+        for i in inputs:
+            m = re.fullmatch(r"input\[(\d+)\]", i)
+            if m:
+                idx = int(m.group(1))
+                if idx < len(arg_info):
+                    return arg_info[idx]["shape"]
+            elif i in var_shapes:
+                return var_shapes[i]
+        return ""
+
+    def resolve_shape(op, out, inputs):
+        b = bare_op(op)
+        if b in PASSTHROUGH:
+            return first_operand_shape(inputs)
+        mlir_name = NAME_MAP.get(b, b)
+        lst = op_shapes.get(mlir_name)
+        if lst is not None and op_cursor[mlir_name] < len(lst):
+            s = lst[op_cursor[mlir_name]]
+            op_cursor[mlir_name] += 1
+            return s
+        return first_operand_shape(inputs)  # fallback
+
+    defined = set()
+    rows = []
+    deallocs = {}      # var -> step at which it is freed
+    outputs = []
+
+    step = 0
+    for stmt in fn.body:
+        if isinstance(stmt, ast.Assign) and isinstance(stmt.value, ast.Call):
+            op = call_name(stmt.value) or "?"
+            target = stmt.targets[0]
+            out = target.id if isinstance(target, ast.Name) else ast.unparse(target)
+            inputs = referenced_vars(stmt.value, defined)
+            dtype, layout, mem = kw_summary(stmt.value)
+            shape = resolve_shape(op, out, inputs)
+            if shape:
+                shape_hits += 1
+                var_shapes[out] = shape
+            else:
+                shape_misses += 1
+            step += 1
+            rows.append([step, out, op, inputs, dtype, layout, mem, shape])
+            defined.add(out)
+        elif isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
+            if call_name(stmt.value) == "ttnn.deallocate" and stmt.value.args:
+                a = stmt.value.args[0]
+                if isinstance(a, ast.Name):
+                    deallocs[a.id] = step  # freed right after current step
+        elif isinstance(stmt, ast.Return):
+            outputs = referenced_vars(stmt.value, defined)
+
+    freed_at = {}  # step -> [vars freed just after that step]
+    for var, st in deallocs.items():
+        freed_at.setdefault(st, []).append(var)
+
+    return {
+        "rows": rows, "arg_info": arg_info, "outputs": outputs,
+        "freed_at": freed_at, "var_shapes": var_shapes, "mlir_path": mlir_path,
+        "has_shapes": bool(op_shapes),
+        "shape_hits": shape_hits, "shape_misses": shape_misses,
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("path")
+    ap.add_argument("-o", "--out")
+    ap.add_argument("--mlir", help="ttnn.mlir to source tensor shapes from "
+                                   "(default: sibling ttnn.mlir)")
+    args = ap.parse_args()
+
+    tr = build_trace(args.path, args.mlir)
+    rows = tr["rows"]
+    arg_info = tr["arg_info"]
+    outputs = tr["outputs"]
+    freed_at = tr["freed_at"]
+    mlir_path = tr["mlir_path"]
+    op_shapes = tr["has_shapes"]
+    shape_hits, shape_misses = tr["shape_hits"], tr["shape_misses"]
+    out_set = set(outputs)
+
+    # ---- emit HTML ----
+    op_counts = {}
+    for r in rows:
+        op_counts[r[2]] = op_counts.get(r[2], 0) + 1
+
+    def esc(x):
+        return html.escape(str(x))
+
+    parts = []
+    parts.append("""<!doctype html><meta charset=utf-8>
+<title>Compute trace</title>
+<style>
+ body{font:13px/1.4 ui-monospace,Menlo,Consolas,monospace;margin:1rem;color:#111;background:#fff}
+ h1{font-size:16px} .meta{color:#555;margin-bottom:.6rem}
+ input{font:inherit;padding:4px 6px;width:280px;margin-bottom:.6rem}
+ table{border-collapse:collapse;width:100%}
+ th,td{border:1px solid #ddd;padding:3px 6px;text-align:left;vertical-align:top}
+ th{position:sticky;top:0;background:#f4f4f4;cursor:default}
+ tbody tr:nth-child(even){background:#fafafa}
+ td.num{color:#999;text-align:right}
+ .op{font-weight:600}
+ .in{color:#06c} .free{color:#c00} .out{background:#fff6d5}
+ .argname{font-style:italic}
+ .k-parameter{color:#a0740a} .k-kv_cache{color:#8a2be2} .k-constant{color:#0a8a8a}
+ .k-input{color:#c0392b}
+ .shape{color:#093;white-space:nowrap} .stype{color:#787} .noshape{color:#bbb}
+ .t-matmul{color:#0a7} .t-rms_norm{color:#a60} .t-slice,.t-reshape{color:#777}
+</style>
+<h1>Computation trace</h1>""")
+    shape_note = (f' &middot; shapes: {shape_hits}/{len(rows)} resolved'
+                  + (f' ({shape_misses} unknown)' if shape_misses else '')
+                  + f' from {esc(os.path.basename(mlir_path))}'
+                  if op_shapes else ' &middot; no MLIR shapes')
+    parts.append(f'<div class=meta>{esc(os.path.abspath(args.path))} &middot; '
+                 f'{len(rows)} ops &middot; {len(outputs)} outputs{shape_note}<br>'
+                 + " &middot; ".join(f"{esc(k.replace('ttnn.',''))}:{v}"
+                                     for k, v in sorted(op_counts.items(), key=lambda x: -x[1]))
+                 + "</div>")
+    parts.append('<input id=f placeholder="filter rows (op name, var…)" '
+                 'oninput="var q=this.value.toLowerCase();'
+                 "for(var r of document.querySelectorAll('tbody tr'))"
+                 "r.style.display=r.textContent.toLowerCase().includes(q)?'':'none'\">")
+    parts.append("<table><thead><tr>"
+                 "<th>#</th><th>output</th><th>op</th><th>dims</th><th>type</th>"
+                 "<th>inputs</th>"
+                 "<th>dtype</th><th>layout</th><th>mem</th><th>frees</th>"
+                 "</tr></thead><tbody>")
+
+    def render_input(i):
+        m = re.fullmatch(r"input\[(\d+)\]", i)
+        if m and int(m.group(1)) < len(arg_info):
+            info = arg_info[int(m.group(1))]
+            label, kind = info["label"], info["kind"]
+            title = esc(info["name"] or "") + (f" [{esc(kind)}]" if kind else "")
+            name_html = (f' <span class="argname k-{esc(kind)}">{esc(label)}</span>'
+                         if label else "")
+            return f'<span class=in title="{title}">{esc(i)}</span>{name_html}'
+        return f'<span class=in>{esc(i)}</span>'
+
+    for step, out, op, inputs, dtype, layout, mem, shape in rows:
+        opshort = op.replace("ttnn.", "")
+        ins = ", ".join(render_input(i) for i in inputs)
+        frees = ", ".join(f'<span class=free>{esc(v)}</span>' for v in freed_at.get(step, []))
+        out_cls = " class=out" if out in out_set else ""
+        if shape:
+            dims, _, stype = shape.partition("·")
+            dims_html = f'<span class=shape>{esc(dims)}</span>'
+            stype_html = f'<span class=stype>{esc(stype)}</span>'
+        else:
+            dims_html = stype_html = '<span class=noshape>?</span>'
+        parts.append(
+            f"<tr><td class=num>{step}</td>"
+            f"<td{out_cls}>{esc(out)}</td>"
+            f'<td class="op t-{esc(opshort)}">{esc(opshort)}</td>'
+            f"<td>{dims_html}</td><td>{stype_html}</td>"
+            f"<td>{ins}</td><td>{esc(dtype)}</td><td>{esc(layout)}</td>"
+            f"<td>{esc(mem)}</td><td>{frees}</td></tr>")
+    parts.append("</tbody></table>")
+
+    out_path = args.out or os.path.join(os.path.dirname(os.path.abspath(args.path)), "trace.html")
+    with open(out_path, "w") as f:
+        f.write("".join(parts))
+    print(f"wrote {out_path}  ({len(rows)} rows)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/codegen_trace_table.py
+++ b/scripts/codegen_trace_table.py
@@ -26,7 +26,6 @@ import os
 import re
 from collections import defaultdict
 
-
 # main.py op name -> MLIR op name
 NAME_MAP = {
     "slice": "slice_static",
@@ -36,8 +35,14 @@ NAME_MAP = {
 # ops whose result shape == shape of their first tensor operand (no MLIR result)
 PASSTHROUGH = {"to_device", "to_layout", "to_memory_config", "paged_update_cache"}
 # pure shape/layout/movement ops hidden by --no-plumbing (matches the graph tool)
-PLUMBING = {"to_device", "to_layout", "from_device", "to_memory_config",
-            "typecast", "reshape"}
+PLUMBING = {
+    "to_device",
+    "to_layout",
+    "from_device",
+    "to_memory_config",
+    "typecast",
+    "reshape",
+}
 
 
 def pretty_arg_name(raw):
@@ -49,7 +54,7 @@ def pretty_arg_name(raw):
         km = re.search(r"(kv_cache_\d+)", raw)
         if lm and km:
             return f"layers.{lm.group(1)}.{km.group(1)}"
-    s = re.sub(r"^L__self___(model_)+", "", raw)   # drop L__self___model_model_
+    s = re.sub(r"^L__self___(model_)+", "", raw)  # drop L__self___model_model_
     s = re.sub(r"^model_", "", s)
     return s
 
@@ -73,12 +78,14 @@ def parse_mlir_shapes(path):
             kind = kd.group(1) if kd else ""
             if "kv_cache" in attrs:
                 kind = "kv_cache"
-            arg_info.append({
-                "shape": f"{m.group(1)}·{m.group(2)}",
-                "name": name,
-                "label": pretty_arg_name(name),
-                "kind": kind,
-            })
+            arg_info.append(
+                {
+                    "shape": f"{m.group(1)}·{m.group(2)}",
+                    "name": name,
+                    "label": pretty_arg_name(name),
+                    "kind": kind,
+                }
+            )
 
     op_shapes = defaultdict(list)
     # result-producing ops:  %N = "ttnn.NAME"(...) ... -> tensor<DIMSxDTYPE,
@@ -160,15 +167,19 @@ def build_trace(main_path, mlir_path=None):
       mlir_path, has_shapes, shape_hits, shape_misses
     """
     tree = ast.parse(open(main_path).read())
-    fn = next(n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "forward")
+    fn = next(
+        n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "forward"
+    )
 
     if mlir_path is None:
-        mlir_path = os.path.join(os.path.dirname(os.path.abspath(main_path)), "ttnn.mlir")
+        mlir_path = os.path.join(
+            os.path.dirname(os.path.abspath(main_path)), "ttnn.mlir"
+        )
     arg_info, op_shapes = ([], {})
     if os.path.exists(mlir_path):
         arg_info, op_shapes = parse_mlir_shapes(mlir_path)
-    op_cursor = defaultdict(int)     # mlir_op_name -> next occurrence index to consume
-    var_shapes = {}                  # main.py var -> shape string
+    op_cursor = defaultdict(int)  # mlir_op_name -> next occurrence index to consume
+    var_shapes = {}  # main.py var -> shape string
     shape_hits = shape_misses = 0
 
     def bare_op(op):
@@ -199,7 +210,7 @@ def build_trace(main_path, mlir_path=None):
 
     defined = set()
     rows = []
-    deallocs = {}      # var -> step at which it is freed
+    deallocs = {}  # var -> step at which it is freed
     outputs = []
 
     step = 0
@@ -232,10 +243,15 @@ def build_trace(main_path, mlir_path=None):
         freed_at.setdefault(st, []).append(var)
 
     return {
-        "rows": rows, "arg_info": arg_info, "outputs": outputs,
-        "freed_at": freed_at, "var_shapes": var_shapes, "mlir_path": mlir_path,
+        "rows": rows,
+        "arg_info": arg_info,
+        "outputs": outputs,
+        "freed_at": freed_at,
+        "var_shapes": var_shapes,
+        "mlir_path": mlir_path,
         "has_shapes": bool(op_shapes),
-        "shape_hits": shape_hits, "shape_misses": shape_misses,
+        "shape_hits": shape_hits,
+        "shape_misses": shape_misses,
     }
 
 
@@ -243,12 +259,17 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("path")
     ap.add_argument("-o", "--out")
-    ap.add_argument("--mlir", help="ttnn.mlir to source tensor shapes from "
-                                   "(default: sibling ttnn.mlir)")
-    ap.add_argument("--no-plumbing", action="store_true",
-                    help="hide plumbing ops (to_device/to_layout/from_device/"
-                         "to_memory_config/typecast/reshape); rewire kept ops' "
-                         "inputs through the folded ops")
+    ap.add_argument(
+        "--mlir",
+        help="ttnn.mlir to source tensor shapes from " "(default: sibling ttnn.mlir)",
+    )
+    ap.add_argument(
+        "--no-plumbing",
+        action="store_true",
+        help="hide plumbing ops (to_device/to_layout/from_device/"
+        "to_memory_config/typecast/reshape); rewire kept ops' "
+        "inputs through the folded ops",
+    )
     args = ap.parse_args()
 
     tr = build_trace(args.path, args.mlir)
@@ -265,11 +286,13 @@ def main():
     # plumbing to the nearest real (non-plumbing) producer var.
     def bare(op):
         return op.rsplit(".", 1)[-1] if op else op
-    producer = {r[1]: r for r in rows}          # out var -> row
+
+    producer = {r[1]: r for r in rows}  # out var -> row
     plumb_vars = {r[1] for r in rows if bare(r[2]) in PLUMBING}
     display = rows
     if args.no_plumbing:
         memo = {}
+
         def kept_srcs(var, seen=None):
             if var in memo:
                 return memo[var]
@@ -279,7 +302,7 @@ def main():
             seen.add(var)
             r = producer.get(var)
             if r is None or bare(r[2]) not in PLUMBING:
-                res = [var]                     # leaf (input[i]) or real producer
+                res = [var]  # leaf (input[i]) or real producer
             else:
                 res = []
                 for inp in r[3]:
@@ -288,6 +311,7 @@ def main():
                             res.append(s)
             memo[var] = res
             return res
+
         display = []
         for step, out, op, inputs, dtype, layout, mem, shape in rows:
             if bare(op) in PLUMBING:
@@ -308,7 +332,8 @@ def main():
         return html.escape(str(x))
 
     parts = []
-    parts.append("""<!doctype html><meta charset=utf-8>
+    parts.append(
+        """<!doctype html><meta charset=utf-8>
 <title>Compute trace</title>
 <style>
  body{font:13px/1.4 ui-monospace,Menlo,Consolas,monospace;margin:1rem;color:#111;background:#fff}
@@ -327,27 +352,42 @@ def main():
  .shape{color:#093;white-space:nowrap} .stype{color:#787} .noshape{color:#bbb}
  .t-matmul{color:#0a7} .t-rms_norm{color:#a60} .t-slice,.t-reshape{color:#777}
 </style>
-<h1>Computation trace</h1>""")
-    shape_note = (f' &middot; shapes: {shape_hits}/{len(rows)} resolved'
-                  + (f' ({shape_misses} unknown)' if shape_misses else '')
-                  + f' from {esc(os.path.basename(mlir_path))}'
-                  if op_shapes else ' &middot; no MLIR shapes')
-    op_count_note = (f'{len(display)} ops (of {len(rows)}, plumbing hidden)'
-                     if args.no_plumbing else f'{len(rows)} ops')
-    parts.append(f'<div class=meta>{esc(os.path.abspath(args.path))} &middot; '
-                 f'{op_count_note} &middot; {len(outputs)} outputs{shape_note}<br>'
-                 + " &middot; ".join(f"{esc(k.replace('ttnn.',''))}:{v}"
-                                     for k, v in sorted(op_counts.items(), key=lambda x: -x[1]))
-                 + "</div>")
-    parts.append('<input id=f placeholder="filter rows (op name, var…)" '
-                 'oninput="var q=this.value.toLowerCase();'
-                 "for(var r of document.querySelectorAll('tbody tr'))"
-                 "r.style.display=r.textContent.toLowerCase().includes(q)?'':'none'\">")
-    parts.append("<table><thead><tr>"
-                 "<th>#</th><th>inputs</th><th>op</th><th>layout</th><th>output</th>"
-                 "<th>dims</th><th>type</th>"
-                 "<th>dtype</th><th>mem</th><th>frees</th>"
-                 "</tr></thead><tbody>")
+<h1>Computation trace</h1>"""
+    )
+    shape_note = (
+        f" &middot; shapes: {shape_hits}/{len(rows)} resolved"
+        + (f" ({shape_misses} unknown)" if shape_misses else "")
+        + f" from {esc(os.path.basename(mlir_path))}"
+        if op_shapes
+        else " &middot; no MLIR shapes"
+    )
+    op_count_note = (
+        f"{len(display)} ops (of {len(rows)}, plumbing hidden)"
+        if args.no_plumbing
+        else f"{len(rows)} ops"
+    )
+    parts.append(
+        f"<div class=meta>{esc(os.path.abspath(args.path))} &middot; "
+        f"{op_count_note} &middot; {len(outputs)} outputs{shape_note}<br>"
+        + " &middot; ".join(
+            f"{esc(k.replace('ttnn.',''))}:{v}"
+            for k, v in sorted(op_counts.items(), key=lambda x: -x[1])
+        )
+        + "</div>"
+    )
+    parts.append(
+        '<input id=f placeholder="filter rows (op name, var…)" '
+        'oninput="var q=this.value.toLowerCase();'
+        "for(var r of document.querySelectorAll('tbody tr'))"
+        "r.style.display=r.textContent.toLowerCase().includes(q)?'':'none'\">"
+    )
+    parts.append(
+        "<table><thead><tr>"
+        "<th>#</th><th>inputs</th><th>op</th><th>layout</th><th>output</th>"
+        "<th>dims</th><th>type</th>"
+        "<th>dtype</th><th>mem</th><th>frees</th>"
+        "</tr></thead><tbody>"
+    )
 
     def render_input(i):
         m = re.fullmatch(r"input\[(\d+)\]", i)
@@ -355,24 +395,29 @@ def main():
             info = arg_info[int(m.group(1))]
             label, kind = info["label"], info["kind"]
             title = esc(info["name"] or "") + (f" [{esc(kind)}]" if kind else "")
-            name_html = (f' <span class="argname k-{esc(kind)}">{esc(label)}</span>'
-                         if label else "")
+            name_html = (
+                f' <span class="argname k-{esc(kind)}">{esc(label)}</span>'
+                if label
+                else ""
+            )
             return f'<span class=in title="{title}">{esc(i)}</span>{name_html}'
-        return f'<span class=in>{esc(i)}</span>'
+        return f"<span class=in>{esc(i)}</span>"
 
     for step, out, op, inputs, dtype, layout, mem, shape in display:
         opshort = op.replace("ttnn.", "")
         ins = ", ".join(render_input(i) for i in inputs)
-        frees = ", ".join(f'<span class=free>{esc(v)}</span>'
-                          for v in freed_at.get(step, [])
-                          if not (args.no_plumbing and v in plumb_vars))
+        frees = ", ".join(
+            f"<span class=free>{esc(v)}</span>"
+            for v in freed_at.get(step, [])
+            if not (args.no_plumbing and v in plumb_vars)
+        )
         out_cls = " class=out" if out in out_set else ""
         if shape:
             dims, _, stype = shape.partition("·")
-            dims_html = f'<span class=shape>{esc(dims)}</span>'
-            stype_html = f'<span class=stype>{esc(stype)}</span>'
+            dims_html = f"<span class=shape>{esc(dims)}</span>"
+            stype_html = f"<span class=stype>{esc(stype)}</span>"
         else:
-            dims_html = stype_html = '<span class=noshape>?</span>'
+            dims_html = stype_html = "<span class=noshape>?</span>"
         parts.append(
             f"<tr><td class=num>{step}</td>"
             f"<td>{ins}</td>"
@@ -381,10 +426,13 @@ def main():
             f"<td{out_cls}>{esc(out)}</td>"
             f"<td>{dims_html}</td><td>{stype_html}</td>"
             f"<td>{esc(dtype)}</td>"
-            f"<td>{esc(mem)}</td><td>{frees}</td></tr>")
+            f"<td>{esc(mem)}</td><td>{frees}</td></tr>"
+        )
     parts.append("</tbody></table>")
 
-    out_path = args.out or os.path.join(os.path.dirname(os.path.abspath(args.path)), "trace.html")
+    out_path = args.out or os.path.join(
+        os.path.dirname(os.path.abspath(args.path)), "trace.html"
+    )
     with open(out_path, "w") as f:
         f.write("".join(parts))
     print(f"wrote {out_path}  ({len(rows)} rows)")

--- a/scripts/codegen_trace_table.py
+++ b/scripts/codegen_trace_table.py
@@ -296,9 +296,9 @@ def main():
                  "for(var r of document.querySelectorAll('tbody tr'))"
                  "r.style.display=r.textContent.toLowerCase().includes(q)?'':'none'\">")
     parts.append("<table><thead><tr>"
-                 "<th>#</th><th>output</th><th>op</th><th>dims</th><th>type</th>"
-                 "<th>inputs</th>"
-                 "<th>dtype</th><th>layout</th><th>mem</th><th>frees</th>"
+                 "<th>#</th><th>inputs</th><th>op</th><th>layout</th><th>output</th>"
+                 "<th>dims</th><th>type</th>"
+                 "<th>dtype</th><th>mem</th><th>frees</th>"
                  "</tr></thead><tbody>")
 
     def render_input(i):
@@ -325,10 +325,12 @@ def main():
             dims_html = stype_html = '<span class=noshape>?</span>'
         parts.append(
             f"<tr><td class=num>{step}</td>"
-            f"<td{out_cls}>{esc(out)}</td>"
+            f"<td>{ins}</td>"
             f'<td class="op t-{esc(opshort)}">{esc(opshort)}</td>'
+            f"<td>{esc(layout)}</td>"
+            f"<td{out_cls}>{esc(out)}</td>"
             f"<td>{dims_html}</td><td>{stype_html}</td>"
-            f"<td>{ins}</td><td>{esc(dtype)}</td><td>{esc(layout)}</td>"
+            f"<td>{esc(dtype)}</td>"
             f"<td>{esc(mem)}</td><td>{frees}</td></tr>")
     parts.append("</tbody></table>")
 

--- a/scripts/codegen_trace_table.py
+++ b/scripts/codegen_trace_table.py
@@ -25,6 +25,17 @@ import html
 import os
 import re
 from collections import defaultdict
+from pathlib import Path
+
+
+def load_template(name):
+    """Read a page template shipped beside these scripts."""
+    path = Path(__file__).resolve().parent / name
+    try:
+        return path.read_text()
+    except OSError as e:
+        raise SystemExit(f"cannot read page template {path}: {e}")
+
 
 # main.py op name -> MLIR op name
 NAME_MAP = {
@@ -331,29 +342,6 @@ def main():
     def esc(x):
         return html.escape(str(x))
 
-    parts = []
-    parts.append(
-        """<!doctype html><meta charset=utf-8>
-<title>Compute trace</title>
-<style>
- body{font:13px/1.4 ui-monospace,Menlo,Consolas,monospace;margin:1rem;color:#111;background:#fff}
- h1{font-size:16px} .meta{color:#555;margin-bottom:.6rem}
- input{font:inherit;padding:4px 6px;width:280px;margin-bottom:.6rem}
- table{border-collapse:collapse;width:100%}
- th,td{border:1px solid #ddd;padding:3px 6px;text-align:left;vertical-align:top}
- th{position:sticky;top:0;background:#f4f4f4;cursor:default}
- tbody tr:nth-child(even){background:#fafafa}
- td.num{color:#999;text-align:right}
- .op{font-weight:600}
- .in{color:#06c} .free{color:#c00} .out{background:#fff6d5}
- .argname{font-style:italic}
- .k-parameter{color:#a0740a} .k-kv_cache{color:#8a2be2} .k-constant{color:#0a8a8a}
- .k-input{color:#c0392b}
- .shape{color:#093;white-space:nowrap} .stype{color:#787} .noshape{color:#bbb}
- .t-matmul{color:#0a7} .t-rms_norm{color:#a60} .t-slice,.t-reshape{color:#777}
-</style>
-<h1>Computation trace</h1>"""
-    )
     shape_note = (
         f" &middot; shapes: {shape_hits}/{len(rows)} resolved"
         + (f" ({shape_misses} unknown)" if shape_misses else "")
@@ -366,28 +354,15 @@ def main():
         if args.no_plumbing
         else f"{len(rows)} ops"
     )
-    parts.append(
-        f"<div class=meta>{esc(os.path.abspath(args.path))} &middot; "
+    meta_html = (
+        f"{esc(os.path.abspath(args.path))} &middot; "
         f"{op_count_note} &middot; {len(outputs)} outputs{shape_note}<br>"
         + " &middot; ".join(
             f"{esc(k.replace('ttnn.',''))}:{v}"
             for k, v in sorted(op_counts.items(), key=lambda x: -x[1])
         )
-        + "</div>"
     )
-    parts.append(
-        '<input id=f placeholder="filter rows (op name, var…)" '
-        'oninput="var q=this.value.toLowerCase();'
-        "for(var r of document.querySelectorAll('tbody tr'))"
-        "r.style.display=r.textContent.toLowerCase().includes(q)?'':'none'\">"
-    )
-    parts.append(
-        "<table><thead><tr>"
-        "<th>#</th><th>inputs</th><th>op</th><th>layout</th><th>output</th>"
-        "<th>dims</th><th>type</th>"
-        "<th>dtype</th><th>mem</th><th>frees</th>"
-        "</tr></thead><tbody>"
-    )
+    rows_html = []
 
     def render_input(i):
         m = re.fullmatch(r"input\[(\d+)\]", i)
@@ -418,7 +393,7 @@ def main():
             stype_html = f"<span class=stype>{esc(stype)}</span>"
         else:
             dims_html = stype_html = "<span class=noshape>?</span>"
-        parts.append(
+        rows_html.append(
             f"<tr><td class=num>{step}</td>"
             f"<td>{ins}</td>"
             f'<td class="op t-{esc(opshort)}">{esc(opshort)}</td>'
@@ -428,13 +403,17 @@ def main():
             f"<td>{esc(dtype)}</td>"
             f"<td>{esc(mem)}</td><td>{frees}</td></tr>"
         )
-    parts.append("</tbody></table>")
 
+    doc = (
+        load_template("codegen_trace_table_template.html")
+        .replace("<!--__META__-->", meta_html)
+        .replace("<!--__ROWS__-->", "".join(rows_html))
+    )
     out_path = args.out or os.path.join(
         os.path.dirname(os.path.abspath(args.path)), "trace.html"
     )
     with open(out_path, "w") as f:
-        f.write("".join(parts))
+        f.write(doc)
     print(f"wrote {out_path}  ({len(rows)} rows)")
 
 

--- a/scripts/codegen_trace_table.py
+++ b/scripts/codegen_trace_table.py
@@ -71,6 +71,17 @@ def pretty_arg_name(raw):
     return s
 
 
+def main_func_body(text):
+    """The body of @main. Const-eval helpers are separate funcs whose results
+    main.py's forward() never runs, so counting them breaks occurrence alignment."""
+    start = re.search(r"func\.func @main\(", text)
+    if not start:
+        return text
+    rest = text[start.end() :]
+    nxt = re.search(r"\n\s*func\.func ", rest)
+    return rest[: nxt.start()] if nxt else rest
+
+
 def parse_mlir_shapes(path):
     """Return (arg_info, op_shapes) where op_shapes maps mlir_op_name -> list of
     result shape-strings in program order, and arg_info is an ordered list (by %argN)
@@ -103,7 +114,7 @@ def parse_mlir_shapes(path):
     # result-producing ops:  %N = "ttnn.NAME"(...) ... -> tensor<DIMSxDTYPE,
     for m in re.finditer(
         r'%\d+ = "ttnn\.([a-z0-9_]+)"\(.*?->\s*tensor<([0-9x]+)x([a-z0-9_]+)[,>]',
-        text,
+        main_func_body(text),
     ):
         op_shapes[m.group(1)].append(f"{m.group(2)}·{m.group(3)}")
     return arg_info, op_shapes

--- a/scripts/codegen_trace_table_template.html
+++ b/scripts/codegen_trace_table_template.html
@@ -1,0 +1,30 @@
+<!doctype html><meta charset=utf-8>
+<title>Compute trace</title>
+<style>
+ body{font:13px/1.4 ui-monospace,Menlo,Consolas,monospace;margin:1rem;color:#111;background:#fff}
+ h1{font-size:16px} .meta{color:#555;margin-bottom:.6rem}
+ input{font:inherit;padding:4px 6px;width:280px;margin-bottom:.6rem}
+ table{border-collapse:collapse;width:100%}
+ th,td{border:1px solid #ddd;padding:3px 6px;text-align:left;vertical-align:top}
+ th{position:sticky;top:0;background:#f4f4f4;cursor:default}
+ tbody tr:nth-child(even){background:#fafafa}
+ td.num{color:#999;text-align:right}
+ .op{font-weight:600}
+ .in{color:#06c} .free{color:#c00} .out{background:#fff6d5}
+ .argname{font-style:italic}
+ .k-parameter{color:#a0740a} .k-kv_cache{color:#8a2be2} .k-constant{color:#0a8a8a}
+ .k-input{color:#c0392b}
+ .shape{color:#093;white-space:nowrap} .stype{color:#787} .noshape{color:#bbb}
+ .t-matmul{color:#0a7} .t-rms_norm{color:#a60} .t-slice,.t-reshape{color:#777}
+</style>
+<h1>Computation trace</h1>
+<div class=meta><!--__META__--></div>
+<input id=f placeholder="filter rows (op name, var…)" oninput="var q=this.value.toLowerCase();for(var r of document.querySelectorAll('tbody tr'))r.style.display=r.textContent.toLowerCase().includes(q)?'':'none'">
+<table>
+<thead><tr>
+<th>#</th><th>inputs</th><th>op</th><th>layout</th><th>output</th>
+<th>dims</th><th>type</th>
+<th>dtype</th><th>mem</th><th>frees</th>
+</tr></thead>
+<tbody><!--__ROWS__--></tbody>
+</table>

--- a/scripts/codegen_trace_tools.md
+++ b/scripts/codegen_trace_tools.md
@@ -85,8 +85,12 @@ dead-ends we already ruled out).
 - **Occurrence-index alignment**: `main.py` and `ttnn.mlir` are linear traces of
   the same IR in the same order, so the k-th occurrence of op X in `main.py` maps
   to the k-th `ttnn.X` result in the MLIR. `resolve_shape` consumes MLIR results
-  per-op via `op_cursor`. Validated at 100% coverage on qwen (2096 ops) and mnist
-  (41 ops).
+  per-op via `op_cursor`. The op-name pattern must allow digits (`conv2d`,
+  `max_pool2d`) — without them those ops match nothing in the MLIR.
+- **A miss is silent**: `resolve_shape` falls back to the first operand's shape and
+  still counts toward `shapes: N/N resolved`, so the header confirms every op got
+  *a* shape, not that it came from the MLIR. Check a known op against `ttnn.mlir`
+  when changing the alignment.
 - **`NAME_MAP`** bridges name mismatches between the two forms — currently
   `slice` (main.py) -> `slice_static` (MLIR). Add here when a new op's Python name
   differs from its MLIR spelling, or alignment silently drifts.

--- a/scripts/codegen_trace_tools.md
+++ b/scripts/codegen_trace_tools.md
@@ -7,29 +7,41 @@ SPDX-License-Identifier: Apache-2.0
 
 Two small, dependency-free tools for understanding a TTNN **codegen dump** — the
 per-graph `main.py` / `ttnn.mlir` folders that the emitpy codegen path produces
-(e.g. `resnet50_codegen/graph_0/`, `qwen_codegen/graph_N/`). Both read a graph's
+(e.g. `mnist_codegen/graph_0/`, `qwen_codegen/graph_N/`). Both read a graph's
 `main.py`, enrich it with tensor shapes from the sibling `ttnn.mlir`, and emit a
 single self-contained HTML file (no CDN, works offline and in sandboxed viewers).
 
 ## Producing a dump
 
-Any codegen example under `examples/pytorch/codegen/python/` emits one, but the
-tools parse the `forward(input, device)` entrypoint, which `codegen_py` only emits
-when asked:
+Set `TTXLA_CODEGEN_EXPORT_DIR` and run any example that compiles with the TT
+backend. The MNIST CNN gives a 27-op graph — small enough to read end to end,
+with convolutions and a classifier head:
+
+```bash
+TTXLA_CODEGEN_EXPORT_DIR=$PWD/mnist_codegen XLA_HLO_DEBUG=1 \
+    python examples/pytorch/mnist.py
+```
+
+The run exits non-zero on its own `PCC: nan` assertion. That is expected: emit is
+a dry run that returns zero-filled buffers, so the example's CPU comparison cannot
+pass. The dump under `mnist_codegen/graph_0/` is complete. `XLA_HLO_DEBUG=1` is
+what puts source locations in the IRs.
+
+The examples under `examples/pytorch/codegen/python/` call `codegen_py` directly
+and need `target_module`, because the tools parse the `forward(input, device)`
+entrypoint and `codegen_py` emits it only when asked:
 
 ```python
 codegen_py(model, x, export_path="resnet50_codegen",
            compiler_options={"target_module": True})
 ```
 
-Without `target_module` the dump is the standalone flavor — `_main(activations,
-weights)` plus tensor loaders — and both tools fail with `StopIteration`.
-`TTXLA_CODEGEN_EXPORT_DIR` sets `target_module` itself, so dumps captured that
-way (the vLLM examples, `tests/torch/codegen/`) need nothing extra.
+Without it the dump is the standalone `_main(activations, weights)` flavor plus
+tensor loaders, and both tools fail with `StopIteration`. The env var sets
+`target_module` itself, so that route needs nothing extra.
 
-Good starting points: `custom_module.py` for a minimal graph (18 ops),
-`resnet.py` for a conv-heavy one (436 ops), `graph_break.py` for a
-multi-graph dump.
+Other sizes: `custom_module.py` for a minimal graph (18 ops), `resnet.py` for a
+deep one (436 ops), `graph_break.py` for a multi-graph dump.
 
 ## Usage
 
@@ -53,7 +65,7 @@ python3 scripts/codegen_trace_graph.py <path>/main.py --no-collapse   # graph: o
   it deallocates. `input[i]` references are annotated with the arg's `ttir.name`
   (weight / kv_cache / constant / activation). Has a live filter box. Pass
   `--no-plumbing` to hide the six plumbing ops and rewire kept ops' inputs through
-  the folded ops (resnet50 436 -> 277 rows, qwen 2096 -> 1098); off by default so
+  the folded ops (mnist 27 -> 14 rows, qwen 2096 -> 1098); off by default so
   the table stays a faithful execution trace.
 - **`codegen_trace_graph.py`** — top-down layered dataflow DAG (SVG). Pan (drag),
   zoom (wheel), hover to highlight a node's edges, click to pin its full
@@ -113,7 +125,8 @@ dead-ends we already ruled out).
   when changing the alignment.
 - **Alignment holds only while both traces emit an op the same number of times, and
   that is a property of the graph, not a guarantee.** Verified aligned on the
-  ResNet-50 dump (436 ops) and on all 31 graphs of the vLLM Qwen3-0.6B dump,
+  MNIST (27 ops) and ResNet-50 (436 ops) dumps and on all 31 graphs of the vLLM
+  Qwen3-0.6B dump,
   including the 2203-op prefill graph. Drift is reachable, though: a Qwen3-0.6B prefill graph
   emitted through plain torch_xla + transformers instead of vLLM had the MLIR
   declaring 174 `reshape` results against 171 calls, 126 `typecast` against 115 and
@@ -131,9 +144,12 @@ dead-ends we already ruled out).
   `slice` -> `slice_static` and `batch_norm` -> `batch_norm_inference`. Add here
   when a new op's Python name differs from its MLIR spelling, or alignment
   silently drifts.
-- **Const-eval hoisting is invisible to the trace.** With it on, ResNet-50 puts 211
-  `main_const_eval_N` helpers and a `consteval_forward` beside `forward`; only
-  `forward` is parsed, so weight preprocessing does not appear as rows or nodes.
+- **Const-eval hoisting is scoped out, and must stay that way.** It emits
+  `main_const_eval_N` / `cpu_hoisted_const_eval_*` functions *ahead of* `@main` in
+  the MLIR (211 of them for ResNet-50, 6 for MNIST). `main_func_body()` restricts
+  the shape scan to `@main`; without it those results are consumed first and any op
+  appearing in both places draws a weight shape where an activation belongs.
+  The hoisted work is invisible in the trace either way — only `forward` is parsed.
 - **`PASSTHROUGH`** (`to_device`, `to_layout`, `to_memory_config`,
   `paged_update_cache`): ops with no MLIR result to align against. They inherit
   their first tensor operand's shape. `paged_update_cache` is void in the MLIR
@@ -146,14 +162,13 @@ dead-ends we already ruled out).
   attrs; `pretty_arg_name` shortens the torch module path and normalizes
   `kv_cache` names. Kind drives color (parameter / kv_cache / constant / input).
 - **Arg metadata depends on how the graph was captured, and can be absent
-  entirely.** The `codegen_py` dumps name everything (ResNet-50 268/268, e.g.
-  `resnet.encoder.stages.3.layers.0.shortcut.normalization.running_var`), and the
-  vLLM Qwen dump names 310/315 — only the 5 genuine runtime inputs are opaque. A
-  graph captured straight through `torch.compile(backend="tt")` can instead give
-  every arg `argument_type<input>` and an empty `ttir.name`, leaving weights
-  distinguishable from activations only by shape. `codegen_py` passes
-  `tt_legacy_compile` for this reason. Empty names are a property of the capture,
-  not a script bug.
+  entirely.** Dumps from the examples name everything (MNIST 9/9, ResNet-50
+  268/268, e.g. `resnet.encoder.stages.3.layers.0.shortcut.normalization.running_var`);
+  the vLLM Qwen dump names 310/315, leaving only the 5 genuine runtime inputs
+  opaque. A model driven straight as lazy tensors, with no `model.compile(...)`
+  to trace through, instead gives every arg `argument_type<input>` and an empty
+  `ttir.name`, leaving weights distinguishable from activations only by shape.
+  Empty names are a property of the capture, not a script bug.
 - **Deliberately NOT implemented: role inference for opaque inputs.** The 5 Qwen
   runtime inputs (`argNNN_1` placeholders) have no real name anywhere in the
   source. Their role *is* recoverable by walking to the first non-plumbing

--- a/scripts/codegen_trace_tools.md
+++ b/scripts/codegen_trace_tools.md
@@ -7,9 +7,29 @@ SPDX-License-Identifier: Apache-2.0
 
 Two small, dependency-free tools for understanding a TTNN **codegen dump** — the
 per-graph `main.py` / `ttnn.mlir` folders that the emitpy codegen path produces
-(e.g. `qwen_codegen/graph_N/`, `mnist_codegen/graph_0/`). Both read a graph's
+(e.g. `resnet50_codegen/graph_0/`, `qwen_codegen/graph_N/`). Both read a graph's
 `main.py`, enrich it with tensor shapes from the sibling `ttnn.mlir`, and emit a
 single self-contained HTML file (no CDN, works offline and in sandboxed viewers).
+
+## Producing a dump
+
+Any codegen example under `examples/pytorch/codegen/python/` emits one, but the
+tools parse the `forward(input, device)` entrypoint, which `codegen_py` only emits
+when asked:
+
+```python
+codegen_py(model, x, export_path="resnet50_codegen",
+           compiler_options={"target_module": True})
+```
+
+Without `target_module` the dump is the standalone flavor — `_main(activations,
+weights)` plus tensor loaders — and both tools fail with `StopIteration`.
+`TTXLA_CODEGEN_EXPORT_DIR` sets `target_module` itself, so dumps captured that
+way (the vLLM examples, `tests/torch/codegen/`) need nothing extra.
+
+Good starting points: `custom_module.py` for a minimal graph (18 ops),
+`resnet.py` for a conv-heavy one (436 ops), `graph_break.py` for a
+multi-graph dump.
 
 ## Usage
 
@@ -33,8 +53,8 @@ python3 scripts/codegen_trace_graph.py <path>/main.py --no-collapse   # graph: o
   it deallocates. `input[i]` references are annotated with the arg's `ttir.name`
   (weight / kv_cache / constant / activation). Has a live filter box. Pass
   `--no-plumbing` to hide the six plumbing ops and rewire kept ops' inputs through
-  the folded ops (mnist 41 -> 13 rows, qwen 2096 -> 1098); off by default so the
-  table stays a faithful execution trace.
+  the folded ops (resnet50 436 -> 277 rows, qwen 2096 -> 1098); off by default so
+  the table stays a faithful execution trace.
 - **`codegen_trace_graph.py`** — top-down layered dataflow DAG (SVG). Pan (drag),
   zoom (wheel), hover to highlight a node's edges, click to pin its full
   ancestor+descendant lineage, filter by op/var. Reuses `build_trace` from the
@@ -93,8 +113,8 @@ dead-ends we already ruled out).
   when changing the alignment.
 - **Alignment holds only while both traces emit an op the same number of times, and
   that is a property of the graph, not a guarantee.** Verified aligned on the
-  MNIST dump (41 ops) and on all 31 graphs of the vLLM Qwen3-0.6B dump, including
-  the 2203-op prefill graph. Drift is reachable, though: a Qwen3-0.6B prefill graph
+  ResNet-50 dump (436 ops) and on all 31 graphs of the vLLM Qwen3-0.6B dump,
+  including the 2203-op prefill graph. Drift is reachable, though: a Qwen3-0.6B prefill graph
   emitted through plain torch_xla + transformers instead of vLLM had the MLIR
   declaring 174 `reshape` results against 171 calls, 126 `typecast` against 115 and
   30 `where` against 28; the extras are not trailing, so every later occurrence took
@@ -103,12 +123,17 @@ dead-ends we already ruled out).
 - **`ttnn.reshape` carries its literal target dims in `main.py`**, which is the
   cheapest ground truth for checking alignment on a new dump — compare it against
   the resolved shape before trusting a graph the tools have not seen before.
-- **Function calls in `main.py` are not ttnn ops** (`transformer.concatenate_heads`,
+- **Function calls in `main.py` are not ttnn ops** (`consteval_forward` in the
+  ResNet dump; `transformer.concatenate_heads`,
   `transformer.chunked_scaled_dot_product_attention` in the vLLM dump). They have no
   MLIR result and fall back by design; a count mismatch for these is expected.
 - **`NAME_MAP`** bridges name mismatches between the two forms — currently
-  `slice` (main.py) -> `slice_static` (MLIR). Add here when a new op's Python name
-  differs from its MLIR spelling, or alignment silently drifts.
+  `slice` -> `slice_static` and `batch_norm` -> `batch_norm_inference`. Add here
+  when a new op's Python name differs from its MLIR spelling, or alignment
+  silently drifts.
+- **Const-eval hoisting is invisible to the trace.** With it on, ResNet-50 puts 211
+  `main_const_eval_N` helpers and a `consteval_forward` beside `forward`; only
+  `forward` is parsed, so weight preprocessing does not appear as rows or nodes.
 - **`PASSTHROUGH`** (`to_device`, `to_layout`, `to_memory_config`,
   `paged_update_cache`): ops with no MLIR result to align against. They inherit
   their first tensor operand's shape. `paged_update_cache` is void in the MLIR
@@ -120,14 +145,15 @@ dead-ends we already ruled out).
 - Names come from the MLIR arg signature's `ttir.name` + `argument_type<...>`
   attrs; `pretty_arg_name` shortens the torch module path and normalizes
   `kv_cache` names. Kind drives color (parameter / kv_cache / constant / input).
-- **Two export flavors seen, and they differ:**
-  - *Qwen* export carries full metadata — every arg has a `ttir.name` and a real
-    `argument_type` (parameter / constant / kv_cache / input). 310/315 args are
-    well-named; only the 5 genuine runtime inputs are opaque.
-  - *MNIST* export carries **none** — all 9 args are `argument_type<input>` with
-    empty `ttir.name`. So weights are indistinguishable from the real image input
-    except by shape (e.g. `32x1x3x3` = conv1 weight, `4x1x28x28` = the batch).
-    This is a property of how the graph was captured, not a script bug.
+- **Arg metadata depends on how the graph was captured, and can be absent
+  entirely.** The `codegen_py` dumps name everything (ResNet-50 268/268, e.g.
+  `resnet.encoder.stages.3.layers.0.shortcut.normalization.running_var`), and the
+  vLLM Qwen dump names 310/315 — only the 5 genuine runtime inputs are opaque. A
+  graph captured straight through `torch.compile(backend="tt")` can instead give
+  every arg `argument_type<input>` and an empty `ttir.name`, leaving weights
+  distinguishable from activations only by shape. `codegen_py` passes
+  `tt_legacy_compile` for this reason. Empty names are a property of the capture,
+  not a script bug.
 - **Deliberately NOT implemented: role inference for opaque inputs.** The 5 Qwen
   runtime inputs (`argNNN_1` placeholders) have no real name anywhere in the
   source. Their role *is* recoverable by walking to the first non-plumbing

--- a/scripts/codegen_trace_tools.md
+++ b/scripts/codegen_trace_tools.md
@@ -91,6 +91,21 @@ dead-ends we already ruled out).
   still counts toward `shapes: N/N resolved`, so the header confirms every op got
   *a* shape, not that it came from the MLIR. Check a known op against `ttnn.mlir`
   when changing the alignment.
+- **Alignment holds only while both traces emit an op the same number of times, and
+  that is a property of the graph, not a guarantee.** Verified aligned on the
+  MNIST dump (41 ops) and on all 31 graphs of the vLLM Qwen3-0.6B dump, including
+  the 2203-op prefill graph. Drift is reachable, though: a Qwen3-0.6B prefill graph
+  emitted through plain torch_xla + transformers instead of vLLM had the MLIR
+  declaring 174 `reshape` results against 171 calls, 126 `typecast` against 115 and
+  30 `where` against 28; the extras are not trailing, so every later occurrence took
+  an earlier op's shape and all 171 `reshape` shapes were wrong while the header
+  still read `2123/2124 resolved`.
+- **`ttnn.reshape` carries its literal target dims in `main.py`**, which is the
+  cheapest ground truth for checking alignment on a new dump — compare it against
+  the resolved shape before trusting a graph the tools have not seen before.
+- **Function calls in `main.py` are not ttnn ops** (`transformer.concatenate_heads`,
+  `transformer.chunked_scaled_dot_product_attention` in the vLLM dump). They have no
+  MLIR result and fall back by design; a count mismatch for these is expected.
 - **`NAME_MAP`** bridges name mismatches between the two forms — currently
   `slice` (main.py) -> `slice_static` (MLIR). Add here when a new op's Python name
   differs from its MLIR spelling, or alignment silently drifts.

--- a/scripts/codegen_trace_tools.md
+++ b/scripts/codegen_trace_tools.md
@@ -76,6 +76,10 @@ dead-ends we already ruled out).
   output works offline, in sandboxed viewers, and as a publishable Claude Artifact.
   The SVG graph hand-rolls pan/zoom/highlight in inline JS for the same reason —
   don't reach for d3/graphviz/cytoscape.
+- **Page chrome lives in `*_template.html` beside each script**, loaded via
+  `load_template()` and filled by replacing `<!--__NAME__-->` placeholders, matching
+  `scripts/telemetry/telemetry_viz.py`. Edit markup, CSS and the graph's JS in the
+  template; the scripts only generate rows and SVG fragments.
 
 ### Shape resolution (the subtle part)
 - **Occurrence-index alignment**: `main.py` and `ttnn.mlir` are linear traces of

--- a/scripts/codegen_trace_tools.md
+++ b/scripts/codegen_trace_tools.md
@@ -1,0 +1,52 @@
+<!--
+SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Codegen trace tools
+
+Two small, dependency-free tools for understanding a TTNN **codegen dump** — the
+per-graph `main.py` / `ttnn.mlir` folders that the emitpy codegen path produces
+(e.g. `qwen_codegen/graph_N/`, `mnist_codegen/graph_0/`). Both read a graph's
+`main.py`, enrich it with tensor shapes from the sibling `ttnn.mlir`, and emit a
+single self-contained HTML file (no CDN, works offline and in sandboxed viewers).
+
+## Usage
+
+```bash
+# table of computation steps  -> <graph>/trace.html
+python3 scripts/codegen_trace_table.py <path>/main.py
+
+# interactive dataflow graph  -> <graph>/graph.html
+python3 scripts/codegen_trace_graph.py <path>/main.py
+
+# shapes are auto-sourced from the sibling ttnn.mlir; override with:
+python3 scripts/codegen_trace_table.py <path>/main.py --mlir other/ttnn.mlir
+```
+
+- **`codegen_trace_table.py`** — one row per `ttnn` op in execution order: output
+  var, op, result dims + element type, inputs, dtype/layout/memory, and the tensors
+  it deallocates. `input[i]` references are annotated with the arg's `ttir.name`
+  (weight / kv_cache / constant / activation). Has a live filter box.
+- **`codegen_trace_graph.py`** — top-down layered dataflow DAG (SVG). Pan (drag),
+  zoom (wheel), hover to highlight a node's edges, click to pin its full
+  ancestor+descendant lineage, filter by op/var. Reuses `build_trace` from the
+  table script, so shape resolution is identical.
+
+## How shape resolution works
+
+`main.py` carries almost no shapes; `ttnn.mlir` carries them on every value.
+`main.py` and `ttnn.mlir` are both linear traces of the *same* IR in the same
+order, so the k-th occurrence of an op in one matches the k-th in the other — that
+alignment sources each op's result shape. Shape-preserving ops that codegen
+inserts and the MLIR doesn't emit as results (`to_device`, `to_layout`,
+`to_memory_config`, `paged_update_cache`) inherit their input operand's shape.
+Coverage is reported in the table header (`shapes: N/N resolved`).
+
+## Note on main.py vs ttnn.mlir
+
+The MLIR is the codegen **input**; `main.py` is the executed **output**. The
+compute ops match one-to-one, but codegen adds the execution layer — explicit
+host<->device transfers (`to_device`/`from_device`), layout casts, and the real
+deallocate schedule. So `main.py` is authoritative for *what runs*, while the MLIR
+is the richer semantic source (shapes, `ttir.name`s, sharding, source locations).

--- a/scripts/codegen_trace_tools.md
+++ b/scripts/codegen_trace_tools.md
@@ -50,3 +50,81 @@ compute ops match one-to-one, but codegen adds the execution layer — explicit
 host<->device transfers (`to_device`/`from_device`), layout casts, and the real
 deallocate schedule. So `main.py` is authoritative for *what runs*, while the MLIR
 is the richer semantic source (shapes, `ttir.name`s, sharding, source locations).
+
+## Design decisions & rationale
+
+Context for anyone extending these scripts (captures non-obvious choices and the
+dead-ends we already ruled out).
+
+### Architecture
+- **`main.py` is parsed, not `ttnn.mlir`.** We considered flipping to make the
+  MLIR primary (it has shapes/names natively) but kept `main.py` primary: it is
+  the exact executed program, and its straight-line `forward(input, device)` has
+  no control flow, so a plain `ast` walk over `fn.body` is trivial and robust. The
+  MLIR is used only as a side-table for shapes/arg-metadata.
+- **`build_trace()` lives in `codegen_trace_table.py` and is imported by the graph
+  script.** Single source of truth for parsing + shape resolution, so table and
+  graph never disagree. Keep new parsing there, not duplicated.
+- **Output is one self-contained HTML file, no CDN / no JS deps.** Required so the
+  output works offline, in sandboxed viewers, and as a publishable Claude Artifact.
+  The SVG graph hand-rolls pan/zoom/highlight in inline JS for the same reason —
+  don't reach for d3/graphviz/cytoscape.
+
+### Shape resolution (the subtle part)
+- **Occurrence-index alignment**: `main.py` and `ttnn.mlir` are linear traces of
+  the same IR in the same order, so the k-th occurrence of op X in `main.py` maps
+  to the k-th `ttnn.X` result in the MLIR. `resolve_shape` consumes MLIR results
+  per-op via `op_cursor`. Validated at 100% coverage on qwen (2096 ops) and mnist
+  (41 ops).
+- **`NAME_MAP`** bridges name mismatches between the two forms — currently
+  `slice` (main.py) -> `slice_static` (MLIR). Add here when a new op's Python name
+  differs from its MLIR spelling, or alignment silently drifts.
+- **`PASSTHROUGH`** (`to_device`, `to_layout`, `to_memory_config`,
+  `paged_update_cache`): ops with no MLIR result to align against. They inherit
+  their first tensor operand's shape. `paged_update_cache` is void in the MLIR
+  (in-place cache write) so it must be here, not in the occurrence table.
+- Note this set is *different* from the graph's `PLUMBING` set (below) — they
+  solve different problems; don't merge them.
+
+### Input naming (`input[i]`)
+- Names come from the MLIR arg signature's `ttir.name` + `argument_type<...>`
+  attrs; `pretty_arg_name` shortens the torch module path and normalizes
+  `kv_cache` names. Kind drives color (parameter / kv_cache / constant / input).
+- **Two export flavors seen, and they differ:**
+  - *Qwen* export carries full metadata — every arg has a `ttir.name` and a real
+    `argument_type` (parameter / constant / kv_cache / input). 310/315 args are
+    well-named; only the 5 genuine runtime inputs are opaque.
+  - *MNIST* export carries **none** — all 9 args are `argument_type<input>` with
+    empty `ttir.name`. So weights are indistinguishable from the real image input
+    except by shape (e.g. `32x1x3x3` = conv1 weight, `4x1x28x28` = the batch).
+    This is a property of how the graph was captured, not a script bug.
+- **Deliberately NOT implemented: role inference for opaque inputs.** The 5 Qwen
+  runtime inputs (`argNNN_1` placeholders) have no real name anywhere in the
+  source. Their role *is* recoverable by walking to the first non-plumbing
+  consumer (embedding -> input_ids, rope multiply -> position_ids, paged-sdpa 2D ->
+  page_table, paged-sdpa scalar -> seq_len), but that is heuristic and
+  decode/vLLM-specific, so we left it out to keep the tools source-faithful. If
+  added, render it distinctly (e.g. `~input_ids`) to flag "inferred, not from
+  source".
+
+### Graph layout
+- **Plumbing collapse is on by default** (`--no-collapse` to disable). `PLUMBING`
+  = `to_device`, `to_layout`, `from_device`, `to_memory_config`, `typecast`,
+  `reshape` — pure shape/layout/movement ops that bury the compute backbone. When
+  collapsed, edges are rewired through folded nodes by resolving each node's
+  nearest *kept* predecessors in topological order.
+- **Left-to-right, longest-path depth layering.** x = depth * COL_W. Weight/input
+  leaves are stacked vertically above their consumer (not given their own depth
+  column) so the backbone stays compact instead of one tall column.
+- **Stage bands** (`--no-stages` to disable): background bands labeled by op
+  `FAMILY` (conv / pool / linear / norm / attention / reshape / elementwise /
+  embed), merged across consecutive same-family depths. On Qwen these visually
+  expose the repeating 28-layer decoder rhythm.
+
+### Known limitation / next step
+- **Qwen graph is still large**: collapse takes it from 2411 -> 1469 nodes, but
+  it remains ~106k px wide with ~450 stage bands because the 28 decoder layers are
+  fully unrolled. The natural next feature is **decoder-block layer-folding**:
+  detect the repeating block (the stage-band signature makes it easy) and render
+  one representative layer + an expandable "x28" super-node. Would generalize to
+  any repeated-block model. Not yet built.

--- a/scripts/codegen_trace_tools.md
+++ b/scripts/codegen_trace_tools.md
@@ -22,12 +22,19 @@ python3 scripts/codegen_trace_graph.py <path>/main.py
 
 # shapes are auto-sourced from the sibling ttnn.mlir; override with:
 python3 scripts/codegen_trace_table.py <path>/main.py --mlir other/ttnn.mlir
+
+# hide plumbing ops (both tools default differently — see below):
+python3 scripts/codegen_trace_table.py <path>/main.py --no-plumbing   # table: opt-in
+python3 scripts/codegen_trace_graph.py <path>/main.py --no-collapse   # graph: opt-out
 ```
 
 - **`codegen_trace_table.py`** — one row per `ttnn` op in execution order: output
   var, op, result dims + element type, inputs, dtype/layout/memory, and the tensors
   it deallocates. `input[i]` references are annotated with the arg's `ttir.name`
-  (weight / kv_cache / constant / activation). Has a live filter box.
+  (weight / kv_cache / constant / activation). Has a live filter box. Pass
+  `--no-plumbing` to hide the six plumbing ops and rewire kept ops' inputs through
+  the folded ops (mnist 41 -> 13 rows, qwen 2096 -> 1098); off by default so the
+  table stays a faithful execution trace.
 - **`codegen_trace_graph.py`** — top-down layered dataflow DAG (SVG). Pan (drag),
   zoom (wheel), hover to highlight a node's edges, click to pin its full
   ancestor+descendant lineage, filter by op/var. Reuses `build_trace` from the
@@ -112,7 +119,10 @@ dead-ends we already ruled out).
   = `to_device`, `to_layout`, `from_device`, `to_memory_config`, `typecast`,
   `reshape` — pure shape/layout/movement ops that bury the compute backbone. When
   collapsed, edges are rewired through folded nodes by resolving each node's
-  nearest *kept* predecessors in topological order.
+  nearest *kept* predecessors in topological order. The table's `--no-plumbing`
+  uses the *same* `PLUMBING` set and the same nearest-kept-producer rewiring, but
+  is **opt-in** rather than default: the table's job is a faithful execution trace
+  (plumbing included), whereas the graph's job is readability (plumbing hidden).
 - **Left-to-right, longest-path depth layering.** x = depth * COL_W. Weight/input
   leaves are stacked vertically above their consumer (not given their own depth
   column) so the backbone stays compact instead of one tall column.


### PR DESCRIPTION
Two dependency-free tools for reading a TTNN **codegen dump** — the per-graph `main.py` / `ttnn.mlir` folders the emitpy codegen path emits.

Both tools parse a graph's `main.py`, enrich it with tensor shapes sourced from the sibling `ttnn.mlir`, and write a single self-contained HTML file (no CDN, so it works offline and in sandboxed viewers).

- `scripts/codegen_trace_table.py` — one row per `ttnn` op in execution order: output var, op, result dims and element type, inputs, dtype/layout/memory, and the tensors the op deallocates. `input[i]` references are annotated with the arg's `ttir.name` (weight / kv_cache / constant / activation), and there is a live filter box. `--no-plumbing` hides the six plumbing ops and rewires kept ops' inputs through the folded ones (MNIST 27 → 14 rows, qwen 2096 → 1098); it is off by default so the table stays a faithful execution trace.
- `scripts/codegen_trace_graph.py` — interactive left-to-right layered dataflow DAG as inline SVG: pan, zoom, hover to highlight a node's edges, click to pin full ancestor+descendant lineage, filter by op or var. Plumbing ops are collapsed by default so the compute backbone stands out (`--no-collapse` keeps them), with labeled stage bands behind the graph (`--no-stages` omits them). It reuses `build_trace` from the table script, so shape resolution is identical between the two.
- `scripts/codegen_trace_tools.md` — usage, how occurrence-index shape resolution works, and a "Design decisions & rationale" section recording the non-obvious choices and the dead-ends already ruled out.
- `scripts/codegen_trace_table_template.html`, `scripts/codegen_trace_graph_template.html` — the page chrome (markup, CSS, and the graph's pan/zoom/lineage JavaScript), loaded by `load_template()` and filled by replacing `<!--__NAME__-->` placeholders. This follows `scripts/telemetry/telemetry_viz.py`, which already ships its page as a sibling `_template.html`. It matters most for the graph, whose ~90 lines of JavaScript previously lived inside an f-string with every brace doubled, leaving it unreadable and impossible to lint. The scripts now generate only rows and SVG fragments.

No new model or example is added. `examples/pytorch/mnist.py` and the examples under `examples/pytorch/codegen/python/` already emit dumps these tools can read, and the docs point at those.

### Producing a dump

Set `TTXLA_CODEGEN_EXPORT_DIR` and run any example that compiles with the TT backend. The existing MNIST example gives a 27-op graph, small enough to read end to end:

```bash
TTXLA_CODEGEN_EXPORT_DIR=$PWD/mnist_codegen XLA_HLO_DEBUG=1 python examples/pytorch/mnist.py
```

It exits non-zero on its own `PCC: nan` assertion, which is expected — emit is a dry run returning zero-filled buffers, so the example's CPU comparison cannot pass. The dump is complete regardless. This is now documented, along with the fact that `XLA_HLO_DEBUG=1` is what puts source locations in the IRs.

The examples under `examples/pytorch/codegen/python/` call `codegen_py` directly and need one extra option, because the tools parse the `forward(input, device)` entrypoint and `codegen_py` emits it only when asked:

```python
codegen_py(model, x, export_path="resnet50_codegen", compiler_options={"target_module": True})
```

Without it the dump is the standalone `_main(activations, weights)` flavor plus tensor loaders, and both tools fail to find a `forward()`. The env var sets `target_module` itself (`compile_options.cc`), so that route needs nothing extra. This asymmetry was not obvious and is now documented.

### How shape resolution works

`main.py` carries almost no shapes; `ttnn.mlir` carries them on every value. The two are linear traces of the same IR in the same order, so the k-th occurrence of an op in one matches the k-th in the other, and that alignment sources each op's result shape. Shape-preserving ops that codegen inserts but the MLIR does not emit as results (`to_device`, `to_layout`, `to_memory_config`, `paged_update_cache`) inherit their input operand's shape. Coverage is reported in the table header as `shapes: N/N resolved`.

### Provenance

Split out of `avorozcovs/first-steps`, which mixed these tracing tools with unrelated vLLM example and venv fixes; `avorozcovs/first-steps` keeps the rest.

### Testing

Tools only — no library or runtime code is touched, so no CI job exercises them.

Verified against real dumps emitted on a `wormhole_b0`: MNIST (`examples/pytorch/mnist.py`, 27 ops), ResNet-50 (`examples/pytorch/codegen/python/resnet.py`, 436 ops), the two-layer MLP in `custom_module.py` (18 ops), and all 31 graphs of the vLLM Qwen3-0.6B dump (2203 ops in the prefill graph). Shapes were checked rather than assumed: `ttnn.reshape` carries its literal target dims in `main.py`, and every reshape matches the resolved shape — 3 in MNIST, 102 in ResNet-50, 143 in the Qwen prefill graph, 0 mismatches across the full Qwen dump. The 53 ResNet batch norms were spot-checked directly against `ttnn.mlir` (`1x64x112x112` after the stem, `1x2048x7x7` at the end).

Running against real dumps is what surfaced the three shape bugs fixed here, none of which raised an error — the header reported every op resolved while the numbers were wrong:

1. The MLIR op-name pattern excluded digits, so `conv2d` and `max_pool2d` matched nothing and silently inherited their input's shape.
2. `main.py` emits `ttnn.batch_norm` where the MLIR declares `ttnn.batch_norm_inference`, so all 53 ResNet batch norms fell back the same way.
3. Const-eval helpers (`main_const_eval_N`, `cpu_hoisted_const_eval_*`) sit ahead of `@main` in the MLIR and were being counted into the occurrence table. MNIST's four activation typecasts reported the weight shapes `32`, `1x1x1x32`, `128x9216` and `10x128` instead of `1x1x576x64`, `4x128`, `4x128` and `4x10`. The shape scan is now scoped to `@main`, the only function `main.py`'s `forward()` corresponds to.

That is also why the docs now record that a miss is silent and name `ttnn.reshape` as the cheap ground-truth check for a dump the tools have not seen.

The template extraction is output-preserving, checked rather than assumed. 14 pages were generated across both fixtures and every flag combination (`--no-plumbing`, `--no-collapse`, `--no-stages`, both together, and the no-MLIR fallback) before and after the change. The graph HTML is byte-identical apart from a trailing newline, and all 14 pages compare equal once whitespace between tags is normalized.

Two commits apply the repo's pinned `black` 25.9.0 and `isort` hooks, which the two scripts previously failed; output was re-verified after each.

### Known gaps

Const-eval hoisted work is invisible to the trace: MNIST emits 6 helpers beside `forward()` and ResNet-50 emits 211, and only `forward()` is parsed, so weight preprocessing appears nowhere. The `consteval_forward` call into that block is the one entry behind MNIST's `26/27 resolved` and ResNet-50's `435/436`.

Occurrence-index alignment holds on every dump tested but is a property of the graph rather than a guarantee, and a miss is silent. The `--no-plumbing` stdout line reports the pre-filter row count while the HTML header correctly reports the filtered one. Qwen-scale dumps produce a large graph; decoder-block layer-folding is the next step there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
