### PR TITLE
[HiDream-I1] Use A2aSparseMLP for MoE to remove per-step recompiles

### DIFF
--- a/python_package/tt_torch/sparse_mlp.py
+++ b/python_package/tt_torch/sparse_mlp.py
@@ -795,7 +795,8 @@ class DeepseekV3MoEToA2AAdapter(nn.Module):
                 # Raw-logits gate: use external routing function
                 topk_idx, topk_weight = self._route_fn(gate_output)
             elif isinstance(gate_output, (tuple, list)):
-                out1, out2 = gate_output
+                # Index rather than unpack: HiDream's MoEGate appends aux_loss.
+                out1, out2 = gate_output[0], gate_output[1]
                 if self._gate_returns_idx_first:
                     topk_idx, topk_weight = out1, out2
                 else:

--- a/tests/torch/graphs/test_mlp.py
+++ b/tests/torch/graphs/test_mlp.py
@@ -2,16 +2,20 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from types import SimpleNamespace
 from typing import Callable
 
 import numpy as np
 import pytest
 import torch
 import torch_xla
+import torch_xla.core.xla_model as xm
 import torch_xla.distributed.spmd as xs
 import torch_xla.runtime as xr
+from diffusers.models.transformers.transformer_hidream_image import MOEFeedForwardSwiGLU
 from infra import Framework, run_graph_test
-from infra.evaluators import ComparisonConfig, PccConfig
+from infra.evaluators import ComparisonConfig, PccConfig, TorchComparisonEvaluator
+from infra.utilities.torch_multichip_utils import enable_spmd, get_mesh
 from torch_xla.distributed.spmd import Mesh
 from transformers import AutoModelForCausalLM
 from transformers.models.falcon.modeling_falcon import FalconMLP
@@ -728,3 +732,71 @@ def test_moe_activation_swiglu_limit():
     gate_up = torch.randn(1, 64, 256, dtype=torch.bfloat16) * 5.0
 
     run_graph_test(model, [gate_up], framework=Framework.TORCH)
+
+
+"""HiDream-I1 MoE block (stock moe_infer on CPU vs A2aSparseMLP on TT)"""
+
+
+@pytest.mark.nightly
+@pytest.mark.qb2_blackhole
+@pytest.mark.parametrize(
+    "seq_len", [4096, 4480], ids=["double_stream", "single_stream"]
+)
+def test_hidream_moe_cpu_vs_tt(seq_len):
+    """
+    Verify enable_sparse_mlp reproduces HiDream-I1's stock MoE block on TT.
+
+    Stock moe_infer sorts tokens by expert and slices one ragged group per
+    expert, so its shapes follow the router's output: a bincount graph break
+    plus a recompile per distinct group size. A2aSparseMLP keeps them static.
+    seq_len covers both block types -- the 16 double-stream blocks call ff_i
+    with 4096 image tokens, the 32 single-stream blocks with 4480 (image plus
+    text), batch 2 in both cases for CFG.
+    """
+    xr.set_device_type("TT")
+    torch.manual_seed(0)
+
+    dim = 2560
+    # hidden_dim is folded down internally: int(2 * 10240 / 3) -> 6912.
+    moe = MOEFeedForwardSwiGLU(
+        dim=dim,
+        hidden_dim=4 * dim,
+        num_routed_experts=4,
+        num_activated_experts=2,
+    )
+    moe = moe.to(torch.bfloat16).eval()
+
+    hidden_states = torch.randn(2, seq_len, dim, dtype=torch.bfloat16)
+
+    # Run stock moe_infer BEFORE enable_sparse_mlp (init restacks the experts)
+    with torch.no_grad():
+        golden = moe(hidden_states)
+
+    enable_spmd()
+    device = xm.xla_device()
+    mesh_shape = (1, xr.global_runtime_device_count())
+    mesh = get_mesh(mesh_shape, ("batch", "model"))
+    xs.set_global_mesh(mesh)
+
+    # HiDream spells it num_activated_experts, so without num_experts_per_tok
+    # create_a2a_from_deepseek_v3_moe falls back to its default of 6.
+    config = SimpleNamespace(n_routed_experts=4, num_experts_per_tok=2)
+    # cluster_axis=1: mesh is (1, N), so axis 0 would dispatch nowhere.
+    tt_moe = enable_sparse_mlp(moe, mesh=mesh_shape, cluster_axis=1, config=config).to(
+        device
+    )
+
+    # Experts stack into one tensor each, sharded on the expert dim. Mirrors
+    # get_tt_moe_shard_specs, which cannot be called here -- it walks
+    # model.model.layers.
+    experts = tt_moe.mlp.experts
+    compound = ("batch", "model")
+    xs.mark_sharding(experts.gate_proj, mesh, (compound, None, None))
+    xs.mark_sharding(experts.up_proj, mesh, (compound, None, None))
+    xs.mark_sharding(experts.down_proj, mesh, (compound, None, None))
+
+    compiled = torch.compile(tt_moe, backend="tt")
+    with torch.no_grad():
+        tt_out = compiled(hidden_states.to(device)).to("cpu")
+
+    TorchComparisonEvaluator(ComparisonConfig()).evaluate(tt_out, golden)


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/5947

### Problem description

- Step 1/10 of the denoising loop in HiDream-I1-Full took 4h 14m, caused by a graph break in the MoE. Full root cause analysis documented here: [Root cause analysis](https://github.com/tenstorrent/tt-xla/issues/5947#issuecomment-5306192623)

### What's changed

- HiDream-I1's MoE block (`MOEFeedForwardSwiGLU`) is now swapped to `A2aSparseMLP` via `enable_sparse_mlp`, which keeps every shape static. Stock `moe_infer` sorts tokens by expert and slices one ragged group per expert, so its shapes follow the router's output — a `bincount` graph break plus a recompile for every distinct group size.
- `RouterAdapter` now indexes the gate's return instead of unpacking it. HiDream's `MoEGate` returns `(topk_idx, topk_weight, aux_loss)`; the adapter assumed exactly two values and raised `ValueError: too many values to unpack (expected 2)`. Applies to any gate that appends an aux loss — not HiDream-specific.
- Added `test_hidream_moe_cpu_vs_tt` alongside the other sparse-MLP tests in `tests/torch/graphs/test_mlp.py`: stock `moe_infer` on CPU as golden vs `A2aSparseMLP` on TT, at the real block shapes (2, 4096, 2560) and (2, 4480, 2560). Both parametrizations pass.
- Bumps `third_party/tt_forge_models`: after the swap the per-expert `w1`/`w3`/`w2` Linears no longer exist, so `_shard_moe` specs the stacked `gate_proj`/`up_proj`/`down_proj` instead. 
- Effect on compilation, same e2e test, measured within step 1 of the denoising loop:

  | | before | after |
  | --- | --- | --- |
  | `PJRT_Client_Compile` | 564 | **1** |
  | `bincount` graph breaks | 149 | **0** |
  | distinct ragged `[K, 2560]` shapes | 191 | **none** |

- The two runs do not cover the same span — the before run completed step 1 and died in step 2, while the after run hits the rope OOM partway through step 1. Restricting to step 1 keeps the comparison like-for-like. Since the after run still does not complete a denoising step, whether this resolves the duration issue can only be confirmed once that OOM is fixed.

### Checklist

- [x] Verify the changes through local testing on QB2

### Logs

- [aug16_hidream_moe_sanity.log](https://github.com/user-attachments/files/31114128/aug16_hidream_moe_sanity.log)
- [hidream_before_fix.zip](https://github.com/user-attachments/files/31113495/org.zip)
- [hidream_after_fix.zip](https://github.com/user-attachments/files/31113491/after_fix.zip)
