### PR TITLE
Add ttnn-visualizer graph-capture examples

### DIFF
--- a/examples/visualizer/README.md
+++ b/examples/visualizer/README.md
@@ -134,8 +134,8 @@ vLLM pulls several GB of packages you will not want in a general-purpose environ
    bash examples/vllm/TinyLlama-1.1B-Chat-v1.0/service.sh
    ```
 
-4. Wait for it to come up — measured at 7m31s with weights already cached — then send one
-   request from a second shell.
+4. Wait for it to come up — 5m35s and 7m31s on two runs with weights already cached — then
+   send one request from a second shell.
 
    ```bash
    until curl -sf http://localhost:8000/v1/models >/dev/null; do sleep 5; done

--- a/examples/visualizer/README.md
+++ b/examples/visualizer/README.md
@@ -232,17 +232,26 @@ Absent, and not fixable with a build flag:
   device-op level** (`MatmulDeviceOperation` rather than `ttnn.matmul`). All three come
   from `python_io` records, which only ttnn's Python decorators write; ops arriving from
   a C++ caller get none.
-- **The Graph tab fragments, by an amount that depends on the op mix.** Without
-  `python_io` the importer falls back to the graph tracker's own argument scan, which
-  matches only plain `Tensor`-shaped types. Convolutional graphs fare badly, because halo
-  and conv ops pass tensors inside attribute structs that match nothing: in one measured
-  run 160 of 339 captured ops recorded no inputs, and after the importer folds
-  `Tensor::to_device`, `reshape`, `to_dtype` and `deallocate` away and rejects inputs whose
-  producer went with them, 111 operations were left with 65 links across 58 components. A
-  transformer decode fares much better — a TinyLlama capture gave 1236 operations with
-  *every* one recording an input, 1287 links from 1948 references, and a largest component
-  of 414 ops (191 components in total, 617 orphaned inputs). A JAX-driven capture fragments
-  the same way as a torch one, so none of this is a property of the hook.
+- **The Graph tab never comes out connected.** Without `python_io` the importer falls back
+  to the graph tracker's own argument scan, which matches only plain `Tensor`-shaped types,
+  and it folds `Tensor::to_device`, `reshape`, `to_dtype` and `deallocate` away, rejecting
+  inputs whose producer went with them. Every capture measured breaks into many components:
+
+  | Capture | Operations | Edges | Components | Largest | Isolated |
+  | --- | --- | --- | --- | --- | --- |
+  | mnist, one program | 59 | 28 | 31 | 11 | 20 |
+  | ConvNet, three programs | 67 | 17 | 50 | 4 | 39 |
+  | JAX, three programs | 9 | 5 | 4 | 3 | 1 |
+  | TinyLlama, one program | 19 | 11 | 8 | 9 | 6 |
+  | TinyLlama, wide window | 1236 | 1287 | 191 | 414 | 164 |
+
+  The op mix moves the degree of fragmentation, not the outcome, and single-program captures
+  fragment as much as merged ones. Recording an input is not the same as having an edge to
+  draw: in the 1236-operation capture every operation records at least one input, yet 617 of
+  its 1948 input references name a tensor with no producer in the database. Convolutional
+  graphs fare worst, because halo and conv ops pass tensors inside attribute structs that
+  match nothing. A JAX-driven capture fragments like a torch one, so none of this is a
+  property of the hook.
 - **The perf half of a report.** Tracy zones exist in Metalium and tt-mlir, but tt-xla's
   wheel build forces `TTMLIR_ENABLE_PERF_TRACE` off, so kernel timings need a source
   build under the tracy wrapper.

--- a/examples/visualizer/README.md
+++ b/examples/visualizer/README.md
@@ -97,15 +97,24 @@ server process, send a request, then shut the server down.
 These steps were run end to end on an n300. Use a checkout dedicated to this — installing
 vLLM pulls several GB of packages you will not want in a general-purpose environment.
 
-1. Install vLLM and the TT plugin into the activated venv. `vllm==0.26.0` does not displace
-   the venv's `torch` or `torch-xla`, but it does add its CUDA-flavoured dependencies.
+1. Install vLLM and register the TT plugin. `venv/activate` puts
+   `integrations/vllm_plugin` on `PYTHONPATH`, which makes `vllm_tt` importable; vLLM finds
+   the platform through a `vllm.platform_plugins` entry point, and that scan reads installed
+   distribution metadata. An editable install supplies the metadata and leaves the code where
+   it is. The pinned `vllm` leaves the venv's `torch` and `torch-xla` alone, and adds its
+   CUDA-flavoured dependencies.
 
    ```bash
    source venv/activate
-   (cd integrations/vllm_plugin && python setup.py bdist_wheel)
-   pip install --force-reinstall --no-deps \
-       integrations/vllm_plugin/dist/vllm_tt-0.1-cp312-cp312-linux_x86_64.whl
-   pip install "vllm==0.26.0" "transformers==5.14.1"
+   pip install --no-deps -e integrations/vllm_plugin
+   pip install -r integrations/vllm_plugin/requirements-vllm-plugin.txt
+   ```
+
+   Confirm the plugin is visible before starting a server — this prints `TTPlatform xla`
+   when it is and `UnspecifiedPlatform` when the metadata is missing:
+
+   ```bash
+   python -c "from vllm.platforms import current_platform as p; print(type(p).__name__, p.device_type)"
    ```
 
 2. Enable capture for the server process. `SKIP` has to clear weight loading — see the

--- a/examples/visualizer/README.md
+++ b/examples/visualizer/README.md
@@ -216,6 +216,75 @@ Measured on TinyLlama-1.1B-Chat-v1.0 with `FIRST=40 REPORTS=1` and a 64-token co
 program is a slice of a decode step rather than the whole model, so raise `REPORTS` to follow
 consecutive programs — each lands as its own numbered file.
 
+## SDXL-Lightning — `examples/pytorch/sdxl_lightning.py`
+
+A four-component diffusion model is where a report stops being cheap. Capture one program, and
+pick which one deliberately. Everything below was measured on an n300 (wh-17).
+
+`REPORTS=8` from the start of the run does not survive. The eight reports come to 12 GB on disk
+and the process is OOM-killed at 2152 s, because a report's graph data is held in memory until
+the report is written. The container's `memory.max` is 62.95 GiB and the kill recorded 64.4 GB
+of anonymous RSS, while the same run with capture off peaks at 31.98 GB — so a capture has
+about 33 GiB of headroom to fit into, and eight windows do not.
+
+Those eight, in execution order: 45.8 MB for text encoder 1, 252 MB for text encoder 2, 435 KB
+and 27.6 KB for two small programs, 6.09 GB for the first UNet step, 337 KB, 6.33 GB for the
+second UNet step, 337 KB. Pick from the small end:
+
+```bash
+export TT_RUNTIME_GRAPH_CAPTURE_DIR=$PWD/reports_sdxl
+export TT_RUNTIME_GRAPH_CAPTURE_FIRST=0
+export TT_RUNTIME_GRAPH_CAPTURE_REPORTS=1
+mkdir -p "$TT_RUNTIME_GRAPH_CAPTURE_DIR"
+python examples/pytorch/sdxl_lightning.py
+```
+
+`FIRST=0` records text encoder 1 at 45.8 MB and `FIRST=2` a 435 KB program. `FIRST=4` is the
+first UNet step, and it is the one to avoid: 6.09 GB of pretty-printed JSON over 252110474
+lines, of which the graph is 1.0%. `per_operation_buffers` accounts for 62.6% — 22565156 buffer
+records across 11977 snapshots, averaging 1884 live buffers each — and `buffer_pages_by_address`
+for another 36.3%, 8328320 page records across 64 addresses. The graph itself is 142359 nodes,
+and the 7.8 MB sidecar holds 14311 operations over 24 distinct names: 7781 `DeallocateOp`, then
+1315 `ReshapeOp`, 901 `EltwiseBinaryOp`, 636 `PermuteOp`, 425 `MatmulOp` and 307 `LinearOp`.
+
+The UNet runs on one of the two chips. Both appear in `devices` with 64 compute cores each, and
+all 22.5 M of those buffer records are on `device_id` 2 with none on `device_id` 0.
+
+**Warm the kernel cache before capturing.** On a fresh machine the first run spends minutes
+between reports with nothing on the terminal — tt-metal is JIT-compiling device kernels, 2314
+ELFs into `~/.cache/tt-metal-cache`, and only compiles that emit a warning reach the log. The
+cache is keyed by build key and compile hash and persists across runs, so a second run
+recompiled 8 objects out of 6030. One uncaptured run first keeps that cost out of the window.
+
+## Reading the time a capture covers
+
+A captured UNet step reports `total_duration_ns` of 466 s, which is compilation rather than
+compute. `time_sdxl_stages.py` shows the split: the demo marks its stages and denoising steps
+with `[STAGE]` and `[STEP]` lines that the plugin's log level hides, and the script runs it with
+a stand-in logger that prints them with elapsed and per-stage times.
+
+```bash
+python examples/visualizer/time_sdxl_stages.py
+```
+
+| segment | duration |
+| --- | --- |
+| startup and model load | 20.0 s |
+| text encoder 1 | 10.9 s |
+| text encoder 2 | 34.9 s |
+| UNet step 1, compile and run | 245.1 s |
+| UNet step 2 | 2.3 s |
+| UNet step 3 | 2.3 s |
+| UNet step 4, then evict to host | 9.6 s |
+| VAE decode, compile and run | 122.1 s |
+| save PNG | 0.5 s |
+
+462 s end to end, and four denoising steps are about 9 s of it. A warm step costs 2.3 s and
+repeats to the hundredth, so a captured window measures the one-time compile: 245 s for the
+UNet graph, 122 s for the VAE. Read those numbers against how the demo is built — one component
+resident on the device at a time, and a host round-trip per step because the scheduler runs on
+CPU — rather than as a throughput figure.
+
 ## Checking the hook without picking a sample
 
 `capture_graph_report.py` drives a small ConvNet of its own and sets the variables from its

--- a/examples/visualizer/README.md
+++ b/examples/visualizer/README.md
@@ -35,15 +35,24 @@ nested inside the program that needs its result and is recorded in that program'
 a file carries a complete program tree rather than a slice of one. Reports are named
 `<program>_pid<pid>_tid<tid>_exec<index>.json` after the program and its execution index.
 
+Each report is written with a `<report>.python_io.json` sidecar holding one record per program
+operation: its op name, its MLIR location and op text, and the tensor ids it read and wrote.
+The importer reads the sidecar when it sits next to the report, and that is what fills the
+operation names, arguments, stack traces and the Graph tab — so keep the pair together when
+you move reports around. The format is ttnn's
+[`python_io`](https://github.com/tenstorrent/tt-metal/blob/main/tech_reports/ttnn/graph-tracing.md),
+which ttnn's own Python decorators write when a capture starts from Python.
+
 `REPORTS=0` records every execution from `FIRST` onwards, which is the mode to reach for on a
-short script. `capture_graph_report.py --steps 3 --reports 0` writes three files: 5.88 MB for
-the first step, which carries the const-eval subprograms, and 5.90 MB for each later step,
+short script. `capture_graph_report.py --steps 3 --reports 0` writes three files: 5.78 MB for
+the first step, which carries the const-eval subprograms, and 5.70 MB for each later step,
 which reuses their results.
 
 Both counters exist to bound cost, and detailed buffer tracing is what makes that cost real.
-One mnist forward is 12.19 MB. On a TinyLlama server the programs range from 5 KB to 188 MB
+One mnist forward is 12.15 MB. On a TinyLlama server the programs range from 5 KB to 188 MB
 apiece, and `REPORTS=0` wrote 1.7 GB over 23 reports before the server had finished starting
-— so `REPORTS=0` is a mode for a short script, not for a serving model.
+— so `REPORTS=0` is a mode for a short script, not for a serving model. Sidecars are small
+next to that: 8 KB to 53 KB across every capture measured here.
 
 Import merges as many reports as you point it at, so capturing several executions separately
 and merging at import time gives the same database as one wide window would.
@@ -75,16 +84,17 @@ the hook. Numbers are measured on an n300 (wh-17).
    python examples/pytorch/mnist.py
    ```
 
-3. Import the report. Expect one file of 12.19 MB named `main_pid<pid>_tid<tid>_exec0.json`
-   — the pid and tid differ because torch_xla executes on a worker thread.
+3. Import the report. Expect one file of 12.15 MB named `main_pid<pid>_tid<tid>_exec0.json`
+   plus its 53 KB sidecar — the pid and tid differ because torch_xla executes on a worker
+   thread.
 
    ```bash
    python examples/visualizer/import_graph_report.py \
        "$TT_RUNTIME_GRAPH_CAPTURE_DIR" --out dbs_mnist
    ```
 
-   The database holds 59 operations, 104 tensors and 1813 buffers, including
-   `Conv2dDeviceOperation`, `HaloDeviceOperation` and `InterleavedToShardedDeviceOperation`.
+   The database holds 71 operations, 82 tensors and 2491 buffers, including `Conv2dOp`,
+   `LinearOp` and `Pool2dOp`, each carrying the HLO instruction it came from.
 
 ## JAX — `examples/jax/simple_regression.py`
 
@@ -105,17 +115,17 @@ place to see numbered reports.
    python examples/jax/simple_regression.py
    ```
 
-3. Import them. Expect `main_pid<pid>_tid<tid>_exec{0,1,2}.json` at 34, 48 and 36 KB, with
-   pid and tid equal because JAX executes on the calling thread.
+3. Import them. Expect `main_pid<pid>_tid<tid>_exec{0,1,2}.json` at 52, 72 and 56 KB with
+   8–12 KB sidecars, and pid equal to tid because JAX executes on the calling thread.
 
    ```bash
    python examples/visualizer/import_graph_report.py \
        "$TT_RUNTIME_GRAPH_CAPTURE_DIR" --out dbs_jax
    ```
 
-   The merged database holds 9 operations, 17 tensors and 88 buffers — the tilize, matmul and
-   binary of three gradient steps. Pass the JSONs individually instead to get one database
-   per step.
+   The merged database holds 23 operations, 17 tensors and 220 buffers — the matmul, binary
+   and layout changes of three gradient steps, located as `loc("a")` and `loc("b")` after the
+   HLO argument names. Pass the JSONs individually instead to get one database per step.
 
 ## vLLM — `examples/vllm/TinyLlama-1.1B-Chat-v1.0`
 
@@ -201,9 +211,10 @@ served requests normally. The gap is upstream in tt-metal, so a bounded window i
 around it.
 
 Measured on TinyLlama-1.1B-Chat-v1.0 with `FIRST=40 REPORTS=1` and a 64-token completion: a
-3.65 MB report, importing in 4 s to a 438 KB database with 19 operations, 33 tensors and 8393
-buffer rows. One program is a slice of a decode step rather than the whole model, so raise
-`REPORTS` to follow consecutive programs — each lands as its own numbered file.
+2.99 MB report and a 17 KB sidecar, importing in 4 s to a 756 KB database with 38 operations,
+27 tensors and 17222 buffer rows. The server was ready in 4m51s and answered normally. One
+program is a slice of a decode step rather than the whole model, so raise `REPORTS` to follow
+consecutive programs — each lands as its own numbered file.
 
 ## Checking the hook without picking a sample
 
@@ -216,42 +227,44 @@ python examples/visualizer/import_graph_report.py graph_reports --out visualizer
 ```
 
 `--first` and `--reports` map straight onto the two variables. At `--steps 3 --reports 0` the
-run writes one report per step — 5.88 MB for the first, which carries the const-eval
-subprograms, then 5.90 MB each — and importing all three together gives 67 operations over
-1581 buffers.
+run writes one report per step — 5.78 MB for the first, which carries the const-eval
+subprograms, then 5.70 MB each — and importing all three together gives 93 operations over
+1820 buffers.
 
 ## What a tt-xla capture does and does not contain
 
-Present: the operation list, tensors, buffers and buffer pages, per-op device-operation
-trees, devices, the cluster descriptor, and report metadata carrying the tt-xla git URL
-and SHA.
+Present: the operation list, tensors, buffers and buffer pages, per-op device-operation trees,
+tensor lifetimes, devices, the cluster descriptor, and report metadata carrying the tt-xla git
+URL and SHA.
 
-Absent, and not fixable with a build flag:
+Operations are named after the program op — `Conv2dOp`, `LinearOp`, `Pool2dOp` — with the
+device operations each one dispatched nested inside it as its captured sub-graph. Every
+operation carries two arguments: `loc`, the MLIR location, which on a torch_xla or JAX capture
+is the HLO instruction name (`loc("convolution.49")`); and `mlir`, the op with all of its
+attributes. The stack-trace panel shows the same location. A few ops carry `loc(unknown)` — 3
+of 38 in the TinyLlama capture, among them the const-eval hoisting call and the typecasts
+around it, which no HLO instruction stands behind.
 
-- **Stack traces, source files and tensor lifetimes are empty, and operation names are
-  device-op level** (`MatmulDeviceOperation` rather than `ttnn.matmul`). All three come
-  from `python_io` records, which only ttnn's Python decorators write; ops arriving from
-  a C++ caller get none.
-- **The Graph tab never comes out connected.** Without `python_io` the importer falls back
-  to the graph tracker's own argument scan, which matches only plain `Tensor`-shaped types,
-  and it folds `Tensor::to_device`, `reshape`, `to_dtype` and `deallocate` away, rejecting
-  inputs whose producer went with them. Every capture measured breaks into many components:
+The Graph tab connects. What stays isolated is what has no edge to draw — the deallocation of
+a program input, and `GetDeviceOp`:
 
-  | Capture | Operations | Edges | Components | Largest | Isolated |
-  | --- | --- | --- | --- | --- | --- |
-  | mnist, one program | 59 | 28 | 31 | 11 | 20 |
-  | ConvNet, three programs | 67 | 17 | 50 | 4 | 39 |
-  | JAX, three programs | 9 | 5 | 4 | 3 | 1 |
-  | TinyLlama, one program | 19 | 11 | 8 | 9 | 6 |
-  | TinyLlama, wide window | 1236 | 1287 | 191 | 414 | 164 |
+| Capture | Operations | Edges | Components | Largest | Isolated |
+| --- | --- | --- | --- | --- | --- |
+| mnist, one program | 71 | 62 | 11 | 61 | 10 |
+| ConvNet, three programs | 93 | 72 | 25 | 69 | 24 |
+| JAX, three programs | 23 | 14 | 9 | 7 | 6 |
+| TinyLlama, one program | 38 | 33 | 5 | 34 | 4 |
 
-  The op mix moves the degree of fragmentation, not the outcome, and single-program captures
-  fragment as much as merged ones. Recording an input is not the same as having an edge to
-  draw: in the 1236-operation capture every operation records at least one input, yet 617 of
-  its 1948 input references name a tensor with no producer in the database. Convolutional
-  graphs fare worst, because halo and conv ops pass tensors inside attribute structs that
-  match nothing. A JAX-driven capture fragments like a torch one, so none of this is a
-  property of the hook.
+Every input reference naming a tensor that some operation in the report produced resolves to
+an edge. The ones left over name program inputs: in the mnist capture all 18 are weights or
+the input image, each referenced by the first op that touches it and by the deallocation that
+follows.
+
+Absent:
+
+- **Source files.** The Source tab resolves a stack trace by parsing Python frames, and an
+  MLIR location is not one, so `source_files` stays empty. The location names the HLO
+  instruction, not the line of model code behind it.
 - **The perf half of a report.** Tracy zones exist in Metalium and tt-mlir, but tt-xla's
   wheel build forces `TTMLIR_ENABLE_PERF_TRACE` off, so kernel timings need a source
   build under the tracy wrapper.
@@ -266,6 +279,7 @@ with ttnn.graph.full_graph_capture(out_path):
     ...
 ```
 
-That path records `python_io`, so its reports carry framework op names, stack traces and
-a fully connected Graph tab. It is the right reference to compare a tt-xla capture
-against.
+That path records `python_io` from ttnn's decorators, so its operations are named at the ttnn
+API level (`ttnn.matmul`) and its stack traces are real Python frames, which the Source tab
+can resolve to files. A tt-xla capture names operations at the program-op level and locates
+them in MLIR instead.

--- a/examples/visualizer/README.md
+++ b/examples/visualizer/README.md
@@ -23,37 +23,30 @@ variables work on a torch_xla script, a JAX script and a `vllm serve` process al
 | Variable | Meaning |
 | --- | --- |
 | `TT_RUNTIME_GRAPH_CAPTURE_DIR` | Where to write reports. Unset disables capture entirely. |
-| `TT_RUNTIME_GRAPH_CAPTURE_SKIP` | Execution scopes to run before the window opens. |
-| `TT_RUNTIME_GRAPH_CAPTURE_COUNT` | Execution scopes the window stays open for, merged into one report. |
+| `TT_RUNTIME_GRAPH_CAPTURE_FIRST` | Top-level program executions to run before the first report. Defaults to 0. |
+| `TT_RUNTIME_GRAPH_CAPTURE_REPORTS` | Reports to write, one per top-level execution. Defaults to 1; 0 records every execution. |
 
 Set `TT_METAL_HOME` during capture if you want the Topology tab's mesh coordinate mapping.
 
-## Sizing the window
+## What lands in a report
 
-Both counters count every `ProgramExecutor::execute()` scope, and a const-eval subprogram
-executes nested inside the program that needs its result. The window is flushed when the
-`COUNT`th scope exits, so a count smaller than a program's subprogram tree closes the window
-inside that tree: the report then holds the weight-preparation ops that ran first, and
-imports to zero operations because the importer folds `to_device`, `to_dtype`, `reshape` and
-`deallocate` away. A count equal to the whole tree closes the window as the top-level
-program's own scope exits, and the report holds that program entire.
+One report holds one top-level program execution, whole. A const-eval subprogram executes
+nested inside the program that needs its result and is recorded in that program's report, so
+a file carries a complete program tree rather than a slice of one. Reports are named
+`<program>_pid<pid>_tid<tid>_exec<index>.json` after the program and its execution index.
 
-To find the count for a run, capture with `COUNT=1` and raise `SKIP` until no report
-appears; that first empty `SKIP` is the run's total scope count. `examples/pytorch/mnist.py`
-produced a report at `SKIP` 0 through 6 and none at 7, so `COUNT=7` captures its single
-forward pass whole — 59 operations against 5 for `COUNT=5`.
+`REPORTS=0` records every execution from `FIRST` onwards, which is the mode to reach for on a
+short script. `capture_graph_report.py --steps 3 --reports 0` writes three files: 5.88 MB for
+the first step, which carries the const-eval subprograms, and 5.90 MB for each later step,
+which reuses their results.
 
-Reports are named `<program>_pid<pid>_tid<tid>_exec<index>.json` after the program that
-opened the window, which is how you tell where a window landed: `main_const_eval_3_…` means
-it opened inside a subprogram, so lower `SKIP`.
+Both counters exist to bound cost, and detailed buffer tracing is what makes that cost real.
+One mnist forward is 12.19 MB. On a TinyLlama server the programs range from 5 KB to 188 MB
+apiece, and `REPORTS=0` wrote 1.7 GB over 23 reports before the server had finished starting
+— so `REPORTS=0` is a mode for a short script, not for a serving model.
 
-Two limits of the current hook are worth knowing.
-
-- **`COUNT` must not exceed the run's total scope count.** A window still open when the
-  process exits is flushed by a `thread_local` destructor after the mesh device is gone, and
-  the process dumps core inside `ttnn::reports::get_buffer_pages`.
-- **One window per process.** It cannot reopen once closed, so a run produces a single
-  report. Capturing a different program means another run with a different `SKIP`.
+Import merges as many reports as you point it at, so capturing several executions separately
+and merging at import time gives the same database as one wide window would.
 
 ## Import
 
@@ -69,13 +62,10 @@ files to keep them separate. Then point ttnn-visualizer at `visualizer_dbs`.
 Every step below assumes an activated venv (`source venv/activate`) and a plugin carrying
 the hook. Numbers are measured on an n300 (wh-17).
 
-1. Enable capture. The whole forward is 7 scopes, one program plus six const-eval
-   subprograms.
+1. Enable capture. The sample runs one forward pass, so the defaults are what you want.
 
    ```bash
    export TT_RUNTIME_GRAPH_CAPTURE_DIR=$PWD/reports_mnist
-   export TT_RUNTIME_GRAPH_CAPTURE_SKIP=0
-   export TT_RUNTIME_GRAPH_CAPTURE_COUNT=7
    mkdir -p "$TT_RUNTIME_GRAPH_CAPTURE_DIR"
    ```
 
@@ -85,7 +75,7 @@ the hook. Numbers are measured on an n300 (wh-17).
    python examples/pytorch/mnist.py
    ```
 
-3. Import the report. Expect one file of about 12 MB named `main_pid<pid>_tid<tid>_exec0.json`
+3. Import the report. Expect one file of 12.19 MB named `main_pid<pid>_tid<tid>_exec0.json`
    — the pid and tid differ because torch_xla executes on a worker thread.
 
    ```bash
@@ -93,21 +83,19 @@ the hook. Numbers are measured on an n300 (wh-17).
        "$TT_RUNTIME_GRAPH_CAPTURE_DIR" --out dbs_mnist
    ```
 
-   The database holds 59 operations over 1813 buffers, including `Conv2dDeviceOperation`,
-   `HaloDeviceOperation` and `InterleavedToShardedDeviceOperation`. A database with 0
-   operations means the window closed inside the const-eval tree — raise `COUNT`.
+   The database holds 59 operations, 104 tensors and 1813 buffers, including
+   `Conv2dDeviceOperation`, `HaloDeviceOperation` and `InterleavedToShardedDeviceOperation`.
 
 ## JAX — `examples/jax/simple_regression.py`
 
-This example's programs carry no const-eval subprograms, so one scope is one execution of
-the jitted gradient and `COUNT` is simply how many training steps to merge.
+This example trains for 500 steps, each one a separate program execution, which makes it the
+place to see numbered reports.
 
-1. Enable capture for four steps. The example runs 500, so nothing here can outrun it.
+1. Ask for three of them.
 
    ```bash
    export TT_RUNTIME_GRAPH_CAPTURE_DIR=$PWD/reports_jax
-   export TT_RUNTIME_GRAPH_CAPTURE_SKIP=0
-   export TT_RUNTIME_GRAPH_CAPTURE_COUNT=4
+   export TT_RUNTIME_GRAPH_CAPTURE_REPORTS=3
    mkdir -p "$TT_RUNTIME_GRAPH_CAPTURE_DIR"
    ```
 
@@ -117,17 +105,17 @@ the jitted gradient and `COUNT` is simply how many training steps to merge.
    python examples/jax/simple_regression.py
    ```
 
-3. Import the report — about 182 KB, named `main_pid<pid>_tid<tid>_exec0.json` with pid and
-   tid equal, since JAX executes on the calling thread.
+3. Import them. Expect `main_pid<pid>_tid<tid>_exec{0,1,2}.json` at 34, 48 and 36 KB, with
+   pid and tid equal because JAX executes on the calling thread.
 
    ```bash
    python examples/visualizer/import_graph_report.py \
        "$TT_RUNTIME_GRAPH_CAPTURE_DIR" --out dbs_jax
    ```
 
-   The database holds 14 operations, 20 tensors, 143 buffers and 2 devices: the tilize,
-   matmul, binary and untilize of four gradient steps. Raising `SKIP` past 4 on this example
-   lands on a different program, and past 5 on a const-eval subprogram.
+   The merged database holds 9 operations, 17 tensors and 88 buffers — the tilize, matmul and
+   binary of three gradient steps. Pass the JSONs individually instead to get one database
+   per step.
 
 ## vLLM — `examples/vllm/TinyLlama-1.1B-Chat-v1.0`
 
@@ -154,13 +142,13 @@ want in a general-purpose environment.
    python -c "from vllm.platforms import current_platform as p; print(type(p).__name__, p.device_type)"
    ```
 
-2. Enable capture for the server process. `SKIP` has to clear weight loading — see the
-   warning below — and `COUNT` stays small because a decode step is one scope each.
+2. Enable capture for the server process. `FIRST` picks which program to record — 40 lands on
+   a serving program on this model — and one report keeps the run bounded.
 
    ```bash
    export TT_RUNTIME_GRAPH_CAPTURE_DIR=$PWD/reports_vllm
-   export TT_RUNTIME_GRAPH_CAPTURE_SKIP=40
-   export TT_RUNTIME_GRAPH_CAPTURE_COUNT=2
+   export TT_RUNTIME_GRAPH_CAPTURE_FIRST=40
+   export TT_RUNTIME_GRAPH_CAPTURE_REPORTS=1
    mkdir -p "$TT_RUNTIME_GRAPH_CAPTURE_DIR"
    ```
 
@@ -171,8 +159,8 @@ want in a general-purpose environment.
    bash examples/vllm/TinyLlama-1.1B-Chat-v1.0/service.sh
    ```
 
-4. Wait for it to come up — 5m35s and 7m31s on two runs with weights already cached — then
-   send one request from a second shell.
+4. Wait for it to come up — between 4m50s and 7m31s across four runs with weights already
+   cached — then send one request from a second shell.
 
    ```bash
    until curl -sf http://localhost:8000/v1/models >/dev/null; do sleep 5; done
@@ -183,8 +171,8 @@ want in a general-purpose environment.
             "max_tokens": 64, "temperature": 0}'
    ```
 
-5. Confirm the report landed, then stop the server. The window closes as soon as `COUNT`
-   scopes are done, so the file appears while the server is still serving.
+5. Confirm the report landed, then stop the server. The window closes when the recorded
+   program finishes, so the file appears while the server is still serving.
 
    ```bash
    ls -la "$TT_RUNTIME_GRAPH_CAPTURE_DIR"   # main_pid<pid>_tid<tid>_exec40.json
@@ -200,23 +188,22 @@ want in a general-purpose environment.
        "$TT_RUNTIME_GRAPH_CAPTURE_DIR"/main_pid*_exec40.json --out dbs_vllm
    ```
 
-If step 5 shows an empty directory, the run performed fewer than `SKIP` scopes — lower
-`SKIP` and repeat. If the server dies during startup with `Unsupported buffer type!`,
-`SKIP` was too low; raise it.
+If step 5 shows an empty directory, the run performed fewer top-level executions than
+`FIRST` — lower it and repeat.
 
-**The window must open after weight loading, not merely after warm-up.** Weight load
-allocates host-side `SYSTEM_MEMORY` buffers, and the per-op buffer snapshot the capture
-takes walks every buffer on the device and asks the allocator for its bank count.
-`AllocatorImpl::get_num_banks` handles `DRAM`, `L1`, `L1_SMALL` and `TRACE` and throws
-`Unsupported buffer type!` on `SYSTEM_MEMORY`, which surfaces as a `TT_THROW` inside
-`Tensor::to_device` and kills vLLM's engine core during startup. Those buffers are
-transient, so a window opened later is unaffected: `TT_RUNTIME_GRAPH_CAPTURE_SKIP=0` failed
-on TinyLlama while `SKIP=40` served requests normally.
+**Keep `REPORTS` bounded on a server.** Weight loading and warm-up allocate host-side
+`SYSTEM_MEMORY` buffers, and the per-op buffer snapshot walks every buffer on the device and
+asks the allocator for its bank count. `AllocatorImpl::get_num_banks` handles `DRAM`, `L1`,
+`L1_SMALL` and `TRACE` and throws `Unsupported buffer type!` on `SYSTEM_MEMORY`, which
+surfaces as a `TT_THROW` and kills vLLM's engine core. `REPORTS=0` on TinyLlama died that way
+23 reports and 1.7 GB into startup, while a single report at `FIRST=0` and at `FIRST=40` both
+served requests normally. The gap is upstream in tt-metal, so a bounded window is the way
+around it.
 
-Measured on TinyLlama-1.1B-Chat-v1.0 with `SKIP=40 COUNT=2` and a 64-token completion: a
-223 MB report, importing in 8 s to a 22 MB database with 1236 operations, 1701 tensors and
-581456 buffer rows. Reports scale with the window, so keep `COUNT` small for a serving
-model.
+Measured on TinyLlama-1.1B-Chat-v1.0 with `FIRST=40 REPORTS=1` and a 64-token completion: a
+3.65 MB report, importing in 4 s to a 438 KB database with 19 operations, 33 tensors and 8393
+buffer rows. One program is a slice of a decode step rather than the whole model, so raise
+`REPORTS` to follow consecutive programs — each lands as its own numbered file.
 
 ## Checking the hook without picking a sample
 
@@ -228,11 +215,10 @@ python examples/visualizer/capture_graph_report.py --out graph_reports
 python examples/visualizer/import_graph_report.py graph_reports --out visualizer_dbs
 ```
 
-At the default `--steps 3` the run is 6 scopes: `main` plus three const-evals for the first
-step, then one scope per later step, because the const-eval results are reused. The default
-`--skip 0 --count 4` therefore captures the first step whole, at 5.9 MB and 25 operations
-over 335 buffers; `--skip 4 --count 1` captures a steady-state step instead, at the same
-size.
+`--first` and `--reports` map straight onto the two variables. At `--steps 3 --reports 0` the
+run writes one report per step — 5.88 MB for the first, which carries the const-eval
+subprograms, then 5.90 MB each — and importing all three together gives 67 operations over
+1581 buffers.
 
 ## What a tt-xla capture does and does not contain
 

--- a/examples/visualizer/README.md
+++ b/examples/visualizer/README.md
@@ -71,17 +71,41 @@ Absent, and not fixable with a build flag:
   device-op level** (`MatmulDeviceOperation` rather than `ttnn.matmul`). All three come
   from `python_io` records, which only ttnn's Python decorators write; ops arriving from
   a C++ caller get none.
-- **The Graph tab fragments.** Without `python_io` the importer falls back to the graph
-  tracker's own argument scan, which matches only plain `Tensor`-shaped types — in one
-  measured run 160 of 339 captured ops recorded no inputs. The ids that are recorded do
-  line up (189 input references gave 161 links and 28 orphans, largest component 103
-  ops), but the importer then folds `Tensor::to_device`, `reshape`, `to_dtype` and
-  `deallocate` away and rejects inputs whose producer went with them, leaving 111
-  operations with 65 links across 58 components. A JAX-driven capture fragments the same
-  way, so this is not a property of the hook.
+- **The Graph tab fragments, by an amount that depends on the op mix.** Without
+  `python_io` the importer falls back to the graph tracker's own argument scan, which
+  matches only plain `Tensor`-shaped types. Convolutional graphs fare badly, because halo
+  and conv ops pass tensors inside attribute structs that match nothing: in one measured
+  run 160 of 339 captured ops recorded no inputs, and after the importer folds
+  `Tensor::to_device`, `reshape`, `to_dtype` and `deallocate` away and rejects inputs whose
+  producer went with them, 111 operations were left with 65 links across 58 components. A
+  transformer decode fares much better — a TinyLlama capture gave 1236 operations with
+  *every* one recording an input, 1287 links from 1948 references, and a largest component
+  of 414 ops (191 components in total, 617 orphaned inputs). A JAX-driven capture fragments
+  the same way as a torch one, so none of this is a property of the hook.
 - **The perf half of a report.** Tracy zones exist in Metalium and tt-mlir, but tt-xla's
   wheel build forces `TTMLIR_ENABLE_PERF_TRACE` off, so kernel timings need a source
   build under the tracy wrapper.
+
+## Capturing a vLLM server
+
+`capture_graph_report.py` drives its own model, but the same environment variables work on
+anything that runs through the plugin, including `vllm serve`. Export them around the
+server process — for example alongside `examples/vllm/TinyLlama-1.1B-Chat-v1.0/service.sh`
+— then send a request and shut the server down.
+
+**The window must open after weight loading, not merely after warm-up.** Weight load
+allocates host-side `SYSTEM_MEMORY` buffers, and the per-op buffer snapshot the capture
+takes walks every buffer on the device and asks the allocator for its bank count.
+`AllocatorImpl::get_num_banks` handles `DRAM`, `L1`, `L1_SMALL` and `TRACE` and throws
+`Unsupported buffer type!` on `SYSTEM_MEMORY`, which surfaces as a `TT_THROW` inside
+`Tensor::to_device` and kills vLLM's engine core during startup. Those buffers are
+transient, so a window opened later is unaffected: `TT_RUNTIME_GRAPH_CAPTURE_SKIP=0` failed
+on TinyLlama while `SKIP=40` served requests normally.
+
+Measured on TinyLlama-1.1B-Chat-v1.0 with `SKIP=40 COUNT=2` and a 64-token completion: a
+223 MB report, importing in 8 s to a 22 MB database with 1236 operations, 1701 tensors and
+581456 buffer rows. Reports scale with the window, so keep `COUNT` small for a serving
+model.
 
 ## Capturing pure ttnn instead
 

--- a/examples/visualizer/README.md
+++ b/examples/visualizer/README.md
@@ -233,9 +233,8 @@ subprograms, then 5.70 MB each — and importing all three together gives 93 ope
 
 ## What a tt-xla capture does and does not contain
 
-Present: the operation list, tensors, buffers and buffer pages, per-op device-operation trees,
-tensor lifetimes, devices, the cluster descriptor, and report metadata carrying the tt-xla git
-URL and SHA.
+Present: the operation list, tensors, buffers, per-op device-operation trees, tensor lifetimes,
+devices, the cluster descriptor, and report metadata carrying the tt-xla git URL and SHA.
 
 Operations are named after the program op — `Conv2dOp`, `LinearOp`, `Pool2dOp` — with the
 device operations each one dispatched nested inside it as its captured sub-graph. Every
@@ -265,6 +264,13 @@ Absent:
 - **Source files.** The Source tab resolves a stack trace by parsing Python frames, and an
   MLIR location is not one, so `source_files` stays empty. The location names the HLO
   instruction, not the line of model code behind it.
+- **Per-page buffer detail.** `buffer_chunks` stays empty — 0 rows for the mnist capture,
+  against 10463 for a native ttnn capture of the same network. The importer attaches pages to
+  an operation by address, and the buffers live at a program-op boundary are program tensors
+  allocated before the window opened, so no page snapshot exists for them; the intermediates
+  that were snapshotted are freed by then. tt-metal takes that snapshot only at graph stacking
+  level 1, which the hook's per-op scope now occupies. The buffer list and totals are
+  unaffected.
 - **The perf half of a report.** Tracy zones exist in Metalium and tt-mlir, but tt-xla's
   wheel build forces `TTMLIR_ENABLE_PERF_TRACE` off, so kernel timings need a source
   build under the tracy wrapper.
@@ -283,3 +289,12 @@ That path records `python_io` from ttnn's decorators, so its operations are name
 API level (`ttnn.matmul`) and its stack traces are real Python frames, which the Source tab
 can resolve to files. A tt-xla capture names operations at the program-op level and locates
 them in MLIR instead.
+
+The two are worth comparing on one network. The mnist model of `examples/pytorch/mnist.py`,
+hand-written in ttnn and captured this way, gives 17 operations — `ttnn.conv2d`,
+`ttnn.max_pool2d`, `ttnn.linear`, `ttnn.softmax` — each with its Python call stack and every
+keyword argument recorded by name, in a single graph component with nothing isolated. The
+tt-xla capture of the same network gives 71, because it records what the compiler produced:
+25 compute ops where the native path has 11, since `log_softmax` becomes eight, plus 6
+`LoadCachedOp`, a `GetDeviceOp` and 39 explicit `DeallocateOp`. Reach for the native path to
+study a ttnn op, and for the tt-xla path to study what a model lowered to.

--- a/examples/visualizer/README.md
+++ b/examples/visualizer/README.md
@@ -90,8 +90,73 @@ Absent, and not fixable with a build flag:
 
 `capture_graph_report.py` drives its own model, but the same environment variables work on
 anything that runs through the plugin, including `vllm serve`. Export them around the
-server process — for example alongside `examples/vllm/TinyLlama-1.1B-Chat-v1.0/service.sh`
-— then send a request and shut the server down.
+server process, send a request, then shut the server down.
+
+### TinyLlama, step by step
+
+These steps were run end to end on an n300. Use a checkout dedicated to this — installing
+vLLM pulls several GB of packages you will not want in a general-purpose environment.
+
+1. Install vLLM and the TT plugin into the activated venv. `vllm==0.26.0` does not displace
+   the venv's `torch` or `torch-xla`, but it does add its CUDA-flavoured dependencies.
+
+   ```bash
+   source venv/activate
+   (cd integrations/vllm_plugin && python setup.py bdist_wheel)
+   pip install --force-reinstall --no-deps \
+       integrations/vllm_plugin/dist/vllm_tt-0.1-cp312-cp312-linux_x86_64.whl
+   pip install "vllm==0.26.0" "transformers==5.14.1"
+   ```
+
+2. Enable capture for the server process. `SKIP` has to clear weight loading — see the
+   warning below — and `COUNT` stays small because a decode step is one execution each.
+
+   ```bash
+   export TT_RUNTIME_GRAPH_CAPTURE_DIR=$PWD/vllm_reports
+   export TT_RUNTIME_GRAPH_CAPTURE_SKIP=40
+   export TT_RUNTIME_GRAPH_CAPTURE_COUNT=2
+   mkdir -p "$TT_RUNTIME_GRAPH_CAPTURE_DIR"
+   ```
+
+3. Start the server in that same shell, so it inherits those variables. The weights
+   download on first run.
+
+   ```bash
+   bash examples/vllm/TinyLlama-1.1B-Chat-v1.0/service.sh
+   ```
+
+4. Wait for it to come up — measured at 7m31s with weights already cached — then send one
+   request from a second shell.
+
+   ```bash
+   until curl -sf http://localhost:8000/v1/models >/dev/null; do sleep 5; done
+   curl -s http://localhost:8000/v1/completions \
+       -H 'Content-Type: application/json' \
+       -d '{"model": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+            "prompt": "The capital of France is",
+            "max_tokens": 64, "temperature": 0}'
+   ```
+
+5. Confirm the report landed, then stop the server. The window closes as soon as `COUNT`
+   executions are done, so the file appears while the server is still serving.
+
+   ```bash
+   ls -la "$TT_RUNTIME_GRAPH_CAPTURE_DIR"   # main_pid<pid>_tid<tid>_exec40.json
+   ```
+
+   Then interrupt the server. It did not exit within 120 s of `SIGINT` in this run and
+   needed `SIGKILL`; the report is already written by then, so killing it costs nothing.
+
+6. Import it.
+
+   ```bash
+   python examples/visualizer/import_graph_report.py \
+       "$TT_RUNTIME_GRAPH_CAPTURE_DIR"/main_pid*_exec40.json --out vllm_dbs
+   ```
+
+If step 5 shows an empty directory, the run performed fewer than `SKIP` executions — lower
+`SKIP` and repeat. If the server dies during startup with `Unsupported buffer type!`,
+`SKIP` was too low; raise it.
 
 **The window must open after weight loading, not merely after warm-up.** Weight load
 allocates host-side `SYSTEM_MEMORY` buffers, and the per-op buffer snapshot the capture

--- a/examples/visualizer/README.md
+++ b/examples/visualizer/README.md
@@ -1,0 +1,86 @@
+<!-- SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+
+     SPDX-License-Identifier: Apache-2.0 -->
+
+# Capturing ttnn graph reports from tt-xla
+
+[ttnn-visualizer](https://github.com/tenstorrent/ttnn-visualizer) reads a memory report
+produced by ttnn's graph tracker: the operations that ran, the buffers they allocated,
+per-core pages, and the cluster topology. These scripts capture one from a tt-xla run and
+import it.
+
+## Requirements
+
+The capture is opened by tt-mlir's runtime, so the plugin has to be built against a
+tt-mlir that carries the graph-capture hook in `ProgramExecutor::execute()`. **No released
+`pjrt-plugin-tt` wheel has it yet** — `capture_graph_report.py` exits with a message
+rather than producing an empty report if the hook is absent.
+
+## Capture
+
+```bash
+python capture_graph_report.py --out graph_reports --skip 1 --count 1
+```
+
+The runtime reads three environment variables, which the script sets for you:
+
+| Variable | Meaning |
+| --- | --- |
+| `TT_RUNTIME_GRAPH_CAPTURE_DIR` | Where to write reports. Unset disables capture entirely. |
+| `TT_RUNTIME_GRAPH_CAPTURE_SKIP` | Program executions to run before capturing. Skip at least one to leave warm-up compilation out. |
+| `TT_RUNTIME_GRAPH_CAPTURE_COUNT` | Program executions per capture window, merged into a single report. |
+
+One model step becomes several program executions — the main program plus one per
+const-eval subgraph — so reports are named
+`<program>_pid<pid>_tid<tid>_exec<index>.json`. Spanning several executions is what makes
+per-op buffer detail accumulate; in one measured run a single program yielded no buffer
+chunks while eight yielded 2654.
+
+Set `TT_METAL_HOME` during capture if you want the Topology tab's mesh coordinate mapping.
+
+## Import
+
+```bash
+python import_graph_report.py graph_reports --out visualizer_dbs
+```
+
+A directory argument merges every capture inside it into one database; pass individual
+JSON files to keep them separate. Then point ttnn-visualizer at `visualizer_dbs`.
+
+## What a tt-xla capture does and does not contain
+
+Present: the operation list, tensors, buffers and buffer pages, per-op device-operation
+trees, devices, the cluster descriptor, and report metadata carrying the tt-xla git URL
+and SHA.
+
+Absent, and not fixable with a build flag:
+
+- **Stack traces, source files and tensor lifetimes are empty, and operation names are
+  device-op level** (`MatmulDeviceOperation` rather than `ttnn.matmul`). All three come
+  from `python_io` records, which only ttnn's Python decorators write; ops arriving from
+  a C++ caller get none.
+- **The Graph tab fragments.** Without `python_io` the importer falls back to the graph
+  tracker's own argument scan, which matches only plain `Tensor`-shaped types — in one
+  measured run 160 of 339 captured ops recorded no inputs. The ids that are recorded do
+  line up (189 input references gave 161 links and 28 orphans, largest component 103
+  ops), but the importer then folds `Tensor::to_device`, `reshape`, `to_dtype` and
+  `deallocate` away and rejects inputs whose producer went with them, leaving 111
+  operations with 65 links across 58 components. A JAX-driven capture fragments the same
+  way, so this is not a property of the hook.
+- **The perf half of a report.** Tracy zones exist in Metalium and tt-mlir, but tt-xla's
+  wheel build forces `TTMLIR_ENABLE_PERF_TRACE` off, so kernel timings need a source
+  build under the tracy wrapper.
+
+## Capturing pure ttnn instead
+
+For ops issued directly through ttnn's Python API — no tt-xla involved — capture from
+Python and skip these scripts entirely:
+
+```python
+with ttnn.graph.full_graph_capture(out_path):
+    ...
+```
+
+That path records `python_io`, so its reports carry framework op names, stack traces and
+a fully connected Graph tab. It is the right reference to compare a tt-xla capture
+against.

--- a/examples/visualizer/README.md
+++ b/examples/visualizer/README.md
@@ -19,7 +19,7 @@ rather than producing an empty report if the hook is absent.
 ## Capture
 
 ```bash
-python capture_graph_report.py --out graph_reports --skip 1 --count 1
+python capture_graph_report.py --out graph_reports --skip 0 --count 4
 ```
 
 The runtime reads three environment variables, which the script sets for you:
@@ -27,14 +27,26 @@ The runtime reads three environment variables, which the script sets for you:
 | Variable | Meaning |
 | --- | --- |
 | `TT_RUNTIME_GRAPH_CAPTURE_DIR` | Where to write reports. Unset disables capture entirely. |
-| `TT_RUNTIME_GRAPH_CAPTURE_SKIP` | Program executions to run before capturing. Skip at least one to leave warm-up compilation out. |
+| `TT_RUNTIME_GRAPH_CAPTURE_SKIP` | Program executions to run before capturing. Execution 0 is the forward program; compilation is not an execution. |
 | `TT_RUNTIME_GRAPH_CAPTURE_COUNT` | Program executions per capture window, merged into a single report. |
 
-One model step becomes several program executions — the main program plus one per
-const-eval subgraph — so reports are named
-`<program>_pid<pid>_tid<tid>_exec<index>.json`. Spanning several executions is what makes
-per-op buffer detail accumulate; in one measured run a single program yielded no buffer
-chunks while eight yielded 2654.
+One model step becomes several program executions — the forward program plus one per
+const-eval subgraph — and reports are named
+`<program>_pid<pid>_tid<tid>_exec<index>.json` after the program that opened the window.
+Spanning several executions is what makes per-op buffer detail accumulate: measured on
+the example model, `--skip 1 --count 1` lands on a const-eval subgraph and yields a
+5 KB report of two `to_dtype` calls, while `--skip 0 --count 4` yields 5.9 MB — 25
+operations over 335 buffers.
+
+Two limits of the current hook are worth knowing before you change these numbers.
+
+- **`--count` must not exceed the executions the run performs.** A window still open when
+  the process exits is flushed by a `thread_local` destructor after the mesh device is
+  gone, and the process dumps core inside `ttnn::reports::get_buffer_pages`. Raise
+  `--steps` alongside `--count`.
+- **One window per process.** The window cannot reopen once closed, so a run produces a
+  single report. Selecting a different program means another run with a different
+  `--skip`.
 
 Set `TT_METAL_HOME` during capture if you want the Topology tab's mesh coordinate mapping.
 

--- a/examples/visualizer/README.md
+++ b/examples/visualizer/README.md
@@ -290,11 +290,47 @@ API level (`ttnn.matmul`) and its stack traces are real Python frames, which the
 can resolve to files. A tt-xla capture names operations at the program-op level and locates
 them in MLIR instead.
 
-The two are worth comparing on one network. The mnist model of `examples/pytorch/mnist.py`,
-hand-written in ttnn and captured this way, gives 17 operations — `ttnn.conv2d`,
+`capture_ttnn_mnist.py` writes that report for the network of `examples/pytorch/mnist.py`,
+built op by op in ttnn, which makes the two paths comparable on one model. ttnn is not in the
+tt-xla venv, so point at the tt-metal the plugin was built against:
+
+```bash
+export TT_METAL_HOME=third_party/tt-mlir/src/tt-mlir/third_party/tt-metal/src/tt-metal
+export PYTHONPATH=$TT_METAL_HOME/ttnn:$TT_METAL_HOME
+python examples/visualizer/capture_ttnn_mnist.py --report graph_reports_ttnn/report.json
+python examples/visualizer/import_graph_report.py graph_reports_ttnn/report.json \
+    --out visualizer_dbs_ttnn
+```
+
+The report is 11.79 MB with a 350 KB sidecar, importing to 17 operations — `ttnn.conv2d`,
 `ttnn.max_pool2d`, `ttnn.linear`, `ttnn.softmax` — each with its Python call stack and every
-keyword argument recorded by name, in a single graph component with nothing isolated. The
-tt-xla capture of the same network gives 71, because it records what the compiler produced:
-25 compute ops where the native path has 11, since `log_softmax` becomes eight, plus 6
-`LoadCachedOp`, a `GetDeviceOp` and 39 explicit `DeallocateOp`. Reach for the native path to
-study a ttnn op, and for the tt-xla path to study what a model lowered to.
+keyword argument recorded by name, in a single graph component with nothing isolated, over
+585 buffers and 10463 buffer chunks. The tt-xla capture of the same network gives 71
+operations, because it records what the compiler produced: 25 compute ops where the native
+path has 11, since `log_softmax` becomes eight, plus 6 `LoadCachedOp`, a `GetDeviceOp` and 39
+explicit `DeallocateOp`. Reach for the native path to study a ttnn op, and for the tt-xla path
+to study what a model lowered to.
+
+For the Source tab to populate, run the import from a directory that contains the captured
+script: the importer only reads a stack-trace path lying under the current directory, the venv
+or `sys.path`, and drops the source silently otherwise.
+
+## References
+
+- [ttnn-visualizer](https://github.com/tenstorrent/ttnn-visualizer) — the viewer these reports
+  are for, and its [installation and usage
+  docs](https://github.com/tenstorrent/ttnn-visualizer/blob/main/README.md).
+- [Graph tracing in ttnn](https://github.com/tenstorrent/tt-metal/blob/main/tech_reports/ttnn/graph-tracing.md)
+  — the tech report for the mechanism underneath: what the graph tracker records, what
+  `python_io` adds, and how tensor ids link operations.
+- [`ttnn/ttnn/graph.py`](https://github.com/tenstorrent/tt-metal/blob/main/ttnn/ttnn/graph.py) —
+  the Python capture entry points, including `full_graph_capture`.
+- [`ttnn/ttnn/graph_report.py`](https://github.com/tenstorrent/tt-metal/blob/main/ttnn/ttnn/graph_report.py)
+  — the importer `import_graph_report.py` calls, and the authority on the database schema and
+  on which report keys fill which table.
+- [`ttnn/core/graph/graph_processor.cpp`](https://github.com/tenstorrent/tt-metal/blob/main/ttnn/core/graph/graph_processor.cpp)
+  — the C++ side that records the graph and takes the buffer snapshots.
+- [`runtime/lib/ttnn/program_executor.cpp`](https://github.com/tenstorrent/tt-mlir/blob/main/runtime/lib/ttnn/program_executor.cpp)
+  in tt-mlir — where the capture hook lives once it lands.
+- [tt-xla issue #5816](https://github.com/tenstorrent/tt-xla/issues/5816) — the validation work
+  this directory came out of, including the tab-by-tab state of a tt-xla capture.

--- a/examples/visualizer/README.md
+++ b/examples/visualizer/README.md
@@ -6,8 +6,9 @@
 
 [ttnn-visualizer](https://github.com/tenstorrent/ttnn-visualizer) reads a memory report
 produced by ttnn's graph tracker: the operations that ran, the buffers they allocated,
-per-core pages, and the cluster topology. These scripts capture one from a tt-xla run and
-import it.
+per-core pages, and the cluster topology. This directory holds an import script, a
+self-contained capture script, and a walkthrough for one sample from each of
+`examples/pytorch`, `examples/jax` and `examples/vllm`.
 
 ## Requirements
 
@@ -16,48 +17,222 @@ tt-mlir that carries the graph-capture hook in `ProgramExecutor::execute()`. **N
 `pjrt-plugin-tt` wheel has it yet** — `capture_graph_report.py` exits with a message
 rather than producing an empty report if the hook is absent.
 
-## Capture
-
-```bash
-python capture_graph_report.py --out graph_reports --skip 0 --count 4
-```
-
-The runtime reads three environment variables, which the script sets for you:
+Because the runtime opens it, no sample needs changing: the same three environment
+variables work on a torch_xla script, a JAX script and a `vllm serve` process alike.
 
 | Variable | Meaning |
 | --- | --- |
 | `TT_RUNTIME_GRAPH_CAPTURE_DIR` | Where to write reports. Unset disables capture entirely. |
-| `TT_RUNTIME_GRAPH_CAPTURE_SKIP` | Program executions to run before capturing. Execution 0 is the forward program; compilation is not an execution. |
-| `TT_RUNTIME_GRAPH_CAPTURE_COUNT` | Program executions per capture window, merged into a single report. |
-
-One model step becomes several program executions — the forward program plus one per
-const-eval subgraph — and reports are named
-`<program>_pid<pid>_tid<tid>_exec<index>.json` after the program that opened the window.
-Spanning several executions is what makes per-op buffer detail accumulate: measured on
-the example model, `--skip 1 --count 1` lands on a const-eval subgraph and yields a
-5 KB report of two `to_dtype` calls, while `--skip 0 --count 4` yields 5.9 MB — 25
-operations over 335 buffers.
-
-Two limits of the current hook are worth knowing before you change these numbers.
-
-- **`--count` must not exceed the executions the run performs.** A window still open when
-  the process exits is flushed by a `thread_local` destructor after the mesh device is
-  gone, and the process dumps core inside `ttnn::reports::get_buffer_pages`. Raise
-  `--steps` alongside `--count`.
-- **One window per process.** The window cannot reopen once closed, so a run produces a
-  single report. Selecting a different program means another run with a different
-  `--skip`.
+| `TT_RUNTIME_GRAPH_CAPTURE_SKIP` | Execution scopes to run before the window opens. |
+| `TT_RUNTIME_GRAPH_CAPTURE_COUNT` | Execution scopes the window stays open for, merged into one report. |
 
 Set `TT_METAL_HOME` during capture if you want the Topology tab's mesh coordinate mapping.
+
+## Sizing the window
+
+Both counters count every `ProgramExecutor::execute()` scope, and a const-eval subprogram
+executes nested inside the program that needs its result. The window is flushed when the
+`COUNT`th scope exits, so a count smaller than a program's subprogram tree closes the window
+inside that tree: the report then holds the weight-preparation ops that ran first, and
+imports to zero operations because the importer folds `to_device`, `to_dtype`, `reshape` and
+`deallocate` away. A count equal to the whole tree closes the window as the top-level
+program's own scope exits, and the report holds that program entire.
+
+To find the count for a run, capture with `COUNT=1` and raise `SKIP` until no report
+appears; that first empty `SKIP` is the run's total scope count. `examples/pytorch/mnist.py`
+produced a report at `SKIP` 0 through 6 and none at 7, so `COUNT=7` captures its single
+forward pass whole — 59 operations against 5 for `COUNT=5`.
+
+Reports are named `<program>_pid<pid>_tid<tid>_exec<index>.json` after the program that
+opened the window, which is how you tell where a window landed: `main_const_eval_3_…` means
+it opened inside a subprogram, so lower `SKIP`.
+
+Two limits of the current hook are worth knowing.
+
+- **`COUNT` must not exceed the run's total scope count.** A window still open when the
+  process exits is flushed by a `thread_local` destructor after the mesh device is gone, and
+  the process dumps core inside `ttnn::reports::get_buffer_pages`.
+- **One window per process.** It cannot reopen once closed, so a run produces a single
+  report. Capturing a different program means another run with a different `SKIP`.
 
 ## Import
 
 ```bash
-python import_graph_report.py graph_reports --out visualizer_dbs
+python examples/visualizer/import_graph_report.py <reports-dir> --out visualizer_dbs
 ```
 
-A directory argument merges every capture inside it into one database; pass individual
-JSON files to keep them separate. Then point ttnn-visualizer at `visualizer_dbs`.
+A directory argument merges every capture inside it into one database; pass individual JSON
+files to keep them separate. Then point ttnn-visualizer at `visualizer_dbs`.
+
+## PyTorch — `examples/pytorch/mnist.py`
+
+Every step below assumes an activated venv (`source venv/activate`) and a plugin carrying
+the hook. Numbers are measured on an n300 (wh-17).
+
+1. Enable capture. The whole forward is 7 scopes, one program plus six const-eval
+   subprograms.
+
+   ```bash
+   export TT_RUNTIME_GRAPH_CAPTURE_DIR=$PWD/reports_mnist
+   export TT_RUNTIME_GRAPH_CAPTURE_SKIP=0
+   export TT_RUNTIME_GRAPH_CAPTURE_COUNT=7
+   mkdir -p "$TT_RUNTIME_GRAPH_CAPTURE_DIR"
+   ```
+
+2. Run the sample. It takes 22 s and ends with a PCC check against CPU.
+
+   ```bash
+   python examples/pytorch/mnist.py
+   ```
+
+3. Import the report. Expect one file of about 12 MB named `main_pid<pid>_tid<tid>_exec0.json`
+   — the pid and tid differ because torch_xla executes on a worker thread.
+
+   ```bash
+   python examples/visualizer/import_graph_report.py \
+       "$TT_RUNTIME_GRAPH_CAPTURE_DIR" --out dbs_mnist
+   ```
+
+   The database holds 59 operations over 1813 buffers, including `Conv2dDeviceOperation`,
+   `HaloDeviceOperation` and `InterleavedToShardedDeviceOperation`. A database with 0
+   operations means the window closed inside the const-eval tree — raise `COUNT`.
+
+## JAX — `examples/jax/simple_regression.py`
+
+This example's programs carry no const-eval subprograms, so one scope is one execution of
+the jitted gradient and `COUNT` is simply how many training steps to merge.
+
+1. Enable capture for four steps. The example runs 500, so nothing here can outrun it.
+
+   ```bash
+   export TT_RUNTIME_GRAPH_CAPTURE_DIR=$PWD/reports_jax
+   export TT_RUNTIME_GRAPH_CAPTURE_SKIP=0
+   export TT_RUNTIME_GRAPH_CAPTURE_COUNT=4
+   mkdir -p "$TT_RUNTIME_GRAPH_CAPTURE_DIR"
+   ```
+
+2. Run the sample. It takes 15 s and prints a falling loss.
+
+   ```bash
+   python examples/jax/simple_regression.py
+   ```
+
+3. Import the report — about 182 KB, named `main_pid<pid>_tid<tid>_exec0.json` with pid and
+   tid equal, since JAX executes on the calling thread.
+
+   ```bash
+   python examples/visualizer/import_graph_report.py \
+       "$TT_RUNTIME_GRAPH_CAPTURE_DIR" --out dbs_jax
+   ```
+
+   The database holds 14 operations, 20 tensors, 143 buffers and 2 devices: the tilize,
+   matmul, binary and untilize of four gradient steps. Raising `SKIP` past 4 on this example
+   lands on a different program, and past 5 on a const-eval subprogram.
+
+## vLLM — `examples/vllm/TinyLlama-1.1B-Chat-v1.0`
+
+Use a checkout dedicated to this — installing vLLM pulls several GB of packages you will not
+want in a general-purpose environment.
+
+1. Install vLLM and register the TT plugin. `venv/activate` puts
+   `integrations/vllm_plugin` on `PYTHONPATH`, which makes `vllm_tt` importable; vLLM finds
+   the platform through a `vllm.platform_plugins` entry point, and that scan reads installed
+   distribution metadata. An editable install supplies the metadata and leaves the code where
+   it is. The pinned `vllm` leaves the venv's `torch` and `torch-xla` alone, and adds its
+   CUDA-flavoured dependencies.
+
+   ```bash
+   source venv/activate
+   pip install --no-deps -e integrations/vllm_plugin
+   pip install -r integrations/vllm_plugin/requirements-vllm-plugin.txt
+   ```
+
+   Confirm the plugin is visible before starting a server — this prints `TTPlatform xla`
+   when it is and `UnspecifiedPlatform` when the metadata is missing:
+
+   ```bash
+   python -c "from vllm.platforms import current_platform as p; print(type(p).__name__, p.device_type)"
+   ```
+
+2. Enable capture for the server process. `SKIP` has to clear weight loading — see the
+   warning below — and `COUNT` stays small because a decode step is one scope each.
+
+   ```bash
+   export TT_RUNTIME_GRAPH_CAPTURE_DIR=$PWD/reports_vllm
+   export TT_RUNTIME_GRAPH_CAPTURE_SKIP=40
+   export TT_RUNTIME_GRAPH_CAPTURE_COUNT=2
+   mkdir -p "$TT_RUNTIME_GRAPH_CAPTURE_DIR"
+   ```
+
+3. Start the server in that same shell, so it inherits those variables. The weights
+   download on first run.
+
+   ```bash
+   bash examples/vllm/TinyLlama-1.1B-Chat-v1.0/service.sh
+   ```
+
+4. Wait for it to come up — 5m35s and 7m31s on two runs with weights already cached — then
+   send one request from a second shell.
+
+   ```bash
+   until curl -sf http://localhost:8000/v1/models >/dev/null; do sleep 5; done
+   curl -s http://localhost:8000/v1/completions \
+       -H 'Content-Type: application/json' \
+       -d '{"model": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+            "prompt": "The capital of France is",
+            "max_tokens": 64, "temperature": 0}'
+   ```
+
+5. Confirm the report landed, then stop the server. The window closes as soon as `COUNT`
+   scopes are done, so the file appears while the server is still serving.
+
+   ```bash
+   ls -la "$TT_RUNTIME_GRAPH_CAPTURE_DIR"   # main_pid<pid>_tid<tid>_exec40.json
+   ```
+
+   Then interrupt the server. It did not exit within 120 s of `SIGINT` in either run and
+   needed `SIGKILL`; the report is already written by then, so killing it costs nothing.
+
+6. Import it.
+
+   ```bash
+   python examples/visualizer/import_graph_report.py \
+       "$TT_RUNTIME_GRAPH_CAPTURE_DIR"/main_pid*_exec40.json --out dbs_vllm
+   ```
+
+If step 5 shows an empty directory, the run performed fewer than `SKIP` scopes — lower
+`SKIP` and repeat. If the server dies during startup with `Unsupported buffer type!`,
+`SKIP` was too low; raise it.
+
+**The window must open after weight loading, not merely after warm-up.** Weight load
+allocates host-side `SYSTEM_MEMORY` buffers, and the per-op buffer snapshot the capture
+takes walks every buffer on the device and asks the allocator for its bank count.
+`AllocatorImpl::get_num_banks` handles `DRAM`, `L1`, `L1_SMALL` and `TRACE` and throws
+`Unsupported buffer type!` on `SYSTEM_MEMORY`, which surfaces as a `TT_THROW` inside
+`Tensor::to_device` and kills vLLM's engine core during startup. Those buffers are
+transient, so a window opened later is unaffected: `TT_RUNTIME_GRAPH_CAPTURE_SKIP=0` failed
+on TinyLlama while `SKIP=40` served requests normally.
+
+Measured on TinyLlama-1.1B-Chat-v1.0 with `SKIP=40 COUNT=2` and a 64-token completion: a
+223 MB report, importing in 8 s to a 22 MB database with 1236 operations, 1701 tensors and
+581456 buffer rows. Reports scale with the window, so keep `COUNT` small for a serving
+model.
+
+## Checking the hook without picking a sample
+
+`capture_graph_report.py` drives a small ConvNet of its own and sets the variables from its
+flags, which makes it the quickest way to tell whether a build has the hook at all.
+
+```bash
+python examples/visualizer/capture_graph_report.py --out graph_reports
+python examples/visualizer/import_graph_report.py graph_reports --out visualizer_dbs
+```
+
+At the default `--steps 3` the run is 6 scopes: `main` plus three const-evals for the first
+step, then one scope per later step, because the const-eval results are reused. The default
+`--skip 0 --count 4` therefore captures the first step whole, at 5.9 MB and 25 operations
+over 335 buffers; `--skip 4 --count 1` captures a steady-state step instead, at the same
+size.
 
 ## What a tt-xla capture does and does not contain
 
@@ -85,101 +260,6 @@ Absent, and not fixable with a build flag:
 - **The perf half of a report.** Tracy zones exist in Metalium and tt-mlir, but tt-xla's
   wheel build forces `TTMLIR_ENABLE_PERF_TRACE` off, so kernel timings need a source
   build under the tracy wrapper.
-
-## Capturing a vLLM server
-
-`capture_graph_report.py` drives its own model, but the same environment variables work on
-anything that runs through the plugin, including `vllm serve`. Export them around the
-server process, send a request, then shut the server down.
-
-### TinyLlama, step by step
-
-These steps were run end to end on an n300. Use a checkout dedicated to this — installing
-vLLM pulls several GB of packages you will not want in a general-purpose environment.
-
-1. Install vLLM and register the TT plugin. `venv/activate` puts
-   `integrations/vllm_plugin` on `PYTHONPATH`, which makes `vllm_tt` importable; vLLM finds
-   the platform through a `vllm.platform_plugins` entry point, and that scan reads installed
-   distribution metadata. An editable install supplies the metadata and leaves the code where
-   it is. The pinned `vllm` leaves the venv's `torch` and `torch-xla` alone, and adds its
-   CUDA-flavoured dependencies.
-
-   ```bash
-   source venv/activate
-   pip install --no-deps -e integrations/vllm_plugin
-   pip install -r integrations/vllm_plugin/requirements-vllm-plugin.txt
-   ```
-
-   Confirm the plugin is visible before starting a server — this prints `TTPlatform xla`
-   when it is and `UnspecifiedPlatform` when the metadata is missing:
-
-   ```bash
-   python -c "from vllm.platforms import current_platform as p; print(type(p).__name__, p.device_type)"
-   ```
-
-2. Enable capture for the server process. `SKIP` has to clear weight loading — see the
-   warning below — and `COUNT` stays small because a decode step is one execution each.
-
-   ```bash
-   export TT_RUNTIME_GRAPH_CAPTURE_DIR=$PWD/vllm_reports
-   export TT_RUNTIME_GRAPH_CAPTURE_SKIP=40
-   export TT_RUNTIME_GRAPH_CAPTURE_COUNT=2
-   mkdir -p "$TT_RUNTIME_GRAPH_CAPTURE_DIR"
-   ```
-
-3. Start the server in that same shell, so it inherits those variables. The weights
-   download on first run.
-
-   ```bash
-   bash examples/vllm/TinyLlama-1.1B-Chat-v1.0/service.sh
-   ```
-
-4. Wait for it to come up — 5m35s and 7m31s on two runs with weights already cached — then
-   send one request from a second shell.
-
-   ```bash
-   until curl -sf http://localhost:8000/v1/models >/dev/null; do sleep 5; done
-   curl -s http://localhost:8000/v1/completions \
-       -H 'Content-Type: application/json' \
-       -d '{"model": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
-            "prompt": "The capital of France is",
-            "max_tokens": 64, "temperature": 0}'
-   ```
-
-5. Confirm the report landed, then stop the server. The window closes as soon as `COUNT`
-   executions are done, so the file appears while the server is still serving.
-
-   ```bash
-   ls -la "$TT_RUNTIME_GRAPH_CAPTURE_DIR"   # main_pid<pid>_tid<tid>_exec40.json
-   ```
-
-   Then interrupt the server. It did not exit within 120 s of `SIGINT` in this run and
-   needed `SIGKILL`; the report is already written by then, so killing it costs nothing.
-
-6. Import it.
-
-   ```bash
-   python examples/visualizer/import_graph_report.py \
-       "$TT_RUNTIME_GRAPH_CAPTURE_DIR"/main_pid*_exec40.json --out vllm_dbs
-   ```
-
-If step 5 shows an empty directory, the run performed fewer than `SKIP` executions — lower
-`SKIP` and repeat. If the server dies during startup with `Unsupported buffer type!`,
-`SKIP` was too low; raise it.
-
-**The window must open after weight loading, not merely after warm-up.** Weight load
-allocates host-side `SYSTEM_MEMORY` buffers, and the per-op buffer snapshot the capture
-takes walks every buffer on the device and asks the allocator for its bank count.
-`AllocatorImpl::get_num_banks` handles `DRAM`, `L1`, `L1_SMALL` and `TRACE` and throws
-`Unsupported buffer type!` on `SYSTEM_MEMORY`, which surfaces as a `TT_THROW` inside
-`Tensor::to_device` and kills vLLM's engine core during startup. Those buffers are
-transient, so a window opened later is unaffected: `TT_RUNTIME_GRAPH_CAPTURE_SKIP=0` failed
-on TinyLlama while `SKIP=40` served requests normally.
-
-Measured on TinyLlama-1.1B-Chat-v1.0 with `SKIP=40 COUNT=2` and a 64-token completion: a
-223 MB report, importing in 8 s to a 22 MB database with 1236 operations, 1701 tensors and
-581456 buffer rows. Reports scale with the window, so keep `COUNT` small for a serving
-model.
 
 ## Capturing pure ttnn instead
 

--- a/examples/visualizer/capture_graph_report.py
+++ b/examples/visualizer/capture_graph_report.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Capture ttnn graph reports from a torch_xla run on TT hardware.
+
+The capture is opened by tt-mlir's runtime inside ProgramExecutor::execute(), not
+from Python: torch_xla dispatches execution to a worker thread and ttnn's
+GraphTracker keeps its processors in thread_local storage, so a capture opened
+around the model call sees nothing.
+
+Import the resulting JSONs with import_graph_report.py.
+"""
+
+import argparse
+import os
+from pathlib import Path
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path("graph_reports"),
+        help="directory to write capture JSONs to",
+    )
+    parser.add_argument(
+        "--skip",
+        type=int,
+        default=1,
+        help="program executions to run before capturing; skips warm-up compilation",
+    )
+    parser.add_argument(
+        "--count",
+        type=int,
+        default=1,
+        help="program executions per capture window, all merged into one report",
+    )
+    parser.add_argument("--steps", type=int, default=3, help="model invocations to run")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    args.out.mkdir(parents=True, exist_ok=True)
+
+    # The runtime reads these once, on the first program execution.
+    os.environ["TT_RUNTIME_GRAPH_CAPTURE_DIR"] = str(args.out.resolve())
+    os.environ["TT_RUNTIME_GRAPH_CAPTURE_SKIP"] = str(args.skip)
+    os.environ["TT_RUNTIME_GRAPH_CAPTURE_COUNT"] = str(args.count)
+
+    import torch
+    import torch.nn as nn
+    import torch_xla.core.xla_model as xm
+    import torch_xla.runtime as xr
+
+    class ConvNet(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = nn.Conv2d(1, 32, 3, 1)
+            self.fc = nn.Linear(32 * 26 * 26, 10)
+
+        def forward(self, x):
+            x = torch.relu(self.conv(x))
+            return self.fc(x.flatten(1))
+
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    device = xm.xla_device()
+    model = ConvNet().to(dtype=torch.bfloat16).eval()
+    model.compile(backend="tt")
+    model = model.to(device)
+
+    with torch.no_grad():
+        for step in range(args.steps):
+            inp = torch.full((4, 1, 28, 28), step + 1.0, dtype=torch.bfloat16)
+            out = model(inp.to(device))
+            print(f"step {step}: {out.cpu()[0, :3].tolist()}")
+
+    reports = sorted(p.name for p in args.out.glob("*.json"))
+    if not reports:
+        raise SystemExit(
+            f"no reports in {args.out} — the tt-mlir runtime in this build has no "
+            "graph-capture hook (see README.md)"
+        )
+    print(f"\n{len(reports)} report(s) in {args.out}:")
+    for name in reports:
+        print(f"  {name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/visualizer/capture_graph_report.py
+++ b/examples/visualizer/capture_graph_report.py
@@ -26,17 +26,16 @@ def parse_args():
         help="directory to write capture JSONs to",
     )
     parser.add_argument(
-        "--skip",
+        "--first",
         type=int,
         default=0,
-        help="execution scopes to run before the window opens",
+        help="top-level program executions to run before the first report",
     )
     parser.add_argument(
-        "--count",
+        "--reports",
         type=int,
-        default=4,
-        help="execution scopes the window stays open for, merged into one report; "
-        "must not exceed the run's total scope count (see README.md)",
+        default=1,
+        help="reports to write, one per top-level execution; 0 records every execution",
     )
     parser.add_argument("--steps", type=int, default=3, help="model invocations to run")
     return parser.parse_args()
@@ -48,8 +47,8 @@ def main():
 
     # The runtime reads these once, on the first program execution.
     os.environ["TT_RUNTIME_GRAPH_CAPTURE_DIR"] = str(args.out.resolve())
-    os.environ["TT_RUNTIME_GRAPH_CAPTURE_SKIP"] = str(args.skip)
-    os.environ["TT_RUNTIME_GRAPH_CAPTURE_COUNT"] = str(args.count)
+    os.environ["TT_RUNTIME_GRAPH_CAPTURE_FIRST"] = str(args.first)
+    os.environ["TT_RUNTIME_GRAPH_CAPTURE_REPORTS"] = str(args.reports)
 
     import torch
     import torch.nn as nn

--- a/examples/visualizer/capture_graph_report.py
+++ b/examples/visualizer/capture_graph_report.py
@@ -28,14 +28,15 @@ def parse_args():
     parser.add_argument(
         "--skip",
         type=int,
-        default=1,
-        help="program executions to run before capturing; skips warm-up compilation",
+        default=0,
+        help="program executions to run before capturing; index 0 is the forward program",
     )
     parser.add_argument(
         "--count",
         type=int,
-        default=1,
-        help="program executions per capture window, all merged into one report",
+        default=4,
+        help="program executions per capture window, merged into one report; "
+        "must not exceed the executions the run performs (see README.md)",
     )
     parser.add_argument("--steps", type=int, default=3, help="model invocations to run")
     return parser.parse_args()

--- a/examples/visualizer/capture_graph_report.py
+++ b/examples/visualizer/capture_graph_report.py
@@ -29,14 +29,14 @@ def parse_args():
         "--skip",
         type=int,
         default=0,
-        help="program executions to run before capturing; index 0 is the forward program",
+        help="execution scopes to run before the window opens",
     )
     parser.add_argument(
         "--count",
         type=int,
         default=4,
-        help="program executions per capture window, merged into one report; "
-        "must not exceed the executions the run performs (see README.md)",
+        help="execution scopes the window stays open for, merged into one report; "
+        "must not exceed the run's total scope count (see README.md)",
     )
     parser.add_argument("--steps", type=int, default=3, help="model invocations to run")
     return parser.parse_args()

--- a/examples/visualizer/capture_ttnn_mnist.py
+++ b/examples/visualizer/capture_ttnn_mnist.py
@@ -1,0 +1,187 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Capture a graph report for the mnist network written directly in ttnn.
+
+Same architecture as the model in examples/pytorch/mnist.py — conv(1->32,3x3)
+relu, conv(32->64,3x3) relu, max_pool 2x2, flatten, linear(9216->128) relu,
+linear(128->10), log_softmax — so the report it writes is a reference point for
+what the same network looks like captured through tt-xla. Dropout is an
+inference-time identity and is left out, as it is in the tt-xla graph.
+
+Requires ttnn on the path, which the tt-xla venv does not provide; see the
+README section on capturing pure ttnn for the two variables to set.
+"""
+
+import argparse
+import pathlib
+
+import torch
+import ttnn
+
+BATCH = 4
+
+
+def build_weights():
+    torch.manual_seed(42)
+    return {
+        name: torch.randn(shape, dtype=torch.bfloat16)
+        for name, shape in (
+            ("conv1.weight", (32, 1, 3, 3)),
+            ("conv1.bias", (32,)),
+            ("conv2.weight", (64, 32, 3, 3)),
+            ("conv2.bias", (64,)),
+            ("fc1.weight", (128, 9216)),
+            ("fc1.bias", (128,)),
+            ("fc2.weight", (10, 128)),
+            ("fc2.bias", (10,)),
+        )
+    }
+
+
+def conv_params(weights, name):
+    # conv2d takes its weights host-side in row-major, bias as 1x1x1xC.
+    weight = ttnn.from_torch(
+        weights[f"{name}.weight"], layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16
+    )
+    bias = ttnn.from_torch(
+        weights[f"{name}.bias"].reshape((1, 1, 1, -1)),
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+    )
+    return weight, bias
+
+
+def linear_params(weights, name, device):
+    weight = ttnn.from_torch(
+        weights[f"{name}.weight"].transpose(0, 1).contiguous(),
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        device=device,
+    )
+    bias = ttnn.from_torch(
+        weights[f"{name}.bias"].reshape((1, -1)),
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        device=device,
+    )
+    return weight, bias
+
+
+def forward(device, weights, x_torch):
+    relu = ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU)
+
+    # conv2d takes NHWC.
+    x = ttnn.from_torch(
+        x_torch.permute(0, 2, 3, 1).contiguous(),
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        device=device,
+    )
+
+    weight, bias = conv_params(weights, "conv1")
+    x = ttnn.conv2d(
+        input_tensor=x,
+        weight_tensor=weight,
+        bias_tensor=bias,
+        in_channels=1,
+        out_channels=32,
+        device=device,
+        kernel_size=(3, 3),
+        stride=(1, 1),
+        padding=(0, 0),
+        batch_size=BATCH,
+        input_height=28,
+        input_width=28,
+        conv_config=ttnn.Conv2dConfig(weights_dtype=ttnn.bfloat16, activation=relu),
+        groups=1,
+    )
+
+    weight, bias = conv_params(weights, "conv2")
+    x = ttnn.conv2d(
+        input_tensor=x,
+        weight_tensor=weight,
+        bias_tensor=bias,
+        in_channels=32,
+        out_channels=64,
+        device=device,
+        kernel_size=(3, 3),
+        stride=(1, 1),
+        padding=(0, 0),
+        batch_size=BATCH,
+        input_height=26,
+        input_width=26,
+        conv_config=ttnn.Conv2dConfig(weights_dtype=ttnn.bfloat16, activation=relu),
+        groups=1,
+    )
+
+    x = ttnn.max_pool2d(
+        x,
+        batch_size=BATCH,
+        input_h=24,
+        input_w=24,
+        channels=64,
+        kernel_size=[2, 2],
+        stride=[2, 2],
+        padding=[0, 0],
+        dilation=[1, 1],
+        ceil_mode=False,
+    )
+
+    # Pooling returns a sharded L1 tensor; reshape needs it interleaved.
+    x = ttnn.to_memory_config(x, ttnn.DRAM_MEMORY_CONFIG)
+    x = ttnn.reshape(x, (BATCH, 9216))
+    x = ttnn.to_layout(x, ttnn.TILE_LAYOUT)
+
+    # The flattened activations stay NHWC-ordered, so fc1's columns are reordered
+    # to match rather than permuting the activations on device.
+    nhwc_weights = dict(weights)
+    nhwc_weights["fc1.weight"] = (
+        weights["fc1.weight"]
+        .reshape(128, 64, 12, 12)
+        .permute(0, 2, 3, 1)
+        .reshape(128, 9216)
+    )
+
+    weight, bias = linear_params(nhwc_weights, "fc1", device)
+    x = ttnn.relu(ttnn.linear(x, weight, bias=bias))
+
+    weight, bias = linear_params(weights, "fc2", device)
+    x = ttnn.linear(x, weight, bias=bias)
+
+    # ttnn has no log_softmax.
+    return ttnn.log(ttnn.softmax(x, dim=-1))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--report",
+        default="graph_reports_ttnn/report.json",
+        help="destination JSON file for the report (default: %(default)s)",
+    )
+    args = parser.parse_args()
+
+    report = pathlib.Path(args.report).resolve()
+    report.parent.mkdir(parents=True, exist_ok=True)
+
+    device = ttnn.open_device(device_id=0, l1_small_size=8192)
+    try:
+        with ttnn.graph.full_graph_capture(str(report)):
+            x = torch.ones((BATCH, 1, 28, 28), dtype=torch.bfloat16)
+            output = forward(device, build_weights(), x)
+        print(f"output shape: {tuple(output.shape)}")
+    finally:
+        ttnn.close_device(device)
+
+    sidecar = report.with_suffix(".python_io.json")
+    print(f"report:  {report} ({report.stat().st_size} bytes)")
+    if sidecar.exists():
+        print(f"sidecar: {sidecar} ({sidecar.stat().st_size} bytes)")
+    else:
+        print(f"sidecar: {sidecar} MISSING")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/visualizer/import_graph_report.py
+++ b/examples/visualizer/import_graph_report.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Import captured ttnn graph reports into ttnn-visualizer SQLite databases.
+
+Offline step: needs the ttnn Python package, not a device.
+"""
+
+import argparse
+from pathlib import Path
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "reports",
+        type=Path,
+        nargs="+",
+        help="capture JSON files, or directories whose captures are merged into one database",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path("visualizer_dbs"),
+        help="directory to create the databases in",
+    )
+    parser.add_argument(
+        "--svgs", action="store_true", help="also render per-report SVGs"
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    from ttnn.graph_report import import_report
+
+    for report in args.reports:
+        if not report.exists():
+            raise SystemExit(f"no such report: {report}")
+        out_dir = args.out / report.stem
+        db = import_report(report, out_dir, generate_svgs=args.svgs)
+        print(f"{report} -> {db}")
+
+    print(f"\nOpen {args.out} in ttnn-visualizer as a local report directory.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/visualizer/time_sdxl_stages.py
+++ b/examples/visualizer/time_sdxl_stages.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Time each stage of the SDXL-Lightning demo.
+
+`examples/pytorch/sdxl_lightning.py` marks its stages and denoising steps with
+loguru `[STAGE]`/`[STEP]` lines, which the plugin's log level hides. This runs the
+demo with a stand-in logger that prints them with elapsed and per-stage times,
+which separates compilation from steady-state execution.
+
+Run from the repository root:
+    python examples/visualizer/time_sdxl_stages.py
+"""
+
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "examples" / "pytorch"))
+
+import sdxl_lightning
+import torch_xla.runtime as xr
+
+OUTPUT_PATH = "sdxl_lightning_output.png"
+
+
+class StageTimer:
+    """Stands in for the demo's module-level logger, timing the lines it emits."""
+
+    def __init__(self, inner):
+        self._inner = inner
+        self._start = time.perf_counter()
+        self._previous = self._start
+
+    def info(self, message, *args, **kwargs):
+        now = time.perf_counter()
+        elapsed = now - self._start
+        delta = now - self._previous
+        print(f"[T+{elapsed:8.2f}s  +{delta:7.2f}s] {message}", flush=True)
+        self._previous = now
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+
+def main(output_path: str = OUTPUT_PATH):
+    xr.set_device_type("TT")
+    sdxl_lightning.logger = StageTimer(sdxl_lightning.logger)
+
+    output_file = Path(output_path)
+    if output_file.exists():
+        output_file.unlink()
+
+    sdxl_lightning.run_sdxl_lightning(output_path=output_path)
+    sdxl_lightning.logger.info(f"Output image saved to {output_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### What

Adds `examples/visualizer/`: a capture script, an import script, a native-ttnn comparison script, a stage-timing script and a README for producing a ttnn-visualizer memory report from a tt-xla run.

### Why an example is needed

Capturing a report from tt-xla is not the documented Python flow. torch_xla dispatches execution to a worker thread and ttnn's `GraphTracker` keeps its processors in `thread_local` storage, so a capture opened around the model call records 2 nodes where the same run captured from inside the runtime records 1706. Under JAX the identical Python capture works, because `Execute` stays on the caller's thread, which is what makes the failure mode worth writing down. The capture has to be opened by tt-mlir's runtime instead, driven by three environment variables that work the same on a torch_xla script, a JAX script and a `vllm serve` process.

### Dependency: instrumentation in tt-mlir

The hook is C++ only, 188 lines in `runtime/lib/ttnn/program_executor.cpp`: a capture window per top-level program execution, and a tracked scope per flatbuffer op that writes a `<report>.python_io.json` sidecar carrying the op's MLIR location, its op text and the tensor ids it read and wrote. That sidecar is ttnn's [`python_io`](https://github.com/tenstorrent/tt-metal/blob/main/tech_reports/ttnn/graph-tracing.md) format, and it gives the report its operation names, arguments, stack traces and a connected Graph tab. Capture stays off unless `TT_RUNTIME_GRAPH_CAPTURE_DIR` is set.

Up for review as tenstorrent/tt-mlir#9180, draft and marked do-not-merge, at `1aefe6c5a2`. No released `pjrt-plugin-tt` wheel carries it, so the plugin has to be built from source; `capture_graph_report.py` exits with a message naming the missing hook rather than producing an empty report. Worth reviewing now, and not for merging before the tt-mlir side lands.

### Related: two gaps in tt-metal

Both surfaced while validating this workflow, both are in tt-metal rather than in tt-xla or tt-mlir, and neither blocks this PR. Both sit behind detailed buffer tracing, so neither fix below touches a run that is not capturing. Neither is filed yet; the recommendation is to file both against tt-metal and work around them here in the meantime, which the README already does.

**`get_num_banks` throws on host buffers, so a capture spanning weight loading kills the process.** `AllocatorImpl::get_num_banks` (`tt_metal/impl/allocator/allocator.cpp:287`) answers for `DRAM`, `L1`, `L1_SMALL` and `TRACE` and throws `Unsupported buffer type!` for anything else. `ttnn::reports::get_buffers` (`ttnn/core/reports.cpp:54`) calls it for every buffer `get_allocated_buffers()` returns, with no filter, and `get_buffer_pages` does the same — so one host-side `SYSTEM_MEMORY` buffer alive at a snapshot point takes the process down. Weight loading allocates them, which is why `REPORTS=0` dies during vLLM startup. Recommendation: filter the reports walk to the buffer types the allocator banks, rather than relaxing `get_num_banks`. A memory report models device memory, and a host buffer has no banks or pages to report, so the allocator's contract is the one worth keeping. Cost is a buffer-type check per allocated buffer, in a loop that already computes page counts and bank maps, and it removes the work currently done for host buffers. Workaround in place: open a bounded window after weight loading.

**Live-buffer snapshots only happen at graph stacking level 1, which leaves `buffer_chunks` empty for a capture driven from C++.** `GraphProcessor::track_function_end_impl` (`ttnn/core/graph/graph_processor.cpp:496`) takes the snapshot only at that level, and page detail is recorded per address when a buffer is allocated. With the runtime hook opening a scope per program op, level 1 is the program op: the buffers live at its boundary are program tensors allocated before the capture window, which have no page record, while the intermediates that do have one are already freed. Measured at 0 rows, against 1327 when device ops occupied level 1 and 10463 for a native ttnn capture of the same network. Recommendation: at snapshot time, capture pages for any live buffer whose address has no entry in the page timeline. That fixes the root cause — pages are only recorded on allocation, so nothing allocated before the window ever gets them — and it covers program inputs and weights, which the level-1 behaviour never did. Its cost is bounded by distinct addresses rather than by op count, since a captured address needs capturing once: the mnist report page-captures 11 addresses at ~3457 pages each, and 72 distinct addresses appear across its snapshots, so covering all of them would be in the region of six times the page data — an extrapolation from those averages rather than a measurement, and it grows with live-buffer count on a larger model. Measured on SDXL below: a snapshot per program op costs 22565156 buffer records across 11977 snapshots.

Snapshotting at every stacking level is the smaller change and would restore the 1327 rows, but it costs more: the mnist capture has 71 `function_start` nodes at stacking level 1, 158 at level 2 and 74 at level 3, so 303 full buffer walks in place of the 67 taken today, each walking every allocated buffer — a mean of 37 live buffers per snapshot and a maximum of 62 for mnist, against the 17222 buffer rows one TinyLlama program's database holds.

### A large model: SDXL-Lightning

`examples/pytorch/sdxl_lightning.py` is the first sample here big enough to break the format. Eight windows from the start of the run produce 12 GB of reports and get the process OOM-killed at 2152 s, because a report's graph data is held in memory until the file is written: the container's `memory.max` is 62.95 GiB, the kill recorded 64.4 GB of anonymous RSS, and the same run with capture off peaks at 31.98 GB. The eight are 45.8 MB (text encoder 1), 252 MB (text encoder 2), 435 KB, 27.6 KB, 6.09 GB (first UNet step), 337 KB, 6.33 GB (second UNet step) and 337 KB — so `FIRST` matters more here than in any other walkthrough, and the README recommends one small program.

The 6.09 GB UNet report is the measurement the second gap above was missing. It is 252110474 lines of pretty-printed JSON, of which the graph is 1.0% at 142359 nodes, while `per_operation_buffers` takes 62.6% — 22565156 buffer records across 11977 snapshots, averaging 1884 live buffers each — and `buffer_pages_by_address` another 36.3% at 8328320 page records across 64 addresses. A snapshot per program op costs 22.5 M records at this size, which is the argument for capturing pages lazily per address instead of snapshotting at every stacking level.

Two things the capture surfaced that are not about capture. The UNet runs on one of the n300's two chips: both are opened and appear in `devices` with 64 compute cores each, and all 22.5 M buffer records sit on `device_id` 2 with none on `device_id` 0. And a captured window's `total_duration_ns` of 466 s is compilation rather than compute — `time_sdxl_stages.py` runs the demo with a stand-in logger for the `[STAGE]` and `[STEP]` lines the plugin's log level hides, and measures 20.0 s to load, 10.9 s and 34.9 s for the text encoders, 245.1 s for the first UNet step against 2.3 s for each later one, 122.1 s for the VAE decode, and 462 s end to end, of which four denoising steps are about 9 s. A cold kernel cache compounds that: the first run on a machine JIT-compiles 2314 kernel ELFs with nothing on the terminal, where a second recompiles 8 objects out of 6030, so one uncaptured run before capturing keeps the compile out of the window.

### What the README documents

One walkthrough per examples category — `examples/pytorch/mnist.py`, `examples/jax/simple_regression.py`, `examples/vllm/TinyLlama-1.1B-Chat-v1.0`, `examples/pytorch/sdxl_lightning.py` — plus `capture_graph_report.py` as the quickest way to tell whether a build carries the hook at all.

A capture yields the operation list, tensors, buffers, per-op device-operation trees, tensor lifetimes, devices, the cluster descriptor and report metadata. Operations are named after the program op — `Conv2dOp`, `LinearOp`, `Pool2dOp` — with the device operations each dispatched nested inside it as a sub-graph, and the MLIR location it was lowered from as its argument and its stack trace, which on a torch_xla or JAX capture is the HLO instruction name (`loc("convolution.49")`). The Graph tab connects: mnist 71 operations in 11 components with a largest of 61, the ConvNet 93 in 25 with 69, JAX 23 in 9 with 7, one TinyLlama serving program 38 in 5 with 34. What stays isolated is what has no edge to draw — the deallocation of a program input, and `GetDeviceOp`.

Two tables stay empty, and the README says why. `source_files`, because the Source tab resolves a stack trace by parsing Python frames and an MLIR location is not one. And `buffer_chunks`, the per-page detail behind the Buffers tab — the second tt-metal gap above, measured at 0 rows against 10463 for a native ttnn capture of the same network. The buffer list and totals are unaffected. Kernel timings need a source build, since wheel builds force `TTMLIR_ENABLE_PERF_TRACE` off.

`capture_ttnn_mnist.py` builds the same mnist network op by op in ttnn and captures it through `ttnn.graph.full_graph_capture`, which shows how much of the format a tt-xla capture reaches. Natively it is 17 operations — `ttnn.conv2d`, `ttnn.max_pool2d`, `ttnn.linear`, `ttnn.softmax` — each with its Python call stack and every keyword argument recorded by name, in one component with nothing isolated. Through tt-xla it is 71, because the report records what the compiler produced: 25 compute ops against 11, since `log_softmax` becomes eight, plus 6 `LoadCachedOp`, a `GetDeviceOp` and 39 explicit `DeallocateOp`.

### Testing

Every walkthrough captured and imported end to end on n300 (wh-17) against a source build carrying the hook. mnist on the defaults gives one 12.15 MB report and a 53 KB sidecar, importing to 71 operations, 82 tensors and 2491 buffers. `REPORTS=3` on the JAX example gives three reports of 52, 72 and 56 KB, merging to 23 operations over 220 buffers. `--steps 3 --reports 0` on the ConvNet gives 5.78 MB then 5.70 MB each, merging to 93 operations over 1820 buffers. One TinyLlama serving program is 2.99 MB, importing in 4 s to 38 operations over 17222 buffers, with the server ready in 4m51s and answering normally. The native ttnn capture is 11.79 MB with a 350 KB sidecar, importing to 17 operations over 585 buffers. SDXL-Lightning was captured at `REPORTS=8` until the OOM kill described above, and `time_sdxl_stages.py` ran it uncaptured to a 1024x1024 image in 462 s.

Two caveats the README carries. `REPORTS=0` against a serving model dies during weight load, 23 reports and 1.7 GB in — the first tt-metal gap above, which a bounded window avoids. Second, the vLLM walkthrough needs `pip install --no-deps -e integrations/vllm_plugin`: `venv/activate` makes `vllm_tt` importable, but vLLM finds the platform through a `vllm.platform_plugins` entry point that reads installed distribution metadata, and without it `current_platform` resolves to `UnspecifiedPlatform` and the server never reaches the device.

### References

- [Graph tracing in ttnn](https://github.com/tenstorrent/tt-metal/blob/main/tech_reports/ttnn/graph-tracing.md) — what the graph tracker records, what `python_io` adds, and how tensor ids link operations.
- [`ttnn/ttnn/graph_report.py`](https://github.com/tenstorrent/tt-metal/blob/main/ttnn/ttnn/graph_report.py) — the importer `import_graph_report.py` calls, and the authority on the database schema.
- [`ttnn/ttnn/graph.py`](https://github.com/tenstorrent/tt-metal/blob/main/ttnn/ttnn/graph.py) — the Python capture entry points, including `full_graph_capture`.
- [`ttnn/core/graph/graph_processor.cpp`](https://github.com/tenstorrent/tt-metal/blob/main/ttnn/core/graph/graph_processor.cpp) — the C++ side that records the graph and takes the buffer snapshots, and where the `buffer_chunks` condition lives.
- [ttnn-visualizer](https://github.com/tenstorrent/ttnn-visualizer) — the viewer, and its [usage docs](https://github.com/tenstorrent/ttnn-visualizer/blob/main/README.md).

Part of #5816.






