### PR TITLE
[vLLM] Fix DP row corruption: batch-axis sharding, dp_size-aligned buckets, active-row chunk offset

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -2244,8 +2244,10 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             ParallelismMode.DATA_TENSOR_PARALLEL,
         ):
             return
-        # 2D mesh: batch dim -> "batch"; pure 1D-TP: "batch" is size 1, use "model".
-        batch_axis = "batch" if self.use_2d_mesh else "model"
+        # Only pure 1D-TP (mesh (1, N)) lacks a batch axis. Keying off
+        # use_2d_mesh instead picked size-1 "model" for DP-only (dp, 1), a
+        # silent no-op that left activations replicated.
+        batch_axis = "model" if self.mesh.mesh_shape[0] == 1 else "batch"
         if input_ids is not None:
             safe_mark_sharding(input_ids, self.mesh, (batch_axis, None))
         if inputs_embeds is not None:

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -485,6 +485,24 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             if self.tt_config.max_prefill_num_seqs is not None
             else self.max_num_reqs
         )
+        # Resolved from the *unpadded* max_num_seqs in platform.py, so under DP
+        # they can land on a non-multiple of dp_size. Align them up.
+        if self.dp_size > 1:
+            for _name in ("min_num_reqs", "max_prefill_num_reqs"):
+                _old = getattr(self, _name)
+                _new = min(
+                    _align_num_reqs_for_dp(_old, self.dp_size, round_up=True),
+                    self.max_num_reqs,
+                )
+                if _new != _old:
+                    logger.warning(
+                        "Data parallel requires %s divisible by dp_size; "
+                        "adjusting from %d to %d.",
+                        _name,
+                        _old,
+                        _new,
+                    )
+                    setattr(self, _name, _new)
         if scheduler_config.max_num_batched_tokens < self.tt_config.min_context_len:
             logger.warning(
                 f"max_num_batched_tokens {scheduler_config.max_num_batched_tokens} is less than min_context_len {self.tt_config.min_context_len}, setting min_context_len to max_num_batched_tokens"
@@ -660,6 +678,27 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # absolute block ids. Set in initialize_kv_cache.
         self._group_is_sliding: list[bool] = [False]
         self._group_window_blocks: list[int] = [0]
+        # SMEM-capped, so round DOWN to stay under the limit. Rounding to 0
+        # means this context length cannot host dp_size rows at all.
+        if self.dp_size > 1:
+            _old = self.num_reqs_max_model_len
+            _new = _align_num_reqs_for_dp(_old, self.dp_size, round_up=False)
+            if _new == 0:
+                raise ValueError(
+                    f"num_reqs_max_model_len={_old} is below dp_size="
+                    f"{self.dp_size}: this max_model_len/block_size only fits "
+                    f"{_old} rows in SMEM, so a data-parallel batch cannot be "
+                    f"sharded across {self.dp_size} replicas. Lower dp_size or "
+                    f"max_model_len."
+                )
+            if _new != _old:
+                logger.warning(
+                    "Data parallel requires num_reqs_max_model_len divisible by "
+                    "dp_size; adjusting from %d to %d.",
+                    _old,
+                    _new,
+                )
+                self.num_reqs_max_model_len = _new
         self.query_start_loc_cpu = torch.zeros(
             self.max_num_reqs + 1,
             dtype=torch.int32,
@@ -5023,6 +5062,20 @@ def _row_lead(num_computed: np.ndarray, block_size: int) -> np.ndarray:
     of a speculative decode row.
     """
     return (num_computed % block_size).astype(np.int32)
+
+
+def _align_num_reqs_for_dp(value: int, dp_size: int, *, round_up: bool) -> int:
+    """Round a request-count bucket to a multiple of ``dp_size``.
+
+    A bucket that is not a multiple leaves the batch dim indivisible by the
+    mesh's "batch" axis, so ``safe_mark_sharding`` replicates it and DP
+    degenerates into every device computing the whole batch.
+    """
+    if dp_size <= 1 or value % dp_size == 0:
+        return value
+    if round_up:
+        return ((value + dp_size - 1) // dp_size) * dp_size
+    return (value // dp_size) * dp_size
 
 
 def _bucket_num_reqs(

--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -1747,22 +1747,35 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # prefill take the standard path (chunk_start_idx stays None). Shared
         # across all groups.
         num_computed_for_reqs = self.input_batch.num_computed_tokens_cpu[req_slice]
+        # Only rows contributing tokens this step matter. An inactive re-batched
+        # row (see zero_sched_rows above) says nothing about what the prefilling
+        # rows need, and handing its offset to a fresh row made that row attend
+        # a prefix it does not have.
+        active_rows = np.nonzero(num_scheduled_tokens_per_req > 0)[0]
+        active_computed = num_computed_for_reqs[active_rows]
         prefix_chunk_step = padded_total_num_scheduled_tokens > 1 and bool(
-            np.any(num_computed_for_reqs > 0)
+            np.any(active_computed > 0)
         )
         chunk_start_idx = None
         if prefix_chunk_step and (
             self._chunked_sdpa_active or self._spec_prefix_rows()
         ):
-            # Same-stage batching => one shared [1] prefix offset; the op masks
-            # causally and applies it internally (no host attn_mask). row_lead
-            # moved the row back to its block boundary, so the read offset must
-            # match, otherwise it disagrees with where paged_fill_cache wrote.
-            self._chunk_start_idx_dev.copy_(
-                torch.tensor(
-                    [int(num_computed_for_reqs[0]) - int(row_lead[0])],
-                    dtype=torch.int32,
+            # One offset for the whole batch, so take it from an active row and
+            # refuse mixed stages rather than applying one row's offset to
+            # another. row_lead moved the row back to its block boundary, so the
+            # read offset must match where paged_fill_cache wrote.
+            active_starts = active_computed - row_lead[active_rows]
+            offsets = {int(v) for v in active_starts}
+            if len(offsets) > 1:
+                raise RuntimeError(
+                    "chunked-prefill SDPA takes a single prefix offset for the "
+                    f"batch, but active rows are at different stages: "
+                    f"start={sorted(offsets)} for rows "
+                    f"{active_rows.tolist()}. Batching mixed stages would apply "
+                    "one row's offset to another."
                 )
+            self._chunk_start_idx_dev.copy_(
+                torch.tensor([int(active_starts[0])], dtype=torch.int32)
             )
             chunk_start_idx = self._chunk_start_idx_dev
 

--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -543,6 +543,21 @@ class TTPlatform(Platform):
         # For v0, the default block size is 16.
         if cache_config and cache_config.block_size is None:
             cache_config.block_size = cast(BlockSize, 32)
+
+        # The block pool is global but each replica holds its own KV cache, so
+        # block id N is different memory per device and a cross-replica hit
+        # reads zeros. Chunked-prefill continuation is unaffected (same request,
+        # same replica).
+        if (
+            tt_config.enable_data_parallel
+            and cache_config
+            and cache_config.enable_prefix_caching
+        ):
+            logger.warning(
+                "[TT] Disabling prefix caching: it is not safe under data "
+                "parallelism (per-replica KV cache vs global block pool)."
+            )
+            cache_config.enable_prefix_caching = False
         compilation_config = vllm_config.compilation_config
 
         # TT only supports DYNAMO_TRACE_ONCE compilation level

--- a/integrations/vllm_plugin/vllm_tt/vllm_distributed_utils.py
+++ b/integrations/vllm_plugin/vllm_tt/vllm_distributed_utils.py
@@ -29,6 +29,10 @@ from .logger import tt_init_logger
 logger = tt_init_logger(__name__)
 
 
+# Deduplicates the size-1-axis warning below; see the call site for why.
+_WARNED_SIZE1_AXIS: set = set()
+
+
 def safe_mark_sharding(tensor, mesh, partition_spec, strict=False):
     """xs.mark_sharding that replicates any dim whose size is not divisible
     by the mesh axis it would be sharded on. When ``strict`` is True, raise
@@ -58,6 +62,24 @@ def safe_mark_sharding(tensor, mesh, partition_spec, strict=False):
             safe_spec.append(None)
             continue
         mesh_axis_size = _axis_size(axis)
+        if mesh_axis_size == 1:
+            # No-op: the dim stays replicated while siblings shard on a real
+            # axis. This is how DP-only pinned the batch dim to size-1 "model"
+            # on a (dp, 1) mesh and corrupted rows silently.
+            msg = (
+                f"safe_mark_sharding: dim {i} (size {tensor.shape[i]}) asked to "
+                f"shard on mesh axis {axis!r}, which has size 1 -- this is a "
+                f"no-op and the dim stays replicated"
+            )
+            if strict:
+                raise ValueError(msg + "; strict=True")
+            # Deduped: pure-TP legitimately marks a size-1 "batch" axis from
+            # _dummy_run on every step.
+            if msg not in _WARNED_SIZE1_AXIS:
+                _WARNED_SIZE1_AXIS.add(msg)
+                logger.warning("%s", msg)
+            safe_spec.append(None)
+            continue
         if mesh_axis_size is None or tensor.shape[i] % mesh_axis_size != 0:
             msg = (
                 f"safe_mark_sharding: dim {i} (size {tensor.shape[i]}) "

--- a/tests/integrations/vllm_plugin/generative/conftest.py
+++ b/tests/integrations/vllm_plugin/generative/conftest.py
@@ -57,19 +57,75 @@ _STOPWORDS = frozenset(
 _WORD_RE = re.compile(r"[A-Za-z']+")
 _MIN_STOPWORD_RATIO = 0.10
 _MIN_WORDS = 5
+# Longest plausible English word in generated text. Degenerate repetition with
+# no separators ("BlockBlockBlock...") lands in a single _WORD_RE match, which
+# the stopword check cannot see because it is one word.
+_MAX_WORD_LEN = 30
+# Distinct words required once there are enough words to judge. Catches
+# low-diversity loops like 'and "r" and "r" and "r"', whose stopword ratio is
+# high precisely *because* the repeated token is a stopword.
+_MIN_UNIQUE_WORDS = 3
+# Non-Latin script characters (Hebrew/CJK/Cyrillic ...) as a fraction of the
+# output. Restored after #4563 removed the original check: that one tested
+# `ord(c) > 127`, i.e. non-ASCII, so it failed on ordinary smart quotes. This
+# allows Latin-1/Latin-Extended plus General Punctuation (smart quotes, dashes,
+# ellipsis) and only counts genuinely non-Latin scripts.
+_MAX_NON_LATIN_RATIO = 0.03
+# Fraction of the output made of word characters. Catches a lone real word
+# adrift in punctuation ('celona. ( ( ( ( (' -- observed on main under DP),
+# which every other check either passes or skips as "too short to judge".
+_MIN_WORD_CHAR_RATIO = 0.35
+
+
+def _non_latin_ratio(s: str) -> float:
+    def is_latin_ish(c: str) -> bool:
+        o = ord(c)
+        # Latin blocks through Latin Extended-B, General Punctuation, whitespace.
+        return o < 0x250 or 0x2000 <= o <= 0x206F or c.isspace()
+
+    return sum(1 for c in s if not is_latin_ish(c)) / len(s)
 
 
 def assert_output_coherent(text: str) -> None:
     """Heuristic assertion: text is natural-language, not token soup.
 
-    Uses English stopword ratio as the token-soup detector — coherent
-    continuations contain several stopwords per ~30-token output, while
-    token-soup garbage contains ~zero.
+    Stopword ratio is the primary token-soup detector (#4440), but it cannot see
+    every degeneration we have actually shipped: a single repeated token is one
+    "word", and a loop over a stopword scores a *high* ratio. So also reject
+    over-long single words, low word diversity, and non-Latin script runs. These
+    checks run before the short-output early return, since garbage is frequently
+    short by this measure.
     """
     s = text.strip()
     assert s, f"empty output: {text!r}"
     words = [w.lower() for w in _WORD_RE.findall(s)]
     assert words, f"output has no word characters: {text!r}"
+
+    nlr = _non_latin_ratio(s)
+    assert nlr <= _MAX_NON_LATIN_RATIO, (
+        f"non-Latin script ratio too high ({nlr:.3f} > {_MAX_NON_LATIN_RATIO}): "
+        f"{text!r}"
+    )
+
+    wcr = sum(len(w) for w in words) / len(s)
+    assert wcr >= _MIN_WORD_CHAR_RATIO, (
+        f"too little of the output is words ({wcr:.3f} < "
+        f"{_MIN_WORD_CHAR_RATIO}): {text!r}"
+    )
+
+    longest = max(words, key=len)
+    assert len(longest) <= _MAX_WORD_LEN, (
+        f"degenerate repeated token ({len(longest)} chars > {_MAX_WORD_LEN}): "
+        f"{longest[:40]!r} in {text!r}"
+    )
+
+    if len(words) >= _MIN_UNIQUE_WORDS + 1:
+        unique = len(set(words))
+        assert unique >= _MIN_UNIQUE_WORDS, (
+            f"too few distinct words ({unique} < {_MIN_UNIQUE_WORDS}) in "
+            f"{len(words)} words: {text!r}"
+        )
+
     if len(words) < _MIN_WORDS:
         return
     sr = sum(1 for w in words if w in _STOPWORDS) / len(words)


### PR DESCRIPTION
### Ticket
closes #5892

### Problem description

Under data parallelism, replicas other than replica 0 can return garbage, and the test covering it passes anyway.

`test_data_parallel_chunked_prefill_n300` sends the same prompt twice with greedy decoding, so both replicas should say the same thing. On `main` replica 0 is correct and replica 1 returns `BlockBlockBlock...`. It stays green because `assert_output_coherent` counts that as a single word.

Four things are wrong. See #5892 for detail.

1. DP-only never shards the batch: the axis is picked via `use_2d_mesh`, false for a `(dp, 1)` mesh, so it shards on size-1 `"model"` and nothing happens.
2. Prefix caching is unsafe under DP: the block pool is global but each replica has its own KV cache, so a cross-replica hit reads zeros.
3. Request-count buckets are not multiples of `dp_size`, so the batch dim ends up indivisible by the mesh axis and gets replicated.
4. Chunked prefill reads its prefix offset off row 0, so an inactive row's offset can land on a row starting its first chunk.

### What's changed

- **`model_runner.py`**: pick the batch axis from the mesh shape, since only pure 1D-TP lacks a batch axis. Align the prefill bounds up and the SMEM-capped counts down to a multiple of `dp_size`, and raise if a capped count rounds to zero. Take the chunked-prefill offset from rows with scheduled tokens, and raise on mixed stages instead of applying one row's offset to another.
- **`platform.py`**: disable prefix caching under DP. It cannot work as built, so this fails safe rather than serving wrong tokens.
- **`vllm_distributed_utils.py`**: warn when `safe_mark_sharding` gets a size-1 axis. That no-op is how defect 1 stayed invisible. Deduped, since pure-TP marks a size-1 `"batch"` axis legitimately.
- **`generative/conftest.py`**: teach `assert_output_coherent` to catch repeated tokens, punctuation soup and non-Latin garbage, all before the short-output early return. Checked against seven real garbage outputs and against normal generations with smart quotes and lists.

### Verification

On an n300 at dp=2:

- `test_data_parallel_chunked_prefill_n300` passes with both replicas byte-identical. Reverting only the offset commit brings `BlockBlockBlock...` back, so that fix is doing the work.
- The dp=2 matrix from bring-up is clean in all four shapes, including two rows per replica, which used to corrupt rows 1 through 3.

Defects 2 and 3 were validated on an 8-chip llmbox: dp=8 went from 7/8 garbage rows to 8/8 correct, and 4 requests at dp=8 went from a replication warning on every batch tensor to none.

Wider coverage on the rebased branch:

- dp=8 on an llmbox: `test_data_parallel_chunked_prefill_n300` passes, as do the llmbox padding and tight tests.
- DP+TP: `test_data_tensor_parallel_generation_push` passes in 118s against a 567s budget.
- Speculative decode, all four configs pass (single device, TP, DP, DP+TP). Worth checking because the chunked-prefill offset is shared with the spec-decode block-alignment path.

### Notes

Prefix caching under DP is disabled, not fixed. Making it work needs per-replica block accounting.

### Checklist
- [x] New/Existing tests provide coverage for changes
