### PR TITLE
Workaround to make TT_VISIBLE_DEVICES integer pinning usable (Production DP workaround)

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/__init__.py
+++ b/integrations/vllm_plugin/vllm_tt/__init__.py
@@ -20,6 +20,14 @@ register_backend(
 def register():
     # Setting worker multiprocessing method to spawn to avoid hangs in consecutive vllm pytest runs
     os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+
+    # WORKAROUND (tt-xla#5521), not a fix; no-op unless TT_VISIBLE_DEVICES is set.
+    # Needed here as well: TT_VISIBLE_DEVICES is vLLM's device_control_env_var,
+    # and this is the earliest hook that runs in every spawned worker.
+    from pjrt_plugin_tt import normalize_tt_visible_devices
+
+    normalize_tt_visible_devices()
+
     return "vllm_tt.platform.TTPlatform"
 
 

--- a/python_package/jax_plugin_tt/__init__.py
+++ b/python_package/jax_plugin_tt/__init__.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import jax._src.xla_bridge as xb
 from pjrt_plugin_tt import (
     get_library_path,
+    normalize_tt_visible_devices,
     setup_tt_metal_home,
     setup_tt_pjrt_plugin_dir,
 )
@@ -18,6 +19,8 @@ from .monkeypatch import setup_monkey_patches
 def initialize():
     setup_tt_pjrt_plugin_dir()
     setup_tt_metal_home()
+    # WORKAROUND (tt-xla#5521), not a fix; no-op unless TT_VISIBLE_DEVICES is set.
+    normalize_tt_visible_devices()
     library_path = get_library_path()
 
     xb.register_plugin(

--- a/python_package/pjrt_plugin_tt/__init__.py
+++ b/python_package/pjrt_plugin_tt/__init__.py
@@ -21,6 +21,67 @@ TT_PJRT_PLUGIN_NAME = "pjrt_plugin_tt.so"
 _shutdown_hook_registered = False
 
 
+def _device_bdfs_in_umd_order():
+    """
+    PCI BDFs of all Tenstorrent devices, sorted by BDF.
+
+    This is the order UMD's `PCIDevice::enumerate_devices()` indexes with an
+    integer token -- not `/dev/tenstorrent/<n>` node numbers. Empty when no
+    devices are visible in sysfs.
+    """
+    dev_dir = Path("/dev/tenstorrent")
+    if not dev_dir.exists():
+        return []
+
+    bdfs = []
+    for node in dev_dir.iterdir():
+        try:
+            bdf = Path(
+                f"/sys/class/tenstorrent/tenstorrent!{node.name}/device"
+            ).resolve()
+        except OSError:
+            continue  # UMD skips devices it cannot read; do the same.
+        if bdf.name:
+            bdfs.append(bdf.name)
+
+    return sorted(bdfs)
+
+
+def normalize_tt_visible_devices():
+    """
+    WORKAROUND (tt-xla#5521) -- NOT a fix. Delete once tt-metal is fixed.
+
+    Rewrites an integer `TT_VISIBLE_DEVICES` to the equivalent PCI BDFs, which
+    are immune to the double-application that rejects every integer except 0.
+    The fix is two lines in tt-metal's `Cluster::open_driver()` (pass the mock
+    descriptor's own chips as `target_devices`); when that lands, delete this
+    and its three call sites.
+
+    Inert unless translation is both needed and safe: no-op when the variable is
+    unset or empty, when any token is not a plain integer (so BDFs pass through
+    and this is idempotent), when no devices are visible in sysfs, and when an
+    index is out of range -- leaving UMD to report that itself.
+    """
+    value = os.getenv("TT_VISIBLE_DEVICES")
+    if not value or not value.strip():
+        return
+
+    tokens = [token.strip() for token in value.split(",") if token.strip()]
+    if not tokens or not all(token.isdigit() for token in tokens):
+        return
+
+    bdfs = _device_bdfs_in_umd_order()
+    if any(int(token) >= len(bdfs) for token in tokens):
+        return
+
+    normalized = ",".join(bdfs[int(token)] for token in tokens)
+    os.environ["TT_VISIBLE_DEVICES"] = normalized
+    logger.info(
+        f"Normalized TT_VISIBLE_DEVICES from '{value}' to '{normalized}' so device "
+        f"selection survives UMD chip-id renumbering (tt-xla#5521)."
+    )
+
+
 def setup_tt_pjrt_plugin_dir():
     """
     Setup the `TT_PJRT_PLUGIN_DIR` environment variable by looking for the `pjrt_plugin_tt.so` file.

--- a/python_package/torch_plugin_tt/__init__.py
+++ b/python_package/torch_plugin_tt/__init__.py
@@ -9,6 +9,7 @@ import torch_xla
 import tt_torch  # registers "tt" backend for torch.compile
 from pjrt_plugin_tt import (
     get_library_path,
+    normalize_tt_visible_devices,
     register_shutdown_hook,
     setup_tt_metal_home,
     setup_tt_pjrt_plugin_dir,
@@ -30,6 +31,8 @@ class TTPlugin(DevicePlugin):
         super().__init__()
         setup_tt_pjrt_plugin_dir()
         setup_tt_metal_home()
+        # WORKAROUND (tt-xla#5521), not a fix; no-op unless TT_VISIBLE_DEVICES is set.
+        normalize_tt_visible_devices()
         register_shutdown_hook()
 
         # For using the PJRT plugin with `torch_xla` we need to set


### PR DESCRIPTION
**A workaround, not a fix for DP production models.** It picks a device-identifier format that survives a tt-metal/tt-mlir bug; the defect itself is untouched. The proper fix and the removal plan are at the bottom.

## Ticket

https://github.com/tenstorrent/tt-xla/issues/5521

## Problem

A bare integer `TT_VISIBLE_DEVICES` is rejected for every value except `0`, so **per-chip data parallelism is broken by default** — one process per chip with `TT_VISIBLE_DEVICES=N` is the standard throughput layout, and on a 32-chip Blackhole galaxy every worker except device 0 dies with:

```
ValueError: Invalid chip ID in TT_VISIBLE_DEVICES: 1. Valid ID needs to be in range of actual chip IDs in the cluster.
```

Seen in production CI on a 32-chip galaxy: tt-shield run [31215681444](https://github.com/tenstorrent/tt-shield/actions/runs/31215681444) (2026-08-07) hits it 53 times, rejecting ids `1, 3, 8, 13, 16, 17, 19, 20, 21, 22, 26, 27, 31` — `0` is the only id never rejected.

SPMD data parallelism (one process, all chips visible) is unaffected — no subset is selected, so nothing is renumbered.

## Root cause

The variable is applied **twice in one process**, and the two applications disagree on what an integer means.

1. `PCIDevice::enumerate_devices()` treats it as an **index into the BDF-sorted device list**, and topology discovery then renumbers the surviving chips **from 0** — so the selected chip becomes id `0`.
2. tt-mlir's op-model opens a **mock** device: `makeEnvDescriptor()` serializes that already-narrowed descriptor and passes it back as the mock cluster descriptor, and tt-metal's `Cluster::open_driver()` constructs it with an **empty `target_devices`**, so UMD re-reads the variable and demands an existing chip id. The only chip is now `0`, so it throws.

```
 1. ClusterDescriptor::create_constrained_cluster_descriptor(...)   <- throws, cluster_descriptor.cpp:335
 4. tt::Cluster::open_driver(bool const&)
 7. MetalEnvImpl::initialize_base_objects()
12. SingletonDeviceContext::openMockDevice(...)
```

BDFs are immune: both application points match them against each chip's PCI address, which survives the renumbering. `0` works only because it remaps to itself.

Anything that applies the filter once is fine — standalone `ttnn` and a real `torch_xla` computation both pass with `TT_VISIBLE_DEVICES=1`; only paths running the TTNN optimizer passes fail. It also fails with `VLLM_ENABLE_V1_MULTIPROCESSING=0` (so not parent/child env inheritance) and stops failing with `TTMLIR_DISABLE_MOCK_DEVICE=1` (confirming the mock device is the trigger; not usable as a workaround, since op-model queries then hit the real device and the same test goes 18s → 227s+).

@jasonmacTT reached the same diagnosis independently in [this comment](https://github.com/tenstorrent/tt-xla/issues/5521#issuecomment-5092554636).

## Change

`normalize_tt_visible_devices()` in `pjrt_plugin_tt` translates integer tokens to BDFs, preserving UMD's integer semantics. Called from `torch_plugin_tt.TTPlugin.__init__`, `jax_plugin_tt.initialize()`, and `vllm_tt.register()` — the last because `TT_VISIBLE_DEVICES` is vLLM's `device_control_env_var` and workers are spawned, so that is the earliest hook running in every worker.

75 insertions, no deletions, no behaviour change to any existing path. It runs before any device is opened and never touches the compiler or its device, which is what keeps it low-risk.

## Safety

Inert unless translation is both needed and safe:

| Condition | Behaviour |
| --- | --- |
| unset or empty | untouched, never introduced |
| any token not a plain integer (BDF, or unrecognised) | untouched — also idempotent for inheriting workers |
| no devices visible in sysfs (mock/simulation, no `/dev/tenstorrent`) | untouched |
| index out of range | untouched, so UMD reports it instead of us masking it |

15 unit cases cover these, including `""`, `abc`, `-1`, `0x1`, `9`, `0,9`, an already-BDF value, mixed integer/BDF, and two consecutive calls.

## Verification (4-chip host, 2x P300, tt-forge 1.4.0)

`test_opt_generation`, on stock tt-metal:

- `TT_VISIBLE_DEVICES=1`, `2`, `3` — all pass (each **fails** without this change)
- `0` and unset — pass, unchanged
- `TT_VISIBLE_DEVICES=3` confirmed holding `/dev/tenstorrent/3` via `fuser` mid-run, so pinning selects the requested chip rather than silently falling back to 0
- **four pinned processes concurrently, one per chip** — 4/4 pass, each holding its own `/dev/tenstorrent/N` ([logs](https://gist.github.com/kmabeeTT/c3b506b64570f9236c82befa9db4f220))
- `tests/torch/ops/test_add.py` — 4/4 pass

**Known limitation:** if the op-model falls back to a *canned* mock cluster board (discovered arch/chip-count differs from requested), those descriptors carry synthesized BDFs, so a real BDF fails to match and UMD reports `Invalid BDF` instead. Needs a filtered subset *plus* a mock chip count differing from the visible count, which does not arise in per-chip DP.

## The proper fix, and removing this

**Corrected:** an earlier version of this description proposed a one-line tt-metal change as the real fix. That has since been withdrawn, along with a second attempt. Both are recorded here so nobody retries them:

- **tt-metal `.target_devices = mock_cluster_desc->get_all_chips()`** in `Cluster::open_driver()`'s mock branches. Does fix it, but removes the ability to subset a *mock* cluster via `TT_VISIBLE_DEVICES` — deliberate and tested (`test_cluster_descriptor_offline.cpp`), and `ttrun.py` relies on it for per-rank device slices, which would silently get all chips instead of their slice.
- **Reusing the already-open device as the optimizer's `devicePtr`** (#5931, closed). Fails CI with `extract_mock_allocator_state requires a mock device`: `TTNNOpModel.cpp:731` calls it unguarded, and the stateful L1 spill queries deliberately mutate the shared *mock* device's allocator. Also hung a 4-chip DP run, with execution blocked in `TransferFromDevice`.

The proper fix may be **@jasonmacTT's approach** — scope an unset/restore of `TT_VISIBLE_DEVICES` around `SingletonDeviceContext::openDevice`. That keeps the private mock device, so all of the mock-allocator machinery stays intact, and only stops UMD re-reading the variable. No tt-metal change and no mock-subsetting regression.

**When a proper fix lands, delete `normalize_tt_visible_devices()`, `_device_bdfs_in_umd_order()`, and the three call sites.** The docstring says so too, so this does not quietly become permanent. This change is independent of whichever fix lands — it only normalises an env var before device open — so it can be removed afterwards rather than in lockstep.
