### PR TITLE
Add new tensor-parallel inference configs for qb2-blackhole . 

### DIFF
--- a/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
+++ b/tests/runner/test_config/torch/test_config_inference_tensor_parallel.yaml
@@ -570,3 +570,53 @@ test_config:
   seed_oss/pytorch-Seed-OSS-36B-Instruct-tensor_parallel-inference:
     supported_archs: [qb2-blackhole]
     status: EXPECTED_PASSING
+
+  nvidia/nemotron/pytorch-Nvidia_Nemotron_3_5_Lightning_30B_A3B_BF16-tensor_parallel-inference:
+    supported_archs: [qb2-blackhole]
+    status: EXPECTED_PASSING
+    inject_custom_moe: true
+    required_pcc: 0.95
+
+  deepseek/deepseek_moe_16b/pytorch-DEEPSEEK_MOE_16B_CHAT-tensor_parallel-inference:
+    supported_archs: [qb2-blackhole]
+    status: EXPECTED_PASSING
+
+  qwen_3_vl/multimodal/pytorch-32b_instruct-tensor_parallel-inference:
+    supported_archs: [qb2-blackhole]
+    status: EXPECTED_PASSING
+    required_pcc: 0.91
+
+  qwen_3_6/causal_lm/pytorch-35B_A3B-tensor_parallel-inference:
+    supported_archs: [qb2-blackhole]
+    status: EXPECTED_PASSING
+    inject_custom_moe: true
+
+  qwen_3_6/multimodal/pytorch-Qwen/Qwen3.6-35B-A3B-tensor_parallel-inference:
+    supported_archs: [qb2-blackhole]
+    status: EXPECTED_PASSING
+    inject_custom_moe: true
+    required_pcc: 0.85
+
+  qwen_3_8/causal_lm/pytorch-27B-tensor_parallel-inference:
+    supported_archs: [qb2-blackhole]
+    status: EXPECTED_PASSING
+
+  qwen_3_8/multimodal/pytorch-Qwen/Qwen3.8-27B-tensor_parallel-inference:
+    supported_archs: [qb2-blackhole]
+    status: EXPECTED_PASSING
+    required_pcc: 0.87
+
+  qwen_3_coder/causal_lm/pytorch-30B_A3B_Instruct-tensor_parallel-inference:
+    supported_archs: [qb2-blackhole]
+    status: EXPECTED_PASSING
+    inject_custom_moe: true
+
+  kat_coder/causal_lm/pytorch-KAT-Coder-V2.5-Dev-tensor_parallel-inference:
+    supported_archs: [qb2-blackhole]
+    inject_custom_moe: true
+    status: EXPECTED_PASSING
+
+  ai21labs/pytorch-AI21-Jamba-Mini-1.7-tensor_parallel-inference:
+    supported_archs: [qb2-blackhole]
+    inject_custom_moe: true
+    status: EXPECTED_PASSING


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/6035
https://github.com/tenstorrent/tt-xla/issues/6029
https://github.com/tenstorrent/tt-xla/issues/5968
https://github.com/tenstorrent/tt-xla/issues/5962
https://github.com/tenstorrent/tt-xla/issues/6036
https://github.com/tenstorrent/tt-xla/issues/6037


### Problem description
Add new tensor-parallel inference configs for qb2-blackhole . 

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] New/Existing tests provide coverage for changes
