### PR TITLE
[VibeVoice] Add the end-to-end TTS pipeline test, benchmark and demo

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -102,6 +102,11 @@
         "group": "experimental"
       },
       {
+        "name": "vibevoice_1_5b",
+        "pytest": "tests/benchmark/test_tts.py::test_vibevoice_1_5b",
+        "group": "experimental"
+      },
+      {
         "name": "llama_3_1_8b_instruct",
         "pytest": "tests/benchmark/test_llms.py::test_llama_3_1_8b",
         "group": "regular"

--- a/examples/pytorch/vibevoice_1_5b.py
+++ b/examples/pytorch/vibevoice_1_5b.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Runnable VibeVoice-1.5B (microsoft/VibeVoice-1.5B) text-to-speech example.
+
+The pipeline implementation lives in ``tt_forge_models``; this is a thin runnable
+demo that calls it.
+
+VibeVoice clones the timbre of a reference clip rather than selecting a fixed
+speaker ID, so the inputs are a script and a voice-prompt wav; the demo defaults
+to the clip shipped with the vendored submodule. The diffusion head and both
+speech connectors run on the Tenstorrent backend; the acoustic/semantic
+tokenizers and the Qwen2 LM backbone run on CPU. That hybrid is the target
+configuration — see ``pipeline.LM_RESIDENCY_NOTE`` for what moving the LM needs.
+
+Each component on device is PCC-gated per forward against a CPU twin of itself,
+so the run reports whether the device path actually matched, not just that it
+produced audio. Pass ``gate=False`` for a plain synthesis without the twins.
+
+Run (single-chip wormhole, n150/n300):
+    python examples/pytorch/vibevoice_1_5b.py
+"""
+
+import torch
+import torch_xla.runtime as xr
+
+from third_party.tt_forge_models.vibevoice.pytorch.pipeline import (
+    DEFAULT_TEXT,
+    OUTPUT_SAMPLE_RATE,
+    run_vibevoice_pipeline,
+)
+
+OUTPUT_PATH = "vibevoice_1_5b_output.wav"
+
+
+def main():
+    xr.set_device_type("TT")
+
+    # max_new_tokens is left at the pipeline default so generation runs until the
+    # model emits EOS, i.e. the full utterance rather than a fixed budget.
+    wav, pipeline = run_vibevoice_pipeline(
+        output_path=OUTPUT_PATH,
+        text=DEFAULT_TEXT,
+        # float32: the CPU twins are the PCC reference for the device forwards,
+        # so they should not themselves be quantised.
+        dtype=torch.float32,
+        seed=0,
+    )
+
+    duration = wav.shape[-1] / OUTPUT_SAMPLE_RATE
+    print(
+        f"\nSaved output audio to {OUTPUT_PATH} "
+        f"({duration:.2f}s @ {OUTPUT_SAMPLE_RATE} Hz, {pipeline.steps} LM steps, "
+        f"stop={'EOS' if pipeline.saw_eos else 'step cap'})"
+    )
+    print(f"\n{pipeline.summary()}")
+    print(
+        "\nPer-forward PCC is the device-correctness check. It is NOT an "
+        "end-to-end acceptance criterion: waveform PCC against a CPU golden "
+        "reads 0.734 on a fully correct run, because each frame's latent feeds "
+        "back into the next LM step and a 3e-05 per-forward difference compounds. "
+        "Listen to the wav, or transcribe it."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmark/benchmarks/vibevoice_pipeline.py
+++ b/tests/benchmark/benchmarks/vibevoice_pipeline.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""VibeVoice-1.5B (microsoft/VibeVoice-1.5B) — benchmark-side wiring for the TTS harness.
+
+``VibeVoicePipeline`` in tt-forge-models already populates the whole ``_perf``
+contract when built with ``collect_perf=True``, ``compile_curve`` included, so
+this module is configuration rather than instrumentation.
+
+Stage decomposition, in ``run()`` order: ``tokenizer_encode`` (voice-prompt
+conditioning) -> the per-acoustic-frame loop (``steps``: ``ddpm_steps`` diffusion
+head forwards on TT, both connectors on TT, and the CPU LM decode for that step)
+-> ``audio_decode`` (latents to waveform).
+
+Two settings differ from the nightly test and both are deliberate:
+
+* ``gate=False``. The nightly test runs a CPU twin of every resident component in
+  lockstep to PCC-gate each forward. That roughly doubles the wall time and would
+  be measured as if it were device work — the 85.9 s / RTF 22.20x first reading
+  of this model was exactly that mistake.
+* ``max_new_tokens`` is pinned rather than left to EOS. The harness requires the
+  generated length to be identical across passes; pinning it makes that a
+  property of the configuration instead of something the run has to reproduce.
+"""
+
+# Acoustic frames per run. Each is one LM decode step plus ddpm_steps diffusion
+# head forwards, and yields ~3200 output samples at 24 kHz, so 32 frames is
+# roughly 4 s of audio — the same order as the natural EOS length of the default
+# script, which keeps the number comparable to the nightly test's.
+MAX_NEW_TOKENS = 32
+
+# Re-applied before every generate(). The diffusion loop draws noise per frame
+# and that noise feeds back into the next LM step, so without a fixed seed the
+# generated length itself drifts run to run and the harness's equal-length
+# assertion fires.
+DEFAULT_SEED = 0
+
+
+def make_bench_vibevoice_pipeline():
+    """Build a benchmark-configured ``VibeVoicePipeline`` (not yet set up)."""
+    import torch
+
+    from third_party.tt_forge_models.vibevoice.pytorch.pipeline import (
+        DEFAULT_COMPONENTS,
+        VibeVoiceConfig,
+        VibeVoicePipeline,
+    )
+
+    config = VibeVoiceConfig(
+        components=DEFAULT_COMPONENTS,
+        # float32: the acoustic decoder reads 0.988 in bf16 against 0.998 in
+        # fp32, so the pipeline is benchmarked in the precision it is correct in.
+        dtype=torch.float32,
+        max_new_tokens=MAX_NEW_TOKENS,
+        seed=DEFAULT_SEED,
+        gate=False,
+        collect_perf=True,
+    )
+    return VibeVoicePipeline(config), config

--- a/tests/benchmark/test_tts.py
+++ b/tests/benchmark/test_tts.py
@@ -12,7 +12,8 @@ second.
 
 XTTS-v2 needs ``coqui-tts`` + ``torchaudio``, absent from the base test
 environment, so every run is wrapped in ``RequirementsManager``. Its weights are
-CPML-gated behind ``COQUI_TOS_AGREED``.
+CPML-gated behind ``COQUI_TOS_AGREED``. VibeVoice-1.5B needs neither: its
+inference code is a pinned submodule and it runs on the base transformers.
 """
 
 import inspect
@@ -105,5 +106,72 @@ def test_xtts_v2(output_file, request):
             save_wav_fn=save_wav,
             data_format=DEFAULT_DATA_FORMAT,
         )
+
+    _write_results(results, output_file, model_info_name, perf_metrics_file)
+
+
+def test_vibevoice_1_5b(output_file, request):
+    """VibeVoice-1.5B end-to-end text-to-speech benchmark (real-time factor).
+
+    Unlike XTTS-v2 this needs no ``RequirementsManager``: the loader runs on the
+    base test environment's transformers, and the vendored inference code is a
+    pinned submodule rather than a pip dependency.
+
+    The diffusion head and both speech connectors run on TT; the acoustic and
+    semantic tokenizers and the Qwen2 LM backbone run on CPU. That hybrid is the
+    target configuration for this model, so the ``lm_cpu`` share of the reported
+    stage times is expected to be large — it is host work that is *meant* to be
+    there, not an unaccounted gap.
+    """
+    from benchmarks.tts_benchmark import benchmark_tts_torch_xla
+    from benchmarks.vibevoice_pipeline import (
+        MAX_NEW_TOKENS,
+        make_bench_vibevoice_pipeline,
+    )
+
+    from third_party.tt_forge_models.vibevoice.pytorch.pipeline import (
+        DEFAULT_TEXT as VIBEVOICE_TEXT,
+    )
+    from third_party.tt_forge_models.vibevoice.pytorch.pipeline import (
+        OUTPUT_SAMPLE_RATE as VIBEVOICE_SAMPLE_RATE,
+    )
+    from third_party.tt_forge_models.vibevoice.pytorch.pipeline import save_wav
+
+    model_info_name = "vibevoice-1.5b"
+    display_name = resolve_display_name(request=request, fallback=model_info_name)
+    perf_metrics_file = f"tt_xla_{display_name}_perf_metrics"
+
+    # Held so save_wav can reuse the pipeline's processor rather than loading a
+    # second one off disk just to write the output file.
+    built = {}
+
+    def build_pipeline_fn(compile_options):
+        pipeline, config = make_bench_vibevoice_pipeline()
+        pipeline.setup()
+        built["pipeline"] = pipeline
+
+        def generate_fn(text, max_audio_tokens):
+            config.text = text
+            config.max_new_tokens = max_audio_tokens
+            return pipeline.run()
+
+        return pipeline, generate_fn
+
+    results = benchmark_tts_torch_xla(
+        build_pipeline_fn=build_pipeline_fn,
+        model_info_name=model_info_name,
+        display_name=display_name,
+        text=VIBEVOICE_TEXT,
+        max_audio_tokens=MAX_NEW_TOKENS,
+        sample_rate=VIBEVOICE_SAMPLE_RATE,
+        optimization_level=DEFAULT_OPTIMIZATION_LEVEL,
+        trace_enabled=DEFAULT_TRACE_ENABLED,
+        ttnn_perf_metrics_output_file=perf_metrics_file,
+        output_wav_path="test_vibevoice_1_5b_output.wav",
+        save_wav_fn=lambda wav, path: save_wav(
+            wav, path, processor=built["pipeline"].processor
+        ),
+        data_format=DEFAULT_DATA_FORMAT,
+    )
 
     _write_results(results, output_file, model_info_name, perf_metrics_file)

--- a/tests/torch/models/vibevoice/__init__.py
+++ b/tests/torch/models/vibevoice/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/torch/models/vibevoice/test_acoustic_decoder.py
+++ b/tests/torch/models/vibevoice/test_acoustic_decoder.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""VibeVoice-1.5B — acoustic tokenizer decoder component test. Params: ~344 M.
+
+Decodes one acoustic latent frame into a 3200-sample waveform chunk; the
+generation loop calls this once per emitted frame.
+
+Runs in **float32**, not bfloat16, deliberately. In bfloat16 this component
+lands at PCC 0.988, just under the 0.99 gate; in float32 it is 0.998. The
+error is precision in a deep causal-conv stack rather than a compiler defect,
+so the fix is the dtype rather than a weakened threshold.
+"""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+
+from third_party.tt_forge_models.vibevoice.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.nightly
+@pytest.mark.model_test
+@pytest.mark.single_device
+def test_acoustic_decoder():
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.ACOUSTIC_DECODER)
+    model = loader.load_model(dtype_override=torch.float32)
+    inputs = loader.load_inputs(dtype_override=torch.float32)
+
+    run_graph_test(model, inputs, framework=Framework.TORCH)

--- a/tests/torch/models/vibevoice/test_acoustic_encoder.py
+++ b/tests/torch/models/vibevoice/test_acoustic_encoder.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""VibeVoice-1.5B — acoustic tokenizer encoder component test. Params: ~344 M.
+
+Encodes the full 222480-sample voice prompt into 70 acoustic latent frames
+(3200:1 compression), which is the length the real conditioning path produces.
+
+The encode is **chunked**, in 32000-sample pieces carrying upstream's streaming
+conv cache across the boundaries. One pass over the whole prompt overflows L1 in
+``ttnn.pad`` — 8115264 B of circular buffers against a 1499136 B limit — and the
+boundary is an input-length one: 3200, 12800 and 32000 samples all pass, 64000
+does not. The chunking lives in the loader's wrapper rather than in this test so
+the e2e path gets it too, and it is exact rather than approximate: against a
+single full-length encode it reads PCC 1.00000000 on CPU, where chunking the
+naive way (each chunk independent) reads 0.9616.
+"""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+
+from third_party.tt_forge_models.vibevoice.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.nightly
+@pytest.mark.model_test
+@pytest.mark.single_device
+def test_acoustic_encoder():
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.ACOUSTIC_ENCODER)
+    model = loader.load_model(dtype_override=torch.bfloat16)
+    inputs = loader.load_inputs(dtype_override=torch.bfloat16)
+
+    run_graph_test(model, inputs, framework=Framework.TORCH)

--- a/tests/torch/models/vibevoice/test_connectors.py
+++ b/tests/torch/models/vibevoice/test_connectors.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""VibeVoice-1.5B — both SpeechConnectors component test. Params: ~5 M."""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+
+from third_party.tt_forge_models.vibevoice.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.nightly
+@pytest.mark.model_test
+@pytest.mark.single_device
+def test_connectors():
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.CONNECTORS)
+    model = loader.load_model(dtype_override=torch.bfloat16)
+    inputs = loader.load_inputs(dtype_override=torch.bfloat16)
+
+    run_graph_test(model, inputs, framework=Framework.TORCH)

--- a/tests/torch/models/vibevoice/test_diffusion_head.py
+++ b/tests/torch/models/vibevoice/test_diffusion_head.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""VibeVoice-1.5B — diffusion prediction head component test. Params: ~123 M.
+
+One denoise step of the acoustic diffusion head, conditioned on the LM hidden
+state. Batch 2 because the CFG path concatenates the conditional and negative
+branches into a single forward.
+"""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+
+from third_party.tt_forge_models.vibevoice.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.nightly
+@pytest.mark.model_test
+@pytest.mark.single_device
+def test_diffusion_head():
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.DIFFUSION_HEAD)
+    model = loader.load_model(dtype_override=torch.bfloat16)
+    inputs = loader.load_inputs(dtype_override=torch.bfloat16)
+
+    run_graph_test(model, inputs, framework=Framework.TORCH)

--- a/tests/torch/models/vibevoice/test_lm_prefill.py
+++ b/tests/torch/models/vibevoice/test_lm_prefill.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""VibeVoice-1.5B — Qwen2.5 decoder prefill + LM head component test.
+
+Params: ~1.54 B. This is the backbone the landed logits-only bringup already
+covered; the test here differs by running it with **pretrained** weights at the
+128-token conditioning-prompt length the TTS path actually produces.
+"""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+
+from third_party.tt_forge_models.vibevoice.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.nightly
+@pytest.mark.model_test
+@pytest.mark.single_device
+def test_lm_prefill():
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.LM_PREFILL)
+    model = loader.load_model(dtype_override=torch.bfloat16)
+    inputs = loader.load_inputs(dtype_override=torch.bfloat16)
+
+    run_graph_test(model, inputs, framework=Framework.TORCH)

--- a/tests/torch/models/vibevoice/test_semantic_encoder.py
+++ b/tests/torch/models/vibevoice/test_semantic_encoder.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""VibeVoice-1.5B — semantic tokenizer encoder component test. Params: ~345 M.
+
+Encodes one 3200-sample audio chunk (the acoustic tokenizer's compression
+ratio, so one latent frame's worth) into semantic features.
+"""
+
+import pytest
+import torch
+import torch_xla
+import torch_xla.runtime as xr
+from infra import Framework, run_graph_test
+
+from third_party.tt_forge_models.vibevoice.pytorch import ModelLoader, ModelVariant
+
+
+@pytest.mark.nightly
+@pytest.mark.model_test
+@pytest.mark.single_device
+def test_semantic_encoder():
+    xr.set_device_type("TT")
+    torch.manual_seed(42)
+
+    loader = ModelLoader(ModelVariant.SEMANTIC_ENCODER)
+    model = loader.load_model(dtype_override=torch.bfloat16)
+    inputs = loader.load_inputs(dtype_override=torch.bfloat16)
+
+    run_graph_test(model, inputs, framework=Framework.TORCH)

--- a/tests/torch/models/vibevoice/test_vibevoice_e2e_pipeline.py
+++ b/tests/torch/models/vibevoice/test_vibevoice_e2e_pipeline.py
@@ -1,0 +1,216 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""VibeVoice-1.5B nightly end-to-end text-to-speech pipeline test.
+
+Runs the full ``generate()`` path — text + voice prompt in, waveform out — with
+the diffusion head and both speech connectors resident on TT and the acoustic /
+semantic tokenizers and the LM backbone on CPU. That split is the target shape
+rather than a workaround; see ``pipeline.LM_RESIDENCY_NOTE`` for why the LM is
+not in it.
+
+Three gates, in increasing order of what they can catch:
+
+1. the output artifact is a finite, non-empty 24 kHz waveform;
+2. every forward of every TT-resident component matches a CPU twin of itself
+   (per-forward PCC, accumulated in float64);
+3. **the generated audio transcribes back to the requested sentence.**
+
+(3) is the one that is both necessary and sufficient, and this model is the
+reason to say so out loud. The acceptance-criteria question has failed here in
+both directions:
+
+* A broken run — fluent, well-formed, correctly-scaled speech that said nothing
+  like the input text — passed every signal statistic there is (finite values,
+  amplitude range, RMS, near-silent-frame fraction). Those are not acceptance
+  criteria for this model.
+* A fully **correct** run fails waveform PCC. Per-forward PCC of 0.99997 lands at
+  a waveform PCC of 0.734 against a CPU golden while being the same length,
+  stopping at the same step and transcribing identically: there are
+  ``ddpm_steps`` solver steps per acoustic frame and each frame's latent feeds
+  back through the connectors into the next LM step, so a 3e-05 per-forward
+  difference compounds across the autoregressive frames.
+
+So there is deliberately **no waveform-PCC assert here**, and adding one would
+fail a correct run. For any model with a stochastic sampling loop feeding an
+autoregressive one, the semantic check is the only gate stable under correct
+numerics.
+"""
+
+import pytest
+import torch
+from infra import RunMode
+from utils import BringupStatus, Category, ModelGroup
+
+# Per-forward correlation floor for each TT-resident component against its CPU
+# twin. The measured minimum across a passing run is 0.999939.
+PCC_THRESHOLD = 0.99
+
+# Word-error-rate ceiling for the transcript gate.
+#
+# The absolute number looks loose and is not. The reference sentence normalises
+# to 11 words, three of which no ASR renders as one token — "Tenstorrent" comes
+# back as "Ten Store", "VibeVoice" as "Vibe Voice", "end to end" as
+# "end-to-end" — so a *fully correct* waveform reads 0.45-0.64, and the
+# transformers-4.51.3 reference implementation scores 0.64 on its own output.
+# The failure this gate exists to catch reads 20-51. The margin is ~20x, and
+# tightening the threshold would fail correct runs rather than catch more.
+MAX_WER = 0.9
+
+ASR_MODEL = "openai/whisper-small.en"
+ASR_SAMPLE_RATE = 16000
+
+
+def _normalise(text):
+    """Lowercase, strip punctuation, split on whitespace."""
+    import re
+
+    return re.sub(r"[^a-z0-9 ]", "", text.lower()).split()
+
+
+def _wer(reference, hypothesis):
+    """Standard Levenshtein word error rate."""
+    import numpy as np
+
+    ref, hyp = _normalise(reference), _normalise(hypothesis)
+    distance = np.zeros((len(ref) + 1, len(hyp) + 1), dtype=np.int32)
+    distance[:, 0] = np.arange(len(ref) + 1)
+    distance[0, :] = np.arange(len(hyp) + 1)
+    for i in range(1, len(ref) + 1):
+        for j in range(1, len(hyp) + 1):
+            cost = 0 if ref[i - 1] == hyp[j - 1] else 1
+            distance[i, j] = min(
+                distance[i - 1, j] + 1,
+                distance[i, j - 1] + 1,
+                distance[i - 1, j - 1] + cost,
+            )
+    return distance[len(ref), len(hyp)] / max(len(ref), 1)
+
+
+def _transcribe(wav_path):
+    """Transcribe a wav with Whisper on CPU.
+
+    Resampling is done with scipy rather than the ASR pipeline's own resampler,
+    which needs torchaudio (absent from the base test environment).
+    """
+    from math import gcd
+
+    import soundfile as sf
+    from scipy.signal import resample_poly
+    from transformers import pipeline as hf_pipeline
+
+    asr = hf_pipeline(
+        "automatic-speech-recognition",
+        model=ASR_MODEL,
+        dtype=torch.float32,
+        device="cpu",
+        chunk_length_s=30,
+    )
+
+    audio, sample_rate = sf.read(wav_path, dtype="float32")
+    if audio.ndim > 1:
+        audio = audio.mean(axis=1)
+    if sample_rate != ASR_SAMPLE_RATE:
+        divisor = gcd(sample_rate, ASR_SAMPLE_RATE)
+        audio = resample_poly(
+            audio, ASR_SAMPLE_RATE // divisor, sample_rate // divisor
+        ).astype("float32")
+    return asr({"raw": audio, "sampling_rate": ASR_SAMPLE_RATE})["text"].strip()
+
+
+@pytest.mark.nightly
+@pytest.mark.model_test
+@pytest.mark.large
+@pytest.mark.single_device
+@pytest.mark.record_test_properties(
+    category=Category.MODEL_TEST,
+    model_name="VibeVoice_1_5B_Pipeline",
+    model_group=ModelGroup.GENERALITY,
+    run_mode=RunMode.INFERENCE,
+    bringup_status=BringupStatus.PASSED,
+)
+def test_vibevoice_e2e_pipeline(tmp_path):
+    """Full VibeVoice chain on TT: waveform validity, per-forward PCC, transcript."""
+    pytest.importorskip("torch_xla")
+    import torch_xla.runtime as xr
+
+    from third_party.tt_forge_models.vibevoice.pytorch.pipeline import (
+        DEFAULT_REFERENCE_TRANSCRIPT,
+        OUTPUT_SAMPLE_RATE,
+        VibeVoiceConfig,
+        VibeVoicePipeline,
+        save_wav,
+    )
+
+    xr.set_device_type("TT")
+    if xr.global_runtime_device_count() < 1:
+        pytest.skip("No TT device available")
+
+    pipeline = VibeVoicePipeline(
+        VibeVoiceConfig(
+            # float32 throughout: the CPU twin is the PCC golden for the TT run,
+            # so it must not itself be quantised, and the acoustic decoder reads
+            # 0.988 in bf16 against 0.998 in fp32 (precision in a deep causal-conv
+            # stack, not a compiler defect).
+            dtype=torch.float32,
+            gate=True,
+            pcc_threshold=PCC_THRESHOLD,
+        )
+    ).setup()
+    wav = pipeline.run()
+
+    output_path = str(tmp_path / "vibevoice_e2e_output.wav")
+    save_wav(wav, output_path, processor=pipeline.processor)
+
+    # 1) Output artifact validity. Necessary, nowhere near sufficient — the
+    #    broken run this model produced in August satisfied all of this.
+    assert wav.shape[-1] > 0, "pipeline produced an empty waveform"
+    assert torch.isfinite(wav).all(), "waveform contains non-finite samples"
+    seconds = wav.shape[-1] / OUTPUT_SAMPLE_RATE
+    # print, not logger: the loguru sinks are torn down around tests (see
+    # conftest's newline_logger), and these numbers are what the run is for.
+    print(
+        f"[e2e] {wav.shape[-1]} samples = {seconds:.2f}s over {pipeline.steps} "
+        f"LM steps, stop={'EOS' if pipeline.saw_eos else 'STEP CAP (truncated)'}",
+        flush=True,
+    )
+
+    # 2) Per-forward PCC for every component resident on TT. Raised inside the
+    #    residency wrapper the moment a forward drops below the threshold, so
+    #    reaching here means every forward passed; assert the summary anyway so
+    #    a residency that recorded nothing cannot pass silently.
+    print(f"[e2e] {pipeline.summary()}", flush=True)
+    for residency in pipeline.residencies:
+        assert residency.pccs, (
+            f"{residency.name} is resident on TT but recorded no gated forwards; "
+            f"the residency wrapper was bypassed"
+        )
+    worst = pipeline.worst_pcc()
+    assert (
+        worst >= PCC_THRESHOLD
+    ), f"worst per-forward PCC {worst:.6f} < {PCC_THRESHOLD}"
+
+    # 3) The transcript gate. Deliberately last and deliberately the only content
+    #    check — see the module docstring for why waveform PCC is not used.
+    try:
+        transcript = _transcribe(output_path)
+    except Exception as exc:  # ASR weights unreachable -> the gate did not run
+        pytest.skip(
+            f"could not run the transcript gate ({type(exc).__name__}: {exc}); "
+            f"the waveform and PCC checks passed but CONTENT WAS NOT VERIFIED, "
+            f"which is the only check that catches this model's failure mode"
+        )
+
+    score = _wer(DEFAULT_REFERENCE_TRANSCRIPT, transcript)
+    print(
+        f"[e2e] reference:  {DEFAULT_REFERENCE_TRANSCRIPT!r}\n"
+        f"[e2e] transcript: {transcript!r}\n"
+        f"[e2e] WER={score:.2f} (gate <= {MAX_WER})",
+        flush=True,
+    )
+    assert score <= MAX_WER, (
+        f"generated audio does not say the requested sentence: WER {score:.2f} > "
+        f"{MAX_WER}\n  reference:  {DEFAULT_REFERENCE_TRANSCRIPT!r}\n"
+        f"  transcript: {transcript!r}"
+    )


### PR DESCRIPTION
### Ticket

Closes #5217 — `[Model Bringup] VibeVoice 1.5B`

### Problem description

VibeVoice-1.5B was brought up single-device on n150, but that bringup deliberately
exercised only the Qwen2.5 LM backbone: `speech_tensors=None`, seq_len 32, random
weights from the vendored `config.json`, and a bare logits tensor as the output. None
of the actual text-to-speech stack — the acoustic and semantic VAE tokenizers, both
speech connectors, the diffusion head, the sampling loop — had ever touched hardware,
and the model produces no audio on that path. "1.5B" refers to the LM backbone; the
full model is ~2.7B params, and the remaining ~1.2B was entirely uncovered.

### What's changed

Brings the model to a real end-to-end result on TT: text plus a voice prompt in,
waveform out, with real `microsoft/VibeVoice-1.5B` weights.

The diffusion head and both speech connectors run resident on TT; the acoustic and
semantic tokenizers and the LM backbone run on CPU. **That split is the target shape,
not a workaround.** Moving the LM on device needs a static, max-length-padded KV
cache: upstream's `DynamicCache` grows by one token per decode step, so every step
presents a new shape and recompiles (measured ~76–157 s per step, tripping
`recompile_limit` at step 4). It is a dynamic-shape problem, not a missing-op or a
capacity one. Documented on `pipeline.LM_RESIDENCY_NOTE` and tracked separately.

Added:

- **Six per-component single-device tests** plus the e2e test under
  `tests/torch/models/vibevoice/`. Every component fits on one device, so nothing is
  xfailed. Measured PCC vs CPU, accumulated in float64: connectors 0.999995,
  `semantic_encoder` 0.999952, `diffusion_head` 0.999867, `lm_prefill` 0.999494,
  `acoustic_decoder` 0.998248.
- **The nightly e2e test**, with three gates in increasing order of what they catch:
  waveform validity; per-forward PCC against a CPU twin of each resident component;
  and the transcript.
- **`tests/benchmark/test_tts.py::test_vibevoice_1_5b`** plus its pipeline wiring,
  registered in `perf-bench-matrix.json` under `experimental`, alongside `xtts_v2`.
- **`examples/pytorch/vibevoice_1_5b.py`**, picked up automatically by the examples
  glob — it needs no `RequirementsManager` entry, because the inference code is a
  pinned submodule rather than a pip dependency.

#### Why the e2e gate is a transcript and not a waveform PCC assert

This is the part worth reviewing, and this model is the reason to state it out loud.
The acceptance-criteria question failed here in *both* directions:

- A **broken** run — fluent, well-formed, correctly-scaled speech that said nothing
  like the input text — passed every signal statistic available: finite values,
  amplitude range, RMS, near-silent-frame fraction. Those are not acceptance criteria
  for this model.
- A fully **correct** run fails waveform PCC. Per-forward PCC of 0.99997 lands at a
  waveform PCC of 0.734 against a CPU golden while being the same length, stopping at
  the same step, and transcribing identically. There are `ddpm_steps` solver steps per
  acoustic frame and each frame's latent feeds back through the connectors into the
  next LM step, so a 3e-05 per-forward difference compounds across the autoregressive
  frames.

So there is deliberately no waveform-PCC assert — adding one would fail a correct run.
For any model with a stochastic sampling loop feeding an autoregressive one, the
semantic check is the only gate stable under correct numerics.

The WER ceiling of 0.9 looks loose and is not: the reference sentence normalises to 11
words, three of which no ASR renders as one token ("Tenstorrent" → "Ten Store",
"VibeVoice" → "Vibe Voice"), so a *correct* waveform reads 0.45–0.64 — the
transformers-4.51.3 reference implementation scores 0.64 on its own output. The failure
this gate exists to catch reads 20–51. That is ~20x of margin, and tightening it would
fail correct runs rather than catch more.

#### Two other deliberate choices

- **fp32 throughout.** The CPU twin is the PCC reference for the device forwards, so it
  must not itself be quantised; and the acoustic decoder reads 0.988 in bf16 against
  0.998 in fp32 — precision in a deep causal-conv stack, not a compiler defect.
- **The benchmark runs with the CPU twins off** (`gate=False`) while the nightly test
  runs with them on. Gated, the twins execute in lockstep and roughly double the wall
  time while being measured as if they were device work; the first reading of this
  model, 85.9 s at RTF 22.20x, was exactly that mistake.

### Measurements (n150)

| | Result |
| --- | --- |
| `test_vibevoice_e2e_pipeline` | 1 passed in 58.04s |
| `test_vibevoice_1_5b` (benchmark) | 1 passed in 71.59s — RTF **0.272x**, 3.31 decode tok/s, **0 recompiles** in the steady-state pass (29 → 29) |
| Demo | 4.13s of audio over 33 LM steps, terminating at a real EOS |
| Per-forward PCC over a full run | `diffusion_head` 310 forwards, min 0.999939 / mean 0.999997; both connectors 32 and 31 forwards at 1.000000 |

### Depends on

- **tt-forge-models `[VibeVoice] Add the end-to-end TTS pipeline …`** — this PR imports
  `third_party/tt_forge_models/vibevoice/pytorch/pipeline.py`, which lands there. CI
  here cannot go green until that merges and the submodule pin is uplifted. No
  submodule change is included in this PR.
- **The `apply_xla_dynamo_guard_repr_patch` fix in `python_package/tt_torch/utils.py`**
  (separate PR). Two divergences from torch on the `NN_MODULE` → `ID_MATCH` guard path
  block compilation of *any* model reaching it, including this one's diffusion head.

### Supersedes

- **#5343** — adds `test_encoders.py::test_vibevoice`, the LM-only seq_len-32
  logits benchmark. `test_tts.py::test_vibevoice_1_5b` measures the actual TTS pipeline
  instead; keeping both would double-count device time in nightly. Recommend closing
  #5343 as superseded.

### Checklist

- [x] New/Existing tests provide coverage for changes
