### PR TITLE
[Benchmark] Wire the Voxtral-Mini-3B audio e2e pipeline into nightly + benchmark CI

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -115,6 +115,10 @@
         "runs-on": "qb2-blackhole"
       },
       {
+        "name": "voxtral_mini_3b",
+        "pytest": "tests/benchmark/test_audio.py::test_voxtral_mini_3b"
+      },
+      {
         "name": "bge_m3_encode",
         "pyreq": "transformers==4.57.1 FlagEmbedding",
         "pytest": "tests/benchmark/test_encoders.py::test_bge_m3"

--- a/tests/benchmark/benchmarks/audio_benchmark.py
+++ b/tests/benchmark/benchmarks/audio_benchmark.py
@@ -1,0 +1,252 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generic audio-pipeline benchmark harness for torch-xla / TT.
+
+Sibling of ``imagegen_benchmark.py`` / ``ar_imagegen_benchmark.py``, for models
+whose input or output is audio and whose generation is an autoregressive decode
+loop: audio-understanding models that answer in text (Voxtral) and TTS models
+that emit audio tokens (XTTS-v2, Llasa). The per-model configuration lives in
+``test_audio.py``; this module owns the reusable measurement logic.
+
+Two-pass scheme (same idea as the image-gen harnesses):
+
+  - Pass 1 (warmup): a full ``generate()``. It has to use the *same* token
+    budget as the measured pass: these pipelines decode over a static
+    right-padded window whose shape is ``prefill + max_new_tokens``, so a
+    shorter warmup would compile a different shape and leave the compile in the
+    measured pass.
+  - Pass 2 (steady-state): a second full ``generate()`` where every forward is
+    a cache hit. This is the pass that is reported.
+
+The pipeline reports its own per-stage timings in ``pipeline._perf``, in the
+schema shared with the image-gen harness — ``components`` and ``steps`` hold
+seconds, counts live in their own top-level keys::
+
+    _perf = {
+        "components": {<name>: seconds, ...},   # scalar per-stage device times
+        "steps": [seconds, ...],                # one entry per decode step
+        "step_metric_name": "decode_step",      # e.g. "audio_token_step"
+        "total": seconds,                       # full generate() wall time
+        <count_name>: int,                      # e.g. prefill_tokens, output_tokens
+    }
+
+Every extra scalar key is emitted verbatim as a dashboard measurement, so a
+pipeline can report its own counts (``prefill_tokens``, ``audio_samples``, ...)
+without touching this harness.
+
+Headline throughput is decode tokens/second, and ``total_time`` /
+``total_samples`` are the decode-loop totals — the same convention as
+``llm_benchmark.py``, so a generative audio model is comparable with the LLMs on
+the dashboard. ``steps[0]`` is reported as TTFT: these pipelines carry no KV
+cache, so the first step is the one that also computes the prompt.
+"""
+
+import socket
+import time
+
+import torch_xla
+import torch_xla.runtime as xr
+from utils import (
+    build_xla_export_name,
+    create_benchmark_result,
+    get_benchmark_metadata,
+    get_xla_device_arch,
+    print_benchmark_results,
+)
+
+xr.set_device_type("TT")
+
+MODULE_EXPORT_PATH = "modules"
+
+# Keys of the ``_perf`` schema that this harness interprets itself; any other
+# scalar key is passed through to the dashboard as-is.
+_PERF_RESERVED_KEYS = frozenset({"components", "steps", "step_metric_name", "total"})
+
+
+def benchmark_audio_torch_xla(
+    build_pipeline_fn,
+    model_info_name,
+    num_generation_steps,
+    optimization_level,
+    trace_enabled,
+    ttnn_perf_metrics_output_file,
+    model_type,
+    dataset_name,
+    display_name=None,
+    save_output_fn=None,
+):
+    """Benchmark an audio generation/understanding pipeline on the TT backend.
+
+    Args:
+        build_pipeline_fn: ``build_pipeline_fn(compile_options) -> (pipeline, generate_fn)``.
+            ``compile_options`` is forwarded so the pipeline can merge instead of
+            overwrite if it needs to switch an option inline.
+            ``generate_fn(num_generation_steps) -> output`` runs one full
+            generation and populates ``pipeline._perf``.
+        model_info_name: Model name for identification and reporting.
+        num_generation_steps: Token budget per generation (the decode-loop cap).
+        optimization_level: tt-mlir optimization level for compilation.
+        trace_enabled: Whether to enable tracing.
+        ttnn_perf_metrics_output_file: Base path for TTNN perf metrics files.
+        model_type: Dashboard model type (e.g. "audio-to-text").
+        dataset_name: Dashboard dataset name (e.g. "Audio Prompt").
+        display_name: Display name used for export naming / dashboard.
+        save_output_fn: If set, ``save_output_fn(output)`` persists the
+            steady-state output (a text answer, a waveform, ...).
+
+    Returns:
+        Standardized benchmark result dict (see ``create_benchmark_result``).
+    """
+    export_model_name = build_xla_export_name(
+        model_name=display_name or model_info_name,
+        num_layers=None,
+        batch_size=1,
+        input_sequence_length=None,
+    )
+
+    options = {
+        "optimization_level": optimization_level,
+        "export_path": MODULE_EXPORT_PATH,
+        "export_model_name": export_model_name,
+        "ttnn_perf_metrics_enabled": True,
+        "ttnn_perf_metrics_output_file": ttnn_perf_metrics_output_file,
+        "enable_trace": trace_enabled,
+    }
+    torch_xla.set_custom_compile_options(options)
+
+    # Build the pipeline (registers the "tt" backend and moves the model to the
+    # XLA device; kernels compile lazily on the first forward, i.e. during the
+    # warmup pass below).
+    pipeline, generate_fn = build_pipeline_fn(options)
+
+    # Pass 1 (warmup): same token budget as the measured pass, so the decode
+    # window has the shape the steady-state pass reuses.
+    print("Starting warmup pass (includes compile)...")
+    warmup_start = time.perf_counter()
+    generate_fn(num_generation_steps)
+    warmup_time = time.perf_counter() - warmup_start
+    print(f"Warmup pass: {warmup_time:.3f}s")
+
+    # Pass 2 (steady-state): every forward is a cache hit; this is the reported
+    # pass and the output that gets saved.
+    print("Starting steady-state pass...")
+    steady_state_start = time.perf_counter()
+    steady_state_output = generate_fn(num_generation_steps)
+    steady_state_time = time.perf_counter() - steady_state_start
+    print(f"Steady-state pass: {steady_state_time:.3f}s")
+
+    if save_output_fn is not None:
+        save_output_fn(steady_state_output)
+
+    # Per-stage times from the pipeline's own instrumentation (steady-state pass).
+    perf = pipeline._perf
+    components = perf["components"]
+    steps = perf["steps"]
+    step_metric_name = perf["step_metric_name"]
+    if not steps:
+        raise AssertionError(
+            f"{model_info_name}: the pipeline reported no generation steps"
+        )
+
+    # No KV cache in these loops: step 0 is the one that also computes the
+    # prompt, so it is TTFT and is kept out of the steady-state decode stats.
+    ttft_ms = steps[0] * 1000.0
+    decode_steps = steps[1:]
+    decode_total_s = sum(decode_steps)
+    decode_step_mean_s = decode_total_s / len(decode_steps) if decode_steps else 0.0
+    tokens_per_second = (
+        len(decode_steps) / decode_total_s if decode_total_s > 0 else 0.0
+    )
+    tt_stages_total = sum(components.values()) + sum(steps)
+    cpu_overhead = max(0.0, perf["total"] - tt_stages_total)
+
+    # Counts (and any other scalar) the pipeline reports next to the timings.
+    extra_measurements = {
+        name: value
+        for name, value in perf.items()
+        if name not in _PERF_RESERVED_KEYS and isinstance(value, (int, float))
+    }
+    prefill_tokens = extra_measurements.get("prefill_tokens")
+
+    metadata = get_benchmark_metadata()
+    full_model_name = model_info_name
+
+    print_benchmark_results(
+        model_title=full_model_name,
+        full_model_name=full_model_name,
+        model_type=model_type,
+        dataset_name=dataset_name,
+        date=metadata["date"],
+        machine_name=metadata["machine_name"],
+        total_time=decode_total_s,
+        total_samples=len(decode_steps),
+        samples_per_sec=tokens_per_second,
+        evaluation_score=0.0,
+        ttft_ms=ttft_ms,
+        batch_size=1,
+        data_format="bfloat16",
+        input_sequence_length=prefill_tokens,
+    )
+    component_lines = "".join(
+        f"|   {name} (s):  {value:.3f}\n" for name, value in components.items()
+    )
+    extra_lines = "".join(
+        f"|   {name}:  {value}\n" for name, value in extra_measurements.items()
+    )
+    print(
+        f"| Token budget: {num_generation_steps}\n"
+        f"| Steady-state:\n"
+        f"{component_lines}"
+        f"{extra_lines}"
+        f"|   TTFT (s):                 {steps[0]:.3f}\n"
+        f"|   {step_metric_name} mean (s):  {decode_step_mean_s:.4f}\n"
+        f"|   Decode tokens/s:          {tokens_per_second:.2f}\n"
+        f"|   e2e latency (s):          {steady_state_time:.3f}\n"
+        f"|   CPU overhead (s):         {cpu_overhead:.3f}"
+    )
+
+    custom_measurements = [
+        {"measurement_name": "tokens_per_second", "value": tokens_per_second},
+        {"measurement_name": "ttft", "value": ttft_ms},
+        {"measurement_name": "e2e_latency", "value": steady_state_time},
+        {"measurement_name": f"{step_metric_name}_mean_s", "value": decode_step_mean_s},
+        {"measurement_name": "cpu_overhead_s", "value": cpu_overhead},
+    ]
+    # One measurement per scalar component (e.g. speaker_encoder_s, hifigan_s).
+    for name, value in components.items():
+        custom_measurements.append({"measurement_name": f"{name}_s", "value": value})
+    # Pipeline-reported counts (prefill_tokens, output_tokens, audio_samples, ...).
+    for name, value in extra_measurements.items():
+        custom_measurements.append({"measurement_name": name, "value": value})
+
+    result = create_benchmark_result(
+        full_model_name=full_model_name,
+        model_type=model_type,
+        dataset_name=dataset_name,
+        num_layers=-1,
+        batch_size=1,
+        input_size=(prefill_tokens if prefill_tokens is not None else -1,),
+        loop_count=num_generation_steps,
+        data_format="bfloat16",
+        total_time=decode_total_s,
+        total_samples=len(decode_steps),
+        evaluation_score=0.0,
+        custom_measurements=custom_measurements,
+        optimization_level=optimization_level,
+        program_cache_enabled=True,
+        trace_enabled=trace_enabled,
+        model_info=model_info_name,
+        display_name=display_name,
+        torch_xla_enabled=True,
+        backend="tt",
+        device_name=socket.gethostname(),
+        arch=get_xla_device_arch(),
+        device_count=xr.global_runtime_device_count(),
+        mesh_shape=getattr(pipeline, "mesh_shape", None),
+        input_is_image=False,
+        input_sequence_length=prefill_tokens if prefill_tokens is not None else -1,
+    )
+
+    return result

--- a/tests/benchmark/test_audio.py
+++ b/tests/benchmark/test_audio.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Audio-pipeline benchmarks.
+
+Config-driven entry points (one ``test_<model>`` per model) that drive per-model
+pipelines through the shared harness in ``benchmarks/audio_benchmark.py``. Same
+split as ``test_imagegen.py`` / ``imagegen_benchmark.py``: model-specific config
+lives here, the reusable measurement logic lives in ``benchmarks/``.
+
+Covers models whose input or output is audio and whose generation is an
+autoregressive decode loop; throughput is reported as decode tokens/second.
+"""
+
+import json
+
+from benchmarks.audio_benchmark import benchmark_audio_torch_xla
+from utils import aggregate_ttnn_perf_metrics, resolve_display_name
+
+from third_party.tt_forge_models.voxtral.pytorch.pipeline import (
+    VoxtralConfig,
+    VoxtralPipeline,
+)
+
+# Defaults shared by all audio models.
+DEFAULT_OPTIMIZATION_LEVEL = 1
+DEFAULT_TRACE_ENABLED = False
+
+
+def test_audio(
+    build_pipeline_fn,
+    model_info_name,
+    output_file,
+    num_generation_steps,
+    model_type,
+    dataset_name,
+    request=None,
+    optimization_level=DEFAULT_OPTIMIZATION_LEVEL,
+    trace_enabled=DEFAULT_TRACE_ENABLED,
+    save_output_fn=None,
+):
+    """Run an audio-pipeline benchmark with the given configuration.
+
+    Args:
+        build_pipeline_fn: Callable returning ``(pipeline, generate_fn)``;
+            see ``benchmark_audio_torch_xla``.
+        model_info_name: Model name for identification and reporting.
+        output_file: Path to save benchmark results as JSON.
+        num_generation_steps: Token budget per generation (decode-loop cap).
+        model_type: Dashboard model type (e.g. "audio-to-text").
+        dataset_name: Dashboard dataset name (e.g. "Audio Prompt").
+        optimization_level: Optimization level (0, 1, or 2).
+        trace_enabled: Enable trace.
+        save_output_fn: If set, persists the steady-state output.
+    """
+    resolved_display_name = resolve_display_name(
+        request=request, fallback=model_info_name
+    )
+    ttnn_perf_metrics_output_file = f"tt_xla_{resolved_display_name}_perf_metrics"
+
+    print(f"Running audio benchmark for model: {model_info_name}")
+    print(
+        f"""Configuration:
+    optimization_level={optimization_level}
+    trace_enabled={trace_enabled}
+    num_generation_steps={num_generation_steps}
+    ttnn_perf_metrics_output_file={ttnn_perf_metrics_output_file}
+    """
+    )
+
+    results = benchmark_audio_torch_xla(
+        build_pipeline_fn=build_pipeline_fn,
+        model_info_name=model_info_name,
+        display_name=resolved_display_name,
+        num_generation_steps=num_generation_steps,
+        optimization_level=optimization_level,
+        trace_enabled=trace_enabled,
+        ttnn_perf_metrics_output_file=ttnn_perf_metrics_output_file,
+        model_type=model_type,
+        dataset_name=dataset_name,
+        save_output_fn=save_output_fn,
+    )
+
+    if output_file:
+        results["project"] = "tt-forge/tt-xla"
+        results["model_rawname"] = model_info_name
+
+        aggregate_ttnn_perf_metrics(ttnn_perf_metrics_output_file, results)
+
+        with open(output_file, "w") as file:
+            json.dump(results, file, indent=2)
+
+
+def test_voxtral_mini_3b(output_file, request):
+    # Audio tower + audio/text merge run on the host (the HF merge is a
+    # data-dependent masked_scatter); the 30-layer Ministral-3B LM decodes on TT.
+    # 32 tokens is enough for a full answer to the sample question and bounds the
+    # run: the loop has no KV cache, so every step is a full-window forward.
+    num_generation_steps = 32
+    answer_path = "test_voxtral_mini_3b_answer.txt"
+
+    def build_pipeline_fn(compile_options):
+        pipeline = VoxtralPipeline(
+            config=VoxtralConfig(max_new_tokens=num_generation_steps)
+        )
+        pipeline.setup()
+
+        def generate_fn(max_new_tokens):
+            return pipeline.generate(max_new_tokens=max_new_tokens)
+
+        return pipeline, generate_fn
+
+    def save_output_fn(answer):
+        print(f"Voxtral answer: {answer}")
+        with open(answer_path, "w") as file:
+            file.write(answer)
+        print(f"Saved answer to {answer_path}")
+
+    test_audio(
+        build_pipeline_fn=build_pipeline_fn,
+        model_info_name="Voxtral-Mini-3B-2507",
+        output_file=output_file,
+        request=request,
+        num_generation_steps=num_generation_steps,
+        model_type="audio-to-text",
+        dataset_name="Audio Prompt",
+        save_output_fn=save_output_fn,
+    )

--- a/tests/torch/models/voxtral/__init__.py
+++ b/tests/torch/models/voxtral/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/torch/models/voxtral/test_voxtral_pipeline.py
+++ b/tests/torch/models/voxtral/test_voxtral_pipeline.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Voxtral-Mini-3B-2507 — nightly end-to-end audio+text -> text pipeline test.
+
+Runs the full audio-understanding pipeline: the Whisper-style audio tower and the
+audio/text merge run on the host (the HF merge is a data-dependent
+``masked_scatter`` that cannot be lowered), and the 30-layer Ministral-3B
+language model greedy-decodes the answer on Tenstorrent. The pipeline
+implementation lives in ``tt_forge_models`` and is shared with the audio
+benchmark (``tests/benchmark/test_audio.py``).
+
+The test asserts the model actually answered the sample question — the answer has
+to name the sport in the audio, a word that appears nowhere in the prompt —
+instead of only checking that some text came back.
+"""
+
+from pathlib import Path
+
+import pytest
+import torch_xla.runtime as xr
+from infra import RunMode
+from loguru import logger
+from utils import BringupStatus, Category, ModelGroup
+
+from third_party.tt_forge_models.voxtral.pytorch.pipeline import (
+    VoxtralConfig,
+    VoxtralPipeline,
+)
+
+# Token budget for the answer. The decode loop carries no KV cache, so every
+# step is a full-window forward, which bounds how long this can run: 48 tokens
+# is a full answer to the sample question plus margin, so the keyword assertion
+# below does not depend on the model naming both clips in its first few words.
+MAX_NEW_TOKENS = 48
+
+OUTPUT_PATH = "voxtral_mini_3b_answer.txt"
+
+# The sample conversation feeds two clips (a baseball radio call and "Mary Had a
+# Little Lamb") and asks which sport and which nursery rhyme are referenced.
+# "baseball" is the check that matters: the word is nowhere in the prompt, so the
+# model can only produce it by understanding the audio. Which *game* it names, and
+# whether it gets to naming the rhyme within the token budget, vary with device
+# numerics (n150 and p150 word the answer differently), so neither is asserted.
+EXPECTED_KEYWORD = "baseball"
+
+# A one-word reply would satisfy the keyword check without being an answer.
+MIN_ANSWER_WORDS = 8
+
+
+@pytest.mark.nightly
+@pytest.mark.model_test
+@pytest.mark.single_device
+@pytest.mark.large
+@pytest.mark.record_test_properties(
+    category=Category.MODEL_TEST,
+    model_name="Voxtral_Mini_3B_Pipeline",
+    model_group=ModelGroup.RED,
+    run_mode=RunMode.INFERENCE,
+    bringup_status=BringupStatus.PASSED,
+)
+def test_voxtral_mini_3b_pipeline():
+    """Full Voxtral audio->text chain with the language model on TT."""
+    xr.set_device_type("TT")
+
+    output_file = Path(OUTPUT_PATH)
+    if output_file.exists():
+        output_file.unlink()
+
+    pipeline = VoxtralPipeline(config=VoxtralConfig(max_new_tokens=MAX_NEW_TOKENS))
+    pipeline.setup()
+    answer = pipeline.generate(max_new_tokens=MAX_NEW_TOKENS)
+
+    output_file.write_text(answer)
+    logger.info(f"Voxtral answer ({len(answer)} chars): {answer!r}")
+
+    steps = pipeline._perf["steps"]
+    assert steps, "Decode loop ran no steps"
+
+    assert len(answer.split()) >= MIN_ANSWER_WORDS, (
+        f"answer is too short to be an answer ({len(answer.split())} words < "
+        f"{MIN_ANSWER_WORDS}): {answer!r}"
+    )
+    assert EXPECTED_KEYWORD in answer.lower(), (
+        f"answer does not name the sport in the audio ({EXPECTED_KEYWORD!r}) — the "
+        f"model did not understand the audio prompt. Answer: {answer!r}"
+    )
+
+    logger.info(
+        "[voxtral] prefill_tokens={} decode_steps={} answer saved to {}",
+        pipeline._perf["prefill_tokens"],
+        len(steps),
+        OUTPUT_PATH,
+    )

--- a/venv/requirements-dev.txt
+++ b/venv/requirements-dev.txt
@@ -13,6 +13,14 @@ librosa==0.11.0
 numba==0.63.1
 llvmlite==0.46.0
 
+# Voxtral tokenizes through the mistral_common backend (it ships a tekken.json,
+# not a Jinja chat template). This cannot be installed per-loader at test time:
+# transformers resolves what is available while it is being imported and memoizes
+# it, so a later install leaves the processor on a tokenizer with no chat template
+# ("tokenizer.chat_template is not set"). It has to be in the environment before
+# pytest starts.
+mistral-common[audio]
+
 lit
 loguru
 graphviz


### PR DESCRIPTION
### Problem description

Same policy as #5047 / #5085: every model that passes bringup gets wired into **both** nightly and benchmark CI. **Voxtral-Mini-3B-2507** (Mistral's audio-understanding model) passed bringup and its end-to-end audio+text -> text pipeline landed in tt-forge-models (tenstorrent/tt-forge-models#802), but nothing runs it in CI — no nightly e2e test, no benchmark entry, so a regression in the audio path would only surface by hand.

There is also no shared harness for audio models. Image-gen has two (`imagegen_benchmark.py` for diffusion, `ar_imagegen_benchmark.py` for autoregressive image tokens); an audio pipeline fits neither: the interesting throughput is decode tokens/second and there is no image to save.

### What's changed

**Benchmark** — mirrors the reviewed image-gen pattern (shared harness in `benchmarks/`, per-model config in the `test_*.py`):

- **`tests/benchmark/benchmarks/audio_benchmark.py`** (new) — shared harness for audio pipelines whose generation is an autoregressive decode loop: audio-understanding models that answer in text (Voxtral) and TTS models that emit audio tokens (XTTS-v2, Llasa) can both use it. It reads the same model-agnostic `_perf` schema the image-gen harness reads, with the seconds/counts split the XTTS-v2 pipeline already uses:
  ```python
  _perf = {
      "components": {<name>: seconds, ...},   # scalar per-stage device times
      "steps": [seconds, ...],                # one entry per decode step
      "step_metric_name": "decode_step",      # e.g. "audio_token_step"
      "total": seconds,                       # full generate() wall time
      <count_name>: int,                      # prefill_tokens, output_tokens, ...
  }
  ```
  Every extra scalar key is emitted verbatim as a dashboard measurement, so a pipeline can report its own counts without touching the harness. Emits `tokens_per_second` (headline), `ttft`, `e2e_latency`, `<step_metric_name>_mean_s`, `cpu_overhead_s` and one measurement per component; `total_time` / `total_samples` are the decode-loop totals, the same convention as `llm_benchmark.py`, so a generative audio model is comparable with the LLMs on the dashboard. No `compile_time` / `per_step_latency_ms` (per @nvukobratTT on #5044).

  Two-pass scheme as in the image-gen harnesses, with one difference worth calling out: the warmup pass uses the **same** token budget as the measured pass. These pipelines decode over a static right-padded window whose shape is `prefill + max_new_tokens`, so a 1-step warmup would compile a *different* shape and leave the compile inside the measured pass.

- **`tests/benchmark/test_audio.py`** (new) — config-driven `test_voxtral_mini_3b`. Canonical API: `build_pipeline_fn(compile_options) -> (pipeline, generate_fn)`, `generate_fn(max_new_tokens)`; imports at the top of the file (per review on #5044/#5085). The answer text is written next to the perf JSON.

- **`.github/workflows/perf-bench-matrix.json`** — `voxtral_mini_3b` entry, default runners (both n150 and p150 pass).

- **`venv/requirements-dev.txt`** — `mistral-common[audio]`. Voxtral tokenizes through the mistral_common backend (it ships a `tekken.json`, not a Jinja chat template), and this **cannot** be installed per-loader at test time: transformers resolves what is available while it is being imported and memoizes it, so a later install leaves the processor holding a tokenizer with no chat template and `apply_chat_template` raises `tokenizer.chat_template is not set`. A p150 nightly run caught exactly that; see the comment below. `venv/activate` installs this file, so both the test and perf jobs get it.

**Nightly** — mirrors #5085's `test_stable_diffusion_1_5_pipeline` and the XTTS-v2 audio test:

- **`tests/torch/models/voxtral/test_voxtral_pipeline.py`** (new) — full e2e audio -> text test: the Whisper-style audio tower and the audio/text merge stay on the host (the HF merge is a data-dependent `masked_scatter` that will not lower), the 30-layer Ministral-3B LM greedy-decodes on TT. Reuses the `tt_forge_models` pipeline shared with the benchmark, and installs the loader's own requirements through `RequirementsManager` exactly as the XTTS-v2 test does. Markers: `nightly`, `model_test`, `single_device`, `large`, `record_test_properties(MODEL_TEST, RED, INFERENCE, PASSED)`. No xfail.

  The test asserts the model actually *understood* the prompt: the answer has to name the sport in the audio (`baseball`, a word that appears nowhere in the prompt) and be a real sentence, rather than only checking that some text came back. It deliberately does not assert the rhyme's name or the specific game — n150 and p150 word the answer differently, so those would be device-dependent.

This PR carries **no `third_party/tt_forge_models` submodule bump** — the companion pipeline change lands separately (below) and is picked up via the normal submodule **uplift**.

**Blast radius:** nothing existing is touched. `audio_benchmark.py` and `test_audio.py` are new files with a single consumer, and no other model reads the Voxtral `_perf` (so nothing can repeat the `sdxl_lightning` `KeyError: 'components'` regression from #5575 — `imagegen_benchmark.py` and its models are untouched). The one shared file edited is `perf-bench-matrix.json`, where only a new entry is appended. Voxtral runs **single-chip** (3B at bf16 fits one Wormhole; verified on n150).

### Depends on (delivered via submodule uplift, not a bump in this PR)

- tt-forge-models companion: **tenstorrent/tt-forge-models#864** (`lelanchelian/voxtral-perf-schema`) — moves the Voxtral `_perf` counts out of `components` (the harness sums `components` as seconds) and adds the loader `requirements.txt` for `mistral-common`.
- **Land order:** merge the companion -> uplift `third_party/tt_forge_models` to the resulting main SHA -> this PR's benchmark + nightly imports resolve and run green.

### Verification

Every number below is from the code as it stands on this branch. The CI runs use `lelanchelian/voxtral-benchmark-ci-verify` (this branch + a temporary submodule bump to #864) for the benchmark, and the PR branch itself with `forge_models_override` for the nightly test — the pipeline is not in the current pin yet.

**Benchmark** — `tests/benchmark/test_audio.py::test_voxtral_mini_3b`, optimization_level 1, 32-token budget, 2-pass:

| | [n150-perf](https://github.com/tenstorrent/tt-xla/actions/runs/31816664740) | [p150-perf](https://github.com/tenstorrent/tt-xla/actions/runs/31816674271) |
|---|---|---|
| warmup pass (incl. compile) | 109.2 s | 133.2 s |
| steady-state pass (`e2e_latency`) | 44.5 s | 78.3 s |
| `ttft` | 1415 ms | 2436 ms |
| `decode_step_mean_s` | 1.4859 s | 2.4444 s |
| `tokens_per_second` | 0.67 | 0.41 |
| `cpu_overhead_s` | 0.002 s | 0.003 s |
| `prefill_tokens` | 765 | 765 |
| `output_tokens` | 29 (hit EOS) | 32 (hit budget) |
| pytest | **1 passed** (277 s) | **1 passed** (277 s) |

Answers, both correct:

- **n150** — "The sport referenced is baseball, specifically the 1969 World Series. The nursery rhyme referenced is "Mary Had a Little Lamb.""
- **p150** — "The audio references both baseball and a nursery rhyme. The baseball reference is about a home run hit by Edgar Martinez, ..." (cut off by the 32-token budget)

So the matrix entry keeps the **default runners** — no n150-only restriction like SD 1.5 / SD 3 needed in #5085.

**Nightly** — `tests/torch/models/voxtral/test_voxtral_pipeline.py`:

- p150 in CI: **1 passed** (256 s) — https://github.com/tenstorrent/tt-xla/actions/runs/31816684529
- n150 locally: **1 passed** (117 s), answer "The audio references both a nursery rhyme and a baseball game. The nursery rhyme is "Mary Had a Little Lamb," and the baseball game is a playoff game between the Baltimore Orioles and the Oakland Athletics."

The wording differs between the two because the benchmark sets `optimization_level=1` while the nightly test uses the default — different numerics, so greedy decode picks a different phrasing. Both answer correctly, which is why the assertion keys on the one content word that cannot come from the prompt (`baseball`) plus a minimum answer length, rather than an exact string.

On the throughput figure: 0.67 tokens/s is what this pipeline is, not a regression. There is no KV cache, so every decode step recomputes the full `prefill + max_new_tokens` window (797 tokens of a 3B LM) to keep the graph static. Wiring it into the benchmark means a future KV-cache version shows up as a step change instead of an anecdote. Also visible in the two runs: p150 is ~1.6x slower per decode step than n150 on the same graph.


### Checklist
- [x] Benchmark green in CI on n150 **and** p150 (with the companion pipeline change present), so the matrix entry keeps the default runners
- [x] Nightly e2e pipeline test green on n150 (local) and p150 (CI)
- [ ] Merge tenstorrent/tt-forge-models#864, then uplift the tt-xla submodule
