### PR TITLE
Reuse the open device for op-model queries instead of a mock one (Production DP TT_VISIBLE_DEVICES fix)

### DIFF
--- a/pjrt_implementation/src/api/module_builder/module_builder.cc
+++ b/pjrt_implementation/src/api/module_builder/module_builder.cc
@@ -1014,6 +1014,20 @@ tt_pjrt_status ModuleBuilder::convertFromTTIRToTTNN(
   }
 
   options.optimizationLevel = compile_options.optimization_level;
+
+  // Let the optimizer reuse the device we already have open rather than opening
+  // a mock one. Constructing the mock device re-applies TT_VISIBLE_DEVICES to a
+  // descriptor whose chips discovery already renumbered, which aborts any
+  // per-chip pinning other than device 0 (#5521). Reusing the live device also
+  // makes op-model queries reflect real hardware instead of a mock.
+  if (client_instance != nullptr && client_instance->parentMesh().has_value()) {
+    options.devicePtr =
+        client_instance->parentMesh()
+            ->asSharedPtr<::tt::tt_metal::distributed::MeshDevice>(
+                tt::runtime::getCurrentDeviceRuntime());
+  } else {
+    LOG_F(INFO, "No open mesh device; OpModel falls back to a mock device");
+  }
   // Map user-facing dtype names to BFPDtype enum values.
   if (compile_options.experimental_weight_dtype == "bfp_bf8") {
     options.experimentalWeightDtype = mlir::tt::ttnn::BFPDtype::BFP_BFloat8;


### PR DESCRIPTION
## Ticket

https://github.com/tenstorrent/tt-xla/issues/5521

## Problem

`TT_VISIBLE_DEVICES=N` is rejected for every `N` except `0`, so per-chip data parallelism is impossible on a multi-chip host. On a 32-chip galaxy every worker except device 0 dies ([CI run](https://github.com/tenstorrent/tt-shield/actions/runs/31215681444): 53 hits, ids `1,3,8,13,16,17,19,20,21,22,26,27,31`).

```
ValueError: Invalid chip ID in TT_VISIBLE_DEVICES: 1. Valid ID needs to be in range of actual chip IDs in the cluster.
```

## Cause

The variable is applied twice in one process. `PCIDevice::enumerate_devices()` treats an integer as an index into the BDF-sorted device list, and topology discovery then renumbers the surviving chips from 0. The optimizer then opens a **mock** device for op-model queries: `makeEnvDescriptor()` serializes that already-narrowed descriptor and hands it back as a mock cluster descriptor, and constructing it re-reads `TT_VISIBLE_DEVICES` and demands an existing chip id. The only chip is now `0`, so it throws.

```
 1. ClusterDescriptor::create_constrained_cluster_descriptor(...)   <- throws
 4. tt::Cluster::open_driver(bool const&)
12. SingletonDeviceContext::openMockDevice(...)
```

## Fix

Pass the mesh device we already have open as the optimizer's `devicePtr`. `DevicePassesWrapper` already honours it by calling `setExternalDevice()` instead of `openMockDevice()`, so no mock device is created, no second cluster construction happens, and the failure cannot occur. The option exists for exactly this — *"allows frontends to pass in an active device without closing it"* — it simply had no producer.

```cpp
if (client_instance != nullptr && client_instance->parentMesh().has_value()) {
  options.devicePtr =
      client_instance->parentMesh()
          ->asSharedPtr<::tt::tt_metal::distributed::MeshDevice>(
              tt::runtime::getCurrentDeviceRuntime());
}
```

14 lines, tt-xla only. The mock device stays as the fallback when no mesh is open.

## Why this over the alternatives

- **vs #5930 (BDF translation):** that only picks an identifier format that survives the bug. This removes the bug from the path.
- **vs changing tt-metal's `open_driver` to pass the mock descriptor's chips:** that would break `TT_VISIBLE_DEVICES` subsetting of mock clusters, which is deliberate and tested (`test_cluster_descriptor_offline.cpp`) and used by `ttrun` for per-rank device slices. Rejected for that reason.
- **vs unsetting `TT_VISIBLE_DEVICES` around `openDevice`:** no global env mutation and nothing to restore on exit paths.
- Bonus: op-model queries now reflect real hardware rather than a mock approximation.

## Verification (4-chip host, 2x P300, tt-forge 1.4.0)

With #5930's shim and the tt-metal change both reverted, so this is the fix alone:

| Case | Result |
| --- | --- |
| `TT_VISIBLE_DEVICES=1` | passes (previously `Invalid chip ID`) |
| **4 pinned processes concurrently** | **4/4 pass**, each holding its own `/dev/tenstorrent/N` (verified with `fuser` + ppid walk) |
| `=0`, unset, BDF form | pass |
| `tests/torch/ops` | 72 tests pass (one existing failure) |

Logs confirmed 12/12 compile invocations took the reuse path with no mock fallback.

