### PR TITLE
Raise galaxy-bh CI test timeout floor to 300 minutes

### DIFF
--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -398,6 +398,12 @@ jobs:
           ESTIMATED_DURATION=$(echo "$SCRIPT_OUTPUT" | tail -n 1)
         fi
 
+        # galaxy-bh jobs often exceed duration-based estimates (e.g. large e2e models).
+        if [[ "${{ matrix.build.runs-on }}" == "galaxy-bh" && "$ESTIMATED_DURATION" -lt 300 ]]; then
+          echo "Raising timeout for galaxy-bh from $ESTIMATED_DURATION to 300 minutes"
+          ESTIMATED_DURATION=300
+        fi
+
         echo "Estimated duration: $ESTIMATED_DURATION minutes"
         echo "timeout-minutes=$ESTIMATED_DURATION" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
- Floor the calculated `Run tests` step timeout at **300 minutes** when `runs-on` is `galaxy-bh` only
- Other runners keep the existing duration-based timeout (default/cap still 240 unless estimated higher)

This addresses galaxy-bh e2e jobs that exceed the 3× duration estimate — e.g. [deepseek_v4 streaming on galaxy-bh](https://github.com/tenstorrent/tt-xla/actions/runs/31357144043/job/93361529451) timed out at 150 minutes.

## Test plan
- [ ] Re-run a long galaxy-bh e2e via Run Test Single and confirm Collect Tests logs `Raising timeout for galaxy-bh ... to 300 minutes` and the Run tests step does not cut off at 150
- [ ] Confirm a non-galaxy-bh Run Test Single job still uses the calculated timeout (no 300 floor)


Made with [Cursor](https://cursor.com)