### PR TITLE
[Mochi]Add pcc gated test for Decoder in Pipeline test

### DIFF
--- a/tests/torch/models/mochi/test_mochi_1_pipeline.py
+++ b/tests/torch/models/mochi/test_mochi_1_pipeline.py
@@ -3,14 +3,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Mochi-1 preview — nightly e2e pipeline test, every TT component PCC-gated
-against a CPU twin in the same dtype. The T5-XXL text encoder (fp32) and the DiT
-(bf16) both run tensor-parallel on TT; scheduler and VAE stay on CPU. The encoder
-is checked on each of its two forwards (cond + uncond), the DiT once per
-denoising step.
+against a CPU twin in the same dtype. The T5-XXL text encoder (fp32), the DiT
+(bf16) and the VAE decoder (bf16) all run tensor-parallel on TT; the scheduler
+stays on CPU. The encoder is checked on each of its two forwards (cond +
+uncond), the DiT once per denoising step, the decoder on its single forward.
 
 CFG is on (guidance_scale=4.5), so every DiT forward — and every twin forward —
 sees a batch-2 cat([uncond, cond]) input.
+
+The generated clip is written out as an MP4 and its dimensions asserted, the
+same way the image-gen pipeline tests check their saved PNG.
 """
+
+from pathlib import Path
 
 import pytest
 import torch
@@ -24,9 +29,14 @@ from utils import BringupStatus, Category
 from third_party.tt_forge_models.config import Parallelism
 from third_party.tt_forge_models.mochi.pytorch import ModelLoader, ModelVariant
 from third_party.tt_forge_models.mochi.pytorch.src.pipeline import (
+    FPS,
+    HEIGHT,
     TEXT_ENCODER_DTYPE,
+    VAE_TEMPORAL_SCALE_FACTOR,
+    WIDTH,
     Mochi1Config,
     Mochi1Pipeline,
+    save_video,
 )
 
 PROMPT = (
@@ -36,9 +46,10 @@ PROMPT = (
 SEED = 0
 NUM_INFERENCE_STEPS = 10
 NUM_FRAMES = 24
+OUTPUT_PATH = "mochi_1_pipeline_output.mp4"
 # Set by the text encoder, which tops out ~0.95 even in fp32 (0.9494 cond /
-# 0.9518 uncond); the DiT runs ~1.0. See
-# https://github.com/tenstorrent/tt-xla/issues/5995
+# 0.9518 uncond); the DiT runs ~1.0, and the VAE decoder clears 0.99 in its
+# component test. See https://github.com/tenstorrent/tt-xla/issues/5995
 PCC_THRESHOLD = 0.94
 
 VARIANT_NAME = ModelVariant.MOCHI
@@ -61,7 +72,14 @@ def _attach_pcc_checks(pipeline: Mochi1Pipeline) -> None:
     asserted per forward so a diverging step fails fast; the pipeline continues
     using the real TT output regardless."""
 
-    def attach(module, name, subfolder, dtype, pick=lambda out: out):
+    def attach(
+        module,
+        name,
+        subfolder,
+        dtype,
+        pick=lambda out: out,
+        twin_pick=lambda loaded: loaded,
+    ):
         orig_forward = module.forward
         twin = {"model": None}
         step = {"n": 0}
@@ -69,9 +87,14 @@ def _attach_pcc_checks(pipeline: Mochi1Pipeline) -> None:
         def _cpu_twin():
             if twin["model"] is None:
                 logger.info("[PCC] loading {} CPU twin: {}", dtype, name)
-                twin["model"] = ModelLoader(
-                    VARIANT_NAME, subfolder=subfolder
-                ).load_model(dtype_override=dtype)
+                # twin_pick selects the submodule under test when the loader
+                # returns a larger container (the "vae" subfolder gives the
+                # whole autoencoder, but only its decoder runs on TT).
+                twin["model"] = twin_pick(
+                    ModelLoader(VARIANT_NAME, subfolder=subfolder).load_model(
+                        dtype_override=dtype
+                    )
+                )
             return twin["model"]
 
         # The twin sees the same args, positional or keyword, moved to host.
@@ -110,6 +133,19 @@ def _attach_pcc_checks(pipeline: Mochi1Pipeline) -> None:
         torch.bfloat16,
         pick=lambda out: out[0] if isinstance(out, (tuple, list)) else out,
     )
+    if pipeline.config.vae_on_tt:
+        # MochiDecoder3D.forward returns (sample, conv_cache). The twin runs the
+        # same math as the device path: patch_vae_decoder_ops() rebinds the two
+        # rewritten decoder ops process-wide, and pipeline.setup() has already
+        # called it by the time this twin is loaded.
+        attach(
+            pipeline.vae.decoder,
+            "vae_decoder",
+            "vae",
+            torch.bfloat16,
+            pick=lambda out: out[0] if isinstance(out, (tuple, list)) else out,
+            twin_pick=lambda vae: vae.decoder.eval(),
+        )
 
 
 @pytest.mark.nightly
@@ -130,10 +166,32 @@ def test_pipeline():
 
     pipeline = Mochi1Pipeline(
         config=Mochi1Config(
-            num_inference_steps=NUM_INFERENCE_STEPS, num_frames=NUM_FRAMES
+            num_inference_steps=NUM_INFERENCE_STEPS,
+            num_frames=NUM_FRAMES,
         )
     )
     pipeline.setup()
     _attach_pcc_checks(pipeline)
 
-    pipeline.generate(prompt=PROMPT, seed=SEED)
+    # ``generate`` post-processes via the diffusers video processor and returns a
+    # list of PIL frames (output_type="pil").
+    frames = pipeline.generate(prompt=PROMPT, seed=SEED)
+
+    save_video(frames, OUTPUT_PATH, fps=FPS)
+
+    output = Path(OUTPUT_PATH)
+    assert output.exists(), f"Output video {OUTPUT_PATH} was not created"
+    assert output.stat().st_size > 0, f"Output video {OUTPUT_PATH} is empty"
+
+    # The decoder upsamples temporally, so the frame count is not NUM_FRAMES:
+    # the requested frames map onto ceil(NUM_FRAMES / 6) latent frames, which
+    # decode back to (latent - 1) * 6 + 1 -- 19 for the 24 asked for here.
+    latent_frames = (NUM_FRAMES - 1) // VAE_TEMPORAL_SCALE_FACTOR + 1
+    expected_frames = (latent_frames - 1) * VAE_TEMPORAL_SCALE_FACTOR + 1
+    assert (
+        len(frames) == expected_frames
+    ), f"Expected {expected_frames} frames, got {len(frames)}"
+
+    width, height = frames[0].size
+    assert width == WIDTH, f"Expected width {WIDTH}, got {width}"
+    assert height == HEIGHT, f"Expected height {HEIGHT}, got {height}"

--- a/tests/torch/models/mochi/test_vae_decoder.py
+++ b/tests/torch/models/mochi/test_vae_decoder.py
@@ -4,14 +4,13 @@
 
 """Mochi VAE decoder component test at original Mochi-1 resolution (0.36B)."""
 
-import os
-
-import pytest
 import torch
 import torch_xla
-import torch_xla.core.xla_model as xm
-import torch_xla.distributed.spmd as xs
 import torch_xla.runtime as xr
+from diffusers.models.autoencoders.autoencoder_kl_cogvideox import CogVideoXCausalConv3d
+from diffusers.models.autoencoders.autoencoder_kl_mochi import MochiChunkedGroupNorm3D
+from infra import Framework, run_graph_test
+from infra.testers.compiler_config import CompilerConfig
 from infra.utilities.torch_multichip_utils import get_mesh
 
 from third_party.tt_forge_models.mochi.pytorch import ModelLoader, ModelVariant
@@ -20,42 +19,138 @@ from third_party.tt_forge_models.mochi.pytorch.src.utils import (
 )
 
 
-@pytest.mark.xfail(
-    reason="DRAM OOM during sharded decoder pixel-shuffle intermediate — "
-    "https://github.com/tenstorrent/tt-xla/issues/4252"
+def _replicate_pad_in_native_dtype(self, inputs, conv_cache=None):
+    """CogVideoXCausalConv3d replicate padding without the f32 round trip.
+
+    torch has no bf16 replication_pad3d kernel, so the stock
+    F.pad(..., mode="replicate") upcasts. XLA keeps that upcast in the graph,
+    and the permute plus three pad concats that follow all run at f32 - each
+    one twice the DRAM it needs, on the largest tensors in the decoder.
+
+    Replication is clamp(index) per axis and therefore separable, so padding
+    one axis at a time with slice + expand + cat gives identical values while
+    staying in the input's own dtype. Order across axes doesn't matter.
+    """
+    if self.pad_mode != "replicate":
+        return _STOCK_FAKE_CONTEXT_PARALLEL_FORWARD(self, inputs, conv_cache)
+
+    x = inputs
+    if self.time_pad:
+        # Causal: leading pad only, replicating frame 0.
+        x = torch.cat([x[:, :, :1].expand(-1, -1, self.time_pad, -1, -1), x], dim=2)
+    if self.height_pad:
+        pad = self.height_pad
+        x = torch.cat(
+            [
+                x[:, :, :, :1].expand(-1, -1, -1, pad, -1),
+                x,
+                x[:, :, :, -1:].expand(-1, -1, -1, pad, -1),
+            ],
+            dim=3,
+        )
+    if self.width_pad:
+        pad = self.width_pad
+        x = torch.cat(
+            [
+                x[..., :1].expand(-1, -1, -1, -1, pad),
+                x,
+                x[..., -1:].expand(-1, -1, -1, -1, pad),
+            ],
+            dim=4,
+        )
+    return x
+
+
+_STOCK_FAKE_CONTEXT_PARALLEL_FORWARD = (
+    CogVideoXCausalConv3d.fake_context_parallel_forward
 )
+
+
+def _group_norm_with_affine_on_channels(self, x: torch.Tensor = None) -> torch.Tensor:
+    """MochiChunkedGroupNorm3D with the affine applied outside F.group_norm.
+
+    F.group_norm normalizes in group space, [chunks*groups, C/groups*H*W], where
+    a per-channel weight varies along the *inner* axis and so cannot broadcast
+    implicitly. Since up_block.proj was sharded the compiler keeps the affine in
+    that space, and each norm materializes its weight and bias as full
+    1x8x128x480x848 f32 tensors - 1.70 GB apiece, via ttnn.repeat.
+
+    Applying the affine ourselves on the [chunk, C, H, W] output puts channel
+    back on a real dimension, where the broadcast is implicit and free. Same
+    arithmetic: group_norm scales by weight[c] and shifts by bias[c] after
+    normalizing, which is exactly what this does.
+
+    The normalize is also open-coded so it can run in the input's dtype.
+    F.group_norm upcasts everything to f32, which costs 1.67 GB per
+    1x256x1628160 intermediate. Only the reductions actually need f32 - their
+    outputs are tiny - so mean and variance are computed in f32 and the
+    full-size centre-and-scale runs in bf16. That is a real precision
+    reduction: the centred values are O(1) so bf16 carries them fine, but the
+    subtraction rounds the mean to bf16 first, which costs accuracy in
+    proportion to mean/std.
+    """
+    batch_size = x.size(0)
+    norm = self.norm_layer
+
+    x = x.permute(0, 2, 1, 3, 4).flatten(0, 1)
+
+    normalized_chunks = []
+    for chunk in x.split(self.chunk_size, dim=0):
+        grouped = chunk.reshape(chunk.shape[0], norm.num_groups, -1)
+
+        stats = grouped.float()
+        mean = stats.mean(dim=2, keepdim=True)
+        # Biased variance, matching F.group_norm.
+        var = stats.var(dim=2, unbiased=False, keepdim=True)
+        rstd = torch.rsqrt(var + norm.eps)
+
+        centred = grouped - mean.to(grouped.dtype)
+        normalized_chunks.append((centred * rstd.to(grouped.dtype)).reshape_as(chunk))
+
+    output = torch.cat(normalized_chunks, dim=0)
+    if norm.affine:
+        output = output * norm.weight.view(1, -1, 1, 1) + norm.bias.view(1, -1, 1, 1)
+
+    return output.unflatten(0, (batch_size, -1)).permute(0, 2, 1, 3, 4)
+
+
 def test_torch_mochi_vae_decoder_inference():
-    # Not using run_graph_test: it runs the model on CPU as a golden
-    # reference first, and the Mochi VAE decoder CPU pass takes > 50 min at
-    # full resolution. TT-only for now.
-    # TODO: re-enable CPU golden + PCC check via run_graph_test once the
-    # TT path is passing - https://github.com/tenstorrent/tt-xla/issues/4885
-    # SPMD setup must come before any tensor lands on the XLA device.
-    torch_xla.set_custom_compile_options(
-        {"experimental-enable-dram-space-saving-optimization": "true"}
-    )
+    # run_graph_test runs the decoder on CPU as a golden reference before
+    # comparing against TT, and the CPU pass takes > 50 min at full
+    # resolution - https://github.com/tenstorrent/tt-xla/issues/4885
     xr.set_device_type("TT")
-    os.environ["CONVERT_SHLO_TO_SHARDY"] = "1"
-    xr.use_spmd()
     torch.manual_seed(42)
 
-    device = xm.xla_device()
+    CogVideoXCausalConv3d.fake_context_parallel_forward = _replicate_pad_in_native_dtype
+    MochiChunkedGroupNorm3D.forward = _group_norm_with_affine_on_channels
 
     loader = ModelLoader(ModelVariant.MOCHI, subfolder="vae")
     vae = loader.load_model(dtype_override=torch.bfloat16)
-    decoder = vae.decoder.eval().to(device)
+    decoder = vae.decoder.eval()
 
-    compiled = torch.compile(decoder, backend="tt")
-
-    # Megatron-style sharding applied after weights are on the XLA device.
+    # Megatron-style sharding; run_graph_test enables SPMD and applies the
+    # shard specs once the weights are on the XLA device.
     mesh_shape, mesh_names = loader.get_mesh_config(xr.global_runtime_device_count())
     mesh = get_mesh(mesh_shape, mesh_names)
-    shard_spec = loader.load_shard_spec(decoder)
-    for tensor, partition_spec in shard_spec.items():
-        xs.mark_sharding(tensor, mesh, partition_spec)
 
     [latent] = load_vae_decoder_inputs_full_res(dtype=torch.bfloat16)
-    tt_latent = latent.to(device)
 
-    with torch.no_grad():
-        tt_out = compiled(tt_latent)
+    # Const-eval is off because the chunked GroupNorm's affine params get
+    # hoisted into full-activation-size f32 broadcasts (a 128-element bias
+    # becomes a 1.67 GB 1x256x1628160 constant), and const-eval'd results stay
+    # pinned in DRAM for the whole execution - 14 GiB of them, against 12.8 GB
+    # of DRAM.
+    compiler_config = CompilerConfig(
+        optimization_level=1,
+        experimental_enable_dram_space_saving_optimization=True,
+        enable_const_eval=False,
+    )
+
+    run_graph_test(
+        decoder,
+        [latent],
+        framework=Framework.TORCH,
+        mesh=mesh,
+        shard_spec_fn=loader.load_shard_spec,
+        compiler_config=compiler_config,
+    )


### PR DESCRIPTION
### Ticket
Fixes #6051 

### Problem description
The Mochi pipeline ran the DiT (bf16) and T5-XXL encoder (fp32) tensor-parallel on TT but decoded on CPU. Moving the decoder onto the device in this PR and addressing the problems faced on doing so.

### What's changed
- test_mochi_1_pipeline.py extends the existing twin machinery to cover the decoder. attach gains a twin_pick hook, defaulting to identity, because the "vae" subfolder loader returns the whole autoencoder while only decoder runs on TT — the decoder gate passes twin_pick=lambda vae: vae.decoder.eval() alongside a pick that unwraps MochiDecoder3D.forward's (sample, conv_cache) tuple, and is registered under if pipeline.config.vae_on_tt. The twin is valid because patch_vae_decoder_ops() rebinds process-wide from pipeline.setup(), so golden and device run the same math. The test then saves its output the way the image-gen tests do: save_video(frames, "mochi_1_pipeline_output.mp4", fps=FPS) followed by existence, non-empty, frame-count and dimension assertions, with the frame count derived through VAE_TEMPORAL_SCALE_FACTOR rather than hardcoded (24 requested → 4 latent → 19 decoded) since the decoder upsamples temporally.

### Validation
Details from Log:

Nightly PCC-instrumented e2e run of [tests/torch/models/mochi/test_mochi_1_pipeline.py](vscode-webview://06au5agk3n3l1goitdjc21pifc212bo2pqnidhpgjtlagmk28gaf/tests/torch/models/mochi/test_mochi_1_pipeline.py), with the T5-XXL text encoder (fp32), the DiT (bf16) and the VAE decoder (bf16) all on TT, tensor-parallel sharded on a shared (1, 4) mesh over 4 devices, sequential_offload on so each component is resident only for its own stage. Scheduler on CPU.

Prompt: "Close-up of a chameleon's eye, with its scaly skin changing color. Ultra high resolution 4k.", 848×480, 24 frames requested → 19 decoded, 10 steps, seed 0, CFG 4.5 (batch-2 cat([uncond, cond]) per DiT forward)

All 13 per-forward PCC ≥ 0.949355 against same-dtype CPU twins, threshold 0.94 — text encoder 0.949355 / 0.951844 (it tops out ~0.95 even in fp32), DiT 1.000000 on 8 of 10 steps and 1.007812 on steps 1 and 4, VAE decoder 1.000000. The two >1.0 readings are a bf16 quantization artifact of the correlation itself, not a divergence.

```
[load_models] text_encoder / transformer / vae      10:43:55.947 → 10:44:18.800
[setup] mesh (1, 4) over 4 device(s)                10:44:18.800
[STAGE] text_encoder (T5-XXL, sharded, fp32): start 10:44:21.427
[STAGE] text_encoder: done (2 forwards)             10:45:50.395   (~1:29)
encoder offload + DiT placement                     10:45:50.395 → 10:46:30.389  (~40.0s)
[STAGE] DiT denoising loop: start (10 steps)        10:46:30.389
[STAGE] DiT denoising loop: done                    11:27:34.737   (41:04)
DiT offload + VAE decoder placement                 11:27:34.737 → 11:28:01.416  (~26.7s)
[STAGE] VAE decode (TT): start                      11:28:01.416
[STAGE] VAE decode (TT): done, 19 frames            11:32:28.983   (~4:28)
```

Final video generated from pipeline:

https://github.com/user-attachments/assets/95df8b5e-2449-4658-875a-e9b5290465ac
