### PR TITLE
Reenable tracy in tt-xla - Revert "Temporarily disable profiling for manylinux (released) whl to solve tracy host memory leak (#5663)"

### DIFF
--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -84,8 +84,6 @@ jobs:
       regression_check: false # toggle on #5486 completion
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
-      # temporary override due to tt-xla #5663
-      wheel_build: release
 
   perf-benchmark-accuracy:
     if: needs.inspect-changes.outputs.skip-build-and-test == 'false' && needs.inspect-changes.outputs.only-run-forge-models != 'true' && vars.RUN_PERF_ON_UPLIFT == 'true' && github.event_name == 'pull_request' && (contains(needs.inspect-changes.outputs.detected-uplifts, 'tt-mlir') || contains(needs.inspect-changes.outputs.detected-uplifts, 'transformers'))
@@ -103,8 +101,6 @@ jobs:
       regression_check: true
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
-      # temporary override due to tt-xla #5663
-      wheel_build: release
 
   test_forge_models_push:
     if: needs.inspect-changes.outputs.skip-build-and-test == 'false'

--- a/.github/workflows/schedule-nightly.yml
+++ b/.github/workflows/schedule-nightly.yml
@@ -107,8 +107,7 @@ jobs:
       adv_filter: '[ {"accuracy-testing": false}, {"runs-on": "n150-perf"}, {"runs-on": "p150-perf"}, {"runs-on": "galaxy-wh-6u"}, {"runs-on": "qb2-blackhole"} ]'
       artifact_release_run_id: ${{ needs.build-ttxla.outputs.artifacts_run_id }}
       artifact_suffix: ${{ needs.build-ttxla.outputs.artifact_suffix }}
-      # temporary override, default to manylinux, due to tt-xla #5663
-      wheel_build: release
+      wheel_build: manylinux
 
   nightly-benchmark-report:
     name: "Nightly benchmark report"

--- a/python_package/setup.py
+++ b/python_package/setup.py
@@ -298,7 +298,6 @@ class CMakeBuildPy(build_py):
         code_coverage = "OFF"
         enable_explorer = "OFF"
         enable_emitpy_execution = "ON"
-        enable_profiling = "ON"
 
         if config.build_type == "codecov":
             code_coverage = "ON"
@@ -309,10 +308,6 @@ class CMakeBuildPy(build_py):
             # avoid depending on the embedded-Python runner and its non-portable
             # transitive ABI surface.
             enable_emitpy_execution = "OFF"
-
-            # tt-xla 5504 - temporarily disabling release wheel tracy-enabled build
-            # due to host memory leak
-            enable_profiling = "OFF"
 
         cmake_args = [
             "-G",
@@ -327,9 +322,7 @@ class CMakeBuildPy(build_py):
             "-DTTXLA_ENABLE_EMITPY_EXECUTION=" + enable_emitpy_execution,
             "-DCMAKE_INSTALL_PREFIX=" + str(install_dir),
             "-DTT_USE_SYSTEM_SFPI=ON",
-            "-DTTMLIR_ENABLE_PERF_TRACE=" + enable_profiling,
         ]
-
         build_command = ["--build", "build"]
         install_command = ["--install", "build"]
 


### PR DESCRIPTION
This reverts commit 911505261a692f1533384f38e88b9225514fa5ab.

### Ticket
#5504

### Problem description
Now that tracy host memory patch is uplifted in #5850 we can undo the blanket disablement of profiler-off build in tt-xla tests and release.

Thanks to @kmabeeTT for running tests and validating this fix works as expected to bound host memory growth.

### What's changed
Reenable tracy for tt-xla tests and release build


### Checklist
- [ ] New/Existing tests provide coverage for changes
