### PR TITLE
Add p300 (2-chip Blackhole) to ALLOWED_ARCHES and qwen_3_5 27B TP test config

### DIFF
--- a/tests/runner/test_config/constants.py
+++ b/tests/runner/test_config/constants.py
@@ -14,6 +14,7 @@ ALLOWED_ARCHES = {
     "galaxy-bh",
     "qb2-blackhole",
     "lb-blackhole",
+    "p300",
 }
 
 # Allowed fields in test_config YAML entries

--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -518,7 +518,7 @@ test_config:
     enable_weight_bfp8_conversion: true
 
   qwen_3_5/causal_lm/pytorch-27B-tensor_parallel-inference:
-    supported_archs: [n300-llmbox]
+    supported_archs: [n300-llmbox, \"p300\"]
     status: EXPECTED_PASSING
 
   internlm2/pytorch-internlm2-chat-20b-tensor_parallel-inference:

--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -520,6 +520,10 @@ test_config:
   qwen_3_5/causal_lm/pytorch-27B-tensor_parallel-inference:
     supported_archs: [n300-llmbox, p300]
     status: EXPECTED_PASSING
+    arch_overrides:
+      p300:
+        status: KNOWN_FAILURE_XFAIL
+        reason: stock GDN conv1d DRAM auto-slice TT_FATAL on 2-die Blackhole (tt-metal #53303)
 
   internlm2/pytorch-internlm2-chat-20b-tensor_parallel-inference:
     supported_archs: [qb2-blackhole]

--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -518,7 +518,7 @@ test_config:
     enable_weight_bfp8_conversion: true
 
   qwen_3_5/causal_lm/pytorch-27B-tensor_parallel-inference:
-    supported_archs: [n300-llmbox, \"p300\"]
+    supported_archs: [n300-llmbox, p300]
     status: EXPECTED_PASSING
 
   internlm2/pytorch-internlm2-chat-20b-tensor_parallel-inference:


### PR DESCRIPTION
Adds `p300` to `ALLOWED_ARCHES` (2-die Blackhole alias used by metal/TIS) and lists it on the qwen_3_5 27B TP row so `pytest -m p300` can select that config.

Second commit un-escapes a YAML defect: `\"p300\"` parsed as a literal backslash-quoted string, so `-m p300` never matched.

Third commit marks **p300** as `KNOWN_FAILURE_XFAIL`. Stock GDN conv1d still hits DRAM auto-slice `TT_FATAL` on this 2-die topology (tt-metal #53303). `n300-llmbox` stays `EXPECTED_PASSING`.

This PR is host test-config only. It does not claim a passing official tt-xla 27B forward on p300.