### PR TITLE
[op-by-op] Keep per-model attribution in the unique-ops flow

### DIFF
--- a/.github/scripts/ir_process_analyzer.py
+++ b/.github/scripts/ir_process_analyzer.py
@@ -12,6 +12,11 @@ from pathlib import Path
 
 SECONDS_PER_MB = 120
 
+# Name of the unique-ops manifest written inside the extraction output root, so
+# it travels with the unique-op tree into the processing jobs. Kept in sync with
+# tests/op_by_op/op_by_op_test.py, which reads it to recover origin models.
+MANIFEST_FILENAME = "unique_ops_manifest.json"
+
 # Max model/op names listed inline per job in the human-readable plan summary.
 SUMMARY_MODEL_LIMIT = 25
 
@@ -289,6 +294,14 @@ def materialize_job(
         destination_dir.parent.mkdir(parents=True, exist_ok=True)
         shutil.move(str(source_dir), str(destination_dir))
 
+    # Carry top-level files across. Only the assigned directories are moved, so
+    # anything else at the root would be destroyed by the rmtree below -- which
+    # would take the unique-ops manifest with it, and op_by_op_test needs that
+    # manifest to report the models an op actually came from.
+    for entry in root.iterdir():
+        if entry.is_file():
+            shutil.move(str(entry), str(target_root / entry.name))
+
     shutil.rmtree(root)
     shutil.move(str(target_root), str(root))
 
@@ -523,6 +536,15 @@ def command_extract_unique_ops(args: argparse.Namespace) -> int:
 
     if args.manifest is not None:
         args.manifest.write_text(json.dumps(stats, indent=2), encoding="utf-8")
+
+    # Always drop a copy inside the output root as well. The processing jobs
+    # download only the unique-op tree, so this is what makes the op -> origin
+    # models mapping travel with the ops it describes; op_by_op_test reads it to
+    # report the real model names instead of the generated op directory names.
+    args.output_root.mkdir(parents=True, exist_ok=True)
+    (args.output_root / MANIFEST_FILENAME).write_text(
+        json.dumps(stats, indent=2), encoding="utf-8"
+    )
 
     total = stats["total_ops_after_filter"]
     unique = stats["unique_ops"]

--- a/tests/op_by_op/op_by_op_test.py
+++ b/tests/op_by_op/op_by_op_test.py
@@ -46,6 +46,7 @@ Note:
     - Each file should contain a MLIR module in StableHLO/TTIR/TTNN dialect
 """
 
+import json
 from pathlib import Path
 from typing import List
 
@@ -96,6 +97,48 @@ def match_and_extract_model_name(file_path: Path, ir_file_prefix: str) -> str | 
             return dir_parts[0]
 
     return None
+
+
+# Written into the extraction output root by
+# `.github/scripts/ir_process_analyzer.py extract-unique-ops`.
+UNIQUE_OPS_MANIFEST_FILENAME = "unique_ops_manifest.json"
+
+
+def load_origin_models_by_op_dir(folder_path: Path) -> dict:
+    """
+    Map each unique-op directory to the models its op actually came from.
+
+    In the unique-ops flow the IRs are single-op modules living in generated
+    directories (``unique_ops/op_00042_stablehlo_add/irs/...``), so the model
+    name recovered from the path is that generated directory name rather than a
+    model. The extraction step records the real origin models per op in a
+    manifest; this reads it back so the recorded ``model_name`` stays meaningful.
+
+    Returns an empty dict when no manifest is present, which is the normal
+    whole-model flow where the directory name *is* the model name.
+    """
+    manifest_path = folder_path / UNIQUE_OPS_MANIFEST_FILENAME
+    if not manifest_path.is_file():
+        return {}
+
+    try:
+        with open(manifest_path, "r") as f:
+            manifest = json.load(f)
+    except (OSError, ValueError) as e:
+        print(f"WARNING: could not read unique-ops manifest {manifest_path}: {e}")
+        return {}
+
+    mapping = {}
+    for entry in manifest.get("manifest", []):
+        op_dir = entry.get("op_dir")
+        origin_models = [m for m in entry.get("origin_models", []) if m]
+        if op_dir and origin_models:
+            mapping[op_dir] = origin_models
+    print(
+        f"Loaded unique-ops manifest: {len(mapping)} op directories mapped to "
+        f"their origin models ({manifest_path})"
+    )
+    return mapping
 
 
 def filter_and_deduplicate_ops(
@@ -160,6 +203,8 @@ def test_op_by_op(request, whitelist, blacklist, record_property):
         else:
             pytest.skip(f"No .mlir files found in {folder_path}")
 
+    origin_models_by_op_dir = load_origin_models_by_op_dir(folder_path)
+
     ops = []
     # Collect per-file failures so that a single unreadable or unsplittable IR does
     # not abort the whole job (which would drop every remaining model/op). Each
@@ -182,8 +227,18 @@ def test_op_by_op(request, whitelist, blacklist, record_property):
             continue
         print(f"Processing IR file: {ir_file_path}")
 
+        # In the unique-ops flow `origin_model` is the generated op directory
+        # name; swap in the real models recorded at extraction time.
+        models_for_file = origin_models_by_op_dir.get(origin_model) or [origin_model]
+
         try:
-            module_ops = extract_ops_from_module(module, origin_model=origin_model)
+            module_ops = extract_ops_from_module(
+                module, origin_model=models_for_file[0]
+            )
+            # An op deduplicated across several models carries all of them.
+            for extra_model in models_for_file[1:]:
+                for op_wrapper in module_ops:
+                    op_wrapper.add_origin_model(extra_model)
         except Exception as e:
             print(
                 f"WARNING: Failed to extract ops from IR file, skipping.\n"


### PR DESCRIPTION
### Ticket

Item 1 of #5867 — the one flagged there as **blocking for the unique-ops rollout**. It stopped being hypothetical when #5868 merged.

### Problem description

With #5868 landed, the processing jobs no longer run whole-model IRs. They run single-op modules from generated directories:

```
unique_ops/op_00042_stablehlo_add/irs/shlo_compiler_00042.mlir
```

`op_by_op_test` recovers the model name from the IR path (`match_and_extract_model_name` takes the component before `irs`), so that **generated directory name** is what reaches `OpTest.model_name`. From the next processing run onward the ops-status "models" column would read `op_00042_stablehlo_add` instead of naming the models an op actually came from.

`extract-unique-ops` already records the real origin models per op — but the manifest never reached the test:

1. it was uploaded as its own artifact (`unique-ops-manifest-*`), while the processing jobs download only the unique-op tree (`unique-ops-ir-*`); and
2. even if it had been in that tree, `materialize_job` would have deleted it — it moves the assigned directories into the job slice and `rmtree`s whatever else is at the root.

### What's changed

Three small pieces, so the mapping travels with the ops and is used at record time:

- **`extract-unique-ops`** also writes the manifest *inside* the output root (`unique_ops_manifest.json`), so it ships with the unique-op tree. The existing `--manifest` artifact is unchanged.
- **`materialize_job`** carries top-level files across to the job slice instead of destroying them.
- **`op_by_op_test`** reads that manifest when present and maps each op directory back to its origin models. An op deduplicated across several models records **all** of them, so the comma-joined value matches what the whole-model flow produced.

No manifest means the whole-model flow, where the directory name *is* the model name — behaviour there is untouched.

This is option (b) of the two fixes I described in #5868. It needs no ingestion-side change, so the DB keeps working as before. If the ingestion side would rather join the manifest itself (option a), this can be dropped — but it seemed wrong to leave attribution broken while that's decided.

### Verification

Against a real nightly dump (2 models, 54 IRs → 366 unique ops):

| Check | Result |
|---|---|
| Manifest lands in the output root | ✅ `unique_ops_manifest.json`, 366 entries |
| Survives `materialize` (61-op slice) | ✅ present after — **on `main` it is destroyed** |
| Recorded `model_name`, single-model op | `pytorch_HIP-NN_Default_atomic_ml_github` (was `op_00017_stablehlo_reshape`) |
| Recorded `model_name`, multi-model op | `pytorch_ModelAlpha, pytorch_ModelBeta` |
| No manifest (whole-model flow) | mapping empty → directory name used, unchanged |
| Corrupt manifest | warns, falls back to directory name, run continues |
| Manifest missing its `manifest` key | empty mapping, no crash |

The recorded values above are `op.as_module().origin_model` — exactly the string that becomes `OpTest.model_name` — not a proxy for it.

`py_compile` clean, `black` clean, workflow YAML still parses with all four jobs.

### Notes for the reviewer

Rebased onto current `main` (2026-08-10).

**Not yet exercised through a full `workflow_dispatch` run**, unlike #5868. That validation is currently blocked by a separate regression: in the 2026-08-09 weekly run — the first op-by-op run after #5868 merged — `extract_unique_ops` was killed by the 6h job timeout at 5h45m and every processing shard was skipped, so the stage produced no data at all. Extraction is superlinear in a module's op count and ran single-threaded over 3,458 IR files. That is fixed separately in #5923 (parallel extraction, explicit `timeout-minutes`, progress logging, time budget); once it lands, a dispatch run can validate both together.

Worth being explicit about the consequence for this PR: while the stage produces nothing, the attribution bug this fixes is latent rather than actively corrupting rows. It still needs fixing before shards resume, which is why this is up for review now rather than waiting.

Three things to look at:

- **The multi-model join is `", "`**, which is what `utils.py:418` already produced for the whole-model flow. That is also the delimiter behind the model-count inflation on the dashboard (#5659): querying `/api/ops-status` on 2026-08-10 gives 2,184 distinct `models` values, of which 1,212 are comma-joined composites, collapsing to 1,005 real model names — a 2.17× inflation at that point in time. This PR deliberately does not change it — it restores prior behaviour rather than mixing a data-shape change into an attribution fix.
- **`materialize_job` now moves every top-level file**, not just the manifest. That is intentional (generic and future-proof), but it is a behaviour change worth a look.

### Checklist
- [x] New/Existing tests provide coverage for changes

