### PR TITLE
[vLLM] Fix sliding-window KV sizing at short and long context

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/__init__.py
+++ b/integrations/vllm_plugin/vllm_tt/__init__.py
@@ -50,3 +50,9 @@ def register_oot_layers():
     from .platform import install_tt_accelerator_memory_info
 
     install_tt_accelerator_memory_info()
+
+    # Bound a sliding-window layer's per-request KV by the per-request prefill
+    # chunk instead of the batch-wide token budget.
+    from .platform import install_tt_sliding_window_admission
+
+    install_tt_sliding_window_admission()

--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -720,6 +720,7 @@ class TTPlatform(Platform):
                 # TT-internal per-sequence chunk cap, read by AscendScheduler
                 # (per-request chunk sizing) and TTModelRunner (bucket ladder).
                 scheduler_config.tt_prefill_chunk_size = per_seq_chunk
+                publish_tt_per_request_prefill_chunk(scheduler_config)
                 # Derived value: a user-supplied max_num_batched_tokens is
                 # intentionally overridden here (logged above).
                 scheduler_config.max_num_batched_tokens = budget
@@ -799,6 +800,80 @@ class TTPlatform(Platform):
         worker after initializing the device.
         """
         return
+
+
+# Per-request prefill chunk, published for the sliding-window admission bound
+# below. Set from the scheduler config in both TTPlatform.check_and_update_config
+# and TTWorker.__init__: the former runs in the front-end process, while both
+# consumers of the bound run in EngineCore, where the worker is constructed
+# before either of them. 0 = TT chunked prefill is off, patch is a no-op.
+_TT_PER_REQUEST_PREFILL_CHUNK = 0
+
+
+def publish_tt_per_request_prefill_chunk(scheduler_config) -> None:
+    """Record the per-request prefill chunk for the admission bound.
+
+    Always assigns, so a config without TT chunked prefill clears any value a
+    previous config published rather than leaving it stale.
+    """
+    global _TT_PER_REQUEST_PREFILL_CHUNK
+    _TT_PER_REQUEST_PREFILL_CHUNK = (
+        getattr(scheduler_config, "tt_prefill_chunk_size", 0)
+        if getattr(scheduler_config, "tt_chunked_prefill_enabled", False)
+        else 0
+    )
+
+
+def install_tt_sliding_window_admission() -> None:
+    """Bound a sliding-window layer by one request's chunk, not the batch's.
+
+    ``SlidingWindowSpec.max_admission_blocks_per_request`` bounds a single
+    request at ``sliding_window - 1 + max_num_batched_tokens`` tokens -- it reads
+    ``max_num_batched_tokens`` as the largest chunk ONE request can be scheduled.
+
+    Under TT chunked prefill that reading is wrong. ``max_num_batched_tokens`` is
+    the batch-wide budget (``tt_prefill_chunk_size * max_num_seqs``), while
+    AscendScheduler caps each individual request at ``tt_prefill_chunk_size``
+    ("so one long prompt can't eat the whole budget and serialize others"). A
+    request can therefore never hold the batch-wide budget, and the bound is
+    inflated by up to ``max_num_seqs`` x -- for gemma-4-31B at
+    max_model_len=65536, chunk 1024, batch 32, each sliding group is charged
+    ``cdiv(1023 + 32768, 32) + 1 = 1057`` blocks instead of
+    ``cdiv(1023 + 1024, 32) + 1 = 65``.
+
+    That 16x over-charge feeds the startup admission check
+    (``_max_memory_usage_bytes_from_groups``), which rejects long-context
+    configurations over pool memory they would never use.
+
+    Patch the spec method rather than either caller: vLLM treats it as the
+    single source of truth for both the startup pool sizer and the runtime
+    admission cap in ``get_manager_for_kv_cache_spec``, and warns that drift
+    between the two re-introduces a deadlock (vllm#39734) or mid-prefill OOM.
+    Clamping here keeps them consistent by construction.
+    """
+    from vllm.v1.kv_cache_interface import SlidingWindowSpec
+
+    original = SlidingWindowSpec.max_admission_blocks_per_request
+    if getattr(original, "_tt_patched", False):
+        return  # idempotent: never stack wrappers and clamp twice
+
+    def _tt_max_admission_blocks_per_request(
+        self, max_num_batched_tokens: int, max_model_len: int
+    ) -> int:
+        if _TT_PER_REQUEST_PREFILL_CHUNK:
+            max_num_batched_tokens = min(
+                max_num_batched_tokens, _TT_PER_REQUEST_PREFILL_CHUNK
+            )
+        return original(
+            self,
+            max_num_batched_tokens=max_num_batched_tokens,
+            max_model_len=max_model_len,
+        )
+
+    _tt_max_admission_blocks_per_request._tt_patched = True
+    SlidingWindowSpec.max_admission_blocks_per_request = (
+        _tt_max_admission_blocks_per_request
+    )
 
 
 def install_tt_accelerator_memory_info() -> None:

--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -360,50 +360,24 @@ class TTPlatform(Platform):
         # Emit per-attention-type kv_cache_groups (like every other platform);
         # the base default False downgrades sliding-window layers to full
         # attention, making them pay the full max_model_len KV cost.
-        # NOTE: capability only. Whether it actually *pays off* for the current
-        # max_model_len is decided per-run by
-        # _maybe_disable_unprofitable_hybrid_kv_cache.
         return True
 
     @classmethod
     def _maybe_disable_unprofitable_hybrid_kv_cache(
         cls, vllm_config: "VllmConfig"
     ) -> None:
-        """Opt out of the sliding-window ring when it would cost MORE than
-        plain full attention.
+        """Opt out of the sliding-window ring where it costs more than full
+        attention.
 
-        On TT each sliding layer gets its own per-user ring buffer of
-        ``sliding_window_blocks()`` blocks (vLLM's byte-overlay across groups is
-        impossible here), so a sliding layer's per-user cost is that block count
-        rather than ``cdiv(max_model_len, block_size)``.
+        Each sliding layer gets its own per-user ring on TT (vLLM's cross-group
+        byte-overlay is impossible here), which only beats full attention once
+        the window actually clips the context. Below that the window never
+        slides yet the ring still pays its ``+1`` straddle block and stick
+        alignment, so let vLLM unify the specs into the shared pool instead.
 
-        The ring only pays off once the window actually clips the context. At
-        ``max_model_len <= sliding_window`` the window never slides -- every
-        request's whole context already fits inside it -- yet the ring still pays
-        the ``+1`` straddle block and the 8-block page-table-stick round-up. For
-        gemma-4-31B (window 1024, block 32) at max_model_len=128 that is 8 blocks
-        per user per layer against 4 for full attention: a 2x regression across
-        50 sliding layers, which is what drops the reported KV pool/concurrency
-        below its pre-hybrid value.
-
-        So enable the hybrid path only when the ring is strictly smaller than its
-        full-attention equivalent; otherwise let vLLM unify the specs and put
-        every layer in the shared pool (pre-hybrid behavior). Long-context runs
-        -- the case the ring exists for -- are unaffected.
-
-        Two limits are inherent to deciding this at config time, before any model
-        or KV spec exists:
-          - the window comes from ``model_config.get_sliding_window()`` (the HF
-            config) rather than the per-layer specs the worker and runner
-            actually size against, so the two can disagree (e.g. a config
-            carrying ``sliding_window`` with sliding layers disabled). The
-            worker derives its reservation from the specs, so a mismatch here
-            costs nothing;
-          - the decision is model-wide, because vLLM's
-            ``disable_hybrid_kv_cache_manager`` is a single switch feeding
-            ``unify_hybrid_kv_cache_specs`` over the whole spec dict -- there is
-            no per-layer dial. TT does not support multiple window sizes yet
-            either (see the uniform-window assert in the model runner).
+        Decided at config time from the HF config rather than the per-layer
+        specs, and model-wide because ``disable_hybrid_kv_cache_manager`` is a
+        single switch.
         """
         model_config = vllm_config.model_config
         scheduler_config = vllm_config.scheduler_config
@@ -411,10 +385,8 @@ class TTPlatform(Platform):
         if scheduler_config.disable_hybrid_kv_cache_manager is not None:
             return
         sliding_window = model_config.get_sliding_window()
-        # No sliding-window layers means nothing to trade off. max_model_len == -1
-        # means vLLM auto-fits it later from the KV budget, so the value here is a
-        # placeholder -- leave the ring enabled (auto-fit targets long contexts,
-        # where it wins).
+        # max_model_len == -1 means vLLM auto-fits it later from the KV budget,
+        # so the value here is a placeholder -- leave the ring enabled.
         if not sliding_window or model_config.original_max_model_len == -1:
             return
 
@@ -425,14 +397,11 @@ class TTPlatform(Platform):
 
         scheduler_config.disable_hybrid_kv_cache_manager = True
         logger.info(
-            "[TT] Disabling the hybrid KV cache manager: at max_model_len=%d "
-            "(sliding_window=%d, block_size=%d) a sliding-window ring costs %d "
-            "blocks per user per layer vs %d for full attention, so the ring "
-            "cannot pay for itself. Sliding layers will share the "
-            "full-attention pool.",
+            "[TT] Disabling the hybrid KV cache manager: at max_model_len=%d a "
+            "sliding-window ring costs %d blocks per user per layer against %d "
+            "for full attention. Sliding layers will share the full-attention "
+            "pool.",
             max_model_len,
-            sliding_window,
-            block_size,
             sliding_window_blocks(sliding_window, block_size, max_model_len),
             cdiv(max_model_len, block_size),
         )
@@ -720,12 +689,17 @@ class TTPlatform(Platform):
                 # TT-internal per-sequence chunk cap, read by AscendScheduler
                 # (per-request chunk sizing) and TTModelRunner (bucket ladder).
                 scheduler_config.tt_prefill_chunk_size = per_seq_chunk
-                publish_tt_per_request_prefill_chunk(scheduler_config)
                 # Derived value: a user-supplied max_num_batched_tokens is
                 # intentionally overridden here (logged above).
                 scheduler_config.max_num_batched_tokens = budget
                 scheduler_config.max_num_encoder_input_tokens = budget
                 scheduler_config.encoder_cache_size = budget
+
+        # Outside the branch chain on purpose: the MLA branch, a zero chunk_size
+        # and the pooling path all leave TT chunked prefill off, and the global
+        # has to be cleared for them too rather than keep a previous config's
+        # value in a shared process.
+        publish_tt_per_request_prefill_chunk(vllm_config)
 
     @classmethod
     def update_block_size_for_backend(cls, vllm_config: "VllmConfig") -> int:
@@ -802,54 +776,52 @@ class TTPlatform(Platform):
         return
 
 
-# Per-request prefill chunk, published for the sliding-window admission bound
-# below. Set from the scheduler config in both TTPlatform.check_and_update_config
-# and TTWorker.__init__: the former runs in the front-end process, while both
-# consumers of the bound run in EngineCore, where the worker is constructed
-# before either of them. 0 = TT chunked prefill is off, patch is a no-op.
+# Per-request prefill chunk for the sliding-window admission bound below.
+# Published from both TTPlatform.check_and_update_config (front-end process) and
+# TTWorker.__init__ (EngineCore, where the bound's consumers live).
+# 0 = TT chunked prefill is off, patch is a no-op.
 _TT_PER_REQUEST_PREFILL_CHUNK = 0
 
 
-def publish_tt_per_request_prefill_chunk(scheduler_config) -> None:
-    """Record the per-request prefill chunk for the admission bound.
+def publish_tt_per_request_prefill_chunk(vllm_config) -> None:
+    """Record one request's in-flight token bound for the admission bound below.
 
-    Always assigns, so a config without TT chunked prefill clears any value a
-    previous config published rather than leaving it stale.
+    vLLM's own bound is ``max_concurrent_batches * max_num_batched_tokens`` --
+    every concurrent batch may hold a full batch-wide budget -- so the
+    per-request analogue carries the same multiplier over the per-request chunk.
+    Reading it from the config rather than assuming 1 keeps this correct if TT
+    ever enables pipeline parallelism or async scheduling.
+
+    Always assigns, so a config without TT chunked prefill clears a value a
+    previous config published.
     """
     global _TT_PER_REQUEST_PREFILL_CHUNK
+    scheduler_config = vllm_config.scheduler_config
+    if not getattr(scheduler_config, "tt_chunked_prefill_enabled", False):
+        _TT_PER_REQUEST_PREFILL_CHUNK = 0
+        return
     _TT_PER_REQUEST_PREFILL_CHUNK = (
         getattr(scheduler_config, "tt_prefill_chunk_size", 0)
-        if getattr(scheduler_config, "tt_chunked_prefill_enabled", False)
-        else 0
+        * vllm_config.max_concurrent_batches
     )
 
 
 def install_tt_sliding_window_admission() -> None:
     """Bound a sliding-window layer by one request's chunk, not the batch's.
 
-    ``SlidingWindowSpec.max_admission_blocks_per_request`` bounds a single
-    request at ``sliding_window - 1 + max_num_batched_tokens`` tokens -- it reads
-    ``max_num_batched_tokens`` as the largest chunk ONE request can be scheduled.
-
-    Under TT chunked prefill that reading is wrong. ``max_num_batched_tokens`` is
-    the batch-wide budget (``tt_prefill_chunk_size * max_num_seqs``), while
-    AscendScheduler caps each individual request at ``tt_prefill_chunk_size``
-    ("so one long prompt can't eat the whole budget and serialize others"). A
-    request can therefore never hold the batch-wide budget, and the bound is
-    inflated by up to ``max_num_seqs`` x -- for gemma-4-31B at
-    max_model_len=65536, chunk 1024, batch 32, each sliding group is charged
-    ``cdiv(1023 + 32768, 32) + 1 = 1057`` blocks instead of
-    ``cdiv(1023 + 1024, 32) + 1 = 65``.
-
-    That 16x over-charge feeds the startup admission check
-    (``_max_memory_usage_bytes_from_groups``), which rejects long-context
-    configurations over pool memory they would never use.
+    ``SlidingWindowSpec.max_admission_blocks_per_request`` sizes a request's
+    in-flight KV from ``VllmConfig.max_in_flight_tokens``, which is built on
+    ``max_num_batched_tokens``. Under TT chunked prefill that is the batch-wide
+    budget (``tt_prefill_chunk_size * max_num_seqs``) while AscendScheduler caps
+    each request at ``tt_prefill_chunk_size``, so the bound is inflated by up to
+    ``max_num_seqs`` x. That over-charge feeds the startup admission check,
+    which then rejects long-context configurations over pool memory they would
+    never use.
 
     Patch the spec method rather than either caller: vLLM treats it as the
     single source of truth for both the startup pool sizer and the runtime
-    admission cap in ``get_manager_for_kv_cache_spec``, and warns that drift
-    between the two re-introduces a deadlock (vllm#39734) or mid-prefill OOM.
-    Clamping here keeps them consistent by construction.
+    admission cap, and warns that drift between the two re-introduces a deadlock
+    (vllm#39734) or mid-prefill OOM.
     """
     from vllm.v1.kv_cache_interface import SlidingWindowSpec
 
@@ -858,15 +830,15 @@ def install_tt_sliding_window_admission() -> None:
         return  # idempotent: never stack wrappers and clamp twice
 
     def _tt_max_admission_blocks_per_request(
-        self, max_num_batched_tokens: int, max_model_len: int
+        self, max_in_flight_tokens: int, max_model_len: int
     ) -> int:
         if _TT_PER_REQUEST_PREFILL_CHUNK:
-            max_num_batched_tokens = min(
-                max_num_batched_tokens, _TT_PER_REQUEST_PREFILL_CHUNK
+            max_in_flight_tokens = min(
+                max_in_flight_tokens, _TT_PER_REQUEST_PREFILL_CHUNK
             )
         return original(
             self,
-            max_num_batched_tokens=max_num_batched_tokens,
+            max_in_flight_tokens=max_in_flight_tokens,
             max_model_len=max_model_len,
         )
 

--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Optional, Union, cast
 
 import torch
 from vllm.platforms.interface import Platform, PlatformEnum
+from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
 if TYPE_CHECKING:
@@ -32,6 +33,7 @@ else:
 from torch_xla import runtime as xrt
 
 from .logger import tt_init_logger
+from .swa_cache_utils import sliding_ring_is_profitable, sliding_window_blocks
 
 logger = tt_init_logger(__name__)
 
@@ -358,7 +360,82 @@ class TTPlatform(Platform):
         # Emit per-attention-type kv_cache_groups (like every other platform);
         # the base default False downgrades sliding-window layers to full
         # attention, making them pay the full max_model_len KV cost.
+        # NOTE: capability only. Whether it actually *pays off* for the current
+        # max_model_len is decided per-run by
+        # _maybe_disable_unprofitable_hybrid_kv_cache.
         return True
+
+    @classmethod
+    def _maybe_disable_unprofitable_hybrid_kv_cache(
+        cls, vllm_config: "VllmConfig"
+    ) -> None:
+        """Opt out of the sliding-window ring when it would cost MORE than
+        plain full attention.
+
+        On TT each sliding layer gets its own per-user ring buffer of
+        ``sliding_window_blocks()`` blocks (vLLM's byte-overlay across groups is
+        impossible here), so a sliding layer's per-user cost is that block count
+        rather than ``cdiv(max_model_len, block_size)``.
+
+        The ring only pays off once the window actually clips the context. At
+        ``max_model_len <= sliding_window`` the window never slides -- every
+        request's whole context already fits inside it -- yet the ring still pays
+        the ``+1`` straddle block and the 8-block page-table-stick round-up. For
+        gemma-4-31B (window 1024, block 32) at max_model_len=128 that is 8 blocks
+        per user per layer against 4 for full attention: a 2x regression across
+        50 sliding layers, which is what drops the reported KV pool/concurrency
+        below its pre-hybrid value.
+
+        So enable the hybrid path only when the ring is strictly smaller than its
+        full-attention equivalent; otherwise let vLLM unify the specs and put
+        every layer in the shared pool (pre-hybrid behavior). Long-context runs
+        -- the case the ring exists for -- are unaffected.
+
+        Two limits are inherent to deciding this at config time, before any model
+        or KV spec exists:
+          - the window comes from ``model_config.get_sliding_window()`` (the HF
+            config) rather than the per-layer specs the worker and runner
+            actually size against, so the two can disagree (e.g. a config
+            carrying ``sliding_window`` with sliding layers disabled). The
+            worker derives its reservation from the specs, so a mismatch here
+            costs nothing;
+          - the decision is model-wide, because vLLM's
+            ``disable_hybrid_kv_cache_manager`` is a single switch feeding
+            ``unify_hybrid_kv_cache_specs`` over the whole spec dict -- there is
+            no per-layer dial. TT does not support multiple window sizes yet
+            either (see the uniform-window assert in the model runner).
+        """
+        model_config = vllm_config.model_config
+        scheduler_config = vllm_config.scheduler_config
+        # Respect an explicit user choice (either direction).
+        if scheduler_config.disable_hybrid_kv_cache_manager is not None:
+            return
+        sliding_window = model_config.get_sliding_window()
+        # No sliding-window layers means nothing to trade off. max_model_len == -1
+        # means vLLM auto-fits it later from the KV budget, so the value here is a
+        # placeholder -- leave the ring enabled (auto-fit targets long contexts,
+        # where it wins).
+        if not sliding_window or model_config.original_max_model_len == -1:
+            return
+
+        max_model_len = model_config.max_model_len
+        block_size = vllm_config.cache_config.block_size
+        if sliding_ring_is_profitable(sliding_window, block_size, max_model_len):
+            return
+
+        scheduler_config.disable_hybrid_kv_cache_manager = True
+        logger.info(
+            "[TT] Disabling the hybrid KV cache manager: at max_model_len=%d "
+            "(sliding_window=%d, block_size=%d) a sliding-window ring costs %d "
+            "blocks per user per layer vs %d for full attention, so the ring "
+            "cannot pay for itself. Sliding layers will share the "
+            "full-attention pool.",
+            max_model_len,
+            sliding_window,
+            block_size,
+            sliding_window_blocks(sliding_window, block_size, max_model_len),
+            cdiv(max_model_len, block_size),
+        )
 
     @classmethod
     def is_async_output_supported(cls, enforce_eager: Optional[bool]) -> bool:
@@ -585,6 +662,8 @@ class TTPlatform(Platform):
         cache_config.block_size = TTAttentionBackend.get_page_size(
             vllm_config
         )  # type: ignore[assignment]
+
+        cls._maybe_disable_unprofitable_hybrid_kv_cache(vllm_config)
 
         parallel_config = vllm_config.parallel_config
         scheduler_config = vllm_config.scheduler_config

--- a/integrations/vllm_plugin/vllm_tt/swa_cache_utils.py
+++ b/integrations/vllm_plugin/vllm_tt/swa_cache_utils.py
@@ -41,6 +41,21 @@ def sliding_window_blocks(
     return ((n + align - 1) // align) * align
 
 
+def sliding_ring_is_profitable(
+    sliding_window: int, block_size: int, max_model_len: int
+) -> bool:
+    """Whether a sliding ring is cheaper than leaving the layer in the pool.
+
+    A ring costs ``sliding_window_blocks()`` blocks per user per layer; plain
+    full attention costs ``cdiv(max_model_len, block_size)``. The ring only wins
+    once the window actually clips the context -- below that the window never
+    slides, yet the ring still pays its ``+1`` straddle block and the stick
+    alignment round-up, making it strictly more expensive.
+    """
+    ring_blocks = sliding_window_blocks(sliding_window, block_size, max_model_len)
+    return ring_blocks < cdiv(max_model_len, block_size)
+
+
 def sliding_ring_phys_blocks(window_blocks: int, max_num_reqs: int) -> int:
     """Physical blocks for one sliding layer: one sub-ring per batch slot, plus
     a leading null block (index 0) that padded / inactive rows write to."""

--- a/integrations/vllm_plugin/vllm_tt/worker.py
+++ b/integrations/vllm_plugin/vllm_tt/worker.py
@@ -48,7 +48,7 @@ from vllm.v1.worker.worker_base import CompilationTimes
 from .attention_impls.attention import TT_HEAD_SIZE_ALIGNMENT
 from .logger import tt_init_logger
 from .model_runner import TTModelRunner
-from .platform import TTConfig
+from .platform import TTConfig, publish_tt_per_request_prefill_chunk
 from .pooling_runner import TTPoolingModelRunner
 from .swa_cache_utils import sliding_ring_reserve_bytes, sliding_window_blocks
 from .vllm_distributed_utils import kv_cache_shard_factor
@@ -96,6 +96,10 @@ class TTWorker:
             os.environ["CONVERT_SHLO_TO_SHARDY"] = "1"
 
         self.scheduler_config = vllm_config.scheduler_config
+        # check_and_update_config runs in the front-end process; republish here
+        # so the sliding-window admission bound sees the per-request chunk in
+        # EngineCore, where both of its consumers live.
+        publish_tt_per_request_prefill_chunk(self.scheduler_config)
         self.device_config = vllm_config.device_config
         self.speculative_config = vllm_config.speculative_config
         self.observability_config = vllm_config.observability_config

--- a/integrations/vllm_plugin/vllm_tt/worker.py
+++ b/integrations/vllm_plugin/vllm_tt/worker.py
@@ -4,6 +4,7 @@
 
 """A TT worker class."""
 
+import logging
 import os
 import sys
 import time
@@ -58,6 +59,58 @@ logger = tt_init_logger(__name__)
 _R = TypeVar("_R")
 
 
+def sliding_ring_reserve_for_spec(
+    kv_cache_spec: dict[str, KVCacheSpec],
+    max_num_reqs: int,
+    max_model_len: int,
+    hybrid_kv_cache_disabled: bool,
+) -> tuple[int, int]:
+    """Bytes to reserve for sliding-window rings, and how many layers pay them.
+
+    Every layer gets its own tensor (no byte-overlay on TT), so the rings are
+    carved out of the KV budget to keep pool + rings within it.
+
+    Reserve against the spec vLLM will actually group on: with the hybrid
+    manager disabled it first runs ``unify_hybrid_kv_cache_specs()``, which
+    rewrites SlidingWindowSpec to FullAttentionSpec so no rings are allocated
+    and reserving for them would strand the bytes. Running vLLM's own function
+    over a copy keeps the two in agreement, including the uniform all-sliding
+    case it leaves alone -- whose rings are real and must still be reserved.
+
+    Under pipeline parallelism this worker's spec is a subset of the merged spec
+    vLLM unifies, so a stage holding only sliding layers can still disagree.
+    """
+    effective_spec = dict(kv_cache_spec)
+    if hybrid_kv_cache_disabled:
+        # unify_hybrid_kv_cache_specs() warns that no KV-saving optimizations are
+        # enabled. vLLM logs that once for real downstream; this call is a probe
+        # on a copy, and a second copy of the warning reads like a fault when the
+        # plugin picked the shared pool deliberately because it is cheaper.
+        vllm_logger = logging.getLogger(unify_hybrid_kv_cache_specs.__module__)
+        previous_level = vllm_logger.level
+        vllm_logger.setLevel(logging.ERROR)
+        try:
+            unify_hybrid_kv_cache_specs(effective_spec)
+        finally:
+            vllm_logger.setLevel(previous_level)
+    sliding_reserve = 0
+    num_sliding = 0
+    for layer_spec in effective_spec.values():
+        if isinstance(layer_spec, SlidingWindowSpec):
+            # Same helpers the model runner sizes the rings with, so the
+            # reservation here cannot drift from what it later allocates.
+            window_blocks = sliding_window_blocks(
+                layer_spec.sliding_window,
+                layer_spec.block_size,
+                max_model_len,
+            )
+            sliding_reserve += sliding_ring_reserve_bytes(
+                window_blocks, max_num_reqs, layer_spec.page_size_bytes
+            )
+            num_sliding += 1
+    return sliding_reserve, num_sliding
+
+
 class TTWorker:
     def __init__(
         self,
@@ -96,10 +149,9 @@ class TTWorker:
             os.environ["CONVERT_SHLO_TO_SHARDY"] = "1"
 
         self.scheduler_config = vllm_config.scheduler_config
-        # check_and_update_config runs in the front-end process; republish here
-        # so the sliding-window admission bound sees the per-request chunk in
-        # EngineCore, where both of its consumers live.
-        publish_tt_per_request_prefill_chunk(self.scheduler_config)
+        # check_and_update_config runs in the front-end process; republish so
+        # the admission bound sees the chunk in EngineCore too.
+        publish_tt_per_request_prefill_chunk(vllm_config)
         self.device_config = vllm_config.device_config
         self.speculative_config = vllm_config.speculative_config
         self.observability_config = vllm_config.observability_config
@@ -341,41 +393,13 @@ class TTWorker:
             # We adjust the usable memory size for the KV cache to prevent OOM
             # errors, even after padding the head_size.
             kv_cache_bytes = kv_cache_bytes * head_size // padded_head_size
-        # Reserve physical bytes for sliding-window layers' small ring buffers.
-        # Every layer gets its own tensor (no byte-overlay on TT), so carving the
-        # rings out here keeps the full-attention pool + rings within the budget.
-        #
-        # Reserve against the spec vLLM will actually group on, not the one we
-        # were handed: when the hybrid manager is disabled it first runs
-        # unify_hybrid_kv_cache_specs(), which rewrites SlidingWindowSpec to
-        # FullAttentionSpec so the runner allocates no rings at all -- reserving
-        # for them would strand the bytes (6.27 GiB of a 25.50 GiB budget for
-        # gemma-4-31B at max_model_len=128). Running vLLM's own function on a
-        # copy keeps the two in agreement by construction, including the case it
-        # deliberately leaves alone: an all-sliding (uniform) model keeps its
-        # SlidingWindowSpecs, so the rings are real and must still be reserved.
-        # NOTE: under pipeline parallelism this worker's spec is a subset of the
-        # merged spec vLLM unifies, so a stage holding only sliding layers can
-        # still disagree with the global decision.
-        effective_spec = dict(kv_cache_spec)
-        if self.scheduler_config.disable_hybrid_kv_cache_manager:
-            unify_hybrid_kv_cache_specs(effective_spec)
         max_num_reqs = self.model_runner.max_num_reqs
-        sliding_reserve = 0
-        num_sliding = 0
-        for layer_spec in effective_spec.values():
-            if isinstance(layer_spec, SlidingWindowSpec):
-                # Same helpers the model runner sizes the rings with, so the
-                # reservation here cannot drift from what it later allocates.
-                window_blocks = sliding_window_blocks(
-                    layer_spec.sliding_window,
-                    layer_spec.block_size,
-                    self.model_runner.max_model_len,
-                )
-                sliding_reserve += sliding_ring_reserve_bytes(
-                    window_blocks, max_num_reqs, layer_spec.page_size_bytes
-                )
-                num_sliding += 1
+        sliding_reserve, num_sliding = sliding_ring_reserve_for_spec(
+            kv_cache_spec,
+            max_num_reqs,
+            self.model_runner.max_model_len,
+            bool(self.scheduler_config.disable_hybrid_kv_cache_manager),
+        )
         if sliding_reserve > 0:
             logger.info(
                 "Reserving %.3f GiB for %d sliding-window per-user rings "

--- a/integrations/vllm_plugin/vllm_tt/worker.py
+++ b/integrations/vllm_plugin/vllm_tt/worker.py
@@ -32,6 +32,7 @@ from vllm.platforms import current_platform
 from vllm.tasks import SupportedTask
 from vllm.utils.math_utils import cdiv
 from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE, set_random_seed
+from vllm.v1.core.kv_cache_utils import unify_hybrid_kv_cache_specs
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
@@ -339,10 +340,26 @@ class TTWorker:
         # Reserve physical bytes for sliding-window layers' small ring buffers.
         # Every layer gets its own tensor (no byte-overlay on TT), so carving the
         # rings out here keeps the full-attention pool + rings within the budget.
+        #
+        # Reserve against the spec vLLM will actually group on, not the one we
+        # were handed: when the hybrid manager is disabled it first runs
+        # unify_hybrid_kv_cache_specs(), which rewrites SlidingWindowSpec to
+        # FullAttentionSpec so the runner allocates no rings at all -- reserving
+        # for them would strand the bytes (6.27 GiB of a 25.50 GiB budget for
+        # gemma-4-31B at max_model_len=128). Running vLLM's own function on a
+        # copy keeps the two in agreement by construction, including the case it
+        # deliberately leaves alone: an all-sliding (uniform) model keeps its
+        # SlidingWindowSpecs, so the rings are real and must still be reserved.
+        # NOTE: under pipeline parallelism this worker's spec is a subset of the
+        # merged spec vLLM unifies, so a stage holding only sliding layers can
+        # still disagree with the global decision.
+        effective_spec = dict(kv_cache_spec)
+        if self.scheduler_config.disable_hybrid_kv_cache_manager:
+            unify_hybrid_kv_cache_specs(effective_spec)
         max_num_reqs = self.model_runner.max_num_reqs
         sliding_reserve = 0
         num_sliding = 0
-        for layer_spec in kv_cache_spec.values():
+        for layer_spec in effective_spec.values():
             if isinstance(layer_spec, SlidingWindowSpec):
                 # Same helpers the model runner sizes the rings with, so the
                 # reservation here cannot drift from what it later allocates.

--- a/tests/integrations/vllm_plugin/test_hybrid_kv_profitability.py
+++ b/tests/integrations/vllm_plugin/test_hybrid_kv_profitability.py
@@ -11,6 +11,7 @@ these tests pin the decision boundary and the cases it must leave alone.
 Pure config manipulation -- no device, no engine.
 """
 
+import inspect
 import types
 
 import pytest
@@ -52,7 +53,7 @@ def _gate(
 @pytest.mark.parametrize(
     "max_model_len,expect_disabled",
     [
-        (128, True),  # ring 8 vs full 4 -- the reported regression
+        (128, True),  # ring 8 vs full 4
         (512, True),  # ring 24 vs full 16
         (1024, True),  # ring 40 vs full 32 -- window == max_model_len
         (2048, False),  # ring 40 vs full 64 -- window finally clips
@@ -121,17 +122,19 @@ class TestSlidingWindowAdmissionBound:
         )
 
     @staticmethod
-    def _publish(chunk, enabled=True):
+    def _publish(chunk, enabled=True, concurrent_batches=1):
         from vllm_tt.platform import publish_tt_per_request_prefill_chunk
 
         publish_tt_per_request_prefill_chunk(
             types.SimpleNamespace(
-                tt_chunked_prefill_enabled=enabled, tt_prefill_chunk_size=chunk
+                scheduler_config=types.SimpleNamespace(
+                    tt_chunked_prefill_enabled=enabled, tt_prefill_chunk_size=chunk
+                ),
+                max_concurrent_batches=concurrent_batches,
             )
         )
 
     def test_clamps_to_the_per_request_chunk(self):
-        """gemma-4-31B at max_model_len=65536, chunk 1024, batch 32."""
         import vllm_tt.platform as platform_mod
 
         spec = self._spec()
@@ -139,7 +142,7 @@ class TestSlidingWindowAdmissionBound:
         try:
             self._publish(1024)
             clamped = spec.max_admission_blocks_per_request(
-                max_num_batched_tokens=1024 * 32, max_model_len=65536
+                max_in_flight_tokens=1024 * 32, max_model_len=65536
             )
             # cdiv(1023 + 1024, 32) + 1, not cdiv(1023 + 32768, 32) + 1 = 1057
             assert clamped == 65
@@ -154,7 +157,7 @@ class TestSlidingWindowAdmissionBound:
         self._publish(0, enabled=False)
         assert (
             spec.max_admission_blocks_per_request(
-                max_num_batched_tokens=1024 * 32, max_model_len=65536
+                max_in_flight_tokens=1024 * 32, max_model_len=65536
             )
             == 1057
         )
@@ -168,12 +171,12 @@ class TestSlidingWindowAdmissionBound:
         try:
             self._publish(0, enabled=False)
             unclamped = spec.max_admission_blocks_per_request(
-                max_num_batched_tokens=4096, max_model_len=65536
+                max_in_flight_tokens=4096, max_model_len=65536
             )
             self._publish(1 << 20)  # chunk far above the budget
             assert (
                 spec.max_admission_blocks_per_request(
-                    max_num_batched_tokens=4096, max_model_len=65536
+                    max_in_flight_tokens=4096, max_model_len=65536
                 )
                 == unclamped
             )
@@ -191,9 +194,55 @@ class TestSlidingWindowAdmissionBound:
             self._publish(1024)
             assert (
                 spec.max_admission_blocks_per_request(
-                    max_num_batched_tokens=1024 * 32, max_model_len=65536
+                    max_in_flight_tokens=1024 * 32, max_model_len=65536
                 )
                 == 65
             )
         finally:
             self._publish(0, enabled=False)
+
+
+def test_gate_reads_config_attributes_that_still_exist_upstream():
+    """The gate tests above use a stand-in config, which cannot notice a rename.
+
+    vLLM 0.26 renamed ``max_num_batched_tokens`` to ``max_in_flight_tokens`` on
+    the admission bound and that only surfaced in a benchmark run, so pin the
+    names the gate reads against the real classes. ``original_max_model_len`` is
+    assigned in ModelConfig.__post_init__ rather than declared, so check the
+    source of truth for each name separately.
+    """
+    from dataclasses import fields
+
+    from vllm.config import CacheConfig, ModelConfig, SchedulerConfig, VllmConfig
+
+    assert hasattr(ModelConfig, "get_sliding_window")
+    assert "max_model_len" in {f.name for f in fields(ModelConfig)}
+    assert "block_size" in {f.name for f in fields(CacheConfig)}
+    assert "disable_hybrid_kv_cache_manager" in {
+        f.name for f in fields(SchedulerConfig)
+    }
+    # Read by publish_tt_per_request_prefill_chunk for the in-flight multiplier.
+    assert hasattr(VllmConfig, "max_concurrent_batches")
+    # Not a declared field: set in ModelConfig.__post_init__.
+    assert "original_max_model_len" in inspect.getsource(ModelConfig.__post_init__)
+
+
+def test_publish_carries_the_in_flight_multiplier():
+    """vLLM's bound is max_concurrent_batches x max_num_batched_tokens, so the
+    per-request analogue must carry the same multiplier -- assuming 1 would
+    under-charge silently if PP or async scheduling is ever enabled."""
+    import vllm_tt.platform as platform_mod
+
+    spec = TestSlidingWindowAdmissionBound._spec()
+    platform_mod.install_tt_sliding_window_admission()
+    try:
+        TestSlidingWindowAdmissionBound._publish(1024, concurrent_batches=2)
+        # cdiv(1023 + 2*1024, 32) + 1, not the single-batch cdiv(1023+1024,32)+1
+        assert (
+            spec.max_admission_blocks_per_request(
+                max_in_flight_tokens=1024 * 32, max_model_len=65536
+            )
+            == 97
+        )
+    finally:
+        TestSlidingWindowAdmissionBound._publish(0, enabled=False)

--- a/tests/integrations/vllm_plugin/test_hybrid_kv_profitability.py
+++ b/tests/integrations/vllm_plugin/test_hybrid_kv_profitability.py
@@ -95,3 +95,105 @@ def test_larger_block_size_shifts_the_boundary():
     full attention at max_model_len=2048 is 8 blocks -- not yet a win."""
     assert _gate(max_model_len=2048, sliding_window=1024, block_size=256) is True
     assert _gate(max_model_len=4096, sliding_window=1024, block_size=256) is False
+
+
+class TestSlidingWindowAdmissionBound:
+    """``install_tt_sliding_window_admission`` clamps a sliding-window layer's
+    per-request KV bound to the per-request prefill chunk.
+
+    vLLM reads ``max_num_batched_tokens`` as the largest chunk one request can be
+    scheduled; under TT chunked prefill it is the batch-wide budget
+    (``chunk * max_num_seqs``) while AscendScheduler caps each request at
+    ``chunk``, so the unclamped bound over-charges by up to ``max_num_seqs`` x.
+    """
+
+    @staticmethod
+    def _spec():
+        import torch
+        from vllm.v1.kv_cache_interface import SlidingWindowSpec
+
+        return SlidingWindowSpec(
+            block_size=32,
+            num_kv_heads=16,
+            head_size=256,
+            dtype=torch.bfloat16,
+            sliding_window=1024,
+        )
+
+    @staticmethod
+    def _publish(chunk, enabled=True):
+        from vllm_tt.platform import publish_tt_per_request_prefill_chunk
+
+        publish_tt_per_request_prefill_chunk(
+            types.SimpleNamespace(
+                tt_chunked_prefill_enabled=enabled, tt_prefill_chunk_size=chunk
+            )
+        )
+
+    def test_clamps_to_the_per_request_chunk(self):
+        """gemma-4-31B at max_model_len=65536, chunk 1024, batch 32."""
+        import vllm_tt.platform as platform_mod
+
+        spec = self._spec()
+        platform_mod.install_tt_sliding_window_admission()
+        try:
+            self._publish(1024)
+            clamped = spec.max_admission_blocks_per_request(
+                max_num_batched_tokens=1024 * 32, max_model_len=65536
+            )
+            # cdiv(1023 + 1024, 32) + 1, not cdiv(1023 + 32768, 32) + 1 = 1057
+            assert clamped == 65
+        finally:
+            self._publish(0, enabled=False)
+
+    def test_is_a_noop_when_tt_chunked_prefill_is_off(self):
+        import vllm_tt.platform as platform_mod
+
+        spec = self._spec()
+        platform_mod.install_tt_sliding_window_admission()
+        self._publish(0, enabled=False)
+        assert (
+            spec.max_admission_blocks_per_request(
+                max_num_batched_tokens=1024 * 32, max_model_len=65536
+            )
+            == 1057
+        )
+
+    def test_never_raises_the_bound(self):
+        """Clamping is a min(): a chunk larger than the batch budget is inert."""
+        import vllm_tt.platform as platform_mod
+
+        spec = self._spec()
+        platform_mod.install_tt_sliding_window_admission()
+        try:
+            self._publish(0, enabled=False)
+            unclamped = spec.max_admission_blocks_per_request(
+                max_num_batched_tokens=4096, max_model_len=65536
+            )
+            self._publish(1 << 20)  # chunk far above the budget
+            assert (
+                spec.max_admission_blocks_per_request(
+                    max_num_batched_tokens=4096, max_model_len=65536
+                )
+                == unclamped
+            )
+        finally:
+            self._publish(0, enabled=False)
+
+    def test_install_is_idempotent(self):
+        """Re-installing must not stack wrappers and shrink the bound twice."""
+        import vllm_tt.platform as platform_mod
+
+        spec = self._spec()
+        platform_mod.install_tt_sliding_window_admission()
+        platform_mod.install_tt_sliding_window_admission()
+        try:
+            self._publish(1024)
+            assert (
+                spec.max_admission_blocks_per_request(
+                    max_num_batched_tokens=1024 * 32, max_model_len=65536
+                )
+                == 65
+            )
+        finally:
+            self._publish(0, enabled=False)

--- a/tests/integrations/vllm_plugin/test_hybrid_kv_profitability.py
+++ b/tests/integrations/vllm_plugin/test_hybrid_kv_profitability.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the hybrid-KV profitability gate.
+
+``TTPlatform._maybe_disable_unprofitable_hybrid_kv_cache`` opts out of vLLM's
+hybrid KV cache manager in the regime where a per-user sliding ring costs more
+than plain full attention (see that method and ``sliding_ring_is_profitable``);
+these tests pin the decision boundary and the cases it must leave alone.
+
+Pure config manipulation -- no device, no engine.
+"""
+
+import types
+
+import pytest
+from vllm_tt.platform import TTPlatform
+
+pytestmark = [pytest.mark.push, pytest.mark.cpu]
+
+
+def _gate(
+    max_model_len,
+    sliding_window,
+    block_size=32,
+    disable_hybrid=None,
+    original_max_model_len=None,
+):
+    """Run the gate over a stand-in for the slice of VllmConfig it reads.
+
+    Returns whether it disabled the hybrid KV cache manager.
+    """
+    cfg = types.SimpleNamespace(
+        model_config=types.SimpleNamespace(
+            max_model_len=max_model_len,
+            original_max_model_len=original_max_model_len or max_model_len,
+            get_sliding_window=lambda: sliding_window,
+        ),
+        scheduler_config=types.SimpleNamespace(
+            disable_hybrid_kv_cache_manager=disable_hybrid
+        ),
+        cache_config=types.SimpleNamespace(block_size=block_size),
+    )
+    TTPlatform._maybe_disable_unprofitable_hybrid_kv_cache(cfg)
+    return bool(cfg.scheduler_config.disable_hybrid_kv_cache_manager)
+
+
+# gemma-4-31B geometry: sliding_window=1024, block_size=32. A ring needs
+# align8(cdiv(min(window, max_model_len), 32) + 1) blocks per user per layer
+# against cdiv(max_model_len, 32) for full attention, so the ring only wins
+# once max_model_len exceeds the window.
+@pytest.mark.parametrize(
+    "max_model_len,expect_disabled",
+    [
+        (128, True),  # ring 8 vs full 4 -- the reported regression
+        (512, True),  # ring 24 vs full 16
+        (1024, True),  # ring 40 vs full 32 -- window == max_model_len
+        (2048, False),  # ring 40 vs full 64 -- window finally clips
+        (131072, False),  # ring 40 vs full 4096 -- what the ring exists for
+    ],
+)
+def test_gate_follows_the_ring_vs_full_crossover(max_model_len, expect_disabled):
+    assert (
+        _gate(max_model_len=max_model_len, sliding_window=1024) is expect_disabled
+    ), f"wrong decision at max_model_len={max_model_len}"
+
+
+def test_no_sliding_layers_leaves_hybrid_alone():
+    """Nothing to trade off -- vLLM already emits a single full-attention group."""
+    assert _gate(max_model_len=128, sliding_window=None) is False
+
+
+@pytest.mark.parametrize("explicit", [True, False])
+def test_explicit_user_choice_is_respected(explicit):
+    """An explicit --[no-]disable-hybrid-kv-cache-manager wins in both
+    directions, even where the gate would decide the other way."""
+    # max_model_len=128 is where the gate would otherwise disable hybrid.
+    assert _gate(max_model_len=128, sliding_window=1024, disable_hybrid=explicit) is (
+        explicit
+    )
+
+
+def test_auto_fit_max_model_len_keeps_the_ring():
+    """max_model_len == -1 means vLLM auto-fits it later from the KV budget, so
+    the value present now is a placeholder and must not drive the decision."""
+    assert (
+        _gate(max_model_len=128, sliding_window=1024, original_max_model_len=-1)
+        is False
+    )
+
+
+def test_larger_block_size_shifts_the_boundary():
+    """The comparison is in blocks, so block_size moves the crossover: at
+    block_size=256 a 1024-token window is 8 blocks (4+1 rounded to 8) while
+    full attention at max_model_len=2048 is 8 blocks -- not yet a win."""
+    assert _gate(max_model_len=2048, sliding_window=1024, block_size=256) is True
+    assert _gate(max_model_len=4096, sliding_window=1024, block_size=256) is False

--- a/tests/integrations/vllm_plugin/test_sliding_ring_reserve.py
+++ b/tests/integrations/vllm_plugin/test_sliding_ring_reserve.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the worker's sliding-window ring reservation.
+
+``sliding_ring_reserve_for_spec`` must reserve exactly the rings the model runner
+later allocates, and the runner keys off spec type. The trap these tests pin:
+unification early-returns on a *uniform* spec dict, so an all-sliding model keeps
+its SlidingWindowSpecs and its rings are real even with the hybrid manager
+disabled -- skipping on the flag alone would under-reserve it, while reserving
+unconditionally strands the bytes for a mixed model.
+
+Pure spec manipulation -- no device, no engine.
+"""
+
+import pytest
+import torch
+from vllm.v1.kv_cache_interface import FullAttentionSpec, SlidingWindowSpec
+from vllm_tt.swa_cache_utils import sliding_ring_reserve_bytes, sliding_window_blocks
+from vllm_tt.worker import sliding_ring_reserve_for_spec
+
+pytestmark = [pytest.mark.push, pytest.mark.cpu]
+
+MAX_NUM_REQS = 32
+MAX_MODEL_LEN = 128
+SLIDING_WINDOW = 1024
+
+
+def _sliding(**kwargs):
+    # gemma-4-31B sliding-layer geometry: 16 kv heads x head_size 256.
+    return SlidingWindowSpec(
+        block_size=32,
+        num_kv_heads=16,
+        head_size=256,
+        dtype=torch.bfloat16,
+        sliding_window=SLIDING_WINDOW,
+        **kwargs,
+    )
+
+
+def _full():
+    # gemma-4-31B full-attention geometry: 4 kv heads x head_size 512.
+    return FullAttentionSpec(
+        block_size=32, num_kv_heads=4, head_size=512, dtype=torch.bfloat16
+    )
+
+
+def _reserve(spec, hybrid_disabled):
+    return sliding_ring_reserve_for_spec(
+        spec, MAX_NUM_REQS, MAX_MODEL_LEN, hybrid_disabled
+    )
+
+
+def _expected_bytes(n_sliding):
+    window_blocks = sliding_window_blocks(SLIDING_WINDOW, 32, MAX_MODEL_LEN)
+    return n_sliding * sliding_ring_reserve_bytes(
+        window_blocks, MAX_NUM_REQS, _sliding().page_size_bytes
+    )
+
+
+def _mixed_spec():
+    """gemma-4-31B shape in miniature: sliding layers interleaved with full."""
+    return {f"sliding.{i}": _sliding() for i in range(5)} | {
+        f"full.{i}": _full() for i in range(2)
+    }
+
+
+def _all_sliding_spec():
+    """Mistral shape: every layer sliding, so the dict is uniform."""
+    return {f"sliding.{i}": _sliding() for i in range(5)}
+
+
+def test_mixed_model_reserves_rings_when_hybrid_is_on():
+    """The hybrid path is live, the runner allocates rings, so reserve them."""
+    reserve, num_sliding = _reserve(_mixed_spec(), hybrid_disabled=False)
+    assert num_sliding == 5
+    assert reserve == _expected_bytes(5)
+
+
+def test_mixed_model_reserves_nothing_when_hybrid_is_disabled():
+    """Unification rewrites every SlidingWindowSpec to FullAttentionSpec, so the
+    runner allocates no rings -- reserving for them would strand the bytes."""
+    assert _reserve(_mixed_spec(), hybrid_disabled=True) == (0, 0)
+
+
+def test_all_sliding_model_reserves_rings_when_hybrid_is_on():
+    reserve, num_sliding = _reserve(_all_sliding_spec(), hybrid_disabled=False)
+    assert num_sliding == 5
+    assert reserve == _expected_bytes(5)
+
+
+def test_all_sliding_model_still_reserves_when_hybrid_is_disabled():
+    """The trap: unification early-returns on a uniform spec dict, so these
+    specs survive and the runner really does allocate rings. Keying the skip on
+    the flag instead of the post-unification spec would under-reserve here."""
+    reserve, num_sliding = _reserve(_all_sliding_spec(), hybrid_disabled=True)
+    assert num_sliding == 5, (
+        "an all-sliding model keeps its SlidingWindowSpecs through unification; "
+        "its rings are real and must still be reserved"
+    )
+    assert reserve == _expected_bytes(5)
+
+
+def test_no_sliding_layers_reserves_nothing():
+    full_only = {f"full.{i}": _full() for i in range(3)}
+    assert _reserve(full_only, hybrid_disabled=False) == (0, 0)
+    assert _reserve(full_only, hybrid_disabled=True) == (0, 0)
+
+
+def test_caller_spec_is_not_mutated():
+    """Unification runs over a copy: the worker is handed the runner's own spec
+    dict and must not rewrite it underneath."""
+    spec = _mixed_spec()
+    _reserve(spec, hybrid_disabled=True)
+    assert all(isinstance(spec[f"sliding.{i}"], SlidingWindowSpec) for i in range(5))

--- a/tests/integrations/vllm_plugin/test_swa_cache_utils.py
+++ b/tests/integrations/vllm_plugin/test_swa_cache_utils.py
@@ -16,6 +16,7 @@ from vllm_tt.swa_cache_utils import (
     assign_ring_slots,
     build_sliding_ring_page_table,
     sliding_page_table_width,
+    sliding_ring_is_profitable,
     sliding_ring_phys_blocks,
     sliding_ring_reserve_bytes,
     sliding_window_blocks,
@@ -142,3 +143,25 @@ def test_page_table_wraps_once_past_the_window():
         np.array([3], dtype=np.int64), np.array([0], dtype=np.int64), wb, width
     )
     assert pt[0].tolist() == [1 + ((3 + i) % wb) for i in range(width)]
+
+
+@pytest.mark.parametrize(
+    "max_model_len,profitable",
+    # gemma-4-31B geometry (window 1024, block 32). Below the window the ring
+    # pays its +1 straddle block and the stick round-up for nothing.
+    [(128, False), (512, False), (1024, False), (2048, True), (131072, True)],
+)
+def test_ring_is_profitable_only_past_the_window(max_model_len, profitable):
+    assert sliding_ring_is_profitable(1024, 32, max_model_len) is profitable
+
+
+def test_ring_profitability_agrees_with_the_block_counts():
+    """The predicate must not drift from the two block counts it compares."""
+    for max_model_len in (32, 128, 1024, 2048, 8192, 65536):
+        for window in (256, 1024, 4096):
+            expected = sliding_window_blocks(window, 32, max_model_len) < cdiv(
+                max_model_len, 32
+            )
+            assert (
+                sliding_ring_is_profitable(window, 32, max_model_len) is expected
+            ), f"window={window} max_model_len={max_model_len}"


### PR DESCRIPTION
### Ticket
#5860  
#5879  partially

### Problem description
#5786 introduced two sizing defects in per-layer sliding-window rings:
 - Short Context: At max_model_len <= sliding_window, ring overhead (straddle block & alignment) shrinks the KV pool by ~29% unnecessarily.
 - Long Context: Admission bound calculates memory using max_num_batched_tokens instead of tt_prefill_chunk_size, over-charging budget up to max_num_seqsx and incorrectly rejecting valid configs at startup.

### What's changed
 - Hybrid KV Cache Switch: Enabled the hybrid manager only when a ring is actually cheaper than full attention (otherwise fallback to a shared pool). Manual user settings still take priority.
 - Fixed Admission Bound Over-charging: Clamped the sliding-window admission bound to the per-request prefill chunk size in the spec method (used for both startup sizing and runtime admission).
 - Aligned Ring Reservation: Sized worker ring reservations based on the actual grouped spec, preventing ghost allocations. Added unit tests for sizing paths.
 

### Tests
New unit tests, all CPU-only (no device, no engine):

| file | covers |
|---|---|
| `test_hybrid_kv_profitability.py` | the ring-vs-full crossover and the cases the gate must leave alone (no sliding layers, explicit user setting, auto-fit `max_model_len`, larger block size); the admission clamp, its no-op when TT chunked prefill is off, that it never raises the bound, install idempotence, and the in-flight multiplier |
| `test_sliding_ring_reserve.py` | the four spec/flag combinations the reservation must get right, including the uniform all-sliding model that keeps its specs through unification; that the caller's spec dict is not mutated |
| `test_swa_cache_utils.py` (extended) | ring width capped by `max_model_len`, the profitability helper's boundary |

One test pins the config attribute names the gate reads against the real
`ModelConfig` / `CacheConfig` / `SchedulerConfig` / `VllmConfig`, so an upstream
rename breaks here rather than in a benchmark run.

Existing tests: `tests/integrations/vllm_plugin/` passes (46 tests).

### Benchmark results
`gemma-4-31B-it`, bhqb, `bfp_bf8`:

| config | before | after |
|---|---|---|
| `max_model_len=128`, batch 32, `gmu 0.40` | 43,420 tokens / 339x | **60,768 / 475x** (pre-#5786 size) |
| 64K, batch 32, `gmu 0.225`, chunk 1024 | fails to start | **passes**, 259,666 tokens / 3.96x |
| 64K, batch 32, `gmu 0.30` | 96,210 tokens / 1.47x | **449,958 / 6.87x** |

#5879's batch-size coupling drops from 3.9x to 1.5x; the reserve still scales
with `max_num_seqs`, which is what remains there.

### Checklist
- [x] New/Existing tests provide coverage for changes
