### PR TITLE
[CI] Fix perf benchmarks skipped by broken matrix_skip guard

### DIFF
--- a/.github/workflows/call-filtered-perf-tests.yml
+++ b/.github/workflows/call-filtered-perf-tests.yml
@@ -63,6 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-perf-benchmarks.outputs.matrix }}
+      matrix_skip: ${{ steps.set-perf-benchmarks.outputs.matrix_skip }}
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
@@ -90,10 +91,12 @@ jobs:
         echo $result
         matrix=$(echo $result | jq -r -c '.matrix')
         echo "matrix=$matrix" >> $GITHUB_OUTPUT
+        matrix_skip=$(echo $result | jq -r -c '.matrix_skip')
+        echo "matrix_skip=$matrix_skip" >> $GITHUB_OUTPUT
 
   run-perf-benchmarks:
     needs: filter-tests
-    if: ${{ !cancelled() && fromJson(needs.filter-tests.outputs.matrix.matrix_skip) != 'true' && needs.filter-tests.result == 'success' }}
+    if: ${{ !cancelled() && needs.filter-tests.result == 'success' && needs.filter-tests.outputs.matrix_skip != 'true' }}
     secrets: inherit
     uses: ./.github/workflows/call-perf-test.yml
     with:


### PR DESCRIPTION
## Problem

The nightly perf comparison has no data because **all perf-benchmark jobs are being skipped**. On run [31444942259](https://github.com/tenstorrent/tt-xla/actions/runs/31444942259), `perf-benchmark / filter-tests` succeeded but `run-perf-benchmarks` (and every per-model job) was skipped, even though the nightly passes a normal, non-empty `adv_filter`.

This is a regression introduced by #5925 (`cf1eb30`). The last nightly *before* that commit ([31343580920](https://github.com/tenstorrent/tt-xla/actions/runs/31343580920)) ran all 168 perf jobs; the first nightly *after* it skipped them all.

## Root cause

The guard added in #5925 reads a value that does not exist:

```yaml
if: ${{ !cancelled() && fromJson(needs.filter-tests.outputs.matrix.matrix_skip) != 'true' && needs.filter-tests.result == 'success' }}
```

1. **`matrix_skip` is never exported.** `filter-test-matrix.py` prints `{"matrix": [...], "matrix_skip": "true|false"}`, but the `filter-tests` step only extracts `.matrix` into `$GITHUB_OUTPUT`, and the job only declares a `matrix` output. `matrix_skip` is discarded.
2. **The access path is malformed.** `needs.filter-tests.outputs.matrix` is a JSON *string* (the array), so `.matrix_skip` on it does not resolve, and wrapping that in `fromJson(...)` never yields `'true'`/`'false'`.

Net effect: the middle term never reflects the real filter decision and collapses to "skip" for the nightly, so the entire perf matrix disappears.

## Fix

- Export `matrix_skip` as a real job output of `filter-tests`.
- Write it to `$GITHUB_OUTPUT` alongside `matrix`.
- Compare it directly as a string in the guard (it is already `"true"`/`"false"` from the Python script), so no `fromJson` is needed.

```yaml
if: ${{ !cancelled() && needs.filter-tests.result == 'success' && needs.filter-tests.outputs.matrix_skip != 'true' }}
```

This preserves the original intent of #5925 (cleanly skip when the filter matches nothing, instead of erroring on an empty matrix) while ensuring perf benchmarks actually run when the filter is non-empty.

## Test plan

- [x] Trigger the nightly (or a manual perf run with a non-empty `adv_filter`) and confirm `run-perf-benchmarks` runs and per-model perf jobs execute ([pipeline](https://github.com/tenstorrent/tt-xla/actions/runs/31477097226))
- [x] Confirm a filter that matches nothing (empty matrix / `matrix_skip == 'true'`) still cleanly skips `run-perf-benchmarks` without erroring ([pipeline](https://github.com/tenstorrent/tt-xla/actions/runs/31480195616)).

## Note

This does **not** address issue #5918 (rerun-passed tests still reported as failed in `TT-XLA basic-test` / `check-all-green`), which is an unrelated JUnit-aggregation problem in `call-test.yml`. #5925 was linked as "closes #5918" but did not fix it; that issue should be reopened and handled separately.