### PR TITLE
[Ideogram 4] Register the tensor-parallel runner test and fix -s capture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import os
 import shutil
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 from contextlib import contextmanager
@@ -634,10 +635,27 @@ class _StreamTee:
         self._read_pos = 0
         self._final_size = None
 
+    def _create_backing_fd(self):
+        """Create an anonymous file to back the tee buffer.
+
+        Prefers ``os.memfd_create``. Some CPython builds (e.g. certain
+        manylinux/uv-provided interpreters) omit ``memfd_create``; fall back to
+        an immediately-unlinked tempfile, which behaves identically for our use
+        (a scratch buffer read via an independent fd). Without this fallback,
+        ``start()`` raises ``AttributeError`` at setup for any collected test
+        whenever ``-s`` is used and the interpreter lacks ``memfd_create``.
+        """
+        if hasattr(os, "memfd_create"):
+            return os.memfd_create(f"tee_capture_{self._original_fd}")
+        fd, path = tempfile.mkstemp(prefix=f"tee_capture_{self._original_fd}_")
+        # Keep the fd, drop the name: the file stays alive until the fd closes.
+        os.unlink(path)
+        return fd
+
     def start(self):
         """Redirect stream to memfd and start reader thread."""
         self._saved_fd = os.dup(self._original_fd)
-        self._memfd = os.memfd_create(f"tee_capture_{self._original_fd}")
+        self._memfd = self._create_backing_fd()
         self._read_fd = os.open(f"/proc/self/fd/{self._memfd}", os.O_RDONLY)
         self._thread = threading.Thread(target=self._reader_loop, daemon=True)
         self._thread.start()

--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -497,3 +497,14 @@ test_config:
   phi4/causal_lm/pytorch-Phi_4_Reasoning_Plus-tensor_parallel-inference:
     supported_archs: [qb2-blackhole]
     status: EXPECTED_PASSING
+
+  # Ideogram 4 (9.3B single-stream DiT). Single-p150a run HANGS in tt-metal's
+  # mesh command queue (enqueue_write_shards) at 34-layer scale; sharded across
+  # the 4-chip (1x4) mesh to cut per-chip weight writes. Attention (fused qkv +
+  # num_heads=18) can't be head-parallel, so only the SwiGLU MLP shards 4-way
+  # (53.3% weight/chip, 34 all-reduces). llm_cond_proj stays replicated: row-
+  # sharding it overflows Blackhole L1 in llm_cond_norm. See sharding_analysis.md.
+  ideogram_4/pytorch-Transformer_FP8_512-tensor_parallel-inference:
+    supported_archs: [qb2-blackhole, lb-blackhole]
+    status: EXPECTED_PASSING
+    enable_weight_bfp8_conversion: true


### PR DESCRIPTION
### Ticket

Ideogram 4 bringup. Companion to tenstorrent/tt-forge-models#859, which adds the shard specs this test consumes.

### Problem description

The 9.3B Ideogram 4 conditional DiT had no runner registration, and on a single chip it cannot get one: the device forward **hangs** in tt-metal's mesh command queue (`enqueue_write_shards` → `read_completion_queue`) at 34-layer scale, pegging a core and taking the board off PCIe until `tt-smi -r`.

Separately, `pytest -s` was unusable on this box — `_StreamTee.start()` raised `AttributeError` at setup for every collected test — which blocked the fd-level C++ logs needed to triage that hang.

### What's changed

**Registers the tensor-parallel test.** `ideogram_4/pytorch-Transformer_FP8_512-tensor_parallel-inference` as EXPECTED_PASSING on `[qb2-blackhole, lb-blackhole]` with `enable_weight_bfp8_conversion: true`. Sharding the SwiGLU MLP across the (1,4) mesh cuts the per-chip weight write to 53.3% and clears the hang; forge-models#859 has the shard-spec derivation.

**The single-device entry is deliberately NOT registered.** That configuration passed on the original single-chip box but hangs on Blackhole. Registering it as EXPECTED_PASSING would hang CI boards and require a manual `tt-smi -r`. It needs either an arch restriction verified on the arch that actually passes, or a tracking issue for the hang — neither of which this change can establish, so it is left out rather than guessed at.

**`_StreamTee` falls back to an unlinked tempfile** when `os.memfd_create` is unavailable. Some CPython builds (certain manylinux/uv interpreters, including this venv's) omit it, so `start()` raised `AttributeError` at setup whenever `-s` was passed. The fallback keeps an fd and drops the name, which behaves identically for a scratch buffer read through an independent fd. This mattered for the triage above: `capfd` loses the C++ logs on SIGABRT, and `TT_METAL_WATCHER=1` itself SIGABRTs on this Blackhole, so `-s` was the only usable channel.

### Validation

YAML parses and the entry is present (101 entries in the tensor-parallel config after the merge with main).

Sharding arithmetic, computed from the model config rather than quoted:

| Quantity | Value |
|---|---|
| Total parameters | 9.279B |
| Sharded (SwiGLU MLP) | 5.776B |
| Per chip, 4-chip mesh | 4.948B = **53.3%** |
| All-reduces per forward | **34** |

End-to-end text-to-image on the 4-chip mesh, 512×512, 28 steps, seed 1234, guidance 7.0, prompt "A ginger cat wearing a tiny wizard hat reading a spellbook, cozy library, warm light, digital illustration":

| Stage | Device | Time |
|---|---|---|
| Both DiTs (cond + uncond), 28 steps | TT, (1,4) mesh | **130 s** |
| Same pipeline, all CPU | CPU | 1585 s |
| Pipeline build (weights + text encoder + VAE) | CPU | 242 s |

Single-forward TT-vs-CPU **PCC 0.9957**. The DiT runs the full pipeline with no hang and no crash — which is the point of this PR, since the same model on one chip takes the board off PCIe.

The e2e image also exposed an MRoPE lowering problem, measured as energy at the 16 px patch period (FFT magnitude of the column-averaged row profile):

| Image | 16 px-period FFT magnitude | RGB PCC vs CPU |
|---|---|---|
| CPU golden | 61.4 | — |
| TT, **before** MRoPE fix | **1890.0** (31× CPU) | 0.1918 |
| TT, **after** MRoPE fix | **68.7** (CPU baseline) | 0.5949 |

Before the fix the TT output is a pure 16 px grid with no image content; after it, a coherent on-prompt image. **RGB PCC 0.5949 is not a close match** — both images are coherent but are different samples, the usual trajectory divergence when a 0.9957 per-forward PCC compounds over 28 steps × 2 CFG forwards. The fix is a driver-side patch to the `ideogram4` package and is **not** part of either PR.

`pre-commit run --files tests/conftest.py tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml` passes (black, copyright, yaml, isort, whitespace, EOF).

### Artifacts

Collected under **`pr 1/`** on shared `/proj_sw/user_dev/ctr-lelanchelian/tt-xla/`: `01_cpu_golden.png`, `02_tt_before_mrope_fix.png` (the pure grid), `03_tt_after_mrope_fix.png`, `04_proof_strip.png`, `05_cpu_vs_tt_side_by_side.png`, `log_tt_generation.log` (68 MB, with compiler IR) plus a 16-line excerpt, `log_cpu_generation.log`, both runner logs, `sharding_analysis.md`, the driver, and a README.

**Provenance:** both images were regenerated on 2026-08-12 and came out **bit-identical** to the original bringup runs, so the pipeline is reproducible at a fixed seed on both backends. That also confirms the MRoPE masked-sum rewrite is bit-exact on CPU: the July golden predates the patch, today's run includes it, and the two are identical.

### Land order

forge-models#859 first — this test fails without `get_mesh_config` / `load_shard_spec`. **No submodule bump in this PR**; the pointer should move in the regular uplift once #859 is on main.

### Limitations

- The single-chip hang is bypassed, not fixed; the root cause is upstream in tt-metal's mesh command queue.
- Attention stays replicated (fused qkv, `num_heads=18` ∤ 4), so per-chip weight drops only to 53.3%, not 25%.
- The corrected comment in this PR fixes two claims that were wrong in the draft: `llm_cond_proj` is **not** sharded (row-sharding it overflows Blackhole L1 in `llm_cond_norm` at 3.36 MB vs the 1.5 MB limit), and the per-chip figure is 53.3%, not ~51%.

### Checklist

- [x] New/Existing tests provide coverage for changes — this PR is the test registration.
