### PR TITLE
Cast mixed integer index dtypes to int64 for XLA advanced indexing

### DIFF
--- a/python_package/tt_torch/backend/backend.py
+++ b/python_package/tt_torch/backend/backend.py
@@ -48,6 +48,7 @@ from .passes import (
     bypass_dtype_promotion_and_redundant_cast,
     bypass_redundant_getitem,
     cast_bool_cumsum_to_int32,
+    cast_index_tensors_to_long,
     clamp_neg_getitem_bounds,
     clamp_neg_slice_bounds,
     fold_view_bmm_view_to_einsum,
@@ -524,6 +525,10 @@ def torch_pass_pipeline(
     # bool cumsum inputs to int32. Runs for both the AOTAutograd and torch.export
     # paths (common point after the branch). Refs: whisper find_packed_sequence_indices.
     cast_bool_cumsum_to_int32(compiled_graph)
+
+    # Widen mixed integer index dtypes to int64: torch_xla concatenates index
+    # tensors when lowering advanced indexing, and XLA rejects mixed types.
+    cast_index_tensors_to_long(compiled_graph)
 
     compiled_graph = insert_argument_type_markers(
         compiled_graph, graph_signature, flat_name_to_original_fqn

--- a/python_package/tt_torch/backend/passes.py
+++ b/python_package/tt_torch/backend/passes.py
@@ -386,6 +386,53 @@ def cast_bool_cumsum_to_int32(gm: torch.fx.GraphModule) -> None:
         gm.recompile()
 
 
+def cast_index_tensors_to_long(gm: torch.fx.GraphModule) -> None:
+    """Cast non-int64 integer index tensors of aten.index / aten.index_put
+    variants to int64. torch_xla concatenates index tensors when lowering
+    advanced indexing, and XLA's concatenate rejects mixed int32/int64
+    (e.g. FlexAttention's create_block_mask)."""
+    index_targets = {
+        torch.ops.aten.index.Tensor,
+        torch.ops.aten._unsafe_index.Tensor,
+        torch.ops.aten.index_put.default,
+        torch.ops.aten.index_put_.default,
+        torch.ops.aten._unsafe_index_put.default,
+    }
+    changed = False
+    for node in list(gm.graph.nodes):
+        if node.op != "call_function" or node.target not in index_targets:
+            continue
+        indices = node.args[1]
+        if not isinstance(indices, (list, tuple)):
+            continue
+        new_indices = []
+        node_changed = False
+        for idx in indices:
+            val = idx.meta.get("val") if isinstance(idx, torch.fx.Node) else None
+            if (
+                val is None
+                or val.dtype.is_floating_point
+                or val.dtype in (torch.bool, torch.int64)
+            ):
+                new_indices.append(idx)
+                continue
+            with gm.graph.inserting_before(node):
+                cast = gm.graph.call_function(
+                    torch.ops.aten._to_copy.default,
+                    args=(idx,),
+                    kwargs={"dtype": torch.int64},
+                )
+                cast.meta["val"] = val.to(torch.int64)
+            new_indices.append(cast)
+            node_changed = True
+        if node_changed:
+            node.update_arg(1, type(indices)(new_indices))
+            changed = True
+    if changed:
+        gm.graph.lint()
+        gm.recompile()
+
+
 def handle_composite_ops(gm: torch.fx.GraphModule) -> None:
     """
     Replaces torch ops with composite ops if we have a proper replacement.

--- a/python_package/tt_torch/torch_overrides.py
+++ b/python_package/tt_torch/torch_overrides.py
@@ -42,6 +42,26 @@ def _to_pair(value: int | tuple[int, int] | list[int]) -> tuple[int, int]:
     return (value, value) if isinstance(value, int) else tuple(value)
 
 
+def _cast_int_indices_to_long(key):
+    """Cast non-int64 integer index tensors to int64. torch_xla concatenates
+    index tensors when lowering advanced indexing, and XLA's concatenate
+    rejects mixed int32/int64 (e.g. FlexAttention's create_block_mask)."""
+
+    def cast(item):
+        if (
+            isinstance(item, torch.Tensor)
+            and not item.dtype.is_floating_point
+            and item.dtype not in (torch.bool, torch.int64)
+        ):
+            return item.long(), True
+        return item, False
+
+    if isinstance(key, (tuple, list)):
+        items, changes = zip(*(cast(item) for item in key)) if key else ((), ())
+        return type(key)(items), any(changes)
+    return cast(key)
+
+
 def _unfold_via_gather(
     inp: torch.Tensor,
     kernel_size,
@@ -106,6 +126,17 @@ class TorchFunctionOverride(TorchFunctionMode):
             and args[0].device.type == "xla"
         ):
             new_key, changed = clamp_neg_slice_key(args[0].shape, args[1])
+            if changed:
+                args = (args[0], new_key, *args[2:])
+
+        if (
+            func.__name__ in ("__setitem__", "__getitem__", "index_put", "index_put_")
+            and not torch.compiler.is_compiling()
+            and len(args) >= 2
+            and isinstance(args[0], torch.Tensor)
+            and args[0].device.type == "xla"
+        ):
+            new_key, changed = _cast_int_indices_to_long(args[1])
             if changed:
                 args = (args[0], new_key, *args[2:])
 

--- a/tests/torch/models/krea_realtime/test_krea_realtime_e2e_pipeline.py
+++ b/tests/torch/models/krea_realtime/test_krea_realtime_e2e_pipeline.py
@@ -36,7 +36,7 @@ from third_party.tt_forge_models.krea_realtime_video.pytorch.src.model_utils imp
     load_transformer,
 )
 
-NUM_BLOCKS = 1  # >1 pending investigation (S64/S32 dtype mismatch in flex_attention's create_block_mask): https://github.com/tenstorrent/tt-xla/issues/5837
+NUM_BLOCKS = 1  # TODO: >1 needs ttnn::sort stable=True support (flex_attention's create_block_mask): https://github.com/tenstorrent/tt-xla/issues/6041
 PCC_THRESHOLD = 0.95
 
 _PCC_EVALUATOR = TorchComparisonEvaluator(ComparisonConfig(assert_on_failure=False))

--- a/tests/torch/ops/test_index_put_mixed_dtype.py
+++ b/tests/torch/ops/test_index_put_mixed_dtype.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Advanced-index assignment with mixed int32/int64 indices. torch_xla
+concatenates index tensors when lowering; mixed dtypes fail XLA's type check.
+Hit by FlexAttention's create_block_mask (Krea Realtime builds it on device,
+eagerly), hence both the eager and compiled paths are covered."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra.utilities.types import Framework
+
+from tests.infra.testers.single_chip.op.op_tester import run_op_test
+
+
+def _index_put(dense, rows, cols):
+    dense = dense.clone()
+    dense[rows, cols] = 1.0
+    return dense
+
+
+def _make_inputs(device=None):
+    dense = torch.zeros(4, 6, device=device)
+    rows = torch.arange(4, dtype=torch.int32, device=device).unsqueeze(-1)
+    cols = torch.arange(4, dtype=torch.int64, device=device).unsqueeze(-1)
+    return dense, rows, cols
+
+
+@pytest.mark.nightly
+@pytest.mark.single_device
+def test_index_put_mixed_dtype_compiled():
+    run_op_test(_index_put, list(_make_inputs()), framework=Framework.TORCH)
+
+
+@pytest.mark.nightly
+@pytest.mark.single_device
+def test_index_put_mixed_dtype_eager():
+    """Eager lazy-tensor path — the one the Krea model takes."""
+    xr.set_device_type("TT")
+    device_out = _index_put(*_make_inputs(torch_xla.device()))
+    torch_xla.sync()
+    assert torch.equal(device_out.cpu(), _index_put(*_make_inputs()))


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-xla/issues/5837

### Problem description

- Advanced indexing with mixed int32/int64 index tensors is legal PyTorch and runs fine on CPU/CUDA, but fails on TT with `RuntimeError: Cannot concatenate arrays with different element types: S64 vs S32`. torch_xla lowers multi-tensor advanced indexing by concatenating the index tensors into one scatter/gather coordinate tensor, and XLA's concatenate requires uniform element types. Hit by FlexAttention's `create_block_mask` (int32 arange indices meeting torch.vmap's int64 batch index), which Krea Realtime builds on device — blocking the e2e pipeline in both eager and compiled execution.

### What's changed

- Widen non-int64 integer index tensors to int64 before torch_xla lowers them (index widening doesn't change which elements are selected). Applied at both entry points, since eager and compiled routes reach torch_xla independently:
  -  **Eager:** `_cast_int_indices_to_long` in `torch_overrides.py` — normalizes indices of `__setitem__` / `__getitem__` / `index_put(_)` on XLA tensors via the existing `TorchFunctionOverride`.
  - **Compiled:** `cast_index_tensors_to_long` FX pass in `backend/passes.py` — inserts `_to_copy(dtype=int64)` on integer index args of `aten.index` / `aten.index_put` variants; wired into `torch_pass_pipeline` after `cast_bool_cumsum_to_int32` (common point for AOTAutograd and torch.export paths).
- Impact: Krea Realtime e2e gets past block-mask construction (previous failure);  The e2e now surfaces the next pre-existing gap, `ttnn::sort stable=True` (#6041) — comment updated in the e2e test.

### Checklist
- [x] New/Existing tests provide coverage for changes — `tests/torch/ops/test_index_put_mixed_dtype.py`: one test per path (eager + compiled), both red before the fix and green after, with CPU-golden comparison.

### Logs

- [sep2_krea_e2e_nb_2_before_fix.log.zip](https://github.com/user-attachments/files/31746840/sep2_krea_e2e_nb_2_before_fix.log.zip)
- [sep2_index_put_before_fix.log](https://github.com/user-attachments/files/31746835/sep2_index_put_before_fix.log)
- [sep2_index_put_after_fix.log](https://github.com/user-attachments/files/31746834/sep2_index_put_after_fix.log)
- [sep2_krea_e2e_nb_2_after_fix.log.zip](https://github.com/user-attachments/files/31746837/sep2_krea_e2e_nb_2_after_fix.log.zip)
