### PR TITLE
Benchmark CI model cleanup

### DIFF
--- a/.github/scripts/filter-test-matrix.py
+++ b/.github/scripts/filter-test-matrix.py
@@ -6,23 +6,7 @@ import json
 import sys
 from pathlib import Path
 
-# Scheduled nightly that owns a benchmark. Not consulted for accuracy-testing
-# entries, which are selected by the accuracy axis instead.
 VALID_GROUPS = ("regular", "experimental")
-
-# Fields compared for equality between a filter condition and a matrix entry,
-# mapped to the value assumed when an entry omits them. A condition that omits
-# a field does not constrain it.
-EQUALITY_FIELDS = {"accuracy-testing": False, "group": "regular"}
-
-
-def _validate_group(group, context):
-    """Reject unknown groups so a typo cannot silently drop a benchmark."""
-    if group is None or group in VALID_GROUPS:
-        return group
-
-    valid = ", ".join(VALID_GROUPS)
-    raise ValueError(f"Invalid group '{group}' in {context}. Expected one of: {valid}.")
 
 
 def flatten_matrix(data):
@@ -33,11 +17,14 @@ def flatten_matrix(data):
         for test in proj.get("tests", []):
             if test.get("skip"):
                 continue
+            # Required per test: a missing or misspelled group would drop the
+            # benchmark from every nightly without any error.
+            if test.get("group") not in VALID_GROUPS:
+                raise ValueError(
+                    f"Test '{test.get('name', '<unnamed>')}': \"group\" must be one of "
+                    f"{', '.join(VALID_GROUPS)}, got {test.get('group')!r}"
+                )
             merged_test = {**test_defaults, **test, "project": proj["project"]}
-            merged_test.setdefault("group", EQUALITY_FIELDS["group"])
-            _validate_group(
-                merged_test["group"], f"test '{merged_test.get('name', '<unnamed>')}'"
-            )
 
             runs_on = merged_test.get("runs-on", [])
             if isinstance(runs_on, list):
@@ -61,13 +48,10 @@ def filter_matrix_adv(matrix, adv_filter):
       - "runs-on": machine(s) on which the test should run. If ommited, condition will be applied to all unskipped machines. Parameter can be string or array of strings.
       - "filter": string (or comma-separated list / list of strings) that should be present in the test name (include match).
       - "exclude": string (or comma-separated list / list of strings) — any test whose name contains one of these substrings is dropped. Applied AFTER "filter".
-      - "accuracy-testing": whether to include accuracy testing or not.
-      - "group": scheduled nightly that owns the test ("regular" or "experimental"). If ommited, the group is not constrained.
+      - "accuracy-testing": whether to include accuracy testing or not. If ommited, the accuracy flag is not constrained.
+      - "group": scheduled nightly that owns the test ("regular" or "experimental").
       - "skip": whether to skip tests matching the condition or not. If ommited, it is assumed to be true.
     """
-    for condition in adv_filter:
-        _validate_group(condition.get("group"), "filter condition")
-
     # Create initial structure with all runners marked as skip=True
     runners = get_unique_runners(matrix)
     runner_conditions = {runner: {"skip": True} for runner in runners}
@@ -109,11 +93,9 @@ def filter_matrix_adv(matrix, adv_filter):
                         runner_conditions[runner][key].extend(
                             v.lower() for v in value.split(",")
                         )
-            for field in EQUALITY_FIELDS:
-                if condition.get(field) is not None:
-                    runner_conditions[runner][field] = condition[field]
-            if condition.get("skip") is not None:
-                runner_conditions[runner]["skip"] = condition["skip"]
+            for key in ("accuracy-testing", "group", "skip"):
+                if condition.get(key) is not None:
+                    runner_conditions[runner][key] = condition[key]
 
     # Filter the matrix based on the constructed runner conditions
     filtered_matrix = []
@@ -130,10 +112,11 @@ def filter_matrix_adv(matrix, adv_filter):
             if "exclude" in conditions and conditions["exclude"]:
                 if any(e in name_lc for e in conditions["exclude"]):
                     continue
-            if any(
-                field in conditions and conditions[field] != item.get(field, default)
-                for field, default in EQUALITY_FIELDS.items()
-            ):
+            if "accuracy-testing" in conditions and conditions[
+                "accuracy-testing"
+            ] != item.get("accuracy-testing", False):
+                continue
+            if "group" in conditions and conditions["group"] != item["group"]:
                 continue
             filtered_matrix.append(item)
 

--- a/.github/scripts/filter-test-matrix.py
+++ b/.github/scripts/filter-test-matrix.py
@@ -6,6 +6,24 @@ import json
 import sys
 from pathlib import Path
 
+# Scheduled nightly that owns a benchmark. Not consulted for accuracy-testing
+# entries, which are selected by the accuracy axis instead.
+VALID_GROUPS = ("regular", "experimental")
+
+# Fields compared for equality between a filter condition and a matrix entry,
+# mapped to the value assumed when an entry omits them. A condition that omits
+# a field does not constrain it.
+EQUALITY_FIELDS = {"accuracy-testing": False, "group": "regular"}
+
+
+def _validate_group(group, context):
+    """Reject unknown groups so a typo cannot silently drop a benchmark."""
+    if group is None or group in VALID_GROUPS:
+        return group
+
+    valid = ", ".join(VALID_GROUPS)
+    raise ValueError(f"Invalid group '{group}' in {context}. Expected one of: {valid}.")
+
 
 def flatten_matrix(data):
     """Flatten the matrix."""
@@ -16,6 +34,10 @@ def flatten_matrix(data):
             if test.get("skip"):
                 continue
             merged_test = {**test_defaults, **test, "project": proj["project"]}
+            merged_test.setdefault("group", EQUALITY_FIELDS["group"])
+            _validate_group(
+                merged_test["group"], f"test '{merged_test.get('name', '<unnamed>')}'"
+            )
 
             runs_on = merged_test.get("runs-on", [])
             if isinstance(runs_on, list):
@@ -40,8 +62,12 @@ def filter_matrix_adv(matrix, adv_filter):
       - "filter": string (or comma-separated list / list of strings) that should be present in the test name (include match).
       - "exclude": string (or comma-separated list / list of strings) — any test whose name contains one of these substrings is dropped. Applied AFTER "filter".
       - "accuracy-testing": whether to include accuracy testing or not.
+      - "group": scheduled nightly that owns the test ("regular" or "experimental"). If ommited, the group is not constrained.
       - "skip": whether to skip tests matching the condition or not. If ommited, it is assumed to be true.
     """
+    for condition in adv_filter:
+        _validate_group(condition.get("group"), "filter condition")
+
     # Create initial structure with all runners marked as skip=True
     runners = get_unique_runners(matrix)
     runner_conditions = {runner: {"skip": True} for runner in runners}
@@ -83,10 +109,9 @@ def filter_matrix_adv(matrix, adv_filter):
                         runner_conditions[runner][key].extend(
                             v.lower() for v in value.split(",")
                         )
-            if condition.get("accuracy-testing") is not None:
-                runner_conditions[runner]["accuracy-testing"] = condition[
-                    "accuracy-testing"
-                ]
+            for field in EQUALITY_FIELDS:
+                if condition.get(field) is not None:
+                    runner_conditions[runner][field] = condition[field]
             if condition.get("skip") is not None:
                 runner_conditions[runner]["skip"] = condition["skip"]
 
@@ -105,9 +130,10 @@ def filter_matrix_adv(matrix, adv_filter):
             if "exclude" in conditions and conditions["exclude"]:
                 if any(e in name_lc for e in conditions["exclude"]):
                     continue
-            if "accuracy-testing" in conditions and conditions[
-                "accuracy-testing"
-            ] != item.get("accuracy-testing", False):
+            if any(
+                field in conditions and conditions[field] != item.get(field, default)
+                for field, default in EQUALITY_FIELDS.items()
+            ):
                 continue
             filtered_matrix.append(item)
 

--- a/.github/workflows/call-filtered-perf-tests.yml
+++ b/.github/workflows/call-filtered-perf-tests.yml
@@ -45,11 +45,6 @@ on:
         required: false
         type: boolean
         default: false
-      regression_baseline_workflow:
-        description: "Workflow file to use for regression baseline results"
-        required: false
-        type: string
-        default: ""
       check_fusions:
         description: "Verify expected fusion ops are present in compiled IR"
         required: false
@@ -113,5 +108,4 @@ jobs:
       torchxla_build_run_id: ${{ inputs.torchxla_build_run_id }}
       skip-device-perf: ${{ inputs.skip-device-perf || false }}
       regression_check: ${{ inputs.regression_check || false }}
-      regression_baseline_workflow: ${{ inputs.regression_baseline_workflow }}
       check_fusions: ${{ inputs.check_fusions }}

--- a/.github/workflows/call-filtered-perf-tests.yml
+++ b/.github/workflows/call-filtered-perf-tests.yml
@@ -45,6 +45,11 @@ on:
         required: false
         type: boolean
         default: false
+      regression_baseline_workflow:
+        description: "Workflow file to use for regression baseline results"
+        required: false
+        type: string
+        default: ""
       check_fusions:
         description: "Verify expected fusion ops are present in compiled IR"
         required: false
@@ -108,4 +113,5 @@ jobs:
       torchxla_build_run_id: ${{ inputs.torchxla_build_run_id }}
       skip-device-perf: ${{ inputs.skip-device-perf || false }}
       regression_check: ${{ inputs.regression_check || false }}
+      regression_baseline_workflow: ${{ inputs.regression_baseline_workflow }}
       check_fusions: ${{ inputs.check_fusions }}

--- a/.github/workflows/call-perf-test.yml
+++ b/.github/workflows/call-perf-test.yml
@@ -39,11 +39,6 @@ on:
         required: false
         type: boolean
         default: false
-      regression_baseline_workflow:
-        description: "Workflow file to use for regression baseline results"
-        required: false
-        type: string
-        default: ""
       check_fusions:
         description: "Verify expected fusion ops are present in compiled IR"
         required: false
@@ -451,13 +446,10 @@ jobs:
       run: |
         echo "display_name=$(cat ${{ steps.strings.outputs.perf_report_json_file }} | jq -r '.config.display_name')" >> $GITHUB_OUTPUT
 
-        workflow_file="${{ inputs.regression_baseline_workflow }}"
-        if [[ -z "$workflow_file" ]]; then
-          if [[ "${{ matrix.build.accuracy-testing }}" == "true" ]]; then
-            workflow_file="schedule-benchmark-experimental.yml"
-          else
-            workflow_file="schedule-nightly.yml"
-          fi
+        if [[ "${{ matrix.build.group }}" == "experimental" ]]; then
+          workflow_file="schedule-benchmark-experimental.yml"
+        else
+          workflow_file="schedule-nightly.yml"
         fi
 
         if [[ "${{ matrix.build.accuracy-testing }}" == "true" ]]; then

--- a/.github/workflows/call-perf-test.yml
+++ b/.github/workflows/call-perf-test.yml
@@ -39,6 +39,11 @@ on:
         required: false
         type: boolean
         default: false
+      regression_baseline_workflow:
+        description: "Workflow file to use for regression baseline results"
+        required: false
+        type: string
+        default: ""
       check_fusions:
         description: "Verify expected fusion ops are present in compiled IR"
         required: false
@@ -446,12 +451,19 @@ jobs:
       run: |
         echo "display_name=$(cat ${{ steps.strings.outputs.perf_report_json_file }} | jq -r '.config.display_name')" >> $GITHUB_OUTPUT
 
+        workflow_file="${{ inputs.regression_baseline_workflow }}"
+        if [[ -z "$workflow_file" ]]; then
+          if [[ "${{ matrix.build.accuracy-testing }}" == "true" ]]; then
+            workflow_file="schedule-benchmark-experimental.yml"
+          else
+            workflow_file="schedule-nightly.yml"
+          fi
+        fi
+
         if [[ "${{ matrix.build.accuracy-testing }}" == "true" ]]; then
           mode="accuracy"
-          workflow_file="schedule-benchmark-experimental.yml"
         else
           mode="perf"
-          workflow_file="schedule-nightly.yml"
         fi
         echo "mode=$mode" >> $GITHUB_OUTPUT
         workflow_id=$(curl -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \

--- a/.github/workflows/manual-benchmark.yml
+++ b/.github/workflows/manual-benchmark.yml
@@ -11,6 +11,14 @@ on:
         description: "Filter tests based on the name property. One or more strings which are contained (case insensitive) in the name (e.g. 'resn' or 'resn,mni,yol')"
         required: false
         type: string
+      benchmark_group:
+        description: "Benchmark group to run"
+        required: true
+        type: choice
+        options:
+          - regular
+          - experimental
+        default: regular
       runs-on-filter:
         description: "Architecture you want to run the tests on"
         required: false
@@ -91,9 +99,9 @@ jobs:
         # Prepare the advanced filter for the perf benchmarks
         echo "[" > adv_filter.json
         if [ "${{ inputs.runs-on-filter }}" = "All" ]; then
-          echo '{ "skip": false, "accuracy-testing": false }' >> adv_filter.json
+          echo '{ "skip": false, "accuracy-testing": false, "group": "${{ inputs.benchmark_group }}" }' >> adv_filter.json
         else
-          echo '{"runs-on": "${{ inputs.runs-on-filter }}", "accuracy-testing": false }' >> adv_filter.json
+          echo '{"runs-on": "${{ inputs.runs-on-filter }}", "accuracy-testing": false, "group": "${{ inputs.benchmark_group }}" }' >> adv_filter.json
         fi
         if [ -n "${{ inputs.test_filter }}" ]; then
           echo ',{"filter": "${{ inputs.test_filter }}"}' >> adv_filter.json
@@ -105,6 +113,7 @@ jobs:
         # Set up the summary for the job
         echo "### Perf benchmarks inputs" >> $GITHUB_STEP_SUMMARY
         echo "Test filter: ${{ inputs.test_filter }}" >> $GITHUB_STEP_SUMMARY
+        echo "Benchmark group: ${{ inputs.benchmark_group }}" >> $GITHUB_STEP_SUMMARY
         echo "Runs-on filter: ${{ inputs.runs-on-filter }}" >> $GITHUB_STEP_SUMMARY
         echo "Skip device perf: ${{ inputs.skip-device-perf }}" >> $GITHUB_STEP_SUMMARY
         echo "Perf regression check: ${{ inputs.regression_check }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -18,49 +18,8 @@
     },
     "tests": [
       {
-        "name": "resnet_jax",
-        "pyreq": "transformers==4.57.1 flax==0.10.4",
-        "pytest": "tests/benchmark/resnet_jax_benchmark.py::test_resnet_jax"
-      },
-      {
-        "name": "mnist",
-        "pytest": "tests/benchmark/test_vision.py::test_mnist"
-      },
-      {
         "name": "resnet",
         "pytest": "tests/benchmark/test_vision.py::test_resnet50"
-      },
-      {
-        "name": "mobilenetv2",
-        "pytest": "tests/benchmark/test_vision.py::test_mobilenetv2"
-      },
-      {
-        "name": "efficientnet",
-        "pytest": "tests/benchmark/test_vision.py::test_efficientnet"
-      },
-      {
-        "name": "segformer",
-        "pytest": "tests/benchmark/test_vision.py::test_segformer"
-      },
-      {
-        "name": "swin",
-        "pytest": "tests/benchmark/test_vision.py::test_swin"
-      },
-      {
-        "name": "ufld_v2",
-        "pytest": "tests/benchmark/test_vision.py::test_ufld_v2"
-      },
-      {
-        "name": "unet",
-        "pytest": "tests/benchmark/test_vision.py::test_unet"
-      },
-      {
-        "name": "vit",
-        "pytest": "tests/benchmark/test_vision.py::test_vit"
-      },
-      {
-        "name": "vovnet",
-        "pytest": "tests/benchmark/test_vision.py::test_vovnet"
       },
       {
         "name": "playground_v2_5",
@@ -115,37 +74,6 @@
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "bge_m3_encode",
-        "pyreq": "transformers==4.57.1 FlagEmbedding",
-        "pytest": "tests/benchmark/test_encoders.py::test_bge_m3"
-      },
-      {
-        "name": "vllm_bge_m3_encode_batch1",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_embedding_benchmark[bge-m3-batch1]",
-        "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
-        "skip-device-perf": true
-      },
-      {
-        "name": "vllm_bge_m3_encode_batch32",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_embedding_benchmark[bge-m3-batch32]",
-        "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
-        "skip-device-perf": true
-      },
-      {
-        "name": "llama_3_2_1b_instruct",
-        "pytest": "tests/benchmark/test_llms.py::test_llama_3_2_1b"
-      },
-      {
-        "name": "llama_3_2_3b_instruct",
-        "pytest": "tests/benchmark/test_llms.py::test_llama_3_2_3b"
-      },
-      {
         "name": "llama_3_1_8b_instruct",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b"
       },
@@ -160,16 +88,6 @@
         "runs-on": "galaxy-wh-6u"
       },
       {
-        "name": "test_gpt_oss_120b_tp_dp_galaxy_batch_size_128",
-        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_120b_tp_dp_galaxy_batch_size_128",
-        "runs-on": "galaxy-wh-6u"
-      },
-      {
-        "name": "gpt_oss_120b_tp_qb2",
-        "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_120b_tp_qb2",
-        "runs-on": "qb2-blackhole"
-      },
-      {
         "name": "llama_3_1_70b_tp_qb2",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp_qb2",
         "runs-on": "qb2-blackhole"
@@ -180,33 +98,8 @@
         "runs-on": "qb2-blackhole"
       },
       {
-        "name": "falcon3_7b_tp_qb2",
-        "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b_tp_qb2",
-        "runs-on": "qb2-blackhole"
-      },
-      {
-        "name": "falcon3_10b_tp_qb2",
-        "pytest": "tests/benchmark/test_llms.py::test_falcon3_10b_tp_qb2",
-        "runs-on": "qb2-blackhole"
-      },
-      {
         "name": "llama_3_1_8b_instruct_tp_qb2",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b_instruct_tp_qb2",
-        "runs-on": "qb2-blackhole"
-      },
-      {
-        "name": "mistral_small_24b_instruct_2501_tp_qb2",
-        "pytest": "tests/benchmark/test_llms.py::test_mistral_small_24b_instruct_2501_tp_qb2",
-        "runs-on": "qb2-blackhole"
-      },
-      {
-        "name": "qwen_2_5_coder_32b_instruct_tp_qb2",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_coder_32b_instruct_tp_qb2",
-        "runs-on": "qb2-blackhole"
-      },
-      {
-        "name": "qwen_3_32b_tp_qb2",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_3_32b_tp_qb2",
         "runs-on": "qb2-blackhole"
       },
       {
@@ -631,23 +524,11 @@
         "accuracy-testing": true
       },
       {
-        "name": "vllm_llama_3_2_3b",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[llama-3.2-3b]",
-        "vllm": true,
-        "skip-device-perf": true
-      },
-      {
         "name": "vllm_llama_3_2_3b_instruct_production",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[llama-3.2-3b-instruct-production]",
         "vllm": true,
         "skip-device-perf": true,
         "runs-on": "p150-perf"
-      },
-      {
-        "name": "vllm_llama_3_2_1b_instruct",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[llama-3.2-1b]",
-        "vllm": true,
-        "skip-device-perf": true
       },
       {
         "name": "vllm_llama_3_1_8b",
@@ -663,59 +544,11 @@
         "runs-on": "p150-perf"
       },
       {
-        "name": "vllm_qwen2_5_0_5b_instruct",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen2.5-0.5b-instruct]",
-        "vllm": true,
-        "skip-device-perf": true
-      },
-      {
-        "name": "vllm_qwen2_5_1_5b_instruct",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen2.5-1.5b-instruct]",
-        "vllm": true,
-        "skip-device-perf": true
-      },
-      {
-        "name": "vllm_qwen2_5_3b_instruct",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen2.5-3b-instruct]",
-        "vllm": true,
-        "skip-device-perf": true
-      },
-      {
-        "name": "vllm_qwen2_5_7b_instruct",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen2.5-7b-instruct]",
-        "vllm": true,
-        "skip-device-perf": true
-      },
-      {
-        "name": "vllm_qwen3_0_6b",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen3-0.6b]",
-        "vllm": true,
-        "skip-device-perf": true
-      },
-      {
-        "name": "vllm_qwen3_1_7b",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen3-1.7b]",
-        "vllm": true,
-        "skip-device-perf": true
-      },
-      {
-        "name": "vllm_qwen3_4b",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen3-4b]",
-        "vllm": true,
-        "skip-device-perf": true
-      },
-      {
         "name": "vllm_qwen3_4b_production",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen3-4b-production]",
         "vllm": true,
         "skip-device-perf": true,
         "runs-on": "p150-perf"
-      },
-      {
-        "name": "vllm_qwen3_8b",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen3-8b]",
-        "vllm": true,
-        "skip-device-perf": true
       },
       {
         "name": "vllm_qwen3_8b_production",
@@ -725,42 +558,6 @@
         "runs-on": "p150-perf"
       },
       {
-        "name": "vllm_phi_1",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[phi-1]",
-        "vllm": true,
-        "skip-device-perf": true
-      },
-      {
-        "name": "vllm_phi_1_5",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[phi-1_5]",
-        "vllm": true,
-        "skip-device-perf": true
-      },
-      {
-        "name": "vllm_phi_2",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[phi-2]",
-        "vllm": true,
-        "skip-device-perf": true
-      },
-      {
-        "name": "vllm_falcon3_1b_base",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[falcon3-1b-base]",
-        "vllm": true,
-        "skip-device-perf": true
-      },
-      {
-        "name": "vllm_falcon3_3b_base",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[falcon3-3b-base]",
-        "vllm": true,
-        "skip-device-perf": true
-      },
-      {
-        "name": "vllm_falcon3_7b_base",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[falcon3-7b-base]",
-        "vllm": true,
-        "skip-device-perf": true
-      },
-      {
         "name": "vllm_falcon3_7b_instruct_production",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[falcon3-7b-instruct-production]",
         "vllm": true,
@@ -768,55 +565,8 @@
         "runs-on": "p150-perf"
       },
       {
-        "name": "vllm_mistral_7b_instruct",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[mistral-7b-instruct]",
-        "vllm": true,
-        "skip-device-perf": true
-      },
-      {
-        "name": "vllm_ministral_8b",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[ministral-8b]",
-        "vllm": true,
-        "skip-device-perf": true
-      },
-      {
         "name": "vllm_gemma4_31b_it_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[gemma4-31b-it-tp]",
-        "vllm": true,
-        "skip-device-perf": true,
-        "runs-on": "qb2-blackhole"
-      },
-      {
-        "name": "vllm_qwen3_32b_qb2_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen3-32b-qb2-tp]",
-        "vllm": true,
-        "skip-device-perf": true,
-        "runs-on": "qb2-blackhole"
-      },
-      {
-        "name": "vllm_falcon3_7b_qb2_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[falcon3-7b-qb2-tp]",
-        "vllm": true,
-        "skip-device-perf": true,
-        "runs-on": "qb2-blackhole"
-      },
-      {
-        "name": "vllm_falcon3_10b_qb2_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[falcon3-10b-qb2-tp]",
-        "vllm": true,
-        "skip-device-perf": true,
-        "runs-on": "qb2-blackhole"
-      },
-      {
-        "name": "vllm_qwen2_5_coder_32b_instruct_qb2_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[qwen2.5-coder-32b-instruct-qb2-tp]",
-        "vllm": true,
-        "skip-device-perf": true,
-        "runs-on": "qb2-blackhole"
-      },
-      {
-        "name": "vllm_mistral_small_24b_instruct_2501_qb2_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[mistral-small-24b-instruct-2501-qb2-tp]",
         "vllm": true,
         "skip-device-perf": true,
         "runs-on": "qb2-blackhole"

--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -14,7 +14,8 @@
       "libreq": "libgl1 libglib2.0-0",
       "skip-ttir-dump": false,
       "skip-ttnn-dump": false,
-      "skip-device-perf": true
+      "skip-device-perf": true,
+      "group": "regular"
     },
     "tests": [
       {
@@ -23,55 +24,66 @@
       },
       {
         "name": "playground_v2_5",
-        "pytest": "tests/benchmark/test_imagegen.py::test_playground_v2_5"
+        "pytest": "tests/benchmark/test_imagegen.py::test_playground_v2_5",
+        "group": "experimental"
       },
       {
         "name": "stable_diffusion_1_5",
         "pytest": "tests/benchmark/test_imagegen.py::test_stable_diffusion_1_5",
-        "runs-on": "n150-perf"
+        "runs-on": "n150-perf",
+        "group": "experimental"
       },
       {
         "name": "stable_diffusion_3",
         "pytest": "tests/benchmark/test_imagegen.py::test_stable_diffusion_3",
-        "runs-on": "n150-perf"
+        "runs-on": "n150-perf",
+        "group": "experimental"
       },
       {
         "name": "sdxl_lightning",
-        "pytest": "tests/benchmark/test_imagegen.py::test_sdxl_lightning"
+        "pytest": "tests/benchmark/test_imagegen.py::test_sdxl_lightning",
+        "group": "experimental"
       },
       {
         "name": "flux2",
         "pytest": "tests/benchmark/test_imagegen.py::test_flux2",
-        "runs-on": "qb2-blackhole"
+        "runs-on": "qb2-blackhole",
+        "group": "experimental"
       },
       {
         "name": "flux1",
         "pytest": "tests/benchmark/test_imagegen.py::test_flux",
-        "runs-on": "qb2-blackhole"
+        "runs-on": "qb2-blackhole",
+        "group": "experimental"
       },
       {
         "name": "hunyuan_image_2_1",
         "pytest": "tests/benchmark/test_imagegen.py::test_hunyuan_image_2_1",
-        "runs-on": "qb2-blackhole"
+        "runs-on": "qb2-blackhole",
+        "group": "experimental"
       },
       {
         "name": "janus_pro_1b",
-        "pytest": "tests/benchmark/test_imagegen.py::test_janus_pro"
+        "pytest": "tests/benchmark/test_imagegen.py::test_janus_pro",
+        "group": "experimental"
       },
       {
         "name": "janus_pro_7b",
         "runs-on": ["p150-perf"],
-        "pytest": "tests/benchmark/test_imagegen.py::test_janus_pro_7b"
+        "pytest": "tests/benchmark/test_imagegen.py::test_janus_pro_7b",
+        "group": "experimental"
       },
       {
         "name": "zimage",
         "pytest": "tests/benchmark/test_imagegen.py::test_zimage",
-        "runs-on": "p150-perf"
+        "runs-on": "p150-perf",
+        "group": "experimental"
       },
       {
         "name": "glm_image",
         "pytest": "tests/benchmark/test_imagegen.py::test_glm_image",
-        "runs-on": "qb2-blackhole"
+        "runs-on": "qb2-blackhole",
+        "group": "experimental"
       },
       {
         "name": "llama_3_1_8b_instruct",
@@ -623,84 +635,96 @@
         "pytest": "tests/benchmark/test_wan.py::test_wan_umt5[14b-sharded]",
         "runs-on": [
           "qb2-blackhole"
-        ]
+        ],
+        "group": "experimental"
       },
       {
         "name": "wan14b_vae_encoder_480p_unsharded",
         "pytest": "tests/benchmark/test_wan.py::test_wan_vae_encoder[14b-480p-unsharded]",
         "runs-on": [
           "qb2-blackhole"
-        ]
+        ],
+        "group": "experimental"
       },
       {
         "name": "wan14b_vae_encoder_720p_unsharded",
         "pytest": "tests/benchmark/test_wan.py::test_wan_vae_encoder[14b-720p-unsharded]",
         "runs-on": [
           "qb2-blackhole"
-        ]
+        ],
+        "group": "experimental"
       },
       {
         "name": "wan14b_vae_encoder_480p_sharded",
         "pytest": "tests/benchmark/test_wan.py::test_wan_vae_encoder[14b-480p-sharded]",
         "runs-on": [
           "qb2-blackhole"
-        ]
+        ],
+        "group": "experimental"
       },
       {
         "name": "wan14b_vae_encoder_720p_sharded",
         "pytest": "tests/benchmark/test_wan.py::test_wan_vae_encoder[14b-720p-sharded]",
         "runs-on": [
           "qb2-blackhole"
-        ]
+        ],
+        "group": "experimental"
       },
       {
         "name": "wan14b_vae_decoder_480p_unsharded",
         "pytest": "tests/benchmark/test_wan.py::test_wan_vae_decoder[14b-480p-unsharded]",
         "runs-on": [
           "qb2-blackhole"
-        ]
+        ],
+        "group": "experimental"
       },
       {
         "name": "wan14b_vae_decoder_720p_unsharded",
         "pytest": "tests/benchmark/test_wan.py::test_wan_vae_decoder[14b-720p-unsharded]",
         "runs-on": [
           "qb2-blackhole"
-        ]
+        ],
+        "group": "experimental"
       },
       {
         "name": "wan14b_vae_decoder_480p_sharded",
         "pytest": "tests/benchmark/test_wan.py::test_wan_vae_decoder[14b-480p-sharded]",
         "runs-on": [
           "qb2-blackhole"
-        ]
+        ],
+        "group": "experimental"
       },
       {
         "name": "wan14b_vae_decoder_720p_sharded",
         "pytest": "tests/benchmark/test_wan.py::test_wan_vae_decoder[14b-720p-sharded]",
         "runs-on": [
           "qb2-blackhole"
-        ]
+        ],
+        "group": "experimental"
       },
       {
         "name": "wan14b_dit_480p_sharded",
         "pytest": "tests/benchmark/test_wan.py::test_wan_dit[14b-480p-sharded]",
         "runs-on": [
           "qb2-blackhole"
-        ]
+        ],
+        "group": "experimental"
       },
       {
         "name": "wan14b_dit_720p_sharded",
         "pytest": "tests/benchmark/test_wan.py::test_wan_dit[14b-720p-sharded]",
         "runs-on": [
           "qb2-blackhole"
-        ]
+        ],
+        "group": "experimental"
       },
       {
         "name": "hunyuan_video_1_5",
         "pytest": "tests/benchmark/test_video_gen.py::test_hunyuan_video_1_5",
         "runs-on": [
           "qb2-blackhole"
-        ]
+        ],
+        "group": "experimental"
       }
     ]
   }

--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -14,13 +14,13 @@
       "libreq": "libgl1 libglib2.0-0",
       "skip-ttir-dump": false,
       "skip-ttnn-dump": false,
-      "skip-device-perf": true,
-      "group": "regular"
+      "skip-device-perf": true
     },
     "tests": [
       {
         "name": "resnet",
-        "pytest": "tests/benchmark/test_vision.py::test_resnet50"
+        "pytest": "tests/benchmark/test_vision.py::test_resnet50",
+        "group": "regular"
       },
       {
         "name": "playground_v2_5",
@@ -87,508 +87,459 @@
       },
       {
         "name": "llama_3_1_8b_instruct",
-        "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b"
+        "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b",
+        "group": "regular"
       },
       {
         "name": "llama_3_1_70b_tp_galaxy",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp_galaxy",
-        "runs-on": "galaxy-wh-6u"
+        "runs-on": "galaxy-wh-6u",
+        "group": "regular"
       },
       {
         "name": "test_gpt_oss_20b_tp_galaxy_batch_size_64",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_galaxy_batch_size_64",
-        "runs-on": "galaxy-wh-6u"
+        "runs-on": "galaxy-wh-6u",
+        "group": "regular"
       },
       {
         "name": "llama_3_1_70b_tp_qb2",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp_qb2",
-        "runs-on": "qb2-blackhole"
+        "runs-on": "qb2-blackhole",
+        "group": "regular"
       },
       {
         "name": "gpt_oss_20b_tp_batch_size_1_qb2",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_batch_size_1_qb2",
-        "runs-on": "qb2-blackhole"
+        "runs-on": "qb2-blackhole",
+        "group": "regular"
       },
       {
         "name": "llama_3_1_8b_instruct_tp_qb2",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b_instruct_tp_qb2",
-        "runs-on": "qb2-blackhole"
+        "runs-on": "qb2-blackhole",
+        "group": "regular"
       },
       {
         "name": "gpt_oss_120b_tp_qb2_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_120b_tp_qb2",
         "runs-on": "qb2-blackhole",
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "llama_3_1_70b_tp_qb2_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp_qb2",
         "runs-on": "qb2-blackhole",
         "accuracy-testing": true,
-        "batch-size": 16
+        "batch-size": 16,
+        "group": "experimental"
       },
       {
         "name": "gpt_oss_20b_tp_batch_size_1_qb2_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_batch_size_1_qb2",
         "runs-on": "qb2-blackhole",
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "falcon3_7b_tp_qb2_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b_tp_qb2",
         "runs-on": "qb2-blackhole",
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "falcon3_10b_tp_qb2_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_10b_tp_qb2",
         "runs-on": "qb2-blackhole",
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "llama_3_1_8b_instruct_tp_qb2_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b_instruct_tp_qb2",
         "runs-on": "qb2-blackhole",
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "mistral_small_24b_instruct_2501_tp_qb2_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_mistral_small_24b_instruct_2501_tp_qb2",
         "runs-on": "qb2-blackhole",
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "qwen_2_5_coder_32b_instruct_tp_qb2_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_coder_32b_instruct_tp_qb2",
         "runs-on": "qb2-blackhole",
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "qwen_3_32b_tp_qb2_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_32b_tp_qb2",
         "runs-on": "qb2-blackhole",
         "accuracy-testing": true,
-        "skip": true
-      },
-      {
-        "name": "microsoft_phi-1",
-        "pytest": "tests/benchmark/test_llms.py::test_phi1"
-      },
-      {
-        "name": "microsoft_phi-1_5",
-        "pytest": "tests/benchmark/test_llms.py::test_phi1_5"
-      },
-      {
-        "name": "microsoft_phi-2",
-        "pytest": "tests/benchmark/test_llms.py::test_phi2"
-      },
-      {
-        "name": "google_gemma-1.1-2b-it",
-        "pytest": "tests/benchmark/test_llms.py::test_gemma_1_1_2b"
-      },
-      {
-        "name": "tiiuae_falcon3-1b-base",
-        "pytest": "tests/benchmark/test_llms.py::test_falcon3_1b"
-      },
-      {
-        "name": "tiiuae_falcon3-3b-base",
-        "pytest": "tests/benchmark/test_llms.py::test_falcon3_3b"
-      },
-      {
-        "name": "tiiuae_falcon3-7b-base",
-        "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b"
-      },
-      {
-        "name": "qwen_2_5_0_5b_instruct",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_0_5b"
-      },
-      {
-        "name": "qwen_2_5_1_5b_instruct",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_1_5b"
-      },
-      {
-        "name": "qwen_2_5_3b_instruct",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_3b"
-      },
-      {
-        "name": "qwen_3_0_6b",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_3_0_6b"
-      },
-      {
-        "name": "qwen_3_1_7b",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_3_1_7b"
-      },
-      {
-        "name": "qwen_3_4b",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_3_4b"
-      },
-      {
-        "name": "qwen_3_8b",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_3_8b"
-      },
-      {
-        "name": "qwen_2_5_7b_instruct",
-        "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_7b"
-      },
-      {
-        "name": "mistral_7b",
-        "pytest": "tests/benchmark/test_llms.py::test_mistral_7b"
-      },
-      {
-        "name": "ministral_8b",
-        "pytest": "tests/benchmark/test_llms.py::test_ministral_8b"
-      },
-      {
-        "name": "qwen_3_4b_embedding",
-        "pytest": "tests/benchmark/test_encoders.py::test_qwen3_embedding_4b"
-      },
-      {
-        "name": "vllm_qwen_3_4b_embedding_batch1",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_embedding_benchmark[qwen3-embedding-4b-batch1]",
-        "vllm": true,
-        "skip-stablehlo-dump": true,
-        "skip-ttir-dump": true,
-        "skip-ttnn-dump": true,
-        "skip-device-perf": true
-      },
-      {
-        "name": "bert",
-        "pytest": "tests/benchmark/test_encoders.py::test_bert"
-      },
-      {
-        "name": "unet_for_conditional_generation",
-        "pytest": "tests/benchmark/test_encoders.py::test_unet_for_conditional_generation"
-      },
-      {
-        "name": "deepseek_v3_1_tp_galaxy_4_layers",
-        "pytest": "tests/benchmark/test_llms.py::test_deepseek_v3_1_tp_galaxy_4_layers",
-        "runs-on": "galaxy-wh-6u"
-      },
-      {
-        "name": "deepseek_v3_2_exp_tp_galaxy_2_layers",
-        "pytest": "tests/benchmark/test_llms.py::test_deepseek_v3_2_exp_tp_galaxy_2_layers",
-        "runs-on": "galaxy-wh-6u"
-      },
-      {
-        "name": "glm_4_7_tp_galaxy_4_layers",
-        "pytest": "tests/benchmark/test_llms.py::test_glm_4_7_tp_galaxy_4_layers",
-        "runs-on": "galaxy-wh-6u"
-      },
-      {
-        "name": "kimi_k2_tp_galaxy_2_layers",
-        "pyreq": "tiktoken",
-        "pytest": "tests/benchmark/test_llms.py::test_kimi_k2_tp_galaxy_2_layers",
-        "runs-on": "galaxy-wh-6u"
-      },
-      {
-        "name": "kimi_k2_6_tp_galaxy_2_layers",
-        "pyreq": "tiktoken",
-        "pytest": "tests/benchmark/test_llms.py::test_kimi_k2_6_tp_galaxy_2_layers",
-        "runs-on": "galaxy-wh-6u"
+        "group": "experimental"
       },
       {
         "name": "llama_3_2_1b_instruct_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_2_1b",
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "llama_3_2_3b_instruct_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_2_3b",
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "llama_3_1_8b_instruct_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b",
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "mistral_7b_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_mistral_7b",
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "qwen_2_5_7b_instruct_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_7b",
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "google_gemma-1.1-2b-it_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_gemma_1_1_2b",
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "google_gemma-2-2b-it_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_gemma_2_2b",
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "microsoft_phi-1_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_phi1",
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "microsoft_phi-1_5_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_phi1_5",
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "microsoft_phi-2_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_phi2",
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "tiiuae_falcon3-1b-base_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_1b",
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "tiiuae_falcon3-3b-base_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_3b",
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "tiiuae_falcon3-7b-base_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_falcon3_7b",
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "qwen_2_5_0_5b_instruct_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_0_5b",
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "qwen_2_5_1_5b_instruct_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_1_5b",
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "qwen_2_5_3b_instruct_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_2_5_3b",
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "qwen_3_0_6b_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_0_6b",
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "qwen_3_1_7b_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_1_7b",
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "qwen_3_4b_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_4b",
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "qwen_3_8b_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_qwen_3_8b",
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "ministral_8b_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_ministral_8b",
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "llama_3_1_70b_tp_galaxy_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_70b_tp_galaxy",
         "runs-on": "galaxy-wh-6u",
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "gpt_oss_20b_tp_galaxy_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_20b_tp_galaxy_batch_size_64",
         "runs-on": "galaxy-wh-6u",
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "gpt_oss_120b_tp_galaxy_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_120b_tp_galaxy_batch_size_64",
         "runs-on": "galaxy-wh-6u",
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "gpt_oss_120b_tp_dp_galaxy_accuracy",
         "pytest": "tests/benchmark/test_llms.py::test_gpt_oss_120b_tp_dp_galaxy_batch_size_128",
         "runs-on": "galaxy-wh-6u",
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "vllm_llama_3_2_1b_instruct_accuracy",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[llama-3.2-1b]",
         "vllm": true,
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "vllm_llama_3_2_3b_instruct_accuracy",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[llama-3.2-3b]",
         "vllm": true,
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "vllm_llama_3_1_8b_instruct_accuracy",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[llama-3.1-8b]",
         "vllm": true,
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "vllm_qwen2_5_0_5b_instruct_accuracy",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen2.5-0.5b-instruct]",
         "vllm": true,
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "vllm_qwen2_5_1_5b_instruct_accuracy",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen2.5-1.5b-instruct]",
         "vllm": true,
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "vllm_qwen2_5_3b_instruct_accuracy",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen2.5-3b-instruct]",
         "vllm": true,
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "vllm_qwen2_5_7b_instruct_accuracy",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen2.5-7b-instruct]",
         "vllm": true,
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "vllm_qwen3_0_6b_accuracy",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen3-0.6b]",
         "vllm": true,
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "vllm_qwen3_1_7b_accuracy",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen3-1.7b]",
         "vllm": true,
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "vllm_qwen3_4b_accuracy",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen3-4b]",
         "vllm": true,
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "vllm_qwen3_8b_accuracy",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen3-8b]",
         "vllm": true,
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "vllm_gemma_1_1_2b_it_accuracy",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[gemma-1.1-2b-it]",
         "vllm": true,
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "vllm_phi_1_accuracy",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[phi-1]",
         "vllm": true,
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "vllm_phi_1_5_accuracy",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[phi-1_5]",
         "vllm": true,
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "vllm_phi_2_accuracy",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[phi-2]",
         "vllm": true,
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "vllm_falcon3_1b_base_accuracy",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[falcon3-1b-base]",
         "vllm": true,
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "vllm_falcon3_3b_base_accuracy",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[falcon3-3b-base]",
         "vllm": true,
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "vllm_falcon3_7b_base_accuracy",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[falcon3-7b-base]",
         "vllm": true,
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "vllm_mistral_7b_instruct_accuracy",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[mistral-7b-instruct]",
         "vllm": true,
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "vllm_ministral_8b_accuracy",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[ministral-8b]",
         "vllm": true,
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "vllm_llama_3_2_3b_instruct_production",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[llama-3.2-3b-instruct-production]",
         "vllm": true,
         "skip-device-perf": true,
-        "runs-on": "p150-perf"
+        "runs-on": "p150-perf",
+        "group": "regular"
       },
       {
         "name": "vllm_llama_3_1_8b",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[llama-3.1-8b]",
         "vllm": true,
-        "skip-device-perf": true
+        "skip-device-perf": true,
+        "group": "regular"
       },
       {
         "name": "vllm_llama_3_1_8b_instruct_production",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[llama-3.1-8b-instruct-production]",
         "vllm": true,
         "skip-device-perf": true,
-        "runs-on": "p150-perf"
+        "runs-on": "p150-perf",
+        "group": "regular"
       },
       {
         "name": "vllm_qwen3_4b_production",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen3-4b-production]",
         "vllm": true,
         "skip-device-perf": true,
-        "runs-on": "p150-perf"
+        "runs-on": "p150-perf",
+        "group": "regular"
       },
       {
         "name": "vllm_qwen3_8b_production",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[qwen3-8b-production]",
         "vllm": true,
         "skip-device-perf": true,
-        "runs-on": "p150-perf"
+        "runs-on": "p150-perf",
+        "group": "regular"
       },
       {
         "name": "vllm_falcon3_7b_instruct_production",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_benchmark[falcon3-7b-instruct-production]",
         "vllm": true,
         "skip-device-perf": true,
-        "runs-on": "p150-perf"
+        "runs-on": "p150-perf",
+        "group": "regular"
       },
       {
         "name": "vllm_gemma4_31b_it_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[gemma4-31b-it-tp]",
         "vllm": true,
         "skip-device-perf": true,
-        "runs-on": "qb2-blackhole"
+        "runs-on": "qb2-blackhole",
+        "group": "regular"
       },
       {
         "name": "vllm_llama_3_1_8b_qb2_tp",
         "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[llama-3.1-8b-qb2-tp]",
         "vllm": true,
         "skip-device-perf": true,
-        "runs-on": "qb2-blackhole"
+        "runs-on": "qb2-blackhole",
+        "group": "regular"
       },
       {
         "name": "vllm_llama_3_1_8b_qb2_tp_accuracy",
@@ -596,7 +547,8 @@
         "vllm": true,
         "skip-device-perf": true,
         "runs-on": "qb2-blackhole",
-        "accuracy-testing": true
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "vllm_qwen3_32b_qb2_tp_accuracy",
@@ -604,21 +556,8 @@
         "vllm": true,
         "skip-device-perf": true,
         "runs-on": "qb2-blackhole",
-        "accuracy-testing": true
-      },
-      {
-        "name": "vllm_mistral_small_3_1_24b_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[mistral-small-3.1-24b-tp]",
-        "vllm": true,
-        "skip-device-perf": true,
-        "runs-on": "galaxy-wh-6u"
-      },
-      {
-        "name": "vllm_llama_3_1_8b_sharded_sampling_galaxy_tp",
-        "pytest": "tests/benchmark/test_vllm_benchmarks.py::test_vllm_tp_benchmark[llama-3.1-8b-sharded-sampling-galaxy-tp]",
-        "vllm": true,
-        "skip-device-perf": true,
-        "runs-on": "galaxy-wh-6u"
+        "accuracy-testing": true,
+        "group": "experimental"
       },
       {
         "name": "vllm_llama_3_1_70b_qb2_tp",
@@ -628,7 +567,8 @@
         "skip-ttir-dump": true,
         "skip-ttnn-dump": true,
         "skip-device-perf": true,
-        "runs-on": "qb2-blackhole"
+        "runs-on": "qb2-blackhole",
+        "group": "regular"
       },
       {
         "name": "wan_umt5_sharded",

--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -28,12 +28,12 @@
       {
         "name": "stable_diffusion_1_5",
         "pytest": "tests/benchmark/test_imagegen.py::test_stable_diffusion_1_5",
-        "runs-on": "n150"
+        "runs-on": "n150-perf"
       },
       {
         "name": "stable_diffusion_3",
         "pytest": "tests/benchmark/test_imagegen.py::test_stable_diffusion_3",
-        "runs-on": "n150"
+        "runs-on": "n150-perf"
       },
       {
         "name": "sdxl_lightning",

--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -77,8 +77,8 @@ jobs:
       #   - llama_3_1_70b_tp_galaxy (galaxy-wh-6u): fabric pinning (#5210)
       adv_filter: '[
         { "accuracy-testing": false },
-        { "runs-on": "n150-perf", "filter": ["resnet","llama_3_1_8b","falcon3-1b","qwen_3_8b"] },
-        { "runs-on": "qb2-blackhole", "filter": ["qwen_3_32b_tp_qb2"] } ]'
+        { "runs-on": "n150-perf", "filter": ["resnet","llama_3_1_8b"] },
+        { "runs-on": "qb2-blackhole", "filter": ["llama_3_1_70b_tp_qb2"] } ]'
       sh-runner: false
       skip-device-perf: true
       regression_check: false # toggle on #5486 completion
@@ -95,10 +95,10 @@ jobs:
       # On-PR accuracy uplift check: llama_3_1_70b TP accuracy on qb2-blackhole.
       adv_filter: '[
         { "accuracy-testing": true },
-        { "runs-on": "qb2-blackhole", "filter": ["qwen_3_32b_tp_qb2"] } ]'
+        { "runs-on": "qb2-blackhole", "filter": ["llama_3_1_70b_tp_qb2"] } ]'
       sh-runner: false
       skip-device-perf: true
-      regression_check: true
+      regression_check: false
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
 

--- a/.github/workflows/schedule-benchmark-experimental.yml
+++ b/.github/workflows/schedule-benchmark-experimental.yml
@@ -41,7 +41,6 @@ jobs:
       sh-runner: false
       skip-device-perf: true
       regression_check: true
-      regression_baseline_workflow: schedule-benchmark-experimental.yml
 
   run-n150-accuracy-benchmarks:
     needs: [build-image, build-ttxla]

--- a/.github/workflows/schedule-benchmark-experimental.yml
+++ b/.github/workflows/schedule-benchmark-experimental.yml
@@ -31,38 +31,10 @@ jobs:
     uses: ./.github/workflows/call-filtered-perf-tests.yml
     with:
       adv_filter: '[
-        { "accuracy-testing": false },
-        { "runs-on": "n150-perf", "filter": [
-          "playground_v2_5",
-          "stable_diffusion_1_5",
-          "stable_diffusion_3",
-          "sdxl_lightning",
-          "janus_pro_1b"
-        ] },
-        { "runs-on": "p150-perf", "filter": [
-          "playground_v2_5",
-          "sdxl_lightning",
-          "janus_pro_1b",
-          "janus_pro_7b",
-          "zimage"
-        ] },
-        { "runs-on": "qb2-blackhole", "filter": [
-          "flux2",
-          "flux1",
-          "hunyuan_image_2_1",
-          "glm_image",
-          "wan_umt5_sharded",
-          "wan14b_vae_encoder_480p_unsharded",
-          "wan14b_vae_encoder_720p_unsharded",
-          "wan14b_vae_encoder_480p_sharded",
-          "wan14b_vae_encoder_720p_sharded",
-          "wan14b_vae_decoder_480p_unsharded",
-          "wan14b_vae_decoder_720p_unsharded",
-          "wan14b_vae_decoder_480p_sharded",
-          "wan14b_vae_decoder_720p_sharded",
-          "wan14b_dit_480p_sharded",
-          "wan14b_dit_720p_sharded"
-        ] }
+        { "accuracy-testing": false, "group": "experimental" },
+        { "runs-on": "n150-perf" },
+        { "runs-on": "p150-perf" },
+        { "runs-on": "qb2-blackhole" }
       ]'
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}

--- a/.github/workflows/schedule-benchmark-experimental.yml
+++ b/.github/workflows/schedule-benchmark-experimental.yml
@@ -25,6 +25,52 @@ jobs:
     with:
       docker_image: ${{ needs.build-image.outputs.docker-image }}
 
+  run-media-benchmarks:
+    needs: [build-image, build-ttxla]
+    secrets: inherit
+    uses: ./.github/workflows/call-filtered-perf-tests.yml
+    with:
+      adv_filter: '[
+        { "accuracy-testing": false },
+        { "runs-on": "n150-perf", "filter": [
+          "playground_v2_5",
+          "stable_diffusion_1_5",
+          "stable_diffusion_3",
+          "sdxl_lightning",
+          "janus_pro_1b"
+        ] },
+        { "runs-on": "p150-perf", "filter": [
+          "playground_v2_5",
+          "sdxl_lightning",
+          "janus_pro_1b",
+          "janus_pro_7b",
+          "zimage"
+        ] },
+        { "runs-on": "qb2-blackhole", "filter": [
+          "flux2",
+          "flux1",
+          "hunyuan_image_2_1",
+          "glm_image",
+          "wan_umt5_sharded",
+          "wan14b_vae_encoder_480p_unsharded",
+          "wan14b_vae_encoder_720p_unsharded",
+          "wan14b_vae_encoder_480p_sharded",
+          "wan14b_vae_encoder_720p_sharded",
+          "wan14b_vae_decoder_480p_unsharded",
+          "wan14b_vae_decoder_720p_unsharded",
+          "wan14b_vae_decoder_480p_sharded",
+          "wan14b_vae_decoder_720p_sharded",
+          "wan14b_dit_480p_sharded",
+          "wan14b_dit_720p_sharded"
+        ] }
+      ]'
+      artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
+      artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
+      sh-runner: false
+      skip-device-perf: true
+      regression_check: true
+      regression_baseline_workflow: schedule-benchmark-experimental.yml
+
   run-n150-accuracy-benchmarks:
     needs: [build-image, build-ttxla]
     secrets: inherit
@@ -58,6 +104,7 @@ jobs:
 
   fail-notify:
     needs:
+      - run-media-benchmarks
       - run-n150-accuracy-benchmarks
       - run-qb2-accuracy-benchmarks
       - run-galaxy-accuracy-benchmarks

--- a/.github/workflows/schedule-benchmark-experimental.yml
+++ b/.github/workflows/schedule-benchmark-experimental.yml
@@ -48,7 +48,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/call-filtered-perf-tests.yml
     with:
-      adv_filter: '[ {"runs-on": "n150-perf", "accuracy-testing": true} ]'
+      adv_filter: '[ {"runs-on": "n150-perf", "accuracy-testing": true, "group": "experimental"} ]'
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
       sh-runner: true
@@ -59,7 +59,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/call-filtered-perf-tests.yml
     with:
-      adv_filter: '[ {"runs-on": "qb2-blackhole", "accuracy-testing": true} ]'
+      adv_filter: '[ {"runs-on": "qb2-blackhole", "accuracy-testing": true, "group": "experimental"} ]'
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
       regression_check: true
@@ -69,7 +69,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/call-filtered-perf-tests.yml
     with:
-      adv_filter: '[ {"runs-on": "galaxy-wh-6u", "accuracy-testing": true} ]'
+      adv_filter: '[ {"runs-on": "galaxy-wh-6u", "accuracy-testing": true, "group": "experimental"} ]'
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
       regression_check: true

--- a/.github/workflows/schedule-nightly.yml
+++ b/.github/workflows/schedule-nightly.yml
@@ -105,31 +105,7 @@ jobs:
       skip-device-perf: true
       regression_check: true
       adv_filter: '[
-        { "accuracy-testing": false },
-        { "exclude": [
-          "playground_v2_5",
-          "stable_diffusion_1_5",
-          "stable_diffusion_3",
-          "sdxl_lightning",
-          "flux2",
-          "flux1",
-          "hunyuan_image_2_1",
-          "janus_pro_1b",
-          "janus_pro_7b",
-          "zimage",
-          "glm_image",
-          "wan_umt5_sharded",
-          "wan14b_vae_encoder_480p_unsharded",
-          "wan14b_vae_encoder_720p_unsharded",
-          "wan14b_vae_encoder_480p_sharded",
-          "wan14b_vae_encoder_720p_sharded",
-          "wan14b_vae_decoder_480p_unsharded",
-          "wan14b_vae_decoder_720p_unsharded",
-          "wan14b_vae_decoder_480p_sharded",
-          "wan14b_vae_decoder_720p_sharded",
-          "wan14b_dit_480p_sharded",
-          "wan14b_dit_720p_sharded"
-        ] },
+        { "accuracy-testing": false, "group": "regular" },
         { "runs-on": "n150-perf" },
         { "runs-on": "p150-perf" },
         { "runs-on": "galaxy-wh-6u" },

--- a/.github/workflows/schedule-nightly.yml
+++ b/.github/workflows/schedule-nightly.yml
@@ -104,7 +104,37 @@ jobs:
       sh-runner: false
       skip-device-perf: true
       regression_check: true
-      adv_filter: '[ {"accuracy-testing": false}, {"runs-on": "n150-perf"}, {"runs-on": "p150-perf"}, {"runs-on": "galaxy-wh-6u"}, {"runs-on": "qb2-blackhole"} ]'
+      adv_filter: '[
+        { "accuracy-testing": false },
+        { "exclude": [
+          "playground_v2_5",
+          "stable_diffusion_1_5",
+          "stable_diffusion_3",
+          "sdxl_lightning",
+          "flux2",
+          "flux1",
+          "hunyuan_image_2_1",
+          "janus_pro_1b",
+          "janus_pro_7b",
+          "zimage",
+          "glm_image",
+          "wan_umt5_sharded",
+          "wan14b_vae_encoder_480p_unsharded",
+          "wan14b_vae_encoder_720p_unsharded",
+          "wan14b_vae_encoder_480p_sharded",
+          "wan14b_vae_encoder_720p_sharded",
+          "wan14b_vae_decoder_480p_unsharded",
+          "wan14b_vae_decoder_720p_unsharded",
+          "wan14b_vae_decoder_480p_sharded",
+          "wan14b_vae_decoder_720p_sharded",
+          "wan14b_dit_480p_sharded",
+          "wan14b_dit_720p_sharded"
+        ] },
+        { "runs-on": "n150-perf" },
+        { "runs-on": "p150-perf" },
+        { "runs-on": "galaxy-wh-6u" },
+        { "runs-on": "qb2-blackhole" }
+      ]'
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
       wheel_build: manylinux

--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -133,3 +133,23 @@ Vision and encoder tests follow the same pattern — import the existing `ModelL
 ### Adding the test to CI
 
 In order for a new test to run in CI, it needs to be added to `.github/workflows/perf-bench-matrix.json`.
+
+#### Choosing a nightly with `group`
+
+Each entry carries a `group` that decides which scheduled nightly runs it:
+
+| `group` | Workflow | Use for |
+| --- | --- | --- |
+| `regular` (default) | `schedule-nightly.yml` | Priority benchmarks tracked for perf regressions every night. |
+| `experimental` | `schedule-benchmark-experimental.yml` | Experimental benchmarks. |
+
+Example of adding an imagegen benchmark model that runs on qb2-blackhole in experimental nightly CI:
+
+```json
+{
+  "name": "my_new_model",
+  "pytest": "tests/benchmark/test_imagegen.py::test_my_new_model",
+  "runs-on": "qb2-blackhole",
+  "group": "experimental"
+}
+```


### PR DESCRIPTION
### What's changed
- Removed a large number of models from benchmarking CI.
- Moved imagegen and videogen models from regular to experimental nightly workflow.
- Added `group` field to determine if the model from the `.github/workflows/perf-bench-matrix.json` entry belongs to regular or experimental workflow. This also determines the baseline workflow for regression checks.
- Decoupled `accuracy_testing` field from workflow `group`. Tests are explicitly assigned to experimental workflow by group, not by accuracy label.
- Updated models used on uplift PR CI. 


### Checklist
- [x] [experimental benchmark run](https://github.com/tenstorrent/tt-xla/actions/runs/32022949803)
- [x] [regular benchmark run](https://github.com/tenstorrent/tt-xla/actions/runs/32022921866)
