### PR TITLE
[HunyuanVideo1.5] Replace distilled variant with base variant

### DIFF
--- a/examples/pytorch/hunyuan_video_1_5.py
+++ b/examples/pytorch/hunyuan_video_1_5.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Runnable HunyuanVideo 1.5 (480p t2v distilled) text-to-video example on Tenstorrent.
+"""Runnable HunyuanVideo 1.5 (480p t2v base) text-to-video example on Tenstorrent.
 
 Pipeline implementation lives in ``tt_forge_models``; this is a thin demo. The
 DiT (the heavy net) and the Qwen2.5-VL text encoder run tensor-parallel sharded

--- a/tests/benchmark/test_video_gen.py
+++ b/tests/benchmark/test_video_gen.py
@@ -85,8 +85,10 @@ def _run_video_gen(
 
 
 def test_hunyuan_video_1_5(output_file, request):
-    """HunyuanVideo 1.5 (480p t2v distilled): DiT and text encoders on TT,
-    scheduler/VAE on CPU. Config matches the nightly pipeline test."""
+    """HunyuanVideo 1.5 (480p t2v base): DiT and text encoders on TT,
+    scheduler/guider combine/VAE on CPU. Config matches the nightly pipeline
+    test. Guidance is real CFG, so each step is two DiT forwards and one
+    `transformer_step` entry covers both."""
     from third_party.tt_forge_models.hunyuan_1_5.pytorch.src.pipeline import (
         HunyuanVideo15Config,
         HunyuanVideo15Pipeline,
@@ -126,7 +128,7 @@ def test_hunyuan_video_1_5(output_file, request):
 
     _run_video_gen(
         build_pipeline_fn=build_pipeline_fn,
-        model_info_name="HunyuanVideo-1.5-480p-t2v-distilled",
+        model_info_name="HunyuanVideo-1.5-480p-t2v",
         output_file=output_file,
         prompt=PROMPT,
         num_inference_steps=NUM_INFERENCE_STEPS,

--- a/tests/torch/models/Hunyuan_1_5/test_hunyuan_video_1_5_pipeline.py
+++ b/tests/torch/models/Hunyuan_1_5/test_hunyuan_video_1_5_pipeline.py
@@ -2,10 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""HunyuanVideo 1.5 (480p t2v distilled) — nightly e2e pipeline test, every TT
+"""HunyuanVideo 1.5 (480p t2v base) — nightly e2e pipeline test, every TT
 component PCC-gated against a CPU twin in the same dtype. The Qwen2.5-VL and
-ByT5 encoders and the DiT run bf16 on TT; scheduler and VAE stay on CPU. The
-encoders are checked once each, the DiT once per denoising step.
+ByT5 encoders and the DiT run bf16 on TT; scheduler and VAE stay on CPU.
+
+Guidance is real CFG, so Qwen is checked twice (cond + uncond) and the DiT twice
+per denoising step; ByT5 once, since the negative prompt's glyph stream is zeros.
 """
 
 import pytest


### PR DESCRIPTION
## Ticket
[[HunyuanVideo-1.5] Replace distilled variant with base variant #5986](https://github.com/tenstorrent/tt-xla/issues/5986)

## Problem description

The component loader and the e2e pipeline both targeted `480p_t2v_distilled`, which was brought up for its 1x DiT forward per step — it is CFG-distilled (guidance-distilled), so guidance is baked into the weights, the unconditional branch is skipped, and the denoise loop runs ~2x faster. The current required variant is the base model, so both should target it: guidance is no longer baked into the weights, so the denoising loop needs restructuring — two forwards per step with a host-side combine — not just a new checkpoint. Full variant comparison in [#5986](https://github.com/tenstorrent/tt-xla/issues/5986).


## What's changed

- Tracks [tt-forge-models#892](https://github.com/tenstorrent/tt-forge-models/pull/892), which carries the loader and pipeline changes. Once it lands and the auto-uplift picks it up, this PR will be rebased onto the new submodule pointer.
- `examples/pytorch/hunyuan_video_1_5.py`: docstring updated to the base variant. No code change — guidance comes from the repo's `guider`, not a `generate()` kwarg, so the demo's call signature is unchanged.
- `tests/benchmark/test_video_gen.py`: `model_info_name` `HunyuanVideo-1.5-480p-t2v-distilled` → `HunyuanVideo-1.5-480p-t2v`, and docstring updated for the CFG call pattern. Each step is now two DiT forwards, so device time per video roughly doubles at the same step count; `perf["steps"]` keeps one entry per denoising step covering both forwards, so `transformer_step_mean_s` roughly doubles too.
- `tests/torch/models/Hunyuan_1_5/test_hunyuan_video_1_5_pipeline.py`: docstring updated for the CFG call pattern — Qwen checked twice (conditional + unconditional), ByT5 once (the negative prompt's glyph stream is zeros), transformer twice per denoising step.

## Known issue

The base variant's e2e nightly PCC test can intermittently collapse (~-0.08) at a random forward — 1/2 local runs, 0/4 CI runs (all green). RCA in [#5991](https://github.com/tenstorrent/tt-xla/issues/5991#issuecomment-5461679912). Safe to merge as CI is green.


## Checklist

- Cpu parity check -  [cpu_parity_check.zip](https://github.com/user-attachments/files/31292833/cpu_parity_check.zip)
- PCC gated nightly test - [run 33239390557](https://github.com/tenstorrent/tt-xla/actions/runs/33239390557/job/99067448364)
- Benchmark - https://github.com/tenstorrent/tt-xla/actions/runs/33173999819
- Demo - [run 33244902988](https://github.com/tenstorrent/tt-xla/actions/runs/33244902988/job/99081973755)

## Generated Video

Prompt : `A girl holding a paper with words "Hello, world!"`, 10 inference steps, 25 frames, 15 fps

https://github.com/user-attachments/assets/ec9e89cd-79b7-46bd-9e03-ba6c0bd503ae



