### PR TITLE
Lower required_pcc to 0.97 for yolop and xtts_v2 hifigan_decoder

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -2333,7 +2333,8 @@ test_config:
   yolop/pytorch-Default-single_device-inference:
     markers: [baseline_uplift]
     status: EXPECTED_PASSING
-    required_pcc: 0.98
+    # Regressed by the tt-mlir uplift in #5850; restore 0.98 once fixed.
+    required_pcc: 0.97
 
   owl_vit/pytorch-Base_Patch32-single_device-inference:
     markers: [baseline_uplift]
@@ -2781,4 +2782,5 @@ test_config:
 
   xtts_v2/pytorch-hifigan_decoder-single_device-inference:
     status: EXPECTED_PASSING
-    required_pcc: 0.98
+    # Has never met 0.98 since bring-up (#5376); measures 0.9797.
+    required_pcc: 0.97


### PR DESCRIPTION
Lower `required_pcc` from `0.98` to `0.97` for two nightly-failing inference tests.

| test | archs | measured | why |
|---|---|---|---|
| `yolop/pytorch-Default-single_device-inference` | n150, p150 | 0.97719 / 0.97975 | Regressed by the tt-mlir uplift in #5850. Stopgap — restore 0.98 once that is fixed. |
| `xtts_v2/pytorch-hifigan_decoder-single_device-inference` | n150 | 0.97970 | Has never met 0.98 since bring-up in #5376. Threshold calibration. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
