### PR TITLE
Build SDPA composite bool-mask bias in query dtype to avoid f32 round trip

### DIFF
--- a/python_package/tt_torch/composite_ops.py
+++ b/python_package/tt_torch/composite_ops.py
@@ -346,7 +346,15 @@ def composite_scaled_dot_product_attention(
             os.environ.get("TT_XLA_CATCH_BOOL_MASK_SDPA", "0") == "1"
             and attn_mask.dtype == torch.bool
         ):
-            attn_mask = torch.where(attn_mask, 0.0, float("-inf")).to(query.dtype)
+            # Build the branches in query dtype: with Python float scalars the
+            # where resolves to f32 and holds two full f32 copies of the mask
+            # before the cast to query dtype.
+            # See https://github.com/tenstorrent/tt-xla/issues/6071.
+            zero = torch.zeros((), dtype=query.dtype, device=attn_mask.device)
+            neg_inf = torch.full(
+                (), float("-inf"), dtype=query.dtype, device=attn_mask.device
+            )
+            attn_mask = torch.where(attn_mask, zero, neg_inf)
         query, key, value, attn_mask = builder.mark_inputs(query, key, value, attn_mask)
     else:
         query, key, value = builder.mark_inputs(query, key, value)

--- a/tests/torch/ops/test_composite_ops.py
+++ b/tests/torch/ops/test_composite_ops.py
@@ -838,3 +838,60 @@ def test_sdpa_bool_mask_broadcast(monkeypatch, qkv_shape, mask_shape):
         shard_spec_fn=get_shard_spec,
         compiler_config=CompilerConfig(optimization_level=1),
     )
+
+
+@pytest.mark.nightly
+@pytest.mark.qb2_blackhole
+def test_sdpa_bool_mask_hunyuan_video_1_5_121_frames(monkeypatch):
+    """HunyuanVideo-1.5 DiT joint attention at 121 frames (S = 51275): the
+    (1, 1, S, S) bool mask is built on device from a 1-D token mask, as in
+    diffusers' HunyuanVideo15AttnProcessor2_0. The composite's bool -> additive
+    conversion must stay in the query dtype; an f32 round trip holds two extra
+    f32 copies of the mask (21 GB) and OOMs DRAM.
+    See https://github.com/tenstorrent/tt-xla/issues/6071.
+    """
+    monkeypatch.setenv("TT_XLA_CATCH_BOOL_MASK_SDPA", "1")
+
+    num_devices = xr.global_runtime_device_count()
+    batch_size, num_heads, head_dim = 1, 16, 128
+    video_tokens, text_tokens, text_valid = 49290, 1985, 1000
+    seq_len = video_tokens + text_tokens
+    if num_heads % num_devices != 0:
+        pytest.skip(f"num_heads={num_heads} not divisible by num_devices={num_devices}")
+
+    class HunyuanVideo15Attention(torch.nn.Module):
+        def forward(self, query, key, value, token_mask):
+            # Mask construction from HunyuanVideo15AttnProcessor2_0 (the front
+            # F.pad of the text mask to seq_len is done on the host here).
+            batch_size, _, seq_len, _ = query.shape
+            token_mask = token_mask.bool()
+            mask_1 = token_mask.view(batch_size, 1, 1, seq_len).repeat(1, 1, seq_len, 1)
+            mask_2 = mask_1.transpose(2, 3)
+            attn_mask = (mask_1 & mask_2).bool()
+            out = F.scaled_dot_product_attention(query, key, value, attn_mask=attn_mask)
+            # Rows of padding tokens are fully masked; the model drops them.
+            return out[:, :, : video_tokens + text_valid]
+
+    shape = (batch_size, num_heads, seq_len, head_dim)
+    query = torch.randn(*shape, dtype=torch.bfloat16)
+    key = torch.randn(*shape, dtype=torch.bfloat16)
+    value = torch.randn(*shape, dtype=torch.bfloat16)
+    token_mask = torch.ones(batch_size, seq_len, dtype=torch.bool)
+    token_mask[:, video_tokens + text_valid :] = False  # text padding
+
+    mesh = xs.Mesh(np.array(range(num_devices)), (1, num_devices), ("batch", "model"))
+
+    def get_shard_spec(args, kwargs):
+        head_sharded = (None, "model", None, None)
+        # Q/K/V are head-sharded; the token mask stays replicated.
+        return {args[0]: head_sharded, args[1]: head_sharded, args[2]: head_sharded}
+
+    run_graph_test(
+        HunyuanVideo15Attention(),
+        [query, key, value, token_mask],
+        comparison_config=ComparisonConfig(),
+        framework=Framework.TORCH,
+        mesh=mesh,
+        shard_spec_fn=get_shard_spec,
+        compiler_config=CompilerConfig(optimization_level=1),
+    )


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/6071

### Problem description
With `TT_XLA_CATCH_BOOL_MASK_SDPA=1`, `composite_scaled_dot_product_attention` converts a bool `attn_mask` to an additive bias with `torch.where(mask, 0.0, float("-inf")).to(query.dtype)`. The Python float scalars make the `where` resolve to f32, so the compiled graph carries a bf16 → f32 typecast, an f32 `where`, and an f32 → bf16 typecast. Two full f32 copies of the mask are live before the bf16 result exists.

For the HunyuanVideo-1.5 DiT at 121 frames the mask is `(1, 1, 51275, 51275)`: 5.26 GB in bf16, 10.5 GB in f32, so the round trip costs ~21 GB per chip and OOMs DRAM in the transformer blocks.

### What's changed
Build the `where` branches as 0-d tensors in `query.dtype`, so the additive mask is produced in the query dtype directly with no f32 round trip.

Compiled mask ops for the 51275-token case, before → after:
```
logical_and → typecast(f32) → where(f32) → typecast(bf16) → sdpa
logical_and → where(bf16) → sdpa
```

| | Before | After |
|---|---|---|
| DRAM peak per chip | 19.8 GB | 10.0 GB |
| HunyuanVideo-1.5 DiT, 54 blocks | OOM at block 14 | passes, PCC 0.98 |

Adds `test_sdpa_bool_mask_hunyuan_video_1_5_121_frames` (qb2_blackhole), which builds the mask on device from a 1-D token mask as the diffusers attention processor does. It passes before and after the fix on a fresh chip; the memory difference is visible in the DRAM MemoryView log lines.

### Checklist
- [x] Verify the changes through local testing in QB2

### Logs

- [sep12_sdpa_after_fix.log](https://github.com/user-attachments/files/32145078/sep12_sdpa_after_fix.log)
- [sep12_Hunyuan_1_5_transformer_before_fix.log.zip](https://github.com/user-attachments/files/32145073/sep12_Hunyuan_1_5_transformer_d2.log.zip)
- [sep12_Hunyuan_1_5_transformer_after_fix.log.zip](https://github.com/user-attachments/files/32145075/sep12_Hunyuan_1_5_transformer_d3.log.zip)
- [sep12_sdpa_before_fix.log](https://github.com/user-attachments/files/32145079/sep12_sdpa_bf.log)

