### PR TITLE
[vLLM] Narrow the fill page table to the columns paged_fill_cache reads

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/model_runner.py
+++ b/integrations/vllm_plugin/vllm_tt/model_runner.py
@@ -1212,6 +1212,60 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         return tuple(tasks)
 
+    def _fill_page_table_width(self, group_idx: int, read_width: int) -> int:
+        """Columns the fill page table needs, far fewer than the read table.
+
+        paged_fill_cache only indexes ``cdiv(step_tokens, block_size)`` entries --
+        the bound its validator enforces -- but reads the whole row with a single
+        noc_async_read, and a large single read from interleaved DRAM can hang the
+        device. The roll in _prepare_inputs puts the chunk's blocks up front, so the
+        leading columns are the ones it wants.
+
+        The bound is the per-step token budget, not the context length: without
+        chunked prefill the width comes back at the read table's.
+
+        Guarded here rather than at each caller so allocation and both warmup
+        graph builders fail on the host at startup, not on the device.
+        """
+        block_size = (
+            self._group_block_sizes[group_idx]
+            if group_idx < len(self._group_block_sizes)
+            else self.block_size
+        )
+        # Round to 8 entries: a ttnn page-table stick must be 32B-aligned, the
+        # same rule _chunked_sdpa_active checks against max_num_blocks_per_req.
+        width = cdiv(cdiv(self.max_num_tokens, block_size), 8) * 8
+        fill_width = min(width, read_width)
+        # Do not relax: paged_fill_cache's page-table lookup is unbounded, so a
+        # sliding ring shorter than the chunk hangs or silently corrupts KV.
+        # https://github.com/tenstorrent/tt-xla/issues/5911
+        assert fill_width * block_size >= self.max_num_tokens, (
+            f"group {group_idx} fill page table ({fill_width} cols x block_size "
+            f"{block_size}) cannot cover a {self.max_num_tokens}-token step"
+        )
+        return fill_width
+
+    def _copy_narrow_fill_page_table(
+        self,
+        dev_buf: torch.Tensor,
+        host_table: torch.Tensor,
+        block_size: int,
+        step_tokens: int,
+        group_idx: int,
+    ) -> None:
+        """Stage the leading columns of ``host_table`` into the narrow fill buffer.
+
+        Narrower than the read table (see ``_fill_page_table_width``), so this
+        always truncates; assert the truncation still spans the step.
+        """
+        fill_width = dev_buf.shape[1]
+        # Per-step backstop for the invariant _fill_page_table_width pins.
+        assert fill_width * block_size >= step_tokens, (
+            f"group {group_idx} fill page table ({fill_width} cols x block_size "
+            f"{block_size}) cannot cover this step's {step_tokens} tokens"
+        )
+        dev_buf.copy_(host_table[:, :fill_width])
+
     def _alloc_page_table_device_buffers(self, num_groups: int) -> None:
         """(Re)allocate per-group page_table / fill_page_table device buffers.
 
@@ -1240,6 +1294,11 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 )
             return base_width
 
+        def _fill_pt_width(group_idx, base_width):
+            return self._fill_page_table_width(
+                group_idx, _pt_width(group_idx, base_width)
+            )
+
         self._page_table_dev_max = {
             g: {
                 nr: _alloc_dev((nr, _pt_width(g, self.max_num_blocks_per_req)), dt)
@@ -1249,7 +1308,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         }
         self._fill_page_table_dev_max = {
             g: {
-                nr: _alloc_dev((nr, _pt_width(g, self.max_num_blocks_per_req)), dt)
+                nr: _alloc_dev((nr, _fill_pt_width(g, self.max_num_blocks_per_req)), dt)
                 for nr in max_reqs
             }
             for g in range(num_groups)
@@ -1789,20 +1848,21 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 # cache_position (computed above; shared across sliding groups).
                 # fill == read except for inactive-row null redirect (also above).
                 page_table_dev.copy_(sliding_page_table)
-                if sliding_fill_page_table is sliding_page_table:
-                    fill_page_table_dev = page_table_dev
-                else:
-                    fill_page_table_dev_buf.copy_(sliding_fill_page_table)
-                    fill_page_table_dev = fill_page_table_dev_buf
+                # Narrower than the read table, so never an alias.
+                self._copy_narrow_fill_page_table(
+                    fill_page_table_dev_buf,
+                    sliding_fill_page_table,
+                    self._group_block_sizes[g],
+                    padded_total_num_scheduled_tokens,
+                    g,
+                )
+                fill_page_table_dev = fill_page_table_dev_buf
                 if self.parallel_mode in (
                     ParallelismMode.DATA_PARALLEL_ONLY,
                     ParallelismMode.DATA_TENSOR_PARALLEL,
                 ):
                     safe_mark_sharding(page_table_dev, self.mesh, ("batch", None))
-                    if fill_page_table_dev is not page_table_dev:
-                        safe_mark_sharding(
-                            fill_page_table_dev, self.mesh, ("batch", None)
-                        )
+                    safe_mark_sharding(fill_page_table_dev, self.mesh, ("batch", None))
                 attn_metadata_per_group.append(
                     TTMetadata(
                         page_table=page_table_dev,
@@ -1870,11 +1930,15 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     fill_page_table[zero_sched_rows, :] = 0
 
             page_table_dev.copy_(page_table)
-            if fill_page_table is page_table:
-                fill_page_table_dev = page_table_dev
-            else:
-                fill_page_table_dev_buf.copy_(fill_page_table)
-                fill_page_table_dev = fill_page_table_dev_buf
+            # Narrowed like the sliding branch, so never an alias.
+            self._copy_narrow_fill_page_table(
+                fill_page_table_dev_buf,
+                fill_page_table,
+                block_size_g,
+                padded_total_num_scheduled_tokens,
+                g,
+            )
+            fill_page_table_dev = fill_page_table_dev_buf
 
             if self.parallel_mode in (
                 ParallelismMode.DATA_PARALLEL_ONLY,
@@ -1882,8 +1946,7 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             ):
                 # page_table shares the K/V input's per-device leading dim.
                 safe_mark_sharding(page_table_dev, self.mesh, ("batch", None))
-                if fill_page_table_dev is not page_table_dev:
-                    safe_mark_sharding(fill_page_table_dev, self.mesh, ("batch", None))
+                safe_mark_sharding(fill_page_table_dev, self.mesh, ("batch", None))
 
             attn_metadata_per_group.append(
                 TTMetadata(
@@ -3133,20 +3196,17 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             page_table = torch.zeros((num_reqs, pt_w), dtype=torch.int32).to(
                 self.device
             )
-            fill_page_table = None
-            if prefix_chunk:
-                # A continuation chunk uses a distinct fill_page_table at runtime;
-                # pass a separate tensor so the traced graph has matching arity.
-                fill_page_table = torch.zeros((num_reqs, pt_w), dtype=torch.int32).to(
-                    self.device
-                )
+            # Runtime fill table is narrower and always distinct; trace it so.
+            fill_w = self._fill_page_table_width(_g, pt_w)
+            fill_page_table = torch.zeros((num_reqs, fill_w), dtype=torch.int32).to(
+                self.device
+            )
             if self.parallel_mode in (
                 ParallelismMode.DATA_PARALLEL_ONLY,
                 ParallelismMode.DATA_TENSOR_PARALLEL,
             ):
                 safe_mark_sharding(page_table, self.mesh, ("batch", None))
-                if fill_page_table is not None:
-                    safe_mark_sharding(fill_page_table, self.mesh, ("batch", None))
+                safe_mark_sharding(fill_page_table, self.mesh, ("batch", None))
             attn_metadata_per_group.append(
                 TTMetadata(
                     page_table=page_table,
@@ -3608,18 +3668,16 @@ class TTModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 (num_reqs, pt_w),
                 dtype=torch.int32,
             ).to(self.device)
-            fill_page_table = page_table
-            if prefix_chunk:
-                fill_page_table = torch.zeros((num_reqs, pt_w), dtype=torch.int32).to(
-                    self.device
-                )
+            fill_w = self._fill_page_table_width(_g, pt_w)
+            fill_page_table = torch.zeros((num_reqs, fill_w), dtype=torch.int32).to(
+                self.device
+            )
             if self.parallel_mode in (
                 ParallelismMode.DATA_PARALLEL_ONLY,
                 ParallelismMode.DATA_TENSOR_PARALLEL,
             ):
                 safe_mark_sharding(page_table, self.mesh, ("batch", None))
-                if fill_page_table is not page_table:
-                    safe_mark_sharding(fill_page_table, self.mesh, ("batch", None))
+                safe_mark_sharding(fill_page_table, self.mesh, ("batch", None))
             attn_metadata_per_group.append(
                 TTMetadata(
                     page_table=page_table,

--- a/tests/integrations/vllm_plugin/test_fill_page_table_width.py
+++ b/tests/integrations/vllm_plugin/test_fill_page_table_width.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the narrowed paged_fill_cache page table.
+
+The fill page table is allocated at the width ``paged_fill_cache`` actually
+indexes rather than the read table's full ``max_model_len`` width, which makes
+"the fill table always spans the step's tokens" a load-bearing invariant. These
+tests pin that bound, the 32B stick alignment, the read-width clamp, and both
+host-side guards (at width computation and per step), all without a device.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from vllm_tt.model_runner import TTModelRunner
+
+# Device-free, but the vLLM push matrix only runs device-marked jobs; tag so the
+# single_device job collects these (they need no device and run in milliseconds).
+pytestmark = [pytest.mark.push, pytest.mark.single_device]
+
+# Wide enough that the read-table clamp is never the binding constraint.
+_UNCLAMPED = 1 << 20
+
+# (max_num_tokens, block_size). Token buckets are 1 (decode_only) or a power of
+# two >= 32 (_get_token_paddings); block sizes are what the platform and the
+# tests that override it actually use.
+_BOUND_CASES = [
+    (1, 32),  # decode_only=True -> num_tokens_paddings == [1]
+    (32, 8),  # test_model_runner_buffer_keying's shrunken block size
+    (32, 32),
+    (128, 32),
+    (2048, 32),
+    (2048, 64),
+    (2048, 128),
+    (4096, 32),
+    (131072, 32),  # single-shot prefill of a full 128K context
+    (131072, 64),
+]
+
+
+def _runner(max_num_tokens, block_size, group_block_sizes=None):
+    """The only runner state ``_fill_page_table_width`` reads."""
+    return SimpleNamespace(
+        max_num_tokens=max_num_tokens,
+        block_size=block_size,
+        _group_block_sizes=(
+            [block_size] if group_block_sizes is None else group_block_sizes
+        ),
+    )
+
+
+def _width(runner, group_idx=0, read_width=_UNCLAMPED):
+    return TTModelRunner._fill_page_table_width(runner, group_idx, read_width)
+
+
+@pytest.mark.parametrize("max_num_tokens,block_size", _BOUND_CASES)
+def test_width_covers_the_largest_possible_step(max_num_tokens, block_size):
+    """The bound paged_fill_cache's validator enforces on the device."""
+    width = _width(_runner(max_num_tokens, block_size))
+    assert width * block_size >= max_num_tokens
+
+
+@pytest.mark.parametrize("max_num_tokens,block_size", _BOUND_CASES)
+def test_width_is_stick_aligned_when_the_read_table_does_not_clamp(
+    max_num_tokens, block_size
+):
+    """A ttnn page-table stick is 32B aligned: 8 int32 block ids."""
+    width = _width(_runner(max_num_tokens, block_size))
+    assert width > 0
+    assert width % 8 == 0
+
+
+@pytest.mark.parametrize("read_width", [64, 65, 4096, _UNCLAMPED])
+def test_never_wider_than_the_read_table(read_width):
+    """Widening past the read table would break the ``[:, :fill_width]`` copy."""
+    assert _width(_runner(2048, 32), read_width=read_width) <= read_width
+
+
+def test_clamped_to_the_read_width_when_the_read_table_is_narrower():
+    """Sliding groups only address their window ring, which can be the narrower
+    of the two -- then the clamp wins and the 8-alignment comes from the ring
+    (``sliding_window_blocks`` already rounds to 8)."""
+    assert _width(_runner(128, 32), read_width=4) == 4
+
+
+@pytest.mark.parametrize("read_width", [1, 7, 8, 63])
+def test_rejects_a_read_table_too_short_for_the_largest_step(read_width):
+    """A ring shorter than the chunk must fail at startup, not on the device."""
+    with pytest.raises(AssertionError, match="cannot cover"):
+        _width(_runner(2048, 32), read_width=read_width)
+
+
+def test_uses_each_groups_own_block_size():
+    """Hybrid KV caches can assign a different block_size per group; a larger
+    block means fewer page-table entries for the same token count."""
+    runner = _runner(2048, 32, group_block_sizes=[32, 128])
+    assert _width(runner, group_idx=0) == 64  # cdiv(2048, 32)
+    assert _width(runner, group_idx=1) == 16  # cdiv(2048, 128)
+
+
+def test_falls_back_to_the_base_block_size_for_an_unknown_group():
+    """The base block_size is the smallest, so the fallback errs wide (safe)."""
+    runner = _runner(2048, 32, group_block_sizes=[32])
+    assert _width(runner, group_idx=5) == _width(runner, group_idx=0)
+
+
+def test_long_context_fill_table_is_far_narrower_than_the_read_table():
+    """The case this narrowing exists for: at max_model_len=131072 / block_size=32
+    the read table is 4096 entries, of which a 2048-token chunk indexes 64."""
+    read_width = 131072 // 32
+    assert _width(_runner(2048, 32), read_width=read_width) == 64
+
+
+def test_copy_narrow_stages_the_leading_columns():
+    """``_prepare_inputs`` rolls the chunk's blocks to the front, so the leading
+    columns are exactly the ones paged_fill_cache wants."""
+    host = torch.arange(2 * 16, dtype=torch.int32).reshape(2, 16)
+    dev_buf = torch.zeros((2, 8), dtype=torch.int32)
+    TTModelRunner._copy_narrow_fill_page_table(
+        None, dev_buf, host, block_size=32, step_tokens=8 * 32, group_idx=0
+    )
+    assert torch.equal(dev_buf, host[:, :8])
+
+
+def test_copy_narrow_rejects_a_table_too_short_for_the_step():
+    """Fail on the host, where the page table is, instead of inside tt-metal."""
+    host = torch.zeros((2, 16), dtype=torch.int32)
+    dev_buf = torch.zeros((2, 8), dtype=torch.int32)
+    with pytest.raises(AssertionError, match="cannot cover this step"):
+        TTModelRunner._copy_narrow_fill_page_table(
+            None, dev_buf, host, block_size=32, step_tokens=8 * 32 + 1, group_idx=0
+        )

--- a/tests/integrations/vllm_plugin/test_model_runner_buffer_keying.py
+++ b/tests/integrations/vllm_plugin/test_model_runner_buffer_keying.py
@@ -93,3 +93,33 @@ def test_per_batch_buffers_keyed_by_smem_clamped_count(
     # Regression guard: the pre-#5416 keying used max_num_reqs, which under the
     # clamp is absent from the (now consistent) key set.
     assert runner.max_num_reqs not in input_ids_keys
+
+
+@pytest.mark.push
+@pytest.mark.single_device
+def test_fill_page_tables_are_narrow_but_cover_the_largest_step():
+    """Every allocated fill page table spans a full token bucket.
+
+    The fill table is deliberately narrower than the read table, so "wide enough
+    for the step" is an invariant the allocation must hold up. Companion to the
+    device-free checks in ``test_fill_page_table_width.py``.
+    """
+    runner = TTModelRunner(_build_clamp_config(None, None), xm.xla_device())
+
+    read = runner._page_table_dev_max
+    fill = runner._fill_page_table_dev_max
+    # Both are looked up by the same (group, target_num_reqs) key at runtime.
+    assert fill.keys() == read.keys()
+
+    for group, per_num_reqs in fill.items():
+        assert per_num_reqs.keys() == read[group].keys()
+        block_size = runner._group_block_sizes[group]
+        for num_reqs, buf in per_num_reqs.items():
+            assert buf.shape[0] == num_reqs
+            # The bound paged_fill_cache's validator enforces on device.
+            assert buf.shape[1] * block_size >= runner.max_num_tokens, (
+                f"group {group} fill page table ({buf.shape[1]} cols x block_size "
+                f"{block_size}) cannot cover {runner.max_num_tokens} tokens"
+            )
+            # ...and the narrowing is actually active, else this proves nothing.
+            assert buf.shape[1] < read[group][num_reqs].shape[1]


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/5897)

### Problem description
Gemma4 31b benchmark test with 128k context hangs on qb2 device. The kernel fetches the row with a single `noc_async_read` of the entire stick, and a large single read from interleaved DRAM intermittently never completes, wedging the device in `async_read_barrier()`. The root cause belongs in tt-metal.

### What's changed
`paged_fill_cache` indexes at most `cdiv(step_tokens, block_size)` page-table entries -- the bound its own validator enforces -- but we passed it the read table, sized for the whole context: 4096 entries (16KB per row) at max_model_len=131072, where 128B does the job.

Allocate and populate the fill table at that width, rounded up to the 8-entry stick alignment this file already applies elsewhere. Prefix caching is unaffected -- `_prepare_inputs` already rolls each row so the chunk's blocks lead. The read table is untouched, and sliding-window groups were never exposed (their ring rows are already small).

The narrowed buffer can no longer alias the read table, so both branches now always copy into a dedicated one, through a helper that asserts the narrowing still spans the step. That buys back tens of MB of page-table reads the kernel no longer issues, since every core re-reads the row on every layer's fill.

Unit tests cover the width helper and the guard; the buffer-keying test checks that the allocated widths hold the bound.


### Checklist
- [ ] New/Existing tests provide coverage for changes
