### PR TITLE
Uplift pytorch-xla to ed8a445

### DIFF
--- a/python_package/requirements.txt
+++ b/python_package/requirements.txt
@@ -4,7 +4,7 @@ jaxlib==0.7.1
 requests
 torch@https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl
 loguru
-torch-xla@https://pypi.eng.aws.tenstorrent.com/torch-xla/torch_xla-2.9.0%2Bgitb230007-cp312-cp312-linux_x86_64.whl
+torch-xla@https://pypi.eng.aws.tenstorrent.com/torch-xla/torch_xla-2.9.0%2Bgited8a445-cp312-cp312-linux_x86_64.whl
 
 # Pin nanobind to match tt-metal's version (v2.10.2) for ABI compatibility.
 # A mismatch causes segfaults in nb_type_c2p when PythonModelRunner converts


### PR DESCRIPTION
### Ticket

N/A

### Problem description

The torch-xla wheel pin points at `2.9.0+gitb230007`, built on 2026-07-23 by the release pipeline that was silently producing incomplete matrices — that run published only cp312, and the following push to master published nothing at all. https://github.com/tenstorrent/pytorch-xla/pull/40 fixed the pipeline, and its merge is the first master commit whose wheels were published by the fixed workflow.

### What's changed

One line: the `torch-xla` pin in `python_package/requirements.txt` moves from `gitb230007` to `gited8a445`.

The `torch_xla` sources are identical between the two commits — pytorch-xla#40 touches only `.github/workflows/` — so there is no functional change to the runtime. What changes is how the wheel was built: a cold Bazel output base and an explicitly exported `HERMETIC_PYTHON_VERSION`, instead of pyenv and Bazel state inherited from whichever Python version last built on that builder. Both cp311 and cp312 wheels exist for `ed8a445`; this repo consumes cp312, as before.

### Checklist

- [x] New/Existing tests provide coverage for changes — the existing CI suites run against the new wheel; no new tests apply to a dependency pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)