### PR TITLE
[pyramid_flow] Wire the text-to-video e2e pipeline into nightly

### DIFF
--- a/tests/torch/models/pyramid_flow/__init__.py
+++ b/tests/torch/models/pyramid_flow/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/torch/models/pyramid_flow/test_pyramid_flow_pipeline.py
+++ b/tests/torch/models/pyramid_flow/test_pyramid_flow_pipeline.py
@@ -6,18 +6,26 @@
 
 Runs the full text-to-video pipeline end-to-end: the CLIP text encoder, the
 1.97B ``PyramidFluxTransformer`` DiT and the ``CausalVideoVAE`` decoder all run
-on Tenstorrent via ``torch.compile(backend="tt")``. The pyramid flow-matching
-sampler stays on CPU - it is control flow, not a net.
+on Tenstorrent via ``torch.compile(backend="tt")``. Two pieces stay on host on
+purpose: the 4.76B T5-XXL encoder, which feeds the DiT's
+``encoder_hidden_states`` but reaches only PCC 0.8598 on device, and the pyramid
+flow-matching sampler, which is control flow rather than a net.
 
 Per-component bringup that this test assembles:
   - DiT + CLIP text encoder: tt-forge-models#841
   - CausalVideoVAE decode:   tt-forge-models#900 (PCC 0.999956, T=1, n150)
+  - the pipeline itself:      tt-forge-models#905
 
-The reusable pipeline implementation belongs in ``tt_forge_models`` next to the
+The reusable pipeline implementation lives in ``tt_forge_models`` next to the
 components it drives, the way SD1.5's does
 (``third_party/tt_forge_models/stable_diffusion_1_5/pytorch/pipeline.py``), so
-this file only wires it into CI. Until that companion PR lands the import below
-fails and the test skips rather than erroring at collection.
+this file only wires it into CI. Until #905 merges and the submodule is uplifted
+the import below fails and the test skips rather than erroring at collection.
+
+Measured on one n150 through #905's own driver (bf16, 384p, ``temp=1``, 4 steps
+per pyramid stage): host-vs-device final latent PCC 0.983202. That is
+accumulated drift over 12 bf16 DiT forwards plus the decode, not a component
+number - the gated per-component PCCs are in #900 and #841.
 
 Scope, for now: one temporal unit (``temp=1``, a single latent frame), 384p,
 single device. That is the shape #900 validated the VAE decode at; the
@@ -49,7 +57,9 @@ PROMPT = (
     "A red double-decker bus driving along a sunny coastal road, "
     "waves breaking on the beach below"
 )
-NEGATIVE_PROMPT = ""
+# None keeps upstream's own negative prompt, which the pipeline applies by
+# default - the frame a prompt produces then matches upstream's for that prompt.
+NEGATIVE_PROMPT = None
 SEED = 12345
 VARIANT = "diffusion_transformer_384p"
 # 384p renders 640x384. temp=1 -> a single frame (temp=k -> 8k-7 frames).

--- a/tests/torch/models/pyramid_flow/test_pyramid_flow_pipeline.py
+++ b/tests/torch/models/pyramid_flow/test_pyramid_flow_pipeline.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pyramid Flow (miniFLUX) - nightly e2e pipeline test. WORK IN PROGRESS.
+
+Runs the full text-to-video pipeline end-to-end: the CLIP text encoder, the
+1.97B ``PyramidFluxTransformer`` DiT and the ``CausalVideoVAE`` decoder all run
+on Tenstorrent via ``torch.compile(backend="tt")``. The pyramid flow-matching
+sampler stays on CPU - it is control flow, not a net.
+
+Per-component bringup that this test assembles:
+  - DiT + CLIP text encoder: tt-forge-models#841
+  - CausalVideoVAE decode:   tt-forge-models#900 (PCC 0.999956, T=1, n150)
+
+The reusable pipeline implementation belongs in ``tt_forge_models`` next to the
+components it drives, the way SD1.5's does
+(``third_party/tt_forge_models/stable_diffusion_1_5/pytorch/pipeline.py``), so
+this file only wires it into CI. Until that companion PR lands the import below
+fails and the test skips rather than erroring at collection.
+
+Scope, for now: one temporal unit (``temp=1``, a single latent frame), 384p,
+single device. That is the shape #900 validated the VAE decode at; the
+multi-frame chunked decode still does not trace.
+"""
+
+from pathlib import Path
+
+import pytest
+import torch_xla.runtime as xr
+from infra import RunMode
+from loguru import logger
+from utils import BringupStatus, Category, ModelGroup
+
+try:
+    from third_party.tt_forge_models.pyramid_flow.pytorch.pipeline import (
+        PyramidFlowConfig,
+        PyramidFlowPipeline,
+        save_video,
+    )
+
+    PIPELINE_AVAILABLE = True
+except ImportError:
+    # The pipeline module lands with the companion tt-forge-models PR; skip
+    # instead of failing collection for every other test in the file's package.
+    PIPELINE_AVAILABLE = False
+
+PROMPT = (
+    "A red double-decker bus driving along a sunny coastal road, "
+    "waves breaking on the beach below"
+)
+NEGATIVE_PROMPT = ""
+SEED = 12345
+VARIANT = "diffusion_transformer_384p"
+# 384p renders 640x384. temp=1 -> a single frame (temp=k -> 8k-7 frames).
+WIDTH = 640
+HEIGHT = 384
+TEMP = 1
+GUIDANCE_SCALE = 7.0
+FPS = 24
+
+
+def run_pyramid_flow_pipeline(
+    output_path: str = "pyramid_flow_output.mp4",
+    num_inference_steps: tuple = (8, 8, 8),
+):
+    """Run the Pyramid Flow pipeline with CLIP, the DiT and the VAE on TT."""
+    config = PyramidFlowConfig(
+        variant=VARIANT,
+        text_encoder_on_tt=True,
+        transformer_on_tt=True,
+        vae_on_tt=True,
+    )
+    pipeline = PyramidFlowPipeline(config=config)
+    pipeline.setup()
+
+    frames = pipeline.generate(
+        prompt=PROMPT,
+        negative_prompt=NEGATIVE_PROMPT,
+        temp=TEMP,
+        guidance_scale=GUIDANCE_SCALE,
+        num_inference_steps=list(num_inference_steps),
+        seed=SEED,
+    )
+
+    save_video(frames, output_path, fps=FPS)
+    return output_path
+
+
+@pytest.mark.skipif(
+    not PIPELINE_AVAILABLE,
+    reason="Pyramid Flow pipeline module lands with the companion tt-forge-models PR",
+)
+@pytest.mark.nightly
+@pytest.mark.model_test
+@pytest.mark.single_device
+@pytest.mark.large
+@pytest.mark.record_test_properties(
+    category=Category.MODEL_TEST,
+    model_name="PyramidFlow_Pipeline",
+    model_group=ModelGroup.GENERALITY,
+    run_mode=RunMode.INFERENCE,
+    bringup_status=BringupStatus.NOT_STARTED,
+)
+def test_pyramid_flow_pipeline():
+    """Run the full Pyramid Flow text-to-video pipeline with the DiT on TT."""
+    xr.set_device_type("TT")
+
+    output_path = "pyramid_flow_output.mp4"
+    output_file = Path(output_path)
+    if output_file.exists():
+        output_file.unlink()
+
+    run_pyramid_flow_pipeline(output_path=output_path)
+
+    assert output_file.exists(), f"Output video {output_path} was not created"
+    logger.info(f"Output video saved to {output_path} ({WIDTH}x{HEIGHT}, temp={TEMP})")


### PR DESCRIPTION
> **Draft — the CI wiring is here; the pipeline module it drives is now open as tenstorrent/tt-forge-models#905 and needs merging plus a submodule uplift before this test can run.** The e2e path is measured (numbers below); this stays draft until the import guard can come off.

### Ticket

Part of #4447 (Bringup pyramid flow model). Depends on tenstorrent/tt-forge-models#900 (`CausalVideoVAE` decode on TT), which closes #6006.

Jira: TEN-1066 → follow-up TEN-1074.

### Problem description

Pyramid Flow's components have been brought up one at a time, and with tt-forge-models#900 the last heavy net gets a device path:

| Component | Params | State |
|---|---:|---|
| `PyramidFluxTransformer` DiT | 1.97B | on TT — tt-forge-models#841 |
| CLIP text encoder | 0.12B | on TT — tt-forge-models#841 |
| `CausalVideoVAE` decode | 225.77M | on TT — tt-forge-models#900, PCC 0.999956 at T=1 |
| T5-XXL text encoder (`text_encoder_2`) | 4.76B | on device but PCC 0.8598, not exposed — TEN-1074 |
| Pyramid flow-matching sampler | — | CPU; control flow, not a net |

What is missing is the thing that runs them together. Every component test drives one net on synthetic inputs, so nothing in CI executes Pyramid Flow as a model: no end-to-end signal, no e2e latency number, and no coverage of the host↔device handoffs between the three nets — which is where the interesting failures live (dtype at the boundary, the sampler's per-stage reshapes, the latent the VAE is handed).

The existing evidence for the full path is a local CPU-vs-TT video comparison (latent PCC 0.9258 on one chip, 0.9156 tensor-parallel over four) run from a script against a clone of upstream's repo. That is not runnable in CI.

### What's changed

The tt-xla side of the wiring:

- `tests/torch/models/pyramid_flow/test_pyramid_flow_pipeline.py` — a nightly `model_test` that runs text → video with the CLIP encoder, the DiT and the VAE decoder all on TT, and asserts an mp4 comes out. Marked `nightly`, `model_test`, `single_device`, `large`.
- Scope for this first pass, matching what the components are validated at: 384p (640×384), `temp=1` (one temporal unit, i.e. a single latent frame — the shape #900 measured the VAE decode at, since the multi-frame chunked decode still does not trace), single device.

The pipeline implementation itself is deliberately **not** in this file. Pyramid Flow has no diffusers integration, so its module code is vendored in tt-forge-models (`src/flux_modules/` for the DiT, `src/video_vae/` in #900), and the pipeline belongs next to the components it drives — the same split SD1.5 and SD3 use, where `tests/torch/models/.../test_*_pipeline.py` is a thin CI wrapper over `third_party/tt_forge_models/<model>/pytorch/pipeline.py` shared with the benchmark harness. Copying upstream's sampler into a tt-xla test would duplicate vendored code and leave the benchmark path unable to reuse it.

So the import of `PyramidFlowPipeline` is guarded: until the companion tt-forge-models PR lands, the test skips with a stated reason instead of erroring at collection. `bringup_status` is `NOT_STARTED` for the same honesty — it flips to `PASSED` with a measured run in this PR before it leaves draft.

### Land order

1. tt-forge-models#900 (VAE decode) — approved-and-merge path, green, no companion needed.
2. Companion tt-forge-models#905: `pyramid_flow/pytorch/pipeline.py` — vendors the pyramid flow-matching sampler and provides the `PyramidFlowPipeline` / `PyramidFlowConfig` / `save_video` surface this test imports, with `text_encoder_on_tt` / `transformer_on_tt` / `vae_on_tt` flags. **Open (draft, stacked on #900).**
3. Uplift `third_party/tt_forge_models` on tt-xla.
4. This PR: drop the import guard, set `bringup_status=PASSED`, attach the measured e2e run (CPU-vs-TT frame comparison + wall-clock split), and add the `pyramid_flow/pytorch-Vae-single_device-inference` runner entry.
5. Benchmark entry (`tests/benchmark`), following the shape of #5085 for SD1.5/SD3 and #5960 for Ideogram 4.

### Out of scope

- Multi-frame video: `temp>1` walks temporal windows in a stateful Python loop carrying causal-conv state, which does not trace. `temp=1` is one frame.
- The T5-XXL encoder stays on host and stays unexposed until its PCC gap is root-caused (TEN-1074). The pipeline uses the CLIP encoder path.
- Multi-device: the tensor-parallel DiT path exists locally but is not what this test exercises.

### Verification

The tt-xla side is formatted and collects (the test skips on the guarded import, by design). The end-to-end path it will run is measured through #905's own driver on one Wormhole **n150** (`ARCH_NAME=wormhole_b0`, bf16, 384p, `temp=1`, 4 steps per pyramid stage = 12 DiT forwards, seed 12345):

| Leg | setup | sample | decode | total |
|---|---:|---:|---:|---:|
| all host | 4.2 s | 24.7 s | 6.0 s | 30.7 s |
| DiT + VAE on TT | 5.1 s | 402.1 s | 108.8 s | 511.0 s |

Final latent `(1, 16, 1, 48, 80)`, host golden vs device: **PCC 0.983202**, MAE 0.168899, max abs diff 2.843750 on a golden max abs of 5.093750. That is accumulated drift over 12 bf16 DiT forwards plus a bf16 decode — not a component PCC, and not claimed against the 0.99 component gate (the gated numbers are #900's 0.999956 for the decode). It is consistent with the 0.9258 single-chip latent PCC measured earlier on this model through upstream's own script. Both frames render the same scene; the device frame is lower in contrast and fine detail.

Graph count, for the record: 13 compilations — three during sampling (one per pyramid stage, which is the minimum since the latent shape changes at each stage) and ten inside the single VAE decode, where the 48x80 → 640x384 decode breaks up into ten subgraphs against one for the 32x32 → 256x256 shape #900 measures. Sampling is then ~33 s per step with no recompilation. Both are follow-ups, not blockers for the wiring.

When the guard comes off in step 4, this test flips to `bringup_status=PASSED` with the runner log attached.

### Checklist

- [ ] New/Existing tests provide coverage for changes
