### PR TITLE
Add Mochi-1 video-gen benchmark

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -670,6 +670,14 @@
           "qb2-blackhole"
         ],
         "group": "experimental"
+      },
+      {
+        "name": "mochi_1_preview",
+        "pytest": "tests/benchmark/test_video_gen.py::test_mochi_1_preview",
+        "runs-on": [
+          "qb2-blackhole"
+        ],
+        "group": "experimental"
       }
     ]
   }

--- a/tests/benchmark/benchmarks/video_gen_pipeline_benchmark.py
+++ b/tests/benchmark/benchmarks/video_gen_pipeline_benchmark.py
@@ -10,8 +10,8 @@ components (a compiled wrapper + input tensors); this harness drives a full
 multi-step generation pipeline and reads its per-stage/per-step instrumentation.
 
 Two-pass scheme:
-  - Pass 1 (warmup): a single-step ``generate()`` — triggers the first-forward
-    compile of the model's TT components.
+  - Pass 1 (warmup): a short ``generate()`` (``warmup_steps``, 1 by default) —
+    triggers the first-forward compile of the model's TT components.
   - Pass 2 (steady-state): a full ``generate(num_inference_steps)`` — every
     forward is a cache hit; this pass's video is saved and drives the report.
 
@@ -53,6 +53,7 @@ def benchmark_video_gen_pipeline_torch_xla(
     ttnn_perf_metrics_output_file,
     display_name=None,
     output_video_path=None,
+    warmup_steps=1,
 ):
     """Benchmark a text-to-video diffusion pipeline on the TT backend.
 
@@ -72,6 +73,10 @@ def benchmark_video_gen_pipeline_torch_xla(
         ttnn_perf_metrics_output_file: Base path for TTNN perf metrics files.
         display_name: Display name used for export naming / dashboard.
         output_video_path: If set, the steady-state video is saved here.
+        warmup_steps: Denoising steps for the warmup pass. 1 is enough to trigger
+            the compile; raise it only for models whose sigma schedule cannot be
+            built at 1 step (e.g. Mochi-1 divides by zero,
+            https://github.com/tenstorrent/tt-xla/issues/5999).
 
     Returns:
         Standardized benchmark result dict (see ``create_benchmark_result``).
@@ -100,7 +105,7 @@ def benchmark_video_gen_pipeline_torch_xla(
     # Pass 1 (warmup): 1 step is enough to trigger the first-forward compile.
     print("Starting warmup pass (includes compile)...")
     warmup_start = time.perf_counter()
-    generate_fn(prompt, 1)
+    generate_fn(prompt, warmup_steps)
     warmup_time = time.perf_counter() - warmup_start
     print(f"Warmup pass: {warmup_time:.3f}s")
 

--- a/tests/benchmark/test_video_gen.py
+++ b/tests/benchmark/test_video_gen.py
@@ -18,6 +18,7 @@ from utils import aggregate_ttnn_perf_metrics, resolve_display_name
 DEFAULT_OPTIMIZATION_LEVEL = 0
 DEFAULT_TRACE_ENABLED = False
 DEFAULT_SEED = 42
+DEFAULT_WARMUP_STEPS = 1
 
 
 def _run_video_gen(
@@ -34,6 +35,7 @@ def _run_video_gen(
     optimization_level=DEFAULT_OPTIMIZATION_LEVEL,
     trace_enabled=DEFAULT_TRACE_ENABLED,
     output_video_path=None,
+    warmup_steps=DEFAULT_WARMUP_STEPS,
 ):
     """Run a text-to-video benchmark with the given configuration."""
     resolved_display_name = resolve_display_name(
@@ -69,6 +71,7 @@ def _run_video_gen(
         trace_enabled=trace_enabled,
         ttnn_perf_metrics_output_file=ttnn_perf_metrics_output_file,
         output_video_path=output_video_path,
+        warmup_steps=warmup_steps,
     )
 
     if output_file:
@@ -132,4 +135,67 @@ def test_hunyuan_video_1_5(output_file, request):
         num_frames=NUM_FRAMES,
         fps=FPS,
         request=request,
+    )
+
+
+def test_mochi_1_preview(output_file, request):
+    """Mochi-1 preview: DiT and T5-XXL text encoder on TT, scheduler/VAE on CPU.
+    Config matches the nightly pipeline test."""
+    from third_party.tt_forge_models.mochi.pytorch.src.pipeline import (
+        Mochi1Config,
+        Mochi1Pipeline,
+    )
+
+    PROMPT = (
+        "Close-up of a chameleon's eye, with its scaly skin changing color. "
+        "Ultra high resolution 4k."
+    )
+    HEIGHT = 480
+    WIDTH = 848
+    # 24 frames / 10 steps instead of the stock 84 / 64:
+    # https://github.com/tenstorrent/tt-xla/issues/4638
+    NUM_FRAMES = 24
+    NUM_INFERENCE_STEPS = 10
+    FPS = 15
+    # Mochi's linear_quadratic_schedule splits the steps into a linear and a
+    # quadratic half, so at 1 step linear_steps == 0 and it divides by zero.
+    # 2 is the smallest workable value; the compiled graph is the same either
+    # way. https://github.com/tenstorrent/tt-xla/issues/5999
+    WARMUP_STEPS = 2
+
+    def build_pipeline_fn(compile_options):
+        # compile_options are applied globally by the harness before this call;
+        # the pipeline configures TT via SPMD sharding and needs nothing further.
+        pipeline = Mochi1Pipeline(
+            config=Mochi1Config(
+                num_inference_steps=NUM_INFERENCE_STEPS,
+                height=HEIGHT,
+                width=WIDTH,
+                num_frames=NUM_FRAMES,
+            )
+        )
+        pipeline.setup()
+
+        def generate_fn(prompt, num_inference_steps):
+            return pipeline.generate(
+                prompt=prompt,
+                seed=DEFAULT_SEED,
+                num_inference_steps=num_inference_steps,
+                output_type="pil",
+            )
+
+        return pipeline, generate_fn
+
+    _run_video_gen(
+        build_pipeline_fn=build_pipeline_fn,
+        model_info_name="Mochi-1-preview",
+        output_file=output_file,
+        prompt=PROMPT,
+        num_inference_steps=NUM_INFERENCE_STEPS,
+        height=HEIGHT,
+        width=WIDTH,
+        num_frames=NUM_FRAMES,
+        fps=FPS,
+        request=request,
+        warmup_steps=WARMUP_STEPS,
     )


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-xla/issues/6001
- fixes https://github.com/tenstorrent/tt-xla/issues/5999

### Problem description

- Mochi-1 has no video-gen benchmark, so it isn't covered by the nightly perf matrix.

### What's changed

- Add `test_mochi_1_preview` to `tests/benchmark/test_video_gen.py` — 480x848, 24 frames, 10 steps (per #4638), mirroring `test_hunyuan_video_1_5`.
- Register `mochi_1_preview` in `perf-bench-matrix.json` (qb2-blackhole, `experimental` group).
- Add a `warmup_steps` knob to the video-gen harness, default 1 so other models are unchanged. Mochi uses 2: its `linear_quadratic_schedule` divides by zero at 1 step. For additional details see [#5999](https://github.com/tenstorrent/tt-xla/issues/5999).

### Checklist
- [x] Performance Benchmark - https://github.com/tenstorrent/tt-xla/actions/runs/32704610418/job/97366196825
