### PR TITLE
Remove xfail from topk[input_shape5-300] (ttnn sort bug #1797 fixed)

### DIFF
--- a/tests/torch/ops/test_topk.py
+++ b/tests/torch/ops/test_topk.py
@@ -79,13 +79,7 @@ def topk_both_comparator(device_output, golden_output, args, kwargs):
         ((1, 30), 5),
         ((1, 40), 5),
         ((1, 50000), 100),
-        pytest.param(
-            (1, 8400),
-            300,
-            marks=pytest.mark.xfail(
-                reason="Bad PCC due to ttnn sort bug for greater than 256 elements - https://github.com/tenstorrent/tt-xla/issues/1797"
-            ),
-        ),
+        ((1, 8400), 300),
     ],
 )
 def test_topk_indices(input_shape: tuple, k: int):
@@ -160,13 +154,7 @@ def test_topk_values(input_shape: tuple, k: int):
         ((1, 30), 5),
         ((1, 40), 5),
         ((1, 50000), 100),
-        pytest.param(
-            (1, 8400),
-            300,
-            marks=pytest.mark.xfail(
-                reason="Bad PCC due to ttnn sort bug for greater than 256 elements - https://github.com/tenstorrent/tt-xla/issues/1797"
-            ),
-        ),
+        ((1, 8400), 300),
     ],
 )
 def test_topk_both(input_shape: tuple, k: int):


### PR DESCRIPTION
## What

`test_topk_both[input_shape5-300]` and `test_topk_indices[input_shape5-300]` (the `((1, 8400), 300)` param) were xfailed for the ttnn sort bug on >256 elements (#1797). Both now **XPASS** in nightly, so the underlying bug is fixed upstream. This drops the two stale xfail markers so the params run as normal coverage.

## Evidence

- **Tonight's nightly** (run 31136914175, 2026-08-07): both tests reported `XPASS` on **n150 and p150** ("2 xpassed" in each `run_torch` job).
- **No hard failure in the last 16 tracked nightlies** for either test.
- **CI on this branch** (`manual-test-single.yml`, `-k "test_topk_both or test_topk_indices"`):
  - n150 (run 31164917539): `test_topk_both[input_shape5-300] PASSED`, `test_topk_indices[input_shape5-300] PASSED` — 12 passed, 0 xfailed
  - p150 (run 31164920839): same — 12 passed, 0 xfailed

Genuine PASS (not xfail-masked) on both archs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)