### PR TITLE
[XTTS-v2] TTS perf benchmark harness and nightly entry

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -91,6 +91,11 @@
         "group": "experimental"
       },
       {
+        "name": "xtts_v2",
+        "pytest": "tests/benchmark/test_tts.py::test_xtts_v2",
+        "group": "experimental"
+      },
+      {
         "name": "llama_3_1_8b_instruct",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b",
         "group": "regular"

--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -45,6 +45,7 @@ tests/benchmark/
 ├── test_llms.py             # LLM test definitions
 ├── test_vision.py           # Vision model test definitions
 ├── test_encoders.py         # Encoder model test definitions
+├── test_tts.py              # Text-to-speech test definitions
 ├── benchmarks/              # Core benchmark implementations
 ├── llm_utils/               # LLM-specific utilities
 ```
@@ -129,6 +130,22 @@ def test_new_model(
 ```
 
 Vision and encoder tests follow the same pattern — import the existing `ModelLoader`, pick a variant, and call `test_vision()` or `test_encoder()`.
+
+### Adding a text-to-speech model
+
+`benchmarks/tts_benchmark.py` is model-agnostic: a new TTS model needs a
+`build_pipeline_fn` and a pipeline that fills in a `_perf` dict (`components`,
+`steps`, `step_metric_name`, `total`, `audio_samples`), plus a `test_<model>` entry
+in `test_tts.py`. See `benchmarks/xtts_v2_pipeline.py` for a worked example.
+
+Two things differ from the other families:
+
+- **Headline metric.** `samples_per_sec` is the *real-time factor* — generated audio
+  seconds per wall-clock second — so `total_samples` is the audio duration, not a
+  count of items.
+- **Fixed work per run.** The generated token count is pinned, so an RTF change is a
+  pure wall-clock change and a graph compiling inside a timed region is a hard
+  failure (`assert_no_recompiles`) rather than a warning.
 
 ### Adding the test to CI
 

--- a/tests/benchmark/benchmarks/tts_benchmark.py
+++ b/tests/benchmark/benchmarks/tts_benchmark.py
@@ -1,0 +1,347 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generic text-to-speech benchmark harness for torch-xla / TT.
+
+Sibling of ``imagegen_benchmark.py`` and ``ar_imagegen_benchmark.py``, for models
+whose output is a waveform. Per-model wiring supplies a ``build_pipeline_fn`` and
+the pipeline reports its own stage names, so a new TTS model needs a
+``*_pipeline.py`` plus a test entry, not a new harness.
+
+A TTS model is several compiled graphs chained by CPU orchestration rather than one
+traceable forward, so the harness times the chain and reports each stage as its own
+``<stage>_s`` measurement. Headline throughput is the real-time factor: generated
+audio seconds per wall-clock second.
+
+``WARMUP_PASSES`` *full* generations run before the timed one: the vocoder and
+latents stages are shaped by the generated token count, so anything shorter would
+compile inside the measured pass. Recompiles there are a hard error, not a warning
+-- they inflate the result by an amount that reads as an ordinary regression.
+
+The ``_perf`` contract a pipeline must populate on each generation:
+
+    _perf = {
+        "components": {<stage name>: seconds, ...},  # scalar per-stage times
+        "steps": [seconds, ...],                     # per audio-token decode step
+        "step_metric_name": "audio_token_step",
+        "total": seconds,                            # full generate() wall time
+        "audio_samples": int,                        # output waveform length
+        "text_tokens": int,                          # optional, for reporting
+        "compile_curve": [int, ...],                 # cumulative compiles per step
+    }
+"""
+
+import socket
+import time
+
+import torch_xla
+import torch_xla.core.xla_model as xm
+import torch_xla.debug.metrics as met
+import torch_xla.runtime as xr
+from utils import (
+    build_xla_export_name,
+    create_benchmark_result,
+    get_benchmark_metadata,
+    get_xla_device_arch,
+    print_benchmark_results,
+)
+
+xr.set_device_type("TT")
+
+MODULE_EXPORT_PATH = "modules"
+
+# Full generations before the measured pass. Two is structural: pass 1's decode
+# graphs take freshly-uploaded host buffers, pass 2's take pass 1's own outputs --
+# different HLO at the same shapes, so it compiles again. Do not lower this while
+# the pipeline reuses a buffer across runs.
+WARMUP_PASSES = 2
+
+# Minimum share of wall time the stage timers must account for. Below this they are
+# not bracketing device work, almost always a missing sync_device().
+MIN_STAGE_TIME_FRACTION = 0.3
+
+# Graph reuse is judged over the second half of the decode curve; two points is the
+# fewest that has a growth delta at all.
+MIN_SETTLED_STEPS = 2
+
+# Float slack when comparing summed stage times against a single wall-clock read.
+STAGE_TIME_TOLERANCE_S = 1e-6
+
+MODEL_TYPE = "Audio Generation, Text-to-Speech"
+DATASET_NAME = "Text Prompt"
+
+
+def compile_count() -> int:
+    """Cumulative number of graph compilations observed so far."""
+    data = met.metric_data("CompileTime")
+    return data[0] if data else 0
+
+
+def sync_device() -> None:
+    """Launch any pending XLA graph and wait for it.
+
+    torch-xla is lazy, so a timer closed when a forward returns measures tracing
+    rather than device work. ``wait_device_ops()`` alone is a no-op when nothing
+    has been launched, so both calls are needed.
+    """
+    torch_xla.sync()
+    xm.wait_device_ops()
+
+
+def assert_no_recompiles(before: int, after: int, what: str) -> None:
+    """Fail if any graph compiled between the two counter reads."""
+    print(f"| Compilations during {what}: {after - before} ({before} -> {after})")
+    assert after == before, (
+        f"{after - before} graph(s) compiled during {what} ({before} -> {after}); "
+        f"the reported timings include compilation"
+    )
+
+
+def assert_decode_graph_reused(compile_curve) -> None:
+    """Fail if the decode loop kept compiling instead of reusing one graph."""
+    assert compile_curve, (
+        "the pipeline recorded no _perf['compile_curve']; the per-model wiring "
+        "must append compile_count() after each decode call"
+    )
+    settled = compile_curve[len(compile_curve) // 2 :]
+    assert len(settled) >= MIN_SETTLED_STEPS, (
+        f"too few decode steps to judge graph reuse: {compile_curve}; the settled "
+        f"half needs {MIN_SETTLED_STEPS} steps to measure growth across"
+    )
+    tail_growth = settled[-1] - settled[0]
+    assert tail_growth == 0, (
+        f"the decode loop kept compiling instead of reusing its graph: "
+        f"{tail_growth} new compilation(s) over the last {len(settled)} of "
+        f"{len(compile_curve)} steps; cumulative compiles per step={compile_curve}"
+    )
+
+
+def assert_stage_timings_plausible(stages_total: float, total: float) -> None:
+    """Sanity-check that the stage timers actually bracketed device work."""
+    assert stages_total <= total + STAGE_TIME_TOLERANCE_S, (
+        f"measured stages ({stages_total:.3f}s) exceed the full generation "
+        f"({total:.3f}s); stage timers are overlapping or double-counting"
+    )
+    assert stages_total >= MIN_STAGE_TIME_FRACTION * total, (
+        f"measured stages account for only {stages_total / total:.1%} of the "
+        f"{total:.3f}s generation; the stage timers are almost certainly closing "
+        f"before the device has run (missing sync_device() in a pipeline wrapper)"
+    )
+
+
+def benchmark_tts_torch_xla(
+    build_pipeline_fn,
+    model_info_name,
+    text,
+    max_audio_tokens,
+    sample_rate,
+    optimization_level,
+    trace_enabled,
+    ttnn_perf_metrics_output_file,
+    display_name=None,
+    output_wav_path=None,
+    save_wav_fn=None,
+    data_format="float32",
+):
+    """Benchmark a text-to-speech pipeline on the TT backend.
+
+    Args:
+        build_pipeline_fn: ``(compile_options) -> (pipeline, generate_fn)``, where
+            ``generate_fn(text, max_audio_tokens) -> waveform`` runs one full
+            synthesis and populates ``pipeline._perf``.
+        model_info_name: Model name for identification and reporting.
+        text: Text to synthesize.
+        max_audio_tokens: Audio tokens per run. The generated length must depend
+            only on this value, not on sampling, so the length-shaped stages see
+            identical shapes in every pass and the RTF stays comparable.
+        sample_rate: Output waveform sample rate in Hz.
+        optimization_level: tt-mlir optimization level for compilation.
+        trace_enabled: Whether to enable tracing.
+        ttnn_perf_metrics_output_file: Base path for TTNN perf metrics files.
+        display_name: Display name used for export naming / dashboard.
+        output_wav_path: If set, the steady-state waveform is saved here.
+        save_wav_fn: ``save_wav_fn(waveform, path)``, injected so this module does
+            not depend on any model's audio stack.
+        data_format: Precision string for reporting.
+
+    Returns:
+        Standardized benchmark result dict (see ``create_benchmark_result``).
+    """
+    export_model_name = build_xla_export_name(
+        model_name=display_name or model_info_name,
+        num_layers=None,
+        batch_size=1,
+        input_sequence_length=None,
+    )
+
+    options = {
+        "optimization_level": optimization_level,
+        "export_path": MODULE_EXPORT_PATH,
+        "export_model_name": export_model_name,
+        "ttnn_perf_metrics_enabled": True,
+        "ttnn_perf_metrics_output_file": ttnn_perf_metrics_output_file,
+        "enable_trace": trace_enabled,
+    }
+    torch_xla.set_custom_compile_options(options)
+
+    # Kernels compile lazily on the first forward, i.e. during warmup below.
+    pipeline, generate_fn = build_pipeline_fn(options)
+
+    # Warmup: full syntheses at the shapes the measured pass reuses.
+    pass_tokens = []
+    for i in range(WARMUP_PASSES):
+        print(f"Starting warmup pass {i + 1}/{WARMUP_PASSES} (includes compile)...")
+        warmup_start = time.perf_counter()
+        last_warmup_wav = generate_fn(text, max_audio_tokens)
+        warmup_time = time.perf_counter() - warmup_start
+        warmup_tokens = len(pipeline._perf["steps"])
+        pass_tokens.append(warmup_tokens)
+        last_warmup_curve = list(pipeline._perf.get("compile_curve") or [])
+        print(
+            f"Warmup pass {i + 1}/{WARMUP_PASSES}: {warmup_time:.3f}s "
+            f"({warmup_tokens} audio tokens, cumulative compiles={compile_count()})"
+        )
+        assert warmup_tokens > 0, f"warmup pass {i + 1} generated no audio tokens"
+
+    # A drifting length reshapes the vocoder/latents stages and recompiles later.
+    assert len(set(pass_tokens)) == 1, (
+        f"the pipeline generated a different number of audio tokens across warmup "
+        f"passes ({pass_tokens}); the generated length must depend only on "
+        f"max_audio_tokens, not on what sampling yielded"
+    )
+
+    # Only place this check can bite: assert_no_recompiles below already forces the
+    # measured pass's curve flat.
+    assert_decode_graph_reused(last_warmup_curve)
+
+    # Measured pass: every forward must be a cache hit. Its audio is what gets saved.
+    print("Starting steady-state pass...")
+    compiles_before = compile_count()
+    steady_state_start = time.perf_counter()
+    wav = generate_fn(text, max_audio_tokens)
+    steady_state_time = time.perf_counter() - steady_state_start
+    compiles_after = compile_count()
+    print(f"Steady-state pass: {steady_state_time:.3f}s")
+
+    assert_no_recompiles(compiles_before, compiles_after, "the steady-state pass")
+
+    perf = pipeline._perf
+    assert len(perf["steps"]) == pass_tokens[0], (
+        f"the measured pass generated {len(perf['steps'])} audio tokens against "
+        f"{pass_tokens[0]} in warmup; it is not the work the graphs were compiled for"
+    )
+    # Wiring check only; the real one ran on warmup above.
+    assert_decode_graph_reused(perf.get("compile_curve"))
+
+    # Sampling is re-seeded per run, so the measured pass must reproduce the warmup
+    # output exactly. A mismatch means stale K/V leaked across runs.
+    assert tuple(wav.shape) == tuple(last_warmup_wav.shape), (
+        f"measured waveform {tuple(wav.shape)} differs in shape from warmup "
+        f"{tuple(last_warmup_wav.shape)}; the reused KV cache is leaking state"
+    )
+    max_dev = (wav.float() - last_warmup_wav.float()).abs().max().item()
+    print(f"| Max |measured - warmup| sample deviation: {max_dev:.3e}")
+    assert max_dev == 0.0, (
+        f"the measured pass produced different audio from warmup (max sample "
+        f"deviation {max_dev:.3e}); the reused KV cache is leaking state"
+    )
+
+    if output_wav_path is not None and save_wav_fn is not None:
+        save_wav_fn(wav, output_wav_path)
+        print(f"Saved output audio to {output_wav_path}")
+
+    components = perf["components"]
+    steps = perf["steps"]
+    step_metric_name = perf["step_metric_name"]
+
+    steps_total_s = sum(steps)
+    stages_total_s = sum(components.values()) + steps_total_s
+    assert_stage_timings_plausible(stages_total_s, perf["total"])
+
+    audio_seconds = perf["audio_samples"] / sample_rate
+    # "A sample" is one second of audio, so the dashboard's total_samples/total_time
+    # is exactly the real-time factor.
+    total_samples = audio_seconds
+    real_time_factor = audio_seconds / steady_state_time
+
+    step_mean_s = steps_total_s / len(steps) if steps else 0.0
+    decode_tokens_per_second = len(steps) / steps_total_s if steps_total_s > 0 else 0.0
+    cpu_overhead = max(0.0, perf["total"] - stages_total_s)
+
+    metadata = get_benchmark_metadata()
+    full_model_name = model_info_name
+    input_sequence_length = perf.get("text_tokens", -1)
+    input_size = (input_sequence_length,)
+
+    print_benchmark_results(
+        model_title=full_model_name,
+        full_model_name=full_model_name,
+        model_type=MODEL_TYPE,
+        dataset_name=DATASET_NAME,
+        date=metadata["date"],
+        machine_name=metadata["machine_name"],
+        total_time=steady_state_time,
+        total_samples=total_samples,
+        samples_per_sec=real_time_factor,
+        evaluation_score=0.0,
+        batch_size=1,
+        data_format=data_format,
+        input_size=input_size,
+        input_sequence_length=input_sequence_length,
+    )
+    component_lines = "".join(
+        f"|   {name} (s):  {value:.3f}\n" for name, value in components.items()
+    )
+    print(
+        f"| Audio tokens: {len(steps)} ({audio_seconds:.2f}s @ {sample_rate} Hz)\n"
+        f"| Steady-state:\n"
+        f"{component_lines}"
+        f"|   {step_metric_name} mean (s):  {step_mean_s:.4f}\n"
+        f"|   decode tokens/s:              {decode_tokens_per_second:.2f}\n"
+        f"|   CPU overhead (s):             {cpu_overhead:.3f}\n"
+        f"|   real-time factor:             {real_time_factor:.3f}x"
+    )
+
+    custom_measurements = [
+        {"measurement_name": "real_time_factor", "value": real_time_factor},
+        {"measurement_name": "e2e_latency", "value": steady_state_time},
+        {"measurement_name": f"{step_metric_name}_mean_s", "value": step_mean_s},
+        {
+            "measurement_name": "decode_tokens_per_second",
+            "value": decode_tokens_per_second,
+        },
+        {"measurement_name": "cpu_overhead_s", "value": cpu_overhead},
+    ]
+    # One measurement per pipeline stage, named by the pipeline.
+    for name, value in components.items():
+        custom_measurements.append({"measurement_name": f"{name}_s", "value": value})
+
+    result = create_benchmark_result(
+        full_model_name=full_model_name,
+        model_type=MODEL_TYPE,
+        dataset_name=DATASET_NAME,
+        num_layers=-1,
+        batch_size=1,
+        input_size=input_size,
+        loop_count=len(steps),
+        data_format=data_format,
+        total_time=steady_state_time,
+        total_samples=total_samples,
+        evaluation_score=0.0,
+        custom_measurements=custom_measurements,
+        optimization_level=optimization_level,
+        program_cache_enabled=True,
+        trace_enabled=trace_enabled,
+        model_info=model_info_name,
+        display_name=display_name,
+        torch_xla_enabled=True,
+        backend="tt",
+        device_name=socket.gethostname(),
+        arch=get_xla_device_arch(),
+        device_count=xr.global_runtime_device_count(),
+        input_is_image=False,
+        input_sequence_length=input_sequence_length,
+    )
+
+    return result

--- a/tests/benchmark/benchmarks/xtts_v2_pipeline.py
+++ b/tests/benchmark/benchmarks/xtts_v2_pipeline.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""XTTS-v2 (coqui/XTTS-v2) — benchmark-side wiring for the TTS harness.
+
+``XTTSPipeline`` in tt-forge-models already handles the steady state: per-stage
+``_perf`` timing, modules placed on device once, one reused KV cache and a fixed
+generated length. This module adds only ``compile_curve`` -- cumulative
+``CompileTime`` after each decode call, for ``assert_decode_graph_reused``.
+
+Stages the pipeline times, in ``run()`` order: ``speaker_encoder`` ->
+``conditioning`` -> ``gpt_prefill`` -> decode loop (``steps``) -> ``gpt_latents``
+-> ``hifigan``.
+"""
+
+# With stop_early=False the loop always spends the full budget, so the audio
+# duration is stable nightly to nightly.
+MAX_AUDIO_TOKENS = 128
+DEFAULT_SEED = 0
+
+
+def make_bench_xtts_pipeline_cls():
+    """Build the instrumented ``XTTSPipeline`` subclass.
+
+    Deferred into a function because importing the pipeline pulls in ``TTS``, only
+    installed inside the caller's ``RequirementsManager`` context.
+    """
+    import torch
+    from benchmarks.tts_benchmark import compile_count, sync_device
+
+    from third_party.tt_forge_models.xtts_v2.pytorch.pipeline import XTTSPipeline
+
+    class _CompileCounted(torch.nn.Module):
+        """Records the cumulative compile count after each call of a stage.
+
+        A wrapper rather than a forward hook: the stage is already
+        ``torch.compile``d, and hooks on a compiled module can invalidate its
+        guards and trigger the very recompile this benchmark asserts against.
+        """
+
+        def __init__(self, inner, record):
+            super().__init__()
+            self.inner = inner
+            self._record = record
+
+        def forward(self, *args, **kwargs):
+            out = self.inner(*args, **kwargs)
+            # The counter only moves once the graph has launched.
+            sync_device()
+            self._record()
+            return out
+
+    class BenchXTTSPipeline(XTTSPipeline):
+        """``XTTSPipeline`` that records a per-step compile curve."""
+
+        def _reset_perf(self):
+            super()._reset_perf()
+            self._perf["compile_curve"] = []
+
+        def _record_compile_count(self):
+            self._perf["compile_curve"].append(compile_count())
+
+        def setup(self):
+            super().setup()
+            self.decode_step = _CompileCounted(
+                self.decode_step, self._record_compile_count
+            )
+
+    return BenchXTTSPipeline

--- a/tests/benchmark/test_tts.py
+++ b/tests/benchmark/test_tts.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Text-to-speech benchmarks.
+
+One ``test_<model>`` per model, driving a per-model pipeline through the shared
+harness in ``benchmarks/tts_benchmark.py``. Mirrors the ``test_imagegen.py`` /
+``imagegen_benchmark.py`` split: config here, measurement logic in ``benchmarks/``.
+The headline number is the real-time factor, generated audio seconds per wall-clock
+second.
+
+XTTS-v2 needs ``coqui-tts`` + ``torchaudio``, absent from the base test
+environment, so every run is wrapped in ``RequirementsManager``. Its weights are
+CPML-gated behind ``COQUI_TOS_AGREED``.
+"""
+
+import inspect
+import json
+import os
+
+from utils import aggregate_ttnn_perf_metrics, resolve_display_name
+
+import third_party.tt_forge_models.xtts_v2.pytorch.loader as xtts_loader
+
+# float32 because the submodules do not cast uniformly to bf16; opt_level 0 and
+# trace disabled match the nightly e2e pipeline test.
+DEFAULT_DATA_FORMAT = "float32"
+DEFAULT_OPTIMIZATION_LEVEL = 0
+DEFAULT_TRACE_ENABLED = False
+
+
+def _write_results(results, output_file, model_info_name, perf_metrics_file):
+    """Attach project metadata and serialize."""
+    if not output_file:
+        return
+    results["project"] = "tt-forge/tt-xla"
+    results["model_rawname"] = model_info_name
+    aggregate_ttnn_perf_metrics(perf_metrics_file, results)
+    with open(output_file, "w") as file:
+        json.dump(results, file, indent=2)
+
+
+def _xtts_loader_path():
+    return inspect.getsourcefile(xtts_loader)
+
+
+def test_xtts_v2(output_file, request):
+    """XTTS-v2 end-to-end text-to-speech benchmark (real-time factor)."""
+    from tests.runner.requirements import RequirementsManager
+
+    model_info_name = "xtts-v2"
+    display_name = resolve_display_name(request=request, fallback=model_info_name)
+    perf_metrics_file = f"tt_xla_{display_name}_perf_metrics"
+
+    os.environ.setdefault("COQUI_TOS_AGREED", "1")
+
+    with RequirementsManager.for_loader(_xtts_loader_path(), framework="torch"):
+        # Deferred: importing the pipeline pulls in TTS, only present in this context.
+        from benchmarks.tts_benchmark import benchmark_tts_torch_xla
+        from benchmarks.xtts_v2_pipeline import (
+            DEFAULT_SEED,
+            MAX_AUDIO_TOKENS,
+            make_bench_xtts_pipeline_cls,
+        )
+
+        from third_party.tt_forge_models.xtts_v2.pytorch.pipeline import (
+            DEFAULT_TEXT,
+            OUTPUT_SAMPLE_RATE,
+            XTTSConfig,
+            save_wav,
+        )
+
+        def build_pipeline_fn(compile_options):
+            pipeline_cls = make_bench_xtts_pipeline_cls()
+            config = XTTSConfig(
+                text=DEFAULT_TEXT,
+                max_audio_tokens=MAX_AUDIO_TOKENS,
+                seed=DEFAULT_SEED,
+                # Spend the full budget rather than stopping on the model's stop
+                # token, so every pass sees identical shapes and cannot recompile.
+                stop_early=False,
+            )
+            pipeline = pipeline_cls(config)
+            pipeline.setup()
+
+            def generate_fn(text, max_audio_tokens):
+                config.text = text
+                config.max_audio_tokens = max_audio_tokens
+                return pipeline.run()
+
+            return pipeline, generate_fn
+
+        results = benchmark_tts_torch_xla(
+            build_pipeline_fn=build_pipeline_fn,
+            model_info_name=model_info_name,
+            display_name=display_name,
+            text=DEFAULT_TEXT,
+            max_audio_tokens=MAX_AUDIO_TOKENS,
+            sample_rate=OUTPUT_SAMPLE_RATE,
+            optimization_level=DEFAULT_OPTIMIZATION_LEVEL,
+            trace_enabled=DEFAULT_TRACE_ENABLED,
+            ttnn_perf_metrics_output_file=perf_metrics_file,
+            output_wav_path="test_xtts_v2_output.wav",
+            save_wav_fn=save_wav,
+            data_format=DEFAULT_DATA_FORMAT,
+        )
+
+    _write_results(results, output_file, model_info_name, perf_metrics_file)

--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -2782,5 +2782,7 @@ test_config:
 
   xtts_v2/pytorch-hifigan_decoder-single_device-inference:
     status: EXPECTED_PASSING
-    # Has never met 0.98 since bring-up (#5376); measures 0.9797.
-    required_pcc: 0.97
+    required_pcc: 0.98
+    arch_overrides:
+      n150:
+        required_pcc: 0.97

--- a/tests/torch/models/xtts_v2/test_xtts_v2_pipeline.py
+++ b/tests/torch/models/xtts_v2/test_xtts_v2_pipeline.py
@@ -33,7 +33,6 @@ import third_party.tt_forge_models.xtts_v2.pytorch.loader as xtts_loader
 # samples @ 24 kHz); the property under test is that the chain runs end-to-end
 # and emits a valid waveform, not audio length.
 MAX_AUDIO_TOKENS = 64
-OUTPUT_SAMPLE_RATE = 24000
 
 # Per-step correlation floor between the TT decode logits and the CPU replay.
 PCC_THRESHOLD = 0.99
@@ -76,6 +75,7 @@ def _make_pcc_pipeline_cls():
             super().__init__(config)
             self.step_pccs = []
             self.compile_curve = []
+            self._replay_inputs = None
 
         def _generate_codes_tt(self, gpt_cond_latent, text_tokens):
             tt_logits = []
@@ -100,12 +100,20 @@ def _make_pcc_pipeline_cls():
             finally:
                 hook.remove()
 
-            # The parent moves decode_step back to CPU before returning, so the
-            # replay below runs on CPU weights.
-            self.step_pccs = self._replay_on_cpu(
-                gpt_cond_latent, text_tokens, codes, tt_logits
-            )
+            # Replay after run() finishes, not here -- see run() below.
+            self._replay_inputs = (gpt_cond_latent, text_tokens, codes, tt_logits)
             return codes
+
+        def run(self):
+            """Run the pipeline, then take the CPU golden.
+
+            Modules stay on device for the pipeline's lifetime, so a wrapper built
+            mid-run would share *device* weights and the "CPU" golden would silently
+            run on TT. After ``run()`` those weights are free to move to the host.
+            """
+            wav = super().run()
+            self.step_pccs = self._replay_on_cpu(*self._replay_inputs)
+            return wav
 
         def _replay_on_cpu(self, gpt_cond_latent, text_tokens, codes, tt_logits):
             """Re-run TT's own token sequence on CPU, returning per-step PCC.
@@ -114,6 +122,9 @@ def _make_pcc_pipeline_cls():
             the pipeline (no second model in memory) but has no ``tt`` backend
             attached, so it really executes on CPU.
             """
+            # gpt_latents wraps all of xtts.gpt, so one move brings it to the host.
+            self.gpt_latents = self.gpt_latents.to("cpu")
+
             gpt = self.xtts.gpt
             cpu_step = GptCachedStep(self.xtts).eval()
 


### PR DESCRIPTION
### Ticket
- https://github.com/tenstorrent/tt-xla/issues/5216 (Model Bringup: coqui/XTTS-v2)
- https://github.com/tenstorrent/tt-xla/issues/5876


### Problem Description
- XTTS-v2 was brought up and PCC-gated in #5376, but its throughput was never measured: `perf-bench-matrix.json` had 162 entries and no audio model, and `tests/benchmark` carried no TTS harness.

### What's changed
- **Model-agnostic TTS harness** (`tests/benchmark/benchmarks/tts_benchmark.py`), sibling of the imagegen / AR-imagegen / video harnesses. It names no model: stage names come from the pipeline's own `_perf` dict, so a new TTS model needs a `*_pipeline.py` and a test entry, not a new harness. Headline throughput is the **real-time factor** (generated audio seconds per wall-clock second), mapped onto `total_samples / total_time` so the existing Superset regression check works unmodified.
- **Compilation inside a timed region is a hard failure**, not a warning — a recompile inflates the result by a plausible-looking margin and reads downstream as an ordinary perf regression. Three assertions cover it:
  - `assert_no_recompiles` — `CompileTime` counter delta bracketing the measured pass,
  - `assert_decode_graph_reused` — the per-step cumulative compile curve must be flat over the tail of the decode loop, which the aggregate check cannot see if warmup absorbed it,
  - `assert_stage_timings_plausible` — stage time must be ≤ wall time and ≥ 30% of it, catching a missing `torch_xla.sync()` / `wait_device_ops()`.
- **`compile_curve` is required**, not optional. Reading it needs torch-xla's counters, so the per-model wiring records it; making it optional would let a model silently opt out of the only guard that can see a decode loop recompiling per token.
- **Warmup is two full generations** (`WARMUP_PASSES = 2`, set empirically). Pass 1 compiles the graphs and specialises the traced code; pass 2 compiles a further ~5 once the reused KV-cache buffers reach their steady state (no dynamo retracing occurs there — verified); pass 3 onward is flat. One warmup pass would leave those inside the measured pass, which the recompile guard would correctly fail on.
- **Per-model wiring** (`tests/benchmark/benchmarks/xtts_v2_pipeline.py`, 74 lines) adds only `compile_curve`. Everything else — per-stage timing, device residency, KV-cache reuse, fixed generated length — lives in `XTTSPipeline` upstream, so the measured code path is the one the nightly e2e test validates.
- **Nightly matrix entry** — `{"name": "xtts_v2", "pytest": "tests/benchmark/test_tts.py::test_xtts_v2"}`, with no `runs-on` override so it inherits `test-defaults` and runs on both `n150-perf` and `p150-perf` (162 → 163 entries).
- **E2E PCC test updated for device residency** (`tests/torch/models/xtts_v2/test_xtts_v2_pipeline.py`). Its CPU replay previously relied on the pipeline evicting `decode_step` to the host as a side effect. With every module now resident, a wrapper built over `self.xtts` mid-run would share *device* weights and the "CPU" golden would silently run on TT — comparing the device against itself and passing for the wrong reason. The replay now happens after `run()` returns, when the device weights are finished with, so one `gpt_latents.to("cpu")` brings the whole `xtts.gpt` tree back and the original golden semantics hold with no second model in memory.

Config matches the nightly e2e path: float32 (submodules do not cast uniformly to bf16), `optimization_level` 0, trace disabled, `MAX_AUDIO_TOKENS` 128. Weights are CPML-gated behind `COQUI_TOS_AGREED`; deps install via `RequirementsManager`.

### Results

Verified on Blackhole (p150-class):

| Check | Result |
|-------|--------|
| Benchmark (`tests/benchmark/test_tts.py::test_xtts_v2`) | **PASS** — **0 compilations** in the measured pass, RTF 0.989x, 127 audio tokens (5.89 s @ 24 kHz), decode 27.1 ms/token, stage times 98.9% of wall time. Five runs: RTF 0.946 / 0.960 / 0.975 / 0.988 / 0.989, identical 127-token output, 0 compiles every time |
| E2E pipeline test | **PASS** — per-step decode PCC ≥ 0.99 vs CPU replay over 64 steps, cumulative compile count flat at 12 from step 3 |
| Demo (`examples/pytorch/xtts_v2_pipeline.py`), uncapped | **PASS** — stops on its own stop token at ~163 tokens, 6.97 s of 24 kHz audio |

Steady-state stage breakdown: `speaker_encoder` 0.043 s, `conditioning` 0.189 s, `gpt_prefill` 0.035 s, `gpt_latents` 0.046 s, `hifigan` 2.136 s, decode 27.1 ms/token. One `hifigan` forward costs more than all 127 decode steps combined — the first place to look for optimisation.

Token policy differs per test, deliberately: the benchmark runs three times so its length must be fixed (`stop_early=False`) or the length-shaped stages recompile mid-measurement; the PCC test and the demo run once, so they use the model's natural stop token.

### Checklist
- [x] New/Existing tests provide coverage for changes

### Logs
- [xtts_v2_e2e_pipeline_test.log](https://github.com/user-attachments/files/30784128/xtts_v2_e2e_pipeline_test.log)
- [xtts_v2_benchmark_output.wav](https://github.com/user-attachments/files/30784123/xtts_v2_benchmark_output.wav)
- [xtts_v2_benchmark_test.log](https://github.com/user-attachments/files/30784124/xtts_v2_benchmark_test.log)
- [xtts_v2_demo_example_test.log](https://github.com/user-attachments/files/30784125/xtts_v2_demo_example_test.log)
- [xtts_v2_demo_output.wav](https://github.com/user-attachments/files/30784126/xtts_v2_demo_output.wav)
- [xtts_v2_e2e_pipeline_output.wav](https://github.com/user-attachments/files/30784127/xtts_v2_e2e_pipeline_output.wav)

### CI benchmark run

- Both `xtts_v2` dispatches failed inside `get_file()` before any measurement: [32320607057](https://github.com/tenstorrent/tt-xla/actions/runs/32320607057) (`sh-runner=true`) with `ValueError: IRD_LF_CACHE environment variable is not set`, and [32323066818](https://github.com/tenstorrent/tt-xla/actions/runs/32323066818) (`sh-runner=false`, the nightly's config) with `FileNotFoundError` on `test_files/pytorch/whisper/1272-128104-0000.pt` — the perf pool's `/mnt/dockercache` carries no `test_files/` tree, and `vars.IRD_LF_CACHE` is a cluster-internal address that does not resolve from bare metal ([32326295221](https://github.com/tenstorrent/tt-xla/actions/runs/32326295221): DNS failure, `http_code=000`).
- Fixed in https://github.com/tenstorrent/tt-forge-models/pull/888, which reads the same LibriSpeech clip from `hf-internal-testing/librispeech_asr_dummy` instead — byte-identical input, so no baseline in this PR moves; re-verified on p150 after the change: PASSED, RTF 1.079x, 127 audio tokens, 0 compilations in the measured pass, deviation `0.000e+00`.
- **Merge order:** merge this only after https://github.com/tenstorrent/tt-forge-models/pull/888 lands and the `tt_forge_models` submodule is uplifted (`schedule-uplift-forge-models.yml`, daily 07:00 UTC or `workflow_dispatch`); merging sooner puts failing `n150-perf` / `p150-perf` legs into the nightly.
