### PR TITLE
[deepseek_v4] Set TT device type before enable_spmd in e2e

### DIFF
--- a/tests/torch/models/deepseek_v4/test_deepseek_v4_e2e.py
+++ b/tests/torch/models/deepseek_v4/test_deepseek_v4_e2e.py
@@ -172,8 +172,9 @@ def transformer_shard_spec(model: mdo.Transformer):
 def test_prefill_and_decode_pcc_e2e(
     model_name, num_iterations, num_layers, use_cpu_decode_inputs
 ):
-    enable_spmd()
+    # Device type must be set before any XLA runtime / SPMD init.
     xr.set_device_type("TT")
+    enable_spmd()
 
     mesh = utils.make_2d_mesh()
     bsz = len(PROMPTS)


### PR DESCRIPTION
## Summary
- In `test_deepseek_v4_e2e.py`, call `xr.set_device_type("TT")` before `enable_spmd()`.
- Matches streaming e2e init order ([#5822](https://github.com/tenstorrent/tt-xla/pull/5822)) so the TT PJRT device is selected before SPMD / mesh device counting.

## Test plan
- [ ] `pytest tests/torch/models/deepseek_v4/test_deepseek_v4_e2e.py::test_prefill_and_decode_pcc_e2e` on galaxy-bh (`install_vllm_wheel=false`)
- [ ] Confirm mesh init succeeds (`make_2d_mesh` / no `unordered_map::at` at device count)


Made with [Cursor](https://cursor.com)