### PR TITLE
[vLLM] Allow multimodal items to span prefill chunks

### DIFF
--- a/integrations/vllm_plugin/vllm_tt/platform.py
+++ b/integrations/vllm_plugin/vllm_tt/platform.py
@@ -655,14 +655,19 @@ class TTPlatform(Platform):
         if parallel_config.worker_cls == "auto":
             parallel_config.worker_cls = "vllm_tt.worker.TTWorker"
 
+        # Only models with multimodal-bidirectional attention need whole items:
+        # the placeholder span attends to itself, so it cannot be split across
+        # chunks. Everything else re-slices the cached encoder output per chunk
+        # (tt-xla #5824). Mirrors vllm/platforms/cuda.py.
         if (
-            scheduler_config.is_multimodal_model
+            model_config is not None
+            and model_config.is_mm_prefix_lm
+            and scheduler_config.is_multimodal_model
             and not scheduler_config.disable_chunked_mm_input
         ):
             logger.warning(
-                "TT does not support running Multimodal models"
-                " without setting `--disable_chunked_mm_input`. "
-                "Forcing --disable_chunked_mm_input."
+                "Forcing --disable_chunked_mm_input for models with "
+                "multimodal-bidirectional attention."
             )
             scheduler_config.disable_chunked_mm_input = True
 

--- a/integrations/vllm_plugin/vllm_tt/scheduler/ascend_scheduler.py
+++ b/integrations/vllm_plugin/vllm_tt/scheduler/ascend_scheduler.py
@@ -344,6 +344,7 @@ class AscendScheduler(Scheduler):
                 # num_new_tokens so we only schedule decoder tokens up to the
                 # point where the encoder output is available.
                 if request.has_encoder_inputs:
+                    num_new_tokens_pre_encoder = num_new_tokens
                     (
                         encoder_inputs_to_schedule,
                         num_new_tokens,
@@ -355,9 +356,23 @@ class AscendScheduler(Scheduler):
                         num_new_tokens,
                         encoder_compute_budget,
                     )
+                    # The encoder path truncates to an mm-item boundary, which is
+                    # not block-aligned. Re-align, or the next chunk starts
+                    # mid-block: paged_fill_cache writes from the start of a block
+                    # while chunked SDPA reads at chunk_start_idx == num_computed
+                    # exactly, and the two only agree on a block boundary.
+                    if (
+                        chunked_prefill
+                        and num_new_tokens < num_new_tokens_pre_encoder
+                        and num_computed_tokens + num_new_tokens < request.num_tokens
+                    ):
+                        num_new_tokens = self._block_aligned_chunk(
+                            request.num_tokens - num_computed_tokens, num_new_tokens
+                        )
                     if num_new_tokens == 0:
-                        # The encoder budget or encoder cache is exhausted, so
-                        # the request cannot be scheduled this step.
+                        # The encoder budget or encoder cache is exhausted, or the
+                        # truncated chunk is shorter than one block, so the request
+                        # cannot be scheduled this step.
                         skip_cur_request()
                         continue
 

--- a/tests/integrations/vllm_plugin/generative/test_chunked_mm_generation.py
+++ b/tests/integrations/vllm_plugin/generative/test_chunked_mm_generation.py
@@ -1,0 +1,201 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""On-device chunked multi-modal prefill equivalence (tt-xla #5824).
+
+Greedy generation must agree whether an image's placeholder span is prefilled in
+one chunk or split across several. Unlike
+``test_chunked_mm_embed_equivalence.py`` (host-side index arithmetic only), this
+runs the real path on device: cached encoder output -> per-chunk slice ->
+``index_copy`` scatter -> cached-prefix attention -> logits -> sampled tokens.
+
+The vision tower is replaced by deterministic synthetic embeddings. That is
+deliberate and load-bearing, not a convenience: Qwen2-VL's vision encoder
+currently emits ~39% ``inf`` on TT (tt-xla #5858), and comparing two token
+streams computed from saturated inputs proves nothing -- any difference in graph
+shape just relocates the ``inf``/``nan``. Substituting well-scaled values makes
+the comparison meaningful and keeps this test independent of #5858. Everything
+downstream of the encoder -- the part #5824 actually changed -- is real.
+
+Each configuration runs in its own subprocess: the in-process engine
+(``VLLM_ENABLE_V1_MULTIPROCESSING=0``, required so the class-level patch reaches
+the model runner) calls ``sys.exit`` on shutdown, so two engines cannot share
+one interpreter.
+"""
+
+import base64
+import io
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+_MODEL = "Qwen/Qwen2-VL-2B-Instruct"
+_MAX_MODEL_LEN = 2048
+_MAX_TOKENS = 16
+# ~1024 image tokens (roughly max_pixels/784): larger than the split chunk below,
+# and small enough that the vision tower still compiles.
+_MAX_PIXELS = 802816
+_SPLIT_CHUNK = 512  # image spans 3 chunks
+_WHOLE_CHUNK = _MAX_MODEL_LEN  # single prefill chunk (the oracle)
+
+# The two paths use different attention kernels (single-shot SDPA vs the chunked
+# SDPA op) and different prefill bucket shapes, so low-precision drift can flip a
+# late greedy argmax. Compare a leading prefix, as test_chunked_prefill.py does:
+# a real slice/scatter bug corrupts the very first generated token.
+_MATCH_PREFIX_TOKENS = 8
+_WORKER_TIMEOUT = 1800
+
+
+def _image_url() -> str:
+    from PIL import Image, ImageDraw
+
+    image = Image.new("RGB", (1024, 1024), (20, 80, 200))
+    ImageDraw.Draw(image).rectangle([256, 256, 768, 768], fill=(220, 40, 40))
+    buf = io.BytesIO()
+    image.save(buf, format="PNG")
+    return f"data:image/png;base64,{base64.b64encode(buf.getvalue()).decode()}"
+
+
+def _install_synthetic_encoder() -> None:
+    """Replace the vision tower with deterministic, well-scaled embeddings.
+
+    Patches ``_execute_mm_encoder`` -- the single seam between "run the ViT" and
+    "publish rows into ``encoder_cache``" -- so the slicing/scatter path under
+    test is untouched. Values are bounded (|x| < 0.02) and vary per row and
+    column, so a misplaced row changes the result.
+    """
+    # `vllm` must be imported first: importing vllm_tt directly re-enters the
+    # plugin registration and raises "partially initialized module 'vllm_tt'".
+    import torch
+    import vllm  # noqa: F401
+    from vllm_tt.model_runner import TTModelRunner
+
+    def _fake_execute_mm_encoder(self, scheduler_output):
+        scheduled = scheduler_output.scheduled_encoder_inputs
+        if not scheduled:
+            return
+        hidden = self.inputs_embeds_size
+        for req_id, input_ids in scheduled.items():
+            req_state = self.requests[req_id]
+            for i in input_ids:
+                feature = req_state.mm_features[i]
+                mm_hash = feature.identifier
+                if mm_hash in self.encoder_cache:
+                    continue
+                n = feature.mm_position.get_num_embeds()
+                rows = torch.arange(n, dtype=torch.float32).unsqueeze(1)
+                cols = torch.arange(hidden, dtype=torch.float32).unsqueeze(0)
+                # Bounded, non-repeating across both axes.
+                vals = torch.sin(rows * 0.017 + cols * 0.011) * 0.02
+                self.encoder_cache[mm_hash] = vals.to(torch.bfloat16).to(self.device)
+
+    TTModelRunner._execute_mm_encoder = _fake_execute_mm_encoder
+
+
+def _worker(chunk: int) -> int:
+    """Build one engine, generate greedily, print the token ids as JSON."""
+    import vllm
+
+    _install_synthetic_encoder()
+
+    llm = vllm.LLM(
+        model=_MODEL,
+        max_num_seqs=1,
+        max_model_len=_MAX_MODEL_LEN,
+        gpu_memory_utilization=0.1,
+        enable_prefix_caching=False,
+        limit_mm_per_prompt={"image": 1, "video": 0, "audio": 0},
+        mm_processor_kwargs={"max_pixels": _MAX_PIXELS},
+        additional_config={
+            "min_context_len": 512,
+            "enable_tensor_parallel": False,
+            "cpu_sampling": True,
+            "prefill_chunk_size": chunk,
+        },
+    )
+    messages = [
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": _image_url()}},
+                    {"type": "text", "text": "Describe this image in one sentence."},
+                ],
+            }
+        ]
+    ]
+    sp = vllm.SamplingParams(
+        temperature=0.0, top_p=1.0, max_tokens=_MAX_TOKENS, ignore_eos=True
+    )
+    out = llm.chat(messages, sp)[0].outputs[0]
+    print(f"__RESULT__{json.dumps(list(out.token_ids))}", flush=True)
+    return 0
+
+
+def _run_worker(chunk: int) -> list[int]:
+    env = {**os.environ, "VLLM_ENABLE_V1_MULTIPROCESSING": "0"}
+    proc = subprocess.run(
+        [sys.executable, __file__, str(chunk)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=_WORKER_TIMEOUT,
+    )
+    marker = [ln for ln in proc.stdout.splitlines() if ln.startswith("__RESULT__")]
+    if not marker:
+        print(proc.stdout[-4000:], flush=True)
+        print(proc.stderr[-4000:], file=sys.stderr, flush=True)
+        pytest.fail(
+            f"worker for chunk={chunk} produced no result (exit={proc.returncode})"
+        )
+    return json.loads(marker[-1][len("__RESULT__") :])
+
+
+def _require_qwen2vl_vision_rope() -> None:
+    """Skip until the Qwen2-VL vision rotary embedding lands (tt-xla #5859).
+
+    Qwen2VisionTransformer.rot_pos_emb calls ``get_cos_sin`` on the rotary module,
+    which the TT replacement (``TTRotaryEmbedding``) does not implement yet, so
+    the model cannot be built at all. Nothing about #5824 depends on it -- this is
+    purely the vehicle. The check runs here rather than at import so collection
+    stays cheap.
+    """
+    import vllm  # noqa: F401  must precede vllm_tt (plugin registration)
+    from vllm_tt.layers.rotary_embedding import TTRotaryEmbedding
+
+    if not hasattr(TTRotaryEmbedding, "get_cos_sin"):
+        pytest.skip(
+            "TTRotaryEmbedding.get_cos_sin is required to build Qwen2-VL's vision "
+            "tower; blocked on tt-xla #5859"
+        )
+
+
+@pytest.mark.nightly
+@pytest.mark.single_device
+def test_chunked_mm_generation_matches_whole_item():
+    """Splitting an image across prefill chunks must not change greedy output."""
+    _require_qwen2vl_vision_rope()
+
+    whole = _run_worker(_WHOLE_CHUNK)
+    split = _run_worker(_SPLIT_CHUNK)
+
+    print(f"whole-item prefill: {whole}")
+    print(f"split-item prefill: {split}")
+
+    n = _MATCH_PREFIX_TOKENS
+    assert len(whole) >= n and len(split) >= n, (
+        f"need >= {n} generated tokens to compare "
+        f"(whole={len(whole)}, split={len(split)})"
+    )
+    assert whole[:n] == split[:n], (
+        f"first {n} greedy tokens differ between whole-item and split-item "
+        "prefill -- the per-chunk encoder-output slice or its scatter position is "
+        f"wrong.\n  whole={whole}\n  split={split}"
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(_worker(int(sys.argv[1])))

--- a/tests/integrations/vllm_plugin/test_chunked_mm_embed_equivalence.py
+++ b/tests/integrations/vllm_plugin/test_chunked_mm_embed_equivalence.py
@@ -1,0 +1,302 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Chunked multi-modal input equivalence (tt-xla #5824).
+
+The load-bearing property of chunked multimodal prefill: the vision encoder runs
+once on the whole item and its output is parked in ``encoder_cache``, then each
+prefill chunk re-slices that cached tensor. Splitting the prompt must therefore
+reconstruct **exactly** the embedding stream that a single-shot prefill builds --
+the same encoder rows in the same positions.
+
+That is pure index arithmetic in ``_gather_mm_embeddings`` (item-relative
+``start_idx``/``end_idx``, the possibly-negative ``col_base``, the row-major
+``mm_indices``) plus the ``index_copy`` scatter in ``_get_model_inputs``. Both
+are exercised here on CPU against a synthetic encoder output, so the test is
+independent of any particular vision tower -- notably of the Qwen2-VL encoder
+saturation tracked in #5858, which makes on-device token comparison for that
+model meaningless.
+
+The complementary guarantees live elsewhere: chunk sizing/scheduling in
+``unit_tests/test_ascend_scheduler_batching.py``, and cached-prefix attention in
+``generative/test_chunked_prefill.py``.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from vllm.multimodal.inputs import MultiModalFeatureSpec, PlaceholderRange
+from vllm_tt.model_runner import TTModelRunner
+
+# Device-free, but the vLLM push matrix only runs device-marked jobs; tag so the
+# single_device job collects these (they need no device and run in milliseconds).
+pytestmark = [pytest.mark.push, pytest.mark.single_device]
+
+_H = 8  # hidden size
+_IMG_TOKEN_ID = 999  # placeholder token id occupying the image span
+_PADDINGS = [1, 8, 16, 32, 64, 128, 256]
+
+
+def _encoder_output(length: int, salt: float = 0.0) -> torch.Tensor:
+    """Deterministic stand-in for a vision tower output, distinct per row."""
+    base = torch.arange(length * _H, dtype=torch.float32).reshape(length, _H)
+    return base / 1000.0 + salt
+
+
+def _prompt_ids(total: int, offset: int, length: int) -> list[int]:
+    """Text ids, with the image placeholder span at ``offset``."""
+    ids = [(i % 97) + 1 for i in range(total)]
+    for i in range(offset, offset + length):
+        ids[i] = _IMG_TOKEN_ID
+    return ids
+
+
+class _FakeEmbedder:
+    """Stands in for ``model.embed_input_ids``.
+
+    Mirrors the real contract: embed the text ids and zero the positions marked
+    multimodal (upstream masks those ids because they can be out of vocab). The
+    mm rows are then written by the ``index_copy`` scatter under test.
+    """
+
+    def embed_input_ids(self, input_ids, is_multimodal=None):
+        emb = input_ids.unsqueeze(-1).to(torch.float32) * 10.0 + torch.arange(
+            _H, dtype=torch.float32
+        )
+        if is_multimodal is not None:
+            emb = torch.where(is_multimodal.unsqueeze(-1), torch.zeros_like(emb), emb)
+        return emb
+
+
+def _runner(reqs: dict, max_num_reqs: int, encoder_cache: dict):
+    """The only runner state the two methods under test read."""
+    return SimpleNamespace(
+        input_batch=SimpleNamespace(req_ids=list(reqs)),
+        requests=reqs,
+        num_tokens_paddings=_PADDINGS,
+        max_num_reqs=max_num_reqs,
+        encoder_cache=encoder_cache,
+        device="cpu",
+        supports_mm_inputs=True,
+        model=_FakeEmbedder(),
+    )
+
+
+def _req_state(prompt_ids: list[int], num_computed: int, features: list):
+    return SimpleNamespace(
+        num_computed_tokens=num_computed,
+        mm_features=features,
+        prompt_token_ids=prompt_ids,
+        num_tokens=len(prompt_ids),
+    )
+
+
+def _feature(identifier: str, offset: int, length: int, is_embed=None):
+    return MultiModalFeatureSpec(
+        data=None,
+        modality="image",
+        identifier=identifier,
+        mm_position=PlaceholderRange(offset=offset, length=length, is_embed=is_embed),
+    )
+
+
+def _step_embeds(runner, reqs, scheduled: dict) -> torch.Tensor:
+    """Run gather + scatter for one step; return [num_reqs, padded_width, H]."""
+    sched_out = SimpleNamespace(num_scheduled_tokens=scheduled)
+    mm_embed_inputs = TTModelRunner._gather_mm_embeddings(runner, sched_out)
+
+    padded_width = mm_embed_inputs[1].shape[1]
+    rows = []
+    for rid in runner.input_batch.req_ids:
+        st = reqs[rid]
+        n = scheduled.get(rid, 0)
+        start = st.num_computed_tokens
+        row = st.prompt_token_ids[start : start + n]
+        row = row + [0] * (padded_width - len(row))
+        rows.append(row)
+    input_ids = torch.tensor(rows, dtype=torch.int32)
+
+    _, inputs_embeds = TTModelRunner._get_model_inputs(
+        runner, input_ids, mm_embed_inputs
+    )
+    return inputs_embeds
+
+
+def _single_shot(prompt_ids, features, encoder_cache) -> torch.Tensor:
+    """Embedding stream for the whole prompt in one prefill step."""
+    total = len(prompt_ids)
+    reqs = {"r0": _req_state(prompt_ids, 0, features)}
+    runner = _runner(reqs, max_num_reqs=1, encoder_cache=encoder_cache)
+    return _step_embeds(runner, reqs, {"r0": total})[0, :total]
+
+
+def _chunked(prompt_ids, features, encoder_cache, chunk) -> torch.Tensor:
+    """Embedding stream for the same prompt split into ``chunk``-sized steps."""
+    total = len(prompt_ids)
+    pieces = []
+    computed = 0
+    while computed < total:
+        n = min(chunk, total - computed)
+        reqs = {"r0": _req_state(prompt_ids, computed, features)}
+        runner = _runner(reqs, max_num_reqs=1, encoder_cache=encoder_cache)
+        out = _step_embeds(runner, reqs, {"r0": n})
+        pieces.append(out[0, :n])
+        computed += n
+    return torch.cat(pieces, dim=0)
+
+
+# (total, offset, img_len, chunk)
+_CASES = [
+    # Image straddles one chunk boundary.
+    (64, 8, 32, 32),
+    # Image spans several whole chunks plus partial head and tail -- the case
+    # that produced slices 497/512/15 on device at chunk=512.
+    (128, 5, 100, 32),
+    # Image starts exactly on a chunk boundary.
+    (96, 32, 48, 32),
+    # Image ends exactly on a chunk boundary.
+    (96, 16, 48, 32),
+    # Chunk smaller than the image by a lot: many interior chunks are all-image.
+    (128, 3, 120, 8),
+    # Image is the entire prompt.
+    (64, 0, 64, 16),
+    # Final chunk is a short remainder.
+    (70, 9, 40, 32),
+]
+
+
+@pytest.mark.parametrize("total,offset,img_len,chunk", _CASES)
+def test_chunked_mm_embeddings_match_single_shot(total, offset, img_len, chunk):
+    """Splitting a prompt must reproduce the single-shot embedding stream exactly.
+
+    A wrong ``start_idx``/``end_idx``/``col_base`` puts the right number of
+    encoder rows in the wrong columns, or the wrong rows in the right columns --
+    either way this comparison fails while token counts still look consistent.
+    """
+    prompt_ids = _prompt_ids(total, offset, img_len)
+    features = [_feature("img0", offset, img_len)]
+    cache = {"img0": _encoder_output(img_len)}
+
+    single = _single_shot(prompt_ids, features, cache)
+    multi = _chunked(prompt_ids, features, cache, chunk)
+
+    assert single.shape == multi.shape == (total, _H)
+    assert torch.equal(single, multi), (
+        "chunked prefill produced a different embedding stream than single-shot "
+        f"(total={total}, image=[{offset},{offset + img_len}), chunk={chunk}); "
+        f"first mismatching row = {int((single != multi).any(dim=1).nonzero()[0])}"
+    )
+
+
+@pytest.mark.parametrize("chunk", [16, 32])
+def test_chunked_mm_places_the_correct_encoder_rows(chunk):
+    """Pin the mapping itself, not just self-consistency.
+
+    Every image position must carry its own encoder row, and every text position
+    must carry a text embedding. Guards against an off-by-one that shifts the
+    whole image by a row (which the equivalence test alone could miss if both
+    paths shifted identically).
+    """
+    total, offset, img_len = 96, 7, 50
+    prompt_ids = _prompt_ids(total, offset, img_len)
+    features = [_feature("img0", offset, img_len)]
+    enc = _encoder_output(img_len)
+    cache = {"img0": enc}
+
+    multi = _chunked(prompt_ids, features, cache, chunk)
+
+    for i in range(img_len):
+        assert torch.equal(
+            multi[offset + i], enc[i]
+        ), f"prompt position {offset + i} should hold encoder row {i}"
+    text_embed = _FakeEmbedder().embed_input_ids(
+        torch.tensor(prompt_ids, dtype=torch.int32)
+    )
+    for pos in list(range(offset)) + list(range(offset + img_len, total)):
+        assert torch.equal(
+            multi[pos], text_embed[pos]
+        ), f"text position {pos} should hold a text embedding, not an encoder row"
+
+
+@pytest.mark.parametrize("chunk", [16, 32])
+def test_chunked_mm_interleaved_placeholders_match_single_shot(chunk):
+    """Same guarantee for an ``is_embed`` mask (Pixtral-style break tokens).
+
+    Here the placeholder span interleaves real text tokens with embedding slots,
+    so the token range must be mapped through ``get_embeds_indices_in_range``
+    before slicing the encoder output. Splitting must not shift that mapping.
+    """
+    total, offset, span = 96, 5, 60
+    prompt_ids = _prompt_ids(total, offset, span)
+    # Every 6th position in the span is a real token (e.g. [IMG_BREAK]).
+    is_embed = torch.ones(span, dtype=torch.bool)
+    is_embed[5::6] = False
+    num_embeds = int(is_embed.sum())
+    features = [_feature("img0", offset, span, is_embed=is_embed)]
+    cache = {"img0": _encoder_output(num_embeds, salt=7.0)}
+
+    single = _single_shot(prompt_ids, features, cache)
+    multi = _chunked(prompt_ids, features, cache, chunk)
+
+    assert torch.equal(
+        single, multi
+    ), f"interleaved-placeholder chunking diverged from single-shot (chunk={chunk})"
+    # And the embedding rows must land only on is_embed positions, in order.
+    enc = cache["img0"]
+    k = 0
+    for i in range(span):
+        if bool(is_embed[i]):
+            assert torch.equal(
+                multi[offset + i], enc[k]
+            ), f"span position {i} should hold encoder row {k}"
+            k += 1
+    assert k == num_embeds
+
+
+def test_chunked_mm_two_requests_match_single_shot():
+    """Two same-stage requests, each with its own image.
+
+    ``_gather_mm_embeddings`` builds a ``[max_num_reqs, padded_width]`` mask and
+    flattens it row-major to index a reshaped ``[num_reqs * padded_width, H]``
+    buffer, so the row count and stride must agree across both requests. With one
+    request that is trivially true; this is the case that would catch a stride or
+    concatenation-order bug.
+    """
+    total, chunk = 96, 32
+    specs = {
+        "r0": (7, 50),  # (offset, img_len)
+        "r1": (20, 40),
+    }
+    prompts = {r: _prompt_ids(total, o, n) for r, (o, n) in specs.items()}
+    features = {r: [_feature(f"{r}-img", o, n)] for r, (o, n) in specs.items()}
+    cache = {
+        f"{r}-img": _encoder_output(n, salt=float(i))
+        for i, (r, (o, n)) in enumerate(specs.items())
+    }
+
+    def run(chunk_size):
+        pieces = {r: [] for r in specs}
+        computed = 0
+        while computed < total:
+            n = min(chunk_size, total - computed)
+            reqs = {r: _req_state(prompts[r], computed, features[r]) for r in specs}
+            runner = _runner(reqs, max_num_reqs=len(specs), encoder_cache=cache)
+            out = _step_embeds(runner, reqs, {r: n for r in specs})
+            for idx, r in enumerate(runner.input_batch.req_ids):
+                pieces[r].append(out[idx, :n])
+            computed += n
+        return {r: torch.cat(v, dim=0) for r, v in pieces.items()}
+
+    single = run(total)
+    multi = run(chunk)
+
+    for r in specs:
+        assert torch.equal(
+            single[r], multi[r]
+        ), f"request {r} diverged between single-shot and chunk={chunk}"
+    # The two requests must not have swapped embeddings.
+    o0, n0 = specs["r0"]
+    assert torch.equal(
+        multi["r0"][o0 : o0 + n0], cache["r0-img"]
+    ), "r0 did not receive its own encoder output"

--- a/tests/integrations/vllm_plugin/unit_tests/test_ascend_scheduler_batching.py
+++ b/tests/integrations/vllm_plugin/unit_tests/test_ascend_scheduler_batching.py
@@ -31,8 +31,10 @@ from vllm.config import (
     SchedulerConfig,
     VllmConfig,
 )
+from vllm.multimodal.inputs import MultiModalFeatureSpec, PlaceholderRange
 from vllm.sampling_params import SamplingParams
 from vllm.utils.hashing import sha256
+from vllm.v1.core.encoder_cache_manager import EncoderCacheManager
 from vllm.v1.core.kv_cache_utils import get_request_block_hasher, init_none_hash
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
@@ -248,3 +250,208 @@ def test_new_prefill_preempts_decode_then_decode_combines_old_and_new():
     out4 = sched.schedule()
     step4_ids = set(out4.num_scheduled_tokens.keys())
     assert {"old-0", "old-1", "new-0"}.issubset(step4_ids)
+
+
+# --------------------------------------------------------------------------- #
+# Chunked multi-modal inputs (tt-xla #5824)
+# --------------------------------------------------------------------------- #
+
+
+def _make_mm_request(rid: str, num_tokens: int, offset: int, length: int) -> Request:
+    """A request whose prompt carries one image placeholder at ``offset``.
+
+    ``data=None`` is the "already cached upstream" form; the scheduler never
+    reads it, only ``mm_position``.
+    """
+    init_none_hash(sha256)
+    return Request(
+        request_id=rid,
+        prompt_token_ids=[1] * num_tokens,
+        sampling_params=SamplingParams(ignore_eos=True, max_tokens=16),
+        pooling_params=None,
+        mm_features=[
+            MultiModalFeatureSpec(
+                data=None,
+                modality="image",
+                identifier=f"{rid}-img0",
+                mm_position=PlaceholderRange(offset=offset, length=length),
+            )
+        ],
+        block_hasher=get_request_block_hasher(_BLOCK_SIZE, sha256),
+    )
+
+
+def _fake_prefill_only_output(sched_out) -> ModelRunnerOutput:
+    """Model output for a step that sampled nothing.
+
+    The real runner discards the sampled token of a request whose prefill is
+    still partial (``discard_sampled_tokens_req_indices``). Emitting a token here
+    instead would grow ``request.num_tokens`` and shift every later chunk.
+    """
+    req_ids = list(sched_out.num_scheduled_tokens.keys())
+    return ModelRunnerOutput(
+        req_ids=req_ids,
+        req_id_to_index={r: i for i, r in enumerate(req_ids)},
+        sampled_token_ids=[[] for _ in req_ids],
+        logprobs=None,
+        prompt_logprobs_dict={r: None for r in req_ids},
+    )
+
+
+def _prefill_chunk_boundaries(sched, req_id: str, isl: int) -> list[int]:
+    """Cumulative prompt position after each prefill chunk of ``req_id``."""
+    boundaries: list[int] = []
+    consumed = 0
+    for _ in range(32):
+        out = sched.schedule()
+        n = out.num_scheduled_tokens.get(req_id, 0)
+        if n == 0:
+            break
+        consumed += n
+        boundaries.append(consumed)
+        sched.update_from_output(out, _fake_prefill_only_output(out))
+        if consumed >= isl:
+            break
+    return boundaries
+
+
+def _enable_encoder_cache(sched, cache_size: int, compute_budget: int) -> None:
+    """Give the scheduler a real encoder budget.
+
+    ``_make_scheduler`` uses a text-only model, so upstream sizes the encoder
+    cache at 0 (``supports_mm_inputs`` is False). Install a real one so the
+    multimodal scheduling path is exercised rather than short-circuited.
+    """
+    sched.encoder_cache_manager = EncoderCacheManager(cache_size=cache_size)
+    sched.max_num_encoder_input_tokens = compute_budget
+    sched.scheduler_config.disable_chunked_mm_input = False
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_chunked_mm_item_splits_across_chunks_and_encodes_once():
+    """An image larger than the prefill chunk must span chunks, encoded once.
+
+    This is the whole point of tt-xla #5824: the vision encoder is atomic (it
+    runs on the whole item and the output is parked in the encoder cache), while
+    the decoder placeholder tokens are chunkable. So the item must appear in
+    ``scheduled_encoder_inputs`` on exactly one step -- the first chunk that
+    touches it -- and later chunks must re-slice the cache instead of
+    re-encoding.
+    """
+    chunk = 2 * _BLOCK_SIZE  # 32
+    img_len = 3 * chunk  # 96: spans several chunks
+    isl = _BLOCK_SIZE + img_len + _BLOCK_SIZE  # text, image, text
+    sched = _make_scheduler(chunk=chunk, max_num_seqs=1)
+    _enable_encoder_cache(sched, cache_size=img_len, compute_budget=img_len)
+    sched.add_request(_make_mm_request("r0", isl, offset=_BLOCK_SIZE, length=img_len))
+
+    steps: list[int] = []
+    encode_steps: list[int] = []
+    for i in range(32):
+        out = sched.schedule()
+        n = out.num_scheduled_tokens.get("r0", 0)
+        if n == 0:
+            break
+        steps.append(n)
+        if out.scheduled_encoder_inputs.get("r0"):
+            encode_steps.append(i)
+        sched.update_from_output(out, _fake_prefill_only_output(out))
+        if sum(steps) >= isl:
+            break
+
+    assert sum(steps) == isl, f"chunks {steps} must cover the {isl}-token prompt"
+    assert len(steps) > 1, f"prompt should have been split, got a single chunk {steps}"
+    # Every non-final chunk must be block-aligned (see _block_aligned_chunk).
+    for n in steps[:-1]:
+        assert (
+            n % _BLOCK_SIZE == 0
+        ), f"non-final chunk {n} is not block-aligned: {steps}"
+    assert len(encode_steps) == 1, (
+        "the encoder must run exactly once for one image; it was scheduled on "
+        f"steps {encode_steps} (chunks {steps})"
+    )
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_disable_chunked_mm_input_keeps_item_whole():
+    """With chunking disabled, no chunk boundary may fall inside the image.
+
+    Guards the other half of the tt-xla #5824 platform decision: models with
+    multimodal-bidirectional attention (``is_mm_prefix_lm`` -- Gemma-3/Gemma-4)
+    keep ``disable_chunked_mm_input=True`` because the placeholder span attends
+    to itself.
+
+    Note what upstream actually does (``Scheduler._try_schedule_encoder_inputs``):
+    it only rolls a chunk back to the item's *offset*, and the guard is skipped
+    once ``num_computed_tokens == start_pos``. So keeping an item whole also
+    relies on the item fitting in one chunk -- which is exactly the invariant
+    ``compute_mm_encoder_budget`` enforces by rejecting
+    ``max_tokens_per_mm_item > max_num_batched_tokens``. This test uses such a
+    legal config (image == one chunk) and a deliberately non-chunk-aligned
+    offset, so the rollback is what has to keep the image intact.
+    """
+    chunk = 4 * _BLOCK_SIZE  # 64
+    offset = 3 * _BLOCK_SIZE  # 48: block-aligned but NOT chunk-aligned
+    img_len = chunk  # fits exactly one chunk (the legal-config invariant)
+    isl = offset + img_len + _BLOCK_SIZE
+    sched = _make_scheduler(chunk=chunk, max_num_seqs=1)
+    _enable_encoder_cache(sched, cache_size=img_len, compute_budget=img_len)
+    # The Gemma-4 path: never partially schedule an mm item.
+    sched.scheduler_config.disable_chunked_mm_input = True
+    sched.add_request(_make_mm_request("r0", isl, offset=offset, length=img_len))
+
+    boundaries = _prefill_chunk_boundaries(sched, "r0", isl)
+
+    assert (
+        boundaries[-1] == isl
+    ), f"boundaries {boundaries} must cover exactly {isl} tokens"
+    assert offset in boundaries, (
+        f"expected a chunk boundary exactly at the image offset {offset} (the "
+        f"upstream roll-back), got boundaries={boundaries}"
+    )
+    for b in boundaries[:-1]:
+        assert not (offset < b < offset + img_len), (
+            f"chunk boundary at {b} falls strictly inside the image "
+            f"[{offset}, {offset + img_len}) even though chunked mm input is "
+            f"disabled; boundaries={boundaries}"
+        )
+
+
+@pytest.mark.push
+@pytest.mark.cpu
+def test_encoder_truncated_chunk_stays_block_aligned():
+    """A chunk the encoder path shortens must still be block-aligned.
+
+    ``_try_schedule_encoder_inputs`` truncates ``num_new_tokens`` to just before
+    an mm item it cannot fit in the encoder cache/budget. That boundary is the
+    image's ``offset``, which is not block-aligned in general. Leaving it
+    unaligned makes the next chunk start mid-block, and then
+    ``paged_fill_cache`` (writes from the start of a block) and the chunked SDPA
+    read (offsets by ``chunk_start_idx == num_computed`` exactly) disagree.
+
+    Here the encoder cache is too small to ever hold the image, so the scheduler
+    can only advance over the leading text -- block-aligned, not to the raw
+    offset.
+    """
+    chunk = 4 * _BLOCK_SIZE  # 64
+    offset = _BLOCK_SIZE + 5  # deliberately NOT a multiple of the block size
+    img_len = 2 * chunk  # bigger than the encoder cache below
+    isl = offset + img_len + _BLOCK_SIZE
+    sched = _make_scheduler(chunk=chunk, max_num_seqs=1)
+    # Cache far too small for the image: can_allocate() always fails, so the
+    # encoder path truncates every chunk back to `offset`.
+    _enable_encoder_cache(sched, cache_size=_BLOCK_SIZE, compute_budget=_BLOCK_SIZE)
+    sched.add_request(_make_mm_request("r0", isl, offset=offset, length=img_len))
+
+    out = sched.schedule()
+    n = out.num_scheduled_tokens.get("r0", 0)
+
+    assert n > 0, "the leading text before the image should still be schedulable"
+    assert n <= offset, f"scheduled {n} tokens must not run past the image at {offset}"
+    assert n % _BLOCK_SIZE == 0, (
+        f"chunk truncated by the encoder path is {n} tokens, which is not a "
+        f"multiple of block_size {_BLOCK_SIZE}; the next chunk would start "
+        "mid-block and corrupt the cached-prefix fill"
+    )


### PR DESCRIPTION
### Ticket
Closes #5824

### Problem description

We were force-setting `disable_chunked_mm_input` for every multimodal model. Upstream reads that flag and then insists `max_num_batched_tokens >= max_tokens_per_mm_item`, and on TT that number isn't just a scheduler budget: it also sizes the prefill activation buckets and the precompiled prefill graphs. So image size ended up coupled to prefill chunk size, which is exactly what chunked prefill (#4986) exists to avoid.

Concretely, Qwen2-VL with a 1024-token image and a 512-token chunk didn't even start:

```
ValueError: Chunked MM input disabled but max_tokens_per_mm_item (1024) is
larger than max_num_batched_tokens (512). Please increase max_num_batched_tokens.
```

### What's changed

Two small edits.

**The gate.** Narrowed the force so it only applies to models whose image span attends to itself (`is_mm_prefix_lm`: gemma3, paligemma, and gemma-4 variants with `use_bidirectional_attention="vision"`). That mirrors what `vllm/platforms/cuda.py` does. Everything else now re-slices the cached encoder output per chunk. Worth knowing: the slicing code already existed in `_gather_mm_embeddings`, it was just unreachable with the flag always on. That's why the change is 13 lines.

**A bug the flag was hiding.** `_block_aligned_chunk` runs before `_try_schedule_encoder_inputs`, and the encoder path can shorten a chunk to an image's offset. That offset isn't block-aligned, so the next chunk starts mid-block, and there `paged_fill_cache` (writes from a block boundary) and the chunked SDPA read (offsets by `chunk_start_idx == num_computed` exactly) disagree. Now we re-align after the encoder step and defer the request if it floors to zero. Without the fix a 21-token chunk gets through; with it, 16.

Three layers of tests:

* Scheduler, CPU: an item spanning chunks is encoded exactly once, a truncated chunk stays block-aligned, and `disable_chunked_mm_input` still keeps an item whole.
* Embedding equivalence, CPU: splitting a prompt reconstructs the single-shot embedding stream exactly, including Pixtral-style interleaved `is_embed` placeholders and two concurrent requests.
* Generation, device: whole-item vs split-item greedy output must agree.

I mutation-checked both new test files rather than trusting a green first run. Five injected index-arithmetic bugs, all caught, including one that keeps the row count correct but reads the wrong encoder offset, which the device test catches as a token divergence at position 2.

### Notes for reviewers

The device test replaces the vision tower with deterministic embeddings, on purpose. Qwen2-VL's encoder currently emits about 39% `inf` on TT (#5858), and comparing two token streams computed from saturated inputs tells you nothing, since any change in graph shape just moves the `inf` around. With sane values the two configs come out token-identical on all 16 tokens. Everything downstream of the encoder, which is the part this PR touches, is real.

That test self-skips until #5859 lands, because `get_cos_sin` is needed to build Qwen2-VL's vision tower at all. I applied #5859 locally to get the result above and then reverted it, so it isn't in this diff.

Two things I found while investigating that belong to #5858, not here:

* The OOM in that ticket isn't about chunking. It's the ViT attention score matrix at the worst-case dummy image: `65536^2 x 16 heads x 4 bytes = 256 GiB`, exactly the number in the log. Bounding `mm_processor_kwargs={"max_pixels": N}` fixes it, no code change needed.
* `_fill_pass_positions` writes a plain `arange` into all three M-RoPE sections and never reads `mrope_positions`, so image inputs get wrong T/H/W positions. Text-only is unaffected, which is why `test_mrope` passes.

Longer term `gemma-4-E4B-it` is the better vehicle for this test: it's chunkable (`use_bidirectional_attention` is unset, unlike the 31B) and its vision tower is a real HF module that already gets routed to the TT op. I couldn't use it here because that test is Blackhole-marked and I'm on Wormhole.

### Checklist
- [x] New/Existing tests provide coverage for changes
