### PR TITLE
[Benchmark] Wire the Ideogram 4 e2e pipeline into benchmark CI

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -96,6 +96,11 @@
         "runs-on": "qb2-blackhole"
       },
       {
+        "name": "ideogram_4",
+        "pytest": "tests/benchmark/test_imagegen.py::test_ideogram_4",
+        "runs-on": "qb2-blackhole"
+      },
+      {
         "name": "janus_pro_1b",
         "pytest": "tests/benchmark/test_imagegen.py::test_janus_pro"
       },

--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -98,7 +98,8 @@
       {
         "name": "ideogram_4",
         "pytest": "tests/benchmark/test_imagegen.py::test_ideogram_4",
-        "runs-on": "qb2-blackhole"
+        "runs-on": "qb2-blackhole",
+        "pyreq": "git+https://github.com/ideogram-oss/ideogram4.git"
       },
       {
         "name": "janus_pro_1b",

--- a/tests/benchmark/test_imagegen.py
+++ b/tests/benchmark/test_imagegen.py
@@ -602,3 +602,68 @@ def test_hunyuan_image_2_1(output_file, request):
         optimization_level=0,
         output_image_path="test_hunyuan_image_2_1_output.png",
     )
+
+
+def test_ideogram_4(output_file, request):
+    """Ideogram 4 diffusion text-to-image benchmark (DiT tensor-parallel).
+
+    Ideogram 4 is a 9.3B single-stream conditional DiT. Unlike the other image-gen
+    entries it runs **two** heavy transformer branches — conditional and
+    unconditional — and both are sharded Megatron-1D across the mesh, while the
+    Qwen3-VL text encoder, scheduler and VAE stay on CPU. Drives the shared
+    Ideogram4Pipeline from tt_forge_models (companion pipeline PR
+    tenstorrent/tt-forge-models#872). 512x512, 28 steps, guidance 7.0 — the shape
+    the tensor-parallel component test validates. Multichip — the matrix pins this
+    entry to the 4-chip blackhole (qb2-blackhole); a single chip hangs in
+    tt-metal's mesh command queue at 34-layer scale.
+
+    Note that classifier-free guidance means two transformer forwards per denoising
+    step, so the pipeline reports 2x num_inference_steps step samples under the
+    ``transformer_forward`` metric name.
+    """
+    from third_party.tt_forge_models.ideogram_4.pytorch.pipeline import (
+        GUIDANCE_SCALE,
+        HEIGHT,
+        WIDTH,
+        Ideogram4Config,
+        Ideogram4Pipeline,
+    )
+
+    prompt = (
+        "A ginger cat wearing a tiny wizard hat reading a spellbook, cozy library, "
+        "warm light, digital illustration"
+    )
+    num_inference_steps = 28
+    height, width = HEIGHT, WIDTH
+
+    def build_pipeline_fn(compile_options):
+        # Both DiT branches on TT (tensor-parallel sharded across the mesh); text
+        # encoder, scheduler and VAE on CPU. compile_options are already applied
+        # globally by the harness.
+        pipeline = Ideogram4Pipeline(
+            config=Ideogram4Config(compile_options=compile_options)
+        )
+        pipeline.setup()
+
+        def generate_fn(prompt, steps):
+            return pipeline.generate(
+                prompt=prompt,
+                num_inference_steps=steps,
+                seed=DEFAULT_SEED,
+                guidance_scale=GUIDANCE_SCALE,
+            )
+
+        return pipeline, generate_fn
+
+    test_imagegen(
+        build_pipeline_fn=build_pipeline_fn,
+        model_info_name="ideogram-4",
+        output_file=output_file,
+        request=request,
+        prompt=prompt,
+        num_inference_steps=num_inference_steps,
+        height=height,
+        width=width,
+        optimization_level=0,
+        output_image_path="test_ideogram_4_output.png",
+    )


### PR DESCRIPTION
### Ticket
N/A — benchmark wiring follow-up to the Ideogram 4 tensor-parallel bringup
(tt-forge-models#859 / #860) and the pipeline module (tt-forge-models#872).

### Problem description
Ideogram 4's DiT is brought up and runs tensor-parallel on the 4-chip Blackhole mesh, but nothing
measures the **full text-to-image pipeline** in the perf benchmark. Until now it could not be
wired at all: Ideogram 4 shipped only a component loader, and every image-gen benchmark entry
drives a shared `pipeline.py` from tt-forge-models. tt-forge-models#872 adds that module; this PR
consumes it.

### What's changed
- `tests/benchmark/test_imagegen.py` — adds `test_ideogram_4`, following the
  `test_hunyuan_image_2_1` / `test_glm_image` multichip pattern. Drives the shared
  `Ideogram4Pipeline`: both DiT branches tensor-parallel on the mesh, Qwen3-VL text encoder,
  scheduler and VAE on CPU. 512×512, 28 steps, guidance 7.0 — the shape the
  `tensor_parallel-inference` component test validates.
- `.github/workflows/perf-bench-matrix.json` — adds the `ideogram_4` entry pinned to
  `qb2-blackhole`, with `pyreq` installing the `ideogram4` package
  (`git+https://github.com/ideogram-oss/ideogram4.git`). The model-runner installs a loader's
  `requirements.txt` automatically (`tests/runner/requirements.py`); the perf-benchmark path does
  not, so the entry has to name the dependency itself.
- `third_party/tt_forge_models` — **temporary** pin to
  tenstorrent/tt-forge-models@`59042d4e`, the head of the #872 pipeline branch, purely so the
  benchmark below can execute before #872 lands. See *Land order*.

Two Ideogram-specific notes for reviewers:

- **Two heavy forwards per step.** Ideogram 4 runs a conditional *and* an unconditional
  transformer, and classifier-free guidance calls both every denoising step. The pipeline reports
  `2 × num_inference_steps` step samples under the `transformer_forward` metric name, rather than
  the `transformer_step` used by the single-branch models. Worth knowing before reading the step
  counts as anomalous.
- **Multichip only.** Pinned to `qb2-blackhole` because a single chip hangs in tt-metal's mesh
  command queue (`enqueue_write_shards`) at 34-layer scale. Sharding the SwiGLU MLP 4-way clears
  it. There is deliberately no single-device entry.

`optimization_level=0`, matching the other multichip DiT entries.

### Benchmark CI run
`Performance Benchmark` (`manual-benchmark.yml`) dispatched on this branch with
`test_filter=ideogram`, `runs-on-filter=qb2-blackhole`, `skip-device-perf=true`, i.e. the
`ideogram_4` matrix entry exactly as added here.

| Run | Commit | Result |
|---|---|---|
| [32130623856](https://github.com/tenstorrent/tt-xla/actions/runs/32130623856) | `a5cb9fe` | failed — `ModuleNotFoundError: No module named 'ideogram4'` |
| [32132498059](https://github.com/tenstorrent/tt-xla/actions/runs/32132498059) | `3e0c05e` | **success** — `1 passed in 563.05s`, numbers below |

The first run reached the runner, opened the mesh and entered `Ideogram4Pipeline.setup()`, then
failed importing `ideogram4.pipeline_ideogram4` — the benchmark job never installs a loader's
`requirements.txt`, unlike the model-runner. That is a genuine gap in this PR's matrix entry, not
an environment fluke, and it is what the `pyreq` field above fixes.

**Measured on `qb2-blackhole`, 512×512, 28 steps, guidance 7.0, bf16, batch 1:**

```
| Total samples: 1
| Total time (s): 47.433756782033015
| Avg. time per sample (s): 47.433756782033015
| Avg. samples per second: 0.021082032456235484
| Batch size: 1        | Data format: bfloat16      | Input size: (3, 512, 512)
| Num inference steps: 28
| Steady-state:
|   transformer_forward mean (s):  0.635
|   CPU overhead (s):    11.858
Warmup pass (includes compile): 70.916s     Steady-state pass: 47.434s
```

The numbers are internally consistent with the two-forwards-per-step behaviour described above:
28 steps × 2 forwards × 0.635 s = 35.6 s of transformer time, plus 11.86 s CPU overhead, equals the
47.43 s steady-state pass. So `transformer_forward` is being counted per *forward*, not per step,
as intended — 56 step samples for 28 denoising steps.

`0.021 samples/sec` is one 512×512 image every 47 s with the text encoder, scheduler and VAE on
host and `optimization_level=0`; the 11.86 s of CPU overhead (25% of the pass) is the host-side
pipeline, and is the obvious first target if we want this entry faster. The run also uploaded the
StableHLO / TTIR / TTNN dumps and `perf-reports-95700205185`, and saved
`test_ideogram_4_output.png`.

This is also why the submodule pin below exists: `test_ideogram_4` imports
`third_party.tt_forge_models.ideogram_4.pytorch.pipeline`, so with the previous pointer the
benchmark could not run at all. The gated `ideogram-ai/ideogram-4-fp8` weights are reachable in CI
via `secrets.HF_TOKEN` (`call-perf-test.yml`), which is what blocked running it on my box.

### Land order
merge tt-forge-models#872 → uplift `third_party/tt_forge_models` on tt-xla → **re-point the
submodule at the merged uplift commit** (dropping the temporary pin) → merge this PR.

Kept as a **draft** until #872 lands, so neither the matrix entry nor the temporary submodule pin
can go in ahead of the module they depend on. The
`from third_party.tt_forge_models.ideogram_4.pytorch.pipeline import ...` is inside the test
function (matching every other entry here), so **collection is unaffected**, and this PR cannot
break the existing benchmark or model-test jobs while it waits.

### Verification
- `perf-bench-matrix.json` parses, and every `test_imagegen.py::test_*` target it references
  resolves to a real function in the file (checked across the whole matrix, not just the new entry).
- `test_imagegen.py` compiles; `black 25.9.0` and `isort --profile black` (the pinned pre-commit
  versions) both clean.
- Every symbol the test imports (`HEIGHT`, `WIDTH`, `GUIDANCE_SCALE`, `Ideogram4Config`,
  `Ideogram4Pipeline`) exists at the pinned #872 commit, with `generate(prompt,
  num_inference_steps, seed, guidance_scale)` matching the call site.
- Benchmark **executed green in CI** on `qb2-blackhole` — see the run table and numbers above. The
  first run exposed the missing `ideogram4` dependency, fixed in the matrix entry.

The underlying TT path was already validated independently: both DiTs on the (1, 4) mesh,
single-forward PCC 0.9957, clean on-prompt image.

### Checklist
- [x] New/Existing tests provide coverage for changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
