### PR TITLE
Skip MNIST CNN Dropout and compiler_options: SIGFPE in ttnn matmul config

### DIFF
--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -56,6 +56,7 @@ XFAIL_FILES: dict[str, str] = {
     "jax/codegen/python/emitpy_execute.py": "Broken by a change in EmitPy, fix tracked at https://github.com/tenstorrent/tt-mlir/issues/8325",
     "pytorch/olmo3_1025_7b.py": "Failing with Device count mismatch: 1 vs 2 - Related #4624",
     "pytorch/mistral_8b.py": "Failing with Device count mismatch: 1 vs 2 - Related #4624",
+    "pytorch/compiler_options.py": "SIGFPE (integer divide-by-zero) in ttnn create_simple_matmul_program_config for MNIST fc1 - https://github.com/tenstorrent/tt-metal/issues/54639. Triggered by the optimization_level: 2 this example sets; crashes the process rather than failing.",
 }
 
 

--- a/tests/runner/test_config/torch/test_config_inference_single_device.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_single_device.yaml
@@ -161,7 +161,8 @@ test_config:
     status: EXPECTED_PASSING
 
   mnist/image_classification/pytorch-Cnn_Dropout-single_device-inference:
-    status: EXPECTED_PASSING
+    status: NOT_SUPPORTED_SKIP
+    reason: "SIGFPE (integer divide-by-zero) in ttnn create_simple_matmul_program_config for the 4x9216 @ 9216x128 fc1 - https://github.com/tenstorrent/tt-metal/issues/54639. Crashes the process, so it cannot run to a classified failure. Needs optimization_level >= 1; restore status and the settings below once the metal fix lands."
     # Set required_pcc here to verify in push that required_pcc set is safe (it wasn't always)
     required_pcc: 0.99
     markers: [push, nightly]


### PR DESCRIPTION
Companion frontend PR for the tt-metal uplift in tenstorrent/tt-mlir#9244.

Both tests crash the process with `SIGFPE` (integer divide-by-zero) on the uplift.

### Root cause

`ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp:1160`
divides by `per_core_M` without guarding zero:

```cpp
per_core_M = std::min(get_per_core_factor(...), Mt);
num_blocks_y = (Mt - 1) / per_core_M + 1;   // SIGFPE when per_core_M == 0
```

Reached via `OpModel<LinearOp>::getOpConstraints` -> `ttnn::linear` ->
`bound_matmul` -> `get_program_config` for MNIST fc1 (`4x9216 @ 9216x128`, M=4,
below the 32-row tile height).

Filed as **tenstorrent/tt-metal#54639**, with a `ttmlir-opt` repro.

### Why skip and not xfail

The process dies, so neither test can run to a classified failure — same
rationale as the existing `pocket_tts` and host-OOM skips in that config file.
For the example, `pytest.xfail()` short-circuits before launching the
subprocess, so the `XFAIL_FILES` entry is effectively a skip there.

### Confirmed uplift-specific

Both pass on tt-mlir main (metal `d5f9bc4a`) and fail on the uplift to
`58342a6f`. Verified by running `full-mlir-uplift-qualification.json` against
main — those jobs are green there.

### Restoring

Triggered at `optimization_level >= 1`. Both keep their existing settings
(`optimization_level: 2`, `required_pcc: 0.99`, markers), so restoring is
flipping `status` back and dropping the `XFAIL_FILES` entry once #54639 is
fixed.

### Merge order -- please do not merge early

Both tests **currently pass on tt-xla main**, which pins a tt-mlir without this
uplift (verified: the full qualification suite is green for these jobs against
tt-mlir main). Merging this before tt-xla picks up the uplift drops working
coverage for no benefit.

Raised now so it is *ready* per the uplift process bar, not to merge
immediately.