### PR TITLE
Add Molmo, Qwen3.5, and Qwen2-VL TP inference configs for qb2-blackhole.

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -497,3 +497,54 @@ test_config:
   phi4/causal_lm/pytorch-Phi_4_Reasoning_Plus-tensor_parallel-inference:
     supported_archs: [qb2-blackhole]
     status: EXPECTED_PASSING
+
+  molmo/multimodal/pytorch-Molmo-72B-0924-tensor_parallel-inference:
+    supported_archs: [qb2-blackhole]
+    status: EXPECTED_PASSING
+    enable_weight_bfp8_conversion: true
+    inject_custom_moe: true
+    required_pcc: 0.97
+
+  molmo/causal_lm/pytorch-Molmo-72B-0924-tensor_parallel-inference:
+    supported_archs: [qb2-blackhole]
+    status: EXPECTED_PASSING
+    enable_weight_bfp8_conversion: true
+    inject_custom_moe: true
+
+  qwen_3_5/causal_lm/pytorch-35B_A3B-tensor_parallel-inference:
+    supported_archs: [n300-llmbox]
+    status: EXPECTED_PASSING
+    inject_custom_moe: true
+    enable_weight_bfp8_conversion: true
+
+  qwen_3_5/causal_lm/pytorch-27B-tensor_parallel-inference:
+    supported_archs: [n300-llmbox]
+    status: EXPECTED_PASSING
+
+  internlm2/pytorch-internlm2-chat-20b-tensor_parallel-inference:
+    supported_archs: [qb2-blackhole]
+    status: EXPECTED_PASSING
+    required_pcc: 0.98
+
+  llama2_70b_chat/pytorch-Llama-2-70b-chat-hf-tensor_parallel-inference:
+    supported_archs: [qb2-blackhole]
+    status: EXPECTED_PASSING
+
+  metamath_70b/pytorch-MetaMath-70B-V1.0-tensor_parallel-inference:
+    supported_archs: [qb2-blackhole]
+    status: EXPECTED_PASSING
+    enable_weight_bfp8_conversion: true
+
+  solar/pytorch-Solar-Pro-Preview-Instruct-tensor_parallel-inference:
+    supported_archs: [qb2-blackhole]
+    status: EXPECTED_PASSING
+    required_pcc: 0.98
+    enable_weight_bfp8_conversion: true
+
+  exaone_4_5/pytorch-EXAONE_4_5_33B-tensor_parallel-inference:
+    supported_archs: [qb2-blackhole]
+    status: EXPECTED_PASSING
+
+  llava/pytorch-1.6_34B-tensor_parallel-inference:
+    supported_archs: [qb2-blackhole]
+    status: EXPECTED_PASSING


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Add Molmo, Qwen3.5, and Qwen2-VL TP inference configs for qb2-blackhole.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] New/Existing tests provide coverage for changes
