### PR TITLE
[HiDream-I1] Enable the Llama text encoder on TT; fix stale dynamo-bridge constant inputs

### DIFF
--- a/examples/pytorch/hidream_i1.py
+++ b/examples/pytorch/hidream_i1.py
@@ -7,10 +7,10 @@
 The pipeline implementation lives in ``tt_forge_models``; this is a thin runnable
 demo that calls it.
 
-The CLIP-L and CLIP-G text encoders, the Sparse-MoE MM-DiT transformer and the
-VAE decoder run on the Tenstorrent backend in bf16, with the transformer
-tensor-parallel sharded across the device mesh. The T5-XXL and Llama-3.1-8B
-encoders and the scheduler run on CPU.
+The CLIP-L, CLIP-G and Llama-3.1-8B text encoders, the Sparse-MoE MM-DiT
+transformer and the VAE decoder run on the Tenstorrent backend in bf16, with
+Llama and the transformer tensor-parallel sharded across the device mesh. The
+T5-XXL encoder and the scheduler run on CPU.
 
 Run (multichip blackhole, qb2):
     python examples/pytorch/hidream_i1.py

--- a/python_package/tt_torch/backend/backend.py
+++ b/python_package/tt_torch/backend/backend.py
@@ -592,13 +592,60 @@ class XLAExecutor:
         self.compiled_graph = None
         self.lazy_execution = lazy_execution
 
+    def _isolate_user_inputs(self, full_args):
+        """Trace-time only: replace USER_INPUT tensors with private device copies.
+
+        torch-xla's dynamo bridge matches HLO inputs to arguments by the tensor
+        id on the device buffer, which its pre-trace clone shares. An argument
+        shared by two dynamo graphs is thus unmatched in the second graph and
+        frozen as a trace-time constant, so later calls read the first call's
+        value. Private copies share nothing. Weights are untouched; calls use
+        the caller's tensors; a copy whose sharding spec differs is not used.
+        https://github.com/tenstorrent/tt-xla/issues/6019#issuecomment-5514921811
+        """
+        n_user = sum(
+            spec.kind is InputKind.USER_INPUT for spec in self.signature.input_specs
+        )
+        if n_user == 0:
+            return full_args
+        head, tail = full_args[:-n_user], full_args[-n_user:]
+        copies = []
+        for arg in tail:
+            if isinstance(arg, torch.Tensor) and arg.device.type == "xla":
+                # Host round trip: a fresh device buffer with no device op, so
+                # nothing extra is compiled (an XLA clone would share the buffer).
+                # Keep the FunctionalTensorWrapper the original carries: without
+                # it a view op with no XLA kernel (e.g. view_as_complex) cannot
+                # take the functionalization/CPU-fallback path in the bridge's
+                # partitioner and fails to trace.
+                with torch.no_grad():
+                    copy = arg.cpu().to(arg.device)
+                if torch._is_functional_tensor(arg) and not torch._is_functional_tensor(
+                    copy
+                ):
+                    copy = torch._to_functional_tensor(copy)
+                arg = copy
+            copies.append(arg)
+        if xr.is_spmd():
+            from torch_xla.distributed.spmd.xla_sharding import get_xla_sharding_specs
+
+            for i, (orig, copy) in enumerate(zip(tail, copies)):
+                if isinstance(orig, torch.Tensor) and get_xla_sharding_specs(
+                    [orig]
+                ) != get_xla_sharding_specs([copy]):
+                    copies[i] = orig
+        return tuple(head) + tuple(copies)
+
     def _call_experimental_compile(self, full_args):
         if self.compiled_graph is None:
             # Use `torch_xla` function to replace the graph module with the `optimized_mod`.
             # This helps us avoid tracing the graph on the subsequent model execution. On the next
             # invocation of forward - `optimized_mod` will just look up in its cache and execute the graph
-            # without any tracing.
-            self.compiled_graph = bridge.extract_compiled_graph(self.module, full_args)
+            # without any tracing. Traced against isolated user inputs, see
+            # _isolate_user_inputs.
+            self.compiled_graph = bridge.extract_compiled_graph(
+                self.module, self._isolate_user_inputs(full_args)
+            )
 
         return self.compiled_graph(*full_args)
 

--- a/tests/benchmark/test_imagegen.py
+++ b/tests/benchmark/test_imagegen.py
@@ -632,10 +632,10 @@ def test_hidream_i1(output_file, request):
     )
 
     # HiDream-I1-Full: 1024x1024, CFG guidance 5.0 (model card). The CLIP-L/CLIP-G
-    # text encoders, the ~17B Sparse-MoE MM-DiT (tensor-parallel sharded across the
-    # mesh's model axis) and the VAE decoder run on TT in bf16; the T5/Llama
-    # encoders and the scheduler run on CPU. Multichip — wired to the 4-chip
-    # blackhole (qb2).
+    # and Llama-3.1-8B text encoders, the ~17B Sparse-MoE MM-DiT and the VAE
+    # decoder run on TT in bf16 (Llama and the MM-DiT tensor-parallel sharded
+    # across the mesh's model axis); the T5 encoder and the scheduler run on CPU.
+    # Multichip — wired to the 4-chip blackhole (qb2).
     prompt = PROMPT
     # 10 for now, will be bumped to 50 once the rest of the components are
     # enabled on TT.

--- a/tests/torch/models/HiDream_I1/test_hidream_e2e_pipeline.py
+++ b/tests/torch/models/HiDream_I1/test_hidream_e2e_pipeline.py
@@ -3,11 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """HiDream-I1-Full — nightly e2e pipeline test, every TT component PCC-gated
-against a CPU twin in the same dtype. The CLIP-L and CLIP-G text encoders, the
-Sparse-MoE MM-DiT transformer (tensor-parallel sharded) and the VAE decoder run
-bf16 on TT; the T5 and Llama encoders and the scheduler stay on CPU. Each CLIP
-encoder is checked once per prompt — twice under CFG, positive and negative — the
-transformer once per denoising step, and the VAE once.
+against a CPU twin in the same dtype. The CLIP-L, CLIP-G and Llama text encoders,
+the Sparse-MoE MM-DiT transformer and the VAE decoder run bf16 on TT (Llama and
+the transformer tensor-parallel sharded); the T5 encoder and the scheduler stay
+on CPU. Each encoder is checked once per prompt — twice under CFG, positive and
+negative — the transformer once per denoising step, and the VAE once.
 
 The pipeline itself lives in ``tt_forge_models`` and is shared with the runnable
 demo and the benchmark; this test only wraps the TT components' forwards.
@@ -93,9 +93,13 @@ def _attach_pcc_checks(pipeline: HiDreamI1Pipeline) -> None:
         "text_encoder_2 (CLIP-G)",
         lambda: _twin(ModelVariant.TEXT_ENCODER_2),
     )
-    # text_encoder_3 (T5) and text_encoder_4 (Llama) run on CPU, so there is
-    # nothing to gate: https://github.com/tenstorrent/tt-xla/issues/6018 and
-    # https://github.com/tenstorrent/tt-xla/issues/6019
+    # text_encoder_3 (T5) runs on CPU, so there is nothing to gate.
+    # https://github.com/tenstorrent/tt-xla/issues/6018
+    attach(
+        pipeline.text_encoder_4,
+        "text_encoder_4 (Llama)",
+        lambda: _twin(ModelVariant.TEXT_ENCODER_4),
+    )
     # The twin is the stock diffusers MoE — enable_sparse_mlp is applied to the
     # device copy only, so the golden exercises the unswapped expert path.
     attach(pipeline.transformer, "transformer", lambda: _twin(ModelVariant.TRANSFORMER))


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/6019

### Problem description

- When dynamo splits a forward into several graphs and one tensor is an input to two of them, torch-xla's dynamo bridge fails to recognise that input as an argument of the second graph and freezes it as a trace-time constant. Every call after the first then silently reuses the first call's value. On HiDream-I1 this stacked forward 1's final hidden state into forward 2 of the Llama text encoder (pcc 0.83). Full analysis with evidence: [#6019](https://github.com/tenstorrent/tt-xla/issues/6019#issuecomment-5514921811).

### What's changed

- **Fix (`tt_torch/backend/backend.py`)** — the bridge matches HLO inputs to arguments by the tensor id stamped on the device buffer, and its pre-trace `clone` of each argument shares that buffer, so a tensor cloned while compiling one graph carries a foreign id when the next graph compiles. `XLAExecutor._isolate_user_inputs` now hands the one-time `extract_compiled_graph` call private copies of the USER_INPUT tensors, made as a host round trip (`.cpu().to(device)`) so each owns a fresh buffer without compiling any extra program, and re-wrapped as `FunctionalTensorWrapper` when the original was one so view ops without an XLA kernel keep their functionalization fallback. Every argument is then matched and nothing is frozen.
  - Compile-time only; every call, including the first, still runs on the caller's tensors, so input-mutation semantics are unchanged.
  - Parameters/buffers/constants are not copied.
  - Under SPMD a copy is used only if its sharding spec matches the original, otherwise the original is kept (a mismatch would make the bridge retrace against the shared tensor).
- **HiDream-I1** — with the fix in place, `text_encoder_4` (Llama-3.1-8B) moves to TT, tensor-parallel sharded ([tenstorrent/tt-forge-models#918](https://github.com/tenstorrent/tt-forge-models/pull/918)): the e2e PCC test now gates it, and the demo/benchmark comments are updated. T5-XXL stays on CPU ([#6018](https://github.com/tenstorrent/tt-xla/issues/6018)). The e2e PCC test passes with every component gated at 0.99; Llama's second forward, previously 0.83, now clears the gate.

### Checklist
- [x] E2E PCC gated nightly test - https://github.com/tenstorrent/tt-xla/actions/runs/33748090335
- [x] Benchmark test - https://github.com/tenstorrent/tt-xla/actions/runs/33748154233
- [x] Demo - [sep3_hidream_enc4_on_tt_demo_a1.log.zip](https://github.com/user-attachments/files/31790133/sep3_hidream_enc3_on_tt_demo_a1.log.zip)

### Generated Image

- Prompt: `'A cat holding a sign that says "HiDream.ai".'`, 10 inference steps, guidance 5.0, 1024x1024

<img width="1024" height="1024" alt="hidream_i1_output" src="https://github.com/user-attachments/assets/6da0b7b3-c790-44c6-acd4-3f2ca9d29708" />
